### PR TITLE
Fix MET Significance, Covariance Matrix and unclustered energy lepton subtraction

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -50,7 +50,7 @@ void CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetu
       bool addcand = true;
       if (useDeltaRforFootprint_)
         for (const auto& it : vetoedPtrs)
-          if (reco::deltaR2(it->p4(), c->p4()) < 0.00000025) {
+          if ((it.isNonnull()) && (it.isAvailable()) && (reco::deltaR2(it->p4(), c->p4()) < 0.00000025)) {
             addcand = false;
             break;
           }

--- a/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
+++ b/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
@@ -1,0 +1,72 @@
+/**
+  Take as input:
+     - the electron and photon collections
+     - the electron and photon pf maps (edm::ValueMap<std::vector<reco::PFCandidateRef>>) pointing to old PF candidates
+  Produce as output:
+     - the electron and photon collections as VertexCompositePtrCandidates
+*/
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+
+class PFEGammaToCandidate : public edm::global::EDProducer<> {
+public:
+  explicit PFEGammaToCandidate(const edm::ParameterSet &iConfig);
+  ~PFEGammaToCandidate() override {}
+
+  void produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
+
+private:
+  edm::EDGetTokenT<edm::View<pat::Photon>> photons_;
+  edm::EDGetTokenT<edm::View<pat::Electron>> electrons_;
+  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> photon2pf_, electron2pf_;
+
+  template <typename T>
+  void run(edm::Event &iEvent,
+           const edm::EDGetTokenT<edm::View<T>> &colltoken,
+           const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> &oldmaptoken,
+           const std::string &name) const {
+    edm::Handle<edm::View<T>> handle;
+    iEvent.getByToken(colltoken, handle);
+
+    edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> oldmap;
+    iEvent.getByToken(oldmaptoken, oldmap);
+
+    auto result = std::make_unique<std::vector<reco::VertexCompositePtrCandidate>>();
+    for (unsigned int i = 0, n = handle->size(); i < n; ++i) {
+      auto &obj = (*handle)[i];
+      result->push_back(reco::VertexCompositePtrCandidate(obj));
+      for (reco::PFCandidateRef pfRef : (*oldmap)[obj.originalObjectRef()])
+        result->back().addDaughter(refToPtr(pfRef));
+    }
+    iEvent.put(std::move(result), name);
+  }
+};
+
+PFEGammaToCandidate::PFEGammaToCandidate(const edm::ParameterSet &iConfig)
+    : photons_(consumes<edm::View<pat::Photon>>(iConfig.getParameter<edm::InputTag>("photons"))),
+      electrons_(consumes<edm::View<pat::Electron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
+      photon2pf_(
+          consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>("photon2pf"))),
+      electron2pf_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
+          iConfig.getParameter<edm::InputTag>("electron2pf"))) {
+  produces<std::vector<reco::VertexCompositePtrCandidate>>("photons");
+  produces<std::vector<reco::VertexCompositePtrCandidate>>("electrons");
+}
+
+void PFEGammaToCandidate::produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  run<pat::Photon>(iEvent, photons_, photon2pf_, "photons");
+  run<pat::Electron>(iEvent, electrons_, electron2pf_, "electrons");
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PFEGammaToCandidate);

