### PR TITLE
Add possibility to specify GBT Id only to DTC cabling map producer

### DIFF
--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -47,7 +47,7 @@ static constexpr const unsigned int gbt_id_maxvalue = 72;
 static constexpr const unsigned int elink_id_minvalue = 0;
 static constexpr const unsigned int elink_id_maxvalue = 7;
 
-enum {DUMMY_FILL_DISABLED = 0, DUMMY_FILL_ELINK_ID = 1, DUMMY_FILL_ELINK_ID_AND_GBT_ID = 2};
+enum { DUMMY_FILL_DISABLED = 0, DUMMY_FILL_ELINK_ID = 1, DUMMY_FILL_ELINK_ID_AND_GBT_ID = 2 };
 
 //
 // SOME HELPER FUNCTIONS
@@ -114,16 +114,16 @@ void DTCCablingMapProducer::fillDescriptions(edm::ConfigurationDescriptions& des
 
 DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig)
     : verbosity_(iConfig.getParameter<int>("verbosity")),
-      csvFormat_ncolumns_  (iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
-      csvFormat_idetid_    (iConfig.getParameter<unsigned>("csvFormat_idetid")),
-      csvFormat_idtcid_    (iConfig.getParameter<unsigned>("csvFormat_idtcid")),
+      csvFormat_ncolumns_(iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
+      csvFormat_idetid_(iConfig.getParameter<unsigned>("csvFormat_idetid")),
+      csvFormat_idtcid_(iConfig.getParameter<unsigned>("csvFormat_idtcid")),
       csvFormat_igbtlinkid_(iConfig.getParameter<unsigned>("csvFormat_igbtlinkid")),
-      csvFormat_ielinkid_  (iConfig.getParameter<unsigned>("csvFormat_ielinkid")),
+      csvFormat_ielinkid_(iConfig.getParameter<unsigned>("csvFormat_ielinkid")),
       iovBeginTime_(iConfig.getParameter<long long unsigned int>("iovBeginTime")),
       pCablingMap_(std::make_unique<TrackerDetToDTCELinkCablingMap>()),
       record_(iConfig.getParameter<std::string>("record")) {
   std::string const dummy_fill_mode_param = iConfig.getParameter<std::string>("dummy_fill_mode");
-  
+
   // We pass from the easy to use string to an int representation for this mode flag, as it is more efficient in comparisons
   if (dummy_fill_mode_param == "DUMMY_FILL_DISABLED")
     dummy_fill_mode_ = DUMMY_FILL_DISABLED;
@@ -136,7 +136,7 @@ DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig)
     message << "Parameter dummy_fill_mode with invalid value: " << dummy_fill_mode_param;
     throw cms::Exception(message.str());
   }
-  
+
   LoadModulesToDTCCablingMapFromCSV(iConfig.getParameter<std::vector<std::string>>("modulesToDTCCablingCSVFileNames"));
 }
 
@@ -145,7 +145,7 @@ void DTCCablingMapProducer::beginJob() {}
 void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
     std::vector<std::string> const& modulesToDTCCablingCSVFileNames) {
   using namespace std;
-  
+
   for (std::string const& csvFileName : modulesToDTCCablingCSVFileNames) {
     edm::FileInPath csvFilePath(csvFileName);
 
@@ -213,7 +213,7 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
             case DUMMY_FILL_DISABLED:
               gbt_id = strtoul(csvColumn.at(csvFormat_igbtlinkid_).c_str(), nullptr, 10);
               elink_id = strtoul(csvColumn.at(csvFormat_ielinkid_).c_str(), nullptr, 10);
-              break; 
+              break;
             case DUMMY_FILL_ELINK_ID:
               gbt_id = strtoul(csvColumn.at(csvFormat_igbtlinkid_).c_str(), nullptr, 10);
               for (elink_id = elink_id_minvalue; elink_id < elink_id_maxvalue + 1u; ++elink_id) {
@@ -228,11 +228,11 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
                     goto gbtlink_and_elinkid_generator_end;  //break out of this double loop, this is one of the few "proper" uses of goto
                 }
               }
-              gbtlink_and_elinkid_generator_end:
-                ((void)0);  // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
+            gbtlink_and_elinkid_generator_end:
+              ((void)0);  // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
               break;
           }
