### PR TITLE
Add EventsPerLumi for relvals workflows and prod-like concurrentLS relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -5,6 +5,7 @@ import os
 import copy
 import multiprocessing
 import time
+import re
 
 def performInjectionOptionTest(opt):
     if opt.show:
@@ -361,12 +362,10 @@ class MatrixInjector(object):
                                     chainDict['nowmTasklist'][-1]['EventsPerLumi'] = ns[1]
                                     #overwrite EventsPerLumi if numberEventsInLuminosityBlock is set in cmsDriver
                                     if 'numberEventsInLuminosityBlock' in s[2][index]:
-                                        nEventsInLuminosityBlock = (((s[2][index].replace(" ","").replace("numberEventsInLuminosityBlock=cms.untracked.uint32("," ")).split()[1]).split(')'))[0]
-                                        if nEventsInLuminosityBlock.isdigit() and int(nEventsInLuminosityBlock) < ns[1]:
-                                            #print('Overwrite EventsPerLumi using cmsDriver customisation')
-                                            chainDict['nowmTasklist'][-1]['EventsPerLumi'] = nEventsInLuminosityBlock
+                                        nEventsInLuminosityBlock = re.findall('process.source.numberEventsInLuminosityBlock=cms.untracked.uint32\(([ 0-9 ]*)\)', s[2][index],re.DOTALL)
+                                        if nEventsInLuminosityBlock[-1].isdigit() and int(nEventsInLuminosityBlock[-1]) < ns[1]:
+                                            chainDict['nowmTasklist'][-1]['EventsPerLumi'] = int(nEventsInLuminosityBlock[-1])
                                     if(self.numberEventsInLuminosityBlock > 0 and self.numberEventsInLuminosityBlock < ns[1]):
-                                        #print('Overwrite EventsPerLumi (again) using runTheMatrix parameter')
                                         chainDict['nowmTasklist'][-1]['EventsPerLumi'] = self.numberEventsInLuminosityBlock
                                 if 'FASTSIM' in s[2][index] or '--fast' in s[2][index]:
                                     thisLabel+='_FastSim'

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -53,6 +53,7 @@ class MatrixInjector(object):
         self.keep = opt.keep
         self.memoryOffset = opt.memoryOffset
         self.memPerCore = opt.memPerCore
+        self.numberEventsInLuminosityBlock = opt.numberEventsInLuminosityBlock
         self.batchName = ''
         self.batchTime = str(int(time.time()))
         if(opt.batchName):
@@ -128,6 +129,7 @@ class MatrixInjector(object):
             "GlobalTag": None,
             "SplittingAlgo"  : "EventBased",             #Splitting Algorithm
             "EventsPerJob" : None,                       #Size of jobs in terms of splitting algorithm
+            "EventsPerLumi" : None,
             "RequestNumEvents" : None,                      #Total number of events to generate
             "Seeding" : "AutomaticSeeding",                          #Random seeding method
             "PrimaryDataset" : None,                          #Primary Dataset to be created
@@ -356,6 +358,16 @@ class MatrixInjector(object):
                                     ns=map(int,arg[arg.index('--relval')+1].split(','))
                                     chainDict['nowmTasklist'][-1]['RequestNumEvents'] = ns[0]
                                     chainDict['nowmTasklist'][-1]['EventsPerJob'] = ns[1]
+                                    chainDict['nowmTasklist'][-1]['EventsPerLumi'] = ns[1]
+                                    #overwrite EventsPerLumi if numberEventsInLuminosityBlock is set in cmsDriver
+                                    if 'numberEventsInLuminosityBlock' in s[2][index]:
+                                        nEventsInLuminosityBlock = (((s[2][index].replace(" ","").replace("numberEventsInLuminosityBlock=cms.untracked.uint32("," ")).split()[1]).split(')'))[0]
+                                        if nEventsInLuminosityBlock.isdigit() and int(nEventsInLuminosityBlock) < ns[1]:
+                                            #print('Overwrite EventsPerLumi using cmsDriver customisation')
+                                            chainDict['nowmTasklist'][-1]['EventsPerLumi'] = nEventsInLuminosityBlock
+                                    if(self.numberEventsInLuminosityBlock > 0 and self.numberEventsInLuminosityBlock < ns[1]):
+                                        #print('Overwrite EventsPerLumi (again) using runTheMatrix parameter')
+                                        chainDict['nowmTasklist'][-1]['EventsPerLumi'] = self.numberEventsInLuminosityBlock
                                 if 'FASTSIM' in s[2][index] or '--fast' in s[2][index]:
                                     thisLabel+='_FastSim'
                                 if 'lhe' in s[2][index] in s[2][index]:

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -32,12 +32,15 @@ workflows.addOverride(1303.17,overridesEv5)
 
 #####Prod2018
 #workflows[1301.18] = ['', ['ProdMinBias_13UP18','DIGIUP18PROD1','RECOPRODUP18']]
