### PR TITLE
Cleaning of  Geometry/CSCGeometryBuilder/plugins/BuildFile.xml 

### DIFF
--- a/Geometry/CSCGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/CSCGeometryBuilder/plugins/BuildFile.xml
@@ -10,18 +10,15 @@
  <use name="Geometry/Records"/>
 
 <library name="CSCGeometryPlugins" file="CSCGeometryESModule.cc">
-<use name="DetectorDescription/Core"/>
 <use name="DetectorDescription/DDCMS"/>
 <use name="Geometry/RPCGeometry"/>
 <use name="dd4hep"/>
 <lib name="Geom"/>
-<use name="Geometry/CSCGeometryBuilder"/>
  <flags EDM_PLUGIN="1"/>
 </library>
 
 <library name="CSCGeometryValidationPlugins" file="CSCGeometryValidate.cc">
 <use name="Fireworks/Core"/>
-<use name="Geometry/CSCGeometry"/>
 <use name="rootgeom"/>
 <flags EDM_PLUGIN="1"/>
 </library> 

--- a/Geometry/CSCGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/CSCGeometryBuilder/plugins/BuildFile.xml
@@ -1,24 +1,24 @@
  <use name="CondFormats/Alignment"/>
  <use name="CondFormats/DataRecord"/>
  <use name="CondFormats/GeometryObjects"/>
- <use name="DetectorDescription/Core"/>
  <use name="FWCore/Framework"/>
  <use name="FWCore/ParameterSet"/>
- <use name="Geometry/CSCGeometry"/>
- <use name="Geometry/CSCGeometryBuilder"/>
  <use name="Geometry/MuonNumbering"/>
  <use name="Geometry/Records"/>
 
 <library name="CSCGeometryPlugins" file="CSCGeometryESModule.cc">
+<use name="DetectorDescription/Core"/>
 <use name="DetectorDescription/DDCMS"/>
 <use name="Geometry/RPCGeometry"/>
 <use name="dd4hep"/>
 <lib name="Geom"/>
+<use name="Geometry/CSCGeometryBuilder"/>
  <flags EDM_PLUGIN="1"/>
 </library>
 
 <library name="CSCGeometryValidationPlugins" file="CSCGeometryValidate.cc">
 <use name="Fireworks/Core"/>
+<use name="Geometry/CSCGeometry"/>
 <use name="rootgeom"/>
 <flags EDM_PLUGIN="1"/>
 </library> 


### PR DESCRIPTION
This is a cleaning of `Geometry/CSCGeometryBuilder/plugins/BuildFile.xml ` in order to remove the warnings 
```
***WARNING: Multiple usage of "Geometry/CSCGeometry". Please cleanup "use" in "non-export" section of "src/Geometry/CSCGeometryBuilder/plugins/BuildFile".
***WARNING: Multiple usage of "DetectorDescription/Core". Please cleanup "use" in "non-export" section of "src/Geometry/CSCGeometryBuilder/plugins/BuildFile".
***WARNING: Multiple usage of "Geometry/CSCGeometryBuilder". Please cleanup "use" in "non-export" section of "src/Geometry/CSCGeometryBuilder/plugins/BuildFile".
```
see https://cmssdt.cern.ch/SDT/jenkins-artifacts/check_headers/CMSSW_11_1_X_2020-03-18-1100/slc7_amd64_gcc820/build.log