### PR TITLE
Test inter process random state transfers

### DIFF
--- a/DataFormats/Common/interface/RandomNumberGeneratorState.h
+++ b/DataFormats/Common/interface/RandomNumberGeneratorState.h
@@ -1,0 +1,26 @@
+#ifndef DataFormats_Common_RandomNumberGeneratorState_h
+#define DataFormats_Common_RandomNumberGeneratorState_h
+
+/*----------------------------------------------------------------------
+  
+RandomNumberGeneratorState is used to communicate with an external process
+----------------------------------------------------------------------*/
+
+#include <vector>
+namespace edm {
+  struct RandomNumberGeneratorState {
+    RandomNumberGeneratorState() = default;
+    RandomNumberGeneratorState(std::vector<unsigned long> iState, long iSeed)
+        : state_(std::move(iState)), seed_{iSeed} {}
+
+    RandomNumberGeneratorState(RandomNumberGeneratorState const&) = default;
+    RandomNumberGeneratorState(RandomNumberGeneratorState&&) = default;
+
+    RandomNumberGeneratorState& operator=(RandomNumberGeneratorState const&) = default;
+    RandomNumberGeneratorState& operator=(RandomNumberGeneratorState&&) = default;
+
+    std::vector<unsigned long> state_;
+    long seed_;
+  };
+}  // namespace edm
+#endif

--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -31,5 +31,6 @@
 #include "DataFormats/Common/interface/SecondaryEventIDAndFileInfo.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
 
 #include <vector>

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -187,5 +187,8 @@
 
  <class name="edm::RefProd<std::vector<int> >"/>
  <class name="edm::RefToBaseProd<int>"/>
+ <class name="edm::RandomNumberGeneratorState" ClassVersion="3">
+  <version ClassVersion="3" checksum="2237762164"/>
+ </class>
 
 </lcgdict>

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -30,6 +30,7 @@
 #include "DataFormats/Common/interface/Holder.h"
 #include "DataFormats/Common/interface/RefToBaseProd.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -5,6 +5,7 @@
  <class name="edmtest::IntProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="4286676158"/>
  </class>
+ <class name="std::pair<edmtest::IntProduct, edm::RandomNumberGeneratorState>"/>
  <class name="edmtest::UInt64Product" ClassVersion="11">
   <version ClassVersion="11" checksum="3240540910"/>
   <version ClassVersion="10" checksum="380152127"/>

--- a/FWCore/Integration/bin/BuildFile.xml
+++ b/FWCore/Integration/bin/BuildFile.xml
@@ -4,3 +4,12 @@
   <use   name="FWCore/TestProcessor"/>
   <use   name="FWCore/SharedMemory"/>
 </bin>
+
+<bin   name="cmsTestInterProcessRandom" file="interprocess_random.cc">
+  <use   name="boost"/>
+  <use   name="boost_program_options"/>
+  <use   name="FWCore/TestProcessor"/>
+  <use   name="FWCore/SharedMemory"/>
+  <use   name="FWCore/Services"/>
+  <use   name="FWCore/Utilities"/>
+</bin>

