### PR TITLE
avoiding overflow in TDC regime

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -56,9 +56,10 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet& ps)
     tdcLSB_fC_ = tdcSaturation_fC_ / pow(2., tdcNbits);
     // lower tdcSaturation_fC_ by one part in a million
     // to ensure largest charge converted in bits is 0xfff and not 0x000
-    tdcSaturation_fC_ *= (1.-1e-6); 
+    tdcSaturation_fC_ *= (1. - 1e-6);
     edm::LogVerbatim("HGCFE") << "[HGCFEElectronics] " << tdcNbits << " bit TDC defined with LSB=" << tdcLSB_fC_
-                              << " saturation to occur @ " << tdcSaturation_fC_ << " (NB lowered by 1 part in a million)" << std::endl;
+                              << " saturation to occur @ " << tdcSaturation_fC_
+                              << " (NB lowered by 1 part in a million)" << std::endl;
   }
   if (ps.exists("targetMIPvalue_ADC"))
     targetMIPvalue_ADC_ = ps.getParameter<uint32_t>("targetMIPvalue_ADC");

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -54,8 +54,11 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet& ps)
     uint32_t tdcNbits = ps.getParameter<uint32_t>("tdcNbits");
     tdcSaturation_fC_ = ps.getParameter<double>("tdcSaturation_fC");
     tdcLSB_fC_ = tdcSaturation_fC_ / pow(2., tdcNbits);
+    // lower tdcSaturation_fC_ by one part in a million
+    // to ensure largest charge converted in bits is 0xfff and not 0x000
+    tdcSaturation_fC_ *= (1.-1e-6); 
     edm::LogVerbatim("HGCFE") << "[HGCFEElectronics] " << tdcNbits << " bit TDC defined with LSB=" << tdcLSB_fC_
-                              << " saturation to occur @ " << tdcSaturation_fC_ << std::endl;
+                              << " saturation to occur @ " << tdcSaturation_fC_ << " (NB lowered by 1 part in a million)" << std::endl;
   }
   if (ps.exists("targetMIPvalue_ADC"))
     targetMIPvalue_ADC_ = ps.getParameter<uint32_t>("targetMIPvalue_ADC");
@@ -119,7 +122,7 @@ void HGCFEElectronics<DFr>::runTrivialShaper(
     lsbADC = adcLSB_fC_;
   if (maxADC < 0)
     // lower adcSaturation_fC_ by one part in a million
-    // to esure largest charge convertred in bits is 0xfff==4095, not 0x1000
+    // to ensure largest charge converted in bits is 0xfff==4095, not 0x1000
     // no effect on charges loewer than; no impact on cpu time, only done once
     maxADC = adcSaturation_fC_ * (1 - 1e-6);
   for (int it = 0; it < (int)(chargeColl.size()); it++) {


### PR DESCRIPTION
#### PR description:

* Issue: for very high energetic hits (equal or larger than the TDC saturation value), the value assigned to the digis was overflowing with respect to the mask and the hits ended up being assigned with a 0 energy.

* Changes expected: migration of hits with 0 ADC energy in TDC mode to 4096 ADC energy. This is very rare and requires very energetic photons/jets (typically >500 GeV)

* Impacts other PRs: no to my knowledge

#### PR validation:

Local production of approx. 2k events of photon gun events with E=500 GeV, uniform in pseudo-rapidity

DIGIs in TDC mode before the fix (sample 1):
![DIGIs in TDC mode before the fix](https://user-images.githubusercontent.com/4624574/76448712-13356a00-63cb-11ea-8854-c91074c598bb.png)

DIGIs in TDC mode after the fix (sample 2):
![DIGIs in TDC mode after the fix](https://user-images.githubusercontent.com/4624574/76448604-e5e8bc00-63ca-11ea-9d0d-6c892d2b371f.png)