### PR TITLE
Update phase-2 Inner Tracker Templates and GenError conditions

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -40,15 +40,15 @@ allTags["SimLA"] = {
 }
 
 allTags["GenError"] = {
-    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v2_mc'  ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v4_mc_bugfix'  ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v4_mc_bugfix' ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v4_mc_bugfix' ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
 }
 
 allTags["Template"] = {
-    'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v2_mc'  ,SiPixelTemplatesRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v4_mc_bugfix' ,SiPixelTemplatesRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v4_mc_bugfix',SiPixelTemplatesRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v4_mc_bugfix',SiPixelTemplatesRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
 }
 
 ##


### PR DESCRIPTION
#### PR description:

In the validation for Phase-2 of `CMSSW_11_1_0_pre1`, it was noticed that w.r.t. the `CMSSW_11_0_0_pre13` there had been a degradation of the tracking fake rate by roughly 7%, (see validation report at [valDB](https://hypernews.cern.ch/HyperNews/CMS/get/relval/14390/1/1/1.html) ), seemingly after the switching on of the CPE template reconstruction for the phase-2 tracker (in PR #28448).
The problem has persisted in all subsequent validation cycles, making the tracking performance for phase-2 sub-optimal since `CMSSW_11_1_0_pre1`.
The problem has been traced back by @OzAmram, @cmantill et al. to several small inconsistencies in the payloads firstly proposed in the original PR (see report at [Phase-2 tracker simulation meeting during Tracker Week](https://indico.cern.ch/event/889563/contributions/3760871/attachments/1992262/3322319/CMS_pixel_Feb24.pdf) ):
   * Incomplete spanning of the local x angle space in FPIX -> not enough angles were generated in first round. 
   * Different dimension of sensors: switch to 25x100.115 µm²  (taking into account the fact that big pixels are not simulated in the phase-2 IT sensors) instead of 25x100 µm².
   * A further issue was found in the GenErrors,  due to a combination of assuming readout noise as for phase1 (but is currently turned off for phase2), and a minimum error allowed by the templates  and against which the old estimate was bumping for some of the angle space. 

#### PR validation:
@cmantill  and @OzAmram validated the new payloads using the Multi-Track Validator, (PU200 TTbar14 TeV sample). Validation results are available [here](http://cmantill.web.cern.ch/cmantill/phase2/PU200_100ev/plots/plots_highPurity/effandfakePtEtaPhi.pdf), showing substantially  consistency with the `CMSSW_11_0_0_pre13` results.
Further technical validation has been run locally with this branch by using:
```
runTheMatrix.py --what upgrade -l 20007.0,20407.0,20807.0,21607.0,22007.0,22807.0,22834.0
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.
cc:
@tsusa @tvami @mtosi @JanFSchulte @jalimena @emiglior @skinnari

