### PR TITLE
PF track propagator fix for pixel tracks

### DIFF
--- a/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
@@ -58,7 +58,9 @@ bool PFTrackTransformer::addPoints(reco::PFRecTrack& pftrack,
       B_.z());
 
   float pfoutenergy = sqrt((pfmass * pfmass) + track.outerMomentum().Mag2());
-  BaseParticlePropagator theOutParticle = BaseParticlePropagator(
+  BaseParticlePropagator theOutParticle;
+  if (track.outerOk())
+    theOutParticle = BaseParticlePropagator(
       RawParticle(
           XYZTLorentzVector(
               track.outerMomentum().x(), track.outerMomentum().y(), track.outerMomentum().z(), pfoutenergy),
@@ -67,7 +69,8 @@ bool PFTrackTransformer::addPoints(reco::PFRecTrack& pftrack,
       0.,
       0.,
       B_.z());
-
+  else theOutParticle = theParticle;
+    
   math::XYZTLorentzVector momClosest = math::XYZTLorentzVector(track.px(), track.py(), track.pz(), track.p());
   const math::XYZPoint& posClosest = track.vertex();
 

--- a/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
@@ -61,16 +61,17 @@ bool PFTrackTransformer::addPoints(reco::PFRecTrack& pftrack,
   BaseParticlePropagator theOutParticle;
   if (track.outerOk())
     theOutParticle = BaseParticlePropagator(
-      RawParticle(
-          XYZTLorentzVector(
-              track.outerMomentum().x(), track.outerMomentum().y(), track.outerMomentum().z(), pfoutenergy),
-          XYZTLorentzVector(track.outerPosition().x(), track.outerPosition().y(), track.outerPosition().z(), 0.),
-          track.charge()),
-      0.,
-      0.,
-      B_.z());
-  else theOutParticle = theParticle;
-    
+        RawParticle(
+            XYZTLorentzVector(
+                track.outerMomentum().x(), track.outerMomentum().y(), track.outerMomentum().z(), pfoutenergy),
+            XYZTLorentzVector(track.outerPosition().x(), track.outerPosition().y(), track.outerPosition().z(), 0.),
+            track.charge()),
+        0.,
+        0.,
+        B_.z());
+  else
+    theOutParticle = theParticle;  // if outer state is not available, use the information at the closest approach
+
   math::XYZTLorentzVector momClosest = math::XYZTLorentzVector(track.px(), track.py(), track.pz(), track.p());
   const math::XYZPoint& posClosest = track.vertex();
 


### PR DESCRIPTION
#### PR description:

This PR will fix the PF track propagator for pixel tracks for which the outer state is not defined. If the outer state is not defined, now it will use the position and momentum at the closest approach for propagation to calorimeters.

Results shown in this talk [1] is a good proof that this propagator fix does a reasonable job for patatrack pixel tracks in PF.

This PR should have no effect on PF based on full tracking (i.e. any matrix tests in jenkins).

[1] https://indico.cern.ch/event/894094/contributions/3797556/

#### PR validation:

Results presented in [1] may serve as validation.
Also, I made sure the that 11634.0 (TTbar_14TeV+TTbar_14TeV_TuneCP5_2021_....) runs fine.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is not a backport.

@bendavid @jsalfeld 
