### PR TITLE
SimTrack to CSC digi and stub matching in CSC Validation code

### DIFF
--- a/Validation/MuonCSCDigis/BuildFile.xml
+++ b/Validation/MuonCSCDigis/BuildFile.xml
@@ -1,20 +1,20 @@
-<use   name="DQMServices/Core"/>
 <use   name="DataFormats/CSCDigi"/>
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/GEMDigi"/>
+<use   name="DataFormats/MuonDetId"/>
+<use   name="DQMServices/Core"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="Geometry/CSCGeometry"/>
+<use   name="Geometry/GEMGeometry"/>
 <use   name="Geometry/Records"/>
 <use   name="SimDataFormats/CrossingFrame"/>
 <use   name="SimDataFormats/TrackingHit"/>
 <use   name="SimMuon/MCTruth"/>
-<use   name="Geometry/GEMGeometry"/>
-<use   name="DataFormats/GEMDigi"/>
 <use   name="Validation/MuonGEMDigis"/>
 <use   name="Validation/MuonHits"/>
-<use   name="DataFormats/MuonDetId"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Validation/MuonCSCDigis/BuildFile.xml
+++ b/Validation/MuonCSCDigis/BuildFile.xml
@@ -9,7 +9,12 @@
 <use   name="Geometry/Records"/>
 <use   name="SimDataFormats/CrossingFrame"/>
 <use   name="SimDataFormats/TrackingHit"/>
-<use   name="SimMuon/MCTruth"/> 
+<use   name="SimMuon/MCTruth"/>
+<use   name="Geometry/GEMGeometry"/>
+<use   name="DataFormats/GEMDigi"/>
+<use   name="Validation/MuonGEMDigis"/>
+<use   name="Validation/MuonHits"/>
+<use   name="DataFormats/MuonDetId"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Validation/MuonCSCDigis/BuildFile.xml
+++ b/Validation/MuonCSCDigis/BuildFile.xml
@@ -1,14 +1,11 @@
 <use   name="DataFormats/CSCDigi"/>
 <use   name="DataFormats/Common"/>
-<use   name="DataFormats/GEMDigi"/>
-<use   name="DataFormats/MuonDetId"/>
 <use   name="DQMServices/Core"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="Geometry/CSCGeometry"/>
-<use   name="Geometry/GEMGeometry"/>
 <use   name="Geometry/Records"/>
 <use   name="SimDataFormats/CrossingFrame"/>
 <use   name="SimDataFormats/TrackingHit"/>

--- a/Validation/MuonCSCDigis/interface/CSCALCTDigiValidation.h
+++ b/Validation/MuonCSCDigis/interface/CSCALCTDigiValidation.h
@@ -1,5 +1,5 @@
-#ifndef CSCALCTDigiValidation_H
-#define CSCALCTDigiValidation_H
+#ifndef Validation_MuonCSCDigis_CSCALCTDigiValidation_H
+#define Validation_MuonCSCDigis_CSCALCTDigiValidation_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 

--- a/Validation/MuonCSCDigis/interface/CSCBaseValidation.h
+++ b/Validation/MuonCSCDigis/interface/CSCBaseValidation.h
@@ -1,5 +1,5 @@
-#ifndef CSCBaseValidation_h
-#define CSCBaseValidation_h
+#ifndef Validation_MuonCSCDigis_CSCBaseValidation_h
+#define Validation_MuonCSCDigis_CSCBaseValidation_h
 
 // user include files
 

--- a/Validation/MuonCSCDigis/interface/CSCCLCTDigiValidation.h
+++ b/Validation/MuonCSCDigis/interface/CSCCLCTDigiValidation.h
@@ -1,5 +1,5 @@
-#ifndef CSCCLCTDigiValidation_H
-#define CSCCLCTDigiValidation_H
+#ifndef Validation_MuonCSCDigis_CSCCLCTDigiValidation_H
+#define Validation_MuonCSCDigis_CSCCLCTDigiValidation_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 

--- a/Validation/MuonCSCDigis/interface/CSCComparatorDigiValidation.h
+++ b/Validation/MuonCSCDigis/interface/CSCComparatorDigiValidation.h
@@ -1,5 +1,5 @@
-#ifndef CSCComparatorDigiValidation_H
-#define CSCComparatorDigiValidation_H
+#ifndef Validation_MuonCSCDigis_CSCComparatorDigiValidation_H
+#define Validation_MuonCSCDigis_CSCComparatorDigiValidation_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 

