### PR TITLE
vavilov parameters kappa fix

### DIFF
--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -4056,9 +4056,11 @@ void SiPixelTemplate::vavilov_pars(double& mpv, double& sigma, double& kappa)
 
   // Copy to parameter list
 
-  //avoid rounding difference between floats and doubles causing issues later
-  if (kappavav_ == 0.01f)
+  //Avoid rounding difference between floats and doubles causing issues later
+  if (kappavav_ <= 0.01f) {
+    LOGERROR("SiPixelTemplate") << "Vavilov kappa value is " << kappavav_ << " changing it to be above 0.01" << ENDL;
     kappavav_ = 0.01f + 0.0000001f;
+  }
 
   mpv = (double)mpvvav_;
   sigma = (double)sigmavav_;

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -4057,7 +4057,8 @@ void SiPixelTemplate::vavilov_pars(double& mpv, double& sigma, double& kappa)
   // Copy to parameter list
 
   //avoid rounding difference between floats and doubles causing issues later
-  if(kappavav_ == 0.01f) kappavav_ = 0.01f + 0.0000001f;
+  if (kappavav_ == 0.01f)
+    kappavav_ = 0.01f + 0.0000001f;
 
   mpv = (double)mpvvav_;
   sigma = (double)sigmavav_;

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -4056,6 +4056,9 @@ void SiPixelTemplate::vavilov_pars(double& mpv, double& sigma, double& kappa)
 
   // Copy to parameter list
 
+  //avoid rounding difference between floats and doubles causing issues later
+  if(kappavav_ == 0.01f) kappavav_ = 0.01f + 0.0000001f;
+
   mpv = (double)mpvvav_;
   sigma = (double)sigmavav_;
   kappa = (double)kappavav_;


### PR DESCRIPTION
A small PR to fix the issue reported [here](https://github.com/cms-sw/cmssw/issues/29251). The issue was caused by rounding differences between float and doubles. Namely that the value of kappa when on the edge of its allowed range as a float (0.01f) was less than the double value (0.01) used to check for errors. This fix simply adds a small amount to Kappa if it is exactly on the edge. 

Tested by following the procedure outlined [here](https://github.com/cms-sw/cmssw/issues/29251#issuecomment-607706773) and checking that this does indeed fix the error.

