### PR TITLE
Reduce boost dependence in EcalDigi data formats

### DIFF
--- a/DataFormats/EcalDigi/test/EcalDigi_t.cpp
+++ b/DataFormats/EcalDigi/test/EcalDigi_t.cpp
@@ -7,7 +7,7 @@
 
 #include <vector>
 #include <algorithm>
-#include <boost/function.hpp>
+#include <functional>
 
 template <typename DigiCollection>
 class TestEcalDigi : public CppUnit::TestFixture {
@@ -162,7 +162,7 @@ namespace {
 
   // an alternative way
   void iterate(EcalDigiCollection const& frames) {
-    boost::function<void(edm::DataFrame::id_type)> verifyId;
+    std::function<void(edm::DataFrame::id_type)> verifyId;
     if (frames.subdetId() == EcalBarrel)
       verifyId = verifyBarrelId;
     else if (frames.subdetId() == EcalEndcap)


### PR DESCRIPTION
#### PR description:
A simple use case has been changed in which std :: function and boost: function should behave identically.

#### PR validation:


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