--- a/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
+++ b/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
@@ -10,6 +10,8 @@
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
@@ -21,29 +23,28 @@
 class PFEGammaToCandidate : public edm::global::EDProducer<> {
 public:
   explicit PFEGammaToCandidate(const edm::ParameterSet &iConfig);
-  ~PFEGammaToCandidate() override {}
+  ~PFEGammaToCandidate() override = default;
 
   void produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  edm::EDGetTokenT<edm::View<pat::Photon>> photons_;
-  edm::EDGetTokenT<edm::View<pat::Electron>> electrons_;
-  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> photon2pf_, electron2pf_;
+  const edm::EDGetTokenT<edm::View<pat::Photon>> photons_;
+  const edm::EDGetTokenT<edm::View<pat::Electron>> electrons_;
+  const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> photon2pf_, electron2pf_;
 
   template <typename T>
   void run(edm::Event &iEvent,
            const edm::EDGetTokenT<edm::View<T>> &colltoken,
            const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> &oldmaptoken,
            const std::string &name) const {
-    edm::Handle<edm::View<T>> handle;
-    iEvent.getByToken(colltoken, handle);
+    auto const &coll = iEvent.get(colltoken);
 
     edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> oldmap;
     iEvent.getByToken(oldmaptoken, oldmap);
 
     auto result = std::make_unique<std::vector<reco::VertexCompositePtrCandidate>>();
-    for (unsigned int i = 0, n = handle->size(); i < n; ++i) {
-      auto &obj = (*handle)[i];
+    for (auto const &obj : coll) {
       result->push_back(reco::VertexCompositePtrCandidate(obj));
       for (reco::PFCandidateRef pfRef : (*oldmap)[obj.originalObjectRef()])
         result->back().addDaughter(refToPtr(pfRef));
@@ -66,6 +67,15 @@ PFEGammaToCandidate::PFEGammaToCandidate(const edm::ParameterSet &iConfig)
 void PFEGammaToCandidate::produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   run<pat::Photon>(iEvent, photons_, photon2pf_, "photons");
   run<pat::Electron>(iEvent, electrons_, electron2pf_, "electrons");
+}
+
+void PFEGammaToCandidate::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("photons", edm::InputTag("selectedPatPhotons"));
+  desc.add<edm::InputTag>("electrons", edm::InputTag("selectedPatElectron"));
+  desc.add<edm::InputTag>("photon2pf", edm::InputTag("particleBasedIsolation", "gedPhotons"));
+  desc.add<edm::InputTag>("electron2pf", edm::InputTag("particleBasedIsolation", "gedGsfElectrons"));
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
+++ b/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
@@ -72,7 +72,7 @@ void PFEGammaToCandidate::produce(edm::StreamID iID, edm::Event &iEvent, const e
 void PFEGammaToCandidate::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("photons", edm::InputTag("selectedPatPhotons"));
-  desc.add<edm::InputTag>("electrons", edm::InputTag("selectedPatElectron"));
+  desc.add<edm::InputTag>("electrons", edm::InputTag("selectedPatElectrons"));
   desc.add<edm::InputTag>("photon2pf", edm::InputTag("particleBasedIsolation", "gedPhotons"));
   desc.add<edm::InputTag>("electron2pf", edm::InputTag("particleBasedIsolation", "gedGsfElectrons"));
   descriptions.addWithDefaultLabel(desc);

--- a/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
+++ b/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+pfEGammaToCandidate = cms.EDProducer("PFEGammaToCandidate",
+    electrons = cms.InputTag("selectedPatElectrons"),
+    photons = cms.InputTag("selectedPatPhotons"),
+    electron2pf = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap"),
+    photon2pf = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap")
+)

--- a/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
+++ b/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
@@ -1,8 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-pfEGammaToCandidate = cms.EDProducer("PFEGammaToCandidate",
-    electrons = cms.InputTag("selectedPatElectrons"),
-    photons = cms.InputTag("selectedPatPhotons"),
-    electron2pf = cms.InputTag("particleBasedIsolation","gedGsfElectrons"),
-    photon2pf = cms.InputTag("particleBasedIsolation","gedPhotons")
-)

--- a/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
+++ b/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 pfEGammaToCandidate = cms.EDProducer("PFEGammaToCandidate",
     electrons = cms.InputTag("selectedPatElectrons"),
     photons = cms.InputTag("selectedPatPhotons"),
-    electron2pf = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap"),
-    photon2pf = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap")
+    electron2pf = cms.InputTag("particleBasedIsolation","gedGsfElectrons"),
+    photon2pf = cms.InputTag("particleBasedIsolation","gedPhotons")
 )

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -499,16 +499,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp, addToTask = True)
             addToProcessAndTask(_myPatMet,  getattr(process,'patPFMet').clone(), process, task)
             getattr(process, _myPatMet).metSource = cms.InputTag("pfMet"+postfix)
-            getattr(process, _myPatMet).srcPFCands = self._parameters["pfCandCollection"].value
+            getattr(process, _myPatMet).srcPFCands = self.getvalue("pfCandCollection")
         if metType == "PF":
             getattr(process, _myPatMet).srcLeptons = \
-              cms.VInputTag(self._parameters["electronCollection"].value if self._parameters["onMiniAOD"].value else
-                              cms.InputTag("pfeGammaToCandidate","electrons"),
-                            self._parameters["muonCollection"].value,
-                            self._parameters["photonCollection"].value if self._parameters["onMiniAOD"].value else
-                              cms.InputTag("pfeGammaToCandidate","photons"))
+              cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
+                            self.getvalue("muonCollection"),
+                            self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))
 
-        if self._parameters["runOnData"].value:
+        if self.getvalue("runOnData"):
             getattr(process, _myPatMet).addGenMET  = False
 
 
@@ -619,20 +617,18 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #Enable MET significance if the type1 MET is computed
         if "T1" in correctionLevel:
             _myPatMet = "pat"+metType+"Met"+postfix
-            getattr(process, _myPatMet).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
-            getattr(process, _myPatMet).srcPFCands = self._parameters["pfCandCollection"].value
-            getattr(process, _myPatMet).srcLeptons = \
-              cms.VInputTag(self._parameters["electronCollection"].value if self._parameters["onMiniAOD"].value else
-                              cms.InputTag("pfeGammaToCandidate","electrons"),
-                            self._parameters["muonCollection"].value,
-                            self._parameters["photonCollection"].value if self._parameters["onMiniAOD"].value else
-                              cms.InputTag("pfeGammaToCandidate","photons"))
+            getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
+            getattr(process, _myPatMet).srcPFCands = self.getvalue("pfCandCollection")
+            getattr(process, _myPatMet).tons = \
+              cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
+                            self.getvalue("muonCollection"),
+                            self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))
             if postfix=="NoHF":
                 getattr(process, _myPatMet).computeMETSignificance = cms.bool(False)
