### PR TITLE
Changing handling of color indexes and anti particle creation for pythia8 EGun (9_3_X backport)

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -6,115 +6,120 @@
 
 namespace gen {
 
-class Py8EGun : public Py8GunBase {
-   
-   public:
-      
-      Py8EGun( edm::ParameterSet const& );
-      ~Py8EGun() {}
-	 
-      bool generatePartonsAndHadronize() override;
-      const char* classname() const override;
-	 
-   private:
-      
-      // EGun particle(s) characteristics
-      double  fMinEta;
-      double  fMaxEta;
-      double  fMinE ;
-      double  fMaxE ;
-      bool    fAddAntiParticle;
+  class Py8EGun : public Py8GunBase {
+  public:
+    Py8EGun(edm::ParameterSet const&);
+    ~Py8EGun() override {}
 
-};
+    bool generatePartonsAndHadronize() override;
+    const char* classname() const override;
 
-// implementation 
-//
-Py8EGun::Py8EGun( edm::ParameterSet const& ps )
-   : Py8GunBase(ps) 
-{
+  private:
+    // EGun particle(s) characteristics
+    double fMinEta;
+    double fMaxEta;
+    double fMinE;
+    double fMaxE;
+    bool fAddAntiParticle;
+  };
 
-   // ParameterSet defpset ;
-   edm::ParameterSet pgun_params = 
-      ps.getParameter<edm::ParameterSet>("PGunParameters"); // , defpset ) ;
-   fMinEta     = pgun_params.getParameter<double>("MinEta"); // ,-2.2);
-   fMaxEta     = pgun_params.getParameter<double>("MaxEta"); // , 2.2);
-   fMinE       = pgun_params.getParameter<double>("MinE"); // ,  0.);
-   fMaxE       = pgun_params.getParameter<double>("MaxE"); // ,  0.);
-   fAddAntiParticle = pgun_params.getParameter<bool>("AddAntiParticle"); //, false) ;  
+  // implementation
+  //
+  Py8EGun::Py8EGun(edm::ParameterSet const& ps) : Py8GunBase(ps) {
+    // ParameterSet defpset ;
+    edm::ParameterSet pgun_params = ps.getParameter<edm::ParameterSet>("PGunParameters");  // , defpset ) ;
+    fMinEta = pgun_params.getParameter<double>("MinEta");                                  // ,-2.2);
+    fMaxEta = pgun_params.getParameter<double>("MaxEta");                                  // , 2.2);
+    fMinE = pgun_params.getParameter<double>("MinE");                                      // ,  0.);
+    fMaxE = pgun_params.getParameter<double>("MaxE");                                      // ,  0.);
+    fAddAntiParticle = pgun_params.getParameter<bool>("AddAntiParticle");                  //, false) ;
+  }
 
-}
+  bool Py8EGun::generatePartonsAndHadronize() {
+    fMasterGen->event.reset();
 
-bool Py8EGun::generatePartonsAndHadronize()
-{
+    int colorindex = 101;
 
-   fMasterGen->event.reset();
-   
-   for ( size_t i=0; i<fPartIDs.size(); i++ )
-   {
+    for (size_t i = 0; i < fPartIDs.size(); i++) {
+      int particleID = fPartIDs[i];  // this is PDG - need to convert to Py8 ???
+      if ((std::abs(particleID) <= 6 || particleID == 21) && !(fAddAntiParticle)) {
+        throw cms::Exception("PythiaError") << "Attempting to generate quarks or gluons without setting "
+                                               "AddAntiParticle to true. This will not handle color properly."
+                                            << std::endl;
+      }
 
-      int particleID = fPartIDs[i]; // this is PDG - need to convert to Py8 ???
+      double phi = (fMaxPhi - fMinPhi) * randomEngine().flat() + fMinPhi;
+      double ee = (fMaxE - fMinE) * randomEngine().flat() + fMinE;
+      double eta = (fMaxEta - fMinEta) * randomEngine().flat() + fMinEta;
+      double the = 2. * atan(exp(-eta));
 
-      double phi = (fMaxPhi-fMinPhi) * randomEngine().flat() + fMinPhi;
-      double ee   = (fMaxE-fMinE) * randomEngine().flat() + fMinE;
-      double eta  = (fMaxEta-fMinEta) * randomEngine().flat() + fMinEta;
-      double the  = 2.*atan(exp(-eta));
+      double mass = (fMasterGen->particleData).m0(particleID);
 
-      double mass = (fMasterGen->particleData).m0( particleID );
-
-      double pp = sqrt( ee*ee - mass*mass );
+      double pp = sqrt(ee * ee - mass * mass);
       double px = pp * sin(the) * cos(phi);
       double py = pp * sin(the) * sin(phi);
       double pz = pp * cos(the);
 
-      if ( !((fMasterGen->particleData).isParticle( particleID )) )
-      {
-         particleID = std::fabs(particleID) ;
+      if (!((fMasterGen->particleData).isParticle(particleID))) {
+        particleID = std::fabs(particleID);
       }
-      (fMasterGen->event).append( particleID, 1, 0, 0, px, py, pz, ee, mass ); 
-      int eventSize = (fMasterGen->event).size()-1;
-// -log(flat) = exponential distribution
-      double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
-      (fMasterGen->event)[eventSize].tau( tauTmp );
-
-
-// Here also need to add anti-particle (if any)
-// otherwise just add a 2nd particle of the same type 
-// (for example, gamma)
-//
-      if ( fAddAntiParticle )
-      {
-         if ( (fMasterGen->particleData).isParticle( -particleID ) )
-	 {
-	    (fMasterGen->event).append( -particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
-	 }
-	 else
-	 {
-	    (fMasterGen->event).append( particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
-	 }
-         eventSize = (fMasterGen->event).size()-1;
-// -log(flat) = exponential distribution
-         tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
-         (fMasterGen->event)[eventSize].tau( tauTmp );
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
+        (fMasterGen->event).append(particleID, 23, colorindex, 0, px, py, pz, ee, mass);
+        if (!fAddAntiParticle)
+          colorindex += 1;
+      } else if (std::abs(particleID) == 21) {  // gluons
+        (fMasterGen->event).append(21, 23, colorindex, colorindex + 1, px, py, pz, ee, mass);
+        if (!fAddAntiParticle) {
+          colorindex += 2;
+        }
+      }
+      // other
+      else {
+        (fMasterGen->event).append(particleID, 1, 0, 0, px, py, pz, ee, mass);
+        int eventSize = (fMasterGen->event).size() - 1;
+        // -log(flat) = exponential distribution
+        double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+        (fMasterGen->event)[eventSize].tau(tauTmp);
       }
 
-   }
-   
-   if ( !fMasterGen->next() ) return false;
-   evtGenDecay();
+      // Here also need to add anti-particle (if any)
+      // otherwise just add a 2nd particle of the same type
+      // (for example, gamma)
+      //
+      if (fAddAntiParticle) {
+        if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
+          (fMasterGen->event).append(-particleID, 23, 0, colorindex, -px, -py, -pz, ee, mass);
+          colorindex += 1;
+        } else if (std::abs(particleID) == 21) {  // gluons
+          (fMasterGen->event).append(21, 23, colorindex + 1, colorindex, -px, -py, -pz, ee, mass);
+          colorindex += 2;
+        } else {
+          if ((fMasterGen->particleData).isParticle(-particleID)) {
+            (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
+          } else {
+            (fMasterGen->event).append(particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
+          }
+          int eventSize = (fMasterGen->event).size() - 1;
+          // -log(flat) = exponential distribution
+          double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+          (fMasterGen->event)[eventSize].tau(tauTmp);
+        }
+      }
+    }
 
-   event().reset(new HepMC::GenEvent);
-   return toHepMC.fill_next_event( fMasterGen->event, event().get() );
-  
-}
+    if (!fMasterGen->next())
+      return false;
+    evtGenDecay();
 
-const char* Py8EGun::classname() const
-{
-   return "Py8EGun"; 
-}
+    event().reset(new HepMC::GenEvent);
+    return toHepMC.fill_next_event(fMasterGen->event, event().get());
+  }
 
-typedef edm::GeneratorFilter<gen::Py8EGun, gen::ExternalDecayDriver> Pythia8EGun;
+  const char* Py8EGun::classname() const { return "Py8EGun"; }
 
-} // end namespace
+  typedef edm::GeneratorFilter<gen::Py8EGun, gen::ExternalDecayDriver> Pythia8EGun;
+
+}  // namespace gen
 
 using gen::Pythia8EGun;
 DEFINE_FWK_MODULE(Pythia8EGun);


### PR DESCRIPTION
#### if this PR is a backport please specify the original PR and why you need to backport that PR
Backport for PR #29000 to CMSSW_9_3_17 for MC production (Fall17GS campaign). #29000 already approved and merged.

#### PR description (from original request):

Changes for proper treatment of color (conservation and codes):

- Increasing color index after generating one particle (anti particle obtains the same color, just on the anticolor column)
- Adding a check that if only colored particles are generated, the AddAntiParticle option is used to make sure that all colors are balanced
- Only affecting pythia8 EGun

#### PR validation (from original request):

Ran some tests locally with a core CMSSW script:

- not set AddAntiParticle at all (does not start, option must be set)
- set option to False (runs but does not generate anything and throws errors)
- set option to True (as expected: anti particle gets same anti color as particle gets color, index is not the same for two different particles)

