### PR TITLE
Remove drop and update the event content formats

### DIFF
--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -2,24 +2,6 @@
 
 import FWCore.ParameterSet.Config as cms
 
-# Full Event content 
-RecoLocalMuonFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_dt1DRecHits_*_*', 
-        'keep *_dt4DSegments_*_*', 
-        'keep *_csc2DRecHits_*_*', 
-        'keep *_cscSegments_*_*', 
-        'keep *_rpcRecHits_*_*')
-)
-# RECO content
-RecoLocalMuonRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_dt1DRecHits_*_*', 
-        'keep *_dt4DSegments_*_*', 
-        'keep *_dt1DCosmicRecHits_*_*',
-        'keep *_dt4DCosmicSegments_*_*',
-        'keep *_csc2DRecHits_*_*', 
-        'keep *_cscSegments_*_*', 
-        'keep *_rpcRecHits_*_*')
-)
 # AOD content
 RecoLocalMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -28,14 +10,33 @@ RecoLocalMuonAOD = cms.PSet(
         'keep *_cscSegments_*_*', 
         'keep *_rpcRecHits_*_*')
 )
-def _updateOutput( era, outputPSets, commands):
-   for o in outputPSets:
-      era.toModify( o, outputCommands = o.outputCommands + commands )
-
+#def _updateOutput( era, outputPSets, commands):
+#   for o in outputPSets:
+#      era.toModify( o, outputCommands = o.outputCommands + commands )
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-_outputs = [RecoLocalMuonFEVT, RecoLocalMuonRECO, RecoLocalMuonAOD]
-_updateOutput( run2_GEM_2017, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
-_updateOutput( run3_GEM, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
-_updateOutput(phase2_muon, _outputs, ['keep *_me0RecHits_*_*', 'keep *_me0Segments_*_*'])
+for e in [run2_GEM_2017, run3_GEM]:
+    e.toModify( RecoLocalMuonAOD, 
+                outputCommands = RecoLocalMuonAOD.outputCommands + [
+        'keep *_gemRecHits_*_*', 
+        'keep *_gemSegments_*_*'])
+
+phase2_muon.toModify( RecoLocalMuonAOD, 
+    outputCommands = RecoLocalMuonAOD.outputCommands + [
+        'keep *_me0RecHits_*_*', 
+        'keep *_me0Segments_*_*'])
+
+# RECO content
+RecoLocalMuonRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring('keep *_dt1DRecHits_*_*', 
+        'keep *_dt1DCosmicRecHits_*_*',
+        'keep *_csc2DRecHits_*_*')
+)
+RecoLocalMuonRECO.outputCommands.extend(RecoLocalMuonAOD.outputCommands)
+
+# Full Event content 
+RecoLocalMuonFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoLocalMuonFEVT.outputCommands.extend(RecoLocalMuonRECO.outputCommands)

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -10,9 +10,6 @@ RecoLocalMuonAOD = cms.PSet(
         'keep *_cscSegments_*_*', 
         'keep *_rpcRecHits_*_*')
 )
-#def _updateOutput( era, outputPSets, commands):
-#   for o in outputPSets:
-#      era.toModify( o, outputCommands = o.outputCommands + commands )
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon

--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_EventContent_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_EventContent_cff.py
@@ -1,15 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content 
-RecoLocalTrackerFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-    'keep DetIdedmEDCollection_siStripDigis_*_*',
-    'keep DetIdedmEDCollection_siPixelDigis_*_*',
-    'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*',
-    'keep *_siPixelClusters_*_*', 
-    'keep *_siStripClusters_*_*',
-    'keep *_clusterSummaryProducer_*_*')
+#AOD content
+RecoLocalTrackerAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring('keep ClusterSummary_clusterSummaryProducer_*_*')
 )
+from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+egamma_lowPt_exclusive.toModify( RecoLocalTrackerAOD,
+    outputCommands = RecoLocalTrackerAOD.outputCommands + ['keep *_siPixelRecHits_*_*', 
+							   'keep *_siPixelClusters_*_*'])
 #RECO content
 RecoLocalTrackerRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -17,21 +15,17 @@ RecoLocalTrackerRECO = cms.PSet(
     'keep DetIdedmEDCollection_siPixelDigis_*_*',
     'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*',
     'keep *_siPixelClusters_*_*', 
-    'keep *_siStripClusters_*_*',
-    'keep ClusterSummary_clusterSummaryProducer_*_*')
+    'keep *_siStripClusters_*_*')
 )