-workflows[1302.18] = ['', ['ProdTTbar_13UP18','DIGIUP18PROD1','RECOPRODUP18']]
+workflows[1302.18] = ['', ['ProdTTbar_13UP18','DIGIUP18PROD1','RECOPRODUP18','MINIAODMCUP18','NANOPRODUP18']]
 #workflows[1303.18] = ['', ['ProdQCD_Pt_3000_3500_13UP18','DIGIUP18PROD1','RECOPRODUP18']]
-workflows[1304.18] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1','RECOPRODUP18','MINIAODMCUP18']]
-workflows[1304.181] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1','RECOPRODUP18bParking','MINIAODMCUP18bParking']]
+workflows[1304.18] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1','RECOPRODUP18','MINIAODMCUP18','NANOPRODUP18']]
+workflows[1304.182] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1','RECOPRODUP18bParking','MINIAODMCUP18bParking']]
 #workflows.addOverride(1303.17,overridesEv5)
 
+#####Prod2018 with concurrentlumi
+workflows[1302.181] = ['', ['ProdTTbar_13UP18ml','DIGIUP18PROD1ml','RECOPRODUP18ml','MINIAODMCUP18ml','NANOPRODUP18ml']]
+workflows[1304.181] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1ml','RECOPRODUP18ml','MINIAODMCUP18ml','NANOPRODUP18ml']]
 
 ### data ###
 workflows[4.5]  = ['', ['RunCosmicsA','RECOCOSD','ALCACOSD','HARVESTDC']]

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -40,7 +40,7 @@ workflows[1304.182] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1','RECOPRODUP18bParki
 
 #####Prod2018 with concurrentlumi
 workflows[1302.181] = ['', ['ProdTTbar_13UP18ml','DIGIUP18PROD1ml','RECOPRODUP18ml','MINIAODMCUP18ml','NANOPRODUP18ml']]
-workflows[1304.181] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1ml','RECOPRODUP18ml','MINIAODMCUP18ml','NANOPRODUP18ml']]
+workflows[1304.181] = ['', ['ProdZEE_13UP18ml','DIGIUP18PROD1ml','RECOPRODUP18ml','MINIAODMCUP18ml','NANOPRODUP18ml']]
 
 ### data ###
 workflows[4.5]  = ['', ['RunCosmicsA','RECOCOSD','ALCACOSD','HARVESTDC']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -508,6 +508,9 @@ def gen2018(fragment,howMuch):
 def gen2018prod(fragment,howMuch):
     global step1Up2018ProdDefaults
     return merge([{'cfg':fragment},howMuch,step1Up2018ProdDefaults])
+def gen2018prodml(fragment,howMuch): #Prod with concurrentLumis
+    global step1Up2018ProdDefaults
+    return merge([{'cfg':fragment},howMuch,{'--customise_commands': '"process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(5)"'},concurrentLumis,step1Up2018ProdDefaults]) #this setting is to allow job to cross LS in IB
 def gen2018hiprod(fragment,howMuch):
     global step1Up2018HiProdDefaults
     return merge([{'cfg':fragment},howMuch,step1Up2018HiProdDefaults])
@@ -606,8 +609,10 @@ steps['SMS-T1tttt_mGl-1500_mLSP-100_13UP17']=gen2017('SMS-T1tttt_mGl-1500_mLSP-1
 ### 2018 wf: only the ones for premixing (for the moment)
 steps['NuGun_UP18']=gen2018('SingleNuE10_cfi.py',Kby(9,50))
 steps['ProdTTbar_13UP18']=gen2018prod('TTbar_13TeV_TuneCUETP8M1_cfi',Kby(9,50))
+steps['ProdTTbar_13UP18ml']=gen2018prodml('TTbar_13TeV_TuneCUETP8M1_cfi',Kby(9,50))
 steps['TTbar_13UP18']=gen2018('TTbar_13TeV_TuneCUETP8M1_cfi',Kby(9,50))
 steps['ProdZEE_13UP18']=gen2018prod('ZEE_13TeV_TuneCUETP8M1_cfi',Kby(9,50))
+steps['ProdZEE_13UP18ml']=gen2018prodml('ZEE_13TeV_TuneCUETP8M1_cfi',Kby(9,50))
 steps['ZEE_13UP18']=gen2018('ZEE_13TeV_TuneCUETP8M1_cfi',Kby(9,50))
 steps['ProdZMM_13UP18']=gen2018prod('ZMM_13TeV_TuneCUETP8M1_cfi',Kby(18,100))
 steps['ZMM_13UP18']=gen2018('ZMM_13TeV_TuneCUETP8M1_cfi',Kby(18,100))
@@ -1643,6 +1648,7 @@ steps['DIGIUP18']=merge([step2Upg2018Defaults])
 steps['DIGIUP18ml']=merge([concurrentLumis,step2Upg2018Defaults])
 steps['DIGIUP17PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2017','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW'},step2Upg2017Defaults])
 steps['DIGIUP18PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2018','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW'},step2Upg2018Defaults])
