### PR TITLE
Fix Python3 problems with #28920 

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2232,7 +2232,7 @@ class ConfigBuilder(object):
             self.pythonCfgCode +="process.options.numberOfThreads=cms.untracked.uint32("+self._options.nThreads+")\n"
             self.pythonCfgCode +="process.options.numberOfStreams=cms.untracked.uint32("+self._options.nStreams+")\n"
             self.pythonCfgCode +="process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32("+self._options.nConcurrentLumis+")\n"
-            if self._options.nConcurrentLumis > 1:
+            if int(self._options.nConcurrentLumis) > 1:
               self.pythonCfgCode +="if hasattr(process, 'DQMStore'): process.DQMStore.assertLegacySafe=cms.untracked.bool(False)\n"
             self.process.options.numberOfThreads=cms.untracked.uint32(int(self._options.nThreads))
             self.process.options.numberOfStreams=cms.untracked.uint32(int(self._options.nStreams))


### PR DESCRIPTION
As discussed during the Core software meeting, we can trivially fix the failures in PY3 IB by forcing `int(self._options.nConcurrentLumis)`.
The error affecting almost all workflows in CMSSW_11_1_PY3_X_2020-03-16-2300 was 
```Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/nweek-02620/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_11_1_PY3_X_2020-03-16-2300/bin/slc7_amd64_gcc820/cmsDriver.py", line 56, in &lt;module&gt;
    run()
  File "/cvmfs/cms-ib.cern.ch/nweek-02620/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_11_1_PY3_X_2020-03-16-2300/bin/slc7_amd64_gcc820/cmsDriver.py", line 28, in run
    configBuilder.prepare()
  File "/cvmfs/cms-ib.cern.ch/nweek-02620/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_11_1_PY3_X_2020-03-16-2300/python/Configuration/Applications/ConfigBuilder.py", line 2235, in prepare
    if self._options.nConcurrentLumis &gt; 1:
TypeError: '&gt;' not supported between instances of 'str' and 'int'```
This bug was related to https://github.com/cms-sw/cmssw/pull/28920.
