### PR TITLE
Remove unused deps from TrackingTools and TrackPropagation subsystems

### DIFF
--- a/EgammaAnalysis/ElectronTools/plugins/BuildFile.xml
+++ b/EgammaAnalysis/ElectronTools/plugins/BuildFile.xml
@@ -11,6 +11,7 @@
 <use   name="EgammaAnalysis/ElectronTools"/>
 <use   name="RecoEcal/EgammaCoreTools"/>
 <use   name="PhysicsTools/SelectorUtils"/>
+<use   name="TrackingTools/Records"/>
 <library name="EgammaAnalysisElectronToolsPlugins" file="*.cc">
    <flags   EDM_PLUGIN="1"/>
 </library>

--- a/EgammaAnalysis/ElectronTools/test/BuildFile.xml
+++ b/EgammaAnalysis/ElectronTools/test/BuildFile.xml
@@ -9,6 +9,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="RecoParticleFlow/PFProducer"/>
   <use   name="EgammaAnalysis/ElectronTools"/>
+  <use   name="TrackingTools/Records"/>
   <use   name="clhep"/>
   <use   name="root"/>
   <use   name="roottmva"/>

--- a/RecoBTag/FeatureTools/plugins/BuildFile.xml
+++ b/RecoBTag/FeatureTools/plugins/BuildFile.xml
@@ -8,6 +8,7 @@
   <use name="RecoBTag/TrackProbability"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/BTauObjects"/>
+  <use name="TrackingTools/Records"/>
 
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/TrackPropagation/Geant4e/BuildFile.xml
+++ b/TrackPropagation/Geant4e/BuildFile.xml
@@ -1,11 +1,7 @@
 <use   name="root"/>
 <use   name="geant4"/>
-<use   name="FWCore/ParameterSet"/>
-<use   name="FWCore/Utilities"/>
 <use   name="TrackingTools/GeomPropagators"/>
-<use   name="TrackingTools/Records"/>
 <use   name="TrackingTools/TrajectoryState"/>
-<use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/CLHEP"/>
 <use   name="CLHEP"/>

--- a/TrackPropagation/Geant4e/plugins/BuildFile.xml
+++ b/TrackPropagation/Geant4e/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="MagneticField/Engine"/>
+<use   name="TrackingTools/Records"/>
 <use   name="TrackPropagation/Geant4e"/>
 <use   name="CLHEP"/>
 <use   name="DataFormats/CLHEP"/>

--- a/TrackPropagation/RungeKutta/BuildFile.xml
+++ b/TrackPropagation/RungeKutta/BuildFile.xml
@@ -4,7 +4,6 @@
 <use   name="MagneticField/VolumeGeometry"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>
-<use   name="FWCore/Framework"/>
 <use   name="MagneticField/Engine"/>
 <export>
   <lib   name="1"/>

--- a/TrackPropagation/SteppingHelixPropagator/BuildFile.xml
+++ b/TrackPropagation/SteppingHelixPropagator/BuildFile.xml
@@ -3,9 +3,6 @@
 <use   name="MagneticField/Engine"/>
 <use   name="MagneticField/VolumeBasedEngine"/>
 <use   name="MagneticField/VolumeGeometry"/>
-<use   name="FWCore/Framework"/>
-<use   name="FWCore/PluginManager"/>
-<use   name="FWCore/ParameterSet"/>
 <use   name="TrackingTools/AnalyticalJacobians"/>
 <export>
   <lib   name="1"/>

--- a/TrackingTools/DetLayers/BuildFile.xml
+++ b/TrackingTools/DetLayers/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="TrackingTools/TrajectoryState"/>
-<use   name="TrackingTools/TrajectoryParametrization"/>
 <use   name="TrackingTools/GeomPropagators"/>
 <use   name="boost"/>
 <use   name="clhep"/>

--- a/TrackingTools/GsfTools/BuildFile.xml
+++ b/TrackingTools/GsfTools/BuildFile.xml
@@ -3,9 +3,7 @@
 <export>
   <lib   name="1"/>
 </export>
-<use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="DataFormats/GeometrySurface"/>

--- a/TrackingTools/IPTools/BuildFile.xml
+++ b/TrackingTools/IPTools/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/PatternTools"/>
 <use name="TrackingTools/TrajectoryState"/>
-<use name="TrackingTools/Records"/>
 <use name="RecoVertex/VertexTools"/>
 <use name="clhep"/>
 <export>

--- a/TrackingTools/MaterialEffects/BuildFile.xml
+++ b/TrackingTools/MaterialEffects/BuildFile.xml
@@ -1,8 +1,5 @@
 <use   name="ofast-flag"/>
-<use   name="FWCore/Framework"/>
-<use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
-<use   name="MagneticField/Engine"/>
 <use   name="TrackingTools/GeomPropagators"/>
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackPropagation/RungeKutta"/>

