### PR TITLE
[HGCal] RecHits calibration using regional e/m factors

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -151,7 +151,7 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
         case HGCHEF:
           idtype = hgcfh;
           thickness = ddds_[detid.subdetId() - 3]->waferTypeL(HGCalDetId(detid).wafer());
-	  break;
+          break;
         case HcalEndcap:
           [[fallthrough]];
         case HGCHEB:
@@ -175,8 +175,8 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
     case hgcfh:
       rechitMaker_->setADCToGeVConstant(float(hgchefUncalib2GeV_));
       cce_correction = hgcHEF_cce_[thickness - 1];
-      sigmaNoiseGeV =  
-	  1e-3 * weights_[layer] * rcorr_[thickness+deltasi_index_regemfac] * hgcHEF_noise_fC_[thickness - 1]  / hgcHEF_fCPerMIP_[thickness - 1];
+      sigmaNoiseGeV = 1e-3 * weights_[layer] * rcorr_[thickness + deltasi_index_regemfac] *
+                      hgcHEF_noise_fC_[thickness - 1] / hgcHEF_fCPerMIP_[thickness - 1];
       break;
     case hgcbh:
       rechitMaker_->setADCToGeVConstant(float(hgchebUncalib2GeV_));
@@ -198,10 +198,10 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
   double new_E = myrechit.energy();
   if (detid.det() == DetId::Forward && detid.subdetId() == ForwardSubdetector::HFNose) {
     new_E *= (thickness == -1 ? 1.0 : rcorrNose_[thickness]) / cce_correction;
-  } //regional factors for silicon in CE_H 
-  else if (idtype == hgcfh){
-    new_E *= rcorr_[thickness+deltasi_index_regemfac] / cce_correction;
-  } //regional factors for scintillator and silicon in CE_E
+  }  //regional factors for silicon in CE_H
+  else if (idtype == hgcfh) {
+    new_E *= rcorr_[thickness + deltasi_index_regemfac] / cce_correction;
+  }  //regional factors for scintillator and silicon in CE_E
   else {
     new_E *= (thickness == -1 ? rcorrscint_ : rcorr_[thickness]) / cce_correction;
   }

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -58,7 +58,7 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps) : 
   // here for scintillator
   rcorrscint_ = ps.getParameter<double>("sciThicknessCorrection");
   //This is for the index position in CE_H silicon thickness cases
-  deltasi_index_regemfac = ps.getParameter<int>("deltasi_index_regemfac");
+  deltasi_index_regemfac_ = ps.getParameter<int>("deltasi_index_regemfac");
   const auto& rcorrnose = ps.getParameter<std::vector<double> >("thicknessNoseCorrection");
   rcorrNose_.clear();
   rcorrNose_.push_back(1.f);
@@ -175,7 +175,7 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
     case hgcfh:
       rechitMaker_->setADCToGeVConstant(float(hgchefUncalib2GeV_));
       cce_correction = hgcHEF_cce_[thickness - 1];
-      sigmaNoiseGeV = 1e-3 * weights_[layer] * rcorr_[thickness + deltasi_index_regemfac] *
+      sigmaNoiseGeV = 1e-3 * weights_[layer] * rcorr_[thickness + deltasi_index_regemfac_] *
                       hgcHEF_noise_fC_[thickness - 1] / hgcHEF_fCPerMIP_[thickness - 1];
       break;
     case hgcbh:
