### PR TITLE
Run3-sim63 Remove reference to DetectorDescription in some packages

### DIFF
--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -13,7 +13,6 @@
 #include "SimG4CMS/Calo/interface/EnergyResolutionVsLumi.h"
 #include "Geometry/EcalCommonData/interface/EcalNumberingScheme.h"
 #include "CondFormats/GeometryObjects/interface/EcalSimulationParameters.h"
-#include "DetectorDescription/Core/interface/DDsvalues.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <memory>
 
-class DDCompactView;
 class G4Step;
 class G4ParticleTable;
 

--- a/SimG4CMS/FP420/BuildFile.xml
+++ b/SimG4CMS/FP420/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="SimDataFormats/SimHitMaker"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="SimDataFormats/CaloHit"/>
-<use   name="DetectorDescription/Core"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/MessageLogger"/>

--- a/SimG4CMS/ShowerLibraryProducer/BuildFile.xml
+++ b/SimG4CMS/ShowerLibraryProducer/BuildFile.xml
@@ -8,7 +8,6 @@
 <use   name="SimDataFormats/HcalTestBeam"/>
 <use   name="SimDataFormats/CaloHit"/>
 <use   name="SimDataFormats/Forward"/>
-<use   name="DetectorDescription/Core"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/MessageLogger"/>

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -4,10 +4,7 @@
 #include "Geometry/HcalCommonData/interface/HcalDDDSimConstants.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDSimulationConstants.h"
 #include "Geometry/Records/interface/HcalSimNumberingRecord.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "G4VPhysicalVolume.hh"


### PR DESCRIPTION
#### PR description:

Remove reference to DetectorDescription in some packages

#### PR validation:

Use standard runTheMatrix.py

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special