### PR TITLE
Running code-format for reconstruction-upgrade

### DIFF
--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -503,7 +503,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   if (useVertex_ && !useSimVertex_) {
     edm::Handle<VertexCollection> vtxH;
     ev.getByToken(vtxToken_, vtxH);
-    if (vtxH.product()->size() > 0)
+    if (!vtxH.product()->empty())
       pv = &(vtxH.product()->at(0));
   }
 


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction,upgrade.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/493//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
