### PR TITLE
Running code-format for reconstructio

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -295,7 +295,7 @@ TemplatedSecondaryVertexProducer<IPTI, VTX>::TemplatedSecondaryVertexProducer(co
     token_fatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("fatJets"));
   }
   edm::InputTag srcWeights = params.getParameter<edm::InputTag>("weights");
-  if (srcWeights.label() != "")
+  if (!srcWeights.label().empty())
     token_weights = consumes<edm::ValueMap<float> >(srcWeights);
   if (useGroomedFatJets) {
     token_groomedFatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("groomedFatJets"));

--- a/RecoHI/HiJetAlgos/src/MultipleAlgoIterator.cc
+++ b/RecoHI/HiJetAlgos/src/MultipleAlgoIterator.cc
@@ -1,7 +1,5 @@
 #include <memory>
 
-
-
 #include "RecoHI/HiJetAlgos/interface/MultipleAlgoIterator.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"

--- a/RecoHI/HiJetAlgos/src/MultipleAlgoIterator.cc
+++ b/RecoHI/HiJetAlgos/src/MultipleAlgoIterator.cc
@@ -1,3 +1,7 @@
+#include <memory>
+
+
+
 #include "RecoHI/HiJetAlgos/interface/MultipleAlgoIterator.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -22,7 +26,7 @@ void MultipleAlgoIterator::offsetCorrectJets() {
   subtractPedestal(*fjInputs_);
   const fastjet::JetDefinition& def = *fjJetDefinition_;
   if (!doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(*fjInputs_, def));
+    fjClusterSeq_ = std::make_shared<fastjet::ClusterSequence>(*fjInputs_, def);
   } else {
     fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequenceArea(*fjInputs_, def, *fjActiveArea_));
   }

--- a/RecoJets/JetProducers/plugins/CATopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CATopJetProducer.cc
@@ -1,7 +1,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoJets/JetProducers/plugins/CATopJetProducer.h"
 
-
 #include <memory>
 
 #include "RecoJets/JetProducers/plugins/FastjetJetProducer.h"

--- a/RecoJets/JetProducers/plugins/CATopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CATopJetProducer.cc
@@ -1,5 +1,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoJets/JetProducers/plugins/CATopJetProducer.h"
+
+
+#include <memory>
+
 #include "RecoJets/JetProducers/plugins/FastjetJetProducer.h"
 
 using namespace edm;
