### PR TITLE
EMTF configures from Global Tag conditions in MC for 2016 only

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -164,7 +164,7 @@ void TrackFinder::process(
       const int es = (endcap - emtf::MIN_ENDCAP) * (emtf::MAX_TRIGSECTOR - emtf::MIN_TRIGSECTOR + 1) + (sector - emtf::MIN_TRIGSECTOR);
 
       // Run-dependent configure. This overwrites many of the configurables passed by the python config file.
-      if (iEvent.isRealData() && fwConfig_) {
+      if (fwConfig_) {
         sector_processors_.at(es).configure_by_fw_version(condition_helper_.get_fw_version());
       }
 

--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -164,7 +164,7 @@ void TrackFinder::process(
       const int es = (endcap - emtf::MIN_ENDCAP) * (emtf::MAX_TRIGSECTOR - emtf::MIN_TRIGSECTOR + 1) + (sector - emtf::MIN_TRIGSECTOR);
 
       // Run-dependent configure. This overwrites many of the configurables passed by the python config file.
-      if (fwConfig_) {
+      if ((iEvent.isRealData() || era_ == "Run2_2016") && fwConfig_) {
         sector_processors_.at(es).configure_by_fw_version(condition_helper_.get_fw_version());
       }
 


### PR DESCRIPTION
We have unfortunately uncovered another error in the EMTF emulation for 2016, which had been masked by the previous one. [1]  As it turns out the emulator was not accessing the 2016 Global Tag conditions for most of the algorithm settings, creating a mix of 2016 and 2018 logic which is internally inconsistent.  Efe measured the efficiency in the latest RelVal samples (see attached slides), and due to this bug it is 10% lower in the negative endcap than in the positive.

Thankfully the fix is quite simple, as you can see in this pull request.  Efe's plots confirm that the efficiency looks good when re-running the newest RelVals with this patch applied, and is consistent with the efficiency in 2016 data. [2]

For historical background on the likely cause for this bug, between 2016 and 2017 we completely overhauled the EMTF emulator, in part to handle the new RPC inputs.  Unfortunately both the CondDB code and payloads for EMTF at that point were in disarray (very long story), and accessing the conditions payload was crashing the MC RelVals.  At that point (if my hazy memory serves) we decided to configure by firmware version only for data, and by "fake conditions" for MC, with 3 different "fake conditions" python config files.  Sometime subsequently the "fake conditions" for each year went away, so the MC emulation (again, for some but not all of the algorithm settings) used the default settings, instead of the time-dependent firmware version settings.  This worked fine when the "default" settings were also the "current" settings (which was true when the 2017 and 2018 MC were produced), but fails for 2016. re-emulation.  Long story short, our workflows had never been fully validated for legacy MC, and now we're finding the bugs - for which we apologize.

Let us know if you have any other questions.
Best regards,Andrew, Efe, Olivier, and Benjamin

[1] https://github.com/cms-sw/cmssw/pull/29080
[2] https://twiki.cern.ch/twiki/bin/view/CMSPublic/L1TMuonPerformanceICHEP16

[EMTF_UL16MC_validation_19.03.2020.pdf](https://github.com/cms-sw/cmssw/files/4359945/EMTF_UL16MC_validation_19.03.2020.pdf)
