### PR TITLE
Update event content structure in RecoEcal and RecoVertex

### DIFF
--- a/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
@@ -45,6 +45,7 @@ for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
                 func=lambda outputCommands: outputCommands.extend(['keep recoSuperClusters_correctedIslandBarrelSuperClusters_*_*',
                                                                    'keep recoSuperClusters_correctedIslandEndcapSuperClusters_*_*'])
               )
+
 # RECO content
 RecoEcalRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -53,17 +54,15 @@ RecoEcalRECO = cms.PSet(
         'keep recoSuperClusters_correctedHybridSuperClusters_*_*',
 	# Endcap clusters
         'keep *_multi5x5SuperClusters_*_*',
-        'keep recoSuperClusters_multi5x5SuperClusters_*_*',
         'keep recoSuperClusters_multi5x5SuperClustersWithPreshower_*_*',
         # Particle Flow superclusters
         'keep *_particleFlowSuperClusterECAL_*_*',
         'keep *_particleFlowSuperClusterOOTECAL_*_*',
-	# DROP statements # not used
-        #'drop recoClusterShapes_*_*_*', 
-        #'drop recoBasicClustersToOnerecoClusterShapesAssociation_*_*_*',
-        #'drop recoBasicClusters_multi5x5BasicClusters_multi5x5BarrelBasicClusters_*',
-        #'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*')
-        )
+	# DROP statements 
+        'drop recoClusterShapes_*_*_*', 
+        'drop recoBasicClustersToOnerecoClusterShapesAssociation_*_*_*',
+        'drop recoBasicClusters_multi5x5BasicClusters_multi5x5BarrelBasicClusters_*',
+        'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*')
 )
 RecoEcalRECO.outputCommands.extend(RecoEcalAOD.outputCommands)
 _phase2_hgcal_scCommands = ['keep *_particleFlowSuperClusterHGCal_*_*',
@@ -75,6 +74,7 @@ for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
     e.toModify( RecoEcalRECO.outputCommands,
                 func=lambda outputCommands: outputCommands.extend(['keep recoCaloClusters_islandBasicClusters_*_*'])
               )
+
 # Full Event content 
 RecoEcalFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -88,7 +88,6 @@ RecoEcalFEVT = cms.PSet(
 	# Barrel clusters
         'keep *_correctedHybridSuperClusters_*_*',
 	# Endcap clusters
-        'keep *_multi5x5*_*_*',
-        'keep *_correctedMulti5x5*_*_*')
+        'keep *_multi5x5*_*_*')
 )
 RecoEcalFEVT.outputCommands.extend(RecoEcalRECO.outputCommands)

