### PR TITLE
Update HCAL zero suppression condition for Run 3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -67,15 +67,15 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '110X_mcRun3_2021_design_v6', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '111X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '111X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v5',
+    'phase1_2021_cosmics'      : '111X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v8', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '111X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v8', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

The DB tag specifying the HCAL zero suppression is updated for all Run 3 scenarios. Currently the HCAL zero suppression is calculated using two ADC samples but this PR switches to using only one sample.

This change will also need to be applied to the new 2021 heavy ion GT introduced in PR #29078. To avoid potential conflicts, I will update that PR with the modified ZS after this PR is merged.

The diffs of the updated GTs with respect to the previous are as follows:

**2021 pp collision design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_design_v6/111X_mcRun3_2021_design_v1 

**2021 pp collision realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_realistic_v8/111X_mcRun3_2021_realistic_v1 

**2021 cosmic realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021cosmics_realistic_deco_v5/111X_mcRun3_2021cosmics_realistic_deco_v1 

**2023 pp collision realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2023_realistic_v8/111X_mcRun3_2023_realistic_v1 

**2024 pp collision realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2024_realistic_v8/111X_mcRun3_2024_realistic_v1 

#### PR validation:

In addition, a technical test was performed: `runTheMatrix.py -l limited,12024.0,7.23,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and should not be backported.