### PR TITLE
Support of condition updates per-lumisection

### DIFF
--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -105,7 +105,7 @@ namespace cond {
     void loadTag(std::string const& tag, boost::posix_time::ptime const& snapshotTime);
     void reload();
 
-    ValidityInterval setIntervalFor(Time_t target);
+    ValidityInterval setIntervalFor(Time_t target, Time_t defaultIovSize);
     TimeType timeType() const { return m_iovProxy.tagInfo().timeType; }
 
   private:

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -347,14 +347,17 @@ void CondDBESSource::setIntervalFor(const EventSetupRecordKey& iKey,
   }
   //}
   cond::Time_t lastTime = m_lastRun;
-  auto iR = m_refreshTimeForRecord.find(recordname);
-  bool refreshThisRecord = (iR != m_refreshTimeForRecord.end());
   cond::Time_t defaultIovSize = cond::time::MAX_VAL;
   cond::Time_t minDiffTime = 1;
-  if (refreshThisRecord) {
-    lastTime = cond::time::lumiTime(m_lastRun, m_lastLumi);
-    defaultIovSize = iR->second;
-    minDiffTime = defaultIovSize;
+  bool refreshThisRecord = false;
+  if (m_policy != REFRESH_ALWAYS) {
+    auto iR = m_refreshTimeForRecord.find(recordname);
+    refreshThisRecord = (iR != m_refreshTimeForRecord.end());
+    if (refreshThisRecord) {
+      lastTime = cond::time::lumiTime(m_lastRun, m_lastLumi);
+      defaultIovSize = iR->second;
+      minDiffTime = defaultIovSize;
+    }
   }
   bool doRefresh = false;
   if (m_policy == REFRESH_EACH_RUN || m_policy == RECONNECT_EACH_RUN || refreshThisRecord) {
@@ -363,7 +366,8 @@ void CondDBESSource::setIntervalFor(const EventSetupRecordKey& iKey,
     if (iRec != m_lastRecordRuns.end()) {
       cond::Time_t lastRecordRun = iRec->second;
       cond::Time_t diffTime = lastTime - lastRecordRun;
-      if( lastRecordRun > lastTime ) diffTime = lastRecordRun - lastTime;
+      if (lastRecordRun > lastTime)
+        diffTime = lastRecordRun - lastTime;
       if (diffTime >= minDiffTime) {
         // a refresh is required!
         doRefresh = true;

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -362,7 +362,9 @@ void CondDBESSource::setIntervalFor(const EventSetupRecordKey& iKey,
     std::map<std::string, cond::Time_t>::iterator iRec = m_lastRecordRuns.find(recordname);
     if (iRec != m_lastRecordRuns.end()) {
       cond::Time_t lastRecordRun = iRec->second;
-      if (lastTime - lastRecordRun >= minDiffTime) {
+      cond::Time_t diffTime = lastTime - lastRecordRun;
+      if( lastRecordRun > lastTime ) diffTime = lastRecordRun - lastTime;
+      if (diffTime >= minDiffTime) {
         // a refresh is required!
         doRefresh = true;
         iRec->second = lastTime;

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -165,6 +165,11 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
           boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP));
       if (itToGet->exists("snapshotTime"))
         tagSnapshotTime = boost::posix_time::time_from_string(itToGet->getParameter<std::string>("snapshotTime"));
+      if (itToGet->exists("refreshTime")) {
+        cond::Time_t refreshTime = itToGet->getParameter<unsigned long long>("refreshTime");
+        m_refreshTimeForRecord.insert(std::make_pair(recordname, refreshTime));
+      }
+
       std::string recordLabelKey = joinRecordAndLabel(recordname, labelname);
       replacements.insert(
           std::make_pair(recordLabelKey, cond::GTEntry_t(std::make_tuple(recordname, labelname, fqTag))));
@@ -341,24 +346,33 @@ void CondDBESSource::setIntervalFor(const EventSetupRecordKey& iKey,
     m_stats.nLumi++;
   }
   //}
-
+  cond::Time_t lastTime = m_lastRun;
+  auto iR = m_refreshTimeForRecord.find(recordname);
+  bool refreshThisRecord = (iR != m_refreshTimeForRecord.end());
+  cond::Time_t defaultIovSize = cond::time::MAX_VAL;
+  cond::Time_t minDiffTime = 1;
+  if (refreshThisRecord) {
+    lastTime = cond::time::lumiTime(m_lastRun, m_lastLumi);
+    defaultIovSize = iR->second;
+    minDiffTime = defaultIovSize;
+  }
   bool doRefresh = false;
-  if (m_policy == REFRESH_EACH_RUN || m_policy == RECONNECT_EACH_RUN) {
+  if (m_policy == REFRESH_EACH_RUN || m_policy == RECONNECT_EACH_RUN || refreshThisRecord) {
     // find out the last run number for the proxy of the specified record
-    std::map<std::string, unsigned int>::iterator iRec = m_lastRecordRuns.find(recordname);
+    std::map<std::string, cond::Time_t>::iterator iRec = m_lastRecordRuns.find(recordname);
     if (iRec != m_lastRecordRuns.end()) {
-      unsigned int lastRecordRun = iRec->second;
-      if (lastRecordRun != m_lastRun) {
+      cond::Time_t lastRecordRun = iRec->second;
+      if (lastTime - lastRecordRun >= minDiffTime) {
         // a refresh is required!
         doRefresh = true;
-        iRec->second = m_lastRun;
+        iRec->second = lastTime;
         edm::LogInfo("CondDBESSource") << "Preparing refresh for record \"" << recordname
-                                       << "\" since there has been a transition from run " << lastRecordRun
-                                       << " to run " << m_lastRun << "; from CondDBESSource::setIntervalFor";
+                                       << "\" since there has been a transition from run/lumi " << lastRecordRun
+                                       << " to run/lumi " << lastTime << "; from CondDBESSource::setIntervalFor";
       }
     } else {
       doRefresh = true;
-      m_lastRecordRuns.insert(std::make_pair(recordname, m_lastRun));
+      m_lastRecordRuns.insert(std::make_pair(recordname, lastTime));
       edm::LogInfo("CondDBESSource") << "Preparing refresh for record \"" << recordname << "\" for " << iTime.eventID()
                                      << ", timestamp: " << iTime.time().value()
                                      << "; from CondDBESSource::setIntervalFor";
@@ -414,21 +428,24 @@ void CondDBESSource::setIntervalFor(const EventSetupRecordKey& iKey,
       }
 
       // first reconnect if required
-      if (m_policy == RECONNECT_EACH_RUN) {
+      if (m_policy == RECONNECT_EACH_RUN || refreshThisRecord) {
         edm::LogInfo("CondDBESSource")
             << "Checking if the session must be closed and re-opened for getting correct conditions"
             << "; from CondDBESSource::setIntervalFor";
         std::stringstream transId;
         //transId << "long" << m_lastRun;
-        transId << m_lastRun;
+        transId << lastTime;
         std::string connStr = m_connectionString;
         std::pair<std::string, std::string> tagParams = cond::persistency::parseTag(tcIter->second.tagName());
         if (!tagParams.second.empty())
           connStr = tagParams.second;
-        std::map<std::string, std::pair<cond::persistency::Session, std::string>>::iterator iSess =
-            m_sessionPool.find(connStr);
+        std::map<std::string, std::pair<cond::persistency::Session, std::string>>* sessionPool = &m_sessionPool;
+        if (refreshThisRecord) {
+          sessionPool = &m_sessionPoolForLumiConditions;
+        }
+        auto iSess = sessionPool->find(connStr);
         bool reopen = false;
-        if (iSess != m_sessionPool.end()) {
+        if (iSess != sessionPool->end()) {
           if (iSess->second.second != transId.str()) {
             // the available session is open for a different run: reopen
             reopen = true;
@@ -437,7 +454,7 @@ void CondDBESSource::setIntervalFor(const EventSetupRecordKey& iKey,
         } else {
           // no available session: probably first run analysed...
           iSess =
-              m_sessionPool.insert(std::make_pair(connStr, std::make_pair(cond::persistency::Session(), transId.str())))
+              sessionPool->insert(std::make_pair(connStr, std::make_pair(cond::persistency::Session(), transId.str())))
                   .first;
           reopen = true;
         }
@@ -485,7 +502,7 @@ void CondDBESSource::setIntervalFor(const EventSetupRecordKey& iKey,
     */
 
     //query the IOVSequence
-    cond::ValidityInterval validity = (*pmIter).second->setIntervalFor(abtime);
+    cond::ValidityInterval validity = (*pmIter).second->setIntervalFor(abtime, defaultIovSize);
 
     edm::LogInfo("CondDBESSource") << "Validity coming from IOV sequence for record \"" << recordname
                                    << "\" and label \"" << pmIter->second->label() << "\": (" << validity.first << ", "

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -90,8 +90,10 @@ private:
   typedef std::map<std::string, cond::GTEntry_t> TagCollection;
   // the collections of tag, record/label used in this ESSource
   TagCollection m_tagCollection;
+  std::map<std::string, cond::Time_t> m_refreshTimeForRecord;
   std::map<std::string, std::pair<cond::persistency::Session, std::string> > m_sessionPool;
-  std::map<std::string, unsigned int> m_lastRecordRuns;
+  std::map<std::string, std::pair<cond::persistency::Session, std::string> > m_sessionPoolForLumiConditions;
+  std::map<std::string, cond::Time_t> m_lastRecordRuns;
 
   struct Stats {
     int nData;

--- a/CondCore/ESSources/src/ProxyFactory.cc
+++ b/CondCore/ESSources/src/ProxyFactory.cc
@@ -48,11 +48,11 @@ void cond::DataProxyWrapperBase::reload() {
     loadTag(tag);
 }
 
-cond::ValidityInterval cond::DataProxyWrapperBase::setIntervalFor(Time_t time) {
+cond::ValidityInterval cond::DataProxyWrapperBase::setIntervalFor(Time_t time, Time_t defaultIovSize) {
   if (!m_currentIov.isValidFor(time)) {
     m_currentIov.clear();
     m_session.transaction().start(true);
-    m_currentIov = m_iovProxy.getInterval(time);
+    m_currentIov = m_iovProxy.getInterval(time, defaultIovSize);
     m_session.transaction().commit();
   }
   return cond::ValidityInterval(m_currentIov.since, m_currentIov.till);

--- a/CondCore/ESSources/test/BuildFile.xml
+++ b/CondCore/ESSources/test/BuildFile.xml
@@ -22,3 +22,6 @@
   <flags   TEST_RUNNER_ARGS=" /bin/bash CondCore/ESSources/test TestConcurrentIOVsCondCore.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>
+<library   file="stubs/LumiTestReadAnalyzer.cc" name="LumiTestReadAnalyzer">
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/CondCore/ESSources/test/python/loadall_from_one_record_empty_source_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_one_record_empty_source_cfg.py
@@ -1,0 +1,173 @@
+from __future__ import print_function
+import time
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from Configuration.AlCa.autoCond import autoCond
+import six
+
+options = VarParsing.VarParsing()
+options.register('processId',
+                 '0',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Process Id")
+options.register('connectionString',
+                 #'sqlite_file:cms_conditions.db', #default value
+                 #'frontier://FrontierProd/CMS_CONDITIONS', #default value
+                 'frontier://FrontierPrep/CMS_CONDITIONS',
+                 #'oracle://cms_orcon_prod/CMS_CONDITIONS',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "CondDB Connection string")
+options.register('tag',
+                 'BeamSpot_test_updateByLumi_00',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "tag for record BeamSpotObjectsRcd")
+options.register('snapshotTime',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "GlobalTag snapshot time")
+options.register('refresh',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Refresh type: default no refresh")
+options.register('runNumber',
+                 115, #default value, int limit -3
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number; default gives latest IOV")
+options.register('eventsPerLumi',
+                 2, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "number of events per lumi")
+options.register('numberOfLumis',
+                 20, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "number of lumisections per run")
+options.register('numberOfRuns',
+                 1, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "number of runs in the job")
+options.register('messageLevel',
+                 0, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Message level; default to 0")
+options.register('security',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "FroNTier connection security: activate it with 'sig'")
+
+options.parseArguments()
+
+process = cms.Process("TEST")
+
+process.MessageLogger = cms.Service("MessageLogger",
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
+                                    destinations = cms.untracked.vstring('cout')
+                                    )
+#process.MessageLogger = cms.Service( "MessageLogger",
+#                                     destinations = cms.untracked.vstring( 'detailedInfo' ),
+#                                     detailedInfo = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) ),
+#                                     )
+
+CondDBParameters = cms.PSet( authenticationPath = cms.untracked.string( '/build/gg/' ),
+                             authenticationSystem = cms.untracked.int32( 0 ),
+                             messageLevel = cms.untracked.int32( options.messageLevel ),
+                             security = cms.untracked.string( options.security ),
+                             )
+
+refreshAlways, refreshOpenIOVs, refreshEachRun, reconnectEachRun = False, False, False, False
+if options.refresh == 0:
+    refreshAlways, refreshOpenIOVs, refreshEachRun, reconnectEachRun = False, False, False, False
+elif options.refresh == 1:
+    refreshAlways = True
+    refreshOpenIOVs, refreshEachRun, reconnectEachRun = False, False, False
+elif options.refresh == 2:
+    refreshAlways = False
+    refreshOpenIOVs = True
+    refreshEachRun, reconnectEachRun = False, False
+elif options.refresh == 3:
+    refreshAlways, refreshOpenIOVs = False, False
+    refreshEachRun = True
+    reconnectEachRun = False
+elif options.refresh == 4:
+    refreshAlways, refreshOpenIOVs, refreshEachRun = False, False, False
+    reconnectEachRun = True
+
+process.GlobalTag = cms.ESSource( "PoolDBESSource",
+                                  DBParameters = CondDBParameters,
+                                  connect = cms.string( options.connectionString ),
+                                  snapshotTime = cms.string( options.snapshotTime ),
+                                  toGet = cms.VPSet(cms.PSet(
+                                      record = cms.string('BeamSpotObjectsRcd'),
+                                      tag = cms.string( options.tag ),
+                                      refreshTime = cms.uint64( 1 )
+                                  )),
+                                  RefreshAlways = cms.untracked.bool( refreshAlways ),
+                                  RefreshOpenIOVs = cms.untracked.bool( refreshOpenIOVs ),
+                                  RefreshEachRun = cms.untracked.bool( refreshEachRun ),
+                                  ReconnectEachRun = cms.untracked.bool( reconnectEachRun ),
+                                  DumpStat = cms.untracked.bool( True ),
+                                  )
+
+
+#TODO: add VarParsing support for adding custom conditions
+#process.GlobalTag.toGet.append( cms.PSet( record = cms.string( "BeamSpotObjectsRcd" ),
+#                                          tag = cms.string( "firstcollisions" ),
+#                                          connect = cms.string( "frontier://FrontierProd/CMS_CONDITIONS" ),
+#                                          snapshotTime = cms.string('2014-01-01 00:00:00.000'),
+#                                          )
+#                                )
+
+process.source = cms.Source( "FileBasedEmptySource",
+                             interval = cms.uint32( 5 ),
+                             maxEvents = cms.uint32( 2 ),
+                             pathForLastLumiFile = cms.string('/build/gg/last_lumi.txt'),
+                             firstLuminosityBlock = cms.untracked.uint32(1),
+                             firstRun = cms.untracked.uint32( options.runNumber ),
+                             firstTime = cms.untracked.uint64( ( long( time.time() ) - 24 * 3600 ) << 32 ), #24 hours ago in nanoseconds
+                             numberEventsInRun = cms.untracked.uint32( 1000 ), # options.numberOfLumis lumi sections per run
+                             numberEventsInLuminosityBlock = cms.untracked.uint32( options.eventsPerLumi )
+                             )
+
+#process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( options.eventsPerLumi *  options.numberOfLumis * options.numberOfRuns ) ) #options.numberOfRuns runs per job
+
+process.prod = cms.EDAnalyzer("LumiTestReadAnalyzer",
+                              processId = cms.untracked.string( options.processId ),
+                              pathForLastLumiFile = cms.untracked.string("/build/gg/last_lumi.txt"),
+                              pathForAllLumiFile = cms.untracked.string("./all_time.txt" ),
+                              pathForErrorFile = cms.untracked.string("./lumi_read_errors")
+)
+
+#process.get = cms.EDAnalyzer( "EventSetupRecordDataGetter",
+#                              toGet =  cms.VPSet(),
+#                              verbose = cms.untracked.bool( True )
+#                              )
+
+#process.escontent = cms.EDAnalyzer( "PrintEventSetupContent",
+#                                    compact = cms.untracked.bool( True ),
+#                                    printProviders = cms.untracked.bool( True )
+#                                    )
+
+#process.esretrieval = cms.EDAnalyzer( "PrintEventSetupDataRetrieval",
+#                                      printProviders = cms.untracked.bool( True )
+#                                      )
+
+process.p = cms.Path( process.prod )
+#process.esout = cms.EndPath( process.escontent + process.esretrieval )
+#if process.schedule_() is not None:
+#    process.schedule_().append( process.esout )
+
+for name, module in six.iteritems(process.es_sources_()):
+    print("ESModules> provider:%s '%s'" % ( name, module.type_() ))
+for name, module in six.iteritems(process.es_producers_()):
+    print("ESModules> provider:%s '%s'" % ( name, module.type_() ))

--- a/CondCore/ESSources/test/stubs/LumiTestReadAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/LumiTestReadAnalyzer.cc
@@ -1,0 +1,93 @@
+
+/*----------------------------------------------------------------------
+
+Toy EDProducers and EDProducts for testing purposes only.
+
+----------------------------------------------------------------------*/
+
+#include <stdexcept>
+#include <string>
+#include <iostream>
+//#include <map>
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+//#include "CondFormats/DataRecord/interface/LumiTestPayloadRcd.h"
+//#include "CondFormats/Common/interface/LumiTestPayload.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include <fstream>
+
+using namespace std;
+
+namespace edmtest
+{
+  class LumiTestReadAnalyzer : public edm::EDAnalyzer
+  {
+  public:
+    explicit  LumiTestReadAnalyzer(edm::ParameterSet const& p):
+      m_processId( p.getUntrackedParameter<std::string>("processId") ),
+      m_pathForLastLumiFile( p.getUntrackedParameter<std::string>("lastLumiFile","")),
+      m_pathForErrorFile("")
+    { 
+      std::string pathForErrorFolder = p.getUntrackedParameter<std::string>("pathForErrorFile");
+      m_pathForErrorFile = pathForErrorFolder+"/lumi_read_"+m_processId+".txt";
+    }
+    explicit  LumiTestReadAnalyzer(int i) 
+    { 
+    }
+    virtual ~LumiTestReadAnalyzer() {  
+    }
+    virtual void beginJob();
+    virtual void beginRun(const edm::Run&, const edm::EventSetup& context);
+    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+  private:
+    std::string m_processId;
+    std::string m_pathForLastLumiFile;
+    std::string m_pathForErrorFile;
+  };
+  void
+  LumiTestReadAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context){
+  }
+  void
+  LumiTestReadAnalyzer::beginJob(){
+  }
+  void
+  LumiTestReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context){
+    static constexpr const char* const MSGSOURCE = "LumiTestReadAnalyzer:";
+    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("BeamSpotObjectsRcd"));
+    if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+      //record not found
+      edm::LogError(MSGSOURCE)<< "Record \"BeamSpotObjectsRcd\" does not exist ";
+    }
+    edm::ESHandle<BeamSpotObjects> ps;
+    context.get<BeamSpotObjectsRcd>().get(ps);
+    const BeamSpotObjects* payload=ps.product();
+    edm::LogInfo(MSGSOURCE) << "Event "<<e.id().event()<<" Run "<<e.id().run()<<" Lumi "<<e.id().luminosityBlock()<<" Time "<<e.time().value()<<
+      " LumiTestPayload id "<<payload->GetBeamType()<<std::endl;
+    //cond::Time_t target = cond::time::lumiTime( e.id().run(), e.id().luminosityBlock());
+    unsigned int target = e.id().luminosityBlock();
+    unsigned int found = payload->GetBeamType();
+    if( target != found ){
+      boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
+      std::stringstream msg;
+      msg << "On time "<<boost::posix_time::to_iso_extended_string(now)<<" Target "<<target<<"; found "<<found;
+      edm::LogWarning( MSGSOURCE)<< msg.str();
+      std::cout <<"ERROR ( process "<<m_processId<<" ) : "<<msg.str()<<std::endl;
+      std::cout <<"### dumping in file "<<m_pathForErrorFile<<std::endl;
+      {  
+	std::ofstream errorFile( m_pathForErrorFile, std::ios_base::app );
+	errorFile << msg.str()<<std::endl;
+      }
+      //throw std::runtime_error( msg.str() );
+    } else {
+      std::cout <<"Info: read was ok."<<std::endl;
+    }
+  }
+  DEFINE_FWK_MODULE(LumiTestReadAnalyzer);
+}

--- a/CondCore/ESSources/test/stubs/LumiTestReadAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/LumiTestReadAnalyzer.cc
@@ -25,69 +25,62 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 using namespace std;
 
-namespace edmtest
-{
-  class LumiTestReadAnalyzer : public edm::EDAnalyzer
-  {
+namespace edmtest {
+  class LumiTestReadAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit  LumiTestReadAnalyzer(edm::ParameterSet const& p):
-      m_processId( p.getUntrackedParameter<std::string>("processId") ),
-      m_pathForLastLumiFile( p.getUntrackedParameter<std::string>("lastLumiFile","")),
-      m_pathForErrorFile("")
-    { 
+    explicit LumiTestReadAnalyzer(edm::ParameterSet const& p)
+        : m_processId(p.getUntrackedParameter<std::string>("processId")),
+          m_pathForLastLumiFile(p.getUntrackedParameter<std::string>("lastLumiFile", "")),
+          m_pathForErrorFile("") {
       std::string pathForErrorFolder = p.getUntrackedParameter<std::string>("pathForErrorFile");
-      m_pathForErrorFile = pathForErrorFolder+"/lumi_read_"+m_processId+".txt";
+      m_pathForErrorFile = pathForErrorFolder + "/lumi_read_" + m_processId + ".txt";
     }
-    explicit  LumiTestReadAnalyzer(int i) 
-    { 
-    }
-    virtual ~LumiTestReadAnalyzer() {  
-    }
+    explicit LumiTestReadAnalyzer(int i) {}
+    virtual ~LumiTestReadAnalyzer() {}
     virtual void beginJob();
     virtual void beginRun(const edm::Run&, const edm::EventSetup& context);
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+
   private:
     std::string m_processId;
     std::string m_pathForLastLumiFile;
     std::string m_pathForErrorFile;
   };
-  void
-  LumiTestReadAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context){
-  }
-  void
-  LumiTestReadAnalyzer::beginJob(){
-  }
-  void
-  LumiTestReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context){
+  void LumiTestReadAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context) {}
+  void LumiTestReadAnalyzer::beginJob() {}
+  void LumiTestReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     static constexpr const char* const MSGSOURCE = "LumiTestReadAnalyzer:";
-    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("BeamSpotObjectsRcd"));
-    if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    edm::eventsetup::EventSetupRecordKey recordKey(
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("BeamSpotObjectsRcd"));
+    if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      edm::LogError(MSGSOURCE)<< "Record \"BeamSpotObjectsRcd\" does not exist ";
+      edm::LogError(MSGSOURCE) << "Record \"BeamSpotObjectsRcd\" does not exist ";
     }
     edm::ESHandle<BeamSpotObjects> ps;
     context.get<BeamSpotObjectsRcd>().get(ps);
-    const BeamSpotObjects* payload=ps.product();
-    edm::LogInfo(MSGSOURCE) << "Event "<<e.id().event()<<" Run "<<e.id().run()<<" Lumi "<<e.id().luminosityBlock()<<" Time "<<e.time().value()<<
-      " LumiTestPayload id "<<payload->GetBeamType()<<std::endl;
+    const BeamSpotObjects* payload = ps.product();
+    edm::LogInfo(MSGSOURCE) << "Event " << e.id().event() << " Run " << e.id().run() << " Lumi "
+                            << e.id().luminosityBlock() << " Time " << e.time().value() << " LumiTestPayload id "
+                            << payload->GetBeamType() << std::endl;
     //cond::Time_t target = cond::time::lumiTime( e.id().run(), e.id().luminosityBlock());
     unsigned int target = e.id().luminosityBlock();
     unsigned int found = payload->GetBeamType();
-    if( target != found ){
+    if (target != found) {
       boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
       std::stringstream msg;
-      msg << "On time "<<boost::posix_time::to_iso_extended_string(now)<<" Target "<<target<<"; found "<<found;
-      edm::LogWarning( MSGSOURCE)<< msg.str();
-      std::cout <<"ERROR ( process "<<m_processId<<" ) : "<<msg.str()<<std::endl;
-      std::cout <<"### dumping in file "<<m_pathForErrorFile<<std::endl;
-      {  
-	std::ofstream errorFile( m_pathForErrorFile, std::ios_base::app );
-	errorFile << msg.str()<<std::endl;
+      msg << "On time " << boost::posix_time::to_iso_extended_string(now) << " Target " << target << "; found "
+          << found;
+      edm::LogWarning(MSGSOURCE) << msg.str();
+      std::cout << "ERROR ( process " << m_processId << " ) : " << msg.str() << std::endl;
+      std::cout << "### dumping in file " << m_pathForErrorFile << std::endl;
+      {
+        std::ofstream errorFile(m_pathForErrorFile, std::ios_base::app);
+        errorFile << msg.str() << std::endl;
       }
       //throw std::runtime_error( msg.str() );
     } else {
-      std::cout <<"Info: read was ok."<<std::endl;
+      std::cout << "Info: read was ok." << std::endl;
     }
   }
   DEFINE_FWK_MODULE(LumiTestReadAnalyzer);
-}
+}  // namespace edmtest

--- a/CondCore/Utilities/plugins/BuildFile.xml
+++ b/CondCore/Utilities/plugins/BuildFile.xml
@@ -1,4 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
 <library   file="EmptyIOVSource.cc" name="CondEmptyIOVSource">
+  <use   name="CondCore/CondDB"/>
+  <use   name="FWCore/Sources"/>
+</library>
+<library   file="FileBasedEmptySource.cc" name="CondFileBasedEmptySource">
   <use   name="CondCore/CondDB"/>
   <use   name="FWCore/Sources"/>
 </library>

--- a/CondCore/Utilities/plugins/FileBasedEmptySource.cc
+++ b/CondCore/Utilities/plugins/FileBasedEmptySource.cc
@@ -11,10 +11,14 @@ namespace cond {
     FileBasedEmptySource(edm::ParameterSet const&, edm::InputSourceDescription const&);
     ~FileBasedEmptySource() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   private:
-    void produce(edm::Event & e) override;
-    bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType) override;
+    void produce(edm::Event& e) override;
+    bool setRunAndEventInfo(edm::EventID& id,
+                            edm::TimeValue_t& time,
+                            edm::EventAuxiliary::ExperimentType& eType) override;
     void initialize(edm::EventID& id, edm::TimeValue_t& time, edm::TimeValue_t& interval) override;
+
   private:
     unsigned int m_interval;
     unsigned long long m_eventId;
@@ -24,54 +28,52 @@ namespace cond {
     unsigned int m_currentLumi;
     boost::posix_time::ptime m_currentLumiTime;
   };
-}
+}  // namespace cond
 
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 //#include "DataFormats/Provenance/interface/EventID.h"
 
-namespace cond{
-  //allowed parameters: firstRun, firstTime, lastRun, lastTime, 
+namespace cond {
+  //allowed parameters: firstRun, firstTime, lastRun, lastTime,
   //common paras: timetype,interval
-  FileBasedEmptySource::FileBasedEmptySource(edm::ParameterSet const& pset,
-					     edm::InputSourceDescription const& desc):
-    edm::ProducerSourceBase(pset,desc,true),
-    m_interval(  pset.getParameter<unsigned int>("interval") ),
-    m_eventId( 0 ),
-    m_eventsPerLumi( pset.getUntrackedParameter<unsigned int>("numberEventsInLuminosityBlock" ) ),
-    m_pathForLastLumiFile( pset.getParameter<std::string>("pathForLastLumiFile") ),
-    m_currentRun( 0 ),
-    m_currentLumi( 0 ),
-    m_currentLumiTime(){
-  }
+  FileBasedEmptySource::FileBasedEmptySource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
+      : edm::ProducerSourceBase(pset, desc, true),
+        m_interval(pset.getParameter<unsigned int>("interval")),
+        m_eventId(0),
+        m_eventsPerLumi(pset.getUntrackedParameter<unsigned int>("numberEventsInLuminosityBlock")),
+        m_pathForLastLumiFile(pset.getParameter<std::string>("pathForLastLumiFile")),
+        m_currentRun(0),
+        m_currentLumi(0),
+        m_currentLumiTime() {}
 
-  FileBasedEmptySource::~FileBasedEmptySource() {
-  }
+  FileBasedEmptySource::~FileBasedEmptySource() {}
 
-  void FileBasedEmptySource::produce( edm::Event & ) {
-  }  
+  void FileBasedEmptySource::produce(edm::Event&) {}
 
-  bool FileBasedEmptySource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&){
+  bool FileBasedEmptySource::setRunAndEventInfo(edm::EventID& id,
+                                                edm::TimeValue_t& time,
+                                                edm::EventAuxiliary::ExperimentType&) {
     cond::Time_t lastLumi = cond::time::MIN_VAL;
     {
-      std::ifstream lastLumiFile( m_pathForLastLumiFile );
-      if( lastLumiFile) { 
-	lastLumiFile >> lastLumi;
+      std::ifstream lastLumiFile(m_pathForLastLumiFile);
+      if (lastLumiFile) {
+        lastLumiFile >> lastLumi;
       } else {
-	std::cout <<"Error: last lumi file can't be read."<<std::endl;
-	return false;
-      } 
+        std::cout << "Error: last lumi file can't be read." << std::endl;
+        return false;
+      }
     }
-    auto t = cond::time::unpack( lastLumi );
+    auto t = cond::time::unpack(lastLumi);
     unsigned int runId = t.first;
     unsigned int lumiId = t.second;
     //std::cout <<"###### setRunAndEventInfo Run: "<<runId<<" lumi: "<<lumiId<<std::endl;
     boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
-    if( runId == m_currentRun && lumiId == m_currentLumi ){
+    if (runId == m_currentRun && lumiId == m_currentLumi) {
       m_eventId += 1;
-      if( m_eventId >= m_eventsPerLumi ){
-	return false;
+      if (m_eventId >= m_eventsPerLumi) {
+        return false;
       }
     } else {
       m_currentRun = runId;
@@ -79,29 +81,30 @@ namespace cond{
       m_currentLumiTime = now;
       m_eventId = 1;
     }
-    std::cout <<"###### setRunAndEventInfo Run: "<<runId<<" lumi: "<<lumiId<<" event id: "<<m_eventId<<" time:"<<boost::posix_time::to_simple_string(now)<<std::endl;
+    std::cout << "###### setRunAndEventInfo Run: " << runId << " lumi: " << lumiId << " event id: " << m_eventId
+              << " time:" << boost::posix_time::to_simple_string(now) << std::endl;
     time = cond::time::from_boost(now);
     id = edm::EventID(runId, lumiId, m_eventId);
     usleep(20000);
     return true;
   }
 
-  void FileBasedEmptySource::initialize(edm::EventID& id, edm::TimeValue_t& time, edm::TimeValue_t& interval){
+  void FileBasedEmptySource::initialize(edm::EventID& id, edm::TimeValue_t& time, edm::TimeValue_t& interval) {
     cond::Time_t lastLumi = cond::time::MIN_VAL;
     {
-      std::ifstream lastLumiFile( m_pathForLastLumiFile );
-      if( lastLumiFile) { 
-	lastLumiFile >> lastLumi;
+      std::ifstream lastLumiFile(m_pathForLastLumiFile);
+      if (lastLumiFile) {
+        lastLumiFile >> lastLumi;
       } else {
-	std::cout <<"Error: last lumi file can't be read."<<std::endl;
-	return;
-      } 
+        std::cout << "Error: last lumi file can't be read." << std::endl;
+        return;
+      }
     }
     m_eventId = 0;
-    auto t = cond::time::unpack( lastLumi );
+    auto t = cond::time::unpack(lastLumi);
     unsigned int runId = t.first;
     unsigned int lumiId = t.second;
-    std::cout <<"###### initialize Run: "<<runId<<" lumi: "<<lumiId<<std::endl;
+    std::cout << "###### initialize Run: " << runId << " lumi: " << lumiId << std::endl;
     m_currentRun = runId;
     m_currentLumi = lumiId;
     boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
@@ -111,8 +114,7 @@ namespace cond{
     interval = m_interval;
   }
 
-  void
-  FileBasedEmptySource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  void FileBasedEmptySource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.setComment("Creates runs, lumis and events containing no products.");
     ProducerSourceBase::fillDescription(desc);
@@ -130,8 +132,7 @@ namespace cond{
     descriptions.add("source", desc);
   }
 
-
-}//ns cond
+}  // namespace cond
 
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 using cond::FileBasedEmptySource;

--- a/CondCore/Utilities/plugins/FileBasedEmptySource.cc
+++ b/CondCore/Utilities/plugins/FileBasedEmptySource.cc
@@ -1,0 +1,139 @@
+#include "FWCore/Sources/interface/ProducerSourceBase.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include <string>
+#include <fstream>
+#include <unistd.h>
+namespace cond {
+  class FileBasedEmptySource : public edm::ProducerSourceBase {
+  public:
+    FileBasedEmptySource(edm::ParameterSet const&, edm::InputSourceDescription const&);
+    ~FileBasedEmptySource() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  private:
+    void produce(edm::Event & e) override;
+    bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType) override;
+    void initialize(edm::EventID& id, edm::TimeValue_t& time, edm::TimeValue_t& interval) override;
+  private:
+    unsigned int m_interval;
+    unsigned long long m_eventId;
+    unsigned int m_eventsPerLumi;
+    std::string m_pathForLastLumiFile;
+    unsigned int m_currentRun;
+    unsigned int m_currentLumi;
+    boost::posix_time::ptime m_currentLumiTime;
+  };
+}
+
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+//#include "DataFormats/Provenance/interface/EventID.h"
+
+namespace cond{
+  //allowed parameters: firstRun, firstTime, lastRun, lastTime, 
+  //common paras: timetype,interval
+  FileBasedEmptySource::FileBasedEmptySource(edm::ParameterSet const& pset,
+					     edm::InputSourceDescription const& desc):
+    edm::ProducerSourceBase(pset,desc,true),
+    m_interval(  pset.getParameter<unsigned int>("interval") ),
+    m_eventId( 0 ),
+    m_eventsPerLumi( pset.getUntrackedParameter<unsigned int>("numberEventsInLuminosityBlock" ) ),
+    m_pathForLastLumiFile( pset.getParameter<std::string>("pathForLastLumiFile") ),
+    m_currentRun( 0 ),
+    m_currentLumi( 0 ),
+    m_currentLumiTime(){
+  }
+
+  FileBasedEmptySource::~FileBasedEmptySource() {
+  }
+
+  void FileBasedEmptySource::produce( edm::Event & ) {
+  }  
+
+  bool FileBasedEmptySource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&){
+    cond::Time_t lastLumi = cond::time::MIN_VAL;
+    {
+      std::ifstream lastLumiFile( m_pathForLastLumiFile );
+      if( lastLumiFile) { 
+	lastLumiFile >> lastLumi;
+      } else {
+	std::cout <<"Error: last lumi file can't be read."<<std::endl;
+	return false;
+      } 
+    }
+    auto t = cond::time::unpack( lastLumi );
+    unsigned int runId = t.first;
+    unsigned int lumiId = t.second;
+    //std::cout <<"###### setRunAndEventInfo Run: "<<runId<<" lumi: "<<lumiId<<std::endl;
+    boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
+    if( runId == m_currentRun && lumiId == m_currentLumi ){
+      m_eventId += 1;
+      if( m_eventId >= m_eventsPerLumi ){
+	return false;
+      }
+    } else {
+      m_currentRun = runId;
+      m_currentLumi = lumiId;
+      m_currentLumiTime = now;
+      m_eventId = 1;
+    }
+    std::cout <<"###### setRunAndEventInfo Run: "<<runId<<" lumi: "<<lumiId<<" event id: "<<m_eventId<<" time:"<<boost::posix_time::to_simple_string(now)<<std::endl;
+    time = cond::time::from_boost(now);
+    id = edm::EventID(runId, lumiId, m_eventId);
+    usleep(20000);
+    return true;
+  }
+
+  void FileBasedEmptySource::initialize(edm::EventID& id, edm::TimeValue_t& time, edm::TimeValue_t& interval){
+    cond::Time_t lastLumi = cond::time::MIN_VAL;
+    {
+      std::ifstream lastLumiFile( m_pathForLastLumiFile );
+      if( lastLumiFile) { 
+	lastLumiFile >> lastLumi;
+      } else {
+	std::cout <<"Error: last lumi file can't be read."<<std::endl;
+	return;
+      } 
+    }
+    m_eventId = 0;
+    auto t = cond::time::unpack( lastLumi );
+    unsigned int runId = t.first;
+    unsigned int lumiId = t.second;
+    std::cout <<"###### initialize Run: "<<runId<<" lumi: "<<lumiId<<std::endl;
+    m_currentRun = runId;
+    m_currentLumi = lumiId;
+    boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
+    m_currentLumiTime = now;
+    time = cond::time::from_boost(now);
+    id = edm::EventID(runId, lumiId, m_eventId);
+    interval = m_interval;
+  }
+
+  void
+  FileBasedEmptySource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.setComment("Creates runs, lumis and events containing no products.");
+    ProducerSourceBase::fillDescription(desc);
+
+    //desc.add<unsigned int>("firstRunnumber")->setComment("The first run number to use");
+    //desc.add<unsigned int>("lastRunnumber")->setComment("The last run number to use");
+    //desc.add<unsigned int>("firstLumi")->setComment("The first lumi id to use");
+    //desc.add<unsigned int>("lastLumi")->setComment("The last lumi id to use");
+    //desc.add<unsigned int>("maxLumiInRun");
+    //desc.add<std::string>("startTime");
+    //desc.add<std::string>("endTime");
+    desc.add<unsigned int>("interval");
+    desc.add<unsigned int>("maxEvents");
+    desc.add<std::string>("pathForLastLumiFile");
+    descriptions.add("source", desc);
+  }
+
+
+}//ns cond
+
+#include "FWCore/Framework/interface/InputSourceMacros.h"
+using cond::FileBasedEmptySource;
+
+DEFINE_FWK_INPUT_SOURCE(FileBasedEmptySource);


### PR DESCRIPTION
#### PR description:

Adding support of condition updates with lumisection granularity. Targeted for HLT workflow. 
The updates will be forced by an 'artificial' fixed lenght of the IOV, determined by configuration and set when the since value is identified for a given target event time.

#### PR validation:

A full test workflow for this case has been added. The existing unit tests are running.