### PR TITLE
Phase2-hgx234 Transfer the constants for HGCal and also HGCalTB for DDD/DD4Hep

### DIFF
--- a/Geometry/HGCalCommonData/data/TB160/16Module/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB160/16Module/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"          value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB160/4Module/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB160/4Module/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"          value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB160/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB160/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"          value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB161/1Module/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB161/1Module/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"          value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB161/8Module/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB161/8Module/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"          value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB161/TimingLayer/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB161/TimingLayer/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"          value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB170/July17/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB170/July17/hgcalCons.xml
@@ -24,7 +24,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>
@@ -56,7 +56,7 @@
     <Parameter name="GroupingZOut"  value="3"/>
     <Parameter name="GroupingZOut"  value="3"/>
   </SpecPar>
-  <SpecPar name="HGCalHESiliconReco">
+  <SpecPar name="HGCalHESiliconSensitive">
     <PartSelector path="//HGCalHESiliconSensitive.*"/>
     <Parameter name="Volume" value="HGCalHESiliconSensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB170/Sep17/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB170/Sep17/hgcalCons.xml
@@ -24,7 +24,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>
@@ -92,7 +92,7 @@
     <Parameter name="GroupingZOut"  value="7"/>
     <Parameter name="GroupingZOut"  value="7"/>
   </SpecPar>
-  <SpecPar name="HGCalHESiliconReco">
+  <SpecPar name="HGCalHESiliconSensitive">
     <PartSelector path="//HGCalHESiliconSensitive.*"/>
     <Parameter name="Volume" value="HGCalHESiliconSensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB170/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB170/hgcalCons.xml
@@ -24,7 +24,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>
@@ -281,7 +281,7 @@
     <Parameter name="GroupingZOut"  value="28"/>
     <Parameter name="GroupingZOut"  value="28"/>
   </SpecPar>
-  <SpecPar name="HGCalHESiliconReco">
+  <SpecPar name="HGCalHESiliconSensitive">
     <PartSelector path="//HGCalHESiliconSensitive.*"/>
     <Parameter name="Volume" value="HGCalHESiliconSensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB180/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB180/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB181/June18/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB181/June18/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB181/Oct181/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB181/Oct181/hgcalCons.xml
@@ -24,7 +24,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalEEReco">
+  <SpecPar name="HGCalEESensitive">
     <PartSelector path="//HGCalEESensitive.*"/>
     <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>
@@ -281,7 +281,7 @@
     <Parameter name="GroupingZOut"  value="28"/>
     <Parameter name="GroupingZOut"  value="28"/>
   </SpecPar>
-  <SpecPar name="HGCalHESiliconReco">
+  <SpecPar name="HGCalHESiliconSensitive">
     <PartSelector path="//HGCalHESiliconSensitive.*"/>
     <Parameter name="Volume" value="HGCalHESiliconSensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>

--- a/Geometry/HGCalCommonData/data/TB181/Test/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB181/Test/hgcalCons.xml
@@ -13,7 +13,7 @@
     <Parameter name="CellSize"      value="[hgcalwafer:CellWF]"/>
     <Parameter name="CellSize"      value="[hgcalwafer:CellWC]"/>
   </SpecPar>
-  <SpecPar name="HGCalHESiliconReco">
+  <SpecPar name="HGCalHESiliconSensitive">
     <PartSelector path="//HGCalHESiliconSensitive.*"/>
     <Parameter name="Volume" value="HGCalHESiliconSensitive" eval="false"/>
     <Parameter name="Slope"  value="0.0"/>

--- a/Geometry/HGCalCommonData/data/dd4hep/cms-test-ddhgcalTB181V1-algorithm.xml
+++ b/Geometry/HGCalCommonData/data/dd4hep/cms-test-ddhgcalTB181V1-algorithm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+<!-- 
+    <debug_shapes/>
+    <debug_includes/>
+    <debug_rotations/>
+    <debug_includes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_materials/>
+    <debug_visattr/>
+-->
+  </debug>
+  
+  <open_geometry/>
+  <close_geometry/>
+
+  <IncludeSection>
+    <Include ref="Geometry/CMSCommonData/data/materials/2021/v1/materials.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalMaterial/v1/hgcalMaterial.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/TB181/cms.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/TB181/Oct181/hgcal.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalwafer/v7/hgcalwafer.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/TB181/Oct181/hgcalEE.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/TB181/Oct181/hgcalsense.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/TB181/hgcProdCuts.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/TB181/Oct181/hgcalCons.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/dd4hep/world.xml"/>
+  </IncludeSection>
+  
+</DDDefinition>
+

