### PR TITLE
Solve all overlaps detected in Phase I Tracker

### DIFF
--- a/Geometry/MTCCTrackerCommonData/data/tecwheeld_mtcc.xml
+++ b/Geometry/MTCCTrackerCommonData/data/tecwheeld_mtcc.xml
@@ -12,7 +12,7 @@
 		<Tubs name="TECWheelDiskD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECFixSupportD" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
-		<Tubs name="TECOptConnectorD" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+		<Tubs name="TECOptConnectorD" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnWEpsilonShrink]/2" deltaPhi="[tecwheel:OptConnWEpsilonShrink]"/>
 		<Box name="TECRadialCableD" dx="[tecwheel:CableW]/2" dy="[CableL]/2" dz="[tecwheel:CableT]/2"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheeld_mtcc.xml">

--- a/Geometry/TrackerCommonData/data/tecservices.xml
+++ b/Geometry/TrackerCommonData/data/tecservices.xml
@@ -2,6 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
   <ConstantsSection label="tecservices.xml" eval="true">
     <Constant name="zero" value="0.0*fm"/>
+    <Constant name="angularEpsilon" value="1E-10*deg"/>
     <Constant name="Rin" value="[tec:WheelR]"/>
     <Constant name="Rout" value="[tec:OuterSkinRin]"/>
     <Constant name="Dz" value="[tec:TECDz]"/>
@@ -20,6 +21,7 @@
     <Constant name="ChannelEndInsertZ" value="0.5*[ChannelEndInsertHeight]-0.5*[ChannelHeight]"/>
     <!--[tec:Wheel0Z]-[tec:ZPos]-0.5*[tecwheel:DiskT]+0.5*[ChannelHeight]-77.5*mm"/-->
     <Constant name="AxialGroundingWidth" value="20*mm/([Rin]+0.5*2.5*mm)"/>
+    <Constant name="AxialGroundingWidthEpsilonShrink" value="[AxialGroundingWidth]-[angularEpsilon]"/>
     <Constant name="AxialGroundingRin" value="[Rin]"/>
     <Constant name="AxialGroundingRout" value="[Rin]+2.5*mm"/>
     <Constant name="AxialGroundingHeight" value="1538*mm"/>
@@ -85,7 +87,7 @@
   <SolidSection label="tecservices.xml">
     <Tubs name="TECServices" rMin="[Rin]" rMax="[Rout]" dz="[Dz]" startPhi="0*deg" deltaPhi="360*deg"/>
     <Tubs name="TECServChannel" rMin="[ChannelRin]" rMax="[ChannelRout]" dz="0.5*[ChannelHeight]" startPhi="-0.5*[ChannelWidth]" deltaPhi="[ChannelWidth]"/>
-    <Tubs name="TECAxGrounding" rMin="[AxialGroundingRin]" rMax="[AxialGroundingRout]" dz="0.5*[ChannelHeight]" startPhi="-0.5*[AxialGroundingWidth]" deltaPhi="[AxialGroundingWidth]"/>
+    <Tubs name="TECAxGrounding" rMin="[AxialGroundingRin]" rMax="[AxialGroundingRout]" dz="0.5*[ChannelHeight]" startPhi="-0.5*[AxialGroundingWidthEpsilonShrink]" deltaPhi="[AxialGroundingWidthEpsilonShrink]"/>
     <Tubs name="TECChannelEndInsert" rMin="[ChannelEndInsertRin]" rMax="[ChannelEndInsertRout]" dz="0.5*[ChannelEndInsertHeight]" startPhi="-0.5*[ChannelEndInsertWidth]" deltaPhi="[ChannelEndInsertWidth]"/>
     <Tubs name="TECGasPipe" rMin="[GasPipeRin]" rMax="[GasPipeRout]" dz="0.5*[GasPipeHeight]" startPhi="0*deg" deltaPhi="360*deg"/>
     <Tubs name="TECCoolPipeS" rMin="[CoolPipeRin]" rMax="[CoolPipeRout]" dz="0.5*[CoolPipeHeightS]" startPhi="0*deg" deltaPhi="360*deg"/>

--- a/Geometry/TrackerCommonData/data/tecwheel.xml
+++ b/Geometry/TrackerCommonData/data/tecwheel.xml
@@ -2,6 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
 	<ConstantsSection label="tecwheel.xml" eval="true">
 		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="angularEpsilon" value="1E-10*deg"/>
 		<Constant name="WheelRmax" value="110.30*cm"/>
 		<Constant name="WheelT" value="12.22*cm"/>
 		<Constant name="DiskT" value="1.680*cm"/>
