### PR TITLE
Run-3 CLCT and LCT data formats (CCLUT-3)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -1,5 +1,5 @@
-#ifndef CSCDigi_CSCCLCTDigi_h
-#define CSCDigi_CSCCLCTDigi_h
+#ifndef DataFormats_CSCDigi_CSCCLCTDigi_h
+#define DataFormats_CSCDigi_CSCCLCTDigi_h
 
 /**\class CSCCLCTDigi
  *
@@ -11,9 +11,15 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <vector>
 
 class CSCCLCTDigi {
 public:
+  typedef std::vector<std::vector<uint16_t>> ComparatorContainer;
+
+  enum CLCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0x1f };
+  enum CLCTKeyStripShifts { kEightStripShift = 6, kQuartStripShift = 5, kHalfStripShift = 0 };
+
   /// Constructors
   CSCCLCTDigi(const int valid,
               const int quality,
@@ -24,7 +30,8 @@ public:
               const int cfeb,
               const int bx,
               const int trknmb = 0,
-              const int fullbx = 0);
+              const int fullbx = 0,
+              const int compCode = -1);
   /// default
   CSCCLCTDigi();
 
@@ -61,11 +68,23 @@ public:
   /// set bend
   void setBend(const int bend) { bend_ = bend; }
 
-  /// return halfstrip that goes from 0 to 31
-  int getStrip() const { return strip_; }
+  /// return halfstrip that goes from 0 to 31 in a (D)CFEB
+  int getStrip() const;
 
   /// set strip
   void setStrip(const int strip) { strip_ = strip; }
+
+  /// set single quart strip bit
+  void setQuartStrip(const bool quartStrip);
+
+  /// get single quart strip bit
+  bool getQuartStrip() const;
+
+  /// set single eight strip bit
+  void setEightStrip(const bool eightStrip);
+
+  /// get single eight strip bit
+  bool getEightStrip() const;
 
   /// return Key CFEB ID
   int getCFEB() const { return cfeb_; }
@@ -85,16 +104,10 @@ public:
   /// Convert strip_ and cfeb_ to keyStrip. Each CFEB has up to 16 strips
   /// (32 halfstrips). There are 5 cfebs.  The "strip_" variable is one
   /// of 32 halfstrips on the keylayer of a single CFEB, so that
-  /// Distrip   = (cfeb*32 + strip)/4.
   /// Halfstrip = (cfeb*32 + strip).
-  /// Always return halfstrip number since this is what is stored in
-  /// the correlated LCT digi.  For distrip patterns, the convention is
-  /// the same as for persistent strip numbers: low halfstrip of a distrip.
-  /// SV, June 15th, 2006.
-  int getKeyStrip() const {
-    int keyStrip = cfeb_ * 32 + strip_;
-    return keyStrip;
-  }
+  /// This function can also return the quartstrip or eightstrip
+  /// when the comparator code has been set
+  int getKeyStrip(int n = 2) const;
 
   /// Set track number (1,2) after sorting CLCTs.
   void setTrknmb(const uint16_t number) { trknmb_ = number; }
@@ -104,6 +117,16 @@ public:
 
   /// Set 12-bit full BX.
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
+
+  // 12-bit comparator code
+  int getCompCode() const { return compCode_; }
+
+  void setCompCode(const int16_t code) { compCode_ = code; }
+
+  // comparator hits in this CLCT
+  ComparatorContainer getHits() const { return hits_; }
+
+  void setHits(const ComparatorContainer& hits) { hits_ = hits; }
 
   /// True if the left-hand side has a larger "quality".  Full definition
   /// of "quality" depends on quality word itself, pattern type, and strip
@@ -130,6 +153,12 @@ private:
   uint16_t bx_;
   uint16_t trknmb_;
   uint16_t fullbx_;
+
+  // new in Run-3: 12-bit comparator code
+  // set by default to -1 for Run-1 and Run-2 CLCTs
+  int16_t compCode_;
+  // which hits are in this CLCT?
+  ComparatorContainer hits_;
 };
 
 std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi);

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -1,9 +1,9 @@
-#ifndef CSCDigi_CSCCorrelatedLCTDigi_h
-#define CSCDigi_CSCCorrelatedLCTDigi_h
+#ifndef DataFormats_CSCDigi_CSCCorrelatedLCTDigi_h
+#define DataFormats_CSCDigi_CSCCorrelatedLCTDigi_h
 
 /**\class CSCCorrelatedLCTDigi
  *
- * Digi for Correlated LCT trigger primitives. 
+ * Digi for Correlated LCT trigger primitives.
  *
  *
  * \author L. Gray, UF
@@ -17,6 +17,9 @@
 
 class CSCCorrelatedLCTDigi {
 public:
+  enum LCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
+  enum LCTKeyStripShifts { kEightStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
+
   /// Constructors
   CSCCorrelatedLCTDigi(const int trknmb,
                        const int valid,
@@ -41,17 +44,29 @@ public:
   /// return valid pattern bit
   bool isValid() const { return valid; }
 
-  /// return the 4 bit Correlated LCT Quality
+  /// return the Quality
   int getQuality() const { return quality; }
 
   /// return the key wire group. counts from 0.
   int getKeyWG() const { return keywire; }
 
   /// return the key halfstrip from 0,159
-  int getStrip() const { return strip; }
+  int getStrip(int n = 2) const;
+
+  /// set single quart strip bit
+  void setQuartStrip(const bool quartStrip);
+
+  /// get single quart strip bit
+  bool getQuartStrip() const;
+
+  /// set single eight strip bit
+  void setEightStrip(const bool eightStrip);
+
+  /// get single eight strip bit
+  bool getEightStrip() const;
 
   /// return the fractional strip. counts from 0.25
-  float getFractionalStrip() const;
+  float getFractionalStrip(int n = 2) const;
 
   /// return pattern
   int getPattern() const { return pattern; }

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -11,10 +11,7 @@
 #include <iomanip>
 #include <iostream>
 
-enum Pattern_Info {
-  NUM_LAYERS = 6,
-  CLCT_PATTERN_WIDTH = 11
-};
+enum Pattern_Info { NUM_LAYERS = 6, CLCT_PATTERN_WIDTH = 11 };
 
 /// Constructors
 CSCCLCTDigi::CSCCLCTDigi(const int valid,
@@ -99,10 +96,7 @@ int CSCCLCTDigi::getKeyStrip(int n) const {
   }
 }
 
-int CSCCLCTDigi::getStrip() const
-{
-  return strip_ & kHalfStripMask;
-}
+int CSCCLCTDigi::getStrip() const { return strip_ & kHalfStripMask; }
 
 bool CSCCLCTDigi::getQuartStrip() const { return (strip_ >> kQuartStripShift) & kQuartStripMask; }
 

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -11,6 +11,11 @@
 #include <iomanip>
 #include <iostream>
 
+enum Pattern_Info {
+  NUM_LAYERS = 6,
+  CLCT_PATTERN_WIDTH = 11
+};
+
 /// Constructors
 CSCCLCTDigi::CSCCLCTDigi(const int valid,
                          const int quality,
@@ -21,7 +26,8 @@ CSCCLCTDigi::CSCCLCTDigi(const int valid,
                          const int cfeb,
                          const int bx,
                          const int trknmb,
-                         const int fullbx)
+                         const int fullbx,
+                         const int compCode)
     : valid_(valid),
       quality_(quality),
       pattern_(pattern),
@@ -31,23 +37,31 @@ CSCCLCTDigi::CSCCLCTDigi(const int valid,
       cfeb_(cfeb),
       bx_(bx),
       trknmb_(trknmb),
-      //fullbx_(0)
-      fullbx_(fullbx) {
-  //valid_     = valid;
-  //quality_   = quality;
-  //pattern_   = pattern;
-  //striptype_ = striptype;
-  //bend_      = bend;
-  //strip_     = strip;
-  //cfeb_      = cfeb;
-  //bx_        = bx;
-  //trknmb_    = trknmb;
+      fullbx_(fullbx),
+      compCode_(compCode) {
+  hits_.resize(NUM_LAYERS);
+  for (auto& p : hits_) {
+    p.resize(CLCT_PATTERN_WIDTH);
+  }
 }
 
 /// Default
 CSCCLCTDigi::CSCCLCTDigi()
-    : valid_(0), quality_(0), pattern_(0), striptype_(0), bend_(0), strip_(0), cfeb_(0), bx_(0), trknmb_(0), fullbx_(0) {
-  //  clear(); // set contents to zero
+    : valid_(0),
+      quality_(0),
+      pattern_(0),
+      striptype_(0),
+      bend_(0),
+      strip_(0),
+      cfeb_(0),
+      bx_(0),
+      trknmb_(0),
+      fullbx_(0),
+      compCode_(-1) {
+  hits_.resize(NUM_LAYERS);
+  for (auto& p : hits_) {
+    p.resize(CLCT_PATTERN_WIDTH);
+  }
 }
 
 /// Clears this CLCT.
@@ -62,6 +76,52 @@ void CSCCLCTDigi::clear() {
   bx_ = 0;
   trknmb_ = 0;
   fullbx_ = 0;
+  compCode_ = -1;
+  hits_.clear();
+  hits_.resize(NUM_LAYERS);
+  for (auto& p : hits_) {
+    p.resize(CLCT_PATTERN_WIDTH);
+  }
+}
+
+int CSCCLCTDigi::getKeyStrip(int n) const {
+  // 10-bit case for strip data word
+  if (compCode_ != -1 and n == 8) {
+    return getKeyStrip(4) * 2 + getEightStrip();
+  }
+  // 9-bit case for strip data word
+  else if (compCode_ != -1 and n == 4) {
+    return getKeyStrip(2) * 2 + getQuartStrip();
+  }
+  // 8-bit case for strip data word (all other cases)
+  else {
+    return cfeb_ * 32 + getStrip();
+  }
+}
+
+int CSCCLCTDigi::getStrip() const
+{
+  return strip_ & kHalfStripMask;
+}
+
+bool CSCCLCTDigi::getQuartStrip() const { return (strip_ >> kQuartStripShift) & kQuartStripMask; }
+
+bool CSCCLCTDigi::getEightStrip() const { return (strip_ >> kEightStripShift) & kEightStripMask; }
+
+void CSCCLCTDigi::setQuartStrip(const bool quartStrip) {
+  // clear the old value
+  strip_ &= ~(kQuartStripMask << kQuartStripShift);
+
+  // set the new value
+  strip_ |= quartStrip << kQuartStripShift;
+}
+
+void CSCCLCTDigi::setEightStrip(const bool eightStrip) {
+  // clear the old value
+  strip_ &= ~(kEightStripMask << kEightStripShift);
+
+  // set the new value
+  strip_ |= eightStrip << kEightStripShift;
 }
 
 bool CSCCLCTDigi::operator>(const CSCCLCTDigi& rhs) const {
@@ -96,7 +156,7 @@ bool CSCCLCTDigi::operator==(const CSCCLCTDigi& rhs) const {
   bool returnValue = false;
   if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getPattern() == rhs.getPattern() &&
       getKeyStrip() == rhs.getKeyStrip() && getStripType() == rhs.getStripType() && getBend() == getBend() &&
-      getBX() == rhs.getBX()) {
+      getBX() == rhs.getBX() && getCompCode() == rhs.getCompCode()) {
     returnValue = true;
   }
   return returnValue;
@@ -122,7 +182,8 @@ void CSCCLCTDigi::print() const {
                                 << getQuality() << " Pattern = " << std::setw(1) << getPattern()
                                 << " Bend = " << std::setw(1) << bend << " Strip type = " << std::setw(1) << stripType
                                 << " CFEB ID = " << std::setw(1) << getCFEB() << " BX = " << std::setw(1) << getBX()
-                                << " Full BX= " << std::setw(1) << getFullBX();
+                                << " Full BX= " << std::setw(1) << getFullBX() << " Comp Code= " << std::setw(1)
+                                << getCompCode();
   } else {
     edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
   }
@@ -132,5 +193,5 @@ std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi) {
   return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
            << " Pattern = " << digi.getPattern() << " StripType = " << digi.getStripType()
            << " Bend = " << digi.getBend() << " Strip = " << digi.getStrip() << " KeyStrip = " << digi.getKeyStrip()
-           << " CFEB = " << digi.getCFEB() << " BX = " << digi.getBX();
+           << " CFEB = " << digi.getCFEB() << " BX = " << digi.getBX() << " Comp Code " << digi.getCompCode();
 }

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -57,8 +57,51 @@ void CSCCorrelatedLCTDigi::clear() {
   cscID = 0;
 }
 
+int CSCCorrelatedLCTDigi::getStrip(int n) const {
+  // all 10 bits
+  if (n == 8) {
+    return 2 * getStrip(4) + getEightStrip();
+  }
+  // lowest 9 bits
+  else if (n == 4) {
+    return 2 * getStrip(2) + getQuartStrip();
+  }
+  // lowest 8 bits
+  else {
+    return strip & kHalfStripMask;
+  }
+}
+
+void CSCCorrelatedLCTDigi::setQuartStrip(const bool quartStrip) {
+  // clear the old value
+  strip &= ~(kQuartStripMask << kQuartStripShift);
+
+  // set the new value
+  strip |= quartStrip << kQuartStripShift;
+}
+
+void CSCCorrelatedLCTDigi::setEightStrip(const bool eightStrip) {
+  // clear the old value
+  strip &= ~(kEightStripMask << kEightStripShift);
+
+  // set the new value
+  strip |= eightStrip << kEightStripShift;
+}
+
+bool CSCCorrelatedLCTDigi::getQuartStrip() const { return (strip >> kQuartStripShift) & kQuartStripMask; }
+
+bool CSCCorrelatedLCTDigi::getEightStrip() const { return (strip >> kEightStripShift) & kEightStripMask; }
+
 /// return the fractional strip
-float CSCCorrelatedLCTDigi::getFractionalStrip() const { return 0.5f * (getStrip() + 1) - 0.25f; }
+float CSCCorrelatedLCTDigi::getFractionalStrip(int n) const {
+  if (n == 8) {
+    return 0.125f * (getStrip() + 1) - 0.0625f;
+  } else if (n == 4) {
+    return 0.25f * (getStrip() + 1) - 0.125f;
+  } else {
+    return 0.5f * (getStrip() + 1) - 0.25f;
+  }
+}
 
 /// Comparison
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -19,9 +19,11 @@
     <version ClassVersion="10" checksum="967689346"/>
     <version ClassVersion="11" checksum="56593764"/>
    </class>
-   <class name="CSCCLCTDigi" ClassVersion="10">
+   <class name="CSCCLCTDigi" ClassVersion="11">
     <version ClassVersion="10" checksum="3910057547"/>
+    <version ClassVersion="11" checksum="511203876"/>
    </class>
+   <ioread sourceClass="CSCCLCTDigi"  targetClass="CSCCLCTDigi" version="[-10]" target="compCode_" source=""> <![CDATA[ compCode_ = -1; ]]> </ioread>
    <class name="CSCCLCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="1207676078"/>
    </class>


### PR DESCRIPTION
#### PR description:

This pull requests implements the CLCT and LCT data formats for Run-3 data taking. The Run-3 CSC local trigger will be notably different than then Run-1/2 trigger. CSC stubs will have a higher resolution in position (x2 to x4) and bending (x3). This is achieved by implementing a 12-bit comparator code data word (CCLUT algorithm). It is set by default to -1 for Run-1/2 CLCTs. For Run-3 it takes a value between 0 and 2^12 - 1. The halfstrip number of CLCT and LCT is given 2 extra bits, one for the 1/4 strip value and one for the 1/8 strip value. In addition, I added a new `ComparatorContainer` object to keep track of which comparators were used to build a CLCT. 

This PR is a follow-up of https://github.com/cms-sw/cmssw/pull/28846. But the code is written such that the original functions retain their original meaning for the default arguments. The actual CCLUT algorithm will be implemented in a separate PR.

More information can be found here: 
https://indico.cern.ch/event/881406/contributions/3713334/attachments/1973349/3283422/CSC_NewPatterns_SD_20200121.pdf

#### PR validation:

Tested with WF 22034.0.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@barvic @tahuang1991 @ptcox 
