### PR TITLE
Additional Tracker DQM residual plots

### DIFF
--- a/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
+++ b/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
@@ -68,6 +68,7 @@ private:
 
   std::map<std::string, MonitorElement*> summaryMap_;
   MonitorElement* deadROCSummary;
+  std::map<std::string, MonitorElement*> residuals_;
   MonitorElement* reportSummary;  //Float value of the average of the ins in the grand summary
 
   std::map<std::string, std::string> summaryPlotName_;

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -143,44 +143,100 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
   for (unsigned int i = 0; i < xAxisLabelsReduced_.size(); i++) {
     deadROCSummary->setBinLabel(i + 1, xAxisLabelsReduced_[i]);
   }
-  
+
   //New residual plots for the PXBarrel separated by inner and outer modules per layer
   iBooker.setCurrentFolder("PixelPhase1/Tracks/PXBarrel");
-  for (std::string layer:{"1","2","3","4"}){
-    residuals_["residual_mean_x_Inner_PXLayer_"+layer] = iBooker.book1D("residual_mean_x_Inner_PXLayer_"+layer, "Mean Track Residuals X Inner Modules for Layer "+layer+";mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-    residuals_["residual_mean_x_Outer_PXLayer_"+layer] = iBooker.book1D("residual_mean_x_Outer_PXLayer_"+layer, "Mean Track Residuals X Outer Modules for Layer "+layer+";mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-    residuals_["residual_mean_y_Inner_PXLayer_"+layer] = iBooker.book1D("residual_mean_y_Inner_PXLayer_"+layer, "Mean Track Residuals Y Inner Modules for Layer "+layer+";mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-    residuals_["residual_mean_y_Outer_PXLayer_"+layer] = iBooker.book1D("residual_mean_y_Outer_PXLayer_"+layer, "Mean Track Residuals Y Outer Modules for Layer "+layer+";mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-    
-    residuals_["residual_rms_x_Inner_PXLayer_"+layer] = iBooker.book1D("residual_rms_x_Inner_PXLayer_"+layer, "RMS of Track Residuals X Inner Modules for Layer "+layer+";rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-    residuals_["residual_rms_x_Outer_PXLayer_"+layer] = iBooker.book1D("residual_rms_x_Outer_PXLayer_"+layer, "RMS of Track Residuals X Outer Modules for Layer "+layer+";rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-    residuals_["residual_rms_y_Inner_PXLayer_"+layer] = iBooker.book1D("residual_rms_y_Inner_PXLayer_"+layer, "RMS of Track Residuals Y Inner Modules for Layer "+layer+";rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-    residuals_["residual_rms_y_Outer_PXLayer_"+layer] = iBooker.book1D("residual_rms_y_Outer_PXLayer_"+layer, "RMS of Track Residuals Y Outer Modules for Layer "+layer+";rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  for (std::string layer : {"1", "2", "3", "4"}) {
+    residuals_["residual_mean_x_Inner_PXLayer_" + layer] =
+        iBooker.book1D("residual_mean_x_Inner_PXLayer_" + layer,
+                       "Mean Track Residuals X Inner Modules for Layer " + layer + ";mean(x_rec-x_pred)[cm]",
+                       100,
+                       -0.1,
+                       0.1);
+    residuals_["residual_mean_x_Outer_PXLayer_" + layer] =
+        iBooker.book1D("residual_mean_x_Outer_PXLayer_" + layer,
+                       "Mean Track Residuals X Outer Modules for Layer " + layer + ";mean(x_rec-x_pred)[cm]",
+                       100,
+                       -0.1,
+                       0.1);
+    residuals_["residual_mean_y_Inner_PXLayer_" + layer] =
+        iBooker.book1D("residual_mean_y_Inner_PXLayer_" + layer,
+                       "Mean Track Residuals Y Inner Modules for Layer " + layer + ";mean(x_rec-x_pred)[cm]",
+                       100,
+                       -0.1,
+                       0.1);
+    residuals_["residual_mean_y_Outer_PXLayer_" + layer] =
+        iBooker.book1D("residual_mean_y_Outer_PXLayer_" + layer,
+                       "Mean Track Residuals Y Outer Modules for Layer " + layer + ";mean(x_rec-x_pred)[cm]",
+                       100,
+                       -0.1,
+                       0.1);
+
+    residuals_["residual_rms_x_Inner_PXLayer_" + layer] =
+        iBooker.book1D("residual_rms_x_Inner_PXLayer_" + layer,
+                       "RMS of Track Residuals X Inner Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
+                       100,
+                       -0.1,
+                       0.1);
+    residuals_["residual_rms_x_Outer_PXLayer_" + layer] =
+        iBooker.book1D("residual_rms_x_Outer_PXLayer_" + layer,
+                       "RMS of Track Residuals X Outer Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
+                       100,
+                       -0.1,
+                       0.1);
+    residuals_["residual_rms_y_Inner_PXLayer_" + layer] =
+        iBooker.book1D("residual_rms_y_Inner_PXLayer_" + layer,
+                       "RMS of Track Residuals Y Inner Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
+                       100,
+                       -0.1,
+                       0.1);
+    residuals_["residual_rms_y_Outer_PXLayer_" + layer] =
+        iBooker.book1D("residual_rms_y_Outer_PXLayer_" + layer,
+                       "RMS of Track Residuals Y Outer Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
+                       100,
+                       -0.1,
+                       0.1);
   }
-  
+
   //New residual plots for the PXForward separated by inner and outer modules
   iBooker.setCurrentFolder("PixelPhase1/Tracks/PXForward");
-  residuals_["residual_mean_x_Inner"] = iBooker.book1D("residual_mean_x_Inner", "Mean Track Residuals X Inner Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_x_Outer"] = iBooker.book1D("residual_mean_x_Outer", "Mean Track Residuals X Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_y_Inner"] = iBooker.book1D("residual_mean_y_Inner", "Mean Track Residuals Y Inner Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_y_Outer"] = iBooker.book1D("residual_mean_y_Outer", "Mean Track Residuals Y Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  
-  residuals_["residual_rms_x_Inner"] = iBooker.book1D("residual_rms_x_Inner", "RMS of Track Residuals X Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_rms_x_Outer"] = iBooker.book1D("residual_rms_x_Outer", "RMS of Track Residuals X Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_rms_y_Inner"] = iBooker.book1D("residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_rms_y_Outer"] = iBooker.book1D("residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  
+  residuals_["residual_mean_x_Inner"] = iBooker.book1D(
+      "residual_mean_x_Inner", "Mean Track Residuals X Inner Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_x_Outer"] = iBooker.book1D(
+      "residual_mean_x_Outer", "Mean Track Residuals X Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_y_Inner"] = iBooker.book1D(
+      "residual_mean_y_Inner", "Mean Track Residuals Y Inner Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_y_Outer"] = iBooker.book1D(
+      "residual_mean_y_Outer", "Mean Track Residuals Y Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+
+  residuals_["residual_rms_x_Inner"] = iBooker.book1D(
+      "residual_rms_x_Inner", "RMS of Track Residuals X Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_x_Outer"] = iBooker.book1D(
+      "residual_rms_x_Outer", "RMS of Track Residuals X Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_y_Inner"] = iBooker.book1D(
+      "residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_y_Outer"] = iBooker.book1D(
+      "residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+
   //New residual plots for the PXForward separated by positive and negative side
   iBooker.setCurrentFolder("PixelPhase1/Tracks/PXForward");
-  residuals_["residual_mean_x_pos"] = iBooker.book1D("residual_mean_x_pos", "Mean Track Residuals X pos. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_x_neg"] = iBooker.book1D("residual_mean_x_neg", "Mean Track Residuals X neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_y_pos"] = iBooker.book1D("residual_mean_y_pos", "Mean Track Residuals Y pos. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_y_neg"] = iBooker.book1D("residual_mean_y_neg", "Mean Track Residuals Y neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  
-  residuals_["residual_rms_x_pos"] = iBooker.book1D("residual_rms_x_pos", "RMS of Track Residuals X pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_rms_x_neg"] = iBooker.book1D("residual_rms_x_neg", "RMS of Track Residuals X neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_rms_y_pos"] = iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_rms_y_neg"] = iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_x_pos"] =
+      iBooker.book1D("residual_mean_x_pos", "Mean Track Residuals X pos. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_x_neg"] =
+      iBooker.book1D("residual_mean_x_neg", "Mean Track Residuals X neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_y_pos"] =
+      iBooker.book1D("residual_mean_y_pos", "Mean Track Residuals Y pos. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_y_neg"] =
+      iBooker.book1D("residual_mean_y_neg", "Mean Track Residuals Y neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+
+  residuals_["residual_rms_x_pos"] =
+      iBooker.book1D("residual_rms_x_pos", "RMS of Track Residuals X pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_x_neg"] =
+      iBooker.book1D("residual_rms_x_neg", "RMS of Track Residuals X neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_y_pos"] =
+      iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_y_neg"] =
+      iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
 
   //Book the summary plot
   iBooker.setCurrentFolder("PixelPhase1/EventInfo");
@@ -320,98 +376,99 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
     }
     deadROCSummary->setBinContent(xBin, yBin, nROCs / nRocsPerTrend[i]);
   }
-  
+
   //Fill additional residuals plots
   //PXBarrel
-  for (std::string layer:{"1","2","3","4"}) {
-    MonitorElement* me_x = iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_"+layer);
-    MonitorElement* me_y = iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_"+layer);
-    for (int i=1; i<=me_x->getNbinsY(); i++) {
-      
-      if (i == (me_x->getNbinsY()/2+1)) continue;   //Middle bin of y axis is empty
-      
-      switch (i <= me_x->getNbinsY()/2) {
-        
+  for (std::string layer : {"1", "2", "3", "4"}) {
+    MonitorElement* me_x =
+        iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
+    MonitorElement* me_y =
+        iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
+    for (int i = 1; i <= me_x->getNbinsY(); i++) {
+      if (i == (me_x->getNbinsY() / 2 + 1))
+        continue;  //Middle bin of y axis is empty
+
+      switch (i <= me_x->getNbinsY() / 2) {
         case true:
-          if (i%2 == 0) {
-            for (int j : {1,2,3,4,6,7,8,9}){
-              residuals_["residual_mean_x_Inner_PXLayer_"+layer]->Fill(me_x->getBinContent(j,i));
-              residuals_["residual_mean_y_Inner_PXLayer_"+layer]->Fill(me_y->getBinContent(j,i));
-              residuals_["residual_rms_x_Inner_PXLayer_"+layer]->Fill(me_x->getBinError(j,i));
-              residuals_["residual_rms_y_Inner_PXLayer_"+layer]->Fill(me_y->getBinError(j,i));
+          if (i % 2 == 0) {
+            for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
+              residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
+              residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
+              residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
+              residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
             }
-          }
-          else {
-            for (int j : {1,2,3,4,6,7,8,9}){
-              residuals_["residual_mean_x_Outer_PXLayer_"+layer]->Fill(me_x->getBinContent(j,i));
-              residuals_["residual_mean_y_Outer_PXLayer_"+layer]->Fill(me_y->getBinContent(j,i));
-              residuals_["residual_rms_x_Outer_PXLayer_"+layer]->Fill(me_x->getBinError(j,i));
-              residuals_["residual_rms_y_Outer_PXLayer_"+layer]->Fill(me_y->getBinError(j,i));
+          } else {
+            for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
+              residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
+              residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
+              residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
+              residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
             }
           }
           break;
-        
+
         case false:
-          if (i%2 == 1) {
-            for (int j : {1,2,3,4,6,7,8,9}){
-              residuals_["residual_mean_x_Inner_PXLayer_"+layer]->Fill(me_x->getBinContent(j,i));
-              residuals_["residual_mean_y_Inner_PXLayer_"+layer]->Fill(me_y->getBinContent(j,i));
-              residuals_["residual_rms_x_Inner_PXLayer_"+layer]->Fill(me_x->getBinError(j,i));
-              residuals_["residual_rms_y_Inner_PXLayer_"+layer]->Fill(me_y->getBinError(j,i));
+          if (i % 2 == 1) {
+            for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
+              residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
+              residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
+              residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
+              residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
             }
-          }
-          else {
-            for (int j : {1,2,3,4,6,7,8,9}){
-              residuals_["residual_mean_x_Outer_PXLayer_"+layer]->Fill(me_x->getBinContent(j,i));
-              residuals_["residual_mean_y_Outer_PXLayer_"+layer]->Fill(me_y->getBinContent(j,i));
-              residuals_["residual_rms_x_Outer_PXLayer_"+layer]->Fill(me_x->getBinError(j,i));
-              residuals_["residual_rms_y_Outer_PXLayer_"+layer]->Fill(me_y->getBinError(j,i));
+          } else {
+            for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
+              residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
+              residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
+              residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
+              residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
             }
           }
       }
     }
   }
-  
+
   //PXForward separating outer and inner modules as well as positive and negative side
-  for (std::string ring:{"1","2"}){
-    MonitorElement* me_x = iGetter.get("PixelPhase1/Tracks/PXForward/residual_x_per_PXDisk_per_SignedBladePanel_PXRing_"+ring);
-    MonitorElement* me_y = iGetter.get("PixelPhase1/Tracks/PXForward/residual_y_per_PXDisk_per_SignedBladePanel_PXRing_"+ring);
+  for (std::string ring : {"1", "2"}) {
+    MonitorElement* me_x =
+        iGetter.get("PixelPhase1/Tracks/PXForward/residual_x_per_PXDisk_per_SignedBladePanel_PXRing_" + ring);
+    MonitorElement* me_y =
+        iGetter.get("PixelPhase1/Tracks/PXForward/residual_y_per_PXDisk_per_SignedBladePanel_PXRing_" + ring);
     bool posSide = false;
-    for (int j=1; j<=me_x->getNbinsX(); j++) {
-      
-      if (j==4) continue;  //fourth x-bin in profile plots is empty
-      
-      if (j==5) posSide = true;   //change to postive side
-      
-      for (int i=1; i<=me_x->getNbinsY(); i++) {
-        
-        if (i == me_x->getNbinsY()/2) continue;//Middle bins of y axis is empty
-        if (i == (me_x->getNbinsY()/2)+1) continue;
-        
-        if (i%2 == 0) {   //separate inner and outer modules
-          residuals_["residual_mean_x_Inner"]->Fill(me_x->getBinContent(j,i));
-          residuals_["residual_mean_y_Inner"]->Fill(me_y->getBinContent(j,i));
-          residuals_["residual_rms_x_Inner"]->Fill(me_x->getBinError(j,i));
-          residuals_["residual_rms_y_Inner"]->Fill(me_y->getBinError(j,i));
+    for (int j = 1; j <= me_x->getNbinsX(); j++) {
+      if (j == 4)
+        continue;  //fourth x-bin in profile plots is empty
+
+      if (j == 5)
+        posSide = true;  //change to postive side
+
+      for (int i = 1; i <= me_x->getNbinsY(); i++) {
+        if (i == me_x->getNbinsY() / 2)
+          continue;  //Middle bins of y axis is empty
+        if (i == (me_x->getNbinsY() / 2) + 1)
+          continue;
+
+        if (i % 2 == 0) {  //separate inner and outer modules
+          residuals_["residual_mean_x_Inner"]->Fill(me_x->getBinContent(j, i));
+          residuals_["residual_mean_y_Inner"]->Fill(me_y->getBinContent(j, i));
+          residuals_["residual_rms_x_Inner"]->Fill(me_x->getBinError(j, i));
+          residuals_["residual_rms_y_Inner"]->Fill(me_y->getBinError(j, i));
+        } else {
+          residuals_["residual_mean_x_Outer"]->Fill(me_x->getBinContent(j, i));
+          residuals_["residual_mean_y_Outer"]->Fill(me_y->getBinContent(j, i));
+          residuals_["residual_rms_x_Outer"]->Fill(me_x->getBinError(j, i));
+          residuals_["residual_rms_y_Outer"]->Fill(me_y->getBinError(j, i));
         }
-        else {
-          residuals_["residual_mean_x_Outer"]->Fill(me_x->getBinContent(j,i));
-          residuals_["residual_mean_y_Outer"]->Fill(me_y->getBinContent(j,i));
-          residuals_["residual_rms_x_Outer"]->Fill(me_x->getBinError(j,i));
-          residuals_["residual_rms_y_Outer"]->Fill(me_y->getBinError(j,i));
-        }
-        
-        if (!posSide) {   //separate postive and negative side
-          residuals_["residual_mean_x_neg"]->Fill(me_x->getBinContent(j,i));
-          residuals_["residual_mean_y_neg"]->Fill(me_y->getBinContent(j,i));
-          residuals_["residual_rms_x_neg"]->Fill(me_x->getBinError(j,i));
-          residuals_["residual_rms_y_neg"]->Fill(me_y->getBinError(j,i));
-        }
-        else {
-          residuals_["residual_mean_x_pos"]->Fill(me_x->getBinContent(j,i));
-          residuals_["residual_mean_y_pos"]->Fill(me_y->getBinContent(j,i));
-          residuals_["residual_rms_x_pos"]->Fill(me_x->getBinError(j,i));
-          residuals_["residual_rms_y_pos"]->Fill(me_y->getBinError(j,i));
+
+        if (!posSide) {  //separate postive and negative side
+          residuals_["residual_mean_x_neg"]->Fill(me_x->getBinContent(j, i));
+          residuals_["residual_mean_y_neg"]->Fill(me_y->getBinContent(j, i));
+          residuals_["residual_rms_x_neg"]->Fill(me_x->getBinError(j, i));
+          residuals_["residual_rms_y_neg"]->Fill(me_y->getBinError(j, i));
+        } else {
+          residuals_["residual_mean_x_pos"]->Fill(me_x->getBinContent(j, i));
+          residuals_["residual_mean_y_pos"]->Fill(me_y->getBinContent(j, i));
+          residuals_["residual_rms_x_pos"]->Fill(me_x->getBinError(j, i));
+          residuals_["residual_rms_y_pos"]->Fill(me_y->getBinError(j, i));
         }
       }
     }

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -386,7 +386,7 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
   //Fill additional residuals plots
   //PXBarrel
 
-  int minHits = 30;  //Miniminal number of hits needed for module to be filled in histograms
+  constexpr int minHits = 30;  //Miniminal number of hits needed for module to be filled in histograms
 
   for (std::string layer : {"1", "2", "3", "4"}) {
     MonitorElement* me_x =

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -143,6 +143,44 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
   for (unsigned int i = 0; i < xAxisLabelsReduced_.size(); i++) {
     deadROCSummary->setBinLabel(i + 1, xAxisLabelsReduced_[i]);
   }
+  
+  //New residual plots for the PXBarrel separated by inner and outer modules per layer
+  iBooker.setCurrentFolder("PixelPhase1/Tracks/PXBarrel");
+  for (std::string layer:{"1","2","3","4"}){
+    residuals_["residual_mean_x_Inner_PXLayer_"+layer] = iBooker.book1D("residual_mean_x_Inner_PXLayer_"+layer, "Mean Track Residuals X Inner Modules for Layer "+layer+";mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+    residuals_["residual_mean_x_Outer_PXLayer_"+layer] = iBooker.book1D("residual_mean_x_Outer_PXLayer_"+layer, "Mean Track Residuals X Outer Modules for Layer "+layer+";mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+    residuals_["residual_mean_y_Inner_PXLayer_"+layer] = iBooker.book1D("residual_mean_y_Inner_PXLayer_"+layer, "Mean Track Residuals Y Inner Modules for Layer "+layer+";mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+    residuals_["residual_mean_y_Outer_PXLayer_"+layer] = iBooker.book1D("residual_mean_y_Outer_PXLayer_"+layer, "Mean Track Residuals Y Outer Modules for Layer "+layer+";mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+    
+    residuals_["residual_rms_x_Inner_PXLayer_"+layer] = iBooker.book1D("residual_rms_x_Inner_PXLayer_"+layer, "RMS of Track Residuals X Inner Modules for Layer "+layer+";rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+    residuals_["residual_rms_x_Outer_PXLayer_"+layer] = iBooker.book1D("residual_rms_x_Outer_PXLayer_"+layer, "RMS of Track Residuals X Outer Modules for Layer "+layer+";rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+    residuals_["residual_rms_y_Inner_PXLayer_"+layer] = iBooker.book1D("residual_rms_y_Inner_PXLayer_"+layer, "RMS of Track Residuals Y Inner Modules for Layer "+layer+";rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+    residuals_["residual_rms_y_Outer_PXLayer_"+layer] = iBooker.book1D("residual_rms_y_Outer_PXLayer_"+layer, "RMS of Track Residuals Y Outer Modules for Layer "+layer+";rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  }
+  
+  //New residual plots for the PXForward separated by inner and outer modules
+  iBooker.setCurrentFolder("PixelPhase1/Tracks/PXForward");
+  residuals_["residual_mean_x_Inner"] = iBooker.book1D("residual_mean_x_Inner", "Mean Track Residuals X Inner Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_x_Outer"] = iBooker.book1D("residual_mean_x_Outer", "Mean Track Residuals X Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_y_Inner"] = iBooker.book1D("residual_mean_y_Inner", "Mean Track Residuals Y Inner Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_y_Outer"] = iBooker.book1D("residual_mean_y_Outer", "Mean Track Residuals Y Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  
+  residuals_["residual_rms_x_Inner"] = iBooker.book1D("residual_rms_x_Inner", "RMS of Track Residuals X Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_x_Outer"] = iBooker.book1D("residual_rms_x_Outer", "RMS of Track Residuals X Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_y_Inner"] = iBooker.book1D("residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_y_Outer"] = iBooker.book1D("residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  
+  //New residual plots for the PXForward separated by positive and negative side
+  iBooker.setCurrentFolder("PixelPhase1/Tracks/PXForward");
+  residuals_["residual_mean_x_pos"] = iBooker.book1D("residual_mean_x_pos", "Mean Track Residuals X pos. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_x_neg"] = iBooker.book1D("residual_mean_x_neg", "Mean Track Residuals X neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_y_pos"] = iBooker.book1D("residual_mean_y_pos", "Mean Track Residuals Y pos. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_y_neg"] = iBooker.book1D("residual_mean_y_neg", "Mean Track Residuals Y neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  
+  residuals_["residual_rms_x_pos"] = iBooker.book1D("residual_rms_x_pos", "RMS of Track Residuals X pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_x_neg"] = iBooker.book1D("residual_rms_x_neg", "RMS of Track Residuals X neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_y_pos"] = iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_rms_y_neg"] = iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
 
   //Book the summary plot
   iBooker.setCurrentFolder("PixelPhase1/EventInfo");
@@ -281,6 +319,102 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
       nROCs = tempProfile->GetBinContent(i + 1);
     }
     deadROCSummary->setBinContent(xBin, yBin, nROCs / nRocsPerTrend[i]);
+  }
+  
+  //Fill additional residuals plots
+  //PXBarrel
+  for (std::string layer:{"1","2","3","4"}) {
+    MonitorElement* me_x = iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_"+layer);
+    MonitorElement* me_y = iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_"+layer);
+    for (int i=1; i<=me_x->getNbinsY(); i++) {
+      
+      if (i == (me_x->getNbinsY()/2+1)) continue;   //Middle bin of y axis is empty
+      
+      switch (i <= me_x->getNbinsY()/2) {
+        
+        case true:
+          if (i%2 == 0) {
+            for (int j : {1,2,3,4,6,7,8,9}){
+              residuals_["residual_mean_x_Inner_PXLayer_"+layer]->Fill(me_x->getBinContent(j,i));
+              residuals_["residual_mean_y_Inner_PXLayer_"+layer]->Fill(me_y->getBinContent(j,i));
+              residuals_["residual_rms_x_Inner_PXLayer_"+layer]->Fill(me_x->getBinError(j,i));
+              residuals_["residual_rms_y_Inner_PXLayer_"+layer]->Fill(me_y->getBinError(j,i));
+            }
+          }
+          else {
+            for (int j : {1,2,3,4,6,7,8,9}){
+              residuals_["residual_mean_x_Outer_PXLayer_"+layer]->Fill(me_x->getBinContent(j,i));
+              residuals_["residual_mean_y_Outer_PXLayer_"+layer]->Fill(me_y->getBinContent(j,i));
+              residuals_["residual_rms_x_Outer_PXLayer_"+layer]->Fill(me_x->getBinError(j,i));
+              residuals_["residual_rms_y_Outer_PXLayer_"+layer]->Fill(me_y->getBinError(j,i));
+            }
+          }
+          break;
+        
+        case false:
+          if (i%2 == 1) {
+            for (int j : {1,2,3,4,6,7,8,9}){
+              residuals_["residual_mean_x_Inner_PXLayer_"+layer]->Fill(me_x->getBinContent(j,i));
+              residuals_["residual_mean_y_Inner_PXLayer_"+layer]->Fill(me_y->getBinContent(j,i));
+              residuals_["residual_rms_x_Inner_PXLayer_"+layer]->Fill(me_x->getBinError(j,i));
+              residuals_["residual_rms_y_Inner_PXLayer_"+layer]->Fill(me_y->getBinError(j,i));
+            }
+          }
+          else {
+            for (int j : {1,2,3,4,6,7,8,9}){
+              residuals_["residual_mean_x_Outer_PXLayer_"+layer]->Fill(me_x->getBinContent(j,i));
+              residuals_["residual_mean_y_Outer_PXLayer_"+layer]->Fill(me_y->getBinContent(j,i));
+              residuals_["residual_rms_x_Outer_PXLayer_"+layer]->Fill(me_x->getBinError(j,i));
+              residuals_["residual_rms_y_Outer_PXLayer_"+layer]->Fill(me_y->getBinError(j,i));
+            }
+          }
+      }
+    }
+  }
+  
+  //PXForward separating outer and inner modules as well as positive and negative side
+  for (std::string ring:{"1","2"}){
+    MonitorElement* me_x = iGetter.get("PixelPhase1/Tracks/PXForward/residual_x_per_PXDisk_per_SignedBladePanel_PXRing_"+ring);
+    MonitorElement* me_y = iGetter.get("PixelPhase1/Tracks/PXForward/residual_y_per_PXDisk_per_SignedBladePanel_PXRing_"+ring);
+    bool posSide = false;
+    for (int j=1; j<=me_x->getNbinsX(); j++) {
+      
+      if (j==4) continue;  //fourth x-bin in profile plots is empty
+      
+      if (j==5) posSide = true;   //change to postive side
+      
+      for (int i=1; i<=me_x->getNbinsY(); i++) {
+        
+        if (i == me_x->getNbinsY()/2) continue;//Middle bins of y axis is empty
+        if (i == (me_x->getNbinsY()/2)+1) continue;
+        
+        if (i%2 == 0) {   //separate inner and outer modules
+          residuals_["residual_mean_x_Inner"]->Fill(me_x->getBinContent(j,i));
+          residuals_["residual_mean_y_Inner"]->Fill(me_y->getBinContent(j,i));
+          residuals_["residual_rms_x_Inner"]->Fill(me_x->getBinError(j,i));
+          residuals_["residual_rms_y_Inner"]->Fill(me_y->getBinError(j,i));
+        }
+        else {
+          residuals_["residual_mean_x_Outer"]->Fill(me_x->getBinContent(j,i));
+          residuals_["residual_mean_y_Outer"]->Fill(me_y->getBinContent(j,i));
+          residuals_["residual_rms_x_Outer"]->Fill(me_x->getBinError(j,i));
+          residuals_["residual_rms_y_Outer"]->Fill(me_y->getBinError(j,i));
+        }
+        
+        if (!posSide) {   //separate postive and negative side
+          residuals_["residual_mean_x_neg"]->Fill(me_x->getBinContent(j,i));
+          residuals_["residual_mean_y_neg"]->Fill(me_y->getBinContent(j,i));
+          residuals_["residual_rms_x_neg"]->Fill(me_x->getBinError(j,i));
+          residuals_["residual_rms_y_neg"]->Fill(me_y->getBinError(j,i));
+        }
+        else {
+          residuals_["residual_mean_x_pos"]->Fill(me_x->getBinContent(j,i));
+          residuals_["residual_mean_y_pos"]->Fill(me_y->getBinContent(j,i));
+          residuals_["residual_rms_x_pos"]->Fill(me_x->getBinError(j,i));
+          residuals_["residual_rms_y_pos"]->Fill(me_y->getBinError(j,i));
+        }
+      }
+    }
   }
 
   //Sum of non-negative bins for the reportSummary

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -147,96 +147,102 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
   //New residual plots for the PXBarrel separated by inner and outer modules per layer
   iBooker.setCurrentFolder("PixelPhase1/Tracks/PXBarrel");
   for (std::string layer : {"1", "2", "3", "4"}) {
+    float mean_range = 100.;
+    float rms_range = 200.;
+    if (layer == "1") {
+      mean_range = 200.;
+      rms_range = 1000.;
+    }
     residuals_["residual_mean_x_Inner_PXLayer_" + layer] =
         iBooker.book1D("residual_mean_x_Inner_PXLayer_" + layer,
-                       "Mean Track Residuals X Inner Modules for Layer " + layer + ";mean(x_rec-x_pred)[cm]",
+                       "Mean Track Residuals X Inner Modules for Layer " + layer + ";mean(x_rec-x_pred)[#mum]",
                        100,
-                       -0.1,
-                       0.1);
+                       -1 * mean_range,
+                       mean_range);
     residuals_["residual_mean_x_Outer_PXLayer_" + layer] =
         iBooker.book1D("residual_mean_x_Outer_PXLayer_" + layer,
-                       "Mean Track Residuals X Outer Modules for Layer " + layer + ";mean(x_rec-x_pred)[cm]",
+                       "Mean Track Residuals X Outer Modules for Layer " + layer + ";mean(x_rec-x_pred)[#mum]",
                        100,
-                       -0.1,
-                       0.1);
+                       -1 * mean_range,
+                       mean_range);
     residuals_["residual_mean_y_Inner_PXLayer_" + layer] =
         iBooker.book1D("residual_mean_y_Inner_PXLayer_" + layer,
-                       "Mean Track Residuals Y Inner Modules for Layer " + layer + ";mean(y_rec-y_pred)[cm]",
+                       "Mean Track Residuals Y Inner Modules for Layer " + layer + ";mean(y_rec-y_pred)[#mum]",
                        100,
-                       -0.1,
-                       0.1);
+                       -1 * mean_range,
+                       mean_range);
     residuals_["residual_mean_y_Outer_PXLayer_" + layer] =
         iBooker.book1D("residual_mean_y_Outer_PXLayer_" + layer,
-                       "Mean Track Residuals Y Outer Modules for Layer " + layer + ";mean(y_rec-y_pred)[cm]",
+                       "Mean Track Residuals Y Outer Modules for Layer " + layer + ";mean(y_rec-y_pred)[#mum]",
                        100,
-                       -0.1,
-                       0.1);
+                       -1 * mean_range,
+                       mean_range);
 
     residuals_["residual_rms_x_Inner_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_x_Inner_PXLayer_" + layer,
-                       "RMS of Track Residuals X Inner Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
+                       "RMS of Track Residuals X Inner Modules for Layer " + layer + ";rms(x_rec-x_pred)[#mum]",
                        100,
                        0.,
-                       0.1);
+                       rms_range);
     residuals_["residual_rms_x_Outer_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_x_Outer_PXLayer_" + layer,
-                       "RMS of Track Residuals X Outer Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
+                       "RMS of Track Residuals X Outer Modules for Layer " + layer + ";rms(x_rec-x_pred)[#mum]",
                        100,
                        0.,
-                       0.1);
+                       rms_range);
     residuals_["residual_rms_y_Inner_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_y_Inner_PXLayer_" + layer,
-                       "RMS of Track Residuals Y Inner Modules for Layer " + layer + ";rms(y_rec-y_pred)[cm]",
+                       "RMS of Track Residuals Y Inner Modules for Layer " + layer + ";rms(y_rec-y_pred)[#mum]",
                        100,
                        0.,
-                       0.1);
+                       rms_range);
     residuals_["residual_rms_y_Outer_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_y_Outer_PXLayer_" + layer,
-                       "RMS of Track Residuals Y Outer Modules for Layer " + layer + ";rms(y_rec-y_pred)[cm]",
+                       "RMS of Track Residuals Y Outer Modules for Layer " + layer + ";rms(y_rec-y_pred)[#mum]",
                        100,
                        0.,
-                       0.1);
+                       rms_range);
   }
 
   //New residual plots for the PXForward separated by inner and outer modules
   iBooker.setCurrentFolder("PixelPhase1/Tracks/PXForward");
   residuals_["residual_mean_x_Inner"] = iBooker.book1D(
-      "residual_mean_x_Inner", "Mean Track Residuals X Inner Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      "residual_mean_x_Inner", "Mean Track Residuals X Inner Modules;mean(x_rec-x_pred)[#mum]", 100, -100., 100.);
   residuals_["residual_mean_x_Outer"] = iBooker.book1D(
-      "residual_mean_x_Outer", "Mean Track Residuals X Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      "residual_mean_x_Outer", "Mean Track Residuals X Outer Modules;mean(x_rec-x_pred)[#mum]", 100, -100., 100.);
   residuals_["residual_mean_y_Inner"] = iBooker.book1D(
-      "residual_mean_y_Inner", "Mean Track Residuals Y Inner Modules;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
+      "residual_mean_y_Inner", "Mean Track Residuals Y Inner Modules;mean(y_rec-y_pred)[#mum]", 100, -100., 100.);
   residuals_["residual_mean_y_Outer"] = iBooker.book1D(
-      "residual_mean_y_Outer", "Mean Track Residuals Y Outer Modules;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
+      "residual_mean_y_Outer", "Mean Track Residuals Y Outer Modules;mean(y_rec-y_pred)[#mum]", 100, -100., 100.);
 
   residuals_["residual_rms_x_Inner"] = iBooker.book1D(
-      "residual_rms_x_Inner", "RMS of Track Residuals X Inner Modules;rms(x_rec-x_pred)[cm]", 100, 0., 0.1);
+      "residual_rms_x_Inner", "RMS of Track Residuals X Inner Modules;rms(x_rec-x_pred)[#mum]", 100, 0., 200.);
   residuals_["residual_rms_x_Outer"] = iBooker.book1D(
-      "residual_rms_x_Outer", "RMS of Track Residuals X Outer Modules;rms(x_rec-x_pred)[cm]", 100, 0., 0.1);
+      "residual_rms_x_Outer", "RMS of Track Residuals X Outer Modules;rms(x_rec-x_pred)[#mum]", 100, 0., 200.);
   residuals_["residual_rms_y_Inner"] = iBooker.book1D(
-      "residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(y_rec-y_pred)[cm]", 100, 0., 0.1);
+      "residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(y_rec-y_pred)[#mum]", 100, 0., 200.);
   residuals_["residual_rms_y_Outer"] = iBooker.book1D(
-      "residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(y_rec-y_pred)[cm]", 100, 0., 0.1);
+      "residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(y_rec-y_pred)[#mum]", 100, 0., 200.);
 
   //New residual plots for the PXForward separated by positive and negative side
   iBooker.setCurrentFolder("PixelPhase1/Tracks/PXForward");
-  residuals_["residual_mean_x_pos"] =
-      iBooker.book1D("residual_mean_x_pos", "Mean Track Residuals X pos. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_x_neg"] =
-      iBooker.book1D("residual_mean_x_neg", "Mean Track Residuals X neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_y_pos"] =
-      iBooker.book1D("residual_mean_y_pos", "Mean Track Residuals Y pos. Side;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
-  residuals_["residual_mean_y_neg"] =
-      iBooker.book1D("residual_mean_y_neg", "Mean Track Residuals Y neg. Side;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
+  residuals_["residual_mean_x_pos"] = iBooker.book1D(
+      "residual_mean_x_pos", "Mean Track Residuals X pos. Side;mean(x_rec-x_pred)[#mum]", 100, -100., 100.);
+  residuals_["residual_mean_x_neg"] = iBooker.book1D(
+      "residual_mean_x_neg", "Mean Track Residuals X neg. Side;mean(x_rec-x_pred)[#mum]", 100, -100., 100.);
+  residuals_["residual_mean_y_pos"] = iBooker.book1D(
+      "residual_mean_y_pos", "Mean Track Residuals Y pos. Side;mean(y_rec-y_pred)[#mum]", 100, -100., 100.);
+  residuals_["residual_mean_y_neg"] = iBooker.book1D(
+      "residual_mean_y_neg", "Mean Track Residuals Y neg. Side;mean(y_rec-y_pred)[#mum]", 100, -100., 100.);
 
   residuals_["residual_rms_x_pos"] =
-      iBooker.book1D("residual_rms_x_pos", "RMS of Track Residuals X pos. Side;rms(x_rec-x_pred)[cm]", 100, 0., 0.1);
+      iBooker.book1D("residual_rms_x_pos", "RMS of Track Residuals X pos. Side;rms(x_rec-x_pred)[#mum]", 100, 0., 200.);
   residuals_["residual_rms_x_neg"] =
-      iBooker.book1D("residual_rms_x_neg", "RMS of Track Residuals X neg. Side;rms(x_rec-x_pred)[cm]", 100, 0., 0.1);
+      iBooker.book1D("residual_rms_x_neg", "RMS of Track Residuals X neg. Side;rms(x_rec-x_pred)[#mum]", 100, 0., 200.);
   residuals_["residual_rms_y_pos"] =
-      iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(y_rec-y_pred)[cm]", 100, 0., 0.1);
+      iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(y_rec-y_pred)[#mum]", 100, 0., 200.);
   residuals_["residual_rms_y_neg"] =
-      iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(y_rec-y_pred)[cm]", 100, 0., 0.1);
+      iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(y_rec-y_pred)[#mum]", 100, 0., 200.);
 
   //Book the summary plot
   iBooker.setCurrentFolder("PixelPhase1/EventInfo");
@@ -384,40 +390,51 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
         iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
     MonitorElement* me_y =
         iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
+
+    bool isLayer_4 = layer == "4";  //Order of inner and outer ladders is reversed for Layer 4
+
     for (int i = 1; i <= me_x->getNbinsY(); i++) {
       if (i == (me_x->getNbinsY() / 2 + 1))
         continue;  //Middle bin of y axis is empty
 
       if (i <= me_x->getNbinsY() / 2) {
-        if (i % 2 == 0) {
+        if ((i % 2 == 0 && !isLayer_4) || (i % 2 == 1 && isLayer_4)) {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-            residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
-            residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
-            residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
-            residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
+            if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+              continue;
+            residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i) * 1e4);
+            residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i) * 1e4);
+            residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i) * 1e4);
+            residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i) * 1e4);
           }
         } else {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-            residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
-            residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
-            residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
-            residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
+            if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+              continue;
+            residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i) * 1e4);
+            residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i) * 1e4);
+            residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i) * 1e4);
+            residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i) * 1e4);
           }
         }
       } else {
-        if (i % 2 == 1) {
+        if ((i % 2 == 1 && !isLayer_4) || (i % 2 == 0 && isLayer_4)) {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-            residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
-            residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
-            residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
-            residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
+            if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+              continue;
+            residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i) * 1e4);
+            residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i) * 1e4);
+            residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i) * 1e4);
+            residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i) * 1e4);
           }
         } else {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-            residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
-            residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
-            residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
-            residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
+            if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+              continue;
+            residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i) * 1e4);
+            residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i) * 1e4);
+            residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i) * 1e4);
+            residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i) * 1e4);
           }
         }
       }
