### PR TITLE
DQM: Python DQMIO IO library

### DIFF
--- a/DQMServices/FwkIO/python/DQMIO.py
+++ b/DQMServices/FwkIO/python/DQMIO.py
@@ -1,0 +1,491 @@
+import ROOT
+# try to get some better multi-threading support out of root. Needs to happen as early as possible.
+ROOT.ROOT.EnableThreadSafety()
+ROOT.TFile.Open._threaded = True
+
+import time
+from collections import namedtuple, defaultdict
+
+MonitorElement = namedtuple('MonitorElement', ['run', 'lumi', 'name', 'type', 'data'])
+IndexEntry = namedtuple('IndexEntry', ['run', 'lumi', 'type', 'file', 'firstidx', 'lastidx'])
+# Some parameters that could be adjusted. We wait a bit longer when opening 
+# files for reading than when testing if they are accessible to avoid spurious
+# failures.
+TESTTIMEOUT = 3
+OPENTIMEOUT = 5
+CACHEDFILES = 500
+
+TREENAMES = { 
+  0: "Ints",
+  1: "Floats",
+  2: "Strings",
+  3: "TH1Fs",
+  4: "TH1Ss",
+  5: "TH1Ds",
+  6: "TH2Fs",
+  7: "TH2Ss",
+  8: "TH2Ds",
+  9: "TH3Fs",
+  10: "TProfiles",
+  11: "TProfile2Ds",
+}
+
+# 
+# This first part is low-level IO on DQMIO files. All the dealing with ROOT
+# happens here. No threads are created, but all operations are thread-safe.
+#
+
+# open ROOT file using the lower level AsyncOpen to get some concurrency.
+def asyncopen(name, timeout):
+    handle = ROOT.TFile.AsyncOpen(name)
+    while timeout > 0 and ROOT.TFile.GetAsyncOpenStatus(handle) == 1: # kAOSInProgress
+        time.sleep(1)
+        timeout -= 1
+    if timeout == 0:
+        return None
+    try: # not really sure what possible failure modes are, better be careful
+        tfile = ROOT.TFile.Open(handle)
+        if tfile.IsOpen():
+            return tfile
+    except:
+        return None
+    
+# open a file using a context manager, using a potentially cached connection.
+# also sets up the TTree for the type of IO we need.
+class METree(object):
+    def __init__(self, cache, indexentry):
+        self.name = indexentry.file
+        self.treename = TREENAMES[indexentry.type]
+        self.cache = cache
+
+    def __enter__(self):
+        self.tfile = self.cache.getfromcache(self.name)
+        if self.tfile:
+            metree = getattr(self.tfile, self.treename)
+        else:
+            self.tfile = asyncopen(self.name, OPENTIMEOUT)
+            if not self.tfile: return None
+            metree = getattr(self.tfile, self.treename)
+        # TODO: might be counterproductive to do this every time.
+        metree.GetEntry(0)
+        metree.SetBranchStatus("*",0)
+        metree.SetBranchStatus("FullName",1)
+        # release GIL in long operations. Disable if it causes trouble.
+        metree.GetEntry._threaded = True
+        return metree
+
+    def __exit__(self, type, value, traceback):
+        self.cache.addtocache(self.name, self.tfile)
+
+# the DQMIO files are sorted by (dir, name) pairs. Splits FullName into (dir, name).
+def searchkey(fullname):
+    return ("/".join(fullname.split("/")[:-1]), fullname.split("/")[-1])
+
+# Return the index of the first element that is not smaller than key.
+# lower is the index of the first element to consider.
+# upper is the first element known to be not smaller than key. Must not be touched.
+# access is a function used to access elements, and lessthan the comparison functor.
+def bound(access, lessthan, key, lower, upper):
+    # nothing more to do, upper is always a valid return value.
+    if lower == upper: return upper
+    # mid will be smaller than upper, but may be equal to lower.
+    mid = lower + int((upper-lower)/2)
+    # therefore, it is always save to read a(mid), and we have not done so before.
+    if lessthan(access(mid), key): 
+        # if it is too small, exclude it from the range.
+        return bound(access, lessthan, key, mid+1, upper)
+    else:
+        # if it is a valid return value, reduce the range and never touch it again.
+        return bound(access, lessthan, key, lower, mid)
+
+# with bound, this finds the first matching element
+def normallessthan(a, b):
+    return a < b
+
+# with bound, this skips to the next directory
+def skiplessthan(a, key):
+    if a[0].startswith(key[0]): return True
+    else: return a < key
+
+class DQMIOFileIO:
+    """
+    This class maintains a cache of open ROOT files (or rather XrootD 
+    connections and allows low-level read operations on these files.
+    Most operations work on `IndexEntry`s, which can be read from the DQMIO
+    file's `Indices` Tree using `readindex`.
+    
+    Apart form the caching, all operations are stateless and safe to be called 
+    from multiple threads.
+    """
+    def __init__(self):
+        # open file cache that operations can "borrow" open files from
+        self.openfiles = defaultdict(list)
+
+    def getfromcache(self, name):
+        if self.openfiles[name]:
+            tfile, _ = self.openfiles[name].pop()
+            return tfile
+        return None
+        
+    def addtocache(self, name, tfile):
+        if tfile:
+            self.openfiles[name].append((tfile, time.time()))
+            
+    # TODO: this is not as threadsafe as it should be.
+    def cleancache(self):
+        nowopen = dict(self.openfiles)
+        if sum(len(l) for l in nowopen.values()) > CACHEDFILES:
+            pairs = [(age, tfile, name) for name in nowopen for tfile, age in nowopen[name]]
+            pairs = sorted(pairs)
+            self.openfiles = defaultdict(list)
+            for age, tfile, name in pairs[-CACHEDFILES:]:
+                self.openfiles[name].append((tfile, age))
+            
+    def checkreadable(self, filename):
+        """
+        Check if `file` can be opened, and return a (filename, bool) pair.
+
+        This will typically wait for a timeout if the cannot be read. Should
+        be called multi-threaded for high throughput.
+        """
+        tfile = asyncopen(filename, TESTTIMEOUT)
+        self.addtocache(filename, tfile)
+        return file, tfile != None
+    
+    def readindex(self, file):
+        """
+        Read the index table out of a DQMIO file.
+
+        Returns the contents as a list of `IndexEntry`s.
+        """
+        tfile = self.getfromcache(file)
+        if not tfile:
+            tfile = asyncopen(file, OPENTIMEOUT)
+        if not tfile: return []
+        index = []
+        idxtree = getattr(tfile, "Indices")
+        idxtree.GetEntry._threaded = True
+        knownlumis = set()
+        for i in range(idxtree.GetEntries()):
+            idxtree.GetEntry(i)
+            run, lumi, metype = idxtree.Run, idxtree.Lumi, idxtree.Type
+            # inclusive range -- for 0 entries, row is left out
+            firstidx, lastidx = idxtree.FirstIndex, idxtree.LastIndex
+            e = IndexEntry(run, lumi, metype, file, firstidx, lastidx)
+            index.append(e)
+        self.addtocache(file, tfile)
+        return index
+        
+    def listentry(self, indexentry, path):
+        """
+        List direct children (folders or objects) of the given path in the set
+        of MonitorElements identified by `indexentry`.
+
+        Returns a list of relative names, ending in "/" for subdirectories.
+
+        This is implemented as a skip scan using binary search over the FullName
+        branch in the DQMIO data; it will not read the full list of names.
+        """
+        assert path == "" or path[-1] == "/", "Can only list directories!"
+        with METree(self, indexentry) as metree:
+            if not metree: return []
+
+            def getentry(idx):
+                metree.GetEntry(idx)
+                return searchkey(str(metree.FullName))
+
+            first, last = indexentry.firstidx, indexentry.lastidx+1
+            key = searchkey(path)
+            # start by skipping to the first item in the directory
+            start = bound(getentry, normallessthan, key, first, last)
+            pos = start
+            elements = []
+            # first, list the objects.
+            while pos != last:
+                dirname, objname = getentry(pos)
+                if not dirname == key[0]:
+                    # we are done, hit subdirectories
+                    break
+                #print("obj", dirname, objname)
+                elements.append(objname)
+                pos += 1
+
+            # then, skip over directories.
+            while pos != last:
+                dirname, objname = getentry(pos)
+                if not dirname.startswith(key[0]):
+                    # we are done, left the directory.
+                    break
+                relative = dirname[len(path):]
+                reldirname = relative.split("/")[0]
+                elements.append(reldirname + "/")
+                #print("dir", dirname, objname, relative, reldirname)
+                pos = bound(getentry, skiplessthan, (path + reldirname, ""), pos, last)
+
+            return elements
+
+    def filterentry(self, indexentry, pathfilter, first=0, last=1e9):
+        """
+        List MonitorElements matching the `pathfilter` re object in the set of
+        MEs indentified by the given indexentry. The search range can be 
+        reduced with the first/last parameters to allow for a parallel search.
+
+        Returns a list of matching ME fullnames.
+
+        This is implemented as a linear scan.
+        """
+        with METree(self, indexentry) as metree:
+            if not metree: return []
+            begin = max(first, indexentry.firstidx)
+            end = min(last, indexentry.lastidx+1)
+            result = []
+            for i in range(begin, end):
+                metree.GetEntry(i)
+                fullname = str(metree.FullName)
+                m = pathfilter.match(fullname)
+                if m:
+                    result.append(fullname)
+            return result
+    
+    def readoneME(self, indexentry, fullname):
+        """
+        Read a MonitorElement with the given fullname from the set of MEs
+        ientified by indexentry. Returns a `MonitorElement` object with a ROOT
+        object as `value`, or None if no matching ME is found.
+        """
+        with METree(self, indexentry) as metree:
+            if not metree: return None
+            
+            def getentry(idx):
+                metree.GetEntry(idx)
+                return searchkey(str(metree.FullName))
+
+            first, last = indexentry.firstidx, indexentry.lastidx+1
+            key = searchkey(fullname)
+            # start by skipping to the first item in the directory
+            pos = bound(getentry, normallessthan, key, first, last)
+            if pos == last:
+                return None
+            metree.GetEntry(pos, 1) # read full row
+            if str(metree.FullName) != fullname:
+                return None
+            value = metree.Value
+            return MonitorElement(indexentry.run, indexentry.lumi, fullname, indexentry.type, value)
+
+#
+# This second part is a higher level abstraction over full datasets consisting
+# of many DQMIO files. A large thread pool is used to make the high latency 
+# remote reads acceptably fast. A SQLite database is kept for metadata.
+#
+import re
+import sqlite3
+import fnmatch
+import subprocess
+from multiprocessing.pool import ThreadPool
+
+DASFILEPREFIX = "root://cms-xrd-global.cern.ch/"
+DBSCHEMA = """
+    CREATE TABLE IF NOT EXISTS dataset(id INTEGER PRIMARY KEY, datasetname, lastchecked);
+    CREATE UNIQUE INDEX IF NOT EXISTS datasets ON dataset(datasetname);
+    CREATE TABLE IF NOT EXISTS file(id INTEGER PRIMARY KEY, datasetid, name, readable, lastchecked, indexed);
+    CREATE INDEX IF NOT EXISTS datasettofile ON file(datasetid);
+    CREATE UNIQUE INDEX IF NOT EXISTS filetoid ON file(name);
+    CREATE TABLE IF NOT EXISTS indexentry(id INTEGER PRIMARY KEY, run, lumi, type, file, firstidx, lastidx);
+    CREATE UNIQUE INDEX IF NOT EXISTS entries ON indexentry(run, lumi, type, file, firstidx, lastidx);
+    CREATE INDEX IF NOT EXISTS fileentries ON indexentry(file);
+    CREATE INDEX IF NOT EXISTS runlumi ON indexentry(run, lumi);
+"""
+
+# helper function for building simple task managers.
+def splitdone(tasks):
+    running = []
+    done = []
+    for t in tasks:
+        if t.ready():
+            done.append(t)
+        else:
+            running.append(t)
+    return running, done
+
+class DQMIOReader:
+    """
+    This class manages data from a set of DQMIO files. This can be a full
+    dataset read from DAS. Operations are internally multi-threaded.
+    All state is kept in a SQLite database, caches are managed by `DQMIOFileIO`.
+    """
+    def __init__(self, dbname="", nthreads=32):
+        self.db = sqlite3.connect(dbname)
+        self.db.executescript(DBSCHEMA)
+        self.pool = ThreadPool(nthreads)
+        self.io = DQMIOFileIO()
+          
+    def importdatasets(self, datasetpattern):
+        """
+        Query DAS for datasets matching `datasetpattern` and add their files.
+        """
+        dqmiodatasets = subprocess.check_output(['dasgoclient', '-query', 'dataset dataset=/*/*/DQMIO'])
+        datasets = []
+        for name in dqmiodatasets.splitlines():
+            datasetname = name.decode("utf-8")
+            if fnmatch.fnmatch(datasetname, datasetpattern):
+                datasets.append(datasetname)
+        self.importdataset(datasets) 
+    
+    def importdataset(self, datasetnames):
+        """
+        Query DAS for files from the given datasets and add them.
+        """
+        if isinstance(datasetnames, str):
+            return self.readdataset([datasetnames])
+        
+        # helper function for parallel running
+        def getfiles(datasetname):
+            filelist = subprocess.check_output(['dasgoclient', '-query', 'file dataset=%s' % datasetname])
+            return datasetname, [DASFILEPREFIX + f.decode("utf8") for f in filelist.splitlines()]
+
+        tasks = [self.pool.map_async(getfiles, [d,]) for d in datasetnames] 
+        while tasks:
+            time.sleep(1)
+            tasks, done = splitdone(tasks)
+            self.db.execute("BEGIN;")
+            for t in done:
+                if not t.successful():
+                    print("DAS file listing task failed.")
+                    continue
+                for it in t.get(): # should only be one
+                    datasetname, filelist = it
+                    self.addfiles(datasetname, filelist)
+            self.db.execute("COMMIT;")
+        print(str(len(tasks)) + " tasks remaining")
+        
+    def addfiles(self, datasetname, filelist):
+        """
+        Add ROOT files to the metadata database, under the given dataset name.
+        """
+        self.db.execute(f"INSERT OR REPLACE INTO dataset(datasetname, lastchecked) VALUES (?, datetime('now'));", (datasetname,))
+        datasetid = self.db.execute(f"SELECT id FROM dataset WHERE datasetname = ?;", (datasetname,))
+        datasetid = list(datasetid)[0][0]
+        self.db.executemany("INSERT OR IGNORE INTO file(datasetid, name) VALUES (?, ?)", [(datasetid, name) for name in filelist])  
+          
+    def datasets(self):
+        """
+        Return a list of known dataset names.
+        """
+        return [row[0] for row in self.db.execute("SELECT datasetname FROM dataset;")]
+
+    def checkfiles(self, since="+1 day"):
+        """
+        Update metadata for all known files. Checks if files are readable and
+        reads the Index trees, re-checks files last checked more than `since` ago.
+        """
+        cur = self.db.cursor()
+        newfiles = list(cur.execute("""
+           SELECT name FROM file 
+           WHERE (readable and indexed is null)
+              or (  (readable is null or not readable) 
+                and (lastchecked is null or datetime(lastchecked, ?) <  datetime('now')));
+        """, (since,)))
+        cur.close()
+        checktasks = [self.pool.map_async(self.io.checkreadable, [f,]) for f, in newfiles] 
+        readtasks = []
+        
+        while checktasks or readtasks:
+            time.sleep(1)
+            self.io.cleancache()
+            print(str(len(checktasks)) + " readablility check tasks, " + str(len(readtasks)) + " index read tasks remaining")
+            checktasks, done = splitdone(checktasks)
+            results = []
+            for t in done:
+                if not t.successful():
+                    print("Readability check task failed.")
+                for file, readable in t.get(): # should only be one
+                    results.append((file, readable))
+                    if readable:
+                        readtasks.append(self.pool.map_async(self.io.readindex, [file,]))
+            if results:
+                self.db.execute("BEGIN;")
+                self.db.executemany("UPDATE file SET readable = ? WHERE name = ?;", 
+                                    [(readable, name) for name, readable in results])
+                self.db.executemany("UPDATE file SET lastchecked = datetime('now') WHERE name = ?;", 
+                                    [(name,) for name, _ in results])
+                self.db.execute("COMMIT;")
+            
+            readtasks, done = splitdone(readtasks)
+            entries = []
+            for t in done:
+                if not t.successful():
+                    print("Index read task failed.")
+                for index in t.get(): # should only be one
+                    entries += index
+            if entries:
+                self.db.execute("BEGIN;")
+                self.db.executemany("""INSERT OR REPLACE INTO indexentry(run, lumi, type, file, firstidx, lastidx) 
+                    VALUES (?, ?, ?, (SELECT id FROM file WHERE name = ?), ?, ?);""", entries)
+                files = set(e.file for e in entries)
+                self.db.executemany('UPDATE file SET indexed = 1 WHERE id = (SELECT id FROM file WHERE name = ?);', [(f, ) for f in files])
+                self.db.execute("COMMIT;")
+    
+    def samples(self):
+        """
+        Return a list of known samples ((datasetname, run, lumi) tuples).
+        """
+        return list(self.db.execute("""
+            SELECT DISTINCT datasetname, run, lumi FROM indexentry 
+            INNER JOIN file ON indexentry.file = file.id 
+            INNER JOIN dataset ON file.datasetid = dataset.id;"""))
+
+    def entriesforsample(self, datasetname, run, lumi, onefileonly=False):
+        query = f"""
+            SELECT run, lumi, type, file.name, firstidx, lastidx
+            FROM dataset
+            INNER JOIN file ON file.datasetid = dataset.id 
+            INNER JOIN indexentry on indexentry.file = file.id 
+            WHERE datasetname = ? AND run = ? AND lumi = ?
+        """
+        if onefileonly:
+            query += "GROUP BY type" #we only need one entry per type, no need to read all files.
+        entries = self.db.execute(query, (datasetname, run, lumi))
+        return [IndexEntry(*row) for row in entries]
+        
+    def filtersample(self, datasetname, run, lumi, pathfilter):
+        """
+        Return ME names matching the regular expression `pathfilter` in the
+        given sample.
+        """
+        entries = self.entriesforsample(datasetname, run, lumi, onefileonly=True)
+        tasks = []
+        exp = re.compile(pathfilter)
+        for e in entries:
+            for i in range(e.firstidx, e.lastidx+1, 5000):
+                tasks.append((e, exp, i, i + 5000))
+        pathsets = self.pool.map(lambda t: self.io.filterentry(*t), tasks)
+        paths = set().union(*pathsets)
+        self.io.cleancache()
+        return paths
+
+    def listsample(self, datasetname, run, lumi, path):
+        """
+        Return object names that are children of `path`  in the
+        given sample.
+        """
+        entries = self.entriesforsample(datasetname, run, lumi, onefileonly=True)
+        pathsets = self.pool.map(lambda e: self.io.listentry(e, path), entries)
+        paths = set().union(*pathsets)
+        self.io.cleancache()
+        return paths
+    
+    def readsampleme(self, datasetname, run, lumi, fullnames):
+        """
+        Return `MonitorElement`s matching the given names in the given sample.
+
+        For RUN MEs (lumi = 0), there may be multiple objects in different files
+        that need to be merged; these are returned as individual objects.
+        """
+        if isinstance(fullnames, str):
+            return self.readsampleme(datasetname, run, lumi, [fullnames])
+        entries = self.entriesforsample(datasetname, run, lumi)
+        # TODO: maybe try the most common `type`s first, to make the common case fast.
+        mes = self.pool.starmap(self.io.readoneME, [(e, fullname) for e in entries for fullname in fullnames])
+        self.io.cleancache()
+        return [me for me in mes if me]
+    

