### PR TITLE
DQM: fix some autoDQM.py harvesting sequences

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2000,6 +2000,8 @@ class ConfigBuilder(object):
         for name in harvestingList:
             if not name in harvestingConfig.__dict__:
                 print(name,"is not a possible harvesting type. Available are",harvestingConfig.__dict__.keys())
+                # trigger hard error, like for other sequence types
+                getattr(self.process, name)
                 continue
             harvestingstream = getattr(harvestingConfig,name)
             if isinstance(harvestingstream,cms.Path):

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
@@ -13,6 +13,8 @@ from DQM.RPCMonitorClient.RPCTier0Client_cff import *
 from DQM.CSCMonitorModule.csc_dqm_offlineclient_cosmics_cff import *
 from DQMServices.Components.DQMFEDIntegrityClient_cff import *
 
+DQMNone = cms.Sequence()
+
 DQMOfflineCosmics_SecondStepEcal = cms.Sequence( ecal_dqm_client_offline *
 						es_dqm_client_offline )
 

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
@@ -14,6 +14,8 @@ from DQM.CSCMonitorModule.csc_dqm_sourceclient_offline_cff import *
 from DQM.EcalPreshowerMonitorModule.es_dqm_source_offline_cosmic_cff import *
 from DQM.CastorMonitor.castor_dqm_sourceclient_offline_cff import *
 
+DQMNone = cms.Sequence()
+
 dqmProvInfo.runType = "cosmics_run"
 dqmProvInfo.dcsRecord = cms.untracked.InputTag("onlineMetaDataDigis")
 DQMOfflineCosmicsDCS = cms.Sequence( dqmProvInfo )

--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_SecondStep_cff.py
@@ -13,6 +13,8 @@ from DQM.RPCMonitorClient.RPCTier0Client_cff import *
 from DQM.CSCMonitorModule.csc_dqm_offlineclient_collisions_cff import *
 from DQMServices.Components.DQMFEDIntegrityClient_cff import *
 
+DQMNone = cms.Sequence()
+
 DQMOfflineHeavyIons_SecondStepEcal = cms.Sequence( ecal_dqm_client_offline *
 						    es_dqm_client_offline )
 

--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
@@ -15,6 +15,8 @@ from DQM.RPCMonitorClient.RPCTier0Source_cff import *
 from DQM.CSCMonitorModule.csc_dqm_sourceclient_offline_cff import *
 from DQM.BeamMonitor.AlcaBeamMonitorHeavyIons_cff import *
 
+DQMNone = cms.Sequence()
+
 dqmProvInfo.runType = "hi_run"
 DQMOfflineHeavyIonsDCS = cms.Sequence( dqmProvInfo )
 

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -16,6 +16,8 @@ from DQMServices.Components.DQMFEDIntegrityClient_cff import *
 from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
 from DQM.SiTrackerPhase2.Phase2TrackerDQMHarvesting_cff import *
 
+DQMNone = cms.Sequence()
+
 DQMOffline_SecondStepEcal = cms.Sequence( ecal_dqm_client_offline *
 					  es_dqm_client_offline )
 

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -35,7 +35,7 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                               'DQMHarvestTrackerPhase2'],
 	    'dcs': ['DQMOfflineDCS',
 		    'PostDQMOffline',
-		    'DQMHarvestDCS'],
+		    'DQMNone'],
 
 	    'strip': ['DQMOfflineTrackerStrip',
 		      'PostDQMOffline',


### PR DESCRIPTION
#### PR description:
It turns out that `ConfigBuilder` treats failing to find a HARVESTING sequence not as an error, and in fact we have some non-existing sequences in `autoDQM.py`. One of them is `DQMHarvestDCS`, which I forgot to remove in #28829.

But also `DQMNone`, which is used to signify that there is nothing to do (`''` could be understood as default sequence, as usual in `cmsDriver`) is not actually defined in harvesting. So I added that to all the main config files.

Finally, this PR makes `ConfigBuilder` fail on undefined harvesting sequences, like it does for other sequences. 

#### PR validation:

Functionality should not be affected, but misconfigured jobs may crash now. I expect some PR and even IB failures untilwe catch all of them.