### PR TITLE
Minor enhancements to special geometry comparison test

### DIFF
--- a/CondTools/Geometry/test/writehelpers/splitExtended2021Database.sh
+++ b/CondTools/Geometry/test/writehelpers/splitExtended2021Database.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-conddb_import -f sqlite_file:myfile.db -t XMLFILE_Geometry_TagXX_Extended2021_mc -i XMLFILE_Geometry_TagXX_Extended2021_mc -c sqlite_file:GeometryFileExtended2021.db
-conddb_import -f sqlite_file:myfile.db -t TKRECO_Geometry_TagXX -i TKRECO_Geometry_TagXX -c sqlite_file:TKRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t TKExtra_Geometry_TagXX -i TKExtra_Geometry_TagXX -c sqlite_file:TKExtra_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t TKParameters_Geometry_TagXX -i TKParameters_Geometry_TagXX -c sqlite_file:TKParameters_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t EBRECO_Geometry_TagXX -i EBRECO_Geometry_TagXX -c sqlite_file:EBRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t EERECO_Geometry_TagXX -i EERECO_Geometry_TagXX -c sqlite_file:EERECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t EPRECO_Geometry_TagXX -i EPRECO_Geometry_TagXX -c sqlite_file:EPRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t HCALRECO_Geometry_TagXX -i HCALRECO_Geometry_TagXX -c sqlite_file:HCALRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t HCALParameters_Geometry_TagXX -i HCALParameters_Geometry_TagXX -c sqlite_file:HCALParameters_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t CTRECO_Geometry_TagXX -i CTRECO_Geometry_TagXX -c sqlite_file:CTRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t ZDCRECO_Geometry_TagXX -i ZDCRECO_Geometry_TagXX -c sqlite_file:ZDCRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t CASTORRECO_Geometry_TagXX -i CASTORRECO_Geometry_TagXX -c sqlite_file:CASTORRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t CSCRECO_Geometry_TagXX -i CSCRECO_Geometry_TagXX -c sqlite_file:CSCRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t CSCRECODIGI_Geometry_TagXX -i CSCRECODIGI_Geometry_TagXX -c sqlite_file:CSCRECODIGI_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t DTRECO_Geometry_TagXX -i DTRECO_Geometry_TagXX -c sqlite_file:DTRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t RPCRECO_Geometry_TagXX -i RPCRECO_Geometry_TagXX -c sqlite_file:RPCRECO_Geometry.db
-conddb_import -f sqlite_file:myfile.db -t GEMRECO_Geometry_TagXX -i GEMRECO_Geometry_TagXX -c sqlite_file:GEMRECO_Geometry.db
+conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2021_mc --destdb GeometryFileExtended2021.db
+conddb --yes --db myfile.db copy TKRECO_Geometry_TagXX                  --destdb TKRECO_Geometry.db
+conddb --yes --db myfile.db copy TKExtra_Geometry_TagXX                 --destdb TKExtra_Geometry.db
+conddb --yes --db myfile.db copy TKParameters_Geometry_TagXX            --destdb TKParameters_Geometry.db
+conddb --yes --db myfile.db copy EBRECO_Geometry_TagXX                  --destdb EBRECO_Geometry.db
+conddb --yes --db myfile.db copy EERECO_Geometry_TagXX                  --destdb EERECO_Geometry.db
+conddb --yes --db myfile.db copy EPRECO_Geometry_TagXX                  --destdb EPRECO_Geometry.db
+conddb --yes --db myfile.db copy HCALRECO_Geometry_TagXX                --destdb HCALRECO_Geometry.db
+conddb --yes --db myfile.db copy HCALParameters_Geometry_TagXX          --destdb HCALParameters_Geometry.db
+conddb --yes --db myfile.db copy CTRECO_Geometry_TagXX                  --destdb CTRECO_Geometry.db
+conddb --yes --db myfile.db copy ZDCRECO_Geometry_TagXX                 --destdb ZDCRECO_Geometry.db
+conddb --yes --db myfile.db copy CASTORRECO_Geometry_TagXX              --destdb CASTORRECO_Geometry.db
+conddb --yes --db myfile.db copy CSCRECO_Geometry_TagXX                 --destdb CSCRECO_Geometry.db
+conddb --yes --db myfile.db copy CSCRECODIGI_Geometry_TagXX             --destdb CSCRECODIGI_Geometry.db
+conddb --yes --db myfile.db copy DTRECO_Geometry_TagXX                  --destdb DTRECO_Geometry.db
+conddb --yes --db myfile.db copy RPCRECO_Geometry_TagXX                 --destdb RPCRECO_Geometry.db
+conddb --yes --db myfile.db copy GEMRECO_Geometry_TagXX                 --destdb GEMRECO_Geometry.db

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -1,4 +1,5 @@
 #! /bin/tcsh
+
 cmsenv
 
 echo " START Geometry Validation"
@@ -79,7 +80,19 @@ endif
 
 diff outLocalDB.log outGTDB.log > logDiffLocalvsGT.log
 if ( -s logDiffLocalvsGT.log ) then
