### PR TITLE
use edm::createGlobalIdentifier instead of boost::uuids::random_generator

### DIFF
--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -3,14 +3,12 @@
 
 #include "CondCore/CondDB/interface/Utils.h"
 #include "CondCore/CondDB/interface/Session.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include <iostream>
 
 #include <string>
 #include <tuple>
 #include <vector>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/dict.hpp>
 
@@ -614,7 +612,7 @@ namespace cond {
         m_plotAnnotations.m[PlotAnnotations::TITLE_K] = title;
         std::string payloadTypeName = cond::demangledName(typeid(PayloadType));
         m_plotAnnotations.m[PlotAnnotations::PAYLOAD_TYPE_K] = payloadTypeName;
-        m_imageFileName = boost::lexical_cast<std::string>((boost::uuids::random_generator())()) + ".png";
+        m_imageFileName = edm::createGlobalIdentifier() + ".png";
       }
 
       std::string serializeData() { return serialize(m_plotAnnotations, m_imageFileName); }

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
@@ -1,10 +1,7 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromBinnedTFormula.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/lexical_cast.hpp>
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 const int PerformancePayloadFromBinnedTFormula::InvalidPos = -1;
 
@@ -12,12 +9,10 @@ const int PerformancePayloadFromBinnedTFormula::InvalidPos = -1;
 using namespace std;
 
 void PerformancePayloadFromBinnedTFormula::initialize() {
-  boost::uuids::random_generator gen;
   for (unsigned int t = 0; t < pls.size(); ++t) {
     std::vector<std::shared_ptr<TFormula> > temp;
     for (unsigned int i = 0; i < (pls[t].formulas()).size(); ++i) {
-      boost::uuids::uuid uniqueFormulaId = gen();
-      const auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
+      const auto formulaUniqueName = edm::createGlobalIdentifier();
       PhysicsTFormulaPayload tmp = pls[t];
       std::shared_ptr<TFormula> tt(new TFormula(formulaUniqueName.c_str(), tmp.formulas()[i].c_str()));
       tt->Compile();

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -1,23 +1,17 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 const int PerformancePayloadFromTFormula::InvalidPos = -1;
-
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <iostream>
 using namespace std;
 
 void PerformancePayloadFromTFormula::initialize() {
-  boost::uuids::random_generator gen;
 
   for (std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end();
        ++formula) {
-    boost::uuids::uuid uniqueFormulaId = gen();
-    const auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
+    const auto formulaUniqueName = edm::createGlobalIdentifier();
     //be sure not to add TFormula to ROOT's global list
     auto temp = std::make_shared<TFormula>(formulaUniqueName.c_str(), formula->c_str(), false);
     temp->Compile();

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -8,7 +8,6 @@ const int PerformancePayloadFromTFormula::InvalidPos = -1;
 using namespace std;
 
 void PerformancePayloadFromTFormula::initialize() {
-
   for (std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end();
        ++formula) {
     const auto formulaUniqueName = edm::createGlobalIdentifier();


### PR DESCRIPTION
This is a follow up to https://github.com/cms-sw/cmsdist/issues/5657

All 3 cases were using ```boost::uuids::random_generator``` to generate a random string.
Somewhat equivalent functionality is available as ```edm::createGlobalIdentifier```.

I only tested that the problematic case described in https://github.com/cms-sw/cmsdist/issues/5657 runs with this update