-            if self._parameters["runOnData"].value:
+            if self.getvalue("runOnData"):
                 from RecoMET.METProducers.METSignificanceParams_cfi import METSignificanceParams_Data
                 getattr(process, _myPatMet).parameters = METSignificanceParams_Data
-            if self._parameters["Puppi"].value:
+            if self.getvalue("Puppi"):
                 getattr(process, _myPatMet).srcPFCands = cms.InputTag('puppiForMET')
                 getattr(process, _myPatMet).srcJets = cms.InputTag('cleanedPatJets'+postfix)
                 getattr(process, _myPatMet).srcJetSF = 'AK4PFPuppi'
@@ -642,14 +638,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #MET significance bypass for the patMETs from AOD
         if not self._parameters["onMiniAOD"].value and not postfix=="NoHF":
             _myPatMet = "patMETs"+postfix
-            getattr(process, _myPatMet).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
-            getattr(process, _myPatMet).srcPFCands=self._parameters["pfCandCollection"].value
+            getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
+            getattr(process, _myPatMet).srcPFCands=self.getvalue("pfCandCollection")
             getattr(process, _myPatMet).srcLeptons = \
-              cms.VInputTag(self._parameters["electronCollection"].value if self._parameters["onMiniAOD"].value else
-                              cms.InputTag("pfeGammaToCandidate","electrons"),
-                            self._parameters["muonCollection"].value,
-                            self._parameters["photonCollection"].value if self._parameters["onMiniAOD"].value else
-                              cms.InputTag("pfeGammaToCandidate","photons"))
+              cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
+                            self.getvalue("muonCollection"),
+                            self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))
 
         if hasattr(process, "patCaloMet"):
             getattr(process, "patCaloMet").computeMETSignificance = cms.bool(False)
@@ -820,7 +814,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                            veto = jetCollection,
                                            useDeltaRforFootprint = cms.bool(False)
                                            )
-            if self._parameters["Puppi"].value:
+            if self.getvalue("Puppi"):
               pfCandsNoJets.useDeltaRforFootprint = True
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
@@ -831,7 +825,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                 veto = electronCollection,
                                                 useDeltaRforFootprint = cms.bool(False),
                                                 )
-            if not self._parameters["onMiniAOD"].value:
+            if not self.getvalue("onMiniAOD"):
               pfCandsNoJetsNoEle.useDeltaRforFootprint = True
               pfCandsNoJetsNoEle.veto = "pfeGammaToCandidate:electrons"
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
@@ -843,7 +837,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               veto = muonCollection,
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
-            if not self._parameters["onMiniAOD"].value:
+            if not self.getvalue("onMiniAOD"):
               pfCandsNoJetsNoEleNoMu.useDeltaRforFootprint = True
             addToProcessAndTask("pfCandsNoJetsNoEleNoMu"+postfix, pfCandsNoJetsNoEleNoMu, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMu"+postfix)
@@ -854,7 +848,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               veto = tauCollection,
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
-            if self._parameters["Puppi"].value:
+            if self.getvalue("Puppi"):
               pfCandsNoJetsNoEleNoMuNoTau.useDeltaRforFootprint = True
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)
@@ -865,7 +859,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               veto = photonCollection,
                                               useDeltaRforFootprint = cms.bool(False),
                                               )
