### PR TITLE
Running code-format for alca-db

### DIFF
--- a/CondCore/DBOutputService/interface/OnlineDBOutputService.h
+++ b/CondCore/DBOutputService/interface/OnlineDBOutputService.h
@@ -36,7 +36,7 @@ namespace cond {
     public:
       OnlineDBOutputService(const edm::ParameterSet& iConfig, edm::ActivityRegistry& iAR);
 
-      virtual ~OnlineDBOutputService();
+      ~OnlineDBOutputService() override;
 
       cond::Iov_t preLoadIov(const std::string& recordName, cond::Time_t targetTime);
 
@@ -48,7 +48,7 @@ namespace cond {
         edm::LogInfo(MSGSOURCE) << "Updating lumisection " << targetTime;
         cond::Hash payloadId = PoolDBOutputService::writeOne<PayloadType>(payload, targetTime, recordName);
         bool ret = true;
-        if (payloadId.size() == 0) {
+        if (payloadId.empty()) {
           return false;
         }
         auto t1 = std::chrono::high_resolution_clock::now();

--- a/CondCore/DBOutputService/src/OnlineDBOutputService.cc
+++ b/CondCore/DBOutputService/src/OnlineDBOutputService.cc
@@ -10,7 +10,7 @@ cond::service::OnlineDBOutputService::OnlineDBOutputService(const edm::Parameter
       m_lastLumiUrl(iConfig.getUntrackedParameter<std::string>("lastLumiUrl", "")),
       m_preLoadConnectionString(iConfig.getUntrackedParameter<std::string>("preLoadConnectionString", "")),
       m_debug(iConfig.getUntrackedParameter<bool>("debugLogging", false)) {
-  if (m_lastLumiUrl.size() != 0) {
+  if (!m_lastLumiUrl.empty()) {
     startTransaction();
     m_runNumber = PoolDBOutputService::session().getCurrentRun().run;
   } else {
@@ -39,7 +39,7 @@ bool getLatestLumiFromDAQ(const std::string& urlString, std::string& info) {
   curl = curl_easy_init();
   bool ret = false;
   if (curl) {
-    struct curl_slist* chunk = NULL;
+    struct curl_slist* chunk = nullptr;
     chunk = curl_slist_append(chunk, "content-type:document/plain");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
     curl_easy_setopt(curl, CURLOPT_URL, urlString.c_str());
@@ -75,7 +75,7 @@ cond::Time_t cond::service::OnlineDBOutputService::getLastLumiProcessed() {
     edm::LogInfo(MSGSOURCE) << "Last lumi: " << lastLumiProcessed << " Current run: " << m_runNumber
                             << " lumi id:" << lastL;
   } else {
-    if (m_lastLumiFile.size() == 0) {
+    if (m_lastLumiFile.empty()) {
       //auto t1 = std::chrono::steady_clock::now();
       //auto deltat = std::chrono::duration_cast<std::chrono::seconds>( t1 - m_startRunTime ).count();
       //lastL = (unsigned int)(deltat/23);

--- a/CondFormats/HcalObjects/interface/HcalLUTCorrs.h
+++ b/CondFormats/HcalObjects/interface/HcalLUTCorrs.h
@@ -24,7 +24,7 @@ public:
 #endif
   HcalLUTCorrs(const HcalTopology* topo) : HcalCondObjectContainer<HcalLUTCorr>(topo) {}
 
-  std::string myname() const { return (std::string) "HcalLUTCorrs"; }
+  std::string myname() const override { return (std::string) "HcalLUTCorrs"; }
 
 private:
   COND_SERIALIZABLE;

--- a/CondFormats/HcalObjects/interface/HcalPedestals.h
+++ b/CondFormats/HcalObjects/interface/HcalPedestals.h
@@ -31,7 +31,7 @@ public:
   // set unit boolean
   void setUnitADC(bool isADC) { unitIsADC = isADC; }
 
-  std::string myname() const { return (std::string) "HcalPedestals"; }
+  std::string myname() const override { return (std::string) "HcalPedestals"; }
 
 private:
   bool unitIsADC;


### PR DESCRIPTION

Applying code-format for CMSSW category alca,db.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/482//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
