### PR TITLE
DQM: Added unit test support for most online DQM clients

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 #from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 #process = cms.Process("BeamMonitor", Run2_2018) FIXME
+import sys
 from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
 process = cms.Process("BeamMonitor", Run2_2018_pp_on_AA)
 
@@ -17,10 +18,17 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 # switch
 live = True # FIXME
+unitTest = False
+
+if 'unitTest=True' in sys.argv:
+    live=False
+    unitTest=True
 
 #---------------
 # Input sources
-if (live):
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+elif live:
     process.load("DQM.Integration.config.inputsource_cfi")
 else:
     process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 #from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 #process = cms.Process("BeamMonitor", Run2_2018) # FIMXE
+import sys
 from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
 process = cms.Process("BeamMonitor", Run2_2018_pp_on_AA)
 
@@ -20,15 +21,23 @@ process = cms.Process("BeamMonitor", Run2_2018_pp_on_AA)
 #    destinations = cms.untracked.vstring('cerr'),
 #)
 
+unitTest=False
+if 'unitTest=True' in sys.argv:
+  unitTest=True
+
 # Common part for PP and H.I Running
 #-----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+  process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+  # for live online DQM in P5
+  process.load("DQM.Integration.config.inputsource_cfi")
+
+  # new stream label
+  process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
+
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")
-
-# new stream label
-process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
 
 #--------------------------
 # HLT Filter

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -1,17 +1,25 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
+import sys
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 process = cms.Process("BeamPixel", Run2_2018)
 
+unitTest=False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
 
 #----------------------------
 # Common for PP and HI running
 #----------------------------
+
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    process.load("DQM.Integration.config.inputsource_cfi")
+
 # Use this to run locally (for testing purposes)
 #process.load("DQM.Integration.config.fileinputsource_cfi")
-# Otherwise use this
-process.load("DQM.Integration.config.inputsource_cfi")
 
 
 #----------------------------

--- a/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
@@ -1,12 +1,22 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process("CASTORDQM")
+
+unitTest=False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
+
 #=================================
 # Event Source
 #================================+
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # for live online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process("CSCDQMLIVE")
 
@@ -32,8 +33,16 @@ process.csc2DRecHits.readBadChambers = cms.bool(False)
 #----------------------------
 # Event Source
 #-----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+
+unitTest=False
+if 'unitTest=True' in sys.argv:
+  unitTest=True
+
+if unitTest:
+  process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+  # for live online DQM in P5
+  process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
@@ -1,12 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
+import sys
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 process = cms.Process('CTPPSDQM', Run2_2018)
 
 test = False
+unitTest = False
+
+if 'unitTest=True' in sys.argv:
+  unitTest=True
 
 # event source
-if not test:
+if unitTest:
+  process.load("DQM.Integration.config.unittestinputsource_cfi")
+elif not test:
   # for live online DQM in P5
   process.load("DQM.Integration.config.inputsource_cfi")
 else:

--- a/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
@@ -1,14 +1,22 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
+import sys
 import os
 
 process = cms.Process("DTDQM")
 
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
+
 #----------------------------
 #### Event Source
 #----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # for live online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")
@@ -38,7 +46,9 @@ except:
 
 process.dqmSaver.backupLumiCount = 10
 process.dqmSaver.keepBackupLumi = True
-process.dqmSaver.path = filePath
+
+if not unitTest:
+    process.dqmSaver.path = filePath
 
 # disable DQM gui
 print("old:",process.DQM.collectorHost)

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -1,13 +1,21 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process("DTDQM")
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+  unitTest=True
 
 #----------------------------
 #### Event Source
 #----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # for live online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")
@@ -28,7 +36,8 @@ process.dqmSaver.tag = "DT"
 
 #Enable HLT*Mu* filtering to monitor on Muon events
 #OR HLT_Physics* to monitor FEDs in commissioning runs
-process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*")
+if not unitTest:
+    process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*")
 
 # DT reco and DQM sequences
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -1,12 +1,20 @@
 ### AUTO-GENERATED CMSRUN CONFIGURATION FOR ECAL DQM ###
 import FWCore.ParameterSet.Config as cms
 from EventFilter.Utilities.tcdsRawToDigi_cfi import * # To monitor LHC status, e.g. to mask trigger primitives quality alarm during Cosmics