--- a/Validation/MuonCSCDigis/interface/CSCDigiMatcher.h
+++ b/Validation/MuonCSCDigis/interface/CSCDigiMatcher.h
@@ -1,0 +1,148 @@
+#ifndef Validation_MuonCSCDigis_CSCDigiMatcher_h
+#define Validation_MuonCSCDigis_CSCDigiMatcher_h
+
+/**\class CSCDigiMatcher
+
+   Description: Matching of Digis to SimTrack in CSC
+
+   Author: Sven Dildick (TAMU), Tao Huang (TAMU)
+*/
+
+#include "Validation/MuonHits/interface/CSCSimHitMatcher.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
+
+typedef std::vector<CSCComparatorDigi> CSCComparatorDigiContainer;
+typedef std::vector<CSCStripDigi> CSCStripDigiContainer;
+typedef std::vector<CSCWireDigi> CSCWireDigiContainer;
+
+typedef std::vector<std::pair<unsigned int, CSCComparatorDigi> > CSCComparatorDigiDetIdContainer;
+typedef std::vector<std::pair<unsigned int, CSCStripDigi> > CSCStripDigiDetIdContainer;
+typedef std::vector<std::pair<unsigned int, CSCWireDigi> > CSCWireDigiDetIdContainer;
+
+class CSCDigiMatcher
+{
+public:
+
+  // constructor
+  CSCDigiMatcher(edm::ParameterSet const& iPS, edm::ConsumesCollector && iC);
+
+  // destructor
+  ~CSCDigiMatcher() {}
+
+  // initialize the event
+  void init(const edm::Event& e, const edm::EventSetup& eventSetup);
+
+  // do the matching
+  void match(const SimTrack& t, const SimVertex& v);
+
+  // layer detIds with digis
+  std::set<unsigned int> detIdsComparator(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> detIdsStrip(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> detIdsWire(int csc_type = MuonHitHelper::CSC_ALL) const;
+
+  // chamber detIds with digis
+  std::set<unsigned int> chamberIdsComparator(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> chamberIdsStrip(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> chamberIdsWire(int csc_type = MuonHitHelper::CSC_ALL) const;
+
+  // CSC strip digis from a particular layer or chamber
+  const CSCComparatorDigiContainer& comparatorDigisInDetId(unsigned int) const;
+  const CSCComparatorDigiContainer& comparatorDigisInChamber(unsigned int) const;
+
+  // CSC strip digis from a particular layer or chamber
+  const CSCStripDigiContainer& stripDigisInDetId(unsigned int) const;
+  const CSCStripDigiContainer& stripDigisInChamber(unsigned int) const;
+
+  // CSC wire digis from a particular layer or chamber
+  const CSCWireDigiContainer& wireDigisInDetId(unsigned int) const;
+  const CSCWireDigiContainer& wireDigisInChamber(unsigned int) const;
+
+  // #layers with hits
+  int nLayersWithComparatorInChamber(unsigned int) const;
+  int nLayersWithStripInChamber(unsigned int) const;
+  int nLayersWithWireInChamber(unsigned int) const;
+
+  // How many CSC chambers with minimum number of layer with digis did this simtrack get?
+  int nCoincidenceComparatorChambers(int min_n_layers = 4) const;
+  int nCoincidenceStripChambers(int min_n_layers = 4) const;
+  int nCoincidenceWireChambers(int min_n_layers = 4) const;
+
+  std::set<int> comparatorsInDetId(unsigned int) const;
+  std::set<int> stripsInDetId(unsigned int) const;
+  std::set<int> wiregroupsInDetId(unsigned int) const;
+
+  // A non-zero max_gap_to_fill parameter would insert extra half-strips or wiregroups
+  // so that gaps of that size or smaller would be filled.
+  // E.g., if max_gap_to_fill = 1, and there are digis with strips 4 and 6 in a chamber,
+  // the resulting set of digis would be 4,5,6
+  std::set<int> comparatorsInChamber(unsigned int, int max_gap_to_fill = 0) const;
+  std::set<int> stripsInChamber(unsigned int, int max_gap_to_fill = 0) const;
+  std::set<int> wiregroupsInChamber(unsigned int, int max_gap_to_fill = 0) const;
+
+  std::shared_ptr<CSCSimHitMatcher> muonSimHitMatcher() const {return muonSimHitMatcher_;}
+
+private:
+
+  // match simtracks to digis
+  void matchComparatorsToSimTrack(const CSCComparatorDigiCollection& comparators);
+  void matchStripsToSimTrack(const CSCStripDigiCollection& strips);
+  void matchWiresToSimTrack(const CSCWireDigiCollection& wires);
+
+  template <class T>
+  std::set<unsigned int> selectDetIds(const T &digis, int csc_type) const;
+
+  edm::EDGetTokenT<CSCComparatorDigiCollection> comparatorDigiInput_;
+  edm::EDGetTokenT<CSCStripDigiCollection> stripDigiInput_;
+  edm::EDGetTokenT<CSCWireDigiCollection> wireDigiInput_;
+
+  edm::Handle<CSCComparatorDigiCollection> comparatorDigisH_;
+  edm::Handle<CSCStripDigiCollection> stripDigisH_;
+  edm::Handle<CSCWireDigiCollection> wireDigisH_;
+
+  std::shared_ptr<CSCSimHitMatcher> muonSimHitMatcher_;
+
+  int minBXComparator_, maxBXComparator_;
+  int minBXStrip_, maxBXStrip_;
+  int minBXWire_, maxBXWire_;
+
+  int matchDeltaComparator_;
+  int matchDeltaStrip_;
+  int matchDeltaWG_;
+
+  int verboseComparator_;
+  int verboseStrip_;
+  int verboseWG_;
+
+  std::map<unsigned int, CSCComparatorDigiContainer> detid_to_comparators_;
+  std::map<unsigned int, CSCComparatorDigiContainer> chamber_to_comparators_;
+
+  std::map<unsigned int, CSCStripDigiContainer> detid_to_strips_;
+  std::map<unsigned int, CSCStripDigiContainer> chamber_to_strips_;
+
+  std::map<unsigned int, CSCWireDigiContainer> detid_to_wires_;
+  std::map<unsigned int, CSCWireDigiContainer> chamber_to_wires_;
+
+  CSCComparatorDigiContainer no_comparators_;
+  CSCStripDigiContainer no_strips_;
+  CSCWireDigiContainer no_wires_;
+};
+
+template <class T>
+std::set<unsigned int> CSCDigiMatcher::selectDetIds(const T &digis, int csc_type) const
+{
+  std::set<unsigned int> result;
+  for (const auto& p: digis) {
+    const auto& id = p.first;
+    if (csc_type > 0) {
+      CSCDetId detId(id);
+      if (MuonHitHelper::toCSCType(detId.station(), detId.ring()) != csc_type) continue;
+    }
+    result.insert(p.first);
+  }
+  return result;
+}
+
+#endif

--- a/Validation/MuonCSCDigis/interface/CSCDigiMatcher.h
+++ b/Validation/MuonCSCDigis/interface/CSCDigiMatcher.h
@@ -22,12 +22,10 @@ typedef std::vector<std::pair<unsigned int, CSCComparatorDigi> > CSCComparatorDi
 typedef std::vector<std::pair<unsigned int, CSCStripDigi> > CSCStripDigiDetIdContainer;
 typedef std::vector<std::pair<unsigned int, CSCWireDigi> > CSCWireDigiDetIdContainer;
 
-class CSCDigiMatcher
-{
+class CSCDigiMatcher {
 public:
-
   // constructor
-  CSCDigiMatcher(edm::ParameterSet const& iPS, edm::ConsumesCollector && iC);
+  CSCDigiMatcher(edm::ParameterSet const& iPS, edm::ConsumesCollector&& iC);
 
   // destructor
   ~CSCDigiMatcher() {}
@@ -82,17 +80,16 @@ public:
   std::set<int> stripsInChamber(unsigned int, int max_gap_to_fill = 0) const;
   std::set<int> wiregroupsInChamber(unsigned int, int max_gap_to_fill = 0) const;
 
-  std::shared_ptr<CSCSimHitMatcher> muonSimHitMatcher() const {return muonSimHitMatcher_;}
+  std::shared_ptr<CSCSimHitMatcher> muonSimHitMatcher() const { return muonSimHitMatcher_; }
 
 private:
-
   // match simtracks to digis
   void matchComparatorsToSimTrack(const CSCComparatorDigiCollection& comparators);
   void matchStripsToSimTrack(const CSCStripDigiCollection& strips);
   void matchWiresToSimTrack(const CSCWireDigiCollection& wires);
 
   template <class T>
-  std::set<unsigned int> selectDetIds(const T &digis, int csc_type) const;
+  std::set<unsigned int> selectDetIds(const T& digis, int csc_type) const;
 
   edm::EDGetTokenT<CSCComparatorDigiCollection> comparatorDigiInput_;
   edm::EDGetTokenT<CSCStripDigiCollection> stripDigiInput_;
@@ -131,14 +128,14 @@ private:
 };
 
 template <class T>
-std::set<unsigned int> CSCDigiMatcher::selectDetIds(const T &digis, int csc_type) const
-{
+std::set<unsigned int> CSCDigiMatcher::selectDetIds(const T& digis, int csc_type) const {
   std::set<unsigned int> result;
-  for (const auto& p: digis) {
+  for (const auto& p : digis) {
     const auto& id = p.first;
     if (csc_type > 0) {
       CSCDetId detId(id);
-      if (MuonHitHelper::toCSCType(detId.station(), detId.ring()) != csc_type) continue;
+      if (MuonHitHelper::toCSCType(detId.station(), detId.ring()) != csc_type)
+        continue;
     }
     result.insert(p.first);
   }

--- a/Validation/MuonCSCDigis/interface/CSCStripDigiValidation.h
+++ b/Validation/MuonCSCDigis/interface/CSCStripDigiValidation.h
@@ -1,5 +1,5 @@
-#ifndef CSCStripDigiValidation_H
-#define CSCStripDigiValidation_H
+#ifndef Validation_MuonCSCDigis_CSCStripDigiValidation_H
+#define Validation_MuonCSCDigis_CSCStripDigiValidation_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 

--- a/Validation/MuonCSCDigis/interface/CSCStubMatcher.h
+++ b/Validation/MuonCSCDigis/interface/CSCStubMatcher.h
@@ -1,0 +1,170 @@
+#ifndef Validation_MuonCSCDigis_CSCStubMatcher_h
+#define Validation_MuonCSCDigis_CSCStubMatcher_h
+
+/**\class CSCStubMatcher
+
+   Description: Matching of CSC L1 trigger stubs to SimTrack
+
+   Author: Sven Dildick (TAMU), Tao Huang (TAMU)
+*/
+
+#include "Validation/MuonCSCDigis/interface/CSCDigiMatcher.h"
+#include "Validation/MuonGEMDigis/interface/GEMDigiMatcher.h"
+
+#include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+
+typedef std::vector<CSCALCTDigi> CSCALCTDigiContainer;
+typedef std::vector<CSCCLCTDigi> CSCCLCTDigiContainer;
+typedef std::vector<CSCCorrelatedLCTDigi> CSCCorrelatedLCTDigiContainer;
+
+class CSCStubMatcher
+{
+public:
+
+  CSCStubMatcher(edm::ParameterSet const& iPS, edm::ConsumesCollector && iC);
+
+  ~CSCStubMatcher() {}
+
+  /// initialize the event
+  void init(const edm::Event& e, const edm::EventSetup& eventSetup);
+
+  /// do the matching
+  void match(const SimTrack& t, const SimVertex& v);
+
+  /// crossed chamber detIds with not necessarily matching stubs
+  std::set<unsigned int> chamberIdsAllCLCT(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> chamberIdsAllALCT(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> chamberIdsAllLCT(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> chamberIdsAllMPLCT(int csc_type = MuonHitHelper::CSC_ALL) const;
+
+  /// chamber detIds with matching stubs
+  std::set<unsigned int> chamberIdsCLCT(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> chamberIdsALCT(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> chamberIdsLCT(int csc_type = MuonHitHelper::CSC_ALL) const;
+  std::set<unsigned int> chamberIdsMPLCT(int csc_type = MuonHitHelper::CSC_ALL) const;
+
+  /// all stubs (not necessarily matching) from a particular crossed chamber
+  const CSCCLCTDigiContainer& allCLCTsInChamber(unsigned int) const;
+  const CSCALCTDigiContainer& allALCTsInChamber(unsigned int) const;
+  const CSCCorrelatedLCTDigiContainer& allLCTsInChamber(unsigned int) const;
+  const CSCCorrelatedLCTDigiContainer& allMPLCTsInChamber(unsigned int) const;
+
+  /// all matching from a particular crossed chamber
+  const CSCCLCTDigiContainer& clctsInChamber(unsigned int) const;
+  const CSCALCTDigiContainer& alctsInChamber(unsigned int) const;
+  const CSCCorrelatedLCTDigiContainer& lctsInChamber(unsigned int) const;
+  const CSCCorrelatedLCTDigiContainer& mplctsInChamber(unsigned int) const;
+
+  /// all matching lcts
+  std::map<unsigned int, CSCCLCTDigiContainer> clcts() const { return chamber_to_clcts_; }
+  std::map<unsigned int, CSCALCTDigiContainer> alcts() const { return chamber_to_alcts_; }
+  std::map<unsigned int, CSCCorrelatedLCTDigiContainer> lcts() const { return chamber_to_lcts_; }
+  std::map<unsigned int, CSCCorrelatedLCTDigiContainer> mplcts() const { return chamber_to_mplcts_; }
+
+  /// best matching from a particular crossed chamber
+  CSCCLCTDigi bestClctInChamber(unsigned int) const;
+  CSCALCTDigi bestAlctInChamber(unsigned int) const;
+  CSCCorrelatedLCTDigi bestLctInChamber(unsigned int) const;
+  CSCCorrelatedLCTDigi bestMplctInChamber(unsigned int) const;
+
+  //z position of  certain layer
+  float zpositionOfLayer(unsigned int detid, int layer) const;
+
+  /// How many CSC chambers with matching stubs of some minimal quality did this SimTrack hit?
+  int nChambersWithCLCT(int min_quality = 0) const;
+  int nChambersWithALCT(int min_quality = 0) const;
+  int nChambersWithLCT(int min_quality = 0) const;
+  int nChambersWithMPLCT(int min_quality = 0) const;
+
+  bool lctInChamber(const CSCDetId& id, const CSCCorrelatedLCTDigi& lct) const;
+
+  // get the position of an LCT in global coordinates
+  GlobalPoint getGlobalPosition(unsigned int rawId, const CSCCorrelatedLCTDigi& lct) const;
+
+  std::shared_ptr<CSCDigiMatcher> cscDigiMatcher() {return cscDigiMatcher_;}
+  std::shared_ptr<GEMDigiMatcher> gemDigiMatcher() {return gemDigiMatcher_;}
+
+private:
+
+  void matchCLCTsToSimTrack(const CSCCLCTDigiCollection&);
+  void matchALCTsToSimTrack(const CSCALCTDigiCollection&);
+  void matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection&);
+  void matchMPLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection&);
+
+  edm::EDGetTokenT<CSCCLCTDigiCollection> clctToken_;
+  edm::EDGetTokenT<CSCALCTDigiCollection> alctToken_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> lctToken_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> mplctToken_;
+
+  edm::Handle<CSCCLCTDigiCollection> clctsH_;
+  edm::Handle<CSCALCTDigiCollection> alctsH_;
+  edm::Handle<CSCCorrelatedLCTDigiCollection> lctsH_;
+  edm::Handle<CSCCorrelatedLCTDigiCollection> mplctsH_;
+
+  std::shared_ptr<CSCDigiMatcher> cscDigiMatcher_;
+  std::shared_ptr<GEMDigiMatcher> gemDigiMatcher_;
+
+  edm::ESHandle<CSCGeometry> csc_geom_;
+  const CSCGeometry* cscGeometry_;
+
+  // all stubs (not necessarily matching) in crossed chambers with digis
+  std::map<unsigned int, CSCCLCTDigiContainer> chamber_to_clcts_all_;
+  std::map<unsigned int, CSCALCTDigiContainer> chamber_to_alcts_all_;
+  std::map<unsigned int, CSCCorrelatedLCTDigiContainer> chamber_to_lcts_all_;
+  std::map<unsigned int, CSCCorrelatedLCTDigiContainer> chamber_to_mplcts_all_;
+
+  // all matching stubs in crossed chambers with digis
+  std::map<unsigned int, CSCCLCTDigiContainer> chamber_to_clcts_;
+  std::map<unsigned int, CSCALCTDigiContainer> chamber_to_alcts_;
+  std::map<unsigned int, CSCCorrelatedLCTDigiContainer> chamber_to_lcts_;
+  std::map<unsigned int, CSCCorrelatedLCTDigiContainer> chamber_to_mplcts_;
+
+  template<class D>
+  std::set<unsigned int> selectDetIds(D &, int) const;
+
+  bool hsFromSimHitMean_;
+
+  int minNHitsChamber_;
+  int minNHitsChamberALCT_;
+  int minNHitsChamberCLCT_;
+  int minNHitsChamberLCT_;
+  int minNHitsChamberMPLCT_;
+
+  bool verboseALCT_;
+  bool verboseCLCT_;
+  bool verboseLCT_;
+  bool verboseMPLCT_;
+
+  int minBXCLCT_, maxBXCLCT_;
+  int minBXALCT_, maxBXALCT_;
+  int minBXLCT_, maxBXLCT_;
+  int minBXMPLCT_, maxBXMPLCT_;
+
+  CSCCLCTDigiContainer no_clcts_;
+  CSCALCTDigiContainer no_alcts_;
+  CSCCorrelatedLCTDigiContainer no_lcts_;
+  CSCCorrelatedLCTDigiContainer no_mplcts_;
+};
+
+
+template<class D>
+std::set<unsigned int>
+CSCStubMatcher::selectDetIds(D &digis, int csc_type) const
+{
+  std::set<unsigned int> result;
+  for (auto& p: digis)
+  {
+    auto id = p.first;
+    if (csc_type > 0)
+    {
+      CSCDetId detId(id);
+      if (MuonHitHelper::toCSCType(detId.station(), detId.ring()) != csc_type) continue;
+    }
+    result.insert(p.first);
+  }
+  return result;
+}
+
+#endif

--- a/Validation/MuonCSCDigis/interface/CSCStubMatcher.h
+++ b/Validation/MuonCSCDigis/interface/CSCStubMatcher.h
@@ -19,11 +19,9 @@ typedef std::vector<CSCALCTDigi> CSCALCTDigiContainer;
 typedef std::vector<CSCCLCTDigi> CSCCLCTDigiContainer;
 typedef std::vector<CSCCorrelatedLCTDigi> CSCCorrelatedLCTDigiContainer;
 
-class CSCStubMatcher
-{
+class CSCStubMatcher {
 public:
-
-  CSCStubMatcher(edm::ParameterSet const& iPS, edm::ConsumesCollector && iC);
+  CSCStubMatcher(edm::ParameterSet const& iPS, edm::ConsumesCollector&& iC);
 
   ~CSCStubMatcher() {}
 
@@ -83,11 +81,10 @@ public:
   // get the position of an LCT in global coordinates
   GlobalPoint getGlobalPosition(unsigned int rawId, const CSCCorrelatedLCTDigi& lct) const;
 
-  std::shared_ptr<CSCDigiMatcher> cscDigiMatcher() {return cscDigiMatcher_;}
-  std::shared_ptr<GEMDigiMatcher> gemDigiMatcher() {return gemDigiMatcher_;}
+  std::shared_ptr<CSCDigiMatcher> cscDigiMatcher() { return cscDigiMatcher_; }
+  std::shared_ptr<GEMDigiMatcher> gemDigiMatcher() { return gemDigiMatcher_; }
 
 private:
-
   void matchCLCTsToSimTrack(const CSCCLCTDigiCollection&);
   void matchALCTsToSimTrack(const CSCALCTDigiCollection&);
   void matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection&);
@@ -121,8 +118,8 @@ private:
   std::map<unsigned int, CSCCorrelatedLCTDigiContainer> chamber_to_lcts_;
   std::map<unsigned int, CSCCorrelatedLCTDigiContainer> chamber_to_mplcts_;
 
-  template<class D>
-  std::set<unsigned int> selectDetIds(D &, int) const;
+  template <class D>
+  std::set<unsigned int> selectDetIds(D&, int) const;
 
   bool hsFromSimHitMean_;
 
@@ -148,19 +145,15 @@ private:
   CSCCorrelatedLCTDigiContainer no_mplcts_;
 };
 
-
-template<class D>
-std::set<unsigned int>
-CSCStubMatcher::selectDetIds(D &digis, int csc_type) const
-{
+template <class D>
+std::set<unsigned int> CSCStubMatcher::selectDetIds(D& digis, int csc_type) const {
   std::set<unsigned int> result;
-  for (auto& p: digis)
-  {
+  for (auto& p : digis) {
     auto id = p.first;
-    if (csc_type > 0)
-    {
+    if (csc_type > 0) {
       CSCDetId detId(id);
-      if (MuonHitHelper::toCSCType(detId.station(), detId.ring()) != csc_type) continue;
+      if (MuonHitHelper::toCSCType(detId.station(), detId.ring()) != csc_type)
+        continue;
     }
     result.insert(p.first);
   }

--- a/Validation/MuonCSCDigis/interface/CSCWireDigiValidation.h
+++ b/Validation/MuonCSCDigis/interface/CSCWireDigiValidation.h
@@ -1,5 +1,5 @@
-#ifndef CSCWireDigiValidation_H
-#define CSCWireDigiValidation_H
+#ifndef Validation_MuonCSCDigis_CSCWireDigiValidation_H
+#define Validation_MuonCSCDigis_CSCWireDigiValidation_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 

--- a/Validation/MuonCSCDigis/plugins/BuildFile.xml
+++ b/Validation/MuonCSCDigis/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<library   file="Module.cc" name="ValidationMuonCSCDigisPlugin">
+<library   file="*.cc" name="ValidationMuonCSCDigisPlugin">
   <use   name="FWCore/Framework"/>
   <use   name="Validation/MuonCSCDigis"/>
   <flags   EDM_PLUGIN="1"/>

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
@@ -3,12 +3,12 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
-#include "Validation/MuonCSCDigis/src/CSCALCTDigiValidation.h"
-#include "Validation/MuonCSCDigis/src/CSCCLCTDigiValidation.h"
-#include "Validation/MuonCSCDigis/src/CSCComparatorDigiValidation.h"
-#include "Validation/MuonCSCDigis/src/CSCDigiValidation.h"
-#include "Validation/MuonCSCDigis/src/CSCStripDigiValidation.h"
-#include "Validation/MuonCSCDigis/src/CSCWireDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCALCTDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCCLCTDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCComparatorDigiValidation.h"
+#include "Validation/MuonCSCDigis/plugins/CSCDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCStripDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCWireDigiValidation.h"
 #include <iostream>
 
 CSCDigiValidation::CSCDigiValidation(const edm::ParameterSet &ps)
@@ -20,15 +20,13 @@ CSCDigiValidation::CSCDigiValidation(const edm::ParameterSet &ps)
       theComparatorDigiValidation(nullptr),
       theALCTDigiValidation(nullptr),
       theCLCTDigiValidation(nullptr) {
-  theStripDigiValidation =
-      new CSCStripDigiValidation(ps.getParameter<edm::InputTag>("stripDigiTag"), consumesCollector());
-  theWireDigiValidation =
-      new CSCWireDigiValidation(ps.getParameter<edm::InputTag>("wireDigiTag"), consumesCollector(), doSim_);
-  theComparatorDigiValidation = new CSCComparatorDigiValidation(ps.getParameter<edm::InputTag>("comparatorDigiTag"),
-                                                                ps.getParameter<edm::InputTag>("stripDigiTag"),
-                                                                consumesCollector());
-  theALCTDigiValidation = new CSCALCTDigiValidation(ps.getParameter<edm::InputTag>("alctDigiTag"), consumesCollector());
-  theCLCTDigiValidation = new CSCCLCTDigiValidation(ps.getParameter<edm::InputTag>("clctDigiTag"), consumesCollector());
+  theStripDigiValidation.reset(new CSCStripDigiValidation(ps.getParameter<edm::InputTag>("stripDigiTag"), consumesCollector()));
+  theWireDigiValidation.reset(new CSCWireDigiValidation(ps.getParameter<edm::InputTag>("wireDigiTag"), consumesCollector(), doSim_));
+  theComparatorDigiValidation.reset(new CSCComparatorDigiValidation(ps.getParameter<edm::InputTag>("comparatorDigiTag"),
+                                                                    ps.getParameter<edm::InputTag>("stripDigiTag"),
+                                                                    consumesCollector()));
+  theALCTDigiValidation.reset(new CSCALCTDigiValidation(ps.getParameter<edm::InputTag>("alctDigiTag"), consumesCollector()));
+  theCLCTDigiValidation.reset(new CSCCLCTDigiValidation(ps.getParameter<edm::InputTag>("clctDigiTag"), consumesCollector()));
 
   if (doSim_) {
     theStripDigiValidation->setSimHitMap(&theSimHitMap);
@@ -37,12 +35,8 @@ CSCDigiValidation::CSCDigiValidation(const edm::ParameterSet &ps)
   }
 }
 
-CSCDigiValidation::~CSCDigiValidation() {
-  delete theStripDigiValidation;
-  delete theWireDigiValidation;
-  delete theComparatorDigiValidation;
-  delete theALCTDigiValidation;
-  delete theCLCTDigiValidation;
+CSCDigiValidation::~CSCDigiValidation()
+{
 }
 
 void CSCDigiValidation::bookHistograms(DQMStore::IBooker &iBooker,

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
@@ -1,5 +1,3 @@
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
@@ -18,13 +18,17 @@ CSCDigiValidation::CSCDigiValidation(const edm::ParameterSet &ps)
       theComparatorDigiValidation(nullptr),
       theALCTDigiValidation(nullptr),
       theCLCTDigiValidation(nullptr) {
-  theStripDigiValidation.reset(new CSCStripDigiValidation(ps.getParameter<edm::InputTag>("stripDigiTag"), consumesCollector()));
-  theWireDigiValidation.reset(new CSCWireDigiValidation(ps.getParameter<edm::InputTag>("wireDigiTag"), consumesCollector(), doSim_));
+  theStripDigiValidation.reset(
+      new CSCStripDigiValidation(ps.getParameter<edm::InputTag>("stripDigiTag"), consumesCollector()));
+  theWireDigiValidation.reset(
+      new CSCWireDigiValidation(ps.getParameter<edm::InputTag>("wireDigiTag"), consumesCollector(), doSim_));
   theComparatorDigiValidation.reset(new CSCComparatorDigiValidation(ps.getParameter<edm::InputTag>("comparatorDigiTag"),
                                                                     ps.getParameter<edm::InputTag>("stripDigiTag"),
                                                                     consumesCollector()));
-  theALCTDigiValidation.reset(new CSCALCTDigiValidation(ps.getParameter<edm::InputTag>("alctDigiTag"), consumesCollector()));
-  theCLCTDigiValidation.reset(new CSCCLCTDigiValidation(ps.getParameter<edm::InputTag>("clctDigiTag"), consumesCollector()));
+  theALCTDigiValidation.reset(
+      new CSCALCTDigiValidation(ps.getParameter<edm::InputTag>("alctDigiTag"), consumesCollector()));
+  theCLCTDigiValidation.reset(
+      new CSCCLCTDigiValidation(ps.getParameter<edm::InputTag>("clctDigiTag"), consumesCollector()));
 
   if (doSim_) {
     theStripDigiValidation->setSimHitMap(&theSimHitMap);
@@ -33,9 +37,7 @@ CSCDigiValidation::CSCDigiValidation(const edm::ParameterSet &ps)
   }
 }
 
-CSCDigiValidation::~CSCDigiValidation()
-{
-}
+CSCDigiValidation::~CSCDigiValidation() {}
 
 void CSCDigiValidation::bookHistograms(DQMStore::IBooker &iBooker,
                                        edm::Run const &iRun,

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.h
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.h
@@ -1,13 +1,13 @@
-#ifndef CSCDigiValidation_H
-#define CSCDigiValidation_H
+#ifndef Validation_MuonCSCDigis_CSCDigiValidation_H
+#define Validation_MuonCSCDigis_CSCDigiValidation_H
 
 // user include files
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
-#include <DQMServices/Core/interface/DQMStore.h>
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
 
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "SimMuon/MCTruth/interface/PSimHitMap.h"

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.h
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.h
@@ -30,11 +30,11 @@ private:
   PSimHitMap theSimHitMap;
   CSCGeometry *theCSCGeometry;
 
-  CSCStripDigiValidation *theStripDigiValidation;
-  CSCWireDigiValidation *theWireDigiValidation;
-  CSCComparatorDigiValidation *theComparatorDigiValidation;
-  CSCALCTDigiValidation *theALCTDigiValidation;
-  CSCCLCTDigiValidation *theCLCTDigiValidation;
+  std::unique_ptr<CSCStripDigiValidation> theStripDigiValidation;
+  std::unique_ptr<CSCWireDigiValidation> theWireDigiValidation;
+  std::unique_ptr<CSCComparatorDigiValidation> theComparatorDigiValidation;
+  std::unique_ptr<CSCALCTDigiValidation> theALCTDigiValidation;
+  std::unique_ptr<CSCCLCTDigiValidation> theCLCTDigiValidation;
 };
 
 #endif

--- a/Validation/MuonCSCDigis/plugins/Module.cc
+++ b/Validation/MuonCSCDigis/plugins/Module.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "Validation/MuonCSCDigis/src/CSCDigiValidation.h"
+#include "Validation/MuonCSCDigis/plugins/CSCDigiValidation.h"
 
 DEFINE_FWK_MODULE(CSCDigiValidation);

--- a/Validation/MuonCSCDigis/python/muonCSCDigiPSet.py
+++ b/Validation/MuonCSCDigis/python/muonCSCDigiPSet.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+muonCSCDigiPSet = cms.PSet(
+    #csc comparator digi, central BX 7
+    cscComparatorDigi = cms.PSet(
+        verbose = cms.int32(0),
+        inputTag = cms.InputTag("simMuonCSCDigis", "MuonCSCComparatorDigi"),
+        minBX = cms.int32(4),
+        maxBX = cms.int32(10),
+        matchDeltaStrip = cms.int32(2),
+        minNHitsChamber = cms.int32(4),
+    ),
+    cscStripDigi = cms.PSet(
+        verbose = cms.int32(0),
+        inputTag = cms.InputTag("simMuonCSCDigis", "MuonCSCStripDigi"),
+        minBX = cms.int32(4),
+        maxBX = cms.int32(10),
+        matchDeltaStrip = cms.int32(2),
+        minNHitsChamber = cms.int32(4),
+    ),
+    #csc wire digi, central BX 8
+    cscWireDigi = cms.PSet(
+        verbose = cms.int32(0),
+        inputTag = cms.InputTag("simMuonCSCDigis", "MuonCSCWireDigi"),
+        minBX = cms.int32(5),
+        maxBX = cms.int32(11),
+        matchDeltaWG = cms.int32(2),
+        minNHitsChamber = cms.int32(4),
+    ),
+)

--- a/Validation/MuonCSCDigis/python/muonCSCStubPSet.py
+++ b/Validation/MuonCSCDigis/python/muonCSCStubPSet.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+muonCSCStubPSet = cms.PSet(
+    #csc CLCT, central BX 7
+    cscCLCT = cms.PSet(
+        verbose = cms.int32(0),
+        inputTag = cms.InputTag("simCscTriggerPrimitiveDigis"),
+        minBX = cms.int32(6),
+        maxBX = cms.int32(8),
+        minNHitsChamber = cms.int32(4),
+    ),
+    #csc ALCT, central BX 3 in CMSSW
+    cscALCT = cms.PSet(
+        verbose = cms.int32(0),
+        inputTag = cms.InputTag("simCscTriggerPrimitiveDigis"),
+        minBX = cms.int32(2),
+        maxBX = cms.int32(4),
+        minNHitsChamber = cms.int32(4),
+    ),
+    #csc LCT, central BX 8
+    cscLCT = cms.PSet(
+        verbose = cms.int32(0),
+        inputTag = cms.InputTag("simCscTriggerPrimitiveDigis"),
+        minBX = cms.int32(7),
+        maxBX = cms.int32(9),
+        minNHitsChamber = cms.int32(4),
+        hsFromSimHitMean = cms.bool(True),
+    ),
+    #csc LCT, central BX 8
+    cscMPLCT = cms.PSet(
+        verbose = cms.int32(0),
+        inputTag = cms.InputTag("simCscTriggerPrimitiveDigis","MPCSORTED"),
+        minBX = cms.int32(7),
+        maxBX = cms.int32(9),
+        minNHitsChamber = cms.int32(4),
+    ),
+)

--- a/Validation/MuonCSCDigis/src/CSCALCTDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCALCTDigiValidation.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Validation/MuonCSCDigis/src/CSCALCTDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCALCTDigiValidation.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"

--- a/Validation/MuonCSCDigis/src/CSCCLCTDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCCLCTDigiValidation.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Validation/MuonCSCDigis/src/CSCCLCTDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCCLCTDigiValidation.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"

--- a/Validation/MuonCSCDigis/src/CSCComparatorDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCComparatorDigiValidation.cc
@@ -1,7 +1,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Validation/MuonCSCDigis/src/CSCComparatorDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCComparatorDigiValidation.h"
 
 CSCComparatorDigiValidation::CSCComparatorDigiValidation(const edm::InputTag &inputTag,
                                                          const edm::InputTag &stripDigiInputTag,

--- a/Validation/MuonCSCDigis/src/CSCDigiMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCDigiMatcher.cc
@@ -2,8 +2,7 @@
 
 using namespace std;
 
-CSCDigiMatcher::CSCDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
-{
+CSCDigiMatcher::CSCDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC) {
   const auto& wireDigi = pset.getParameterSet("cscWireDigi");
   verboseWG_ = wireDigi.getParameter<int>("verbose");
   minBXWire_ = wireDigi.getParameter<int>("minBX");
@@ -25,14 +24,13 @@ CSCDigiMatcher::CSCDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesColle
   // make a new simhits matcher
   muonSimHitMatcher_.reset(new CSCSimHitMatcher(pset, std::move(iC)));
 
-  comparatorDigiInput_ = iC.consumes<CSCComparatorDigiCollection>(comparatorDigi.getParameter<edm::InputTag>("inputTag"));
+  comparatorDigiInput_ =
+      iC.consumes<CSCComparatorDigiCollection>(comparatorDigi.getParameter<edm::InputTag>("inputTag"));
   stripDigiInput_ = iC.consumes<CSCStripDigiCollection>(stripDigi.getParameter<edm::InputTag>("inputTag"));
   wireDigiInput_ = iC.consumes<CSCWireDigiCollection>(wireDigi.getParameter<edm::InputTag>("inputTag"));
 }
 
-
-void CSCDigiMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void CSCDigiMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   muonSimHitMatcher_->init(iEvent, iSetup);
 
   iEvent.getByToken(comparatorDigiInput_, comparatorDigisH_);
@@ -41,10 +39,9 @@ void CSCDigiMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetu
 }
 
 /// do the matching
-void CSCDigiMatcher::match(const SimTrack& t, const SimVertex& v)
-{
+void CSCDigiMatcher::match(const SimTrack& t, const SimVertex& v) {
   // match simhits first
-  muonSimHitMatcher_->match(t,v);
+  muonSimHitMatcher_->match(t, v);
 
   // get the digi collections
   const CSCComparatorDigiCollection& comparators = *comparatorDigisH_.product();
@@ -57,224 +54,185 @@ void CSCDigiMatcher::match(const SimTrack& t, const SimVertex& v)
   matchWiresToSimTrack(wires);
 }
 
-void
-CSCDigiMatcher::matchComparatorsToSimTrack(const CSCComparatorDigiCollection& comparators)
-{
-
-  for (auto detUnitIt= comparators.begin(); detUnitIt!= comparators.end(); ++detUnitIt){
+void CSCDigiMatcher::matchComparatorsToSimTrack(const CSCComparatorDigiCollection& comparators) {
+  for (auto detUnitIt = comparators.begin(); detUnitIt != comparators.end(); ++detUnitIt) {
     const CSCDetId& id = (*detUnitIt).first;
-    const auto& range =(*detUnitIt).second;
-    for (auto digiIt =  range.first; digiIt!=range.second; ++digiIt){
-      if (id.station() == 1 and (id.ring() == 1 or id.ring() ==4 ))
-        if (verboseComparator_) cout <<"CSCid "<< id <<" Comparator digi (comparator, comparator, Tbin ) "<< (*digiIt) << endl;
+    const auto& range = (*detUnitIt).second;
+    for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
+      if (id.station() == 1 and (id.ring() == 1 or id.ring() == 4))
+        if (verboseComparator_)
+          cout << "CSCid " << id << " Comparator digi (comparator, comparator, Tbin ) " << (*digiIt) << endl;
     }
   }
 
   const auto& det_ids = muonSimHitMatcher_->detIds(0);
-  for (const auto& id: det_ids)
-  {
+  for (const auto& id : det_ids) {
     CSCDetId layer_id(id);
 
     const auto& hit_comparators = muonSimHitMatcher_->hitStripsInDetId(id, matchDeltaStrip_);
-    if (verboseComparator_)
-    {
-      cout<<"hit_comparators_fat, CSCid " << layer_id <<" ";
+    if (verboseComparator_) {
+      cout << "hit_comparators_fat, CSCid " << layer_id << " ";
       copy(hit_comparators.begin(), hit_comparators.end(), ostream_iterator<int>(cout, " "));
-      cout<<endl;
+      cout << endl;
     }
 
     const auto& comp_digis_in_det = comparators.get(layer_id);
-    for (auto c = comp_digis_in_det.first; c != comp_digis_in_det.second; ++c)
-    {
-      if (verboseComparator_) cout<<"sdigi "<<layer_id<<" (comparator, comparator, Tbin ) "<<*c<<endl;
+    for (auto c = comp_digis_in_det.first; c != comp_digis_in_det.second; ++c) {
+      if (verboseComparator_)
+        cout << "sdigi " << layer_id << " (comparator, comparator, Tbin ) " << *c << endl;
 
       // check that the first BX for this digi wasn't too early or too late
-      if (c->getTimeBin() < minBXComparator_ || c->getTimeBin() > maxBXComparator_) continue;
+      if (c->getTimeBin() < minBXComparator_ || c->getTimeBin() > maxBXComparator_)
+        continue;
 
-      int comparator = c->getStrip(); // comparators are counted from 1
+      int comparator = c->getStrip();  // comparators are counted from 1
       // check that it matches a comparator that was hit by SimHits from our track
-      if (hit_comparators.find(comparator) == hit_comparators.end()) continue;
+      if (hit_comparators.find(comparator) == hit_comparators.end())
+        continue;
 
-      if (verboseComparator_) cout<< "Matched comparator "<< *c << endl;
+      if (verboseComparator_)
+        cout << "Matched comparator " << *c << endl;
       detid_to_comparators_[id].push_back(*c);
-      chamber_to_comparators_[ layer_id.chamberId().rawId() ].push_back(*c);
+      chamber_to_comparators_[layer_id.chamberId().rawId()].push_back(*c);
     }
   }
 }
 
-
-void
-CSCDigiMatcher::matchStripsToSimTrack(const CSCStripDigiCollection& strips)
-{
-
- for (auto detUnitIt= strips.begin(); detUnitIt!= strips.end(); ++detUnitIt){
-     const CSCDetId& id = (*detUnitIt).first;
-     const auto& range =(*detUnitIt).second;
-     for (auto digiIt =  range.first; digiIt!=range.second; ++digiIt){
-       if (id.station() == 1 and (id.ring() == 1 or id.ring() ==4 ))
-         if (verboseStrip_) cout <<"CSCid "<< id <<" Strip digi (strip, strip, Tbin ) "<< (*digiIt) << endl;
-     }
- }
+void CSCDigiMatcher::matchStripsToSimTrack(const CSCStripDigiCollection& strips) {
+  for (auto detUnitIt = strips.begin(); detUnitIt != strips.end(); ++detUnitIt) {
+    const CSCDetId& id = (*detUnitIt).first;
+    const auto& range = (*detUnitIt).second;
+    for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
+      if (id.station() == 1 and (id.ring() == 1 or id.ring() == 4))
+        if (verboseStrip_)
+          cout << "CSCid " << id << " Strip digi (strip, strip, Tbin ) " << (*digiIt) << endl;
+    }
+  }
 
   const auto& det_ids = muonSimHitMatcher_->detIds(0);
-  for (const auto& id: det_ids)
-  {
+  for (const auto& id : det_ids) {
     CSCDetId layer_id(id);
 
     const auto& hit_strips = muonSimHitMatcher_->hitStripsInDetId(id, matchDeltaStrip_);
-    if (verboseStrip_)
-    {
-      cout<<"hit_strips_fat, CSCid " << layer_id <<" ";
+    if (verboseStrip_) {
+      cout << "hit_strips_fat, CSCid " << layer_id << " ";
       copy(hit_strips.begin(), hit_strips.end(), ostream_iterator<int>(cout, " "));
-      cout<<endl;
+      cout << endl;
     }
 
     const auto& strip_digis_in_det = strips.get(layer_id);
-    for (auto c = strip_digis_in_det.first; c != strip_digis_in_det.second; ++c)
-    {
-      if (verboseStrip_) cout<<"sdigi "<<layer_id<<" (strip, Tbin ) "<<*c<<endl;
+    for (auto c = strip_digis_in_det.first; c != strip_digis_in_det.second; ++c) {
+      if (verboseStrip_)
+        cout << "sdigi " << layer_id << " (strip, Tbin ) " << *c << endl;
 
-      int strip = c->getStrip(); // strips are counted from 1
+      int strip = c->getStrip();  // strips are counted from 1
       // check that it matches a strip that was hit by SimHits from our track
-      if (hit_strips.find(strip) == hit_strips.end()) continue;
+      if (hit_strips.find(strip) == hit_strips.end())
+        continue;
 
-      if (verboseStrip_) cout<< "Matched strip "<< *c << endl;
+      if (verboseStrip_)
+        cout << "Matched strip " << *c << endl;
       detid_to_strips_[id].push_back(*c);
-      chamber_to_strips_[ layer_id.chamberId().rawId() ].push_back(*c);
+      chamber_to_strips_[layer_id.chamberId().rawId()].push_back(*c);
     }
   }
 }
 
-
-void
-CSCDigiMatcher::matchWiresToSimTrack(const CSCWireDigiCollection& wires)
-{
+void CSCDigiMatcher::matchWiresToSimTrack(const CSCWireDigiCollection& wires) {
   const auto& det_ids = muonSimHitMatcher_->detIds(0);
-  for (const auto& id: det_ids)
-  {
+  for (const auto& id : det_ids) {
     CSCDetId layer_id(id);
 
     const auto& hit_wires = muonSimHitMatcher_->hitWiregroupsInDetId(id, matchDeltaWG_);
-    if (verboseWG_)
-    {
-      cout<<"hit_wires ";
+    if (verboseWG_) {
+      cout << "hit_wires ";
       copy(hit_wires.begin(), hit_wires.end(), ostream_iterator<int>(cout, " "));
-      cout<<endl;
+      cout << endl;
     }
 
     const auto& wire_digis_in_det = wires.get(layer_id);
-    for (auto w = wire_digis_in_det.first; w != wire_digis_in_det.second; ++w)
-    {
+    for (auto w = wire_digis_in_det.first; w != wire_digis_in_det.second; ++w) {
       // check that the first BX for this digi wasn't too early or too late
-      if (w->getTimeBin() < minBXWire_ || w->getTimeBin() > maxBXWire_) continue;
+      if (w->getTimeBin() < minBXWire_ || w->getTimeBin() > maxBXWire_)
+        continue;
 
-      int wg = w->getWireGroup(); // wiregroups are counted from 1
+      int wg = w->getWireGroup();  // wiregroups are counted from 1
       // check that it matches a strip that was hit by SimHits from our track
-      if (hit_wires.find(wg) == hit_wires.end()) continue;
+      if (hit_wires.find(wg) == hit_wires.end())
+        continue;
 
-      if (verboseStrip_) cout<< "Matched wire digi "<< *w << endl;
+      if (verboseStrip_)
+        cout << "Matched wire digi " << *w << endl;
       detid_to_wires_[id].push_back(*w);
-      chamber_to_wires_[ layer_id.chamberId().rawId() ].push_back(*w);
+      chamber_to_wires_[layer_id.chamberId().rawId()].push_back(*w);
     }
   }
 }
 
-std::set<unsigned int>
-CSCDigiMatcher::detIdsComparator(int csc_type) const
-{
+std::set<unsigned int> CSCDigiMatcher::detIdsComparator(int csc_type) const {
   return selectDetIds(detid_to_comparators_, csc_type);
 }
 
-
-std::set<unsigned int>
-CSCDigiMatcher::detIdsStrip(int csc_type) const
-{
+std::set<unsigned int> CSCDigiMatcher::detIdsStrip(int csc_type) const {
   return selectDetIds(detid_to_strips_, csc_type);
 }
 
-
-std::set<unsigned int>
-CSCDigiMatcher::detIdsWire(int csc_type) const
-{
+std::set<unsigned int> CSCDigiMatcher::detIdsWire(int csc_type) const {
   return selectDetIds(detid_to_wires_, csc_type);
 }
 
-
-std::set<unsigned int>
-CSCDigiMatcher::chamberIdsComparator(int csc_type) const
-{
+std::set<unsigned int> CSCDigiMatcher::chamberIdsComparator(int csc_type) const {
   return selectDetIds(chamber_to_comparators_, csc_type);
 }
 
-
-std::set<unsigned int>
-CSCDigiMatcher::chamberIdsStrip(int csc_type) const
-{
+std::set<unsigned int> CSCDigiMatcher::chamberIdsStrip(int csc_type) const {
   return selectDetIds(chamber_to_strips_, csc_type);
 }
 
-
-std::set<unsigned int>
-CSCDigiMatcher::chamberIdsWire(int csc_type) const
-{
+std::set<unsigned int> CSCDigiMatcher::chamberIdsWire(int csc_type) const {
   return selectDetIds(chamber_to_wires_, csc_type);
 }
 
-
-const CSCComparatorDigiContainer&
-CSCDigiMatcher::comparatorDigisInDetId(unsigned int detid) const
-{
-  if (detid_to_comparators_.find(detid) == detid_to_comparators_.end()) return no_comparators_;
+const CSCComparatorDigiContainer& CSCDigiMatcher::comparatorDigisInDetId(unsigned int detid) const {
+  if (detid_to_comparators_.find(detid) == detid_to_comparators_.end())
+    return no_comparators_;
   return detid_to_comparators_.at(detid);
 }
 
-
-const CSCComparatorDigiContainer&
-CSCDigiMatcher::comparatorDigisInChamber(unsigned int detid) const
-{
-  if (chamber_to_comparators_.find(detid) == chamber_to_comparators_.end()) return no_comparators_;
+const CSCComparatorDigiContainer& CSCDigiMatcher::comparatorDigisInChamber(unsigned int detid) const {
+  if (chamber_to_comparators_.find(detid) == chamber_to_comparators_.end())
+    return no_comparators_;
   return chamber_to_comparators_.at(detid);
 }
 
-
-const CSCStripDigiContainer&
-CSCDigiMatcher::stripDigisInDetId(unsigned int detid) const
-{
-  if (detid_to_strips_.find(detid) == detid_to_strips_.end()) return no_strips_;
+const CSCStripDigiContainer& CSCDigiMatcher::stripDigisInDetId(unsigned int detid) const {
+  if (detid_to_strips_.find(detid) == detid_to_strips_.end())
+    return no_strips_;
   return detid_to_strips_.at(detid);
 }
 
-
-const CSCStripDigiContainer&
-CSCDigiMatcher::stripDigisInChamber(unsigned int detid) const
-{
-  if (chamber_to_strips_.find(detid) == chamber_to_strips_.end()) return no_strips_;
+const CSCStripDigiContainer& CSCDigiMatcher::stripDigisInChamber(unsigned int detid) const {
+  if (chamber_to_strips_.find(detid) == chamber_to_strips_.end())
+    return no_strips_;
   return chamber_to_strips_.at(detid);
 }
 
-
-const CSCWireDigiContainer&
-CSCDigiMatcher::wireDigisInDetId(unsigned int detid) const
-{
-  if (detid_to_wires_.find(detid) == detid_to_wires_.end()) return no_wires_;
+const CSCWireDigiContainer& CSCDigiMatcher::wireDigisInDetId(unsigned int detid) const {
+  if (detid_to_wires_.find(detid) == detid_to_wires_.end())
+    return no_wires_;
   return detid_to_wires_.at(detid);
 }
 
-
-const CSCWireDigiContainer&
-CSCDigiMatcher::wireDigisInChamber(unsigned int detid) const
-{
-  if (chamber_to_wires_.find(detid) == chamber_to_wires_.end()) return no_wires_;
+const CSCWireDigiContainer& CSCDigiMatcher::wireDigisInChamber(unsigned int detid) const {
+  if (chamber_to_wires_.find(detid) == chamber_to_wires_.end())
+    return no_wires_;
   return chamber_to_wires_.at(detid);
 }
 
-
-int
-CSCDigiMatcher::nLayersWithComparatorInChamber(unsigned int detid) const
-{
+int CSCDigiMatcher::nLayersWithComparatorInChamber(unsigned int detid) const {
   int nLayers = 0;
   CSCDetId chamberId(detid);
-  for (int i=1;i<=6;++i) {
+  for (int i = 1; i <= 6; ++i) {
     CSCDetId layerId(chamberId.endcap(), chamberId.station(), chamberId.ring(), chamberId.chamber(), i);
     if (!comparatorDigisInDetId(layerId.rawId()).empty()) {
       nLayers++;
@@ -283,13 +241,10 @@ CSCDigiMatcher::nLayersWithComparatorInChamber(unsigned int detid) const
   return nLayers;
 }
 
-
-int
-CSCDigiMatcher::nLayersWithStripInChamber(unsigned int detid) const
-{
+int CSCDigiMatcher::nLayersWithStripInChamber(unsigned int detid) const {
   int nLayers = 0;
   CSCDetId chamberId(detid);
-  for (int i=1;i<=6;++i) {
+  for (int i = 1; i <= 6; ++i) {
     CSCDetId layerId(chamberId.endcap(), chamberId.station(), chamberId.ring(), chamberId.chamber(), i);
     if (!stripDigisInDetId(layerId.rawId()).empty()) {
       nLayers++;
@@ -298,13 +253,10 @@ CSCDigiMatcher::nLayersWithStripInChamber(unsigned int detid) const
   return nLayers;
 }
 
-
-int
-CSCDigiMatcher::nLayersWithWireInChamber(unsigned int detid) const
-{
+int CSCDigiMatcher::nLayersWithWireInChamber(unsigned int detid) const {
   int nLayers = 0;
   CSCDetId chamberId(detid);
-  for (int i=1;i<=6;++i) {
+  for (int i = 1; i <= 6; ++i) {
     CSCDetId layerId(chamberId.endcap(), chamberId.station(), chamberId.ring(), chamberId.chamber(), i);
     if (!wireDigisInDetId(layerId.rawId()).empty()) {
       nLayers++;
@@ -313,104 +265,77 @@ CSCDigiMatcher::nLayersWithWireInChamber(unsigned int detid) const
   return nLayers;
 }
 
-
-int
-CSCDigiMatcher::nCoincidenceComparatorChambers(int min_n_layers) const
-{
+int CSCDigiMatcher::nCoincidenceComparatorChambers(int min_n_layers) const {
   int result = 0;
   const auto& chamber_ids = chamberIdsComparator();
-  for (const auto& id: chamber_ids)
-  {
-    if (nLayersWithComparatorInChamber(id) >= min_n_layers) result += 1;
+  for (const auto& id : chamber_ids) {
+    if (nLayersWithComparatorInChamber(id) >= min_n_layers)
+      result += 1;
   }
   return result;
 }
 
-
-int
-CSCDigiMatcher::nCoincidenceStripChambers(int min_n_layers) const
-{
+int CSCDigiMatcher::nCoincidenceStripChambers(int min_n_layers) const {
   int result = 0;
   const auto& chamber_ids = chamberIdsStrip();
-  for (const auto& id: chamber_ids)
-  {
-    if (nLayersWithStripInChamber(id) >= min_n_layers) result += 1;
+  for (const auto& id : chamber_ids) {
+    if (nLayersWithStripInChamber(id) >= min_n_layers)
+      result += 1;
   }
   return result;
 }
 
-
-int
-CSCDigiMatcher::nCoincidenceWireChambers(int min_n_layers) const
-{
+int CSCDigiMatcher::nCoincidenceWireChambers(int min_n_layers) const {
   int result = 0;
   const auto& chamber_ids = chamberIdsWire();
-  for (const auto& id: chamber_ids)
-  {
-    if (nLayersWithWireInChamber(id) >= min_n_layers) result += 1;
+  for (const auto& id : chamber_ids) {
+    if (nLayersWithWireInChamber(id) >= min_n_layers)
+      result += 1;
   }
   return result;
 }
 
-
-std::set<int>
-CSCDigiMatcher::comparatorsInDetId(unsigned int detid) const
-{
+std::set<int> CSCDigiMatcher::comparatorsInDetId(unsigned int detid) const {
   set<int> result;
   const auto& digis = comparatorDigisInDetId(detid);
-  for (const auto& d: digis)
-  {
-    result.insert( d.getHalfStrip() );
+  for (const auto& d : digis) {
+    result.insert(d.getHalfStrip());
   }
   return result;
 }
 
-
-std::set<int>
-CSCDigiMatcher::stripsInDetId(unsigned int detid) const
-{
+std::set<int> CSCDigiMatcher::stripsInDetId(unsigned int detid) const {
   set<int> result;
   const auto& digis = stripDigisInDetId(detid);
-  for (const auto& d: digis)
-  {
-    result.insert( d.getStrip() );
+  for (const auto& d : digis) {
+    result.insert(d.getStrip());
   }
   return result;
 }
 
-
-std::set<int>
-CSCDigiMatcher::wiregroupsInDetId(unsigned int detid) const
-{
+std::set<int> CSCDigiMatcher::wiregroupsInDetId(unsigned int detid) const {
   set<int> result;
   const auto& digis = wireDigisInDetId(detid);
-  for (const auto& d: digis)
-  {
-    result.insert( d.getWireGroup() );
+  for (const auto& d : digis) {
+    result.insert(d.getWireGroup());
   }
   return result;
 }
 
-
-std::set<int>
-CSCDigiMatcher::comparatorsInChamber(unsigned int detid, int max_gap_to_fill) const
-{
+std::set<int> CSCDigiMatcher::comparatorsInChamber(unsigned int detid, int max_gap_to_fill) const {
   set<int> result;
   const auto& digis = comparatorDigisInChamber(detid);
-  for (const auto& d: digis)
-  {
-    result.insert( d.getStrip() );
+  for (const auto& d : digis) {
+    result.insert(d.getStrip());
   }
-  if (max_gap_to_fill > 0)
-  {
+  if (max_gap_to_fill > 0) {
     int prev = -111;
-    for (const auto& s: result)
-    {
+    for (const auto& s : result) {
       //cout<<"gap "<<s<<" - "<<prev<<" = "<<s - prev<<"  added 0";
-      if (s - prev > 1 && s - prev - 1 <= max_gap_to_fill)
-      {
+      if (s - prev > 1 && s - prev - 1 <= max_gap_to_fill) {
         //int sz = result.size();
-        for (int fill_s = prev+1; fill_s < s; ++fill_s) result.insert(fill_s);
+        for (int fill_s = prev + 1; fill_s < s; ++fill_s)
+          result.insert(fill_s);
         //cout<<result.size() - sz;
       }
       //cout<<" elems"<<endl;
@@ -421,26 +346,20 @@ CSCDigiMatcher::comparatorsInChamber(unsigned int detid, int max_gap_to_fill) co
   return result;
 }
 
-
-std::set<int>
-CSCDigiMatcher::stripsInChamber(unsigned int detid, int max_gap_to_fill) const
-{
+std::set<int> CSCDigiMatcher::stripsInChamber(unsigned int detid, int max_gap_to_fill) const {
   set<int> result;
   const auto& digis = stripDigisInChamber(detid);
-  for (const auto& d: digis)
-  {
-    result.insert( d.getStrip() );
+  for (const auto& d : digis) {
+    result.insert(d.getStrip());
   }
-  if (max_gap_to_fill > 0)
-  {
+  if (max_gap_to_fill > 0) {
     int prev = -111;
-    for (const auto& s: result)
-    {
+    for (const auto& s : result) {
       //cout<<"gap "<<s<<" - "<<prev<<" = "<<s - prev<<"  added 0";
-      if (s - prev > 1 && s - prev - 1 <= max_gap_to_fill)
-      {
+      if (s - prev > 1 && s - prev - 1 <= max_gap_to_fill) {
         //int sz = result.size();
-        for (int fill_s = prev+1; fill_s < s; ++fill_s) result.insert(fill_s);
+        for (int fill_s = prev + 1; fill_s < s; ++fill_s)
+          result.insert(fill_s);
         //cout<<result.size() - sz;
       }
       //cout<<" elems"<<endl;
@@ -451,23 +370,18 @@ CSCDigiMatcher::stripsInChamber(unsigned int detid, int max_gap_to_fill) const
   return result;
 }
 
-std::set<int>
-CSCDigiMatcher::wiregroupsInChamber(unsigned int detid, int max_gap_to_fill) const
-{
+std::set<int> CSCDigiMatcher::wiregroupsInChamber(unsigned int detid, int max_gap_to_fill) const {
   set<int> result;
   const auto& digis = wireDigisInChamber(detid);
-  for (const auto& d: digis)
-  {
-    result.insert( d.getWireGroup() );
+  for (const auto& d : digis) {
+    result.insert(d.getWireGroup());
   }
-  if (max_gap_to_fill > 0)
-  {
+  if (max_gap_to_fill > 0) {
     int prev = -111;
-    for (const auto& w: result)
-    {
-      if (w - prev > 1 && w - prev - 1 <= max_gap_to_fill)
-      {
-        for (int fill_w = prev+1; fill_w < w; ++fill_w) result.insert(fill_w);
+    for (const auto& w : result) {
+      if (w - prev > 1 && w - prev - 1 <= max_gap_to_fill) {
+        for (int fill_w = prev + 1; fill_w < w; ++fill_w)
+          result.insert(fill_w);
       }
       prev = w;
     }

--- a/Validation/MuonCSCDigis/src/CSCDigiMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCDigiMatcher.cc
@@ -1,0 +1,476 @@
+#include "Validation/MuonCSCDigis/interface/CSCDigiMatcher.h"
+
+using namespace std;
+
+CSCDigiMatcher::CSCDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
+{
+  const auto& wireDigi = pset.getParameterSet("cscWireDigi");
+  verboseWG_ = wireDigi.getParameter<int>("verbose");
+  minBXWire_ = wireDigi.getParameter<int>("minBX");
+  maxBXWire_ = wireDigi.getParameter<int>("maxBX");
+  matchDeltaWG_ = wireDigi.getParameter<int>("matchDeltaWG");
+
+  const auto& comparatorDigi = pset.getParameterSet("cscComparatorDigi");
+  verboseComparator_ = comparatorDigi.getParameter<int>("verbose");
+  minBXComparator_ = comparatorDigi.getParameter<int>("minBX");
+  maxBXComparator_ = comparatorDigi.getParameter<int>("maxBX");
+  matchDeltaComparator_ = comparatorDigi.getParameter<int>("matchDeltaStrip");
+
+  const auto& stripDigi = pset.getParameterSet("cscStripDigi");
+  verboseStrip_ = stripDigi.getParameter<int>("verbose");
+  minBXStrip_ = stripDigi.getParameter<int>("minBX");
+  maxBXStrip_ = stripDigi.getParameter<int>("maxBX");
+  matchDeltaStrip_ = stripDigi.getParameter<int>("matchDeltaStrip");
+
+  // make a new simhits matcher
+  muonSimHitMatcher_.reset(new CSCSimHitMatcher(pset, std::move(iC)));
+
+  comparatorDigiInput_ = iC.consumes<CSCComparatorDigiCollection>(comparatorDigi.getParameter<edm::InputTag>("inputTag"));
+  stripDigiInput_ = iC.consumes<CSCStripDigiCollection>(stripDigi.getParameter<edm::InputTag>("inputTag"));
+  wireDigiInput_ = iC.consumes<CSCWireDigiCollection>(wireDigi.getParameter<edm::InputTag>("inputTag"));
+}
+
+
+void CSCDigiMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  muonSimHitMatcher_->init(iEvent, iSetup);
+
+  iEvent.getByToken(comparatorDigiInput_, comparatorDigisH_);
+  iEvent.getByToken(stripDigiInput_, stripDigisH_);
+  iEvent.getByToken(wireDigiInput_, wireDigisH_);
+}
+
+/// do the matching
+void CSCDigiMatcher::match(const SimTrack& t, const SimVertex& v)
+{
+  // match simhits first
+  muonSimHitMatcher_->match(t,v);
+
+  // get the digi collections
+  const CSCComparatorDigiCollection& comparators = *comparatorDigisH_.product();
+  const CSCStripDigiCollection& strips = *stripDigisH_.product();
+  const CSCWireDigiCollection& wires = *wireDigisH_.product();
+
+  // now match the digis
+  matchComparatorsToSimTrack(comparators);
+  matchStripsToSimTrack(strips);
+  matchWiresToSimTrack(wires);
+}
+
+void
+CSCDigiMatcher::matchComparatorsToSimTrack(const CSCComparatorDigiCollection& comparators)
+{
+
+  for (auto detUnitIt= comparators.begin(); detUnitIt!= comparators.end(); ++detUnitIt){
+    const CSCDetId& id = (*detUnitIt).first;
+    const auto& range =(*detUnitIt).second;
+    for (auto digiIt =  range.first; digiIt!=range.second; ++digiIt){
+      if (id.station() == 1 and (id.ring() == 1 or id.ring() ==4 ))
+        if (verboseComparator_) cout <<"CSCid "<< id <<" Comparator digi (comparator, comparator, Tbin ) "<< (*digiIt) << endl;
+    }
+  }
+
+  const auto& det_ids = muonSimHitMatcher_->detIds(0);
+  for (const auto& id: det_ids)
+  {
+    CSCDetId layer_id(id);
+
+    const auto& hit_comparators = muonSimHitMatcher_->hitStripsInDetId(id, matchDeltaStrip_);
+    if (verboseComparator_)
+    {
+      cout<<"hit_comparators_fat, CSCid " << layer_id <<" ";
+      copy(hit_comparators.begin(), hit_comparators.end(), ostream_iterator<int>(cout, " "));
+      cout<<endl;
+    }
+
+    const auto& comp_digis_in_det = comparators.get(layer_id);
+    for (auto c = comp_digis_in_det.first; c != comp_digis_in_det.second; ++c)
+    {
+      if (verboseComparator_) cout<<"sdigi "<<layer_id<<" (comparator, comparator, Tbin ) "<<*c<<endl;
+
+      // check that the first BX for this digi wasn't too early or too late
+      if (c->getTimeBin() < minBXComparator_ || c->getTimeBin() > maxBXComparator_) continue;
+
+      int comparator = c->getStrip(); // comparators are counted from 1
+      // check that it matches a comparator that was hit by SimHits from our track
+      if (hit_comparators.find(comparator) == hit_comparators.end()) continue;
+
+      if (verboseComparator_) cout<< "Matched comparator "<< *c << endl;
+      detid_to_comparators_[id].push_back(*c);
+      chamber_to_comparators_[ layer_id.chamberId().rawId() ].push_back(*c);
+    }
+  }
+}
+
+
+void
+CSCDigiMatcher::matchStripsToSimTrack(const CSCStripDigiCollection& strips)
+{
+
+ for (auto detUnitIt= strips.begin(); detUnitIt!= strips.end(); ++detUnitIt){
+     const CSCDetId& id = (*detUnitIt).first;
+     const auto& range =(*detUnitIt).second;
+     for (auto digiIt =  range.first; digiIt!=range.second; ++digiIt){
+       if (id.station() == 1 and (id.ring() == 1 or id.ring() ==4 ))
+         if (verboseStrip_) cout <<"CSCid "<< id <<" Strip digi (strip, strip, Tbin ) "<< (*digiIt) << endl;
+     }
+ }
+
+  const auto& det_ids = muonSimHitMatcher_->detIds(0);
+  for (const auto& id: det_ids)
+  {
+    CSCDetId layer_id(id);
+
+    const auto& hit_strips = muonSimHitMatcher_->hitStripsInDetId(id, matchDeltaStrip_);
+    if (verboseStrip_)
+    {
+      cout<<"hit_strips_fat, CSCid " << layer_id <<" ";
+      copy(hit_strips.begin(), hit_strips.end(), ostream_iterator<int>(cout, " "));
+      cout<<endl;
+    }
+
+    const auto& strip_digis_in_det = strips.get(layer_id);
+    for (auto c = strip_digis_in_det.first; c != strip_digis_in_det.second; ++c)
+    {
+      if (verboseStrip_) cout<<"sdigi "<<layer_id<<" (strip, Tbin ) "<<*c<<endl;
+
+      int strip = c->getStrip(); // strips are counted from 1
+      // check that it matches a strip that was hit by SimHits from our track
+      if (hit_strips.find(strip) == hit_strips.end()) continue;
+
+      if (verboseStrip_) cout<< "Matched strip "<< *c << endl;
+      detid_to_strips_[id].push_back(*c);
+      chamber_to_strips_[ layer_id.chamberId().rawId() ].push_back(*c);
+    }
+  }
+}
+
+
+void
+CSCDigiMatcher::matchWiresToSimTrack(const CSCWireDigiCollection& wires)
+{
+  const auto& det_ids = muonSimHitMatcher_->detIds(0);
+  for (const auto& id: det_ids)
+  {
+    CSCDetId layer_id(id);
+
+    const auto& hit_wires = muonSimHitMatcher_->hitWiregroupsInDetId(id, matchDeltaWG_);
+    if (verboseWG_)
+    {
+      cout<<"hit_wires ";
+      copy(hit_wires.begin(), hit_wires.end(), ostream_iterator<int>(cout, " "));
+      cout<<endl;
+    }
+
+    const auto& wire_digis_in_det = wires.get(layer_id);
+    for (auto w = wire_digis_in_det.first; w != wire_digis_in_det.second; ++w)
+    {
+      // check that the first BX for this digi wasn't too early or too late
+      if (w->getTimeBin() < minBXWire_ || w->getTimeBin() > maxBXWire_) continue;
+
+      int wg = w->getWireGroup(); // wiregroups are counted from 1
+      // check that it matches a strip that was hit by SimHits from our track
+      if (hit_wires.find(wg) == hit_wires.end()) continue;
+
+      if (verboseStrip_) cout<< "Matched wire digi "<< *w << endl;
+      detid_to_wires_[id].push_back(*w);
+      chamber_to_wires_[ layer_id.chamberId().rawId() ].push_back(*w);
+    }
+  }
+}
+
+std::set<unsigned int>
+CSCDigiMatcher::detIdsComparator(int csc_type) const
+{
+  return selectDetIds(detid_to_comparators_, csc_type);
+}
+
+
+std::set<unsigned int>
+CSCDigiMatcher::detIdsStrip(int csc_type) const
+{
+  return selectDetIds(detid_to_strips_, csc_type);
+}
+
+
+std::set<unsigned int>
+CSCDigiMatcher::detIdsWire(int csc_type) const
+{
+  return selectDetIds(detid_to_wires_, csc_type);
+}
+
+
+std::set<unsigned int>
+CSCDigiMatcher::chamberIdsComparator(int csc_type) const
+{
+  return selectDetIds(chamber_to_comparators_, csc_type);
+}
+
+
+std::set<unsigned int>
+CSCDigiMatcher::chamberIdsStrip(int csc_type) const
+{
+  return selectDetIds(chamber_to_strips_, csc_type);
+}
+
+
+std::set<unsigned int>
+CSCDigiMatcher::chamberIdsWire(int csc_type) const
+{
+  return selectDetIds(chamber_to_wires_, csc_type);
+}
+
+
+const CSCComparatorDigiContainer&
+CSCDigiMatcher::comparatorDigisInDetId(unsigned int detid) const
+{
+  if (detid_to_comparators_.find(detid) == detid_to_comparators_.end()) return no_comparators_;
+  return detid_to_comparators_.at(detid);
+}
+
+
+const CSCComparatorDigiContainer&
+CSCDigiMatcher::comparatorDigisInChamber(unsigned int detid) const
+{
+  if (chamber_to_comparators_.find(detid) == chamber_to_comparators_.end()) return no_comparators_;
+  return chamber_to_comparators_.at(detid);
+}
+
+
+const CSCStripDigiContainer&
+CSCDigiMatcher::stripDigisInDetId(unsigned int detid) const
+{
+  if (detid_to_strips_.find(detid) == detid_to_strips_.end()) return no_strips_;
+  return detid_to_strips_.at(detid);
+}
+
+
+const CSCStripDigiContainer&
+CSCDigiMatcher::stripDigisInChamber(unsigned int detid) const
+{
+  if (chamber_to_strips_.find(detid) == chamber_to_strips_.end()) return no_strips_;
+  return chamber_to_strips_.at(detid);
+}
+
+
+const CSCWireDigiContainer&
+CSCDigiMatcher::wireDigisInDetId(unsigned int detid) const
+{
+  if (detid_to_wires_.find(detid) == detid_to_wires_.end()) return no_wires_;
+  return detid_to_wires_.at(detid);
+}
+
+
+const CSCWireDigiContainer&
+CSCDigiMatcher::wireDigisInChamber(unsigned int detid) const
+{
+  if (chamber_to_wires_.find(detid) == chamber_to_wires_.end()) return no_wires_;
+  return chamber_to_wires_.at(detid);
+}
+
+
+int
+CSCDigiMatcher::nLayersWithComparatorInChamber(unsigned int detid) const
+{
+  int nLayers = 0;
+  CSCDetId chamberId(detid);
+  for (int i=1;i<=6;++i) {
+    CSCDetId layerId(chamberId.endcap(), chamberId.station(), chamberId.ring(), chamberId.chamber(), i);
+    if (!comparatorDigisInDetId(layerId.rawId()).empty()) {
+      nLayers++;
+    }
+  }
+  return nLayers;
+}
+
+
+int
+CSCDigiMatcher::nLayersWithStripInChamber(unsigned int detid) const
+{
+  int nLayers = 0;
+  CSCDetId chamberId(detid);
+  for (int i=1;i<=6;++i) {
+    CSCDetId layerId(chamberId.endcap(), chamberId.station(), chamberId.ring(), chamberId.chamber(), i);
+    if (!stripDigisInDetId(layerId.rawId()).empty()) {
+      nLayers++;
+    }
+  }
+  return nLayers;
+}
+
+
+int
+CSCDigiMatcher::nLayersWithWireInChamber(unsigned int detid) const
+{
+  int nLayers = 0;
+  CSCDetId chamberId(detid);
+  for (int i=1;i<=6;++i) {
+    CSCDetId layerId(chamberId.endcap(), chamberId.station(), chamberId.ring(), chamberId.chamber(), i);
+    if (!wireDigisInDetId(layerId.rawId()).empty()) {
+      nLayers++;
+    }
+  }
+  return nLayers;
+}
+
+
+int
+CSCDigiMatcher::nCoincidenceComparatorChambers(int min_n_layers) const
+{
+  int result = 0;
+  const auto& chamber_ids = chamberIdsComparator();
+  for (const auto& id: chamber_ids)
+  {
+    if (nLayersWithComparatorInChamber(id) >= min_n_layers) result += 1;
+  }
+  return result;
+}
+
+
+int
+CSCDigiMatcher::nCoincidenceStripChambers(int min_n_layers) const
+{
+  int result = 0;
+  const auto& chamber_ids = chamberIdsStrip();
+  for (const auto& id: chamber_ids)
+  {
+    if (nLayersWithStripInChamber(id) >= min_n_layers) result += 1;
+  }
+  return result;
+}
+
+
+int
+CSCDigiMatcher::nCoincidenceWireChambers(int min_n_layers) const
+{
+  int result = 0;
+  const auto& chamber_ids = chamberIdsWire();
+  for (const auto& id: chamber_ids)
+  {
+    if (nLayersWithWireInChamber(id) >= min_n_layers) result += 1;
+  }
+  return result;
+}
+
+
+std::set<int>
+CSCDigiMatcher::comparatorsInDetId(unsigned int detid) const
+{
+  set<int> result;
+  const auto& digis = comparatorDigisInDetId(detid);
+  for (const auto& d: digis)
+  {
+    result.insert( d.getHalfStrip() );
+  }
+  return result;
+}
+
+
+std::set<int>
+CSCDigiMatcher::stripsInDetId(unsigned int detid) const
+{
+  set<int> result;
+  const auto& digis = stripDigisInDetId(detid);
+  for (const auto& d: digis)
+  {
+    result.insert( d.getStrip() );
+  }
+  return result;
+}
+
+
+std::set<int>
+CSCDigiMatcher::wiregroupsInDetId(unsigned int detid) const
+{
+  set<int> result;
+  const auto& digis = wireDigisInDetId(detid);
+  for (const auto& d: digis)
+  {
+    result.insert( d.getWireGroup() );
+  }
+  return result;
+}
+
+
+std::set<int>
+CSCDigiMatcher::comparatorsInChamber(unsigned int detid, int max_gap_to_fill) const
+{
+  set<int> result;
+  const auto& digis = comparatorDigisInChamber(detid);
+  for (const auto& d: digis)
+  {
+    result.insert( d.getStrip() );
+  }
+  if (max_gap_to_fill > 0)
+  {
+    int prev = -111;
+    for (const auto& s: result)
+    {
+      //cout<<"gap "<<s<<" - "<<prev<<" = "<<s - prev<<"  added 0";
+      if (s - prev > 1 && s - prev - 1 <= max_gap_to_fill)
+      {
+        //int sz = result.size();
+        for (int fill_s = prev+1; fill_s < s; ++fill_s) result.insert(fill_s);
+        //cout<<result.size() - sz;
+      }
+      //cout<<" elems"<<endl;
+      prev = s;
+    }
+  }
+
+  return result;
+}
+
+
+std::set<int>
+CSCDigiMatcher::stripsInChamber(unsigned int detid, int max_gap_to_fill) const
+{
+  set<int> result;
+  const auto& digis = stripDigisInChamber(detid);
+  for (const auto& d: digis)
+  {
+    result.insert( d.getStrip() );
+  }
+  if (max_gap_to_fill > 0)
+  {
+    int prev = -111;
+    for (const auto& s: result)
+    {
+      //cout<<"gap "<<s<<" - "<<prev<<" = "<<s - prev<<"  added 0";
+      if (s - prev > 1 && s - prev - 1 <= max_gap_to_fill)
+      {
+        //int sz = result.size();
+        for (int fill_s = prev+1; fill_s < s; ++fill_s) result.insert(fill_s);
+        //cout<<result.size() - sz;
+      }
+      //cout<<" elems"<<endl;
+      prev = s;
+    }
+  }
+
+  return result;
+}
+
+std::set<int>
+CSCDigiMatcher::wiregroupsInChamber(unsigned int detid, int max_gap_to_fill) const
+{
+  set<int> result;
+  const auto& digis = wireDigisInChamber(detid);
+  for (const auto& d: digis)
+  {
+    result.insert( d.getWireGroup() );
+  }
+  if (max_gap_to_fill > 0)
+  {
+    int prev = -111;
+    for (const auto& w: result)
+    {
+      if (w - prev > 1 && w - prev - 1 <= max_gap_to_fill)
+      {
+        for (int fill_w = prev+1; fill_w < w; ++fill_w) result.insert(fill_w);
+      }
+      prev = w;
+    }
+  }
+  return result;
+}

--- a/Validation/MuonCSCDigis/src/CSCStripDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCStripDigiValidation.cc
@@ -1,7 +1,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Validation/MuonCSCDigis/src/CSCStripDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCStripDigiValidation.h"
 
 CSCStripDigiValidation::CSCStripDigiValidation(const edm::InputTag &inputTag, edm::ConsumesCollector &&iC)
     : CSCBaseValidation(inputTag),

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -5,8 +5,7 @@
 
 using namespace std;
 
-CSCStubMatcher::CSCStubMatcher(const edm::ParameterSet& pSet, edm::ConsumesCollector && iC)
-{
+CSCStubMatcher::CSCStubMatcher(const edm::ParameterSet& pSet, edm::ConsumesCollector&& iC) {
   const auto& cscCLCT = pSet.getParameter<edm::ParameterSet>("cscCLCT");
   minBXCLCT_ = cscCLCT.getParameter<int>("minBX");
   maxBXCLCT_ = cscCLCT.getParameter<int>("maxBX");
@@ -36,14 +35,12 @@ CSCStubMatcher::CSCStubMatcher(const edm::ParameterSet& pSet, edm::ConsumesColle
   cscDigiMatcher_.reset(new CSCDigiMatcher(pSet, std::move(iC)));
 
   clctToken_ = iC.consumes<CSCCLCTDigiCollection>(cscCLCT.getParameter<edm::InputTag>("inputTag"));
-  alctToken_  = iC.consumes<CSCALCTDigiCollection>(cscALCT.getParameter<edm::InputTag>("inputTag"));
-  lctToken_  = iC.consumes<CSCCorrelatedLCTDigiCollection>(cscLCT.getParameter<edm::InputTag>("inputTag"));
+  alctToken_ = iC.consumes<CSCALCTDigiCollection>(cscALCT.getParameter<edm::InputTag>("inputTag"));
+  lctToken_ = iC.consumes<CSCCorrelatedLCTDigiCollection>(cscLCT.getParameter<edm::InputTag>("inputTag"));
   mplctToken_ = iC.consumes<CSCCorrelatedLCTDigiCollection>(cscMPLCT.getParameter<edm::InputTag>("inputTag"));
 }
 
-
-void CSCStubMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void CSCStubMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   gemDigiMatcher_->init(iEvent, iSetup);
   cscDigiMatcher_->init(iEvent, iSetup);
 
@@ -61,11 +58,10 @@ void CSCStubMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetu
 }
 
 // do the matching
-void CSCStubMatcher::match(const SimTrack& t, const SimVertex& v)
-{
+void CSCStubMatcher::match(const SimTrack& t, const SimVertex& v) {
   // match simhits first
-  gemDigiMatcher_->match(t,v);
-  cscDigiMatcher_->match(t,v);
+  gemDigiMatcher_->match(t, v);
+  cscDigiMatcher_->match(t, v);
 
   const CSCCLCTDigiCollection& clcts = *clctsH_.product();
   const CSCALCTDigiCollection& alcts = *alctsH_.product();
@@ -78,147 +74,149 @@ void CSCStubMatcher::match(const SimTrack& t, const SimVertex& v)
   matchMPLCTsToSimTrack(mplcts);
 }
 
-void
-CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts)
-{
+void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
   const auto& cathode_ids = cscDigiMatcher_->chamberIdsStrip(0);
   int n_minLayers = 0;
-  for (const auto& id: cathode_ids)
-  {
+  for (const auto& id : cathode_ids) {
     CSCDetId ch_id(id);
-    if (verboseCLCT_){
-	cout <<"To check CSC chamber "<< ch_id << endl;
+    if (verboseCLCT_) {
+      cout << "To check CSC chamber " << ch_id << endl;
     }
-    if (cscDigiMatcher_->nLayersWithStripInChamber(id) >= minNHitsChamberCLCT_) ++n_minLayers;
+    if (cscDigiMatcher_->nLayersWithStripInChamber(id) >= minNHitsChamberCLCT_)
+      ++n_minLayers;
 
     // fill 1 half-strip wide gaps
     const auto& digi_strips = cscDigiMatcher_->stripsInChamber(id, 1);
-    if (verboseCLCT_)
-    {
-      cout<<"clct: digi_strips "<<ch_id<<" Nlayers " << cscDigiMatcher_->nLayersWithStripInChamber(id) <<" ";
-      copy(digi_strips.begin(), digi_strips.end(), ostream_iterator<int>(cout, " ")); cout<<endl;
+    if (verboseCLCT_) {
+      cout << "clct: digi_strips " << ch_id << " Nlayers " << cscDigiMatcher_->nLayersWithStripInChamber(id) << " ";
+      copy(digi_strips.begin(), digi_strips.end(), ostream_iterator<int>(cout, " "));
+      cout << endl;
     }
 
     int ring = ch_id.ring();
-    if (ring == 4) ring =1; //use ME1b id to get CLCTs
-    CSCDetId ch_id2(ch_id.endcap(), ch_id.station(),  ring, ch_id.chamber(), 0);
+    if (ring == 4)
+      ring = 1;  //use ME1b id to get CLCTs
+    CSCDetId ch_id2(ch_id.endcap(), ch_id.station(), ring, ch_id.chamber(), 0);
 
     const auto& clcts_in_det = clcts.get(ch_id2);
 
-    for (auto c = clcts_in_det.first; c != clcts_in_det.second; ++c)
-    {
-      if (verboseCLCT_) cout<<"clct "<<ch_id<<" "<<*c<<endl;
+    for (auto c = clcts_in_det.first; c != clcts_in_det.second; ++c) {
+      if (verboseCLCT_)
+        cout << "clct " << ch_id << " " << *c << endl;
 
-      if (!c->isValid()) continue;
+      if (!c->isValid())
+        continue;
 
       // check that the BX for this stub wasn't too early or too late
-      if (c->getBX() < minBXCLCT_ || c->getBX() > maxBXCLCT_) continue;
+      if (c->getBX() < minBXCLCT_ || c->getBX() > maxBXCLCT_)
+        continue;
 
-      int half_strip = c->getKeyStrip() + 1; // CLCT halfstrip numbers start from 0
+      int half_strip = c->getKeyStrip() + 1;  // CLCT halfstrip numbers start from 0
       if (ch_id.ring() == 4 and ch_id.station() == 1 and half_strip > 128)
-        half_strip  = half_strip - 128;
+        half_strip = half_strip - 128;
 
       // store all CLCTs in this chamber
       chamber_to_clcts_all_[id].push_back(*c);
 
       // match by half-strip with the digis
-      if (digi_strips.find(half_strip) == digi_strips.end())
-      {
-        if (verboseCLCT_) cout<<"clctBAD, half_strip "<< half_strip <<endl;
+      if (digi_strips.find(half_strip) == digi_strips.end()) {
+        if (verboseCLCT_)
+          cout << "clctBAD, half_strip " << half_strip << endl;
         continue;
       }
-      if (verboseCLCT_) cout<<"clctGOOD"<<endl;
+      if (verboseCLCT_)
+        cout << "clctGOOD" << endl;
 
       // store matching CLCTs in this chamber
       chamber_to_clcts_[id].push_back(*c);
     }
-    if (chamber_to_clcts_[id].size() > 2)
-    {
-      cout<<"WARNING!!! too many CLCTs "<<chamber_to_clcts_[id].size()<<" in "<<ch_id<<endl;
-      for (auto &c: chamber_to_clcts_[id]) cout<<"  "<<c<<endl;
+    if (chamber_to_clcts_[id].size() > 2) {
+      cout << "WARNING!!! too many CLCTs " << chamber_to_clcts_[id].size() << " in " << ch_id << endl;
+      for (auto& c : chamber_to_clcts_[id])
+        cout << "  " << c << endl;
     }
   }
 }
 
-void
-CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts)
-{
+void CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts) {
   const auto& anode_ids = cscDigiMatcher_->chamberIdsWire(0);
   int n_minLayers = 0;
-  for (const auto& id: anode_ids)
-  {
-    if (cscDigiMatcher_->nLayersWithWireInChamber(id) >= minNHitsChamberALCT_) ++n_minLayers;
+  for (const auto& id : anode_ids) {
+    if (cscDigiMatcher_->nLayersWithWireInChamber(id) >= minNHitsChamberALCT_)
+      ++n_minLayers;
     CSCDetId ch_id(id);
 
     // fill 1 WG wide gaps
     const auto& digi_wgs = cscDigiMatcher_->wiregroupsInChamber(id, 1);
-    if (verboseALCT_)
-    {
-      cout<<"alct: digi_wgs "<<ch_id<<" ";
-      copy(digi_wgs.begin(), digi_wgs.end(), ostream_iterator<int>(cout, " ")); cout<<endl;
+    if (verboseALCT_) {
+      cout << "alct: digi_wgs " << ch_id << " ";
+      copy(digi_wgs.begin(), digi_wgs.end(), ostream_iterator<int>(cout, " "));
+      cout << endl;
     }
 
     int ring = ch_id.ring();
-    if (ring == 4) ring =1; //use ME1b id to get CLCTs
-    CSCDetId ch_id2(ch_id.endcap(), ch_id.station(),  ring, ch_id.chamber(), 0);
+    if (ring == 4)
+      ring = 1;  //use ME1b id to get CLCTs
+    CSCDetId ch_id2(ch_id.endcap(), ch_id.station(), ring, ch_id.chamber(), 0);
 
     const auto& alcts_in_det = alcts.get(ch_id2);
-    for (auto a = alcts_in_det.first; a != alcts_in_det.second; ++a)
-    {
-      if (!a->isValid()) continue;
+    for (auto a = alcts_in_det.first; a != alcts_in_det.second; ++a) {
+      if (!a->isValid())
+        continue;
 
       if (verboseALCT_)
-        cout<<"alct "<<ch_id<<" "<<*a<<endl;
+        cout << "alct " << ch_id << " " << *a << endl;
 
       // check that the BX for stub wasn't too early or too late
-      if (a->getBX() < minBXALCT_ || a->getBX() > maxBXALCT_) continue;
+      if (a->getBX() < minBXALCT_ || a->getBX() > maxBXALCT_)
+        continue;
 
-      int wg = a->getKeyWG() + 1; // as ALCT wiregroups numbers start from 0
+      int wg = a->getKeyWG() + 1;  // as ALCT wiregroups numbers start from 0
 
       // store all ALCTs in this chamber
       chamber_to_alcts_all_[id].push_back(*a);
 
       // match by wiregroup with the digis
-      if (digi_wgs.find(wg) == digi_wgs.end())
-      {
-        if (verboseALCT_) cout<<"alctBAD"<<endl;
+      if (digi_wgs.find(wg) == digi_wgs.end()) {
+        if (verboseALCT_)
+          cout << "alctBAD" << endl;
         continue;
       }
-      if (verboseALCT_) cout<<"alctGOOD"<<endl;
+      if (verboseALCT_)
+        cout << "alctGOOD" << endl;
 
       // store matching ALCTs in this chamber
       chamber_to_alcts_[id].push_back(*a);
     }
-    if (chamber_to_alcts_[id].size() > 2)
-    {
-      cout<<"WARNING!!! too many ALCTs "<<chamber_to_alcts_[id].size()<<" in "<<ch_id<<endl;
-      for (auto &a: chamber_to_alcts_[id]) cout<<"  "<<a<<endl;
+    if (chamber_to_alcts_[id].size() > 2) {
+      cout << "WARNING!!! too many ALCTs " << chamber_to_alcts_[id].size() << " in " << ch_id << endl;
+      for (auto& a : chamber_to_alcts_[id])
+        cout << "  " << a << endl;
     }
   }
 }
 
-
-void
-CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& lcts)
-{
+void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& lcts) {
   // only look for stubs in chambers that already have CLCT and ALCT
   const auto& cathode_ids = chamberIdsAllCLCT(0);
   const auto& anode_ids = chamberIdsAllALCT(0);
 
   std::set<int> cathode_and_anode_ids;
-  std::set_union(cathode_ids.begin(), cathode_ids.end(),
-                 anode_ids.begin(), anode_ids.end(),
-                 std::inserter(cathode_and_anode_ids, cathode_and_anode_ids.end())
-                 );
+  std::set_union(cathode_ids.begin(),
+                 cathode_ids.end(),
+                 anode_ids.begin(),
+                 anode_ids.end(),
+                 std::inserter(cathode_and_anode_ids, cathode_and_anode_ids.end()));
 
-  for (const auto& id: cathode_and_anode_ids) {
+  for (const auto& id : cathode_and_anode_ids) {
     int iLct = -1;
 
     CSCDetId ch_id(id);
 
     //use ME1b id to get LCTs
     int ring = ch_id.ring();
-    if (ring == 4) ring = 1;
+    if (ring == 4)
+      ring = 1;
     CSCDetId ch_id2(ch_id.endcap(), ch_id.station(), ring, ch_id.chamber(), 0);
 
     const auto& lcts_in_det = lcts.get(ch_id2);
@@ -229,7 +227,7 @@ CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& lcts)
       lcts_tmp.push_back(*lct);
     }
 
-    for (const auto& lct: lcts_tmp) {
+    for (const auto& lct : lcts_tmp) {
       iLct++;
 
       bool lct_matched(false);
@@ -238,18 +236,19 @@ CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& lcts)
       bool lct_gem1_match(false);
       bool lct_gem2_match(false);
 
-      if (verboseLCT_) cout <<"in LCT, getCLCT "<< lct.getCLCT() <<" getALCT "<< lct.getALCT() << endl;
+      if (verboseLCT_)
+        cout << "in LCT, getCLCT " << lct.getCLCT() << " getALCT " << lct.getALCT() << endl;
 
       // Check if matched to an CLCT
-      for (const auto& p: clctsInChamber(id)){
-        if (p==lct.getCLCT()) {
+      for (const auto& p : clctsInChamber(id)) {
+        if (p == lct.getCLCT()) {
           lct_clct_match = true;
           break;
         }
       }
 
       // Check if matched to an ALCT
-      for (const auto& p: alctsInChamber(id)){
+      for (const auto& p : alctsInChamber(id)) {
         if (p == lct.getALCT()) {
           lct_alct_match = true;
           break;
@@ -257,54 +256,51 @@ CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& lcts)
       }
 
       // fixME here: double check the timing of GEMPad
-      if (ch_id.ring()==1 and (ch_id.station()==1 or ch_id.station()==2)) {
-
+      if (ch_id.ring() == 1 and (ch_id.station() == 1 or ch_id.station() == 2)) {
         // Check if matched to an GEM pad L1
-        const GEMDetId gemDetIdL1(ch_id.zendcap(),1,ch_id.station(),1,ch_id.chamber(),0);
-        for (const auto& p: gemDigiMatcher_->padsInChamber(gemDetIdL1.rawId())){
-          if (p==lct.getGEM1()){
+        const GEMDetId gemDetIdL1(ch_id.zendcap(), 1, ch_id.station(), 1, ch_id.chamber(), 0);
+        for (const auto& p : gemDigiMatcher_->padsInChamber(gemDetIdL1.rawId())) {
+          if (p == lct.getGEM1()) {
             lct_gem1_match = true;
             break;
           }
         }
 
         // Check if matched to an GEM pad L2
-        const GEMDetId gemDetIdL2(ch_id.zendcap(),1,ch_id.station(),2,ch_id.chamber(),0);
-        for (const auto& p: gemDigiMatcher_->padsInChamber(gemDetIdL2.rawId())){
-          if (p==lct.getGEM2()){
+        const GEMDetId gemDetIdL2(ch_id.zendcap(), 1, ch_id.station(), 2, ch_id.chamber(), 0);
+        for (const auto& p : gemDigiMatcher_->padsInChamber(gemDetIdL2.rawId())) {
+          if (p == lct.getGEM2()) {
             lct_gem2_match = true;
             break;
           }
         }
       }
 
-      lct_matched = ((lct_clct_match and lct_alct_match) or
-                     (lct_alct_match and lct_gem1_match and lct_gem2_match) or
+      lct_matched = ((lct_clct_match and lct_alct_match) or (lct_alct_match and lct_gem1_match and lct_gem2_match) or
                      (lct_clct_match and lct_gem1_match and lct_gem2_match));
 
       if (lct_matched) {
-        if (verboseLCT_) cout<<"this LCT matched to simtrack in chamber "<< ch_id << endl;
+        if (verboseLCT_)
+          cout << "this LCT matched to simtrack in chamber " << ch_id << endl;
         chamber_to_lcts_[id].emplace_back(lct);
       }
-    } // lct loop over
+    }  // lct loop over
   }
 }
 
-void
-CSCStubMatcher::matchMPLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& mplcts)
-{
+void CSCStubMatcher::matchMPLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& mplcts) {
   // match simtrack to MPC LCT by looking only in chambers
   // that already have LCTs matched to this simtrack
   const auto& lcts_ids = chamberIdsLCT(0);
 
   // loop on the detids
-  for (const auto& id: lcts_ids) {
-
+  for (const auto& id : lcts_ids) {
     const auto& mplcts_in_det = mplcts.get(id);
 
     // loop on the MPC LCTs in this detid
     for (auto lct = mplcts_in_det.first; lct != mplcts_in_det.second; ++lct) {
-      if (!lct->isValid()) continue;
+      if (!lct->isValid())
+        continue;
 
       // std::cout << "MPC Stub ALL " << *lct << std::endl;
       chamber_to_mplcts_all_[id].emplace_back(*lct);
@@ -319,278 +315,234 @@ CSCStubMatcher::matchMPLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& mplc
   }
 }
 
-std::set<unsigned int>
-CSCStubMatcher::chamberIdsAllCLCT(int csc_type) const
-{
+std::set<unsigned int> CSCStubMatcher::chamberIdsAllCLCT(int csc_type) const {
   return selectDetIds(chamber_to_clcts_all_, csc_type);
 }
 
-std::set<unsigned int>
-CSCStubMatcher::chamberIdsAllALCT(int csc_type) const
-{
+std::set<unsigned int> CSCStubMatcher::chamberIdsAllALCT(int csc_type) const {
   return selectDetIds(chamber_to_alcts_all_, csc_type);
 }
 
-std::set<unsigned int>
-CSCStubMatcher::chamberIdsAllLCT(int csc_type) const
-{
+std::set<unsigned int> CSCStubMatcher::chamberIdsAllLCT(int csc_type) const {
   return selectDetIds(chamber_to_lcts_all_, csc_type);
 }
 
-std::set<unsigned int>
-CSCStubMatcher::chamberIdsAllMPLCT(int csc_type) const
-{
+std::set<unsigned int> CSCStubMatcher::chamberIdsAllMPLCT(int csc_type) const {
   return selectDetIds(chamber_to_mplcts_all_, csc_type);
 }
 
-std::set<unsigned int>
-CSCStubMatcher::chamberIdsCLCT(int csc_type) const
-{
+std::set<unsigned int> CSCStubMatcher::chamberIdsCLCT(int csc_type) const {
   return selectDetIds(chamber_to_clcts_, csc_type);
 }
 
-std::set<unsigned int>
-CSCStubMatcher::chamberIdsALCT(int csc_type) const
-{
+std::set<unsigned int> CSCStubMatcher::chamberIdsALCT(int csc_type) const {
   return selectDetIds(chamber_to_alcts_, csc_type);
 }
 
-std::set<unsigned int>
-CSCStubMatcher::chamberIdsLCT(int csc_type) const
-{
+std::set<unsigned int> CSCStubMatcher::chamberIdsLCT(int csc_type) const {
   return selectDetIds(chamber_to_lcts_, csc_type);
 }
 
-std::set<unsigned int>
-CSCStubMatcher::chamberIdsMPLCT(int csc_type) const
-{
+std::set<unsigned int> CSCStubMatcher::chamberIdsMPLCT(int csc_type) const {
   return selectDetIds(chamber_to_mplcts_, csc_type);
 }
 
-const CSCCLCTDigiContainer&
-CSCStubMatcher::allCLCTsInChamber(unsigned int detid) const
-{
-  if (chamber_to_clcts_all_.find(detid) == chamber_to_clcts_all_.end()) return no_clcts_;
+const CSCCLCTDigiContainer& CSCStubMatcher::allCLCTsInChamber(unsigned int detid) const {
+  if (chamber_to_clcts_all_.find(detid) == chamber_to_clcts_all_.end())
+    return no_clcts_;
   return chamber_to_clcts_all_.at(detid);
 }
 
-const CSCALCTDigiContainer&
-CSCStubMatcher::allALCTsInChamber(unsigned int detid) const
-{
-  if (chamber_to_alcts_all_.find(detid) == chamber_to_alcts_all_.end()) return no_alcts_;
+const CSCALCTDigiContainer& CSCStubMatcher::allALCTsInChamber(unsigned int detid) const {
+  if (chamber_to_alcts_all_.find(detid) == chamber_to_alcts_all_.end())
+    return no_alcts_;
   return chamber_to_alcts_all_.at(detid);
 }
 
-const CSCCorrelatedLCTDigiContainer&
-CSCStubMatcher::allLCTsInChamber(unsigned int detid) const
-{
-  if (chamber_to_lcts_all_.find(detid) == chamber_to_lcts_all_.end()) return no_lcts_;
+const CSCCorrelatedLCTDigiContainer& CSCStubMatcher::allLCTsInChamber(unsigned int detid) const {
+  if (chamber_to_lcts_all_.find(detid) == chamber_to_lcts_all_.end())
+    return no_lcts_;
   return chamber_to_lcts_all_.at(detid);
 }
 
-const CSCCorrelatedLCTDigiContainer&
-CSCStubMatcher::allMPLCTsInChamber(unsigned int detid) const
-{
-  if (chamber_to_mplcts_all_.find(detid) == chamber_to_mplcts_all_.end()) return no_mplcts_;
+const CSCCorrelatedLCTDigiContainer& CSCStubMatcher::allMPLCTsInChamber(unsigned int detid) const {
+  if (chamber_to_mplcts_all_.find(detid) == chamber_to_mplcts_all_.end())
+    return no_mplcts_;
   return chamber_to_mplcts_all_.at(detid);
 }
 
-const CSCCLCTDigiContainer&
-CSCStubMatcher::clctsInChamber(unsigned int detid) const
-{
-  if (chamber_to_clcts_.find(detid) == chamber_to_clcts_.end()) return no_clcts_;
+const CSCCLCTDigiContainer& CSCStubMatcher::clctsInChamber(unsigned int detid) const {
+  if (chamber_to_clcts_.find(detid) == chamber_to_clcts_.end())
+    return no_clcts_;
   return chamber_to_clcts_.at(detid);
 }
 
-const CSCALCTDigiContainer&
-CSCStubMatcher::alctsInChamber(unsigned int detid) const
-{
-  if (chamber_to_alcts_.find(detid) == chamber_to_alcts_.end()) return no_alcts_;
+const CSCALCTDigiContainer& CSCStubMatcher::alctsInChamber(unsigned int detid) const {
+  if (chamber_to_alcts_.find(detid) == chamber_to_alcts_.end())
+    return no_alcts_;
   return chamber_to_alcts_.at(detid);
 }
 
-const CSCCorrelatedLCTDigiContainer&
-CSCStubMatcher::lctsInChamber(unsigned int detid) const
-{
-  if (chamber_to_lcts_.find(detid) == chamber_to_lcts_.end()) return no_lcts_;
+const CSCCorrelatedLCTDigiContainer& CSCStubMatcher::lctsInChamber(unsigned int detid) const {
+  if (chamber_to_lcts_.find(detid) == chamber_to_lcts_.end())
+    return no_lcts_;
   return chamber_to_lcts_.at(detid);
 }
 
-const CSCCorrelatedLCTDigiContainer&
-CSCStubMatcher::mplctsInChamber(unsigned int detid) const
-{
-  if (chamber_to_mplcts_.find(detid) == chamber_to_mplcts_.end()) return no_mplcts_;
+const CSCCorrelatedLCTDigiContainer& CSCStubMatcher::mplctsInChamber(unsigned int detid) const {
+  if (chamber_to_mplcts_.find(detid) == chamber_to_mplcts_.end())
+    return no_mplcts_;
   return chamber_to_mplcts_.at(detid);
 }
 
-CSCCLCTDigi
-CSCStubMatcher::bestClctInChamber(unsigned int detid) const
-{
+CSCCLCTDigi CSCStubMatcher::bestClctInChamber(unsigned int detid) const {
   //sort stubs based on quality
   const auto& input(clctsInChamber(detid));
   int bestQ = 0;
   int index = -1;
-  for (unsigned int i=0; i<input.size(); ++i){
+  for (unsigned int i = 0; i < input.size(); ++i) {
     int quality = input[i].getQuality();
-    if (quality>bestQ){
+    if (quality > bestQ) {
       bestQ = quality;
       index = i;
     }
   }
-  if (index != -1) return input[index];
+  if (index != -1)
+    return input[index];
   return CSCCLCTDigi();
 }
 
-CSCALCTDigi
-CSCStubMatcher::bestAlctInChamber(unsigned int detid) const
-{
+CSCALCTDigi CSCStubMatcher::bestAlctInChamber(unsigned int detid) const {
   //sort stubs based on quality
   const auto& input(alctsInChamber(detid));
   int bestQ = 0;
   int index = -1;
-  for (unsigned int i=0; i<input.size(); ++i){
+  for (unsigned int i = 0; i < input.size(); ++i) {
     int quality = input[i].getQuality();
-    if (quality>bestQ){
+    if (quality > bestQ) {
       bestQ = quality;
       index = i;
     }
   }
-  if (index != -1) return input[index];
+  if (index != -1)
+    return input[index];
   return CSCALCTDigi();
 }
 
-CSCCorrelatedLCTDigi
-CSCStubMatcher::bestLctInChamber(unsigned int detid) const
-{
-
+CSCCorrelatedLCTDigi CSCStubMatcher::bestLctInChamber(unsigned int detid) const {
   //sort stubs based on quality
   const auto& input(lctsInChamber(detid));
   int bestQ = 0;
   int index = -1;
-  for (unsigned int i=0; i<input.size(); ++i){
+  for (unsigned int i = 0; i < input.size(); ++i) {
     int quality = input[i].getQuality();
-    if (quality>bestQ){
+    if (quality > bestQ) {
       bestQ = quality;
       index = i;
     }
   }
-  if (index != -1) return input[index];
+  if (index != -1)
+    return input[index];
   return CSCCorrelatedLCTDigi();
 }
 
-float
-CSCStubMatcher::zpositionOfLayer(unsigned int detid, int layer) const{
-
+float CSCStubMatcher::zpositionOfLayer(unsigned int detid, int layer) const {
   const auto& id = CSCDetId(detid);
   const auto& chamber(cscGeometry_->chamber(id));
   return fabs(chamber->layer(layer)->centerOfStrip(20).z());
 }
 
-int
-CSCStubMatcher::nChambersWithCLCT(int min_quality) const
-{
+int CSCStubMatcher::nChambersWithCLCT(int min_quality) const {
   int result = 0;
   const auto& chamber_ids = chamberIdsCLCT();
-  for (const auto& id: chamber_ids)
-  {
+  for (const auto& id : chamber_ids) {
     int nStubChamber = 0;
     const auto& clcts = clctsInChamber(id);
-    for (const auto& clct: clcts){
-      if (!clct.isValid()) continue;
+    for (const auto& clct : clcts) {
+      if (!clct.isValid())
+        continue;
       if (clct.getQuality() >= min_quality) {
         nStubChamber++;
       }
     }
-    if (nStubChamber>0){
+    if (nStubChamber > 0) {
       ++result;
     }
   }
   return result;
 }
 
-int
-CSCStubMatcher::nChambersWithALCT(int min_quality) const
-{
+int CSCStubMatcher::nChambersWithALCT(int min_quality) const {
   int result = 0;
   const auto& chamber_ids = chamberIdsALCT();
-  for (const auto& id: chamber_ids)
-  {
+  for (const auto& id : chamber_ids) {
     int nStubChamber = 0;
     const auto& alcts = alctsInChamber(id);
-    for (const auto& alct: alcts){
-      if (!alct.isValid()) continue;
+    for (const auto& alct : alcts) {
+      if (!alct.isValid())
+        continue;
       if (alct.getQuality() >= min_quality) {
         nStubChamber++;
       }
     }
-    if (nStubChamber>0){
+    if (nStubChamber > 0) {
       ++result;
     }
   }
   return result;
 }
 
-int
-CSCStubMatcher::nChambersWithLCT(int min_quality) const
-{
+int CSCStubMatcher::nChambersWithLCT(int min_quality) const {
   int result = 0;
   const auto& chamber_ids = chamberIdsLCT();
-  for (const auto& id: chamber_ids)
-  {
+  for (const auto& id : chamber_ids) {
     int nStubChamber = 0;
     const auto& lcts = lctsInChamber(id);
-    for (const auto& lct: lcts){
-      if (!lct.isValid()) continue;
+    for (const auto& lct : lcts) {
+      if (!lct.isValid())
+        continue;
       if (lct.getQuality() >= min_quality) {
         nStubChamber++;
       }
     }
-    if (nStubChamber>0){
+    if (nStubChamber > 0) {
       ++result;
     }
   }
   return result;
 }
 
-int
-CSCStubMatcher::nChambersWithMPLCT(int min_quality) const
-{
+int CSCStubMatcher::nChambersWithMPLCT(int min_quality) const {
   int result = 0;
   const auto& chamber_ids = chamberIdsMPLCT();
-  for (const auto& id: chamber_ids)
-  {
+  for (const auto& id : chamber_ids) {
     int nStubChamber = 0;
     const auto& mplcts = mplctsInChamber(id);
-    for (const auto& mplct: mplcts){
-      if (!mplct.isValid()) continue;
+    for (const auto& mplct : mplcts) {
+      if (!mplct.isValid())
+        continue;
       if (mplct.getQuality() >= min_quality) {
         nStubChamber++;
       }
     }
-    if (nStubChamber>0){
+    if (nStubChamber > 0) {
       ++result;
     }
   }
   return result;
 }
 
-
-bool
-CSCStubMatcher::lctInChamber(const CSCDetId& id, const CSCCorrelatedLCTDigi& lct) const
-{
-  for (const auto& stub: lctsInChamber(id.rawId())){
-    if (stub == lct) return true;
+bool CSCStubMatcher::lctInChamber(const CSCDetId& id, const CSCCorrelatedLCTDigi& lct) const {
+  for (const auto& stub : lctsInChamber(id.rawId())) {
+    if (stub == lct)
+      return true;
   }
   return false;
 }
 
-
-GlobalPoint
-CSCStubMatcher::getGlobalPosition(unsigned int rawId, const CSCCorrelatedLCTDigi& lct) const
-{
+GlobalPoint CSCStubMatcher::getGlobalPosition(unsigned int rawId, const CSCCorrelatedLCTDigi& lct) const {
   CSCDetId cscId(rawId);
-  CSCDetId key_id(cscId.endcap(), cscId.station(), cscId.ring(),
-                  cscId.chamber(), CSCConstants::KEY_CLCT_LAYER);
+  CSCDetId key_id(cscId.endcap(), cscId.station(), cscId.ring(), cscId.chamber(), CSCConstants::KEY_CLCT_LAYER);
   const auto& chamber = cscGeometry_->chamber(cscId);
   float fractional_strip = lct.getFractionalStrip();
   const auto& layer_geo = chamber->layer(CSCConstants::KEY_CLCT_LAYER)->geometry();

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -1,0 +1,602 @@
+#include "Validation/MuonCSCDigis/interface/CSCStubMatcher.h"
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+
+#include <algorithm>
+
+using namespace std;
+
+CSCStubMatcher::CSCStubMatcher(const edm::ParameterSet& pSet, edm::ConsumesCollector && iC)
+{
+  const auto& cscCLCT = pSet.getParameter<edm::ParameterSet>("cscCLCT");
+  minBXCLCT_ = cscCLCT.getParameter<int>("minBX");
+  maxBXCLCT_ = cscCLCT.getParameter<int>("maxBX");
+  verboseCLCT_ = cscCLCT.getParameter<int>("verbose");
+  minNHitsChamberCLCT_ = cscCLCT.getParameter<int>("minNHitsChamber");
+
+  const auto& cscALCT = pSet.getParameter<edm::ParameterSet>("cscALCT");
+  minBXALCT_ = cscALCT.getParameter<int>("minBX");
+  maxBXALCT_ = cscALCT.getParameter<int>("maxBX");
+  verboseALCT_ = cscALCT.getParameter<int>("verbose");
+  minNHitsChamberALCT_ = cscALCT.getParameter<int>("minNHitsChamber");
+
+  const auto& cscLCT = pSet.getParameter<edm::ParameterSet>("cscLCT");
+  minBXLCT_ = cscLCT.getParameter<int>("minBX");
+  maxBXLCT_ = cscLCT.getParameter<int>("maxBX");
+  verboseLCT_ = cscLCT.getParameter<int>("verbose");
+  minNHitsChamberLCT_ = cscLCT.getParameter<int>("minNHitsChamber");
+  hsFromSimHitMean_ = cscLCT.getParameter<bool>("hsFromSimHitMean");
+
+  const auto& cscMPLCT = pSet.getParameter<edm::ParameterSet>("cscMPLCT");
+  minBXMPLCT_ = cscMPLCT.getParameter<int>("minBX");
+  maxBXMPLCT_ = cscMPLCT.getParameter<int>("maxBX");
+  verboseMPLCT_ = cscMPLCT.getParameter<int>("verbose");
+  minNHitsChamberMPLCT_ = cscMPLCT.getParameter<int>("minNHitsChamber");
+
+  gemDigiMatcher_.reset(new GEMDigiMatcher(pSet, std::move(iC)));
+  cscDigiMatcher_.reset(new CSCDigiMatcher(pSet, std::move(iC)));
+
+  clctToken_ = iC.consumes<CSCCLCTDigiCollection>(cscCLCT.getParameter<edm::InputTag>("inputTag"));
+  alctToken_  = iC.consumes<CSCALCTDigiCollection>(cscALCT.getParameter<edm::InputTag>("inputTag"));
+  lctToken_  = iC.consumes<CSCCorrelatedLCTDigiCollection>(cscLCT.getParameter<edm::InputTag>("inputTag"));
+  mplctToken_ = iC.consumes<CSCCorrelatedLCTDigiCollection>(cscMPLCT.getParameter<edm::InputTag>("inputTag"));
+}
+
+
+void CSCStubMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  gemDigiMatcher_->init(iEvent, iSetup);
+  cscDigiMatcher_->init(iEvent, iSetup);
+
+  iEvent.getByToken(clctToken_, clctsH_);
+  iEvent.getByToken(alctToken_, alctsH_);
+  iEvent.getByToken(lctToken_, lctsH_);
+  iEvent.getByToken(mplctToken_, mplctsH_);
+
+  iSetup.get<MuonGeometryRecord>().get(csc_geom_);
+  if (csc_geom_.isValid()) {
+    cscGeometry_ = &*csc_geom_;
+  } else {
+    std::cout << "+++ Info: CSC geometry is unavailable. +++\n";
+  }
+}
+
+// do the matching
+void CSCStubMatcher::match(const SimTrack& t, const SimVertex& v)
+{
+  // match simhits first
+  gemDigiMatcher_->match(t,v);
+  cscDigiMatcher_->match(t,v);
+
+  const CSCCLCTDigiCollection& clcts = *clctsH_.product();
+  const CSCALCTDigiCollection& alcts = *alctsH_.product();
+  const CSCCorrelatedLCTDigiCollection& lcts = *lctsH_.product();
+  const CSCCorrelatedLCTDigiCollection& mplcts = *mplctsH_.product();
+
+  matchCLCTsToSimTrack(clcts);
+  matchALCTsToSimTrack(alcts);
+  matchLCTsToSimTrack(lcts);
+  matchMPLCTsToSimTrack(mplcts);
+}
+
+void
+CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts)
+{
+  const auto& cathode_ids = cscDigiMatcher_->chamberIdsStrip(0);
+  int n_minLayers = 0;
+  for (const auto& id: cathode_ids)
+  {
+    CSCDetId ch_id(id);
+    if (verboseCLCT_){
+	cout <<"To check CSC chamber "<< ch_id << endl;
+    }
+    if (cscDigiMatcher_->nLayersWithStripInChamber(id) >= minNHitsChamberCLCT_) ++n_minLayers;
+
+    // fill 1 half-strip wide gaps
+    const auto& digi_strips = cscDigiMatcher_->stripsInChamber(id, 1);
+    if (verboseCLCT_)
+    {
+      cout<<"clct: digi_strips "<<ch_id<<" Nlayers " << cscDigiMatcher_->nLayersWithStripInChamber(id) <<" ";
+      copy(digi_strips.begin(), digi_strips.end(), ostream_iterator<int>(cout, " ")); cout<<endl;
+    }
+
+    int ring = ch_id.ring();
+    if (ring == 4) ring =1; //use ME1b id to get CLCTs
+    CSCDetId ch_id2(ch_id.endcap(), ch_id.station(),  ring, ch_id.chamber(), 0);
+
+    const auto& clcts_in_det = clcts.get(ch_id2);
+
+    for (auto c = clcts_in_det.first; c != clcts_in_det.second; ++c)
+    {
+      if (verboseCLCT_) cout<<"clct "<<ch_id<<" "<<*c<<endl;
+
+      if (!c->isValid()) continue;
+
+      // check that the BX for this stub wasn't too early or too late
+      if (c->getBX() < minBXCLCT_ || c->getBX() > maxBXCLCT_) continue;
+
+      int half_strip = c->getKeyStrip() + 1; // CLCT halfstrip numbers start from 0
+      if (ch_id.ring() == 4 and ch_id.station() == 1 and half_strip > 128)
+        half_strip  = half_strip - 128;
+
+      // store all CLCTs in this chamber
+      chamber_to_clcts_all_[id].push_back(*c);
+
+      // match by half-strip with the digis
+      if (digi_strips.find(half_strip) == digi_strips.end())
+      {
+        if (verboseCLCT_) cout<<"clctBAD, half_strip "<< half_strip <<endl;
+        continue;
+      }
+      if (verboseCLCT_) cout<<"clctGOOD"<<endl;
+
+      // store matching CLCTs in this chamber
+      chamber_to_clcts_[id].push_back(*c);
+    }
+    if (chamber_to_clcts_[id].size() > 2)
+    {
+      cout<<"WARNING!!! too many CLCTs "<<chamber_to_clcts_[id].size()<<" in "<<ch_id<<endl;
+      for (auto &c: chamber_to_clcts_[id]) cout<<"  "<<c<<endl;
+    }
+  }
+}
+
+void
+CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts)
+{
+  const auto& anode_ids = cscDigiMatcher_->chamberIdsWire(0);
+  int n_minLayers = 0;
+  for (const auto& id: anode_ids)
+  {
+    if (cscDigiMatcher_->nLayersWithWireInChamber(id) >= minNHitsChamberALCT_) ++n_minLayers;
+    CSCDetId ch_id(id);
+
+    // fill 1 WG wide gaps
+    const auto& digi_wgs = cscDigiMatcher_->wiregroupsInChamber(id, 1);
+    if (verboseALCT_)
+    {
+      cout<<"alct: digi_wgs "<<ch_id<<" ";
+      copy(digi_wgs.begin(), digi_wgs.end(), ostream_iterator<int>(cout, " ")); cout<<endl;
+    }
+
+    int ring = ch_id.ring();
+    if (ring == 4) ring =1; //use ME1b id to get CLCTs
+    CSCDetId ch_id2(ch_id.endcap(), ch_id.station(),  ring, ch_id.chamber(), 0);
+
+    const auto& alcts_in_det = alcts.get(ch_id2);
+    for (auto a = alcts_in_det.first; a != alcts_in_det.second; ++a)
+    {
+      if (!a->isValid()) continue;
+
+      if (verboseALCT_)
+        cout<<"alct "<<ch_id<<" "<<*a<<endl;
+
+      // check that the BX for stub wasn't too early or too late
+      if (a->getBX() < minBXALCT_ || a->getBX() > maxBXALCT_) continue;
+
+      int wg = a->getKeyWG() + 1; // as ALCT wiregroups numbers start from 0
+
+      // store all ALCTs in this chamber
+      chamber_to_alcts_all_[id].push_back(*a);
+
+      // match by wiregroup with the digis
+      if (digi_wgs.find(wg) == digi_wgs.end())
+      {
+        if (verboseALCT_) cout<<"alctBAD"<<endl;
+        continue;
+      }
+      if (verboseALCT_) cout<<"alctGOOD"<<endl;
+
+      // store matching ALCTs in this chamber
+      chamber_to_alcts_[id].push_back(*a);
+    }
+    if (chamber_to_alcts_[id].size() > 2)
+    {
+      cout<<"WARNING!!! too many ALCTs "<<chamber_to_alcts_[id].size()<<" in "<<ch_id<<endl;
+      for (auto &a: chamber_to_alcts_[id]) cout<<"  "<<a<<endl;
+    }
+  }
+}
+
+
+void
+CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& lcts)
+{
+  // only look for stubs in chambers that already have CLCT and ALCT
+  const auto& cathode_ids = chamberIdsAllCLCT(0);
+  const auto& anode_ids = chamberIdsAllALCT(0);
+
+  std::set<int> cathode_and_anode_ids;
+  std::set_union(cathode_ids.begin(), cathode_ids.end(),
+                 anode_ids.begin(), anode_ids.end(),
+                 std::inserter(cathode_and_anode_ids, cathode_and_anode_ids.end())
+                 );
+
+  for (const auto& id: cathode_and_anode_ids) {
+    int iLct = -1;
+
+    CSCDetId ch_id(id);
+
+    //use ME1b id to get LCTs
+    int ring = ch_id.ring();
+    if (ring == 4) ring = 1;
+    CSCDetId ch_id2(ch_id.endcap(), ch_id.station(), ring, ch_id.chamber(), 0);
+
+    const auto& lcts_in_det = lcts.get(ch_id2);
+
+    // collect all LCTs in a handy container
+    CSCCorrelatedLCTDigiContainer lcts_tmp;
+    for (auto lct = lcts_in_det.first; lct != lcts_in_det.second; ++lct) {
+      lcts_tmp.push_back(*lct);
+    }
+
+    for (const auto& lct: lcts_tmp) {
+      iLct++;
+
+      bool lct_matched(false);
+      bool lct_clct_match(false);
+      bool lct_alct_match(false);
+      bool lct_gem1_match(false);
+      bool lct_gem2_match(false);
+
+      if (verboseLCT_) cout <<"in LCT, getCLCT "<< lct.getCLCT() <<" getALCT "<< lct.getALCT() << endl;
+
+      // Check if matched to an CLCT
+      for (const auto& p: clctsInChamber(id)){
+        if (p==lct.getCLCT()) {
+          lct_clct_match = true;
+          break;
+        }
+      }
+
+      // Check if matched to an ALCT
+      for (const auto& p: alctsInChamber(id)){
+        if (p == lct.getALCT()) {
+          lct_alct_match = true;
+          break;
+        }
+      }
+
+      // fixME here: double check the timing of GEMPad
+      if (ch_id.ring()==1 and (ch_id.station()==1 or ch_id.station()==2)) {
+
+        // Check if matched to an GEM pad L1
+        const GEMDetId gemDetIdL1(ch_id.zendcap(),1,ch_id.station(),1,ch_id.chamber(),0);
+        for (const auto& p: gemDigiMatcher_->padsInChamber(gemDetIdL1.rawId())){
+          if (p==lct.getGEM1()){
+            lct_gem1_match = true;
+            break;
+          }
+        }
+
+        // Check if matched to an GEM pad L2
+        const GEMDetId gemDetIdL2(ch_id.zendcap(),1,ch_id.station(),2,ch_id.chamber(),0);
+        for (const auto& p: gemDigiMatcher_->padsInChamber(gemDetIdL2.rawId())){
+          if (p==lct.getGEM2()){
+            lct_gem2_match = true;
+            break;
+          }
+        }
+      }
+
+      lct_matched = ((lct_clct_match and lct_alct_match) or
+                     (lct_alct_match and lct_gem1_match and lct_gem2_match) or
+                     (lct_clct_match and lct_gem1_match and lct_gem2_match));
+
+      if (lct_matched) {
+        if (verboseLCT_) cout<<"this LCT matched to simtrack in chamber "<< ch_id << endl;
+        chamber_to_lcts_[id].emplace_back(lct);
+      }
+    } // lct loop over
+  }
+}
+
+void
+CSCStubMatcher::matchMPLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& mplcts)
+{
+  // match simtrack to MPC LCT by looking only in chambers
+  // that already have LCTs matched to this simtrack
+  const auto& lcts_ids = chamberIdsLCT(0);
+
+  // loop on the detids
+  for (const auto& id: lcts_ids) {
+
+    const auto& mplcts_in_det = mplcts.get(id);
+
+    // loop on the MPC LCTs in this detid
+    for (auto lct = mplcts_in_det.first; lct != mplcts_in_det.second; ++lct) {
+      if (!lct->isValid()) continue;
+
+      // std::cout << "MPC Stub ALL " << *lct << std::endl;
+      chamber_to_mplcts_all_[id].emplace_back(*lct);
+
+      // check if this stub corresponds with a previously matched stub
+      for (const auto& sim_stub : lctsInChamber(id)) {
+        if (sim_stub == *lct) {
+          chamber_to_mplcts_[id].emplace_back(*lct);
+        }
+      }
+    }
+  }
+}
+
+std::set<unsigned int>
+CSCStubMatcher::chamberIdsAllCLCT(int csc_type) const
+{
+  return selectDetIds(chamber_to_clcts_all_, csc_type);
+}
+
+std::set<unsigned int>
+CSCStubMatcher::chamberIdsAllALCT(int csc_type) const
+{
+  return selectDetIds(chamber_to_alcts_all_, csc_type);
+}
+
+std::set<unsigned int>
+CSCStubMatcher::chamberIdsAllLCT(int csc_type) const
+{
+  return selectDetIds(chamber_to_lcts_all_, csc_type);
+}
+
+std::set<unsigned int>
+CSCStubMatcher::chamberIdsAllMPLCT(int csc_type) const
+{
+  return selectDetIds(chamber_to_mplcts_all_, csc_type);
+}
+
+std::set<unsigned int>
+CSCStubMatcher::chamberIdsCLCT(int csc_type) const
+{
+  return selectDetIds(chamber_to_clcts_, csc_type);
+}
+
+std::set<unsigned int>
+CSCStubMatcher::chamberIdsALCT(int csc_type) const
+{
+  return selectDetIds(chamber_to_alcts_, csc_type);
+}
+
+std::set<unsigned int>
+CSCStubMatcher::chamberIdsLCT(int csc_type) const
+{
+  return selectDetIds(chamber_to_lcts_, csc_type);
+}
+
+std::set<unsigned int>
+CSCStubMatcher::chamberIdsMPLCT(int csc_type) const
+{
+  return selectDetIds(chamber_to_mplcts_, csc_type);
+}
+
+const CSCCLCTDigiContainer&
+CSCStubMatcher::allCLCTsInChamber(unsigned int detid) const
+{
+  if (chamber_to_clcts_all_.find(detid) == chamber_to_clcts_all_.end()) return no_clcts_;
+  return chamber_to_clcts_all_.at(detid);
+}
+
+const CSCALCTDigiContainer&
+CSCStubMatcher::allALCTsInChamber(unsigned int detid) const
+{
+  if (chamber_to_alcts_all_.find(detid) == chamber_to_alcts_all_.end()) return no_alcts_;
+  return chamber_to_alcts_all_.at(detid);
+}
+
+const CSCCorrelatedLCTDigiContainer&
+CSCStubMatcher::allLCTsInChamber(unsigned int detid) const
+{
+  if (chamber_to_lcts_all_.find(detid) == chamber_to_lcts_all_.end()) return no_lcts_;
+  return chamber_to_lcts_all_.at(detid);
+}
+
+const CSCCorrelatedLCTDigiContainer&
+CSCStubMatcher::allMPLCTsInChamber(unsigned int detid) const
+{
+  if (chamber_to_mplcts_all_.find(detid) == chamber_to_mplcts_all_.end()) return no_mplcts_;
+  return chamber_to_mplcts_all_.at(detid);
+}
+
+const CSCCLCTDigiContainer&
+CSCStubMatcher::clctsInChamber(unsigned int detid) const
+{
+  if (chamber_to_clcts_.find(detid) == chamber_to_clcts_.end()) return no_clcts_;
+  return chamber_to_clcts_.at(detid);
+}
+
+const CSCALCTDigiContainer&
+CSCStubMatcher::alctsInChamber(unsigned int detid) const
+{
+  if (chamber_to_alcts_.find(detid) == chamber_to_alcts_.end()) return no_alcts_;
+  return chamber_to_alcts_.at(detid);
+}
+
+const CSCCorrelatedLCTDigiContainer&
+CSCStubMatcher::lctsInChamber(unsigned int detid) const
+{
+  if (chamber_to_lcts_.find(detid) == chamber_to_lcts_.end()) return no_lcts_;
+  return chamber_to_lcts_.at(detid);
+}
+
+const CSCCorrelatedLCTDigiContainer&
+CSCStubMatcher::mplctsInChamber(unsigned int detid) const
+{
+  if (chamber_to_mplcts_.find(detid) == chamber_to_mplcts_.end()) return no_mplcts_;
+  return chamber_to_mplcts_.at(detid);
+}
+
+CSCCLCTDigi
+CSCStubMatcher::bestClctInChamber(unsigned int detid) const
+{
+  //sort stubs based on quality
+  const auto& input(clctsInChamber(detid));
+  int bestQ = 0;
+  int index = -1;
+  for (unsigned int i=0; i<input.size(); ++i){
+    int quality = input[i].getQuality();
+    if (quality>bestQ){
+      bestQ = quality;
+      index = i;
+    }
+  }
+  if (index != -1) return input[index];
+  return CSCCLCTDigi();
+}
+
+CSCALCTDigi
+CSCStubMatcher::bestAlctInChamber(unsigned int detid) const
+{
+  //sort stubs based on quality
+  const auto& input(alctsInChamber(detid));
+  int bestQ = 0;
+  int index = -1;
+  for (unsigned int i=0; i<input.size(); ++i){
+    int quality = input[i].getQuality();
+    if (quality>bestQ){
+      bestQ = quality;
+      index = i;
+    }
+  }
+  if (index != -1) return input[index];
+  return CSCALCTDigi();
+}
+
+CSCCorrelatedLCTDigi
+CSCStubMatcher::bestLctInChamber(unsigned int detid) const
+{
+
+  //sort stubs based on quality
+  const auto& input(lctsInChamber(detid));
+  int bestQ = 0;
+  int index = -1;
+  for (unsigned int i=0; i<input.size(); ++i){
+    int quality = input[i].getQuality();
+    if (quality>bestQ){
+      bestQ = quality;
+      index = i;
+    }
+  }
+  if (index != -1) return input[index];
+  return CSCCorrelatedLCTDigi();
+}
+
+float
+CSCStubMatcher::zpositionOfLayer(unsigned int detid, int layer) const{
+
+  const auto& id = CSCDetId(detid);
+  const auto& chamber(cscGeometry_->chamber(id));
+  return fabs(chamber->layer(layer)->centerOfStrip(20).z());
+}
+
+int
+CSCStubMatcher::nChambersWithCLCT(int min_quality) const
+{
+  int result = 0;
+  const auto& chamber_ids = chamberIdsCLCT();
+  for (const auto& id: chamber_ids)
+  {
+    int nStubChamber = 0;
+    const auto& clcts = clctsInChamber(id);
+    for (const auto& clct: clcts){
+      if (!clct.isValid()) continue;
+      if (clct.getQuality() >= min_quality) {
+        nStubChamber++;
+      }
+    }
+    if (nStubChamber>0){
+      ++result;
+    }
+  }
+  return result;
+}
+
+int
+CSCStubMatcher::nChambersWithALCT(int min_quality) const
+{
+  int result = 0;
+  const auto& chamber_ids = chamberIdsALCT();
+  for (const auto& id: chamber_ids)
+  {
+    int nStubChamber = 0;
+    const auto& alcts = alctsInChamber(id);
+    for (const auto& alct: alcts){
+      if (!alct.isValid()) continue;
+      if (alct.getQuality() >= min_quality) {
+        nStubChamber++;
+      }
+    }
+    if (nStubChamber>0){
+      ++result;
+    }
+  }
+  return result;
+}
+
+int
+CSCStubMatcher::nChambersWithLCT(int min_quality) const
+{
+  int result = 0;
+  const auto& chamber_ids = chamberIdsLCT();
+  for (const auto& id: chamber_ids)
+  {
+    int nStubChamber = 0;
+    const auto& lcts = lctsInChamber(id);
+    for (const auto& lct: lcts){
+      if (!lct.isValid()) continue;
+      if (lct.getQuality() >= min_quality) {
+        nStubChamber++;
+      }
+    }
+    if (nStubChamber>0){
+      ++result;
+    }
+  }
+  return result;
+}
+
+int
+CSCStubMatcher::nChambersWithMPLCT(int min_quality) const
+{
+  int result = 0;
+  const auto& chamber_ids = chamberIdsMPLCT();
+  for (const auto& id: chamber_ids)
+  {
+    int nStubChamber = 0;
+    const auto& mplcts = mplctsInChamber(id);
+    for (const auto& mplct: mplcts){
+      if (!mplct.isValid()) continue;
+      if (mplct.getQuality() >= min_quality) {
+        nStubChamber++;
+      }
+    }
+    if (nStubChamber>0){
+      ++result;
+    }
+  }
+  return result;
+}
+
+
+bool
+CSCStubMatcher::lctInChamber(const CSCDetId& id, const CSCCorrelatedLCTDigi& lct) const
+{
+  for (const auto& stub: lctsInChamber(id.rawId())){
+    if (stub == lct) return true;
+  }
+  return false;
+}
+
+
+GlobalPoint
+CSCStubMatcher::getGlobalPosition(unsigned int rawId, const CSCCorrelatedLCTDigi& lct) const
+{
+  CSCDetId cscId(rawId);
+  CSCDetId key_id(cscId.endcap(), cscId.station(), cscId.ring(),
+                  cscId.chamber(), CSCConstants::KEY_CLCT_LAYER);
+  const auto& chamber = cscGeometry_->chamber(cscId);
+  float fractional_strip = lct.getFractionalStrip();
+  const auto& layer_geo = chamber->layer(CSCConstants::KEY_CLCT_LAYER)->geometry();
+  // LCT::getKeyWG() also starts from 0
+  float wire = layer_geo->middleWireOfGroup(lct.getKeyWG() + 1);
+  const LocalPoint& csc_intersect = layer_geo->intersectionOfStripAndWire(fractional_strip, wire);
+  const GlobalPoint& csc_gp = cscGeometry_->idToDet(key_id)->surface().toGlobal(csc_intersect);
+  return csc_gp;
+}

--- a/Validation/MuonCSCDigis/src/CSCWireDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCWireDigiValidation.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Validation/MuonCSCDigis/src/CSCWireDigiValidation.h"
+#include "Validation/MuonCSCDigis/interface/CSCWireDigiValidation.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"


### PR DESCRIPTION
#### PR description:

This PR builds on top of https://github.com/cms-sw/cmssw/pull/26249 and https://github.com/cms-sw/cmssw/pull/29042. This code matches CSC wire/strip/comparator digis and ALCT/CLCT/LCT stubs to SimTracks. 

Tao Huang and I have been developing this validation code since ~2013 and have been using it in our trigger studies for the GEM TDR, Muon Phase-II TP, Muon Upgrade TDR. Most recently in the L1T TDR (https://cms-docdb.cern.ch/cgi-bin/DocDB/RetrieveFile?docid=13929&filename=TDR-20-001-paper-v1.pdf&version=4, section 2.5.5).

#### PR validation:

The code was tested with WF 22034.0.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

FYI @tahuang1991