### PR TITLE
MTD geometry: updates of xml and RECO geometry for new TDR ETL

### DIFF
--- a/DataFormats/ForwardDetId/interface/ETLDetId.h
+++ b/DataFormats/ForwardDetId/interface/ETLDetId.h
@@ -27,10 +27,12 @@ public:
   static const uint32_t kETLnDiscMask = 0x1;
   static const uint32_t kETLdiscSideOffset = 2;
   static const uint32_t kETLdiscSideMask = 0x1;
-  static const uint32_t kETLquarterMask = 0x3;
+  static const uint32_t kETLsectorMask = 0x3;
 
   static constexpr int kETLv2maxRing = 16;
   static constexpr int kETLv2maxModule = 292;
+
+  static constexpr uint32_t kSoff = 4;
 
   // ---------- Constructors, enumerated types ----------
 
@@ -53,6 +55,19 @@ public:
            (modtyp & kETLmodTypeMask) << kETLmodTypeOffset;
   }
 
+  /** ETL TDR Construct and fill only the det and sub-det fields. */
+
+  inline uint32_t encodeSector(uint32_t& disc, uint32_t& discside, uint32_t& sector) const {
+    return (sector + discside * kSoff + 2 * kSoff * disc);
+  }
+
+  ETLDetId(uint32_t zside, uint32_t disc, uint32_t discside, uint32_t sector, uint32_t module, uint32_t modtyp)
+      : MTDDetId(DetId::Forward, ForwardSubdetector::FastTime) {
+    id_ |= (MTDType::ETL & kMTDsubdMask) << kMTDsubdOffset | (zside & kZsideMask) << kZsideOffset |
+           (encodeSector(disc, discside, sector) & kRodRingMask) << kRodRingOffset |
+           (module & kETLmoduleMask) << kETLmoduleOffset | (modtyp & kETLmodTypeMask) << kETLmodTypeOffset;
+  }
+
   // ---------- Common methods ----------
 
   /** Returns ETL module number. */
@@ -67,7 +82,7 @@ public:
   // meaningless for TP model
 
   // starting from 1
