### PR TITLE
PFEGammaProducer to global producer

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -121,17 +121,12 @@ public:
   };
 
   //constructor
-  PFEGammaAlgo(const PFEGConfigInfo&, GBRForests const& gbrForests);
-
-  void setEEtoPSAssociation(EEtoPSAssociation const& eetops) { eetops_ = &eetops; }
-
-  void setAlphaGamma_ESplanes_fromDB(const ESEEIntercalibConstants* esEEInterCalib) {
-    thePFEnergyCalibration_.initAlphaGamma_ESplanes_fromDB(esEEInterCalib);
-  }
-
-  void setESChannelStatus(const ESChannelStatus* channelStatus) { channelStatus_ = channelStatus; }
-
-  void setPrimaryVertex(reco::Vertex const& primaryVertex) { primaryVertex_ = &primaryVertex; }
+  PFEGammaAlgo(const PFEGConfigInfo&,
+               GBRForests const& gbrForests,
+               EEtoPSAssociation const& eetops,
+               ESEEIntercalibConstants const& esEEInterCalib,
+               ESChannelStatus const& channelStatus,
+               reco::Vertex const& primaryVertex);
 
   // this runs the functions below
   EgammaObjects operator()(const reco::PFBlockRef& block);
@@ -145,7 +140,7 @@ private:
 
   // useful pre-cached mappings:
   // hopefully we get an enum that lets us just make an array in the future
-  reco::PFCluster::EEtoPSAssociation const* eetops_;
+  reco::PFCluster::EEtoPSAssociation const& eetops_;
   reco::PFBlockRef _currentblock;
   reco::PFBlock::LinkData _currentlinks;
   // keep a map of pf indices to the splayed block for convenience
@@ -223,10 +218,10 @@ private:
 
   bool isPrimaryTrack(const reco::PFBlockElementTrack& KfEl, const reco::PFBlockElementGsfTrack& GsfEl);
 
-  const PFEGConfigInfo cfg_;
-  reco::Vertex const* primaryVertex_;
+  PFEGConfigInfo const& cfg_;
+  reco::Vertex const& primaryVertex_;
 
-  const ESChannelStatus* channelStatus_;
+  ESChannelStatus const& channelStatus_;
 
   float evaluateSingleLegMVA(const reco::PFBlockRef& blockref, const reco::Vertex& primaryVtx, unsigned int trackIndex);
 };

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -15,77 +15,51 @@ This producer makes use of PFAlgo, the particle flow algorithm.
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "CondFormats/DataRecord/interface/PFCalibrationRcd.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperClusterFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"
 #include "CondFormats/DataRecord/interface/ESEEIntercalibConstantsRcd.h"
 #include "CondFormats/DataRecord/interface/ESChannelStatusRcd.h"
 #include "CondFormats/ESObjects/interface/ESEEIntercalibConstants.h"
 #include "CondFormats/ESObjects/interface/ESChannelStatus.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtraFwd.h"
-#include "DataFormats/EgammaReco/interface/PreshowerClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/PreshowerCluster.h"
-#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h"
 