--- a/Geometry/HGCalCommonData/interface/HGCalParameters.h
+++ b/Geometry/HGCalCommonData/interface/HGCalParameters.h
@@ -25,6 +25,7 @@ public:
   static constexpr double k_ScaleFromDD4HepToG4 = 10.0;
   static constexpr double k_ScaleToDD4HepFromG4 = 0.1;
   static constexpr uint32_t k_CornerSize = 6;
+  static constexpr double tol = 1.0e-12;
 
   struct hgtrap {
     int lay;

--- a/Geometry/HGCalCommonData/python/testTB181V1XML_cfi.py
+++ b/Geometry/HGCalCommonData/python/testTB181V1XML_cfi.py
@@ -6,11 +6,11 @@ XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
                                'Geometry/HGCalCommonData/data/hgcalMaterial/v1/hgcalMaterial.xml',
                                'Geometry/HGCalCommonData/data/TB181/cms.xml',
                                'Geometry/HGCalCommonData/data/TB181/Oct181/hgcal.xml',
-                               'Geometry/HGCalCommonData/data/TB181/Oct181/hgcalHE.xml',
                                'Geometry/HGCalCommonData/data/hgcalwafer/v7/hgcalwafer.xml',
-                               'Geometry/HGCalCommonData/data/TB181/Test/hgcalsense.xml',
-                               'Geometry/HGCalCommonData/data/TB181/Test/hgcProdCuts.xml',
-                               'Geometry/HGCalCommonData/data/TB181/Test/hgcalCons.xml'
+                               'Geometry/HGCalCommonData/data/TB181/Oct181/hgcalEE.xml',
+                               'Geometry/HGCalCommonData/data/TB181/Oct181/hgcalsense.xml',
+                               'Geometry/HGCalCommonData/data/TB181/hgcProdCuts.xml',
+                               'Geometry/HGCalCommonData/data/TB181/Oct181/hgcalCons.xml'
                                ),
     rootNodeName = cms.string('cms:OCMS')
 )

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -242,9 +242,9 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
             xx += (HGCalParameters::k_ScaleFromDDD * (p2.X()));
             yy += (HGCalParameters::k_ScaleFromDDD * (p2.Y()));
 #ifdef EDM_ML_DEBUG
-            if (std::abs(p2.X()) < 1.0e-12)
+            if (std::abs(p2.X()) < HGCalParameters::tol)
               p2.SetX(0.0);
-            if (std::abs(p2.Z()) < 1.0e-12)
+            if (std::abs(p2.Z()) < HGCalParameters::tol)
               p2.SetZ(0.0);
             edm::LogVerbatim("HGCalGeom") << "Wafer " << wafer << " Type " << type << " Cell " << cellx << " local "
                                           << xx << ":" << yy << " new " << p1 << ":" << p2;