-#AOD content
-RecoLocalTrackerAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep ClusterSummary_clusterSummaryProducer_*_*')
-)
+RecoLocalTrackerRECO.outputCommands.extend(RecoLocalTrackerAOD.outputCommands)
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(RecoLocalTrackerFEVT, outputCommands = RecoLocalTrackerFEVT.outputCommands + ['keep *_siPhase2Clusters_*_*'] )
 phase2_tracker.toModify(RecoLocalTrackerRECO, outputCommands = RecoLocalTrackerRECO.outputCommands + ['keep *_siPhase2Clusters_*_*'] )
 
-from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
-egamma_lowPt_exclusive.toModify( RecoLocalTrackerAOD,
-    outputCommands = RecoLocalTrackerAOD.outputCommands + ['keep *_siPixelRecHits_*_*', 
-							   'keep *_siPixelClusters_*_*'])
+#Full Event content 
+RecoLocalTrackerFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring('keep *_clusterSummaryProducer_*_*')
+)
+RecoLocalTrackerFEVT.outputCommands.extend(RecoLocalTrackerRECO.outputCommands)
 
-
+phase2_tracker.toModify(RecoLocalTrackerFEVT, outputCommands = RecoLocalTrackerFEVT.outputCommands + ['keep *_siPhase2Clusters_*_*'] )

--- a/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
+++ b/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
@@ -1,62 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-##______________________________________________________ Full Event content __||
-RecoMETFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoCaloMETs_caloMet_*_*',
-                                           'keep recoCaloMETs_caloMetBE_*_*',
-                                           'keep recoCaloMETs_caloMetBEFO_*_*',
-                                           'keep recoCaloMETs_caloMetM_*_*',
-                                           'keep recoPFMETs_pfMet_*_*',
-                                           'keep recoPFMETs_pfChMet_*_*',
-                                           'keep recoMuonMETCorrectionDataedmValueMap_muonMETValueMapProducer_*_*',
-                                           'keep recoHcalNoiseRBXs_hcalnoise_*_*',
-                                           'keep HcalNoiseSummary_hcalnoise_*_*',
-                                           'keep *HaloData_*_*_*',
-                                           'keep *BeamHaloSummary_BeamHaloSummary_*_*'
-                                           )
-    )
-
-RecoGenMETFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoGenMETs_*_*_*')
-    )
-
-RecoHcalNoiseFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoHcalNoiseRBXs_hcalnoise_*_*',
-                                           'keep HcalNoiseSummary_hcalnoise_*_*'
-                                           )
-    )
-
-##____________________________________________________________ RECO content __||
-RecoMETRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoCaloMETs_caloMet_*_*',
-                                           'keep recoCaloMETs_caloMetBE_*_*',
-                                           'keep recoCaloMETs_caloMetBEFO_*_*',
-                                           'keep recoCaloMETs_caloMetM_*_*',
-                                           'keep recoPFMETs_pfMet_*_*',
-                                           'keep recoPFMETs_pfChMet_*_*',
-                                           'keep recoPFMETs_pfMetEI_*_*',
-                                           'keep recoMuonMETCorrectionDataedmValueMap_muonMETValueMapProducer_*_*',
-                                           'keep recoHcalNoiseRBXs_hcalnoise_*_*',
-                                           'keep HcalNoiseSummary_hcalnoise_*_*',
-                                           #'keep *HaloData_*_*_*',
-                                           'keep recoCSCHaloData_CSCHaloData_*_*',
-                                           'keep recoEcalHaloData_EcalHaloData_*_*',
-                                           'keep recoGlobalHaloData_GlobalHaloData_*_*',
-                                           'keep recoHcalHaloData_HcalHaloData_*_*',
-                                           'keep recoBeamHaloSummary_BeamHaloSummary_*_*'
-                                           )
-    )
-
-RecoGenMETRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoGenMETs_*_*_*')
-    )
-
-RecoHcalNoiseRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoHcalNoiseRBXs_hcalnoise_*_*',
-                                           'keep HcalNoiseSummary_hcalnoise_*_*'
-                                           )
-    )
-
 ##_____________________________________________________________ AOD content __||
 RecoMETAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCaloMETs_caloMet_*_*',
