### PR TITLE
Add QGL input variables and update jerc variables in JME Custom-NanoAODs

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -174,8 +174,10 @@ JETVARS = cms.PSet(P4Vars,
   muEF      = jetTable.variables.muEF,
   rawFactor = jetTable.variables.rawFactor,
   jetId     = jetTable.variables.jetId,
-  jercCHPUF = jetTable.variables.jercCHPUF,
-  jercCHF   = jetTable.variables.jercCHF,
+  chFPV0EF  = jetTable.variables.chFPV0EF,
+  chFPV1EF  = jetTable.variables.chFPV1EF,
+  chFPV2EF  = jetTable.variables.chFPV2EF,
+  chFPV3EF  = jetTable.variables.chFPV3EF,
 )
 
 #============================================
@@ -386,6 +388,20 @@ def AddPileUpJetIDVars(proc):
   proc.jetTable.variables.jetRchg  = Var("userFloat('jetRchg')", float, doc="fraction of jet pT carried by the leading charged constituent", precision= 6) 
   proc.jetTable.variables.nCharged = Var("userInt('nCharged')",  int, doc="number of charged constituents")
 
+def AddQGLTaggerVars(proc):
+  #
+  # Save variables as userFloats and userInts
+  # 
+  proc.updatedJetsWithUserData.userFloats.qgl_axis2 = cms.InputTag("qgtagger:axis2")
+  proc.updatedJetsWithUserData.userFloats.qgl_ptD = cms.InputTag("qgtagger:ptD")
+  proc.updatedJetsWithUserData.userInts.qgl_mult = cms.InputTag("qgtagger:mult")
+  #
+  # Specfiy variables in the jetTable to save in NanoAOD
+  #
+  proc.jetTable.variables.qgl_axis2 = Var("userFloat('qgl_axis2')", float, doc="ellipse minor jet axis (Quark vs Gluon likelihood input variable)", precision= 6) 
+  proc.jetTable.variables.qgl_ptD   = Var("userFloat('qgl_ptD')", float, doc="pT-weighted average pT of constituents (Quark vs Gluon likelihood input variable)", precision= 6) 
+  proc.jetTable.variables.qgl_mult  = Var("userInt('qgl_mult')", int, doc="PF candidates multiplicity (Quark vs Gluon likelihood input variable)") 
+
 def PrepJMECustomNanoAOD(process,runOnMC):
   #
   # Additional variables to AK4GenJets 
@@ -421,15 +437,19 @@ def PrepJMECustomNanoAOD(process,runOnMC):
     maxDR = 0.8,
   )
   process.jetSequence.insert(process.jetSequence.index(process.updatedJetsAK8WithUserData), process.jercVarsFatJet)
+
+  process.updatedJetsAK8WithUserData.userFloats = cms.PSet(
+    chFPV0EF = cms.InputTag("%s:chargedFromPV0EnergyFraction" %process.jercVarsFatJet.label()),
+    chFPV1EF = cms.InputTag("%s:chargedFromPV1EnergyFraction" %process.jercVarsFatJet.label()),
+    chFPV2EF = cms.InputTag("%s:chargedFromPV2EnergyFraction" %process.jercVarsFatJet.label()),
+    chFPV3EF = cms.InputTag("%s:chargedFromPV3EnergyFraction" %process.jercVarsFatJet.label()),
+  )
   
-  process.updatedJetsAK8WithUserData.userFloats.jercCHPUF = cms.InputTag(
-    "%s:chargedHadronPUEnergyFraction"  % process.jercVarsFatJet.label()
-  )
-  process.updatedJetsAK8WithUserData.userFloats.jercCHF = cms.InputTag(
-    "%s:chargedHadronCHSEnergyFraction" % process.jercVarsFatJet.label()
-  )
-  process.fatJetTable.variables.jercCHPUF = JETVARS.jercCHPUF
-  process.fatJetTable.variables.jercCHF   = JETVARS.jercCHF
+  process.fatJetTable.variables.chFPV0EF  = JETVARS.chFPV0EF
+  process.fatJetTable.variables.chFPV1EF  = JETVARS.chFPV1EF
+  process.fatJetTable.variables.chFPV2EF  = JETVARS.chFPV2EF
+  process.fatJetTable.variables.chFPV3EF  = JETVARS.chFPV3EF
+
   #
   # 
   # 
@@ -443,6 +463,10 @@ def PrepJMECustomNanoAOD(process,runOnMC):
   # Add variables for pileup jet ID studies.
   #
   AddPileUpJetIDVars(process)
+  #
+  # Add variables for quark guon likelihood tagger studies.
+  #
+  AddQGLTaggerVars(process)
 
   ######################################################################################################################
 

--- a/PhysicsTools/PatAlgos/python/tools/jetCollectionTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetCollectionTools.py
@@ -498,8 +498,10 @@ class RecoJetAdder(object):
         cms.EDProducer("PATJetUserDataEmbedder",
           src = cms.InputTag(selJet),
           userFloats = cms.PSet(
-            jercCHPUF = cms.InputTag("{}:chargedHadronPUEnergyFraction".format(jercVar)),
-            jercCHF   = cms.InputTag("{}:chargedHadronCHSEnergyFraction".format(jercVar)),
+            chFPV0EF = cms.InputTag("{}:chargedFromPV0EnergyFraction".format(jercVar)),
+            chFPV1EF = cms.InputTag("{}:chargedFromPV1EnergyFraction".format(jercVar)),
+            chFPV2EF = cms.InputTag("{}:chargedFromPV2EnergyFraction".format(jercVar)),
+            chFPV3EF = cms.InputTag("{}:chargedFromPV3EnergyFraction".format(jercVar)),
           ),
           userInts = cms.PSet(
             tightId        = cms.InputTag(tightJetId),


### PR DESCRIPTION
This PR involves the following changes: 

1. Add input jet variables needed for the quark vs gluon likelihood (QGL) in the JME Custom-NanoAODs. The variables are useful QGL developers when they need to train the likelihood for future new releases. The input variables are already calculated together with the QGL discriminant in the [main](https://github.com/cms-sw/cmssw/blob/CMSSW_10_2_18/PhysicsTools/NanoAOD/python/jets_cff.py#L569) NanoAOD production. They are not saved in the main NanoAODs by default. Previous (closed) PR for this is #29239.

2. Remove deprecated "jerc" variables and add new ones in line with the latest jets_cff.py. This fix is for issue #29245.

This PR needs to be backported to 10_6_X, once merged, for the ultra legacy campaigns.