### PR TITLE
Module on multiple Path threading fix

### DIFF
--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -438,15 +438,17 @@ namespace edm {
         // to hold the exception_ptr
         std::exception_ptr temp_excptr;
         auto excptr = exceptionPtr();
-        if (T::isEvent_ && !m_worker->hasAcquire()) {
-          // Caught exception is passed to Worker::runModuleAfterAsyncPrefetch(), which propagates it via WaitingTaskList
-          CMS_SA_ALLOW try {
-            //pre was called in prefetchAsync
-            m_worker->emitPostModuleEventPrefetchingSignal();
-          } catch (...) {
-            temp_excptr = std::current_exception();
-            if (not excptr) {
-              excptr = &temp_excptr;
+        if constexpr (T::isEvent_) {
+          if (!m_worker->hasAcquire()) {
+            // Caught exception is passed to Worker::runModuleAfterAsyncPrefetch(), which propagates it via WaitingTaskList
+            CMS_SA_ALLOW try {
+              //pre was called in prefetchAsync
+              m_worker->emitPostModuleEventPrefetchingSignal();
+            } catch (...) {
+              temp_excptr = std::current_exception();
+              if (not excptr) {
+                excptr = &temp_excptr;
+              }
             }
           }
         }
@@ -842,7 +844,7 @@ namespace edm {
     bool workStarted = workStarted_.compare_exchange_strong(expected, true);
 
     waitingTasks_.add(task);
-    if (T::isEvent_) {
+    if constexpr (T::isEvent_) {
       timesVisited_.fetch_add(1, std::memory_order_relaxed);
     }
 
@@ -887,11 +889,13 @@ namespace edm {
       } else {
         WaitingTask* moduleTask =
             new (tbb::task::allocate_root()) RunModuleTask<T>(this, ep, es, token, streamID, parentContext, context);
-        if (T::isEvent_ && hasAcquire()) {
-          WaitingTaskWithArenaHolder runTaskHolder(
-              new (tbb::task::allocate_root()) HandleExternalWorkExceptionTask(this, moduleTask, parentContext));
-          moduleTask = new (tbb::task::allocate_root())
-              AcquireTask<T>(this, ep, es, token, parentContext, std::move(runTaskHolder));
+        if constexpr (T::isEvent_) {
+          if (hasAcquire()) {
+            WaitingTaskWithArenaHolder runTaskHolder(
+                new (tbb::task::allocate_root()) HandleExternalWorkExceptionTask(this, moduleTask, parentContext));
+            moduleTask = new (tbb::task::allocate_root())
+                AcquireTask<T>(this, ep, es, token, parentContext, std::move(runTaskHolder));
+          }
         }
         prefetchAsync(moduleTask, token, parentContext, ep);
       }
@@ -972,7 +976,7 @@ namespace edm {
                       StreamID streamID,
                       ParentContext const& parentContext,
                       typename T::Context const* context) {
-    if (T::isEvent_) {
+    if constexpr (T::isEvent_) {
       timesVisited_.fetch_add(1, std::memory_order_relaxed);
     }
     bool rc = false;
@@ -1020,7 +1024,7 @@ namespace edm {
     };
     std::unique_ptr<ModuleCallingContext, decltype(resetContext)> prefetchSentry(&moduleCallingContext_, resetContext);
 
-    if (T::isEvent_) {
+    if constexpr (T::isEvent_) {
       //if have TriggerResults based selection we want to reject the event before doing prefetching
       if (workerhelper::CallImpl<T>::needToRunSelection(this)) {
         auto waitTask = edm::make_empty_waiting_task();
@@ -1099,7 +1103,7 @@ namespace edm {
     //  ++timesVisited_;
     //}
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
-    if (T::isEvent_) {
+    if constexpr (T::isEvent_) {
       timesRun_.fetch_add(1, std::memory_order_relaxed);
     }
 


### PR DESCRIPTION
#### PR description:

From looking at issue #29209 and then doing a code inspection, it was found that the ordering of setting an atomic and adding to the WaitingTaskList of a Worker for a module could cause the module to run after the Event finishes if the thread is paused at the wrong moment and during the rest of the time it takes to process an Event.

In addition, made use of `if constexpr` where appropriate in Worker.h.

#### PR validation:

The code compiles and all framework unit tests pass.

I was never able to replicate the error seen in #29209 so had no way to test to see if this fixes the problem.