### PR TITLE
Fix MET Significance, Covariance Matrix and unclustered energy lepton subtraction [10_6_X]

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -55,7 +55,7 @@ CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup con
       bool addcand = true;
       if (useDeltaRforFootprint_)
         for( const auto& it : vetoedPtrs)
-          if (reco::deltaR2(it->p4(),c->p4())<0.00000025) {
+          if ((it.isNonnull()) && (it.isAvailable()) && (reco::deltaR2(it->p4(), c->p4()) < 0.00000025)) {
             addcand = false;
             break;
           }

--- a/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
+++ b/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
@@ -1,0 +1,72 @@
+/**
+  Take as input:
+     - the electron and photon collections
+     - the electron and photon pf maps (edm::ValueMap<std::vector<reco::PFCandidateRef>>) pointing to old PF candidates
+  Produce as output:
+     - the electron and photon collections as VertexCompositePtrCandidates
+*/
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+
+class PFEGammaToCandidate : public edm::global::EDProducer<> {
+public:
+  explicit PFEGammaToCandidate(const edm::ParameterSet &iConfig);
+  ~PFEGammaToCandidate() override {}
+
+  void produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
+
+private:
+  edm::EDGetTokenT<edm::View<pat::Photon>> photons_;
+  edm::EDGetTokenT<edm::View<pat::Electron>> electrons_;
+  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> photon2pf_, electron2pf_;
+
+  template <typename T>
+  void run(edm::Event &iEvent,
+           const edm::EDGetTokenT<edm::View<T>> &colltoken,
+           const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> &oldmaptoken,
+           const std::string &name) const {
+    edm::Handle<edm::View<T>> handle;
+    iEvent.getByToken(colltoken, handle);
+
+    edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> oldmap;
+    iEvent.getByToken(oldmaptoken, oldmap);
+
+    auto result = std::make_unique<std::vector<reco::VertexCompositePtrCandidate>>();
+    for (unsigned int i = 0, n = handle->size(); i < n; ++i) {
+      auto &obj = (*handle)[i];
+      result->push_back(reco::VertexCompositePtrCandidate(obj));
+      for (reco::PFCandidateRef pfRef : (*oldmap)[obj.originalObjectRef()])
+        result->back().addDaughter(refToPtr(pfRef));
+    }
+    iEvent.put(std::move(result), name);
+  }
+};
+
+PFEGammaToCandidate::PFEGammaToCandidate(const edm::ParameterSet &iConfig)
+    : photons_(consumes<edm::View<pat::Photon>>(iConfig.getParameter<edm::InputTag>("photons"))),
+      electrons_(consumes<edm::View<pat::Electron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
+      photon2pf_(
+          consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>("photon2pf"))),
+      electron2pf_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
+          iConfig.getParameter<edm::InputTag>("electron2pf"))) {
+  produces<std::vector<reco::VertexCompositePtrCandidate>>("photons");
+  produces<std::vector<reco::VertexCompositePtrCandidate>>("electrons");
+}
+
+void PFEGammaToCandidate::produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  run<pat::Photon>(iEvent, photons_, photon2pf_, "photons");
+  run<pat::Electron>(iEvent, electrons_, electron2pf_, "electrons");
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PFEGammaToCandidate);

