### PR TITLE
Fix HGCal_disableNoise customization function

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -246,6 +246,9 @@ def HGCal_setRealisticNoiseSci(process,byDose=True,byDoseAlgo=0):
 
 def HGCal_disableNoise(process):
     process.HGCAL_noise_fC = cms.PSet(
+        scaleByDose = cms.bool(False),
+        scaleByDoseAlgo = cms.uint32(0),
+        doseMap = cms.string(""),
         values = cms.vdouble(0,0,0), #100,200,300 um
     )
     process.HGCAL_noise_heback = cms.PSet(


### PR DESCRIPTION
#### PR description:

The logic with which the parameters are parsed requires the presence of
many parameters that were not present in the customization function.

#### PR validation:

Tested on workflow 23234, with and without the customization function. The code works and the Noise is turned off with the customization active.