-            if not self._parameters["onMiniAOD"].value:
+            if not self.getvalue("onMiniAOD"):
               pfCandsForUnclusteredUnc.useDeltaRforFootprint = True
               pfCandsForUnclusteredUnc.veto = "pfeGammaToCandidate:photons"
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
@@ -1470,17 +1464,15 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 _myPatMet = 'patMETs'+postfix
                 addToProcessAndTask(_myPatMet, getattr(process,'patMETs' ).clone(), process, task)
                 getattr(process, _myPatMet).metSource = cms.InputTag("pfMetT1"+postfix)
-                getattr(process, _myPatMet).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
+                getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
                 getattr(process, _myPatMet).srcLeptons = \
-                  cms.VInputTag(self._parameters["electronCollection"].value if self._parameters["onMiniAOD"].value else
-                                  cms.InputTag("pfeGammaToCandidate","electrons"),
-                                self._parameters["muonCollection"].value,
-                                self._parameters["photonCollection"].value if self._parameters["onMiniAOD"].value else
-                                  cms.InputTag("pfeGammaToCandidate","photons"))
+                  cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
+                                self.getvalue("muonCollection"),
+                                self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))
                 if postfix=="NoHF":
                     getattr(process, _myPatMet).computeMETSignificance = cms.bool(False)
 
-                if self._parameters["Puppi"].value:
+                if self.getvalue("Puppi"):
                     getattr(process, _myPatMet).srcPFCands = cms.InputTag('puppiForMET')
                     getattr(process, _myPatMet).srcJets = cms.InputTag('cleanedPatJets'+postfix)
                     getattr(process, _myPatMet).srcJetSF = cms.string('AK4PFPuppi')

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -827,7 +827,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                 )
             if not self.getvalue("onMiniAOD"):
               pfCandsNoJetsNoEle.useDeltaRforFootprint = True
-              pfCandsNoJetsNoEle.veto = "pfeGammaToCandidate:electrons"
+              pfCandsNoJetsNoEle.veto = cms.InputTag("pfeGammaToCandidate","electrons")
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
@@ -861,7 +861,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               )
             if not self.getvalue("onMiniAOD"):
               pfCandsForUnclusteredUnc.useDeltaRforFootprint = True
-              pfCandsForUnclusteredUnc.veto = "pfeGammaToCandidate:photons"
+              pfCandsForUnclusteredUnc.veto = cms.InputTag("pfeGammaToCandidate","photons")
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -33,14 +33,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                           "enable/disable the uncertainty computation", Type=bool)
         self.addParameter(self._defaultParameters, 'produceIntermediateCorrections', False,
                           "enable/disable the production of all correction schemes (only for the most common)", Type=bool)