--- a/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
+++ b/PhysicsTools/PatUtils/plugins/PFEGammaToCandidate.cc
@@ -10,6 +10,8 @@
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
@@ -21,29 +23,28 @@
 class PFEGammaToCandidate : public edm::global::EDProducer<> {
 public:
   explicit PFEGammaToCandidate(const edm::ParameterSet &iConfig);
-  ~PFEGammaToCandidate() override {}
+  ~PFEGammaToCandidate() override = default;
 
   void produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  edm::EDGetTokenT<edm::View<pat::Photon>> photons_;
-  edm::EDGetTokenT<edm::View<pat::Electron>> electrons_;
-  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> photon2pf_, electron2pf_;
+  const edm::EDGetTokenT<edm::View<pat::Photon>> photons_;
+  const edm::EDGetTokenT<edm::View<pat::Electron>> electrons_;
+  const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> photon2pf_, electron2pf_;
 
   template <typename T>
   void run(edm::Event &iEvent,
            const edm::EDGetTokenT<edm::View<T>> &colltoken,
            const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> &oldmaptoken,
            const std::string &name) const {
-    edm::Handle<edm::View<T>> handle;
-    iEvent.getByToken(colltoken, handle);
+    auto const &coll = iEvent.get(colltoken);
 
     edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> oldmap;
     iEvent.getByToken(oldmaptoken, oldmap);
 
     auto result = std::make_unique<std::vector<reco::VertexCompositePtrCandidate>>();
-    for (unsigned int i = 0, n = handle->size(); i < n; ++i) {
-      auto &obj = (*handle)[i];
+    for (auto const &obj : coll) {
       result->push_back(reco::VertexCompositePtrCandidate(obj));
       for (reco::PFCandidateRef pfRef : (*oldmap)[obj.originalObjectRef()])
         result->back().addDaughter(refToPtr(pfRef));
@@ -66,6 +67,15 @@ PFEGammaToCandidate::PFEGammaToCandidate(const edm::ParameterSet &iConfig)
 void PFEGammaToCandidate::produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   run<pat::Photon>(iEvent, photons_, photon2pf_, "photons");
   run<pat::Electron>(iEvent, electrons_, electron2pf_, "electrons");
+}
+
+void PFEGammaToCandidate::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("photons", edm::InputTag("selectedPatPhotons"));
+  desc.add<edm::InputTag>("electrons", edm::InputTag("selectedPatElectrons"));
+  desc.add<edm::InputTag>("photon2pf", edm::InputTag("particleBasedIsolation", "gedPhotons"));
+  desc.add<edm::InputTag>("electron2pf", edm::InputTag("particleBasedIsolation", "gedGsfElectrons"));
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
+++ b/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+pfEGammaToCandidate = cms.EDProducer("PFEGammaToCandidate",
+    electrons = cms.InputTag("selectedPatElectrons"),
+    photons = cms.InputTag("selectedPatPhotons"),
+    electron2pf = cms.InputTag("particleBasedIsolation","gedGsfElectrons"),
+    photon2pf = cms.InputTag("particleBasedIsolation","gedPhotons")
+)

--- a/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
+++ b/PhysicsTools/PatUtils/python/pfEGammaToCandidate_cfi.py
@@ -1,8 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-pfEGammaToCandidate = cms.EDProducer("PFEGammaToCandidate",
-    electrons = cms.InputTag("selectedPatElectrons"),
-    photons = cms.InputTag("selectedPatPhotons"),
-    electron2pf = cms.InputTag("particleBasedIsolation","gedGsfElectrons"),
-    photon2pf = cms.InputTag("particleBasedIsolation","gedPhotons")
-)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -506,12 +506,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, _myPatMet).metSource = cms.InputTag("pfMet"+postfix)
             getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
         if metType == "PF":
-            getattr(process, _myPatMet).srcLeptons = \
+            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+            run2_miniAOD_devel.toModify(getattr(process, _myPatMet), srcLeptons = \
               cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
                             copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
-                              cms.InputTag("pfeGammaToCandidate","photons"))
+                              cms.InputTag("pfeGammaToCandidate","photons")))
 
         if self.getvalue("runOnData"):
             getattr(process, _myPatMet).addGenMET  = False
@@ -626,12 +627,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             _myPatMet = "pat"+metType+"Met"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
             getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
-            getattr(process, _myPatMet).srcLeptons = \
+            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+            run2_miniAOD_devel.toModify(getattr(process, _myPatMet), srcLeptons = \
               cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
                             copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
-                              cms.InputTag("pfeGammaToCandidate","photons"))
+                              cms.InputTag("pfeGammaToCandidate","photons")))
             if postfix=="NoHF":
                 getattr(process, _myPatMet).computeMETSignificance = cms.bool(False)
             if self.getvalue("runOnData"):
