### PR TITLE
Fix deadlock in MonitorElement::division

### DIFF
--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -737,10 +737,12 @@ namespace dqm::impl {
     TH1 const *denomH = static_cast<TH1 const *>(denom->getRootObject());
     TH1 *thisH = getTH1();
 
-    //Need to take locks in a consistent order to avoid deadlocks. Use pointer value order.
+    //Need to take locks in a consistent order to avoid deadlocks. Use pointer value order of underlying ROOT object..
     //This is known as the monitor pattern.
     std::array<const MonitorElement *, 3> order{{this, num, denom}};
-    std::sort(order.begin(), order.end());
+    std::sort(order.begin(), order.end(), [](auto const *lhs, auto const *rhs) {
+      return lhs->mutable_->data_.value_.object_.get() < rhs->mutable_->data_.value_.object_.get();
+    });
 
     auto a0 = order[0]->access();
     auto a1 = order[1]->access();


### PR DESCRIPTION
#### PR description:

Previously the address of the MonitorElement was used to set the order of the lock acquisition. Those addresses are not unique across stream modules. Now use the actually address of the ROOT object which is guaranteed to be unique.

#### PR validation:

Ran workflow 136.85 using 4 threads without this change and on the first run the deadlock happened. After the fix I ran the same workflow 3 times and no deadlock happened.