@@ -67,7 +10,7 @@ RecoMETAOD = cms.PSet(
                                            'keep recoPFMETs_pfChMet_*_*',
                                            'keep recoPFMETs_pfMetEI_*_*',
                                            'keep recoMuonMETCorrectionDataedmValueMap_muonMETValueMapProducer_*_*',
-                                           'drop recoHcalNoiseRBXs_*_*_*',
+                                          # 'drop recoHcalNoiseRBXs_*_*_*',
                                            'keep HcalNoiseSummary_hcalnoise_*_*',
                                            #'keep *GlobalHaloData_*_*_*',
                                            'keep recoGlobalHaloData_GlobalHaloData_*_*',
@@ -81,9 +24,46 @@ RecoGenMETAOD = cms.PSet(
     )
 
 RecoHcalNoiseAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop recoHcalNoiseRBXs_hcalnoise_*_*',
+    outputCommands = cms.untracked.vstring( # 'drop recoHcalNoiseRBXs_hcalnoise_*_*',
                                            'keep HcalNoiseSummary_hcalnoise_*_*'
                                            )
     )
 
+##____________________________________________________________ RECO content __||
+RecoMETRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring('keep recoHcalNoiseRBXs_hcalnoise_*_*',
+                                           #'keep *HaloData_*_*_*',
+                                           'keep recoEcalHaloData_EcalHaloData_*_*',
+                                           'keep recoHcalHaloData_HcalHaloData_*_*'
+                                           )
+    )
+RecoMETRECO.outputCommands.extend(RecoMETAOD.outputCommands)
+
+RecoGenMETRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+    )
+RecoGenMETRECO.outputCommands.extend(RecoGenMETAOD.outputCommands)
+
+RecoHcalNoiseRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring('keep recoHcalNoiseRBXs_hcalnoise_*_*')
+    )
+RecoHcalNoiseRECO.outputCommands.extend(RecoHcalNoiseAOD.outputCommands)
+
+##______________________________________________________ Full Event content __||
+RecoMETFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring('keep *HaloData_*_*_*',
+                                           'keep *BeamHaloSummary_BeamHaloSummary_*_*'
+                                           )
+    )
+RecoMETFEVT.outputCommands.extend(RecoMETRECO.outputCommands)
+
+RecoGenMETFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+    )
+RecoGenMETFEVT.outputCommands.extend(RecoGenMETRECO.outputCommands)
+
+RecoHcalNoiseFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+    )
+RecoHcalNoiseFEVT.outputCommands.extend(RecoHcalNoiseRECO.outputCommands)
 ##____________________________________________________________________________||

