### PR TITLE
Restrict timestamps in PFCandidates to reliable cases

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
@@ -17,16 +17,24 @@ class TrackTimingImporter : public BlockElementImporterBase {
 public:
   TrackTimingImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
       : BlockElementImporterBase(conf, sumes),
+        useTimeQuality_(conf.existsAs<edm::InputTag>("timeQualityMap")),
+        timeQualityThreshold_(useTimeQuality_ ? conf.getParameter<double>("timeQualityThreshold") : -99.),
         srcTime_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMap"))),
         srcTimeError_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMap"))),
+        srcTimeQuality_(useTimeQuality_ ? sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeQualityMap"))
+                          : edm::EDGetTokenT<edm::ValueMap<float>>()),
         srcTimeGsf_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMapGsf"))),
         srcTimeErrorGsf_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMapGsf"))),
+        srcTimeQualityGsf_(useTimeQuality_ ? sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeQualityMapGsf"))
+                          : edm::EDGetTokenT<edm::ValueMap<float>>()),
         debug_(conf.getUntrackedParameter<bool>("debug", false)) {}
 
   void importToBlock(const edm::Event&, ElementList&) const override;
 
 private:
-  edm::EDGetTokenT<edm::ValueMap<float> > srcTime_, srcTimeError_, srcTimeGsf_, srcTimeErrorGsf_;
+  const bool useTimeQuality_;
+  const double timeQualityThreshold_;
+  edm::EDGetTokenT<edm::ValueMap<float> > srcTime_, srcTimeError_, srcTimeQuality_, srcTimeGsf_, srcTimeErrorGsf_, srcTimeQualityGsf_;
   const bool debug_;
 };
 
