### PR TITLE
Fix MET unclustered energy computation

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -66,7 +66,7 @@ void CandPtrProjector::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<edm::InputTag>("src");
   desc.add<edm::InputTag>("veto");
   desc.add<bool>("useDeltaRforFootprint", false);
-  descriptions.add("CandPtrProjector", desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(CandPtrProjector);

--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 class CandPtrProjector : public edm::global::EDProducer<> {
 public:
@@ -16,11 +17,14 @@ public:
 private:
   edm::EDGetTokenT<edm::View<reco::Candidate>> candSrcToken_;
   edm::EDGetTokenT<edm::View<reco::Candidate>> vetoSrcToken_;
+  bool useDeltaRforFootprint_;
 };
 
 CandPtrProjector::CandPtrProjector(edm::ParameterSet const& iConfig)
     : candSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))},
       vetoSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("veto"))} {
+  useDeltaRforFootprint_ =
+      iConfig.exists("useDeltaRforFootprint") ? iConfig.getParameter<bool>("useDeltaRforFootprint") : false;
   produces<edm::PtrVector<reco::Candidate>>();
 }
 
@@ -43,7 +47,15 @@ void CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetu
   for (size_t i{}; i < cands->size(); ++i) {
     auto const c = cands->ptrAt(i);
     if (vetoedPtrs.find(c) == vetoedPtrs.cend()) {
-      result->push_back(c);
+      bool addcand = true;
+      if (useDeltaRforFootprint_)
+        for (const auto& it : vetoedPtrs)
+          if (reco::deltaR2(it->p4(), c->p4()) < 0.00000025) {
+            addcand = false;
+            break;
+          }
+      if (addcand)
+        result->push_back(c);
     }
   }
   iEvent.put(std::move(result));

--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -13,6 +13,7 @@ class CandPtrProjector : public edm::global::EDProducer<> {
 public:
   explicit CandPtrProjector(edm::ParameterSet const& iConfig);
   void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   edm::EDGetTokenT<edm::View<reco::Candidate>> candSrcToken_;
@@ -22,9 +23,8 @@ private:
 
 CandPtrProjector::CandPtrProjector(edm::ParameterSet const& iConfig)
     : candSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))},
-      vetoSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("veto"))} {
-  useDeltaRforFootprint_ =
-      iConfig.exists("useDeltaRforFootprint") ? iConfig.getParameter<bool>("useDeltaRforFootprint") : false;
+      vetoSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("veto"))},
+      useDeltaRforFootprint_(iConfig.getParameter<bool>("useDeltaRforFootprint")) {
   produces<edm::PtrVector<reco::Candidate>>();
 }
 
@@ -59,6 +59,14 @@ void CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetu
     }
   }
   iEvent.put(std::move(result));
+}
+
+void CandPtrProjector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src");
+  desc.add<edm::InputTag>("veto");
+  desc.add<bool>("useDeltaRforFootprint", false);
+  descriptions.add("CandPtrProjector", desc);
 }
 
 DEFINE_FWK_MODULE(CandPtrProjector);

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -784,10 +784,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #Jet projection ==
             pfCandsNoJets = cms.EDProducer("CandPtrProjector", 
                                            src = pfCandCollection, 
-                                           veto = jetCollection
+                                           veto = jetCollection,
+                                           useDeltaRforFootprint = cms.bool(False)
                                            )
             if self._parameters["Puppi"].value:
-              pfCandsNoJets.useDeltaRforFootprint = cms.bool(True)
+              pfCandsNoJets.useDeltaRforFootprint = True
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -786,6 +786,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                            src = pfCandCollection, 
                                            veto = jetCollection
                                            )
+            if self._parameters["Puppi"].value:
+              pfCandsNoJets.useDeltaRforFootprint = cms.bool(True)
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -94,7 +94,7 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
     if (footprint.find(pfCandidates->ptrAt(i)) == footprint.end()) {
       //dP4 recovery
       for (const auto& it : footprint) {
-        if ((it->p4() - (*pfCandidates)[i].p4()).Et2() < 0.000025) {
+        if (reco::deltaR2(it->p4(), (*pfCandidates)[i].p4()) < 0.00000025) {
           cleancand = false;
           break;
         }


### PR DESCRIPTION
#### PR description:

1. Fix MET significance and unclustered pT computation for PUPPI MET. Previously these lines failed for the candidates inside jets as puppi MET and puppi jets are clustered from different particle collections with different particle momenta:
https://github.com/cms-sw/cmssw/blob/760c98128277dcab5dc4d2887c5c814cb0401740/RecoMET/METAlgorithms/src/METSignificance.cc#L95-L99
Particles from jets with puppi!=puppiForMET weights were not removed or falsely kept from unclustered energy.

2. Fix MET unclusted pT uncertainty computation for PUPPI MET. Previously this line failed for the candidates inside jets as puppi MET and puppi jets are clustered from different particle collections:
https://github.com/cms-sw/cmssw/blob/760c98128277dcab5dc4d2887c5c814cb0401740/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py#L791
Particles from jets were not removed from unclustered energy.

3. Replace dE-matching by dR-matching when computing unclustered pT and MET signficance for PF MET and PUPPI MET. Some low pT particles randomly passed the dE matching even though they did not point in the same direction, leading to changes up to 25%.

In this PR, the issue is fixed by matching candidates based on dR instead of Ptrs. In the following PR #29254, the issue is solved by using the same particle flow collections for puppi jets and puppi MET and separate weight valuemaps.

#### PR validation:

On 100 events of 136.8311, it was checked that this PR obtains the same values of metSumPtUnlustered, metSignficance and unclustered energy uncertainties as the following PR #29254.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport to 10_6 for UL-reminiaod in #29330.