### PR TITLE
Revert "EMTF configures from Global Tag conditions in MC for 2016 only"

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -164,7 +164,7 @@ void TrackFinder::process(
       const int es = (endcap - emtf::MIN_ENDCAP) * (emtf::MAX_TRIGSECTOR - emtf::MIN_TRIGSECTOR + 1) + (sector - emtf::MIN_TRIGSECTOR);
 
       // Run-dependent configure. This overwrites many of the configurables passed by the python config file.
-      if ((iEvent.isRealData() || era_ == "Run2_2016") && fwConfig_) {
+      if (iEvent.isRealData() && fwConfig_) {
         sector_processors_.at(es).configure_by_fw_version(condition_helper_.get_fw_version());
       }
 


### PR DESCRIPTION
Reverts cms-sw/cmssw#29252
I open this PR as a reminder to revert #29252 in case the validation of CMSSW_10_6_10_CANDIDATE2 will give a negative result.