-        self.addParameter(self._defaultParameters, 'electronCollection', cms.InputTag('slimmedElectrons'),
+        self.addParameter(self._defaultParameters, 'electronCollection', cms.InputTag('selectedPatElectrons'),
                           "Input electron collection", Type=cms.InputTag, acceptNoneValue=True)
 #  empty default InputTag for photons to avoid double-counting wrt. cleanPatElectrons collection
-        self.addParameter(self._defaultParameters, 'photonCollection', cms.InputTag('slimmedPhotons'),
+        self.addParameter(self._defaultParameters, 'photonCollection', cms.InputTag('selectedPatPhotons'),
                           "Input photon collection", Type=cms.InputTag, acceptNoneValue=True)
-        self.addParameter(self._defaultParameters, 'muonCollection', cms.InputTag('slimmedMuons'),
+        self.addParameter(self._defaultParameters, 'muonCollection', cms.InputTag('selectedPatMuons'),
                           "Input muon collection", Type=cms.InputTag, acceptNoneValue=True)
-        self.addParameter(self._defaultParameters, 'tauCollection', cms.InputTag('slimmedTaus'),
+        self.addParameter(self._defaultParameters, 'tauCollection', cms.InputTag('selectedPatTaus'),
                           "Input tau collection", Type=cms.InputTag, acceptNoneValue=True)
         self.addParameter(self._defaultParameters, 'jetCollectionUnskimmed', cms.InputTag('patJets'),
                           "Input unskimmed jet collection for T1 MET computation", Type=cms.InputTag, acceptNoneValue=True)
@@ -364,6 +364,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #pre-preparation to run over miniAOD 
         if onMiniAOD:            
             self.miniAODConfigurationPre(process, patMetModuleSequence, pfCandCollection, postfix)
+        else:
+            from PhysicsTools.PatUtils.pfEGammaToCandidate_cfi import pfEGammaToCandidate
+            task = getPatAlgosToolsTask(process)
+            addToProcessAndTask("pfEGammaToCandidate", pfEGammaToCandidate.clone(
+	        electrons = electronCollection, photons = photonCollection), process, task)
 
         #default MET production
         self.produceMET(process, metType,patMetModuleSequence, postfix)
@@ -489,9 +494,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "patPFMet"+postfix).metSource = cms.InputTag("pfMet"+postfix)
             getattr(process, "patPFMet"+postfix).srcPFCands = self._parameters["pfCandCollection"].value
         if metType == "PF":
-            getattr(process, "patPFMet"+postfix).srcLeptons = cms.VInputTag(self._parameters["electronCollection"].value,
+            getattr(process, "patPFMet"+postfix).srcLeptons = cms.VInputTag(cms.InputTag("pfEGammaToCandidate","electrons") if not self._parameters["onMiniAOD"].value else self._parameters["electronCollection"].value,
                                                                             self._parameters["muonCollection"].value,
-                                                                            self._parameters["photonCollection"].value,
+                                                                            cms.InputTag("pfEGammaToCandidate","photons") if not self._parameters["onMiniAOD"].value else self._parameters["photonCollection"].value,
                                                                             )
 
         if self._parameters["runOnData"].value:
@@ -606,9 +611,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if "T1" in correctionLevel:
             getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
             getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = self._parameters["pfCandCollection"].value
-            getattr(process, "pat"+metType+"Met"+postfix).srcLeptons = cms.VInputTag(self._parameters["electronCollection"].value,
+            getattr(process, "pat"+metType+"Met"+postfix).srcLeptons = cms.VInputTag(cms.InputTag("pfEGammaToCandidate","electrons") if not self._parameters["onMiniAOD"].value else self._parameters["electronCollection"].value,
                                                                                      self._parameters["muonCollection"].value,
-                                                                                     self._parameters["photonCollection"].value,
+                                                                                     cms.InputTag("pfEGammaToCandidate","photons") if not self._parameters["onMiniAOD"].value else self._parameters["photonCollection"].value,
                                                                                      )
             if postfix=="NoHF":
                 getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(False)
@@ -626,9 +631,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if not self._parameters["onMiniAOD"].value and not postfix=="NoHF":
             getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
             getattr(process, "patMETs"+postfix).srcPFCands=self._parameters["pfCandCollection"].value
-            getattr(process, "patMETs"+postfix).srcLeptons = cms.VInputTag(self._parameters["electronCollection"].value,
+            getattr(process, "patMETs"+postfix).srcLeptons = cms.VInputTag(cms.InputTag("pfEGammaToCandidate","electrons") if not self._parameters["onMiniAOD"].value else self._parameters["electronCollection"].value,
                                                                            self._parameters["muonCollection"].value,
-                                                                           self._parameters["photonCollection"].value,
+                                                                           cms.InputTag("pfEGammaToCandidate","photons") if not self._parameters["onMiniAOD"].value else self._parameters["photonCollection"].value,
                                                                            )
 
         if hasattr(process, "patCaloMet"):
@@ -809,8 +814,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             pfCandsNoJetsNoEle = cms.EDProducer("CandPtrProjector", 
                                                 src = cms.InputTag("pfCandsNoJets"+postfix),
                                                 veto = electronCollection,
-                                                useDeltaRforFootprint = cms.bool(True)
+                                                useDeltaRforFootprint = cms.bool(False),
                                                 )
+            if not self._parameters["onMiniAOD"].value:
+              pfCandsNoJetsNoEle.useDeltaRforFootprint = True
+              pfCandsNoJetsNoEle.veto = cms.InputTag("pfEGammaToCandidate","electrons")
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
@@ -818,8 +826,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             pfCandsNoJetsNoEleNoMu = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEle"+postfix),
                                               veto = muonCollection,
-                                              useDeltaRforFootprint = cms.bool(True)
+                                              useDeltaRforFootprint = cms.bool(False)
                                               )
+            if not self._parameters["onMiniAOD"].value:
+              pfCandsNoJetsNoEleNoMu.useDeltaRforFootprint = True
             addToProcessAndTask("pfCandsNoJetsNoEleNoMu"+postfix, pfCandsNoJetsNoEleNoMu, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMu"+postfix)
 
@@ -827,8 +837,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             pfCandsNoJetsNoEleNoMuNoTau = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMu"+postfix),
                                               veto = tauCollection,
-                                              useDeltaRforFootprint = cms.bool(True)
+                                              useDeltaRforFootprint = cms.bool(False)
                                               )
+            if not self._parameters["onMiniAOD"].value:
+              pfCandsNoJetsNoEleNoMuNoTau.useDeltaRforFootprint = True
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)
 
@@ -836,8 +848,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             pfCandsForUnclusteredUnc = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMuNoTau"+postfix),
                                               veto = photonCollection,
-                                              useDeltaRforFootprint = cms.bool(True)
+                                              useDeltaRforFootprint = cms.bool(False),
                                               )
+            if not self._parameters["onMiniAOD"].value:
+              pfCandsForUnclusteredUnc.useDeltaRforFootprint = True
+              pfCandsForUnclusteredUnc.veto = cms.InputTag("pfEGammaToCandidate","photons")
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)
 
@@ -1441,9 +1456,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 addToProcessAndTask('patMETs'+postfix, getattr(process,'patMETs' ).clone(), process, task)
                 getattr(process, "patMETs"+postfix).metSource = cms.InputTag("pfMetT1"+postfix)
                 getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
-                getattr(process, "patMETs"+postfix).srcLeptons = cms.VInputTag(self._parameters["electronCollection"].value,
+                getattr(process, "patMETs"+postfix).srcLeptons = cms.VInputTag(cms.InputTag("pfEGammaToCandidate","electrons") if not self._parameters["onMiniAOD"].value else self._parameters["electronCollection"].value,
                                                                                self._parameters["muonCollection"].value,
-                                                                               self._parameters["photonCollection"].value,
+                                                                               cms.InputTag("pfEGammaToCandidate","photons") if not self._parameters["onMiniAOD"].value else self._parameters["photonCollection"].value,
                                                                                )
                 if postfix=="NoHF":
                     getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(False)
@@ -1904,10 +1919,10 @@ runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()
 # miniAOD production ===========================
 def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                         jetCollUnskimmed="patJets",
-                                        photonColl="slimmedPhotons",
-                                        electronColl="slimmedElectrons",
-                                        muonColl="slimmedMuons",
-                                        tauColl="slimmedTaus",
+                                        photonColl="selectedPatPhotons",
+                                        electronColl="selectedPatElectrons",
+                                        muonColl="selectedPatMuons",
+                                        tauColl="selectedPatTaus",
                                         pfCandColl = "particleFlow",
                                         jetCleaning="LepClean",
                                         jetSelection="pt>15 && abs(eta)<9.9",

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -808,7 +808,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #electron projection ==
             pfCandsNoJetsNoEle = cms.EDProducer("CandPtrProjector", 
                                                 src = cms.InputTag("pfCandsNoJets"+postfix),
-                                                veto = electronCollection
+                                                veto = electronCollection,
+                                                useDeltaRforFootprint = cms.bool(True)
                                                 )
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
@@ -816,7 +817,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #muon projection ==
             pfCandsNoJetsNoEleNoMu = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEle"+postfix),
-                                              veto = muonCollection
+                                              veto = muonCollection,
+                                              useDeltaRforFootprint = cms.bool(True)
                                               )
             addToProcessAndTask("pfCandsNoJetsNoEleNoMu"+postfix, pfCandsNoJetsNoEleNoMu, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMu"+postfix)
@@ -824,7 +826,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #tau projection ==
             pfCandsNoJetsNoEleNoMuNoTau = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMu"+postfix),
-                                              veto = tauCollection
+                                              veto = tauCollection,
+                                              useDeltaRforFootprint = cms.bool(True)
                                               )
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)
@@ -832,7 +835,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #photon projection ==
             pfCandsForUnclusteredUnc = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMuNoTau"+postfix),
-                                              veto = photonCollection
+                                              veto = photonCollection,
+                                              useDeltaRforFootprint = cms.bool(True)
                                               )
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -619,7 +619,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             _myPatMet = "pat"+metType+"Met"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
             getattr(process, _myPatMet).srcPFCands = self.getvalue("pfCandCollection")