@@ -649,12 +651,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             _myPatMet = "patMETs"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
             getattr(process, _myPatMet).srcPFCands=copy.copy(self.getvalue("pfCandCollection"))
-            getattr(process, _myPatMet).srcLeptons = \
+            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+            run2_miniAOD_devel.toModify(getattr(process, _myPatMet), srcLeptons = \
               cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
                             copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
-                              cms.InputTag("pfeGammaToCandidate","photons"))
+                              cms.InputTag("pfeGammaToCandidate","photons")))
 
         if hasattr(process, "patCaloMet"):
             getattr(process, "patCaloMet").computeMETSignificance = cms.bool(False)
@@ -1481,12 +1484,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 addToProcessAndTask(_myPatMet, getattr(process,'patMETs' ).clone(), process, task)
                 getattr(process, _myPatMet).metSource = cms.InputTag("pfMetT1"+postfix)
                 getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
-                getattr(process, _myPatMet).srcLeptons = \
+                from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+                run2_miniAOD_devel.toModify(getattr(process, _myPatMet), srcLeptons = \
                   cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                                   cms.InputTag("pfeGammaToCandidate","electrons"),
                                 copy.copy(self.getvalue("muonCollection")),
                                 copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
-                                  cms.InputTag("pfeGammaToCandidate","photons"))
+                                  cms.InputTag("pfeGammaToCandidate","photons")))
                 if postfix=="NoHF":
                     getattr(process, _myPatMet).computeMETSignificance = cms.bool(False)
 
@@ -1745,6 +1749,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if self._parameters["metType"].value == "PF": # not hasattr(process, "pfMet"+postfix)
             if "T1" in self._parameters['correctionLevel'].value:
                 getattr(process, "patPFMet"+postfix).srcJets = jetCollection
+                getattr(process, "patPFMet"+postfix).srcLeptons = cms.VInputTag(self._parameters["electronCollection"].value, 
+                                                                                self._parameters["muonCollection"].value,
+                                                                                self._parameters["photonCollection"].value,
+                                                                                )
             getattr(process, "patPFMet"+postfix).addGenMET  = False
             if not self._parameters["runOnData"].value:
                 getattr(process, "patPFMet"+postfix).addGenMET  = True

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -370,19 +370,16 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if onMiniAOD:            
             self.miniAODConfigurationPre(process, patMetModuleSequence, pfCandCollection, postfix)
         else:
-            from PhysicsTools.PatUtils.pfEGammaToCandidate_cfi import pfEGammaToCandidate
+            from PhysicsTools.PatUtils.pfeGammaToCandidate_cfi import pfeGammaToCandidate
             task = getPatAlgosToolsTask(process)
-            _task=task.copy()
-            addToProcessAndTask("pfEGammaToCandidate", pfEGammaToCandidate.clone(
-                                  electrons = electronCollection,
-                                  photons = photonCollection),
-                                process, _task)
-            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-            run2_miniAOD_devel.toReplaceWith(task, _task)
+            addToProcessAndTask("pfeGammaToCandidate", pfeGammaToCandidate.clone(
+                                  electrons = copy.copy(electronCollection),
+                                  photons = copy.copy(photonCollection)),
+                                process, task)
             if hasattr(process,"patElectrons") and process.patElectrons.electronSource == cms.InputTag("reducedEgamma","reducedGedGsfElectrons"):
-                run2_miniAOD_devel.toModify(process.pfEGammaToCandidate, electron2pf = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap"))
+                process.pfeGammaToCandidate.electron2pf = "reducedEgamma:reducedGsfElectronPfCandMap"
             if hasattr(process,"patPhotons") and process.patPhotons.photonSource == cms.InputTag("reducedEgamma","reducedGedPhotons"):
-                run2_miniAOD_devel.toModify(process.pfEGammaToCandidate, photon2pf = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap"))
+                process.pfeGammaToCandidate.photon2pf = "reducedEgamma:reducedPhotonPfCandMap"
 
         #default MET production
         self.produceMET(process, metType,patMetModuleSequence, postfix)
@@ -501,21 +498,23 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             task.add(process.patPFMetTxyCorrTask)
             task.add(process.jetCorrectorsTask)
 
-        if postfix != "" and metType == "PF" and not hasattr(process, 'pat'+metType+'Met'+postfix):
+        _myPatMet = 'pat'+metType+'Met'+postfix
+        if postfix != "" and metType == "PF" and not hasattr(process, _myPatMet):
             noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ]
             configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp, addToTask = True)
