### PR TITLE
Add functions for memory allocation on a single byte basis

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h
@@ -74,8 +74,8 @@ namespace cms {
     typename device::impl::make_device_unique_selector<T>::bounded_array make_device_unique(Args &&...) = delete;
 
     template <typename T>
-    typename device::impl::make_device_unique_selector<T>::unbounded_array make_device_unique_bytes(size_t n,
-                                                                                              cudaStream_t stream) {
+    typename device::impl::make_device_unique_selector<T>::unbounded_array make_device_unique_bytes(
+        size_t n, cudaStream_t stream) {
       using element_type = typename std::remove_extent<T>::type;
       static_assert(std::is_trivially_constructible<element_type>::value,
                     "Allocating with non-trivial constructor on the device memory is not supported");
@@ -123,8 +123,8 @@ namespace cms {
     }
 
     template <typename T, typename... Args>
-    typename device::impl::make_device_unique_selector<T>::bounded_array make_device_unique_uninitialized_bytes(Args &&...) =
-        delete;
+    typename device::impl::make_device_unique_selector<T>::bounded_array make_device_unique_uninitialized_bytes(
+        Args &&...) = delete;
   }  // namespace cuda
 }  // namespace cms
 

--- a/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
@@ -68,6 +68,22 @@ namespace cms {
     template <typename T, typename... Args>
     typename host::noncached::impl::make_host_unique_selector<T>::bounded_array make_host_noncached_unique(Args &&...) =
         delete;
+
+    template <typename T>
+    typename host::noncached::impl::make_host_unique_selector<T>::unbounded_array make_host_noncached_unique_bytes(
+        size_t n, unsigned int flags = cudaHostAllocDefault) {
+      using element_type = typename std::remove_extent<T>::type;
+      static_assert(std::is_trivially_constructible<element_type>::value,
+                    "Allocating with non-trivial constructor on the pinned host memory is not supported");
+      void *mem;
+      cudaCheck(cudaHostAlloc(&mem, n, flags));
+      return typename host::noncached::impl::make_host_unique_selector<T>::unbounded_array(
+          reinterpret_cast<element_type *>(mem));
+    }
+
+    template <typename T, typename... Args>
+    typename host::noncached::impl::make_host_unique_selector<T>::bounded_array make_host_noncached_unique_bytes(Args &&...) =
+        delete;
   }  // namespace cuda
 }  // namespace cms
 

--- a/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
@@ -82,8 +82,8 @@ namespace cms {
     }
 
     template <typename T, typename... Args>
-    typename host::noncached::impl::make_host_unique_selector<T>::bounded_array make_host_noncached_unique_bytes(Args &&...) =
-        delete;
+    typename host::noncached::impl::make_host_unique_selector<T>::bounded_array make_host_noncached_unique_bytes(
+        Args &&...) = delete;
   }  // namespace cuda
 }  // namespace cms
 

--- a/HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h
@@ -57,6 +57,18 @@ namespace cms {
     template <typename T, typename... Args>
     typename host::impl::make_host_unique_selector<T>::bounded_array make_host_unique(Args &&...) = delete;
 
+    template <typename T>
+    typename host::impl::make_host_unique_selector<T>::unbounded_array make_host_unique_bytes(size_t n, cudaStream_t stream) {
+      using element_type = typename std::remove_extent<T>::type;
+      static_assert(std::is_trivially_constructible<element_type>::value,
+                    "Allocating with non-trivial constructor on the pinned host memory is not supported");
+      void *mem = allocate_host(n, stream);
+      return typename host::impl::make_host_unique_selector<T>::unbounded_array{reinterpret_cast<element_type *>(mem)};
+    }
+
+    template <typename T, typename... Args>
+    typename host::impl::make_host_unique_selector<T>::bounded_array make_host_unique_bytes(Args &&...) = delete;
+
     // No check for the trivial constructor, make it clear in the interface
     template <typename T>
     typename host::impl::make_host_unique_selector<T>::non_array make_host_unique_uninitialized(cudaStream_t stream) {
@@ -74,6 +86,17 @@ namespace cms {
 
     template <typename T, typename... Args>
     typename host::impl::make_host_unique_selector<T>::bounded_array make_host_unique_uninitialized(Args &&...) = delete;
+
+    template <typename T>
+    typename host::impl::make_host_unique_selector<T>::unbounded_array make_host_unique_uninitialized_bytes(
+        size_t n, cudaStream_t stream) {
+      using element_type = typename std::remove_extent<T>::type;
+      void *mem = allocate_host(n, stream);
+      return typename host::impl::make_host_unique_selector<T>::unbounded_array{reinterpret_cast<element_type *>(mem)};
+    }
+
+    template <typename T, typename... Args>
+    typename host::impl::make_host_unique_selector<T>::bounded_array make_host_unique_uninitialized_bytes(Args &&...) = delete;
   }  // namespace cuda
 }  // namespace cms
 

--- a/HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h
@@ -58,7 +58,8 @@ namespace cms {
     typename host::impl::make_host_unique_selector<T>::bounded_array make_host_unique(Args &&...) = delete;
 
     template <typename T>
-    typename host::impl::make_host_unique_selector<T>::unbounded_array make_host_unique_bytes(size_t n, cudaStream_t stream) {
+    typename host::impl::make_host_unique_selector<T>::unbounded_array make_host_unique_bytes(size_t n,
+                                                                                              cudaStream_t stream) {
       using element_type = typename std::remove_extent<T>::type;
       static_assert(std::is_trivially_constructible<element_type>::value,
                     "Allocating with non-trivial constructor on the pinned host memory is not supported");
@@ -96,7 +97,8 @@ namespace cms {
     }
 
     template <typename T, typename... Args>
-    typename host::impl::make_host_unique_selector<T>::bounded_array make_host_unique_uninitialized_bytes(Args &&...) = delete;
+    typename host::impl::make_host_unique_selector<T>::bounded_array make_host_unique_uninitialized_bytes(Args &&...) =
+        delete;
   }  // namespace cuda
 }  // namespace cms
 


### PR DESCRIPTION
#### PR description:
Added functions which allocate memory on the GPU and CPU (device and host) on a single byte basis, instead of requiring multiples of ```sizeof```. This addition allows the usage of a single contiguous chunk of memory to store different types (as an example, two ```double```s and two ```float```s).
This PR has no dependencies.

#### PR validation:
The functions were successfully tested within CMSSW with a producer yet to be released, but the code can be provided upon request.

