### PR TITLE
Running code-format for db

### DIFF
--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -260,13 +260,13 @@ namespace cond {
       }
       if (m_session->iovSchema().tagLogTable().exists()) {
         std::stringstream msg;
-        if (m_data->iovBuffer.size())
+        if (!m_data->iovBuffer.empty())
           msg << m_data->iovBuffer.size() << " iov(s) inserted";
-        if (msg.str().size())
+        if (!msg.str().empty())
           msg << "; ";
         else
           msg << ".";
-        if (m_data->deleteBuffer.size())
+        if (!m_data->deleteBuffer.empty())
           msg << m_data->deleteBuffer.size() << " iov(s) deleted.";
         if (ret) {
           m_session->iovSchema().tagLogTable().insert(


### PR DESCRIPTION

Applying code-format for CMSSW category db.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/486//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
