### PR TITLE
Interface for high multiplicity triggers in CSC

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -84,6 +84,9 @@ public:
   CSCALCTDigi getBestALCT(int bx) const;
   CSCALCTDigi getSecondALCT(int bx) const;
 
+  /* encode special bits for high multiplicity triggers */
+  unsigned getHighMultiplictyBits() const { return highMultiplicityBits_; }
+
 protected:
   /** Best LCTs in this chamber, as found by the processor.
       In old ALCT algorithms, up to two best ALCT per Level-1 accept window
@@ -111,6 +114,10 @@ protected:
   std::vector<CSCALCTDigi> lct_list;
 
   std::vector<CSCALCTPreTriggerDigi> thePreTriggerDigis;
+
+  /* data members for high multiplicity triggers */
+  void encodeHighMultiplicityBits();
+  unsigned int highMultiplicityBits_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig, drift_delay;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -114,6 +114,10 @@ protected:
       if false: do ALCT-to-CLCT matching */
   bool clct_to_alct;
 
+  // encode special bits for high-multiplicity triggers
+  unsigned int highMultiplicityBits_;
+  bool useHighMultiplicityBits_;
+
   /** Default values of configuration parameters. */
   static const unsigned int def_mpc_block_me1a;
   static const unsigned int def_alct_trig_enable, def_clct_trig_enable;
@@ -160,5 +164,8 @@ protected:
 
   /** Dump TMB/MPC configuration parameters. */
   void dumpConfigParams() const;
+
+  /* encode high multiplicity bits for Run-3 exotic triggers */
+  void encodeHighMultiplicityBits(unsigned alctBits);
 };
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -245,6 +245,9 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         #  False = ALCT-centric matching (recommended for SLHC,
         #         take ALCTs in BX look for matching CLCTs in window)
         clctToAlct = cms.bool(False),
+
+        ## bits for high-multiplicity triggers
+        useHighMultiplicityBits = cms.bool(False),
     ),
 
     # to be used by ME11 chambers with upgraded TMB and ALCT
@@ -278,6 +281,9 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         #  False = ALCT-centric matching (recommended for SLHC,
         #         take ALCTs in BX look for matching CLCTs in window)
         clctToAlct = cms.bool(False),
+
+        ## bits for high-multiplicity triggers
+        useHighMultiplicityBits = cms.bool(False),
 
         # For ALCT-centric matching, whether to drop CLCTs that were matched
         # to ALCTs in this BX, and not use them in the following BX
@@ -385,6 +391,9 @@ me11tmbSLHCGEM = cms.PSet(
     promoteALCTGEMquality = cms.bool(True),
     promoteCLCTGEMquality_ME1a = cms.bool(True),
     promoteCLCTGEMquality_ME1b = cms.bool(True),
+
+    ## bits for high-multiplicity triggers
+    useHighMultiplicityBits = cms.bool(False),
 )
 
 # to be used by ME21 chambers with GEM-CSC ILT
@@ -430,6 +439,9 @@ me21tmbSLHCGEM = cms.PSet(
     promoteALCTGEMpattern = cms.bool(True),
     promoteALCTGEMquality = cms.bool(True),
     promoteCLCTGEMquality = cms.bool(True),
+
+    ## bits for high-multiplicity triggers
+    useHighMultiplicityBits = cms.bool(False),
 )
 
 # to be used by ME31-ME41 chambers
@@ -454,6 +466,9 @@ meX1tmbSLHC = cms.PSet(
     ## run in debug mode
     debugLUTs = cms.bool(False),
     debugMatching = cms.bool(False),
+
+    ## bits for high-multiplicity triggers
+    useHighMultiplicityBits = cms.bool(False),
 )
 
 ## unganging in ME1/a

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -189,6 +189,10 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
                                    << " detid " << cscId_ << " with wiregroup " << keyWG << "keyStrip " << keyStrip
                                    << " \n";
 
+  // in Run-3 we plan to use the synchronization error bit
+  // to denote the presence of exotic signatures in the chamber
+  unsigned int syncErr = useHighMultiplicityBits_ ? highMultiplicityBits_ : 0;
+
   // fill the rest of the properties
   thisLCT.setTrknmb(trknmb);
   thisLCT.setValid(valid);
@@ -200,7 +204,7 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
   thisLCT.setBX(bx);
   thisLCT.setMPCLink(0);
   thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
+  thisLCT.setSyncErr(syncErr);
   thisLCT.setCSCID(theTrigChamber);
 
   // future work: add a section that produces LCTs according

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -59,7 +59,9 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   setupGeometry();
   debugLUTs();
 
-  //  generator_->generateLUTs(theEndcap, theStation, theSector, theSubsector, theTrigChamber);
+  // encode high multiplicity bits
+  unsigned alctBits = alctProc->getHighMultiplictyBits();
+  encodeHighMultiplicityBits(alctBits);
 
   if (gem_g != nullptr) {
     if (infoV >= 0)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -42,7 +42,9 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
   setupGeometry();
   debugLUTs();
 
-  //  generator_->generateLUTs(theEndcap, theStation, theSector, theSubsector, theTrigChamber);
+  // encode high multiplicity bits
+  unsigned alctBits = alctProc->getHighMultiplictyBits();
+  encodeHighMultiplicityBits(alctBits);
 
   if (gem_g != nullptr) {
     if (infoV >= 0)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -66,6 +66,10 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
   if (alctV.empty() and clctV.empty())
     return;
 
+  // encode high multiplicity bits
+  unsigned alctBits = alctProc->getHighMultiplictyBits();
+  encodeHighMultiplicityBits(alctBits);
+
   int used_alct_mask[20];
   int used_clct_mask[20];
   for (int b = 0; b < 20; b++)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -66,6 +66,10 @@ void CSCUpgradeMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCCo
   if (alctV.empty() and clctV.empty())
     return;
 
+  // encode high multiplicity bits
+  unsigned alctBits = alctProc->getHighMultiplictyBits();
+  encodeHighMultiplicityBits(alctBits);
+
   int used_clct_mask[20];
   for (int c = 0; c < 20; ++c)
     used_clct_mask[c] = 0;


### PR DESCRIPTION
#### PR description:

This PR add a basic interface for high multiplicity triggers (e.g. boosed tau->3 mu, long-lived particles to muon showers, muon-jets, etc.) in CSCs for Run-3 and beyond. At least 2 bits in the ALCT->(O)TMB data stream and at least 1 bit in the (O)TMB->EMTF data stream can be repurposed for such exotic objects. We will reassign the unused synchronization error (`syncErr`) data word in the LCT. No changes are expected. The bit values have yet to be finalized and implemented.

#### PR validation:

Tested with WF 20434.0. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A