--- a/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
@@ -1,62 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# Full Event content 
-RecoEcalFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        #selected digis
-        'keep *_selectDigi_*_*',
-	# Hits
-	'keep *_reducedEcalRecHitsEB_*_*',
-        'keep *_reducedEcalRecHitsEE_*_*',
-        'keep *_reducedEcalRecHitsES_*_*', 
-        'keep *_interestingEcalDetId*_*_*', 
-        'keep *_ecalWeightUncalibRecHit_*_*', 
-        'keep *_ecalPreshowerRecHit_*_*', 
-	# Barrel clusters
-        'keep *_hybridSuperClusters_*_*',
-        'keep *_correctedHybridSuperClusters_*_*',
-	# Endcap clusters
-        'keep *_multi5x5*_*_*',
-        'keep *_correctedMulti5x5*_*_*',
-        # Preshower clusters
-        'keep recoPreshowerClusters_multi5x5SuperClustersWithPreshower_*_*', 
-        'keep recoPreshowerClusterShapes_multi5x5PreshowerClusterShape_*_*',
-        # Particle Flow superclusters
-        'keep *_particleFlowSuperClusterECAL_*_*',
-        'keep *_particleFlowSuperClusterOOTECAL_*_*',
-	# DROP statements
-	'drop recoBasicClusters_multi5x5BasicClusters_multi5x5BarrelBasicClusters_*',
-        'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*')
-)
-# RECO content
-RecoEcalRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        #selected digis
-        'keep *_selectDigi_*_*',
-	# Hits
-	'keep EcalRecHitsSorted_reducedEcalRecHitsEE_*_*',
-        'keep EcalRecHitsSorted_reducedEcalRecHitsEB_*_*',
-        'keep EcalRecHitsSorted_reducedEcalRecHitsES_*_*',
-	# Barrel clusters
-        'keep *_hybridSuperClusters_*_*',
-        'keep recoSuperClusters_correctedHybridSuperClusters_*_*',
-	# Endcap clusters
-        'keep *_multi5x5SuperClusters_*_*',
-        'keep recoSuperClusters_multi5x5SuperClusters_*_*',
-        'keep recoSuperClusters_multi5x5SuperClustersWithPreshower_*_*',
-        'keep recoSuperClusters_correctedMulti5x5SuperClustersWithPreshower_*_*',
-	# Preshower clusters
-        'keep recoPreshowerClusters_multi5x5SuperClustersWithPreshower_*_*',
-        'keep recoPreshowerClusterShapes_multi5x5PreshowerClusterShape_*_*',
-        # Particle Flow superclusters
-        'keep *_particleFlowSuperClusterECAL_*_*',
-        'keep *_particleFlowSuperClusterOOTECAL_*_*',
-	# DROP statements
-        'drop recoClusterShapes_*_*_*', 
-        'drop recoBasicClustersToOnerecoClusterShapesAssociation_*_*_*',
-        'drop recoBasicClusters_multi5x5BasicClusters_multi5x5BarrelBasicClusters_*',
-        'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*')
-)
 # AOD content
 RecoEcalAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -80,25 +23,16 @@ RecoEcalAOD = cms.PSet(
         'keep recoSuperClusters_particleFlowSuperClusterECAL_*_*',
         'keep recoCaloClusters_particleFlowSuperClusterECAL_*_*',
         'keep recoSuperClusters_particleFlowSuperClusterOOTECAL_*_*',
-        'keep recoCaloClusters_particleFlowSuperClusterOOTECAL_*_*',
-        )
+        'keep recoCaloClusters_particleFlowSuperClusterOOTECAL_*_*')
 )
-
-_phase2_hgcal_scCommands = ['keep *_particleFlowSuperClusterHGCal_*_*', 'keep *_particleFlowSuperClusterHGCalFromMultiCl_*_*']
 _phase2_hgcal_scCommandsAOD = ['keep recoSuperClusters_particleFlowSuperClusterHGCal__*',
                                'keep recoCaloClusters_particleFlowSuperClusterHGCal__*',
                                'keep recoSuperClusters_particleFlowSuperClusterHGCalFromMultiCl__*',
                                'keep recoCaloClusters_particleFlowSuperClusterHGCalFromMultiCl__*']
-_phase2_hgcal_RecoEcalFEVT = RecoEcalFEVT.clone()
-_phase2_hgcal_RecoEcalFEVT.outputCommands += _phase2_hgcal_scCommands
-_phase2_hgcal_RecoEcalRECO = RecoEcalRECO.clone()
-_phase2_hgcal_RecoEcalRECO.outputCommands += _phase2_hgcal_scCommands
-_phase2_hgcal_RecoEcalAOD  = RecoEcalAOD.clone()
-_phase2_hgcal_RecoEcalAOD.outputCommands += _phase2_hgcal_scCommandsAOD
+
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toReplaceWith( RecoEcalFEVT, _phase2_hgcal_RecoEcalFEVT )
-phase2_hgcal.toReplaceWith( RecoEcalRECO, _phase2_hgcal_RecoEcalRECO )
-phase2_hgcal.toReplaceWith( RecoEcalAOD , _phase2_hgcal_RecoEcalAOD  )
+phase2_hgcal.toModify(RecoEcalAOD,
+    outputCommands = RecoEcalAOD.outputCommands + _phase2_hgcal_scCommandsAOD)
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
@@ -107,11 +41,54 @@ from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 #HI-specific products needed in pp scenario special configurations
 for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
