### PR TITLE
Remove parameters of GsfElectronBaseProducer not used after #28429

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -56,7 +56,6 @@ public:
   };
 
   struct Tokens {
-    edm::EDGetTokenT<reco::GsfElectronCollection> pflowGsfElectronsTag;
     edm::EDGetTokenT<reco::GsfElectronCoreCollection> gsfElectronCores;
     edm::EDGetTokenT<CaloTowerCollection> hcalTowersTag;
     edm::EDGetTokenT<reco::SuperClusterCollection> barrelSuperClusters;
@@ -66,13 +65,11 @@ public:
     edm::EDGetTokenT<reco::ElectronSeedCollection> seedsTag;
     edm::EDGetTokenT<reco::TrackCollection> ctfTracks;
     edm::EDGetTokenT<reco::BeamSpot> beamSpotTag;
-    edm::EDGetTokenT<reco::GsfPFRecTrackCollection> gsfPfRecTracksTag;
     edm::EDGetTokenT<reco::VertexCollection> vtxCollectionTag;
     edm::EDGetTokenT<reco::ConversionCollection> conversions;
   };
 
   struct StrategyConfiguration {
-    bool useGsfPfRecTracks;
     // if true, electron preselection is applied
     bool applyPreselection;
     // if true, electron level escale corrections are
@@ -84,8 +81,6 @@ public:
     bool applyAmbResolution;              // if not true, ambiguity solving is not applied
     unsigned ambSortingStrategy;          // 0:isBetter, 1:isInnermost
     unsigned ambClustersOverlapStrategy;  // 0:sc adresses, 1:bc shared energy
-    // if true, trackerDriven electrons are added
-    bool addPflowElectrons;
     // for backward compatibility
     bool ctfTracksCheck;
     float PreSelectMVA;

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -46,9 +46,6 @@
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-#include <list>
-#include <string>
-
 class GsfElectronAlgo {
 public:
   class HeavyObjectCache {
@@ -59,7 +56,6 @@ public:
   };
 
   struct Tokens {
-    edm::EDGetTokenT<reco::GsfElectronCollection> previousGsfElectrons;
     edm::EDGetTokenT<reco::GsfElectronCollection> pflowGsfElectronsTag;
     edm::EDGetTokenT<reco::GsfElectronCoreCollection> gsfElectronCores;
     edm::EDGetTokenT<CaloTowerCollection> hcalTowersTag;
@@ -92,7 +88,6 @@ public:
     bool addPflowElectrons;
     // for backward compatibility
     bool ctfTracksCheck;
-    bool gedElectronMode;
     float PreSelectMVA;
     float MaxElePtForOnlyMVA;
     // GED-Regression (ECAL and combination)
@@ -184,9 +179,7 @@ public:
   GsfElectronAlgo(const Tokens&,
                   const StrategyConfiguration&,
                   const CutsConfiguration& cutsCfg,
-                  const CutsConfiguration& cutsCfgPflow,
                   const ElectronHcalHelper::Configuration& hcalCfg,
-                  const ElectronHcalHelper::Configuration& hcalCfgPflow,
                   const IsolationConfiguration&,
                   const EcalRecHitsConfiguration&,
                   std::unique_ptr<EcalClusterFunctionBaseClass>&& superClusterErrorFunction,
@@ -199,10 +192,9 @@ public:
                   edm::ConsumesCollector&& cc);
 
   // main methods
-  void completeElectrons(reco::GsfElectronCollection& electrons,  // do not redo cloned electrons done previously
-                         edm::Event const& event,
-                         edm::EventSetup const& eventSetup,
-                         const HeavyObjectCache* hoc);
+  reco::GsfElectronCollection completeElectrons(edm::Event const& event,
+                                                edm::EventSetup const& eventSetup,
+                                                const HeavyObjectCache* hoc);
 
 private:
   // internal structures
@@ -212,7 +204,6 @@ private:
     const Tokens tokens;
     const StrategyConfiguration strategy;
     const CutsConfiguration cuts;
-    const CutsConfiguration cutsPflow;
     const IsolationConfiguration iso;
     const EcalRecHitsConfiguration recHits;
   };
@@ -264,7 +255,6 @@ private:
 
   // additional configuration and helpers
   ElectronHcalHelper hcalHelper_;
-  ElectronHcalHelper hcalHelperPflow_;
   std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction_;
   std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction_;
   RegressionHelper regHelper_;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -58,13 +58,11 @@ struct GsfElectronAlgo::EventData {
   const reco::BeamSpot* beamspot;
 
   // input collections
-  edm::Handle<reco::GsfElectronCollection> pflowElectrons;
   edm::Handle<reco::GsfElectronCoreCollection> coreElectrons;
   edm::Handle<EcalRecHitCollection> barrelRecHits;
   edm::Handle<EcalRecHitCollection> endcapRecHits;
   edm::Handle<reco::TrackCollection> currentCtfTracks;
   edm::Handle<reco::ElectronSeedCollection> seeds;
-  edm::Handle<reco::GsfPFRecTrackCollection> gsfPfRecTracks;
   edm::Handle<reco::VertexCollection> vertices;
   edm::Handle<reco::ConversionCollection> conversions;
 
@@ -431,14 +429,11 @@ GsfElectronAlgo::EventData GsfElectronAlgo::beginEvent(edm::Event const& event,
   EventData eventData{
       .event = &event,
       .beamspot = &event.get(cfg_.tokens.beamSpotTag),
-      .pflowElectrons = event.getHandle(cfg_.tokens.pflowGsfElectronsTag),
       .coreElectrons = event.getHandle(cfg_.tokens.gsfElectronCores),
       .barrelRecHits = barrelRecHits,
       .endcapRecHits = endcapRecHits,
       .currentCtfTracks = event.getHandle(cfg_.tokens.ctfTracks),
       .seeds = event.getHandle(cfg_.tokens.seedsTag),
-      .gsfPfRecTracks = cfg_.strategy.useGsfPfRecTracks ? event.getHandle(cfg_.tokens.gsfPfRecTracksTag)
-                                                        : edm::Handle<reco::GsfPFRecTrackCollection>{},
       .vertices = event.getHandle(cfg_.tokens.vtxCollectionTag),
       .conversions = cfg_.strategy.fillConvVtxFitProb ? event.getHandle(cfg_.tokens.conversions)
                                                       : edm::Handle<reco::ConversionCollection>(),

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -58,7 +58,6 @@ struct GsfElectronAlgo::EventData {
   const reco::BeamSpot* beamspot;
 
   // input collections
-  edm::Handle<reco::GsfElectronCollection> previousElectrons;
   edm::Handle<reco::GsfElectronCollection> pflowElectrons;
   edm::Handle<reco::GsfElectronCoreCollection> coreElectrons;
   edm::Handle<EcalRecHitCollection> barrelRecHits;
@@ -76,11 +75,6 @@ struct GsfElectronAlgo::EventData {
   EgammaTowerIsolation hadDepth2Isolation03Bc, hadDepth2Isolation04Bc;
   EgammaRecHitIsolation ecalBarrelIsol03, ecalBarrelIsol04;
   EgammaRecHitIsolation ecalEndcapIsol03, ecalEndcapIsol04;
-
-  //Isolation Value Maps for PF and EcalDriven electrons
-  typedef std::vector<edm::Handle<edm::ValueMap<double>>> IsolationValueMaps;
-  IsolationValueMaps pfIsolationValues;
-  IsolationValueMaps edIsolationValues;
 
   edm::Handle<reco::TrackCollection> originalCtfTracks;
   edm::Handle<reco::GsfTrackCollection> originalGsfTracks;
@@ -370,9 +364,7 @@ reco::GsfElectron::ShowerShape GsfElectronAlgo::calculateShowerShape(const reco:
 GsfElectronAlgo::GsfElectronAlgo(const Tokens& input,
                                  const StrategyConfiguration& strategy,
                                  const CutsConfiguration& cuts,
-                                 const CutsConfiguration& cutsPflow,
                                  const ElectronHcalHelper::Configuration& hcal,
-                                 const ElectronHcalHelper::Configuration& hcalPflow,
                                  const IsolationConfiguration& iso,
                                  const EcalRecHitsConfiguration& recHits,
                                  std::unique_ptr<EcalClusterFunctionBaseClass>&& superClusterErrorFunction,
@@ -383,7 +375,7 @@ GsfElectronAlgo::GsfElectronAlgo(const Tokens& input,
                                  const edm::ParameterSet& tkIsolHEEP03,
                                  const edm::ParameterSet& tkIsolHEEP04,
                                  edm::ConsumesCollector&& cc)
-    : cfg_{input, strategy, cuts, cutsPflow, iso, recHits},
+    : cfg_{input, strategy, cuts, iso, recHits},
       tkIsol03Calc_(tkIsol03),
       tkIsol04Calc_(tkIsol04),
       tkIsolHEEP03Calc_(tkIsolHEEP03),
@@ -394,7 +386,6 @@ GsfElectronAlgo::GsfElectronAlgo(const Tokens& input,
       trackerGeometryToken_{cc.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()},
       ecalSeveretyLevelAlgoToken_{cc.esConsumes<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd>()},
       hcalHelper_{hcal},
-      hcalHelperPflow_{hcalPflow},
       superClusterErrorFunction_{
           std::forward<std::unique_ptr<EcalClusterFunctionBaseClass>>(superClusterErrorFunction)},
       crackCorrectionFunction_{std::forward<std::unique_ptr<EcalClusterFunctionBaseClass>>(crackCorrectionFunction)},
@@ -404,7 +395,6 @@ GsfElectronAlgo::GsfElectronAlgo(const Tokens& input,
 
 void GsfElectronAlgo::checkSetup(const edm::EventSetup& es) {
   hcalHelper_.checkSetup(es);
-  hcalHelperPflow_.checkSetup(es);
   if (cfg_.strategy.useEcalRegression || cfg_.strategy.useCombinationRegression)
     regHelper_.checkSetup(es);
 
@@ -421,7 +411,6 @@ GsfElectronAlgo::EventData GsfElectronAlgo::beginEvent(edm::Event const& event,
                                                        EcalSeverityLevelAlgo const& ecalSeveretyLevelAlgo) {
   // prepare access to hcal data
   hcalHelper_.readEvent(event);
-  hcalHelperPflow_.readEvent(event);
 
   auto const& towers = event.get(cfg_.tokens.hcalTowersTag);
 
@@ -442,7 +431,6 @@ GsfElectronAlgo::EventData GsfElectronAlgo::beginEvent(edm::Event const& event,
   EventData eventData{
       .event = &event,
       .beamspot = &event.get(cfg_.tokens.beamSpotTag),
-      .previousElectrons = event.getHandle(cfg_.tokens.previousGsfElectrons),
       .pflowElectrons = event.getHandle(cfg_.tokens.pflowGsfElectronsTag),
       .coreElectrons = event.getHandle(cfg_.tokens.gsfElectronCores),
       .barrelRecHits = barrelRecHits,
@@ -506,8 +494,6 @@ GsfElectronAlgo::EventData GsfElectronAlgo::beginEvent(edm::Event const& event,
                                                 *endcapRecHits,
                                                 &ecalSeveretyLevelAlgo,
                                                 DetId::Ecal),
-      .pfIsolationValues = {},
-      .edIsolationValues = {},
       .originalCtfTracks = {},
       .originalGsfTracks = {}};
 
@@ -535,10 +521,11 @@ GsfElectronAlgo::EventData GsfElectronAlgo::beginEvent(edm::Event const& event,
   return eventData;
 }
 
-void GsfElectronAlgo::completeElectrons(reco::GsfElectronCollection& electrons,
-                                        edm::Event const& event,
-                                        edm::EventSetup const& eventSetup,
-                                        const GsfElectronAlgo::HeavyObjectCache* hoc) {
+reco::GsfElectronCollection GsfElectronAlgo::completeElectrons(edm::Event const& event,
+                                                               edm::EventSetup const& eventSetup,
+                                                               const GsfElectronAlgo::HeavyObjectCache* hoc) {
+  reco::GsfElectronCollection electrons;
+
   auto const& magneticField = eventSetup.getData(magneticFieldToken_);
   auto const& caloGeometry = eventSetup.getData(caloGeometryToken_);
   auto const& caloTopology = eventSetup.getData(caloTopologyToken_);
@@ -581,6 +568,7 @@ void GsfElectronAlgo::completeElectrons(reco::GsfElectronCollection& electrons,
         electrons, electronData, eventData, caloTopology, caloGeometry, mtsTransform, magneticFieldInTesla, hoc);
 
   }  // loop over tracks
+  return electrons;
 }
 
 void GsfElectronAlgo::setCutBasedPreselectionFlag(GsfElectron& ele, const reco::BeamSpot& bs) const {
@@ -590,7 +578,6 @@ void GsfElectronAlgo::setCutBasedPreselectionFlag(GsfElectron& ele, const reco::
   // kind of seeding
   bool eg = ele.core()->ecalDrivenSeed();
   bool pf = ele.core()->trackerDrivenSeed() && !ele.core()->ecalDrivenSeed();
-  bool gedMode = cfg_.strategy.gedElectronMode;
   if (eg && pf) {
     throw cms::Exception("GsfElectronAlgo|BothEcalAndPureTrackerDriven")
         << "An electron cannot be both egamma and purely pflow";
@@ -600,28 +587,28 @@ void GsfElectronAlgo::setCutBasedPreselectionFlag(GsfElectron& ele, const reco::
         << "An electron cannot be neither egamma nor purely pflow";
   }
 
-  const CutsConfiguration* cfg = ((eg || gedMode) ? &cfg_.cuts : &cfg_.cutsPflow);
+  CutsConfiguration const& cfg = cfg_.cuts;
 
   // Et cut
   double etaValue = EleRelPoint(ele.superCluster()->position(), bs.position()).eta();
   double etValue = ele.superCluster()->energy() / cosh(etaValue);
   LogTrace("GsfElectronAlgo") << "Et : " << etValue;
-  if (ele.isEB() && (etValue < cfg->minSCEtBarrel))
+  if (ele.isEB() && (etValue < cfg.minSCEtBarrel))
     return;
-  if (ele.isEE() && (etValue < cfg->minSCEtEndcaps))
+  if (ele.isEE() && (etValue < cfg.minSCEtEndcaps))
     return;
   LogTrace("GsfElectronAlgo") << "Et criteria are satisfied";
 
   // E/p cut
   double eopValue = ele.eSuperClusterOverP();
   LogTrace("GsfElectronAlgo") << "E/p : " << eopValue;
-  if (ele.isEB() && (eopValue > cfg->maxEOverPBarrel))
+  if (ele.isEB() && (eopValue > cfg.maxEOverPBarrel))
     return;
-  if (ele.isEE() && (eopValue > cfg->maxEOverPEndcaps))
+  if (ele.isEE() && (eopValue > cfg.maxEOverPEndcaps))
     return;
-  if (ele.isEB() && (eopValue < cfg->minEOverPBarrel))
+  if (ele.isEB() && (eopValue < cfg.minEOverPBarrel))
     return;
-  if (ele.isEE() && (eopValue < cfg->minEOverPEndcaps))
+  if (ele.isEE() && (eopValue < cfg.minEOverPEndcaps))
     return;
   LogTrace("GsfElectronAlgo") << "E/p criteria are satisfied";
 
@@ -635,11 +622,11 @@ void GsfElectronAlgo::setCutBasedPreselectionFlag(GsfElectron& ele, const reco::
   double scle = ele.superCluster()->energy();
 
   if (detector == EcalBarrel)
-    HoEveto = hoeCone * scle < cfg->maxHBarrelCone || hoeTower * scle < cfg->maxHBarrelTower ||
-              hoeCone < cfg->maxHOverEBarrelCone || hoeTower < cfg->maxHOverEBarrelTower;
+    HoEveto = hoeCone * scle < cfg.maxHBarrelCone || hoeTower * scle < cfg.maxHBarrelTower ||
+              hoeCone < cfg.maxHOverEBarrelCone || hoeTower < cfg.maxHOverEBarrelTower;
   else if (detector == EcalEndcap)
-    HoEveto = hoeCone * scle < cfg->maxHEndcapsCone || hoeTower * scle < cfg->maxHEndcapsTower ||
-              hoeCone < cfg->maxHOverEEndcapsCone || hoeTower < cfg->maxHOverEEndcapsTower;
+    HoEveto = hoeCone * scle < cfg.maxHEndcapsCone || hoeTower * scle < cfg.maxHEndcapsTower ||
+              hoeCone < cfg.maxHOverEEndcapsCone || hoeTower < cfg.maxHOverEEndcapsTower;
 
   if (!HoEveto)
     return;
@@ -648,35 +635,35 @@ void GsfElectronAlgo::setCutBasedPreselectionFlag(GsfElectron& ele, const reco::
   // delta eta criteria
   double deta = ele.deltaEtaSuperClusterTrackAtVtx();
   LogTrace("GsfElectronAlgo") << "delta eta : " << deta;
-  if (ele.isEB() && (std::abs(deta) > cfg->maxDeltaEtaBarrel))
+  if (ele.isEB() && (std::abs(deta) > cfg.maxDeltaEtaBarrel))
     return;
-  if (ele.isEE() && (std::abs(deta) > cfg->maxDeltaEtaEndcaps))
+  if (ele.isEE() && (std::abs(deta) > cfg.maxDeltaEtaEndcaps))
     return;
   LogTrace("GsfElectronAlgo") << "Delta eta criteria are satisfied";
 
   // delta phi criteria
   double dphi = ele.deltaPhiSuperClusterTrackAtVtx();
   LogTrace("GsfElectronAlgo") << "delta phi : " << dphi;
-  if (ele.isEB() && (std::abs(dphi) > cfg->maxDeltaPhiBarrel))
+  if (ele.isEB() && (std::abs(dphi) > cfg.maxDeltaPhiBarrel))
     return;
-  if (ele.isEE() && (std::abs(dphi) > cfg->maxDeltaPhiEndcaps))
+  if (ele.isEE() && (std::abs(dphi) > cfg.maxDeltaPhiEndcaps))
     return;
   LogTrace("GsfElectronAlgo") << "Delta phi criteria are satisfied";
 
   // sigma ieta ieta
   LogTrace("GsfElectronAlgo") << "sigma ieta ieta : " << ele.sigmaIetaIeta();
-  if (ele.isEB() && (ele.sigmaIetaIeta() > cfg->maxSigmaIetaIetaBarrel))
+  if (ele.isEB() && (ele.sigmaIetaIeta() > cfg.maxSigmaIetaIetaBarrel))
     return;
-  if (ele.isEE() && (ele.sigmaIetaIeta() > cfg->maxSigmaIetaIetaEndcaps))
+  if (ele.isEE() && (ele.sigmaIetaIeta() > cfg.maxSigmaIetaIetaEndcaps))
     return;
   LogTrace("GsfElectronAlgo") << "Sigma ieta ieta criteria are satisfied";
 
   // fiducial
-  if (!ele.isEB() && cfg->isBarrel)
+  if (!ele.isEB() && cfg.isBarrel)
     return;
-  if (!ele.isEE() && cfg->isEndcaps)
+  if (!ele.isEE() && cfg.isEndcaps)
     return;
-  if (cfg->isFiducial &&
+  if (cfg.isFiducial &&
       (ele.isEBEEGap() || ele.isEBEtaGap() || ele.isEBPhiGap() || ele.isEERingGap() || ele.isEEDeeGap()))
     return;
   LogTrace("GsfElectronAlgo") << "Fiducial flags criteria are satisfied";
@@ -694,7 +681,7 @@ void GsfElectronAlgo::setCutBasedPreselectionFlag(GsfElectron& ele, const reco::
   }
 
   // transverse impact parameter
-  if (std::abs(ele.gsfTrack()->dxy(bs.position())) > cfg->maxTIP)
+  if (std::abs(ele.gsfTrack()->dxy(bs.position())) > cfg.maxTIP)
     return;
   LogTrace("GsfElectronAlgo") << "TIP criterion is satisfied";
 
@@ -843,11 +830,9 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
   reco::GsfElectron::ShowerShape showerShape;
   reco::GsfElectron::ShowerShape full5x5_showerShape;
   if (!EcalTools::isHGCalDet((DetId::Detector)region)) {
-    const bool pflow = !(electronData.coreRef->ecalDrivenSeed());
-    auto const& hcalHelper = pflow ? hcalHelperPflow_ : hcalHelper_;
-    showerShape = calculateShowerShape<false>(electronData.superClusterRef, hcalHelper, eventData, topology, geometry);
+    showerShape = calculateShowerShape<false>(electronData.superClusterRef, hcalHelper_, eventData, topology, geometry);
     full5x5_showerShape =
-        calculateShowerShape<true>(electronData.superClusterRef, hcalHelper, eventData, topology, geometry);
+        calculateShowerShape<true>(electronData.superClusterRef, hcalHelper_, eventData, topology, geometry);
   }
 
   //====================================================

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -55,13 +55,6 @@ protected:
   const GsfElectronAlgo::CutsConfiguration cutsCfg_;
   ElectronHcalHelper::Configuration hcalCfg_;
 
-  // used to make some provenance checks
-  edm::EDGetTokenT<edm::ValueMap<float>> pfMVA_;
-
-  //IsoVals (PF and EcalDriven)
-  edm::ParameterSet pfIsoVals_;
-  edm::ParameterSet edIsoVals_;
-
 private:
   bool isPreselected(reco::GsfElectron const& ele) const;
   void setAmbiguityData(reco::GsfElectronCollection& electrons,
@@ -74,7 +67,10 @@ private:
 
   const edm::EDPutTokenT<reco::GsfElectronCollection> electronPutToken_;
 
+  const edm::EDGetTokenT<reco::GsfPFRecTrackCollection> gsfPfRecTracksTag_;
+
   const bool gedElectronMode_;
+  const bool useGsfPfRecTracks_;
 };
 
 #endif

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -38,8 +38,7 @@ public:
 
   // ------------ method called to produce the data  ------------
   void produce(edm::Event& event, const edm::EventSetup& setup) override {
-    reco::GsfElectronCollection electrons;
-    algo_->completeElectrons(electrons, event, setup, globalCache());
+    auto electrons = algo_->completeElectrons(event, setup, globalCache());
     fillEvent(electrons, event);
   }
 
@@ -47,16 +46,14 @@ protected:
   std::unique_ptr<GsfElectronAlgo> algo_;
 
   void beginEvent(edm::Event&, const edm::EventSetup&);
-  void fillEvent(reco::GsfElectronCollection& electrons, edm::Event& event);
-  const edm::OrphanHandle<reco::GsfElectronCollection>& orphanHandle() const { return orphanHandle_; }
+  const edm::OrphanHandle<reco::GsfElectronCollection> fillEvent(reco::GsfElectronCollection& electrons,
+                                                                 edm::Event& event);
 
   // configurables
   GsfElectronAlgo::Tokens inputCfg_;
   GsfElectronAlgo::StrategyConfiguration strategyCfg_;
   const GsfElectronAlgo::CutsConfiguration cutsCfg_;
-  const GsfElectronAlgo::CutsConfiguration cutsCfgPflow_;
   ElectronHcalHelper::Configuration hcalCfg_;
-  ElectronHcalHelper::Configuration hcalCfgPflow_;
 
   // used to make some provenance checks
   edm::EDGetTokenT<edm::ValueMap<float>> pfMVA_;
@@ -74,9 +71,10 @@ private:
   // check expected configuration of previous modules
   bool ecalSeedingParametersChecked_;
   void checkEcalSeedingParameters(edm::ParameterSet const&);
-  edm::OrphanHandle<reco::GsfElectronCollection> orphanHandle_;
 
   const edm::EDPutTokenT<reco::GsfElectronCollection> electronPutToken_;
+
+  const bool gedElectronMode_;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

As a follow up on https://github.com/cms-sw/cmssw/pull/28429, I suggest to remove many of the electron producer configuration parameters that are not needed anymore. That concerns in particular all the selection cuts and HcalHelper parameters which are duplicate right now and don't need to be (in the past there were different cuts for tracker-driven and ecal-driven but that's not used anymore).

#### PR validation:

CMSSW compiles and local matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.