-            addToProcessAndTask('pat'+metType+'Met'+postfix,  getattr(process,'patPFMet' ).clone(), process, task)
-            getattr(process, "patPFMet"+postfix).metSource = cms.InputTag("pfMet"+postfix)
-            getattr(process, "patPFMet"+postfix).srcPFCands = self._parameters["pfCandCollection"].value
+            addToProcessAndTask(_myPatMet,  getattr(process,'patPFMet').clone(), process, task)
+            getattr(process, _myPatMet).metSource = cms.InputTag("pfMet"+postfix)
+            getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
         if metType == "PF":
-            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-            run2_miniAOD_devel.toModify(getattr(process, "patPFMet"+postfix), srcLeptons = cms.VInputTag(cms.InputTag("pfEGammaToCandidate","electrons") if not self._parameters["onMiniAOD"].value else self._parameters["electronCollection"].value,
-                                                                            self._parameters["muonCollection"].value,
-                                                                            cms.InputTag("pfEGammaToCandidate","photons") if not self._parameters["onMiniAOD"].value else self._parameters["photonCollection"].value,
-                                                                            ))
+            getattr(process, _myPatMet).srcLeptons = \
+              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","electrons"),
+                            copy.copy(self.getvalue("muonCollection")),
+                            copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","photons"))
 
-        if self._parameters["runOnData"].value:
-            getattr(process, "patPFMet"+postfix).addGenMET  = False
+        if self.getvalue("runOnData"):
+            getattr(process, _myPatMet).addGenMET  = False
 
 
         #MM: FIXME MVA
@@ -523,11 +522,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
            # process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
             mvaMetProducer = self.createMVAMETModule(process)
             addToProcessAndTask('pfMVAMet'+postfix, mvaMetProducer, process, task)