--- a/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
@@ -2,59 +2,6 @@
 
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content 
-RecoTrackerFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep recoTracks_generalTracks_*_*', 
-        'keep recoTrackExtras_generalTracks_*_*',
-        'keep TrackingRecHitsOwned_generalTracks_*_*',
-        'keep *_generalTracks_MVAValues_*',
-        'keep TrackingRecHitsOwned_extraFromSeeds_*_*',
-        'keep uints_extraFromSeeds_*_*',                                   
-        'keep recoTracks_beamhaloTracks_*_*', 
-        'keep recoTrackExtras_beamhaloTracks_*_*', 
-        'keep TrackingRecHitsOwned_beamhaloTracks_*_*',
-        'keep recoTracks_conversionStepTracks_*_*', 
-        'keep recoTrackExtras_conversionStepTracks_*_*', 
-        'keep TrackingRecHitsOwned_conversionStepTracks_*_*',
-        'keep *_ctfPixelLess_*_*', 
-        'keep *_dedxTruncated40_*_*',
-        'keep *_dedxHitInfo_*_*',
-        'keep *_dedxHarmonic2_*_*',
-        'keep *_dedxPixelHarmonic2_*_*',
-        'keep *_trackExtrapolator_*_*',
-        'keep recoTracks_cosmicDCTracks_*_*',
-        'keep recoTrackExtras_cosmicDCTracks_*_*',
-        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*',
-     )
-)
-#RECO content
-RecoTrackerRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep recoTracks_generalTracks_*_*', 
-        'keep recoTrackExtras_generalTracks_*_*',
-        'keep TrackingRecHitsOwned_generalTracks_*_*',
-        'keep *_generalTracks_MVAValues_*',
-        'keep *_generalTracks_MVAVals_*',
-        'keep TrackingRecHitsOwned_extraFromSeeds_*_*',
-        'keep uints_extraFromSeeds_*_*',                                   
-        'keep recoTracks_beamhaloTracks_*_*', 
-        'keep recoTrackExtras_beamhaloTracks_*_*', 
-        'keep TrackingRecHitsOwned_beamhaloTracks_*_*',
-        'keep recoTracks_conversionStepTracks_*_*', 
-        'keep recoTrackExtras_conversionStepTracks_*_*', 
-        'keep TrackingRecHitsOwned_conversionStepTracks_*_*',
-        'keep *_ctfPixelLess_*_*', 
-        'keep *_dedxTruncated40_*_*',
-        'keep *_dedxHitInfo_*_*',
-        'keep *_dedxHarmonic2_*_*',
-        'keep *_dedxPixelHarmonic2_*_*',
-        'keep *_trackExtrapolator_*_*',
-        'keep recoTracks_cosmicDCTracks_*_*',
-        'keep recoTrackExtras_cosmicDCTracks_*_*',
-        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*',
-    )
-)
 #AOD content
 RecoTrackerAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -70,19 +17,38 @@ RecoTrackerAOD = cms.PSet(
         'keep *_generalTracks_MVAVals_*'
     )
 )
-
 #HI-specific products: needed in AOD, propagate to more inclusive tiers as well
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-for ec in [RecoTrackerAOD.outputCommands, RecoTrackerRECO.outputCommands, RecoTrackerFEVT.outputCommands]:
-      pp_on_AA_2018.toModify( ec, 
-                        func=lambda outputCommands: outputCommands.extend(['keep recoTracks_hiConformalPixelTracks_*_*',
-                                                                           ])
+pp_on_AA_2018.toModify( RecoTrackerAOD.outputCommands, 
+                        func=lambda outputCommands: outputCommands.extend(['keep recoTracks_hiConformalPixelTracks_*_*'])
                         )
-for ec in [RecoTrackerRECO.outputCommands, RecoTrackerFEVT.outputCommands]:
-      pp_on_AA_2018.toModify( ec, 
+#RECO content
+RecoTrackerRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep recoTrackExtras_generalTracks_*_*',
+        'keep TrackingRecHitsOwned_generalTracks_*_*',
+        'keep TrackingRecHitsOwned_extraFromSeeds_*_*',
+        'keep uints_extraFromSeeds_*_*',                                   
+        'keep recoTrackExtras_beamhaloTracks_*_*', 
+        'keep TrackingRecHitsOwned_beamhaloTracks_*_*',
+        'keep recoTrackExtras_conversionStepTracks_*_*', 
+        'keep TrackingRecHitsOwned_conversionStepTracks_*_*',
+        'keep *_ctfPixelLess_*_*', 
+        'keep *_dedxTruncated40_*_*',
+        'keep recoTracks_cosmicDCTracks_*_*',
+        'keep recoTrackExtras_cosmicDCTracks_*_*',
+        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*'
+    )
+)
+RecoTrackerRECO.outputCommands.extend(RecoTrackerAOD.outputCommands)
+pp_on_AA_2018.toModify( RecoTrackerRECO.outputCommands, 
                         func=lambda outputCommands: outputCommands.extend([
 			'keep recoTrackExtras_hiConformalPixelTracks_*_*',
                         'keep TrackingRecHitsOwned_hiConformalPixelTracks_*_*'
                                                                            ])
                         )
-
+#Full Event content 
+RecoTrackerFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoTrackerFEVT.outputCommands.extend(RecoTrackerRECO.outputCommands)

--- a/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
+++ b/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
@@ -21,6 +21,7 @@ TrackingToolsRECO = cms.PSet(
         'keep TrackingRecHitsOwned_electronGsfTracks_*_*'
     )
 )