-            getattr(process, _myPatMet).tons = \
+            getattr(process, _myPatMet).srcLeptons = \
               cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
                             self.getvalue("muonCollection"),
                             self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -368,8 +368,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             from PhysicsTools.PatUtils.pfeGammaToCandidate_cfi import pfeGammaToCandidate
             task = getPatAlgosToolsTask(process)
             addToProcessAndTask("pfeGammaToCandidate", pfeGammaToCandidate.clone(
-                                  electrons = electronCollection,
-                                  photons = photonCollection),
+                                  electrons = copy.copy(electronCollection),
+                                  photons = copy.copy(photonCollection)),
                                 process, task)
             if hasattr(process,"patElectrons") and process.patElectrons.electronSource == cms.InputTag("reducedEgamma","reducedGedGsfElectrons"):
                 process.pfeGammaToCandidate.electron2pf = "reducedEgamma:reducedGsfElectronPfCandMap"
@@ -499,12 +499,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp, addToTask = True)
             addToProcessAndTask(_myPatMet,  getattr(process,'patPFMet').clone(), process, task)
             getattr(process, _myPatMet).metSource = cms.InputTag("pfMet"+postfix)
-            getattr(process, _myPatMet).srcPFCands = self.getvalue("pfCandCollection")
+            getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
         if metType == "PF":
             getattr(process, _myPatMet).srcLeptons = \