-  inline int quarter() const { return ((((id_ >> kRodRingOffset) & kRodRingMask) - 1) & kETLquarterMask) + 1; }
+  inline int sector() const { return ((((id_ >> kRodRingOffset) & kRodRingMask) - 1) & kETLsectorMask) + 1; }
 
   // 0 = front, 1 = back
   inline int discSide() const {

--- a/DataFormats/ForwardDetId/src/ETLDetId.cc
+++ b/DataFormats/ForwardDetId/src/ETLDetId.cc
@@ -11,7 +11,7 @@ std::ostream& operator<<(std::ostream& os, const ETLDetId& id) {
   os << " ETL " << std::endl
      << " Side        : " << id.mtdSide() << std::endl
      << " Ring        : " << id.mtdRR() << "    "
-     << " Disc/Side/Quarter = " << id.nDisc() << " " << id.discSide() << " " << id.quarter() << std::endl
+     << " Disc/Side/Sector = " << id.nDisc() << " " << id.discSide() << " " << id.sector() << std::endl
      << " Module      : " << id.module() << std::endl
      << " Module type : " << id.modType() << std::endl;
   return os;

--- a/DataFormats/ForwardDetId/src/MTDDetId.cc
+++ b/DataFormats/ForwardDetId/src/MTDDetId.cc
@@ -12,8 +12,8 @@ std::ostream& operator<<(std::ostream& os, const MTDDetId& id) {
             << std::bitset<4>((id.rawId() >> 8) & 0xF).to_string() << " "
             << std::bitset<4>((id.rawId() >> 4) & 0xF).to_string() << " "
             << std::bitset<4>(id.rawId() & 0xF).to_string() << std::endl
-            << " rawId       : 0x" << std::hex << std::setfill('0') << std::setw(8) << id.rawId() << std::dec
-            << std::endl
+            << " rawId       : 0x" << std::hex << std::setfill('0') << std::setw(8) << id.rawId() << std::dec << " / "
+            << id.rawId() << std::endl
             << " bits[0:24]  : " << std::hex << std::setfill('0') << std::setw(8) << (0x01FFFFFF & id.rawId())
             << std::dec << std::endl
             << " Detector        : " << id.det() << std::endl

--- a/Geometry/MTDCommonData/data/etl/v4/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v4/etl.xml
@@ -12,7 +12,7 @@
 	<!-- LGAD and ETROC values taken from Ulascan code (line 103 on in ETLDetectorDimensions.cc), same values in the TDR -->
 	<Constant name="LGADdx" value="2.12"/>
 	<Constant name="LGADdy" value="4.2"/>
-	<Constant name="LGAD_TimingActive" value="0.005"/>
+	<Constant name="EModule_Timingactive" value="0.005"/>
 	<Constant name="LGAD_Substrate" value="0.025"/>
 	<Constant name="LGADdz" value="0.03"/>
 	<Constant name="lgadSep_X" value="0.025"/>  <!-- x-offset between lgad in a 2SensorModule, line 232 ETLDetectorDimensions.cc -->
@@ -61,7 +61,7 @@
 	<Box name="LairdFilm" dx="0.5*([ETROCdx]+0.5*[etrocSep_X])*cm" dy="0.5*([ETROCdy]*2+[etrocSep_Y])*cm" dz="0.5*(0.008)*cm"/>
 	<Box name="ETROC" dx="0.5*[ETROCdx]*cm" dy="0.5*[ETROCdy]*cm" dz="0.5*(0.028)*cm"/>  <!-- solder bumps not considered, their thickness is included in that of the ETROC -->
 	<Box name="LGAD" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[LGADdz]*cm"/>
-	<Box name="LGAD_TimingActive" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[LGAD_TimingActive]*cm"/>
+	<Box name="EModule_Timingactive" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[EModule_Timingactive]*cm"/>
 	<Box name="LGAD_Substrate" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[LGAD_Substrate]*cm"/>
 	<Box name="AlN_Cover" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*(0.059)*cm"/>  <!-- epoxy included in the thickness of the AlN cover -->
   </SolidSection>
@@ -167,8 +167,8 @@
       <rSolid name="etl:LGAD"/>
       <rMaterial name="materials:Air"/>
     </LogicalPart>
-    <LogicalPart name="LGAD_TimingActive" category="unspecified">
-      <rSolid name="etl:LGAD_TimingActive"/>
+    <LogicalPart name="EModule_Timingactive" category="unspecified">
+      <rSolid name="etl:EModule_Timingactive"/>
       <rMaterial name="materials:Silicon"/>
     </LogicalPart>
     <LogicalPart name="LGAD_Substrate" category="unspecified">
@@ -356,7 +356,7 @@
 	<!-- definition of LGAD active/substrate volumes -->
 	<PosPart copyNumber="1">
 	  <rParent name="etl:LGAD"/>
-	  <rChild name="etl:LGAD_TimingActive"/>
+	  <rChild name="etl:EModule_Timingactive"/>
 	  <Translation x="0.*cm" y="0.*cm" z="-0.0125*cm" />
 	</PosPart>
 	<PosPart copyNumber="1">

--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -95,7 +95,7 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("MTDGeom") << "BTL Numbering scheme: "
                           << " rod = " << rodCopy << " zside = " << zside << " module = " << modCopy
-                          << " modtyp = " << modtyp << " crystal = " << crystal << " Raw Id = " << intindex
+                          << " modtyp = " << modtyp << " crystal = " << crystal << " Raw Id = " << intindex << "\n"
                           << thisBTLdetid;
 #endif
 

--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -90,7 +90,7 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   // all inputs are fine. Go ahead and decode
 
   BTLDetId thisBTLdetid(zside, rodCopy, modCopy, modtyp, crystal);
-  const int32_t intindex = thisBTLdetid.rawId();
+  const uint32_t intindex = thisBTLdetid.rawId();
 
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("MTDGeom") << "BTL Numbering scheme: "

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -105,8 +105,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("MTDGeom") << "ETL Numbering scheme: "
                           << " ring = " << ringCopy << " zside = " << zside << " module = " << modCopy
-                          << " modtyp = " << modtyp << " Raw Id = " << intindex << "\n"
-                          << thisETLdetid;
+                          << " modtyp = " << modtyp << " Raw Id = " << intindex << thisETLdetid;
   if (!preTDR) {
     ETLDetId altETLdetid(zside, discN, sectorS, sectorN, modCopy, modtyp);
     const uint32_t altintindex = altETLdetid.rawId();

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 ETLNumberingScheme::ETLNumberingScheme() : MTDNumberingScheme() {
 #ifdef EDM_ML_DEBUG
@@ -106,6 +106,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   edm::LogInfo("MTDGeom") << "ETL Numbering scheme: "
                           << " ring = " << ringCopy << " zside = " << zside << " module = " << modCopy
                           << " modtyp = " << modtyp << " Raw Id = " << intindex << thisETLdetid;
+#endif
   if (!preTDR) {
     ETLDetId altETLdetid(zside, discN, sectorS, sectorN, modCopy, modtyp);
     const uint32_t altintindex = altETLdetid.rawId();
@@ -115,7 +116,6 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
                                  << altETLdetid;
     }
   }
-#endif
 
   return intindex;
 }

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -100,7 +100,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   // all inputs are fine. Go ahead and decode
 
   ETLDetId thisETLdetid(zside, ringCopy, modCopy, modtyp);
-  const int32_t intindex = thisETLdetid.rawId();
+  const uint32_t intindex = thisETLdetid.rawId();
 
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("MTDGeom") << "ETL Numbering scheme: "
@@ -109,7 +109,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
                           << thisETLdetid;
   if (!preTDR) {
     ETLDetId altETLdetid(zside, discN, sectorS, sectorN, modCopy, modtyp);
-    const int32_t altintindex = altETLdetid.rawId();
+    const uint32_t altintindex = altETLdetid.rawId();
     if (intindex != altintindex) {
       edm::LogWarning("MTDGeom") << "Incorrect alternative construction \n"
                                  << "disc = " << discN << " disc side = " << sectorS << " sector = " << sectorN << "\n"

--- a/Geometry/MTDCommonData/test/TestMTDPosition.cc
+++ b/Geometry/MTDCommonData/test/TestMTDPosition.cc
@@ -150,11 +150,10 @@ void TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         dump << "Translation vector components: " << std::setw(14) << std::fixed << fv.translation().x() << " "
              << std::setw(14) << fv.translation().y() << " " << std::setw(14) << fv.translation().z() << " "
              << "\n";
-        dump << "Rotation matrix components: " << std::setw(14) << x.X() << " " << std::setw(14) << y.X() << " "
-             << std::setw(14) << z.X() << " " << std::setw(14) << x.Y() << " " << std::setw(14) << y.Y() << " "
-             << std::setw(14) << z.Y() << " " << std::setw(14) << x.Z() << " " << std::setw(14) << y.Z() << " "
-             << std::setw(14) << z.Z() << " "
-             << "\n";
+        dump << "Rotation matrix components: " << std::setw(14) << x.X() << " " << std::setw(14) << x.Y() << " "
+             << std::setw(14) << x.Z() << " " << std::setw(14) << y.X() << " " << std::setw(14) << y.Y() << " "
+             << std::setw(14) << y.Z() << " " << std::setw(14) << z.X() << " " << std::setw(14) << z.Y() << " "
+             << std::setw(14) << z.Z() << "\n";
 
         DD3Vector zeroLocal(0., 0., 0.);
         DD3Vector cn1Local(mySens.halfX(), mySens.halfY(), mySens.halfZ());

--- a/Geometry/MTDNumberingBuilder/interface/CmsMTDStringToEnum.h
+++ b/Geometry/MTDNumberingBuilder/interface/CmsMTDStringToEnum.h
@@ -12,20 +12,16 @@ public:
   static constexpr size_t kModStrLen = 7;
 
   typedef std::map<std::string, GeometricTimingDet::GeometricTimingEnumType> MapEnumType;
-  typedef std::map<GeometricTimingDet::GeometricTimingEnumType, std::string> ReverseMapEnumType;
 
   GeometricTimingDet::GeometricTimingEnumType type(std::string const&) const;
-  std::string const& name(GeometricTimingDet::GeometricTimingEnumType) const;
 
 private:
   static MapEnumType const& map() { return m_impl._map; }
-  static ReverseMapEnumType const& reverseMap() { return m_impl._reverseMap; }
 
   // a quick fix
   struct Impl {
     Impl();
     MapEnumType _map;
-    ReverseMapEnumType _reverseMap;
   };
 
   static const Impl m_impl;

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
@@ -3,8 +3,13 @@
 
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+#include "Geometry/MTDCommonData/interface/MTDBaseNumber.h"
 
 #include "DataFormats/Math/interface/deltaPhi.h"
+
+#define EDM_ML_DEBUG
+
+CmsMTDConstruction::CmsMTDConstruction() : etlScheme_(), baseNumber_() {}
 
 bool CmsMTDConstruction::mtdOrderZ(const GeometricTimingDet* a, const GeometricTimingDet* b) {
   bool order = (a->translation().z() == b->translation().z()) ? a->translation().rho() < b->translation().rho()
@@ -55,18 +60,31 @@ void CmsMTDConstruction::buildETLModule(DDFilteredView& fv, GeometricTimingDet* 
   GeometricTimingDet* det =
       new GeometricTimingDet(&fv, theCmsMTDStringToEnum.type(fv.name().substr(0, CmsMTDStringToEnum::kModStrLen)));
 
-  const auto& copyNumbers = fv.copyNumbers();
-  auto module_number = copyNumbers[copyNumbers.size() - 2];
+  if (isETLtdr(fv)) {
+    //
+    // For the TDR ETL geometry
+    // in principle this method works also for the new geometry, if the main loop points to "Timingactive"
+    // but backward compatibility is kept in order to avoid change in volume name and number of siblings
+    //
 
-  size_t delim_ring = det->name().find("EModule");
-  size_t delim_disc = det->name().find("Disc");
+    baseNumberFromHistory(fv.geoHistory());
 
-  std::string ringN = det->name().substr(delim_ring + CmsMTDStringToEnum::kModStrLen, delim_disc);
+    det->setGeographicalID(ETLDetId(etlScheme_.getUnitID(baseNumber_)));
 
-  const uint32_t side = det->translation().z() > 0 ? 1 : 0;
+  } else {
+    const auto& copyNumbers = fv.copyNumbers();
+    auto module_number = copyNumbers[copyNumbers.size() - 2];
 
-  // label geographic detid is front or back (even though it is one module per entry here)
-  det->setGeographicalID(ETLDetId(side, atoi(ringN.c_str()), module_number, 0));
+    size_t delim_ring = det->name().find("EModule");
+    size_t delim_disc = det->name().find("Disc");
+
+    std::string ringN = det->name().substr(delim_ring + CmsMTDStringToEnum::kModStrLen, delim_disc);
+
+    const uint32_t side = det->translation().z() > 0 ? 1 : 0;
+
+    // label geographic detid is front or back (even though it is one module per entry here)
+    det->setGeographicalID(ETLDetId(side, atoi(ringN.c_str()), module_number, 0));
+  }
 
   mother->addComponent(det);
 }
@@ -105,3 +123,19 @@ GeometricTimingDet* CmsMTDConstruction::buildLayer(DDFilteredView& fv,
 
   return subdet;
 }
+
+void CmsMTDConstruction::baseNumberFromHistory(const DDGeoHistory& gh) {
+  baseNumber_.reset();
+  baseNumber_.setSize(gh.size());
+
+  for (uint i = gh.size(); i-- > 0;) {
+    std::string name(gh[i].logicalPart().name().name());
+    int copyN(gh[i].copyno());
+    baseNumber_.addLevel(name, copyN);
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("CmsMTDConstruction") << name << " " << copyN;
+#endif
+  }
+}
+
+bool CmsMTDConstruction::isETLtdr(DDFilteredView& fv) { return (fv.name() == "EModule_Timingactive"); }

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
@@ -113,15 +113,30 @@ GeometricTimingDet* CmsMTDConstruction::buildLayer(DDFilteredView& fv,
                                                    GeometricTimingDet* mother,
                                                    const std::string& attribute) {
   auto thisDet = theCmsMTDStringToEnum.type(fv.name());
-  GeometricTimingDet* subdet = new GeometricTimingDet(&fv, thisDet);
+  GeometricTimingDet* layer = new GeometricTimingDet(&fv, thisDet);
 
   if (thisDet != GeometricTimingDet::BTLLayer && thisDet != GeometricTimingDet::ETLDisc) {
     throw cms::Exception("CmsMTDConstruction") << " ERROR - I was expecting a SubDet, I got a " << fv.name();
   }
 
-  mother->addComponent(subdet);
+  uint32_t nLayer;
+  if (thisDet == GeometricTimingDet::BTLLayer) {
+    //
+    // only one layer in BTL
+    //
+    nLayer = 1;
+    layer->setGeographicalID(nLayer);
+  } else if (thisDet == GeometricTimingDet::ETLDisc) {
+    //
+    // no change for pre TDR scenarios, otherwise identifiy layer with disc
+    //
+    nLayer = (fv.name().find("Disc1") != std::string::npos) ? 1 : 2;
+    layer->setGeographicalID(nLayer);
+  }
 
-  return subdet;
+  mother->addComponent(layer);
+
+  return layer;
 }
 
 void CmsMTDConstruction::baseNumberFromHistory(const DDGeoHistory& gh) {

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
@@ -7,7 +7,7 @@
 
 #include "DataFormats/Math/interface/deltaPhi.h"
 
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 CmsMTDConstruction::CmsMTDConstruction() : etlScheme_(), baseNumber_() {}
 

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.h
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.h
@@ -4,12 +4,14 @@
 #include <vector>
 #include "Geometry/MTDNumberingBuilder/interface/GeometricTimingDet.h"
 #include "Geometry/MTDNumberingBuilder/interface/CmsMTDStringToEnum.h"
+#include "Geometry/MTDCommonData/interface/ETLNumberingScheme.h"
 
 /**
  * Adds GeometricTimingDets representing final modules to the previous level
  */
 class CmsMTDConstruction {
 public:
+  CmsMTDConstruction();
   ~CmsMTDConstruction() = default;
 
   static bool mtdOrderZ(const GeometricTimingDet* a, const GeometricTimingDet* b);
@@ -22,8 +24,15 @@ public:
   GeometricTimingDet* buildSubdet(DDFilteredView&, GeometricTimingDet*, const std::string&);
   GeometricTimingDet* buildLayer(DDFilteredView&, GeometricTimingDet*, const std::string&);
 
+  void baseNumberFromHistory(const DDGeoHistory& gh);
+
+  bool isETLtdr(DDFilteredView&);
+
 protected:
   CmsMTDStringToEnum theCmsMTDStringToEnum;
+
+  ETLNumberingScheme etlScheme_;
+  MTDBaseNumber baseNumber_;
 };
 
 #endif  // Geometry_MTDNumberingBuilder_CmsMTDConstruction_H

--- a/Geometry/MTDNumberingBuilder/plugins/DDDCmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/DDDCmsMTDConstruction.cc
@@ -54,14 +54,15 @@ std::unique_ptr<GeometricTimingDet> DDDCmsMTDConstruction::construct(const DDCom
   filter.veto("SupportPlate");
   filter.veto("Shield");
   filter.veto("ThermalScreen");
-  filter.veto("Aluminium_Disk");
-  filter.veto("MIC6_Aluminium_Disk");
+  filter.veto("Aluminium_Disc");
+  filter.veto("MIC6_Aluminium_Disc");
   filter.veto("ThermalPad");
-  filter.veto("AlN_Carrier");
+  filter.veto("AlN");
   filter.veto("LairdFilm");
   filter.veto("ETROC");
-  filter.veto("SensorModule*");
-
+  filter.veto("SensorModule");
+  filter.veto("DiscSector");
+  filter.veto("LGAD_Substrate");
 
   DDFilteredView fv(cpv, filter);
 
@@ -113,8 +114,18 @@ std::unique_ptr<GeometricTimingDet> DDDCmsMTDConstruction::construct(const DDCom
     //
     // the level chosen corresponds to wafers for D50 and previous scenarios
     //
-    if ((thisNode == GeometricTimingDet::BTLModule || thisNode == GeometricTimingDet::ETLModule) && limit == 0) {
+    if ((thisNode == GeometricTimingDet::BTLModule) && limit == 0) {
       limit = num + 1;
+    }
+    //
+    // workaround to make old and TDR structure to cohexist until needed
+    //
+    else if ((thisNode == GeometricTimingDet::ETLModule) && limit == 0) {
+      if (theCmsMTDConstruction.isETLtdr(fv)) {
+        limit = num;
+      } else {
+        limit = num + 1;
+      }
     }
     if (num != limit && limit > 0) {
       continue;

--- a/Geometry/MTDNumberingBuilder/plugins/DDDCmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/DDDCmsMTDConstruction.cc
@@ -53,6 +53,15 @@ std::unique_ptr<GeometricTimingDet> DDDCmsMTDConstruction::construct(const DDCom
   filter.veto("Between");
   filter.veto("SupportPlate");
   filter.veto("Shield");
+  filter.veto("ThermalScreen");
+  filter.veto("Aluminium_Disk");
+  filter.veto("MIC6_Aluminium_Disk");
+  filter.veto("ThermalPad");
+  filter.veto("AlN_Carrier");
+  filter.veto("LairdFilm");
+  filter.veto("ETROC");
+  filter.veto("SensorModule*");
+
 
   DDFilteredView fv(cpv, filter);
 

--- a/Geometry/MTDNumberingBuilder/src/CmsMTDStringToEnum.cc
+++ b/Geometry/MTDNumberingBuilder/src/CmsMTDStringToEnum.cc
@@ -22,46 +22,15 @@ CmsMTDStringToEnum::Impl::Impl() {
                                                                                   GeometricTimingDet::ETL));
   _map.insert(
       std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("Disc1", GeometricTimingDet::ETLDisc));
+  _map.insert(
+      std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("Disc2", GeometricTimingDet::ETLDisc));
   _map.insert(std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("Ring", GeometricTimingDet::ETLRing));
   _map.insert(
       std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("EModule", GeometricTimingDet::ETLModule));
   _map.insert(
+      std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("LGAD_Ti", GeometricTimingDet::ETLModule));
+  _map.insert(
       std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("Sensor", GeometricTimingDet::ETLSensor));
-
-  //
-  // build reverse map
-  //
-
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::MTD, "FastTimerRegion"));
-
-  _reverseMap.insert(std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::BTL,
-                                                                                         "BarrelTimingLayer"));
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::BTLLayer, "Layer"));
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::BTLTray, "Rod1"));
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::BTLModule, "Module"));
-  _reverseMap.insert(std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::BTLSensor,
-                                                                                         "SensorPackage"));
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::BTLCrystal, "Crystal"));
-
-  _reverseMap.insert(std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::ETL,
-                                                                                         "EndcapTimingLayer"));
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::ETLDisc, "Disc1"));
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::ETLRing, "Ring"));
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::ETLModule, "Module"));
-  _reverseMap.insert(
-      std::pair<GeometricTimingDet::GeometricTimingEnumType, std::string>(GeometricTimingDet::ETLSensor, "Sensor"));
-
-  //
-  // done
-  //
 }
 
 GeometricTimingDet::GeometricTimingEnumType CmsMTDStringToEnum::type(std::string const& s) const {
@@ -73,12 +42,4 @@ GeometricTimingDet::GeometricTimingEnumType CmsMTDStringToEnum::type(std::string
   if (p != map().end())
     return p->second;
   return GeometricTimingDet::unknown;
-}
-
-std::string const& CmsMTDStringToEnum::name(GeometricTimingDet::GeometricTimingEnumType t) const {
-  static std::string const u("Unknown");
-  ReverseMapEnumType::const_iterator p = reverseMap().find(t);
-  if (p != reverseMap().end())
-    return p->second;
-  return u;
 }

--- a/Geometry/MTDNumberingBuilder/src/CmsMTDStringToEnum.cc
+++ b/Geometry/MTDNumberingBuilder/src/CmsMTDStringToEnum.cc
@@ -28,8 +28,6 @@ CmsMTDStringToEnum::Impl::Impl() {
   _map.insert(
       std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("EModule", GeometricTimingDet::ETLModule));
   _map.insert(
-      std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("LGAD_Ti", GeometricTimingDet::ETLModule));
-  _map.insert(
       std::pair<std::string, GeometricTimingDet::GeometricTimingEnumType>("Sensor", GeometricTimingDet::ETLSensor));
 }
 

--- a/Geometry/MTDSimData/data/v2/mtdProdCuts.xml
+++ b/Geometry/MTDSimData/data/v2/mtdProdCuts.xml
@@ -16,7 +16,7 @@
       <PartSelector path="//BModule1Layer1Timingactive"/>
       <PartSelector path="//BModule17Layer1Timingactive"/>
       <PartSelector path="//BModule33Layer1Timingactive"/>
-      <PartSelector path="//LGAD_TimingActive"/>
+      <PartSelector path="//EModule_Timingactive"/>
       <Parameter name="CMSCutsRegion" value="FastTimerRegion" eval="false"/>
       <Parameter name="ProdCutsForElectrons" value="0.1*mm"/>
       <Parameter name="ProdCutsForPositrons" value="0.1*mm"/>

--- a/Geometry/MTDSimData/data/v2/mtdProdCuts.xml
+++ b/Geometry/MTDSimData/data/v2/mtdProdCuts.xml
@@ -10,6 +10,7 @@
       <Parameter name="ProdCutsForElectrons" value="0.1*mm"/>
       <Parameter name="ProdCutsForPositrons" value="0.1*mm"/>
       <Parameter name="ProdCutsForGamma" value="0.1*mm"/>
+      <Parameter name="ProdCutsForProtons" value="0.1*mm"/>
     </SpecPar>
     <SpecPar name="fasttime-sens">
       <PartSelector path="//BModule1Layer1Timingactive"/>
@@ -20,6 +21,7 @@
       <Parameter name="ProdCutsForElectrons" value="0.1*mm"/>
       <Parameter name="ProdCutsForPositrons" value="0.1*mm"/>
       <Parameter name="ProdCutsForGamma" value="0.1*mm"/>
+      <Parameter name="ProdCutsForProtons" value="0.1*mm"/>
     </SpecPar>
 
   </SpecParSection>

--- a/Geometry/MTDSimData/data/v2/mtdsens.xml
+++ b/Geometry/MTDSimData/data/v2/mtdsens.xml
@@ -12,7 +12,7 @@
       <Parameter name="Type"        value="1"/>
     </SpecPar>
     <SpecPar name="fasttimesenseEndcap">
-      <PartSelector path="//LGAD_TimingActive"/>
+      <PartSelector path="//EModule_Timingactive"/>
       <Parameter name="SensitiveDetector" value="MtdSensitiveDetector" eval="false"/>
       <Parameter name="ReadOutName" value="FastTimerHitsEndcap" eval="false"/>
       <Parameter name="Type"        value="2"/>


### PR DESCRIPTION
#### PR description:

This PR further updates the previous changes of xml in #29100 by:

- updating names for better insertion of new TDR ETL in RECO geometry;

- addition of new TDR ETL in MTDNumberingBuilder, propagated to MTDGeometry, using the ETLNumberingScheme for scenario D53 (removing duplicated code to build DetIds). For previous scenarios and BTL the code has been left so far unchanged to make backward compatibility easier;

- proton production cuts have been added (equal to electron cuts) as pointed by @ianna . The separation of BTL and ETL cuts, and the update of ETL cuts will be done in a separated PR;

- ETLDetId has been updated by adding one more constructor, dedicated to the new ETL design.

#### PR validation:

The test class ```TestMTDPosition``` has been further updated, and all the test classes have been run to ensure that scenario D50 is left unchanged. The assignment of DetIds and corresponding definition of ```GeometricTimingDets``` in the scenario D53 appears consistent with the design implemented by @icosivi .