### PR TITLE
PR 11_1_X L1 Trigger Era modifiers for Phase2, Run3, and Run2_2018.

### DIFF
--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -14,5 +14,6 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
 
-Phase2 = cms.ModifierChain(Run3.copyAndExclude([phase1Pixel,trackingPhase1]), phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer)
+Phase2 = cms.ModifierChain(Run3.copyAndExclude([phase1Pixel,trackingPhase1]), phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer, phase2_trigger)

--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -18,7 +18,9 @@ from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
+from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
 
 Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017, ctpps_2017, run2_jme_2017]),
 run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, 
-run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018)
+run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018, stage2L1Trigger_2018
+)

--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -5,6 +5,7 @@ from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+from Configuration.Eras.Modifier_run3_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, stage2L1Trigger_2021)
 

--- a/Configuration/Eras/python/Modifier_phase2_trigger_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_trigger_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_trigger =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_stage2L1Trigger_2018_cff.py
+++ b/Configuration/Eras/python/Modifier_stage2L1Trigger_2018_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+stage2L1Trigger_2018 =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_stage2L1Trigger_2021_cff.py
+++ b/Configuration/Eras/python/Modifier_stage2L1Trigger_2021_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+stage2L1Trigger_2021 =  cms.Modifier()
+


### PR DESCRIPTION
#### PR description:

Era trigger modifiers `phase2_trigger`, `stage2L1Trigger_2021`, and `stage2L1Trigger_2018` for 
 - Phase2,
 - Run3
 - Run2_2018.

#### PR validation:
These modifiers are not used yet, and are for future developments.  So this PR should have no effect on current CMSSW.
