### PR TITLE
add GPU-capable workflow 11634.502 to the short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -82,6 +82,7 @@ if __name__ == '__main__':
                      10224.0, #2017 ttbar PU
                      10824.0, #2018 ttbar
                      11634.0, #2021 ttbar
+                     11634.502, #2021 ttbar pixel-only GPU-capable 
                      12434.0, #2023 ttbar
                      20034.0, #2026D35 ttbar (MTD TDR baseline)
                      20434.0, #2026D41 ttbar (L1T TDR baseline)


### PR DESCRIPTION
in view of Patatrack integration, I propose to add a GPU-capable workflow to the short matrix so that we have it in the baseline tests as well.

A node without a GPU will run this workflow with a CPU setup via a switch producer.

The extra matrix test takes about 10 mins.

@smuzaffar @makortel 
Ideally, for the jenkins tests not enabled for GPU I'd expect that this workflow to not load the GPU version. Is this expected to be the case if incidentally the node actually has a GPU available?