@@ -200,7 +200,7 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
     new_E *= (thickness == -1 ? 1.0 : rcorrNose_[thickness]) / cce_correction;
   }  //regional factors for silicon in CE_H
   else if (idtype == hgcfh) {
-    new_E *= rcorr_[thickness + deltasi_index_regemfac] / cce_correction;
+    new_E *= rcorr_[thickness + deltasi_index_regemfac_] / cce_correction;
   }  //regional factors for scintillator and silicon in CE_E
   else {
     new_E *= (thickness == -1 ? rcorrscint_ : rcorr_[thickness]) / cce_correction;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
@@ -56,6 +56,8 @@ protected:
   uint32_t rangeMask_;
 
   std::vector<double> rcorr_, rcorrNose_;
+  bool regionalemfactors;
+  int deltasi_index_regemfac, scint_index_regemfac;
   std::vector<float> weights_, weightsNose_;
   std::unique_ptr<HGCalRecHitSimpleAlgo> rechitMaker_;
   std::unique_ptr<hgcal::RecHitTools> tools_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
@@ -57,7 +57,7 @@ protected:
 
   std::vector<double> rcorr_, rcorrNose_;
   double rcorrscint_;
-  int deltasi_index_regemfac;
+  int deltasi_index_regemfac_;
   std::vector<float> weights_, weightsNose_;
   std::unique_ptr<HGCalRecHitSimpleAlgo> rechitMaker_;
   std::unique_ptr<hgcal::RecHitTools> tools_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
@@ -56,8 +56,8 @@ protected:
   uint32_t rangeMask_;
 
   std::vector<double> rcorr_, rcorrNose_;
-  bool regionalemfactors;
-  int deltasi_index_regemfac, scint_index_regemfac;
+  double rcorrscint_;
+  int deltasi_index_regemfac;
   std::vector<float> weights_, weightsNose_;
   std::unique_ptr<HGCalRecHitSimpleAlgo> rechitMaker_;
   std::unique_ptr<hgcal::RecHitTools> tools_;

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -218,6 +218,13 @@ HGCalRecHit = cms.EDProducer(
 
     thicknessCorrection = cms.vdouble(1.132,1.092,1.084), # 100, 200, 300 um
     thicknessNoseCorrection = cms.vdouble(1.132,1.092,1.084), # 100, 200, 300 um
+    #In the regionalemfactors scheme there are 7 factors.
+    #The first 3 are for CE_E silicon, the next three are 
+    #for CE_H silicon and the last one, the seventh is for scint. 
+    regionalemfactors = cms.bool(False),
+    deltasi_index_regemfac = cms.int32(3),
+    scint_index_regemfac = cms.int32(7),
+
     HGCEE_noise_fC = hgceeDigitizer.digiCfg.noise_fC,
     HGCEE_cce = hgceeDigitizer.digiCfg.chargeCollectionEfficiencies,
     HGCHEF_noise_fC = hgchefrontDigitizer.digiCfg.noise_fC,
@@ -238,6 +245,10 @@ HGCalRecHit = cms.EDProducer(
     )
 
 phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = [0.759,0.760,0.773] ) #120um, 200um, 300um
-phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.781,0.775,0.769] ) #120um, 200um, 300um
+#phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.781,0.775,0.769]  ) #120um, 200um, 300um
+
+#With the new regional em factors there are 7 different factors used in the following order 
+# CE_E_120um, CE_E_200um, CE_E_300um, CE_H_120um, CE_H_200um, CE_H_300um, Scint  
+phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.77, 0.77, 0.77, 0.84, 0.84, 0.84, 0.90] , regionalemfactors = cms.bool(True) ) #120um, 200um, 300um
 
 phase2_hfnose.toModify( HGCalRecHit , thicknessNoseCorrection = [0.759,0.760,0.773])

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -216,15 +216,15 @@ HGCalRecHit = cms.EDProducer(
     layerWeights = dEdX.weights,
     layerNoseWeights = dEdX.weightsNose,
 
-    thicknessCorrection = cms.vdouble(1.132,1.092,1.084), # 100, 200, 300 um
-    thicknessNoseCorrection = cms.vdouble(1.132,1.092,1.084), # 100, 200, 300 um
-    #In the regionalemfactors scheme there are 7 factors.
-    #The first 3 are for CE_E silicon, the next three are 
-    #for CE_H silicon and the last one, the seventh is for scint. 
-    regionalemfactors = cms.bool(False),
+    #With the new regional em factors there are 7 different factors used. 
+    #Six of them are for silicon and one for scint. For silicon it is in the following order
+    # CE_E_120um, CE_E_200um, CE_E_300um, CE_H_120um, CE_H_200um, CE_H_300um
+    thicknessCorrection = cms.vdouble(1.132,1.092,1.084, 1.0, 1.0, 1.0), # 100, 200, 300 um
     deltasi_index_regemfac = cms.int32(3),
-    scint_index_regemfac = cms.int32(7),
-
+    #One factor for scint 
+    sciThicknessCorrection = cms.double(1.0),
+    thicknessNoseCorrection = cms.vdouble(1.132,1.092,1.084), # 100, 200, 300 um
+ 
     HGCEE_noise_fC = hgceeDigitizer.digiCfg.noise_fC,
     HGCEE_cce = hgceeDigitizer.digiCfg.chargeCollectionEfficiencies,
     HGCHEF_noise_fC = hgchefrontDigitizer.digiCfg.noise_fC,
@@ -244,11 +244,8 @@ HGCalRecHit = cms.EDProducer(
 
     )
 
-phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = [0.759,0.760,0.773] ) #120um, 200um, 300um
-#phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.781,0.775,0.769]  ) #120um, 200um, 300um
-
-#With the new regional em factors there are 7 different factors used in the following order 
-# CE_E_120um, CE_E_200um, CE_E_300um, CE_H_120um, CE_H_200um, CE_H_300um, Scint  
-phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.77, 0.77, 0.77, 0.84, 0.84, 0.84, 0.90] , regionalemfactors = cms.bool(True) ) #120um, 200um, 300um
+# For silicon the order is: CE_E_120um, CE_E_200um, CE_E_300um, CE_H_120um, CE_H_200um, CE_H_300um
+phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = [0.759,0.760,0.773, 1.0, 1.0, 1.0] ) 
+phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.77, 0.77, 0.77, 0.84, 0.84, 0.84] , sciThicknessCorrection =  cms.double(0.90) ) 
 
 phase2_hfnose.toModify( HGCalRecHit , thicknessNoseCorrection = [0.759,0.760,0.773])


### PR DESCRIPTION
#### PR description:

The calibration of HGCal reconstructed hits is a well documented procedure and details can be found in this [talk](https://indico.cern.ch/event/740826/contributions/3058501/attachments/1678687/2696151/CalibratedRecHits.pdf) and in this [documentation](http://hgcal.web.cern.ch/hgcal/HitCalibration/hitCalibration.html).

After detailed studies, which can be found in [1], we extend the thickness correction factors to 
cover also CE-H silicon and scintillator regions. 

#### PR validation:

We have tested the PR using the usual HGCal validation package as well as the normal HGCal 
reco tools. Results are gathered in these slides [1].

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

[1] http://apsallid.web.cern.ch/apsallid/Regionalemfactors.pdf

@rovere @felicepantaleo @cseez @pfs @amartelli 
