### PR TITLE
BuildFile cleanup: removed the invalud use statement

### DIFF
--- a/PhysicsTools/Utilities/test/BuildFile.xml
+++ b/PhysicsTools/Utilities/test/BuildFile.xml
@@ -48,7 +48,6 @@
   <use   name="rootcore"/>
   <use   name="roofit"/>
   <use   name="PhysicsTools/Utilities"/>
-  <use   lib="Gpad"/>
 </bin>
 <bin   file="test_Poisson.cpp">
   <use   name="PhysicsTools/Utilities"/>


### PR DESCRIPTION
Remove invalide `use` statement from the BuildFile.