@@ -464,9 +464,9 @@ void HGCalGeomParameters::loadGeometryHexagon(const cms::DDCompactView* cpv,
             xx += (HGCalParameters::k_ScaleFromDDD * (p2.X()));
             yy += (HGCalParameters::k_ScaleFromDDD * (p2.Y()));
 #ifdef EDM_ML_DEBUG
-            if (std::abs(p2.X()) < 1.0e-12)
+            if (std::abs(p2.X()) < HGCalParameters::tol)
               p2.SetX(0.0);
-            if (std::abs(p2.Z()) < 1.0e-12)
+            if (std::abs(p2.Z()) < HGCalParameters::tol)
               p2.SetZ(0.0);
             edm::LogVerbatim("HGCalGeom") << "Wafer " << wafer << " Type " << type << " Cell " << cellx << " local "
                                           << xx << ":" << yy << " new " << p1 << ":" << p2;

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -215,7 +215,8 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
       int cell = cellx % 1000;
       int type = cellx / 1000;
       if (type != 1 && type != 2) {
-        throw cms::Exception("DDException") << "Funny cell # " << cell << " type " << type << " in " << nsiz << " components";
+        throw cms::Exception("DDException")
+            << "Funny cell # " << cell << " type " << type << " in " << nsiz << " components";
       } else {
         auto ktr = wafertype.find(wafer);
         if (ktr == wafertype.end())
@@ -241,10 +242,12 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
             xx += (HGCalParameters::k_ScaleFromDDD * (p2.X()));
             yy += (HGCalParameters::k_ScaleFromDDD * (p2.Y()));
 #ifdef EDM_ML_DEBUG
-	    if (std::abs(p2.X()) < 1.0e-12) p2.SetX(0.0);
-	    if (std::abs(p2.Z()) < 1.0e-12) p2.SetZ(0.0);
-            edm::LogVerbatim("HGCalGeom")
-	      << "Wafer " << wafer << " Type " << type << " Cell " << cellx << " local " << xx << ":" << yy << " new " << p1 << ":" << p2;
+            if (std::abs(p2.X()) < 1.0e-12)
+              p2.SetX(0.0);
+            if (std::abs(p2.Z()) < 1.0e-12)
+              p2.SetZ(0.0);
+            edm::LogVerbatim("HGCalGeom") << "Wafer " << wafer << " Type " << type << " Cell " << cellx << " local "
+                                          << xx << ":" << yy << " new " << p1 << ":" << p2;
 #endif
           }
           HGCalGeomParameters::cellParameters cp(half, wafer, GlobalPoint(xx, yy, 0));
@@ -274,7 +277,7 @@ void HGCalGeomParameters::loadGeometryHexagon(const cms::DDCompactView* cpv,
   std::map<int, HGCalGeomParameters::layerParameters> layers;
   std::vector<HGCalParameters::hgtrform> trforms;
   std::vector<bool> trformUse;
-  std::vector<std::pair<int,int> > trused;
+  std::vector<std::pair<int, int> > trused;
 
   while (fv.firstChild()) {
     const std::vector<double>& pars = fv.parameters();
@@ -305,30 +308,30 @@ void HGCalGeomParameters::loadGeometryHexagon(const cms::DDCompactView* cpv,
         HGCalGeomParameters::layerParameters laypar(rin, rout, zz);
         layers[lay] = laypar;
       }
-      std::pair<int,int> layz(lay, zp);
+      std::pair<int, int> layz(lay, zp);
       if (std::find(trused.begin(), trused.end(), layz) == trused.end()) {
-	trused.emplace_back(layz);
-	DD3Vector x, y, z;
-	fv.rotation().GetComponents(x, y, z);
-	const CLHEP::HepRep3x3 rotation(x.X(), y.X(), z.X(), x.Y(), y.Y(), z.Y(), x.Z(), y.Z(), z.Z());
-	const CLHEP::HepRotation hr(rotation);
-	double xx = HGCalParameters::k_ScaleFromDD4Hep * fv.translation().X();
-	if (std::abs(xx) < tolerance)
-	  xx = 0;
-	double yy = HGCalParameters::k_ScaleFromDD4Hep * fv.translation().Y();
-	if (std::abs(yy) < tolerance)
-	  yy = 0;
-	double zz = HGCalParameters::k_ScaleFromDD4Hep * fv.translation().Z();
-	const CLHEP::Hep3Vector h3v(xx, yy, zz);
-	HGCalParameters::hgtrform mytrf;
-	mytrf.zp = zp;
-	mytrf.lay = lay;
-	mytrf.sec = 0;
-	mytrf.subsec = 0;
-	mytrf.h3v = h3v;
-	mytrf.hr = hr;
-	trforms.emplace_back(mytrf);
-	trformUse.emplace_back(false);
+        trused.emplace_back(layz);
+        DD3Vector x, y, z;
+        fv.rotation().GetComponents(x, y, z);
+        const CLHEP::HepRep3x3 rotation(x.X(), y.X(), z.X(), x.Y(), y.Y(), z.Y(), x.Z(), y.Z(), z.Z());
+        const CLHEP::HepRotation hr(rotation);
+        double xx = HGCalParameters::k_ScaleFromDD4Hep * fv.translation().X();
+        if (std::abs(xx) < tolerance)
+          xx = 0;
+        double yy = HGCalParameters::k_ScaleFromDD4Hep * fv.translation().Y();
+        if (std::abs(yy) < tolerance)
+          yy = 0;
+        double zz = HGCalParameters::k_ScaleFromDD4Hep * fv.translation().Z();
+        const CLHEP::Hep3Vector h3v(xx, yy, zz);
+        HGCalParameters::hgtrform mytrf;
+        mytrf.zp = zp;
+        mytrf.lay = lay;
+        mytrf.sec = 0;
+        mytrf.subsec = 0;
+        mytrf.h3v = h3v;
+        mytrf.hr = hr;
+        trforms.emplace_back(mytrf);
+        trformUse.emplace_back(false);
       }
     }
   }
@@ -434,7 +437,8 @@ void HGCalGeomParameters::loadGeometryHexagon(const cms::DDCompactView* cpv,
       int cell = cellx % 1000;
       int type = cellx / 1000;
       if (type != 1 && type != 2) {
-        throw cms::Exception("DDException") << "Funny cell # " << cell << " type " << type << " in " << nsiz << " components";
+        throw cms::Exception("DDException")
+            << "Funny cell # " << cell << " type " << type << " in " << nsiz << " components";
       } else {
         auto ktr = wafertype.find(wafer);
         if (ktr == wafertype.end())
@@ -460,10 +464,12 @@ void HGCalGeomParameters::loadGeometryHexagon(const cms::DDCompactView* cpv,
             xx += (HGCalParameters::k_ScaleFromDDD * (p2.X()));
             yy += (HGCalParameters::k_ScaleFromDDD * (p2.Y()));
 #ifdef EDM_ML_DEBUG
-	    if (std::abs(p2.X()) < 1.0e-12) p2.SetX(0.0);
-	    if (std::abs(p2.Z()) < 1.0e-12) p2.SetZ(0.0);
-            edm::LogVerbatim("HGCalGeom")
-	      << "Wafer " << wafer << " Type " << type << " Cell " << cellx << " local " << xx << ":" << yy << " new " << p1 << ":" << p2;
+            if (std::abs(p2.X()) < 1.0e-12)
+              p2.SetX(0.0);
+            if (std::abs(p2.Z()) < 1.0e-12)
+              p2.SetZ(0.0);
+            edm::LogVerbatim("HGCalGeom") << "Wafer " << wafer << " Type " << type << " Cell " << cellx << " local "
+                                          << xx << ":" << yy << " new " << p1 << ":" << p2;
 #endif
           }
           HGCalGeomParameters::cellParameters cp(half, wafer, GlobalPoint(xx, yy, 0));
@@ -697,7 +703,8 @@ void HGCalGeomParameters::loadGeometryHexagon8(const DDFilteredView& _fv, HGCalP
                                     << " lay " << lay << " z " << zside;
 #endif
       if (lay == 0) {
-        throw cms::Exception("DDException") << "Funny layer # " << lay << " zp " << zside << " in " << nsiz << " components";
+        throw cms::Exception("DDException")
+            << "Funny layer # " << lay << " zp " << zside << " in " << nsiz << " components";
       } else {
         if (std::find(php.layer_.begin(), php.layer_.end(), lay) == php.layer_.end())
           php.layer_.emplace_back(lay);
@@ -771,7 +778,8 @@ void HGCalGeomParameters::loadGeometryHexagon8(const cms::DDCompactView* cpv,
                                     << php.levelZSide_;
 #endif
       if (lay == 0) {
-        throw cms::Exception("DDException") << "Funny layer # " << lay << " zp " << zside << " in " << nsiz << " components";
+        throw cms::Exception("DDException")
+            << "Funny layer # " << lay << " zp " << zside << " in " << nsiz << " components";
       } else {
         if (std::find(php.layer_.begin(), php.layer_.end(), lay) == php.layer_.end())
           php.layer_.emplace_back(lay);
@@ -931,7 +939,8 @@ void HGCalGeomParameters::loadSpecParsHexagon(const cms::DDFilteredView& fv,
   php.layerGroupM_ = dbl_to_int(fv.get<std::vector<double> >(sdTag1, "GroupingZMid"));
   php.layerGroupO_ = dbl_to_int(fv.get<std::vector<double> >(sdTag1, "GroupingZOut"));
   php.slopeMin_ = fv.get<std::vector<double> >(sdTag4, "Slope");
-  if (php.slopeMin_.empty()) php.slopeMin_.emplace_back(0);
+  if (php.slopeMin_.empty())
+    php.slopeMin_.emplace_back(0);
 
   // Wafer size
   const auto& dummy = fv.get<std::vector<double> >(sdTag2, "WaferSize");
@@ -1658,11 +1667,14 @@ std::vector<double> HGCalGeomParameters::getDDDArray(const std::string& str, con
     int nval = fvec.size();
     if (nmin > 0) {
       if (nval < nmin) {
-        throw cms::Exception("DDException") << "HGCalGeomParameters:  # of " << str << " bins " << nval << " < " << nmin << " ==> illegal";
+        throw cms::Exception("DDException")
+            << "HGCalGeomParameters:  # of " << str << " bins " << nval << " < " << nmin << " ==> illegal";
       }
     } else {
       if (nval < 1 && nmin == 0) {
-        throw cms::Exception("DDException") << "HGCalGeomParameters: # of " << str << " bins " << nval << " < 1 ==> illegal" << " (nmin=" << nmin << ")";
+        throw cms::Exception("DDException")
+            << "HGCalGeomParameters: # of " << str << " bins " << nval << " < 1 ==> illegal"
+            << " (nmin=" << nmin << ")";
       }
     }
     return fvec;

--- a/Geometry/HGCalCommonData/src/HGCalParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalParameters.cc
@@ -84,15 +84,15 @@ void HGCalParameters::fillTrForm(const HGCalParameters::hgtrform& mytr) {
   trformTranX_.emplace_back(mytr.h3v.x());
   trformTranY_.emplace_back(mytr.h3v.y());
   trformTranZ_.emplace_back(mytr.h3v.z());
-  trformRotXX_.emplace_back((std::abs(mytr.hr.xx()) > 1.0e-12) ? mytr.hr.xx() : 0);
-  trformRotYX_.emplace_back((std::abs(mytr.hr.yx()) > 1.0e-12) ? mytr.hr.yx() : 0);
-  trformRotZX_.emplace_back((std::abs(mytr.hr.zx()) > 1.0e-12) ? mytr.hr.zx() : 0);
-  trformRotXY_.emplace_back((std::abs(mytr.hr.xy()) > 1.0e-12) ? mytr.hr.xy() : 0);
-  trformRotYY_.emplace_back((std::abs(mytr.hr.yy()) > 1.0e-12) ? mytr.hr.yy() : 0);
-  trformRotZY_.emplace_back((std::abs(mytr.hr.zy()) > 1.0e-12) ? mytr.hr.zy() : 0);
-  trformRotXZ_.emplace_back((std::abs(mytr.hr.xz()) > 1.0e-12) ? mytr.hr.xz() : 0);
-  trformRotYZ_.emplace_back((std::abs(mytr.hr.yz()) > 1.0e-12) ? mytr.hr.yz() : 0);
-  trformRotZZ_.emplace_back((std::abs(mytr.hr.zz()) > 1.0e-12) ? mytr.hr.zz() : 0);
+  trformRotXX_.emplace_back((std::abs(mytr.hr.xx()) > tol) ? mytr.hr.xx() : 0);
+  trformRotYX_.emplace_back((std::abs(mytr.hr.yx()) > tol) ? mytr.hr.yx() : 0);
+  trformRotZX_.emplace_back((std::abs(mytr.hr.zx()) > tol) ? mytr.hr.zx() : 0);
+  trformRotXY_.emplace_back((std::abs(mytr.hr.xy()) > tol) ? mytr.hr.xy() : 0);
+  trformRotYY_.emplace_back((std::abs(mytr.hr.yy()) > tol) ? mytr.hr.yy() : 0);
+  trformRotZY_.emplace_back((std::abs(mytr.hr.zy()) > tol) ? mytr.hr.zy() : 0);
+  trformRotXZ_.emplace_back((std::abs(mytr.hr.xz()) > tol) ? mytr.hr.xz() : 0);
+  trformRotYZ_.emplace_back((std::abs(mytr.hr.yz()) > tol) ? mytr.hr.yz() : 0);
+  trformRotZZ_.emplace_back((std::abs(mytr.hr.zz()) > tol) ? mytr.hr.zz() : 0);
 #ifdef EDM_ML_DEBUG
   unsigned int k = trformIndex_.size() - 1;
   edm::LogVerbatim("HGCalGeom") << "HGCalParameters[" << k << "] Index " << std::hex << trformIndex_[k] << std::dec

--- a/Geometry/HGCalCommonData/src/HGCalParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalParameters.cc
@@ -4,7 +4,7 @@
 
 //#define EDM_ML_DEBUG
 
-HGCalParameters::HGCalParameters(const std::string& nam) : name_(nam), waferMaskMode_(0) {
+HGCalParameters::HGCalParameters(const std::string& nam) : name_(nam), nCells_(0), waferMaskMode_(0) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "Construct HGCalParameters for " << name_;
 #endif
@@ -84,15 +84,15 @@ void HGCalParameters::fillTrForm(const HGCalParameters::hgtrform& mytr) {
   trformTranX_.emplace_back(mytr.h3v.x());
   trformTranY_.emplace_back(mytr.h3v.y());
   trformTranZ_.emplace_back(mytr.h3v.z());
-  trformRotXX_.emplace_back(mytr.hr.xx());
-  trformRotYX_.emplace_back(mytr.hr.yx());
-  trformRotZX_.emplace_back(mytr.hr.zx());
-  trformRotXY_.emplace_back(mytr.hr.xy());
-  trformRotYY_.emplace_back(mytr.hr.yy());
-  trformRotZY_.emplace_back(mytr.hr.zy());
-  trformRotXZ_.emplace_back(mytr.hr.xz());
-  trformRotYZ_.emplace_back(mytr.hr.yz());
-  trformRotZZ_.emplace_back(mytr.hr.zz());
+  trformRotXX_.emplace_back((std::abs(mytr.hr.xx()) > 1.0e-12) ? mytr.hr.xx() : 0);
+  trformRotYX_.emplace_back((std::abs(mytr.hr.yx()) > 1.0e-12) ? mytr.hr.yx() : 0);
+  trformRotZX_.emplace_back((std::abs(mytr.hr.zx()) > 1.0e-12) ? mytr.hr.zx() : 0);
+  trformRotXY_.emplace_back((std::abs(mytr.hr.xy()) > 1.0e-12) ? mytr.hr.xy() : 0);
+  trformRotYY_.emplace_back((std::abs(mytr.hr.yy()) > 1.0e-12) ? mytr.hr.yy() : 0);
+  trformRotZY_.emplace_back((std::abs(mytr.hr.zy()) > 1.0e-12) ? mytr.hr.zy() : 0);
+  trformRotXZ_.emplace_back((std::abs(mytr.hr.xz()) > 1.0e-12) ? mytr.hr.xz() : 0);
+  trformRotYZ_.emplace_back((std::abs(mytr.hr.yz()) > 1.0e-12) ? mytr.hr.yz() : 0);
+  trformRotZZ_.emplace_back((std::abs(mytr.hr.zz()) > 1.0e-12) ? mytr.hr.zz() : 0);
 #ifdef EDM_ML_DEBUG
   unsigned int k = trformIndex_.size() - 1;
   edm::LogVerbatim("HGCalGeom") << "HGCalParameters[" << k << "] Index " << std::hex << trformIndex_[k] << std::dec

--- a/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
+++ b/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
@@ -1,4 +1,5 @@
 #include "Geometry/HGCalCommonData/interface/HGCalParametersFromDD.h"
+
 #include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 #include "DetectorDescription/Core/interface/DDutils.h"
@@ -242,9 +243,11 @@ bool HGCalParametersFromDD::build(const cms::DDCompactView* cpv,
   cms::DDFilteredView fv((*cpv), filter);
   std::vector<std::string> tempS;
   std::vector<double> tempD;
-  tempS = fv.get<std::vector<std::string> >(name, "GeometryMode");
-  std::string sv = (!tempS.empty()) ? tempS[0] : "HGCalGeometryMode::Hexagon8Full";
   bool ok = fv.firstChild();
+  tempS = fv.get<std::vector<std::string> >(name2, "GeometryMode");
+  if (tempS.empty())
+    tempS = fv.get<std::vector<std::string> >(name, "GeometryMode");
+  std::string sv = (!tempS.empty()) ? tempS[0] : "HGCalGeometryMode::Hexagon8Full";
   HGCalGeometryMode::WaferMode mode(HGCalGeometryMode::Polyhedra);
 
   if (ok) {
@@ -260,7 +263,7 @@ bool HGCalParametersFromDD::build(const cms::DDCompactView* cpv,
     php.firstMixedLayer_ = -1;  // defined for post TDR geometry
     std::unique_ptr<HGCalGeomParameters> geom = std::make_unique<HGCalGeomParameters>();
     if ((php.mode_ == HGCalGeometryMode::Hexagon) || (php.mode_ == HGCalGeometryMode::HexagonFull)) {
-      tempS = fv.get<std::vector<std::string> >(name, "WaferMode");
+      tempS = fv.get<std::vector<std::string> >(namet, "WaferMode");
       std::string sv2 = (!tempS.empty()) ? tempS[0] : "HGCalGeometryMode::Polyhedra";
       mode = getGeometryWaferMode(sv2);
 #ifdef EDM_ML_DEBUG
@@ -286,7 +289,7 @@ bool HGCalParametersFromDD::build(const cms::DDCompactView* cpv,
                                     << php.firstMixedLayer_ << " Det Type " << php.detectorType_;
 #endif
 
-      tempS = fv.get<std::vector<std::string> >(name, "WaferMode");
+      tempS = fv.get<std::vector<std::string> >(namet, "WaferMode");
       std::string sv2 = (!tempS.empty()) ? tempS[0] : "HGCalGeometryMode::ExtrudedPolygon";
       mode = getGeometryWaferMode(sv2);
       tempD = fv.get<std::vector<double> >(namet, "NumberOfCellsFine");

--- a/Geometry/HGCalCommonData/test/python/testHGCalTBParametersDD4Hep_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalTBParametersDD4Hep_cfg.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HGCalParametersTest")
+process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+process.load("Geometry.HGCalCommonData.hgcalParametersInitialization_cfi")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('HGCalGeom')
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/HGCalCommonData/data/dd4hep/cms-test-ddhgcalTB181V1-algorithm.xml'),
+                                            appendToDataLabel = cms.string('')
+                                            )
+
+process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
+                                                 appendToDataLabel = cms.string('')
+)
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.generator = cms.EDProducer("FlatRandomEGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(14),
+        MinEta = cms.double(-3.5),
+        MaxEta = cms.double(3.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinE   = cms.double(9.99),
+        MaxE   = cms.double(10.01)
+    ),
+    AddAntiParticle = cms.bool(False),
+    Verbosity       = cms.untracked.int32(0),
+    firstRun        = cms.untracked.uint32(1)
+)
+
+process.hgcalEEParametersInitialize.fromDD4Hep = cms.bool(True)
+process.hgcalHESiParametersInitialize.fromDD4Hep = cms.bool(True)
+process.hgcalHEScParametersInitialize.fromDD4Hep = cms.bool(True)
+
+process.testEE = cms.EDAnalyzer("HGCalParameterTester",
+                                Name = cms.untracked.string("HGCalEESensitive"),
+                                Mode = cms.untracked.int32(0)
+)
+
+ 
+process.p1 = cms.Path(process.generator*process.testEE)

--- a/Geometry/HGCalCommonData/test/python/testHGCalTBParametersDDD_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalTBParametersDDD_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HGCalParametersTest")
+process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+process.load("Geometry.HGCalCommonData.testTB181V1XML_cfi")
+process.load("Geometry.HGCalCommonData.hgcalParametersInitialization_cfi")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('HGCalGeom')
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.generator = cms.EDProducer("FlatRandomEGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(14),
+        MinEta = cms.double(-3.5),
+        MaxEta = cms.double(3.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinE   = cms.double(9.99),
+        MaxE   = cms.double(10.01)
+    ),
+    AddAntiParticle = cms.bool(False),
+    Verbosity       = cms.untracked.int32(0),
+    firstRun        = cms.untracked.uint32(1)
+)
+ 
+process.testEE = cms.EDAnalyzer("HGCalParameterTester",
+                                Name = cms.untracked.string("HGCalEESensitive"),
+                                Mode = cms.untracked.int32(0)
+)
+ 
+process.p1 = cms.Path(process.generator*process.testEE)


### PR DESCRIPTION
#### PR description:

Transfer the constants in HGCalParameters from the XML files for HGCal as well as HGCal TB applications. With this the HGCal code can work for DDD as well as DD4Hep applications

#### PR validation:

Used standard runTheMatrix.py to do the tests

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special