+steps['DIGIUP18PROD1ml']=merge([concurrentLumis,steps['DIGIUP18PROD1']])
 steps['DIGIUP17_PU25']=merge([PU25UP17,step2Upg2017Defaults])
 steps['DIGIUP18_PU25']=merge([PU25UP18,step2Upg2018Defaults])
 
@@ -2338,6 +2344,7 @@ steps['RECOPRODUP15']=merge([{ '-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT','--dat
 steps['RECOPRODUP17']=merge([{ '--era' :'Run2_2017','--conditions': 'auto:phase1_2017_realistic'},steps['RECOPRODUP15']])
 ## for 2018 PROD
 steps['RECOPRODUP18']=merge([{ '-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,EI','--era' :'Run2_2018','--conditions': 'auto:phase1_2018_realistic','--datatier':'AODSIM','--eventcontent':'AODSIM'},step3Up2015Defaults])
+steps['RECOPRODUP18ml']=merge([concurrentLumis,steps['RECOPRODUP18']])
 steps['RECOPRODUP18bParking']=merge([{ '-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,EI','--era' :'Run2_2018,bParking','--conditions': 'auto:phase1_2018_realistic','--datatier':'AODSIM','--eventcontent':'AODSIM'},step3Up2015Defaults])
 ##
 steps['RECOCOS']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,DQM','--scenario':'cosmics','--datatier':'GEN-SIM-RECO,DQMIO','--eventcontent':'RECOSIM,DQM'},stCond,step3Defaults])
@@ -3009,6 +3016,7 @@ steps['MINIAODMCUP17FS']   =merge([{'--filein':'file:step1.root','--fast':'','--
 steps['MINIAODMCUP18']   =merge([{'--conditions':'auto:phase1_2018_realistic','--era':'Run2_2018'},stepMiniAODMC])
 steps['MINIAODMCUP18bParking']   =merge([{'--conditions':'auto:phase1_2018_realistic','--era':'Run2_2018,bParking'},stepMiniAODMC])
 steps['MINIAODMCUP18FS']   =merge([{'--filein':'file:step1.root','--fast':'','--conditions':'auto:phase1_2018_realistic','--era':'Run2_2018_FastSim'},stepMiniAODMC])
+steps['MINIAODMCUP18ml'] =merge([concurrentLumis,steps['MINIAODMCUP18']])
 
 stepNanoAODDefaults = { '-s': 'NANO,DQM:@nanoAODDQM', '-n': 1000 }
 stepNanoAODData = merge([{ '--data':'', '--eventcontent' : 'NANOAOD,DQM' ,'--datatier': 'NANOAOD,DQMIO'    }, stepNanoAODDefaults ])
@@ -3045,7 +3053,9 @@ steps['NANOUP15Data_PU25_JME']=merge([{'--customise_commands':'"from PhysicsTool
 steps['NANOUP17Had']=merge([{'--filein':'file:step4_inMINIAODSIM.root'},steps['NANOUP17']])
 steps['NANOUP18'] = merge([{'--conditions': 'auto:phase1_2018_realistic', '--era': 'Run2_2018','-n':'10', '--filein':'file:step3_inMINIAODSIM.root', '--nThreads':'2'}, stepNanoEDMMCProd ])
 steps['NANOUP18Had']=merge([{'--filein':'file:step4_inMINIAODSIM.root'},steps['NANOUP18']])
+steps['NANOPRODUP18']=merge([{'--filein':'file:step4.root'},steps['NANOUP18']])
 steps['NANOUP18ml']=merge([concurrentLumis,steps['NANOUP18']])
+steps['NANOPRODUP18ml']=merge([{'--filein':'file:step4.root'},steps['NANOUP18ml']])
 steps['NANOEDM2017'] = merge([{'--conditions': 'auto:run2_data_relval', '--era': 'Run2_2017'}, stepNanoEDMData ])
 steps['NANOEDM2017_94XMiniAODv1'] = merge([{'--era': 'Run2_2017,run2_nanoAOD_94XMiniAODv1'}, steps['NANOEDM2017'] ])
 steps['NANOEDM2017_94XMiniAODv2'] = merge([{'--era': 'Run2_2017,run2_nanoAOD_94XMiniAODv2'}, steps['NANOEDM2017'] ])

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -127,6 +127,11 @@ if __name__ == '__main__':
                       dest='nThreads',
                       default=1
                      )
+    parser.add_option('--numberEventsInLuminosityBlock',
+                      help='number of events in a luminosity block',
+                      dest='numberEventsInLuminosityBlock',
+                      default=-1
+                     )
 
     parser.add_option('-n','--showMatrix',
                       help='Only show the worflows. Use --ext to show more',
@@ -335,6 +340,7 @@ if __name__ == '__main__':
     if opt.fromScratch: opt.fromScratch = opt.fromScratch.split(',')
     if opt.nProcs: opt.nProcs=int(opt.nProcs)
     if opt.nThreads: opt.nThreads=int(opt.nThreads)
+    if (opt.numberEventsInLuminosityBlock): opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
     if (opt.memoryOffset): opt.memoryOffset=int(opt.memoryOffset)
     if (opt.memPerCore): opt.memPerCore=int(opt.memPerCore)
 


### PR DESCRIPTION
#### PR description:
This PR is to add an option to set EventsPerLumi in relvals. Normally, GEN relvals will set EventsPerLumi = EventsPerJobs. Setting can be done in 2 ways:
1. propagate from `process.source.numberEventsInLuminosityBlock` in relvals workflow, or
2. parameter of runTheMatrix, `runTheMatrix.py --numberEventsInLuminosityBlock` (overwrite "1." if both options exist)

In addition, 2 additional relvals (1302.181 and 1304.181) are added. They are prod-like 2018 production with concurrentLumis enable.

RelVals: [Link](https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?campaign=CMSSW_11_1_0_pre4__ml_PHATTEST-1585255954)
+ srimanob_RVCMSSW_11_1_0_pre4ProdTTbar_13UP18ml__ml_PHATTEST_200326_215358_6428 (concurrentLumis enable with new EventsPerLumi setting )
+ srimanob_RVCMSSW_11_1_0_pre4ProdTTbar_13UP18__ml_PHATTEST_200326_215402_5324 (normal relvals workflows, with new EventsPerLumi setting )

#### PR validation:

`runTheMatrix.py --what standard -l 1302.18,1304.18,1302.181,1304.181 -t 4 --wm init`
==> only concurrentLumis workflows have EventsPerLumi = 5 (as set in cmsDriver)

`runTheMatrix.py --what standard -l 1302.18,1304.18,1302.181,1304.181 --numberEventsInLuminosityBlock 20 -t 4 --wm init`
==> All workflows have EventsPerLumi = 20

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
-
