### PR TITLE
CondTools/L1Trigger: do not copy scripts in to bin

### DIFF
--- a/CondTools/L1Trigger/scripts/BuildFile.xml
+++ b/CondTools/L1Trigger/scripts/BuildFile.xml
@@ -1,0 +1,1 @@
+<flags SKIP_FILES="%"/>

--- a/CondTools/L1TriggerExt/scripts/BuildFile.xml
+++ b/CondTools/L1TriggerExt/scripts/BuildFile.xml
@@ -1,0 +1,1 @@
+<flags SKIP_FILES="%"/>


### PR DESCRIPTION
`CondTools/L1Trigger` and `CondTools/L1TriggerExt` contain scripts with same names. Looks like these scripts are directly called using full path and no need to have these available in PATH. This change skips the script copying to `CMSSW_BASE/bin` and avoid build errors such as

```
>> copied runL1-O2O-iov.sh
/usr/bin/cp: cannot create regular file 'CMSSW_11_1_X_2020-03-09-2300/bin/slc7_amd64_gcc820/runL1-O2O-rs-keysFromL1Key.sh': File exists
  gmake: *** [src_CondTools_L1TriggerExt_scripts_copy] Error 1
```