-          
+
           DTCELinkId dtcELinkId(dtc_id, gbt_id, elink_id);
 
           if (verbosity_ >= 3) {

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -47,7 +47,7 @@ static constexpr const unsigned int gbt_id_maxvalue = 72;
 static constexpr const unsigned int elink_id_minvalue = 0;
 static constexpr const unsigned int elink_id_maxvalue = 7;
 
-enum {DUMMY_FILL_DISABLED = 0, DUMMY_FILL_ELINK_ID = 1, DUMMY_FILL_ELINK_ID_AND_GBT_ID = 2};
+enum { DUMMY_FILL_DISABLED = 0, DUMMY_FILL_ELINK_ID = 1, DUMMY_FILL_ELINK_ID_AND_GBT_ID = 2 };
 
 //
 // SOME HELPER FUNCTIONS
@@ -114,16 +114,16 @@ void DTCCablingMapProducer::fillDescriptions(edm::ConfigurationDescriptions& des
 
 DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig)
     : verbosity_(iConfig.getParameter<int>("verbosity")),
-      csvFormat_ncolumns_  (iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
-      csvFormat_idetid_    (iConfig.getParameter<unsigned>("csvFormat_idetid")),
-      csvFormat_idtcid_    (iConfig.getParameter<unsigned>("csvFormat_idtcid")),
+      csvFormat_ncolumns_(iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
+      csvFormat_idetid_(iConfig.getParameter<unsigned>("csvFormat_idetid")),
+      csvFormat_idtcid_(iConfig.getParameter<unsigned>("csvFormat_idtcid")),
       csvFormat_igbtlinkid_(iConfig.getParameter<unsigned>("csvFormat_igbtlinkid")),
-      csvFormat_ielinkid_  (iConfig.getParameter<unsigned>("csvFormat_ielinkid")),
+      csvFormat_ielinkid_(iConfig.getParameter<unsigned>("csvFormat_ielinkid")),
       iovBeginTime_(iConfig.getParameter<long long unsigned int>("iovBeginTime")),
       pCablingMap_(std::make_unique<TrackerDetToDTCELinkCablingMap>()),
       record_(iConfig.getParameter<std::string>("record")) {
   std::string const dummy_fill_mode_param = iConfig.getParameter<std::string>("dummy_fill_mode");
-  
+
   // We pass from the easy to use string to an int representation for this mode flag, as it is more efficient in comparisons
   if (dummy_fill_mode_param == "DUMMY_FILL_DISABLED")
     dummy_fill_mode_ = DUMMY_FILL_DISABLED;
@@ -132,9 +132,10 @@ DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig)
   else if (dummy_fill_mode_param == "DUMMY_FILL_ELINK_ID_AND_GBT_ID")
     dummy_fill_mode_ = DUMMY_FILL_ELINK_ID_AND_GBT_ID;
   else {
-    throw cms::Exception("InvalidDummyFillMode") << "Parameter dummy_fill_mode with invalid value: " << dummy_fill_mode_param;
+    throw cms::Exception("InvalidDummyFillMode")
+        << "Parameter dummy_fill_mode with invalid value: " << dummy_fill_mode_param;
   }
-  
+
   LoadModulesToDTCCablingMapFromCSV(iConfig.getParameter<std::vector<std::string>>("modulesToDTCCablingCSVFileNames"));
 }
 
@@ -143,7 +144,7 @@ void DTCCablingMapProducer::beginJob() {}
 void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
     std::vector<std::string> const& modulesToDTCCablingCSVFileNames) {
   using namespace std;
-  
+
   for (std::string const& csvFileName : modulesToDTCCablingCSVFileNames) {
     edm::FileInPath csvFilePath(csvFileName);
 
@@ -211,7 +212,7 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
             case DUMMY_FILL_DISABLED:
               gbt_id = strtoul(csvColumn.at(csvFormat_igbtlinkid_).c_str(), nullptr, 10);
               elink_id = strtoul(csvColumn.at(csvFormat_ielinkid_).c_str(), nullptr, 10);
-              break; 
+              break;
             case DUMMY_FILL_ELINK_ID:
               gbt_id = strtoul(csvColumn.at(csvFormat_igbtlinkid_).c_str(), nullptr, 10);
               for (elink_id = elink_id_minvalue; elink_id < elink_id_maxvalue + 1u; ++elink_id) {
@@ -226,11 +227,11 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
                     goto gbtlink_and_elinkid_generator_end;  //break out of this double loop, this is one of the few "proper" uses of goto
                 }
               }
-              gbtlink_and_elinkid_generator_end:
-                ((void)0);  // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
+            gbtlink_and_elinkid_generator_end:
+              ((void)0);  // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
               break;
           }
-          
+
           DTCELinkId dtcELinkId(dtc_id, gbt_id, elink_id);
 
           if (verbosity_ >= 3) {
@@ -239,9 +240,9 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
           }
 
           if (pCablingMap_->knowsDTCELinkId(dtcELinkId)) {
-            throw cms::Exception("DuplicateDTCELinkIdInCSV") 
-              << "Reading CSV file: CRITICAL ERROR, duplicate dtcELinkId entry about (dtc_id, gbt_id, elink_id) = ("
-              << dtc_id << "," << gbt_id << "," << elink_id << ")";
+            throw cms::Exception("DuplicateDTCELinkIdInCSV")
+                << "Reading CSV file: CRITICAL ERROR, duplicate dtcELinkId entry about (dtc_id, gbt_id, elink_id) = ("
+                << dtc_id << "," << gbt_id << "," << elink_id << ")";
           }
 
           pCablingMap_->insert(dtcELinkId, detIdRaw);

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -43,9 +43,9 @@ Implementation:
 //
 
 static constexpr const unsigned int gbt_id_minvalue = 0;
-static constexpr const unsigned int gbt_id_maxvalue = 72;
+static constexpr const unsigned int gbt_id_maxvalue = 71;
 static constexpr const unsigned int elink_id_minvalue = 0;
-static constexpr const unsigned int elink_id_maxvalue = 7;
+static constexpr const unsigned int elink_id_maxvalue = 6;
 
 enum { DUMMY_FILL_DISABLED = 0, DUMMY_FILL_ELINK_ID = 1, DUMMY_FILL_ELINK_ID_AND_GBT_ID = 2 };
 

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -47,6 +47,8 @@ static constexpr const unsigned int gbt_id_maxvalue = 72;
 static constexpr const unsigned int elink_id_minvalue = 0;
 static constexpr const unsigned int elink_id_maxvalue = 7;
 
+enum {DUMMY_FILL_DISABLED = 0, DUMMY_FILL_ELINK_ID = 1, DUMMY_FILL_ELINK_ID_AND_GBT_ID = 2};
+
 //
 // SOME HELPER FUNCTIONS
 //
@@ -82,7 +84,7 @@ private:
   virtual void LoadModulesToDTCCablingMapFromCSV(std::vector<std::string> const&);
 
 private:
-  bool generate_fake_valid_gbtlink_and_elinkid_;
+  int dummy_fill_mode_;
   int verbosity_;
   unsigned csvFormat_ncolumns_;
   unsigned csvFormat_idetid_;
@@ -97,13 +99,13 @@ private:
 void DTCCablingMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Stores a TrackerDetToDTCELinkCablingMap object into the database from a CSV file.");
-  desc.add<bool>("generate_fake_valid_gbtlink_and_elinkid", false);
+  desc.add<std::string>("dummy_fill_mode", "DUMMY_FILL_DISABLED");
   desc.add<int>("verbosity", 0);
-  desc.add<unsigned>("csvFormat_idetid", 0);
   desc.add<unsigned>("csvFormat_ncolumns", 15);
-  desc.add<unsigned>("csvFormat_idtcid", 10);
-  desc.add<unsigned>("csvFormat_igbtlinkid", 11);
-  desc.add<unsigned>("csvFormat_ielinkid", 12);
+  desc.add<unsigned>("csvFormat_idetid", 0);
+  desc.add<unsigned>("csvFormat_idtcid", 0);
+  desc.add<unsigned>("csvFormat_igbtlinkid", 0);
+  desc.add<unsigned>("csvFormat_ielinkid", 0);
   desc.add<long long unsigned int>("iovBeginTime", 1);
   desc.add<std::string>("record", "TrackerDTCCablingMapRcd");
   desc.add<std::vector<std::string>>("modulesToDTCCablingCSVFileNames", std::vector<std::string>());
@@ -111,14 +113,30 @@ void DTCCablingMapProducer::fillDescriptions(edm::ConfigurationDescriptions& des
 }
 
 DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig)