@@ -39,12 +47,24 @@ void TrackTimingImporter::importToBlock(const edm::Event& e, BlockElementImporte
   auto const& timeErr = e.get(srcTimeError_);
   auto const& timeGsf = e.get(srcTimeGsf_);
   auto const& timeErrGsf = e.get(srcTimeErrorGsf_);
+  
+  edm::Handle<edm::ValueMap<float>> timeQualH, timeQualGsfH;
+  if (useTimeQuality_) {
+    e.getByToken(srcTimeQuality_, timeQualH);
+    e.getByToken(srcTimeQualityGsf_, timeQualGsfH);
+  }
 
   for (auto& elem : elems) {
     if (reco::PFBlockElement::TRACK == elem->type()) {
       const auto& ref = elem->trackRef();
       if (time.contains(ref.id())) {
-        elem->setTime(time[ref], timeErr[ref]);
+        const bool assocQuality = useTimeQuality_ ? (*timeQualH)[ref] > timeQualityThreshold_ : true;
+        if (assocQuality) {
+          elem->setTime(time[ref], timeErr[ref]);
+        }
+        else {
+          elem->setTime(0., -1.);
+        }
       }
       if (debug_) {
         edm::LogInfo("TrackTimingImporter")
@@ -54,7 +74,13 @@ void TrackTimingImporter::importToBlock(const edm::Event& e, BlockElementImporte
     } else if (reco::PFBlockElement::GSF == elem->type()) {
       const auto& ref = static_cast<const reco::PFBlockElementGsfTrack*>(elem.get())->GsftrackRef();
       if (timeGsf.contains(ref.id())) {
-        elem->setTime(timeGsf[ref], timeErrGsf[ref]);
+        const bool assocQuality = useTimeQuality_ ? (*timeQualGsfH)[ref] > timeQualityThreshold_ : true;
+        if (assocQuality) {
+          elem->setTime(timeGsf[ref], timeErrGsf[ref]);
+        }
+        else {
+          elem->setTime(0., -1.);
+        }
       }
       if (debug_) {
         edm::LogInfo("TrackTimingImporter")

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
@@ -19,14 +19,16 @@ public:
       : BlockElementImporterBase(conf, sumes),
         useTimeQuality_(conf.existsAs<edm::InputTag>("timeQualityMap")),
         timeQualityThreshold_(useTimeQuality_ ? conf.getParameter<double>("timeQualityThreshold") : -99.),
-        srcTime_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMap"))),
-        srcTimeError_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMap"))),
-        srcTimeQuality_(useTimeQuality_ ? sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeQualityMap"))
-                          : edm::EDGetTokenT<edm::ValueMap<float>>()),
-        srcTimeGsf_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMapGsf"))),
-        srcTimeErrorGsf_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMapGsf"))),
-        srcTimeQualityGsf_(useTimeQuality_ ? sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeQualityMapGsf"))
-                          : edm::EDGetTokenT<edm::ValueMap<float>>()),
+        srcTime_(sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMap"))),
+        srcTimeError_(sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMap"))),
+        srcTimeQuality_(useTimeQuality_
+                            ? sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeQualityMap"))
+                            : edm::EDGetTokenT<edm::ValueMap<float>>()),
+        srcTimeGsf_(sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMapGsf"))),
+        srcTimeErrorGsf_(sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMapGsf"))),
+        srcTimeQualityGsf_(useTimeQuality_ ? sumes.consumes<edm::ValueMap<float>>(
+                                                 conf.getParameter<edm::InputTag>("timeQualityMapGsf"))
+                                           : edm::EDGetTokenT<edm::ValueMap<float>>()),
         debug_(conf.getUntrackedParameter<bool>("debug", false)) {}
 
   void importToBlock(const edm::Event&, ElementList&) const override;
@@ -34,7 +36,8 @@ public:
 private:
   const bool useTimeQuality_;
   const double timeQualityThreshold_;
-  edm::EDGetTokenT<edm::ValueMap<float> > srcTime_, srcTimeError_, srcTimeQuality_, srcTimeGsf_, srcTimeErrorGsf_, srcTimeQualityGsf_;
+  edm::EDGetTokenT<edm::ValueMap<float>> srcTime_, srcTimeError_, srcTimeQuality_, srcTimeGsf_, srcTimeErrorGsf_,
+      srcTimeQualityGsf_;
   const bool debug_;
 };
 
@@ -47,7 +50,7 @@ void TrackTimingImporter::importToBlock(const edm::Event& e, BlockElementImporte
   auto const& timeErr = e.get(srcTimeError_);
   auto const& timeGsf = e.get(srcTimeGsf_);
   auto const& timeErrGsf = e.get(srcTimeErrorGsf_);
-  
+
   edm::Handle<edm::ValueMap<float>> timeQualH, timeQualGsfH;
   if (useTimeQuality_) {
     e.getByToken(srcTimeQuality_, timeQualH);
@@ -61,8 +64,7 @@ void TrackTimingImporter::importToBlock(const edm::Event& e, BlockElementImporte
         const bool assocQuality = useTimeQuality_ ? (*timeQualH)[ref] > timeQualityThreshold_ : true;
         if (assocQuality) {
           elem->setTime(time[ref], timeErr[ref]);
-        }
-        else {
+        } else {
           elem->setTime(0., -1.);
         }
       }
@@ -77,8 +79,7 @@ void TrackTimingImporter::importToBlock(const edm::Event& e, BlockElementImporte
         const bool assocQuality = useTimeQuality_ ? (*timeQualGsfH)[ref] > timeQualityThreshold_ : true;
         if (assocQuality) {
           elem->setTime(timeGsf[ref], timeErrGsf[ref]);
-        }
-        else {
+        } else {
           elem->setTime(0., -1.);
         }
       }

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -223,11 +223,14 @@ _addTimingLayer = particleFlowBlock.elementImporters.copy()
 _addTimingLayer.append( cms.PSet( importerName = cms.string("TrackTimingImporter"),
                              timeValueMap = cms.InputTag("tofPID:t0"),
                              timeErrorMap = cms.InputTag("tofPID:sigmat0"),
+                             timeQualityMap = cms.InputTag("mtdTrackQualityMVA:mtdQualMVA"),
+                             timeQualityThreshold = cms.double(0.5),
                              #this will cause no time to be set for gsf tracks
                              #(since this is not available for the fullsim/reconstruction yet)
                              #*TODO* update when gsf times are available
                              timeValueMapGsf = cms.InputTag("tofPID:t0"),
-                             timeErrorMapGsf = cms.InputTag("tofPID:sigmat0")
+                             timeErrorMapGsf = cms.InputTag("tofPID:sigmat0"),
+                             timeQualityMapGsf = cms.InputTag("mtdTrackQualityMVA:mtdQualMVA"),
                              )
                    )
 

--- a/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
@@ -30,11 +30,14 @@ phase2_timing_layer.toModify(
     simPFProducer,
     trackTimeValueMap = cms.InputTag("tofPID:t0"),
     trackTimeErrorMap = cms.InputTag("tofPID:sigmat0"),
+    trackTimeQualityMap = cms.InputTag("mtdTrackQualityMVA:mtdQualMVA"),
+    timingQualityThreshold = cms.double(0.5),
     #this will cause no time to be set for gsf tracks
     #(since this is not available for the fullsim/reconstruction yet)
     #*TODO* update when gsf times are available
     gsfTrackTimeValueMap = cms.InputTag("tofPID:t0"),
     gsfTrackTimeErrorMap = cms.InputTag("tofPID:sigmat0"),
+    gsfTrackTimeQualityMap = cms.InputTag("mtdTrackQualityMVA:mtdQualMVA"),
 )
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -68,7 +68,7 @@ private:
   const bool useTiming_;
   const bool useTimingQuality_;
   const double timingQualityThreshold_;
-  
+
   // inputs
   const edm::EDGetTokenT<edm::View<reco::PFRecTrack>> pfRecTracks_;
   const edm::EDGetTokenT<edm::View<reco::Track>> tracks_;
@@ -113,8 +113,8 @@ SimPFProducer::SimPFProducer(const edm::ParameterSet& conf)
                              ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeErrorMap"))
                              : edm::EDGetTokenT<edm::ValueMap<float>>()),
       srcTrackTimeQuality_(useTimingQuality_
-                             ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeQualityMap"))
-                             : edm::EDGetTokenT<edm::ValueMap<float>>()),
+                               ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeQualityMap"))
+                               : edm::EDGetTokenT<edm::ValueMap<float>>()),
       srcGsfTrackTime_(useTiming_
                            ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("gsfTrackTimeValueMap"))
                            : edm::EDGetTokenT<edm::ValueMap<float>>()),
@@ -123,7 +123,7 @@ SimPFProducer::SimPFProducer(const edm::ParameterSet& conf)
                      : edm::EDGetTokenT<edm::ValueMap<float>>()),
       srcGsfTrackTimeQuality_(
           useTimingQuality_ ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("gsfTrackTimeQualityMap"))
-                     : edm::EDGetTokenT<edm::ValueMap<float>>()),
+                            : edm::EDGetTokenT<edm::ValueMap<float>>()),
       trackingParticles_(consumes<TrackingParticleCollection>(conf.getParameter<edm::InputTag>("trackingParticleSrc"))),
       simClustersTruth_(consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterTruthSrc"))),
       caloParticles_(consumes<CaloParticleCollection>(conf.getParameter<edm::InputTag>("caloParticlesSrc"))),
@@ -170,13 +170,14 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
   }
 
   // get timing, if enabled
-  edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, trackTimeQualH, gsfTrackTimeH, gsfTrackTimeErrH, gsfTrackTimeQualH;
+  edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, trackTimeQualH, gsfTrackTimeH, gsfTrackTimeErrH,
+      gsfTrackTimeQualH;
   if (useTiming_) {
     evt.getByToken(srcTrackTime_, trackTimeH);
     evt.getByToken(srcTrackTimeError_, trackTimeErrH);
     evt.getByToken(srcGsfTrackTime_, gsfTrackTimeH);
     evt.getByToken(srcGsfTrackTimeError_, gsfTrackTimeErrH);
-    
+
     if (useTimingQuality_) {
       evt.getByToken(srcTrackTimeQuality_, trackTimeQualH);
       evt.getByToken(srcGsfTrackTimeQuality_, gsfTrackTimeQualH);
@@ -324,8 +325,7 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
       const bool assocQuality = useTimingQuality_ ? (*trackTimeQualH)[tkRef] > timingQualityThreshold_ : true;
       if (assocQuality) {
         candidate.setTime((*trackTimeH)[tkRef], (*trackTimeErrH)[tkRef]);
-      }
-      else {
+      } else {
         candidate.setTime(0., -1.);
       }
     }

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -66,14 +66,16 @@ private:
   // parameters
   const double superClusterThreshold_, neutralEMThreshold_, neutralHADThreshold_;
   const bool useTiming_;
-
+  const bool useTimingQuality_;
+  const double timingQualityThreshold_;
+  
   // inputs
   const edm::EDGetTokenT<edm::View<reco::PFRecTrack>> pfRecTracks_;
   const edm::EDGetTokenT<edm::View<reco::Track>> tracks_;
   const edm::EDGetTokenT<edm::View<reco::Track>> gsfTracks_;
   const edm::EDGetTokenT<reco::MuonCollection> muons_;
-  const edm::EDGetTokenT<edm::ValueMap<float>> srcTrackTime_, srcTrackTimeError_;
-  const edm::EDGetTokenT<edm::ValueMap<float>> srcGsfTrackTime_, srcGsfTrackTimeError_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> srcTrackTime_, srcTrackTimeError_, srcTrackTimeQuality_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> srcGsfTrackTime_, srcGsfTrackTimeError_, srcGsfTrackTimeQuality_;
   const edm::EDGetTokenT<TrackingParticleCollection> trackingParticles_;
   const edm::EDGetTokenT<SimClusterCollection> simClustersTruth_;
   const edm::EDGetTokenT<CaloParticleCollection> caloParticles_;
@@ -99,6 +101,8 @@ SimPFProducer::SimPFProducer(const edm::ParameterSet& conf)
       neutralEMThreshold_(conf.getParameter<double>("neutralEMThreshold")),
       neutralHADThreshold_(conf.getParameter<double>("neutralHADThreshold")),
       useTiming_(conf.existsAs<edm::InputTag>("trackTimeValueMap")),
+      useTimingQuality_(conf.existsAs<edm::InputTag>("trackTimeQualityMap")),
+      timingQualityThreshold_(useTimingQuality_ ? conf.getParameter<double>("timingQualityThreshold") : -99.),
       pfRecTracks_(consumes<edm::View<reco::PFRecTrack>>(conf.getParameter<edm::InputTag>("pfRecTrackSrc"))),
       tracks_(consumes<edm::View<reco::Track>>(conf.getParameter<edm::InputTag>("trackSrc"))),
       gsfTracks_(consumes<edm::View<reco::Track>>(conf.getParameter<edm::InputTag>("gsfTrackSrc"))),
@@ -108,11 +112,17 @@ SimPFProducer::SimPFProducer(const edm::ParameterSet& conf)
       srcTrackTimeError_(useTiming_
                              ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeErrorMap"))
                              : edm::EDGetTokenT<edm::ValueMap<float>>()),
+      srcTrackTimeQuality_(useTimingQuality_
+                             ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeQualityMap"))
+                             : edm::EDGetTokenT<edm::ValueMap<float>>()),
       srcGsfTrackTime_(useTiming_
                            ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("gsfTrackTimeValueMap"))
                            : edm::EDGetTokenT<edm::ValueMap<float>>()),
       srcGsfTrackTimeError_(
           useTiming_ ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("gsfTrackTimeErrorMap"))
+                     : edm::EDGetTokenT<edm::ValueMap<float>>()),
+      srcGsfTrackTimeQuality_(
+          useTimingQuality_ ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("gsfTrackTimeQualityMap"))
                      : edm::EDGetTokenT<edm::ValueMap<float>>()),
       trackingParticles_(consumes<TrackingParticleCollection>(conf.getParameter<edm::InputTag>("trackingParticleSrc"))),
       simClustersTruth_(consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterTruthSrc"))),
@@ -160,12 +170,17 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
   }
 
   // get timing, if enabled
-  edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, gsfTrackTimeH, gsfTrackTimeErrH;
+  edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, trackTimeQualH, gsfTrackTimeH, gsfTrackTimeErrH, gsfTrackTimeQualH;
   if (useTiming_) {
     evt.getByToken(srcTrackTime_, trackTimeH);
     evt.getByToken(srcTrackTimeError_, trackTimeErrH);
     evt.getByToken(srcGsfTrackTime_, gsfTrackTimeH);
     evt.getByToken(srcGsfTrackTimeError_, gsfTrackTimeErrH);
+    
+    if (useTimingQuality_) {
+      evt.getByToken(srcTrackTimeQuality_, trackTimeQualH);
+      evt.getByToken(srcGsfTrackTimeQuality_, gsfTrackTimeQualH);
+    }
   }
 
   //get tracking particle collections
@@ -304,8 +319,16 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
 
     candidate.setTrackRef(tkRef.castTo<reco::TrackRef>());
 
-    if (useTiming_)
-      candidate.setTime((*trackTimeH)[tkRef], (*trackTimeErrH)[tkRef]);
+    if (useTiming_) {
+      // check if track-mtd match is of sufficient quality
+      const bool assocQuality = useTimingQuality_ ? (*trackTimeQualH)[tkRef] > timingQualityThreshold_ : true;
+      if (assocQuality) {
+        candidate.setTime((*trackTimeH)[tkRef], (*trackTimeErrH)[tkRef]);
+      }
+      else {
+        candidate.setTime(0., -1.);
+      }
+    }
 
     // bind to cluster if there is one and try to gather conversions, etc
     for (const auto& match : matches) {

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -415,7 +415,6 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
         candidates->emplace_back(0, clu_p4, part_type);
         auto& candidate = candidates->back();
         candidate.addElementInBlock(blref, elem.index());
-        candidate.setTime(ref->time(), ref->timeError());
       }
     }
   }


### PR DESCRIPTION
Cleanup the timestamps in the PFCandidates in two ways:

1.  Apply track-MTD quality matching criteria, using a cut on the MVA>0.5 corresponding to what was added in https://github.com/cms-sw/cmssw/pull/28815
If this criteria is not satisfied, the PFCandidate is not assigned a time (ie treated as though no timing information is available.)

2.  Don't propagate timestamps from PFClusters to neutrals in the SimPFProducer (used for the realistic simcluster-based HGCal reconstruction) since this information is not reliable/consistently filled.  (Timing for neutral PFCandidates in HGCal is being revisited as part of migration to TICL-based reconstruction for PF.)

These changes should simplify downstream use of MTD timing information by POGs for phase 2 offline and HLT.

Since the PFCandidate timestamps are not used downstream yet in any of the standard workflows, the expected change is only in the PFCandidate and PackedCandidate times and timeErrors, with a larger fraction of candidates having no timestamp assigned (and timeError = -1.0)

@hatakeyamak @pmeridian @parbol @rovere @felicepantaleo 
