### PR TITLE
Add kBMTF DIGI step [Not to merge]

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -933,6 +933,7 @@ class ConfigBuilder(object):
         self.RAW2DIGIDefaultCFF="Configuration/StandardSequences/RawToDigi_Data_cff"
         if self._options.isRepacked: self.RAW2DIGIDefaultCFF="Configuration/StandardSequences/RawToDigi_DataMapper_cff"
         self.L1RecoDefaultCFF="Configuration/StandardSequences/L1Reco_cff"
+        self.KBMTFDefaultCFF="Configuration/StandardSequences/KBMTF_cff"
         self.L1TrackTriggerDefaultCFF="Configuration/StandardSequences/L1TrackTrigger_cff"
         self.RECODefaultCFF="Configuration/StandardSequences/Reconstruction_Data_cff"
         self.RECOSIMDefaultCFF="Configuration/StandardSequences/RecoSim_cff"
@@ -972,6 +973,7 @@ class ConfigBuilder(object):
         self.CFWRITERDefaultSeq=None
         self.RAW2DIGIDefaultSeq='RawToDigi'
         self.L1RecoDefaultSeq='L1Reco'
+        self.KBMTFDefaultSeq='kbmtf'
         self.L1TrackTriggerDefaultSeq='L1TrackTrigger'
         if self._options.fast or ('RAW2DIGI' in self.stepMap and 'RECO' in self.stepMap):
             self.RECODefaultSeq='reconstruction'
@@ -1579,6 +1581,12 @@ class ConfigBuilder(object):
         ''' Enrich the schedule with L1 reconstruction '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.L1RecoDefaultCFF)
         self.scheduleSequence(sequence.split('.')[-1],'L1Reco_step')
+        return
+
+    def prepare_KBMTF(self, sequence = "KBMTF"):
+        ''' Enrich the schedule with KBMTF '''
+        self.loadDefaultOrSpecifiedCFF(sequence,self.KBMTFDefaultCFF)
+        self.scheduleSequence(sequence.split('.')[-1],'KBMTF_step')
         return
 
     def prepare_L1TrackTrigger(self, sequence = "L1TrackTrigger"):

--- a/Configuration/StandardSequences/python/KBMTF_cff.py
+++ b/Configuration/StandardSequences/python/KBMTF_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from EventFilter.L1TRawToDigi.bmtfDigis_cfi import *
+from L1Trigger.L1TMuonBarrel.simKBmtfStubs_cfi import *
+simKBmtfStubs.srcPhi = cms.InputTag("bmtfDigis")
+simKBmtfStubs.srcTheta = cms.InputTag("bmtfDigis")
+
+from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import * #Kalman
+from L1Trigger.L1TMuonBarrel.simBmtfDigis_cfi import * #BMTF
+simBmtfDigis.DTDigi_Source = cms.InputTag("bmtfDigis")
+simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("bmtfDigis")
+
+kbmtf = cms.Task(bmtfDigis,simBmtfDigis,simKBmtfStubs,simKBmtfDigis)


### PR DESCRIPTION
#### PR description:
As a request on Legacy-2018 ZeroBias ReReco to study 40 MHz scouting, the additional step in kMBTF DIGI is needed. This PR is an example of how to handle additional steps. No need to merge at the moment. It will be done properly if need for official CMSSW.

https://indico.cern.ch/event/884665/contributions/3735558/attachments/1987175/3311607/PPD_130220_TJ.pdf

#### PR validation:
Test with the following cmsDriver, the job runs fine with proper output.

`cmsDriver.py step1 -s RAW2DIGI,L1Reco,KBMTF,RECO --runUnscheduled --nThreads 8 --data --era Run2_2018,pf_badHcalMitigation --scenario pp --conditions 106X_dataRun2_v24 --eventcontent RECO --datatier USER --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --python_filename reco_cfg.py --no_exec --customise_commands "process.RECOoutput.outputCommands.append('drop *') \n process.RECOoutput.outputCommands.append('keep *_globalMuons_*_*') \n process.RECOoutput.outputCommands.append('keep *_displacedGlobalMuons_*_*') \n process.RECOoutput.outputCommands.append('keep *_displacedStandaloneMuons_*_*') \n process.RECOoutput.outputCommands.append('keep *_standaloneMuons_*_*') \n process.RECOoutput.outputCommands.append('keep *_simKBmtfDigis_*_*') \n process.RECOoutput.outputCommands.append('keep *_caloStage2Digis_*_*') \n process.RECOoutput.outputCommands.append('keep *_gtStage2Digis_*_*') \n process.RECOoutput.outputCommands.append('keep *_gmtStage2Digis_*_*') \n process.RECOoutput.outputCommands.append('keep *_emtfStage2Digis_*_*') \n process.RECOoutput.outputCommands.append('keep *_omtfStage2Digis_*_*') \n process.RECOoutput.outputCommands.append('keep *_bmtfDigis_*_*') \n process.RECOoutput.outputCommands.append('keep *_simBmtfDigis_*_*') \n" --filein 'root://cmsxrootd.fnal.gov//store/data/Run2018B/ZeroBias/RAW/v1/000/318/820/00000/38741757-717A-E811-9615-02163E019FEB.root' --fileout 'file:output_cmsDriver.root' -n 100`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

