### PR TITLE
Remove outdated jercVars from JME custom NanoAOD for AK4 and AK8 jets

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -174,8 +174,8 @@ JETVARS = cms.PSet(P4Vars,
   muEF      = jetTable.variables.muEF,
   rawFactor = jetTable.variables.rawFactor,
   jetId     = jetTable.variables.jetId,
-  jercCHPUF = jetTable.variables.jercCHPUF,
-  jercCHF   = jetTable.variables.jercCHF,
+#  jercCHPUF = jetTable.variables.jercCHPUF,
+#  jercCHF   = jetTable.variables.jercCHF,
 )
 
 #============================================
@@ -416,20 +416,20 @@ def PrepJMECustomNanoAOD(process,runOnMC):
   #
   #
   #
-  process.jercVarsFatJet = process.jercVars.clone(
-    srcJet = "updatedJetsAK8",
-    maxDR = 0.8,
-  )
-  process.jetSequence.insert(process.jetSequence.index(process.updatedJetsAK8WithUserData), process.jercVarsFatJet)
-  
-  process.updatedJetsAK8WithUserData.userFloats.jercCHPUF = cms.InputTag(
-    "%s:chargedHadronPUEnergyFraction"  % process.jercVarsFatJet.label()
-  )
-  process.updatedJetsAK8WithUserData.userFloats.jercCHF = cms.InputTag(
-    "%s:chargedHadronCHSEnergyFraction" % process.jercVarsFatJet.label()
-  )
-  process.fatJetTable.variables.jercCHPUF = JETVARS.jercCHPUF
-  process.fatJetTable.variables.jercCHF   = JETVARS.jercCHF
+#  process.jercVarsFatJet = process.jercVars.clone(
+#    srcJet = "updatedJetsAK8",
+#    maxDR = 0.8,
+#  )
+#  process.jetSequence.insert(process.jetSequence.index(process.updatedJetsAK8WithUserData), process.jercVarsFatJet)
+#  
+#  process.updatedJetsAK8WithUserData.userFloats.jercCHPUF = cms.InputTag(
+#    "%s:chargedHadronPUEnergyFraction"  % process.jercVarsFatJet.label()
+#  )
+#  process.updatedJetsAK8WithUserData.userFloats.jercCHF = cms.InputTag(
+#    "%s:chargedHadronCHSEnergyFraction" % process.jercVarsFatJet.label()
+#  )
+#  process.fatJetTable.variables.jercCHPUF = JETVARS.jercCHPUF
+#  process.fatJetTable.variables.jercCHF   = JETVARS.jercCHF
   #
   # 
   # 


### PR DESCRIPTION
#### PR description:

Temporarily remove the so-called JERC variables from the JME custom NanoAOD content, to fix the crash in the IB reported in #29245.
JME experts will then re-add updated variables as needed.

@lathomas @ahinzmann please forward this information to the developers