@@ -46,6 +47,7 @@
 		<Constant name="OptConnHeight" value="171*mm"/>
 		<Constant name="OptConnThick" value="46*mm"/>
 		<Constant name="OptConnW" value="45*deg-[tecpetpar:PetalContWidth]"/>
+		<Constant name="OptConnWEpsilonShrink" value="[OptConnW]-[angularEpsilon]"/>
 		<!--there is not enough room for the real width-->
 		<Constant name="OptConnN" value="8"/>
 		<Constant name="OptConnT1" value="2.475*cm"/>

--- a/Geometry/TrackerCommonData/data/tecwheel.xml
+++ b/Geometry/TrackerCommonData/data/tecwheel.xml
@@ -89,7 +89,7 @@
 		<!-- the same for every petal -->
 		<Tubs name="TECInnerManifold" rMin="[tecpetpar:PetalRmax]-[PetalInManifHeight]" rMax="[tecpetpar:PetalRmax]" dz="[PetalManifThick]/2" startPhi="-[PetalInManifWidth]/2" deltaPhi="[PetalInManifWidth]"/>
 		<Tubs name="TECOuterManifold" rMin="[tecpetpar:PetalRmax]" rMax="[tecpetpar:PetalRmax]+[PetalOutManifHeight]" dz="[PetalManifThick]/2" startPhi="-[PetalOutManifWidth]/2" deltaPhi="[PetalOutManifWidth]"/>
-		<Tubs name="TECOptConnector" rMin="[tecpetpar:PetalRmax]-[OptConnHeight]" rMax="[tecpetpar:PetalRmax]" dz="[OptConnThick]/2" startPhi="-[OptConnW]/2" deltaPhi="[OptConnW]"/>
+		<Tubs name="TECOptConnector" rMin="[tecpetpar:PetalRmax]-[OptConnHeight]" rMax="[tecpetpar:PetalRmax]" dz="[OptConnThick]/2" startPhi="-[OptConnWEpsilonShrink]/2" deltaPhi="[OptConnWEpsilonShrink]"/>
 		<Box name="TECCCUM" dx="[tecpetpar:CCUMWidth]/2" dy="[tecpetpar:CCUMHeight]/2" dz="[tecpetpar:CCUMThick]/2"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheel.xml">

--- a/Geometry/TrackerCommonData/data/tecwheel/2021/v1/tecwheel.xml
+++ b/Geometry/TrackerCommonData/data/tecwheel/2021/v1/tecwheel.xml
@@ -2,6 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
 	<ConstantsSection label="tecwheel.xml" eval="true">
 		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="angularEpsilon" value="1E-10*deg"/>
 		<Constant name="WheelRmax" value="110.30*cm"/>
 		<Constant name="WheelT" value="12.22*cm"/>
 		<Constant name="DiskT" value="1.680*cm"/>
@@ -46,6 +47,7 @@
 		<Constant name="OptConnHeight" value="171*mm"/>
 		<Constant name="OptConnThick" value="46*mm"/>
 		<Constant name="OptConnW" value="45*deg-[tecpetpar:PetalContWidth]"/>
+		<Constant name="OptConnWEpsilonShrink" value="[OptConnW]-[angularEpsilon]"/>
 		<!--there is not enough room for the real width-->
 		<Constant name="OptConnN" value="8"/>
 		<Constant name="OptConnT1" value="2.475*cm"/>
@@ -87,7 +89,7 @@
 		<!-- the same for every petal -->
 		<Tubs name="TECInnerManifold" rMin="[tecpetpar:PetalRmax]-[PetalInManifHeight]" rMax="[tecpetpar:PetalRmax]" dz="[PetalManifThick]/2" startPhi="-[PetalInManifWidth]/2" deltaPhi="[PetalInManifWidth]"/>
 		<Tubs name="TECOuterManifold" rMin="[tecpetpar:PetalRmax]" rMax="[tecpetpar:PetalRmax]+[PetalOutManifHeight]" dz="[PetalManifThick]/2" startPhi="-[PetalOutManifWidth]/2" deltaPhi="[PetalOutManifWidth]"/>
-		<Tubs name="TECOptConnector" rMin="[tecpetpar:PetalRmax]-[OptConnHeight]" rMax="[tecpetpar:PetalRmax]" dz="[OptConnThick]/2" startPhi="-[OptConnW]/2" deltaPhi="[OptConnW]"/>
+		<Tubs name="TECOptConnector" rMin="[tecpetpar:PetalRmax]-[OptConnHeight]" rMax="[tecpetpar:PetalRmax]" dz="[OptConnThick]/2" startPhi="-[OptConnWEpsilonShrink]/2" deltaPhi="[OptConnWEpsilonShrink]"/>
 		<Box name="TECCCUM" dx="[tecpetpar:CCUMWidth]/2" dy="[tecpetpar:CCUMHeight]/2" dz="[tecpetpar:CCUMThick]/2"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheel.xml">