--- a/DQMServices/FwkIO/python/DQMIO.py
+++ b/DQMServices/FwkIO/python/DQMIO.py
@@ -113,7 +113,7 @@ def skiplessthan(a, key):
 class DQMIOFileIO:
     """
     This class maintains a cache of open ROOT files (or rather XrootD 
-    connections and allows low-level read operations on these files.
+    connections) and allows low-level read operations on these files.
     Most operations work on `IndexEntry`s, which can be read from the DQMIO
     file's `Indices` Tree using `readindex`.
     
@@ -150,7 +150,7 @@ class DQMIOFileIO:
         """
         Check if `file` can be opened, and return a (filename, bool) pair.
 
-        This will typically wait for a timeout if the cannot be read. Should
+        This will typically wait for a timeout if the file cannot be read. Should
         be called multi-threaded for high throughput.
         """
         tfile = asyncopen(filename, TESTTIMEOUT)
@@ -183,7 +183,6 @@ class DQMIOFileIO:
 
     # function just to get caching here: read one FullName from a file.
     # the cache is set up in __init__ so it is per-instance.
-    # calling this later *will* open every file twice, but that might be worth it.
     def getsearchkey(self, indexentry, idx):
         with METree(self, indexentry) as metree:
             metree.GetEntry(idx)
@@ -262,7 +261,7 @@ class DQMIOFileIO:
     def locateme(self, indexentry, fullname):
         """
         Find a MonitorElement with the given fullname from the set of MEs
