### PR TITLE
Fix L1EMTF modifier (11_1)

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2016_cff import stage2L1Trigger_EMTF2016
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
@@ -13,6 +14,5 @@ from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
 
-Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
- stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)
+Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific, stage2L1Trigger, stage2L1Trigger_EMTF2016, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)
 

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -22,8 +22,8 @@ from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2016_cff import stage2L1Trigger_EMTF2016
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2017_cff import stage2L1Trigger_EMTF2017
 
-Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016]),
-                              phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
-                              trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
+Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016, stage2L1Trigger_EMTF2016]), phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, stage2L1Trigger_EMTF2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
 

--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -18,9 +18,8 @@ from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2017_cff import stage2L1Trigger_EMTF2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
 
-Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017, ctpps_2017, run2_jme_2017]),
-run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, 
-run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018, stage2L1Trigger_2018
-)
+Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017, ctpps_2017, run2_jme_2017, stage2L1Trigger_EMTF2017]), run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018, stage2L1Trigger_2018)
+

--- a/Configuration/Eras/python/Modifier_stage2L1Trigger_EMTF2016_cff.py
+++ b/Configuration/Eras/python/Modifier_stage2L1Trigger_EMTF2016_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+stage2L1Trigger_EMTF2016 =  cms.Modifier()

--- a/Configuration/Eras/python/Modifier_stage2L1Trigger_EMTF2017_cff.py
+++ b/Configuration/Eras/python/Modifier_stage2L1Trigger_EMTF2017_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+stage2L1Trigger_EMTF2017 =  cms.Modifier()

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -136,9 +136,9 @@ simEmtfDigis = simEmtfDigisMC.clone()
 ## Era configuration files are located in Configuration/Eras/python
 
 ## Era: Run2_2016
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-stage2L1Trigger.toModify(simEmtfDigis, RPCEnable = cms.bool(False), Era = cms.string('Run2_2016'))
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2016_cff import stage2L1Trigger_EMTF2016
+stage2L1Trigger_EMTF2016.toModify(simEmtfDigis, RPCEnable = cms.bool(False), Era = cms.string('Run2_2016'))
 
 ## Era: Run2_2017
-from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-stage2L1Trigger_2017.toModify(simEmtfDigis, RPCEnable = cms.bool(True), Era = cms.string('Run2_2017'))
+from Configuration.Eras.Modifier_stage2L1Trigger_EMTF2017_cff import stage2L1Trigger_EMTF2017
+stage2L1Trigger_EMTF2017.toModify(simEmtfDigis, RPCEnable = cms.bool(True), Era = cms.string('Run2_2017'))


### PR DESCRIPTION
#### PR description:

Bugfix on top of https://github.com/cms-sw/cmssw/pull/29080
simEmtfDigis configuration of 2018 is wrong because of wrongly setting of modifiers.

This PR is a master version of https://github.com/cms-sw/cmssw/pull/29287 (10_6) where we want to fix only 2016.

#### PR validation:

Dump configuration from workflow 136.731 (2016), 136.788 (2017) and 136.850 (2018) and check. No changes are expected for 2016 and 2017 as 
- 2016 modifier is triggered as expected from https://github.com/cms-sw/cmssw/pull/29080
- 2017 modifier is triggered on top of 2016
for 2018, using the CMSSW_11_1_X_2020-03-23-2300, simEmtfDigis is wrongly configs as 2017 modifier is used. With the fix, detach EMTF modifier, configurations is done as expected

```
(217) ~/public/forL1EMTF/afterFix-111: diff HLTDR2_2016_IB.py HLTDR2_2016_new.py
(218) ~/public/forL1EMTF/afterFix-111: diff HLTDR2_2017_IB.py HLTDR2_2017_new.py
(219) ~/public/forL1EMTF/afterFix-111: diff HLTDR2_2018_IB.py HLTDR2_2018_new.py
17095c17095
<     Era = cms.string('Run2_2017'),
---
>     Era = cms.string('Run2_2018'),
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
-