### PR TITLE
DQM: Fix dcsRecord input tag in offline for DQMProvInfo

### DIFF
--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
@@ -15,6 +15,7 @@ from DQM.EcalPreshowerMonitorModule.es_dqm_source_offline_cosmic_cff import *
 from DQM.CastorMonitor.castor_dqm_sourceclient_offline_cff import *
 
 dqmProvInfo.runType = "cosmics_run"
+dqmProvInfo.dcsRecord = cms.untracked.InputTag("onlineMetaDataDigis")
 DQMOfflineCosmicsDCS = cms.Sequence( dqmProvInfo )
 
 DQMOfflineCosmicsEcal = cms.Sequence( ecal_dqm_source_offline *

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -23,6 +23,7 @@ DQMNone = cms.Sequence()
 DQMMessageLoggerSeq = cms.Sequence( DQMMessageLogger )
 
 dqmProvInfo.runType = "pp_run"
+dqmProvInfo.dcsRecord = cms.untracked.InputTag("onlineMetaDataDigis")
 DQMOfflineDCS = cms.Sequence( dqmProvInfo )
 
 # L1 trigger sequences

--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -36,7 +36,8 @@ DQMProvInfo::DQMProvInfo(const edm::ParameterSet& ps) {
       ps.getUntrackedParameter<edm::InputTag>("tcdsData", edm::InputTag("tcdsDigis", "tcdsRecord")));
 
   // Used to get the DCS bits:
-  dcsRecordToken_ = consumes<DCSRecord>(edm::InputTag("onlineMetaDataRawToDigi"));
+  dcsRecordToken_ = consumes<DCSRecord>(
+      ps.getUntrackedParameter<edm::InputTag>("dcsRecord", edm::InputTag("onlineMetaDataRawToDigi")));
 
   // Initialization of the global tag
   globalTag_ = "MODULE::DEFAULT";  // default


### PR DESCRIPTION
#### PR description:

The new-to-offline `DQMProvInfo` (#28829) has code to read the new softFED format, but that was never used in offline, since the fallback to the old SCAL FED worked fine. Now in the latest MWGR data used in workflow 138.1, there is no SCAL FED data any more, so we need to use the softFED data instead, but that has a different product name in offline.

This PR makes the input tag configurable and sets it correctly in offline.

Thanks @mmusich for spotting this!

#### PR validation:

Works in 138.1, other WF will be seen in the PR tests. This should not affect online, if things went well.
