### PR TITLE
Running code-format for simulation-upgrade

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -360,7 +360,7 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
         const auto lp = pixdet->specificTopology().localPosition(MeasurementPoint(pixel_x, pixel_y));
         mc.migrate_position(LocalPoint(lp.x(), lp.y(), mc.z()));
       }
-      if (migrated_charges.size() > 0) {
+      if (!migrated_charges.empty()) {
         LogDebug("Pixel3DDigitizerAlgorithm::drift") << "****************"
                                                      << "MIGRATING (super-)charges"
                                                      << "****************";


### PR DESCRIPTION

Applying code-format for CMSSW category simulation,upgrade.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/495//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
