### PR TITLE
Luminosity producer using files from brilcalc

### DIFF
--- a/RecoLuminosity/LumiProducer/README.md
+++ b/RecoLuminosity/LumiProducer/README.md
@@ -1,0 +1,19 @@
+# RecoLuminosity/LumiProducer
+
+This package contains utilities for producing luminosity information in CMSSW. Most of the plugins here are obsolete and only for Run 1; they are kept here for backwards compatibility but are not actively maintained.
+
+For Run 2, the plugin `LumiProducerFromBrilcalc` is available. This allows you to add luminosity information to your CMSSW job by reading in a CSV output file produced by the `brilcalc` utility. In order to use it, add the following to your `cfg` file:
+
+```
+process.LumiInfo = cms.EDProducer('LumiProducerFromBrilcalc',
+                                  lumiFile = cms.untracked.string("./myLumiFile.csv"),
+                                  throwIfNotFound = cms.untracked.bool(False),
+                                  doBunchByBunch = cms.untracked.bool(False))
+```
+where `lumiFile` is the output file created by `brilcalc`, `throwIfNotFound` will determine the behavior if the csv file does not contain information for an event in your input file (if `True`, an exception will be thrown; if `False`, the luminosity will just be taken to be zero for that event), and `doBunchByBunch` should remain `False`, since bunch-by-bunch luminosity is not currently supported.
+
+Add `LumiInfo` to your path, and then you can access the `LumiInfo` object produced under the input tag `("LumiInfo", "brilcalc")`.
+
+For more information on the proper way to use `brilcalc` to produce a luminosity csv file, please consult the [LumiPOG twiki](https://twiki.cern.ch/twiki/bin/view/CMS/TWikiLUM#LumiCMSSW).
+
+												      

--- a/RecoLuminosity/LumiProducer/README.md
+++ b/RecoLuminosity/LumiProducer/README.md
@@ -6,9 +6,9 @@ For Run 2, the plugin `LumiProducerFromBrilcalc` is available. This allows you t
 
 ```
 process.LumiInfo = cms.EDProducer('LumiProducerFromBrilcalc',
-                                  lumiFile = cms.untracked.string("./myLumiFile.csv"),
-                                  throwIfNotFound = cms.untracked.bool(False),
-                                  doBunchByBunch = cms.untracked.bool(False))
+                                  lumiFile = cms.string("./myLumiFile.csv"),
+                                  throwIfNotFound = cms.bool(False),
+                                  doBunchByBunch = cms.bool(False))
 ```
 where `lumiFile` is the output file created by `brilcalc`, `throwIfNotFound` will determine the behavior if the csv file does not contain information for an event in your input file (if `True`, an exception will be thrown; if `False`, the luminosity will just be taken to be zero for that event), and `doBunchByBunch` should remain `False`, since bunch-by-bunch luminosity is not currently supported.
 

--- a/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
@@ -106,3 +106,9 @@
   <use name="FWCore/PluginManager"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
+<library file="LumiProducerFromBrilcalc.cc" name="LumiProducerFromBrilcalc">
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="DataFormats/Luminosity"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
@@ -2,7 +2,7 @@
 //
 // Package:    RecoLuminosity/LumiProducer
 // Class:      LumiProducerFromBrilcalc
-// 
+//
 /**\class LumiProducerFromBrilcalc LumiProducerFromBrilcalc.cc RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
 
    Description: Takes a csv file with luminosity information produced by brilcalc and reads it into the event.
@@ -16,12 +16,10 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <sstream>
 #include <fstream>
-#include <iostream>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -32,6 +30,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Luminosity/interface/LumiInfo.h"
 
@@ -66,7 +66,6 @@ private:
 // constants, enums and typedefs
 //
 
-
 //
 // static data member definitions
 //
@@ -74,47 +73,51 @@ private:
 //
 // constructors and destructor
 //
-LumiProducerFromBrilcalc::LumiProducerFromBrilcalc(const edm::ParameterSet& iConfig) :
-  lumiFile_(iConfig.getUntrackedParameter<std::string>("lumiFile")),
-  throwIfNotFound_(iConfig.getUntrackedParameter<bool>("throwIfNotFound", false)),
-  doBunchByBunch_(iConfig.getUntrackedParameter<bool>("doBunchByBunch", false)) {
+LumiProducerFromBrilcalc::LumiProducerFromBrilcalc(const edm::ParameterSet& iConfig)
+    : lumiFile_(iConfig.getUntrackedParameter<std::string>("lumiFile")),
+      throwIfNotFound_(iConfig.getUntrackedParameter<bool>("throwIfNotFound", false)),
+      doBunchByBunch_(iConfig.getUntrackedParameter<bool>("doBunchByBunch", false)) {
   //register your products
   produces<LumiInfo>("brilcalc");
 
   //now do what ever other initialization is needed
   if (doBunchByBunch_) {
-    throw cms::Exception("LumiProducerFromBrilcalc") << "Sorry, bunch-by-bunch luminosity is not yet supported. Please bug your friendly lumi expert!";
+    throw cms::Exception("LumiProducerFromBrilcalc")
+        << "Sorry, bunch-by-bunch luminosity is not yet supported. Please bug your friendly lumi expert!";
   }
 
   // Read luminosity data and store it in lumiData_.
-  std::cout << "Reading luminosity data from " << lumiFile_ << "...one moment..." << std::endl;
+  edm::LogInfo("LumiProducerFromBrilcalc") << "Reading luminosity data from " << lumiFile_ << "...one moment...";
   std::ifstream lumiFile(lumiFile_);
   if (!lumiFile.is_open()) {
     throw cms::Exception("LumiProducerFromBrilcalc") << "Failed to open input luminosity file " << lumiFile_;
   }
 
-  int nLS=0;
+  int nLS = 0;
   std::string line;
   while (1) {
     std::getline(lumiFile, line);
-    if (lumiFile.eof() || lumiFile.fail()) break;
-    if (line.empty()) continue; // skip blank lines
-    if (line.at(0) == '#') continue; // skip comment lines
-    
+    if (lumiFile.eof() || lumiFile.fail())
+      break;
+    if (line.empty())
+      continue;  // skip blank lines
+    if (line.at(0) == '#')
+      continue;  // skip comment lines
+
     // Break into fields. These should be, in order: run:fill, brills:cmsls, time, beam status, beam energy,
     // delivered lumi, recorded lumi, average pileup, source.
     std::stringstream ss(line);
     std::string field;
     std::vector<std::string> fields;
-    
+
     while (std::getline(ss, field, ','))
       fields.push_back(field);
-    
+
     if (fields.size() != 9) {
-      std::cout << "Malformed line in csv file: " << line << std::endl;
+      edm::LogWarning("LumiProducerFromBrilcalc") << "Malformed line in csv file: " << line;
       continue;
     }
-    
+
     // Extract the run number from fields[0] and the lumisection number from fields[1]. Fortunately since the
     // thing we want is before the colon, we don't have to split them again.
     int run, ls;
@@ -122,7 +125,7 @@ LumiProducerFromBrilcalc::LumiProducerFromBrilcalc(const edm::ParameterSet& iCon
     runfill >> run;
     std::stringstream lsls(fields[1]);
     lsls >> ls;
-    
+
     // Extract the delivered and recorded lumi from fields[5] and fields[6].
     float lumiDel, lumiRec, dtFrac;
     std::stringstream lumiDelString(fields[5]);
@@ -131,25 +134,20 @@ LumiProducerFromBrilcalc::LumiProducerFromBrilcalc(const edm::ParameterSet& iCon
     lumiRecString >> lumiRec;
 
     // Calculate the deadtime fraction
-    dtFrac = 1.0-lumiRec/lumiDel;
-
-    if (nLS < 20 || run==323511)
-      std::cout << run << " " << ls << " del " << lumiDel << " rec " << lumiRec << " dt " << dtFrac << std::endl;
+    dtFrac = 1.0 - lumiRec / lumiDel;
 
     // Finally, store it all.
     lumiData_[std::make_pair(run, ls)] = std::make_pair(lumiDel, dtFrac);
     nLS++;
   }
-  std::cout << "Read " << nLS << " lumisections from " << lumiFile_ << std::endl;
+  edm::LogInfo("LumiProducerFromBrilcalc") << "Read " << nLS << " lumisections from " << lumiFile_;
   lumiFile.close();
 }
-
 
 LumiProducerFromBrilcalc::~LumiProducerFromBrilcalc() {
   // do anything here that needs to be done at destruction time
   // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -161,54 +159,48 @@ void LumiProducerFromBrilcalc::produce(edm::Event& iEvent, const edm::EventSetup
   std::pair<int, int> runls = std::make_pair(iEvent.run(), iEvent.luminosityBlock());
   if (lumiData_.count(runls) == 1) {
     // if we have data for this run/LS, put it in the event
-    std::cout << "filling for run " << runls.first << " ls " << runls.second << " with " << lumiData_[runls].second << " dt " << lumiData_[runls].first << std::endl;
+    LogDebug("LumiProducerFromBrilcalc") << "Filling for run " << runls.first << " ls " << runls.second << " with delivered "
+					 << lumiData_[runls].first << " dt " << lumiData_[runls].second;
     iEvent.put(std::make_unique<LumiInfo>(lumiData_[runls].second, bxlumi, lumiData_[runls].first), "brilcalc");
   } else {
     if (throwIfNotFound_) {
-      throw cms::Exception("LumiProducerFromBrilcalc") << "Failed to find luminosity for run " << runls.first << " LS " << runls.second;
+      throw cms::Exception("LumiProducerFromBrilcalc")
+          << "Failed to find luminosity for run " << runls.first << " LS " << runls.second;
     } else {
       // just put in zeroes
-      std::cout << "warning: failed to find luminosity for run " << runls.first << " ls " << runls.second << std::endl;
+      edm::LogWarning("LumiProducerFromBrilcalc") << "Failed to find luminosity for run " << runls.first << " ls " << runls.second;
       iEvent.put(std::make_unique<LumiInfo>(0, bxlumi, 0), "brilcalc");
     }
   }
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-LumiProducerFromBrilcalc::beginStream(edm::StreamID)
-{
-}
+void LumiProducerFromBrilcalc::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-LumiProducerFromBrilcalc::endStream() {
-}
+void LumiProducerFromBrilcalc::endStream() {}
 
 // ------------ method called when starting to processes a run  ------------
-void
-LumiProducerFromBrilcalc::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
- 
+void LumiProducerFromBrilcalc::beginRun(edm::Run const&, edm::EventSetup const&) {}
+
 // ------------ method called when ending the processing of a run  ------------
 /*
   void LumiProducerFromBrilcalc::endRun(edm::Run const&, edm::EventSetup const&) {
   }
 */
- 
+
 // ------------ method called when starting to processes a luminosity block  ------------
 /*
   void LumiProducerFromBrilcalc::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
   }
 */
- 
+
 // ------------ method called when ending the processing of a luminosity block  ------------
 /*
   void LumiProducerFromBrilcalc::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
   }
 */
- 
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void LumiProducerFromBrilcalc::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // Allowed parameters

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
@@ -1,0 +1,223 @@
+// -*- C++ -*-
+//
+// Package:    RecoLuminosity/LumiProducer
+// Class:      LumiProducerFromBrilcalc
+// 
+/**\class LumiProducerFromBrilcalc LumiProducerFromBrilcalc.cc RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
+
+   Description: Takes a csv file with luminosity information produced by brilcalc and reads it into the event.
+
+   Implementation:
+   [Notes on implementation]
+*/
+//
+// Original Author:  Paul Lujan
+//         Created:  Fri, 28 Feb 2020 16:32:38 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <sstream>
+#include <fstream>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/Luminosity/interface/LumiInfo.h"
+
+//
+// class declaration
+//
+
+class LumiProducerFromBrilcalc : public edm::stream::EDProducer<> {
+public:
+  explicit LumiProducerFromBrilcalc(const edm::ParameterSet&);
+  ~LumiProducerFromBrilcalc();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  virtual void beginStream(edm::StreamID) override;
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void endStream() override;
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+  // ----------member data ---------------------------
+  std::string lumiFile_;
+  bool throwIfNotFound_;
+  bool doBunchByBunch_;
+  std::map<std::pair<int, int>, std::pair<float, float> > lumiData_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+LumiProducerFromBrilcalc::LumiProducerFromBrilcalc(const edm::ParameterSet& iConfig) :
+  lumiFile_(iConfig.getUntrackedParameter<std::string>("lumiFile")),
+  throwIfNotFound_(iConfig.getUntrackedParameter<bool>("throwIfNotFound", false)),
+  doBunchByBunch_(iConfig.getUntrackedParameter<bool>("doBunchByBunch", false)) {
+  //register your products
+  produces<LumiInfo>("brilcalc");
+
+  //now do what ever other initialization is needed
+  if (doBunchByBunch_) {
+    throw cms::Exception("LumiProducerFromBrilcalc") << "Sorry, bunch-by-bunch luminosity is not yet supported. Please bug your friendly lumi expert!";
+  }
+
+  // Read luminosity data and store it in lumiData_.
+  std::cout << "Reading luminosity data from " << lumiFile_ << "...one moment..." << std::endl;
+  std::ifstream lumiFile(lumiFile_);
+  if (!lumiFile.is_open()) {
+    throw cms::Exception("LumiProducerFromBrilcalc") << "Failed to open input luminosity file " << lumiFile_;
+  }
+
+  int nLS=0;
+  std::string line;
+  while (1) {
+    std::getline(lumiFile, line);
+    if (lumiFile.eof() || lumiFile.fail()) break;
+    if (line.empty()) continue; // skip blank lines
+    if (line.at(0) == '#') continue; // skip comment lines
+    
+    // Break into fields. These should be, in order: run:fill, brills:cmsls, time, beam status, beam energy,
+    // delivered lumi, recorded lumi, average pileup, source.
+    std::stringstream ss(line);
+    std::string field;
+    std::vector<std::string> fields;
+    
+    while (std::getline(ss, field, ','))
+      fields.push_back(field);
+    
+    if (fields.size() != 9) {
+      std::cout << "Malformed line in csv file: " << line << std::endl;
+      continue;
+    }
+    
+    // Extract the run number from fields[0] and the lumisection number from fields[1]. Fortunately since the
+    // thing we want is before the colon, we don't have to split them again.
+    int run, ls;
+    std::stringstream runfill(fields[0]);
+    runfill >> run;
+    std::stringstream lsls(fields[1]);
+    lsls >> ls;
+    
+    // Extract the delivered and recorded lumi from fields[5] and fields[6].
+    float lumiDel, lumiRec, dtFrac;
+    std::stringstream lumiDelString(fields[5]);
+    lumiDelString >> lumiDel;
+    std::stringstream lumiRecString(fields[6]);
+    lumiRecString >> lumiRec;
+
+    // Calculate the deadtime fraction
+    dtFrac = 1.0-lumiRec/lumiDel;
+
+    if (nLS < 20 || run==323511)
+      std::cout << run << " " << ls << " del " << lumiDel << " rec " << lumiRec << " dt " << dtFrac << std::endl;
+
+    // Finally, store it all.
+    lumiData_[std::make_pair(run, ls)] = std::make_pair(lumiDel, dtFrac);
+    nLS++;
+  }
+  std::cout << "Read " << nLS << " lumisections from " << lumiFile_ << std::endl;
+  lumiFile.close();
+}
+
+
+LumiProducerFromBrilcalc::~LumiProducerFromBrilcalc() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void LumiProducerFromBrilcalc::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::vector<float> bxlumi(3564, 0);
+  std::pair<int, int> runls = std::make_pair(iEvent.run(), iEvent.luminosityBlock());
+  if (lumiData_.count(runls) == 1) {
+    // if we have data for this run/LS, put it in the event
+    std::cout << "filling for run " << runls.first << " ls " << runls.second << " with " << lumiData_[runls].second << " dt " << lumiData_[runls].first << std::endl;
+    iEvent.put(std::make_unique<LumiInfo>(lumiData_[runls].second, bxlumi, lumiData_[runls].first), "brilcalc");
+  } else {
+    if (throwIfNotFound_) {
+      throw cms::Exception("LumiProducerFromBrilcalc") << "Failed to find luminosity for run " << runls.first << " LS " << runls.second;
+    } else {
+      // just put in zeroes
+      std::cout << "warning: failed to find luminosity for run " << runls.first << " ls " << runls.second << std::endl;
+      iEvent.put(std::make_unique<LumiInfo>(0, bxlumi, 0), "brilcalc");
+    }
+  }
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+LumiProducerFromBrilcalc::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+LumiProducerFromBrilcalc::endStream() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+void
+LumiProducerFromBrilcalc::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+ 
+// ------------ method called when ending the processing of a run  ------------
+/*
+  void LumiProducerFromBrilcalc::endRun(edm::Run const&, edm::EventSetup const&) {
+  }
+*/
+ 
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+  void LumiProducerFromBrilcalc::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
+  }
+*/
+ 
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+  void LumiProducerFromBrilcalc::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
+  }
+*/
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void LumiProducerFromBrilcalc::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // Allowed parameters
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("lumiFile");
+  desc.addUntracked<bool>("throwIfNotFound", false);
+  desc.addUntracked<bool>("doBunchByBunch", false);
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(LumiProducerFromBrilcalc);

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
@@ -159,8 +159,9 @@ void LumiProducerFromBrilcalc::produce(edm::Event& iEvent, const edm::EventSetup
   std::pair<int, int> runls = std::make_pair(iEvent.run(), iEvent.luminosityBlock());
   if (lumiData_.count(runls) == 1) {
     // if we have data for this run/LS, put it in the event
-    LogDebug("LumiProducerFromBrilcalc") << "Filling for run " << runls.first << " ls " << runls.second << " with delivered "
-					 << lumiData_[runls].first << " dt " << lumiData_[runls].second;
+    LogDebug("LumiProducerFromBrilcalc") << "Filling for run " << runls.first << " ls " << runls.second
+                                         << " with delivered " << lumiData_[runls].first << " dt "
+                                         << lumiData_[runls].second;
     iEvent.put(std::make_unique<LumiInfo>(lumiData_[runls].second, bxlumi, lumiData_[runls].first), "brilcalc");
   } else {
     if (throwIfNotFound_) {
@@ -168,7 +169,8 @@ void LumiProducerFromBrilcalc::produce(edm::Event& iEvent, const edm::EventSetup
           << "Failed to find luminosity for run " << runls.first << " LS " << runls.second;
     } else {
       // just put in zeroes
-      edm::LogWarning("LumiProducerFromBrilcalc") << "Failed to find luminosity for run " << runls.first << " ls " << runls.second;
+      edm::LogWarning("LumiProducerFromBrilcalc")
+          << "Failed to find luminosity for run " << runls.first << " ls " << runls.second;
       iEvent.put(std::make_unique<LumiInfo>(0, bxlumi, 0), "brilcalc");
     }
   }

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
@@ -136,7 +136,9 @@ LumiProducerFromBrilcalc::LumiProducerFromBrilcalc(const edm::ParameterSet& iCon
 //
 
 // ------------ method called to produce the data  ------------
-void LumiProducerFromBrilcalc::produce(edm::StreamID iStreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void LumiProducerFromBrilcalc::produce(edm::StreamID iStreamID,
+                                       edm::Event& iEvent,
+                                       const edm::EventSetup& iSetup) const {
   std::vector<float> bxlumi(3564, 0);
   std::pair<int, int> runls = std::make_pair(iEvent.run(), iEvent.luminosityBlock());
   if (lumiData_.count(runls) == 1) {

--- a/RecoLuminosity/LumiProducer/test/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/test/BuildFile.xml
@@ -105,3 +105,6 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
+<library file="TestLumiProducerFromBrilcalc.cc" name="TestLumiProducerFromBrilcalc">
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc.cc
+++ b/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc.cc
@@ -1,0 +1,114 @@
+// -*- C++ -*-
+//
+// Package:    RecoLuminosity/TestLumiProducerFromBrilcalc
+// Class:      TestLumiProducerFromBrilcalc
+//
+/**\class TestLumiProducerFromBrilcalc TestLumiProducerFromBrilcalc.cc RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc.cc
+
+   Description: A simple analyzer class to test the functionality of TestLumiProducerFromBrilcalc.
+
+   Implementation:
+   Get the luminosity and prints it out.
+*/
+//
+// Original Author:  Paul Lujan
+//         Created:  Fri, 20 Mar 2020 09:32:27 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/Luminosity/interface/LumiInfo.h"
+
+//
+// class declaration
+//
+
+// If the analyzer does not use TFileService, please remove
+// the template argument to the base class so the class inherits
+// from edm::one::EDAnalyzer<>
+// This will improve performance in multithreaded jobs.
+
+class TestLumiProducerFromBrilcalc : public edm::one::EDAnalyzer<> {
+public:
+  explicit TestLumiProducerFromBrilcalc(const edm::ParameterSet&);
+  ~TestLumiProducerFromBrilcalc();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
+
+  // ----------member data ---------------------------
+  edm::InputTag inputTag_;
+  edm::EDGetTokenT<LumiInfo> lumiToken_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+TestLumiProducerFromBrilcalc::TestLumiProducerFromBrilcalc(const edm::ParameterSet& iConfig)
+  : inputTag_(iConfig.getUntrackedParameter<edm::InputTag>("inputTag")),
+    lumiToken_(consumes<LumiInfo>(inputTag_)) {
+}
+
+TestLumiProducerFromBrilcalc::~TestLumiProducerFromBrilcalc() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void TestLumiProducerFromBrilcalc::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  const LumiInfo& lumi = iEvent.get(lumiToken_);
+
+  std::cout << "Luminosity for " << iEvent.run() << " LS " << iEvent.luminosityBlock() << " is " << lumi.getTotalInstLumi() << std::endl;
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void TestLumiProducerFromBrilcalc::beginJob() {
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void TestLumiProducerFromBrilcalc::endJob() {
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void TestLumiProducerFromBrilcalc::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // Allowed parameters
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<edm::InputTag>("inputTag");
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(TestLumiProducerFromBrilcalc);

--- a/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc.cc
+++ b/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <iostream>
@@ -71,9 +70,7 @@ private:
 // constructors and destructor
 //
 TestLumiProducerFromBrilcalc::TestLumiProducerFromBrilcalc(const edm::ParameterSet& iConfig)
-  : inputTag_(iConfig.getUntrackedParameter<edm::InputTag>("inputTag")),
-    lumiToken_(consumes<LumiInfo>(inputTag_)) {
-}
+    : inputTag_(iConfig.getUntrackedParameter<edm::InputTag>("inputTag")), lumiToken_(consumes<LumiInfo>(inputTag_)) {}
 
 TestLumiProducerFromBrilcalc::~TestLumiProducerFromBrilcalc() {
   // do anything here that needs to be done at destruction time
@@ -90,17 +87,15 @@ void TestLumiProducerFromBrilcalc::analyze(const edm::Event& iEvent, const edm::
 
   const LumiInfo& lumi = iEvent.get(lumiToken_);
 
-  std::cout << "Luminosity for " << iEvent.run() << " LS " << iEvent.luminosityBlock() << " is " << lumi.getTotalInstLumi() << std::endl;
+  std::cout << "Luminosity for " << iEvent.run() << " LS " << iEvent.luminosityBlock() << " is "
+            << lumi.getTotalInstLumi() << std::endl;
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void TestLumiProducerFromBrilcalc::beginJob() {
-}
+void TestLumiProducerFromBrilcalc::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void TestLumiProducerFromBrilcalc::endJob() {
-}
+void TestLumiProducerFromBrilcalc::endJob() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void TestLumiProducerFromBrilcalc::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc_cfg.py
+++ b/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc_cfg.py
@@ -19,9 +19,9 @@ process.source = cms.Source("PoolSource",
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 process.LumiInfo = cms.EDProducer('LumiProducerFromBrilcalc',
-                                  lumiFile = cms.untracked.string("./testLumiFile.csv"),
-                                  throwIfNotFound = cms.untracked.bool(False),
-                                  doBunchByBunch = cms.untracked.bool(False))
+                                  lumiFile = cms.string("./testLumiFile.csv"),
+                                  throwIfNotFound = cms.bool(False),
+                                  doBunchByBunch = cms.bool(False))
 
 process.test = cms.EDAnalyzer('TestLumiProducerFromBrilcalc',
                               inputTag = cms.untracked.InputTag("LumiInfo", "brilcalc"))

--- a/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc_cfg.py
+++ b/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc_cfg.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TestLumiProducerFromBrilcalc")
+
+# just use a random relval which has meaningless run/LS numbers, and then a corresponding test file
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring("/store/relval/CMSSW_10_2_7/RelValMinBias_13/GEN-SIM/102X_mc2017_realistic_v4_AC_v01-v1/20000/BB654FAE-5375-164F-BBFE-B330713759C6.root")
+)
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+
+process.LumiInfoFromBrilcalc = cms.EDProducer('LumiProducerFromBrilcalc',
+                                              lumiFile = cms.untracked.string("./testLumiFile.csv"),
+                                              throwIfNotFound = cms.untracked.bool(False),
+                                              doBunchByBunch = cms.untracked.bool(False))
+
+process.test = cms.EDAnalyzer('TestLumiProducerFromBrilcalc',
+                              inputTag = cms.untracked.InputTag("LumiInfoFromBrilcalc", "brilcalc"))
+
+process.p = cms.Path(process.LumiInfoFromBrilcalc*process.test)
+

--- a/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc_cfg.py
+++ b/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc_cfg.py
@@ -2,19 +2,29 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TestLumiProducerFromBrilcalc")
 
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger = cms.Service("MessageLogger",
+                                    destinations   = cms.untracked.vstring("cout"),
+                                    categories     = cms.untracked.vstring("LumiProducerFromBrilcalc"),
+                                    debugModules   = cms.untracked.vstring("LumiInfo"),
+                                    cout           = cms.untracked.PSet(
+                                        threshold  = cms.untracked.string('DEBUG')
+                                    )
+)
+
 # just use a random relval which has meaningless run/LS numbers, and then a corresponding test file
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring("/store/relval/CMSSW_10_2_7/RelValMinBias_13/GEN-SIM/102X_mc2017_realistic_v4_AC_v01-v1/20000/BB654FAE-5375-164F-BBFE-B330713759C6.root")
 )
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
-process.LumiInfoFromBrilcalc = cms.EDProducer('LumiProducerFromBrilcalc',
-                                              lumiFile = cms.untracked.string("./testLumiFile.csv"),
-                                              throwIfNotFound = cms.untracked.bool(False),
-                                              doBunchByBunch = cms.untracked.bool(False))
+process.LumiInfo = cms.EDProducer('LumiProducerFromBrilcalc',
+                                  lumiFile = cms.untracked.string("./testLumiFile.csv"),
+                                  throwIfNotFound = cms.untracked.bool(False),
+                                  doBunchByBunch = cms.untracked.bool(False))
 
 process.test = cms.EDAnalyzer('TestLumiProducerFromBrilcalc',
-                              inputTag = cms.untracked.InputTag("LumiInfoFromBrilcalc", "brilcalc"))
+                              inputTag = cms.untracked.InputTag("LumiInfo", "brilcalc"))
 
-process.p = cms.Path(process.LumiInfoFromBrilcalc*process.test)
+process.p = cms.Path(process.LumiInfo*process.test)
 

--- a/RecoLuminosity/LumiProducer/test/testLumiFile.csv
+++ b/RecoLuminosity/LumiProducer/test/testLumiFile.csv
@@ -1,0 +1,4 @@
+# This is a dummy file for TestLumiProducerFromBrilcalc.
+#run:fill,ls,time,beamstatus,E(GeV),delivered(hz/ub),recorded(hz/ub),avgpu,source
+1:1,1:1,04/17/18 10:54:40,STABLE BEAMS,6500,16.507442576,16.080153561,58.7,HFOC
+1:1,2:2,04/17/18 10:55:03,STABLE BEAMS,6500,16.483134426,1.668723696,58.6,HFOC


### PR DESCRIPTION
#### PR description:

This adds a new producer, `LumiProducerFromBrilcalc`, which will produce luminosity information in CMSSW using a csv file produced by `brilcalc`.

* For documentation on the `LumiInfo` class that this creates, see https://twiki.cern.ch/twiki/bin/view/CMS/LuminosityCMSSW
* Presentation at RECO meeting: https://indico.cern.ch/event/898980/contributions/3788833/attachments/2006969/3352077/LuminosityCMSSW20200320.pdf
* We will also add further documentation and central files that can be used to the main Luminosity TWiki page.

#### PR validation:

The included `TestLumiProducerFromBrilcalc` has been created and run to verify that it works properly (although it does not work as an automated test).

I have also checked the steps on the PR checklist and added some documentation in README.md.

#### Notes:

* As discussed in the meeting, I will investigate using the conditions DB for bunch-by-bunch luminosity, but for total luminosity, I think including the file will be the simplest solution to make this available quickly.
* As mentioned, this produces the luminosity information in the Event, although (by construction) it will always be the same for all events in a single luminosity section.