### PR TITLE
[Tracker Alignment] All-in-one tool: fix reading of sqlite files

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
@@ -197,7 +197,6 @@ def cppboolstring(string, name):
     """
     return pythonboolstring(string, name).lower()
 
-conddbcode = None
 def conddb(*args):
     """
     Wrapper for conddb, so that you can run
@@ -207,36 +206,29 @@ def conddb(*args):
     getcommandoutput2(conddb ...) doesn't work, it imports
     the wrong sqlalchemy in CondCore/Utilities/python/conddblib.py
     """
-    global conddbcode
-    from tempfile import mkdtemp, NamedTemporaryFile
+    from tempfile import NamedTemporaryFile
 
-    if conddbcode is None:
-        conddbfile = getCommandOutput2("which conddb").strip()
-        tmpdir = mkdtemp()
-        getCommandOutput2("2to3 -f print -o " + tmpdir + " -n -w " + conddbfile)
-
-        with open(os.path.join(tmpdir, "conddb")) as f:
-            conddb = f.read()
-
-        conddbcode = conddb.replace("sys.exit", "sysexit")
+    with open(getCommandOutput2("which conddb").strip()) as f:
+        conddb = f.read()
 
     def sysexit(number):
         if number != 0:
             raise AllInOneError("conddb exited with status {}".format(number))
     namespace = {"sysexit": sysexit, "conddboutput": ""}
 
+    conddb = conddb.replace("sys.exit", "sysexit")
+
     bkpargv = sys.argv
     sys.argv[1:] = args
     bkpstdout = sys.stdout
-    try:
-        with NamedTemporaryFile(bufsize=0) as sys.stdout:
-            exec(conddbcode, namespace)
-            namespace["main"]()
-            with open(sys.stdout.name) as f:
-                result = f.read()
-    finally:
-        sys.argv[:] = bkpargv
-        sys.stdout = bkpstdout
+    with NamedTemporaryFile(bufsize=0) as sys.stdout:
+        exec(conddb, namespace)
+        namespace["main"]()
+        with open(sys.stdout.name) as f:
+            result = f.read()
+
+    sys.argv[:] = bkpargv
+    sys.stdout = bkpstdout
 
     return result
 

--- a/Alignment/OfflineValidation/test/testValidate.ini
+++ b/Alignment/OfflineValidation/test/testValidate.ini
@@ -2,7 +2,7 @@
 # general settings applying to all validations
 # - one can override `jobmode` in the individual validation's section
 [general]
-jobmode = lxBatch, -q cmscaf1nd
+jobmode = condor
 # if you want your root files stored in a subdirectory on eos, put it here:
 eosdir = Test
 # it gets saved in /store/caf/user/$USER/AlignmentValidation/eosdir/
@@ -14,7 +14,8 @@ eosdir = Test
 # configuration of several alignments
 
 [alignment:prompt]
-title = prompt ;unnecessary here, since it defaults to the alignment name, but can contain spaces, TLatex, etc.
+title = prompt
+#;unnecessary here, since it defaults to the alignment name, but can contain spaces, TLatex, etc.
 globaltag = 92X_dataRun2_Prompt_v2
 color = 1
 #first digits = marker style for track splitting and Z->mumu.  Last 2 digits = line style.

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -9,6 +9,11 @@ if test -f "validation_config.ini"; then
     rm -f validation_config.ini
 fi
 
+## copy into local sqlite file the ideal alignment
+echo "COPYING locally Ideal Alignment ..."
+conddb --yes --db pro copy TrackerAlignment_Upgrade2017_design_v4 --destdb myfile.db
+
+echo "GENERATING all-in-one tool configuration ..."
 cat <<EOF >> validation_config.ini
 [general]
 jobmode = interactive
@@ -23,6 +28,7 @@ style = 2001
 [alignment:express]
 title = express
 globaltag = 92X_dataRun2_Express_v2
+condition TrackerAlignmentRcd =  sqlite_file:myfile.db,TrackerAlignment_Upgrade2017_design_v4
 color = 2
 style = 2402
 
@@ -143,4 +149,5 @@ split some_split_validation - prompt :
 split some_split_validation - express :
 EOF
 
+echo "TESTING all-in-one tool ..."
 validateAlignments.py -c validation_config.ini -N testingAllInOneTool --dryRun || die "Failure running all-in-one test" $?


### PR DESCRIPTION
#### PR description:
It was noticed that the commit f0d34bf760a35c90f7b2ac4241f31227b4dc799a introduced in PR #24952 actually breaks the possibility to read SQLite files from local afs storage which is a mandatory feature of the tool. This PR reverts it. 
In addition I instrument the unit test of this package to be able to spot issues with this functionality.

#### PR validation:

It relies on the existing unit test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, but will be backported in all the open release cycle where alignment campaigns are active.

cc:
@vbotta @connorpa @adewit 
