### PR TITLE
DQM: Fix broken plots by MuonTrackValidator

### DIFF
--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -29,6 +29,13 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
       ibooker.cd();
       InputTag algo = label[www];
       string dirName = dirName_;
+
+      auto setBinLogX = [this](TH1* th1) {
+        if (this->useLogPt) {
+           BinLogX(th1);
+        }
+      };
+
       if (!algo.process().empty())
         dirName += algo.process() + "_";
       if (!algo.label().empty())
@@ -64,14 +71,14 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                           minEta,
                                           maxEta));
 
-      h_recopT.push_back(ibooker.book1D("num_reco_pT", "N of reco track vs pT", nintPt, minPt, maxPt));
+      h_recopT.push_back(ibooker.book1D("num_reco_pT", "N of reco track vs pT", nintPt, minPt, maxPt, setBinLogX));
       h_assocpT.push_back(
-          ibooker.book1D("num_assoSimToReco_pT", "N of associated tracks (simToReco) vs pT", nintPt, minPt, maxPt));
+          ibooker.book1D("num_assoSimToReco_pT", "N of associated tracks (simToReco) vs pT", nintPt, minPt, maxPt, setBinLogX));
       h_assoc2pT.push_back(
-          ibooker.book1D("num_assoRecoToSim_pT", "N of associated (recoToSim) tracks vs pT", nintPt, minPt, maxPt));
-      h_simulpT.push_back(ibooker.book1D("num_simul_pT", "N of simulated tracks vs pT", nintPt, minPt, maxPt));
+          ibooker.book1D("num_assoRecoToSim_pT", "N of associated (recoToSim) tracks vs pT", nintPt, minPt, maxPt, setBinLogX));
+      h_simulpT.push_back(ibooker.book1D("num_simul_pT", "N of simulated tracks vs pT", nintPt, minPt, maxPt, setBinLogX));
       h_misidpT.push_back(ibooker.book1D(
-          "num_chargemisid_pT", "N of associated (simToReco) tracks with charge misID vs pT", nintPt, minPt, maxPt));
+          "num_chargemisid_pT", "N of associated (simToReco) tracks with charge misID vs pT", nintPt, minPt, maxPt, setBinLogX));
 
       h_recophi.push_back(ibooker.book1D("num_reco_phi", "N of reco track vs phi", nintPhi, minPhi, maxPhi));
       h_assocphi.push_back(ibooker.book1D(
@@ -214,7 +221,7 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                            maxPt,
                                            ptRes_nbin,
                                            ptRes_rangeMin,
-                                           ptRes_rangeMax));
+                                           ptRes_rangeMax, setBinLogX));
       h_ptpull.push_back(ibooker.book1D("ptpull", "p_{T} Pull", 100, -10., 10.));
       ptpull_vs_eta.push_back(
           ibooker.book2D("ptpull_vs_eta", "p_{T} Pull vs #eta", nintEta, minEta, maxEta, 100, -10., 10.));
@@ -247,7 +254,7 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                                  maxPt,
                                                  cotThetaRes_nbin,
                                                  cotThetaRes_rangeMin,
-                                                 cotThetaRes_rangeMax));
+                                                 cotThetaRes_rangeMax, setBinLogX));
       h_thetapull.push_back(ibooker.book1D("thetapull", "#theta Pull", 100, -10., 10.));
       thetapull_vs_eta.push_back(
           ibooker.book2D("thetapull_vs_eta", "#theta Pull vs #eta", nintEta, minEta, maxEta, 100, -10, 10));
@@ -263,7 +270,7 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                              phiRes_rangeMin,
                                              phiRes_rangeMax));
       phires_vs_pt.push_back(ibooker.book2D(
-          "phires_vs_pt", "#phi Residual vs p_{T}", nintPt, minPt, maxPt, phiRes_nbin, phiRes_rangeMin, phiRes_rangeMax));
+          "phires_vs_pt", "#phi Residual vs p_{T}", nintPt, minPt, maxPt, phiRes_nbin, phiRes_rangeMin, phiRes_rangeMax, setBinLogX));
       phires_vs_phi.push_back(ibooker.book2D("phires_vs_phi",
                                              "#phi Residual vs #phi",
                                              nintPhi,
@@ -287,7 +294,7 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                              dxyRes_rangeMin,
                                              dxyRes_rangeMax));
       dxyres_vs_pt.push_back(ibooker.book2D(
-          "dxyres_vs_pt", "dxy Residual vs p_{T}", nintPt, minPt, maxPt, dxyRes_nbin, dxyRes_rangeMin, dxyRes_rangeMax));
+          "dxyres_vs_pt", "dxy Residual vs p_{T}", nintPt, minPt, maxPt, dxyRes_nbin, dxyRes_rangeMin, dxyRes_rangeMax, setBinLogX));
       h_dxypull.push_back(ibooker.book1D("dxypull", "dxy Pull", 100, -10., 10.));
       dxypull_vs_eta.push_back(
           ibooker.book2D("dxypull_vs_eta", "dxy Pull vs #eta", nintEta, minEta, maxEta, 100, -10, 10));
