### PR TITLE
Replace validationHarvestingNoHLT with validationHarvesting in HI workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2811,7 +2811,7 @@ steps['HARVESTHI2018PPRECO']=merge([hiDefaults2018_ppReco,{'-s':'HARVESTING:vali
                                                            '--era' : 'Run2_2018_pp_on_AA',
                                                            '--filetype':'DQM'}])
 
-steps['HARVESTHI2018']=merge([hiDefaults2018,{'-s':'HARVESTING:validationHarvestingNoHLT+dqmHarvestingFakeHLT',
+steps['HARVESTHI2018']=merge([hiDefaults2018,{'-s':'HARVESTING:validationHarvesting+dqmHarvestingFakeHLT',
                     '--mc':'',
                     '--era' : 'Run2_2017',
                     '--filetype':'DQM',
@@ -2820,12 +2820,12 @@ steps['HARVESTHI2017']=merge([hiDefaults2017,{'-s':'HARVESTING:validationHarvest
                     '--mc':'',
                     '--era' : 'Run2_2017_pp_on_XeXe',
                     '--filetype':'DQM'}])
-steps['HARVESTHI2015']=merge([hiDefaults2015,{'-s':'HARVESTING:validationHarvestingNoHLT+dqmHarvestingFakeHLT',
+steps['HARVESTHI2015']=merge([hiDefaults2015,{'-s':'HARVESTING:validationHarvesting+dqmHarvestingFakeHLT',
                     '--mc':'',
                     '--era' : 'Run2_2016,Run2_HI',
                     '--filetype':'DQM',
                     '--scenario':'HeavyIons'}])
-steps['HARVESTHI2011']=merge([hiDefaults2011,{'-s':'HARVESTING:validationHarvestingNoHLT+dqmHarvestingFakeHLT',
+steps['HARVESTHI2011']=merge([hiDefaults2011,{'-s':'HARVESTING:validationHarvesting+dqmHarvestingFakeHLT',
                                               '--mc':'',
                                               '--filetype':'DQM'}])
 


### PR DESCRIPTION
#### PR description:

This PR fixes the errors obtained in wf 140.0 145.0 150.0.
These errors became visible after https://github.com/cms-sw/cmssw/pull/29343.

```
HARVESTING:validationHarvestingNoHLT+dqmHarvestingFakeHLT
entry file:step3_inDQM.root
Step: HARVESTING Spec: ['validationHarvestingNoHLT', 'dqmHarvestingFakeHLT']
validationHarvestingNoHLT is not a possible harvesting type. Available are [...]
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/nweek-02622/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_11_1_X_2020-04-02-1100/bin/slc7_amd64_gcc820/cmsDriver.py", line 56, in &lt;module&gt;
    run()
  File "/cvmfs/cms-ib.cern.ch/nweek-02622/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_11_1_X_2020-04-02-1100/bin/slc7_amd64_gcc820/cmsDriver.py", line 28, in run
    configBuilder.prepare()
  File "/cvmfs/cms-ib.cern.ch/nweek-02622/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_11_1_X_2020-04-02-1100/python/Configuration/Applications/ConfigBuilder.py", line 2127, in prepare
    self.addStandardSequences()
  File "/cvmfs/cms-ib.cern.ch/nweek-02622/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_11_1_X_2020-04-02-1100/python/Configuration/Applications/ConfigBuilder.py", line 759, in addStandardSequences
    getattr(self,"prepare_"+stepName)(sequence = '+'.join(stepSpec))
  File "/cvmfs/cms-ib.cern.ch/nweek-02622/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_11_1_X_2020-04-02-1100/python/Configuration/Applications/ConfigBuilder.py", line 2004, in prepare_HARVESTING
    getattr(self.process, name)
AttributeError: 'Process' object has no attribute 'validationHarvestingNoHLT'
```

We get this error because when we try to run `HARVESTING:validationHarvestingNoHLT` with `--scenario HeavyIons`, but  `validationHarvestingNoHLT` is not defined in 
https://github.com/cms-sw/cmssw/blob/master/Configuration/StandardSequences/python/HarvestingHeavyIons_cff.py ( called from https://github.com/cms-sw/cmssw/blob/master/Configuration/Applications/python/ConfigBuilder.py#L1040 )

`HARVESTHI2018`, `HARVESTHI2015`, `HARVESTHI2011` are the only Harvesting steps used with `--scenario HeavyIons`

#### PR validation:

The output of `runTheMatrix.py -l 140.0,145.0,150.0 --dryRun ` is ok after the fix 