-    echo "WARNING THE CONTENT OF GLOBAL TAG IS DIFFERENT WITH RESPECT TO THE LOCAL DB FILE" | tee -a GeometryValidation.log
+    echo "WARNING THE CONTENT OF GLOBAL TAG MAY BE DIFFERENT WITH RESPECT TO THE LOCAL DB FILE" | tee -a GeometryValidation.log
+    cp $CMSSW_BASE/src/Validation/Geometry/test/dddvsdb/sortXML.sh .
+    cp $CMSSW_BASE/src/Validation/Geometry/test/dddvsdb/sortCompositeMaterials.py .
+    ./sortXML.sh outLocalDB.log localdb.xml
+    ./sortXML.sh outGTDB.log gtdb.xml
+    diff localdb.xml gtdb.xml > logDiffLocXMLvsGTXML.log
+    sort  localdb.xml > localdb.sort
+    sort gtdb.xml > gtdb.sort
+    diff localdb.sort gtdb.sort > logDiffLocvsGTSort.log
+    echo Examine logDiffLocXMLvsGTXML.log to see the differences in the local and GT XML files. | tee -a GeometryValidation.log
+    echo Examine logDiffLocvsGTSort.log to see the differences in sorted content of the local and GT XML files. | tee -a GeometryValidation.log
+    echo The two XML files may have real differences, or they may have identical content that is simply re-arranged. | tee -a GeometryValidation.log
+    echo Examining these log files can help you determine whether the XML files have significant differences. | tee -a GeometryValidation.log
 endif
 
 echo "End compare the content of GT and the local DB" | tee -a GeometryValidation.log

--- a/Validation/Geometry/test/dddvsdb/sortCompositeMaterials.py
+++ b/Validation/Geometry/test/dddvsdb/sortCompositeMaterials.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python
+
+import sys
+import xml.etree.ElementTree as ET
+
+inputFile = sys.argv[1]
+print ("Reading input file ", inputFile)
+
+tree = ET.parse(inputFile)
+root = tree.getroot()
+
+sortList = []
+elem = root.find('{http://www.cern.ch/cms/DDL}MaterialSection')
+for subelem in elem :
+     key = subelem.get('name')
+     print (key)
+     sortList.append((key, subelem))
+
+sortList.sort()
+for item in sortList :
+  print (item[0])
+
+elem[:] = [item[-1] for item in sortList]
+
+outputFile = sys.argv[2]
+tree.write(outputFile)

--- a/Validation/Geometry/test/dddvsdb/sortXML.sh
+++ b/Validation/Geometry/test/dddvsdb/sortXML.sh
@@ -1,0 +1,7 @@
+# Sorts a geometry XML file to allow for easier comparison
+# $1 -- input XML file name. $2 -- output file name.
+
+sed -e '1 d' -e '2 d' -e '/TRACKER/,$ d' $1 > /tmp/temp$$.xml
+./sortCompositeMaterials.py /tmp/temp$$.xml /tmp/sortTemp$$.xml >& /dev/null
+sed -e 's/ns0://g' -e 's:" /:"/:g' /tmp/sortTemp$$.xml > $2
+rm /tmp/temp$$.xml /tmp/sortTemp$$.xml


### PR DESCRIPTION
`runDDDvsDBGeometryValidation.sh` is a special test to be run by experts to compare the geometry in a local database and the Conditions database. One test in the script is to compare the concatenated geometry XML files in each database. These files may actually differ, or they may only appear to differ because of different ordering of some of the content of the files.

I added a two more tests to the script to try to help the expert determine whether there are real differences in the two geometry XML files or whether the apparent differences are due to minor re-ordering. The overall problem of definitively determining whether two big XML files are functionally identical even if their parts are in different orders is still not solved, though the enhancements in this PR are a step in that direction. Maybe this issue can be fully resolved in a later PR.

One file in this PR is unrelated to the others. `splitExtended2021Database.sh` is used for creating payloads. The DB group requested that I update the command used in the script from 
`conddb_import`, which is intended to be decommissioned, to `conddb`.

#### PR validation:

The scripts run and produce informative output. They have no effect on production workflows or unit tests.

`splitExtended2021Database.sh` continues to work and create payloads. With the change in command, I noticed that the comment field in the payload changed. For example, the old `conddb_import` created the following payload. Note the Description field.
```
Name                    TimeType  ObjectType     Synchronisation  EndOfValidity  Insertion_time              Description                                                             
----------------------  --------  -------------  ---------------  -------------  --------------------------  ---------------------------------------------------------------------   
TKRECO_Geometry_111YV1  Run       PGeometricDet  any              -1             2020-03-02 17:49:31.613191  Created copying tag TKRECO_Geometry_111YV1 from sqlite_file:myfile.db   
```
The new `conddb` created almost the same payload:
```
Name                    TimeType  ObjectType     Synchronisation  EndOfValidity  Insertion_time              Description   
----------------------  --------  -------------  ---------------  -------------  --------------------------  -----------   
TKRECO_Geometry_111YV1  Run       PGeometricDet  any              -1             2020-03-21 02:58:08.136170  New Tag       
```
Note that Description field is different. I assume this difference is harmless.

No backport is needed for this PR.