-#include <sstream>
-#include <string>
-#include <memory>
-
-class PFEGammaProducer : public edm::stream::EDProducer<edm::GlobalCache<PFEGammaAlgo::GBRForests> > {
+class PFEGammaProducer : public edm::global::EDProducer<> {
 public:
-  explicit PFEGammaProducer(const edm::ParameterSet&, const PFEGammaAlgo::GBRForests*);
+  explicit PFEGammaProducer(const edm::ParameterSet&);
 
-  static std::unique_ptr<PFEGammaAlgo::GBRForests> initializeGlobalCache(const edm::ParameterSet& conf) {
-    return std::unique_ptr<PFEGammaAlgo::GBRForests>(new PFEGammaAlgo::GBRForests(conf));
-  }
-
-  static void globalEndJob(PFEGammaAlgo::GBRForests const*) {}
-
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  void beginRun(const edm::Run&, const edm::EventSetup&) override {}
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void setPFVertexParameters(reco::VertexCollection const& primaryVertices);
-
-  void createSingleLegConversions(reco::PFCandidateEGammaExtraCollection& extras,
-                                  reco::ConversionCollection& oneLegConversions,
-                                  const edm::RefProd<reco::ConversionCollection>& convProd);
+  reco::ConversionCollection createSingleLegConversions(reco::PFCandidateEGammaExtraCollection& extras,
+                                                        const edm::RefProd<reco::ConversionCollection>& convProd) const;
 
   const edm::EDGetTokenT<reco::PFBlockCollection> inputTagBlocks_;
   const edm::EDGetTokenT<reco::PFCluster::EEtoPSAssociation> eetopsSrc_;
   const edm::EDGetTokenT<reco::VertexCollection> vertices_;
 
-  // Use vertices for Neutral particles ?
-  const bool useVerticesForNeutral_;
+  const edm::EDPutTokenT<reco::PFCandidateCollection> pfCandidateCollectionPutToken_;
+  const edm::EDPutTokenT<reco::PFCandidateEGammaExtraCollection> pfCandidateEGammaExtraCollectionPutToken_;
+  const edm::EDPutTokenT<reco::SuperClusterCollection> superClusterCollectionPutToken_;
+  const edm::EDPutTokenT<reco::CaloClusterCollection> caloClusterCollectionEBEEPutToken_;
+  const edm::EDPutTokenT<reco::CaloClusterCollection> caloClusterCollectionESPutToken_;
+  const edm::EDPutTokenT<reco::ConversionCollection> conversionCollectionPutToken_;
 
-  /// Variables for PFEGamma
-
-  reco::Vertex primaryVertex_;
-
-  /// particle flow algorithm
-  std::unique_ptr<PFEGammaAlgo> pfeg_;
-
-  const std::string ebeeClustersCollection_;
-  const std::string esClustersCollection_;
+  /// particle flow algorithm configuration
+  const PFEGammaAlgo::PFEGConfigInfo pfEGConfigInfo_;
+  const PFEGammaAlgo::GBRForests gbrForests_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -97,70 +71,58 @@ DEFINE_FWK_MODULE(PFEGammaProducer);
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-PFEGammaProducer::PFEGammaProducer(const edm::ParameterSet& iConfig, const PFEGammaAlgo::GBRForests* gbrForests)
+PFEGammaProducer::PFEGammaProducer(const edm::ParameterSet& iConfig)
     : inputTagBlocks_(consumes<reco::PFBlockCollection>(iConfig.getParameter<edm::InputTag>("blocks"))),
       eetopsSrc_(consumes<reco::PFCluster::EEtoPSAssociation>(iConfig.getParameter<edm::InputTag>("EEtoPS_source"))),
       vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"))),
-      useVerticesForNeutral_(iConfig.getParameter<bool>("useVerticesForNeutral")),
-      primaryVertex_(reco::Vertex()),
-      ebeeClustersCollection_("EBEEClusters"),
-      esClustersCollection_("ESClusters") {
-  PFEGammaAlgo::PFEGConfigInfo algo_config;
+      pfCandidateCollectionPutToken_{produces<reco::PFCandidateCollection>()},
+      pfCandidateEGammaExtraCollectionPutToken_{produces<reco::PFCandidateEGammaExtraCollection>()},
+      superClusterCollectionPutToken_{produces<reco::SuperClusterCollection>()},
+      caloClusterCollectionEBEEPutToken_{produces<reco::CaloClusterCollection>("EBEEClusters")},
+      caloClusterCollectionESPutToken_{produces<reco::CaloClusterCollection>("ESClusters")},
+      conversionCollectionPutToken_{produces<reco::ConversionCollection>()},
+      pfEGConfigInfo_{
+          .mvaEleCut = iConfig.getParameter<double>("pf_electron_mvaCut"),
+          .applyCrackCorrections = iConfig.getParameter<bool>("pf_electronID_crackCorrection"),
+          .produceEGCandsWithNoSuperCluster = iConfig.getParameter<bool>("produceEGCandsWithNoSuperCluster"),
+          .mvaConvCut = iConfig.getParameter<double>("pf_conv_mvaCut"),
+      },
+      gbrForests_{
+          iConfig,
+      } {}
 
-  algo_config.produceEGCandsWithNoSuperCluster = iConfig.getParameter<bool>("produceEGCandsWithNoSuperCluster");
-
-  // register products
-  produces<reco::PFCandidateCollection>();
-  produces<reco::PFCandidateEGammaExtraCollection>();
-  produces<reco::SuperClusterCollection>();
-  produces<reco::CaloClusterCollection>(ebeeClustersCollection_);
-  produces<reco::CaloClusterCollection>(esClustersCollection_);
-  produces<reco::ConversionCollection>();
-
-  //PFElectrons Configuration
-  algo_config.mvaEleCut = iConfig.getParameter<double>("pf_electron_mvaCut");
-
-  algo_config.applyCrackCorrections = iConfig.getParameter<bool>("pf_electronID_crackCorrection");
-
-  algo_config.mvaConvCut = iConfig.getParameter<double>("pf_conv_mvaCut");
-
-  //PFEGamma
-  //for MVA pass PV if there is one in the collection otherwise pass a dummy
-  if (!useVerticesForNeutral_) {  // create a dummy PV
-    reco::Vertex::Error e;
-    e(0, 0) = 0.0015 * 0.0015;
-    e(1, 1) = 0.0015 * 0.0015;
-    e(2, 2) = 15. * 15.;
-    reco::Vertex::Point p(0, 0, 0);
-    primaryVertex_ = reco::Vertex(p, e, 0, 0, 0);
-  }
-  pfeg_ = std::make_unique<PFEGammaAlgo>(algo_config, *gbrForests);
-  pfeg_->setPrimaryVertex(primaryVertex_);
-}
-
-void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void PFEGammaProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   LOGDRESSED("PFEGammaProducer") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run()
                                  << std::endl;
 
   // output collections
-  auto egCandidates_ = std::make_unique<reco::PFCandidateCollection>();
-  auto egExtra_ = std::make_unique<reco::PFCandidateEGammaExtraCollection>();
-  auto sClusters_ = std::make_unique<reco::SuperClusterCollection>();
-
-  // Get the EE-PS associations
-  pfeg_->setEEtoPSAssociation(iEvent.get(eetopsSrc_));
+  reco::PFCandidateCollection egCandidates{};
+  reco::PFCandidateEGammaExtraCollection egExtra{};
+  reco::SuperClusterCollection sClusters{};
 
   // preshower conditions
   edm::ESHandle<ESEEIntercalibConstants> esEEInterCalibHandle_;
   iSetup.get<ESEEIntercalibConstantsRcd>().get(esEEInterCalibHandle_);
-  pfeg_->setAlphaGamma_ESplanes_fromDB(esEEInterCalibHandle_.product());
 
   edm::ESHandle<ESChannelStatus> esChannelStatusHandle_;
   iSetup.get<ESChannelStatusRcd>().get(esChannelStatusHandle_);
-  pfeg_->setESChannelStatus(esChannelStatusHandle_.product());
 
   //Assign the PFAlgo Parameters
-  setPFVertexParameters(iEvent.get(vertices_));
+  auto const& primaryVertices = iEvent.get(vertices_);
+  auto const* primaryVertex = &primaryVertices.front();
+  for (auto const& pv : primaryVertices) {
+    if (pv.isValid() && !pv.isFake()) {
+      primaryVertex = &pv;
+      break;
+    }
+  }
+
+  PFEGammaAlgo pfEGammaAlgo{pfEGConfigInfo_,
+                            gbrForests_,
+                            iEvent.get(eetopsSrc_),
+                            *esEEInterCalibHandle_,
+                            *esChannelStatusHandle_,
+                            *primaryVertex};
 
   // get the collection of blocks
 
@@ -239,38 +201,36 @@ void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     // make a copy of the link data, which will be edited.
     //PFBlock::LinkData linkData =  block.linkData();
 
-    auto output = (*pfeg_)(blockref);
+    auto output = pfEGammaAlgo(blockref);
 
     if (!output.candidates.empty()) {
       LOGDRESSED("PFEGammaProducer") << "Block with " << elements.size() << " elements produced "
                                      << output.candidates.size() << " e-g candidates!" << std::endl;
     }
 
-    const size_t egsize = egCandidates_->size();
-    egCandidates_->resize(egsize + output.candidates.size());
-    std::move(output.candidates.begin(), output.candidates.end(), egCandidates_->begin() + egsize);
+    const size_t egsize = egCandidates.size();
+    egCandidates.resize(egsize + output.candidates.size());
+    std::move(output.candidates.begin(), output.candidates.end(), egCandidates.begin() + egsize);
 
-    const size_t egxsize = egExtra_->size();
-    egExtra_->resize(egxsize + output.candidateExtras.size());
-    std::move(output.candidateExtras.begin(), output.candidateExtras.end(), egExtra_->begin() + egxsize);
+    const size_t egxsize = egExtra.size();
+    egExtra.resize(egxsize + output.candidateExtras.size());
+    std::move(output.candidateExtras.begin(), output.candidateExtras.end(), egExtra.begin() + egxsize);
 
-    const size_t rscsize = sClusters_->size();
-    sClusters_->resize(rscsize + output.refinedSuperClusters.size());
-    std::move(output.refinedSuperClusters.begin(), output.refinedSuperClusters.end(), sClusters_->begin() + rscsize);
+    const size_t rscsize = sClusters.size();
+    sClusters.resize(rscsize + output.refinedSuperClusters.size());
+    std::move(output.refinedSuperClusters.begin(), output.refinedSuperClusters.end(), sClusters.begin() + rscsize);
   }
 
-  LOGDRESSED("PFEGammaProducer") << "Running PFEGammaAlgo on all blocks produced = " << egCandidates_->size()
+  LOGDRESSED("PFEGammaProducer") << "Running PFEGammaAlgo on all blocks produced = " << egCandidates.size()
                                  << " e-g candidates!" << std::endl;
 
-  edm::RefProd<reco::SuperClusterCollection> sClusterProd = iEvent.getRefBeforePut<reco::SuperClusterCollection>();
-
-  edm::RefProd<reco::PFCandidateEGammaExtraCollection> egXtraProd =
-      iEvent.getRefBeforePut<reco::PFCandidateEGammaExtraCollection>();
+  auto sClusterProd = iEvent.getRefBeforePut<reco::SuperClusterCollection>();
+  auto egXtraProd = iEvent.getRefBeforePut<reco::PFCandidateEGammaExtraCollection>();
 
   //set the correct references to refined SC and EG extra using the refprods
-  for (unsigned int i = 0; i < egCandidates_->size(); ++i) {
-    reco::PFCandidate& cand = egCandidates_->at(i);
-    reco::PFCandidateEGammaExtra& xtra = egExtra_->at(i);
+  for (unsigned int i = 0; i < egCandidates.size(); ++i) {
+    reco::PFCandidate& cand = egCandidates.at(i);
+    reco::PFCandidateEGammaExtra& xtra = egExtra.at(i);
 
     reco::PFCandidateEGammaExtraRef extraref(egXtraProd, i);
     reco::SuperClusterRef refinedSCRef(sClusterProd, i);
@@ -281,18 +241,18 @@ void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   }
 
   //build collections of output CaloClusters from the used PFClusters
-  auto caloClustersEBEE = std::make_unique<reco::CaloClusterCollection>();
-  auto caloClustersES = std::make_unique<reco::CaloClusterCollection>();
+  reco::CaloClusterCollection caloClustersEBEE{};
+  reco::CaloClusterCollection caloClustersES{};
 
   std::map<edm::Ptr<reco::CaloCluster>, unsigned int> pfClusterMapEBEE;  //maps of pfclusters to caloclusters
   std::map<edm::Ptr<reco::CaloCluster>, unsigned int> pfClusterMapES;
 
-  for (const auto& sc : *sClusters_) {
+  for (const auto& sc : sClusters) {
     for (reco::CaloCluster_iterator pfclus = sc.clustersBegin(); pfclus != sc.clustersEnd(); ++pfclus) {
       if (!pfClusterMapEBEE.count(*pfclus)) {
         reco::CaloCluster caloclus(**pfclus);
-        caloClustersEBEE->push_back(caloclus);
-        pfClusterMapEBEE[*pfclus] = caloClustersEBEE->size() - 1;
+        caloClustersEBEE.push_back(caloclus);
+        pfClusterMapEBEE[*pfclus] = caloClustersEBEE.size() - 1;
       } else {
         throw cms::Exception("PFEgammaProducer::produce")
             << "Found an EB/EE pfcluster matched to more than one supercluster!" << std::dec << std::endl;
@@ -302,8 +262,8 @@ void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
          ++pfclus) {
       if (!pfClusterMapES.count(*pfclus)) {
         reco::CaloCluster caloclus(**pfclus);
-        caloClustersES->push_back(caloclus);
-        pfClusterMapES[*pfclus] = caloClustersES->size() - 1;
+        caloClustersES.push_back(caloclus);
+        pfClusterMapES[*pfclus] = caloClustersES.size() - 1;
       } else {
         throw cms::Exception("PFEgammaProducer::produce")
             << "Found an ES pfcluster matched to more than one supercluster!" << std::dec << std::endl;
@@ -312,11 +272,11 @@ void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   }
 
   //put calocluster output collections in event and get orphan handles to create ptrs
-  auto const& caloClusHandleEBEE = iEvent.put(std::move(caloClustersEBEE), ebeeClustersCollection_);
-  auto const& caloClusHandleES = iEvent.put(std::move(caloClustersES), esClustersCollection_);
+  auto const& caloClusHandleEBEE = iEvent.emplace(caloClusterCollectionEBEEPutToken_, std::move(caloClustersEBEE));
+  auto const& caloClusHandleES = iEvent.emplace(caloClusterCollectionESPutToken_, std::move(caloClustersES));
 
   //relink superclusters to output caloclusters
-  for (auto& sc : *sClusters_) {
+  for (auto& sc : sClusters) {
     edm::Ptr<reco::CaloCluster> seedptr(caloClusHandleEBEE, pfClusterMapEBEE[sc.seed()]);
     sc.setSeed(seedptr);
 
@@ -337,32 +297,18 @@ void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   }
 
   //create and fill references to single leg conversions
-  edm::RefProd<reco::ConversionCollection> convProd = iEvent.getRefBeforePut<reco::ConversionCollection>();
-  auto singleLegConv_ = std::make_unique<reco::ConversionCollection>();
-  createSingleLegConversions(*egExtra_, *singleLegConv_, convProd);
+  auto singleLegConv = createSingleLegConversions(egExtra, iEvent.getRefBeforePut<reco::ConversionCollection>());
 
   // release our demonspawn into the wild to cause havoc
-  iEvent.put(std::move(sClusters_));
-  iEvent.put(std::move(egExtra_));
-  iEvent.put(std::move(singleLegConv_));
-  iEvent.put(std::move(egCandidates_));
+  iEvent.emplace(superClusterCollectionPutToken_, std::move(sClusters));
+  iEvent.emplace(pfCandidateEGammaExtraCollectionPutToken_, std::move(egExtra));
+  iEvent.emplace(conversionCollectionPutToken_, std::move(singleLegConv));
+  iEvent.emplace(pfCandidateCollectionPutToken_, std::move(egCandidates));
 }
 
-void PFEGammaProducer::setPFVertexParameters(reco::VertexCollection const& primaryVertices) {
-  primaryVertex_ = primaryVertices.front();
-  for (auto const& pv : primaryVertices) {
-    if (pv.isValid() && !pv.isFake()) {
-      primaryVertex_ = pv;
-      break;
-    }
-  }
-
-  pfeg_->setPrimaryVertex(primaryVertex_);
-}
-
-void PFEGammaProducer::createSingleLegConversions(reco::PFCandidateEGammaExtraCollection& extras,
-                                                  reco::ConversionCollection& oneLegConversions,
-                                                  const edm::RefProd<reco::ConversionCollection>& convProd) {
+reco::ConversionCollection PFEGammaProducer::createSingleLegConversions(
+    reco::PFCandidateEGammaExtraCollection& extras, const edm::RefProd<reco::ConversionCollection>& convProd) const {
+  reco::ConversionCollection oneLegConversions{};
   math::Error<3>::type error;
   for (auto& extra : extras) {
     for (const auto& tkrefmva : extra.singleLegConvTrackRefMva()) {
@@ -413,11 +359,11 @@ void PFEGammaProducer::createSingleLegConversions(reco::PFCandidateEGammaExtraCo
       extra.addSingleLegConversionRef(convref);
     }
   }
+  return oneLegConversions;
 }
 
 void PFEGammaProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("useVerticesForNeutral", true);
   desc.add<bool>("produceEGCandsWithNoSuperCluster", false)
       ->setComment("Allow building of candidates with no input or output supercluster?");
   desc.add<double>("pf_electron_mvaCut", -0.1);


### PR DESCRIPTION
#### PR description:

The PF egamma code is still a big chunk of hard-to-understand code; this PR does not really do much about that but it goes in the direction by making the PFEGammaProducer a global module and removing an unused configuration parameter that would not have an effect even if enabled (`useVerticesForNeutral`, the dummy vertex was overwritten by the real reconstructed vertex anyways). Furthermore, the producer got modernized with put tokens and the includes in the `PFProducer` packages were cleaned by not including forward header files in `.cc` sources anymore (which required a few little changes in the DataFormats, as there were some header files which didn't include their own forward header which should optimally be the case).

#### PR validation:

CMSSW compiles and matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.