@@ -295,7 +302,7 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
       dzres_vs_eta.push_back(ibooker.book2D(
           "dzres_vs_eta", "dz Residual vs #eta", nintEta, minEta, maxEta, dzRes_nbin, dzRes_rangeMin, dzRes_rangeMax));
       dzres_vs_pt.push_back(ibooker.book2D(
-          "dzres_vs_pt", "dz Residual vs p_{T}", nintPt, minPt, maxPt, dzRes_nbin, dzRes_rangeMin, dzRes_rangeMax));
+          "dzres_vs_pt", "dz Residual vs p_{T}", nintPt, minPt, maxPt, dzRes_nbin, dzRes_rangeMin, dzRes_rangeMax, setBinLogX));
       h_dzpull.push_back(ibooker.book1D("dzpull", "dz Pull", 100, -10., 10.));
       dzpull_vs_eta.push_back(
           ibooker.book2D("dzpull_vs_eta", "dz Pull vs #eta", nintEta, minEta, maxEta, 100, -10, 10));
@@ -314,20 +321,6 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
       } else if (associators[ww] == "trackAssociatorByHits") {
         h_assocFraction.push_back(ibooker.book1D("assocFraction", "fraction of shared hits", 22, 0., 1.1));
         h_assocSharedHit.push_back(ibooker.book1D("assocSharedHit", "number of shared hits", 41, -0.5, 40.5));
-      }
-
-      if (useLogPt) {
-        BinLogX(h_simulpT.back()->getTH1F());
-        BinLogX(h_assocpT.back()->getTH1F());
-        BinLogX(h_recopT.back()->getTH1F());
-        BinLogX(h_assoc2pT.back()->getTH1F());
-        BinLogX(h_misidpT.back()->getTH1F());
-
-        BinLogX(phires_vs_pt.back()->getTH2F());
-        BinLogX(thetaCotres_vs_pt.back()->getTH2F());
-        BinLogX(dxyres_vs_pt.back()->getTH2F());
-        BinLogX(dzres_vs_pt.back()->getTH2F());
-        BinLogX(ptres_vs_pt.back()->getTH2F());
       }
 
     }  //for (unsigned int www=0;www<label.size();www++)

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -32,7 +32,7 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
 
       auto setBinLogX = [this](TH1* th1) {
         if (this->useLogPt) {
-           BinLogX(th1);
+          BinLogX(th1);
         }
       };
 
@@ -72,13 +72,18 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                           maxEta));
 
       h_recopT.push_back(ibooker.book1D("num_reco_pT", "N of reco track vs pT", nintPt, minPt, maxPt, setBinLogX));
