### PR TITLE
Running code-format for analysis

### DIFF
--- a/PhysicsTools/Heppy/src/ReclusterJets.cc
+++ b/PhysicsTools/Heppy/src/ReclusterJets.cc
@@ -1,3 +1,7 @@
+#include <memory>
+
+
+
 #include "PhysicsTools/Heppy/interface/ReclusterJets.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "fastjet/tools/Pruner.hh"
@@ -39,7 +43,7 @@ namespace heppy {
     //  cout << "Clustering with " << jet_def.description() << endl;
     ///
     // define jet clustering sequence
-    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, jet_def));
+    fjClusterSeq_ = std::make_shared<fastjet::ClusterSequence>(fjInputs_, jet_def);
   }
 
   std::vector<math::XYZTLorentzVector> ReclusterJets::makeP4s(const std::vector<fastjet::PseudoJet> &jets) {

--- a/PhysicsTools/Heppy/src/ReclusterJets.cc
+++ b/PhysicsTools/Heppy/src/ReclusterJets.cc
@@ -1,7 +1,5 @@
 #include <memory>
 
-
-
 #include "PhysicsTools/Heppy/interface/ReclusterJets.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "fastjet/tools/Pruner.hh"


### PR DESCRIPTION

Applying code-format for CMSSW category analysis.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/483//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
