### PR TITLE
add missing initializations in pat::Muon (minimal catch up to #28212 and #29324)

### DIFF
--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -95,7 +95,9 @@ Muon::Muon(const edm::RefToBase<reco::Muon>& aMuonRef)
       jetPtRel_(0),
       mvaValue_(0),
       lowptMvaValue_(0),
-      softMvaValue_(0) {
+      softMvaValue_(0),
+      inverseBeta_(0),
+      inverseBetaErr_(0) {
   initImpactParameters();
   initSimInfo();
 }
@@ -124,7 +126,9 @@ Muon::Muon(const edm::Ptr<reco::Muon>& aMuonRef)
       jetPtRel_(0),
       mvaValue_(0),
       lowptMvaValue_(0),
-      softMvaValue_(0) {
+      softMvaValue_(0),
+      inverseBeta_(0),
+      inverseBetaErr_(0) {
   initImpactParameters();
   initSimInfo();
 }


### PR DESCRIPTION
some missing initializations were discovered during backport of #28212 to 10_6_X, as done in #29324. This PR fixes the master part.
