### PR TITLE
Fix Tracker Alignment all-in-one tool for py3 (again)

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/alignment.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/alignment.py
@@ -4,7 +4,7 @@ import os
 import re
 
 from . import configTemplates
-from .helperFunctions import conddb, parsecolor, parsestyle, replaceByMap, clean_name
+from .helperFunctions import conddb, parsecolor, parsestyle, replaceByMap, clean_name, getTagsMap
 from .TkAlExceptions import AllInOneError
 import six
 
@@ -169,7 +169,7 @@ class Alignment(object):
                     if not os.path.exists(dbfile):
                         raise AllInOneError("No file {}.".format(dbfile))
 
-                    if "\nDeformations" not in conddb("--db", dbfile, "listTags"):
+                    if "Deformations" not in getTagsMap().keys():
                         deformations = False  #so that hp = XXXX works whether or not deformations were aligned
                         if not alignments:    #then it's specified with hp_deformations, which is a mistake
                             raise AllInOneError("{}{} has no deformations".format(option, number))
@@ -257,7 +257,7 @@ class Alignment(object):
         if dbpath.startswith("sqlite_file:"):
             if not os.path.exists( dbpath.split("sqlite_file:")[1] ):
                 raise AllInOneError("could not find file: '%s'"%dbpath.split("sqlite_file:")[1])
-            elif "\n"+tagname not in conddb("--db", dbpath.split("sqlite_file:")[1], "listTags"):
+            elif tagname not in getTagsMap(dbpath).values():
                 raise AllInOneError("{} does not exist in {}".format(tagname, dbpath))
 
     def restrictTo( self, restriction ):

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/alignment.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/alignment.py
@@ -4,7 +4,7 @@ import os
 import re
 
 from . import configTemplates
-from .helperFunctions import conddb, parsecolor, parsestyle, replaceByMap, clean_name, getTagsMap
+from .helperFunctions import parsecolor, parsestyle, replaceByMap, clean_name, getTagsMap
 from .TkAlExceptions import AllInOneError
 import six
 
@@ -169,7 +169,7 @@ class Alignment(object):
                     if not os.path.exists(dbfile):
                         raise AllInOneError("No file {}.".format(dbfile))
 
-                    if "Deformations" not in getTagsMap().keys():
+                    if "Deformations" not in getTagsMap(dbfile).keys():
                         deformations = False  #so that hp = XXXX works whether or not deformations were aligned
                         if not alignments:    #then it's specified with hp_deformations, which is a mistake
                             raise AllInOneError("{}{} has no deformations".format(option, number))

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
@@ -6,6 +6,7 @@ import re
 import ROOT
 import sys
 from .TkAlExceptions import AllInOneError
+import CondCore.Utilities.conddblib as conddblib
 import six
 
 ####################--- Helpers ---############################
@@ -232,6 +233,14 @@ def conddb(*args):
 
     return result
 
+def getTagsMap(db):
+    con = conddblib.connect(url = conddblib.make_url(db))
+    session = con.session()
+    TAG = session.get_dbtype(conddblib.Tag)
+    q1 = session.query(TAG.object_type).order_by(TAG.name).all()[0]
+    q2 = session.query(TAG.name).order_by(TAG.name).all()[0]
+    dictionary = dict(zip(q1, q2))
+    return dictionary
 
 def clean_name(s):
     """Transforms a string into a valid variable or method name.

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
@@ -198,41 +198,6 @@ def cppboolstring(string, name):
     """
     return pythonboolstring(string, name).lower()
 
-def conddb(*args):
-    """
-    Wrapper for conddb, so that you can run
-    conddb("--db", "myfile.db", "listTags"),
-    like from the command line, without explicitly
-    dealing with all the functions in CondCore/Utilities.
-    getcommandoutput2(conddb ...) doesn't work, it imports
-    the wrong sqlalchemy in CondCore/Utilities/python/conddblib.py
-    """
-    from tempfile import NamedTemporaryFile
-
-    with open(getCommandOutput2("which conddb").strip()) as f:
-        conddb = f.read()
-
-    def sysexit(number):
-        if number != 0:
-            raise AllInOneError("conddb exited with status {}".format(number))
-    namespace = {"sysexit": sysexit, "conddboutput": ""}
-
-    conddb = conddb.replace("sys.exit", "sysexit")
-
-    bkpargv = sys.argv
-    sys.argv[1:] = args
-    bkpstdout = sys.stdout
-    with NamedTemporaryFile(bufsize=0) as sys.stdout:
-        exec(conddb, namespace)
-        namespace["main"]()
-        with open(sys.stdout.name) as f:
-            result = f.read()
-
-    sys.argv[:] = bkpargv
-    sys.stdout = bkpstdout
-
-    return result
-
 def getTagsMap(db):
     con = conddblib.connect(url = conddblib.make_url(db))
     session = con.session()


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/29337

#### PR description:

Title says it all. Removed contraption to list tags in favor of DB group supported `conddbllib` commands 

#### PR validation:

Unit test has been exercised successfully with this PR in `CMSSW_11_1_PY3_X_2020-03-29-2300`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, and no backport is meant.