+TrackingToolsRECO.outputCommands.extend(TrackingToolsAOD.outputCommands)
 _phase2_hgcal_TrackingRECO_tokeep = [
         'keep recoGsfTracks_electronGsfTracksFromMultiCl_*_*',
         'keep recoGsfTrackExtras_electronGsfTracksFromMultiCl_*_*',
@@ -30,7 +31,6 @@ _phase2_hgcal_TrackingRECO_tokeep = [
 ]
 phase2_hgcal.toModify( TrackingToolsRECO,
                        outputCommands = TrackingToolsRECO.outputCommands + _phase2_hgcal_TrackingRECO_tokeep)
-TrackingToolsRECO.outputCommands.extend(TrackingToolsAOD.outputCommands)
 
 #FEVT content
 TrackingToolsFEVT = cms.PSet(

--- a/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
+++ b/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
@@ -1,23 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
-TrackingToolsFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_CkfElectronCandidates_*_*', 
-        'keep *_GsfGlobalElectronTest_*_*',
-        'keep *_electronMergedSeeds_*_*',
-        'keep *_electronGsfTracks_*_*'
-        )
+#AOD content
+TrackingToolsAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring('keep recoTracks_GsfGlobalElectronTest_*_*',
+        'keep recoGsfTracks_electronGsfTracks_*_*'
+    )
 )
+
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+phase2_hgcal.toModify( TrackingToolsAOD,
+                       outputCommands = TrackingToolsAOD.outputCommands + ['keep recoGsfTracks_electronGsfTracksFromMultiCl_*_*'])
+
 #RECO content
 TrackingToolsRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_CkfElectronCandidates_*_*', 
         'keep *_GsfGlobalElectronTest_*_*',
         'keep *_electronMergedSeeds_*_*',
-        'keep recoGsfTracks_electronGsfTracks_*_*', 
         'keep recoGsfTrackExtras_electronGsfTracks_*_*', 
         'keep recoTrackExtras_electronGsfTracks_*_*', 
-        'keep TrackingRecHitsOwned_electronGsfTracks_*_*'                                            )
+        'keep TrackingRecHitsOwned_electronGsfTracks_*_*'
+    )
 )
-
 _phase2_hgcal_TrackingRECO_tokeep = [
         'keep recoGsfTracks_electronGsfTracksFromMultiCl_*_*',
         'keep recoGsfTrackExtras_electronGsfTracksFromMultiCl_*_*',
@@ -25,18 +28,13 @@ _phase2_hgcal_TrackingRECO_tokeep = [
         'keep TrackingRecHitsOwned_electronGsfTracksFromMultiCl_*_*',
         'keep *_electronMergedSeedsFromMultiCl_*_*'
 ]
-
-#AOD content
-TrackingToolsAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_GsfGlobalElectronTest_*_*',
-        'keep recoGsfTracks_electronGsfTracks_*_*'
-                                         
-    )
-)
-
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( TrackingToolsRECO,
                        outputCommands = TrackingToolsRECO.outputCommands + _phase2_hgcal_TrackingRECO_tokeep)
-phase2_hgcal.toModify( TrackingToolsAOD,
-                       outputCommands = TrackingToolsAOD.outputCommands + ['keep recoGsfTracks_electronGsfTracksFromMultiCl_*_*'])
+TrackingToolsRECO.outputCommands.extend(TrackingToolsAOD.outputCommands)
 
+#FEVT content
+TrackingToolsFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring('keep *_electronGsfTracks_*_*'
+    )
+)
+TrackingToolsFEVT.outputCommands.extend(TrackingToolsRECO.outputCommands)


### PR DESCRIPTION
#### PR description:
Update event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. (An extension of the task [PR#29025](https://github.com/cms-sw/cmssw/pull/29025)).
5 files changed :
RecoLocalMuon_EventContent_cff.py
RecoLocalTracker_EventContent_cff.py
RecoTracker_EventContent_cff.py 
TrackingTools_EventContent_cff.py
RecoMET_EventContent_cff .py 

In the RecoMETAOD output commands,  "drop recoHcalNoiseRBXs\_\*\_\*\_\*," removed.
 
#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).
