### PR TITLE
Fix of L1EMTF modifier for legacy16

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2016_cff import stage2L1Trigger_EMTF2016
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
@@ -14,6 +15,4 @@ from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 
-Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
-                              stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016,
-                              run2_tau_ul_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)
+Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific, stage2L1Trigger, stage2L1Trigger_EMTF2016, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016, run2_tau_ul_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -23,7 +23,8 @@ from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2016_cff import stage2L1Trigger_EMTF2016
 
-Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,run2_tau_ul_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016]),
+Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,run2_tau_ul_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016, stage2L1Trigger_EMTF2016]),
 phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
 trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)

--- a/Configuration/Eras/python/Modifier_stage2L1Trigger_EMTF2016_cff.py
+++ b/Configuration/Eras/python/Modifier_stage2L1Trigger_EMTF2016_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+stage2L1Trigger_EMTF2016 =  cms.Modifier()
+

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -136,8 +136,8 @@ simEmtfDigis = simEmtfDigisMC.clone()
 ## Era configuration files are located in Configuration/Eras/python
 
 ## Era: Run2_2016
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-stage2L1Trigger.toModify(simEmtfDigis, RPCEnable = cms.bool(False), Era = cms.string('Run2_2016'))
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2016_cff import stage2L1Trigger_EMTF2016
+stage2L1Trigger_EMTF2016.toModify(simEmtfDigis, RPCEnable = cms.bool(False), Era = cms.string('Run2_2016'))
 
 # ## Era: Run2_2017
 # ## Run2_2017 fix disabled for UL2016 processing with CMSSW_10_6_X


### PR DESCRIPTION
#### PR description:
This PR is to detach the stage2L1Trigger introduced in https://github.com/cms-sw/cmssw/pull/29156 for L1EMTF. "stage2L1Trigger" is used for all 2016, 2017, 2018, so changing it means to change all. However, we would like to avoid the change in 2017, 2018 as Legacy program starts.

This PR is for 10_6 only. For master, we need to detach stage2L1Trigger_2017 also.

#### PR validation:
Dumping configurations from following workflows and compare with 10_6_10, results are expected:
- 136.731 (2016): Configuration changes as expected
- 136.788 (2017), 136.850 (2018): No change of configuration

Dump configs can be found at
/afs/cern.ch/user/s/srimanob/public/L1EMTF/afterFix

2016:
```
(424) ~/public/L1EMTF/afterFix: diff HLTDR2_2016_10610.py HLTDR2_2016_10611Cand2.py
15612c15612
<     Era = cms.string('Run2_2018'),
---
>     Era = cms.string('Run2_2016'),
15619c15619
<     RPCEnable = cms.bool(True),
---
>     RPCEnable = cms.bool(False),
```

2017, 2018
```
(425) ~/public/L1EMTF/afterFix: diff HLTDR2_2017_10610.py HLTDR2_2017_10611Cand2.py
(426) ~/public/L1EMTF/afterFix: diff HLTDR2_2018_10610.py HLTDR2_2018_10611Cand2.py 
```

