### PR TITLE
Running code-format for generators

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/GenEventInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenEventInfoProduct.cc
@@ -90,7 +90,7 @@ GenEventInfoProduct &GenEventInfoProduct::operator=(GenEventInfoProduct &&other)
   DJRValues_ = std::move(other.DJRValues_);
   nMEPartons_ = other.nMEPartons_;
   nMEPartonsFiltered_ = other.nMEPartonsFiltered_;
-  pdf_.reset(other.pdf_.release());
+  pdf_ = std::move(other.pdf_);
 
   return *this;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category generators.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/488//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
