### PR TITLE
DQM: Fix fallback in DQMRootSource

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -486,6 +486,7 @@ std::unique_ptr<edm::FileBlock> DQMRootSource::readFile_() {
       }
 
     } catch (cms::Exception const& e) {
+      file = nullptr;  // is there anything we need to free?
       if (!hasFallback) {
         if (m_skipBadFiles) {
           continue;
@@ -530,6 +531,7 @@ std::unique_ptr<edm::FileBlock> DQMRootSource::readFile_() {
           std::rethrow_exception(e);
         }
       } catch (cms::Exception const& e) {
+        file = nullptr;  // is there anything we need to free?
         if (m_skipBadFiles) {
           continue;
         } else {


### PR DESCRIPTION
#### PR description:
A small bugfix to make opening remote files work in `DQMRootSource`, that is, in HARVESTING jobs.

#### PR validation:

This code path is not used in production setups; all production harvesting jobs download the input files locally first. It rarely worked in the past, now it works again (in my private tests). No effect on output expected.
