### PR TITLE
Allow to take DCS Status from software FED, when SCAL is not available

### DIFF
--- a/CalibTracker/SiStripCommon/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="DataFormats/Scalers"/>
+<use   name="DataFormats/OnlineMetaData"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ServiceRegistry"/>

--- a/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
@@ -8,6 +8,7 @@
 #include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DataFormats/Scalers/interface/DcsStatus.h"
+#include "DataFormats/OnlineMetaData/interface/DCSRecord.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 class TrackerTopology;
@@ -32,6 +33,7 @@ private:
 
   edm::EDGetTokenT<DcsStatusCollection> dcsStatusToken_;
   edm::EDGetTokenT<FEDRawDataCollection> rawDataToken_;
+  edm::EDGetTokenT<DCSRecord> dcsRecordToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCablingToken_;
 };

--- a/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
@@ -50,8 +50,8 @@ bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSe
   edm::Handle<DCSRecord> dcsRecord;
   e.getByToken(dcsRecordToken_, dcsRecord);
 
-  bool statusTIBTID, statusTOB, statusTECF, statusTECB = true;
-  bool dcsTIBTID, dcsTOB, dcsTECF, dcsTECB = true;
+  bool statusTIBTID(true), statusTOB(true), statusTECF(true), statusTECB(true);
+  bool dcsTIBTID(true), dcsTOB(true), dcsTECF(true), dcsTECB(true);
 
   if (trackerAbsent || (!dcsStatus.isValid() && !dcsRecord.isValid())) {
     return retVal;

--- a/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
@@ -31,6 +31,7 @@ SiStripDCSStatus::SiStripDCSStatus(edm::ConsumesCollector& iC)
       rawdataAbsent(true),
       initialised(false) {
   dcsStatusToken_ = iC.consumes<DcsStatusCollection>(edm::InputTag("scalersRawToDigi"));
+  dcsRecordToken_ = iC.consumes<DCSRecord>(edm::InputTag("onlineMetaDataDigis"));
   rawDataToken_ = iC.consumes<FEDRawDataCollection>(edm::InputTag("rawDataCollector"));
   tTopoToken_ = iC.esConsumes<TrackerTopology, TrackerTopologyRcd>();
   fedCablingToken_ = iC.esConsumes<SiStripFedCabling, SiStripFedCablingRcd>();
@@ -44,22 +45,30 @@ bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSe
     initialise(e, eSetup);
 
   edm::Handle<DcsStatusCollection> dcsStatus;
-  //  e.getByLabel("scalersRawToDigi", dcsStatus);
   e.getByToken(dcsStatusToken_, dcsStatus);
-  if (trackerAbsent || !dcsStatus.isValid())
-    return retVal;
-  if ((*dcsStatus).empty())
-    return retVal;
 
-  bool statusTIBTID = true;
-  bool statusTOB = true;
-  bool statusTECF = true;
-  bool statusTECB = true;
+  edm::Handle<DCSRecord> dcsRecord;
+  e.getByToken(dcsRecordToken_, dcsRecord);
 
-  bool dcsTIBTID = ((*dcsStatus)[0].ready(DcsStatus::TIBTID));
-  bool dcsTOB = ((*dcsStatus)[0].ready(DcsStatus::TOB));
-  bool dcsTECF = ((*dcsStatus)[0].ready(DcsStatus::TECp));
-  bool dcsTECB = ((*dcsStatus)[0].ready(DcsStatus::TECm));
+  bool statusTIBTID, statusTOB, statusTECF, statusTECB = true;
+  bool dcsTIBTID, dcsTOB, dcsTECF, dcsTECB = true;
+
+  if (trackerAbsent || (!dcsStatus.isValid() && !dcsRecord.isValid())) {
+    return retVal;
+  }
+
+  if ((*dcsStatus).empty()) {
+    dcsTIBTID = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TIBTID);
+    dcsTOB = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TOB);
+    dcsTECF = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TECp);
+    dcsTECB = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TECm);
+  } else {
+    dcsTIBTID = ((*dcsStatus)[0].ready(DcsStatus::TIBTID));
+    dcsTOB = ((*dcsStatus)[0].ready(DcsStatus::TOB));
+    dcsTECF = ((*dcsStatus)[0].ready(DcsStatus::TECp));
+    dcsTECB = ((*dcsStatus)[0].ready(DcsStatus::TECm));
+  }
+
   if (rawdataAbsent) {
     statusTIBTID = dcsTIBTID;
     statusTOB = dcsTOB;

--- a/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
@@ -58,10 +58,14 @@ bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSe
   }
 
   if ((*dcsStatus).empty()) {
-    dcsTIBTID = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TIBTID);
-    dcsTOB = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TOB);
-    dcsTECF = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TECp);
-    dcsTECB = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TECm);
+    if (e.eventAuxiliary().isRealData()) {
+      dcsTIBTID = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TIBTID);
+      dcsTOB = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TOB);
+      dcsTECF = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TECp);
+      dcsTECB = (*dcsRecord).highVoltageReady(DCSRecord::Partition::TECm);
+    } else {
+      return retVal;
+    }
   } else {
     dcsTIBTID = ((*dcsStatus)[0].ready(DcsStatus::TIBTID));
     dcsTOB = ((*dcsStatus)[0].ready(DcsStatus::TOB));

--- a/DPGAnalysis/Skims/BuildFile.xml
+++ b/DPGAnalysis/Skims/BuildFile.xml
@@ -35,4 +35,5 @@
 <use   name="DataFormats/EgammaReco"/>
 <use   name="PhysicsTools/SelectorUtils"/>
 <use   name="DataFormats/Provenance"/>
+<use   name="DataFormats/OnlineMetaData"/>
 <flags   EDM_PLUGIN="1"/>

--- a/DPGAnalysis/Skims/interface/DetStatus.h
+++ b/DPGAnalysis/Skims/interface/DetStatus.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Scalers/interface/DcsStatus.h"
+#include "DataFormats/OnlineMetaData/interface/DCSRecord.h"
 
 class DetStatus : public edm::EDFilter {
 public:
@@ -17,8 +18,13 @@ private:
   bool applyfilter_;
   bool AndOr_;
   std::vector<std::string> DetNames_;
+  std::bitset<DcsStatus::nPartitions> requestedPartitions_;
   unsigned int DetMap_;
   edm::EDGetTokenT<DcsStatusCollection> scalersToken_;
+  edm::EDGetTokenT<DCSRecord> dcsRecordToken_;
+
+  bool checkForDCSStatus(const DcsStatusCollection& dcsStatus);
+  bool checkForDCSRecord(const DCSRecord& dcsRecod);
 };
 
 #endif

--- a/DPGAnalysis/Skims/src/DetStatus.cc
+++ b/DPGAnalysis/Skims/src/DetStatus.cc
@@ -130,7 +130,13 @@ bool DetStatus::filter(edm::Event& evt, edm::EventSetup const& es)
   if (dcsStatus.isValid() && !dcsStatus->empty()) {
     accepted = checkForDCSStatus(*dcsStatus);
   } else if (dcsRecord.isValid()) {
-    accepted = checkForDCSRecord(*dcsRecord);
+    if (evt.eventAuxiliary().isRealData()) {
+      // in case of real data check for DCS
+      accepted = checkForDCSRecord(*dcsRecord);
+    } else {
+      // in case of MC accept in any case
+      accepted = true;
+    }
   } else {
     edm::LogError("DetStatus")
         << "Error! can't get the product, neither DCSRecord, nor scalersRawToDigi: accept in any case!";

--- a/DPGAnalysis/Skims/src/DetStatus.cc
+++ b/DPGAnalysis/Skims/src/DetStatus.cc
@@ -17,18 +17,27 @@ DetStatus::DetStatus(const edm::ParameterSet& pset) {
 
   // build a map
   DetMap_ = 0;
+
   for (unsigned int detreq = 0; detreq < DetNames_.size(); detreq++) {
     for (unsigned int detlist = 0; detlist < DcsStatus::nPartitions; detlist++) {
       if (DetNames_[detreq] == DcsStatus::partitionName[detlist]) {
+        //edm::LogPrint("DetStatus") << __PRETTY_FUNCTION__ << " requested:" << DetNames_[detreq] << std::endl;
+
+        // set for DCSRecord
+        requestedPartitions_.set(detlist, true);
+
+        // set for DCSStatus
         DetMap_ |= (1 << DcsStatus::partitionList[detlist]);
-        if (verbose_)
-          std::cout << "DCSStatus filter: asked partition " << DcsStatus::partitionName[detlist] << " bit "
-                    << DcsStatus::partitionList[detlist] << std::endl;
+
+        if (verbose_) {
+          edm::LogInfo("DetStatus") << "DCSStatus filter: asked partition " << DcsStatus::partitionName[detlist]
+                                    << " bit " << DcsStatus::partitionList[detlist] << std::endl;
+        }
       }
     }
   }
-  edm::InputTag scalersTag("scalersRawToDigi");
-  scalersToken_ = consumes<DcsStatusCollection>(scalersTag);
+  scalersToken_ = consumes<DcsStatusCollection>(edm::InputTag("scalersRawToDigi"));
+  dcsRecordToken_ = consumes<DCSRecord>(edm::InputTag("onlineMetaDataDigis"));
 }
 
 //
@@ -36,48 +45,83 @@ DetStatus::DetStatus(const edm::ParameterSet& pset) {
 //
 DetStatus::~DetStatus() {}
 
+bool DetStatus::checkForDCSStatus(const DcsStatusCollection& dcsStatus) {
+  if (verbose_) {
+    edm::LogInfo("DetStatus") << "Using FED#735 for reading DCS bits" << std::endl;
+  }
+
+  bool accepted = false;
+  unsigned int curr_dcs = (dcsStatus)[0].ready();
+  if (verbose_) {
+    edm::LogVerbatim("DetStatus") << "curr_dcs = " << curr_dcs << std::endl;
+  }
+
+  if (AndOr_)
+    accepted = ((DetMap_ & curr_dcs) == DetMap_);
+  else
+    accepted = ((DetMap_ & curr_dcs) != 0);
+
+  if (verbose_) {
+    edm::LogInfo("DetStatus") << "DCSStatus filter: requested map: " << DetMap_ << " dcs in event: " << curr_dcs
+                              << " filter: " << accepted << "( AndOr: " << AndOr_ << ")" << std::endl;
+    edm::LogVerbatim("DetStatus") << "Partitions ON: ";
+    for (unsigned int detlist = 0; detlist < DcsStatus::nPartitions; detlist++) {
+      if ((dcsStatus)[0].ready(DcsStatus::partitionList[detlist])) {
+        edm::LogVerbatim("DetStatus") << " " << DcsStatus::partitionName[detlist];
+      }
+    }
+    edm::LogVerbatim("DetStatus") << std::endl;
+  }
+  return accepted;
+}
+
+bool DetStatus::checkForDCSRecord(const DCSRecord& dcsRecord) {
+  bool accepted = false;
+
+  if (verbose_) {
+    edm::LogInfo("DetStatus") << "Using softFED#1022 for reading DCS bits" << std::endl;
+  }
+
+  for (unsigned int detlist = 0; detlist < DcsStatus::nPartitions; detlist++) {
+    if (requestedPartitions_.test(detlist)) {
+      if (AndOr_) {
+        accepted = (accepted & dcsRecord.highVoltageReady(detlist));
+      } else {
+        accepted = (accepted || dcsRecord.highVoltageReady(detlist));
+      }
+    }
+  }
+
+  if (verbose_) {
+    edm::LogInfo("DetStatus") << "DCSStatus filter: " << accepted << "( AndOr: " << AndOr_ << ")" << std::endl;
+    edm::LogVerbatim("DetStatus") << "Partitions ON: ";
+    for (unsigned int detlist = 0; detlist < DcsStatus::nPartitions; detlist++) {
+      if ((dcsRecord.highVoltageReady(detlist))) {
+        edm::LogVerbatim("DetStatus") << " " << DcsStatus::partitionName[detlist];
+      }
+    }
+    edm::LogVerbatim("DetStatus") << std::endl;
+  }
+
+  return accepted;
+}
+
 bool DetStatus::filter(edm::Event& evt, edm::EventSetup const& es) {
   bool accepted = false;
 
-  edm::Handle<DcsStatusCollection> dcsStatus;
-  evt.getByToken(scalersToken_, dcsStatus);
+  DcsStatusCollection const& dcsStatus = evt.get(scalersToken_);
+  DCSRecord const& dcsRecord = evt.get(dcsRecordToken_);
 
-  if (dcsStatus.isValid()) {
-    if (dcsStatus->empty()) {
-      // Only complain in case it's real data. Accept in any case.
-      if (evt.eventAuxiliary().isRealData())
-        edm::LogError("DetStatus") << "Error! dcsStatus has size 0, accept in any case";
-      accepted = true;
-    } else {
-      unsigned int curr_dcs = (*dcsStatus)[0].ready();
-      if (verbose_)
-        std::cout << "curr_dcs = " << curr_dcs << std::endl;
-      if (AndOr_)
-        accepted = ((DetMap_ & curr_dcs) == DetMap_);
-      else
-        accepted = ((DetMap_ & curr_dcs) != 0);
-
-      if (verbose_)
-
-      {
-        std::cout << "DCSStatus filter: requested map: " << DetMap_ << " dcs in event: " << curr_dcs
-                  << " filter: " << accepted << std::endl;
-        std::cout << "Partitions ON: ";
-        for (unsigned int detlist = 0; detlist < DcsStatus::nPartitions; detlist++) {
-          if ((*dcsStatus)[0].ready(DcsStatus::partitionList[detlist])) {
-            std::cout << " " << DcsStatus::partitionName[detlist];
-          }
-        }
-        std::cout << std::endl;
-      }
-    }
+  if (!dcsStatus.empty()) {
+    accepted = checkForDCSStatus(dcsStatus);
   } else {
-    edm::LogError("DetStatus") << "Error! can't get the product: scalersRawToDigi, accept in any case";
+    accepted = checkForDCSRecord(dcsRecord);
+  }
+
+  if (!applyfilter_) {
     accepted = true;
   }
 
-  if (!applyfilter_)
-    accepted = true;
   return accepted;
 }
 


### PR DESCRIPTION
#### PR description:

In case the DCS status from SCAL is not available, fall back to `DCSRecord` data provided by the software FED n. 1022. The logic is modified in two classes: `SiStripDCSStatus` and `DetStatus`. 
Both classes are used to select events in different ALCARECO workflows, while `SiStripDCSStatus`
is also used to filter events in several Tracker and Tracking DQM modules.
No differences are expected in Run1 and Run2 workflows. For Run3 data the ALCARECO selectors now work correctly.

#### PR validation:

Tested with `runTheMatrix.py -l 1001.0,138.1` and checked that in runs with SCAL there are no differences, while with recent MWGR 2020 cosmic data the events are filtered correctly.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, but a backport will be proposed in 11.0.X to be used for the next MWGR.