-    for ec in [RecoEcalAOD.outputCommands, RecoEcalRECO.outputCommands, RecoEcalFEVT.outputCommands]:
-        e.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoSuperClusters_correctedIslandBarrelSuperClusters_*_*',
-                                                                           'keep recoSuperClusters_correctedIslandEndcapSuperClusters_*_*'
-                                                                           ])
-                    )
-    for ec in [RecoEcalRECO.outputCommands, RecoEcalFEVT.outputCommands]:
-        e.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoCaloClusters_islandBasicClusters_*_*'])
-                    )
+    e.toModify( RecoEcalAOD.outputCommands, 
+                func=lambda outputCommands: outputCommands.extend(['keep recoSuperClusters_correctedIslandBarrelSuperClusters_*_*',
+                                                                   'keep recoSuperClusters_correctedIslandEndcapSuperClusters_*_*'])
+              )
+# RECO content
+RecoEcalRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	# Barrel clusters
+        'keep *_hybridSuperClusters_*_*',
+        'keep recoSuperClusters_correctedHybridSuperClusters_*_*',
+	# Endcap clusters
+        'keep *_multi5x5SuperClusters_*_*',
+        'keep recoSuperClusters_multi5x5SuperClusters_*_*',
+        'keep recoSuperClusters_multi5x5SuperClustersWithPreshower_*_*',
+        # Particle Flow superclusters
+        'keep *_particleFlowSuperClusterECAL_*_*',
+        'keep *_particleFlowSuperClusterOOTECAL_*_*',
+	# DROP statements # not used
+        #'drop recoClusterShapes_*_*_*', 
+        #'drop recoBasicClustersToOnerecoClusterShapesAssociation_*_*_*',
+        #'drop recoBasicClusters_multi5x5BasicClusters_multi5x5BarrelBasicClusters_*',
+        #'drop recoSuperClusters_multi5x5SuperClusters_multi5x5BarrelSuperClusters_*')
+        )
+)
+RecoEcalRECO.outputCommands.extend(RecoEcalAOD.outputCommands)
+_phase2_hgcal_scCommands = ['keep *_particleFlowSuperClusterHGCal_*_*',
+                            'keep *_particleFlowSuperClusterHGCalFromMultiCl_*_*']
+phase2_hgcal.toModify(RecoEcalRECO,
+    outputCommands = RecoEcalRECO.outputCommands + _phase2_hgcal_scCommands)
+
+for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
+    e.toModify( RecoEcalRECO.outputCommands,
+                func=lambda outputCommands: outputCommands.extend(['keep recoCaloClusters_islandBasicClusters_*_*'])
+              )
+# Full Event content 
+RecoEcalFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	# Hits
+	'keep *_reducedEcalRecHitsEB_*_*',
+        'keep *_reducedEcalRecHitsEE_*_*',
+        'keep *_reducedEcalRecHitsES_*_*', 
+        'keep *_interestingEcalDetId*_*_*', 
+        'keep *_ecalWeightUncalibRecHit_*_*', 
+        'keep *_ecalPreshowerRecHit_*_*', 
+	# Barrel clusters
+        'keep *_correctedHybridSuperClusters_*_*',
+	# Endcap clusters
+        'keep *_multi5x5*_*_*',
+        'keep *_correctedMulti5x5*_*_*')
+)
+RecoEcalFEVT.outputCommands.extend(RecoEcalRECO.outputCommands)

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_EventContent_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_EventContent_cff.py
@@ -1,15 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content
-BeamSpotFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_offlineBeamSpot_*_*')
-)
-#RECO content
-BeamSpotRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_offlineBeamSpot_*_*')
-)
 #AOD content
 BeamSpotAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_offlineBeamSpot_*_*')
 )
+#RECO content
+BeamSpotRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+BeamSpotRECO.outputCommands.extend(BeamSpotAOD.outputCommands)
+#Full Event content
+BeamSpotFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+BeamSpotFEVT.outputCommands.extend(BeamSpotRECO.outputCommands)
 

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_EventContent_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_EventContent_cff.py
@@ -4,11 +4,13 @@ import FWCore.ParameterSet.Config as cms
 BeamSpotAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_offlineBeamSpot_*_*')
 )
+
 #RECO content
 BeamSpotRECO = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 BeamSpotRECO.outputCommands.extend(BeamSpotAOD.outputCommands)
+
 #Full Event content
 BeamSpotFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()