-      h_assocpT.push_back(
-          ibooker.book1D("num_assoSimToReco_pT", "N of associated tracks (simToReco) vs pT", nintPt, minPt, maxPt, setBinLogX));
-      h_assoc2pT.push_back(
-          ibooker.book1D("num_assoRecoToSim_pT", "N of associated (recoToSim) tracks vs pT", nintPt, minPt, maxPt, setBinLogX));
-      h_simulpT.push_back(ibooker.book1D("num_simul_pT", "N of simulated tracks vs pT", nintPt, minPt, maxPt, setBinLogX));
-      h_misidpT.push_back(ibooker.book1D(
-          "num_chargemisid_pT", "N of associated (simToReco) tracks with charge misID vs pT", nintPt, minPt, maxPt, setBinLogX));
+      h_assocpT.push_back(ibooker.book1D(
+          "num_assoSimToReco_pT", "N of associated tracks (simToReco) vs pT", nintPt, minPt, maxPt, setBinLogX));
+      h_assoc2pT.push_back(ibooker.book1D(
+          "num_assoRecoToSim_pT", "N of associated (recoToSim) tracks vs pT", nintPt, minPt, maxPt, setBinLogX));
+      h_simulpT.push_back(
+          ibooker.book1D("num_simul_pT", "N of simulated tracks vs pT", nintPt, minPt, maxPt, setBinLogX));
+      h_misidpT.push_back(ibooker.book1D("num_chargemisid_pT",
+                                         "N of associated (simToReco) tracks with charge misID vs pT",
+                                         nintPt,
+                                         minPt,
+                                         maxPt,
+                                         setBinLogX));
 
       h_recophi.push_back(ibooker.book1D("num_reco_phi", "N of reco track vs phi", nintPhi, minPhi, maxPhi));
       h_assocphi.push_back(ibooker.book1D(
@@ -221,7 +226,8 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                            maxPt,
                                            ptRes_nbin,
                                            ptRes_rangeMin,
-                                           ptRes_rangeMax, setBinLogX));
+                                           ptRes_rangeMax,
+                                           setBinLogX));
       h_ptpull.push_back(ibooker.book1D("ptpull", "p_{T} Pull", 100, -10., 10.));
       ptpull_vs_eta.push_back(
           ibooker.book2D("ptpull_vs_eta", "p_{T} Pull vs #eta", nintEta, minEta, maxEta, 100, -10., 10.));
@@ -254,7 +260,8 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                                  maxPt,
                                                  cotThetaRes_nbin,
                                                  cotThetaRes_rangeMin,
-                                                 cotThetaRes_rangeMax, setBinLogX));
+                                                 cotThetaRes_rangeMax,
+                                                 setBinLogX));
       h_thetapull.push_back(ibooker.book1D("thetapull", "#theta Pull", 100, -10., 10.));
       thetapull_vs_eta.push_back(
           ibooker.book2D("thetapull_vs_eta", "#theta Pull vs #eta", nintEta, minEta, maxEta, 100, -10, 10));
@@ -269,8 +276,15 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                              phiRes_nbin,
                                              phiRes_rangeMin,
                                              phiRes_rangeMax));
