### PR TITLE
EMTF configures from Global Tag conditions in MC as well as data

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -189,7 +189,7 @@ void TrackFinder::process(const edm::Event& iEvent,
                      (sector - emtf::MIN_TRIGSECTOR);
 
       // Run-dependent configure. This overwrites many of the configurables passed by the python config file.
-      if (iEvent.isRealData() && fwConfig_) {
+      if (fwConfig_) {
         sector_processors_.at(es).configure_by_fw_version(condition_helper_.get_fw_version());
       }
 


### PR DESCRIPTION
"master" version of https://github.com/cms-sw/cmssw/pull/29252
Intended for all future versions of EMTF emulator.

We have unfortunately uncovered another error in the EMTF emulation for 2016, which had been masked by the previous one. [1]  As it turns out the emulator was not accessing the 2016 or 2017 Global Tag conditions for most of the algorithm settings, creating a mix of 2016 or 2017 and 2018 logic which is internally inconsistent.  Efe measured the efficiency in the latest 2016 RelVal samples (see attached slides), and due to this bug it is 10% lower in the negative endcap than in the positive.

Thankfully the fix is quite simple, as you can see in this pull request. Efe's plots confirm that the efficiency looks good when re-running the newest RelVals with this patch applied, and is consistent with the efficiency in 2016 data. [2]

For historical background on the likely cause for this bug, between 2016 and 2017 we completely overhauled the EMTF emulator, in part to handle the new RPC inputs.  Unfortunately both the CondDB code and payloads for EMTF at that point were in disarray (very long story), and accessing the conditions payload was crashing the MC RelVals.  At that point (if my hazy memory serves) we decided to configure by firmware version only for data, and by "fake conditions" for MC, with 3 different "fake conditions" python config files.  Sometime subsequently the "fake conditions" for each year went away, so the MC emulation (again, for some but not all of the algorithm settings) used the default settings, instead of the time-dependent firmware version settings.  This worked fine when the "default" settings were also the "current" settings (which was true when the 2017 and 2018 MC were produced), but fails for 2016. re-emulation.  Long story short, our workflows had never been fully validated for legacy MC, and now we're finding the bugs - for which we apologize.

[1] #29080
[2] https://twiki.cern.ch/twiki/bin/view/CMSPublic/L1TMuonPerformanceICHEP16
[EMTF_UL16MC_validation_19.03.2020.pdf](https://github.com/cms-sw/cmssw/files/4361572/EMTF_UL16MC_validation_19.03.2020.pdf)
