### PR TITLE
Protect L1T producers against ME0 hits

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -31,6 +31,10 @@ std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_
   for (auto det_range = in_pads->begin(); det_range != in_pads->end(); ++det_range) {
     const GEMDetId& id = (*det_range).first;
 
+    // coincidence pads are not build for ME0
+    // -> ignore hits from station 0
+    if (id.station()==0) continue;
+
     // same chamber (no restriction on the roll number)
     if (id.region() != theRegion or id.station() != theStation or id.chamber() != theChamber)
       continue;

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -33,7 +33,8 @@ std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_
 
     // coincidence pads are not build for ME0
     // -> ignore hits from station 0
-    if (id.station()==0) continue;
+    if (id.station() == 0)
+      continue;
 
     // same chamber (no restriction on the roll number)
     if (id.region() != theRegion or id.station() != theStation or id.chamber() != theChamber)

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -175,6 +175,11 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
 
   // construct clusters
   for (const auto& part : geometry_->etaPartitions()) {
+
+    // clusters are not build for ME0
+    // -> ignore hits from station 0
+    if (part->id().station()==0) continue;
+
     GEMPadDigiClusters all_pad_clusters;
 
     auto pads = det_pads.get(part->id());

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -175,10 +175,10 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
 
   // construct clusters
   for (const auto& part : geometry_->etaPartitions()) {
-
     // clusters are not build for ME0
     // -> ignore hits from station 0
-    if (part->id().station()==0) continue;
+    if (part->id().station() == 0)
+      continue;
 
     GEMPadDigiClusters all_pad_clusters;
 


### PR DESCRIPTION
#### PR description:

Coincidence pads nor pad clusters will be built for ME0. This PR prevents two L1T producers from using ME0 digis. This is done in preparation of the merger of GEM and ME0.

#### PR validation:

I ran WF 22034.0 successfully. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@watson-ij @jshlee 