### PR TITLE
Clean residual dependency of SimG4Core/Forward on DetectorDescription

### DIFF
--- a/SimG4CMS/Forward/BuildFile.xml
+++ b/SimG4CMS/Forward/BuildFile.xml
@@ -13,7 +13,6 @@
 <use   name="SimDataFormats/SimHitMaker"/>
 <use   name="SimDataFormats/CaloHit"/>
 <use   name="SimDataFormats/Forward"/>
-<use   name="DetectorDescription/Core"/>
 <use   name="Geometry/HGCalCommonData"/>
 <use   name="Geometry/MTDCommonData"/>
 <use   name="boost"/>

--- a/SimG4CMS/Forward/interface/CastorShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/CastorShowerLibrary.h
@@ -13,7 +13,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h"
 #include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
-#include "DetectorDescription/Core/interface/DDsvalues.h"
 
 #include "G4ParticleTable.hh"
 #include "G4ThreeVector.hh"

--- a/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
@@ -12,18 +12,16 @@
 
 #include "G4ParticleTable.hh"
 #include "G4ThreeVector.hh"
-#include "DetectorDescription/Core/interface/DDsvalues.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
 
 #include <string>
 #include <memory>
 
 class G4Step;
-class DDCompactView;
 class ZdcShowerLibrary {
 public:
   //Constructor and Destructor
-  ZdcShowerLibrary(const std::string& name, const DDCompactView& cpv, edm::ParameterSet const& p);
+  ZdcShowerLibrary(const std::string& name, edm::ParameterSet const& p);
   ~ZdcShowerLibrary();
 
 public:

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -8,7 +8,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 
 #include "G4SDManager.hh"
@@ -50,11 +49,8 @@ ZdcSD::ZdcSD(const std::string& name,
 
   edm::LogVerbatim("ZdcSD") << "\nEnergy Threshold Cut set to " << zdcHitEnergyCut / GeV << " (GeV)";
 
-  edm::ESTransientHandle<DDCompactView> cpv;
-  es.get<IdealGeometryRecord>().get(cpv);
-
   if (useShowerLibrary) {
-    showerLibrary.reset(new ZdcShowerLibrary(name, *cpv, p));
+    showerLibrary.reset(new ZdcShowerLibrary(name, p));
     setParameterized(true);
   } else {
     showerLibrary.reset(nullptr);

--- a/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
@@ -17,7 +17,7 @@
 #include "Randomize.hh"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-ZdcShowerLibrary::ZdcShowerLibrary(const std::string& name, const DDCompactView& cpv, edm::ParameterSet const& p) {
+ZdcShowerLibrary::ZdcShowerLibrary(const std::string& name, edm::ParameterSet const& p) {
   edm::ParameterSet m_HS = p.getParameter<edm::ParameterSet>("ZdcShowerLibrary");
   verbose = m_HS.getUntrackedParameter<int>("Verbosity", 0);
 


### PR DESCRIPTION
#### PR description:

This PR follows the comments in #29213 about removing completely an apparently fake dependence of SimG4Core/Forward on DetectorDescription , namely in the ZDC-related classes.

#### PR validation:

Code compiles, test wfs 11634 and 23234 both run smoothly.