### PR TITLE
protect HGCDigitizer from crashing when simHitAccumulator is empty

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -256,9 +256,8 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
   averageOccupancies_[idx] = (averageOccupancies_[idx] * (nEvents_ - 1) + thisOcc) / nEvents_;
 
   if (premixStage1_) {
-    std::unique_ptr<PHGCSimAccumulator> simResult;
+    auto simResult = std::make_unique<PHGCSimAccumulator>();
     if (!simHitAccumulator_->empty()) {
-      simResult = std::make_unique<PHGCSimAccumulator>();
       saveSimHitAccumulator(*simResult, *simHitAccumulator_, validIds_, premixStage1MinCharge_, premixStage1MaxCharge_);
     }
     e.put(std::move(simResult), digiCollection());


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/29274

#### PR description:

Solves the problem reported at: https://github.com/cms-sw/cmssw/issues/29274 by implementing the suggestion from @makortel at https://github.com/cms-sw/cmssw/issues/29274#issuecomment-602727215.

#### PR validation:

Tested the code changes with `runTheMatrix.py --what upgrade -l 20610.99` in `CMSSW_11_1_X_2020-03-23-2300`, which now runs to completion.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.

