### PR TITLE
[10.2.X] use openblas instead of lapack lib

### DIFF
--- a/PhysicsTools/MVATrainer/plugins/BuildFile.xml
+++ b/PhysicsTools/MVATrainer/plugins/BuildFile.xml
@@ -5,7 +5,7 @@
    <flags EDM_PLUGIN="1"/>
 </library>
 <library file="ProcMLP.cc MLP*.cc mlp*.cc" name="PhysicsToolsMVATrainerProcMLP">
-   <lib name="lapack"/>
+   <use name="openblas"/>
    <flags EDM_PLUGIN="1"/>
 </library>
 <library file="ProcTMVA.cc" name="PhysicsToolsMVATrainerProcTMVA">


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/29014
@silviodonato  This should fix 10.2.X IBs and release issues