@@ -443,29 +460,31 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
           continue;  //Middle bins of y axis is empty
         if (i == (me_x->getNbinsY() / 2) + 1)
           continue;
+        if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+          continue;
 
         if (i % 2 == 0) {  //separate inner and outer modules
-          residuals_["residual_mean_x_Inner"]->Fill(me_x->getBinContent(j, i));
-          residuals_["residual_mean_y_Inner"]->Fill(me_y->getBinContent(j, i));
-          residuals_["residual_rms_x_Inner"]->Fill(me_x->getBinError(j, i));
-          residuals_["residual_rms_y_Inner"]->Fill(me_y->getBinError(j, i));
+          residuals_["residual_mean_x_Inner"]->Fill(me_x->getBinContent(j, i) * 1e4);
+          residuals_["residual_mean_y_Inner"]->Fill(me_y->getBinContent(j, i) * 1e4);
+          residuals_["residual_rms_x_Inner"]->Fill(me_x->getBinError(j, i) * 1e4);
+          residuals_["residual_rms_y_Inner"]->Fill(me_y->getBinError(j, i) * 1e4);
         } else {
-          residuals_["residual_mean_x_Outer"]->Fill(me_x->getBinContent(j, i));
-          residuals_["residual_mean_y_Outer"]->Fill(me_y->getBinContent(j, i));
-          residuals_["residual_rms_x_Outer"]->Fill(me_x->getBinError(j, i));
-          residuals_["residual_rms_y_Outer"]->Fill(me_y->getBinError(j, i));
+          residuals_["residual_mean_x_Outer"]->Fill(me_x->getBinContent(j, i) * 1e4);
+          residuals_["residual_mean_y_Outer"]->Fill(me_y->getBinContent(j, i) * 1e4);
+          residuals_["residual_rms_x_Outer"]->Fill(me_x->getBinError(j, i) * 1e4);
+          residuals_["residual_rms_y_Outer"]->Fill(me_y->getBinError(j, i) * 1e4);
         }
 
         if (!posSide) {  //separate postive and negative side
-          residuals_["residual_mean_x_neg"]->Fill(me_x->getBinContent(j, i));
-          residuals_["residual_mean_y_neg"]->Fill(me_y->getBinContent(j, i));
-          residuals_["residual_rms_x_neg"]->Fill(me_x->getBinError(j, i));
-          residuals_["residual_rms_y_neg"]->Fill(me_y->getBinError(j, i));
+          residuals_["residual_mean_x_neg"]->Fill(me_x->getBinContent(j, i) * 1e4);
+          residuals_["residual_mean_y_neg"]->Fill(me_y->getBinContent(j, i) * 1e4);
+          residuals_["residual_rms_x_neg"]->Fill(me_x->getBinError(j, i) * 1e4);
+          residuals_["residual_rms_y_neg"]->Fill(me_y->getBinError(j, i) * 1e4);
         } else {
-          residuals_["residual_mean_x_pos"]->Fill(me_x->getBinContent(j, i));
-          residuals_["residual_mean_y_pos"]->Fill(me_y->getBinContent(j, i));
-          residuals_["residual_rms_x_pos"]->Fill(me_x->getBinError(j, i));
-          residuals_["residual_rms_y_pos"]->Fill(me_y->getBinError(j, i));
+          residuals_["residual_mean_x_pos"]->Fill(me_x->getBinContent(j, i) * 1e4);
+          residuals_["residual_mean_y_pos"]->Fill(me_y->getBinContent(j, i) * 1e4);
+          residuals_["residual_rms_x_pos"]->Fill(me_x->getBinError(j, i) * 1e4);
+          residuals_["residual_rms_y_pos"]->Fill(me_y->getBinError(j, i) * 1e4);
         }
       }
     }

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -385,22 +385,24 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
 
   //Fill additional residuals plots
   //PXBarrel