-      phires_vs_pt.push_back(ibooker.book2D(
-          "phires_vs_pt", "#phi Residual vs p_{T}", nintPt, minPt, maxPt, phiRes_nbin, phiRes_rangeMin, phiRes_rangeMax, setBinLogX));
+      phires_vs_pt.push_back(ibooker.book2D("phires_vs_pt",
+                                            "#phi Residual vs p_{T}",
+                                            nintPt,
+                                            minPt,
+                                            maxPt,
+                                            phiRes_nbin,
+                                            phiRes_rangeMin,
+                                            phiRes_rangeMax,
+                                            setBinLogX));
       phires_vs_phi.push_back(ibooker.book2D("phires_vs_phi",
                                              "#phi Residual vs #phi",
                                              nintPhi,
@@ -293,16 +307,30 @@ void MuonTrackValidator::bookHistograms(DQMEDAnalyzer::DQMStore::IBooker& ibooke
                                              dxyRes_nbin,
                                              dxyRes_rangeMin,
                                              dxyRes_rangeMax));
-      dxyres_vs_pt.push_back(ibooker.book2D(
-          "dxyres_vs_pt", "dxy Residual vs p_{T}", nintPt, minPt, maxPt, dxyRes_nbin, dxyRes_rangeMin, dxyRes_rangeMax, setBinLogX));
+      dxyres_vs_pt.push_back(ibooker.book2D("dxyres_vs_pt",
+                                            "dxy Residual vs p_{T}",
+                                            nintPt,
+                                            minPt,
+                                            maxPt,
+                                            dxyRes_nbin,
+                                            dxyRes_rangeMin,
+                                            dxyRes_rangeMax,
+                                            setBinLogX));
       h_dxypull.push_back(ibooker.book1D("dxypull", "dxy Pull", 100, -10., 10.));
       dxypull_vs_eta.push_back(
           ibooker.book2D("dxypull_vs_eta", "dxy Pull vs #eta", nintEta, minEta, maxEta, 100, -10, 10));
 
       dzres_vs_eta.push_back(ibooker.book2D(
           "dzres_vs_eta", "dz Residual vs #eta", nintEta, minEta, maxEta, dzRes_nbin, dzRes_rangeMin, dzRes_rangeMax));
-      dzres_vs_pt.push_back(ibooker.book2D(
-          "dzres_vs_pt", "dz Residual vs p_{T}", nintPt, minPt, maxPt, dzRes_nbin, dzRes_rangeMin, dzRes_rangeMax, setBinLogX));
+      dzres_vs_pt.push_back(ibooker.book2D("dzres_vs_pt",
+                                           "dz Residual vs p_{T}",
+                                           nintPt,
+                                           minPt,
+                                           maxPt,
+                                           dzRes_nbin,
+                                           dzRes_rangeMin,
+                                           dzRes_rangeMax,
+                                           setBinLogX));
       h_dzpull.push_back(ibooker.book1D("dzpull", "dz Pull", 100, -10., 10.));
       dzpull_vs_eta.push_back(
           ibooker.book2D("dzpull_vs_eta", "dz Pull vs #eta", nintEta, minEta, maxEta, 100, -10, 10));


### PR DESCRIPTION
#### PR description:

We got a report that in the `11_1_0_pre4` relvals, some Moun Validation plots appear completely black in the DQMGUI. This is due to `NaN`s in the bin limits, which are in turn due to (apparently) not idempotent code in `BinLogX`, called in booking to change the binning of the `vs_pt` plots, which is a problem with the introduction of `edm::stream` based `DQMEDAnalyzer` in pre4.

This issue can be fixed by moving the call to `BinLogX` into a booking callback. This fixes `MuonTrackValidator`, there is another `BinLogX` in another module that might have the same issue.

The issue was not spotted in #28813 for multiple reasons:
- The problem only appears when running multiple streams; therefore not in the normal PR tests.
- The relevant plots are probably never filled in the PR/IB tests. _Basically_ not a problem, as this is a booking issue, but
- The bin-to-bin comparison tool only checks bin values, not axis data. @andrius-k promised an improvement to cover this in the future.

#### PR validation:
Tested multi-threaded using
```
runTheMatrix.py -l 11634.7 -t 8
```
The `NaN`s disappeared (for one random affected ME):
```
diff <(dqmdumpme.py 11634.7_*/DQM_*.root Muons/RecoMuonV/MuonTrack/tevMuons_picky/dzres_vs_pt) <(dqmdumpme.py base/11634.7_*/DQM_*.root Muons/RecoMuonV/MuonTrack/tevMuons_picky/dzres_vs_pt)
83c83
<         0., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
...
352,364c352,355
<         0., 0., 0., 0.]], dtype=float32), [(array([8.99999976e-01, 1.04997325e+00, 1.22493768e+00, 1.42905772e+00,
<        1.66719151e+00, 1.94500732e+00, 2.26911759e+00, 2.64723635e+00,
<        3.08836389e+00, 3.60300016e+00, 4.20339298e+00, 4.90383339e+00,
<        5.72099400e+00, 6.67432404e+00, 7.78651285e+00, 9.08403301e+00,
<        1.05977688e+01, 1.23637495e+01, 1.44240093e+01, 1.68275795e+01,
<        1.96316776e+01, 2.29030437e+01, 2.67195320e+01, 3.11719971e+01,
<        3.63664093e+01, 4.24264030e+01, 4.94962120e+01, 5.77441025e+01,
<        6.73664093e+01, 7.85921555e+01, 9.16884918e+01, 1.06967201e+02,
<        1.24791901e+02, 1.45586853e+02, 1.69847031e+02, 1.98149841e+02,
<        2.31168961e+02, 2.69690125e+02, 3.14630493e+02, 3.67059601e+02,
<        4.28225372e+02, 4.99583588e+02, 5.82832764e+02, 6.79954285e+02,
<        7.93259460e+02, 9.25445923e+02, 1.07965955e+03, 1.25957080e+03,
<        1.46946204e+03, 1.71432886e+03, 1.99999963e+03]), array([-0.05 , -0.049, -0.048, -0.047, -0.046, -0.045, -0.044, -0.043,
---
>         0., 0., 0., 0.]], dtype=float32), [(array([nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,
>        nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,
>        nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,
>        nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan]), array([-0.05 , -0.049, -0.048, -0.047, -0.046, -0.045, -0.044, -0.043,
```