--- a/FWCore/Integration/bin/interprocess_random.cc
+++ b/FWCore/Integration/bin/interprocess_random.cc
@@ -1,0 +1,207 @@
+#include "boost/program_options.hpp"
+
+#include <atomic>
+#include <csignal>
+#include <iostream>
+#include <string>
+#include <thread>
+
+//TEMP
+//#include "CLHEP/Random/JamesRandom.h"
+
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
+
+#include "FWCore/Services/interface/ExternalRandomNumberGeneratorService.h"
+
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
+static char const* const kMemoryNameOpt = "memory-name";
+static char const* const kMemoryNameCommandOpt = "memory-name,m";
+static char const* const kUniqueIDOpt = "unique-id";
+static char const* const kUniqueIDCommandOpt = "unique-id,i";
+static char const* const kHelpOpt = "help";
+static char const* const kHelpCommandOpt = "help,h";
+
+//NOTE: Can use TestProcessor as the harness for the worker
+
+using SentType = std::pair<edmtest::IntProduct, edm::RandomNumberGeneratorState>;
+
+using namespace edm::shared_memory;
+class Harness {
+public:
+  Harness(std::string const& iConfig, edm::ServiceToken iToken)
+      : tester_(edm::test::TestProcessor::Config{iConfig}, iToken) {}
+
+  edmtest::IntProduct getBeginLumiValue(unsigned int iLumi) {
+    auto lumi = tester_.testBeginLuminosityBlock(iLumi);
+    return *lumi.get<edmtest::IntProduct>("lumi");
+  }
+
+  edmtest::IntProduct getEventValue() {
+    auto event = tester_.test();
+    return *event.get<edmtest::IntProduct>();
+  }
+
+private:
+  edm::test::TestProcessor tester_;
+};
+
+int main(int argc, char* argv[]) {
+  std::string descString(argv[0]);
+  descString += " [--";
+  descString += kMemoryNameOpt;
+  descString += "] memory_name";
+  boost::program_options::options_description desc(descString);
+
+  desc.add_options()(kHelpCommandOpt, "produce help message")(
+      kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
+      kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
+
+  boost::program_options::positional_options_description p;
+  p.add(kMemoryNameOpt, 1);
+  p.add(kUniqueIDOpt, 2);
+
+  boost::program_options::options_description all_options("All Options");
+  all_options.add(desc);
+
+  boost::program_options::variables_map vm;
+  try {
+    store(boost::program_options::command_line_parser(argc, argv).options(all_options).positional(p).run(), vm);
+    notify(vm);
+  } catch (boost::program_options::error const& iException) {
+    std::cout << argv[0] << ": Error while trying to process command line arguments:\n"
+              << iException.what() << "\nFor usage and an options list, please do 'cmsRun --help'.";
+    return 1;
+  }
+
+  if (vm.count(kHelpOpt)) {
+    std::cout << desc << std::endl;
+    return 0;
+  }
+
+  if (!vm.count(kMemoryNameOpt)) {
+    std::cout << " no argument given" << std::endl;
+    return 1;
+  }
+
+  if (!vm.count(kUniqueIDOpt)) {
+    std::cout << " no second argument given" << std::endl;
+    return 1;
+  }
+
+  WorkerMonitorThread monitorThread;
+
+  monitorThread.startThread();
+
+  CMS_SA_ALLOW try {
+    std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
+    std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
+    {
+      //using namespace boost::interprocess;
+      //auto controlNameUnique = unique_name(memoryName, uniqueID);
+
+      //This class is holding the lock
+      WorkerChannel communicationChannel(memoryName, uniqueID);
+
+      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferIndex()};
+      ReadBuffer sm_readbuffer{std::string("Rand") + memoryName, communicationChannel.toWorkerBufferIndex()};
+      int counter = 0;
+
+      //The lock must be released if there is a catastrophic signal
+      auto lockPtr = communicationChannel.accessLock();
+      monitorThread.setAction([lockPtr]() {
+        if (lockPtr) {
+          std::cerr << "SIGNAL CAUGHT: unlock\n";
+          lockPtr->unlock();
+        }
+      });
+
+      using TCSerializer = ROOTSerializer<SentType, WriteBuffer>;
+      TCSerializer serializer(sm_buffer);
+      TCSerializer bl_serializer(sm_buffer);
+
+      using TCDeserializer = ROOTDeserializer<edm::RandomNumberGeneratorState, ReadBuffer>;
+      TCDeserializer random_deserializer(sm_readbuffer);
+
+      std::cerr << uniqueID << " process: initializing " << std::endl;
+      int nlines;
+      std::cin >> nlines;
+
+      std::string configuration;
+      for (int i = 0; i < nlines; ++i) {
+        std::string c;
+        std::getline(std::cin, c);
+        std::cerr << c << "\n";
+        configuration += c + "\n";
+      }
+
+      edm::ExternalRandomNumberGeneratorService* randomService = new edm::ExternalRandomNumberGeneratorService;
+      auto serviceToken =
+          edm::ServiceRegistry::createContaining(std::unique_ptr<edm::RandomNumberGenerator>(randomService));
+
+      //CLHEP::HepJamesRandom rng(12345);
+      //randomService->setState(rng.put(), rng.getSeed());
+      Harness harness(configuration, serviceToken);
+
+      //Either ROOT or the Framework are overriding the signal handlers
+      monitorThread.setupSignalHandling();
+
+      std::cerr << uniqueID << " process: done initializing" << std::endl;
+      communicationChannel.workerSetupDone();
+
+      std::cerr << uniqueID << " process: waiting " << counter << std::endl;
+      communicationChannel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+        ++counter;
+        switch (iTransition) {
+          case edm::Transition::BeginLuminosityBlock: {
+            std::cerr << uniqueID << " process: start beginLumi " << std::endl;
+            auto randState = random_deserializer.deserialize();
+            std::cerr << " state " << randState.seed_ << std::endl;
+            randomService->setState(randState.state_, randState.seed_);
+            SentType toSend;
+            toSend.first = harness.getBeginLumiValue(iTransitionID);
+            toSend.second.state_ = randomService->getState();
+            toSend.second.seed_ = randomService->mySeed();
+            bl_serializer.serialize(toSend);
+            std::cerr << uniqueID << " process: end beginLumi " << toSend.first.value << std::endl;
+
+            break;
+          }
+          case edm::Transition::Event: {
+            std::cerr << uniqueID << " process: begin event " << counter << std::endl;
+            auto randState = random_deserializer.deserialize();
+            randomService->setState(randState.state_, randState.seed_);
+            SentType toSend;
+            toSend.first = harness.getEventValue();
+            toSend.second.state_ = randomService->getState();
+            toSend.second.seed_ = randomService->mySeed();
+            std::cerr << uniqueID << " process: end event " << counter << std::endl;
+
+            serializer.serialize(toSend);
+            std::cerr << uniqueID << " process: " << toSend.first.value << " " << counter << std::endl;
+            //usleep(10000000);
+            break;
+          }
+          default: {
+            assert(false);
+          }
+        }
+        std::cerr << uniqueID << " process: notifying and waiting" << counter << std::endl;
+      });
+    }
+  } catch (std::exception const& iExcept) {
+    std::cerr << "caught exception \n" << iExcept.what() << "\n";
+    return 1;
+  } catch (...) {
+    std::cerr << "caught unknown exception";
+    return 1;
+  }
+  return 0;
+}

