### PR TITLE
Add a DDFilteredView test in DetectorDescription/DDCMS

### DIFF
--- a/DetectorDescription/DDCMS/plugins/test/DDTestFilteredView.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestFilteredView.cc
@@ -30,13 +30,22 @@ void DDTestFilteredView::analyze(const Event&, const EventSetup& iEventSetup) {
   ESTransientHandle<DDCompactView> cpv;
   iEventSetup.get<IdealGeometryRecord>().get(m_tag, cpv);
 
-  DDFilter filter("CMSCutsRegion", "Muon");
-  DDFilteredView fv((*cpv), filter);
+  DDFilteredView fv(cpv->detector(), cpv->detector()->worldVolume());
+
+  std::string attribute{"CMSCutsRegion"};
+  cms::DDSpecParRefs ref;
+  const cms::DDSpecParRegistry& mypar = cpv->specpars();
+  mypar.filter(ref, attribute, "MuonChamber");
+  fv.mergedSpecifics(ref);
 
   fv.printFilter();
 
-  fv.firstChild();
+  bool doLoop = fv.firstChild();
   LogVerbatim("Geometry") << "DDTestFilteredView::analyze: first child " << fv.path();
+  while (doLoop) {
+    edm::LogVerbatim("Geometry") << "DDTestFilteredView::analyze: next node = " << fv.path();
+    doLoop = fv.firstChild();
+  }
 
   LogVerbatim("Geometry") << "DDTestFilteredView::analyze done.";
 }

--- a/DetectorDescription/DDCMS/plugins/test/DDTestFilteredView.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestFilteredView.cc
@@ -1,0 +1,44 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
+
+#include <iostream>
+
+using namespace std;
+using namespace cms;
+using namespace edm;
+
+class DDTestFilteredView : public one::EDAnalyzer<> {
+public:
+  explicit DDTestFilteredView(const ParameterSet& iConfig) : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")) {}
+
+  void beginJob() override {}
+  void analyze(Event const& iEvent, EventSetup const&) override;
+  void endJob() override {}
+
+private:
+  const ESInputTag m_tag;
+};
+
+void DDTestFilteredView::analyze(const Event&, const EventSetup& iEventSetup) {
+  LogVerbatim("Geometry") << "DDTestFilteredView::analyze: " << m_tag;
+  ESTransientHandle<DDCompactView> cpv;
+  iEventSetup.get<IdealGeometryRecord>().get(m_tag, cpv);
+
+  DDFilter filter("CMSCutsRegion","Muon");
+  DDFilteredView fv((*cpv),filter);
+
+  fv.printFilter();
+
+  fv.firstChild();
+  LogVerbatim("Geometry") << "DDTestFilteredView::analyze: first child " << fv.path();
+
+  LogVerbatim("Geometry") << "DDTestFilteredView::analyze done.";
+}
+
+DEFINE_FWK_MODULE(DDTestFilteredView);

--- a/DetectorDescription/DDCMS/plugins/test/DDTestFilteredView.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestFilteredView.cc
@@ -30,8 +30,8 @@ void DDTestFilteredView::analyze(const Event&, const EventSetup& iEventSetup) {
   ESTransientHandle<DDCompactView> cpv;
   iEventSetup.get<IdealGeometryRecord>().get(m_tag, cpv);
 
-  DDFilter filter("CMSCutsRegion","Muon");
-  DDFilteredView fv((*cpv),filter);
+  DDFilter filter("CMSCutsRegion", "Muon");
+  DDFilteredView fv((*cpv), filter);
 
   fv.printFilter();
 

--- a/DetectorDescription/DDCMS/test/python/testDDFilteredView.py
+++ b/DetectorDescription/DDCMS/test/python/testDDFilteredView.py
@@ -1,0 +1,53 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DDFilteredViewTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout', 'ddfilteredview'),
+    categories = cms.untracked.vstring('Geometry'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING'),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    ddfilteredview = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        Geometry = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            )
+        ),
+    destinations = cms.untracked.vstring('cout',
+                                         'ddfilteredview')
+    )
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
+                                            appendToDataLabel = cms.string('MUON')
+                                            )
+
+process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
+                                                 appendToDataLabel = cms.string('MUON')
+                                                )
+
+process.test = cms.EDAnalyzer("DDTestFilteredView",
+                              DDDetector = cms.ESInputTag('','MUON')
+                              )
+
+process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/runTest.sh
+++ b/DetectorDescription/DDCMS/test/runTest.sh
@@ -24,6 +24,7 @@ F19=${LOCAL_TEST_DIR}/python/testDDCompactView.py
 F20=${LOCAL_TEST_DIR}/python/testDDGEMAngularAlgorithm.py
 F21=${LOCAL_TEST_DIR}/python/testGeometry2021.py
 F22=${LOCAL_TEST_DIR}/python/testGeometry2021FromDB.py
+F23=${LOCAL_TEST_DIR}/python/testDDFilteredView.py
 
 echo " testing DetectorDescription/DDCMS"
 
@@ -74,3 +75,5 @@ echo "===== Test \"cmsRun testGeometry2021.py\" ===="
 (cmsRun $F21) || die "Failure using cmsRun $F21" $?
 echo "===== Test \"cmsRun testGeometry2021FromDB.py\" ===="
 (cmsRun $F22) || die "Failure using cmsRun $F22" $?
+echo "===== Test \"cmsRun testDDFilteredView.py\" ===="
+(cmsRun $F23) || die "Failure using cmsRun $F23" $?


### PR DESCRIPTION
#### PR description:

Addition of a test example for DDFilteredView built using a filter in ```DetectorDescription/DDCMS``` , developed while debugging an issue in the migration of ```MTDNumberingBuilder``` to DD4hep (```fv.printFilter()``` apparently not found, likely an issue with templates).

#### PR validation:

```scram b runtest``` runs correctly, and the output of the test ```ddfilteredview``` looks the expected one.