+import sys
 
 process = cms.Process("process")
 
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
+
 ### Load cfis ###
 
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    process.load("DQM.Integration.config.inputsource_cfi")
 process.load("DQM.Integration.config.environment_cfi")
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
@@ -155,7 +163,8 @@ elif runTypeName == 'hi_run':
     process.ecalDigis.InputLabel = cms.InputTag('rawDataRepacker')
 elif runTypeName == 'hpu_run':
     process.DQMStore.referenceFileName = referenceFileName.replace('.root', '_hpu.root')
-    process.source.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('*'))
+    if not unitTest:
+        process.source.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('*'))
 
 
 ### process customizations included here

--- a/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
@@ -1,14 +1,22 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process("ESDQM")
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
 
 process.load('Configuration/StandardSequences/Services_cff')
 process.load('FWCore/MessageService/MessageLogger_cfi')
 process.load("FWCore.Modules.preScaler_cfi")
 
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # for live online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,12 @@
 import FWCore.ParameterSet.Config as cms
+import sys
 
 # Process initialization
 process = cms.Process('FED')
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
 
 # Logging:
 process.MessageLogger = cms.Service(
@@ -18,7 +23,10 @@ process.load('DQM.Integration.config.environment_cfi')
 # Global tag:
 process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 # Input:
-process.load('DQM.Integration.config.inputsource_cfi')
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    process.load('DQM.Integration.config.inputsource_cfi')
 # Output:
 process.dqmEnv.subSystemFolder = 'FED'
 process.dqmSaver.tag = 'FED'

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process('GEMDQM')
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+  unitTest=True
 
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
@@ -9,7 +14,10 @@ process.load("DQM.Integration.config.environment_cfi")
 process.dqmEnv.subSystemFolder = "GEM"
 process.dqmSaver.tag = "GEM"
 
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+  process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+  process.load("DQM.Integration.config.inputsource_cfi")
 
 process.load("DQMServices.Components.DQMProvInfo_cfi")
 

--- a/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
@@ -31,6 +31,11 @@ useFileInput = False
 useMap       = False
 useMapText   = False
 
+unitTest = False
+if 'unitTest=True' in sys.argv:
+	unitTest=True
+	useFileInput=False
+
 #-------------------------------------
 #	Central DQM Stuff imports
 #-------------------------------------
@@ -42,7 +47,9 @@ if useOfflineGT:
 	#process.GlobalTag.globaltag = '100X_dataRun2_HLT_v1'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
-if useFileInput:
+if unitTest:
+	process.load("DQM.Integration.config.unittestinputsource_cfi")
+elif useFileInput:
 	process.load("DQM.Integration.config.fileinputsource_cfi")
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
@@ -57,7 +64,7 @@ referenceFileName = '/dqmdata/dqm/reference/hcal_reference.root'
 process.DQMStore.referenceFileName = referenceFileName
 process = customise(process)
 process.DQMStore.verbose = 0
-if not useFileInput:
+if not useFileInput and not unitTest:
 	process.source.minEventsPerLumi = 5
 
 #	Note, runType is obtained after importing DQM-related modules

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -22,6 +22,11 @@ useOfflineGT = False
 useFileInput = False
 useMap       = False
 
+unitTest = False
+if 'unitTest=True' in sys.argv:
+	unitTest=True
+	useFileInput=False
+
 #-------------------------------------
 #	Central DQM Stuff imports
 #-------------------------------------
@@ -33,7 +38,9 @@ if useOfflineGT:
 	#process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
-if useFileInput:
+if unitTest:
+	process.load("DQM.Integration.config.unittestinputsource_cfi")
+elif useFileInput:
 	process.load("DQM.Integration.config.fileinputsource_cfi")
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
@@ -48,7 +55,7 @@ referenceFileName = '/dqmdata/dqm/reference/hcal_reference.root'
 process.DQMStore.referenceFileName = referenceFileName
 process = customise(process)
 process.DQMStore.verbose = 0
-if not useFileInput:
+if not useFileInput and not unitTest:
 	process.source.minEventsPerLumi = 100
 
 #-------------------------------------

--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -1,12 +1,21 @@
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process("HARVESTING")
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+	unitTest=True
 
 #----------------------------
 #### Histograms Source
 #----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.pbsource_cfi")
+
+if unitTest:
+   process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+   # for live online DQM in P5
+   process.load("DQM.Integration.config.pbsource_cfi")
 
 #----------------------------
 #### DQM Environment

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -1,9 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
+import sys
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
 process = cms.Process("DQM", run2_HECollapse_2018)
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+	unitTest=True
+
+if unitTest:
+  process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+  # for live online DQM in P5
+  process.load("DQM.Integration.config.inputsource_cfi")
 # used in the old input source
 #process.DQMEventStreamHttpReader.SelectHLTOutput = cms.untracked.string('hltOutputHLTDQM')
 

--- a/DQM/Integration/python/clients/info_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/info_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process("DQM")
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",
@@ -11,8 +16,11 @@ process.MessageLogger = cms.Service("MessageLogger",
 #----------------------------
 #### Event Source
 #----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # for live online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,13 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 
+import sys
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 process = cms.Process("L1TStage2DQM", Run2_2018)
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
 
 #--------------------------------------------------
 # Event Source and Condition
 
-# Live Online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # Live Online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # # Testing in lxplus
 # process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -1,13 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 
+import sys
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 process = cms.Process("L1TStage2EmulatorDQM", Run2_2018)
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
 
 #--------------------------------------------------
 # Event Source and Condition
 
-# Live Online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # Live Online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # Testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
@@ -1,10 +1,15 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
+import sys
 from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
 process = cms.Process("MUTRKDQM", Run2_2018_pp_on_AA)
 
 live=True
+unitTest=False
+if 'unitTest=True' in sys.argv:
+    live=False
+    unitTest=True
 
 offlineTesting=not live
 
@@ -14,7 +19,11 @@ offlineTesting=not live
 #----------------------------
 # for live online DQM in P5
 
-if (live):
+
+if (unitTest):
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+
+elif (live):
     process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -1,11 +1,17 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-
+import sys
 from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
 process = cms.Process("PIXELDQMLIVE", Run2_2018_pp_on_AA)
 
 live=True
+unitTest = False
+
+if 'unitTest=True' in sys.argv:
+    live=False
+    unitTest=True
+
 #set to false for lxplus offline testing
 #live=False
 offlineTesting=not live
@@ -26,7 +32,10 @@ process.MessageLogger = cms.Service("MessageLogger",
 #-----------------------------
 # for live online DQM in P5
 
-if (live):
+if (unitTest):
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+
+elif (live):
     process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus

--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,12 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process("PixelLumiDQM")
+
+unitTest=False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('siPixelDigis', 
@@ -13,8 +18,12 @@ process.MessageLogger = cms.Service("MessageLogger",
 #----------------------------
 # Event Source
 #-----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # for live online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")
@@ -32,12 +41,13 @@ process.load("DQM.Integration.config.environment_cfi")
 process.dqmEnv.subSystemFolder = "PixelLumi"
 process.dqmSaver.tag = "PixelLumi"
 
-process.source.SelectEvents = cms.untracked.vstring("HLT_ZeroBias*","HLT_L1AlwaysTrue*", "HLT_PAZeroBias*", "HLT_PAL1AlwaysTrue*")
+if not unitTest:
+    process.source.SelectEvents = cms.untracked.vstring("HLT_ZeroBias*","HLT_L1AlwaysTrue*", "HLT_PAZeroBias*", "HLT_PAL1AlwaysTrue*")
 #process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/pixel_reference_pp.root'
 #if (process.runType.getRunType() == process.runType.hi_run):
 #    process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/pixel_reference_hi.root'
 
-if (process.runType.getRunType() == process.runType.cosmic_run):
+if (process.runType.getRunType() == process.runType.cosmic_run and not unitTest):
     process.source.SelectEvents = cms.untracked.vstring('HLT*SingleMu*')
 
 #----------------------------
@@ -86,7 +96,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.load('Configuration.StandardSequences.RawToDigi_Repacked_cff')
     process.siPixelDigis.InputLabel   = cms.InputTag("rawDataRepacker")
 
-    process.source.SelectEvents = cms.untracked.vstring('HLT_HIL1MinimumBiasHF2AND*')
+    if not unitTest:
+        process.source.SelectEvents = cms.untracked.vstring('HLT_HIL1MinimumBiasHF2AND*')
 
 
 #    process.DQMEventStreamHttpReader.SelectEvents = cms.untracked.PSet(

--- a/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
@@ -1,16 +1,25 @@
 from __future__ import print_function
 
+import sys
 import FWCore.ParameterSet.Config as cms
 
 ## Use RECO Muons flag
 useMuons = False
 isOfflineDQM = False
 
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
+
 process = cms.Process("RPCDQM")
 
 ############## Event Source #####################
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # for live online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")

--- a/DQM/Integration/python/clients/scal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scal_dqm_sourceclient-live_cfg.py
@@ -1,12 +1,21 @@
 import FWCore.ParameterSet.Config as cms
+import sys
 
 process = cms.Process("DQM")
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+    unitTest=True
 
 #----------------------------
 #### Event Source
 #----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
+
+if unitTest:
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+else:
+    # for live online DQM in P5
+    process.load("DQM.Integration.config.inputsource_cfi")
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")
@@ -38,7 +47,7 @@ gtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone()
 import EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi
 gtEvmDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi.l1GtEvmUnpack.clone()
 
-if (process.runType.getRunType() == process.runType.pp_run):
+if (process.runType.getRunType() == process.runType.pp_run and not unitTest):
     process.source.SelectEvents = cms.untracked.vstring('HLT_ZeroBias*')
 
 process.physicsBitSelector = cms.EDFilter("PhysDecl",

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-
+import sys
 from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
 process = cms.Process("SiStrpDQMLive", Run2_2018_pp_on_AA)
 
@@ -15,6 +15,12 @@ process.MessageLogger = cms.Service("MessageLogger",
 )
 
 live=True
+unitTest=False
+
+if 'unitTest=True' in sys.argv:
+    live=False
+    unitTest=True
+
 # uncomment for running on lxplus
 #live=False
 offlineTesting=not live
@@ -24,7 +30,9 @@ offlineTesting=not live
 # Event Source
 #-----------------------------
 # for live online DQM in P5
-if (live):
+if (unitTest):
+    process.load("DQM.Integration.config.unittestinputsource_cfi")
+elif (live):
     process.load("DQM.Integration.config.inputsource_cfi")
 # for testing in lxplus
 elif(offlineTesting):

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -83,7 +83,9 @@ for ls in range(options.minLumi, options.maxLumi+1):
     secFiles.extend(sec)
 
     # Get last eventsPerLumi of events in this file
-    events = subprocess.check_output("edmFileUtil --events %s | tail -n +9 | head -n -5 | awk '{ print $3 }'" % read[0], shell=True)
+    command = "edmFileUtil --catalog file:/cvmfs/cms-ib.cern.ch/SITECONF/local/PhEDEx/storage.xml?protocol=xrootd --events %s | tail -n +9 | head -n -5 | awk '{ print $3 }'" % read[0]
+    print(command)
+    events = subprocess.check_output(command, shell=True)
     events = events.split('\n')
     events = filter(lambda x: x != "", events)
     events = map(int, events)

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -1,0 +1,107 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import range
+import FWCore.ParameterSet.Config as cms
+
+# Parameters for runType
+import FWCore.ParameterSet.VarParsing as VarParsing
+import fnmatch
+import subprocess
+from .dqmPythonTypes import *
+
+# part of the runTheMatrix magic
+from Configuration.Applications.ConfigBuilder import filesFromDASQuery
+
+# This source will process last eventsPerLumi in each provided lumisection.
+
+options = VarParsing.VarParsing("analysis")
+
+options.register(
+    "runkey",
+    "pp_run",
+    VarParsing.VarParsing.multiplicity.singleton,
+    VarParsing.VarParsing.varType.string,
+    "Run Keys of CMS"
+)
+
+options.register('runNumber',
+                 334393,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number. This run number has to be present in the dataset configured with the dataset option.")
+
+options.register('dataset',
+                 '/ExpressCosmics/Commissioning2019-Express-v1/FEVT',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Dataset name like '/ExpressCosmics/Commissioning2019-Express-v1/FEVT'")
+
+options.register('maxLumi',
+                 2,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Only lumisections up to maxLumi are processed.")
+
+options.register('minLumi',
+                 1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Only lumisections starting from minLumi are processed.")
+
+options.register('lumiPattern',
+                 '*',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Only lumisections with numbers matching lumiPattern are processed.")
+
+options.register('eventsPerLumi',
+                 100,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "This number of last events in each lumisection will be processed.")
+
+# This is used only by the online clients themselves. 
+# We need to register it here because otherwise an error occurs saying that there is an unidentified option.
+options.register('unitTest',
+                 True,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Required to avoid the error.")
+
+options.parseArguments()
+
+print("Querying DAS for files...")
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+eventsToProcess = []
+
+# Query DAS for a ROOT file for every lumisection
+for ls in range(options.minLumi, options.maxLumi+1):
+  if fnmatch.fnmatch(str(ls), options.lumiPattern):
+    read, sec = filesFromDASQuery("file run=%d dataset=%s lumi=%s" % (options.runNumber, options.dataset, ls))
+    readFiles.extend(read)
+    secFiles.extend(sec)
+
+    # Get last eventsPerLumi of events in this file
+    events = subprocess.check_output("edmFileUtil --events %s | tail -n +9 | head -n -5 | awk '{ print $3 }'" % read[0], shell=True)
+    events = events.split('\n')
+    events = filter(lambda x: x != "", events)
+    events = map(int, events)
+    events = sorted(events)
+    events = events[-options.eventsPerLumi:]
+    eventsToProcess.append("%s:%s:%s-%s:%s:%s" % (options.runNumber, ls, events[0], options.runNumber, ls, events[-1]))
+
+eventRange = cms.untracked.VEventRange(eventsToProcess)
+
+print("Got %d files." % len(readFiles))
+
+source = cms.Source ("PoolSource", fileNames = readFiles, secondaryFileNames = secFiles, eventsToProcess = eventRange)
+maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(-1)
+)
+
+runType = RunType()
+if not options.runkey.strip():
+  options.runkey = "pp_run"
+
+runType.setRunType(options.runkey.strip())

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -1,0 +1,48 @@
+<test name="TestDQMOnlineClient1" command="runtest.sh beam_dqm_sourceclient-live_cfg.py" />
+
+<!-- Need an HLT stream -->
+<!-- <test name="TestDQMOnlineClient2" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" /> -->
+
+<!-- MonitorElement " << getName() << " not backed by any data! -->
+<test name="TestDQMOnlineClient3" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py" />
+
+<test name="TestDQMOnlineClient4" command="runtest.sh castor_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient5" command="runtest.sh csc_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient6" command="runtest.sh ctpps_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient7" command="runtest.sh dt4ml_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient8" command="runtest.sh dt_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient9" command="runtest.sh ecal_dqm_sourceclient-live_cfg.py" />
+
+<!-- streamDQMCalibration is required -->
+<!-- <test name="TestDQMOnlineClient10" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
+
+<test name="TestDQMOnlineClient11" command="runtest.sh es_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient12" command="runtest.sh fed_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient13" command="runtest.sh gem_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient14" command="runtest.sh hcal2_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient15" command="runtest.sh hcal_dqm_sourceclient-live_cfg.py" />
+
+<!-- streamDQMCalibration is required -->
+<!-- <test name="TestDQMOnlineClient16" command="runtest.sh hcalcalib_dqm_sourceclient-live_cfg.py" /> -->
+
+<test name="TestDQMOnlineClient17" command="runtest.sh hlt_dqm_clientPB-live_cfg.py" />
+
+<!-- An exception of category 'ESGetTokenWrongTransition' occurred while -->
+<test name="TestDQMOnlineClient18" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py" />
+
+<test name="TestDQMOnlineClient19" command="runtest.sh info_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient20" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient21" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient22" command="runtest.sh mutracking_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient23" command="runtest.sh pixel_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient24" command="runtest.sh pixellumi_dqm_sourceclient-live_cfg.py" />
+
+<!-- DQMServices/Core/interface/MonitorElement.h:221 segmentation violation -->
+<test name="TestDQMOnlineClient25" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py" />
+
+<test name="TestDQMOnlineClient26" command="runtest.sh scal_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient27" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py" />
+
+<!-- No data of type "GBRForestD" with label "electron_eb_ecalOnly_1To300_0p2To2_mean" in record "GBRDWrapperRcd" -->
+<!-- <test name="TestDQMOnlineClient28" command="runtest.sh visualization-live_cfg.py" />  -->
+<!-- <test name="TestDQMOnlineClient29" command="runtest.sh visualization-live-secondInstance_cfg.py" /> -->

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -1,48 +1,39 @@
-<test name="TestDQMOnlineClient1" command="runtest.sh beam_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py" />
+<!-- beampixel_dqm_sourceclient-live_cfg.py -->
+<test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-castor_dqm_sourceclient" command="runtest.sh castor_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-csc_dqm_sourceclient" command="runtest.sh csc_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-ctpps_dqm_sourceclient" command="runtest.sh ctpps_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-dt4ml_dqm_sourceclient" command="runtest.sh dt4ml_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-dt_dqm_sourceclient" command="runtest.sh dt_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-ecal_dqm_sourceclient" command="runtest.sh ecal_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-es_dqm_sourceclient" command="runtest.sh es_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-fed_dqm_sourceclient" command="runtest.sh fed_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-gem_dqm_sourceclient" command="runtest.sh gem_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-hcal2_dqm_sourceclient" command="runtest.sh hcal2_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-hcal_dqm_sourceclient" command="runtest.sh hcal_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-hlt_dqm_clientPB" command="runtest.sh hlt_dqm_clientPB-live_cfg.py" />
+<test name="TestDQMOnlineClient-hlt_dqm_sourceclient" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-info_dqm_sourceclient" command="runtest.sh info_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-l1tstage2_dqm_sourceclient" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-mutracking_dqm_sourceclient" command="runtest.sh mutracking_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-pixel_dqm_sourceclient" command="runtest.sh pixel_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-pixellumi_dqm_sourceclient" command="runtest.sh pixellumi_dqm_sourceclient-live_cfg.py" />
+<!-- segmentation violation -->
+<test name="TestDQMOnlineClient-rpc_dqm_sourceclient" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py" />
 
 <!-- Need an HLT stream -->
-<!-- <test name="TestDQMOnlineClient2" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" /> -->
-
-<!-- MonitorElement " << getName() << " not backed by any data! -->
-<test name="TestDQMOnlineClient3" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py" />
-
-<test name="TestDQMOnlineClient4" command="runtest.sh castor_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient5" command="runtest.sh csc_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient6" command="runtest.sh ctpps_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient7" command="runtest.sh dt4ml_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient8" command="runtest.sh dt_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient9" command="runtest.sh ecal_dqm_sourceclient-live_cfg.py" />
+<!-- <test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" /> -->
 
 <!-- streamDQMCalibration is required -->
-<!-- <test name="TestDQMOnlineClient10" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
-
-<test name="TestDQMOnlineClient11" command="runtest.sh es_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient12" command="runtest.sh fed_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient13" command="runtest.sh gem_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient14" command="runtest.sh hcal2_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient15" command="runtest.sh hcal_dqm_sourceclient-live_cfg.py" />
+<!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 
 <!-- streamDQMCalibration is required -->
-<!-- <test name="TestDQMOnlineClient16" command="runtest.sh hcalcalib_dqm_sourceclient-live_cfg.py" /> -->
-
-<test name="TestDQMOnlineClient17" command="runtest.sh hlt_dqm_clientPB-live_cfg.py" />
-
-<!-- An exception of category 'ESGetTokenWrongTransition' occurred while -->
-<test name="TestDQMOnlineClient18" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py" />
-
-<test name="TestDQMOnlineClient19" command="runtest.sh info_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient20" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient21" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient22" command="runtest.sh mutracking_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient23" command="runtest.sh pixel_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient24" command="runtest.sh pixellumi_dqm_sourceclient-live_cfg.py" />
-
-<!-- DQMServices/Core/interface/MonitorElement.h:221 segmentation violation -->
-<test name="TestDQMOnlineClient25" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py" />
-
-<test name="TestDQMOnlineClient26" command="runtest.sh scal_dqm_sourceclient-live_cfg.py" />
-<test name="TestDQMOnlineClient27" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py" />
+<!-- <test name="TestDQMOnlineClient-hcalcalib_dqm_sourceclient" command="runtest.sh hcalcalib_dqm_sourceclient-live_cfg.py" /> -->
 
 <!-- No data of type "GBRForestD" with label "electron_eb_ecalOnly_1To300_0p2To2_mean" in record "GBRDWrapperRcd" -->
-<!-- <test name="TestDQMOnlineClient28" command="runtest.sh visualization-live_cfg.py" />  -->
-<!-- <test name="TestDQMOnlineClient29" command="runtest.sh visualization-live-secondInstance_cfg.py" /> -->
+<!-- <test name="TestDQMOnlineClient-visualization" command="runtest.sh visualization-live_cfg.py" />  -->
+<!-- <test name="TestDQMOnlineClient-visualization_secondInstance" command="runtest.sh visualization-live-secondInstance_cfg.py" /> -->

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py" />
-<!-- beampixel_dqm_sourceclient-live_cfg.py -->
 <test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py" />
 <test name="TestDQMOnlineClient-castor_dqm_sourceclient" command="runtest.sh castor_dqm_sourceclient-live_cfg.py" />
 <test name="TestDQMOnlineClient-csc_dqm_sourceclient" command="runtest.sh csc_dqm_sourceclient-live_cfg.py" />
@@ -20,7 +19,6 @@
 <test name="TestDQMOnlineClient-mutracking_dqm_sourceclient" command="runtest.sh mutracking_dqm_sourceclient-live_cfg.py" />
 <test name="TestDQMOnlineClient-pixel_dqm_sourceclient" command="runtest.sh pixel_dqm_sourceclient-live_cfg.py" />
 <test name="TestDQMOnlineClient-pixellumi_dqm_sourceclient" command="runtest.sh pixellumi_dqm_sourceclient-live_cfg.py" />
-<!-- segmentation violation -->
 <test name="TestDQMOnlineClient-rpc_dqm_sourceclient" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py" />
 <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py" />
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py" />

--- a/DQM/Integration/test/README.md
+++ b/DQM/Integration/test/README.md
@@ -24,6 +24,9 @@ Running all tests:
 ``` bash
 voms-proxy-init -voms cms -rfc
 scram b runtests
+
+# to run tests in parallel:
+scram b -k -j 16 runtests
 ```
 
 Running a single client test:

--- a/DQM/Integration/test/README.md
+++ b/DQM/Integration/test/README.md
@@ -1,0 +1,34 @@
+# Unit tests of Online DQM clients
+
+There is a dedicated input source for the unit tests: `DQM.Integration.config.unittestinputsource_cfi`.
+
+The input source selects only last 100 events of 1st and 2nd lumisections to make sure that the tests can run fast yet encountering a lumi transition.
+
+The most recent full event data was selected to be used to run the tests. Bellow are the instructions on how to update it:
+
+``` bash
+# Get the workflow number:
+runTheMatrix.py -n | grep 2020
+# And get the info about the workflow:
+runTheMatrix.py -l 138.1 -ne
+# Dataset and run number will appear in the output
+# /ExpressCosmics/Commissioning2019-Express-v1/FEVT
+# 334393
+```
+
+Dataset and run number has to be changed in the default values of the parameters in this file: `DQM/Integration/python/config/unittestinputsource_cfi.py`
+
+## Running locally:
+
+Running all tests:
+``` bash
+voms-proxy-init -voms cms -rfc
+scram b runtests
+```
+
+Running a single client test:
+``` bash
+cd DQM/Integration/python/clients
+mkdir upload
+cmsRun sistrip_dqm_sourceclient-live_cfg.py unitTest=True
+```

--- a/DQM/Integration/test/runtest.sh
+++ b/DQM/Integration/test/runtest.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+set -x
+
+if [[ $# -eq 0 ]]; then
+    echo "Please provide a name of the clinet"
+    exit 1
+fi
+
+if [[ -z ${LOCAL_TEST_DIR} ]]; then
+    LOCAL_TEST_DIR=.
+fi
+
+if [[ -z ${CLIENTS_DIR} ]]; then
+    CLIENTS_DIR=$LOCAL_TEST_DIR/src/DQM/Integration/python/clients
+fi
+
+mkdir -p $LOCAL_TEST_DIR/upload
+cmsRun $CLIENTS_DIR/$1 unitTest=True


### PR DESCRIPTION
#### PR description:

Added a dedicated input source for the unit tests (`unittestinputsource_cfi`) that selects only last 100 events of 1st and 2nd lumisections to make sure that the tests can run fast yet encountering a lumi transition. Each client had to be updated to make use of the newly added input source.

Most clients are tested however, some require more thinking due to reading non-standard streams or GT issues.

#### PR validation:

PR was validated locally.