+
+  int minHits = 30;  //Miniminal number of hits needed for module to be filled in histograms
+
   for (std::string layer : {"1", "2", "3", "4"}) {
     MonitorElement* me_x =
         iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
     MonitorElement* me_y =
         iGetter.get("PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
 
-    bool isLayer_4 = layer == "4";  //Order of inner and outer ladders is reversed for Layer 4
-
     for (int i = 1; i <= me_x->getNbinsY(); i++) {
       if (i == (me_x->getNbinsY() / 2 + 1))
         continue;  //Middle bin of y axis is empty
 
       if (i <= me_x->getNbinsY() / 2) {
-        if ((i % 2 == 0 && !isLayer_4) || (i % 2 == 1 && isLayer_4)) {
+        bool iAmInner = (i % 2 == 0);  //Check whether current ladder is inner or outer ladder
+        if (iAmInner) {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-            if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+            if (me_x->getBinEntries(j, i) < minHits)  //Fill only if number of hits is above threshold
               continue;
             residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i) * 1e4);
             residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i) * 1e4);
@@ -409,7 +411,7 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
           }
         } else {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-            if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+            if (me_x->getBinEntries(j, i) < minHits)  //Fill only if number of hits is above threshold
               continue;
             residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i) * 1e4);
             residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i) * 1e4);
