### PR TITLE
Cleanup FastSimulation/Calorimetry dependency on SimG4Core/GFlash

### DIFF
--- a/FastSimulation/Calorimetry/BuildFile.xml
+++ b/FastSimulation/Calorimetry/BuildFile.xml
@@ -15,7 +15,6 @@
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="Geometry/HcalTowerAlgo"/>
 <use   name="DQMServices/Core"/>
-<use   name="SimG4Core/GFlash"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
Looks like FastSimulation/Calorimetry does not need/use SimG4Core/GFlash.