### PR TITLE
[HGCal] Scintillator support for RecHits calibration 

### DIFF
--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -67,6 +67,7 @@ private:
   hgcal::RecHitTools recHitTools_;
   static constexpr int depletion1_ = 200;
   static constexpr int depletion2_ = 300;
+  static constexpr int scint_ = 400;
 
   std::map<int, MonitorElement*> h_EoP_CPene_calib_fraction_;
   std::map<int, MonitorElement*> hgcal_EoP_CPene_calib_fraction_;
@@ -126,24 +127,31 @@ void HGCalHitCalibration::bookHistograms(DQMStore::IBooker& ibooker,
   h_EoP_CPene_calib_fraction_[depletion0_] = ibooker.book1D("h_EoP_CPene_100_calib_fraction", "", 1000, -0.5, 2.5);
   h_EoP_CPene_calib_fraction_[depletion1_] = ibooker.book1D("h_EoP_CPene_200_calib_fraction", "", 1000, -0.5, 2.5);
   h_EoP_CPene_calib_fraction_[depletion2_] = ibooker.book1D("h_EoP_CPene_300_calib_fraction", "", 1000, -0.5, 2.5);
+  h_EoP_CPene_calib_fraction_[scint_] = ibooker.book1D("h_EoP_CPene_scint_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_EoP_CPene_calib_fraction_[depletion0_] =
       ibooker.book1D("hgcal_EoP_CPene_100_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_EoP_CPene_calib_fraction_[depletion1_] =
       ibooker.book1D("hgcal_EoP_CPene_200_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_EoP_CPene_calib_fraction_[depletion2_] =
       ibooker.book1D("hgcal_EoP_CPene_300_calib_fraction", "", 1000, -0.5, 2.5);
+  hgcal_EoP_CPene_calib_fraction_[scint_] =
+      ibooker.book1D("hgcal_EoP_CPene_scint_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_ele_EoP_CPene_calib_fraction_[depletion0_] =
       ibooker.book1D("hgcal_ele_EoP_CPene_100_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_ele_EoP_CPene_calib_fraction_[depletion1_] =
       ibooker.book1D("hgcal_ele_EoP_CPene_200_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_ele_EoP_CPene_calib_fraction_[depletion2_] =
       ibooker.book1D("hgcal_ele_EoP_CPene_300_calib_fraction", "", 1000, -0.5, 2.5);
+  hgcal_ele_EoP_CPene_calib_fraction_[scint_] =
+      ibooker.book1D("hgcal_ele_EoP_CPene_scint_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_photon_EoP_CPene_calib_fraction_[depletion0_] =
       ibooker.book1D("hgcal_photon_EoP_CPene_100_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_photon_EoP_CPene_calib_fraction_[depletion1_] =
       ibooker.book1D("hgcal_photon_EoP_CPene_200_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_photon_EoP_CPene_calib_fraction_[depletion2_] =
       ibooker.book1D("hgcal_photon_EoP_CPene_300_calib_fraction", "", 1000, -0.5, 2.5);
+  hgcal_photon_EoP_CPene_calib_fraction_[scint_] =
+      ibooker.book1D("hgcal_photon_EoP_CPene_scint_calib_fraction", "", 1000, -0.5, 2.5);
   LayerOccupancy_ = ibooker.book1D("LayerOccupancy", "", layers_, 0., (float)layers_);
 }
 
@@ -167,6 +175,7 @@ void HGCalHitCalibration::fillWithRecHits(std::map<DetId, const HGCRecHit*>& hit
         << hitid.subdetId() << std::endl;
     return;
   }
+
   unsigned int layer = recHitTools_.getLayerWithOffset(hitid);
   assert(hitlayer == layer);
   Energy_layer_calib_fraction_[layer] += hitmap[hitid]->energy() * fraction;
@@ -174,6 +183,7 @@ void HGCalHitCalibration::fillWithRecHits(std::map<DetId, const HGCRecHit*>& hit
   if (seedEnergy < hitmap[hitid]->energy()) {
     seedEnergy = hitmap[hitid]->energy();
     seedDet = recHitTools_.getSiThickness(hitid);
+    if (hitid.det() == DetId::HGCalHSc){ seedDet = scint_;}
   }
 }
 
@@ -312,6 +322,7 @@ void HGCalHitCalibration::analyze(const edm::Event& iEvent, const edm::EventSetu
     if (closest != clusters.end() && reco::deltaR2(*closest, it_caloPart) < 0.01) {
       total_energy = closest->correctedEnergy();
       seedDet = recHitTools_.getSiThickness(closest->seed());
+      if (closest->seed().det() == DetId::HGCalHSc){ seedDet = scint_;}
       if (hgcal_EoP_CPene_calib_fraction_.count(seedDet)) {
         hgcal_EoP_CPene_calib_fraction_[seedDet]->Fill(total_energy / it_caloPart.energy());
       }
@@ -337,6 +348,7 @@ void HGCalHitCalibration::analyze(const edm::Event& iEvent, const edm::EventSetu
            closest->superCluster()->seed()->seed().det() == DetId::HGCalEE) &&
           reco::deltaR2(*closest, it_caloPart) < 0.01) {
         seedDet = recHitTools_.getSiThickness(closest->superCluster()->seed()->seed());
+	if (closest->superCluster()->seed()->seed().det() == DetId::HGCalHSc){ seedDet = scint_;}
         if (hgcal_ele_EoP_CPene_calib_fraction_.count(seedDet)) {
           hgcal_ele_EoP_CPene_calib_fraction_[seedDet]->Fill(closest->energy() / it_caloPart.energy());
         }

--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -134,8 +134,7 @@ void HGCalHitCalibration::bookHistograms(DQMStore::IBooker& ibooker,
       ibooker.book1D("hgcal_EoP_CPene_200_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_EoP_CPene_calib_fraction_[depletion2_] =
       ibooker.book1D("hgcal_EoP_CPene_300_calib_fraction", "", 1000, -0.5, 2.5);
-  hgcal_EoP_CPene_calib_fraction_[scint_] =
-      ibooker.book1D("hgcal_EoP_CPene_scint_calib_fraction", "", 1000, -0.5, 2.5);
+  hgcal_EoP_CPene_calib_fraction_[scint_] = ibooker.book1D("hgcal_EoP_CPene_scint_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_ele_EoP_CPene_calib_fraction_[depletion0_] =
       ibooker.book1D("hgcal_ele_EoP_CPene_100_calib_fraction", "", 1000, -0.5, 2.5);
   hgcal_ele_EoP_CPene_calib_fraction_[depletion1_] =
@@ -183,7 +182,9 @@ void HGCalHitCalibration::fillWithRecHits(std::map<DetId, const HGCRecHit*>& hit
   if (seedEnergy < hitmap[hitid]->energy()) {
     seedEnergy = hitmap[hitid]->energy();
     seedDet = recHitTools_.getSiThickness(hitid);
-    if (hitid.det() == DetId::HGCalHSc){ seedDet = scint_;}
+    if (hitid.det() == DetId::HGCalHSc) {
+      seedDet = scint_;
+    }
   }
 }
 
@@ -322,7 +323,9 @@ void HGCalHitCalibration::analyze(const edm::Event& iEvent, const edm::EventSetu
     if (closest != clusters.end() && reco::deltaR2(*closest, it_caloPart) < 0.01) {
       total_energy = closest->correctedEnergy();
       seedDet = recHitTools_.getSiThickness(closest->seed());
-      if (closest->seed().det() == DetId::HGCalHSc){ seedDet = scint_;}
+      if (closest->seed().det() == DetId::HGCalHSc) {
+        seedDet = scint_;
+      }
       if (hgcal_EoP_CPene_calib_fraction_.count(seedDet)) {
         hgcal_EoP_CPene_calib_fraction_[seedDet]->Fill(total_energy / it_caloPart.energy());
       }
@@ -348,7 +351,9 @@ void HGCalHitCalibration::analyze(const edm::Event& iEvent, const edm::EventSetu
            closest->superCluster()->seed()->seed().det() == DetId::HGCalEE) &&
           reco::deltaR2(*closest, it_caloPart) < 0.01) {
         seedDet = recHitTools_.getSiThickness(closest->superCluster()->seed()->seed());
-	if (closest->superCluster()->seed()->seed().det() == DetId::HGCalHSc){ seedDet = scint_;}
+        if (closest->superCluster()->seed()->seed().det() == DetId::HGCalHSc) {
+          seedDet = scint_;
+        }
         if (hgcal_ele_EoP_CPene_calib_fraction_.count(seedDet)) {
           hgcal_ele_EoP_CPene_calib_fraction_[seedDet]->Fill(closest->energy() / it_caloPart.energy());
         }

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1749,24 +1749,28 @@ _ReconstructableEnergyOverCPenergy = PlotGroup("ReconstructableEnergyOverCPenerg
   Plot("h_EoP_CPene_100_calib_fraction", title="EoP_CPene_100_calib_fraction", **_common),
   Plot("h_EoP_CPene_200_calib_fraction", title="EoP_CPene_200_calib_fraction", **_common),
   Plot("h_EoP_CPene_300_calib_fraction", title="EoP_CPene_300_calib_fraction", **_common),
+  Plot("h_EoP_CPene_scint_calib_fraction", title="EoP_CPene_scint_calib_fraction", **_common),
 ])
 
 _ParticleFlowClusterHGCalFromMultiCl_Closest_EoverCPenergy = PlotGroup("ParticleFlowClusterHGCalFromMultiCl", [
   Plot("hgcal_EoP_CPene_100_calib_fraction", title="hgcal_EoP_CPene_100_calib_fraction", **_common),
   Plot("hgcal_EoP_CPene_200_calib_fraction", title="hgcal_EoP_CPene_200_calib_fraction", **_common),
   Plot("hgcal_EoP_CPene_300_calib_fraction", title="hgcal_EoP_CPene_300_calib_fraction", **_common),
+  Plot("hgcal_EoP_CPene_scint_calib_fraction", title="hgcal_EoP_CPene_scint_calib_fraction", **_common),
 ])
 
 _EcalDrivenGsfElectronsFromMultiCl_Closest_EoverCPenergy = PlotGroup("EcalDrivenGsfElectronsFromMultiCl", [
   Plot("hgcal_ele_EoP_CPene_100_calib_fraction", title="hgcal_ele_EoP_CPene_100_calib_fraction", **_common),
   Plot("hgcal_ele_EoP_CPene_200_calib_fraction", title="hgcal_ele_EoP_CPene_200_calib_fraction", **_common),
   Plot("hgcal_ele_EoP_CPene_300_calib_fraction", title="hgcal_ele_EoP_CPene_300_calib_fraction", **_common),
+  Plot("hgcal_ele_EoP_CPene_scint_calib_fraction", title="hgcal_ele_EoP_CPene_scint_calib_fraction", **_common),
 ])
 
 _PhotonsFromMultiCl_Closest_EoverCPenergy = PlotGroup("PhotonsFromMultiCl", [
   Plot("hgcal_photon_EoP_CPene_100_calib_fraction", title="hgcal_photon_EoP_CPene_100_calib_fraction", **_common),
   Plot("hgcal_photon_EoP_CPene_200_calib_fraction", title="hgcal_photon_EoP_CPene_200_calib_fraction", **_common),
   Plot("hgcal_photon_EoP_CPene_300_calib_fraction", title="hgcal_photon_EoP_CPene_300_calib_fraction", **_common),
+  Plot("hgcal_photon_EoP_CPene_scint_calib_fraction", title="hgcal_photon_EoP_CPene_scint_calib_fraction", **_common),
 ])
 
 #=================================================================================================


### PR DESCRIPTION
#### PR description:

The HGCalHitCalibration package is extensively used each time a new RelVal campaign is 
announced. With the PR #29165 under approval and the addition of a calibration factor for the scintillator region, we extend the code to produce also the relevant calibration plots for scintillator. 

#### PR validation:

We have tested the PR with the usual HGCal validation tools and produce some plots [1].   

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport. 

[1] http://apsallid.web.cern.ch/apsallid/HGCValid_testscint_Plots/

@rovere @bsunanda @cseez @pfs 

