### PR TITLE
HCal: Fix calo sample precision data from SiPM hits

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -238,7 +238,6 @@ CaloSamples HcalSiPMHitResponse::makeSiPMSignal(DetId const& id,
         pulses.push_back(std::pair<double, double>(elapsedTime, hitPixels));
       } else {
         signal[sampleBin] += hitPixels;
-        hitPixels *= invdt;
         signal.preciseAtMod(preciseBin) += 0.6 * hitPixels;
         if (preciseBin > 0)
           signal.preciseAtMod(preciseBin - 1) += 0.2 * hitPixels;
@@ -255,7 +254,7 @@ CaloSamples HcalSiPMHitResponse::makeSiPMSignal(DetId const& id,
         LogDebug("HcalSiPMHitResponse") << " pulse t: " << pulse->first << " pulse A: " << pulse->second
                                         << " timeDiff: " << timeDiff << " pulseBit: " << pulseBit;
         signal[sampleBin] += pulseBit;
-        signal.preciseAtMod(preciseBin) += pulseBit * invdt;
+        signal.preciseAtMod(preciseBin) += pulseBit;
 
         if (timeDiff > 1 && sipmPulseShape(timeDiff) < 1e-7)
           pulse = pulses.erase(pulse);


### PR DESCRIPTION
#### PR description:

A small fix to the hcal simulated calo sample precision data. Each precise bin represents charge in 0.5 ns instead of 1 ns. 
This change will affect the precise pulse shape of the calosample which is used in TDC simulation, thus we should expect changes in TDC related histograms.