-            addToProcessAndTask('pat'+metType+'Met'+postfix,
+            addToProcessAndTask(_myPatMet,
                                 getattr(process,'patPFMet' ).clone(metSource = cms.InputTag('pfMVAMet')),
                                 process, task)
 
-        metModuleSequence += getattr(process, 'pat'+metType+'Met'+postfix )
+        metModuleSequence += getattr(process, _myPatMet )
 
 #====================================================================================================
     def getCorrectedMET(self, process, metType, correctionLevel,produceIntermediateCorrections, 
@@ -624,38 +623,38 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         #Enable MET significance if the type1 MET is computed
         if "T1" in correctionLevel:
-            getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
-            getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = self._parameters["pfCandCollection"].value
-            getattr(process, "pat"+metType+"Met"+postfix).srcLeptons = cms.VInputTag(self._parameters["electronCollection"].value,
-                                                                                     self._parameters["muonCollection"].value,
-                                                                                     self._parameters["photonCollection"].value,
-                                                                                     )
-            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-            run2_miniAOD_devel.toModify(getattr(process, "pat"+metType+"Met"+postfix), srcLeptons = cms.VInputTag(cms.InputTag("pfEGammaToCandidate","electrons") if not self._parameters["onMiniAOD"].value else self._parameters["electronCollection"].value,
-                                                                                     self._parameters["muonCollection"].value,
-                                                                                     cms.InputTag("pfEGammaToCandidate","photons") if not self._parameters["onMiniAOD"].value else self._parameters["photonCollection"].value,
-                                                                                     ))
+            _myPatMet = "pat"+metType+"Met"+postfix
+            getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
+            getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
+            getattr(process, _myPatMet).srcLeptons = \
+              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","electrons"),
+                            copy.copy(self.getvalue("muonCollection")),
+                            copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","photons"))
             if postfix=="NoHF":
-                getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(False)
-            if self._parameters["runOnData"].value:
+                getattr(process, _myPatMet).computeMETSignificance = cms.bool(False)
+            if self.getvalue("runOnData"):
                 from RecoMET.METProducers.METSignificanceParams_cfi import METSignificanceParams_Data
-                getattr(process, "pat"+metType+"Met"+postfix).parameters = METSignificanceParams_Data
-            if self._parameters["Puppi"].value:
-                getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = cms.InputTag('puppiForMET')
-                getattr(process, "pat"+metType+"Met"+postfix).srcJets = cms.InputTag('cleanedPatJets'+postfix)
-                getattr(process, "pat"+metType+"Met"+postfix).srcJetSF = cms.string('AK4PFPuppi')
-                getattr(process, "pat"+metType+"Met"+postfix).srcJetResPt = cms.string('AK4PFPuppi_pt')
-                getattr(process, "pat"+metType+"Met"+postfix).srcJetResPhi = cms.string('AK4PFPuppi_phi')
+                getattr(process, _myPatMet).parameters = METSignificanceParams_Data
+            if self.getvalue("Puppi"):
+                getattr(process, _myPatMet).srcPFCands = cms.InputTag('puppiForMET')
+                getattr(process, _myPatMet).srcJets = cms.InputTag('cleanedPatJets'+postfix)
+                getattr(process, _myPatMet).srcJetSF = 'AK4PFPuppi'
+                getattr(process, _myPatMet).srcJetResPt = 'AK4PFPuppi_pt'
+                getattr(process, _myPatMet).srcJetResPhi = 'AK4PFPuppi_phi'
 
         #MET significance bypass for the patMETs from AOD
         if not self._parameters["onMiniAOD"].value and not postfix=="NoHF":
-            getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
-            getattr(process, "patMETs"+postfix).srcPFCands=self._parameters["pfCandCollection"].value
-            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-            run2_miniAOD_devel.toModify(getattr(process, "patMETs"+postfix), srcLeptons = cms.VInputTag(cms.InputTag("pfEGammaToCandidate","electrons") if not self._parameters["onMiniAOD"].value else self._parameters["electronCollection"].value,
-                                                                           self._parameters["muonCollection"].value,
-                                                                           cms.InputTag("pfEGammaToCandidate","photons") if not self._parameters["onMiniAOD"].value else self._parameters["photonCollection"].value,
-                                                                           ))
+            _myPatMet = "patMETs"+postfix
+            getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
+            getattr(process, _myPatMet).srcPFCands=copy.copy(self.getvalue("pfCandCollection"))
+            getattr(process, _myPatMet).srcLeptons = \
+              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","electrons"),
+                            copy.copy(self.getvalue("muonCollection")),
+                            copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
+                              cms.InputTag("pfeGammaToCandidate","photons"))
 
         if hasattr(process, "patCaloMet"):
             getattr(process, "patCaloMet").computeMETSignificance = cms.bool(False)
@@ -823,10 +822,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #Jet projection ==
             pfCandsNoJets = cms.EDProducer("CandPtrProjector", 
                                            src = pfCandCollection, 
-                                           veto = jetCollection,
+                                           veto = copy.copy(jetCollection),
                                            useDeltaRforFootprint = cms.bool(False)
                                            )
-            if self._parameters["Puppi"].value:
+            if self.getvalue("Puppi"):
               from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
               run2_miniAOD_devel.toModify(pfCandsNoJets, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
@@ -835,23 +834,23 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #electron projection ==
             pfCandsNoJetsNoEle = cms.EDProducer("CandPtrProjector", 
                                                 src = cms.InputTag("pfCandsNoJets"+postfix),
-                                                veto = electronCollection,
+                                                veto = copy.copy(electronCollection),
                                                 useDeltaRforFootprint = cms.bool(False)
                                                 )
-            if not self._parameters["onMiniAOD"].value:
+            if not self.getvalue("onMiniAOD"):
               from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
               run2_miniAOD_devel.toModify(pfCandsNoJetsNoEle, useDeltaRforFootprint = True)
-              run2_miniAOD_devel.toModify(pfCandsNoJetsNoEle, veto = cms.InputTag("pfEGammaToCandidate","electrons"))
+              run2_miniAOD_devel.toModify(pfCandsNoJetsNoEle, veto = cms.InputTag("pfeGammaToCandidate","electrons"))
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
             #muon projection ==
             pfCandsNoJetsNoEleNoMu = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEle"+postfix),
-                                              veto = muonCollection,
+                                              veto = copy.copy(muonCollection),
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
-            if not self._parameters["onMiniAOD"].value:
+            if not self.getvalue("onMiniAOD"):
               from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
               run2_miniAOD_devel.toModify(pfCandsNoJetsNoEleNoMu, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJetsNoEleNoMu"+postfix, pfCandsNoJetsNoEleNoMu, process, task)
@@ -860,10 +859,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #tau projection ==
             pfCandsNoJetsNoEleNoMuNoTau = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMu"+postfix),
-                                              veto = tauCollection,
+                                              veto = copy.copy(tauCollection),
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
-            if self._parameters["Puppi"].value:
+            if self.getvalue("Puppi"):
               from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
               run2_miniAOD_devel.toModify(pfCandsNoJetsNoEleNoMuNoTau, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
@@ -872,13 +871,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #photon projection ==
             pfCandsForUnclusteredUnc = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMuNoTau"+postfix),
-                                              veto = photonCollection,
+                                              veto = copy.copy(photonCollection),
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
-            if not self._parameters["onMiniAOD"].value:
+            if not self.getvalue("onMiniAOD"):
               from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
               run2_miniAOD_devel.toModify(pfCandsForUnclusteredUnc, useDeltaRforFootprint = True)
-              run2_miniAOD_devel.toModify(pfCandsForUnclusteredUnc, veto = cms.InputTag("pfEGammaToCandidate","electrons"))
+              run2_miniAOD_devel.toModify(pfCandsForUnclusteredUnc, veto = cms.InputTag("pfeGammaToCandidate","photons"))
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)
 
@@ -1478,24 +1477,25 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 #correction duplication needed
                 getattr(process, "pfMetT1"+postfix).src = cms.InputTag("pfMet"+postfix)
                 patMetModuleSequence += getattr(process, "pfMetT1"+postfix)
-
-                addToProcessAndTask('patMETs'+postfix, getattr(process,'patMETs' ).clone(), process, task)
-                getattr(process, "patMETs"+postfix).metSource = cms.InputTag("pfMetT1"+postfix)
-                getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
-                from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-                run2_miniAOD_devel.toModify(getattr(process, "patMETs"+postfix), srcLeptons = cms.VInputTag(cms.InputTag("pfEGammaToCandidate","electrons") if not self._parameters["onMiniAOD"].value else self._parameters["electronCollection"].value,
-                                                                               self._parameters["muonCollection"].value,
-                                                                               cms.InputTag("pfEGammaToCandidate","photons") if not self._parameters["onMiniAOD"].value else self._parameters["photonCollection"].value,
-                                                                               ))
+                _myPatMet = 'patMETs'+postfix
+                addToProcessAndTask(_myPatMet, getattr(process,'patMETs' ).clone(), process, task)
+                getattr(process, _myPatMet).metSource = cms.InputTag("pfMetT1"+postfix)
+                getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
+                getattr(process, _myPatMet).srcLeptons = \
+                  cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                                  cms.InputTag("pfeGammaToCandidate","electrons"),
+                                copy.copy(self.getvalue("muonCollection")),
+                                copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
+                                  cms.InputTag("pfeGammaToCandidate","photons"))
                 if postfix=="NoHF":
-                    getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(False)
+                    getattr(process, _myPatMet).computeMETSignificance = cms.bool(False)
 
-                if self._parameters["Puppi"].value:
-                    getattr(process, 'patMETs'+postfix).srcPFCands = cms.InputTag('puppiForMET')
-                    getattr(process, 'patMETs'+postfix).srcJets = cms.InputTag('cleanedPatJets'+postfix)
-                    getattr(process, 'patMETs'+postfix).srcJetSF = cms.string('AK4PFPuppi')
-                    getattr(process, 'patMETs'+postfix).srcJetResPt = cms.string('AK4PFPuppi_pt')
-                    getattr(process, 'patMETs'+postfix).srcJetResPhi = cms.string('AK4PFPuppi_phi')
+                if self.getvalue("Puppi"):
+                    getattr(process, _myPatMet).srcPFCands = cms.InputTag('puppiForMET')
+                    getattr(process, _myPatMet).srcJets = cms.InputTag('cleanedPatJets'+postfix)
+                    getattr(process, _myPatMet).srcJetSF = cms.string('AK4PFPuppi')
+                    getattr(process, _myPatMet).srcJetResPt = cms.string('AK4PFPuppi_pt')
+                    getattr(process, _myPatMet).srcJetResPhi = cms.string('AK4PFPuppi_phi')
 
 
     def extractMET(self, process, correctionLevel, patMetModuleSequence, postfix):

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -70,15 +70,12 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 
    // subtract leptons out of sumPt
    for ( const auto& lep_i : leptons ) {
-     for( const auto& lep : *lep_i ) {
-       if( lep.pt() > 10 ){
-	 for( unsigned int n=0; n < lep.numberOfSourceCandidatePtrs(); n++ ){
-	   if( lep.sourceCandidatePtr(n).isNonnull() and lep.sourceCandidatePtr(n).isAvailable() ){
-	     footprint.insert(lep.sourceCandidatePtr(n));
-	   } 
-	 }
-       }
+    for (const auto& lep : lep_i->ptrs()) {
+      if (lep->pt() > 10) {
+        for (unsigned int n = 0; n < lep->numberOfSourceCandidatePtrs(); n++)
+          footprint.insert(lep->sourceCandidatePtr(n));
      }
+    }
    }
    // subtract jets out of sumPt
    for(const auto& jet : jets) {
@@ -86,9 +83,7 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
      // disambiguate jets and leptons
      if(!cleanJet(jet, leptons) ) continue;
      for( unsigned int n=0; n < jet.numberOfSourceCandidatePtrs(); n++){
-       if( jet.sourceCandidatePtr(n).isNonnull() and jet.sourceCandidatePtr(n).isAvailable() ){
-	 footprint.insert(jet.sourceCandidatePtr(n));
-       }
+      footprint.insert(jet.sourceCandidatePtr(n));
      }
 
    }
@@ -105,8 +100,9 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
        for( const auto& it : footprint) {
 	 // Special treatment for PUPPI with dR, since jet candidates (puppi) and MET candidates (puppiForMet)
 	 // can't be matched through the sourceCandidatePtrs and may have different energy, but same direction.
-	 if( ((!useDeltaRforFootprint_) && ((it->p4()-(*pfCandidates)[i].p4()).Et2()<0.000025)) ||
-	     (( useDeltaRforFootprint_) && (reco::deltaR2(it->p4(),(*pfCandidates)[i].p4())<0.00000025)) ){
+	 if((it.isNonnull()) && (it.isAvailable()) &&
+            (((!useDeltaRforFootprint_) && ((it->p4()-(*pfCandidates)[i].p4()).Et2()<0.000025)) ||
+	     (( useDeltaRforFootprint_) && (reco::deltaR2(it->p4(),(*pfCandidates)[i].p4())<0.00000025)))){
 	   cleancand = false;
 	   break;
 	 }


### PR DESCRIPTION
#### PR description:

Resolve issue #25849

selectedPatLeptons have no sourceCandidatePtrs linked to them.
Therefore lepton subtraction from unclustered energy fails in METSignficance.cc.
slimmedLeptons have properly linked sourceCandidatePtrs and allows lepton subtraction from unclustered energy.
This resulted in a disagreement between MET significance, unclustered energy and covariance matrix stored in MiniAOD and recomputed out of MiniAOD.
The value in MiniAOD was wrong and is now fixed by using slimmedLeptons as well.

#### PR validation:

It was checked that METSignficance.cc now sees all the lepton PF candidates, which were previously not seen on workflow 136.8311.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #29385.