### PR TITLE
FastSim readiness for DD4Hep migration

### DIFF
--- a/FastSimulation/EventProducer/BuildFile.xml
+++ b/FastSimulation/EventProducer/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
-<use   name="DetectorDescription/Core"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>

--- a/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
+++ b/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
@@ -12,7 +12,6 @@
 
 #include "FastSimulation/Utilities/interface/FamosDebug.h"
 
-#include "DetectorDescription/Core/interface/DDsvalues.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 
 #include "SimG4CMS/Calo/interface/HFShowerLibrary.h"
@@ -31,7 +30,6 @@
 #include <memory>
 #include <map>
 
-class DDCompactView;
 class FSimEvent;
 class FSimTrack;
 class HFShowerLibrary;

--- a/FastSimulation/ShowerDevelopment/src/FastHFShowerLibrary.cc
+++ b/FastSimulation/ShowerDevelopment/src/FastHFShowerLibrary.cc
@@ -8,9 +8,6 @@
 #include "FastSimulation/Event/interface/FSimTrack.h"
 #include "FastSimulation/Utilities/interface/RandomEngineAndDistribution.h"
 #include "SimG4CMS/Calo/interface/HFFibreFiducial.h"
-#include "DetectorDescription/Core/interface/DDFilter.h"
-#include "DetectorDescription/Core/interface/DDFilteredView.h"
-#include "DetectorDescription/Core/interface/DDValue.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -49,9 +46,6 @@ FastHFShowerLibrary::FastHFShowerLibrary(edm::ParameterSet const& p) : fast(p) {
 
 void const FastHFShowerLibrary::initHFShowerLibrary(const edm::EventSetup& iSetup) {
   edm::LogInfo("FastCalorimetry") << "initHFShowerLibrary::initialization";
-
-  edm::ESTransientHandle<DDCompactView> cpv;
-  iSetup.get<IdealGeometryRecord>().get(cpv);
 
   edm::ESHandle<HcalDDDSimConstants> hdc;
   iSetup.get<HcalSimNumberingRecord>().get(hdc);


### PR DESCRIPTION
This pull request makes the changes necessary for the DD4Hep migration

#### PR description
The needs were to remove references to  
1) DDCompactView
one header include in FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
one instance declaration in FastSimulation/ShowerDevelopment/src/FastHFShowerLibrary.cc

2) DDFilteredView
one class declaration in ShowerDevelopment/interface/FastHFShowerLibrary.h 

->this object is never actually used (as far as I can tell!) so it shouldn't make any difference

3) DetectorDescription/Core 
one class declaration in ShowerDevelopment/interface/FastHFShowerLibrary.h 
one instance in FastSimulation/ShowerDevelopment/src/FastHFShowerLibrary.cc



#### PR validation
runTheMatrix.py -e -l 135.1
performed smoothly as expected
