### PR TITLE
Add missing dependencyDataFormatsHLTReco to CondFormats/HLTObjects

### DIFF
--- a/CondFormats/HLTObjects/BuildFile.xml
+++ b/CondFormats/HLTObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/HLTReco"/>
 <use   name="FWCore/Utilities"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>


### PR DESCRIPTION
#### PR description:
Add missing dependency DataFormatsHLTReco to CondFormats/HLTObjects

PR fixes: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc820/CMSSW_11_1_CXXMODULE_X_2020-03-18-2300/CondFormats/HLTObjects

cc @davidlange6 @vgvassilev 