-    : generate_fake_valid_gbtlink_and_elinkid_(iConfig.getParameter<bool>("generate_fake_valid_gbtlink_and_elinkid")),
-      verbosity_(iConfig.getParameter<int>("verbosity")),
-      csvFormat_ncolumns_(iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
-      csvFormat_idetid_(iConfig.getParameter<unsigned>("csvFormat_idetid")),
-      csvFormat_idtcid_(iConfig.getParameter<unsigned>("csvFormat_idtcid")),
+    : verbosity_(iConfig.getParameter<int>("verbosity")),
+      csvFormat_ncolumns_  (iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
+      csvFormat_idetid_    (iConfig.getParameter<unsigned>("csvFormat_idetid")),
+      csvFormat_idtcid_    (iConfig.getParameter<unsigned>("csvFormat_idtcid")),
+      csvFormat_igbtlinkid_(iConfig.getParameter<unsigned>("csvFormat_igbtlinkid")),
+      csvFormat_ielinkid_  (iConfig.getParameter<unsigned>("csvFormat_ielinkid")),
       iovBeginTime_(iConfig.getParameter<long long unsigned int>("iovBeginTime")),
       pCablingMap_(std::make_unique<TrackerDetToDTCELinkCablingMap>()),
       record_(iConfig.getParameter<std::string>("record")) {
+  std::string const dummy_fill_mode_param = iConfig.getParameter<std::string>("dummy_fill_mode");
+  
+  // We pass from the easy to use string to an int representation for this mode flag, as it is more efficient in comparisons
+  if (dummy_fill_mode_param == "DUMMY_FILL_DISABLED")
+    dummy_fill_mode_ = DUMMY_FILL_DISABLED;
+  else if (dummy_fill_mode_param == "DUMMY_FILL_ELINK_ID")
+    dummy_fill_mode_ = DUMMY_FILL_ELINK_ID;
+  else if (dummy_fill_mode_param == "DUMMY_FILL_ELINK_ID_AND_GBT_ID")
+    dummy_fill_mode_ = DUMMY_FILL_ELINK_ID_AND_GBT_ID;
+  else {
+    std::ostringstream message;
+    message << "Parameter dummy_fill_mode with invalid value: " << dummy_fill_mode_param;
+    throw cms::Exception(message.str());
+  }
+  
   LoadModulesToDTCCablingMapFromCSV(iConfig.getParameter<std::vector<std::string>>("modulesToDTCCablingCSVFileNames"));
 }
 
@@ -127,7 +145,7 @@ void DTCCablingMapProducer::beginJob() {}
 void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
     std::vector<std::string> const& modulesToDTCCablingCSVFileNames) {
   using namespace std;
-
+  
   for (std::string const& csvFileName : modulesToDTCCablingCSVFileNames) {
     edm::FileInPath csvFilePath(csvFileName);
 
@@ -178,7 +196,7 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
           uint32_t detIdRaw;
 
           try {
-            detIdRaw = std::stoi(csvColumn[csvFormat_idetid_]);
+            detIdRaw = std::stoi(csvColumn.at(csvFormat_idetid_));
           } catch (std::exception const& e) {
             if (verbosity_ >= 0) {
               edm::LogError("CSVParser") << "-- malformed DetId string in CSV file: \"" << csvLine << "\"" << endl;
@@ -186,24 +204,35 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
             throw e;
           }
 
-          unsigned const dtc_id = strtoul(csvColumn[csvFormat_idtcid_].c_str(), nullptr, 10);
+          unsigned const dtc_id = strtoul(csvColumn.at(csvFormat_idtcid_).c_str(), nullptr, 10);
           unsigned gbt_id;
           unsigned elink_id;
 
-          if (generate_fake_valid_gbtlink_and_elinkid_) {
-            for (gbt_id = gbt_id_minvalue; gbt_id < gbt_id_maxvalue + 1u; ++gbt_id) {
+          switch (dummy_fill_mode_) {
+            default:
+            case DUMMY_FILL_DISABLED:
+              gbt_id = strtoul(csvColumn.at(csvFormat_igbtlinkid_).c_str(), nullptr, 10);
+              elink_id = strtoul(csvColumn.at(csvFormat_ielinkid_).c_str(), nullptr, 10);
+              break; 
+            case DUMMY_FILL_ELINK_ID:
+              gbt_id = strtoul(csvColumn.at(csvFormat_igbtlinkid_).c_str(), nullptr, 10);
               for (elink_id = elink_id_minvalue; elink_id < elink_id_maxvalue + 1u; ++elink_id) {
                 if (!(pCablingMap_->knowsDTCELinkId(DTCELinkId(dtc_id, gbt_id, elink_id))))
-                  goto gbtlink_and_elinkid_generator_end;  //break out of this double loop
+                  break;
               }
-            }
-          gbtlink_and_elinkid_generator_end:
-            ((void)0);  // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
-          } else {
-            gbt_id = strtoul(csvColumn[csvFormat_igbtlinkid_].c_str(), nullptr, 10);
-            elink_id = strtoul(csvColumn[csvFormat_ielinkid_].c_str(), nullptr, 10);
+              break;
+            case DUMMY_FILL_ELINK_ID_AND_GBT_ID:
+              for (gbt_id = gbt_id_minvalue; gbt_id < gbt_id_maxvalue + 1u; ++gbt_id) {
+                for (elink_id = elink_id_minvalue; elink_id < elink_id_maxvalue + 1u; ++elink_id) {
+                  if (!(pCablingMap_->knowsDTCELinkId(DTCELinkId(dtc_id, gbt_id, elink_id))))
+                    goto gbtlink_and_elinkid_generator_end;  //break out of this double loop, this is one of the few "proper" uses of goto
+                }
+              }
+              gbtlink_and_elinkid_generator_end:
+                ((void)0);  // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
+              break;
           }
-
+          
           DTCELinkId dtcELinkId(dtc_id, gbt_id, elink_id);
 
           if (verbosity_ >= 3) {

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -47,7 +47,7 @@ static constexpr const unsigned int gbt_id_maxvalue = 72;
 static constexpr const unsigned int elink_id_minvalue = 0;
 static constexpr const unsigned int elink_id_maxvalue = 7;
 
-enum { DUMMY_FILL_DISABLED = 0, DUMMY_FILL_ELINK_ID = 1, DUMMY_FILL_ELINK_ID_AND_GBT_ID = 2 };
+enum {DUMMY_FILL_DISABLED = 0, DUMMY_FILL_ELINK_ID = 1, DUMMY_FILL_ELINK_ID_AND_GBT_ID = 2};
 
 //
 // SOME HELPER FUNCTIONS
@@ -114,16 +114,16 @@ void DTCCablingMapProducer::fillDescriptions(edm::ConfigurationDescriptions& des
 
 DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig)
     : verbosity_(iConfig.getParameter<int>("verbosity")),
-      csvFormat_ncolumns_(iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
-      csvFormat_idetid_(iConfig.getParameter<unsigned>("csvFormat_idetid")),
-      csvFormat_idtcid_(iConfig.getParameter<unsigned>("csvFormat_idtcid")),
+      csvFormat_ncolumns_  (iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
+      csvFormat_idetid_    (iConfig.getParameter<unsigned>("csvFormat_idetid")),
+      csvFormat_idtcid_    (iConfig.getParameter<unsigned>("csvFormat_idtcid")),
       csvFormat_igbtlinkid_(iConfig.getParameter<unsigned>("csvFormat_igbtlinkid")),
-      csvFormat_ielinkid_(iConfig.getParameter<unsigned>("csvFormat_ielinkid")),
+      csvFormat_ielinkid_  (iConfig.getParameter<unsigned>("csvFormat_ielinkid")),
       iovBeginTime_(iConfig.getParameter<long long unsigned int>("iovBeginTime")),
       pCablingMap_(std::make_unique<TrackerDetToDTCELinkCablingMap>()),
       record_(iConfig.getParameter<std::string>("record")) {
   std::string const dummy_fill_mode_param = iConfig.getParameter<std::string>("dummy_fill_mode");
-
+  
   // We pass from the easy to use string to an int representation for this mode flag, as it is more efficient in comparisons
   if (dummy_fill_mode_param == "DUMMY_FILL_DISABLED")
     dummy_fill_mode_ = DUMMY_FILL_DISABLED;
@@ -132,11 +132,9 @@ DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig)
   else if (dummy_fill_mode_param == "DUMMY_FILL_ELINK_ID_AND_GBT_ID")
     dummy_fill_mode_ = DUMMY_FILL_ELINK_ID_AND_GBT_ID;
   else {
-    std::ostringstream message;
-    message << "Parameter dummy_fill_mode with invalid value: " << dummy_fill_mode_param;
-    throw cms::Exception(message.str());
+    throw cms::Exception("InvalidDummyFillMode") << "Parameter dummy_fill_mode with invalid value: " << dummy_fill_mode_param;
   }
-
+  
   LoadModulesToDTCCablingMapFromCSV(iConfig.getParameter<std::vector<std::string>>("modulesToDTCCablingCSVFileNames"));
 }
 
@@ -145,7 +143,7 @@ void DTCCablingMapProducer::beginJob() {}
 void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
     std::vector<std::string> const& modulesToDTCCablingCSVFileNames) {
   using namespace std;
-
+  
   for (std::string const& csvFileName : modulesToDTCCablingCSVFileNames) {
     edm::FileInPath csvFilePath(csvFileName);
 
@@ -213,7 +211,7 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
             case DUMMY_FILL_DISABLED:
               gbt_id = strtoul(csvColumn.at(csvFormat_igbtlinkid_).c_str(), nullptr, 10);
               elink_id = strtoul(csvColumn.at(csvFormat_ielinkid_).c_str(), nullptr, 10);
-              break;
+              break; 
             case DUMMY_FILL_ELINK_ID:
               gbt_id = strtoul(csvColumn.at(csvFormat_igbtlinkid_).c_str(), nullptr, 10);
               for (elink_id = elink_id_minvalue; elink_id < elink_id_maxvalue + 1u; ++elink_id) {
@@ -228,11 +226,11 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
                     goto gbtlink_and_elinkid_generator_end;  //break out of this double loop, this is one of the few "proper" uses of goto
                 }
               }
-            gbtlink_and_elinkid_generator_end:
-              ((void)0);  // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
+              gbtlink_and_elinkid_generator_end:
+                ((void)0);  // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
               break;
           }
-
+          
           DTCELinkId dtcELinkId(dtc_id, gbt_id, elink_id);
 
           if (verbosity_ >= 3) {
@@ -241,12 +239,9 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
           }
 
           if (pCablingMap_->knowsDTCELinkId(dtcELinkId)) {
-            ostringstream message;
-            message
-                << "Reading CSV file: CRITICAL ERROR, duplicated dtcELinkId entry about (dtc_id, gbt_id, elink_id) = ("
-                << dtc_id << "," << gbt_id << "," << elink_id << ")";
-
-            throw cms::Exception(message.str());
+            throw cms::Exception("DuplicateDTCELinkIdInSource") 
+              << "Reading CSV file: CRITICAL ERROR, duplicate dtcELinkId entry about (dtc_id, gbt_id, elink_id) = ("
+              << dtc_id << "," << gbt_id << "," << elink_id << ")";
           }
 
           pCablingMap_->insert(dtcELinkId, detIdRaw);

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -239,7 +239,7 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
           }
 
           if (pCablingMap_->knowsDTCELinkId(dtcELinkId)) {
-            throw cms::Exception("DuplicateDTCELinkIdInSource") 
+            throw cms::Exception("DuplicateDTCELinkIdInCSV") 
               << "Reading CSV file: CRITICAL ERROR, duplicate dtcELinkId entry about (dtc_id, gbt_id, elink_id) = ("
               << dtc_id << "," << gbt_id << "," << elink_id << ")";
           }
@@ -252,7 +252,7 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
         }
       }
     } else {
-      throw cms::Exception("DTCCablingMapProducer: Unable to open input CSV file") << csvFilePath << endl;
+      throw cms::Exception("CSVFileNotFound") << "Unable to open input CSV file" << csvFilePath << endl;
     }
 
     csvFile.close();
@@ -270,7 +270,7 @@ void DTCCablingMapProducer::endJob() {
   if (poolDbService.isAvailable()) {
     poolDbService->writeOne(pCablingMap_.release(), iovBeginTime_, record_);
   } else {
-    throw cms::Exception("PoolDBService required.");
+    throw cms::Exception("PoolDBServiceNotFound") << "A running PoolDBService instance is required.";
   }
 }
 

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write.py
@@ -30,13 +30,17 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 
 process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapProducer",
     record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
-    generate_fake_valid_gbtlink_and_elinkid = cms.bool(True),
+    #dummy_fill_mode = cms.string("DUMMY_FILL_DISABLED"),
+    #dummy_fill_mode = cms.string("DUMMY_FILL_ELINK_ID"),
     modulesToDTCCablingCSVFileNames = cms.vstring(
-      "CondTools/SiPhase2Tracker/data/TrackerModuleToDTCCablingMap__OT616_200_IT613__T14__OTOnly.csv"
+      "CondTools/SiPhase2Tracker/TrackerDetToDTCELinkCablingMap__OT614_200_IT404_layer2_10G__T6__OTOnly.csv"
     ),
-    csvFormat_ncolumns = cms.uint32( 2),
-    csvFormat_idetid   = cms.uint32( 0),
-    csvFormat_idtcid   = cms.uint32( 1),
+    dummy_fill_mode = cms.string("DUMMY_FILL_ELINK_ID_AND_GBT_ID"),
+    csvFormat_ncolumns   = cms.uint32( 2),
+    csvFormat_idetid     = cms.uint32( 0),
+    csvFormat_idtcid     = cms.uint32( 1),
+    csvFormat_igbtlinkid = cms.uint32( 1),
+    csvFormat_ielinkid   = cms.uint32( 1),
     verbosity = cms.int32(0),
     #loggingOn= cms.untracked.bool(True),
     #SinceAppendMode=cms.bool(True),


### PR DESCRIPTION
Change the PSet parameters in the DTCCablingMapProducer, so the user can choose to provide the elink and gbt ids, provide the gbt id and generate a dummy sequential elink id, or generate both

#### PR description:

Following feature request 29390 (https://github.com/cms-sw/cmssw/issues/29390) the producer code was changed, such that the user can choose three operating modes:

- gbtlink id and elink id are provided in the csv
- only gbtlink id is provided in the csv, the elink id is sequentially assigned dummy values to detectors as they are encountered in the same gbt id
- both gbtlink id and elink id are sequentially assigned with dummy values

The parameter choosing the mode is implemented as a string, and the corresponding state flag is implemented as an int type (enum) for performance reasons.

Due to the increased risk of the user choosing the wrong mode or column configuration, and due to the cryptic message resulting from an out-of-bound access to a vector when using operator[], bound checks have been activated replacing operator[] with at() 

No other changes to the code were introduced, and the formatting style was kept the same.
No dependence on external PRs.

#### PR validation:

Validated on the DTC cabling map payload production, retrieve and dump PSets

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.