### PR TITLE
Running code-format for geometry

### DIFF
--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -28,7 +28,7 @@
 template <class T>
 typename CaloGeometryLoader<T>::PtrType CaloGeometryLoader<T>::load(const DDCompactView* cpv,
                                                                     const Alignments* alignments,
- 		                                                    const Alignments* globals) {
+                                                                    const Alignments* globals) {
   PtrType geom = std::make_unique<T>();
 
   makeGeometry(cpv, dynamic_cast<T*>(geom.get()), alignments, globals);
@@ -37,9 +37,9 @@ typename CaloGeometryLoader<T>::PtrType CaloGeometryLoader<T>::load(const DDComp
 }
 
 template <class T>
-typename CaloGeometryLoader<T>::PtrType CaloGeometryLoader<T>::load(const cms::DDCompactView* cpv,	
+typename CaloGeometryLoader<T>::PtrType CaloGeometryLoader<T>::load(const cms::DDCompactView* cpv,
                                                                     const Alignments* alignments,
-  			                                            const Alignments* globals) {
+                                                                    const Alignments* globals) {
   PtrType geom = std::make_unique<T>();
 
   makeGeometry(cpv, dynamic_cast<T*>(geom.get()), alignments, globals);
@@ -49,7 +49,7 @@ typename CaloGeometryLoader<T>::PtrType CaloGeometryLoader<T>::load(const cms::D
 
 template <class T>
 void CaloGeometryLoader<T>::makeGeometry(const DDCompactView* cpv,
-                             		 T* geom,
+                                         T* geom,
                                          const Alignments* alignments,
                                          const Alignments* globals) {
   DDAndFilter<DDSpecificsMatchesValueFilter, DDSpecificsMatchesValueFilter> filter(
@@ -112,7 +112,7 @@ void CaloGeometryLoader<T>::makeGeometry(const DDCompactView* cpv,
 
 template <class T>
 void CaloGeometryLoader<T>::makeGeometry(const cms::DDCompactView* cpv,
-                             		 T* geom,
+                                         T* geom,
                                          const Alignments* alignments,
                                          const Alignments* globals) {
   cms::DDFilteredView fv(cpv->detector(), cpv->detector()->worldVolume());
@@ -207,13 +207,13 @@ unsigned int CaloGeometryLoader<T>::getDetIdForDD4HepNode(const cms::DDFilteredV
   std::string det(""), num("");
   for (size_t i = n; i <= path.size(); ++i) {
     if (i == path.size() || path[i] == '/') {
-      num = path.substr(start, i-start);
+      num = path.substr(start, i - start);
       start = i + 1;
       baseNumber.addLevel(det, std::stoi(num));
     } else if (path[i] == ':') {
       start = i + 1;
     } else if (path[i] == '_') {
-      det = path.substr(start, i-start);
+      det = path.substr(start, i - start);
       start = i + 1;
     }
   }

--- a/Geometry/HcalTestBeamData/src/HcalTB02ParametersFromDD.cc
+++ b/Geometry/HcalTestBeamData/src/HcalTB02ParametersFromDD.cc
@@ -31,7 +31,7 @@ bool HcalTB02ParametersFromDD::build(const DDCompactView* cpv, HcalTB02Parameter
   for (; it != php.lengthMap_.end(); it++, i++) {
     edm::LogVerbatim("HcalTBSim") << " " << i << " " << it->first << " L = " << it->second;
   }
-  return 1;
+  return true;
 }
 
 bool HcalTB02ParametersFromDD::build(const cms::DDCompactView* cpv, HcalTB02Parameters& php, const std::string& name) {
@@ -53,5 +53,5 @@ bool HcalTB02ParametersFromDD::build(const cms::DDCompactView* cpv, HcalTB02Para
   for (; it != php.lengthMap_.end(); it++, i++) {
     edm::LogVerbatim("HcalTBSim") << " " << i << " " << it->first << " L = " << it->second;
   }
-  return 1;
+  return true;
 }

--- a/Geometry/HcalTestBeamData/src/HcalTB06BeamParametersFromDD.cc
+++ b/Geometry/HcalTestBeamData/src/HcalTB06BeamParametersFromDD.cc
@@ -105,7 +105,7 @@ bool HcalTB06BeamParametersFromDD::build(HcalTB06BeamParameters& php,
   edm::LogVerbatim("HcalTBSim") << "HcalTB06BeamParametersFromDD: Material name for ReadOut = " << name2 << ":"
                                 << php.material_;
 #endif
-  return 1;
+  return true;
 }
 
 std::vector<std::string> HcalTB06BeamParametersFromDD::getNames(DDFilteredView& fv) {


### PR DESCRIPTION

Applying code-format for CMSSW category geometry.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/489//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