-              cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
-                            self.getvalue("muonCollection"),
-                            self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))
+              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","electrons"),
+                            copy.copy(self.getvalue("muonCollection")),
+                            copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","photons"))
 
         if self.getvalue("runOnData"):
             getattr(process, _myPatMet).addGenMET  = False
@@ -618,11 +620,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if "T1" in correctionLevel:
             _myPatMet = "pat"+metType+"Met"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
-            getattr(process, _myPatMet).srcPFCands = self.getvalue("pfCandCollection")
+            getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
             getattr(process, _myPatMet).srcLeptons = \
-              cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
-                            self.getvalue("muonCollection"),
-                            self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))
+              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","electrons"),
+                            copy.copy(self.getvalue("muonCollection")),
+                            copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","photons"))
             if postfix=="NoHF":
                 getattr(process, _myPatMet).computeMETSignificance = cms.bool(False)
             if self.getvalue("runOnData"):
@@ -639,11 +643,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if not self._parameters["onMiniAOD"].value and not postfix=="NoHF":
             _myPatMet = "patMETs"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
-            getattr(process, _myPatMet).srcPFCands=self.getvalue("pfCandCollection")
+            getattr(process, _myPatMet).srcPFCands=copy.copy(self.getvalue("pfCandCollection"))
             getattr(process, _myPatMet).srcLeptons = \
-              cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
-                            self.getvalue("muonCollection"),
-                            self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))
+              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","electrons"),
+                            copy.copy(self.getvalue("muonCollection")),
+                            copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","photons"))
 
         if hasattr(process, "patCaloMet"):
             getattr(process, "patCaloMet").computeMETSignificance = cms.bool(False)
@@ -811,7 +817,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #Jet projection ==
             pfCandsNoJets = cms.EDProducer("CandPtrProjector", 
                                            src = pfCandCollection, 
-                                           veto = jetCollection,
+                                           veto = copy.copy(jetCollection),
                                            useDeltaRforFootprint = cms.bool(False)
                                            )
             if self.getvalue("Puppi"):
@@ -822,19 +828,19 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #electron projection ==
             pfCandsNoJetsNoEle = cms.EDProducer("CandPtrProjector", 
                                                 src = cms.InputTag("pfCandsNoJets"+postfix),
-                                                veto = electronCollection,
+                                                veto = copy.copy(electronCollection),
                                                 useDeltaRforFootprint = cms.bool(False),
                                                 )
             if not self.getvalue("onMiniAOD"):
               pfCandsNoJetsNoEle.useDeltaRforFootprint = True
-              pfCandsNoJetsNoEle.veto = cms.InputTag("pfeGammaToCandidate","electrons")
+              pfCandsNoJetsNoEle.veto = "pfeGammaToCandidate:electrons"
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
             #muon projection ==
             pfCandsNoJetsNoEleNoMu = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEle"+postfix),
-                                              veto = muonCollection,
+                                              veto = copy.copy(muonCollection),
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
             if not self.getvalue("onMiniAOD"):
@@ -845,7 +851,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #tau projection ==
             pfCandsNoJetsNoEleNoMuNoTau = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMu"+postfix),
-                                              veto = tauCollection,
+                                              veto = copy.copy(tauCollection),
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
             if self.getvalue("Puppi"):
@@ -856,12 +862,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #photon projection ==
             pfCandsForUnclusteredUnc = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMuNoTau"+postfix),
-                                              veto = photonCollection,
+                                              veto = copy.copy(photonCollection),
                                               useDeltaRforFootprint = cms.bool(False),
                                               )
             if not self.getvalue("onMiniAOD"):
               pfCandsForUnclusteredUnc.useDeltaRforFootprint = True
-              pfCandsForUnclusteredUnc.veto = cms.InputTag("pfeGammaToCandidate","photons")
+              pfCandsForUnclusteredUnc.veto = "pfeGammaToCandidate:photons"
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)
 
