### PR TITLE
added unit test to check for clang-tidy changes

### DIFF
--- a/Utilities/ReleaseScripts/test/BuildFile.xml
+++ b/Utilities/ReleaseScripts/test/BuildFile.xml
@@ -1,4 +1,7 @@
 <test name="TestSCRAM" command="run.sh"/>
+<test name="test-clang-tidy" command="test-clang-tidy.sh">
+  <use name="llvm"/>
+</test>
 <test name="TestValgrind" command="test-valgrind.sh">
   <flags PRE_TEST="test-valgrind-memleak"/>
   <use name="valgrind"/>

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc
@@ -13,7 +13,7 @@ protected:
 };
 
 BaseClass::~BaseClass() {
-  if (ch!=0){
+  if (ch != 0) {
     delete ch;
     ch = 0;
   }

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc
@@ -1,0 +1,31 @@
+class BaseClass {
+public:
+  BaseClass(int x) {
+    m_x = x;
+    ch = 0;
+  };
+  virtual ~BaseClass();
+  virtual int someMethod();
+
+protected:
+  int m_x;
+  char* ch;
+};
+
+BaseClass::~BaseClass() {
+  if (ch!=0){
+    delete ch;
+    ch = 0;
+  }
+}
+int BaseClass::someMethod() { return m_x; }
+
+class DrivedClass : public BaseClass {
+public:
+  DrivedClass(int x) : BaseClass(x){};
+  virtual ~DrivedClass();
+  virtual int someMethod();
+};
+
+DrivedClass::~DrivedClass() {}
+int DrivedClass::someMethod() { return m_x * 2; }

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
@@ -15,48 +15,48 @@ Diagnostics:
     DiagnosticMessage:
       Message:         use nullptr
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      204
+      FileOffset:      206
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          204
+          Offset:          206
           Length:          1
           ReplacementText: nullptr
   - DiagnosticName:  modernize-use-nullptr
     DiagnosticMessage:
       Message:         use nullptr
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      232
+      FileOffset:      235
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          232
+          Offset:          235
           Length:          1
           ReplacementText: nullptr
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      382
+      FileOffset:      385
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          374
+          Offset:          377
           Length:          8
           ReplacementText: ''
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          396
+          Offset:          399
           Length:          0
           ReplacementText: ' override'
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      412
+      FileOffset:      415
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          400
+          Offset:          403
           Length:          8
           ReplacementText: ''
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          424
+          Offset:          427
           Length:          0
           ReplacementText: ' override'
 ...

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
@@ -1,0 +1,62 @@
+---
+MainSourceFile:  'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+Diagnostics:
+  - DiagnosticName:  modernize-use-nullptr
+    DiagnosticMessage:
+      Message:         use nullptr
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      69
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          69
+          Length:          1
+          ReplacementText: nullptr
+  - DiagnosticName:  modernize-use-nullptr
+    DiagnosticMessage:
+      Message:         use nullptr
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      204
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          204
+          Length:          1
+          ReplacementText: nullptr
+  - DiagnosticName:  modernize-use-nullptr
+    DiagnosticMessage:
+      Message:         use nullptr
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      232
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          232
+          Length:          1
+          ReplacementText: nullptr
+  - DiagnosticName:  modernize-use-override
+    DiagnosticMessage:
+      Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      382
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          374
+          Length:          8
+          ReplacementText: ''
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          396
+          Length:          0
+          ReplacementText: ' override'
+  - DiagnosticName:  modernize-use-override
+    DiagnosticMessage:
+      Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      412
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          400
+          Length:          8
+          ReplacementText: ''
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          424
+          Length:          0
+          ReplacementText: ' override'
+...

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.sh
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -ex
+clang-tidy -export-fixes $CMSSW_BASE/test-clang-tidy.cc.yaml -header-filter "$CMSSW_BASE/src/.*" $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc
+sed -i -e "s|$CMSSW_BASE/src/||" $CMSSW_BASE/test-clang-tidy.cc.yaml
+diff -u $CMSSW_BASE/test-clang-tidy.cc.yaml $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
+rm -f $CMSSW_BASE/test-clang-tidy.cc.yaml


### PR DESCRIPTION
This PR runs clang-tidy and make sure the generated yaml files format is not changed. This could happen with new version of llvm. As it happened with llvm 9.0.1 but our build system did not noticed it. This broke clang-tidy in CMSSW_11_1_X (with LLVM 9). https://github.com/cms-sw/cmsdist/pull/5721 fixes the build rules to work with llvm 9.0.1 but we think it would be help help top have a unit test which makes sure that we catch such issues at the time of llvm integration.

Local build and test run successfully.