--- a/FWCore/Integration/bin/interprocess_random.cc
+++ b/FWCore/Integration/bin/interprocess_random.cc
@@ -6,9 +6,6 @@
 #include <string>
 #include <thread>
 
-//TEMP
-//#include "CLHEP/Random/JamesRandom.h"
-
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
@@ -104,9 +101,6 @@ int main(int argc, char* argv[]) {
     std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
     std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
     {
-      //using namespace boost::interprocess;
-      //auto controlNameUnique = unique_name(memoryName, uniqueID);
-
       //This class is holding the lock
       WorkerChannel communicationChannel(memoryName, uniqueID);
 
@@ -146,8 +140,6 @@ int main(int argc, char* argv[]) {
       auto serviceToken =
           edm::ServiceRegistry::createContaining(std::unique_ptr<edm::RandomNumberGenerator>(randomService));
 
-      //CLHEP::HepJamesRandom rng(12345);
-      //randomService->setState(rng.put(), rng.getSeed());
       Harness harness(configuration, serviceToken);
 
       //Either ROOT or the Framework are overriding the signal handlers

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -331,5 +331,29 @@
     <use   name="FWCore/SharedMemory"/>
     <use   name="boost"/>
   </library>
+  <library   file="RandomIntProducer.cc" name="RandomIntProducer">
+    <flags   EDM_PLUGIN="1"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/Utilities"/>
+    <use   name="DataFormats/TestObjects"/>
+    <use   name="clhep"/>
+  </library>
+  <library   file="TestInterProcessRandomProd.cc" name="TestInterProcessRandomProd">
+    <flags   EDM_PLUGIN="1"/>
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/Sources"/>
+    <use   name="FWCore/SharedMemory"/>
+    <use   name="boost"/>
+    <use   name="clhep"/>
+  </library>
+  <bin   file="RandomIntProducer_t.cpp">
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/TestProcessor"/>
+    <use   name="DataFormats/Provenance"/>
+    <use   name="catch2"/>
+  </bin>
   <test name="TestFWCoreIntegrationInterProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TestInterProcessProd_cfg.py"/>
 </environment>

--- a/FWCore/Integration/test/RandomIntProducer.cc
+++ b/FWCore/Integration/test/RandomIntProducer.cc
@@ -31,7 +31,6 @@ namespace edmtest {
 
   void RandomIntProducer::produce(edm::Event& iEvent, edm::EventSetup const&) {
     edm::Service<edm::RandomNumberGenerator> gen;
-    std::cout << gen->getEngine(iEvent.streamID()).name() << std::endl;
     iEvent.emplace(evToken_, CLHEP::RandFlat::shootInt(&gen->getEngine(iEvent.streamID()), 10));
   }
 

--- a/FWCore/Integration/test/RandomIntProducer.cc
+++ b/FWCore/Integration/test/RandomIntProducer.cc
@@ -1,0 +1,46 @@
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+
+#include "CLHEP/Random/RandFlat.h"
+
+namespace edmtest {
+  class RandomIntProducer : public edm::one::EDProducer<edm::BeginLuminosityBlockProducer> {
+  public:
+    RandomIntProducer(edm::ParameterSet const& iPSet);
+
+    void produce(edm::Event&, edm::EventSetup const&) final;
+
+    void beginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) final;
+
+  private:
+    edm::EDPutTokenT<IntProduct> const evToken_;
+    edm::EDPutTokenT<IntProduct> const lumiToken_;
+  };
+  RandomIntProducer::RandomIntProducer(edm::ParameterSet const&)
+      : evToken_{produces<IntProduct>()},
+        lumiToken_{produces<IntProduct, edm::Transition::BeginLuminosityBlock>("lumi")} {}
+
+  void RandomIntProducer::produce(edm::Event& iEvent, edm::EventSetup const&) {
+    edm::Service<edm::RandomNumberGenerator> gen;
+    std::cout << gen->getEngine(iEvent.streamID()).name() << std::endl;
+    iEvent.emplace(evToken_, CLHEP::RandFlat::shootInt(&gen->getEngine(iEvent.streamID()), 10));
+  }
+
+  void RandomIntProducer::beginLuminosityBlockProduce(edm::LuminosityBlock& iLumi, edm::EventSetup const&) {
+    edm::Service<edm::RandomNumberGenerator> gen;
+    iLumi.emplace(lumiToken_, CLHEP::RandFlat::shootInt(&gen->getEngine(iLumi.index()), 10));
+  }
+
+}  // namespace edmtest
+
+using namespace edmtest;
+DEFINE_FWK_MODULE(RandomIntProducer);

--- a/FWCore/Integration/test/RandomIntProducer_t.cpp
+++ b/FWCore/Integration/test/RandomIntProducer_t.cpp
@@ -1,0 +1,109 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+
+static constexpr auto s_tag = "[RandomIntProducer]";
+
+TEST_CASE("Direct", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+process = TestProcess()
+process.test = cms.EDProducer('RandomIntProducer')
+process.add_(cms.Service("RandomNumberGeneratorService",
+                         test = cms.PSet(initialSeed = cms.untracked.uint32(12345))
+))
+process.moduleToTest(process.test)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION("Base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("transitions") {
+    edm::test::TestProcessor tester(config);
+    {
+      auto lumi = tester.testBeginLuminosityBlock(1).get<edmtest::IntProduct>("lumi");
+      REQUIRE(lumi->value == 1);
+    }
+    {
+      auto event = tester.test().get<edmtest::IntProduct>();
+      REQUIRE(event->value == 6);
+    }
+    {
+      auto event = tester.test().get<edmtest::IntProduct>();
+      REQUIRE(event->value == 4);
+    }
+    {
+      auto lumi = tester.testBeginLuminosityBlock(2).get<edmtest::IntProduct>("lumi");
+      REQUIRE(lumi->value == 1);
+    }
+  }
+}
+
+TEST_CASE("External", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class RandomIntExternalProcessProducer(cms.EDProducer):
+  def __init__(self, prod):
+      self.__dict__['_prod'] = prod
+      super(cms.EDProducer,self).__init__('TestInterProcessRandomProd')
+  def __setattr__(self, name, value):
+      setattr(self._prod, name, value)
+  def __getattr__(self, name):
+      if name =='_prod':
+          return self.__dict__['_prod']
+      return getattr(self._prod, name)
+  def clone(self, **params):
+      returnValue = RandomIntExternalProcessProducer.__new__(type(self))
+      returnValue.__init__(self._prod.clone())
+      return returnValue
+  def insertInto(self, parameterSet, myname):
+      newpset = parameterSet.newPSet()
+      newpset.addString(True, "@module_label", self.moduleLabel_(myname))
+      newpset.addString(True, "@module_type", self.type_())
+      newpset.addString(True, "@module_edm_type", cms.EDProducer.__name__)
+      newpset.addString(True, "@external_type", self._prod.type_())
+      newpset.addString(False,"@python_config", self._prod.dumpPython())
+      self._prod.insertContentsInto(newpset)
+      parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
+
+process = TestProcess()
+_generator = cms.EDProducer('RandomIntProducer')
+process.test = RandomIntExternalProcessProducer(_generator)
+process.add_(cms.Service("RandomNumberGeneratorService",
+                         test = cms.PSet(initialSeed = cms.untracked.uint32(12345))
+))
+process.moduleToTest(process.test)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION("Base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("transitions") {
+    edm::test::TestProcessor tester(config);
+    {
+      auto lumi = tester.testBeginLuminosityBlock(1).get<edmtest::IntProduct>("lumi");
+      REQUIRE(lumi->value == 1);
+    }
+    {
+      auto event = tester.test().get<edmtest::IntProduct>();
+      REQUIRE(event->value == 6);
+    }
+    {
+      auto event = tester.test().get<edmtest::IntProduct>();
+      REQUIRE(event->value == 4);
+    }
+    {
+      auto lumi = tester.testBeginLuminosityBlock(2).get<edmtest::IntProduct>("lumi");
+      REQUIRE(lumi->value == 1);
+    }
+  }
+}

--- a/FWCore/Integration/test/TestInterProcessRandomProd.cc
+++ b/FWCore/Integration/test/TestInterProcessRandomProd.cc
@@ -20,6 +20,8 @@
 #include "FWCore/SharedMemory/interface/ROOTSerializer.h"
 
 #include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/engineIDulong.h"
+#include "CLHEP/Random/RanecuEngine.h"
 
 using namespace edm::shared_memory;
 namespace testinter {
@@ -83,7 +85,9 @@ namespace testinter {
       edm::RandomNumberGeneratorState state{engine.put(), engine.getSeed()};
       randSerializer_.serialize(state);
       auto v = doTransition(deserializer_, edm::Transition::Event, iTransitionID);
-      engine.setSeed(v.second.seed_, 0);
+      if (v.second.state_[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+        engine.setSeed(v.second.seed_, 0);
+      }
       engine.get(v.second.state_);
       return v.first;
     }
@@ -217,7 +221,9 @@ void TestInterProcessRandomProd::globalBeginLuminosityBlockProduce(edm::Luminosi
       *luminosityBlockCache(iLuminosityBlock.index()), iLuminosityBlock.luminosityBlock(), iLuminosityBlock.index());
   edm::Service<edm::RandomNumberGenerator> gen;
   auto& engine = gen->getEngine(iLuminosityBlock.index());
-  engine.setSeed(v.second.seed_, 0);
+  if (v.second.state_[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+    engine.setSeed(v.second.seed_, 0);
+  }
   engine.get(v.second.state_);
 
   iLuminosityBlock.emplace(blToken_, v.first);

--- a/FWCore/Integration/test/TestInterProcessRandomProd.cc
+++ b/FWCore/Integration/test/TestInterProcessRandomProd.cc
@@ -1,0 +1,250 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include <stdio.h>
+#include <iostream>
+
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+
+#include "CLHEP/Random/RandomEngine.h"
+
+using namespace edm::shared_memory;
+namespace testinter {
+
+  using ReturnedType = std::pair<edmtest::IntProduct, edm::RandomNumberGeneratorState>;
+
+  struct StreamCache {
+    StreamCache(const std::string& iConfig, int id)
+        : id_{id},
+          channel_("testProd", id_),
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferIndex()},
+          writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferIndex()},
+          deserializer_{readBuffer_},
+          bl_deserializer_{readBuffer_},
+          randSerializer_{writeBuffer_} {
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel_.setupWorker([&]() {
+        using namespace std::string_literals;
+        std::cout << id_ << " starting external process" << std::endl;
+        pipe_ = popen(("cmsTestInterProcessRandom "s + channel_.sharedMemoryName() + " " + channel_.uniqueID()).c_str(),
+                      "w");
+
+        if (NULL == pipe_) {
+          abort();
+        }
+
+        {
+          auto nlines = std::to_string(std::count(iConfig.begin(), iConfig.end(), '\n'));
+          auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
+          assert(result = nlines.size());
+          result = fwrite(iConfig.data(), sizeof(char), iConfig.size(), pipe_);
+          assert(result == iConfig.size());
+          fflush(pipe_);
+        }
+      });
+    }
+
+    template <typename SERIAL>
+    auto doTransition(SERIAL& iDeserializer, edm::Transition iTrans, unsigned long long iTransitionID)
+        -> decltype(iDeserializer.deserialize()) {
+      decltype(iDeserializer.deserialize()) value;
+      if (not channel_.doTransition(
+              [&value, this]() {
+                value = deserializer_.deserialize();
+                std::cout << id_ << " from shared memory " << value.first.value << std::endl;
+              },
+              iTrans,
+              iTransitionID)) {
+        std::cout << id_ << " FAILED waiting for external process" << std::endl;
+        externalFailed_ = true;
+        throw cms::Exception("ExternalFailed");
+      }
+      return value;
+    }
+    edmtest::IntProduct produce(unsigned long long iTransitionID, edm::StreamID iStream) {
+      edm::Service<edm::RandomNumberGenerator> gen;
+      auto& engine = gen->getEngine(iStream);
+      edm::RandomNumberGeneratorState state{engine.put(), engine.getSeed()};
+      randSerializer_.serialize(state);
+      auto v = doTransition(deserializer_, edm::Transition::Event, iTransitionID);
+      engine.setSeed(v.second.seed_, 0);
+      engine.get(v.second.state_);
+      return v.first;
+    }
+
+    ReturnedType beginLumiProduce(edm::RandomNumberGeneratorState const& iState,
+                                  unsigned long long iTransitionID,
+                                  edm::LuminosityBlockIndex iLumi) {
+      edm::Service<edm::RandomNumberGenerator> gen;
+      //NOTE: root serialize requires a `void*` not a `void const*` even though it doesn't modify the object
+      randSerializer_.serialize(const_cast<edm::RandomNumberGeneratorState&>(iState));
+      return doTransition(bl_deserializer_, edm::Transition::BeginLuminosityBlock, iTransitionID);
+    }
+
+    ~StreamCache() {
+      channel_.stopWorker();
+      pclose(pipe_);
+    }
+
+  private:
+    std::string unique_name(std::string iBase) {
+      auto pid = getpid();
+      iBase += std::to_string(pid);
+      iBase += "_";
+      iBase += std::to_string(id_);
+
+      return iBase;
+    }
+
+    int id_;
+    FILE* pipe_;
+    ControllerChannel channel_;
+    ReadBuffer readBuffer_;
+    WriteBuffer writeBuffer_;
+
+    using TCDeserializer = ROOTDeserializer<ReturnedType, ReadBuffer>;
+    TCDeserializer deserializer_;
+    TCDeserializer bl_deserializer_;
+    using TCSerializer = ROOTSerializer<edm::RandomNumberGeneratorState, WriteBuffer>;
+    TCSerializer randSerializer_;
+
+    bool externalFailed_ = false;
+  };
+
+}  // namespace testinter
+
+class TestInterProcessRandomProd
+    : public edm::global::EDProducer<edm::StreamCache<testinter::StreamCache>,
+                                     edm::LuminosityBlockCache<edm::RandomNumberGeneratorState>,
+                                     edm::BeginLuminosityBlockProducer> {
+public:
+  TestInterProcessRandomProd(edm::ParameterSet const&);
+
+  std::unique_ptr<testinter::StreamCache> beginStream(edm::StreamID) const final;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
+
+  void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final {}
+  void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final {}
+
+  std::shared_ptr<edm::RandomNumberGeneratorState> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                              edm::EventSetup const&) const final;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final {}
+
+  void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
+  void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+
+private:
+  edm::EDPutTokenT<edmtest::IntProduct> const token_;
+  edm::EDPutTokenT<edmtest::IntProduct> const blToken_;
+
+  std::string config_;
+
+  //This is set at beginStream and used for globalBeginRun
+  //The framework guarantees that non of those can happen concurrently
+  CMS_THREAD_SAFE mutable testinter::StreamCache* stream0Cache_ = nullptr;
+  //A stream which has finished processing the last lumi is used for the
+  // call to globalBeginLuminosityBlockProduce
+  mutable std::atomic<testinter::StreamCache*> availableForBeginLumi_;
+  //Streams all see the lumis in the same order, we want to be sure to pick a stream cache
+  // to use at globalBeginLumi which just finished the most recent lumi and not a previous one
+  mutable std::atomic<unsigned int> lastLumiIndex_ = 0;
+};
+
+TestInterProcessRandomProd::TestInterProcessRandomProd(edm::ParameterSet const& iPSet)
+    : token_{produces<edmtest::IntProduct>()},
+      blToken_{produces<edmtest::IntProduct, edm::Transition::BeginLuminosityBlock>("lumi")},
+      config_{iPSet.getUntrackedParameter<std::string>("@python_config")} {}
+
+std::unique_ptr<testinter::StreamCache> TestInterProcessRandomProd::beginStream(edm::StreamID iID) const {
+  auto const label = moduleDescription().moduleLabel();
+
+  using namespace std::string_literals;
+
+  std::string config = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+)_";
+  config += "process."s + label + "=" + config_ + "\n";
+  config += "process.moduleToTest(process."s + label + ")\n";
+  config += R"_(
+process.add_(cms.Service("InitRootHandlers", UnloadRootSigHandler=cms.untracked.bool(True)))
+  )_";
+
+  auto cache = std::make_unique<testinter::StreamCache>(config, iID.value());
+  if (iID.value() == 0) {
+    stream0Cache_ = cache.get();
+
+    availableForBeginLumi_ = stream0Cache_;
+  }
+
+  return cache;
+}
+
+void TestInterProcessRandomProd::produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const {
+  auto value = streamCache(iID)->produce(iEvent.id().event(), iID);
+  iEvent.emplace(token_, value);
+}
+
+std::shared_ptr<edm::RandomNumberGeneratorState> TestInterProcessRandomProd::globalBeginLuminosityBlock(
+    edm::LuminosityBlock const& iLumi, edm::EventSetup const&) const {
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iLumi.index());
+  return std::make_shared<edm::RandomNumberGeneratorState>(engine.put(), engine.getSeed());
+}
+
+void TestInterProcessRandomProd::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                                   edm::EventSetup const&) const {
+  while (not availableForBeginLumi_.load()) {
+  }
+
+  auto v = availableForBeginLumi_.load()->beginLumiProduce(
+      *luminosityBlockCache(iLuminosityBlock.index()), iLuminosityBlock.luminosityBlock(), iLuminosityBlock.index());
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iLuminosityBlock.index());
+  engine.setSeed(v.second.seed_, 0);
+  engine.get(v.second.state_);
+
+  iLuminosityBlock.emplace(blToken_, v.first);
+
+  lastLumiIndex_.store(iLuminosityBlock.index());
+}
+
+void TestInterProcessRandomProd::streamBeginLuminosityBlock(edm::StreamID iID,
+                                                            edm::LuminosityBlock const& iLuminosityBlock,
+                                                            edm::EventSetup const&) const {
+  auto cache = streamCache(iID);
+  if (cache != availableForBeginLumi_.load()) {
+    (void)cache->beginLumiProduce(
+        *luminosityBlockCache(iLuminosityBlock.index()), iLuminosityBlock.luminosityBlock(), iLuminosityBlock.index());
+  } else {
+    availableForBeginLumi_ = nullptr;
+  }
+}
+
+void TestInterProcessRandomProd::streamEndLuminosityBlock(edm::StreamID iID,
+                                                          edm::LuminosityBlock const& iLuminosityBlock,
+                                                          edm::EventSetup const&) const {
+  if (lastLumiIndex_ == iLuminosityBlock.index()) {
+    testinter::StreamCache* expected = nullptr;
+
+    availableForBeginLumi_.compare_exchange_strong(expected, streamCache(iID));
+  }
+}
+
+DEFINE_FWK_MODULE(TestInterProcessRandomProd);