@@ -418,9 +420,10 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
           }
         }
       } else {
-        if ((i % 2 == 1 && !isLayer_4) || (i % 2 == 0 && isLayer_4)) {
+        bool iAmInner = (i % 2 == 1);  //Check whether current ladder is inner or outer ladder
+        if (iAmInner) {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-            if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+            if (me_x->getBinEntries(j, i) < minHits)  //Fill only if number of hits is above threshold
               continue;
             residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i) * 1e4);
             residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i) * 1e4);
@@ -429,7 +432,7 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
           }
         } else {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-            if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+            if (me_x->getBinEntries(j, i) < minHits)  //Fill only if number of hits is above threshold
               continue;
             residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i) * 1e4);
             residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i) * 1e4);
@@ -460,10 +463,11 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
           continue;  //Middle bins of y axis is empty
         if (i == (me_x->getNbinsY() / 2) + 1)
           continue;
-        if (me_x->getBinEntries(j + (me_x->getNbinsX() + 2) * i) < 30)  //Fill only if number of hits is above 30
+        if (me_x->getBinEntries(j, i) < minHits)  //Fill only if number of hits is above threshold
           continue;
 
-        if (i % 2 == 0) {  //separate inner and outer modules
+        bool iAmInner = (i % 2 == 0);  //separate inner and outer modules
+        if (iAmInner) {
           residuals_["residual_mean_x_Inner"]->Fill(me_x->getBinContent(j, i) * 1e4);
           residuals_["residual_mean_y_Inner"]->Fill(me_y->getBinContent(j, i) * 1e4);
           residuals_["residual_rms_x_Inner"]->Fill(me_x->getBinError(j, i) * 1e4);

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -176,25 +176,25 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
         iBooker.book1D("residual_rms_x_Inner_PXLayer_" + layer,
                        "RMS of Track Residuals X Inner Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
                        100,
-                       -0.1,
+                       0.,
                        0.1);
     residuals_["residual_rms_x_Outer_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_x_Outer_PXLayer_" + layer,
                        "RMS of Track Residuals X Outer Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
                        100,
-                       -0.1,
+                       0.,
                        0.1);
     residuals_["residual_rms_y_Inner_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_y_Inner_PXLayer_" + layer,
                        "RMS of Track Residuals Y Inner Modules for Layer " + layer + ";rms(y_rec-y_pred)[cm]",
                        100,
-                       -0.1,
+                       0.,
                        0.1);
     residuals_["residual_rms_y_Outer_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_y_Outer_PXLayer_" + layer,
                        "RMS of Track Residuals Y Outer Modules for Layer " + layer + ";rms(y_rec-y_pred)[cm]",
                        100,
-                       -0.1,
+                       0.,
                        0.1);
   }
 
@@ -210,13 +210,13 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
       "residual_mean_y_Outer", "Mean Track Residuals Y Outer Modules;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
 
   residuals_["residual_rms_x_Inner"] = iBooker.book1D(
-      "residual_rms_x_Inner", "RMS of Track Residuals X Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      "residual_rms_x_Inner", "RMS of Track Residuals X Inner Modules;rms(x_rec-x_pred)[cm]", 100, 0., 0.1);
   residuals_["residual_rms_x_Outer"] = iBooker.book1D(
-      "residual_rms_x_Outer", "RMS of Track Residuals X Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      "residual_rms_x_Outer", "RMS of Track Residuals X Outer Modules;rms(x_rec-x_pred)[cm]", 100, 0., 0.1);
   residuals_["residual_rms_y_Inner"] = iBooker.book1D(
-      "residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
+      "residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(y_rec-y_pred)[cm]", 100, 0., 0.1);
   residuals_["residual_rms_y_Outer"] = iBooker.book1D(
-      "residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
+      "residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(y_rec-y_pred)[cm]", 100, 0., 0.1);
 
   //New residual plots for the PXForward separated by positive and negative side
   iBooker.setCurrentFolder("PixelPhase1/Tracks/PXForward");
@@ -230,13 +230,13 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
       iBooker.book1D("residual_mean_y_neg", "Mean Track Residuals Y neg. Side;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
 
   residuals_["residual_rms_x_pos"] =
-      iBooker.book1D("residual_rms_x_pos", "RMS of Track Residuals X pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      iBooker.book1D("residual_rms_x_pos", "RMS of Track Residuals X pos. Side;rms(x_rec-x_pred)[cm]", 100, 0., 0.1);
   residuals_["residual_rms_x_neg"] =
-      iBooker.book1D("residual_rms_x_neg", "RMS of Track Residuals X neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      iBooker.book1D("residual_rms_x_neg", "RMS of Track Residuals X neg. Side;rms(x_rec-x_pred)[cm]", 100, 0., 0.1);
   residuals_["residual_rms_y_pos"] =
-      iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
+      iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(y_rec-y_pred)[cm]", 100, 0., 0.1);
   residuals_["residual_rms_y_neg"] =
-      iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
+      iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(y_rec-y_pred)[cm]", 100, 0., 0.1);
 
   //Book the summary plot
   iBooker.setCurrentFolder("PixelPhase1/EventInfo");

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -388,41 +388,39 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
       if (i == (me_x->getNbinsY() / 2 + 1))
         continue;  //Middle bin of y axis is empty
 
-      switch (i <= me_x->getNbinsY() / 2) {
-        case true:
-          if (i % 2 == 0) {
-            for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-              residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
-              residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
-              residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
-              residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
-            }
-          } else {
-            for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-              residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
-              residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
-              residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
-              residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
-            }
+      if (i <= me_x->getNbinsY() / 2) {
+        if (i % 2 == 0) {
+          for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
+            residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
+            residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
+            residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
+            residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
           }
-          break;
-
-        case false:
-          if (i % 2 == 1) {
-            for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-              residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
-              residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
-              residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
-              residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
-            }
-          } else {
-            for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
-              residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
-              residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
-              residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
-              residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
-            }
+        } else {
+          for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
+            residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
+            residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
+            residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
+            residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
           }
+        }
+      }
+      else {
+        if (i % 2 == 1) {
+          for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
+            residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
+            residuals_["residual_mean_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
+            residuals_["residual_rms_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
+            residuals_["residual_rms_y_Inner_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
+          }
+        } else {
+          for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
+            residuals_["residual_mean_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));
+            residuals_["residual_mean_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinContent(j, i));
+            residuals_["residual_rms_x_Outer_PXLayer_" + layer]->Fill(me_x->getBinError(j, i));
+            residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
+          }
+        }
       }
     }
   }

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -404,8 +404,7 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
             residuals_["residual_rms_y_Outer_PXLayer_" + layer]->Fill(me_y->getBinError(j, i));
           }
         }
-      }
-      else {
+      } else {
         if (i % 2 == 1) {
           for (int j : {1, 2, 3, 4, 6, 7, 8, 9}) {
             residuals_["residual_mean_x_Inner_PXLayer_" + layer]->Fill(me_x->getBinContent(j, i));

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -161,13 +161,13 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
                        0.1);
     residuals_["residual_mean_y_Inner_PXLayer_" + layer] =
         iBooker.book1D("residual_mean_y_Inner_PXLayer_" + layer,
-                       "Mean Track Residuals Y Inner Modules for Layer " + layer + ";mean(x_rec-x_pred)[cm]",
+                       "Mean Track Residuals Y Inner Modules for Layer " + layer + ";mean(y_rec-y_pred)[cm]",
                        100,
                        -0.1,
                        0.1);
     residuals_["residual_mean_y_Outer_PXLayer_" + layer] =
         iBooker.book1D("residual_mean_y_Outer_PXLayer_" + layer,
-                       "Mean Track Residuals Y Outer Modules for Layer " + layer + ";mean(x_rec-x_pred)[cm]",
+                       "Mean Track Residuals Y Outer Modules for Layer " + layer + ";mean(y_rec-y_pred)[cm]",
                        100,
                        -0.1,
                        0.1);
@@ -186,13 +186,13 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
                        0.1);
     residuals_["residual_rms_y_Inner_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_y_Inner_PXLayer_" + layer,
-                       "RMS of Track Residuals Y Inner Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
+                       "RMS of Track Residuals Y Inner Modules for Layer " + layer + ";rms(y_rec-y_pred)[cm]",
                        100,
                        -0.1,
                        0.1);
     residuals_["residual_rms_y_Outer_PXLayer_" + layer] =
         iBooker.book1D("residual_rms_y_Outer_PXLayer_" + layer,
-                       "RMS of Track Residuals Y Outer Modules for Layer " + layer + ";rms(x_rec-x_pred)[cm]",
+                       "RMS of Track Residuals Y Outer Modules for Layer " + layer + ";rms(y_rec-y_pred)[cm]",
                        100,
                        -0.1,
                        0.1);
@@ -205,18 +205,18 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
   residuals_["residual_mean_x_Outer"] = iBooker.book1D(
       "residual_mean_x_Outer", "Mean Track Residuals X Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_mean_y_Inner"] = iBooker.book1D(
-      "residual_mean_y_Inner", "Mean Track Residuals Y Inner Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      "residual_mean_y_Inner", "Mean Track Residuals Y Inner Modules;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_mean_y_Outer"] = iBooker.book1D(
-      "residual_mean_y_Outer", "Mean Track Residuals Y Outer Modules;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      "residual_mean_y_Outer", "Mean Track Residuals Y Outer Modules;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
 
   residuals_["residual_rms_x_Inner"] = iBooker.book1D(
       "residual_rms_x_Inner", "RMS of Track Residuals X Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_rms_x_Outer"] = iBooker.book1D(
       "residual_rms_x_Outer", "RMS of Track Residuals X Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_rms_y_Inner"] = iBooker.book1D(
-      "residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      "residual_rms_y_Inner", "RMS of Track Residuals Y Inner Modules;rms(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_rms_y_Outer"] = iBooker.book1D(
-      "residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      "residual_rms_y_Outer", "RMS of Track Residuals Y Outer Modules;rms(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
 
   //New residual plots for the PXForward separated by positive and negative side
   iBooker.setCurrentFolder("PixelPhase1/Tracks/PXForward");
@@ -225,18 +225,18 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker& iBooker) {
   residuals_["residual_mean_x_neg"] =
       iBooker.book1D("residual_mean_x_neg", "Mean Track Residuals X neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_mean_y_pos"] =
-      iBooker.book1D("residual_mean_y_pos", "Mean Track Residuals Y pos. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      iBooker.book1D("residual_mean_y_pos", "Mean Track Residuals Y pos. Side;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_mean_y_neg"] =
-      iBooker.book1D("residual_mean_y_neg", "Mean Track Residuals Y neg. Side;mean(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      iBooker.book1D("residual_mean_y_neg", "Mean Track Residuals Y neg. Side;mean(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
 
   residuals_["residual_rms_x_pos"] =
       iBooker.book1D("residual_rms_x_pos", "RMS of Track Residuals X pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_rms_x_neg"] =
       iBooker.book1D("residual_rms_x_neg", "RMS of Track Residuals X neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_rms_y_pos"] =
-      iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      iBooker.book1D("residual_rms_y_pos", "RMS of Track Residuals Y pos. Side;rms(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
   residuals_["residual_rms_y_neg"] =
-      iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(x_rec-x_pred)[cm]", 100, -0.1, 0.1);
+      iBooker.book1D("residual_rms_y_neg", "RMS of Track Residuals Y neg. Side;rms(y_rec-y_pred)[cm]", 100, -0.1, 0.1);
 
   //Book the summary plot
   iBooker.setCurrentFolder("PixelPhase1/EventInfo");

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -371,6 +371,7 @@ namespace dqm::impl {
     virtual int getNbinsX() const;
     virtual int getNbinsY() const;
     virtual int getNbinsZ() const;
+    virtual int getBin(int binx, int biny) const;
     virtual std::string getAxisTitle(int axis = 1) const;
     virtual std::string getTitle() const;
 
@@ -387,6 +388,7 @@ namespace dqm::impl {
     virtual double getBinError(int binx, int biny, int binz) const;
     virtual double getEntries() const;
     virtual double getBinEntries(int bin) const;
+    virtual double getBinEntries(int binx, int biny) const;
     virtual double integral() const;
 
     virtual int64_t getIntValue() const;

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -639,6 +639,17 @@ namespace dqm::impl {
     return accessRootObject(access, __PRETTY_FUNCTION__, 1)->GetEntries();
   }
 
+  /// get global bin number (for 2-D profiles)
+  int MonitorElement::getBin(int binx, int biny) const {
+    auto access = this->access();
+    if (kind() == Kind::TPROFILE2D)
+      return static_cast<TProfile2D const *>(accessRootObject(access, __PRETTY_FUNCTION__, 1))->GetBin(binx, biny);
+    else {
+      incompatible(__PRETTY_FUNCTION__);
+      return 0;
+    }
+  }
+
   /// get # of bin entries (for profiles)
   double MonitorElement::getBinEntries(int bin) const {
     auto access = this->access();
@@ -647,6 +658,19 @@ namespace dqm::impl {
     else if (kind() == Kind::TPROFILE2D)
       return static_cast<TProfile2D const *>(accessRootObject(access, __PRETTY_FUNCTION__, 1))->GetBinEntries(bin);
     else {
+      incompatible(__PRETTY_FUNCTION__);
+      return 0;
+    }
+  }
+
+  /// get # of bin entries (for 2-D profiles)
+  double MonitorElement::getBinEntries(int binx, int biny) const {
+    auto access = this->access();
+    if (kind() == Kind::TPROFILE2D) {
+      int globBin =
+          static_cast<TProfile2D const *>(accessRootObject(access, __PRETTY_FUNCTION__, 1))->GetBin(binx, biny);
+      return static_cast<TProfile2D const *>(accessRootObject(access, __PRETTY_FUNCTION__, 1))->GetBinEntries(globBin);
+    } else {
       incompatible(__PRETTY_FUNCTION__);
       return 0;
     }


### PR DESCRIPTION
#### PR description:

We added plots to the TkDQM showing the mean residual and rms of the residual on module level separating:
 - inner/outer modules for BPIX and FPIX
 - positibe/negative side for FPIX

The plots are filled from information already available in the TProfile2D plots.

#### PR validation:

The changes have been tested by running `runTheMatrix.py -l 10024`, which runs without any failed steps and produces the desired additional plots.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.

cc:
@sroychow @arossi83
