### PR TITLE
Running code-format for dqm

### DIFF
--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -394,7 +394,7 @@ namespace sistrip {
     const std::vector<uint32_t>* vectorFromEvent = getProduct<std::vector<uint32_t> >(event, tag);
     if (vectorFromEvent) {
       //vector is from event so, will be deleted when the event is destroyed (and not before)
-      return CountersPtr(new CountersWrapper(vectorFromEvent));
+      return std::make_shared<CountersWrapper>(vectorFromEvent);
     } else {
       const std::map<uint32_t, uint32_t>* mapFromEvent = getProduct<std::map<uint32_t, uint32_t> >(event, tag);
       if (mapFromEvent) {

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -517,7 +517,7 @@ void FlavourHistograms<T>::plot(TPad* theCanvas /* = 0 */) {
       lineStyle[1] = 2;
   }
 
-  histo[0]->setAxisTitle(theBaseNameDescription.c_str());
+  histo[0]->setAxisTitle(theBaseNameDescription);
   histo[0]->getTH1F()->GetYaxis()->SetTitle("Arbitrary Units");
   histo[0]->getTH1F()->GetYaxis()->SetTitleOffset(1.25);
 

--- a/DQMServices/Core/src/ROOTFilePB.pb.h
+++ b/DQMServices/Core/src/ROOTFilePB.pb.h
@@ -74,7 +74,7 @@ namespace dqmstorepb {
                                Message /* @@protoc_insertion_point(class_definition:dqmstorepb.ROOTFilePB.Histo) */ {
   public:
     ROOTFilePB_Histo();
-    virtual ~ROOTFilePB_Histo();
+    ~ROOTFilePB_Histo() override;
 
     ROOTFilePB_Histo(const ROOTFilePB_Histo& from);
     ROOTFilePB_Histo(ROOTFilePB_Histo&& from) noexcept : ROOTFilePB_Histo() { *this = ::std::move(from); }
@@ -227,7 +227,7 @@ namespace dqmstorepb {
       : public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:dqmstorepb.ROOTFilePB) */ {
   public:
     ROOTFilePB();
-    virtual ~ROOTFilePB();
+    ~ROOTFilePB() override;
 
     ROOTFilePB(const ROOTFilePB& from);
     ROOTFilePB(ROOTFilePB&& from) noexcept : ROOTFilePB() { *this = ::std::move(from); }

--- a/Validation/HGCalValidation/plugins/HGCalBHValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalBHValidation.cc
@@ -43,10 +43,10 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  virtual void beginJob() override {}
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}
-  virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void beginJob() override {}
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override {}
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
   template <class T>
   void analyzeDigi(const T&, double const&, bool const&, int const&, unsigned int&);
 

--- a/Validation/RecoParticleFlow/plugins/OffsetDQMPostProcessor.cc
+++ b/Validation/RecoParticleFlow/plugins/OffsetDQMPostProcessor.cc
@@ -61,7 +61,7 @@ void OffsetDQMPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGet
   std::string stitle;
   std::vector<MonitorElement*> vME;
   std::vector<std::string> MEStrings = iget_.getMEs();
-  std::for_each(MEStrings.begin(), MEStrings.end(), [&](auto& s) { s.insert(0, offsetDir.c_str()); });
+  std::for_each(MEStrings.begin(), MEStrings.end(), [&](auto& s) { s.insert(0, offsetDir); });
 
   // temporary ME and root objects
   MonitorElement* mtmp;

--- a/Validation/RecoParticleFlow/plugins/PFAnalysis.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysis.cc
@@ -120,16 +120,16 @@ public:
 
   PFAnalysis();
   explicit PFAnalysis(const edm::ParameterSet&);
-  ~PFAnalysis();
+  ~PFAnalysis() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  virtual void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
-  virtual void endRun(edm::Run const& iEvent, edm::EventSetup const&) override;
+  void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
+  void endRun(edm::Run const& iEvent, edm::EventSetup const&) override;
 
 private:
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   void processTrackingParticles(const edm::View<TrackingParticle>& trackingParticles,
                                 edm::Handle<edm::View<TrackingParticle>>& trackingParticlesHandle);
@@ -605,7 +605,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   const auto& all_elements_distances = processBlocks(pfBlocks);
   const auto& all_elements = all_elements_distances.first;
   const auto& all_distances = all_elements_distances.second;
-  assert(all_elements.size() > 0);
+  assert(!all_elements.empty());
   //assert(all_distances.size() > 0);
   for (const auto& d : all_distances) {
     element_distance_i_.push_back(get<0>(d));
@@ -902,7 +902,7 @@ void PFAnalysis::processTrackingParticles(const edm::View<TrackingParticle>& tra
 
     math::XYZTLorentzVectorD vtx(0, 0, 0, 0);
 
-    if (tp.decayVertices().size() > 0) {
+    if (!tp.decayVertices().empty()) {
       vtx = tp.decayVertices().at(0)->position();
     }
     auto orig_vtx = tp.vertex();
@@ -1072,7 +1072,7 @@ void PFAnalysis::associateClusterToSimCluster(const vector<ElementWithIndex>& al
   int ielement = 0;
   for (const auto& detids : detids_elements) {
     int isimcluster = 0;
-    if (detids.size() > 0) {
+    if (!detids.empty()) {
       double sum_e_tot = 0.0;
       for (const auto& c : detids) {
         sum_e_tot += c.second;


### PR DESCRIPTION

Applying code-format for CMSSW category dqm.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/487//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
