### PR TITLE
BuildFile cleanup: remobe special TAB char

### DIFF
--- a/CalibTracker/SiStripChannelGain/test/BuildFile.xml
+++ b/CalibTracker/SiStripChannelGain/test/BuildFile.xml
@@ -1,7 +1,6 @@
 <environment>
   <bin   name="testSSTGainPCL_fromRECO" file="testSSTGain_PCL_FromRECO.cpp">
-    <flags   TEST_RUNNER_ARGS="/bin/bash
-			       CalibTracker/SiStripChannelGain/test testSSTGain_PCL_FromRECO.sh"/>
+    <flags   TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiStripChannelGain/test testSSTGain_PCL_FromRECO.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
   <bin name="checkMultiRunHarvestingOutput" file="checkMultiRunHarvesting.cpp">


### PR DESCRIPTION
Techinical cleanup. Remove special TAB character which causes converting PERL cache to json