@@ -64,7 +68,7 @@ void CATopJetProducer::produce(edm::Event& e, const edm::EventSetup& c) { Fastje
 
 void CATopJetProducer::runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   if (!doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
+    fjClusterSeq_ = std::make_shared<fastjet::ClusterSequence>(fjInputs_, *fjJetDefinition_);
   } else if (voronoiRfact_ <= 0) {
     fjClusterSeq_ =
         ClusterSequencePtr(new fastjet::ClusterSequenceArea(fjInputs_, *fjJetDefinition_, *fjAreaDefinition_));

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -1,7 +1,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoJets/JetProducers/plugins/CSJetProducer.h"
 
-
 #include <memory>
 
 #include "FWCore/Utilities/interface/Exception.h"

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -1,5 +1,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoJets/JetProducers/plugins/CSJetProducer.h"
+
+
+#include <memory>
+
 #include "FWCore/Utilities/interface/Exception.h"
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
 
@@ -32,7 +36,7 @@ void CSJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 void CSJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSetup) {
   // run algorithm
   if (!doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
+    fjClusterSeq_ = std::make_shared<fastjet::ClusterSequence>(fjInputs_, *fjJetDefinition_);
   } else if (voronoiRfact_ <= 0) {
     fjClusterSeq_ =
         ClusterSequencePtr(new fastjet::ClusterSequenceArea(fjInputs_, *fjJetDefinition_, *fjAreaDefinition_));

--- a/RecoJets/JetProducers/plugins/ECFAdder.cc
+++ b/RecoJets/JetProducers/plugins/ECFAdder.cc
@@ -19,7 +19,7 @@ ECFAdder::ECFAdder(const edm::ParameterSet& iConfig)
   }
 
   edm::InputTag srcWeights = iConfig.getParameter<edm::InputTag>("srcWeights");
-  if (srcWeights.label() != "")
+  if (!srcWeights.label().empty())
     input_weights_token_ = consumes<edm::ValueMap<float>>(srcWeights);
 
   for (std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n) {

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -74,7 +74,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig) : Virtu
   nFilt_ = iConfig.getParameter<int>("nFilt");
   useDynamicFiltering_ = iConfig.getParameter<bool>("useDynamicFiltering");
   if (useDynamicFiltering_)
-    rFiltDynamic_ = DynamicRfiltPtr(new DynamicRfilt(rFilt_, rFiltFactor_));
+    rFiltDynamic_ = std::make_shared<DynamicRfilt>(rFilt_, rFiltFactor_);
   rFiltFactor_ = iConfig.getParameter<double>("rFiltFactor");
 
   useTrimming_ = iConfig.getParameter<bool>("useTrimming");
@@ -355,7 +355,7 @@ void FastjetJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const&
   */
 
   if (!doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
+    fjClusterSeq_ = std::make_shared<fastjet::ClusterSequence>(fjInputs_, *fjJetDefinition_);
   } else if (voronoiRfact_ <= 0) {
     fjClusterSeq_ =
         ClusterSequencePtr(new fastjet::ClusterSequenceArea(fjInputs_, *fjJetDefinition_, *fjAreaDefinition_));

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
@@ -3,6 +3,10 @@
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"
 #include "HTTTopJetProducer.h"
 
+
+#include <memory>
+
+
 using namespace edm;
 using namespace cms;
 using namespace reco;
@@ -90,7 +94,7 @@ void HTTTopJetProducer::produce(edm::Event& e, const edm::EventSetup& c) {
 
 void HTTTopJetProducer::runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   if (!doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
+    fjClusterSeq_ = std::make_shared<fastjet::ClusterSequence>(fjInputs_, *fjJetDefinition_);
   } else if (voronoiRfact_ <= 0) {
     fjClusterSeq_ =
         ClusterSequencePtr(new fastjet::ClusterSequenceArea(fjInputs_, *fjJetDefinition_, *fjAreaDefinition_));

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
@@ -3,9 +3,7 @@
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"
 #include "HTTTopJetProducer.h"
 
-
 #include <memory>
-
 
 using namespace edm;
 using namespace cms;

--- a/RecoJets/JetProducers/plugins/NjettinessAdder.cc
+++ b/RecoJets/JetProducers/plugins/NjettinessAdder.cc
@@ -14,7 +14,7 @@ NjettinessAdder::NjettinessAdder(const edm::ParameterSet& iConfig)
       nPass_(iConfig.getParameter<int>("nPass")),
       akAxesR0_(iConfig.getParameter<double>("akAxesR0")) {
   edm::InputTag srcWeights = iConfig.getParameter<edm::InputTag>("srcWeights");
-  if (srcWeights.label() != "")
+  if (!srcWeights.label().empty())
     input_weights_token_ = consumes<edm::ValueMap<float>>(srcWeights);
 
   for (std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n) {

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
@@ -1,6 +1,10 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoJets/JetProducers/plugins/SubEventGenJetProducer.h"
+
+
+#include <memory>
+
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
@@ -128,7 +132,7 @@ void SubEventGenJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup co
   // run algorithm
   fjJets_.clear();
 
-  fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
+  fjClusterSeq_ = std::make_shared<fastjet::ClusterSequence>(fjInputs_, *fjJetDefinition_);
   fjJets_ = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
 
   using namespace reco;

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
@@ -2,7 +2,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoJets/JetProducers/plugins/SubEventGenJetProducer.h"
 
-
 #include <memory>
 
 #include "FWCore/Utilities/interface/Exception.h"

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -154,7 +154,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
     if (srcWeights.label() == src_.label())
       LogWarning("VirtualJetProducer")
           << "Particle and weights collection have the same label. You may be applying the same weights twice.\n";
-    if (srcWeights.label() != "")
+    if (!srcWeights.label().empty())
       input_weights_token_ = consumes<edm::ValueMap<float>>(srcWeights);
   }
 

--- a/RecoJets/JetProducers/src/PileUpSubtractor.cc
+++ b/RecoJets/JetProducers/src/PileUpSubtractor.cc
@@ -13,6 +13,8 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include <map>
+#include <memory>
+
 using namespace std;
 
 PileUpSubtractor::PileUpSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) {
@@ -28,7 +30,7 @@ PileUpSubtractor::PileUpSubtractor(const edm::ParameterSet& iConfig, edm::Consum
   ghostArea = iConfig.getParameter<double>("GhostArea");
 
   if (doAreaFastjet_ || doRhoFastjet_) {
-    fjActiveArea_ = ActiveAreaSpecPtr(new fastjet::ActiveAreaSpec(ghostEtaMax, activeAreaRepeats, ghostArea));
+    fjActiveArea_ = std::make_shared<fastjet::ActiveAreaSpec>(ghostEtaMax, activeAreaRepeats, ghostArea);
     if ((ghostEtaMax < 0) || (activeAreaRepeats < 0) || (ghostArea < 0))
       throw cms::Exception("doAreaFastjet or doRhoFastjet")
           << "Parameters ghostEtaMax, activeAreaRepeats or ghostArea for doAreaFastjet/doRhoFastjet are not defined."
@@ -49,7 +51,7 @@ void PileUpSubtractor::reset(std::vector<edm::Ptr<reco::Candidate> >& input,
 }
 
 void PileUpSubtractor::setDefinition(JetDefPtr const& jetDef) {
-  fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(*jetDef));
+  fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(*jetDef);
 }
 
 void PileUpSubtractor::setupGeometryMap(edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducerFromBrilcalc.cc
@@ -42,12 +42,12 @@
 class LumiProducerFromBrilcalc : public edm::global::EDProducer<> {
 public:
   explicit LumiProducerFromBrilcalc(const edm::ParameterSet&);
-  ~LumiProducerFromBrilcalc() = default;
+  ~LumiProducerFromBrilcalc() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
   const std::string lumiFile_;
@@ -82,7 +82,7 @@ LumiProducerFromBrilcalc::LumiProducerFromBrilcalc(const edm::ParameterSet& iCon
 
   int nLS = 0;
   std::string line;
-  while (1) {
+  while (true) {
     std::getline(lumiFile, line);
     if (lumiFile.eof() || lumiFile.fail())
       break;

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -1,3 +1,7 @@
+#include <memory>
+
+
+
 #include "RecoTauTag/RecoTau/interface/RecoTauConstructor.h"
 
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
@@ -42,7 +46,7 @@ namespace reco::tau {
     // RefVectors
     for (auto const& colkey : collections_) {
       // Build an empty list for each collection
-      sortedCollections_[colkey.first] = SortedListPtr(new SortedListPtr::element_type);
+      sortedCollections_[colkey.first] = std::make_shared<SortedListPtr::element_type>();
     }
 
     tau_->setjetRef(jet);

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -1,7 +1,5 @@
 #include <memory>
 
-
-
 #include "RecoTauTag/RecoTau/interface/RecoTauConstructor.h"
 
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"


### PR DESCRIPTION

Applying code-format for CMSSW category reconstructio.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/492//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Due to a bug in buildrules, clang-tidy was not run properly since the update of LLVM 9. 