--- a/Geometry/TrackerCommonData/data/tecwheel6.xml
+++ b/Geometry/TrackerCommonData/data/tecwheel6.xml
@@ -20,7 +20,7 @@
         <Tubs name="TECWheelDisk6" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
         <Tubs name="TECWheelNomex6" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
         <Tubs name="TECFixSupport6" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
-        <Tubs name="TECOptConnector6" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT2]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+        <Tubs name="TECOptConnector6" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT2]/2" startPhi="-[tecwheel:OptConnWEpsilonShrink]/2" deltaPhi="[tecwheel:OptConnWEpsilonShrink]"/>
         <Box name="TECBeamsplitter" dx="0.5*[BeamsplitterHeight]" dy="0.5*[BeamsplitterWidth]" dz="0.5*[BeamsplitterThick]"/>
     </SolidSection>
     <LogicalPartSection label="tecwheel6.xml">

--- a/Geometry/TrackerCommonData/data/tecwheela.xml
+++ b/Geometry/TrackerCommonData/data/tecwheela.xml
@@ -13,7 +13,7 @@
 		<Tubs name="TECWheelDiskA" rMin="[tecpetal0:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexA" rMin="[tecpetal0:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECFixSupportA" rMin="[tecpetal0:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
-		<Tubs name="TECOptConnectorA" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT1]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+		<Tubs name="TECOptConnectorA" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT1]/2" startPhi="-[tecwheel:OptConnWEpsilonShrink]/2" deltaPhi="[tecwheel:OptConnWEpsilonShrink]"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheela.xml">
 		<LogicalPart name="TECWheelA" category="unspecified">

--- a/Geometry/TrackerCommonData/data/tecwheelb.xml
+++ b/Geometry/TrackerCommonData/data/tecwheelb.xml
@@ -13,7 +13,7 @@
 		<Tubs name="TECWheelDiskB" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexB" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECFixSupportB" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
-		<Tubs name="TECOptConnectorB" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT2]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+		<Tubs name="TECOptConnectorB" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT2]/2" startPhi="-[tecwheel:OptConnWEpsilonShrink]/2" deltaPhi="[tecwheel:OptConnWEpsilonShrink]"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheelb.xml">
 		<LogicalPart name="TECWheelB" category="unspecified">

--- a/Geometry/TrackerCommonData/data/tecwheelc.xml
+++ b/Geometry/TrackerCommonData/data/tecwheelc.xml
@@ -13,7 +13,7 @@
 		<Tubs name="TECWheelDiskC" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexC" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECFixSupportC" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
-		<Tubs name="TECOptConnectorC" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+		<Tubs name="TECOptConnectorC" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnWEpsilonShrink]/2" deltaPhi="[tecwheel:OptConnWEpsilonShrink]"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheelc.xml">
 		<LogicalPart name="TECWheelC" category="unspecified">

--- a/Geometry/TrackerCommonData/data/tecwheeld.xml
+++ b/Geometry/TrackerCommonData/data/tecwheeld.xml
@@ -13,7 +13,7 @@
 		<Tubs name="TECWheelDiskD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECFixSupportD" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
-		<Tubs name="TECOptConnectorD" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+		<Tubs name="TECOptConnectorD" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnWEpsilonShrink]/2" deltaPhi="[tecwheel:OptConnWEpsilonShrink]"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheeld.xml">
 		<LogicalPart name="TECWheelD" category="unspecified">


### PR DESCRIPTION
Solve all overlaps detected in Phase I Tracker:
- **TEC petals with optical connectors**:
![75704087-b0cfc180-5c86-11ea-8446-11731be4b2b3](https://user-images.githubusercontent.com/11192654/78153657-96326900-743b-11ea-8fa9-8ff2db41ce6f.png)
- **TEC services channel with grounding axis**:
![channel_axgrounding](https://user-images.githubusercontent.com/11192654/78153808-c24dea00-743b-11ea-8c96-ce9f9e1f1f35.png)

In general, I would think it is good practice to avoid having volumes 'sharp' at the same boundary in the XML description, since with default meshing / rounding errors, they can be seen / actually become overlaps.
Directly using an epsilon in the XML description in this kind of situations should solve a lot of headaches, at no cost for the geo and Material Budget.

**PR tests:**
0 overlap with G4 AND Fireworks overlap-checking tools, for both Reference and Migrated 2021 Scenario.
