### PR TITLE
L1T EMTF fix for pT assignment bug in UL2016 MC processing (CMSSW_10_6_X)

### DIFF
--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -131,10 +131,15 @@ simEmtfDigisData = simEmtfDigisMC.clone(
 simEmtfDigis = simEmtfDigisMC.clone()
 
 
-## Era: Run2_2016
-#from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-#stage2L1Trigger.toModify(simEmtfDigis, RPCEnable = cms.bool(False), Era = cms.string('Run2_2016'))
+## Load "Era" modules to adjust RPCEnable and Era (which controls the choice of PtAssignmentEngine)
+## If neither 'Run2_2016' nor 'Run2_2017' are invoked, default 2018 settings are used
+## Era configuration files are located in Configuration/Eras/python
 
-## Era: Run2_2017
-#from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-#stage2L1Trigger_2017.toModify(simEmtfDigis, RPCEnable = cms.bool(True), Era = cms.string('Run2_2017'))
+## Era: Run2_2016
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(simEmtfDigis, RPCEnable = cms.bool(False), Era = cms.string('Run2_2016'))
+
+# ## Era: Run2_2017
+# ## Run2_2017 fix disabled for UL2016 processing with CMSSW_10_6_X
+# from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
+# stage2L1Trigger_2017.toModify(simEmtfDigis, RPCEnable = cms.bool(True), Era = cms.string('Run2_2017'))

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
@@ -72,8 +72,9 @@ void PtAssignment::process(
       address = pt_assign_engine_->calculate_address(track);
       xmlpt   = pt_assign_engine_->calculate_pt(address);
 
-      // Check address packing / unpacking
-      if (not( fabs(xmlpt - pt_assign_engine_->calculate_pt(track)) < 0.001 ) )
+      // Check address packing / unpacking using PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track)
+      if (pt_assign_engine_->get_pt_lut_version() > 5 &&
+          not( fabs(xmlpt - pt_assign_engine_->calculate_pt(track)) < 0.001 ) )
         { edm::LogWarning("L1T") << "EMTF pT assignment mismatch: xmlpt = " << xmlpt
                                  << ", pt_assign_engine_->calculate_pt(track)) = "
                                  << pt_assign_engine_->calculate_pt(track); }


### PR DESCRIPTION
Back-port of https://github.com/cms-sw/cmssw/pull/29080 to CMSSW_10_6_X, fixing only 2016 configuration issues (not 2017).

@srimanob , @rekovic , @davignon , @BenjaminRS , @jiafulow 