### PR TITLE
Apply puppi weight in BoostedDoubleSV btaginfo for packedPFCandidates

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
@@ -42,6 +42,12 @@ def applyDeepBtagging( process, postfix="" ) :
     # delete module not used anymore (slimmedJets substitutes)
     delattr(process, 'selectedUpdatedPatJetsSlimmedDeepFlavour'+postfix)
 
+    from CommonTools.PileupAlgos.Puppi_cff import puppi
+    addToProcessAndTask('packedpuppi', puppi.clone(
+                        useExistingWeights = True,
+                        candName = 'packedPFCandidates',
+                        vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')) , process, task)
+
     from RecoBTag.ONNXRuntime.pfDeepBoostedJet_cff import _pfDeepBoostedJetTagsAll as pfDeepBoostedJetTagsAll
     from RecoBTag.MXNet.pfParticleNet_cff import _pfParticleNetJetTagsAll as pfParticleNetJetTagsAll
 

--- a/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
@@ -42,12 +42,6 @@ def applyDeepBtagging( process, postfix="" ) :
     # delete module not used anymore (slimmedJets substitutes)
     delattr(process, 'selectedUpdatedPatJetsSlimmedDeepFlavour'+postfix)
 
-    from CommonTools.PileupAlgos.Puppi_cff import puppi
-    addToProcessAndTask('packedpuppi', puppi.clone(
-                        useExistingWeights = True,
-                        candName = 'packedPFCandidates',
-                        vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')) , process, task)
-
     from RecoBTag.ONNXRuntime.pfDeepBoostedJet_cff import _pfDeepBoostedJetTagsAll as pfDeepBoostedJetTagsAll
     from RecoBTag.MXNet.pfParticleNet_cff import _pfParticleNetJetTagsAll as pfParticleNetJetTagsAll
 

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -601,6 +601,12 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
               _btagInfo = getattr(process, btagPrefix+btagInfo+labelName+postfix)
               if pfCandidates.value() == 'packedPFCandidates':
                 _btagInfo.weights = cms.InputTag("packedpuppi")
+                if not hasattr(process,"packedpuppi"):
+                  from CommonTools.PileupAlgos.Puppi_cff import puppi
+                  addToProcessAndTask('packedpuppi', puppi.clone(
+                        useExistingWeights = True,
+                        candName = 'packedPFCandidates',
+                        vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')) , process, task)
               else:
                 _btagInfo.weights = cms.InputTag("puppi")
 

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -599,10 +599,10 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
 
             if 'pfBoostedDouble' in btagInfo or 'SecondaryVertex' in btagInfo:
               _btagInfo = getattr(process, btagPrefix+btagInfo+labelName+postfix)
-              if 'Puppi' in jetSource.value() and pfCandidates.value() == 'particleFlow':
-                _btagInfo.weights = cms.InputTag("puppi")
-              if 'SlimmedAK8DeepTags' in jetSource.value() and pfCandidates.value() == 'packedPFCandidates':
+              if pfCandidates.value() == 'packedPFCandidates':
                 _btagInfo.weights = cms.InputTag("packedpuppi")
+              else:
+                _btagInfo.weights = cms.InputTag("puppi")
 
             if 'DeepFlavourTagInfos' in btagInfo:
                 svUsed = svSource

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -600,7 +600,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
             if 'pfBoostedDouble' in btagInfo or 'SecondaryVertex' in btagInfo:
               _btagInfo = getattr(process, btagPrefix+btagInfo+labelName+postfix)
               if pfCandidates.value() == 'packedPFCandidates':
-                _btagInfo.weights = "packedpuppi"
+                _btagInfo.weights = cms.InputTag("packedpuppi")
                 if not hasattr(process,"packedpuppi"):
                   from CommonTools.PileupAlgos.Puppi_cff import puppi
                   addToProcessAndTask('packedpuppi', puppi.clone(
@@ -608,7 +608,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                         candName = 'packedPFCandidates',
                         vertexName = 'offlineSlimmedPrimaryVertices') , process, task)
               else:
-                _btagInfo.weights = "puppi"
+                _btagInfo.weights = cms.InputTag("puppi")
 
             if 'DeepFlavourTagInfos' in btagInfo:
                 svUsed = svSource

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -597,10 +597,12 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     btag.pixelClusterTagInfos.clone(jets = jetSource, vertices=pvSource),
                                     process, task)
 
-            if 'Puppi' in jetSource.value() and pfCandidates.value() == 'particleFlow' and\
-	       ('pfBoostedDouble' in btagInfo or 'SecondaryVertex' in btagInfo):
-                _btagInfo = getattr(process, btagPrefix+btagInfo+labelName+postfix)
+            if 'pfBoostedDouble' in btagInfo or 'SecondaryVertex' in btagInfo:
+              _btagInfo = getattr(process, btagPrefix+btagInfo+labelName+postfix)
+              if 'Puppi' in jetSource.value() and pfCandidates.value() == 'particleFlow':
                 _btagInfo.weights = cms.InputTag("puppi")
+              if 'SlimmedAK8DeepTags' in jetSource.value() and pfCandidates.value() == 'packedPFCandidates':
+                _btagInfo.weights = cms.InputTag("packedpuppi")
 
             if 'DeepFlavourTagInfos' in btagInfo:
                 svUsed = svSource

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -600,15 +600,15 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
             if 'pfBoostedDouble' in btagInfo or 'SecondaryVertex' in btagInfo:
               _btagInfo = getattr(process, btagPrefix+btagInfo+labelName+postfix)
               if pfCandidates.value() == 'packedPFCandidates':
-                _btagInfo.weights = cms.InputTag("packedpuppi")
+                _btagInfo.weights = "packedpuppi"
                 if not hasattr(process,"packedpuppi"):
                   from CommonTools.PileupAlgos.Puppi_cff import puppi
                   addToProcessAndTask('packedpuppi', puppi.clone(
                         useExistingWeights = True,
                         candName = 'packedPFCandidates',
-                        vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')) , process, task)
+                        vertexName = 'offlineSlimmedPrimaryVertices') , process, task)
               else:
-                _btagInfo.weights = cms.InputTag("puppi")
+                _btagInfo.weights = "puppi"
 
             if 'DeepFlavourTagInfos' in btagInfo:
                 svUsed = svSource

--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -672,10 +672,9 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
               if (!weightsToken_.isUninitialized())
                 w = (*weightsHandle_)[constit];
               else {
-                w = 1.0;  // For backward compatibility PUPPI weight is not applied to PackedCandidates.
-                //throw cms::Exception("MissingConstituentWeight")
-                //      << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection"
-                //      << std::endl;
+                throw cms::Exception("MissingConstituentWeight")
+                    << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection"
+                    << std::endl;
               }
               fjParticles.push_back(
                   fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
@@ -698,9 +697,8 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
           if (!weightsToken_.isUninitialized())
             w = (*weightsHandle_)[daughter];
           else {
-            w = 1.0;  // For backward compatibility PUPPI weight is not applied to PackedCandidates.
-            //throw cms::Exception("MissingConstituentWeight")
-            //      << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection" << std::endl;
+            throw cms::Exception("MissingConstituentWeight")
+                << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection" << std::endl;
           }
           fjParticles.push_back(
               fastjet::PseudoJet(daughter->px() * w, daughter->py() * w, daughter->pz() * w, daughter->energy() * w));


### PR DESCRIPTION
#### PR description:

Resolve issue #29132.
This makes the treatment of puppi weights consistent between BoostedDoubleSV btaginfo computed from particleFlow and packedPFcandidates.
It introduces small changes in the b-tag discriminators computed from PackedCandidates, namely pfDeepDouble*v*JetTags and pfMassIndependentDeepDouble*v*JetTags.

#### PR validation:

runTheMatrix -l 136.8311
Verified that the corresponding discriminator value change.
@emilbols @hqucms @XavierAtCERN

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

no backport planned.