### PR TITLE
Update Run3 GEM to use the eMap from the DB

### DIFF
--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -8,10 +8,11 @@ from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 
-Phase2 = cms.ModifierChain(Run3.copyAndExclude([phase1Pixel,trackingPhase1]), phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, hcalHardcodeConditions, phase2_timing, phase2_timing_layer)
+Phase2 = cms.ModifierChain(Run3.copyAndExclude([phase1Pixel,trackingPhase1]), phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer)

--- a/Configuration/Eras/python/Modifier_phase2_GEM_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_GEM_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_GEM =  cms.Modifier()

--- a/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
@@ -4,6 +4,8 @@ gemPacker = _gemPackerDefault.clone()
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(gemPacker, useDBEMap = True)
 run3_GEM.toModify(gemPacker, useDBEMap = True)
+phase2_GEM.toModify(gemPacker, useDBEMap = False)

--- a/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
@@ -3,4 +3,7 @@ from EventFilter.GEMRawToDigi.gemPackerDefault_cfi import gemPackerDefault as _g
 gemPacker = _gemPackerDefault.clone()
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
 run2_GEM_2017.toModify(gemPacker, useDBEMap = True)
+run3_GEM.toModify(gemPacker, useDBEMap = True)

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -3,4 +3,7 @@ from EventFilter.GEMRawToDigi.muonGEMDigisDefault_cfi import muonGEMDigisDefault
 muonGEMDigis = _muonGEMDigisDefault.clone()
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
+run3_GEM.toModify(muonGEMDigis, useDBEMap = True)

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -4,6 +4,8 @@ muonGEMDigis = _muonGEMDigisDefault.clone()
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
 run3_GEM.toModify(muonGEMDigis, useDBEMap = True)
+phase2_GEM.toModify(muonGEMDigis, useDBEMap = False)


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

Fix for GEM crashing in Run3 data due to the emap not being read from the database. This patch instructs run3 to also use dbEmaps, as was done in slice test (its a minimal change as currently only slice test and run 3 emaps are in the db).

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

I tested on one of the files [1] and it no longer crashes. There are still warnings of the form
 
 %MSG-e BadDigiInput:  GEMRecHitProducer:gemRecHits 11-Mar-2020 11:39:34
 CET  Run: 335670 Event: 4434
 Failed to find GEMEtaPartition for ID  Re -1 Ri 1 St 1 La 2 Ch 25 Ro 8
 %MSG
 
which is due to currently only the slice test geometry being in the DB, which is being worked on.

I haven't checked on MC though.

[1] cmsDriver.py GEM --step=RAW2DIGI,L1Reco,RECO --filein=/store/data/Commissioning2020/MinimumBias/RAW/v1/000/335/670/00000/5F3ECF4A-0637-844F-AE67-6BB424F0BF80.root --data --conditions 110X_dataRun3_Prompt_v3 --no_exec --era Run3

@jshlee @hyunyong 