### PR TITLE
Changed boost::scoped_ptr for std::unique_ptr

### DIFF
--- a/Fireworks/Core/interface/FWConfiguration.h
+++ b/Fireworks/Core/interface/FWConfiguration.h
@@ -20,7 +20,7 @@
 
 // system include files
 #include <vector>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <string>
 #include <ostream>
 
@@ -64,8 +64,8 @@ public:
 private:
   // ---------- member data --------------------------------
 
-  boost::scoped_ptr<std::vector<std::string> > m_stringValues;
-  boost::scoped_ptr<std::vector<std::pair<std::string, FWConfiguration> > > m_keyValues;
+  std::unique_ptr<std::vector<std::string> > m_stringValues;
+  std::unique_ptr<std::vector<std::pair<std::string, FWConfiguration> > > m_keyValues;
   unsigned int m_version;
 };
 


### PR DESCRIPTION
#### PR description:

Changed boost :: scoped_ptr to std :: unique_ptr. In this context, they have similar functionality and should be interchangeable.

#### PR validation:

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

