### PR TITLE
fix miniaod_devel modifier use for pileupJetId.algos

### DIFF
--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -15,7 +15,6 @@ _chsalgos_94x = cms.VPSet(full_94x_chs,cutbased)
 _chsalgos_102x = cms.VPSet(full_102x_chs,cutbased)
 
 _stdalgos    = _chsalgos_81x
-run2_miniAOD_devel.toReplaceWith(_stdalgos, _chsalgos_102x)
 
 # Calculate+store variables and run MVAs
 pileupJetId = cms.EDProducer('PileupJetIdProducer',
@@ -32,6 +31,7 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
      residualsFromTxt = cms.bool(False),
 #     residualsTxt     = cms.FileInPath("RecoJets/JetProducers/data/download.url") # must be an existing file
 )
+run2_miniAOD_devel.toModify(pileupJetId, algos = _chsalgos_102x)
 
 # Calculate variables, but don't run MVAs
 pileupJetIdCalculator = pileupJetId.clone(


### PR DESCRIPTION
a problem was observed when testing re-mini and nano workflows with run2_miniAOD_devel: there  is no support in process modifiers ```toReplaceWith``` for a VPset.
This PR fixes the problem.

Tested on 136.8311 and 1325.7 modified to also use run2_miniAOD_devel

This is a fix to the backport of #28984 made in #29044