--- a/TrackingTools/Producers/BuildFile.xml
+++ b/TrackingTools/Producers/BuildFile.xml
@@ -6,7 +6,5 @@
 <use   name="MagneticField/Records"/>
 <use   name="TrackingTools/GeomPropagators"/>
 <use   name="TrackingTools/Records"/>
-<use   name="RecoTracker/Record"/>
 <use   name="TrackingTools/TrajectoryCleaning"/>
-<use   name="TrackingTools/TrajectoryFiltering"/>
 <flags   EDM_PLUGIN="1"/>

--- a/TrackingTools/Records/BuildFile.xml
+++ b/TrackingTools/Records/BuildFile.xml
@@ -1,7 +1,6 @@
 <export>
   <lib   name="1"/>
 </export>
-<use   name="FWCore/Utilities"/>
 <use   name="FWCore/Framework"/>
 <use   name="Geometry/Records"/>
 <use   name="RecoLocalTracker/Records"/>

--- a/TrackingTools/TrackAssociator/BuildFile.xml
+++ b/TrackingTools/TrackAssociator/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="CondFormats/CSCObjects"/>
 <use   name="DataFormats/CaloTowers"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/DetId"/>
@@ -23,7 +22,6 @@
 <use   name="Geometry/CaloGeometry"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="Geometry/CSCGeometry"/>
-<use   name="Geometry/RPCGeometry"/>
 <use   name="Geometry/DTGeometry"/>
 <use   name="Geometry/GEMGeometry"/>
 <use   name="Geometry/Records"/>

--- a/TrackingTools/TrackAssociator/plugins/BuildFile.xml
+++ b/TrackingTools/TrackAssociator/plugins/BuildFile.xml
@@ -1,3 +1,5 @@
+<use   name="CondFormats/CSCObjects"/>
+<use   name="Geometry/RPCGeometry"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="TrackingTools/TrackAssociator"/>
 <use   name="TrackingTools/Records"/>

--- a/TrackingTools/TrackFitters/BuildFile.xml
+++ b/TrackingTools/TrackFitters/BuildFile.xml
@@ -13,5 +13,4 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Framework"/>
 <use   name="TrackingTools/Records"/>
-<use   name="DataFormats/DetId"/>
 <use   name="DataFormats/SiStripDetId"/>

--- a/TrackingTools/TrackRefitter/BuildFile.xml
+++ b/TrackingTools/TrackRefitter/BuildFile.xml
@@ -4,11 +4,9 @@
 <use   name="TrackingTools/TrackFitters"/>
 <use   name="RecoTracker/TransientTrackingRecHit"/>
 <use   name="RecoMuon/TransientTrackingRecHit"/>
-<use   name="RecoMTD/TransientTrackingRecHit"/>
 <use   name="MagneticField/Engine"/>
 <use   name="DataFormats/TrackerCommon"/>
 <use   name="Geometry/Records"/>
-<use   name="Geometry/TrackerNumberingBuilder"/>
 
 <use   name="CLHEP"/>
 <use   name="root"/>

--- a/TrackingTools/TrajectoryCleaning/BuildFile.xml
+++ b/TrackingTools/TrajectoryCleaning/BuildFile.xml
@@ -2,8 +2,4 @@
   <lib   name="1"/>
 </export>
 <use   name="TrackingTools/PatternTools"/>
-<use   name="DataFormats/SiPixelDetId"/>
-<use   name="DataFormats/SiStripDetId"/>
-<use   name="DataFormats/TrackerRecHit2D"/>
-<use   name="DataFormats/TrackingRecHit"/>
 <use   name="FWCore/PluginManager"/>

--- a/TrackingTools/TransientTrack/BuildFile.xml
+++ b/TrackingTools/TransientTrack/BuildFile.xml
@@ -1,11 +1,8 @@
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/Common"/>
-<use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/GsfTrackReco"/>
 <use   name="DataFormats/TrackReco"/>
-<use   name="DataFormats/TrackingRecHit"/>
 <use   name="FWCore/Framework"/>
-<use   name="FWCore/MessageLogger"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="Geometry/Records"/>
 <use   name="TrackingTools/GeomPropagators"/>

--- a/TrackingTools/TransientTrackingRecHit/BuildFile.xml
+++ b/TrackingTools/TransientTrackingRecHit/BuildFile.xml
@@ -1,12 +1,10 @@
 <use   name="boost"/>
 <use   name="clhep"/>
 <use   name="FWCore/Utilities"/>
-<use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="DataFormats/TrackerRecHit2D"/>
-<use   name="FWCore/ServiceRegistry"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="DataFormats/GeometrySurface"/>
 <export>


### PR DESCRIPTION
#### PR description:

Another quick round of automatic BuildFile.xml cleaning to improve the modularity of CMSSW.

After I made sure all of the Reco* Build files don't use dependencies anymore which are not included in the source files, I'm giving the same treatment to some other widely used subsystems.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.