### PR TITLE
[Tracker Alignment] All-in-one tool: fix reading of sqlite files (11.0.X)

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
@@ -197,7 +197,6 @@ def cppboolstring(string, name):
     """
     return pythonboolstring(string, name).lower()
 
-conddbcode = None
 def conddb(*args):
     """
     Wrapper for conddb, so that you can run
@@ -207,36 +206,29 @@ def conddb(*args):
     getcommandoutput2(conddb ...) doesn't work, it imports
     the wrong sqlalchemy in CondCore/Utilities/python/conddblib.py
     """
-    global conddbcode
-    from tempfile import mkdtemp, NamedTemporaryFile
+    from tempfile import NamedTemporaryFile
 
-    if conddbcode is None:
-        conddbfile = getCommandOutput2("which conddb").strip()
-        tmpdir = mkdtemp()
-        getCommandOutput2("2to3 -f print -o " + tmpdir + " -n -w " + conddbfile)
-
-        with open(os.path.join(tmpdir, "conddb")) as f:
-            conddb = f.read()
-
-        conddbcode = conddb.replace("sys.exit", "sysexit")
+    with open(getCommandOutput2("which conddb").strip()) as f:
+        conddb = f.read()
 
     def sysexit(number):
         if number != 0:
             raise AllInOneError("conddb exited with status {}".format(number))
     namespace = {"sysexit": sysexit, "conddboutput": ""}
 
+    conddb = conddb.replace("sys.exit", "sysexit")
+
     bkpargv = sys.argv
     sys.argv[1:] = args
     bkpstdout = sys.stdout
-    try:
-        with NamedTemporaryFile(bufsize=0) as sys.stdout:
-            exec(conddbcode, namespace)
-            namespace["main"]()
-            with open(sys.stdout.name) as f:
-                result = f.read()
-    finally:
-        sys.argv[:] = bkpargv
-        sys.stdout = bkpstdout
+    with NamedTemporaryFile(bufsize=0) as sys.stdout:
+        exec(conddb, namespace)
+        namespace["main"]()
+        with open(sys.stdout.name) as f:
+            result = f.read()
+
+    sys.argv[:] = bkpargv
+    sys.stdout = bkpstdout
 
     return result
 

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -743,7 +743,10 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
 
     map( lambda job: job.runJob(), jobs )
 
-    ValidationJobMultiIOV.runCondorJobs(outPath)
+    if options.dryRun:
+        pass
+    else:
+        ValidationJobMultiIOV.runCondorJobs(outPath)
 
 
 if __name__ == "__main__":

--- a/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
@@ -8,6 +8,7 @@
 [general]
 jobmode = lxBatch, -q cmscaf1nd
 datadir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/results/$USER/PVValidationTest
+eosdir = Test
 # if you want your root files stored in a subdirectory on eos, put it here:
 # eosdir = Test
 # if you want your logs to be stored somewhere else, put it here:
@@ -45,6 +46,7 @@ title= 2017 MC Ideal
 globaltag = auto:phase1_2017_design
 ## need beamspot as in the simulated sample
 condition BeamSpotObjectsRcd  = frontier://FrontierProd/CMS_CONDITIONS,BeamSpotObjects_Realistic25ns_13TeVCollisions_Early2017_v1_mc 
+
 color = kCyan
 style = kOpenSquare
 
@@ -96,7 +98,8 @@ w_dzEtaNormMax = 1.8
 
 [primaryvertex:phase0MC]
 maxevents = 10000
-dataset = /RelValTTbar_13/CMSSW_8_1_0_pre16-TkAlMinBias-81X_mcRun2_asymptotic_v11-v1/ALCARECO 
+multiIOV = false
+dataset = /QCD_Pt_470to600_TuneCP5_13TeV_pythia8/RunIIWinter19PFCalibDRPremix-TkAlMinBias-2016Conditions_newPixCond_105X_mcRun2_asymptotic_newPixCond_v2-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
 isda = True
@@ -110,6 +113,7 @@ runControl = False
 
 [primaryvertex:phaseIMC]
 maxevents = 10000
+multiIOV = false
 dataset =  /QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer17DRPremix-TkAlMinBias-92X_upgrade2017_realistic_v10-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -132,6 +136,7 @@ runControl = False
 
 [primaryvertex:phaseIMC_BPixOnly]
 maxevents = 10000
+multiIOV = false
 dataset =  /QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer17DRPremix-TkAlMinBias-92X_upgrade2017_realistic_v10-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -148,6 +153,7 @@ runControl = False
 
 [primaryvertex:run2016data]
 maxevents = 10000
+multiIOV = false
 dataset = /HLTPhysics/Run2016H-TkAlMinBias-PromptReco-v2/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -162,6 +168,7 @@ runControl = True
 
 [primaryvertex:run2018data]
 maxevents = 10000
+multiIOV = false
 dataset = /StreamExpressAlignment/Run2018B-TkAlMinBias-Express-v1/ALCARECO 
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -182,6 +189,7 @@ runControl = False
 
 [primaryvertex:run2018data_forcedBS]
 maxevents = 10000
+multiIOV = false
 dataset = /StreamExpressAlignment/Run2018B-TkAlMinBias-Express-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices

--- a/Alignment/OfflineValidation/test/testValidate.ini
+++ b/Alignment/OfflineValidation/test/testValidate.ini
@@ -2,7 +2,7 @@
 # general settings applying to all validations
 # - one can override `jobmode` in the individual validation's section
 [general]
-jobmode = lxBatch, -q cmscaf1nd
+jobmode = condor
 # if you want your root files stored in a subdirectory on eos, put it here:
 eosdir = Test
 # it gets saved in /store/caf/user/$USER/AlignmentValidation/eosdir/
@@ -14,7 +14,8 @@ eosdir = Test
 # configuration of several alignments
 
 [alignment:prompt]
-title = prompt ;unnecessary here, since it defaults to the alignment name, but can contain spaces, TLatex, etc.
+title = prompt
+#;unnecessary here, since it defaults to the alignment name, but can contain spaces, TLatex, etc.
 globaltag = 92X_dataRun2_Prompt_v2
 color = 1
 #first digits = marker style for track splitting and Z->mumu.  Last 2 digits = line style.

--- a/Alignment/OfflineValidation/test/testValidate.ini
+++ b/Alignment/OfflineValidation/test/testValidate.ini
@@ -34,20 +34,26 @@ style = 2402
 
 [offline:validation_MinBias]
 maxevents = 1000
+multiIOV = false
+magneticfield = 3.8
 dataset = /MinimumBias/Run2017A-TkAlMinBias-PromptReco-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 
 [offline:validation_cosmics]
 maxevents = 1000
+multiIOV = false
+magneticfield = 3.8
 dataset = /Cosmics/Run2017A-TkAlCosmics0T-PromptReco-v1/ALCARECO
 trackcollection = ALCARECOTkAlCosmicsCTF0T
 
 [compare:Tracker]
+multiIOV = false
 levels = "Tracker","DetUnit"
 dbOutput = false
 
 [zmumu:some_zmumu_validation]
 maxevents = 1000
+multiIOV = false
 dataset = /DoubleMuon/Run2017A-TkAlZMuMu-PromptReco-v3/ALCARECO
 etamaxneg = 2.4
 etaminneg = -2.4
@@ -56,6 +62,7 @@ etaminpos = -2.4
 
 [split:some_split_validation]
 maxevents = 1000
+multiIOV = false
 dataset = /Cosmics/Run2017A-TkAlCosmics0T-PromptReco-v1/ALCARECO
 trackcollection = ALCARECOTkAlCosmicsCTF0T
 


### PR DESCRIPTION
backport of #29255 and #28739

#### PR description:

It was noticed that the commit f0d34bf760a35c90f7b2ac4241f31227b4dc799a introduced in PR #24952 actually breaks the possibility to read SQLite files from local afs storage which is a mandatory feature of the tool. This PR reverts it. 
I profit of this PR to backport as well commit 7d935d3475cfe3f3f4779d912bf8c7e8905447bb and a general clean-up of the example ini files in commit 0d9153a 

#### PR validation:

As there is no unit-test in this release-cycle I locally tested the configuration to run fine.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a combined backport of #29255 and #28739

cc:
@vbotta @connorpa @adewit 