-        ientified by indexentry. Returns a (IndexEntry, Index) pair for `getme`,
+        identified by indexentry. Returns a (IndexEntry, Index) pair for `getme`,
         or None if no matching ME is found.
         """
         with METree(self, indexentry) as metree: # just a check to see if the file opens

--- a/DQMServices/FwkIO/python/DQMIO.py
+++ b/DQMServices/FwkIO/python/DQMIO.py
@@ -65,13 +65,15 @@ class METree(object):
         else:
             self.tfile = asyncopen(self.name, OPENTIMEOUT)
             if not self.tfile: return None
+            for name in TREENAMES.values():
+                t = getattr(self.tfile, name)
+                t.GetEntry(0)
+                t.SetBranchStatus("*",0)
+                t.SetBranchStatus("FullName",1)
+                # release GIL in long operations. Disable if it causes trouble.
+                t.GetEntry._threaded = True
             metree = getattr(self.tfile, self.treename)
-        # TODO: might be counterproductive to do this every time.
-        metree.GetEntry(0)
-        metree.SetBranchStatus("*",0)
-        metree.SetBranchStatus("FullName",1)
-        # release GIL in long operations. Disable if it causes trouble.
-        metree.GetEntry._threaded = True
+            assert(metree.GetEntry._threaded == True)
         return metree
 
     def __exit__(self, type, value, traceback):

--- a/DQMServices/FwkIO/python/DQMIO.py
+++ b/DQMServices/FwkIO/python/DQMIO.py
@@ -266,10 +266,11 @@ class DQMIOFileIO:
             pos = bound(getentry, normallessthan, key, first, last)
             if pos == last:
                 return None
+
             metree.GetEntry(pos, 1) # read full row
             if str(metree.FullName) != fullname:
                 return None
-            value = metree.Value
+            value = metree.Value.Clone()
             return MonitorElement(indexentry.run, indexentry.lumi, fullname, indexentry.type, value)
 
 #

--- a/DQMServices/FwkIO/python/DQMIO.py
+++ b/DQMServices/FwkIO/python/DQMIO.py
@@ -1,7 +1,7 @@
 import ROOT
 # try to get some better multi-threading support out of root. Needs to happen as early as possible.
 ROOT.ROOT.EnableThreadSafety()
-ROOT.TFile.Open._threaded = True
+#ROOT.TFile.Open._threaded = True
 
 import time
 from functools import lru_cache

--- a/DQMServices/FwkIO/python/DQMIO.py
+++ b/DQMServices/FwkIO/python/DQMIO.py
@@ -466,8 +466,8 @@ class DQMIOReader:
         tasks = [(None, self.pool.submit(self.io.locateme, e, fullname)) for e in entries for fullname in fullnames]
         processtasks(tasks, append, "ME locate")
         tasks = [(None, self.pool.submit(self.io.getme, *e_idx)) for e_idx in items if e_idx]
-        processtasks(tasks, append, "ME get")
         items.clear()
+        processtasks(tasks, append, "ME get")
         self.io.cleancache()
         return items
     def readentrymes_fast(self, entries, fullnames):

--- a/DQMServices/FwkIO/python/README.md
+++ b/DQMServices/FwkIO/python/README.md
@@ -3,7 +3,7 @@ DQMIO Python Libraries
 
 This package provides PyROOT based Python code to read DQMIO files.
 
-This library is designed for Python3. Use a `PY3` CMSSW IB to get a Rython3-compatible PyROOT.
+This library is designed for Python3. Use a `PY3` CMSSW IB to get a Python3-compatible PyROOT.
 
 Usage
 -----
@@ -63,6 +63,7 @@ Very basic: Read local files.
  MonitorElement(run=315339, lumi=0, name='Hcal/DigiPhase1Task/ADC/SubdetPM/HEP', type=3, data=<ROOT.TH1F object ("HEP") at 0x7fd0040cd370>),
  ...
 ]
+```
 
 More advanced: Read a dataset from DAS (do `voms-proxy-init -voms cms -rfc` first):
 ```

--- a/DQMServices/FwkIO/python/README.md
+++ b/DQMServices/FwkIO/python/README.md
@@ -1,0 +1,131 @@
+DQMIO Python Libraries
+======================
+
+This package provides PyROOT based Python code to read DQMIO files.
+
+This library is designed for Python3. Use a `PY3` CMSSW IB to get a Rython3-compatible PyROOT.
+
+Usage
+-----
+
+Very basic: Read local files.
+
+```
+> from DQMServices.FwkIO.DQMIO import DQMIOReader
+> r = DQMIOReader()
+> # Add some local DQMIO data files
+> r.addfiles("mydataset", ["/data/mschneid/179BF42D-D53E-3C45-92A5-DB2101E7E9FD.root"])
+> # Read the metadata. This may take a while.
+> r.checkfiles()
+
+> # Now do some queries:
+> r.samples()
+[('mydataset', 315270, 53),
+ ('mydataset', 315270, 54),
+ ('mydataset', 315270, 55),
+ ('mydataset', 315270, 0),
+ ('mydataset', 315322, 540),
+ ...
+]
+> r.listsample('mydataset', 315339, 0, "")
+{'AlCaReco/',
+ 'AlcaBeamMonitor/',
+ 'CTPPS/',
+ 'Castor/',
+ 'DQM/',
+ 'DT/',
+ 'Ecal/',
+ 'EcalBarrel/',
+ 'EcalEndcap/',
+ 'EcalPreshower/',
+ 'Egamma/',
+ 'HLT/',
+ 'Hcal/',
+ 'Info/',
+ 'L1T/',
+ 'Muons/',
+ 'RPC/',
+ 'RecoTauV/',
+ 'SiStrip/',
+ 'Tracking/'}
+> menames = r.filtersample('mydataset', 315339, 43, ".*DigiPhase1Task.*")
+> menames
+{'Hcal/DigiPhase1Task/ADC/SubdetPM/HBM',
+ 'Hcal/DigiPhase1Task/ADC/SubdetPM/HBP',
+ 'Hcal/DigiPhase1Task/ADC/SubdetPM/HEM',
+ 'Hcal/DigiPhase1Task/ADC/SubdetPM/HEP',
+ ...
+}
+> mes = r.readsampleme('mydataset', 315339, 0, menames)
+[MonitorElement(run=315339, lumi=0, name='Hcal/DigiPhase1Task/ADC/SubdetPM/HBM', type=3, data=<ROOT.TH1F object ("HBM") at 0x7fd040061460>),
+ MonitorElement(run=315339, lumi=0, name='Hcal/DigiPhase1Task/ADC/SubdetPM/HBP', type=3, data=<ROOT.TH1F object ("HBM") at 0x7fd0180737e0>),
+ MonitorElement(run=315339, lumi=0, name='Hcal/DigiPhase1Task/ADC/SubdetPM/HEM', type=3, data=<ROOT.TH1F object ("HFP") at 0x7fcff801a370>),
+ MonitorElement(run=315339, lumi=0, name='Hcal/DigiPhase1Task/ADC/SubdetPM/HEP', type=3, data=<ROOT.TH1F object ("HEP") at 0x7fd0040cd370>),
+ ...
+]
+
+More advanced: Read a dataset from DAS (do `voms-proxy-init -voms cms -rfc` first):
+```
+> r = DQMIOReader()
+> r.importdataset("/EGamma/Run2018A-12Nov2019_UL2018-v2/DQMIO") 
+> r.checkfiles() # this will take a while...
+773 readablility check tasks, 0 index read tasks remaining
+773 readablility check tasks, 0 index read tasks remaining
+753 readablility check tasks, 20 index read tasks remaining
+731 readablility check tasks, 42 index read tasks remaining
+...
+0 readablility check tasks, 45 index read tasks remaining
+0 readablility check tasks, 13 index read tasks remaining
+> r.readsampleme('/EGamma/Run2018A-12Nov2019_UL2018-v2/DQMIO', 315339, 39, "Hcal/DigiPhase1Task/Occupancy/depth/depth1")
+[MonitorElement(run=315339, lumi=39, name='Hcal/DigiPhase1Task/Occupancy/depth/depth1', type=6, data=<ROOT.TH2F object ("depth1") at 0x7f5d2c068170>)]
+> # Since this data is not harvested, this will return multiple MEs that need to be added to get the full run histogram.
+> # For this reason, a ME will also only appear either in the per-lumi, or the per-run sections, but not both.
+> # It will also be quite slow, since many files need to be read.
+> r.readsampleme('/EGamma/Run2018A-12Nov2019_UL2018-v2/DQMIO', 315339, 0, "Hcal/DigiPhase1Task/ADC/SubdetPM/HEP")
+[MonitorElement(run=315339, lumi=0, name='Hcal/DigiPhase1Task/ADC/SubdetPM/HEP', type=3, data=<ROOT.TH1F object ("HEP") at 0x7f5d74929110>),
+ MonitorElement(run=315339, lumi=0, name='Hcal/DigiPhase1Task/ADC/SubdetPM/HEP', type=3, data=<ROOT.TH1F object ("HEP") at 0x7f5d749e08b0>),
+ ...
+] 
+```
+Most advanced: Read a lot of data using a database.
+```
+> r = DQMIOReader("/data/mschneid/egamma2018.db", 100) # persistent database and 100 IO threads
+> r.importdatasets("/EGamma/Run2018*-12Nov2019_UL2018-v*/DQMIO")
+> r.datasets()
+['/EGamma/Run2018A-12Nov2019_UL2018-v2/DQMIO',
+ '/EGamma/Run2018B-12Nov2019_UL2018-v2/DQMIO',
+ '/EGamma/Run2018C-12Nov2019_UL2018-v2/DQMIO',
+ '/EGamma/Run2018D-12Nov2019_UL2018-v3/DQMIO',
+ '/EGamma/Run2018D-12Nov2019_UL2018-v4/DQMIO']
+> r.checkfiles() # This will take a long time.
+5394 readablility check tasks, 0 index read tasks remaining
+5379 readablility check tasks, 15 index read tasks remaining
+...
+> # Actually, only 500 files are readable at the moment.
+> list(r.db.execute("select count(*), readable, indexed from file group by readable, indexed")) 
+[(4894, 0, None), (500, 1, 1)]
+> # these are from the 2018B and C eras:
+> set(s[0] for s in r.samples())
+{'/EGamma/Run2018B-12Nov2019_UL2018-v2/DQMIO',
+ '/EGamma/Run2018C-12Nov2019_UL2018-v2/DQMIO'}
+```
+
+Now we can use the existing database to read some MEs:
+```
+from DQMServices.FwkIO.DQMIO import DQMIOReader
+r = DQMIOReader("/data/mschneid/egamma2018.db")
+# Read a ME for all available lumis of a run. This will take a while.
+mes = r.readlumimes('/EGamma/Run2018B-12Nov2019_UL2018-v2/DQMIO', 317649, 'EcalPreshower/ESOccupancyTask/ES RecHit 2D Occupancy Z -1 P 2')
+print(mes)
+```
+
+Implementation
+--------------
+
+The DQMIO format consists of ROOT `TTree`s with ME names and objects. The trees are sorted by name, and an additional tree withmetadata provides run/lumi information. This library implements binary search over the trees to be able to locate MEs in the DQMIO with a minimal amount of bytes read. There is caching and multi-threading to make this as efficient as possible even on remote files.
+
+The code is split in two parts: The first implements all the low-level operations on DQMIO files, while the second provides the `DQMIOReader` class which handles a metadata database and multi-threading.
+
+The low-level interface is built around `IndexEntry`s, the rows of the `Indices` metadata tree in the DQMIO file. This data is read from the datafiles and cached in a local SQLite database, the (potentially) remote ROOT files are only accessed to read MEs. There is a big cache (100's of files) of open `TFile`s, to avoid the long latency of locating remote files.
+
+The high-level interface is built around a rather elaborate database to track file status: First, it is checked if a file is currently readable (on disk), then, it's metadata is extracted. Non-readable files will be re-checked every day. Interrupting and resuming `checkfiles()` should be no problem.

--- a/DQMServices/FwkIO/python/README.md
+++ b/DQMServices/FwkIO/python/README.md
@@ -70,13 +70,6 @@ More advanced: Read a dataset from DAS (do `voms-proxy-init -voms cms -rfc` firs
 > r = DQMIOReader()
 > r.importdataset("/EGamma/Run2018A-12Nov2019_UL2018-v2/DQMIO") 
 > r.checkfiles() # this will take a while...
-773 readablility check tasks, 0 index read tasks remaining
-773 readablility check tasks, 0 index read tasks remaining
-753 readablility check tasks, 20 index read tasks remaining
-731 readablility check tasks, 42 index read tasks remaining
-...
-0 readablility check tasks, 45 index read tasks remaining
-0 readablility check tasks, 13 index read tasks remaining
 > r.readsampleme('/EGamma/Run2018A-12Nov2019_UL2018-v2/DQMIO', 315339, 39, "Hcal/DigiPhase1Task/Occupancy/depth/depth1")
 [MonitorElement(run=315339, lumi=39, name='Hcal/DigiPhase1Task/Occupancy/depth/depth1', type=6, data=<ROOT.TH2F object ("depth1") at 0x7f5d2c068170>)]
 > # Since this data is not harvested, this will return multiple MEs that need to be added to get the full run histogram.
@@ -88,7 +81,9 @@ More advanced: Read a dataset from DAS (do `voms-proxy-init -voms cms -rfc` firs
  ...
 ] 
 ```
+
 Most advanced: Read a lot of data using a database.
+
 ```
 > r = DQMIOReader("/data/mschneid/egamma2018.db", 100) # persistent database and 100 IO threads
 > r.importdatasets("/EGamma/Run2018*-12Nov2019_UL2018-v*/DQMIO")
@@ -99,9 +94,6 @@ Most advanced: Read a lot of data using a database.
  '/EGamma/Run2018D-12Nov2019_UL2018-v3/DQMIO',
  '/EGamma/Run2018D-12Nov2019_UL2018-v4/DQMIO']
 > r.checkfiles() # This will take a long time.
-5394 readablility check tasks, 0 index read tasks remaining
-5379 readablility check tasks, 15 index read tasks remaining
-...
 > # Actually, only 500 files are readable at the moment.
 > list(r.db.execute("select count(*), readable, indexed from file group by readable, indexed")) 
 [(4894, 0, None), (500, 1, 1)]
@@ -112,6 +104,7 @@ Most advanced: Read a lot of data using a database.
 ```
 
 Now we can use the existing database to read some MEs:
+
 ```
 from DQMServices.FwkIO.DQMIO import DQMIOReader
 r = DQMIOReader("/data/mschneid/egamma2018.db")
@@ -119,6 +112,8 @@ r = DQMIOReader("/data/mschneid/egamma2018.db")
 mes = r.readlumimes('/EGamma/Run2018B-12Nov2019_UL2018-v2/DQMIO', 317649, 'EcalPreshower/ESOccupancyTask/ES RecHit 2D Occupancy Z -1 P 2')
 print(mes)
 ```
+
+By default, all operations print progress indications, since all operations might be quite slow (on remote files). However, on local files and/or with warm caches, this is may slow dwon the operations; use `DQMIOReader(..., progress=False) to disable the progress display on `read*` operations.
 
 Implementation
 --------------

--- a/DQMServices/FwkIO/python/README.md
+++ b/DQMServices/FwkIO/python/README.md
@@ -126,6 +126,6 @@ The DQMIO format consists of ROOT `TTree`s with ME names and objects. The trees 
 
 The code is split in two parts: The first implements all the low-level operations on DQMIO files, while the second provides the `DQMIOReader` class which handles a metadata database and multi-threading.
 
-The low-level interface is built around `IndexEntry`s, the rows of the `Indices` metadata tree in the DQMIO file. This data is read from the datafiles and cached in a local SQLite database, the (potentially) remote ROOT files are only accessed to read MEs. There is a big cache (100's of files) of open `TFile`s, to avoid the long latency of locating remote files.
+The low-level interface is built around `IndexEntry`s, the rows of the `Indices` metadata tree in the DQMIO file. This data is read from the datafiles and cached in a local SQLite database, the (potentially) remote ROOT files are only accessed to read MEs. There is a big cache (100's of files) of open `TFile`s, to avoid the long latency of locating remote files. Another cache holds values of the `FullName` column, so most of the binary search can happen without actually touching ROOT.
 
 The high-level interface is built around a rather elaborate database to track file status: First, it is checked if a file is currently readable (on disk), then, it's metadata is extracted. Non-readable files will be re-checked every day. Interrupting and resuming `checkfiles()` should be no problem.


### PR DESCRIPTION
#### PR description:
This PR adds a Python library that can be used to read DQMIO data from individual files or remote datasets. The focus is on reading from full datasets without reading them from disk entirely.

So far there are no usages, but this code might be useful for detector studies on the per-lumi saved data from the UL rereco, Machine Learning studies, and potentially an alternative DQMGUI backend.

#### PR validation:
I gave the code a bit of testing but there might still be problems. Now and then ROOT just dies; multi-threading is hard after all. 

Probably we should not merge that until some users confirm it is useful.

@gbenelli voiced some interest in this.