### PR TITLE
Running code-format for geometry-upgrade

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1047,7 +1047,7 @@ void HGCalGeomParameters::loadSpecParsHexagon8(const cms::DDFilteredView& fv,
     php.slopeTop_.emplace_back(0);
 
   const auto& dummy2 = fv.get<std::vector<double> >(sdTag1, "LayerOffset");
-  if (dummy2.size() > 0) {
+  if (!dummy2.empty()) {
     php.layerOffset_ = dummy2[0];
   } else {
     php.layerOffset_ = 0;


### PR DESCRIPTION

Applying code-format for CMSSW category geometry,upgrade.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/490//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
