### PR TITLE
Make the ThroughputService print the throughput at the end of the job

### DIFF
--- a/FWCore/Utilities/interface/TimeOfDay.h
+++ b/FWCore/Utilities/interface/TimeOfDay.h
@@ -2,12 +2,14 @@
 #define FWCore_Utilities_TimeOfDay_h
 
 #include <sys/time.h>
+#include <chrono>
 #include <iosfwd>
 
 namespace edm {
   struct TimeOfDay {
     TimeOfDay();
     explicit TimeOfDay(struct timeval const& tv);
+    explicit TimeOfDay(std::chrono::system_clock::time_point const& tp);
 
     struct timeval tv_;
 

--- a/FWCore/Utilities/src/TimeOfDay.cc
+++ b/FWCore/Utilities/src/TimeOfDay.cc
@@ -1,8 +1,9 @@
-#include "FWCore/Utilities/interface/TimeOfDay.h"
+#include <ctime>
 #include <iomanip>
 #include <locale>
 #include <ostream>
-#include <ctime>
+
+#include "FWCore/Utilities/interface/TimeOfDay.h"
 
 namespace {
   int const power[] = {1000 * 1000, 100 * 1000, 10 * 1000, 1000, 100, 10, 1};
@@ -13,6 +14,12 @@ namespace edm {
   TimeOfDay::TimeOfDay() : tv_(TimeOfDay::setTime_()) {}
 
   TimeOfDay::TimeOfDay(struct timeval const& tv) : tv_(tv) {}
+
+  TimeOfDay::TimeOfDay(std::chrono::system_clock::time_point const& tp) {
+    auto us = std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch()).count();
+    tv_.tv_sec = us / 1000000;
+    tv_.tv_usec = us % 1000000;
+  }
 
   timeval TimeOfDay::setTime_() {
     timeval tv;
@@ -41,4 +48,5 @@ namespace edm {
     os.flags(oldflags);
     return os;
   }
+
 }  // namespace edm

--- a/FWCore/Utilities/src/TimeOfDay.cc
+++ b/FWCore/Utilities/src/TimeOfDay.cc
@@ -28,7 +28,8 @@ namespace edm {
   }
 
   std::ostream& operator<<(std::ostream& os, TimeOfDay const& tod) {
-    std::ios::fmtflags oldflags = os.flags();  // Save stream formats so they can be left unchanged.
+    auto oldflags = os.flags();  // save the stream format flags so they can be restored
+    auto oldfill = os.fill();    // save the stream fill character so it can be restored
     struct tm timebuf;
     localtime_r(&tod.tv_.tv_sec, &timebuf);
     typedef std::ostreambuf_iterator<char, std::char_traits<char> > Iter;
@@ -46,6 +47,7 @@ namespace edm {
       tp.put(begin, os, ' ', &timebuf, 'Z');
     }
     os.flags(oldflags);
+    os.fill(oldfill);
     return os;
   }
 

--- a/HLTrigger/Timer/plugins/BuildFile.xml
+++ b/HLTrigger/Timer/plugins/BuildFile.xml
@@ -9,6 +9,7 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
   <use name="HLTrigger/Timer"/>
   <use name="RecoLuminosity/LumiProducer"/>
   <use name="SimDataFormats/PileupSummaryInfo"/>

--- a/HLTrigger/Timer/plugins/ThroughputService.cc
+++ b/HLTrigger/Timer/plugins/ThroughputService.cc
@@ -1,11 +1,14 @@
 // C++ headers
 #include <algorithm>
 #include <chrono>
+#include <ctime>
 
 // boost headers
 #include <boost/format.hpp>
 
 // CMSSW headers
+#include "FWCore/ParameterSet/interface/EmptyGroupDescription.h"
+#include "FWCore/Utilities/interface/TimeOfDay.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "ThroughputService.h"
 
@@ -15,33 +18,45 @@
 // describe the module's configuration
 void ThroughputService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.addUntracked<double>("timeRange", 60000.0);
-  desc.addUntracked<double>("timeResolution", 10.0);
-  desc.addUntracked<std::string>("dqmPath", "HLT/Throughput");
-  desc.addUntracked<bool>("dqmPathByProcesses", false);
+  desc.addUntracked<uint32_t>("eventRange", 10000)->setComment("Preallocate a buffer for N events");
+  desc.addUntracked<uint32_t>("eventResolution", 1)->setComment("Sample the processing time every N events");
+  desc.addUntracked<bool>("printEventSummary", false);
+  desc.ifValue(edm::ParameterDescription<bool>("enableDQM", true, false),  // "false" means untracked
+               // parameters if "enableDQM" is "true"
+               true >> (edm::ParameterDescription<bool>("dqmPathByProcesses", false, false) and
+                        edm::ParameterDescription<std::string>("dqmPath", "HLT/Throughput", false) and
+                        edm::ParameterDescription<double>("timeRange", 60000.0, false) and
+                        edm::ParameterDescription<double>("timeResolution", 10.0, false)) or
+                   // parameters if "enableDQM" is "false"
+                   false >> edm::EmptyGroupDescription());
   descriptions.add("ThroughputService", desc);
 }
 
 ThroughputService::ThroughputService(const edm::ParameterSet& config, edm::ActivityRegistry& registry)
     :  // startup time
-      m_startup(std::chrono::steady_clock::now()),
+      m_startup(std::chrono::system_clock::now()),
       // configuration
-      m_time_range(config.getUntrackedParameter<double>("timeRange")),
-      m_time_resolution(config.getUntrackedParameter<double>("timeResolution")),
-      m_dqm_path(config.getUntrackedParameter<std::string>("dqmPath")),
-      m_dqm_bynproc(config.getUntrackedParameter<bool>("dqmPathByProcesses")) {
+      m_resolution(config.getUntrackedParameter<uint32_t>("eventResolution")),
+      m_counter(0),
+      m_events(config.getUntrackedParameter<uint32_t>("eventRange") / m_resolution),  // allocate initial size
+      m_print_event_summary(config.getUntrackedParameter<bool>("printEventSummary")),
+      m_enable_dqm(config.getUntrackedParameter<bool>("enableDQM")),
+      m_dqm_bynproc(m_enable_dqm ? config.getUntrackedParameter<bool>("dqmPathByProcesses") : false),
+      m_dqm_path(m_enable_dqm ? config.getUntrackedParameter<std::string>("dqmPath") : ""),
+      m_time_range(m_enable_dqm ? config.getUntrackedParameter<double>("timeRange") : 0.),
+      m_time_resolution(m_enable_dqm ? config.getUntrackedParameter<double>("timeResolution") : 0.) {
+  m_events.clear();  // erases all elements, but does not free internal arrays
   registry.watchPreGlobalBeginRun(this, &ThroughputService::preGlobalBeginRun);
   registry.watchPreSourceEvent(this, &ThroughputService::preSourceEvent);
   registry.watchPostEvent(this, &ThroughputService::postEvent);
+  registry.watchPostEndJob(this, &ThroughputService::postEndJob);
 }
-
-ThroughputService::~ThroughputService() = default;
 
 void ThroughputService::preallocate(edm::service::SystemBounds const& bounds) {
   auto concurrent_streams = bounds.maxNumberOfStreams();
   auto concurrent_threads = bounds.maxNumberOfThreads();
 
-  if (m_dqm_bynproc)
+  if (m_enable_dqm and m_dqm_bynproc)
     m_dqm_path += (boost::format("/Running on %s with %d streams on %d threads") % processor_model %
                    concurrent_streams % concurrent_threads)
                       .str();
@@ -49,7 +64,14 @@ void ThroughputService::preallocate(edm::service::SystemBounds const& bounds) {
 
 void ThroughputService::preGlobalBeginRun(edm::GlobalContext const& gc) {
   // if the DQMStore is available, book the DQM histograms
-  if (edm::Service<DQMStore>().isAvailable()) {
+  // check that the DQMStore service is available
+  if (m_enable_dqm and not edm::Service<dqm::legacy::DQMStore>().isAvailable()) {
+    // the DQMStore is not available, disable all DQM plots
+    m_enable_dqm = false;
+    edm::LogWarning("ThroughputService") << "The DQMStore is not avalable, the DQM plots will not be generated";
+  }
+
+  if (m_enable_dqm) {
     std::string y_axis_title = (boost::format("events / %g s") % m_time_resolution).str();
     unsigned int bins = std::round(m_time_range / m_time_resolution);
     double range = bins * m_time_resolution;
@@ -68,19 +90,63 @@ void ThroughputService::preGlobalBeginRun(edm::GlobalContext const& gc) {
     // book MonitorElement's for this run
     edm::Service<DQMStore>()->meBookerGetter(bookTransactionCallback);
   } else {
-    std::cerr << "No DQMStore service, aborting." << std::endl;
-    abort();
+    m_sourced_events = nullptr;
+    m_retired_events = nullptr;
   }
 }
 
 void ThroughputService::preSourceEvent(edm::StreamID sid) {
-  auto timestamp = std::chrono::steady_clock::now();
-  m_sourced_events->Fill(std::chrono::duration_cast<std::chrono::duration<double>>(timestamp - m_startup).count());
+  auto timestamp = std::chrono::system_clock::now();
+  auto interval = std::chrono::duration_cast<std::chrono::duration<double>>(timestamp - m_startup).count();
+  if (m_enable_dqm) {
+    m_sourced_events->Fill(interval);
+  }
 }
 
 void ThroughputService::postEvent(edm::StreamContext const& sc) {
-  auto timestamp = std::chrono::steady_clock::now();
-  m_retired_events->Fill(std::chrono::duration_cast<std::chrono::duration<double>>(timestamp - m_startup).count());
+  auto timestamp = std::chrono::system_clock::now();
+  auto interval = std::chrono::duration_cast<std::chrono::duration<double>>(timestamp - m_startup).count();
+  if (m_enable_dqm) {
+    m_retired_events->Fill(interval);
+  }
+  ++m_counter;
+  if (m_counter % m_resolution == 0) {
+    m_events.push_back(timestamp);
+  }
+}
+
+void ThroughputService::postEndJob() {
+  if (m_counter < 2 * m_resolution) {
+    // not enough mesurements to estimate the throughput
+    edm::LogWarning("ThroughputService") << "Not enough events to measure the throughput with a resolution of "
+                                         << m_resolution << " events";
+    return;
+  }
+
+  edm::LogInfo info("ThroughputService");
+
+  if (m_print_event_summary) {
+    for (uint32_t i = 0; i < m_events.size(); ++i) {
+      info << std::setw(8) << (i + 1) * m_resolution << ", " << std::setprecision(6) << edm::TimeOfDay(m_events[i])
+           << "\n";
+    }
+    info << '\n';
+  }
+
+  // measure the time to process each block of m_resolution events
+  uint32_t blocks = m_counter / m_resolution - 1;
+  std::vector<double> delta(blocks);
+  for (uint32_t i = 0; i < blocks; ++i) {
+    delta[i] = std::chrono::duration_cast<std::chrono::duration<double>>(m_events[i + 1] - m_events[i]).count();
+  }
+  // measure the average and standard deviation of the time to process m_resolution
+  double time_avg = TMath::Mean(delta.begin(), delta.begin() + blocks);
+  double time_dev = TMath::StdDev(delta.begin(), delta.begin() + blocks);
+  // compute the throughput and its standard deviation across the job
+  double throughput_avg = double(m_resolution) / time_avg;
+  double throughput_dev = double(m_resolution) * time_dev / time_avg / time_avg;
+
+  info << "Average throughput: " << throughput_avg << " ± " << throughput_dev << " ev/s";
 }
 
 // declare ThroughputService as a framework Service

--- a/HLTrigger/Timer/plugins/ThroughputService.h
+++ b/HLTrigger/Timer/plugins/ThroughputService.h
@@ -2,13 +2,13 @@
 #define ThroughputService_h
 
 // C++ headers
-#include <string>
+#include <atomic>
 #include <chrono>
 #include <functional>
+#include <string>
 
 // TBB headers
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_unordered_set.h>
+#include <tbb/concurrent_vector.h>
 
 // ROOT headers
 #include <TH1F.h>
@@ -16,6 +16,7 @@
 // CMSSW headers
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -31,13 +32,14 @@ public:
   typedef dqm::reco::DQMStore DQMStore;
 
   ThroughputService(const edm::ParameterSet&, edm::ActivityRegistry&);
-  ~ThroughputService();
+  ~ThroughputService() = default;
 
 private:
   void preallocate(edm::service::SystemBounds const& bounds);
   void preGlobalBeginRun(edm::GlobalContext const& gc);
   void preSourceEvent(edm::StreamID sid);
   void postEvent(edm::StreamContext const& sc);
+  void postEndJob();
 
 public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -46,15 +48,20 @@ private:
   dqm::reco::MonitorElement* m_sourced_events;
   dqm::reco::MonitorElement* m_retired_events;
 
-  std::chrono::steady_clock::time_point m_startup;
+  std::chrono::system_clock::time_point m_startup;
 
-  // histogram-related data members
+  // event time buffer
+  const uint32_t m_resolution;
+  std::atomic<uint32_t> m_counter;
+  tbb::concurrent_vector<std::chrono::system_clock::time_point> m_events;
+  bool m_print_event_summary;
+
+  // DQM related data members
+  bool m_enable_dqm;
+  const bool m_dqm_bynproc;
+  std::string m_dqm_path;
   const double m_time_range;
   const double m_time_resolution;
-
-  // DQM service-related data members
-  std::string m_dqm_path;
-  const bool m_dqm_bynproc;
 };
 
 #endif  // ! ThroughputService_h


### PR DESCRIPTION
#### PR description:

Make the ThroughputService print the throughput at the end of the job.

The DQM plots are now optional; if they are requested but the DQMStore is not availbale a warning will be issued, and the DQM plots will be disabled.

#### PR validation:

Run together with the current HLT menu.