### PR TITLE
Backport of inverse beta variable in pat::Muons for 10_6_X

### DIFF
--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -28,6 +28,7 @@
 #include "DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidate.h"
 #include "DataFormats/MuonReco/interface/MuonSimInfo.h"
+#include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 
 // Define typedefs for convenience
 namespace pat {
@@ -124,6 +125,9 @@ namespace pat {
       void embedTpfmsMuon();
       /// embed reference to the above dyt Track
       void embedDytMuon();
+
+      // add extra timing information
+      void readExtraTimerInfo(const reco::MuonTimeExtra& t);
 
       // ---- PF specific methods ----
       /// reference to the source IsolatedPFCandidates
@@ -280,9 +284,16 @@ namespace pat {
       float lowptMvaValue() const { return lowptMvaValue_; }
       void  setLowPtMvaValue(float lowptmva){ lowptMvaValue_ = lowptmva; }
 
+
       /// Soft Muon MVA
       float softMvaValue() const { return softMvaValue_; }
       void  setSoftMvaValue(float softmva){ softMvaValue_ = softmva; }
+
+      /// Inverse beta
+      void setInverseBeta(const float iBeta) { inverseBeta_ = iBeta; };
+      void setInverseBetaErr(const float iBetaErr) { inverseBetaErr_ = iBetaErr; };
+      float inverseBeta() const { return inverseBeta_; };
+      float inverseBetaErr() const { return inverseBetaErr_; };
 
       /// MC matching information
       reco::MuonSimType simType() const { return simType_; }
@@ -319,7 +330,7 @@ namespace pat {
       void setSimEta(float eta){ simEta_ = eta;}
       void setSimPhi(float phi){ simPhi_ = phi;}
       void setSimMatchQuality(float quality){ simMatchQuality_ = quality;}
-      
+
       /// Trigger information
       const pat::TriggerObjectStandAlone* l1Object(const size_t idx=0)  const { 
 	return triggerObjectMatchByType(trigger::TriggerL1Mu,idx);
@@ -407,6 +418,10 @@ namespace pat {
       float mvaValue_;
       float lowptMvaValue_;
       float softMvaValue_;
+      
+      /// Inverse beta
+      float inverseBeta_;
+      float inverseBetaErr_;
 
       /// MC matching information
       reco::MuonSimType simType_;

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -129,8 +129,6 @@ namespace pat {
     void embedDytMuon();
 
     // add extra timing information
-    /// 1/beta for prompt particle hypothesis
-    /// (time is constraint to the bunch crossing time)
     void readTimeExtra(const reco::MuonTimeExtra& t);
 
     // ---- PF specific methods ----
@@ -294,7 +292,8 @@ namespace pat {
     float softMvaValue() const { return softMvaValue_; }
     void setSoftMvaValue(float softmva) { softMvaValue_ = softmva; }
 
-    /// Inverse beta
+    // 1/beta for prompt particle hypothesis
+    /// (time is constraint to the bunch crossing time)
     float inverseBeta() const { return inverseBeta_; }
     float inverseBetaErr() const { return inverseBetaErr_; }
 

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -22,26 +22,26 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/MuonReco/interface/MuonMETCorrectionData.h"
+#include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/PatCandidates/interface/Lepton.h"
 #include "DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidate.h"
 #include "DataFormats/MuonReco/interface/MuonSimInfo.h"
-#include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 
 // Define typedefs for convenience
 namespace pat {
   class Muon;
-  typedef std::vector<Muon>              MuonCollection; 
-  typedef edm::Ref<MuonCollection>       MuonRef; 
-  typedef edm::RefVector<MuonCollection> MuonRefVector; 
-}
+  typedef std::vector<Muon> MuonCollection;
+  typedef edm::Ref<MuonCollection> MuonRef;
+  typedef edm::RefVector<MuonCollection> MuonRefVector;
+}  // namespace pat
 
 namespace reco {
   /// pipe operator (introduced to use pat::Muon with PFTopProjectors)
   std::ostream& operator<<(std::ostream& out, const pat::Muon& obj);
-}
+}  // namespace reco
 
 // Class definition
 namespace pat {
@@ -49,398 +49,397 @@ namespace pat {
   class PATMuonSlimmer;
 
   class Muon : public Lepton<reco::Muon> {
+  public:
+    /// default constructor
+    Muon();
+    /// constructor from a reco muon
+    Muon(const reco::Muon& aMuon);
+    /// constructor from a RefToBase to a reco muon (to be superseded by Ptr counterpart)
+    Muon(const edm::RefToBase<reco::Muon>& aMuonRef);
+    /// constructor from a Ptr to a reco muon
+    Muon(const edm::Ptr<reco::Muon>& aMuonRef);
+    /// destructor
+    ~Muon() override;
 
-    public:
+    /// required reimplementation of the Candidate's clone method
+    Muon* clone() const override { return new Muon(*this); }
 
-      /// default constructor
-      Muon();
-      /// constructor from a reco muon
-      Muon(const reco::Muon & aMuon);
-      /// constructor from a RefToBase to a reco muon (to be superseded by Ptr counterpart)
-      Muon(const edm::RefToBase<reco::Muon> & aMuonRef);
-      /// constructor from a Ptr to a reco muon
-      Muon(const edm::Ptr<reco::Muon> & aMuonRef);
-      /// destructor
-      ~Muon() override;
+    // ---- methods for content embedding ----
+    /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
+    reco::TrackRef track() const override;
+    using reco::RecoCandidate::track;  // avoid hiding the base implementation
+    /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
+    reco::TrackRef innerTrack() const override { return track(); }
+    /// reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
+    reco::TrackRef standAloneMuon() const override;
+    /// reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
+    reco::TrackRef outerTrack() const override { return standAloneMuon(); }
+    /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
+    reco::TrackRef combinedMuon() const override;
+    /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
+    reco::TrackRef globalTrack() const override { return combinedMuon(); }
+    /// Track selected to be the best measurement of the muon parameters (including PFlow global information)
+    const reco::Track* bestTrack() const override { return muonBestTrack().get(); }
+    /// Track selected to be the best measurement of the muon parameters (including PFlow global information)
+    reco::TrackRef muonBestTrack() const override;
+    /// Track selected to be the best measurement of the muon parameters (from muon information alone)
+    reco::TrackRef tunePMuonBestTrack() const override;
 
-      /// required reimplementation of the Candidate's clone method
-      Muon * clone() const override { return new Muon(*this); }
+    /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon)
+    /// if force == false, do not embed this track if it's embedded already (e.g. ig it's a tracker track, and that's already embedded)
+    void embedMuonBestTrack(bool force = false);
+    /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon)
+    /// if force == false, do not embed this track if it's embedded already (e.g. ig it's a tracker track, and that's already embedded)
+    void embedTunePMuonBestTrack(bool force = false);
+    /// set reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
+    void embedTrack();
+    /// set reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
+    void embedStandAloneMuon();
+    /// set reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
+    void embedCombinedMuon();
 
-      // ---- methods for content embedding ----
-      /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
-      reco::TrackRef track() const override;
-      using reco::RecoCandidate::track; // avoid hiding the base implementation
-      /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
-      reco::TrackRef innerTrack() const override { return track(); }
-      /// reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
-      reco::TrackRef standAloneMuon() const override;
-      /// reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
-      reco::TrackRef outerTrack() const override { return standAloneMuon(); }
-      /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
-      reco::TrackRef combinedMuon() const override;
-      /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
-      reco::TrackRef globalTrack() const override { return combinedMuon(); }
-      /// Track selected to be the best measurement of the muon parameters (including PFlow global information)
-      const reco::Track * bestTrack() const override { return muonBestTrack().get(); }
-      /// Track selected to be the best measurement of the muon parameters (including PFlow global information)
-      reco::TrackRef      muonBestTrack() const override ; 
-      /// Track selected to be the best measurement of the muon parameters (from muon information alone)
-      reco::TrackRef tunePMuonBestTrack() const override ;
+    // ---- methods for MuonMETCorrectionData ----
+    /// muon MET corrections for caloMET; returns the muon correction struct if embedded during pat tuple production or an empty element
+    reco::MuonMETCorrectionData caloMETMuonCorrs() const {
+      return (embeddedCaloMETMuonCorrs_ ? caloMETMuonCorrs_.front() : reco::MuonMETCorrectionData());
+    };
+    void embedCaloMETMuonCorrs(const reco::MuonMETCorrectionData& t);
+    /// muon MET corrections for tcMET; returns the muon correction struct if embedded during pat tuple production or an empty element
+    reco::MuonMETCorrectionData tcMETMuonCorrs() const {
+      return (embeddedTCMETMuonCorrs_ ? tcMETMuonCorrs_.front() : reco::MuonMETCorrectionData());
+    };
+    void embedTcMETMuonCorrs(const reco::MuonMETCorrectionData& t);
 
-      /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon)
-      /// if force == false, do not embed this track if it's embedded already (e.g. ig it's a tracker track, and that's already embedded)
-      void embedMuonBestTrack(bool force=false);
-      /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon)
-      /// if force == false, do not embed this track if it's embedded already (e.g. ig it's a tracker track, and that's already embedded)
-      void embedTunePMuonBestTrack(bool force=false);
-      /// set reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
-      void embedTrack();
-      /// set reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
-      void embedStandAloneMuon();
-      /// set reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
-      void embedCombinedMuon();
+    // ---- methods for TeV refit tracks ----
 
-      // ---- methods for MuonMETCorrectionData ----
-      /// muon MET corrections for caloMET; returns the muon correction struct if embedded during pat tuple production or an empty element
-      reco::MuonMETCorrectionData caloMETMuonCorrs() const { return (embeddedCaloMETMuonCorrs_ ? caloMETMuonCorrs_.front() : reco::MuonMETCorrectionData());};
-      void embedCaloMETMuonCorrs(const reco::MuonMETCorrectionData& t);
-      /// muon MET corrections for tcMET; returns the muon correction struct if embedded during pat tuple production or an empty element
-      reco::MuonMETCorrectionData tcMETMuonCorrs() const {return (embeddedTCMETMuonCorrs_ ? tcMETMuonCorrs_.front() : reco::MuonMETCorrectionData());};
-      void embedTcMETMuonCorrs(const reco::MuonMETCorrectionData& t);
+    /// reference to Track reconstructed using hits in the tracker + "good" muon hits (reimplemented from reco::Muon)
+    reco::TrackRef pickyTrack() const override;
+    /// reference to Track reconstructed using hits in the tracker + info from the first muon station that has hits (reimplemented from reco::Muon)
+    reco::TrackRef tpfmsTrack() const override;
+    /// reference to Track reconstructed using DYT algorithm
+    reco::TrackRef dytTrack() const override;
+    /// Deprecated accessors to call the corresponding above two functions; no dytMuon since this naming is deprecated.
+    reco::TrackRef pickyMuon() const { return pickyTrack(); }  // JMTBAD gcc deprecated attribute?
+    reco::TrackRef tpfmsMuon() const { return tpfmsTrack(); }  // JMTBAD gcc deprecated attribute?
+    /// embed reference to the above picky Track
+    void embedPickyMuon();
+    /// embed reference to the above tpfms Track
+    void embedTpfmsMuon();
+    /// embed reference to the above dyt Track
+    void embedDytMuon();
 
-      // ---- methods for TeV refit tracks ----
-    
-      /// reference to Track reconstructed using hits in the tracker + "good" muon hits (reimplemented from reco::Muon)
-      reco::TrackRef pickyTrack() const override;
-      /// reference to Track reconstructed using hits in the tracker + info from the first muon station that has hits (reimplemented from reco::Muon)
-      reco::TrackRef tpfmsTrack() const override;
-      /// reference to Track reconstructed using DYT algorithm
-      reco::TrackRef dytTrack() const override;
-      /// Deprecated accessors to call the corresponding above two functions; no dytMuon since this naming is deprecated.
-      reco::TrackRef pickyMuon() const { return pickyTrack(); } // JMTBAD gcc deprecated attribute?
-      reco::TrackRef tpfmsMuon() const { return tpfmsTrack(); } // JMTBAD gcc deprecated attribute?
-      /// embed reference to the above picky Track
-      void embedPickyMuon();
-      /// embed reference to the above tpfms Track
-      void embedTpfmsMuon();
-      /// embed reference to the above dyt Track
-      void embedDytMuon();
+    // add extra timing information
+    void readExtraTimerInfo(const reco::MuonTimeExtra& t);
 
-      // add extra timing information
-      void readExtraTimerInfo(const reco::MuonTimeExtra& t);
+    // ---- PF specific methods ----
+    /// reference to the source IsolatedPFCandidates
+    /// null if this has been built from a standard muon
+    reco::PFCandidateRef pfCandidateRef() const;
+    /// add a reference to the source IsolatedPFCandidate
+    void setPFCandidateRef(const reco::PFCandidateRef& ref) { pfCandidateRef_ = ref; }
+    /// embed the IsolatedPFCandidate pointed to by pfCandidateRef_
+    void embedPFCandidate();
+    /// get the number of non-null PF candidates
+    size_t numberOfSourceCandidatePtrs() const override {
+      size_t res = 0;
+      if (pfCandidateRef_.isNonnull())
+        res++;
+      if (refToOrig_.isNonnull())
+        res++;
+      return res;
+    }
+    /// get the candidate pointer with index i
+    reco::CandidatePtr sourceCandidatePtr(size_type i) const override;
 
-      // ---- PF specific methods ----
-      /// reference to the source IsolatedPFCandidates
-      /// null if this has been built from a standard muon
-      reco::PFCandidateRef pfCandidateRef() const;
-      /// add a reference to the source IsolatedPFCandidate
-      void setPFCandidateRef(const reco::PFCandidateRef& ref) {
-	pfCandidateRef_ = ref;
-      } 
-      /// embed the IsolatedPFCandidate pointed to by pfCandidateRef_
-      void embedPFCandidate();
-      /// get the number of non-null PF candidates
-      size_t numberOfSourceCandidatePtrs() const override { 
-	size_t res=0;
-        if(pfCandidateRef_.isNonnull()) res++;
-        if(refToOrig_.isNonnull()) res++;
-	return res;
-      }
-      /// get the candidate pointer with index i
-      reco::CandidatePtr sourceCandidatePtr( size_type i ) const override;
+    // ---- methods for accessing muon identification ----
+    /// accessor for the various muon id algorithms currently defined
+    /// in DataFormats/MuonReco/interface/MuonSelectors.h
+    /// e.g. bool result = patmuon.muonID("TMLastStationLoose")
+    bool muonID(const std::string& name) const;
+    /// wrapper for the muonID method to maintain backwards compatibility
+    /// with when the reco::Muon::isGood method existed
+    bool isGood(const std::string& name) const { return muonID(name); }
+    /// if muon id results are ever extracted from muon id value maps
+    /// then the isMuonIDAvailable method will be defined
+    //bool isMuonIDAvailable(const std::string& name) const;
 
-      // ---- methods for accessing muon identification ----
-      /// accessor for the various muon id algorithms currently defined
-      /// in DataFormats/MuonReco/interface/MuonSelectors.h
-      /// e.g. bool result = patmuon.muonID("TMLastStationLoose")
-      bool muonID (const std::string& name) const;
-      /// wrapper for the muonID method to maintain backwards compatibility
-      /// with when the reco::Muon::isGood method existed
-      bool isGood (const std::string& name) const { return muonID(name); }
-      /// if muon id results are ever extracted from muon id value maps
-      /// then the isMuonIDAvailable method will be defined
-      //bool isMuonIDAvailable(const std::string& name) const;
+    /// Muon Selectors as specified in
+    /// https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId
+    bool isTightMuon(const reco::Vertex&) const;
+    bool isLooseMuon() const;
+    bool isMediumMuon() const;
+    bool isSoftMuon(const reco::Vertex&) const;
+    bool isHighPtMuon(const reco::Vertex&) const;
 
-      /// Muon Selectors as specified in
-      /// https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId
-      bool isTightMuon(const reco::Vertex&) const;
-      bool isLooseMuon() const;
-      bool isMediumMuon() const;
-      bool isSoftMuon(const reco::Vertex&) const;
-      bool isHighPtMuon(const reco::Vertex&) const;
+    // ---- overload of isolation functions ----
+    /// Overload of pat::Lepton::trackIso(); returns the value of
+    /// the summed track pt in a cone of deltaR<0.3
+    float trackIso() const { return isolationR03().sumPt; }
+    /// Overload of pat::Lepton::trackIso(); returns the value of
+    /// the summed Et of all recHits in the ecal in a cone of
+    /// deltaR<0.3
+    float ecalIso() const { return isolationR03().emEt; }
+    /// Overload of pat::Lepton::trackIso(); returns the value of
+    /// the summed Et of all caloTowers in the hcal in a cone of
+    /// deltaR<0.4
+    float hcalIso() const { return isolationR03().hadEt; }
+    /// Overload of pat::Lepton::trackIso(); returns the sum of
+    /// ecalIso() and hcalIso
+    float caloIso() const { return ecalIso() + hcalIso(); }
 
-      // ---- overload of isolation functions ----
-      /// Overload of pat::Lepton::trackIso(); returns the value of
-      /// the summed track pt in a cone of deltaR<0.3
-      float trackIso() const { return isolationR03().sumPt; }
-      /// Overload of pat::Lepton::trackIso(); returns the value of 
-      /// the summed Et of all recHits in the ecal in a cone of 
-      /// deltaR<0.3
-      float ecalIso()  const { return isolationR03().emEt; }
-      /// Overload of pat::Lepton::trackIso(); returns the value of 
-      /// the summed Et of all caloTowers in the hcal in a cone of 
-      /// deltaR<0.4
-      float hcalIso()  const { return isolationR03().hadEt; }
-      /// Overload of pat::Lepton::trackIso(); returns the sum of 
-      /// ecalIso() and hcalIso
-      float caloIso()  const { return ecalIso()+hcalIso(); }
+    /// returns PUPPI isolations
+    float puppiChargedHadronIso() const { return puppiChargedHadronIso_; }
+    float puppiNeutralHadronIso() const { return puppiNeutralHadronIso_; }
+    float puppiPhotonIso() const { return puppiPhotonIso_; }
+    /// returns PUPPINoLeptons isolations
+    float puppiNoLeptonsChargedHadronIso() const { return puppiNoLeptonsChargedHadronIso_; }
+    float puppiNoLeptonsNeutralHadronIso() const { return puppiNoLeptonsNeutralHadronIso_; }
+    float puppiNoLeptonsPhotonIso() const { return puppiNoLeptonsPhotonIso_; }
+    /// sets PUPPI isolations
+    void setIsolationPUPPI(float chargedhadrons, float neutralhadrons, float photons) {
+      puppiChargedHadronIso_ = chargedhadrons;
+      puppiNeutralHadronIso_ = neutralhadrons;
+      puppiPhotonIso_ = photons;
+    }
+    /// sets PUPPINoLeptons isolations
+    void setIsolationPUPPINoLeptons(float chargedhadrons, float neutralhadrons, float photons) {
+      puppiNoLeptonsChargedHadronIso_ = chargedhadrons;
+      puppiNoLeptonsNeutralHadronIso_ = neutralhadrons;
+      puppiNoLeptonsPhotonIso_ = photons;
+    }
 
-      /// returns PUPPI isolations			
-      float puppiChargedHadronIso() const {return puppiChargedHadronIso_; }
-      float puppiNeutralHadronIso() const {return puppiNeutralHadronIso_; }
-      float puppiPhotonIso() const {return puppiPhotonIso_; }
-      /// returns PUPPINoLeptons isolations
-      float puppiNoLeptonsChargedHadronIso() const {return puppiNoLeptonsChargedHadronIso_; }
-      float puppiNoLeptonsNeutralHadronIso() const {return puppiNoLeptonsNeutralHadronIso_; }
-      float puppiNoLeptonsPhotonIso() const {return puppiNoLeptonsPhotonIso_; }
-      /// sets PUPPI isolations
-      void setIsolationPUPPI(float chargedhadrons, float neutralhadrons, float photons)
-      {  
-         puppiChargedHadronIso_ = chargedhadrons;
-         puppiNeutralHadronIso_ = neutralhadrons;
-         puppiPhotonIso_ = photons;
-      }
-      /// sets PUPPINoLeptons isolations
-      void setIsolationPUPPINoLeptons(float chargedhadrons, float neutralhadrons, float photons)
-      {  
-         puppiNoLeptonsChargedHadronIso_ = chargedhadrons;
-         puppiNoLeptonsNeutralHadronIso_ = neutralhadrons;
-         puppiNoLeptonsPhotonIso_ = photons;
-      }
-      
-      /// Muon High Level Selection
-      /// The user can choose to cache this info so they can drop the
-      /// global tracks. If the global track is present these should
-      /// not be set, but the "getters" will return the appropriate
-      /// value. The exception is dB which requires the beamline
-      //  as external input. 
-	
-	// ---- embed various impact parameters with errors ----
-	//
-	// example:
-	//
-	//    // this will return the muon inner track
-	//    // transverse impact parameter
-	//    // relative to the primary vertex
-	//    muon->dB(pat::Muon::PV2D);
-	//
-	//    // this will return the uncertainty
-	//    // on the muon inner track
-	//    // transverse impact parameter
-	//    // relative to the primary vertex
-	//    // or -1.0 if there is no valid PV in the event
-	//    muon->edB(pat::Muon::PV2D);
-	//
-	// IpType defines the type of the impact parameter
-	typedef enum IPTYPE 
-	  {
-	    PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, PVDZ = 4, IpTypeSize = 5
-	  } IpType; 
-	void initImpactParameters(void); // init IP defaults in a constructor
-	double dB(IPTYPE type) const;
-	double edB(IPTYPE type) const;
+    /// Muon High Level Selection
+    /// The user can choose to cache this info so they can drop the
+    /// global tracks. If the global track is present these should
+    /// not be set, but the "getters" will return the appropriate
+    /// value. The exception is dB which requires the beamline
+    //  as external input.
 
-        /// the version without arguments returns PD2D, but with an absolute value (for backwards compatibility)
-	double dB() const { return std::abs(dB(PV2D)); }
-        /// the version without arguments returns PD2D, but with an absolute value (for backwards compatibility)
-	double edB() const { return std::abs(edB(PV2D)); }
+    // ---- embed various impact parameters with errors ----
+    //
+    // example:
+    //
+    //    // this will return the muon inner track
+    //    // transverse impact parameter
+    //    // relative to the primary vertex
+    //    muon->dB(pat::Muon::PV2D);
+    //
+    //    // this will return the uncertainty
+    //    // on the muon inner track
+    //    // transverse impact parameter
+    //    // relative to the primary vertex
+    //    // or -1.0 if there is no valid PV in the event
+    //    muon->edB(pat::Muon::PV2D);
+    //
+    // IpType defines the type of the impact parameter
+    typedef enum IPTYPE { PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, PVDZ = 4, IpTypeSize = 5 } IpType;
+    void initImpactParameters(void);  // init IP defaults in a constructor
+    double dB(IPTYPE type) const;
+    double edB(IPTYPE type) const;
 
-	void   setDB ( double dB, double edB, IPTYPE type = PV2D ) { 
-	  ip_[type] = dB; eip_[type] = edB; cachedIP_ |= (1 << int(type));
-	}
+    /// the version without arguments returns PD2D, but with an absolute value (for backwards compatibility)
+    double dB() const { return std::abs(dB(PV2D)); }
+    /// the version without arguments returns PD2D, but with an absolute value (for backwards compatibility)
+    double edB() const { return std::abs(edB(PV2D)); }
 
-      /// numberOfValidHits returns the number of valid hits on the global track.
-      unsigned int numberOfValidHits() const;
-      void setNumberOfValidHits(unsigned int numberOfValidHits ) 
-      { numberOfValidHits_ = numberOfValidHits; cachedNumberOfValidHits_ = true; }
+    void setDB(double dB, double edB, IPTYPE type = PV2D) {
+      ip_[type] = dB;
+      eip_[type] = edB;
+      cachedIP_ |= (1 << int(type));
+    }
 
-      /// Norm chi2 gives the normalized chi2 of the global track. 
-      double normChi2() const;
-      void setNormChi2 (double normChi2 ) 
-      { normChi2_ = normChi2; cachedNormChi2_ = true; }
+    /// numberOfValidHits returns the number of valid hits on the global track.
+    unsigned int numberOfValidHits() const;
+    void setNumberOfValidHits(unsigned int numberOfValidHits) {
+      numberOfValidHits_ = numberOfValidHits;
+      cachedNumberOfValidHits_ = true;
+    }
 
-      /// Returns the segment compatibility, using muon::segmentCompatibility (DataFormats/MuonReco/interface/MuonSelectors.h)
-      double segmentCompatibility(reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration) const ;
+    /// Norm chi2 gives the normalized chi2 of the global track.
+    double normChi2() const;
+    void setNormChi2(double normChi2) {
+      normChi2_ = normChi2;
+      cachedNormChi2_ = true;
+    }
 
-      /// pipe operator (introduced to use pat::Muon with PFTopProjectors)
-      friend std::ostream& reco::operator<<(std::ostream& out, const pat::Muon& obj);
+    /// Returns the segment compatibility, using muon::segmentCompatibility (DataFormats/MuonReco/interface/MuonSelectors.h)
+    double segmentCompatibility(
+        reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration) const;
 
-      friend class PATMuonSlimmer;
+    /// pipe operator (introduced to use pat::Muon with PFTopProjectors)
+    friend std::ostream& reco::operator<<(std::ostream& out, const pat::Muon& obj);
 
-      float pfEcalEnergy() const { return pfEcalEnergy_; }
-      void setPfEcalEnergy(float pfEcalEnergy) { pfEcalEnergy_ = pfEcalEnergy; }
+    friend class PATMuonSlimmer;
 
-      /// near-by jet information
-      float jetPtRatio() const { return jetPtRatio_; }
-      float jetPtRel()   const { return jetPtRel_; }
-      void  setJetPtRatio(float jetPtRatio){ jetPtRatio_ = jetPtRatio; }
-      void  setJetPtRel(float jetPtRel){ jetPtRel_ = jetPtRel; }
+    float pfEcalEnergy() const { return pfEcalEnergy_; }
+    void setPfEcalEnergy(float pfEcalEnergy) { pfEcalEnergy_ = pfEcalEnergy; }
 
-      /// Muon MVA
-      float mvaValue() const { return mvaValue_; }
-      void  setMvaValue(float mva){ mvaValue_ = mva; }
+    /// near-by jet information
+    float jetPtRatio() const { return jetPtRatio_; }
+    float jetPtRel() const { return jetPtRel_; }
+    void setJetPtRatio(float jetPtRatio) { jetPtRatio_ = jetPtRatio; }
+    void setJetPtRel(float jetPtRel) { jetPtRel_ = jetPtRel; }
 
-      // Low pt Muon MVA
-      float lowptMvaValue() const { return lowptMvaValue_; }
-      void  setLowPtMvaValue(float lowptmva){ lowptMvaValue_ = lowptmva; }
+    /// Muon MVA
+    float mvaValue() const { return mvaValue_; }
+    void setMvaValue(float mva) { mvaValue_ = mva; }
 
+    // Low pt Muon MVA
+    float lowptMvaValue() const { return lowptMvaValue_; }
+    void setLowPtMvaValue(float lowptmva) { lowptMvaValue_ = lowptmva; }
 
-      /// Soft Muon MVA
-      float softMvaValue() const { return softMvaValue_; }
-      void  setSoftMvaValue(float softmva){ softMvaValue_ = softmva; }
+    /// Soft Muon MVA
+    float softMvaValue() const { return softMvaValue_; }
+    void setSoftMvaValue(float softmva) { softMvaValue_ = softmva; }
 
-      /// Inverse beta
-      void setInverseBeta(const float iBeta) { inverseBeta_ = iBeta; };
-      void setInverseBetaErr(const float iBetaErr) { inverseBetaErr_ = iBetaErr; };
-      float inverseBeta() const { return inverseBeta_; };
-      float inverseBetaErr() const { return inverseBetaErr_; };
+    /// Inverse beta
+    void setInverseBeta(const float iBeta) { inverseBeta_ = iBeta; };
+    void setInverseBetaErr(const float iBetaErr) { inverseBetaErr_ = iBetaErr; };
+    float inverseBeta() const { return inverseBeta_; };
+    float inverseBetaErr() const { return inverseBetaErr_; };
 
-      /// MC matching information
-      reco::MuonSimType simType() const { return simType_; }
-      reco::ExtendedMuonSimType simExtType() const { return simExtType_; }
-      //  FLAVOUR:
-      //  - for non-muons: 0
-      //  - for primary muons: 13
-      //  - for non primary muons: flavour of the mother: std::abs(pdgId) of heaviest quark, or 15 for tau
-      int simFlavour() const { return simFlavour_;}
-      int simHeaviestMotherFlavour() const { return simHeaviestMotherFlavour_;}
-      int simPdgId() const { return simPdgId_;}
-      int simMotherPdgId() const { return simMotherPdgId_;}
-      int simBX() const { return simBX_;}
-      int simTpEvent() const {   return simTpEvent_;}
-      float simProdRho() const { return simProdRho_;}
-      float simProdZ() const {   return simProdZ_;}
-      float simPt() const {      return simPt_;}
-      float simEta() const {     return simEta_;}
-      float simPhi() const {     return simPhi_;}
-      float simMatchQuality() const {     return simMatchQuality_;}
+    /// MC matching information
+    reco::MuonSimType simType() const { return simType_; }
+    reco::ExtendedMuonSimType simExtType() const { return simExtType_; }
+    //  FLAVOUR:
+    //  - for non-muons: 0
+    //  - for primary muons: 13
+    //  - for non primary muons: flavour of the mother: std::abs(pdgId) of heaviest quark, or 15 for tau
+    int simFlavour() const { return simFlavour_; }
+    int simHeaviestMotherFlavour() const { return simHeaviestMotherFlavour_; }
+    int simPdgId() const { return simPdgId_; }
+    int simMotherPdgId() const { return simMotherPdgId_; }
+    int simBX() const { return simBX_; }
+    int simTpEvent() const { return simTpEvent_; }
+    float simProdRho() const { return simProdRho_; }
+    float simProdZ() const { return simProdZ_; }
+    float simPt() const { return simPt_; }
+    float simEta() const { return simEta_; }
+    float simPhi() const { return simPhi_; }
+    float simMatchQuality() const { return simMatchQuality_; }
 
-      void initSimInfo(void); 
-      void setSimType(reco::MuonSimType type){ simType_ = type; }
-      void setExtSimType(reco::ExtendedMuonSimType type){ simExtType_ = type; }
-      void setSimFlavour(int f){ simFlavour_ = f;}
-      void setSimHeaviestMotherFlavour(int id){ simHeaviestMotherFlavour_ = id;}
-      void setSimPdgId(int id){ simPdgId_ = id;}
-      void setSimMotherPdgId(int id){ simMotherPdgId_ = id;}
-      void setSimBX(int bx){ simBX_ = bx;}
-      void setSimTpEvent(int tpEvent){ simTpEvent_ = tpEvent;}
-      void setSimProdRho(float rho){ simProdRho_ = rho;}
-      void setSimProdZ(float z){ simProdZ_ = z;}
-      void setSimPt(float pt){ simPt_ = pt;}
-      void setSimEta(float eta){ simEta_ = eta;}
-      void setSimPhi(float phi){ simPhi_ = phi;}
-      void setSimMatchQuality(float quality){ simMatchQuality_ = quality;}
+    void initSimInfo(void);
+    void setSimType(reco::MuonSimType type) { simType_ = type; }
+    void setExtSimType(reco::ExtendedMuonSimType type) { simExtType_ = type; }
+    void setSimFlavour(int f) { simFlavour_ = f; }
+    void setSimHeaviestMotherFlavour(int id) { simHeaviestMotherFlavour_ = id; }
+    void setSimPdgId(int id) { simPdgId_ = id; }
+    void setSimMotherPdgId(int id) { simMotherPdgId_ = id; }
+    void setSimBX(int bx) { simBX_ = bx; }
+    void setSimTpEvent(int tpEvent) { simTpEvent_ = tpEvent; }
+    void setSimProdRho(float rho) { simProdRho_ = rho; }
+    void setSimProdZ(float z) { simProdZ_ = z; }
+    void setSimPt(float pt) { simPt_ = pt; }
+    void setSimEta(float eta) { simEta_ = eta; }
+    void setSimPhi(float phi) { simPhi_ = phi; }
+    void setSimMatchQuality(float quality) { simMatchQuality_ = quality; }
 
-      /// Trigger information
-      const pat::TriggerObjectStandAlone* l1Object(const size_t idx=0)  const { 
-	return triggerObjectMatchByType(trigger::TriggerL1Mu,idx);
-      }
-      const pat::TriggerObjectStandAlone* hltObject(const size_t idx=0)  const { 
-	return triggerObjectMatchByType(trigger::TriggerMuon,idx);
-      }
-      bool triggered( const char * pathName ) const {
-	return triggerObjectMatchByPath(pathName,true,true)!=nullptr;
-      }
+    /// Trigger information
+    const pat::TriggerObjectStandAlone* l1Object(const size_t idx = 0) const {
+      return triggerObjectMatchByType(trigger::TriggerL1Mu, idx);
+    }
+    const pat::TriggerObjectStandAlone* hltObject(const size_t idx = 0) const {
+      return triggerObjectMatchByType(trigger::TriggerMuon, idx);
+    }
+    bool triggered(const char* pathName) const { return triggerObjectMatchByPath(pathName, true, true) != nullptr; }
 
-    protected:
+  protected:
+    // ---- for content embedding ----
 
-      // ---- for content embedding ----
+    /// best muon track (global pflow)
+    bool embeddedMuonBestTrack_;
+    std::vector<reco::Track> muonBestTrack_;
+    /// best muon track (muon only)
+    bool embeddedTunePMuonBestTrack_;
+    std::vector<reco::Track> tunePMuonBestTrack_;
+    /// track of inner track detector
+    bool embeddedTrack_;
+    std::vector<reco::Track> track_;
+    /// track of muon system
+    bool embeddedStandAloneMuon_;
+    std::vector<reco::Track> standAloneMuon_;
+    /// track of combined fit
+    bool embeddedCombinedMuon_;
+    std::vector<reco::Track> combinedMuon_;
 
-      /// best muon track (global pflow)
-      bool embeddedMuonBestTrack_;
-      std::vector<reco::Track> muonBestTrack_;
-      /// best muon track (muon only)
-      bool embeddedTunePMuonBestTrack_;
-      std::vector<reco::Track> tunePMuonBestTrack_;
-      /// track of inner track detector
-      bool embeddedTrack_;
-      std::vector<reco::Track> track_;
-      /// track of muon system
-      bool embeddedStandAloneMuon_;
-      std::vector<reco::Track> standAloneMuon_;
-      /// track of combined fit
-      bool embeddedCombinedMuon_;
-      std::vector<reco::Track> combinedMuon_;
+    /// muon MET corrections for tcMET
+    bool embeddedTCMETMuonCorrs_;
+    std::vector<reco::MuonMETCorrectionData> tcMETMuonCorrs_;
+    /// muon MET corrections for caloMET
+    bool embeddedCaloMETMuonCorrs_;
+    std::vector<reco::MuonMETCorrectionData> caloMETMuonCorrs_;
 
-      /// muon MET corrections for tcMET
-      bool embeddedTCMETMuonCorrs_;
-      std::vector<reco::MuonMETCorrectionData> tcMETMuonCorrs_;
-      /// muon MET corrections for caloMET
-      bool embeddedCaloMETMuonCorrs_;
-      std::vector<reco::MuonMETCorrectionData> caloMETMuonCorrs_;
+    // Capability to embed TeV refit tracks as the inner/outer/combined ones.
+    bool embeddedPickyMuon_;
+    bool embeddedTpfmsMuon_;
+    bool embeddedDytMuon_;
+    std::vector<reco::Track> pickyMuon_;
+    std::vector<reco::Track> tpfmsMuon_;
+    std::vector<reco::Track> dytMuon_;
 
-      // Capability to embed TeV refit tracks as the inner/outer/combined ones.
-      bool embeddedPickyMuon_;
-      bool embeddedTpfmsMuon_;
-      bool embeddedDytMuon_;
-      std::vector<reco::Track> pickyMuon_;
-      std::vector<reco::Track> tpfmsMuon_;
-      std::vector<reco::Track> dytMuon_;
+    // ---- PF specific members ----
+    /// true if the IsolatedPFCandidate is embedded
+    bool embeddedPFCandidate_;
+    /// if embeddedPFCandidate_, a copy of the source IsolatedPFCandidate
+    /// is stored in this vector
+    reco::PFCandidateCollection pfCandidate_;
+    /// reference to the IsolatedPFCandidate this has been built from
+    /// null if this has been built from a standard muon
+    reco::PFCandidateRef pfCandidateRef_;
 
-      // ---- PF specific members ----
-      /// true if the IsolatedPFCandidate is embedded
-      bool embeddedPFCandidate_;      
-      /// if embeddedPFCandidate_, a copy of the source IsolatedPFCandidate
-      /// is stored in this vector
-      reco::PFCandidateCollection pfCandidate_;
-      /// reference to the IsolatedPFCandidate this has been built from
-      /// null if this has been built from a standard muon
-      reco::PFCandidateRef pfCandidateRef_;
+    // V+Jets group selection variables.
+    bool cachedNormChi2_;  /// has the normalized chi2 been cached?
+    double normChi2_;      /// globalTrack->chi2() / globalTrack->ndof()
 
-      // V+Jets group selection variables. 
-      bool    cachedNormChi2_;         /// has the normalized chi2 been cached?
-      double  normChi2_;               /// globalTrack->chi2() / globalTrack->ndof()
+    bool cachedNumberOfValidHits_;    /// has the numberOfValidHits been cached?
+    unsigned int numberOfValidHits_;  /// globalTrack->numberOfValidHits()
 
-      bool    cachedNumberOfValidHits_;/// has the numberOfValidHits been cached?
-      unsigned int  numberOfValidHits_;/// globalTrack->numberOfValidHits()
+    // ---- cached impact parameters ----
+    uint8_t cachedIP_;       // has the IP (former dB) been cached?
+    float ip_[IpTypeSize];   // dB and edB are the impact parameter at the primary vertex,
+    float eip_[IpTypeSize];  // and its uncertainty as recommended by the tracking group
 
-      // ---- cached impact parameters ----
-      uint8_t  cachedIP_;  // has the IP (former dB) been cached?
-      float  ip_[IpTypeSize];        // dB and edB are the impact parameter at the primary vertex,
-      float  eip_[IpTypeSize];       // and its uncertainty as recommended by the tracking group
+    /// PUPPI isolations
+    float puppiChargedHadronIso_;
+    float puppiNeutralHadronIso_;
+    float puppiPhotonIso_;
+    /// PUPPINoLeptons isolations
+    float puppiNoLeptonsChargedHadronIso_;
+    float puppiNoLeptonsNeutralHadronIso_;
+    float puppiNoLeptonsPhotonIso_;
 
-      /// PUPPI isolations
-      float puppiChargedHadronIso_;
-      float puppiNeutralHadronIso_;
-      float puppiPhotonIso_;
-      /// PUPPINoLeptons isolations
-      float puppiNoLeptonsChargedHadronIso_;
-      float puppiNoLeptonsNeutralHadronIso_;
-      float puppiNoLeptonsPhotonIso_;
+    float pfEcalEnergy_;
 
-      float pfEcalEnergy_;
+    /// near-by jet information
+    float jetPtRatio_;
+    float jetPtRel_;
 
-      /// near-by jet information
-      float jetPtRatio_;
-      float jetPtRel_;
+    /// Muon MVA
+    float mvaValue_;
+    float lowptMvaValue_;
+    float softMvaValue_;
 
-      /// Muon MVA
-      float mvaValue_;
-      float lowptMvaValue_;
-      float softMvaValue_;
-      
-      /// Inverse beta
-      float inverseBeta_;
-      float inverseBetaErr_;
+    /// Inverse beta
+    float inverseBeta_;
+    float inverseBetaErr_;
 
-      /// MC matching information
-      reco::MuonSimType simType_;
-      reco::ExtendedMuonSimType simExtType_;
-      int simFlavour_;
-      int simHeaviestMotherFlavour_;
-      int simPdgId_;
-      int simMotherPdgId_;
-      int simBX_;
-      int simTpEvent_;
-      float simProdRho_;
-      float simProdZ_;
-      float simPt_;
-      float simEta_;
-      float simPhi_;
-      float simMatchQuality_;
+    /// MC matching information
+    reco::MuonSimType simType_;
+    reco::ExtendedMuonSimType simExtType_;
+    int simFlavour_;
+    int simHeaviestMotherFlavour_;
+    int simPdgId_;
+    int simMotherPdgId_;
+    int simBX_;
+    int simTpEvent_;
+    float simProdRho_;
+    float simProdZ_;
+    float simPt_;
+    float simEta_;
+    float simPhi_;
+    float simMatchQuality_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -129,7 +129,9 @@ namespace pat {
     void embedDytMuon();
 
     // add extra timing information
-    void readExtraTimerInfo(const reco::MuonTimeExtra& t);
+    /// 1/beta for prompt particle hypothesis
+    /// (time is constraint to the bunch crossing time)
+    void readTimeExtra(const reco::MuonTimeExtra& t);
 
     // ---- PF specific methods ----
     /// reference to the source IsolatedPFCandidates
@@ -293,10 +295,8 @@ namespace pat {
     void setSoftMvaValue(float softmva) { softMvaValue_ = softmva; }
 
     /// Inverse beta
-    void setInverseBeta(const float iBeta) { inverseBeta_ = iBeta; };
-    void setInverseBetaErr(const float iBetaErr) { inverseBetaErr_ = iBetaErr; };
-    float inverseBeta() const { return inverseBeta_; };
-    float inverseBetaErr() const { return inverseBetaErr_; };
+    float inverseBeta() const { return inverseBeta_; }
+    float inverseBetaErr() const { return inverseBetaErr_; }
 
     /// MC matching information
     reco::MuonSimType simType() const { return simType_; }

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -95,7 +95,9 @@ Muon::Muon(const edm::RefToBase<reco::Muon>& aMuonRef)
       jetPtRel_(0),
       mvaValue_(0),
       lowptMvaValue_(0),
-      softMvaValue_(0) {
+      softMvaValue_(0),
+      inverseBeta_(0),
+      inverseBetaErr_(0) {
   initImpactParameters();
   initSimInfo();
 }
@@ -124,7 +126,9 @@ Muon::Muon(const edm::Ptr<reco::Muon>& aMuonRef)
       jetPtRel_(0),
       mvaValue_(0),
       lowptMvaValue_(0),
-      softMvaValue_(0) {
+      softMvaValue_(0),
+      inverseBeta_(0),
+      inverseBetaErr_(0) {
   initImpactParameters();
   initSimInfo();
 }

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -421,11 +421,10 @@ void Muon::embedDytMuon() {
 }
 
 /// Add extra timing information
-void Muon::readExtraTimerInfo(const reco::MuonTimeExtra& t){
-  inverseBeta_    = t.inverseBeta();
+void Muon::readExtraTimerInfo(const reco::MuonTimeExtra& t) {
+  inverseBeta_ = t.inverseBeta();
   inverseBetaErr_ = t.inverseBetaErr();
 }
-
 
 /// embed the IsolatedPFCandidate pointed to by pfCandidateRef_
 void Muon::embedPFCandidate() {

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -421,7 +421,7 @@ void Muon::embedDytMuon() {
 }
 
 /// Add extra timing information
-void Muon::readExtraTimerInfo(const reco::MuonTimeExtra& t) {
+void Muon::readTimeExtra(const reco::MuonTimeExtra& t) {
   inverseBeta_ = t.inverseBeta();
   inverseBetaErr_ = t.inverseBetaErr();
 }

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -9,152 +9,145 @@
 
 using namespace pat;
 
-
 /// default constructor
-Muon::Muon() :
-    Lepton<reco::Muon>(),
-    embeddedMuonBestTrack_(false),
-    embeddedTunePMuonBestTrack_(false),
-    embeddedTrack_(false),
-    embeddedStandAloneMuon_(false),
-    embeddedCombinedMuon_(false),
-    embeddedTCMETMuonCorrs_(false),
-    embeddedCaloMETMuonCorrs_(false),
-    embeddedPickyMuon_(false),
-    embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
-    embeddedPFCandidate_(false),
-    pfCandidateRef_(),
-    cachedNormChi2_(false),
-    normChi2_(0.0),
-    cachedNumberOfValidHits_(false),
-    numberOfValidHits_(0),
-    pfEcalEnergy_(0),
-    jetPtRatio_(0),
-    jetPtRel_(0),
-    mvaValue_(0),
-    lowptMvaValue_(0),
-    softMvaValue_(0)
-{
+Muon::Muon()
+    : Lepton<reco::Muon>(),
+      embeddedMuonBestTrack_(false),
+      embeddedTunePMuonBestTrack_(false),
+      embeddedTrack_(false),
+      embeddedStandAloneMuon_(false),
+      embeddedCombinedMuon_(false),
+      embeddedTCMETMuonCorrs_(false),
+      embeddedCaloMETMuonCorrs_(false),
+      embeddedPickyMuon_(false),
+      embeddedTpfmsMuon_(false),
+      embeddedDytMuon_(false),
+      embeddedPFCandidate_(false),
+      pfCandidateRef_(),
+      cachedNormChi2_(false),
+      normChi2_(0.0),
+      cachedNumberOfValidHits_(false),
+      numberOfValidHits_(0),
+      pfEcalEnergy_(0),
+      jetPtRatio_(0),
+      jetPtRel_(0),
+      mvaValue_(0),
+      lowptMvaValue_(0),
+      softMvaValue_(0),
+      inverseBeta_(0),
+      inverseBetaErr_(0) {
   initImpactParameters();
   initSimInfo();
 }
 
 /// constructor from reco::Muon
-Muon::Muon(const reco::Muon & aMuon) :
-    Lepton<reco::Muon>(aMuon),
-    embeddedMuonBestTrack_(false),
-    embeddedTunePMuonBestTrack_(false),
-    embeddedTrack_(false),
-    embeddedStandAloneMuon_(false),
-    embeddedCombinedMuon_(false),
-    embeddedTCMETMuonCorrs_(false),
-    embeddedCaloMETMuonCorrs_(false),
-    embeddedPickyMuon_(false),
-    embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
-    embeddedPFCandidate_(false),
-    pfCandidateRef_(),
-    cachedNormChi2_(false),
-    normChi2_(0.0),
-    cachedNumberOfValidHits_(false),
-    numberOfValidHits_(0),
-    pfEcalEnergy_(0),
-    jetPtRatio_(0),
-    jetPtRel_(0),
-    mvaValue_(0),
-    lowptMvaValue_(0),
-    softMvaValue_(0)
-{
+Muon::Muon(const reco::Muon& aMuon)
+    : Lepton<reco::Muon>(aMuon),
+      embeddedMuonBestTrack_(false),
+      embeddedTunePMuonBestTrack_(false),
+      embeddedTrack_(false),
+      embeddedStandAloneMuon_(false),
+      embeddedCombinedMuon_(false),
+      embeddedTCMETMuonCorrs_(false),
+      embeddedCaloMETMuonCorrs_(false),
+      embeddedPickyMuon_(false),
+      embeddedTpfmsMuon_(false),
+      embeddedDytMuon_(false),
+      embeddedPFCandidate_(false),
+      pfCandidateRef_(),
+      cachedNormChi2_(false),
+      normChi2_(0.0),
+      cachedNumberOfValidHits_(false),
+      numberOfValidHits_(0),
+      pfEcalEnergy_(0),
+      jetPtRatio_(0),
+      jetPtRel_(0),
+      mvaValue_(0),
+      lowptMvaValue_(0),
+      softMvaValue_(0),
+      inverseBeta_(0),
+      inverseBetaErr_(0) {
   initImpactParameters();
   initSimInfo();
 }
 
 /// constructor from ref to reco::Muon
-Muon::Muon(const edm::RefToBase<reco::Muon> & aMuonRef) :
-    Lepton<reco::Muon>(aMuonRef),
-    embeddedMuonBestTrack_(false),
-    embeddedTunePMuonBestTrack_(false),
-    embeddedTrack_(false),
-    embeddedStandAloneMuon_(false),
-    embeddedCombinedMuon_(false),
-    embeddedTCMETMuonCorrs_(false),
-    embeddedCaloMETMuonCorrs_(false),
-    embeddedPickyMuon_(false),
-    embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
-    embeddedPFCandidate_(false),
-    pfCandidateRef_(),
-    cachedNormChi2_(false),
-    normChi2_(0.0),
-    cachedNumberOfValidHits_(false),
-    numberOfValidHits_(0),
-    pfEcalEnergy_(0),
-    jetPtRatio_(0),
-    jetPtRel_(0),
-    mvaValue_(0),
-    lowptMvaValue_(0),
-    softMvaValue_(0)
-{
+Muon::Muon(const edm::RefToBase<reco::Muon>& aMuonRef)
+    : Lepton<reco::Muon>(aMuonRef),
+      embeddedMuonBestTrack_(false),
+      embeddedTunePMuonBestTrack_(false),
+      embeddedTrack_(false),
+      embeddedStandAloneMuon_(false),
+      embeddedCombinedMuon_(false),
+      embeddedTCMETMuonCorrs_(false),
+      embeddedCaloMETMuonCorrs_(false),
+      embeddedPickyMuon_(false),
+      embeddedTpfmsMuon_(false),
+      embeddedDytMuon_(false),
+      embeddedPFCandidate_(false),
+      pfCandidateRef_(),
+      cachedNormChi2_(false),
+      normChi2_(0.0),
+      cachedNumberOfValidHits_(false),
+      numberOfValidHits_(0),
+      pfEcalEnergy_(0),
+      jetPtRatio_(0),
+      jetPtRel_(0),
+      mvaValue_(0),
+      lowptMvaValue_(0),
+      softMvaValue_(0) {
   initImpactParameters();
   initSimInfo();
 }
 
 /// constructor from ref to reco::Muon
-Muon::Muon(const edm::Ptr<reco::Muon> & aMuonRef) :
-    Lepton<reco::Muon>(aMuonRef),
-    embeddedMuonBestTrack_(false),
-    embeddedTunePMuonBestTrack_(false),
-    embeddedTrack_(false),
-    embeddedStandAloneMuon_(false),
-    embeddedCombinedMuon_(false),
-    embeddedTCMETMuonCorrs_(false),
-    embeddedCaloMETMuonCorrs_(false),
-    embeddedPickyMuon_(false),
-    embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
-    embeddedPFCandidate_(false),
-    pfCandidateRef_(),
-    cachedNormChi2_(false),
-    normChi2_(0.0),
-    cachedNumberOfValidHits_(false),
-    numberOfValidHits_(0),
-    pfEcalEnergy_(0),
-    jetPtRatio_(0),
-    jetPtRel_(0),
-    mvaValue_(0),
-    lowptMvaValue_(0),
-    softMvaValue_(0)
-{
+Muon::Muon(const edm::Ptr<reco::Muon>& aMuonRef)
+    : Lepton<reco::Muon>(aMuonRef),
+      embeddedMuonBestTrack_(false),
+      embeddedTunePMuonBestTrack_(false),
+      embeddedTrack_(false),
+      embeddedStandAloneMuon_(false),
+      embeddedCombinedMuon_(false),
+      embeddedTCMETMuonCorrs_(false),
+      embeddedCaloMETMuonCorrs_(false),
+      embeddedPickyMuon_(false),
+      embeddedTpfmsMuon_(false),
+      embeddedDytMuon_(false),
+      embeddedPFCandidate_(false),
+      pfCandidateRef_(),
+      cachedNormChi2_(false),
+      normChi2_(0.0),
+      cachedNumberOfValidHits_(false),
+      numberOfValidHits_(0),
+      pfEcalEnergy_(0),
+      jetPtRatio_(0),
+      jetPtRel_(0),
+      mvaValue_(0),
+      lowptMvaValue_(0),
+      softMvaValue_(0) {
   initImpactParameters();
   initSimInfo();
 }
 
 /// destructor
-Muon::~Muon() {
-}
+Muon::~Muon() {}
 
-std::ostream& 
-reco::operator<<(std::ostream& out, const pat::Muon& obj) 
-{
-  if(!out) return out;
-  
+std::ostream& reco::operator<<(std::ostream& out, const pat::Muon& obj) {
+  if (!out)
+    return out;
+
   out << "\tpat::Muon: ";
   out << std::setiosflags(std::ios::right);
   out << std::setiosflags(std::ios::fixed);
   out << std::setprecision(3);
-  out << " E/pT/eta/phi " 
-      << obj.energy()<<"/"
-      << obj.pt()<<"/"
-      << obj.eta()<<"/"
-      << obj.phi();
-  return out; 
+  out << " E/pT/eta/phi " << obj.energy() << "/" << obj.pt() << "/" << obj.eta() << "/" << obj.phi();
+  return out;
 }
 
 // initialize impact parameter container vars
 void Muon::initImpactParameters() {
-  std::fill(ip_, ip_+IpTypeSize, 0.0f);
-  std::fill(eip_, eip_+IpTypeSize, 0.0f);
+  std::fill(ip_, ip_ + IpTypeSize, 0.0f);
+  std::fill(eip_, eip_ + IpTypeSize, 0.0f);
   cachedIP_ = 0;
 }
 
@@ -174,7 +167,6 @@ void Muon::initSimInfo() {
   simPhi_ = 0.0;
 }
 
-
 /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
 reco::TrackRef Muon::track() const {
   if (embeddedTrack_) {
@@ -184,7 +176,6 @@ reco::TrackRef Muon::track() const {
   }
 }
 
-
 /// reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
 reco::TrackRef Muon::standAloneMuon() const {
   if (embeddedStandAloneMuon_) {
@@ -193,7 +184,6 @@ reco::TrackRef Muon::standAloneMuon() const {
     return reco::Muon::outerTrack();
   }
 }
-
 
 /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
 reco::TrackRef Muon::combinedMuon() const {
@@ -231,7 +221,7 @@ reco::TrackRef Muon::dytTrack() const {
   }
 }
 
-/// reference to Track giving best momentum (global PFlow algo) 
+/// reference to Track giving best momentum (global PFlow algo)
 reco::TrackRef Muon::muonBestTrack() const {
   if (!muonBestTrack_.empty()) {
     return reco::TrackRef(&muonBestTrack_, 0);
@@ -240,7 +230,7 @@ reco::TrackRef Muon::muonBestTrack() const {
   }
 }
 
-/// reference to Track giving best momentum (muon only) 
+/// reference to Track giving best momentum (muon only)
 reco::TrackRef Muon::tunePMuonBestTrack() const {
   if (!tunePMuonBestTrack_.empty()) {
     return reco::TrackRef(&tunePMuonBestTrack_, 0);
@@ -250,9 +240,6 @@ reco::TrackRef Muon::tunePMuonBestTrack() const {
     return reco::Muon::tunePMuonBestTrack();
   }
 }
-
-
-
 
 /// reference to the source IsolatedPFCandidates
 reco::PFCandidateRef Muon::pfCandidateRef() const {
@@ -264,10 +251,13 @@ reco::PFCandidateRef Muon::pfCandidateRef() const {
 }
 
 /// reference to the parent PF candidate for use in TopProjector
-reco::CandidatePtr Muon::sourceCandidatePtr( size_type i ) const {
-  if(pfCandidateRef_.isNonnull() && i==0 ) return reco::CandidatePtr(edm::refToPtr(pfCandidateRef_) );
-  if(refToOrig_.isNonnull() &&  pfCandidateRef_.isNonnull() && i==1 ) return refToOrig_;
-  if(refToOrig_.isNonnull() && ! pfCandidateRef_.isNonnull() && i==0 ) return refToOrig_;
+reco::CandidatePtr Muon::sourceCandidatePtr(size_type i) const {
+  if (pfCandidateRef_.isNonnull() && i == 0)
+    return reco::CandidatePtr(edm::refToPtr(pfCandidateRef_));
+  if (refToOrig_.isNonnull() && pfCandidateRef_.isNonnull() && i == 1)
+    return refToOrig_;
+  if (refToOrig_.isNonnull() && !pfCandidateRef_.isNonnull() && i == 0)
+    return refToOrig_;
   return reco::CandidatePtr();
 }
 
@@ -277,19 +267,39 @@ void Muon::embedMuonBestTrack(bool force) {
   embeddedMuonBestTrack_ = false;
   bool alreadyEmbedded = false;
   if (!force) {
-      switch (muonBestTrackType()) {
-        case None: alreadyEmbedded = true; break;
-        case InnerTrack: if (embeddedTrack_) alreadyEmbedded = true; break;
-        case OuterTrack: if (embeddedStandAloneMuon_) alreadyEmbedded = true; break;
-        case CombinedTrack: if (embeddedCombinedMuon_) alreadyEmbedded = true; break;
-        case TPFMS: if (embeddedTpfmsMuon_) alreadyEmbedded = true; break;
-        case Picky: if (embeddedPickyMuon_) alreadyEmbedded = true; break;
-        case DYT: if (embeddedDytMuon_) alreadyEmbedded = true; break;
-      }
+    switch (muonBestTrackType()) {
+      case None:
+        alreadyEmbedded = true;
+        break;
+      case InnerTrack:
+        if (embeddedTrack_)
+          alreadyEmbedded = true;
+        break;
+      case OuterTrack:
+        if (embeddedStandAloneMuon_)
+          alreadyEmbedded = true;
+        break;
+      case CombinedTrack:
+        if (embeddedCombinedMuon_)
+          alreadyEmbedded = true;
+        break;
+      case TPFMS:
+        if (embeddedTpfmsMuon_)
+          alreadyEmbedded = true;
+        break;
+      case Picky:
+        if (embeddedPickyMuon_)
+          alreadyEmbedded = true;
+        break;
+      case DYT:
+        if (embeddedDytMuon_)
+          alreadyEmbedded = true;
+        break;
+    }
   }
   if (force || !alreadyEmbedded) {
-      muonBestTrack_.push_back(*reco::Muon::muonBestTrack());
-      embeddedMuonBestTrack_ = true;
+    muonBestTrack_.push_back(*reco::Muon::muonBestTrack());
+    embeddedMuonBestTrack_ = true;
   }
 }
 
@@ -299,52 +309,70 @@ void Muon::embedTunePMuonBestTrack(bool force) {
   bool alreadyEmbedded = false;
   embeddedTunePMuonBestTrack_ = false;
   if (!force) {
-      switch (tunePMuonBestTrackType()) {
-          case None: alreadyEmbedded = true; break;
-          case InnerTrack: if (embeddedTrack_) alreadyEmbedded = true; break;
-          case OuterTrack: if (embeddedStandAloneMuon_) alreadyEmbedded = true; break;
-          case CombinedTrack: if (embeddedCombinedMuon_) alreadyEmbedded = true; break;
-          case TPFMS: if (embeddedTpfmsMuon_) alreadyEmbedded = true; break;
-          case Picky: if (embeddedPickyMuon_) alreadyEmbedded = true; break;
-          case DYT: if (embeddedDytMuon_) alreadyEmbedded = true; break;
-      }
-      if (muonBestTrackType() == tunePMuonBestTrackType()) {
-          if (embeddedMuonBestTrack_) alreadyEmbedded = true;
-      }
+    switch (tunePMuonBestTrackType()) {
+      case None:
+        alreadyEmbedded = true;
+        break;
+      case InnerTrack:
+        if (embeddedTrack_)
+          alreadyEmbedded = true;
+        break;
+      case OuterTrack:
+        if (embeddedStandAloneMuon_)
+          alreadyEmbedded = true;
+        break;
+      case CombinedTrack:
+        if (embeddedCombinedMuon_)
+          alreadyEmbedded = true;
+        break;
+      case TPFMS:
+        if (embeddedTpfmsMuon_)
+          alreadyEmbedded = true;
+        break;
+      case Picky:
+        if (embeddedPickyMuon_)
+          alreadyEmbedded = true;
+        break;
+      case DYT:
+        if (embeddedDytMuon_)
+          alreadyEmbedded = true;
+        break;
+    }
+    if (muonBestTrackType() == tunePMuonBestTrackType()) {
+      if (embeddedMuonBestTrack_)
+        alreadyEmbedded = true;
+    }
   }
   if (force || !alreadyEmbedded) {
-      tunePMuonBestTrack_.push_back(*reco::Muon::tunePMuonBestTrack());
-      embeddedTunePMuonBestTrack_ = true;
+    tunePMuonBestTrack_.push_back(*reco::Muon::tunePMuonBestTrack());
+    embeddedTunePMuonBestTrack_ = true;
   }
 }
-
 
 /// embed the Track reconstructed in the tracker only
 void Muon::embedTrack() {
   track_.clear();
   if (reco::Muon::innerTrack().isNonnull()) {
-      track_.push_back(*reco::Muon::innerTrack());
-      embeddedTrack_ = true;
+    track_.push_back(*reco::Muon::innerTrack());
+    embeddedTrack_ = true;
   }
 }
-
 
 /// embed the Track reconstructed in the muon detector only
 void Muon::embedStandAloneMuon() {
   standAloneMuon_.clear();
   if (reco::Muon::outerTrack().isNonnull()) {
-      standAloneMuon_.push_back(*reco::Muon::outerTrack());
-      embeddedStandAloneMuon_ = true;
+    standAloneMuon_.push_back(*reco::Muon::outerTrack());
+    embeddedStandAloneMuon_ = true;
   }
 }
-
 
 /// embed the Track reconstructed in both tracked and muon detector
 void Muon::embedCombinedMuon() {
   combinedMuon_.clear();
   if (reco::Muon::globalTrack().isNonnull()) {
-      combinedMuon_.push_back(*reco::Muon::globalTrack());
-      embeddedCombinedMuon_ = true;
+    combinedMuon_.push_back(*reco::Muon::globalTrack());
+    embeddedCombinedMuon_ = true;
   }
 }
 
@@ -392,11 +420,18 @@ void Muon::embedDytMuon() {
   }
 }
 
+/// Add extra timing information
+void Muon::readExtraTimerInfo(const reco::MuonTimeExtra& t){
+  inverseBeta_    = t.inverseBeta();
+  inverseBetaErr_ = t.inverseBetaErr();
+}
+
+
 /// embed the IsolatedPFCandidate pointed to by pfCandidateRef_
 void Muon::embedPFCandidate() {
   pfCandidate_.clear();
-  if ( pfCandidateRef_.isAvailable() && pfCandidateRef_.isNonnull()) {
-    pfCandidate_.push_back( *pfCandidateRef_ );
+  if (pfCandidateRef_.isAvailable() && pfCandidateRef_.isNonnull()) {
+    pfCandidate_.push_back(*pfCandidateRef_);
     embeddedPFCandidate_ = true;
   }
 }
@@ -406,13 +441,12 @@ bool Muon::muonID(const std::string& name) const {
   return muon::isGoodMuon(*this, st);
 }
 
-
-/// Norm chi2 gives the normalized chi2 of the global track. 
+/// Norm chi2 gives the normalized chi2 of the global track.
 /// The user can choose to cache this info so they can drop the
 /// global track, or they can use the track itself if it is present
-/// in the event. 
+/// in the event.
 double Muon::normChi2() const {
-  if ( cachedNormChi2_ ) {
+  if (cachedNormChi2_) {
     return normChi2_;
   } else {
     reco::TrackRef t = globalTrack();
@@ -423,9 +457,9 @@ double Muon::normChi2() const {
 /// numberOfValidHits returns the number of valid hits on the global track.
 /// The user can choose to cache this info so they can drop the
 /// global track, or they can use the track itself if it is present
-/// in the event. 
+/// in the event.
 unsigned int Muon::numberOfValidHits() const {
-  if ( cachedNumberOfValidHits_ ) {
+  if (cachedNumberOfValidHits_) {
     return numberOfValidHits_;
   } else {
     reco::TrackRef t = innerTrack();
@@ -437,51 +471,35 @@ unsigned int Muon::numberOfValidHits() const {
 // IpType defines the type of the impact parameter
 double Muon::dB(IpType type_) const {
   // more IP types (new)
-  if ( cachedIP_ & (1 << int(type_))) {
+  if (cachedIP_ & (1 << int(type_))) {
     return ip_[type_];
   } else {
     return std::numeric_limits<double>::max();
   }
 }
 
-
 // embed various impact parameters with errors
 // IpType defines the type of the impact parameter
 double Muon::edB(IpType type_) const {
   // more IP types (new)
-  if ( cachedIP_ & (1 << int(type_))) {
+  if (cachedIP_ & (1 << int(type_))) {
     return eip_[type_];
   } else {
     return std::numeric_limits<double>::max();
   }
 }
 
-
 double Muon::segmentCompatibility(reco::Muon::ArbitrationType arbitrationType) const {
-   return muon::segmentCompatibility(*this, arbitrationType);
+  return muon::segmentCompatibility(*this, arbitrationType);
 }
 
 // Selectors
-bool Muon::isTightMuon(const reco::Vertex&vtx) const {
-  return muon::isTightMuon(*this, vtx);
-}
+bool Muon::isTightMuon(const reco::Vertex& vtx) const { return muon::isTightMuon(*this, vtx); }
 
-bool Muon::isLooseMuon() const {
-  return muon::isLooseMuon(*this);
+bool Muon::isLooseMuon() const { return muon::isLooseMuon(*this); }
 
-}
+bool Muon::isMediumMuon() const { return muon::isMediumMuon(*this); }
 
-bool Muon::isMediumMuon() const {
-  return muon::isMediumMuon(*this);
+bool Muon::isSoftMuon(const reco::Vertex& vtx) const { return muon::isSoftMuon(*this, vtx); }
 
-}
-
-bool Muon::isSoftMuon(const reco::Vertex& vtx) const {
-  return muon::isSoftMuon(*this, vtx);
-}
-
-
-bool Muon::isHighPtMuon(const reco::Vertex& vtx) const{
-  return muon::isHighPtMuon(*this, vtx);
-}
-
+bool Muon::isHighPtMuon(const reco::Vertex& vtx) const { return muon::isHighPtMuon(*this, vtx); }

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -67,7 +67,8 @@
   </ioread>
 
 
-  <class name="pat::Muon"  ClassVersion="27">
+  <class name="pat::Muon"  ClassVersion="28">
+   <version ClassVersion="28" checksum="282262684"/>
    <version ClassVersion="27" checksum="3473399161"/>
    <version ClassVersion="26" checksum="1156855644"/>
    <version ClassVersion="25" checksum="574733987"/>

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -618,7 +618,7 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         }
       }
       if (addInverseBeta_) {
-        aMuon.readExtraTimerInfo((*muonsTimeExtra)[muonRef]);
+        aMuon.readTimeExtra((*muonsTimeExtra)[muonRef]);
       }
       // MC info
       aMuon.initSimInfo();

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -111,7 +111,8 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyO
   // embedding of inverse beta variable information
   addInverseBeta_ = iConfig.getParameter<bool>("addInverseBeta");
   if (addInverseBeta_) {
-    muonTimeExtraToken_ = consumes<edm::ValueMap<reco::MuonTimeExtra>>(iConfig.getParameter<edm::InputTag>("sourceMuonTimeExtra"));
+    muonTimeExtraToken_ =
+        consumes<edm::ValueMap<reco::MuonTimeExtra>>(iConfig.getParameter<edm::InputTag>("sourceMuonTimeExtra"));
   }
   // Monte Carlo matching
   addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
@@ -978,7 +979,8 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
 
   // inverse beta computation
   iDesc.add<bool>("addInverseBeta", true)->setComment("add combined inverse beta");
-  iDesc.add<edm::InputTag>("sourceInverseBeta", edm::InputTag("muons","combined"))->setComment("source of inverse beta values");
+  iDesc.add<edm::InputTag>("sourceInverseBeta", edm::InputTag("muons", "combined"))
+      ->setComment("source of inverse beta values");
 
   // MC matching configurables
   iDesc.add<bool>("addGenMatch", true)->setComment("add MC matching");

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -109,11 +109,8 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyO
   embedTpfmsMuon_ = iConfig.getParameter<bool>("embedTpfmsMuon");
   embedDytMuon_ = iConfig.getParameter<bool>("embedDytMuon");
   // embedding of inverse beta variable information
-  addInverseBeta_ = iConfig.getParameter<bool>("addInverseBeta");
-  if (addInverseBeta_) {
-    muonTimeExtraToken_ =
-        consumes<edm::ValueMap<reco::MuonTimeExtra>>(iConfig.getParameter<edm::InputTag>("sourceMuonTimeExtra"));
-  }
+  muonTimeExtraToken_ =
+      consumes<edm::ValueMap<reco::MuonTimeExtra>>(iConfig.getParameter<edm::InputTag>("sourceMuonTimeExtra"));
   // Monte Carlo matching
   addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
@@ -522,10 +519,8 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
 
     edm::Handle<edm::ValueMap<reco::MuonTimeExtra>> muonsTimeExtra;
-    if (addInverseBeta_) {
-      // get MuonTimerExtra value map
-      iEvent.getByToken(muonTimeExtraToken_, muonsTimeExtra);
-    }
+    // get MuonTimerExtra value map
+    iEvent.getByToken(muonTimeExtraToken_, muonsTimeExtra);
 
     for (edm::View<reco::Muon>::const_iterator itMuon = muons->begin(); itMuon != muons->end(); ++itMuon) {
       // construct the Muon from the ref -> save ref to original object
@@ -617,9 +612,7 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
           }
         }
       }
-      if (addInverseBeta_) {
-        aMuon.readTimeExtra((*muonsTimeExtra)[muonRef]);
-      }
+      aMuon.readTimeExtra((*muonsTimeExtra)[muonRef]);
       // MC info
       aMuon.initSimInfo();
       if (simInfoIsAvailalbe) {

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -109,8 +109,11 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyO
   embedTpfmsMuon_ = iConfig.getParameter<bool>("embedTpfmsMuon");
   embedDytMuon_ = iConfig.getParameter<bool>("embedDytMuon");
   // embedding of inverse beta variable information
-  muonTimeExtraToken_ =
-      consumes<edm::ValueMap<reco::MuonTimeExtra>>(iConfig.getParameter<edm::InputTag>("sourceMuonTimeExtra"));
+  addInverseBeta_ = iConfig.getParameter<bool>("addInverseBeta");
+  if (addInverseBeta_) {
+    muonTimeExtraToken_ =
+        consumes<edm::ValueMap<reco::MuonTimeExtra>>(iConfig.getParameter<edm::InputTag>("sourceMuonTimeExtra"));
+  }
   // Monte Carlo matching
   addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
@@ -519,8 +522,10 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
 
     edm::Handle<edm::ValueMap<reco::MuonTimeExtra>> muonsTimeExtra;
-    // get MuonTimerExtra value map
-    iEvent.getByToken(muonTimeExtraToken_, muonsTimeExtra);
+    if (addInverseBeta_) {
+      // get MuonTimerExtra value map
+      iEvent.getByToken(muonTimeExtraToken_, muonsTimeExtra);
+    }
 
     for (edm::View<reco::Muon>::const_iterator itMuon = muons->begin(); itMuon != muons->end(); ++itMuon) {
       // construct the Muon from the ref -> save ref to original object
@@ -612,7 +617,9 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
           }
         }
       }
-      aMuon.readTimeExtra((*muonsTimeExtra)[muonRef]);
+      if (addInverseBeta_) {
+        aMuon.readTimeExtra((*muonsTimeExtra)[muonRef]);
+      }
       // MC info
       aMuon.initSimInfo();
       if (simInfoIsAvailalbe) {

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -54,12 +54,10 @@
 #include <vector>
 #include <memory>
 
-
 using namespace pat;
 using namespace std;
 
 PATMuonHeavyObjectCache::PATMuonHeavyObjectCache(const edm::ParameterSet& iConfig) {
-
   if (iConfig.getParameter<bool>("computeMuonMVA")) {
     edm::FileInPath mvaTrainingFile = iConfig.getParameter<edm::FileInPath>("mvaTrainingFile");
     edm::FileInPath mvaLowPtTrainingFile = iConfig.getParameter<edm::FileInPath>("lowPtmvaTrainingFile");
@@ -74,53 +72,65 @@ PATMuonHeavyObjectCache::PATMuonHeavyObjectCache(const edm::ParameterSet& iConfi
   }
 }
 
-PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavyObjectCache const*) :
-  relMiniIsoPUCorrected_(0),
-  useUserData_(iConfig.exists("userData")),
-  computeMuonMVA_(false),
-  computeSoftMuonMVA_(false),
-  recomputeBasicSelectors_(false),
-  mvaUseJec_(false),
-  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false)
-{
+PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyObjectCache const*)
+    : relMiniIsoPUCorrected_(0),
+      useUserData_(iConfig.exists("userData")),
+      computeMuonMVA_(false),
+      computeSoftMuonMVA_(false),
+      recomputeBasicSelectors_(false),
+      mvaUseJec_(false),
+      isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
+                                                : edm::ParameterSet(),
+                consumesCollector(),
+                false) {
   // input source
-  muonToken_ = consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>( "muonSource" ));
+  muonToken_ = consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("muonSource"));
   // embedding of tracks
-  embedBestTrack_ = iConfig.getParameter<bool>( "embedMuonBestTrack" );
-  embedTunePBestTrack_ = iConfig.getParameter<bool>( "embedTunePMuonBestTrack" );
-  forceEmbedBestTrack_ = iConfig.getParameter<bool>( "forceBestTrackEmbedding" );
-  embedTrack_ = iConfig.getParameter<bool>( "embedTrack" );
-  embedCombinedMuon_ = iConfig.getParameter<bool>( "embedCombinedMuon"   );
-  embedStandAloneMuon_ = iConfig.getParameter<bool>( "embedStandAloneMuon" );
+  embedBestTrack_ = iConfig.getParameter<bool>("embedMuonBestTrack");
+  embedTunePBestTrack_ = iConfig.getParameter<bool>("embedTunePMuonBestTrack");
+  forceEmbedBestTrack_ = iConfig.getParameter<bool>("forceBestTrackEmbedding");
+  embedTrack_ = iConfig.getParameter<bool>("embedTrack");
+  embedCombinedMuon_ = iConfig.getParameter<bool>("embedCombinedMuon");
+  embedStandAloneMuon_ = iConfig.getParameter<bool>("embedStandAloneMuon");
   // embedding of muon MET correction information
-  embedCaloMETMuonCorrs_ = iConfig.getParameter<bool>("embedCaloMETMuonCorrs" );
-  embedTcMETMuonCorrs_ = iConfig.getParameter<bool>("embedTcMETMuonCorrs"   );
-  caloMETMuonCorrsToken_ = mayConsume<edm::ValueMap<reco::MuonMETCorrectionData> >(iConfig.getParameter<edm::InputTag>("caloMETMuonCorrs" ));
-  tcMETMuonCorrsToken_ = mayConsume<edm::ValueMap<reco::MuonMETCorrectionData> >(iConfig.getParameter<edm::InputTag>("tcMETMuonCorrs"   ));
+  embedCaloMETMuonCorrs_ = iConfig.getParameter<bool>("embedCaloMETMuonCorrs");
+  embedTcMETMuonCorrs_ = iConfig.getParameter<bool>("embedTcMETMuonCorrs");
+  caloMETMuonCorrsToken_ =
+      mayConsume<edm::ValueMap<reco::MuonMETCorrectionData>>(iConfig.getParameter<edm::InputTag>("caloMETMuonCorrs"));
+  tcMETMuonCorrsToken_ =
+      mayConsume<edm::ValueMap<reco::MuonMETCorrectionData>>(iConfig.getParameter<edm::InputTag>("tcMETMuonCorrs"));
   // pflow specific configurables
-  useParticleFlow_ = iConfig.getParameter<bool>( "useParticleFlow" );
-  embedPFCandidate_ = iConfig.getParameter<bool>( "embedPFCandidate" );
-  pfMuonToken_ = mayConsume<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfMuonSource" ));
-  embedPfEcalEnergy_ = iConfig.getParameter<bool>( "embedPfEcalEnergy" );
+  useParticleFlow_ = iConfig.getParameter<bool>("useParticleFlow");
+  embedPFCandidate_ = iConfig.getParameter<bool>("embedPFCandidate");
+  pfMuonToken_ = mayConsume<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfMuonSource"));
+  embedPfEcalEnergy_ = iConfig.getParameter<bool>("embedPfEcalEnergy");
   // embedding of tracks from TeV refit
-  embedPickyMuon_ = iConfig.getParameter<bool>( "embedPickyMuon" );
-  embedTpfmsMuon_ = iConfig.getParameter<bool>( "embedTpfmsMuon" );
-  embedDytMuon_ = iConfig.getParameter<bool>( "embedDytMuon" );
+  embedPickyMuon_ = iConfig.getParameter<bool>("embedPickyMuon");
+  embedTpfmsMuon_ = iConfig.getParameter<bool>("embedTpfmsMuon");
+  embedDytMuon_ = iConfig.getParameter<bool>("embedDytMuon");
+  // embedding of inverse beta variable information
+  addInverseBeta_ = iConfig.getParameter<bool>("addInverseBeta");
+  if (addInverseBeta_) {
+    muonTimeExtraToken_ = consumes<edm::ValueMap<reco::MuonTimeExtra>>(iConfig.getParameter<edm::InputTag>("sourceMuonTimeExtra"));
+  }
   // Monte Carlo matching
-  addGenMatch_ = iConfig.getParameter<bool>( "addGenMatch" );
+  addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
-    embedGenMatch_ = iConfig.getParameter<bool>( "embedGenMatch" );
+    embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
     if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genParticleMatch" )));
-    }
-    else {
-      genMatchTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" ), [this](edm::InputTag const & tag){return consumes<edm::Association<reco::GenParticleCollection> >(tag);});
+      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+    } else {
+      genMatchTokens_ = edm::vector_transform(
+          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
+          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
     }
   }
   // efficiencies
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
-  if(addEfficiencies_){
-    efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
+  if (addEfficiencies_) {
+    efficiencyLoader_ =
+        pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
   // resolutions
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
@@ -129,28 +139,34 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
   }
   // puppi
   addPuppiIsolation_ = iConfig.getParameter<bool>("addPuppiIsolation");
-  if(addPuppiIsolation_){
-    PUPPIIsolation_charged_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
-    PUPPIIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
-    PUPPIIsolation_photons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
+  if (addPuppiIsolation_) {
+    PUPPIIsolation_charged_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
+    PUPPIIsolation_neutral_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
+    PUPPIIsolation_photons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
     //puppiNoLeptons
-    PUPPINoLeptonsIsolation_charged_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
-    PUPPINoLeptonsIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
-    PUPPINoLeptonsIsolation_photons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
+    PUPPINoLeptonsIsolation_charged_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
+    PUPPINoLeptonsIsolation_neutral_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
+    PUPPINoLeptonsIsolation_photons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
   }
   // read isoDeposit labels, for direct embedding
   readIsolationLabels(iConfig, "isoDeposits", isoDepositLabels_, isoDepositTokens_);
   // read isolation value labels, for direct embedding
   readIsolationLabels(iConfig, "isolationValues", isolationValueLabels_, isolationValueTokens_);
   // check to see if the user wants to add user data
-  if( useUserData_ ){
+  if (useUserData_) {
     userDataHelper_ = PATUserDataHelper<Muon>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
   // embed high level selection variables
   embedHighLevelSelection_ = iConfig.getParameter<bool>("embedHighLevelSelection");
-  if ( embedHighLevelSelection_ ) {
+  if (embedHighLevelSelection_) {
     beamLineToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamLineSrc"));
-    pvToken_ = consumes<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("pvSrc"));
+    pvToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("pvSrc"));
   }
 
   //for mini-isolation calculation
@@ -158,70 +174,64 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
 
   computePuppiCombinedIso_ = iConfig.getParameter<bool>("computePuppiCombinedIso");
 
-  effectiveAreaVec_ = iConfig.getParameter<std::vector<double> >("effectiveAreaVec");
+  effectiveAreaVec_ = iConfig.getParameter<std::vector<double>>("effectiveAreaVec");
 
-  miniIsoParams_ = iConfig.getParameter<std::vector<double> >("miniIsoParams");
-  if(computeMiniIso_ && miniIsoParams_.size() != 9){
-      throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 9 elements.\n";
+  miniIsoParams_ = iConfig.getParameter<std::vector<double>>("miniIsoParams");
+  if (computeMiniIso_ && miniIsoParams_.size() != 9) {
+    throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 9 elements.\n";
   }
-  if(computeMiniIso_ || computePuppiCombinedIso_)
-      pcToken_ = consumes<pat::PackedCandidateCollection >(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
+  if (computeMiniIso_ || computePuppiCombinedIso_)
+    pcToken_ = consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
 
   // standard selectors
   recomputeBasicSelectors_ = iConfig.getParameter<bool>("recomputeBasicSelectors");
   computeMuonMVA_ = iConfig.getParameter<bool>("computeMuonMVA");
-  if (computeMuonMVA_ and not computeMiniIso_) 
+  if (computeMuonMVA_ and not computeMiniIso_)
     throw cms::Exception("ConfigurationError") << "MiniIso is needed for Muon MVA calculation.\n";
 
   if (computeMuonMVA_) {
     // pfCombinedInclusiveSecondaryVertexV2BJetTags
-    mvaBTagCollectionTag_  = consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("mvaJetTag"));
-    mvaL1Corrector_        = consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("mvaL1Corrector"));
+    mvaBTagCollectionTag_ = consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("mvaJetTag"));
+    mvaL1Corrector_ = consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("mvaL1Corrector"));
     mvaL1L2L3ResCorrector_ = consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("mvaL1L2L3ResCorrector"));
-    rho_                   = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
+    rho_ = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
     mvaUseJec_ = iConfig.getParameter<bool>("mvaUseJec");
   }
 
   computeSoftMuonMVA_ = iConfig.getParameter<bool>("computeSoftMuonMVA");
 
   // MC info
-  simInfo_        = consumes<edm::ValueMap<reco::MuonSimInfo> >(iConfig.getParameter<edm::InputTag>("muonSimInfo"));
+  simInfo_ = consumes<edm::ValueMap<reco::MuonSimInfo>>(iConfig.getParameter<edm::InputTag>("muonSimInfo"));
 
   addTriggerMatching_ = iConfig.getParameter<bool>("addTriggerMatching");
-  if ( addTriggerMatching_ ){
-    triggerObjects_ = consumes<std::vector<pat::TriggerObjectStandAlone>>(iConfig.getParameter<edm::InputTag>("triggerObjects"));
+  if (addTriggerMatching_) {
+    triggerObjects_ =
+        consumes<std::vector<pat::TriggerObjectStandAlone>>(iConfig.getParameter<edm::InputTag>("triggerObjects"));
     triggerResults_ = consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerResults"));
   }
   hltCollectionFilters_ = iConfig.getParameter<std::vector<std::string>>("hltCollectionFilters");
 
   // produces vector of muons
-  produces<std::vector<Muon> >();
+  produces<std::vector<Muon>>();
 }
 
-
-PATMuonProducer::~PATMuonProducer()
-{
-}
+PATMuonProducer::~PATMuonProducer() {}
 
 std::optional<GlobalPoint> PATMuonProducer::getMuonDirection(const reco::MuonChamberMatch& chamberMatch,
                                                              const edm::ESHandle<GlobalTrackingGeometry>& geometry,
-                                                             const DetId& chamberId)
-{
-  const GeomDet* chamberGeometry = geometry->idToDet( chamberId );
-  if (chamberGeometry){
+                                                             const DetId& chamberId) {
+  const GeomDet* chamberGeometry = geometry->idToDet(chamberId);
+  if (chamberGeometry) {
     LocalPoint localPosition(chamberMatch.x, chamberMatch.y, 0);
     return std::optional<GlobalPoint>(std::in_place, chamberGeometry->toGlobal(localPosition));
   }
   return std::optional<GlobalPoint>();
-
 }
 
-
 void PATMuonProducer::fillL1TriggerInfo(pat::Muon& aMuon,
-					edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
-					const edm::TriggerNames & names,
-					const edm::ESHandle<GlobalTrackingGeometry>& geometry)
-{
+                                        edm::Handle<std::vector<pat::TriggerObjectStandAlone>>& triggerObjects,
+                                        const edm::TriggerNames& names,
+                                        const edm::ESHandle<GlobalTrackingGeometry>& geometry) {
   // L1 trigger object parameters are defined at MB2/ME2. Use the muon
   // chamber matching information to get the local direction of the
   // muon trajectory and convert it to a global direction to match the
@@ -229,32 +239,39 @@ void PATMuonProducer::fillL1TriggerInfo(pat::Muon& aMuon,
 
   std::optional<GlobalPoint> muonPosition;
   // Loop over chambers
-  // initialize muonPosition with any available match, just in case 
-  // the second station is missing - it's better folling back to 
+  // initialize muonPosition with any available match, just in case
+  // the second station is missing - it's better folling back to
   // dR matching at IP
-  for ( const auto& chamberMatch: aMuon.matches() ) {
-    if ( chamberMatch.id.subdetId() == MuonSubdetId::DT) {
+  for (const auto& chamberMatch : aMuon.matches()) {
+    if (chamberMatch.id.subdetId() == MuonSubdetId::DT) {
       DTChamberId detId(chamberMatch.id.rawId());
-      if (abs(detId.station())>3) continue; 
+      if (abs(detId.station()) > 3)
+        continue;
       muonPosition = getMuonDirection(chamberMatch, geometry, detId);
-      if (abs(detId.station())==2) break;
+      if (abs(detId.station()) == 2)
+        break;
     }
-    if ( chamberMatch.id.subdetId() == MuonSubdetId::CSC) {
+    if (chamberMatch.id.subdetId() == MuonSubdetId::CSC) {
       CSCDetId detId(chamberMatch.id.rawId());
-      if (abs(detId.station())>3) continue;
+      if (abs(detId.station()) > 3)
+        continue;
       muonPosition = getMuonDirection(chamberMatch, geometry, detId);
-      if (abs(detId.station())==2) break;
+      if (abs(detId.station()) == 2)
+        break;
     }
   }
-  if (not muonPosition) return;
-  for (const auto& triggerObject: *triggerObjects){
-    if (triggerObject.hasTriggerObjectType(trigger::TriggerL1Mu)){
-      if (fabs(triggerObject.eta())<0.001){
-	// L1 is defined in X-Y plain
-	if (deltaPhi(triggerObject.phi(),muonPosition->phi())>0.1) continue;
+  if (not muonPosition)
+    return;
+  for (const auto& triggerObject : *triggerObjects) {
+    if (triggerObject.hasTriggerObjectType(trigger::TriggerL1Mu)) {
+      if (fabs(triggerObject.eta()) < 0.001) {
+        // L1 is defined in X-Y plain
+        if (deltaPhi(triggerObject.phi(), muonPosition->phi()) > 0.1)
+          continue;
       } else {
-	// 3D L1
-	if (deltaR(triggerObject.p4(),*muonPosition)>0.15) continue;
+        // 3D L1
+        if (deltaR(triggerObject.p4(), *muonPosition) > 0.15)
+          continue;
       }
       pat::TriggerObjectStandAlone obj(triggerObject);
       obj.unpackPathNames(names);
@@ -264,23 +281,24 @@ void PATMuonProducer::fillL1TriggerInfo(pat::Muon& aMuon,
 }
 
 void PATMuonProducer::fillHltTriggerInfo(pat::Muon& muon,
-					 edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
-					 const edm::TriggerNames & names,
-					 const std::vector<std::string>& collection_filter_names)
-{
+                                         edm::Handle<std::vector<pat::TriggerObjectStandAlone>>& triggerObjects,
+                                         const edm::TriggerNames& names,
+                                         const std::vector<std::string>& collection_filter_names) {
   // WARNING: in a case of close-by muons the dR matching may select both muons.
   // It's better to select the best match for a given collection.
-  for (const auto& triggerObject: *triggerObjects){
-    if (triggerObject.hasTriggerObjectType(trigger::TriggerMuon)){
+  for (const auto& triggerObject : *triggerObjects) {
+    if (triggerObject.hasTriggerObjectType(trigger::TriggerMuon)) {
       bool keepIt = false;
-      for (const auto& name: collection_filter_names){
-	if (triggerObject.hasCollection(name)){
-	  keepIt = true;
-	  break;
-	}
+      for (const auto& name : collection_filter_names) {
+        if (triggerObject.hasCollection(name)) {
+          keepIt = true;
+          break;
+        }
       }
-      if (not keepIt) continue;
-      if ( deltaR(triggerObject.p4(),muon)>0.1 ) continue;
+      if (not keepIt)
+        continue;
+      if (deltaR(triggerObject.p4(), muon) > 0.1)
+        continue;
       pat::TriggerObjectStandAlone obj(triggerObject);
       obj.unpackPathNames(names);
       muon.addTriggerObjectMatch(obj);
@@ -288,44 +306,44 @@ void PATMuonProducer::fillHltTriggerInfo(pat::Muon& muon,
   }
 }
 
-
-void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
-{
-   // get the tracking Geometry
-   edm::ESHandle<GlobalTrackingGeometry> geometry;
-   iSetup.get<GlobalTrackingGeometryRecord>().get(geometry);
-   if ( ! geometry.isValid() )
-     throw cms::Exception("FatalError") << "Unable to find GlobalTrackingGeometryRecord in event!\n";
+void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // get the tracking Geometry
+  edm::ESHandle<GlobalTrackingGeometry> geometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(geometry);
+  if (!geometry.isValid())
+    throw cms::Exception("FatalError") << "Unable to find GlobalTrackingGeometryRecord in event!\n";
 
   // switch off embedding (in unschedules mode)
-  if (iEvent.isRealData()){
-    addGenMatch_   = false;
+  if (iEvent.isRealData()) {
+    addGenMatch_ = false;
     embedGenMatch_ = false;
   }
 
-  edm::Handle<edm::View<reco::Muon> > muons;
+  edm::Handle<edm::View<reco::Muon>> muons;
   iEvent.getByToken(muonToken_, muons);
 
-  
   edm::Handle<pat::PackedCandidateCollection> pc;
-  if(computeMiniIso_ || computePuppiCombinedIso_)
-      iEvent.getByToken(pcToken_, pc);
+  if (computeMiniIso_ || computePuppiCombinedIso_)
+    iEvent.getByToken(pcToken_, pc);
 
   // get the ESHandle for the transient track builder,
   // if needed for high level selection embedding
   edm::ESHandle<TransientTrackBuilder> trackBuilder;
 
-  if(isolator_.enabled()) isolator_.beginEvent(iEvent,iSetup);
-  if(efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
-  if(resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
+  if (isolator_.enabled())
+    isolator_.beginEvent(iEvent, iSetup);
+  if (efficiencyLoader_.enabled())
+    efficiencyLoader_.newEvent(iEvent);
+  if (resolutionLoader_.enabled())
+    resolutionLoader_.newEvent(iEvent, iSetup);
 
   IsoDepositMaps deposits(isoDepositTokens_.size());
-  for (size_t j = 0; j<isoDepositTokens_.size(); ++j) {
+  for (size_t j = 0; j < isoDepositTokens_.size(); ++j) {
     iEvent.getByToken(isoDepositTokens_[j], deposits[j]);
   }
 
   IsolationValueMaps isolationValues(isolationValueTokens_.size());
-  for (size_t j = 0; j<isolationValueTokens_.size(); ++j) {
+  for (size_t j = 0; j < isolationValueTokens_.size(); ++j) {
     iEvent.getByToken(isolationValueTokens_[j], isolationValues[j]);
   }
 
@@ -337,15 +355,15 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_charged_hadrons;
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_neutral_hadrons;
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_photons;
-  if(addPuppiIsolation_){
+  if (addPuppiIsolation_) {
     //puppi
     iEvent.getByToken(PUPPIIsolation_charged_hadrons_, PUPPIIsolation_charged_hadrons);
     iEvent.getByToken(PUPPIIsolation_neutral_hadrons_, PUPPIIsolation_neutral_hadrons);
-    iEvent.getByToken(PUPPIIsolation_photons_, PUPPIIsolation_photons);  
+    iEvent.getByToken(PUPPIIsolation_photons_, PUPPIIsolation_photons);
     //puppiNoLeptons
     iEvent.getByToken(PUPPINoLeptonsIsolation_charged_hadrons_, PUPPINoLeptonsIsolation_charged_hadrons);
     iEvent.getByToken(PUPPINoLeptonsIsolation_neutral_hadrons_, PUPPINoLeptonsIsolation_neutral_hadrons);
-    iEvent.getByToken(PUPPINoLeptonsIsolation_photons_, PUPPINoLeptonsIsolation_photons);  
+    iEvent.getByToken(PUPPINoLeptonsIsolation_photons_, PUPPINoLeptonsIsolation_photons);
   }
 
   // inputs for muon mva
@@ -353,13 +371,13 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   edm::Handle<reco::JetCorrector> mvaL1Corrector;
   edm::Handle<reco::JetCorrector> mvaL1L2L3ResCorrector;
   if (computeMuonMVA_) {
-    iEvent.getByToken(mvaBTagCollectionTag_,mvaBTagCollectionTag);
-    iEvent.getByToken(mvaL1Corrector_,mvaL1Corrector);
-    iEvent.getByToken(mvaL1L2L3ResCorrector_,mvaL1L2L3ResCorrector);
+    iEvent.getByToken(mvaBTagCollectionTag_, mvaBTagCollectionTag);
+    iEvent.getByToken(mvaL1Corrector_, mvaL1Corrector);
+    iEvent.getByToken(mvaL1L2L3ResCorrector_, mvaL1L2L3ResCorrector);
   }
-  
+
   // prepare the MC genMatchTokens_
-  GenAssociations  genMatches(genMatchTokens_.size());
+  GenAssociations genMatches(genMatchTokens_.size());
   if (addGenMatch_) {
     for (size_t j = 0, nd = genMatchTokens_.size(); j < nd; ++j) {
       iEvent.getByToken(genMatchTokens_[j], genMatches[j]);
@@ -372,173 +390,176 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   reco::BeamSpot beamSpot;
   bool beamSpotIsValid = false;
   bool primaryVertexIsValid = false;
-  if ( embedHighLevelSelection_ ) {
+  if (embedHighLevelSelection_) {
     // get the beamspot
     edm::Handle<reco::BeamSpot> beamSpotHandle;
     iEvent.getByToken(beamLineToken_, beamSpotHandle);
 
     // get the primary vertex
-    edm::Handle< std::vector<reco::Vertex> > pvHandle;
-    iEvent.getByToken( pvToken_, pvHandle );
+    edm::Handle<std::vector<reco::Vertex>> pvHandle;
+    iEvent.getByToken(pvToken_, pvHandle);
 
-    if( beamSpotHandle.isValid() ){
+    if (beamSpotHandle.isValid()) {
       beamSpot = *beamSpotHandle;
       beamSpotIsValid = true;
-    } else{
-      edm::LogError("DataNotAvailable")
-	<< "No beam spot available from EventSetup, not adding high level selection \n";
+    } else {
+      edm::LogError("DataNotAvailable") << "No beam spot available from EventSetup, not adding high level selection \n";
     }
-    if( pvHandle.isValid() && !pvHandle->empty() ) {
+    if (pvHandle.isValid() && !pvHandle->empty()) {
       primaryVertex = pvHandle->at(0);
       primaryVertexIsValid = true;
     } else {
       edm::LogError("DataNotAvailable")
-	<< "No primary vertex available from EventSetup, not adding high level selection \n";
+          << "No primary vertex available from EventSetup, not adding high level selection \n";
     }
     // this is needed by the IPTools methods from the tracking group
     iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
   }
 
   // MC info
-  edm::Handle<edm::ValueMap<reco::MuonSimInfo> > simInfo;
-  bool simInfoIsAvailalbe = iEvent.getByToken(simInfo_,simInfo);
+  edm::Handle<edm::ValueMap<reco::MuonSimInfo>> simInfo;
+  bool simInfoIsAvailalbe = iEvent.getByToken(simInfo_, simInfo);
 
   // this will be the new object collection
-  std::vector<Muon> * patMuons = new std::vector<Muon>();
+  std::vector<Muon>* patMuons = new std::vector<Muon>();
 
-  edm::Handle< reco::PFCandidateCollection >  pfMuons;
-  if( useParticleFlow_ ){
+  edm::Handle<reco::PFCandidateCollection> pfMuons;
+  if (useParticleFlow_) {
     // get the PFCandidates of type muons
     iEvent.getByToken(pfMuonToken_, pfMuons);
 
-    unsigned index=0;
-    for( reco::PFCandidateConstIterator i = pfMuons->begin(); i != pfMuons->end(); ++i, ++index) {
+    unsigned index = 0;
+    for (reco::PFCandidateConstIterator i = pfMuons->begin(); i != pfMuons->end(); ++i, ++index) {
       const reco::PFCandidate& pfmu = *i;
       //const reco::IsolaPFCandidate& pfmu = *i;
       const reco::MuonRef& muonRef = pfmu.muonRef();
-      assert( muonRef.isNonnull() );
+      assert(muonRef.isNonnull());
 
       MuonBaseRef muonBaseRef(muonRef);
       Muon aMuon(muonBaseRef);
 
-      if ( useUserData_ ) {
-	userDataHelper_.add( aMuon, iEvent, iSetup );
+      if (useUserData_) {
+        userDataHelper_.add(aMuon, iEvent, iSetup);
       }
 
       // embed high level selection
-      if ( embedHighLevelSelection_ ) {
-	// get the tracks
-	reco::TrackRef innerTrack = muonBaseRef->innerTrack();
-	reco::TrackRef globalTrack= muonBaseRef->globalTrack();
-	reco::TrackRef bestTrack  = muonBaseRef->muonBestTrack();
-	reco::TrackRef chosenTrack = innerTrack;
-	// Make sure the collection it points to is there
-	if ( bestTrack.isNonnull() && bestTrack.isAvailable() )
-	  chosenTrack = bestTrack;
+      if (embedHighLevelSelection_) {
+        // get the tracks
+        reco::TrackRef innerTrack = muonBaseRef->innerTrack();
+        reco::TrackRef globalTrack = muonBaseRef->globalTrack();
+        reco::TrackRef bestTrack = muonBaseRef->muonBestTrack();
+        reco::TrackRef chosenTrack = innerTrack;
+        // Make sure the collection it points to is there
+        if (bestTrack.isNonnull() && bestTrack.isAvailable())
+          chosenTrack = bestTrack;
 
-	if ( chosenTrack.isNonnull() && chosenTrack.isAvailable() ) {
-	  unsigned int nhits = chosenTrack->numberOfValidHits(); // ????
-	  aMuon.setNumberOfValidHits( nhits );
+        if (chosenTrack.isNonnull() && chosenTrack.isAvailable()) {
+          unsigned int nhits = chosenTrack->numberOfValidHits();  // ????
+          aMuon.setNumberOfValidHits(nhits);
 
-	  reco::TransientTrack tt = trackBuilder->build(chosenTrack);
-	  embedHighLevel( aMuon,
-			  chosenTrack,
-			  tt,
-			  primaryVertex,
-			  primaryVertexIsValid,
-			  beamSpot,
-			  beamSpotIsValid );
+          reco::TransientTrack tt = trackBuilder->build(chosenTrack);
+          embedHighLevel(aMuon, chosenTrack, tt, primaryVertex, primaryVertexIsValid, beamSpot, beamSpotIsValid);
+        }
 
-	}
-
-	if ( globalTrack.isNonnull() && globalTrack.isAvailable() && !embedCombinedMuon_) {
-	  double norm_chi2 = globalTrack->chi2() / globalTrack->ndof();
-	  aMuon.setNormChi2( norm_chi2 );
-	}
+        if (globalTrack.isNonnull() && globalTrack.isAvailable() && !embedCombinedMuon_) {
+          double norm_chi2 = globalTrack->chi2() / globalTrack->ndof();
+          aMuon.setNormChi2(norm_chi2);
+        }
       }
-      reco::PFCandidateRef pfRef(pfMuons,index);
+      reco::PFCandidateRef pfRef(pfMuons, index);
       //reco::PFCandidatePtr ptrToMother(pfMuons,index);
-      reco::CandidateBaseRef pfBaseRef( pfRef );
+      reco::CandidateBaseRef pfBaseRef(pfRef);
 
-      aMuon.setPFCandidateRef( pfRef  );
-      if( embedPFCandidate_ ) aMuon.embedPFCandidate();
-      fillMuon( aMuon, muonBaseRef, pfBaseRef, genMatches, deposits, isolationValues );
+      aMuon.setPFCandidateRef(pfRef);
+      if (embedPFCandidate_)
+        aMuon.embedPFCandidate();
+      fillMuon(aMuon, muonBaseRef, pfBaseRef, genMatches, deposits, isolationValues);
 
-      if(computeMiniIso_) 
-          setMuonMiniIso(aMuon, pc.product());
+      if (computeMiniIso_)
+        setMuonMiniIso(aMuon, pc.product());
 
       if (addPuppiIsolation_) {
-	aMuon.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[muonBaseRef],
-				(*PUPPIIsolation_neutral_hadrons)[muonBaseRef],
-				(*PUPPIIsolation_photons)[muonBaseRef]);
-	
-	aMuon.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[muonBaseRef],
-					 (*PUPPINoLeptonsIsolation_neutral_hadrons)[muonBaseRef],
-					 (*PUPPINoLeptonsIsolation_photons)[muonBaseRef]);
+        aMuon.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[muonBaseRef],
+                                (*PUPPIIsolation_neutral_hadrons)[muonBaseRef],
+                                (*PUPPIIsolation_photons)[muonBaseRef]);
+
+        aMuon.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[muonBaseRef],
+                                         (*PUPPINoLeptonsIsolation_neutral_hadrons)[muonBaseRef],
+                                         (*PUPPINoLeptonsIsolation_photons)[muonBaseRef]);
+      } else {
+        aMuon.setIsolationPUPPI(-999., -999., -999.);
+        aMuon.setIsolationPUPPINoLeptons(-999., -999., -999.);
       }
-      else {
-	aMuon.setIsolationPUPPI(-999., -999.,-999.);
-	aMuon.setIsolationPUPPINoLeptons(-999., -999.,-999.);
-      }
-      
+
       if (embedPfEcalEnergy_) {
         aMuon.setPfEcalEnergy(pfmu.ecalEnergy());
       }
 
       patMuons->push_back(aMuon);
     }
-  }
-  else {
-    edm::Handle<edm::View<reco::Muon> > muons;
+  } else {
+    edm::Handle<edm::View<reco::Muon>> muons;
     iEvent.getByToken(muonToken_, muons);
 
     // embedding of muon MET corrections
-    edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData> > caloMETMuonCorrs;
+    edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData>> caloMETMuonCorrs;
     //edm::ValueMap<reco::MuonMETCorrectionData> caloMETmuCorValueMap;
-    if(embedCaloMETMuonCorrs_){
+    if (embedCaloMETMuonCorrs_) {
       iEvent.getByToken(caloMETMuonCorrsToken_, caloMETMuonCorrs);
       //caloMETmuCorValueMap  = *caloMETmuCorValueMap_h;
     }
-    edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData> > tcMETMuonCorrs;
+    edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData>> tcMETMuonCorrs;
     //edm::ValueMap<reco::MuonMETCorrectionData> tcMETmuCorValueMap;
-    if(embedTcMETMuonCorrs_) {
+    if (embedTcMETMuonCorrs_) {
       iEvent.getByToken(tcMETMuonCorrsToken_, tcMETMuonCorrs);
       //tcMETmuCorValueMap  = *tcMETmuCorValueMap_h;
     }
 
     if (embedPfEcalEnergy_) {
-        // get the PFCandidates of type muons
-        iEvent.getByToken(pfMuonToken_, pfMuons);
+      // get the PFCandidates of type muons
+      iEvent.getByToken(pfMuonToken_, pfMuons);
+    }
+
+    edm::Handle<edm::ValueMap<reco::MuonTimeExtra>> muonsTimeExtra;
+    if (addInverseBeta_) {
+      // get MuonTimerExtra value map
+      iEvent.getByToken(muonTimeExtraToken_, muonsTimeExtra);
     }
 
     for (edm::View<reco::Muon>::const_iterator itMuon = muons->begin(); itMuon != muons->end(); ++itMuon) {
       // construct the Muon from the ref -> save ref to original object
       unsigned int idx = itMuon - muons->begin();
       MuonBaseRef muonRef = muons->refAt(idx);
-      reco::CandidateBaseRef muonBaseRef( muonRef );
+      reco::CandidateBaseRef muonBaseRef(muonRef);
 
       Muon aMuon(muonRef);
-      fillMuon( aMuon, muonRef, muonBaseRef, genMatches, deposits, isolationValues);
-      if(computeMiniIso_)
-          setMuonMiniIso(aMuon, pc.product());
+      fillMuon(aMuon, muonRef, muonBaseRef, genMatches, deposits, isolationValues);
+      if (computeMiniIso_)
+        setMuonMiniIso(aMuon, pc.product());
       if (addPuppiIsolation_) {
-	aMuon.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[muonRef], (*PUPPIIsolation_neutral_hadrons)[muonRef], (*PUPPIIsolation_photons)[muonRef]);
-	aMuon.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[muonRef], (*PUPPINoLeptonsIsolation_neutral_hadrons)[muonRef], (*PUPPINoLeptonsIsolation_photons)[muonRef]);
-      }
-      else {
-	aMuon.setIsolationPUPPI(-999., -999.,-999.);
-	aMuon.setIsolationPUPPINoLeptons(-999., -999.,-999.);
+        aMuon.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[muonRef],
+                                (*PUPPIIsolation_neutral_hadrons)[muonRef],
+                                (*PUPPIIsolation_photons)[muonRef]);
+        aMuon.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[muonRef],
+                                         (*PUPPINoLeptonsIsolation_neutral_hadrons)[muonRef],
+                                         (*PUPPINoLeptonsIsolation_photons)[muonRef]);
+      } else {
+        aMuon.setIsolationPUPPI(-999., -999., -999.);
+        aMuon.setIsolationPUPPINoLeptons(-999., -999., -999.);
       }
 
       // Isolation
       if (isolator_.enabled()) {
-	//reco::CandidatePtr mother =  ptrToMother->sourceCandidatePtr(0);
-	isolator_.fill(*muons, idx, isolatorTmpStorage_);
-	typedef pat::helper::MultiIsolator::IsolationValuePairs IsolationValuePairs;
-	// better to loop backwards, so the vector is resized less times
-	for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(), ed = isolatorTmpStorage_.rend(); it != ed; ++it) {
-	  aMuon.setIsolation(it->first, it->second);
-	}
+        //reco::CandidatePtr mother =  ptrToMother->sourceCandidatePtr(0);
+        isolator_.fill(*muons, idx, isolatorTmpStorage_);
+        typedef pat::helper::MultiIsolator::IsolationValuePairs IsolationValuePairs;
+        // better to loop backwards, so the vector is resized less times
+        for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(),
+                                                         ed = isolatorTmpStorage_.rend();
+             it != ed;
+             ++it) {
+          aMuon.setIsolation(it->first, it->second);
+        }
       }
 
       //       for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
@@ -548,74 +569,74 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 
       // add sel to selected
       edm::Ptr<reco::Muon> muonsPtr = muons->ptrAt(idx);
-      if ( useUserData_ ) {
-	userDataHelper_.add( aMuon, iEvent, iSetup );
+      if (useUserData_) {
+        userDataHelper_.add(aMuon, iEvent, iSetup);
       }
 
       // embed high level selection
-      if ( embedHighLevelSelection_ ) {
-	// get the tracks
-	reco::TrackRef innerTrack = itMuon->innerTrack();
-	reco::TrackRef globalTrack= itMuon->globalTrack();
-	reco::TrackRef bestTrack  = itMuon->muonBestTrack();
-	reco::TrackRef chosenTrack = innerTrack;
-	// Make sure the collection it points to is there
-	if ( bestTrack.isNonnull() && bestTrack.isAvailable() )
-	  chosenTrack = bestTrack;
-	if ( chosenTrack.isNonnull() && chosenTrack.isAvailable() ) {
-	  unsigned int nhits = chosenTrack->numberOfValidHits(); // ????
-	  aMuon.setNumberOfValidHits( nhits );
+      if (embedHighLevelSelection_) {
+        // get the tracks
+        reco::TrackRef innerTrack = itMuon->innerTrack();
+        reco::TrackRef globalTrack = itMuon->globalTrack();
+        reco::TrackRef bestTrack = itMuon->muonBestTrack();
+        reco::TrackRef chosenTrack = innerTrack;
+        // Make sure the collection it points to is there
+        if (bestTrack.isNonnull() && bestTrack.isAvailable())
+          chosenTrack = bestTrack;
+        if (chosenTrack.isNonnull() && chosenTrack.isAvailable()) {
+          unsigned int nhits = chosenTrack->numberOfValidHits();  // ????
+          aMuon.setNumberOfValidHits(nhits);
 
-	  reco::TransientTrack tt = trackBuilder->build(chosenTrack);
-	  embedHighLevel( aMuon,
-			  chosenTrack,
-			  tt,
-			  primaryVertex,
-			  primaryVertexIsValid,
-			  beamSpot,
-			  beamSpotIsValid );
+          reco::TransientTrack tt = trackBuilder->build(chosenTrack);
+          embedHighLevel(aMuon, chosenTrack, tt, primaryVertex, primaryVertexIsValid, beamSpot, beamSpotIsValid);
+        }
 
-	}
-
-	if ( globalTrack.isNonnull() && globalTrack.isAvailable() ) {
-	  double norm_chi2 = globalTrack->chi2() / globalTrack->ndof();
-	  aMuon.setNormChi2( norm_chi2 );
-	}
+        if (globalTrack.isNonnull() && globalTrack.isAvailable()) {
+          double norm_chi2 = globalTrack->chi2() / globalTrack->ndof();
+          aMuon.setNormChi2(norm_chi2);
+        }
       }
 
       // embed MET muon corrections
-      if( embedCaloMETMuonCorrs_ ) aMuon.embedCaloMETMuonCorrs((*caloMETMuonCorrs)[muonRef]);
-      if( embedTcMETMuonCorrs_ ) aMuon.embedTcMETMuonCorrs((*tcMETMuonCorrs  )[muonRef]);
+      if (embedCaloMETMuonCorrs_)
+        aMuon.embedCaloMETMuonCorrs((*caloMETMuonCorrs)[muonRef]);
+      if (embedTcMETMuonCorrs_)
+        aMuon.embedTcMETMuonCorrs((*tcMETMuonCorrs)[muonRef]);
 
       if (embedPfEcalEnergy_) {
-          aMuon.setPfEcalEnergy(-99.0);
-          for (const reco::PFCandidate &pfmu : *pfMuons) {
-              if (pfmu.muonRef().isNonnull()) {
-                  if (pfmu.muonRef().id() != muonRef.id()) throw cms::Exception("Configuration") << "Muon reference within PF candidates does not point to the muon collection." << std::endl;
-                  if (pfmu.muonRef().key() == muonRef.key()) {
-                      aMuon.setPfEcalEnergy(pfmu.ecalEnergy());
-                  }
-              } 
+        aMuon.setPfEcalEnergy(-99.0);
+        for (const reco::PFCandidate& pfmu : *pfMuons) {
+          if (pfmu.muonRef().isNonnull()) {
+            if (pfmu.muonRef().id() != muonRef.id())
+              throw cms::Exception("Configuration")
+                  << "Muon reference within PF candidates does not point to the muon collection." << std::endl;
+            if (pfmu.muonRef().key() == muonRef.key()) {
+              aMuon.setPfEcalEnergy(pfmu.ecalEnergy());
+            }
           }
+        }
+      }
+      if (addInverseBeta_) {
+        aMuon.readExtraTimerInfo((*muonsTimeExtra)[muonRef]);
       }
       // MC info
       aMuon.initSimInfo();
-      if (simInfoIsAvailalbe){
-	const auto& msi = (*simInfo)[muonBaseRef];
-	aMuon.setSimType(msi.primaryClass);
-	aMuon.setExtSimType(msi.extendedClass);
-	aMuon.setSimFlavour(msi.flavour);
-	aMuon.setSimHeaviestMotherFlavour(msi.heaviestMotherFlavour);
-	aMuon.setSimPdgId(msi.pdgId);
-	aMuon.setSimMotherPdgId(msi.motherPdgId);
-	aMuon.setSimBX(msi.tpBX);
-	aMuon.setSimTpEvent(msi.tpEvent);
-	aMuon.setSimProdRho(msi.vertex.Rho());
-	aMuon.setSimProdZ(msi.vertex.Z());
-	aMuon.setSimPt(msi.p4.pt());
-	aMuon.setSimEta(msi.p4.eta());
-	aMuon.setSimPhi(msi.p4.phi());
-	aMuon.setSimMatchQuality(msi.tpAssoQuality);
+      if (simInfoIsAvailalbe) {
+        const auto& msi = (*simInfo)[muonBaseRef];
+        aMuon.setSimType(msi.primaryClass);
+        aMuon.setExtSimType(msi.extendedClass);
+        aMuon.setSimFlavour(msi.flavour);
+        aMuon.setSimHeaviestMotherFlavour(msi.heaviestMotherFlavour);
+        aMuon.setSimPdgId(msi.pdgId);
+        aMuon.setSimMotherPdgId(msi.motherPdgId);
+        aMuon.setSimBX(msi.tpBX);
+        aMuon.setSimTpEvent(msi.tpEvent);
+        aMuon.setSimProdRho(msi.vertex.Rho());
+        aMuon.setSimProdZ(msi.vertex.Z());
+        aMuon.setSimPt(msi.p4.pt());
+        aMuon.setSimEta(msi.p4.eta());
+        aMuon.setSimPhi(msi.p4.phi());
+        aMuon.setSimMatchQuality(msi.tpAssoQuality);
       }
       patMuons->push_back(aMuon);
     }
@@ -624,97 +645,87 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   // sort muons in pt
   std::sort(patMuons->begin(), patMuons->end(), pTComparator_);
 
-  // Store standard muon selection decisions and jet related 
+  // Store standard muon selection decisions and jet related
   // quantaties.
   // Need a separate loop over muons to have all inputs properly
   // computed and stored in the object.
   edm::Handle<double> rho;
-  if (computeMuonMVA_) iEvent.getByToken(rho_,rho);
+  if (computeMuonMVA_)
+    iEvent.getByToken(rho_, rho);
   const reco::Vertex* pv(nullptr);
-  if (primaryVertexIsValid) pv = &primaryVertex;
+  if (primaryVertexIsValid)
+    pv = &primaryVertex;
 
-  edm::Handle<std::vector<pat::TriggerObjectStandAlone> > triggerObjects;
-  edm::Handle< edm::TriggerResults > triggerResults;
+  edm::Handle<std::vector<pat::TriggerObjectStandAlone>> triggerObjects;
+  edm::Handle<edm::TriggerResults> triggerResults;
   bool triggerObjectsAvailable = false;
   bool triggerResultsAvailable = false;
-  if (addTriggerMatching_){
+  if (addTriggerMatching_) {
     triggerObjectsAvailable = iEvent.getByToken(triggerObjects_, triggerObjects);
     triggerResultsAvailable = iEvent.getByToken(triggerResults_, triggerResults);
   }
 
-  for(auto& muon: *patMuons){
+  for (auto& muon : *patMuons) {
     // trigger info
-    if (addTriggerMatching_ and triggerObjectsAvailable and triggerResultsAvailable){
-      const edm::TriggerNames & triggerNames(iEvent.triggerNames( *triggerResults ));
-      fillL1TriggerInfo(muon,triggerObjects,triggerNames,geometry);
-      fillHltTriggerInfo(muon,triggerObjects,triggerNames,hltCollectionFilters_);
+    if (addTriggerMatching_ and triggerObjectsAvailable and triggerResultsAvailable) {
+      const edm::TriggerNames& triggerNames(iEvent.triggerNames(*triggerResults));
+      fillL1TriggerInfo(muon, triggerObjects, triggerNames, geometry);
+      fillHltTriggerInfo(muon, triggerObjects, triggerNames, hltCollectionFilters_);
     }
 
-    if (recomputeBasicSelectors_){
+    if (recomputeBasicSelectors_) {
       muon.setSelectors(0);
       bool isRun2016BCDEF = (272728 <= iEvent.run() && iEvent.run() <= 278808);
       muon.setSelectors(muon::makeSelectorBitset(muon, pv, isRun2016BCDEF));
     }
     float miniIsoValue = -1;
-    if (computeMiniIso_){
+    if (computeMiniIso_) {
       // MiniIsolation working points
 
-      miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho, effectiveAreaVec_);
+      miniIsoValue = getRelMiniIsoPUCorrected(muon, *rho, effectiveAreaVec_);
 
-      muon.setSelector(reco::Muon::MiniIsoLoose,     miniIsoValue<0.40);
-      muon.setSelector(reco::Muon::MiniIsoMedium,    miniIsoValue<0.20);
-      muon.setSelector(reco::Muon::MiniIsoTight,     miniIsoValue<0.10);
-      muon.setSelector(reco::Muon::MiniIsoVeryTight, miniIsoValue<0.05);
+      muon.setSelector(reco::Muon::MiniIsoLoose, miniIsoValue < 0.40);
+      muon.setSelector(reco::Muon::MiniIsoMedium, miniIsoValue < 0.20);
+      muon.setSelector(reco::Muon::MiniIsoTight, miniIsoValue < 0.10);
+      muon.setSelector(reco::Muon::MiniIsoVeryTight, miniIsoValue < 0.05);
     }
 
     double puppiCombinedIsolationPAT = -1;
-    if(computePuppiCombinedIso_){
-
-      puppiCombinedIsolationPAT=puppiCombinedIsolation(muon, pc.product());
-      muon.setSelector(reco::Muon::PuppiIsoLoose, puppiCombinedIsolationPAT<0.27);
-      muon.setSelector(reco::Muon::PuppiIsoMedium, puppiCombinedIsolationPAT<0.22);
-      muon.setSelector(reco::Muon::PuppiIsoTight, puppiCombinedIsolationPAT<0.12);
+    if (computePuppiCombinedIso_) {
+      puppiCombinedIsolationPAT = puppiCombinedIsolation(muon, pc.product());
+      muon.setSelector(reco::Muon::PuppiIsoLoose, puppiCombinedIsolationPAT < 0.27);
+      muon.setSelector(reco::Muon::PuppiIsoMedium, puppiCombinedIsolationPAT < 0.22);
+      muon.setSelector(reco::Muon::PuppiIsoTight, puppiCombinedIsolationPAT < 0.12);
     }
 
     float jetPtRatio = 0.0;
     float jetPtRel = 0.0;
     float mva = 0.0;
     float mva_lowpt = 0.0;
-    if (computeMuonMVA_ && primaryVertexIsValid && computeMiniIso_){
-      if (mvaUseJec_){
+    if (computeMuonMVA_ && primaryVertexIsValid && computeMiniIso_) {
+      if (mvaUseJec_) {
         mva = globalCache()->muonMvaEstimator()->computeMva(muon,
                                                             primaryVertex,
                                                             *(mvaBTagCollectionTag.product()),
                                                             jetPtRatio,
                                                             jetPtRel,
-							    miniIsoValue,
+                                                            miniIsoValue,
                                                             &*mvaL1Corrector,
-                                                            &*mvaL1L2L3ResCorrector
-							    );
+                                                            &*mvaL1L2L3ResCorrector);
         mva_lowpt = globalCache()->muonLowPtMvaEstimator()->computeMva(muon,
-								       primaryVertex,
-								       *(mvaBTagCollectionTag.product()),
-								       jetPtRatio,
-								       jetPtRel,
-								       miniIsoValue,
-								       &*mvaL1Corrector,
-								       &*mvaL1L2L3ResCorrector
-								       );
-	
-      }
-      else{
-	mva = globalCache()->muonMvaEstimator()->computeMva(muon,
-                                                            primaryVertex,
-                                                            *(mvaBTagCollectionTag.product()),
-                                                            jetPtRatio,
-                                                            jetPtRel,
-							    miniIsoValue);
-	mva_lowpt = globalCache()->muonLowPtMvaEstimator()->computeMva(muon,
-								       primaryVertex,
-								       *(mvaBTagCollectionTag.product()),
-								       jetPtRatio,
-								       jetPtRel,
-								       miniIsoValue);
+                                                                       primaryVertex,
+                                                                       *(mvaBTagCollectionTag.product()),
+                                                                       jetPtRatio,
+                                                                       jetPtRel,
+                                                                       miniIsoValue,
+                                                                       &*mvaL1Corrector,
+                                                                       &*mvaL1L2L3ResCorrector);
+
+      } else {
+        mva = globalCache()->muonMvaEstimator()->computeMva(
+            muon, primaryVertex, *(mvaBTagCollectionTag.product()), jetPtRatio, jetPtRel, miniIsoValue);
+        mva_lowpt = globalCache()->muonLowPtMvaEstimator()->computeMva(
+            muon, primaryVertex, *(mvaBTagCollectionTag.product()), jetPtRatio, jetPtRel, miniIsoValue);
       }
 
       muon.setMvaValue(mva);
@@ -723,65 +734,70 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
       muon.setJetPtRel(jetPtRel);
 
       // multi-isolation
-      if (computeMiniIso_){
-	muon.setSelector(reco::Muon::MultiIsoMedium, miniIsoValue<0.11 && (muon.jetPtRatio() > 0.74 || muon.jetPtRel() > 6.8) );
+      if (computeMiniIso_) {
+        muon.setSelector(reco::Muon::MultiIsoMedium,
+                         miniIsoValue < 0.11 && (muon.jetPtRatio() > 0.74 || muon.jetPtRel() > 6.8));
       }
 
       // MVA working points
       // https://twiki.cern.ch/twiki/bin/viewauth/CMS/LeptonMVA
-      double dB2D  = fabs(muon.dB(pat::Muon::PV2D));
-      double dB3D  = fabs(muon.dB(pat::Muon::PV3D));
+      double dB2D = fabs(muon.dB(pat::Muon::PV2D));
+      double dB3D = fabs(muon.dB(pat::Muon::PV3D));
       double edB3D = fabs(muon.edB(pat::Muon::PV3D));
-      double sip3D = edB3D>0?dB3D/edB3D:0.0; 
+      double sip3D = edB3D > 0 ? dB3D / edB3D : 0.0;
       double dz = fabs(muon.muonBestTrack()->dz(primaryVertex.position()));
 
       // muon preselection
-      if (muon.pt()>5 and muon.isLooseMuon() and
-	  muon.passed(reco::Muon::MiniIsoLoose) and 
-	  sip3D<8.0 and dB2D<0.05 and dz<0.1){
-	muon.setSelector(reco::Muon::MvaLoose,  muon.mvaValue()>-0.60);
-	muon.setSelector(reco::Muon::MvaMedium, muon.mvaValue()>-0.20);
-	muon.setSelector(reco::Muon::MvaTight,  muon.mvaValue()> 0.15);
-	muon.setSelector(reco::Muon::MvaVTight,  muon.mvaValue()> 0.45);
-	muon.setSelector(reco::Muon::MvaVVTight,  muon.mvaValue()> 0.9);
+      if (muon.pt() > 5 and muon.isLooseMuon() and muon.passed(reco::Muon::MiniIsoLoose) and sip3D < 8.0 and
+          dB2D < 0.05 and dz < 0.1) {
+        muon.setSelector(reco::Muon::MvaLoose, muon.mvaValue() > -0.60);
+        muon.setSelector(reco::Muon::MvaMedium, muon.mvaValue() > -0.20);
+        muon.setSelector(reco::Muon::MvaTight, muon.mvaValue() > 0.15);
+        muon.setSelector(reco::Muon::MvaVTight, muon.mvaValue() > 0.45);
+        muon.setSelector(reco::Muon::MvaVVTight, muon.mvaValue() > 0.9);
       }
-      if (muon.pt()>5 and muon.isLooseMuon() and
-	  sip3D<4 and dB2D < 0.5 and dz < 1){
-	muon.setSelector(reco::Muon::LowPtMvaLoose,  muon.lowptMvaValue()>-0.60);
-	muon.setSelector(reco::Muon::LowPtMvaMedium, muon.lowptMvaValue()>-0.20);
+      if (muon.pt() > 5 and muon.isLooseMuon() and sip3D < 4 and dB2D < 0.5 and dz < 1) {
+        muon.setSelector(reco::Muon::LowPtMvaLoose, muon.lowptMvaValue() > -0.60);
+        muon.setSelector(reco::Muon::LowPtMvaMedium, muon.lowptMvaValue() > -0.20);
       }
     }
-    
+
     //SOFT MVA
-    if (computeSoftMuonMVA_){
+    if (computeSoftMuonMVA_) {
       float mva = globalCache()->softMuonMvaEstimator()->computeMva(muon);
       muon.setSoftMvaValue(mva);
       //preselection in SoftMuonMvaEstimator.cc
-      muon.setSelector(reco::Muon::SoftMvaId,  muon.softMvaValue() >   0.58  ); //WP choose for bmm4
-      
+      muon.setSelector(reco::Muon::SoftMvaId, muon.softMvaValue() > 0.58);  //WP choose for bmm4
     }
   }
 
   // put products in Event
-  std::unique_ptr<std::vector<Muon> > ptr(patMuons);
+  std::unique_ptr<std::vector<Muon>> ptr(patMuons);
   iEvent.put(std::move(ptr));
 
-  if (isolator_.enabled()) isolator_.endEvent();
+  if (isolator_.enabled())
+    isolator_.endEvent();
 }
 
-
-void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const reco::CandidateBaseRef& baseRef, const GenAssociations& genMatches, const IsoDepositMaps& deposits, const IsolationValueMaps& isolationValues ) const
-{
+void PATMuonProducer::fillMuon(Muon& aMuon,
+                               const MuonBaseRef& muonRef,
+                               const reco::CandidateBaseRef& baseRef,
+                               const GenAssociations& genMatches,
+                               const IsoDepositMaps& deposits,
+                               const IsolationValueMaps& isolationValues) const {
   // in the particle flow algorithm,
   // the muon momentum is recomputed.
   // the new value is stored as the momentum of the
   // resulting PFCandidate of type Muon, and choosen
   // as the pat::Muon momentum
   if (useParticleFlow_)
-    aMuon.setP4( aMuon.pfCandidateRef()->p4() );
-  if (embedTrack_)          aMuon.embedTrack();
-  if (embedStandAloneMuon_) aMuon.embedStandAloneMuon();
-  if (embedCombinedMuon_)   aMuon.embedCombinedMuon();
+    aMuon.setP4(aMuon.pfCandidateRef()->p4());
+  if (embedTrack_)
+    aMuon.embedTrack();
+  if (embedStandAloneMuon_)
+    aMuon.embedStandAloneMuon();
+  if (embedCombinedMuon_)
+    aMuon.embedCombinedMuon();
 
   // embed the TeV refit track refs (only available for globalMuons)
   if (aMuon.isGlobalMuon()) {
@@ -794,49 +810,50 @@ void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const r
   }
 
   // embed best tracks (at the end, so unless forceEmbedBestTrack_ is true we can save some space not embedding them twice)
-  if (embedBestTrack_)      aMuon.embedMuonBestTrack(forceEmbedBestTrack_);
-  if (embedTunePBestTrack_)      aMuon.embedTunePMuonBestTrack(forceEmbedBestTrack_);
+  if (embedBestTrack_)
+    aMuon.embedMuonBestTrack(forceEmbedBestTrack_);
+  if (embedTunePBestTrack_)
+    aMuon.embedTunePMuonBestTrack(forceEmbedBestTrack_);
 
   // store the match to the generated final state muons
   if (addGenMatch_) {
-    for(size_t i = 0, n = genMatches.size(); i < n; ++i) {
+    for (size_t i = 0, n = genMatches.size(); i < n; ++i) {
       reco::GenParticleRef genMuon = (*genMatches[i])[baseRef];
       aMuon.addGenParticleRef(genMuon);
     }
-    if (embedGenMatch_) aMuon.embedGenParticle();
+    if (embedGenMatch_)
+      aMuon.embedGenParticle();
   }
   if (efficiencyLoader_.enabled()) {
-    efficiencyLoader_.setEfficiencies( aMuon, muonRef );
+    efficiencyLoader_.setEfficiencies(aMuon, muonRef);
   }
 
   for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
-    if(useParticleFlow_) {
+    if (useParticleFlow_) {
       if (deposits[j]->contains(baseRef.id())) {
-	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[baseRef]);
-      } else if (deposits[j]->contains(muonRef.id())){
-	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[muonRef]);
+        aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[baseRef]);
+      } else if (deposits[j]->contains(muonRef.id())) {
+        aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[muonRef]);
       } else {
-	reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
-	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[source]);
+        reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
+        aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[source]);
       }
-    }
-    else{
+    } else {
       aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[muonRef]);
     }
   }
 
-  for (size_t j = 0; j<isolationValues.size(); ++j) {
-    if(useParticleFlow_) {
+  for (size_t j = 0; j < isolationValues.size(); ++j) {
+    if (useParticleFlow_) {
       if (isolationValues[j]->contains(baseRef.id())) {
-	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[baseRef]);
+        aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[baseRef]);
       } else if (isolationValues[j]->contains(muonRef.id())) {
-	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[muonRef]);
+        aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[muonRef]);
       } else {
-	reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
-	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[source]);
+        reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
+        aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[source]);
       }
-    }
-    else{
+    } else {
       aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[muonRef]);
     }
   }
@@ -846,90 +863,85 @@ void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const r
   }
 }
 
-void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollection *pc)
-{
-  pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc, aMuon.p4(),
-                                                     miniIsoParams_[0], miniIsoParams_[1], miniIsoParams_[2],
-                                                     miniIsoParams_[3], miniIsoParams_[4], miniIsoParams_[5],
-                                                     miniIsoParams_[6], miniIsoParams_[7], miniIsoParams_[8]);
+void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollection* pc) {
+  pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc,
+                                                     aMuon.p4(),
+                                                     miniIsoParams_[0],
+                                                     miniIsoParams_[1],
+                                                     miniIsoParams_[2],
+                                                     miniIsoParams_[3],
+                                                     miniIsoParams_[4],
+                                                     miniIsoParams_[5],
+                                                     miniIsoParams_[6],
+                                                     miniIsoParams_[7],
+                                                     miniIsoParams_[8]);
   aMuon.setMiniPFIsolation(miniiso);
 }
 
-double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, const std::vector<double> &area)
-{
+double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, const std::vector<double>& area) {
   double mindr(miniIsoParams_[0]);
   double maxdr(miniIsoParams_[1]);
   double kt_scale(miniIsoParams_[2]);
-  double drcut = pat::miniIsoDr(muon.p4(),mindr,maxdr,kt_scale);
+  double drcut = pat::miniIsoDr(muon.p4(), mindr, maxdr, kt_scale);
   return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho, area);
 }
 
-
-double PATMuonProducer::puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection *pc)
-{
+double PATMuonProducer::puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection* pc) {
   double dR_threshold = 0.4;
   double dR2_threshold = dR_threshold * dR_threshold;
   double mix_fraction = 0.5;
-  enum particleType{
-      CH = 0,
-      NH = 1,
-      PH = 2,
-      OTHER = 100000
-    };
+  enum particleType { CH = 0, NH = 1, PH = 2, OTHER = 100000 };
   double val_PuppiWithLep = 0.0;
-  double val_PuppiWithoutLep = 0.0;  
+  double val_PuppiWithoutLep = 0.0;
 
-  for(const auto & cand : *pc){//pat::pat::PackedCandidate loop start
+  for (const auto& cand : *pc) {  //pat::pat::PackedCandidate loop start
 
-     const particleType pType =
-        isChargedHadron( cand.pdgId() ) ? CH :
-        isNeutralHadron( cand.pdgId() ) ? NH :
-        isPhoton( cand.pdgId() ) ? PH : OTHER;
-     if( pType == OTHER ){
-        if( cand.pdgId() != 1 && cand.pdgId() != 2
-        && abs( cand.pdgId() ) != 11
-        && abs( cand.pdgId() ) != 13){
-        LogTrace("PATMuonProducer") <<"candidate with PDGID = " << cand.pdgId() << " is not CH/NH/PH/e/mu or 1/2 (and this is removed from isolation calculation)" << std::endl;
-       }
-       continue;
-     }
-     double d_eta = std::abs( cand.eta() - muon.eta() );
-     if( d_eta > dR_threshold ) continue;
+    const particleType pType =
+        isChargedHadron(cand.pdgId()) ? CH : isNeutralHadron(cand.pdgId()) ? NH : isPhoton(cand.pdgId()) ? PH : OTHER;
+    if (pType == OTHER) {
+      if (cand.pdgId() != 1 && cand.pdgId() != 2 && abs(cand.pdgId()) != 11 && abs(cand.pdgId()) != 13) {
+        LogTrace("PATMuonProducer") << "candidate with PDGID = " << cand.pdgId()
+                                    << " is not CH/NH/PH/e/mu or 1/2 (and this is removed from isolation calculation)"
+                                    << std::endl;
+      }
+      continue;
+    }
+    double d_eta = std::abs(cand.eta() - muon.eta());
+    if (d_eta > dR_threshold)
+      continue;
 
-     double d_phi = std::abs(reco::deltaPhi(cand.phi(),muon.phi()));
-     if( d_phi > dR_threshold ) continue ;
+    double d_phi = std::abs(reco::deltaPhi(cand.phi(), muon.phi()));
+    if (d_phi > dR_threshold)
+      continue;
 
-     double dR2=reco::deltaR2(cand, muon);
-     if( dR2  > dR2_threshold ) continue;
-     if( pType == CH && dR2 < 0.0001*0.0001 ) continue;
-     if( pType == NH && dR2 < 0.01  *0.01   ) continue;
-     if( pType == PH && dR2 < 0.01  *0.01   ) continue;
-     val_PuppiWithLep += cand.pt() * cand.puppiWeight();
-     val_PuppiWithoutLep += cand.pt() * cand.puppiWeightNoLep();
+    double dR2 = reco::deltaR2(cand, muon);
+    if (dR2 > dR2_threshold)
+      continue;
+    if (pType == CH && dR2 < 0.0001 * 0.0001)
+      continue;
+    if (pType == NH && dR2 < 0.01 * 0.01)
+      continue;
+    if (pType == PH && dR2 < 0.01 * 0.01)
+      continue;
+    val_PuppiWithLep += cand.pt() * cand.puppiWeight();
+    val_PuppiWithoutLep += cand.pt() * cand.puppiWeightNoLep();
 
-  }//pat::pat::PackedCandidate loop end
+  }  //pat::pat::PackedCandidate loop end
 
-  double reliso_Puppi_withLep    = val_PuppiWithLep/muon.pt();
-  double reliso_Puppi_withoutlep = val_PuppiWithoutLep/muon.pt();
-  double reliso_Puppi_combined = mix_fraction * reliso_Puppi_withLep + ( 1.0 - mix_fraction) * reliso_Puppi_withoutlep;
+  double reliso_Puppi_withLep = val_PuppiWithLep / muon.pt();
+  double reliso_Puppi_withoutlep = val_PuppiWithoutLep / muon.pt();
+  double reliso_Puppi_combined = mix_fraction * reliso_Puppi_withLep + (1.0 - mix_fraction) * reliso_Puppi_withoutlep;
   return reliso_Puppi_combined;
 }
 
-bool PATMuonProducer::isNeutralHadron( long pdgid ){
- return std::abs(pdgid) == 130;
-}
+bool PATMuonProducer::isNeutralHadron(long pdgid) { return std::abs(pdgid) == 130; }
 
-bool PATMuonProducer::isChargedHadron( long pdgid ){
- return std::abs(pdgid) == 211;
-}
+bool PATMuonProducer::isChargedHadron(long pdgid) { return std::abs(pdgid) == 211; }
 
-bool PATMuonProducer::isPhoton( long pdgid ){
- return pdgid==22;
-}
+bool PATMuonProducer::isPhoton(long pdgid) { return pdgid == 22; }
 
 // ParameterSet description for module
-void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("PAT muon producer module");
 
@@ -937,9 +949,12 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.add<edm::InputTag>("muonSource", edm::InputTag("no default"))->setComment("input collection");
 
   // embedding
-  iDesc.add<bool>("embedMuonBestTrack",      true)->setComment("embed muon best track (global pflow)");
+  iDesc.add<bool>("embedMuonBestTrack", true)->setComment("embed muon best track (global pflow)");
   iDesc.add<bool>("embedTunePMuonBestTrack", true)->setComment("embed muon best track (muon only)");
-  iDesc.add<bool>("forceBestTrackEmbedding", true)->setComment("force embedding separately the best tracks even if they're already embedded e.g. as tracker or global tracks");
+  iDesc.add<bool>("forceBestTrackEmbedding", true)
+      ->setComment(
+          "force embedding separately the best tracks even if they're already embedded e.g. as tracker or global "
+          "tracks");
   iDesc.add<bool>("embedTrack", true)->setComment("embed external track");
   iDesc.add<bool>("embedStandAloneMuon", true)->setComment("embed external stand-alone muon");
   iDesc.add<bool>("embedCombinedMuon", false)->setComment("embed external combined muon");
@@ -949,9 +964,11 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
 
   // embedding of MET muon corrections
   iDesc.add<bool>("embedCaloMETMuonCorrs", true)->setComment("whether to add MET muon correction for caloMET or not");
-  iDesc.add<edm::InputTag>("caloMETMuonCorrs", edm::InputTag("muonMETValueMapProducer"  , "muCorrData"))->setComment("source of MET muon corrections for caloMET");
+  iDesc.add<edm::InputTag>("caloMETMuonCorrs", edm::InputTag("muonMETValueMapProducer", "muCorrData"))
+      ->setComment("source of MET muon corrections for caloMET");
   iDesc.add<bool>("embedTcMETMuonCorrs", true)->setComment("whether to add MET muon correction for tcMET or not");
-  iDesc.add<edm::InputTag>("tcMETMuonCorrs", edm::InputTag("muonTCMETValueMapProducer"  , "muCorrData"))->setComment("source of MET muon corrections for tcMET");
+  iDesc.add<edm::InputTag>("tcMETMuonCorrs", edm::InputTag("muonTCMETValueMapProducer", "muCorrData"))
+      ->setComment("source of MET muon corrections for tcMET");
 
   // pf specific parameters
   iDesc.add<edm::InputTag>("pfMuonSource", edm::InputTag("pfMuons"))->setComment("particle flow input collection");
@@ -959,20 +976,28 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.add<bool>("embedPFCandidate", false)->setComment("embed external particle flow object");
   iDesc.add<bool>("embedPfEcalEnergy", true)->setComment("add ecal energy as reconstructed by PF");
 
+  // inverse beta computation
+  iDesc.add<bool>("addInverseBeta", true)->setComment("add combined inverse beta");
+  iDesc.add<edm::InputTag>("sourceInverseBeta", edm::InputTag("muons","combined"))->setComment("source of inverse beta values");
+
   // MC matching configurables
   iDesc.add<bool>("addGenMatch", true)->setComment("add MC matching");
   iDesc.add<bool>("embedGenMatch", false)->setComment("embed MC matched MC information");
   std::vector<edm::InputTag> emptySourceVector;
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
-                 edm::ParameterDescription<std::vector<edm::InputTag> >("genParticleMatch", emptySourceVector, true)
-		 )->setComment("input with MC match information");
+  iDesc
+      .addNode(edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
+               edm::ParameterDescription<std::vector<edm::InputTag>>("genParticleMatch", emptySourceVector, true))
+      ->setComment("input with MC match information");
 
   // mini-iso
   iDesc.add<bool>("computeMiniIso", false)->setComment("whether or not to compute and store electron mini-isolation");
-  iDesc.add<bool>("computePuppiCombinedIso",false)->setComment("whether or not to compute and store puppi combined isolation");
+  iDesc.add<bool>("computePuppiCombinedIso", false)
+      ->setComment("whether or not to compute and store puppi combined isolation");
 
-  iDesc.add<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))->setComment("collection to use to compute mini-iso");
-  iDesc.add<std::vector<double> >("miniIsoParams", std::vector<double>())->setComment("mini-iso parameters to use for muons");
+  iDesc.add<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))
+      ->setComment("collection to use to compute mini-iso");
+  iDesc.add<std::vector<double>>("miniIsoParams", std::vector<double>())
+      ->setComment("mini-iso parameters to use for muons");
 
   iDesc.add<bool>("addTriggerMatching", false)->setComment("add L1 and HLT matching to offline muon");
 
@@ -989,7 +1014,7 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   isoDepositsPSet.addOptional<edm::InputTag>("pfPUChargedHadrons");
   isoDepositsPSet.addOptional<edm::InputTag>("pfNeutralHadrons");
   isoDepositsPSet.addOptional<edm::InputTag>("pfPhotons");
-  isoDepositsPSet.addOptional<std::vector<edm::InputTag> >("user");
+  isoDepositsPSet.addOptional<std::vector<edm::InputTag>>("user");
   iDesc.addOptional("isoDeposits", isoDepositsPSet);
 
   // isolation values configurables
@@ -1006,17 +1031,35 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.addOptional("isolationValues", isolationValuesPSet);
 
   iDesc.ifValue(edm::ParameterDescription<bool>("addPuppiIsolation", false, true),
-		true >> (edm::ParameterDescription<edm::InputTag>("puppiIsolationChargedHadrons", edm::InputTag("muonPUPPIIsolation","h+-DR030-ThresholdVeto000-ConeVeto000"), true) and
-			 edm::ParameterDescription<edm::InputTag>("puppiIsolationNeutralHadrons", edm::InputTag("muonPUPPIIsolation","h0-DR030-ThresholdVeto000-ConeVeto001"), true) and 
-			 edm::ParameterDescription<edm::InputTag>("puppiIsolationPhotons", edm::InputTag("muonPUPPIIsolation","gamma-DR030-ThresholdVeto000-ConeVeto001"), true) and
-			 edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons", edm::InputTag("muonPUPPINoLeptonsIsolation","h+-DR030-ThresholdVeto000-ConeVeto000"), true) and 
-			 edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons", edm::InputTag("muonPUPPINoLeptonsIsolation","h0-DR030-ThresholdVeto000-ConeVeto001"), true) and 
-			 edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationPhotons", edm::InputTag("muonPUPPINoLeptonsIsolation","gamma-DR030-ThresholdVeto000-ConeVeto001"), true))  or
-		false >> edm::EmptyGroupDescription());
-  
+                true >> (edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationChargedHadrons",
+                             edm::InputTag("muonPUPPIIsolation", "h+-DR030-ThresholdVeto000-ConeVeto000"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationNeutralHadrons",
+                             edm::InputTag("muonPUPPIIsolation", "h0-DR030-ThresholdVeto000-ConeVeto001"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationPhotons",
+                             edm::InputTag("muonPUPPIIsolation", "gamma-DR030-ThresholdVeto000-ConeVeto001"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationChargedHadrons",
+                             edm::InputTag("muonPUPPINoLeptonsIsolation", "h+-DR030-ThresholdVeto000-ConeVeto000"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationNeutralHadrons",
+                             edm::InputTag("muonPUPPINoLeptonsIsolation", "h0-DR030-ThresholdVeto000-ConeVeto001"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationPhotons",
+                             edm::InputTag("muonPUPPINoLeptonsIsolation", "gamma-DR030-ThresholdVeto000-ConeVeto001"),
+                             true)) or
+                    false >> edm::EmptyGroupDescription());
+
   // Efficiency configurables
   edm::ParameterSetDescription efficienciesPSet;
-  efficienciesPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  efficienciesPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("efficiencies", efficienciesPSet);
   iDesc.add<bool>("addEfficiencies", false);
 
@@ -1026,88 +1069,63 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.addOptional("userData", userDataPSet);
 
   edm::ParameterSetDescription isolationPSet;
-  isolationPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  isolationPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("userIsolation", isolationPSet);
 
   iDesc.add<bool>("embedHighLevelSelection", true)->setComment("embed high level selection");
   edm::ParameterSetDescription highLevelPSet;
   highLevelPSet.setAllowAnything();
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("beamLineSrc", edm::InputTag(), true)
-                 )->setComment("input with high level selection");
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true)
-                 )->setComment("input with high level selection");
+  iDesc.addNode(edm::ParameterDescription<edm::InputTag>("beamLineSrc", edm::InputTag(), true))
+      ->setComment("input with high level selection");
+  iDesc.addNode(edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true))
+      ->setComment("input with high level selection");
 
   //descriptions.add("PATMuonProducer", iDesc);
 }
 
-
-
 // embed various impact parameters with errors
 // embed high level selection
-void PATMuonProducer::embedHighLevel( pat::Muon & aMuon,
-				      reco::TrackRef track,
-				      reco::TransientTrack & tt,
-				      reco::Vertex & primaryVertex,
-				      bool primaryVertexIsValid,
-				      reco::BeamSpot & beamspot,
-				      bool beamspotIsValid
-				      )
-{
+void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
+                                     reco::TrackRef track,
+                                     reco::TransientTrack& tt,
+                                     reco::Vertex& primaryVertex,
+                                     bool primaryVertexIsValid,
+                                     reco::BeamSpot& beamspot,
+                                     bool beamspotIsValid) {
   // Correct to PV
 
   // PV2D
-  std::pair<bool,Measurement1D> result =
-    IPTools::signedTransverseImpactParameter(tt,
-					     GlobalVector(track->px(),
-							  track->py(),
-							  track->pz()),
-					     primaryVertex);
+  std::pair<bool, Measurement1D> result =
+      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  aMuon.setDB( d0_corr, d0_err, pat::Muon::PV2D);
-
+  aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D
-  result =
-    IPTools::signedImpactParameter3D(tt,
-				     GlobalVector(track->px(),
-						  track->py(),
-						  track->pz()),
-				     primaryVertex);
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   d0_corr = result.second.value();
   d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  aMuon.setDB( d0_corr, d0_err, pat::Muon::PV3D);
-
+  aMuon.setDB(d0_corr, d0_err, pat::Muon::PV3D);
 
   // Correct to beam spot
   // make a fake vertex out of beam spot
   reco::Vertex vBeamspot(beamspot.position(), beamspot.rotatedCovariance3D());
 
   // BS2D
-  result =
-    IPTools::signedTransverseImpactParameter(tt,
-					     GlobalVector(track->px(),
-							  track->py(),
-							  track->pz()),
-					     vBeamspot);
+  result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  aMuon.setDB( d0_corr, d0_err, pat::Muon::BS2D);
+  aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
 
-    // BS3D
-  result =
-    IPTools::signedImpactParameter3D(tt,
-				     GlobalVector(track->px(),
-						  track->py(),
-						    track->pz()),
-				     vBeamspot);
+  // BS3D
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  aMuon.setDB( d0_corr, d0_err, pat::Muon::BS3D);
+  aMuon.setDB(d0_corr, d0_err, pat::Muon::BS3D);
 
-
-    // PVDZ
-  aMuon.setDB( track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ );
+  // PVDZ
+  aMuon.setDB(
+      track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -37,6 +37,7 @@
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 
 namespace pat {
 
@@ -173,6 +174,10 @@ namespace pat {
     bool embedTpfmsMuon_;
     /// embed track from DYT muon fit into the muon
     bool embedDytMuon_;
+    /// add combined inverse beta measurement into the muon
+    bool addInverseBeta_;
+    /// input tag for reading inverse beta
+    edm::EDGetTokenT<edm::ValueMap<reco::MuonTimeExtra>> muonTimeExtraToken_;
     /// add generator match information
     bool addGenMatch_;
     /// input tags for generator match information

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -43,15 +43,10 @@ namespace pat {
 
   class PATMuonHeavyObjectCache {
   public:
-
     PATMuonHeavyObjectCache(const edm::ParameterSet&);
 
-    std::unique_ptr<const pat::MuonMvaEstimator> const& muonMvaEstimator() const {
-      return muonMvaEstimator_;
-    }
-    std::unique_ptr<const pat::MuonMvaEstimator> const& muonLowPtMvaEstimator() const {
-      return muonLowPtMvaEstimator_;
-    }
+    std::unique_ptr<const pat::MuonMvaEstimator> const& muonMvaEstimator() const { return muonMvaEstimator_; }
+    std::unique_ptr<const pat::MuonMvaEstimator> const& muonLowPtMvaEstimator() const { return muonLowPtMvaEstimator_; }
 
     std::unique_ptr<const pat::SoftMuonMvaEstimator> const& softMuonMvaEstimator() const {
       return softMuonMvaEstimator_;
@@ -69,10 +64,9 @@ namespace pat {
 
   /// class definition
   class PATMuonProducer : public edm::stream::EDProducer<edm::GlobalCache<PATMuonHeavyObjectCache>> {
-
   public:
     /// default constructir
-    explicit PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavyObjectCache const*);
+    explicit PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyObjectCache const*);
     /// default destructur
     ~PATMuonProducer() override;
 
@@ -80,68 +74,73 @@ namespace pat {
       return std::make_unique<PATMuonHeavyObjectCache>(iConfig);
     }
 
-    static void globalEndJob(PATMuonHeavyObjectCache*) { }
+    static void globalEndJob(PATMuonHeavyObjectCache*) {}
 
     /// everything that needs to be done during the event loop
-    void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
     /// description of config file parameters
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
     /// typedefs for convenience
     typedef edm::RefToBase<reco::Muon> MuonBaseRef;
-    typedef std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > GenAssociations;
-    typedef std::vector< edm::Handle< edm::ValueMap<IsoDeposit> > > IsoDepositMaps;
-    typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
-    typedef std::pair<pat::IsolationKeys,edm::InputTag> IsolationLabel;
+    typedef std::vector<edm::Handle<edm::Association<reco::GenParticleCollection>>> GenAssociations;
+    typedef std::vector<edm::Handle<edm::ValueMap<IsoDeposit>>> IsoDepositMaps;
+    typedef std::vector<edm::Handle<edm::ValueMap<double>>> IsolationValueMaps;
+    typedef std::pair<pat::IsolationKeys, edm::InputTag> IsolationLabel;
     typedef std::vector<IsolationLabel> IsolationLabels;
 
-
     /// common muon filling, for both the standard and PF2PAT case
-      void fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const reco::CandidateBaseRef& baseRef, const GenAssociations& genMatches, const IsoDepositMaps& deposits, const IsolationValueMaps& isolationValues) const;
+    void fillMuon(Muon& aMuon,
+                  const MuonBaseRef& muonRef,
+                  const reco::CandidateBaseRef& baseRef,
+                  const GenAssociations& genMatches,
+                  const IsoDepositMaps& deposits,
+                  const IsolationValueMaps& isolationValues) const;
     /// fill label vector from the contents of the parameter set,
     /// for the embedding of isoDeposits or userIsolation values
-    template<typename T> void readIsolationLabels( const edm::ParameterSet & iConfig, const char* psetName, IsolationLabels& labels, std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens);
+    template <typename T>
+    void readIsolationLabels(const edm::ParameterSet& iConfig,
+                             const char* psetName,
+                             IsolationLabels& labels,
+                             std::vector<edm::EDGetTokenT<edm::ValueMap<T>>>& tokens);
 
-    void setMuonMiniIso(pat::Muon& aMuon, const pat::PackedCandidateCollection *pc);
-    double getRelMiniIsoPUCorrected(const pat::Muon& muon,  double rho, const std::vector<double> &area);
+    void setMuonMiniIso(pat::Muon& aMuon, const pat::PackedCandidateCollection* pc);
+    double getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, const std::vector<double>& area);
 
-    double puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection *pc);
-    bool isNeutralHadron( long pdgid );
-    bool isChargedHadron( long pdgid );
-    bool isPhoton( long pdgid );
-
-
-
+    double puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection* pc);
+    bool isNeutralHadron(long pdgid);
+    bool isChargedHadron(long pdgid);
+    bool isPhoton(long pdgid);
 
     // embed various impact parameters with errors
     // embed high level selection
-    void embedHighLevel( pat::Muon & aMuon,
-			 reco::TrackRef track,
-			 reco::TransientTrack & tt,
-			 reco::Vertex & primaryVertex,
-			 bool primaryVertexIsValid,
-			 reco::BeamSpot & beamspot,
-			 bool beamspotIsValid );
-    double relMiniIsoPUCorrected( const pat::Muon& aMuon,
-				  double rho);
+    void embedHighLevel(pat::Muon& aMuon,
+                        reco::TrackRef track,
+                        reco::TransientTrack& tt,
+                        reco::Vertex& primaryVertex,
+                        bool primaryVertexIsValid,
+                        reco::BeamSpot& beamspot,
+                        bool beamspotIsValid);
+    double relMiniIsoPUCorrected(const pat::Muon& aMuon, double rho);
     std::optional<GlobalPoint> getMuonDirection(const reco::MuonChamberMatch& chamberMatch,
                                                 const edm::ESHandle<GlobalTrackingGeometry>& geometry,
                                                 const DetId& chamberId);
     void fillL1TriggerInfo(pat::Muon& muon,
-			   edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
-			   const edm::TriggerNames & names,
-			   const edm::ESHandle<GlobalTrackingGeometry>& geometry);
+                           edm::Handle<std::vector<pat::TriggerObjectStandAlone>>& triggerObjects,
+                           const edm::TriggerNames& names,
+                           const edm::ESHandle<GlobalTrackingGeometry>& geometry);
     void fillHltTriggerInfo(pat::Muon& muon,
-			    edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
-			    const edm::TriggerNames & names,
-			    const std::vector<std::string>& collection_names);
+                            edm::Handle<std::vector<pat::TriggerObjectStandAlone>>& triggerObjects,
+                            const edm::TriggerNames& names,
+                            const std::vector<std::string>& collection_names);
+
   private:
     /// input source
-    edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;
-    
+    edm::EDGetTokenT<edm::View<reco::Muon>> muonToken_;
+
     // for mini-iso calculation
-    edm::EDGetTokenT<pat::PackedCandidateCollection > pcToken_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcToken_;
     bool computeMiniIso_;
     bool computePuppiCombinedIso_;
     std::vector<double> effectiveAreaVec_;
@@ -152,7 +151,7 @@ namespace pat {
     bool embedBestTrack_;
     /// embed the track from best muon measurement (muon only)
     bool embedTunePBestTrack_;
-    /// force separate embed of the best track even if already embedded 
+    /// force separate embed of the best track even if already embedded
     bool forceEmbedBestTrack_;
     /// embed the track from inner tracker into the muon
     bool embedTrack_;
@@ -163,11 +162,11 @@ namespace pat {
     /// embed muon MET correction info for caloMET into the muon
     bool embedCaloMETMuonCorrs_;
     /// source of caloMET muon corrections
-    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > caloMETMuonCorrsToken_;
+    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData>> caloMETMuonCorrsToken_;
     /// embed muon MET correction info for tcMET into the muon
     bool embedTcMETMuonCorrs_;
     /// source of tcMET muon corrections
-    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > tcMETMuonCorrsToken_;
+    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData>> tcMETMuonCorrsToken_;
     /// embed track from picky muon fit into the muon
     bool embedPickyMuon_;
     /// embed track from tpfms muon fit into the muon
@@ -181,7 +180,7 @@ namespace pat {
     /// add generator match information
     bool addGenMatch_;
     /// input tags for generator match information
-    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
+    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>>> genMatchTokens_;
     /// embed the gen match information into the muon
     bool embedGenMatch_;
     /// add resolutions to the muon (this will be data members of th muon even w/o embedding)
@@ -199,13 +198,13 @@ namespace pat {
     /// input source of the primary vertex/beamspot
     edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
     /// input source of the primary vertex
-    edm::EDGetTokenT<std::vector<reco::Vertex> > pvToken_;
+    edm::EDGetTokenT<std::vector<reco::Vertex>> pvToken_;
     /// input source for isoDeposits
     IsolationLabels isoDepositLabels_;
-    std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit>>> isoDepositTokens_;
     /// input source isolation value maps
     IsolationLabels isolationValueLabels_;
-    std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueTokens_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<double>>> isolationValueTokens_;
     /// add efficiencies to the muon (this will be data members of th muon even w/o embedding)
     bool addEfficiencies_;
     /// add user data to the muon (this will be data members of th muon even w/o embedding)
@@ -215,13 +214,13 @@ namespace pat {
     /// add puppi isolation
     bool addPuppiIsolation_;
     //PUPPI isolation tokens
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_charged_hadrons_;
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_neutral_hadrons_;
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_photons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_photons_;
     //PUPPINoLeptons isolation tokens
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_charged_hadrons_;
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_neutral_hadrons_;
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_photons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_photons_;
     /// standard muon selectors
     bool computeMuonMVA_;
     bool computeSoftMuonMVA_;
@@ -231,7 +230,7 @@ namespace pat {
     edm::EDGetTokenT<reco::JetCorrector> mvaL1Corrector_;
     edm::EDGetTokenT<reco::JetCorrector> mvaL1L2L3ResCorrector_;
     edm::EDGetTokenT<double> rho_;
-    
+
     /// --- tools ---
     /// comparator for pt ordering
     GreaterByPt<Muon> pTComparator_;
@@ -245,7 +244,7 @@ namespace pat {
     pat::PATUserDataHelper<pat::Muon> userDataHelper_;
 
     /// MC info
-    edm::EDGetTokenT<edm::ValueMap<reco::MuonSimInfo> > simInfo_;
+    edm::EDGetTokenT<edm::ValueMap<reco::MuonSimInfo>> simInfo_;
 
     /// Trigger
     bool addTriggerMatching_;
@@ -254,51 +253,59 @@ namespace pat {
     std::vector<std::string> hltCollectionFilters_;
   };
 
-}
+}  // namespace pat
 
-
-
-
-template<typename T>
-void pat::PATMuonProducer::readIsolationLabels( const edm::ParameterSet & iConfig, const char* psetName, pat::PATMuonProducer::IsolationLabels& labels, std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens)
-{
+template <typename T>
+void pat::PATMuonProducer::readIsolationLabels(const edm::ParameterSet& iConfig,
+                                               const char* psetName,
+                                               pat::PATMuonProducer::IsolationLabels& labels,
+                                               std::vector<edm::EDGetTokenT<edm::ValueMap<T>>>& tokens) {
   labels.clear();
 
-  if (iConfig.exists( psetName )) {
+  if (iConfig.exists(psetName)) {
     edm::ParameterSet depconf = iConfig.getParameter<edm::ParameterSet>(psetName);
 
-    if (depconf.exists("tracker")) labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
-    if (depconf.exists("ecal"))    labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
-    if (depconf.exists("hcal"))    labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
-    if (depconf.exists("pfAllParticles"))  {
+    if (depconf.exists("tracker"))
+      labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
+    if (depconf.exists("ecal"))
+      labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
+    if (depconf.exists("hcal"))
+      labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
+    if (depconf.exists("pfAllParticles")) {
       labels.push_back(std::make_pair(pat::PfAllParticleIso, depconf.getParameter<edm::InputTag>("pfAllParticles")));
     }
-    if (depconf.exists("pfChargedHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
+    if (depconf.exists("pfChargedHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
     }
-    if (depconf.exists("pfChargedAll"))  {
+    if (depconf.exists("pfChargedAll")) {
       labels.push_back(std::make_pair(pat::PfChargedAllIso, depconf.getParameter<edm::InputTag>("pfChargedAll")));
     }
-    if (depconf.exists("pfPUChargedHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
+    if (depconf.exists("pfPUChargedHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
     }
-    if (depconf.exists("pfNeutralHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
+    if (depconf.exists("pfNeutralHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
     }
     if (depconf.exists("pfPhotons")) {
       labels.push_back(std::make_pair(pat::PfGammaIso, depconf.getParameter<edm::InputTag>("pfPhotons")));
     }
     if (depconf.exists("user")) {
-      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
+      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag>>("user");
       std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
       int key = pat::IsolationKeys::UserBaseIso;
-      for ( ; it != ed; ++it, ++key) {
-       labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
+      for (; it != ed; ++it, ++key) {
+        labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
       }
-      tokens = edm::vector_transform(labels, [this](IsolationLabel const & label){return consumes<edm::ValueMap<T> >(label.second);});
+      tokens = edm::vector_transform(
+          labels, [this](IsolationLabel const& label) { return consumes<edm::ValueMap<T>>(label.second); });
     }
   }
-  tokens = edm::vector_transform(labels, [this](pat::PATMuonProducer::IsolationLabel const & label){return consumes<edm::ValueMap<T> >(label.second);});
+  tokens = edm::vector_transform(labels, [this](pat::PATMuonProducer::IsolationLabel const& label) {
+    return consumes<edm::ValueMap<T>>(label.second);
+  });
 }
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -173,7 +173,9 @@ namespace pat {
     bool embedTpfmsMuon_;
     /// embed track from DYT muon fit into the muon
     bool embedDytMuon_;
-    /// input tag for reading timing information
+    /// add combined inverse beta measurement into the muon
+    bool addInverseBeta_;
+    /// input tag for reading inverse beta
     edm::EDGetTokenT<edm::ValueMap<reco::MuonTimeExtra>> muonTimeExtraToken_;
     /// add generator match information
     bool addGenMatch_;

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -173,9 +173,7 @@ namespace pat {
     bool embedTpfmsMuon_;
     /// embed track from DYT muon fit into the muon
     bool embedDytMuon_;
-    /// add combined inverse beta measurement into the muon
-    bool addInverseBeta_;
-    /// input tag for reading inverse beta
+    /// input tag for reading timing information
     edm::EDGetTokenT<edm::ValueMap<reco::MuonTimeExtra>> muonTimeExtraToken_;
     /// add generator match information
     bool addGenMatch_;

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -71,7 +71,9 @@ patMuons = cms.EDProducer("PATMuonProducer",
         #        deltaR = cms.double(0.3)
         #    )),
     ),
-
+    # Read and store combined inverse beta
+    addInverseBeta    = cms.bool(True),  
+    sourceMuonTimeExtra = cms.InputTag("muons","combined"), #Use combined info, not only csc or dt
     # mc matching
     addGenMatch   = cms.bool(True),
     embedGenMatch = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -71,9 +71,10 @@ patMuons = cms.EDProducer("PATMuonProducer",
         #        deltaR = cms.double(0.3)
         #    )),
     ),
-    # Read and store combined inverse beta
-    addInverseBeta    = cms.bool(False),  
+
+    # Where to read and store from the timing information
     sourceMuonTimeExtra = cms.InputTag("muons","combined"), #Use combined info, not only csc or dt
+
     # mc matching
     addGenMatch   = cms.bool(True),
     embedGenMatch = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -71,10 +71,9 @@ patMuons = cms.EDProducer("PATMuonProducer",
         #        deltaR = cms.double(0.3)
         #    )),
     ),
-
-    # Where to read and store from the timing information
+    # Read and store combined inverse beta
+    addInverseBeta    = cms.bool(True),  
     sourceMuonTimeExtra = cms.InputTag("muons","combined"), #Use combined info, not only csc or dt
-
     # mc matching
     addGenMatch   = cms.bool(True),
     embedGenMatch = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -72,7 +72,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
         #    )),
     ),
     # Read and store combined inverse beta
-    addInverseBeta    = cms.bool(True),  
+    addInverseBeta    = cms.bool(False),  
     sourceMuonTimeExtra = cms.InputTag("muons","combined"), #Use combined info, not only csc or dt
     # mc matching
     addGenMatch   = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -33,10 +33,12 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
     from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
     from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
+    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
     run2_muon_2016.toModify( process.patMuons, effectiveAreaVec = [0.0735,0.0619,0.0465,0.0433,0.0577])
     run2_muon_2017.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
     run2_muon_2018.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
     run2_muon_2016.toModify( process.patMuons, mvaTrainingFile = "RecoMuon/MuonIdentification/data/mu_2016_BDTG.weights.xml")
+    run2_miniAOD_devel.toModify(process.patMuons, addInverseBeta = cms.bool(True))    
 
     process.patMuons.computePuppiCombinedIso = True
     #
@@ -373,7 +375,6 @@ def miniAOD_customizeCommon(process):
     process.deepTau2017v2p1.taus = _noUpdatedTauName
     deepTauIDTaskNew_ = cms.Task(process.deepTau2017v2p1,process.slimmedTaus)
 
-    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
     from Configuration.Eras.Modifier_run2_tau_ul_2016_cff import run2_tau_ul_2016
     from Configuration.Eras.Modifier_run2_tau_ul_2018_cff import run2_tau_ul_2018
     for era in [run2_miniAOD_devel,run2_tau_ul_2016,run2_tau_ul_2018]:

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -33,12 +33,10 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
     from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
     from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
-    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
     run2_muon_2016.toModify( process.patMuons, effectiveAreaVec = [0.0735,0.0619,0.0465,0.0433,0.0577])
     run2_muon_2017.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
     run2_muon_2018.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
     run2_muon_2016.toModify( process.patMuons, mvaTrainingFile = "RecoMuon/MuonIdentification/data/mu_2016_BDTG.weights.xml")
-    run2_miniAOD_devel.toModify(process.patMuons, addInverseBeta = cms.bool(True))    
 
     process.patMuons.computePuppiCombinedIso = True
     #
@@ -375,6 +373,7 @@ def miniAOD_customizeCommon(process):
     process.deepTau2017v2p1.taus = _noUpdatedTauName
     deepTauIDTaskNew_ = cms.Task(process.deepTau2017v2p1,process.slimmedTaus)
 
+    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
     from Configuration.Eras.Modifier_run2_tau_ul_2016_cff import run2_tau_ul_2016
     from Configuration.Eras.Modifier_run2_tau_ul_2018_cff import run2_tau_ul_2018
     for era in [run2_miniAOD_devel,run2_tau_ul_2016,run2_tau_ul_2018]:


### PR DESCRIPTION
#### PR description:

This is a (long overdue) backport of https://github.com/cms-sw/cmssw/pull/28212 to 10_6_X in order to save the inverse beta (timing variable) of pat::muons.  We discussed this-very briefly- this in a reco meeting a couple of months ago. As it's been some time should I raise it again next time?

Our goal would be to have it as part of a possible UL re-miniAOD. Should I also comment on issue https://github.com/cms-sw/cmssw/issues/27889 ?

#### PR validation:

Same tests as the original PR:
No compilation errors or of battery of tests from
runTheMatrix.py -l limited -i all

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/28212 to include the feature in reminiAOD of UL