--- a/FWCore/Services/BuildFile.xml
+++ b/FWCore/Services/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/Provenance"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Streamer"/>
+<use   name="SimDataFormats/RandomEngine"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>
@@ -12,6 +13,7 @@
 <use   name="tinyxml2"/>
 <use   name="rootcore"/>
 <use   name="roothistmatrix"/>
+<use   name="clhep"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FWCore/Services/interface/ExternalRandomNumberGeneratorService.h
+++ b/FWCore/Services/interface/ExternalRandomNumberGeneratorService.h
@@ -1,0 +1,61 @@
+#ifndef FWCore_Services_ExternalRandomNumberGeneratorService_h
+#define FWCore_Services_ExternalRandomNumberGeneratorService_h
+
+/** \class edm::ExternalRandomNumberGenerator
+
+  Description: Interface for obtaining random number engines.
+
+  Usage:
+*/
+
+#include <cstdint>
+#include <iosfwd>
+#include <memory>
+#include <vector>
+
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+namespace edm {
+
+  class ExternalRandomNumberGeneratorService : public RandomNumberGenerator {
+  public:
+    ExternalRandomNumberGeneratorService();
+
+    void setState(std::vector<unsigned long> const&, long seed);
+    std::vector<unsigned long> getState() const;
+
+    CLHEP::HepRandomEngine& getEngine(StreamID const&) final;
+    CLHEP::HepRandomEngine& getEngine(LuminosityBlockIndex const&) final;
+    std::unique_ptr<CLHEP::HepRandomEngine> cloneEngine(LuminosityBlockIndex const&) final;
+    std::uint32_t mySeed() const final;
+
+    // The following functions should not be used by general users.  They
+    // should only be called by Framework code designed to work with the
+    // service while it is saving the engine states or restoring them.
+    // The first two are called by the EventProcessor at special times.
+    // The next two are called by a dedicated producer module (RandomEngineStateProducer).
+
+    void preBeginLumi(LuminosityBlock const& lumi) final;
+    void postEventRead(Event const& event) final;
+
+    void setLumiCache(LuminosityBlockIndex, std::vector<RandomEngineState> const& iStates) final;
+    void setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) final;
+
+    std::vector<RandomEngineState> const& getEventCache(StreamID const&) const final;
+    std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const final;
+
+    void consumes(ConsumesCollector&& iC) const final;
+
+    /// For debugging purposes only.
+    void print(std::ostream& os) const final;
+
+  private:
+    ExternalRandomNumberGeneratorService(ExternalRandomNumberGeneratorService const&) = delete;
+    ExternalRandomNumberGeneratorService const& operator=(ExternalRandomNumberGeneratorService const&) = delete;
+
+    std::unique_ptr<CLHEP::HepRandomEngine> createFromState(std::vector<unsigned long> const&, long seed) const;
+
+    std::unique_ptr<CLHEP::HepRandomEngine> engine_;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/Services/src/ExternalRandomNumberGeneratorService.cc
+++ b/FWCore/Services/src/ExternalRandomNumberGeneratorService.cc
@@ -1,0 +1,89 @@
+#include "FWCore/Services/interface/ExternalRandomNumberGeneratorService.h"
+
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "CLHEP/Random/engineIDulong.h"
+#include "CLHEP/Random/JamesRandom.h"
+#include "CLHEP/Random/RanecuEngine.h"
+#include "CLHEP/Random/MixMaxRng.h"
+
+#include "SimDataFormats/RandomEngine/interface/RandomEngineState.h"
+
+using namespace edm;
+
+const std::vector<RandomEngineState> s_dummyStates;
+
+ExternalRandomNumberGeneratorService::ExternalRandomNumberGeneratorService() {}
+
+void ExternalRandomNumberGeneratorService::setState(std::vector<unsigned long> const& iState, long iSeed) {
+  if (not engine_) {
+    engine_ = createFromState(iState, iSeed);
+  } else {
+    engine_->get(iState);
+  }
+}
+
+std::vector<unsigned long> ExternalRandomNumberGeneratorService::getState() const { return engine_->put(); }
+
+CLHEP::HepRandomEngine& ExternalRandomNumberGeneratorService::getEngine(StreamID const&) { return *engine_; }
+CLHEP::HepRandomEngine& ExternalRandomNumberGeneratorService::getEngine(LuminosityBlockIndex const&) {
+  return *engine_;
+}
+
+std::unique_ptr<CLHEP::HepRandomEngine> ExternalRandomNumberGeneratorService::cloneEngine(LuminosityBlockIndex const&) {
+  std::vector<unsigned long> stateL = engine_->put();
+
+  long seedL = engine_->getSeed();
+  return createFromState(stateL, seedL);
+}
+
+std::unique_ptr<CLHEP::HepRandomEngine> ExternalRandomNumberGeneratorService::createFromState(
+    std::vector<unsigned long> const& stateL, long seedL) const {
+  std::unique_ptr<CLHEP::HepRandomEngine> newEngine;
+  if (stateL[0] == CLHEP::engineIDulong<CLHEP::HepJamesRandom>()) {
+    newEngine = std::make_unique<CLHEP::HepJamesRandom>(seedL);
+  } else if (stateL[0] == CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+    newEngine = std::make_unique<CLHEP::RanecuEngine>();
+  } else if (stateL[0] == CLHEP::engineIDulong<CLHEP::MixMaxRng>()) {
+    newEngine = std::make_unique<CLHEP::MixMaxRng>(seedL);
+    //} else if (stateL[0] == CLHEP::engineIDulong<TRandomAdaptor>()) {
+    //  newEngine = std::make_unique<TRandomAdaptor>(seedL);
+  } else {
+    // Sanity check, it should not be possible for this to happen.
+    throw Exception(errors::Unknown)
+        << "The ExternalRandomNumberGeneratorService is trying to clone unknown engine type\n";
+  }
+  if (stateL[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+    newEngine->setSeed(seedL, 0);
+  }
+  newEngine->get(stateL);
+  return newEngine;
+}
+
+std::uint32_t ExternalRandomNumberGeneratorService::mySeed() const { return 0; }
+
+void ExternalRandomNumberGeneratorService::preBeginLumi(LuminosityBlock const&) {}
+
+void ExternalRandomNumberGeneratorService::postEventRead(Event const&) {}
+
+void ExternalRandomNumberGeneratorService::setLumiCache(LuminosityBlockIndex,
+                                                        std::vector<RandomEngineState> const& iStates) {}
+void ExternalRandomNumberGeneratorService::setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) {}
+
+std::vector<RandomEngineState> const& ExternalRandomNumberGeneratorService::getEventCache(StreamID const&) const {
+  return s_dummyStates;
+}
+
+std::vector<RandomEngineState> const& ExternalRandomNumberGeneratorService::getLumiCache(
+    LuminosityBlockIndex const&) const {
+  return s_dummyStates;
+}
+
+void ExternalRandomNumberGeneratorService::consumes(ConsumesCollector&& iC) const {}
+
+/// For debugging purposes only.
+void ExternalRandomNumberGeneratorService::print(std::ostream& os) const {}

--- a/FWCore/Services/src/ExternalRandomNumberGeneratorService.cc
+++ b/FWCore/Services/src/ExternalRandomNumberGeneratorService.cc
@@ -15,7 +15,9 @@
 
 using namespace edm;
 
-const std::vector<RandomEngineState> s_dummyStates;
+namespace {
+  const std::vector<RandomEngineState> s_dummyStates;
+}
 
 ExternalRandomNumberGeneratorService::ExternalRandomNumberGeneratorService() {}
 

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -15,5 +15,6 @@
 </bin>
 <bin    file="test_catch2_*.cc" name="testFWCoreServicesCatch2">
   <use name="catch2"/>
+  <use name="clhep"/>
   <use name="FWCore/Services"/>
 </bin>

--- a/FWCore/Services/test/test_catch2_ExternalRandomNumberGeneratorService.cc
+++ b/FWCore/Services/test/test_catch2_ExternalRandomNumberGeneratorService.cc
@@ -1,0 +1,59 @@
+#include "FWCore/Services/interface/ExternalRandomNumberGeneratorService.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "CLHEP/Random/JamesRandom.h"
+#include "CLHEP/Random/RanecuEngine.h"
+#include "CLHEP/Random/MixMaxRng.h"
+
+//#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+namespace {
+  void test(CLHEP::HepRandomEngine& iRand, CLHEP::HepRandomEngine& iEngine) {
+    REQUIRE(iRand.flat() == iEngine.flat());
+    REQUIRE(iRand.flat() == iEngine.flat());
+    REQUIRE(iRand.flat() == iEngine.flat());
+    REQUIRE(iRand.flat() == iEngine.flat());
+  }
+}  // namespace
+
+TEST_CASE("Test ExternalRandomNumberGeneratorService", "[externalrandomnumbergeneratorservice]") {
+  SECTION("JamesRandom") {
+    edm::ExternalRandomNumberGeneratorService service;
+    CLHEP::HepJamesRandom rand(12345);
+
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+
+    //advance the one to see how it works
+    rand.flat();
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+  }
+
+  SECTION("RanecuEngine") {
+    edm::ExternalRandomNumberGeneratorService service;
+    CLHEP::RanecuEngine rand(12345);
+
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+
+    //advance the one to see how it works
+    rand.flat();
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+  }
+
+  SECTION("MixMaxRng") {
+    edm::ExternalRandomNumberGeneratorService service;
+    CLHEP::MixMaxRng rand(12345);
+
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+
+    //advance the one to see how it works
+    rand.flat();
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+  }
+}


### PR DESCRIPTION
#### PR description:

Adds a test to show how to use a EDProducer in cmsRun to drive a different EDProducer in a stand alone process where random engine state is passed back and forth.

#### PR validation:

The code compiles and framework unit tests pass.