### PR TITLE
add TrackSelectorBy Region and CandidateRegion

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -33,6 +33,7 @@
 <use   name="CommonTools/Utils"/>
 <use   name="CommonTools/Statistics"/>
 <use   name="RecoTracker/Record"/>
+<use   name="RecoTracker/TkTrackingRegions"/>
 <use   name="clhep"/>
 <use   name="roottmva"/>
 <use   name="lwtnn"/>

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByCandidateRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByCandidateRegion.cc
@@ -15,19 +15,17 @@
 
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
 
-#include<vector>
-#include<memory>
+#include <vector>
+#include <memory>
 
 namespace {
   class TrackSelectorByCandidateRegion final : public edm::global::EDProducer<> {
-   public:
+  public:
+    typedef enum { BEAM_SPOT_FIXED, BEAM_SPOT_SIGMA, VERTICES_FIXED, VERTICES_SIGMA } Mode;
 
-    typedef enum {BEAM_SPOT_FIXED, BEAM_SPOT_SIGMA, VERTICES_FIXED, VERTICES_SIGMA } Mode;
-
-    explicit TrackSelectorByCandidateRegion(const edm::ParameterSet& conf) :
-      tracksToken_  ( consumes<reco::TrackCollection> (conf.getParameter<edm::InputTag>("tracks"))   ),
-      beamspotToken_( consumes<reco::BeamSpot>        (conf.getParameter<edm::InputTag>("beamspot")) ) {
-
+    explicit TrackSelectorByCandidateRegion(const edm::ParameterSet& conf)
+        : tracksToken_(consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracks"))),
+          beamspotToken_(consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamspot"))) {
       edm::ParameterSet trackPSet = conf.getParameter<edm::ParameterSet>("TrackPSet");
       minPt_ = trackPSet.getParameter<double>("minPt");
       edm::ParameterSet chi2_vs_pt = trackPSet.getParameter<edm::ParameterSet>("chi2vsPt");
@@ -38,11 +36,14 @@ namespace {
       value2_ = enabled ? chi2_vs_pt.getParameter<double>("value2") : -1.;
 
       if (enabled && pt1_ >= pt2_)
-	throw cms::Exception("Configuration") << "TrackSelectorByCandidateRegion::chi2vsPt: pt1 (" << pt1_ << ") needs to be smaller than pt2 (" << pt2_ << ")";
+        throw cms::Exception("Configuration") << "TrackSelectorByCandidateRegion::chi2vsPt: pt1 (" << pt1_
+                                              << ") needs to be smaller than pt2 (" << pt2_ << ")";
       if (enabled && pt1_ <= 0)
-	throw cms::Exception("Configuration") << "TrackSelectorByCandidateRegion::chi2vsPt: pt1 needs to be > 0; is " << pt1_;
+        throw cms::Exception("Configuration")
+            << "TrackSelectorByCandidateRegion::chi2vsPt: pt1 needs to be > 0; is " << pt1_;
       if (enabled && pt2_ <= 0)
-	throw cms::Exception("Configuration") << "TrackSelectorByCandidateRegion::chi2vsPt: pt2 needs to be > 0; is " << pt2_;
+        throw cms::Exception("Configuration")
+            << "TrackSelectorByCandidateRegion::chi2vsPt: pt2 needs to be > 0; is " << pt2_;
 
       //      for (auto const & ir : conf.getParameter<edm::VParameterSet>("regions")) {
       edm::ParameterSet regionPSet = conf.getParameter<edm::ParameterSet>("RegionPSet");
@@ -68,232 +69,236 @@ namespace {
 	 *   If, while using one of the "Vertices" modes, there's no vertices in an event, we fall back into
 	 *   either BeamSpotSigma or BeamSpotFixed mode, depending on the positiveness of nSigmaZBeamSpot.
 	 **/
-      
-	inputCandidateToken_ = mayConsume<reco::CandidateView>(regionPSet.getParameter<edm::InputTag>("input"));
-	maxNRegions_ = regionPSet.getParameter<unsigned int>("maxNRegions");
-	
-	std::string mode = regionPSet.getParameter<std::string>("mode");
-	if      (mode == "BeamSpotFixed") mode_ = BEAM_SPOT_FIXED;
-	else if (mode == "BeamSpotSigma") mode_ = BEAM_SPOT_SIGMA;
-	else if (mode == "VerticesFixed") mode_ = VERTICES_FIXED;
-	else if (mode == "VerticesSigma") mode_ = VERTICES_SIGMA;
-	//	else  edm::LogError ("TrackSelectorByCandidateRegion") << "Unknown mode string: " << mode;
 
-	maxNVertices_    = 1;
-	if (mode == VERTICES_FIXED || mode == VERTICES_SIGMA) {
-	  verticesToken_ = mayConsume<reco::VertexCollection>(regionPSet.getParameter<edm::InputTag>("vertices"));
-	  maxNVertices_   = regionPSet.getParameter<int>("maxNVertices");
-	}
-	
-	// RectangularEtaPhiTrackingRegion parameters:
-	deltaEta_         = regionPSet.getParameter<double>("deltaEta");
-	deltaPhi_         = regionPSet.getParameter<double>("deltaPhi");
-	zErrorBeamSpot_   = regionPSet.getParameter<double>("zErrorBeamSpot");
-	// mode-dependent z-halflength of tracking regions
-	nSigmaZVertex_   = ( mode_ == VERTICES_SIGMA   ? regionPSet.getParameter<double>("nSigmaZVertex")   : -1. );
-	zErrorVetex_     = ( mode_ == VERTICES_FIXED   ? regionPSet.getParameter<double>("zErrorVetex")     : -1. );
-	nSigmaZBeamSpot_ = ( mode_ == BEAM_SPOT_SIGMA  ? regionPSet.getParameter<double>("nSigmaZBeamSpot") : -1. );
-	//      }
+      inputCandidateToken_ = mayConsume<reco::CandidateView>(regionPSet.getParameter<edm::InputTag>("input"));
+      maxNRegions_ = regionPSet.getParameter<unsigned int>("maxNRegions");
 
-	produces<reco::TrackCollection>();
-	// produces<edm::RefToBaseVector<T> >();
-	produces<std::vector<bool>>();
-	
+      std::string mode = regionPSet.getParameter<std::string>("mode");
+      if (mode == "BeamSpotFixed")
+        mode_ = BEAM_SPOT_FIXED;
+      else if (mode == "BeamSpotSigma")
+        mode_ = BEAM_SPOT_SIGMA;
+      else if (mode == "VerticesFixed")
+        mode_ = VERTICES_FIXED;
+      else if (mode == "VerticesSigma")
+        mode_ = VERTICES_SIGMA;
+      //	else  edm::LogError ("TrackSelectorByCandidateRegion") << "Unknown mode string: " << mode;
+
+      maxNVertices_ = 1;
+      if (mode == VERTICES_FIXED || mode == VERTICES_SIGMA) {
+        verticesToken_ = mayConsume<reco::VertexCollection>(regionPSet.getParameter<edm::InputTag>("vertices"));
+        maxNVertices_ = regionPSet.getParameter<int>("maxNVertices");
+      }
+
+      // RectangularEtaPhiTrackingRegion parameters:
+      deltaEta_ = regionPSet.getParameter<double>("deltaEta");
+      deltaPhi_ = regionPSet.getParameter<double>("deltaPhi");
+      zErrorBeamSpot_ = regionPSet.getParameter<double>("zErrorBeamSpot");
+      // mode-dependent z-halflength of tracking regions
+      nSigmaZVertex_ = (mode_ == VERTICES_SIGMA ? regionPSet.getParameter<double>("nSigmaZVertex") : -1.);
+      zErrorVetex_ = (mode_ == VERTICES_FIXED ? regionPSet.getParameter<double>("zErrorVetex") : -1.);
+      nSigmaZBeamSpot_ = (mode_ == BEAM_SPOT_SIGMA ? regionPSet.getParameter<double>("nSigmaZBeamSpot") : -1.);
+      //      }
+
+      produces<reco::TrackCollection>();
+      // produces<edm::RefToBaseVector<T> >();
+      produces<std::vector<bool>>();
     }
-      
-    static void  fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<edm::InputTag>("tracks",  edm::InputTag("hltPixelTracks"));
-      desc.add<edm::InputTag>("beamspot",edm::InputTag("hltOnlineBeamSpot"));
+      desc.add<edm::InputTag>("tracks", edm::InputTag("hltPixelTracks"));
+      desc.add<edm::InputTag>("beamspot", edm::InputTag("hltOnlineBeamSpot"));
       edm::ParameterSetDescription tracks_par;
       tracks_par.add<double>("minPt", 0.);
       edm::ParameterSetDescription chi2vsPt_par;
-      chi2vsPt_par.add<bool>("enabled",false);
-      chi2vsPt_par.add<double>("pt1",-1.);
-      chi2vsPt_par.add<double>("pt2",-1.);
-      chi2vsPt_par.add<double>("value1",-1.);
-      chi2vsPt_par.add<double>("value2",-1.);
-      tracks_par.add<edm::ParameterSetDescription>("chi2vsPt",chi2vsPt_par);
-      desc.add<edm::ParameterSetDescription>("TrackPSet",tracks_par);
+      chi2vsPt_par.add<bool>("enabled", false);
+      chi2vsPt_par.add<double>("pt1", -1.);
+      chi2vsPt_par.add<double>("pt2", -1.);
+      chi2vsPt_par.add<double>("value1", -1.);
+      chi2vsPt_par.add<double>("value2", -1.);
+      tracks_par.add<edm::ParameterSetDescription>("chi2vsPt", chi2vsPt_par);
+      desc.add<edm::ParameterSetDescription>("TrackPSet", tracks_par);
 
       edm::ParameterSetDescription region_par;
       region_par.add<std::string>("componentName", "");
-      region_par.add<edm::InputTag>("input",   edm::InputTag(""));
+      region_par.add<edm::InputTag>("input", edm::InputTag(""));
       region_par.add<unsigned int>("maxNRegions", 10);
-      region_par.add<std::string>("mode",    "");
-      region_par.add<edm::InputTag>("vertices",edm::InputTag(""));
-      region_par.add<int>("maxNVertices",3);
+      region_par.add<std::string>("mode", "");
+      region_par.add<edm::InputTag>("vertices", edm::InputTag(""));
+      region_par.add<int>("maxNVertices", 3);
       region_par.add<double>("deltaEta", 0.5);
       region_par.add<double>("deltaPhi", 0.5);
       region_par.add<double>("zErrorBeamSpot", -1.);
-      region_par.add<double>("nSigmaZVertex",  -1.);
-      region_par.add<double>("zErrorVetex",    -1.);
-      region_par.add<double>("nSigmaZBeamSpot",-1.);
-      desc.add<edm::ParameterSetDescription>("RegionPSet",region_par);
+      region_par.add<double>("nSigmaZVertex", -1.);
+      region_par.add<double>("zErrorVetex", -1.);
+      region_par.add<double>("nSigmaZBeamSpot", -1.);
+      desc.add<edm::ParameterSetDescription>("RegionPSet", region_par);
       descriptions.add("trackSelectorByCandidateRegion", desc);
     }
 
-   private:
+  private:
+    using MaskCollection = std::vector<bool>;
 
-      using MaskCollection = std::vector<bool>;
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& eSetup) const override {
+      // products
+      auto mask = std::make_unique<MaskCollection>();                  // mask w/ the same size of the input collection
+      auto output_tracks = std::make_unique<reco::TrackCollection>();  // selected output collection
 
-      void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& eSetup) const override {
+      edm::Handle<reco::CandidateView> objectsHandle;
+      // pick up the candidate objects of interest
+      iEvent.getByToken(inputCandidateToken_, objectsHandle);
 
-	// products
-	auto mask = std::make_unique<MaskCollection>(); // mask w/ the same size of the input collection
-	auto output_tracks = std::make_unique<reco::TrackCollection>(); // selected output collection
+      // always need the beam spot (as a fall back strategy for vertex modes)
+      edm::Handle<reco::BeamSpot> beamspotHandle;
+      iEvent.getByToken(beamspotToken_, beamspotHandle);
 
-	edm::Handle< reco::CandidateView > objectsHandle;
-	// pick up the candidate objects of interest	
-	iEvent.getByToken( inputCandidateToken_, objectsHandle );
-	
-	// always need the beam spot (as a fall back strategy for vertex modes)
-	edm::Handle< reco::BeamSpot > beamspotHandle;
-	iEvent.getByToken( beamspotToken_, beamspotHandle );
-	
-	edm::Handle<reco::TrackCollection> tracksHandle;
-	iEvent.getByToken(tracksToken_,tracksHandle);
+      edm::Handle<reco::TrackCollection> tracksHandle;
+      iEvent.getByToken(tracksToken_, tracksHandle);
 
-	if ( tracksHandle.isValid() ) {
-	  const auto& tracks = *tracksHandle;	  
-	  mask->assign(tracks.size(),false);
+      if (tracksHandle.isValid()) {
+        const auto& tracks = *tracksHandle;
+        mask->assign(tracks.size(), false);
 
-	  if ( objectsHandle.isValid() && beamspotHandle.isValid() ) {
-	    
-	    const auto& beamspot = *beamspotHandle;
-	    // this is a default origin for all modes
-	    math::XYZPoint default_origin( beamspot.x0(), beamspot.y0(), beamspot.z0() );
-	    
-	    // vector of origin & halfLength pairs:
-	    std::vector< std::pair< math::XYZPoint, float > > origins;
-	    
-	    // fill the origins and halfLengths depending on the mode
-	    if (mode_ == BEAM_SPOT_FIXED) 
-	      origins.push_back( std::make_pair(default_origin, zErrorBeamSpot_) );
-	    else if (mode_ == BEAM_SPOT_SIGMA)
-	      origins.push_back( std::make_pair(default_origin, nSigmaZBeamSpot_*beamspot.sigmaZ()) );
-	    else if (mode_ == VERTICES_FIXED || mode_ == VERTICES_SIGMA) {
-	      
-	      edm::Handle< reco::VertexCollection > verticesHandle;
-	      iEvent.getByToken( verticesToken_, verticesHandle );
-	      if ( verticesHandle.isValid() ) {	      
-		int n_vert = 0;
-		const auto& vertices = *verticesHandle;
-		for ( auto v : vertices ) {
-		  if ( n_vert > maxNVertices_ ) break;
-		  if ( v.isFake() || !v.isValid() ) continue;
-		  if (mode_ == VERTICES_FIXED)
-		    origins.push_back( std::make_pair(math::XYZPoint( v.x(), v.y(), v.z() ), zErrorVetex_ ) );
-		  else if (mode_ == VERTICES_SIGMA)
-		    origins.push_back( std::make_pair(math::XYZPoint( v.x(), v.y(), v.z() ), nSigmaZVertex_*v.zError()) );
-		  ++n_vert;
-		}
-	      }
-	      // no-vertex fall-back case:
-	      if (origins.empty())
-		origins.push_back( std::make_pair(default_origin, nSigmaZBeamSpot_*beamspot.z0Error()) );
-	    }
+        if (objectsHandle.isValid() && beamspotHandle.isValid()) {
+          const auto& beamspot = *beamspotHandle;
+          // this is a default origin for all modes
+          math::XYZPoint default_origin(beamspot.x0(), beamspot.y0(), beamspot.z0());
 
-	    std::vector<float> etaMin; etaMin.reserve(maxNRegions_);
-	    std::vector<float> etaMax; etaMax.reserve(maxNRegions_);
-	    std::vector<float> phiMin; phiMin.reserve(maxNRegions_);
-	    std::vector<float> phiMax; phiMax.reserve(maxNRegions_);
-	    std::vector<math::XYZPoint> origin; origin.reserve(maxNRegions_);
-	    std::vector<float> zBound;       zBound.reserve(maxNRegions_);
+          // vector of origin & halfLength pairs:
+          std::vector<std::pair<math::XYZPoint, float>> origins;
 
-	    size_t n_objects = objectsHandle->size();
-	    size_t n_regions = 0;
-	    for ( size_t i = 0; i < n_objects && n_regions < maxNRegions_; ++i ) {
-	      //	      std::cout << "i: " << i << " n_regions: " << n_regions << std::endl;
-	      const reco::Candidate & object = (*objectsHandle)[i];
-	      //	  GlobalVector direction( object.momentum().x(), object.momentum().y(), object.momentum().z() );
-	      for ( size_t j = 0; j < origins.size() && n_regions < maxNRegions_; ++j ) {
-		etaMin.push_back( object.eta() - deltaEta_ );
-		etaMax.push_back( object.eta() + deltaEta_ );
-		phiMin.push_back( Geom::Phi( object.phi() - deltaPhi_ ) );
-		phiMax.push_back( Geom::Phi( object.phi() + deltaPhi_ ) );
-		origin.push_back( origins[j].first );
-		zBound.push_back( origins[j].second );
+          // fill the origins and halfLengths depending on the mode
+          if (mode_ == BEAM_SPOT_FIXED)
+            origins.push_back(std::make_pair(default_origin, zErrorBeamSpot_));
+          else if (mode_ == BEAM_SPOT_SIGMA)
+            origins.push_back(std::make_pair(default_origin, nSigmaZBeamSpot_ * beamspot.sigmaZ()));
+          else if (mode_ == VERTICES_FIXED || mode_ == VERTICES_SIGMA) {
+            edm::Handle<reco::VertexCollection> verticesHandle;
+            iEvent.getByToken(verticesToken_, verticesHandle);
+            if (verticesHandle.isValid()) {
+              int n_vert = 0;
+              const auto& vertices = *verticesHandle;
+              for (auto v : vertices) {
+                if (n_vert > maxNVertices_)
+                  break;
+                if (v.isFake() || !v.isValid())
+                  continue;
+                if (mode_ == VERTICES_FIXED)
+                  origins.push_back(std::make_pair(math::XYZPoint(v.x(), v.y(), v.z()), zErrorVetex_));
+                else if (mode_ == VERTICES_SIGMA)
+                  origins.push_back(std::make_pair(math::XYZPoint(v.x(), v.y(), v.z()), nSigmaZVertex_ * v.zError()));
+                ++n_vert;
+              }
+            }
+            // no-vertex fall-back case:
+            if (origins.empty())
+              origins.push_back(std::make_pair(default_origin, nSigmaZBeamSpot_ * beamspot.z0Error()));
+          }
 
-		n_regions++;
-	      }
-	    }
+          std::vector<float> etaMin;
+          etaMin.reserve(maxNRegions_);
+          std::vector<float> etaMax;
+          etaMax.reserve(maxNRegions_);
+          std::vector<float> phiMin;
+          phiMin.reserve(maxNRegions_);
+          std::vector<float> phiMax;
+          phiMax.reserve(maxNRegions_);
+          std::vector<math::XYZPoint> origin;
+          origin.reserve(maxNRegions_);
+          std::vector<float> zBound;
+          zBound.reserve(maxNRegions_);
 
-	    size_t it = 0;
-	    const auto curvature1 = (value1_ >= 0.) ? PixelRecoUtilities::curvature(1.f / pt1_, eSetup) : -1.;
-	    const auto curvature2 = (value2_ >= 0.) ? PixelRecoUtilities::curvature(1.f / pt2_, eSetup) : -1.;
-	    for ( auto trk : tracks ) {
-	      
-	      const auto pt = trk.pt();
-	      if (pt < minPt_) continue;
-	      if (value1_ >= 0.) {
-		const auto curvature = PixelRecoUtilities::curvature(1.f / pt, eSetup);
-		// https://cmssdt.cern.ch/dxr/CMSSW/source/RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h#58		
-		auto value = -1.;
-		if (curvature1 < curvature)
-		  value = value1_;
-		else if (curvature2 < curvature && curvature <= curvature1)
-		  value = value2_ + (curvature - curvature2) / (curvature1 - curvature2) * (value1_ - value2_);
-		else 
-		  value = value2_;
+          size_t n_objects = objectsHandle->size();
+          size_t n_regions = 0;
+          for (size_t i = 0; i < n_objects && n_regions < maxNRegions_; ++i) {
+            //	      std::cout << "i: " << i << " n_regions: " << n_regions << std::endl;
+            const reco::Candidate& object = (*objectsHandle)[i];
+            //	  GlobalVector direction( object.momentum().x(), object.momentum().y(), object.momentum().z() );
+            for (size_t j = 0; j < origins.size() && n_regions < maxNRegions_; ++j) {
+              etaMin.push_back(object.eta() - deltaEta_);
+              etaMax.push_back(object.eta() + deltaEta_);
+              phiMin.push_back(Geom::Phi(object.phi() - deltaPhi_));
+              phiMax.push_back(Geom::Phi(object.phi() + deltaPhi_));
+              origin.push_back(origins[j].first);
+              zBound.push_back(origins[j].second);
 
-		const auto chi2 = trk.chi2();
-		if (chi2 > value) continue;
-	      }
+              n_regions++;
+            }
+          }
 
-	      const auto eta = trk.eta();
-	      const auto phi = trk.phi();
+          size_t it = 0;
+          const auto curvature1 = (value1_ >= 0.) ? PixelRecoUtilities::curvature(1.f / pt1_, eSetup) : -1.;
+          const auto curvature2 = (value2_ >= 0.) ? PixelRecoUtilities::curvature(1.f / pt2_, eSetup) : -1.;
+          for (auto trk : tracks) {
+            const auto pt = trk.pt();
+            if (pt < minPt_)
+              continue;
+            if (value1_ >= 0.) {
+              const auto curvature = PixelRecoUtilities::curvature(1.f / pt, eSetup);
+              // https://cmssdt.cern.ch/dxr/CMSSW/source/RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h#58
+              auto value = -1.;
+              if (curvature1 < curvature)
+                value = value1_;
+              else if (curvature2 < curvature && curvature <= curvature1)
+                value = value2_ + (curvature - curvature2) / (curvature1 - curvature2) * (value1_ - value2_);
+              else
+                value = value2_;
 
-	      for ( size_t k = 0; k < n_regions; ++k ) {
-		if ( fabs(trk.dz(origin[k])) > zBound[k] ) continue;
-		//		if ( fabs(trk.vz() - origin[k].z()) > zBound[k] ) continue;
-		
-		if ( (eta >= etaMin[k] && eta <= etaMax[k]) &&
-		     (phi >= phiMin[k] && phi <= phiMax[k]) ) {
-		  
-		  output_tracks->push_back(trk);
-		  mask->at(it) = true;
-		  break;
-		}
-	      }
-	      ++it;
-	    }
-	  }
-	  assert(mask->size()==tracks.size());
-	}
+              const auto chi2 = trk.chi2();
+              if (chi2 > value)
+                continue;
+            }
 
-	iEvent.put(std::move(mask));
-	iEvent.put(std::move(output_tracks));
+            const auto eta = trk.eta();
+            const auto phi = trk.phi();
+
+            for (size_t k = 0; k < n_regions; ++k) {
+              if (fabs(trk.dz(origin[k])) > zBound[k])
+                continue;
+              //		if ( fabs(trk.vz() - origin[k].z()) > zBound[k] ) continue;
+
+              if ((eta >= etaMin[k] && eta <= etaMax[k]) && (phi >= phiMin[k] && phi <= phiMax[k])) {
+                output_tracks->push_back(trk);
+                mask->at(it) = true;
+                break;
+              }
+            }
+            ++it;
+          }
+        }
+        assert(mask->size() == tracks.size());
       }
-      
-      Mode mode_;
-      
-      edm::EDGetTokenT<reco::TrackCollection>  tracksToken_;
-      edm::EDGetTokenT<reco::CandidateView>    inputCandidateToken_; 
-      edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
-      edm::EDGetTokenT<reco::BeamSpot>         beamspotToken_;
 
-      float minPt_;
-      float pt1_;
-      float pt2_;
-      float value1_;
-      float value2_;
+      iEvent.put(std::move(mask));
+      iEvent.put(std::move(output_tracks));
+    }
 
-      size_t maxNRegions_;
-      int maxNVertices_;
-      std::string componentName_;
-      float zErrorBeamSpot_;
-      float deltaEta_;
-      float deltaPhi_;
-      float nSigmaZVertex_;
-      float zErrorVetex_;
-      float nSigmaZBeamSpot_;
+    Mode mode_;
 
+    edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+    edm::EDGetTokenT<reco::CandidateView> inputCandidateToken_;
+    edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
+    edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;
+
+    float minPt_;
+    float pt1_;
+    float pt2_;
+    float value1_;
+    float value2_;
+
+    size_t maxNRegions_;
+    int maxNVertices_;
+    std::string componentName_;
+    float zErrorBeamSpot_;
+    float deltaEta_;
+    float deltaPhi_;
+    float nSigmaZVertex_;
+    float zErrorVetex_;
+    float nSigmaZBeamSpot_;
   };
-}
-
+}  // namespace
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(TrackSelectorByCandidateRegion);
-

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByCandidateRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByCandidateRegion.cc
@@ -204,7 +204,7 @@ namespace {
 	    size_t n_objects = objectsHandle->size();
 	    size_t n_regions = 0;
 	    for ( size_t i = 0; i < n_objects && n_regions < maxNRegions_; ++i ) {
-	      std::cout << "i: " << i << " n_regions: " << n_regions << std::endl;
+	      //	      std::cout << "i: " << i << " n_regions: " << n_regions << std::endl;
 	      const reco::Candidate & object = (*objectsHandle)[i];
 	      //	  GlobalVector direction( object.momentum().x(), object.momentum().y(), object.momentum().z() );
 	      for ( size_t j = 0; j < origins.size() && n_regions < maxNRegions_; ++j ) {

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByCandidateRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByCandidateRegion.cc
@@ -1,0 +1,299 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
+
+#include<vector>
+#include<memory>
+
+namespace {
+  class TrackSelectorByCandidateRegion final : public edm::global::EDProducer<> {
+   public:
+
+    typedef enum {BEAM_SPOT_FIXED, BEAM_SPOT_SIGMA, VERTICES_FIXED, VERTICES_SIGMA } Mode;
+
+    explicit TrackSelectorByCandidateRegion(const edm::ParameterSet& conf) :
+      tracksToken_  ( consumes<reco::TrackCollection> (conf.getParameter<edm::InputTag>("tracks"))   ),
+      beamspotToken_( consumes<reco::BeamSpot>        (conf.getParameter<edm::InputTag>("beamspot")) ) {
+
+      edm::ParameterSet trackPSet = conf.getParameter<edm::ParameterSet>("TrackPSet");
+      minPt_ = trackPSet.getParameter<double>("minPt");
+      edm::ParameterSet chi2_vs_pt = trackPSet.getParameter<edm::ParameterSet>("chi2vsPt");
+      bool enabled = chi2_vs_pt.getParameter<bool>("enabled");
+      pt1_ = enabled ? chi2_vs_pt.getParameter<double>("pt1") : -1.;
+      pt2_ = enabled ? chi2_vs_pt.getParameter<double>("pt2") : -1.;
+      value1_ = enabled ? chi2_vs_pt.getParameter<double>("value1") : -1.;
+      value2_ = enabled ? chi2_vs_pt.getParameter<double>("value2") : -1.;
+
+      if (enabled && pt1_ >= pt2_)
+	throw cms::Exception("Configuration") << "TrackSelectorByCandidateRegion::chi2vsPt: pt1 (" << pt1_ << ") needs to be smaller than pt2 (" << pt2_ << ")";
+      if (enabled && pt1_ <= 0)
+	throw cms::Exception("Configuration") << "TrackSelectorByCandidateRegion::chi2vsPt: pt1 needs to be > 0; is " << pt1_;
+      if (enabled && pt2_ <= 0)
+	throw cms::Exception("Configuration") << "TrackSelectorByCandidateRegion::chi2vsPt: pt2 needs to be > 0; is " << pt2_;
+
+      //      for (auto const & ir : conf.getParameter<edm::VParameterSet>("regions")) {
+      edm::ParameterSet regionPSet = conf.getParameter<edm::ParameterSet>("RegionPSet");
+
+      componentName_ = regionPSet.getParameter<std::string>("componentName");
+      /**
+	 eta-phi TrackingRegions producer in directions defined by Candidate-based objects of interest
+	 from a collection defined by the "input" parameter.
+	 Four operational modes are supported ("mode" parameter):
+	 *   BeamSpotFixed:
+	 *     origin is defined by the beam spot
+	 *     z-half-length is defined by a fixed zErrorBeamSpot parameter
+	 *   BeamSpotSigma:
+	 *     origin is defined by the beam spot
+	 *     z-half-length is defined by nSigmaZBeamSpot * beamSpot.sigmaZ
+	 *   VerticesFixed:
+	 *     origins are defined by vertices from VertexCollection (use maximum MaxNVertices of them)
+	 *     z-half-length is defined by a fixed zErrorVetex parameter
+	 *   VerticesSigma:
+	 *     origins are defined by vertices from VertexCollection (use maximum MaxNVertices of them)
+	 *     z-half-length is defined by nSigmaZVertex * vetex.zError
+	 *
+	 *   If, while using one of the "Vertices" modes, there's no vertices in an event, we fall back into
+	 *   either BeamSpotSigma or BeamSpotFixed mode, depending on the positiveness of nSigmaZBeamSpot.
+	 **/
+      
+	inputCandidateToken_ = mayConsume<reco::CandidateView>(regionPSet.getParameter<edm::InputTag>("input"));
+	maxNRegions_ = regionPSet.getParameter<unsigned int>("maxNRegions");
+	
+	std::string mode = regionPSet.getParameter<std::string>("mode");
+	if      (mode == "BeamSpotFixed") mode_ = BEAM_SPOT_FIXED;
+	else if (mode == "BeamSpotSigma") mode_ = BEAM_SPOT_SIGMA;
+	else if (mode == "VerticesFixed") mode_ = VERTICES_FIXED;
+	else if (mode == "VerticesSigma") mode_ = VERTICES_SIGMA;
+	//	else  edm::LogError ("TrackSelectorByCandidateRegion") << "Unknown mode string: " << mode;
+
+	maxNVertices_    = 1;
+	if (mode == VERTICES_FIXED || mode == VERTICES_SIGMA) {
+	  verticesToken_ = mayConsume<reco::VertexCollection>(regionPSet.getParameter<edm::InputTag>("vertices"));
+	  maxNVertices_   = regionPSet.getParameter<int>("maxNVertices");
+	}
+	
+	// RectangularEtaPhiTrackingRegion parameters:
+	deltaEta_         = regionPSet.getParameter<double>("deltaEta");
+	deltaPhi_         = regionPSet.getParameter<double>("deltaPhi");
+	zErrorBeamSpot_   = regionPSet.getParameter<double>("zErrorBeamSpot");
+	// mode-dependent z-halflength of tracking regions
+	nSigmaZVertex_   = ( mode_ == VERTICES_SIGMA   ? regionPSet.getParameter<double>("nSigmaZVertex")   : -1. );
+	zErrorVetex_     = ( mode_ == VERTICES_FIXED   ? regionPSet.getParameter<double>("zErrorVetex")     : -1. );
+	nSigmaZBeamSpot_ = ( mode_ == BEAM_SPOT_SIGMA  ? regionPSet.getParameter<double>("nSigmaZBeamSpot") : -1. );
+	//      }
+
+	produces<reco::TrackCollection>();
+	// produces<edm::RefToBaseVector<T> >();
+	produces<std::vector<bool>>();
+	
+    }
+      
+    static void  fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("tracks",  edm::InputTag("hltPixelTracks"));
+      desc.add<edm::InputTag>("beamspot",edm::InputTag("hltOnlineBeamSpot"));
+      edm::ParameterSetDescription tracks_par;
+      tracks_par.add<double>("minPt", 0.);
+      edm::ParameterSetDescription chi2vsPt_par;
+      chi2vsPt_par.add<bool>("enabled",false);
+      chi2vsPt_par.add<double>("pt1",-1.);
+      chi2vsPt_par.add<double>("pt2",-1.);
+      chi2vsPt_par.add<double>("value1",-1.);
+      chi2vsPt_par.add<double>("value2",-1.);
+      tracks_par.add<edm::ParameterSetDescription>("chi2vsPt",chi2vsPt_par);
+      desc.add<edm::ParameterSetDescription>("TrackPSet",tracks_par);
+
+      edm::ParameterSetDescription region_par;
+      region_par.add<std::string>("componentName", "");
+      region_par.add<edm::InputTag>("input",   edm::InputTag(""));
+      region_par.add<unsigned int>("maxNRegions", 10);
+      region_par.add<std::string>("mode",    "");
+      region_par.add<edm::InputTag>("vertices",edm::InputTag(""));
+      region_par.add<int>("maxNVertices",3);
+      region_par.add<double>("deltaEta", 0.5);
+      region_par.add<double>("deltaPhi", 0.5);
+      region_par.add<double>("zErrorBeamSpot", -1.);
+      region_par.add<double>("nSigmaZVertex",  -1.);
+      region_par.add<double>("zErrorVetex",    -1.);
+      region_par.add<double>("nSigmaZBeamSpot",-1.);
+      desc.add<edm::ParameterSetDescription>("RegionPSet",region_par);
+      descriptions.add("trackSelectorByCandidateRegion", desc);
+    }
+
+   private:
+
+      using MaskCollection = std::vector<bool>;
+
+      void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& eSetup) const override {
+
+	// products
+	auto mask = std::make_unique<MaskCollection>(); // mask w/ the same size of the input collection
+	auto output_tracks = std::make_unique<reco::TrackCollection>(); // selected output collection
+
+	edm::Handle< reco::CandidateView > objectsHandle;
+	// pick up the candidate objects of interest	
+	iEvent.getByToken( inputCandidateToken_, objectsHandle );
+	
+	// always need the beam spot (as a fall back strategy for vertex modes)
+	edm::Handle< reco::BeamSpot > beamspotHandle;
+	iEvent.getByToken( beamspotToken_, beamspotHandle );
+	
+	edm::Handle<reco::TrackCollection> tracksHandle;
+	iEvent.getByToken(tracksToken_,tracksHandle);
+
+	if ( tracksHandle.isValid() ) {
+	  const auto& tracks = *tracksHandle;	  
+	  mask->assign(tracks.size(),false);
+
+	  if ( objectsHandle.isValid() && beamspotHandle.isValid() ) {
+	    
+	    const auto& beamspot = *beamspotHandle;
+	    // this is a default origin for all modes
+	    math::XYZPoint default_origin( beamspot.x0(), beamspot.y0(), beamspot.z0() );
+	    
+	    // vector of origin & halfLength pairs:
+	    std::vector< std::pair< math::XYZPoint, float > > origins;
+	    
+	    // fill the origins and halfLengths depending on the mode
+	    if (mode_ == BEAM_SPOT_FIXED) 
+	      origins.push_back( std::make_pair(default_origin, zErrorBeamSpot_) );
+	    else if (mode_ == BEAM_SPOT_SIGMA)
+	      origins.push_back( std::make_pair(default_origin, nSigmaZBeamSpot_*beamspot.sigmaZ()) );
+	    else if (mode_ == VERTICES_FIXED || mode_ == VERTICES_SIGMA) {
+	      
+	      edm::Handle< reco::VertexCollection > verticesHandle;
+	      iEvent.getByToken( verticesToken_, verticesHandle );
+	      if ( verticesHandle.isValid() ) {	      
+		int n_vert = 0;
+		const auto& vertices = *verticesHandle;
+		for ( auto v : vertices ) {
+		  if ( n_vert > maxNVertices_ ) break;
+		  if ( v.isFake() || !v.isValid() ) continue;
+		  if (mode_ == VERTICES_FIXED)
+		    origins.push_back( std::make_pair(math::XYZPoint( v.x(), v.y(), v.z() ), zErrorVetex_ ) );
+		  else if (mode_ == VERTICES_SIGMA)
+		    origins.push_back( std::make_pair(math::XYZPoint( v.x(), v.y(), v.z() ), nSigmaZVertex_*v.zError()) );
+		  ++n_vert;
+		}
+	      }
+	      // no-vertex fall-back case:
+	      if (origins.empty())
+		origins.push_back( std::make_pair(default_origin, nSigmaZBeamSpot_*beamspot.z0Error()) );
+	    }
+
+	    std::vector<float> etaMin; etaMin.reserve(maxNRegions_);
+	    std::vector<float> etaMax; etaMax.reserve(maxNRegions_);
+	    std::vector<float> phiMin; phiMin.reserve(maxNRegions_);
+	    std::vector<float> phiMax; phiMax.reserve(maxNRegions_);
+	    std::vector<math::XYZPoint> origin; origin.reserve(maxNRegions_);
+	    std::vector<float> zBound;       zBound.reserve(maxNRegions_);
+
+	    size_t n_objects = objectsHandle->size();
+	    size_t n_regions = 0;
+	    for ( size_t i = 0; i < n_objects && n_regions < maxNRegions_; ++i ) {
+	      std::cout << "i: " << i << " n_regions: " << n_regions << std::endl;
+	      const reco::Candidate & object = (*objectsHandle)[i];
+	      //	  GlobalVector direction( object.momentum().x(), object.momentum().y(), object.momentum().z() );
+	      for ( size_t j = 0; j < origins.size() && n_regions < maxNRegions_; ++j ) {
+		etaMin.push_back( object.eta() - deltaEta_ );
+		etaMax.push_back( object.eta() + deltaEta_ );
+		phiMin.push_back( Geom::Phi( object.phi() - deltaPhi_ ) );
+		phiMax.push_back( Geom::Phi( object.phi() + deltaPhi_ ) );
+		origin.push_back( origins[j].first );
+		zBound.push_back( origins[j].second );
+
+		n_regions++;
+	      }
+	    }
+
+	    size_t it = 0;
+	    const auto curvature1 = (value1_ >= 0.) ? PixelRecoUtilities::curvature(1.f / pt1_, eSetup) : -1.;
+	    const auto curvature2 = (value2_ >= 0.) ? PixelRecoUtilities::curvature(1.f / pt2_, eSetup) : -1.;
+	    for ( auto trk : tracks ) {
+	      
+	      const auto pt = trk.pt();
+	      if (pt < minPt_) continue;
+	      if (value1_ >= 0.) {
+		const auto curvature = PixelRecoUtilities::curvature(1.f / pt, eSetup);
+		// https://cmssdt.cern.ch/dxr/CMSSW/source/RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h#58		
+		auto value = -1.;
+		if (curvature1 < curvature)
+		  value = value1_;
+		else if (curvature2 < curvature && curvature <= curvature1)
+		  value = value2_ + (curvature - curvature2) / (curvature1 - curvature2) * (value1_ - value2_);
+		else 
+		  value = value2_;
+
+		const auto chi2 = trk.chi2();
+		if (chi2 > value) continue;
+	      }
+
+	      const auto eta = trk.eta();
+	      const auto phi = trk.phi();
+
+	      for ( size_t k = 0; k < n_regions; ++k ) {
+		if ( fabs(trk.dz(origin[k])) > zBound[k] ) continue;
+		//		if ( fabs(trk.vz() - origin[k].z()) > zBound[k] ) continue;
+		
+		if ( (eta >= etaMin[k] && eta <= etaMax[k]) &&
+		     (phi >= phiMin[k] && phi <= phiMax[k]) ) {
+		  
+		  output_tracks->push_back(trk);
+		  mask->at(it) = true;
+		  break;
+		}
+	      }
+	      ++it;
+	    }
+	  }
+	  assert(mask->size()==tracks.size());
+	}
+
+	iEvent.put(std::move(mask));
+	iEvent.put(std::move(output_tracks));
+      }
+      
+      Mode mode_;
+      
+      edm::EDGetTokenT<reco::TrackCollection>  tracksToken_;
+      edm::EDGetTokenT<reco::CandidateView>    inputCandidateToken_; 
+      edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
+      edm::EDGetTokenT<reco::BeamSpot>         beamspotToken_;
+
+      float minPt_;
+      float pt1_;
+      float pt2_;
+      float value1_;
+      float value2_;
+
+      size_t maxNRegions_;
+      int maxNVertices_;
+      std::string componentName_;
+      float zErrorBeamSpot_;
+      float deltaEta_;
+      float deltaPhi_;
+      float nSigmaZVertex_;
+      float zErrorVetex_;
+      float nSigmaZBeamSpot_;
+
+  };
+}
+
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TrackSelectorByCandidateRegion);
+

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
@@ -1,0 +1,169 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+#include<vector>
+#include<memory>
+
+namespace {
+  class TrackSelectorByRegion final : public edm::global::EDProducer<> {
+   public:
+
+    explicit TrackSelectorByRegion(const edm::ParameterSet& conf) :
+      tracksToken_ ( consumes<reco::TrackCollection> (conf.getParameter<edm::InputTag>("tracks")) ) {
+      //      for (auto const & ir : conf.getParameter<edm::VParameterSet>("regions")) {
+      edm::ParameterSet regionPSet = conf.getParameter<edm::ParameterSet>("RegionPSet");
+      inputTrkRegionToken_ = consumes<edm::OwnVector<TrackingRegion> >(regionPSet.getParameter<edm::InputTag>("input"));
+      phiTollerance_       = regionPSet.getParameter<double>("phiTollerance");
+      edm::ParameterSet trackPSet = conf.getParameter<edm::ParameterSet>("TrackPSet");
+      minPt_ = trackPSet.getParameter<double>("minPt");
+      //      }
+
+      produces<reco::TrackCollection>();
+      // produces<edm::RefToBaseVector<T> >();
+      produces<std::vector<bool>>();
+
+    }
+      
+    static void  fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("tracks",edm::InputTag("hltPixelTracks"));
+      edm::ParameterSetDescription tracks_par;
+      tracks_par.add<double>("minPt", 0.);
+      desc.add<edm::ParameterSetDescription>("TrackPSet",tracks_par);
+
+      edm::ParameterSetDescription region_par;
+      region_par.add<edm::InputTag>("input",edm::InputTag(""));
+      region_par.add<double>("phiTollerance",1.);
+      desc.add<edm::ParameterSetDescription>("RegionPSet",region_par);
+      descriptions.add("trackSelectorByRegion", desc);
+    }
+
+   private:
+
+      using MaskCollection = std::vector<bool>;
+
+      void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const override {
+
+	// products
+	auto mask = std::make_unique<MaskCollection>(); // mask w/ the same size of the input collection
+	auto output_tracks = std::make_unique<reco::TrackCollection>(); // selected output collection
+
+	edm::Handle<edm::OwnVector<TrackingRegion> > regionsHandle;
+	iEvent.getByToken(inputTrkRegionToken_, regionsHandle);
+       	
+	edm::Handle<reco::TrackCollection> tracksHandle;
+	iEvent.getByToken(tracksToken_,tracksHandle);
+
+	std::cout << "[TrackSelectorByRegion::produce] tracksHandle.isValid ? " << (tracksHandle.isValid() ? "YEAP" : "NOPE") << std::endl;
+	if ( tracksHandle.isValid() ) {
+	  const auto& tracks = *tracksHandle;	  
+	  mask->assign(tracks.size(),false);
+
+	  if ( regionsHandle.isValid() ) {
+	    const auto& regions = *regionsHandle;
+
+	    const auto n_regions = regions.size();
+	    std::vector<float> etaMin; etaMin.reserve(n_regions);
+	    std::vector<float> etaMax; etaMax.reserve(n_regions);
+	    std::vector<float> phiMin; phiMin.reserve(n_regions);
+	    std::vector<float> phiMax; phiMax.reserve(n_regions);
+	    std::vector<float> phi0;   phi0.reserve(n_regions);
+	    std::vector<float> phi0margin; phi0margin.reserve(n_regions);
+	    std::vector<math::XYZPoint> origin; origin.reserve(n_regions);
+	    std::vector<float> zBound; zBound.reserve(n_regions);
+	    
+	    for ( const auto& tmp: regions )
+	      if ( const auto *etaPhiRegion = dynamic_cast<const RectangularEtaPhiTrackingRegion *>( &tmp ) ) {
+		
+		const auto& etaRange  = etaPhiRegion->etaRange();
+		const auto& phiMargin = etaPhiRegion->phiMargin();
+
+		etaMin.push_back( etaRange.min() );
+		etaMax.push_back( etaRange.max() );
+		
+		phiMin.push_back( etaPhiRegion->phiDirection() - phiMargin.left() );
+		phiMax.push_back( etaPhiRegion->phiDirection() + phiMargin.right() );
+		phi0.push_back( etaPhiRegion->phiDirection() );
+		phi0margin.push_back( phiMargin.right() );
+
+		GlobalPoint gp = etaPhiRegion->origin();
+		origin.push_back( math::XYZPoint(gp.x(),gp.y(),gp.z()) );
+		zBound.push_back( etaPhiRegion->originZBound() );
+	      }
+
+
+	    size_t it = 0;	    
+	    std::cout << "tracks: " << tracks.size() << std::endl;
+	    for ( auto trk : tracks ) {
+	      
+	      const auto pt = trk.pt();
+	      if (pt < minPt_) {
+		std::cout << " KO !!! for pt" << std::endl;
+		continue;
+	      }
+
+	      const auto eta = trk.eta();
+	      const auto phi = trk.phi();
+	      
+	      for ( size_t k=0; k<n_regions; k++ ) {
+		//		if ( std::abs(trk.vz() - origin[k].z()) > zBound[k] ) {
+		std::cout << "std::abs(trk.vz() - origin[k].z()): " << std::abs(trk.vz() - origin[k].z()) << " zBound: " << zBound[k] << std::endl;
+		std::cout << "std::abs(trk.dz(origin[k])): " << std::abs(trk.dz(origin[k])) << " zBound: " << zBound[k] << std::endl;
+		if ( std::abs(trk.dz(origin[k])) > zBound[k] ) {
+		  std::cout << " KO !! for z" << std::endl;
+		  continue;
+		}
+		std::cout << "eta : " << eta << " etaMin[k]: " << etaMin[k] << " etaMax[k]: " << etaMax[k] << std::endl;
+		if ( eta < etaMin[k] ) {
+		  std::cout << " KO !!! for eta" << std::endl;
+		  continue;
+		}
+		if ( eta > etaMax[k] ) {
+		  std::cout << " KO !!! for eta" << std::endl;
+		  continue;
+		}
+		std::cout << "phi: " << phi << " phi0[k]: " << phi0[k] << " std::abs(reco::deltaPhi(phi,phi0[k])): " << std::abs(reco::deltaPhi(phi,phi0[k])) << " phi0margin: " << phi0margin[k] << std::endl;
+		if ( std::abs(reco::deltaPhi(phi,phi0[k])) > phi0margin[k]*1.1 ) {
+		  std::cout << " KO !!! for phi" << std::endl;
+		  continue;
+		}
+		output_tracks->push_back(trk);
+		mask->at(it) = true;
+		break;
+	      }
+	      it++;
+	    }
+	  }
+	  assert(mask->size()==tracks.size());
+	}
+	
+	iEvent.put(std::move(mask));
+	iEvent.put(std::move(output_tracks));
+	
+      }
+      
+      edm::EDGetTokenT<reco::TrackCollection>  tracksToken_;
+      edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > inputTrkRegionToken_;
+      float phiTollerance_;
+      float minPt_;
+
+  };
+}
+
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TrackSelectorByRegion);
+

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
@@ -66,7 +66,7 @@ namespace {
 	edm::Handle<reco::TrackCollection> tracksHandle;
 	iEvent.getByToken(tracksToken_,tracksHandle);
 
-	std::cout << "[TrackSelectorByRegion::produce] tracksHandle.isValid ? " << (tracksHandle.isValid() ? "YEAP" : "NOPE") << std::endl;
+	//	std::cout << "[TrackSelectorByRegion::produce] tracksHandle.isValid ? " << (tracksHandle.isValid() ? "YEAP" : "NOPE") << std::endl;
 	if ( tracksHandle.isValid() ) {
 	  const auto& tracks = *tracksHandle;	  
 	  mask->assign(tracks.size(),false);
@@ -105,12 +105,12 @@ namespace {
 
 
 	    size_t it = 0;	    
-	    std::cout << "tracks: " << tracks.size() << std::endl;
+	    //	    std::cout << "tracks: " << tracks.size() << std::endl;
 	    for ( auto trk : tracks ) {
 	      
 	      const auto pt = trk.pt();
 	      if (pt < minPt_) {
-		std::cout << " KO !!! for pt" << std::endl;
+		//		std::cout << " KO !!! for pt" << std::endl;
 		continue;
 	      }
 
@@ -119,24 +119,24 @@ namespace {
 	      
 	      for ( size_t k=0; k<n_regions; k++ ) {
 		//		if ( std::abs(trk.vz() - origin[k].z()) > zBound[k] ) {
-		std::cout << "std::abs(trk.vz() - origin[k].z()): " << std::abs(trk.vz() - origin[k].z()) << " zBound: " << zBound[k] << std::endl;
-		std::cout << "std::abs(trk.dz(origin[k])): " << std::abs(trk.dz(origin[k])) << " zBound: " << zBound[k] << std::endl;
+		//		std::cout << "std::abs(trk.vz() - origin[k].z()): " << std::abs(trk.vz() - origin[k].z()) << " zBound: " << zBound[k] << std::endl;
+		//		std::cout << "std::abs(trk.dz(origin[k])): " << std::abs(trk.dz(origin[k])) << " zBound: " << zBound[k] << std::endl;
 		if ( std::abs(trk.dz(origin[k])) > zBound[k] ) {
-		  std::cout << " KO !! for z" << std::endl;
+		  //		  std::cout << " KO !! for z" << std::endl;
 		  continue;
 		}
-		std::cout << "eta : " << eta << " etaMin[k]: " << etaMin[k] << " etaMax[k]: " << etaMax[k] << std::endl;
+		//		std::cout << "eta : " << eta << " etaMin[k]: " << etaMin[k] << " etaMax[k]: " << etaMax[k] << std::endl;
 		if ( eta < etaMin[k] ) {
-		  std::cout << " KO !!! for eta" << std::endl;
+		  //		  std::cout << " KO !!! for eta" << std::endl;
 		  continue;
 		}
 		if ( eta > etaMax[k] ) {
-		  std::cout << " KO !!! for eta" << std::endl;
+		  //		  std::cout << " KO !!! for eta" << std::endl;
 		  continue;
 		}
-		std::cout << "phi: " << phi << " phi0[k]: " << phi0[k] << " std::abs(reco::deltaPhi(phi,phi0[k])): " << std::abs(reco::deltaPhi(phi,phi0[k])) << " phi0margin: " << phi0margin[k] << std::endl;
+		//		std::cout << "phi: " << phi << " phi0[k]: " << phi0[k] << " std::abs(reco::deltaPhi(phi,phi0[k])): " << std::abs(reco::deltaPhi(phi,phi0[k])) << " phi0margin: " << phi0margin[k] << std::endl;
 		if ( std::abs(reco::deltaPhi(phi,phi0[k])) > phi0margin[k]*1.1 ) {
-		  std::cout << " KO !!! for phi" << std::endl;
+		  //		  std::cout << " KO !!! for phi" << std::endl;
 		  continue;
 		}
 		output_tracks->push_back(trk);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
@@ -13,19 +13,18 @@
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
-#include<vector>
-#include<memory>
+#include <vector>
+#include <memory>
 
 namespace {
   class TrackSelectorByRegion final : public edm::global::EDProducer<> {
-   public:
-
-    explicit TrackSelectorByRegion(const edm::ParameterSet& conf) :
-      tracksToken_ ( consumes<reco::TrackCollection> (conf.getParameter<edm::InputTag>("tracks")) ) {
+  public:
+    explicit TrackSelectorByRegion(const edm::ParameterSet& conf)
+        : tracksToken_(consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracks"))) {
       //      for (auto const & ir : conf.getParameter<edm::VParameterSet>("regions")) {
       edm::ParameterSet regionPSet = conf.getParameter<edm::ParameterSet>("RegionPSet");
-      inputTrkRegionToken_ = consumes<edm::OwnVector<TrackingRegion> >(regionPSet.getParameter<edm::InputTag>("input"));
-      phiTollerance_       = regionPSet.getParameter<double>("phiTollerance");
+      inputTrkRegionToken_ = consumes<edm::OwnVector<TrackingRegion>>(regionPSet.getParameter<edm::InputTag>("input"));
+      phiTollerance_ = regionPSet.getParameter<double>("phiTollerance");
       edm::ParameterSet trackPSet = conf.getParameter<edm::ParameterSet>("TrackPSet");
       minPt_ = trackPSet.getParameter<double>("minPt");
       //      }
@@ -33,137 +32,135 @@ namespace {
       produces<reco::TrackCollection>();
       // produces<edm::RefToBaseVector<T> >();
       produces<std::vector<bool>>();
-
     }
-      
-    static void  fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<edm::InputTag>("tracks",edm::InputTag("hltPixelTracks"));
+      desc.add<edm::InputTag>("tracks", edm::InputTag("hltPixelTracks"));
       edm::ParameterSetDescription tracks_par;
       tracks_par.add<double>("minPt", 0.);
-      desc.add<edm::ParameterSetDescription>("TrackPSet",tracks_par);
+      desc.add<edm::ParameterSetDescription>("TrackPSet", tracks_par);
 
       edm::ParameterSetDescription region_par;
-      region_par.add<edm::InputTag>("input",edm::InputTag(""));
-      region_par.add<double>("phiTollerance",1.);
-      desc.add<edm::ParameterSetDescription>("RegionPSet",region_par);
+      region_par.add<edm::InputTag>("input", edm::InputTag(""));
+      region_par.add<double>("phiTollerance", 1.);
+      desc.add<edm::ParameterSetDescription>("RegionPSet", region_par);
       descriptions.add("trackSelectorByRegion", desc);
     }
 
-   private:
+  private:
+    using MaskCollection = std::vector<bool>;
 
-      using MaskCollection = std::vector<bool>;
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const override {
+      // products
+      auto mask = std::make_unique<MaskCollection>();                  // mask w/ the same size of the input collection
+      auto output_tracks = std::make_unique<reco::TrackCollection>();  // selected output collection
 
-      void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const override {
+      edm::Handle<edm::OwnVector<TrackingRegion>> regionsHandle;
+      iEvent.getByToken(inputTrkRegionToken_, regionsHandle);
 
-	// products
-	auto mask = std::make_unique<MaskCollection>(); // mask w/ the same size of the input collection
-	auto output_tracks = std::make_unique<reco::TrackCollection>(); // selected output collection
+      edm::Handle<reco::TrackCollection> tracksHandle;
+      iEvent.getByToken(tracksToken_, tracksHandle);
 
-	edm::Handle<edm::OwnVector<TrackingRegion> > regionsHandle;
-	iEvent.getByToken(inputTrkRegionToken_, regionsHandle);
-       	
-	edm::Handle<reco::TrackCollection> tracksHandle;
-	iEvent.getByToken(tracksToken_,tracksHandle);
+      //	std::cout << "[TrackSelectorByRegion::produce] tracksHandle.isValid ? " << (tracksHandle.isValid() ? "YEAP" : "NOPE") << std::endl;
+      if (tracksHandle.isValid()) {
+        const auto& tracks = *tracksHandle;
+        mask->assign(tracks.size(), false);
 
-	//	std::cout << "[TrackSelectorByRegion::produce] tracksHandle.isValid ? " << (tracksHandle.isValid() ? "YEAP" : "NOPE") << std::endl;
-	if ( tracksHandle.isValid() ) {
-	  const auto& tracks = *tracksHandle;	  
-	  mask->assign(tracks.size(),false);
+        if (regionsHandle.isValid()) {
+          const auto& regions = *regionsHandle;
 
-	  if ( regionsHandle.isValid() ) {
-	    const auto& regions = *regionsHandle;
+          const auto n_regions = regions.size();
+          std::vector<float> etaMin;
+          etaMin.reserve(n_regions);
+          std::vector<float> etaMax;
+          etaMax.reserve(n_regions);
+          std::vector<float> phiMin;
+          phiMin.reserve(n_regions);
+          std::vector<float> phiMax;
+          phiMax.reserve(n_regions);
+          std::vector<float> phi0;
+          phi0.reserve(n_regions);
+          std::vector<float> phi0margin;
+          phi0margin.reserve(n_regions);
+          std::vector<math::XYZPoint> origin;
+          origin.reserve(n_regions);
+          std::vector<float> zBound;
+          zBound.reserve(n_regions);
 
-	    const auto n_regions = regions.size();
-	    std::vector<float> etaMin; etaMin.reserve(n_regions);
-	    std::vector<float> etaMax; etaMax.reserve(n_regions);
-	    std::vector<float> phiMin; phiMin.reserve(n_regions);
-	    std::vector<float> phiMax; phiMax.reserve(n_regions);
-	    std::vector<float> phi0;   phi0.reserve(n_regions);
-	    std::vector<float> phi0margin; phi0margin.reserve(n_regions);
-	    std::vector<math::XYZPoint> origin; origin.reserve(n_regions);
-	    std::vector<float> zBound; zBound.reserve(n_regions);
-	    
-	    for ( const auto& tmp: regions )
-	      if ( const auto *etaPhiRegion = dynamic_cast<const RectangularEtaPhiTrackingRegion *>( &tmp ) ) {
-		
-		const auto& etaRange  = etaPhiRegion->etaRange();
-		const auto& phiMargin = etaPhiRegion->phiMargin();
+          for (const auto& tmp : regions)
+            if (const auto* etaPhiRegion = dynamic_cast<const RectangularEtaPhiTrackingRegion*>(&tmp)) {
+              const auto& etaRange = etaPhiRegion->etaRange();
+              const auto& phiMargin = etaPhiRegion->phiMargin();
 
-		etaMin.push_back( etaRange.min() );
-		etaMax.push_back( etaRange.max() );
-		
-		phiMin.push_back( etaPhiRegion->phiDirection() - phiMargin.left() );
-		phiMax.push_back( etaPhiRegion->phiDirection() + phiMargin.right() );
-		phi0.push_back( etaPhiRegion->phiDirection() );
-		phi0margin.push_back( phiMargin.right() );
+              etaMin.push_back(etaRange.min());
+              etaMax.push_back(etaRange.max());
 
-		GlobalPoint gp = etaPhiRegion->origin();
-		origin.push_back( math::XYZPoint(gp.x(),gp.y(),gp.z()) );
-		zBound.push_back( etaPhiRegion->originZBound() );
-	      }
+              phiMin.push_back(etaPhiRegion->phiDirection() - phiMargin.left());
+              phiMax.push_back(etaPhiRegion->phiDirection() + phiMargin.right());
+              phi0.push_back(etaPhiRegion->phiDirection());
+              phi0margin.push_back(phiMargin.right());
 
+              GlobalPoint gp = etaPhiRegion->origin();
+              origin.push_back(math::XYZPoint(gp.x(), gp.y(), gp.z()));
+              zBound.push_back(etaPhiRegion->originZBound());
+            }
 
-	    size_t it = 0;	    
-	    //	    std::cout << "tracks: " << tracks.size() << std::endl;
-	    for ( auto trk : tracks ) {
-	      
-	      const auto pt = trk.pt();
-	      if (pt < minPt_) {
-		//		std::cout << " KO !!! for pt" << std::endl;
-		continue;
-	      }
+          size_t it = 0;
+          //	    std::cout << "tracks: " << tracks.size() << std::endl;
+          for (auto trk : tracks) {
+            const auto pt = trk.pt();
+            if (pt < minPt_) {
+              //		std::cout << " KO !!! for pt" << std::endl;
+              continue;
+            }
 
-	      const auto eta = trk.eta();
-	      const auto phi = trk.phi();
-	      
-	      for ( size_t k=0; k<n_regions; k++ ) {
-		//		if ( std::abs(trk.vz() - origin[k].z()) > zBound[k] ) {
-		//		std::cout << "std::abs(trk.vz() - origin[k].z()): " << std::abs(trk.vz() - origin[k].z()) << " zBound: " << zBound[k] << std::endl;
-		//		std::cout << "std::abs(trk.dz(origin[k])): " << std::abs(trk.dz(origin[k])) << " zBound: " << zBound[k] << std::endl;
-		if ( std::abs(trk.dz(origin[k])) > zBound[k] ) {
-		  //		  std::cout << " KO !! for z" << std::endl;
-		  continue;
-		}
-		//		std::cout << "eta : " << eta << " etaMin[k]: " << etaMin[k] << " etaMax[k]: " << etaMax[k] << std::endl;
-		if ( eta < etaMin[k] ) {
-		  //		  std::cout << " KO !!! for eta" << std::endl;
-		  continue;
-		}
-		if ( eta > etaMax[k] ) {
-		  //		  std::cout << " KO !!! for eta" << std::endl;
-		  continue;
-		}
-		//		std::cout << "phi: " << phi << " phi0[k]: " << phi0[k] << " std::abs(reco::deltaPhi(phi,phi0[k])): " << std::abs(reco::deltaPhi(phi,phi0[k])) << " phi0margin: " << phi0margin[k] << std::endl;
-		if ( std::abs(reco::deltaPhi(phi,phi0[k])) > phi0margin[k]*1.1 ) {
-		  //		  std::cout << " KO !!! for phi" << std::endl;
-		  continue;
-		}
-		output_tracks->push_back(trk);
-		mask->at(it) = true;
-		break;
-	      }
-	      it++;
-	    }
-	  }
-	  assert(mask->size()==tracks.size());
-	}
-	
-	iEvent.put(std::move(mask));
-	iEvent.put(std::move(output_tracks));
-	
+            const auto eta = trk.eta();
+            const auto phi = trk.phi();
+
+            for (size_t k = 0; k < n_regions; k++) {
+              //		if ( std::abs(trk.vz() - origin[k].z()) > zBound[k] ) {
+              //		std::cout << "std::abs(trk.vz() - origin[k].z()): " << std::abs(trk.vz() - origin[k].z()) << " zBound: " << zBound[k] << std::endl;
+              //		std::cout << "std::abs(trk.dz(origin[k])): " << std::abs(trk.dz(origin[k])) << " zBound: " << zBound[k] << std::endl;
+              if (std::abs(trk.dz(origin[k])) > zBound[k]) {
+                //		  std::cout << " KO !! for z" << std::endl;
+                continue;
+              }
+              //		std::cout << "eta : " << eta << " etaMin[k]: " << etaMin[k] << " etaMax[k]: " << etaMax[k] << std::endl;
+              if (eta < etaMin[k]) {
+                //		  std::cout << " KO !!! for eta" << std::endl;
+                continue;
+              }
+              if (eta > etaMax[k]) {
+                //		  std::cout << " KO !!! for eta" << std::endl;
+                continue;
+              }
+              //		std::cout << "phi: " << phi << " phi0[k]: " << phi0[k] << " std::abs(reco::deltaPhi(phi,phi0[k])): " << std::abs(reco::deltaPhi(phi,phi0[k])) << " phi0margin: " << phi0margin[k] << std::endl;
+              if (std::abs(reco::deltaPhi(phi, phi0[k])) > phi0margin[k] * 1.1) {
+                //		  std::cout << " KO !!! for phi" << std::endl;
+                continue;
+              }
+              output_tracks->push_back(trk);
+              mask->at(it) = true;
+              break;
+            }
+            it++;
+          }
+        }
+        assert(mask->size() == tracks.size());
       }
-      
-      edm::EDGetTokenT<reco::TrackCollection>  tracksToken_;
-      edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > inputTrkRegionToken_;
-      float phiTollerance_;
-      float minPt_;
 
+      iEvent.put(std::move(mask));
+      iEvent.put(std::move(output_tracks));
+    }
+
+    edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+    edm::EDGetTokenT<edm::OwnVector<TrackingRegion>> inputTrkRegionToken_;
+    float phiTollerance_;
+    float minPt_;
   };
-}
-
+}  // namespace
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(TrackSelectorByRegion);
-


### PR DESCRIPTION
#### PR description:
instead of reconstruct tracks in different regions, while having already tracks reconstructed globally,
one can select the subset of tracks based on the ROI a-posteriori

these 2 plugins are meant to be used mainly at HLT, 
where for instance pixel tracks are reconstructed globally
and then they can be selected around muons, electrons, taus, jets
for the different needs, like seeding tracks for the first iteration in the isolation and b-tagging or reconstructing PV, etc