### PR TITLE
Fix infrequent missing LuminosityBlock

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -237,9 +237,7 @@ namespace edm {
 
     void handleEndLumiExceptions(std::exception_ptr const* iPtr, WaitingTaskHolder& holder);
     void globalEndLumiAsync(edm::WaitingTaskHolder iTask, std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus);
-    void streamEndLumiAsync(edm::WaitingTaskHolder iTask,
-                            unsigned int iStreamIndex,
-                            std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus);
+    void streamEndLumiAsync(edm::WaitingTaskHolder iTask, unsigned int iStreamIndex);
     std::pair<ProcessHistoryID, RunNumber_t> readRun();
     std::pair<ProcessHistoryID, RunNumber_t> readAndMergeRun();
     void readLuminosityBlock(LuminosityBlockProcessingStatus&);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1135,29 +1135,34 @@ namespace edm {
                     streamQueues_[i].push([this, i, status, holder, ts, &es]() mutable {
                       streamQueues_[i].pause();
 
-                      auto eventTask = edm::make_waiting_task(
-                          tbb::task::allocate_root(),
-                          [this, i, h = holder](std::exception_ptr const* exceptionFromBeginStreamLumi) mutable {
-                            if (exceptionFromBeginStreamLumi) {
-                              WaitingTaskHolder tmp(h);
-                              tmp.doneWaiting(*exceptionFromBeginStreamLumi);
-                              streamEndLumiAsync(h, i, streamLumiStatus_[i]);
-                            } else {
-                              handleNextEventForStreamAsync(std::move(h), i);
-                            }
-                          });
+                      auto eventTask =
+                          edm::make_waiting_task(tbb::task::allocate_root(),
+                                                 [this, i, h = std::move(holder)](
+                                                     std::exception_ptr const* exceptionFromBeginStreamLumi) mutable {
+                                                   if (exceptionFromBeginStreamLumi) {
+                                                     WaitingTaskHolder tmp(h);
+                                                     tmp.doneWaiting(*exceptionFromBeginStreamLumi);
+                                                     streamEndLumiAsync(h, i);
+                                                   } else {
+                                                     handleNextEventForStreamAsync(std::move(h), i);
+                                                   }
+                                                 });
                       auto& event = principalCache_.eventPrincipal(i);
-                      streamLumiStatus_[i] = status;
+                      //We need to be sure that 'status' and its internal shared_ptr<LuminosityBlockPrincipal> are only
+                      // held by the container as this lambda may not finish executing before all the tasks it
+                      // spawns have already started to run.
+                      auto eventSetupImpls = &status->eventSetupImpls();
+                      auto lp = status->lumiPrincipal().get();
+                      streamLumiStatus_[i] = std::move(status);
                       ++streamLumiActive_;
-                      auto lp = status->lumiPrincipal();
-                      event.setLuminosityBlockPrincipal(lp.get());
+                      event.setLuminosityBlockPrincipal(lp);
                       beginStreamTransitionAsync<Traits>(WaitingTaskHolder{eventTask},
                                                          *schedule_,
                                                          i,
                                                          *lp,
                                                          ts,
                                                          es,
-                                                         &status->eventSetupImpls(),
+                                                         eventSetupImpls,
                                                          serviceToken_,
                                                          subProcesses_);
                     });
@@ -1367,9 +1372,7 @@ namespace edm {
                                      cleaningUpAfterException);
   }
 
-  void EventProcessor::streamEndLumiAsync(edm::WaitingTaskHolder iTask,
-                                          unsigned int iStreamIndex,
-                                          std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus) {
+  void EventProcessor::streamEndLumiAsync(edm::WaitingTaskHolder iTask, unsigned int iStreamIndex) {
     auto t = edm::make_waiting_task(tbb::task::allocate_root(),
                                     [this, iStreamIndex, iTask](std::exception_ptr const* iPtr) mutable {
                                       if (iPtr) {
@@ -1389,16 +1392,20 @@ namespace edm {
 
     edm::WaitingTaskHolder lumiDoneTask{t};
 
-    iLumiStatus->setEndTime();
+    //Need to be sure the lumi status is released before lumiDoneTask can every be called.
+    // therefore we do not want to hold the shared_ptr
+    auto lumiStatus = streamLumiStatus_[iStreamIndex].get();
+    lumiStatus->setEndTime();
 
-    if (iLumiStatus->didGlobalBeginSucceed()) {
-      auto& lumiPrincipal = *iLumiStatus->lumiPrincipal();
+    EventSetupImpl const& es = lumiStatus->eventSetupImpl(esp_->subProcessIndex());
+
+    bool cleaningUpAfterException = lumiStatus->cleaningUpAfterException();
+    auto eventSetupImpls = &lumiStatus->eventSetupImpls();
+
+    if (lumiStatus->didGlobalBeginSucceed()) {
+      auto& lumiPrincipal = *lumiStatus->lumiPrincipal();
       IOVSyncValue ts(EventID(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), EventID::maxEventNumber()),
                       lumiPrincipal.endTime());
-      EventSetupImpl const& es = iLumiStatus->eventSetupImpl(esp_->subProcessIndex());
-
-      bool cleaningUpAfterException = iLumiStatus->cleaningUpAfterException();
-
       using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>;
       endStreamTransitionAsync<Traits>(std::move(lumiDoneTask),
                                        *schedule_,
@@ -1406,7 +1413,7 @@ namespace edm {
                                        lumiPrincipal,
                                        ts,
                                        es,
-                                       &iLumiStatus->eventSetupImpls(),
+                                       eventSetupImpls,
                                        serviceToken_,
                                        subProcesses_,
                                        cleaningUpAfterException);
@@ -1421,7 +1428,7 @@ namespace edm {
         WaitingTaskHolder globalTaskHolder{globalWaitTask.get()};
         for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
           if (streamLumiStatus_[i]) {
-            streamEndLumiAsync(globalTaskHolder, i, streamLumiStatus_[i]);
+            streamEndLumiAsync(globalTaskHolder, i);
           }
         }
       }
@@ -1625,7 +1632,9 @@ namespace edm {
   void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask, unsigned int iStreamIndex) {
     sourceResourcesAcquirer_.serialQueueChain().push([this, iTask, iStreamIndex]() mutable {
       ServiceRegistry::Operate operate(serviceToken_);
-      auto& status = streamLumiStatus_[iStreamIndex];
+      //we do not want to extend the lifetime of the shared_ptr to the end of this function
+      // as steramEndLumiAsync may clear the value from streamLumiStatus_[iStreamIndex]
+      auto status = streamLumiStatus_[iStreamIndex].get();
       // Caught exception is propagated to EventProcessor::runToCompletion() via deferredExceptionPtr_
       CMS_SA_ALLOW try {
         if (readNextEventForStream(iStreamIndex, *status)) {
@@ -1642,7 +1651,7 @@ namespace edm {
                     WaitingTaskHolder tempHolder(iTask);
                     tempHolder.doneWaiting(*iPtr);
                   }
-                  streamEndLumiAsync(std::move(iTask), iStreamIndex, streamLumiStatus_[iStreamIndex]);
+                  streamEndLumiAsync(std::move(iTask), iStreamIndex);
                   //the stream will stop now
                   return;
                 }
@@ -1657,7 +1666,7 @@ namespace edm {
               status->startNextLumi();
               beginLumiAsync(status->nextSyncValue(), status->runResource(), iTask);
             }
-            streamEndLumiAsync(std::move(iTask), iStreamIndex, status);
+            streamEndLumiAsync(std::move(iTask), iStreamIndex);
           } else {
             iTask.doneWaiting(std::exception_ptr{});
           }
@@ -1666,7 +1675,7 @@ namespace edm {
         // It is unlikely we will ever get in here ...
         // But if we do try to clean up and propagate the exception
         if (streamLumiStatus_[iStreamIndex]) {
-          streamEndLumiAsync(iTask, iStreamIndex, streamLumiStatus_[iStreamIndex]);
+          streamEndLumiAsync(iTask, iStreamIndex);
         }
         bool expected = false;
         if (deferredExceptionPtrIsSet_.compare_exchange_strong(expected, true)) {


### PR DESCRIPTION

#### PR description:

Under very heavy load where a thread is paused at just the right part of the function, the LuminosityBlock cache would be empty when the begin LuminosityBlock transition starts. The fix was to not have a local variable holding the std::shared_ptr<> to the LuminosityBlockPrincipal. 
Additionally, removed the unnecessary LuminosityBlockProcessingStatus arguments from streamEndLumiAsync.

#### PR validation:

I was able to modify one of the framework tests to be able to reliably fail. After this fix, it no longer fails.