@@ -1466,9 +1472,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 getattr(process, _myPatMet).metSource = cms.InputTag("pfMetT1"+postfix)
                 getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
                 getattr(process, _myPatMet).srcLeptons = \
-                  cms.VInputTag(self.getvalue("electronCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
-                                self.getvalue("muonCollection"),
-                                self.getvalue("photonCollection") if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons"))
+                  cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                                  cms.InputTag("pfeGammaToCandidate","electrons"),
+                                copy.copy(self.getvalue("muonCollection")),
+                                copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
+                                  cms.InputTag("pfeGammaToCandidate","photons"))
                 if postfix=="NoHF":
                     getattr(process, _myPatMet).computeMETSignificance = cms.bool(False)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -368,7 +368,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             from PhysicsTools.PatUtils.pfEGammaToCandidate_cfi import pfEGammaToCandidate
             task = getPatAlgosToolsTask(process)
             addToProcessAndTask("pfEGammaToCandidate", pfEGammaToCandidate.clone(
-	        electrons = electronCollection, photons = photonCollection), process, task)
+                                  electrons = electronCollection,
+                                  photons = photonCollection),
+                                process, task)
+            if hasattr(process,"patElectrons") and process.patElectrons.electronSource == cms.InputTag("reducedEgamma","reducedGedGsfElectrons"):
+                process.pfEGammaToCandidate.electron2pf = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap")
+            if hasattr(process,"patPhotons") and process.patPhotons.photonSource == cms.InputTag("reducedEgamma","reducedGedPhotons"):
+                process.pfEGammaToCandidate.photon2pf = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap")
 
         #default MET production
         self.produceMET(process, metType,patMetModuleSequence, postfix)
@@ -839,7 +845,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               veto = tauCollection,
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
-            if not self._parameters["onMiniAOD"].value:
+            if self._parameters["Puppi"].value:
               pfCandsNoJetsNoEleNoMuNoTau.useDeltaRforFootprint = True
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -65,13 +65,10 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
 
   // subtract leptons out of sumPtUnclustered
   for (const auto& lep_i : leptons) {
-    for (const auto& lep : *lep_i) {
-      if (lep.pt() > 10) {
-        for (unsigned int n = 0; n < lep.numberOfSourceCandidatePtrs(); n++) {
-          if (lep.sourceCandidatePtr(n).isNonnull() and lep.sourceCandidatePtr(n).isAvailable()) {
-            footprint.insert(lep.sourceCandidatePtr(n));
-          }
-        }
+    for (const auto& lep : lep_i->ptrs()) {
+      if (lep->pt() > 10) {
+        for (unsigned int n = 0; n < lep->numberOfSourceCandidatePtrs(); n++)
+          footprint.insert(lep->sourceCandidatePtr(n));
       }
     }
   }
@@ -81,9 +78,7 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
     if (!cleanJet(jet, leptons))
       continue;
     for (unsigned int n = 0; n < jet.numberOfSourceCandidatePtrs(); n++) {
-      if (jet.sourceCandidatePtr(n).isNonnull() and jet.sourceCandidatePtr(n).isAvailable()) {
-        footprint.insert(jet.sourceCandidatePtr(n));
-      }
+      footprint.insert(jet.sourceCandidatePtr(n));
     }
   }
 
@@ -94,7 +89,7 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
     if (footprint.find(pfCandidates->ptrAt(i)) == footprint.end()) {
       //dP4 recovery
       for (const auto& it : footprint) {
-        if (reco::deltaR2(it->p4(), (*pfCandidates)[i].p4()) < 0.00000025) {
+        if ((it.isNonnull()) && (it.isAvailable()) && (reco::deltaR2(it->p4(), (*pfCandidates)[i].p4()) < 0.00000025)) {
           cleancand = false;
           break;
         }


### PR DESCRIPTION
#### PR description:

Resolve issue #25849

selectedPatLeptons have no sourceCandidatePtrs linked to them.
Therefore lepton subtraction from unclustered energy fails in METSignficance.cc.
slimmedLeptons have properly linked sourceCandidatePtrs and allows lepton subtraction from unclustered energy.
This resulted in a disagreement between MET significance, unclustered energy and covariance matrix stored in MiniAOD and recomputed out of MiniAOD.
The value in MiniAOD was wrong and is now fixed by converting electrons/photons into candidates with sourceCandidatePtrs when running on RECO.

#### PR validation:

It was checked that METSignficance.cc now sees all the lepton PF candidates, which were previously not seen on workflow 136.8311.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport to 106X for UL re-miniAOD in #29392.