--- a/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
@@ -1,22 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-
-RecoVertexFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep  *_offlinePrimaryVertices__*', 
-        'keep *_offlinePrimaryVerticesWithBS_*_*',
-        'keep *_offlinePrimaryVerticesFromCosmicTracks_*_*',
-        'keep *_nuclearInteractionMaker_*_*',
-        'keep *_generalV0Candidates_*_*',
-	'keep *_inclusiveSecondaryVertices_*_*')
-)
-#RECO content
-RecoVertexRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep  *_offlinePrimaryVertices__*', 
-        'keep *_offlinePrimaryVerticesWithBS_*_*',
-        'keep *_offlinePrimaryVerticesFromCosmicTracks_*_*',
-        'keep *_nuclearInteractionMaker_*_*',
-        'keep *_generalV0Candidates_*_*',
-	'keep *_inclusiveSecondaryVertices_*_*')
-)
 #AOD content
 RecoVertexAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep  *_offlinePrimaryVertices__*', 
@@ -35,21 +17,19 @@ _phase2_tktiming_RecoVertexEventContent = [ 'keep *_offlinePrimaryVertices4D__*'
                                             'keep *_trackTimeValueMapProducer_*_*' ]
 
 _phase2_tktiming_layer_RecoVertexEventContent = [ 'keep *_offlinePrimaryVertices4DnoPID__*',
-                                            'keep *_offlinePrimaryVertices4DnoPIDWithBS__*',
-                                            'keep *_tofPID_*_*']
-
-def _phase2_tktiming_AddNewContent(mod):
-    temp = mod.outputCommands + _phase2_tktiming_RecoVertexEventContent
-    phase2_timing.toModify( mod, outputCommands = temp )
-
-_phase2_tktiming_AddNewContent(RecoVertexFEVT)
-_phase2_tktiming_AddNewContent(RecoVertexRECO)
-_phase2_tktiming_AddNewContent(RecoVertexAOD)
-
-def _phase2_tktiming_layer_AddNewContent(mod):
-    temp = mod.outputCommands + _phase2_tktiming_layer_RecoVertexEventContent
-    phase2_timing_layer.toModify( mod, outputCommands = temp )
-
-_phase2_tktiming_layer_AddNewContent(RecoVertexFEVT)
-_phase2_tktiming_layer_AddNewContent(RecoVertexRECO)
-_phase2_tktiming_layer_AddNewContent(RecoVertexAOD)
+                                                  'keep *_offlinePrimaryVertices4DnoPIDWithBS__*',
+                                                  'keep *_tofPID_*_*']
+phase2_timing.toModify( RecoVertexAOD,
+     outputCommands = RecoVertexAOD.outputCommands + _phase2_tktiming_RecoVertexEventContent)
+phase2_timing_layer.toModify( RecoVertexAOD,
+     outputCommands = RecoVertexAOD.outputCommands + _phase2_tktiming_layer_RecoVertexEventContent)
+#RECO content
+RecoVertexRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoVertexRECO.outputCommands.extend(RecoVertexAOD.outputCommands)
+#FEVT content
+RecoVertexFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoVertexFEVT.outputCommands.extend(RecoVertexRECO.outputCommands)

--- a/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+
 #AOD content
 RecoVertexAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep  *_offlinePrimaryVertices__*', 
@@ -23,11 +24,13 @@ phase2_timing.toModify( RecoVertexAOD,
      outputCommands = RecoVertexAOD.outputCommands + _phase2_tktiming_RecoVertexEventContent)
 phase2_timing_layer.toModify( RecoVertexAOD,
      outputCommands = RecoVertexAOD.outputCommands + _phase2_tktiming_layer_RecoVertexEventContent)
+
 #RECO content
 RecoVertexRECO = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 RecoVertexRECO.outputCommands.extend(RecoVertexAOD.outputCommands)
+
 #FEVT content
 RecoVertexFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()


### PR DESCRIPTION
#### PR description:
Update event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. Clean up 'drop' not really used in RecoEcalRECO.
(The previous tasks are [PR#29025](https://github.com/cms-sw/cmssw/pull/29025), [PR#29158](https://github.com/cms-sw/cmssw/pull/29158), and [PR#29225](https://github.com/cms-sw/cmssw/pull/29225).)
3 files changed :
+RecoEcal_EventContent_cff.py
+RecoVertex_EventContent_cff.py
+BeamSpot_EventContent_cff.py
#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X_2020_03-23-1100, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).