### PR TITLE
Extend maximum pileup in SiPixelStatusScenarioProbabilityRcd tag from 100 to 200

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -67,17 +67,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '111X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '111X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '111X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '111X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '111X_mcRun3_2021cosmics_realistic_deco_v2',
+    'phase1_2021_cosmics'      : '111X_mcRun3_2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' :  '111X_mcRun3_2021_realistic_HI_v3',
+    'phase1_2021_realistic_hi' :  '111X_mcRun3_2021_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '111X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '111X_mcRun3_2023_realistic_v3', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v2', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v3', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

This is a purely technical change to extend the maximum pileup in the `SiPixelStatusScenarioProbabilityRcd` from 100 to 200. This is necessary to simulate Run 3 pileup above 100.

The `SiPixelStatusScenarioProbabilityRcd` tag is updated from `SiPixelStatusScenarioProbabilities_default_v0_mc` to `SiPixelStatusScenarioProbabilities_default_v1_mc` in all six Run-3 queues:

**2021 design pp collisions**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_design_v2/111X_mcRun3_2021_design_v3
**2021 realistic pp collisions**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_realistic_v2/111X_mcRun3_2021_realistic_v3
**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021cosmics_realistic_deco_v2/111X_mcRun3_2021cosmics_realistic_deco_v3
**2021 realistic HI collisions**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_realistic_HI_v3/111X_mcRun3_2021_realistic_HI_v4
**2023 realistic pp collisions**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2023_realistic_v2/111X_mcRun3_2023_realistic_v3
**2024 realistic pp collisions**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2024_realistic_v2/111X_mcRun3_2024_realistic_v3

Attn: @mmusich 

#### PR validation:

The plots below from @mmusich show the contents of the tags.

SiPixelStatusScenarioProbabilities_default_v0_mc | SiPixelStatusScenarioProbabilities_default_v1_mc   
------------- | ----- 
 ![SiPixelStatusScenarioProbabilities_defaut_v0_mc](https://user-images.githubusercontent.com/6534323/77603300-b9aa6080-6edd-11ea-95d0-2bd5394ac093.png) | ![SiPixelStatusScenarioProbabilities_default_v1_mc](https://user-images.githubusercontent.com/6534323/77603303-bb742400-6edd-11ea-84b1-2f52b2737a4e.png)


In addition, a technical test has been performed: `runTheMatrix.py -l limited,12024.0,7.23,159.0,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and should not be backported.