### PR TITLE
Fix MET unclustered energy computation [10_6_X]

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -15,6 +15,7 @@ public:
 
   explicit CandPtrProjector(edm::ParameterSet const& iConfig);
   void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   edm::EDGetTokenT<edm::View<reco::Candidate>> candSrcToken_;
@@ -24,9 +25,9 @@ private:
 
 CandPtrProjector::CandPtrProjector(edm::ParameterSet const& iConfig):
   candSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))},
-  vetoSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("veto"))}
+  vetoSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("veto"))},
+  useDeltaRforFootprint_(iConfig.getParameter<bool>("useDeltaRforFootprint"))
 {
-  useDeltaRforFootprint_ = iConfig.exists("useDeltaRforFootprint") ? iConfig.getParameter<bool>("useDeltaRforFootprint") : false;
   produces<edm::PtrVector<reco::Candidate>>();
 }
 
@@ -63,6 +64,14 @@ CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup con
     }
   }
   iEvent.put(std::move(result));
+}
+
+void CandPtrProjector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src");
+  desc.add<edm::InputTag>("veto");
+  desc.add<bool>("useDeltaRforFootprint", false);
+  descriptions.add("CandPtrProjector", desc);
 }
 
 DEFINE_FWK_MODULE(CandPtrProjector);

--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -71,7 +71,7 @@ void CandPtrProjector::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<edm::InputTag>("src");
   desc.add<edm::InputTag>("veto");
   desc.add<bool>("useDeltaRforFootprint", false);
-  descriptions.add("CandPtrProjector", desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(CandPtrProjector);

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -791,6 +791,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                            src = pfCandCollection, 
                                            veto = jetCollection
                                            )
+            if self._parameters["Puppi"].value:
+              from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+              run2_miniAOD_devel.toModify(pfCandsNoJets, useDeltaRforFootprint = cms.bool(True))
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -789,11 +789,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #Jet projection ==
             pfCandsNoJets = cms.EDProducer("CandPtrProjector", 
                                            src = pfCandCollection, 
-                                           veto = jetCollection
+                                           veto = jetCollection,
+                                           useDeltaRforFootprint = cms.bool(False)
                                            )
             if self._parameters["Puppi"].value:
               from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-              run2_miniAOD_devel.toModify(pfCandsNoJets, useDeltaRforFootprint = cms.bool(True))
+              run2_miniAOD_devel.toModify(pfCandsNoJets, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -57,6 +57,7 @@ namespace metsig {
          std::vector<double> jetEtas_;
          std::vector<double> jetParams_;
          std::vector<double> pjetParams_;
+         bool useDeltaRforFootprint_;
 
    };
 

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -39,7 +39,7 @@ metsig::METSignificance::METSignificance(const edm::ParameterSet& iConfig) {
   jetEtas_ = cfgParams.getParameter<std::vector<double> >("jeta");
   jetParams_ = cfgParams.getParameter<std::vector<double> >("jpar");
   pjetParams_ = cfgParams.getParameter<std::vector<double> >("pjpar");
-  useDeltaRforFootprint_ = cfgParams.exists("useDeltaRforFootprint") ? cfgParams.getParameter<bool>("useDeltaRforFootprint") : false;
+  useDeltaRforFootprint_ = cfgParams.getParameter<bool>("useDeltaRforFootprint");
   
 }
 
@@ -87,7 +87,7 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
      if(!cleanJet(jet, leptons) ) continue;
      for( unsigned int n=0; n < jet.numberOfSourceCandidatePtrs(); n++){
        if( jet.sourceCandidatePtr(n).isNonnull() and jet.sourceCandidatePtr(n).isAvailable() ){
-        footprint.insert(jet.sourceCandidatePtr(n));
+	 footprint.insert(jet.sourceCandidatePtr(n));
        }
      }
 

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -39,3 +39,7 @@ METSignificanceParams_Data=cms.PSet(
       jpar = cms.vdouble(1.38,1.28,1.22,1.16,1.10),
       pjpar = cms.vdouble(0.0033,0.5802),
       )
+
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+run2_miniAOD_devel.toModify(METSignificanceParams, useDeltaRforFootprint = cms.bool(True))
+run2_miniAOD_devel.toModify(METSignificanceParams_Data, useDeltaRforFootprint = cms.bool(True))

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -18,6 +18,7 @@ METSignificanceParams = cms.PSet(
       #Run II MC, based on 80X
       jpar = cms.vdouble(1.39,1.26,1.21,1.23,1.28),
       pjpar = cms.vdouble(-0.2586,0.6173),
+      useDeltaRforFootprint = cms.bool(False)
       )
 
 METSignificanceParams_Data=cms.PSet(
@@ -38,8 +39,9 @@ METSignificanceParams_Data=cms.PSet(
       #Run II data, based on 80X
       jpar = cms.vdouble(1.38,1.28,1.22,1.16,1.10),
       pjpar = cms.vdouble(0.0033,0.5802),
+      useDeltaRforFootprint = cms.bool(False)
       )
 
 from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-run2_miniAOD_devel.toModify(METSignificanceParams, useDeltaRforFootprint = cms.bool(True))
-run2_miniAOD_devel.toModify(METSignificanceParams_Data, useDeltaRforFootprint = cms.bool(True))
+run2_miniAOD_devel.toModify(METSignificanceParams, useDeltaRforFootprint = True)
+run2_miniAOD_devel.toModify(METSignificanceParams_Data, useDeltaRforFootprint = True)


### PR DESCRIPTION
#### PR description:

1. Fix MET significance and unclustered pT computation for PUPPI MET. Previously these lines failed for the candidates inside jets as puppi MET and puppi jets are clustered from different particle collections with different particle momenta:
https://github.com/cms-sw/cmssw/blob/760c98128277dcab5dc4d2887c5c814cb0401740/RecoMET/METAlgorithms/src/METSignificance.cc#L95-L99
Particles from jets with puppi!=puppiForMET weights were not removed or falsely kept from unclustered energy.

2. Fix MET unclusted pT uncertainty computation for PUPPI MET. Previously this line failed for the candidates inside jets as puppi MET and puppi jets are clustered from different particle collections:
https://github.com/cms-sw/cmssw/blob/760c98128277dcab5dc4d2887c5c814cb0401740/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py#L791
Particles from jets were not removed from unclustered energy.

3. Replace dE-matching by dR-matching when computing unclustered pT and MET signficance for PF MET and PUPPI MET. Some low pT particles randomly passed the dE matching even though they did not point in the same direction, leading to changes up to 25%.

In this PR for UL-reMiniAOD, the issue is fixed by matching candidates based on dR instead of Ptrs. In the corresponding PR in the master #29254, the issue is solved by using the same particle flow collections for puppi jets and puppi MET and separate weight valuemaps.

#### PR validation:

On 100 events of 136.8311, it was checked that this PR obtains the same values of metSumPtUnlustered, metSignficance and unclustered energy uncertainties as the corresponding PT in the master #29254.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of the fix in #29331.