### PR TITLE
Running code-format for alca

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h
@@ -14,10 +14,10 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 
-#include <stdio.h>
-#include <vector>
+#include <cstdio>
+#include <ctime>
 #include <string>
-#include <time.h>
+#include <vector>
 /**
  */
 class EcalLaserCondTools : public edm::EDAnalyzer {
@@ -36,13 +36,13 @@ public:
 
   /** Destructor
    */
-  ~EcalLaserCondTools();
+  ~EcalLaserCondTools() override;
 
   /** Called by CMSSW event loop
    * @param evt the event
    * @param es events setup
    */
-  virtual void analyze(const edm::Event& evt, const edm::EventSetup& es);
+  void analyze(const edm::Event& evt, const edm::EventSetup& es) override;
 
 private:
   static std::string toNth(int n);
@@ -61,10 +61,10 @@ private:
 
   class FileReader : public EcalLaserCondTools::CorrReader {
   public:
-    FileReader(const std::vector<std::string>& fnames) : f_(0), fnames_(fnames), ifile_(-1), iline_(0) {}
-    virtual bool readTime(int& t1, int t2[nLmes], int& t3);
-    virtual bool readPs(DetId& rawdetid, EcalLaserAPDPNRatios::EcalLaserAPDPNpair& corr);
-    virtual ~FileReader() {}
+    FileReader(const std::vector<std::string>& fnames) : f_(nullptr), fnames_(fnames), ifile_(-1), iline_(0) {}
+    bool readTime(int& t1, int t2[nLmes], int& t3) override;
+    bool readPs(DetId& rawdetid, EcalLaserAPDPNRatios::EcalLaserAPDPNpair& corr) override;
+    ~FileReader() override {}
 
   private:
     bool nextFile();

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -22,8 +22,8 @@
 using namespace std;
 
 EcalLaserCondTools::EcalLaserCondTools(const edm::ParameterSet& ps)
-    : fout_(0),
-      eventList_(0),
+    : fout_(nullptr),
+      eventList_(nullptr),
       eventListFileName_(ps.getParameter<string>("eventListFile")),
       verb_(ps.getParameter<int>("verbosity")),
       mode_(ps.getParameter<string>("mode")),
@@ -35,9 +35,9 @@ EcalLaserCondTools::EcalLaserCondTools(const edm::ParameterSet& ps)
   ferr_ = fopen("corr_errors.txt", "w");
   fprintf(ferr_, "#t1\tdetid\tp1\tp2\tp3");
 
-  if (eventListFileName_.size() != 0) {
+  if (!eventListFileName_.empty()) {
     eventList_ = fopen(eventListFileName_.c_str(), "r");
-    if (eventList_ == 0)
+    if (eventList_ == nullptr)
       throw cms::Exception("User") << "Failed to open file " << eventListFileName_ << "\n";
   }
 }
@@ -252,7 +252,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
       iovStart = db_->beginOfTime();
     }
     timeval t;
-    gettimeofday(&t, 0);
+    gettimeofday(&t, nullptr);
     if (verb_ > 1)
       cout << "[" << timeToString(t.tv_sec) << "] "
            << "Write IOV " << iIov << " starting from " << timeToString(iovStart >> 32) << "... ";
@@ -275,7 +275,7 @@ bool EcalLaserCondTools::FileReader::nextFile() {
       cout << "Opening file " << fnames_[ifile_] << "\n";
     f_ = fopen(fnames_[ifile_].c_str(), "r");
     iline_ = 0;
-    if (f_ == 0) {
+    if (f_ == nullptr) {
       std::cerr << "Failed to open file " << fnames_[ifile_] << ". File skipped!\n";
     } else {
       return true;
@@ -285,19 +285,19 @@ bool EcalLaserCondTools::FileReader::nextFile() {
 
 bool EcalLaserCondTools::FileReader::readTime(int& t1, int t2[EcalLaserCondTools::nLmes], int& t3) {
   trim();
-  if ((f_ == 0 || feof(f_)) && !nextFile()) {
+  if ((f_ == nullptr || feof(f_)) && !nextFile()) {
     if (verb_ > 1)
       cout << "No more record\n";
     return false;
   }
   int i;
-  char* buf = 0;
+  char* buf = nullptr;
   size_t s = 0;
   while ((i = fgetc(f_)) != 'T' && i != 'L' && i >= 0)
     getline(&buf, &s, f_);
   if (buf)
     free(buf);
-  buf = 0;
+  buf = nullptr;
 
   if (i == 'L') {  //last record put 3 consecutive times starting from end of prev. IOV
     t1 = t3;
@@ -333,7 +333,7 @@ bool EcalLaserCondTools::FileReader::readTime(int& t1, int t2[EcalLaserCondTools
 }
 
 bool EcalLaserCondTools::FileReader::readPs(DetId& detid, EcalLaserAPDPNRatios::EcalLaserAPDPNpair& corr) {
-  if (f_ == 0) {
+  if (f_ == nullptr) {
     if (verb_)
       cout << "Requested to read p1..p3 parameter line while no file is closed.\n";
     return false;
@@ -384,7 +384,7 @@ bool EcalLaserCondTools::FileReader::readPs(DetId& detid, EcalLaserAPDPNRatios::
 }
 
 void EcalLaserCondTools::FileReader::trim() {
-  if (f_ == 0)
+  if (f_ == nullptr)
     return;
   bool skipLine = false;
   int c;
@@ -443,9 +443,9 @@ void EcalLaserCondTools::dbToAscii(const edm::EventSetup& es) {
   if (t.size() != EcalLaserCondTools::nLmes)
     throw cms::Exception("LasCor") << "Unexpected number time parameter triplets\n";
 
-  if (fout_ == 0) {
+  if (fout_ == nullptr) {
     fout_ = fopen("corr_dump.txt", "w");
-    if (fout_ == 0)
+    if (fout_ == nullptr)
       throw cms::Exception("LasCor") << "Failed to create file corr_dump.txt\n";
   }
 

--- a/Calibration/IsolatedParticles/plugins/StudyCaloResponse.cc
+++ b/Calibration/IsolatedParticles/plugins/StudyCaloResponse.cc
@@ -959,7 +959,8 @@ void StudyCaloResponse::fillIsolation(int i, double emaxnearP, double eneutIso1,
   h_ediff[i]->Fill(eneutIso2 - eneutIso1, tr_eventWeight);
 }
 
-void StudyCaloResponse::fillEnergy(int flag, int ieta, double p, double enEcal1, double enHcal1, double enEcal2, double enHcal2) {
+void StudyCaloResponse::fillEnergy(
+    int flag, int ieta, double p, double enEcal1, double enHcal1, double enEcal2, double enHcal2) {
   int ip(-1), ie(-1);
   for (int i = 0; i < nPBin_; ++i) {
     if (p >= pBin_[i] && p < pBin_[i + 1]) {
@@ -995,7 +996,8 @@ std::string StudyCaloResponse::truncate_str(const std::string& str) {
   return (truncated_str);
 }
 
-int StudyCaloResponse::trackPID(const reco::Track* pTrack, const edm::Handle<reco::GenParticleCollection>& genParticles) {
+int StudyCaloResponse::trackPID(const reco::Track* pTrack,
+                                const edm::Handle<reco::GenParticleCollection>& genParticles) {
   int id(0);
   if (genParticles.isValid()) {
     unsigned int indx;


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/481//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
