### PR TITLE
Run GeneratorFilter modules in an external process controlled by cmsRun

### DIFF
--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
       //This class is holding the lock
       WorkerChannel communicationChannel(memoryName, uniqueID);
 
-      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferIndex()};
+      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferInfo()};
       int counter = 0;
 
       //The lock must be released if there is a catastrophic signal

--- a/FWCore/Integration/bin/interprocess_random.cc
+++ b/FWCore/Integration/bin/interprocess_random.cc
@@ -104,8 +104,8 @@ int main(int argc, char* argv[]) {
       //This class is holding the lock
       WorkerChannel communicationChannel(memoryName, uniqueID);
 
-      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferIndex()};
-      ReadBuffer sm_readbuffer{std::string("Rand") + memoryName, communicationChannel.toWorkerBufferIndex()};
+      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferInfo()};
+      ReadBuffer sm_readbuffer{std::string("Rand") + memoryName, communicationChannel.toWorkerBufferInfo()};
       int counter = 0;
 
       //The lock must be released if there is a catastrophic signal

--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -20,7 +20,7 @@ namespace testinter {
     StreamCache(const std::string& iConfig, int id)
         : id_{id},
           channel_("testProd", id_),
-          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferIndex()},
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferInfo()},
           deserializer_{readBuffer_},
           br_deserializer_{readBuffer_},
           er_deserializer_{readBuffer_},

--- a/FWCore/Integration/test/TestInterProcessRandomProd.cc
+++ b/FWCore/Integration/test/TestInterProcessRandomProd.cc
@@ -32,8 +32,8 @@ namespace testinter {
     StreamCache(const std::string& iConfig, int id)
         : id_{id},
           channel_("testProd", id_),
-          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferIndex()},
-          writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferIndex()},
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferInfo()},
+          writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferInfo()},
           deserializer_{readBuffer_},
           bl_deserializer_{readBuffer_},
           randSerializer_{writeBuffer_} {

--- a/FWCore/SharedMemory/interface/BufferInfo.h
+++ b/FWCore/SharedMemory/interface/BufferInfo.h
@@ -1,0 +1,33 @@
+#ifndef FWCore_SharedMemory_BufferInfo_h
+#define FWCore_SharedMemory_BufferInfo_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     BufferInfo
+//
+/**\class BufferInfo BufferInfo.h " FWCore/SharedMemory/interface/BufferInfo.h"
+
+ Description: Information needed to manage the buffer
+
+ Usage:
+    This is an internal detail of the system.
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  struct BufferInfo {
+    int identifier_;
+    char index_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -29,6 +29,7 @@
 // user include files
 #include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/SharedMemory/interface/BufferInfo.h"
 
 // forward declarations
 
@@ -48,7 +49,7 @@ namespace edm::shared_memory {
     // ---------- member functions ---------------------------
 
     /** setupWorker must be called only once and done before any calls to doTransition. The functor iF should setup values associated
-     with shared memory use, such as manipulating the value from toWorkerBufferIndex(). The call to setupWorker proper synchronizes
+     with shared memory use, such as manipulating the value from toWorkerBufferInfo(). The call to setupWorker proper synchronizes
      the Controller and Worker processes.
      */
     template <typename F>
@@ -83,9 +84,9 @@ namespace edm::shared_memory {
     }
 
     ///This can be used with WriteBuffer to keep Controller and Worker in sync
-    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    BufferInfo* toWorkerBufferInfo() { return toWorkerBufferInfo_; }
     ///This can be used with ReadBuffer to keep Controller and Worker in sync
-    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
+    BufferInfo* fromWorkerBufferInfo() { return fromWorkerBufferInfo_; }
 
     void stopWorker() {
       //std::cout <<"stopWorker"<<std::endl;
@@ -104,7 +105,7 @@ namespace edm::shared_memory {
     bool shouldKeepEvent() const { return *keepEvent_; }
 
   private:
-    static char* bufferIndex(const char* iWhich, boost::interprocess::managed_shared_memory& mem);
+    static BufferInfo* bufferInfo(const char* iWhich, boost::interprocess::managed_shared_memory& mem);
 
     std::string uniqueName(std::string iBase) const;
 
@@ -116,8 +117,8 @@ namespace edm::shared_memory {
     int id_;
     std::string smName_;
     boost::interprocess::managed_shared_memory managed_sm_;
-    char* toWorkerBufferIndex_;
-    char* fromWorkerBufferIndex_;
+    BufferInfo* toWorkerBufferInfo_;
+    BufferInfo* fromWorkerBufferInfo_;
 
     boost::interprocess::named_mutex mutex_;
     boost::interprocess::named_condition cndFromMain_;

--- a/FWCore/SharedMemory/interface/ROOTDeserializer.h
+++ b/FWCore/SharedMemory/interface/ROOTDeserializer.h
@@ -43,9 +43,10 @@ namespace edm::shared_memory {
     // ---------- member functions ---------------------------
     T deserialize() {
       T value;
-      if (buffer_.mustGetBufferAgain()) {
+      if (previousBufferIdentifier_ != buffer_.bufferIdentifier()) {
         auto buff = buffer_.buffer();
         bufferFile_.SetBuffer(buff.first, buff.second, kFALSE);
+        previousBufferIdentifier_ = buffer_.bufferIdentifier();
       }
 
       class_->ReadBuffer(bufferFile_, &value);
@@ -58,6 +59,7 @@ namespace edm::shared_memory {
     READBUFFER& buffer_;
     TClass* const class_;
     TBufferFile bufferFile_;
+    int previousBufferIdentifier_ = 0;
   };
 }  // namespace edm::shared_memory
 

--- a/FWCore/SharedMemory/interface/WorkerChannel.h
+++ b/FWCore/SharedMemory/interface/WorkerChannel.h
@@ -27,6 +27,7 @@
 
 // user include files
 #include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/SharedMemory/interface/BufferInfo.h"
 
 // forward declarations
 
@@ -47,9 +48,9 @@ namespace edm::shared_memory {
     boost::interprocess::scoped_lock<boost::interprocess::named_mutex>* accessLock() { return &lock_; }
 
     ///This can be used with ReadBuffer to keep Controller and Worker in sync
-    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    BufferInfo* toWorkerBufferInfo() { return toWorkerBufferInfo_; }
     ///This can be used with WriteBuffer to keep Controller and Worker in sync
-    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
+    BufferInfo* fromWorkerBufferInfo() { return fromWorkerBufferInfo_; }
 
     ///Matches the ControllerChannel::setupWorker call
     void workerSetupDone() {
@@ -94,8 +95,8 @@ namespace edm::shared_memory {
     bool* stop_;
     edm::Transition* transitionType_;
     unsigned long long* transitionID_;
-    char* toWorkerBufferIndex_;
-    char* fromWorkerBufferIndex_;
+    BufferInfo* toWorkerBufferInfo_;
+    BufferInfo* fromWorkerBufferInfo_;
     boost::interprocess::named_condition cndToController_;
     bool* keepEvent_;
     boost::interprocess::scoped_lock<boost::interprocess::named_mutex> lock_;

--- a/FWCore/SharedMemory/interface/WriteBuffer.h
+++ b/FWCore/SharedMemory/interface/WriteBuffer.h
@@ -29,6 +29,7 @@
 
 // user include files
 #include "FWCore/SharedMemory/interface/buffer_names.h"
+#include "FWCore/SharedMemory/interface/BufferInfo.h"
 
 // forward declarations
 
@@ -36,14 +37,14 @@ namespace edm::shared_memory {
   class WriteBuffer {
   public:
     /** iUniqueName : must be unique for all processes running on a system.
-        iBufferIndex : is a pointer to a shared_memory address where the same address needs to be shared by ReadBuffer and WriteBuffer.
+        iBufferInfo : is a pointer to a shared_memory address where the same address needs to be shared by ReadBuffer and WriteBuffer.
     */
 
-    WriteBuffer(std::string const& iUniqueName, char* iBufferIndex)
-        : bufferSize_{0}, buffer_{nullptr}, bufferIndex_{iBufferIndex} {
+    WriteBuffer(std::string const& iUniqueName, BufferInfo* iBufferInfo)
+        : bufferSize_{0}, buffer_{nullptr}, bufferInfo_{iBufferInfo} {
       bufferNames_[0] = iUniqueName + buffer_names::kBuffer0;
       bufferNames_[1] = iUniqueName + buffer_names::kBuffer1;
-      assert(bufferIndex_);
+      assert(bufferInfo_);
     }
     WriteBuffer(const WriteBuffer&) = delete;
     const WriteBuffer& operator=(const WriteBuffer&) = delete;
@@ -66,7 +67,7 @@ namespace edm::shared_memory {
     // ---------- member data --------------------------------
     std::size_t bufferSize_;
     char* buffer_;
-    char* bufferIndex_;
+    BufferInfo* bufferInfo_;
     std::array<std::string, 2> bufferNames_;
     std::unique_ptr<boost::interprocess::managed_shared_memory> sm_;
   };

--- a/FWCore/SharedMemory/interface/channel_names.h
+++ b/FWCore/SharedMemory/interface/channel_names.h
@@ -26,8 +26,8 @@
 
 namespace edm::shared_memory {
   namespace channel_names {
-    constexpr char const* const kToWorkerBufferIndex = "bufferIndexToWorker";
-    constexpr char const* const kFromWorkerBufferIndex = "bufferIndexFromWorker";
+    constexpr char const* const kToWorkerBufferInfo = "bufferInfoToWorker";
+    constexpr char const* const kFromWorkerBufferInfo = "bufferInfoFromWorker";
     constexpr char const* const kMutex = "mtx";
     constexpr char const* const kConditionFromMain = "cndFromMain";
     constexpr char const* const kConditionToMain = "cndToMain";

--- a/FWCore/SharedMemory/src/ControllerChannel.cc
+++ b/FWCore/SharedMemory/src/ControllerChannel.cc
@@ -35,8 +35,8 @@ ControllerChannel::ControllerChannel(std::string const& iName, int id)
     : id_{id},
       smName_{uniqueName(iName)},
       managed_sm_{open_or_create, smName_.c_str(), 1024},
-      toWorkerBufferIndex_{bufferIndex(channel_names::kToWorkerBufferIndex, managed_sm_)},
-      fromWorkerBufferIndex_{bufferIndex(channel_names::kFromWorkerBufferIndex, managed_sm_)},
+      toWorkerBufferInfo_{bufferInfo(channel_names::kToWorkerBufferInfo, managed_sm_)},
+      fromWorkerBufferInfo_{bufferInfo(channel_names::kFromWorkerBufferInfo, managed_sm_)},
       mutex_{open_or_create, uniqueName(channel_names::kMutex).c_str()},
       cndFromMain_{open_or_create, uniqueName(channel_names::kConditionFromMain).c_str()},
       cndToMain_{open_or_create, uniqueName(channel_names::kConditionToMain).c_str()} {
@@ -61,8 +61,8 @@ ControllerChannel::~ControllerChannel() {
   managed_sm_.destroy<bool>(channel_names::kStop);
   managed_sm_.destroy<unsigned int>(channel_names::kTransitionType);
   managed_sm_.destroy<unsigned long long>(channel_names::kTransitionID);
-  managed_sm_.destroy<char>(channel_names::kToWorkerBufferIndex);
-  managed_sm_.destroy<char>(channel_names::kFromWorkerBufferIndex);
+  managed_sm_.destroy<BufferInfo>(channel_names::kToWorkerBufferInfo);
+  managed_sm_.destroy<BufferInfo>(channel_names::kFromWorkerBufferInfo);
 
   named_mutex::remove(uniqueName(channel_names::kMutex).c_str());
   named_condition::remove(uniqueName(channel_names::kConditionFromMain).c_str());
@@ -103,8 +103,8 @@ bool ControllerChannel::wait(scoped_lock<named_mutex>& lock, edm::Transition iTr
 //
 // static member functions
 //
-char* ControllerChannel::bufferIndex(const char* iWhich, managed_shared_memory& mem) {
-  mem.destroy<char>(iWhich);
-  char* v = mem.construct<char>(iWhich)();
+BufferInfo* ControllerChannel::bufferInfo(const char* iWhich, managed_shared_memory& mem) {
+  mem.destroy<BufferInfo>(iWhich);
+  BufferInfo* v = mem.construct<BufferInfo>(iWhich)();
   return v;
 }

--- a/FWCore/SharedMemory/src/WorkerChannel.cc
+++ b/FWCore/SharedMemory/src/WorkerChannel.cc
@@ -44,16 +44,16 @@ WorkerChannel::WorkerChannel(std::string const& iName, const std::string& iUniqu
       stop_{managed_shm_.find<bool>(channel_names::kStop).first},
       transitionType_{managed_shm_.find<edm::Transition>(channel_names::kTransitionType).first},
       transitionID_{managed_shm_.find<unsigned long long>(channel_names::kTransitionID).first},
-      toWorkerBufferIndex_{managed_shm_.find<char>(channel_names::kToWorkerBufferIndex).first},
-      fromWorkerBufferIndex_{managed_shm_.find<char>(channel_names::kFromWorkerBufferIndex).first},
+      toWorkerBufferInfo_{managed_shm_.find<BufferInfo>(channel_names::kToWorkerBufferInfo).first},
+      fromWorkerBufferInfo_{managed_shm_.find<BufferInfo>(channel_names::kFromWorkerBufferInfo).first},
       cndToController_{open_or_create, unique_name(channel_names::kConditionToMain, iUniqueID).c_str()},
       keepEvent_{managed_shm_.find<bool>(channel_names::kKeepEvent).first},
       lock_{mutex_} {
   assert(stop_);
   assert(transitionType_);
   assert(transitionID_);
-  assert(toWorkerBufferIndex_);
-  assert(fromWorkerBufferIndex_);
+  assert(toWorkerBufferInfo_);
+  assert(fromWorkerBufferInfo_);
 }
 
 //

--- a/FWCore/SharedMemory/src/WriteBuffer.cc
+++ b/FWCore/SharedMemory/src/WriteBuffer.cc
@@ -32,24 +32,25 @@ WriteBuffer::~WriteBuffer() {
   if (sm_) {
     sm_->destroy<char>(buffer_names::kBuffer);
     sm_.reset();
-    boost::interprocess::shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
+    boost::interprocess::shared_memory_object::remove(bufferNames_[bufferInfo_->index_].c_str());
   }
 }
 //
 // member functions
 //
 void WriteBuffer::growBuffer(std::size_t iLength) {
-  int newBuffer = (*bufferIndex_ + 1) % 2;
+  int newBuffer = (bufferInfo_->index_ + 1) % 2;
   if (sm_) {
     sm_->destroy<char>(buffer_names::kBuffer);
     sm_.reset();
-    boost::interprocess::shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
+    boost::interprocess::shared_memory_object::remove(bufferNames_[bufferInfo_->index_].c_str());
   }
   sm_ = std::make_unique<boost::interprocess::managed_shared_memory>(
       boost::interprocess::open_or_create, bufferNames_[newBuffer].c_str(), iLength + 1024);
   assert(sm_.get());
   bufferSize_ = iLength;
-  *bufferIndex_ = newBuffer;
+  bufferInfo_->index_ = newBuffer;
+  bufferInfo_->identifier_ = bufferInfo_->identifier_ + 1;
   buffer_ = sm_->construct<char>(buffer_names::kBuffer)[iLength](0);
   assert(buffer_);
 }

--- a/FWCore/SharedMemory/test/test_catch2_buffer.cc
+++ b/FWCore/SharedMemory/test/test_catch2_buffer.cc
@@ -9,20 +9,20 @@
 using namespace edm::shared_memory;
 
 TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
-  char bufferIndex = 0;
+  BufferInfo bufferInfo = {0, 0};
 
   std::string const uniqueName = "BufferTest" + std::to_string(getpid());
 
-  WriteBuffer writeBuffer(uniqueName, &bufferIndex);
+  WriteBuffer writeBuffer(uniqueName, &bufferInfo);
 
-  ReadBuffer readBuffer(uniqueName, &bufferIndex);
+  ReadBuffer readBuffer(uniqueName, &bufferInfo);
 
   SECTION("First") {
     std::array<char, 4> dummy = {{'t', 'e', 's', 't'}};
 
     writeBuffer.copyToBuffer(dummy.data(), dummy.size());
 
-    REQUIRE(readBuffer.mustGetBufferAgain());
+    REQUIRE(readBuffer.bufferIdentifier() == 1);
     {
       auto b = readBuffer.buffer();
       REQUIRE(b.second == dummy.size());
@@ -34,7 +34,7 @@ TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
 
       writeBuffer.copyToBuffer(dummy.data(), dummy.size() - 1);
 
-      REQUIRE(not readBuffer.mustGetBufferAgain());
+      REQUIRE(readBuffer.bufferIdentifier() == 1);
       {
         auto b = readBuffer.buffer();
         //the second argument is the buffer capacity, not the last length sent
@@ -46,7 +46,7 @@ TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
         std::array<char, 6> dummy = {{'l', 'a', 'r', 'g', 'e', 'r'}};
         writeBuffer.copyToBuffer(dummy.data(), dummy.size());
 
-        REQUIRE(readBuffer.mustGetBufferAgain());
+        REQUIRE(readBuffer.bufferIdentifier() == 2);
         {
           auto b = readBuffer.buffer();
           REQUIRE(b.second == dummy.size());
@@ -58,7 +58,7 @@ TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
           std::array<char, 7> dummy = {{'l', 'a', 'r', 'g', 'e', 's', 't'}};
           writeBuffer.copyToBuffer(dummy.data(), dummy.size());
 
-          REQUIRE(readBuffer.mustGetBufferAgain());
+          REQUIRE(readBuffer.bufferIdentifier() == 3);
           {
             auto b = readBuffer.buffer();
             REQUIRE(b.second == dummy.size());

--- a/FWCore/SharedMemory/test/test_channels.cc
+++ b/FWCore/SharedMemory/test/test_channels.cc
@@ -38,12 +38,16 @@ namespace {
       });
     }
     {
-      *channel.toWorkerBufferIndex() = 0;
+      *channel.toWorkerBufferInfo() = {0, 0};
       auto result = channel.doTransition(
           [&]() {
-            if (*channel.fromWorkerBufferIndex() != 1) {
+            if (channel.fromWorkerBufferInfo()->index_ != 1) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
               throw cms::Exception("BadValue")
-                  << "wrong value of fromWorkerBufferIndex " << *channel.fromWorkerBufferIndex();
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
             }
             if (not channel.shouldKeepEvent()) {
               throw cms::Exception("BadValue") << "told not to keep event";
@@ -56,12 +60,16 @@ namespace {
       }
     }
     {
-      *channel.toWorkerBufferIndex() = 1;
+      *channel.toWorkerBufferInfo() = {1, 1};
       auto result = channel.doTransition(
           [&]() {
-            if (*channel.fromWorkerBufferIndex() != 0) {
+            if (channel.fromWorkerBufferInfo()->index_ != 0) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
               throw cms::Exception("BadValue")
-                  << "wrong value of fromWorkerBufferIndex " << *channel.fromWorkerBufferIndex();
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
             }
             if (channel.shouldKeepEvent()) {
               throw cms::Exception("BadValue") << "told to keep event";
@@ -105,10 +113,15 @@ namespace {
             throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
           }
 
-          if (*channel.toWorkerBufferIndex() != 0) {
-            throw cms::Exception("BadValue") << "wrong toWorkerBufferIndex received " << *channel.toWorkerBufferIndex();
+          if (channel.toWorkerBufferInfo()->index_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
           }
-          *channel.fromWorkerBufferIndex() = 1;
+          if (channel.toWorkerBufferInfo()->identifier_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {1, 1};
           channel.shouldKeepEvent(true);
           break;
         }
@@ -121,10 +134,15 @@ namespace {
             throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
           }
 
-          if (*channel.toWorkerBufferIndex() != 1) {
-            throw cms::Exception("BadValue") << "wrong toWorkerBufferIndex received " << *channel.toWorkerBufferIndex();
+          if (channel.toWorkerBufferInfo()->index_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
           }
-          *channel.fromWorkerBufferIndex() = 0;
+          if (channel.toWorkerBufferInfo()->identifier_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {2, 0};
           channel.shouldKeepEvent(false);
           break;
         }

--- a/GeneratorInterface/Core/bin/BuildFile.xml
+++ b/GeneratorInterface/Core/bin/BuildFile.xml
@@ -1,0 +1,9 @@
+<bin   name="cmsExternalGenerator" file="externalGenerator.cc">
+  <use   name="boost"/>
+  <use   name="boost_program_options"/>
+  <use   name="FWCore/TestProcessor"/>
+  <use   name="FWCore/SharedMemory"/>
+  <use   name="FWCore/Services"/>
+  <use   name="FWCore/Utilities"/>
+  <use   name="SimDataFormats/GeneratorProducts"/>
+</bin>

--- a/GeneratorInterface/Core/bin/externalGenerator.cc
+++ b/GeneratorInterface/Core/bin/externalGenerator.cc
@@ -132,9 +132,6 @@ int main(int argc, char* argv[]) {
     std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
     std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
     {
-      //using namespace boost::interprocess;
-      //auto controlNameUnique = unique_name(memoryName, uniqueID);
-
       //This class is holding the lock
       WorkerChannel communicationChannel(memoryName, uniqueID);
 

--- a/GeneratorInterface/Core/bin/externalGenerator.cc
+++ b/GeneratorInterface/Core/bin/externalGenerator.cc
@@ -1,0 +1,250 @@
+#include "boost/program_options.hpp"
+
+#include <atomic>
+#include <csignal>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h"
+
+#include "FWCore/Services/interface/ExternalRandomNumberGeneratorService.h"
+
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
+static char const* const kMemoryNameOpt = "memory-name";
+static char const* const kMemoryNameCommandOpt = "memory-name,m";
+static char const* const kUniqueIDOpt = "unique-id";
+static char const* const kUniqueIDCommandOpt = "unique-id,i";
+static char const* const kHelpOpt = "help";
+static char const* const kHelpCommandOpt = "help,h";
+
+//NOTE: Can use TestProcessor as the harness for the worker
+
+using namespace edm::shared_memory;
+class Harness {
+public:
+  Harness(std::string const& iConfig, edm::ServiceToken iToken)
+      : tester_(edm::test::TestProcessor::Config{iConfig}, iToken) {}
+
+  ExternalGeneratorLumiInfo getBeginLumiValue(unsigned int iLumi) {
+    auto lumi = tester_.testBeginLuminosityBlock(iLumi);
+    ExternalGeneratorLumiInfo returnValue;
+    returnValue.header_ = *lumi.get<GenLumiInfoHeader>();
+    return returnValue;
+  }
+
+  ExternalGeneratorEventInfo getEventValue() {
+    ExternalGeneratorEventInfo returnValue;
+    auto event = tester_.test();
+    returnValue.hepmc_ = *event.get<edm::HepMCProduct>("unsmeared");
+    returnValue.eventInfo_ = *event.get<GenEventInfoProduct>();
+    returnValue.keepEvent_ = event.modulePassed();
+    return returnValue;
+  }
+
+  GenLumiInfoProduct getEndLumiValue() {
+    auto lumi = tester_.testEndLuminosityBlock();
+    return *lumi.get<GenLumiInfoProduct>();
+  }
+
+  GenRunInfoProduct getEndRunValue() {
+    auto run = tester_.testEndRun();
+    return *run.get<GenRunInfoProduct>();
+  }
+
+private:
+  edm::test::TestProcessor tester_;
+};
+
+template <typename T>
+using Serializer = ROOTSerializer<T, WriteBuffer>;
+
+int main(int argc, char* argv[]) {
+  std::string descString(argv[0]);
+  descString += " [--";
+  descString += kMemoryNameOpt;
+  descString += "] memory_name";
+  boost::program_options::options_description desc(descString);
+
+  desc.add_options()(kHelpCommandOpt, "produce help message")(
+      kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
+      kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
+
+  boost::program_options::positional_options_description p;
+  p.add(kMemoryNameOpt, 1);
+  p.add(kUniqueIDOpt, 2);
+
+  boost::program_options::options_description all_options("All Options");
+  all_options.add(desc);
+
+  boost::program_options::variables_map vm;
+  try {
+    store(boost::program_options::command_line_parser(argc, argv).options(all_options).positional(p).run(), vm);
+    notify(vm);
+  } catch (boost::program_options::error const& iException) {
+    std::cout << argv[0] << ": Error while trying to process command line arguments:\n"
+              << iException.what() << "\nFor usage and an options list, please do 'cmsRun --help'.";
+    return 1;
+  }
+
+  if (vm.count(kHelpOpt)) {
+    std::cout << desc << std::endl;
+    return 0;
+  }
+
+  if (!vm.count(kMemoryNameOpt)) {
+    std::cout << " no argument given" << std::endl;
+    return 1;
+  }
+
+  if (!vm.count(kUniqueIDOpt)) {
+    std::cout << " no second argument given" << std::endl;
+    return 1;
+  }
+
+  WorkerMonitorThread monitorThread;
+
+  monitorThread.startThread();
+
+  CMS_SA_ALLOW try {
+    std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
+    std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
+    {
+      //using namespace boost::interprocess;
+      //auto controlNameUnique = unique_name(memoryName, uniqueID);
+
+      //This class is holding the lock
+      WorkerChannel communicationChannel(memoryName, uniqueID);
+
+      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferInfo()};
+      ReadBuffer sm_readbuffer{std::string("Rand") + memoryName, communicationChannel.toWorkerBufferInfo()};
+      int counter = 0;
+
+      //The lock must be released if there is a catastrophic signal
+      auto lockPtr = communicationChannel.accessLock();
+      monitorThread.setAction([lockPtr]() {
+        if (lockPtr) {
+          std::cerr << "SIGNAL CAUGHT: unlock\n";
+          lockPtr->unlock();
+        }
+      });
+
+      Serializer<ExternalGeneratorEventInfo> serializer(sm_buffer);
+      Serializer<ExternalGeneratorLumiInfo> bl_serializer(sm_buffer);
+      Serializer<GenLumiInfoProduct> el_serializer(sm_buffer);
+      Serializer<GenRunInfoProduct> er_serializer(sm_buffer);
+
+      ROOTDeserializer<edm::RandomNumberGeneratorState, ReadBuffer> random_deserializer(sm_readbuffer);
+
+      std::cerr << uniqueID << " process: initializing " << std::endl;
+      int nlines;
+      std::cin >> nlines;
+
+      std::string configuration;
+      for (int i = 0; i < nlines; ++i) {
+        std::string c;
+        std::getline(std::cin, c);
+        std::cerr << c << "\n";
+        configuration += c + "\n";
+      }
+
+      edm::ExternalRandomNumberGeneratorService* randomService = new edm::ExternalRandomNumberGeneratorService;
+      auto serviceToken =
+          edm::ServiceRegistry::createContaining(std::unique_ptr<edm::RandomNumberGenerator>(randomService));
+      Harness harness(configuration, serviceToken);
+
+      //Either ROOT or the Framework are overriding the signal handlers
+      monitorThread.setupSignalHandling();
+
+      std::cerr << uniqueID << " process: done initializing" << std::endl;
+      communicationChannel.workerSetupDone();
+
+      std::cerr << uniqueID << " process: waiting " << counter << std::endl;
+      communicationChannel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+        ++counter;
+        switch (iTransition) {
+          case edm::Transition::BeginRun: {
+            std::cerr << uniqueID << " process: start beginRun " << std::endl;
+            std::cerr << uniqueID << " process: end beginRun " << std::endl;
+
+            break;
+          }
+          case edm::Transition::BeginLuminosityBlock: {
+            std::cerr << uniqueID << " process: start beginLumi " << std::endl;
+            auto randState = random_deserializer.deserialize();
+            std::cerr << uniqueID << " random " << randState.state_.size() << " " << randState.seed_ << std::endl;
+            randomService->setState(randState.state_, randState.seed_);
+            auto value = harness.getBeginLumiValue(iTransitionID);
+            value.randomState_.state_ = randomService->getState();
+            value.randomState_.seed_ = randomService->mySeed();
+
+            bl_serializer.serialize(value);
+            std::cerr << uniqueID << " process: end beginLumi " << std::endl;
+            std::cerr << uniqueID << "   rand " << value.randomState_.state_.size() << " " << value.randomState_.seed_
+                      << std::endl;
+            break;
+          }
+          case edm::Transition::Event: {
+            std::cerr << uniqueID << " process: event " << counter << std::endl;
+            auto randState = random_deserializer.deserialize();
+            randomService->setState(randState.state_, randState.seed_);
+            auto value = harness.getEventValue();
+            value.randomState_.state_ = randomService->getState();
+            value.randomState_.seed_ = randomService->mySeed();
+
+            std::cerr << uniqueID << " process: event " << counter << std::endl;
+
+            serializer.serialize(value);
+            std::cerr << uniqueID << " process: "
+                      << " " << counter << std::endl;
+            //usleep(10000000);
+            break;
+          }
+          case edm::Transition::EndLuminosityBlock: {
+            std::cerr << uniqueID << " process: start endLumi " << std::endl;
+            auto value = harness.getEndLumiValue();
+
+            el_serializer.serialize(value);
+            std::cerr << uniqueID << " process: end endLumi " << std::endl;
+
+            break;
+          }
+          case edm::Transition::EndRun: {
+            std::cerr << uniqueID << " process: start endRun " << std::endl;
+            auto value = harness.getEndRunValue();
+
+            er_serializer.serialize(value);
+            std::cerr << uniqueID << " process: end endRun " << std::endl;
+
+            break;
+          }
+          default: {
+            assert(false);
+          }
+        }
+        std::cerr << uniqueID << " process: notifying and waiting " << counter << std::endl;
+      });
+    }
+  } catch (std::exception const& iExcept) {
+    std::cerr << "caught exception \n" << iExcept.what() << "\n";
+    return 1;
+  } catch (...) {
+    std::cerr << "caught unknown exception";
+    return 1;
+  }
+  return 0;
+}

--- a/GeneratorInterface/Core/plugins/BuildFile.xml
+++ b/GeneratorInterface/Core/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="GeneratorInterface/Core"/>
+<use   name="FWCore/SharedMemory"/>
 
 <library   name="GeneratorInterfaceCore_plugins" file="*.cc" >
   <flags   EDM_PLUGIN="1"/>

--- a/GeneratorInterface/Core/plugins/CompareGeneratorResultsAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/CompareGeneratorResultsAnalyzer.cc
@@ -1,0 +1,342 @@
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
+#include <sstream>
+#include <iostream>
+
+namespace cgra {
+  struct DummyCache {};
+};  // namespace cgra
+
+class CompareGeneratorResultsAnalyzer
+    : public edm::global::EDAnalyzer<edm::RunCache<cgra::DummyCache>, edm::LuminosityBlockCache<cgra::DummyCache>> {
+public:
+  CompareGeneratorResultsAnalyzer(edm::ParameterSet const&);
+
+  std::shared_ptr<cgra::DummyCache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const;
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const;
+
+  std::shared_ptr<cgra::DummyCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                               edm::EventSetup const&) const;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const;
+
+  void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const;
+
+private:
+  std::string mod1_;
+  std::string mod2_;
+
+  edm::EDGetTokenT<GenEventInfoProduct> evToken1_;
+  edm::EDGetTokenT<GenEventInfoProduct> evToken2_;
+
+  edm::EDGetTokenT<edm::HepMCProduct> hepMCToken1_;
+  edm::EDGetTokenT<edm::HepMCProduct> hepMCToken2_;
+
+  edm::EDGetTokenT<GenLumiInfoHeader> lumiHeaderToken1_;
+  edm::EDGetTokenT<GenLumiInfoHeader> lumiHeaderToken2_;
+
+  edm::EDGetTokenT<GenLumiInfoProduct> lumiProductToken1_;
+  edm::EDGetTokenT<GenLumiInfoProduct> lumiProductToken2_;
+
+  edm::EDGetTokenT<GenRunInfoProduct> runProductToken1_;
+  edm::EDGetTokenT<GenRunInfoProduct> runProductToken2_;
+};
+
+CompareGeneratorResultsAnalyzer::CompareGeneratorResultsAnalyzer(edm::ParameterSet const& iPSet)
+    : mod1_{iPSet.getUntrackedParameter<std::string>("module1")},
+      mod2_{iPSet.getUntrackedParameter<std::string>("module2")},
+      evToken1_{consumes<GenEventInfoProduct>(mod1_)},
+      evToken2_{consumes<GenEventInfoProduct>(mod2_)},
+      hepMCToken1_{consumes<edm::HepMCProduct>(edm::InputTag(mod1_, "unsmeared"))},
+      hepMCToken2_{consumes<edm::HepMCProduct>(edm::InputTag(mod2_, "unsmeared"))},
+      lumiHeaderToken1_{consumes<GenLumiInfoHeader, edm::InLumi>(mod1_)},
+      lumiHeaderToken2_{consumes<GenLumiInfoHeader, edm::InLumi>(mod2_)},
+      lumiProductToken1_{consumes<GenLumiInfoProduct, edm::InLumi>(mod1_)},
+      lumiProductToken2_{consumes<GenLumiInfoProduct, edm::InLumi>(mod2_)},
+      runProductToken1_{consumes<GenRunInfoProduct, edm::InRun>(mod1_)},
+      runProductToken2_{consumes<GenRunInfoProduct, edm::InRun>(mod2_)} {}
+
+std::shared_ptr<cgra::DummyCache> CompareGeneratorResultsAnalyzer::globalBeginRun(edm::Run const&,
+                                                                                  edm::EventSetup const&) const {
+  return std::shared_ptr<cgra::DummyCache>();
+}
+
+void CompareGeneratorResultsAnalyzer::globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const {
+  auto const& prod1 = iRun.get(runProductToken1_);
+  auto const& prod2 = iRun.get(runProductToken2_);
+
+  if (not prod1.isProductEqual(prod2)) {
+    throw cms::Exception("ComparisonFailure") << "The GenRunInfoProducts are different";
+  }
+}
+
+std::shared_ptr<cgra::DummyCache> CompareGeneratorResultsAnalyzer::globalBeginLuminosityBlock(
+    edm::LuminosityBlock const& iLumi, edm::EventSetup const&) const {
+  auto const& prod1 = iLumi.get(lumiHeaderToken1_);
+  auto const& prod2 = iLumi.get(lumiHeaderToken2_);
+
+  if (prod1.randomConfigIndex() != prod2.randomConfigIndex()) {
+    throw cms::Exception("ComparisonFailure") << "The GenLumiInfoHeaders have different randomConfigIndex "
+                                              << prod1.randomConfigIndex() << " " << prod2.randomConfigIndex();
+  }
+
+  if (prod1.configDescription() != prod2.configDescription()) {
+    throw cms::Exception("ComparisonFailure") << "The GenLumiInfoHeaders have different configDescription "
+                                              << prod1.configDescription() << " " << prod2.configDescription();
+  }
+
+  if (prod1.lheHeaders().size() != prod2.lheHeaders().size()) {
+    throw cms::Exception("ComparisonFailure") << "The GenLumiInfoHeaders have different lheHeaders "
+                                              << prod1.lheHeaders().size() << " " << prod2.lheHeaders().size();
+  }
+
+  if (prod1.weightNames().size() != prod2.weightNames().size()) {
+    throw cms::Exception("ComparisonFailure") << "The GenLumiInfoHeaders have different weightNames "
+                                              << prod1.weightNames().size() << " " << prod2.weightNames().size();
+  }
+
+  return std::shared_ptr<cgra::DummyCache>();
+}
+
+namespace {
+  void compare(size_t iIndex, GenLumiInfoProduct::ProcessInfo const& p1, GenLumiInfoProduct::ProcessInfo const& p2) {
+    if (p1.process() != p2.process()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] process " << p1.process() << " " << p2.process();
+    }
+
+    if (p1.nPassPos() != p2.nPassPos()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] nPassPos " << p1.nPassPos() << " " << p2.nPassPos();
+    }
+
+    if (p1.nPassNeg() != p2.nPassNeg()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] nPassNeg " << p1.nPassNeg() << " " << p2.nPassNeg();
+    }
+
+    if (p1.nTotalPos() != p2.nTotalPos()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] nTotalPos " << p1.nTotalPos() << " " << p2.nTotalPos();
+    }
+
+    if (p1.nTotalNeg() != p2.nTotalNeg()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] nTotalNeg " << p1.nTotalNeg() << " " << p2.nTotalNeg();
+    }
+
+    if (p1.lheXSec().error() != p2.lheXSec().error()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] lheXSec.error "
+          << p1.lheXSec().error() << " " << p2.lheXSec().error();
+    }
+
+    if (p1.lheXSec().value() != p2.lheXSec().value()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] lheXSec.value "
+          << p1.lheXSec().value() << " " << p2.lheXSec().value();
+    }
+
+    if (p1.tried().n() != p2.tried().n()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] tried.n " << p1.tried().n() << " " << p2.tried().n();
+    }
+
+    if (p1.tried().sum() != p2.tried().sum()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] tried.sum " << p1.tried().sum() << " " << p2.tried().sum();
+    }
+
+    if (p1.tried().sum2() != p2.tried().sum2()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] tried.sum2 " << p1.tried().sum2() << " " << p2.tried().sum2();
+    }
+
+    if (p1.selected().n() != p2.selected().n()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] selected.n " << p1.selected().n() << " " << p2.selected().n();
+    }
+
+    if (p1.selected().sum() != p2.selected().sum()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] selected.sum "
+          << p1.selected().sum() << " " << p2.selected().sum();
+    }
+
+    if (p1.selected().sum2() != p2.selected().sum2()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] selected.sum2 "
+          << p1.selected().sum2() << " " << p2.selected().sum2();
+    }
+
+    if (p1.killed().n() != p2.killed().n()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] killed.n " << p1.killed().n() << " " << p2.killed().n();
+    }
+
+    if (p1.killed().sum() != p2.killed().sum()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] killed sum " << p1.killed().sum() << " " << p2.killed().sum();
+    }
+
+    if (p1.killed().sum2() != p2.killed().sum2()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] killed.sum2 " << p1.killed().sum2() << " " << p2.killed().sum2();
+    }
+
+    if (p1.accepted().n() != p2.accepted().n()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] accepted.n " << p1.accepted().n() << " " << p2.accepted().n();
+    }
+
+    if (p1.accepted().sum() != p2.accepted().sum()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] accepted.sum "
+          << p1.accepted().sum() << " " << p2.accepted().sum();
+    }
+
+    if (p1.accepted().sum2() != p2.accepted().sum2()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] accepted.sum2 "
+          << p1.accepted().sum2() << " " << p2.accepted().sum2();
+    }
+
+    if (p1.acceptedBr().n() != p2.acceptedBr().n()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] acceptedBr.n "
+          << p1.acceptedBr().n() << " " << p2.acceptedBr().n();
+    }
+
+    if (p1.acceptedBr().sum() != p2.acceptedBr().sum()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] acceptedZBr.sum "
+          << p1.acceptedBr().sum() << " " << p2.acceptedBr().sum();
+    }
+
+    if (p1.acceptedBr().sum2() != p2.acceptedBr().sum2()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] acceptedBr.sum2 "
+          << p1.acceptedBr().sum2() << " " << p2.acceptedBr().sum2();
+    }
+  }
+}  // namespace
+
+void CompareGeneratorResultsAnalyzer::globalEndLuminosityBlock(edm::LuminosityBlock const& iLumi,
+                                                               edm::EventSetup const&) const {
+  auto const& prod1 = iLumi.get(lumiProductToken1_);
+  auto const& prod2 = iLumi.get(lumiProductToken2_);
+
+  if (not prod1.isProductEqual(prod2)) {
+    if (prod1.getHEPIDWTUP() != prod1.getHEPIDWTUP()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getHEPIDWTUP "
+                                                << prod1.getHEPIDWTUP() << " " << prod2.getHEPIDWTUP();
+    }
+
+    if (prod1.getProcessInfos().size() != prod2.getProcessInfos().size()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoHeaders have different getProcessInfos " << prod1.getProcessInfos().size() << " "
+          << prod2.getProcessInfos().size();
+    }
+
+    for (size_t i = 0; i < prod1.getProcessInfos().size(); ++i) {
+      compare(i, prod1.getProcessInfos()[i], prod2.getProcessInfos()[i]);
+    }
+
+    throw cms::Exception("ComparisionFailure") << "The GenLumiInfoProducts are different";
+  }
+}
+
+namespace {
+  void compare(GenEventInfoProduct const& prod1, GenEventInfoProduct const& prod2) {
+    if (prod1.weights().size() != prod2.weights().size()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different weights "
+                                                << prod1.weights().size() << " " << prod2.weights().size();
+    }
+
+    if (prod1.binningValues().size() != prod2.binningValues().size()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different binningValues "
+                                                << prod1.binningValues().size() << " " << prod2.binningValues().size();
+    }
+
+    if (prod1.DJRValues().size() != prod2.DJRValues().size()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different DJRValues "
+                                                << prod1.DJRValues().size() << " " << prod2.DJRValues().size();
+    }
+
+    if (prod1.signalProcessID() != prod2.signalProcessID()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different signalProcessID "
+                                                << prod1.signalProcessID() << " " << prod2.signalProcessID();
+    }
+
+    if (prod1.qScale() != prod2.qScale()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenEventInfoProducts have different qScale " << prod1.qScale() << " " << prod2.qScale();
+    }
+
+    if (prod1.alphaQCD() != prod2.alphaQCD()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenEventInfoProducts have different alphaQCD " << prod1.alphaQCD() << " " << prod2.alphaQCD();
+    }
+
+    if (prod1.alphaQED() != prod2.alphaQED()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenEventInfoProducts have different alphaQED " << prod1.alphaQED() << " " << prod2.alphaQED();
+    }
+
+    if (prod1.nMEPartons() != prod2.nMEPartons()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenEventInfoProducts have different nMEPartons " << prod1.nMEPartons() << " " << prod2.nMEPartons();
+    }
+
+    if (prod1.nMEPartonsFiltered() != prod2.nMEPartonsFiltered()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different nMEPartonsFiltered "
+                                                << prod1.nMEPartonsFiltered() << " " << prod2.nMEPartonsFiltered();
+    }
+  }
+
+  void compare(HepMC::GenEvent const& prod1, HepMC::GenEvent const& prod2) {
+    //std::cout <<"2\n"<<s2.str();
+
+    if (prod1.signal_process_id() != prod2.signal_process_id()) {
+      throw cms::Exception("ComparisonFailure") << "The HepMCProducts have different signal_process_id "
+                                                << prod1.signal_process_id() << " " << prod2.signal_process_id();
+    }
+
+    if (prod1.vertices_size() != prod2.vertices_size()) {
+      throw cms::Exception("ComparisonFailure") << "The HepMCProducts have different vertices_size() "
+                                                << prod1.vertices_size() << " " << prod2.vertices_size();
+    }
+
+    if (prod1.particles_size() != prod2.particles_size()) {
+      throw cms::Exception("ComparisonFailure") << "The HepMCProducts have different particles_size() "
+                                                << prod1.particles_size() << " " << prod2.particles_size();
+    }
+  }
+}  // namespace
+
+void CompareGeneratorResultsAnalyzer::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
+  auto const& prod1 = iEvent.get(evToken1_);
+  auto const& prod2 = iEvent.get(evToken2_);
+
+  compare(prod1, prod2);
+
+  auto const& hepmc1 = iEvent.get(hepMCToken1_);
+  auto const& hepmc2 = iEvent.get(hepMCToken2_);
+
+  compare(hepmc1.getHepMCData(), hepmc2.getHepMCData());
+}
+
+DEFINE_FWK_MODULE(CompareGeneratorResultsAnalyzer);

--- a/GeneratorInterface/Core/plugins/CompareGeneratorResultsAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/CompareGeneratorResultsAnalyzer.cc
@@ -26,14 +26,14 @@ class CompareGeneratorResultsAnalyzer
 public:
   CompareGeneratorResultsAnalyzer(edm::ParameterSet const&);
 
-  std::shared_ptr<cgra::DummyCache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const;
-  void globalEndRun(edm::Run const&, edm::EventSetup const&) const;
+  std::shared_ptr<cgra::DummyCache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override;
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const override;
 
   std::shared_ptr<cgra::DummyCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
-                                                               edm::EventSetup const&) const;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const;
+                                                               edm::EventSetup const&) const override;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override;
 
-  void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const;
+  void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
 
 private:
   std::string mod1_;

--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -76,7 +76,7 @@ namespace externalgen {
         -> decltype(iDeserializer.deserialize()) {
       decltype(iDeserializer.deserialize()) value;
       if (not channel_.doTransition(
-              [&value, &iDeserializer, this]() { value = iDeserializer.deserialize(); }, iTrans, iTransitionID)) {
+              [&value, &iDeserializer]() { value = iDeserializer.deserialize(); }, iTrans, iTransitionID)) {
         externalFailed_ = true;
         throw cms::Exception("ExternalFailed") << "failed waiting for external process";
       }

--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -23,7 +23,7 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Random/RanecuEngine.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace edm::shared_memory;
@@ -56,7 +56,7 @@ namespace externalgen {
                       .c_str(),
                   "w");
 
-        if (NULL == pipe_) {
+        if (nullptr == pipe_) {
           abort();
         }
 

--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -1,0 +1,333 @@
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h"
+
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/engineIDulong.h"
+#include "CLHEP/Random/RanecuEngine.h"
+
+
+#include <stdio.h>
+#include <iostream>
+
+using namespace edm::shared_memory;
+namespace externalgen {
+
+  struct StreamCache {
+    StreamCache(const std::string& iConfig, int id)
+        : id_{id},
+          channel_("extGen", id_),
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferInfo()},
+          writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferInfo()},
+          deserializer_{readBuffer_},
+          er_deserializer_{readBuffer_},
+          bl_deserializer_{readBuffer_},
+      el_deserializer_(readBuffer_),
+      randSerializer_(writeBuffer_) {
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel_.setupWorker([&]() {
+        using namespace std::string_literals;
+        std::cout << id_ << " starting external process" << std::endl;
+        pipe_ = popen(("cmsExternalGenerator "s + channel_.sharedMemoryName() + " " + channel_.uniqueID()).c_str(), "w");
+
+        if (NULL == pipe_) {
+          abort();
+        }
+
+        {
+          auto nlines = std::to_string(std::count(iConfig.begin(), iConfig.end(), '\n'));
+          auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
+          assert(result = nlines.size());
+          result = fwrite(iConfig.data(), sizeof(char), iConfig.size(), pipe_);
+          assert(result == iConfig.size());
+          fflush(pipe_);
+        }
+      });
+    }
+
+    template <typename SERIAL>
+    auto doTransition(SERIAL& iDeserializer, edm::Transition iTrans, unsigned long long iTransitionID)
+        -> decltype(iDeserializer.deserialize()) {
+      decltype(iDeserializer.deserialize()) value;
+      if (not channel_.doTransition(
+                                    [&value, &iDeserializer, this]() {
+                value = iDeserializer.deserialize();
+              },
+              iTrans,
+              iTransitionID)) {
+        externalFailed_ = true;
+        throw cms::Exception("ExternalFailed") <<"failed waiting for external process";
+      }
+      return value;
+    }
+    ExternalGeneratorEventInfo produce(edm::StreamID iStream, unsigned long long iTransitionID) {
+      edm::Service<edm::RandomNumberGenerator> gen;
+      auto& engine = gen->getEngine(iStream);
+      edm::RandomNumberGeneratorState state{engine.put(), engine.getSeed()};
+      randSerializer_.serialize(state);
+
+      return doTransition(deserializer_, edm::Transition::Event, iTransitionID);
+    }
+
+    std::optional<GenRunInfoProduct> endRunProduce(unsigned long long iTransitionID) {
+      if (not externalFailed_) {
+        return doTransition(er_deserializer_, edm::Transition::EndRun, iTransitionID);
+      }
+      return {};
+    }
+
+    ExternalGeneratorLumiInfo beginLumiProduce(unsigned long long iTransitionID, edm::RandomNumberGeneratorState const& iState) {
+      //NOTE: root serialize requires a `void*` not a `void const*` even though it doesn't modify the object
+      randSerializer_.serialize(const_cast<edm::RandomNumberGeneratorState&>(iState));
+      return doTransition(bl_deserializer_, edm::Transition::BeginLuminosityBlock, iTransitionID);
+    }
+
+    std::optional<GenLumiInfoProduct> endLumiProduce(unsigned long long iTransitionID) {
+      if (not externalFailed_) {
+        return doTransition(el_deserializer_, edm::Transition::EndLuminosityBlock, iTransitionID);
+      }
+      return {};
+    }
+
+    ~StreamCache() {
+      channel_.stopWorker();
+      pclose(pipe_);
+    }
+
+  private:
+    std::string unique_name(std::string iBase) {
+      auto pid = getpid();
+      iBase += std::to_string(pid);
+      iBase += "_";
+      iBase += std::to_string(id_);
+
+      return iBase;
+    }
+
+    int id_;
+    FILE* pipe_;
+    ControllerChannel channel_;
+    ReadBuffer readBuffer_;
+    WriteBuffer writeBuffer_;
+
+    template<typename T> using Deserializer = ROOTDeserializer<T, ReadBuffer>;
+    Deserializer<ExternalGeneratorEventInfo> deserializer_;
+    Deserializer<GenRunInfoProduct> er_deserializer_;
+    Deserializer<ExternalGeneratorLumiInfo> bl_deserializer_;
+    Deserializer<GenLumiInfoProduct> el_deserializer_;
+    ROOTSerializer<edm::RandomNumberGeneratorState, WriteBuffer>  randSerializer_;
+
+    bool externalFailed_ = false;
+  };
+
+  struct RunCache {
+    //Only stream 0 sets this at stream end Run and it is read at global end run
+    // the framework guarantees those calls can not happen simultaneously
+    CMS_THREAD_SAFE mutable GenRunInfoProduct runInfo_;
+  };
+  struct LumiCache {
+    LumiCache(std::vector<unsigned long> iState, long iSeed):
+      randomState_(std::move(iState), iSeed) {}
+    //Only stream 0 sets this at stream end Lumi and it is read at global end Lumi
+    // the framework guarantees those calls can not happen simultaneously
+    CMS_THREAD_SAFE mutable GenLumiInfoProduct lumiInfo_;
+    CMS_THREAD_SAFE mutable edm::RandomNumberGeneratorState randomState_;
+  };
+}  // namespace externalgen
+
+class ExternalGeneratorFilter : public edm::global::EDFilter<edm::StreamCache<externalgen::StreamCache>,
+                                                            edm::RunCache<externalgen::RunCache>,
+                                                            edm::EndRunProducer,
+                                                            edm::LuminosityBlockCache<externalgen::LumiCache>,
+                                                            edm::BeginLuminosityBlockProducer,
+                                                            edm::EndLuminosityBlockProducer> {
+public:
+  ExternalGeneratorFilter(edm::ParameterSet const&);
+
+  std::unique_ptr<externalgen::StreamCache> beginStream(edm::StreamID) const final;
+  bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
+
+  std::shared_ptr<externalgen::RunCache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const final;
+  void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final;
+  void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final;
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const final {}
+  void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const final;
+
+  void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
+  std::shared_ptr<externalgen::LumiCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                   edm::EventSetup const&) const final;
+  void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final {}
+  void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
+
+private:
+  edm::EDPutTokenT<edm::HepMCProduct> const hepMCToken_;
+  edm::EDPutTokenT<GenEventInfoProduct> const genEventToken_;
+  edm::EDPutTokenT<GenRunInfoProduct> const runInfoToken_;
+  edm::EDPutTokenT<GenLumiInfoHeader> const lumiHeaderToken_;
+  edm::EDPutTokenT<GenLumiInfoProduct> const lumiInfoToken_;
+
+  std::string config_;
+
+  //This is set at beginStream and used for globalBeginRun
+  //The framework guarantees that non of those can happen concurrently
+  CMS_THREAD_SAFE mutable externalgen::StreamCache* stream0Cache_ = nullptr;
+  //A stream which has finished processing the last lumi is used for the
+  // call to globalBeginLuminosityBlockProduce
+  mutable std::atomic<externalgen::StreamCache*> availableForBeginLumi_;
+  //Streams all see the lumis in the same order, we want to be sure to pick a stream cache
+  // to use at globalBeginLumi which just finished the most recent lumi and not a previous one
+  mutable std::atomic<unsigned int> lastLumiIndex_ = 0;
+};
+
+ExternalGeneratorFilter::ExternalGeneratorFilter(edm::ParameterSet const& iPSet)
+  : hepMCToken_{produces<edm::HepMCProduct>("unsmeared")},
+                     genEventToken_{produces<GenEventInfoProduct>()},
+      runInfoToken_{produces<GenRunInfoProduct, edm::Transition::EndRun>()},
+      lumiHeaderToken_{produces<GenLumiInfoHeader, edm::Transition::BeginLuminosityBlock>("beginLumi")},
+      lumiInfoToken_{produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>("endLumi")},
+      config_{iPSet.getUntrackedParameter<std::string>("@python_config")} {}
+
+std::unique_ptr<externalgen::StreamCache> ExternalGeneratorFilter::beginStream(edm::StreamID iID) const {
+  auto const label = moduleDescription().moduleLabel();
+
+  using namespace std::string_literals;
+
+  std::string config = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+)_";
+  config += "process."s + label + "=" + config_ + "\n";
+  config += "process.moduleToTest(process."s + label + ")\n";
+  config += R"_(
+process.add_(cms.Service("InitRootHandlers", UnloadRootSigHandler=cms.untracked.bool(True)))
+  )_";
+
+  auto cache = std::make_unique<externalgen::StreamCache>(config, iID.value());
+  if (iID.value() == 0) {
+    stream0Cache_ = cache.get();
+
+    availableForBeginLumi_ = stream0Cache_;
+  }
+
+  return cache;
+}
+
+bool ExternalGeneratorFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const {
+  auto value = streamCache(iID)->produce(iID, iEvent.id().event());
+
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iID);
+  //if (value.randomState_.state_[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+  //  engine.setSeed(value.randomState_.seed_, 0);
+  //}
+  engine.get(value.randomState_.state_);
+
+  iEvent.emplace(hepMCToken_, std::move(value.hepmc_));
+  iEvent.emplace(genEventToken_, std::move(value.eventInfo_));
+  return value.keepEvent_;
+}
+
+std::shared_ptr<externalgen::RunCache> ExternalGeneratorFilter::globalBeginRun(edm::Run const&,
+                                                                          edm::EventSetup const&) const {
+  return std::make_shared<externalgen::RunCache>();
+}
+
+void ExternalGeneratorFilter::streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const {
+}
+void ExternalGeneratorFilter::streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const {
+  if (iID.value() == 0) {
+    runCache(iRun.index())->runInfo_ = *streamCache(iID)->endRunProduce(iRun.run());
+  } else {
+    (void)streamCache(iID)->endRunProduce(iRun.run());
+  }
+}
+void ExternalGeneratorFilter::globalEndRunProduce(edm::Run& iRun, edm::EventSetup const&) const {
+  iRun.emplace(runInfoToken_, std::move(runCache(iRun.index())->runInfo_));
+}
+
+void ExternalGeneratorFilter::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                             edm::EventSetup const&) const {
+  while (not availableForBeginLumi_.load()) {
+  }
+
+  auto v = availableForBeginLumi_.load()->beginLumiProduce(iLuminosityBlock.luminosityBlock(),
+                                                           luminosityBlockCache(iLuminosityBlock.index())->randomState_);
+
+  std::cerr <<"globalBeginLuminosityBlockProduce rand "<<v.randomState_.state_.size()<<" "<<v.randomState_.seed_<<std::endl;
+
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iLuminosityBlock.index());
+  //if (v.randomState_.state_[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+  //  engine.setSeed(v.randomState_.seed_, 0);
+  //}
+  engine.get(v.randomState_.state_);
+
+  iLuminosityBlock.emplace(lumiHeaderToken_, std::move(v.header_));
+
+  lastLumiIndex_.store(iLuminosityBlock.index());
+}
+
+std::shared_ptr<externalgen::LumiCache> ExternalGeneratorFilter::globalBeginLuminosityBlock(edm::LuminosityBlock const& iLumi,
+                                                                                       edm::EventSetup const&) const {
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iLumi.index());
+  auto s = engine.put();
+  //std::cerr <<" globalBeginLuminosityBlock rand "<<s.size()<<" "<<engine.getSeed()<<std::endl;
+  return std::make_shared<externalgen::LumiCache>(s, engine.getSeed());
+}
+
+void ExternalGeneratorFilter::streamBeginLuminosityBlock(edm::StreamID iID,
+                                                      edm::LuminosityBlock const& iLuminosityBlock,
+                                                      edm::EventSetup const&) const {
+  auto cache = streamCache(iID);
+  if (cache != availableForBeginLumi_.load()) {
+    (void)cache->beginLumiProduce(iLuminosityBlock.run(), luminosityBlockCache(iLuminosityBlock.index())->randomState_);
+  } else {
+    availableForBeginLumi_ = nullptr;
+  }
+}
+
+void ExternalGeneratorFilter::streamEndLuminosityBlock(edm::StreamID iID,
+                                                    edm::LuminosityBlock const& iLuminosityBlock,
+                                                    edm::EventSetup const&) const {
+  if (iID.value() == 0) {
+    luminosityBlockCache(iLuminosityBlock.index())->lumiInfo_ =
+        *streamCache(iID)->endLumiProduce(iLuminosityBlock.run());
+  } else {
+    (void)streamCache(iID)->endLumiProduce(iLuminosityBlock.run());
+  }
+
+  if (lastLumiIndex_ == iLuminosityBlock.index()) {
+    externalgen::StreamCache* expected = nullptr;
+
+    availableForBeginLumi_.compare_exchange_strong(expected, streamCache(iID));
+  }
+}
+
+void ExternalGeneratorFilter::globalEndLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                           edm::EventSetup const&) const {
+  iLuminosityBlock.emplace(lumiInfoToken_, std::move(luminosityBlockCache(iLuminosityBlock.index())->lumiInfo_));
+}
+
+DEFINE_FWK_MODULE(ExternalGeneratorFilter);

--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -29,3 +29,15 @@ class ExternalGeneratorFilter(cms.EDFilter):
         newpset.addBool(False,"_external_process_verbose_", self._external_process_verbose_.value())
         self._prod.insertContentsInto(newpset)
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
+    def dumpPython(self, options=cms.PrintOptions()):
+        cms.specialImportRegistry.registerUse(self)
+        result = "%s(" % self.__class__.__name__ # not including cms. since the deriving classes are not in cms "namespace"
+        options.indent()
+        result += "\n"+options.indentation() + self._prod.dumpPython(options)
+        result +=options.indentation()+",\n"
+        result += options.indentation() + self._external_process_verbose_.dumpPython(options)
+        options.unindent()
+        result += "\n)\n"
+        return result
+
+cms.specialImportRegistry.registerSpecialImportForType(ExternalGeneratorFilter, "from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter")

--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+class ExternalGeneratorFilter(cms.EDFilter):
+    def __init__(self, prod):
+        self.__dict__['_prod'] = prod
+        super(cms.EDFilter,self).__init__('ExternalGeneratorFilter')
+    def __setattr__(self, name, value):
+        setattr(self._prod, name, value)
+    def __getattr__(self, name):
+        if name =='_prod':
+            return self.__dict__['_prod']
+        return getattr(self._prod, name)
+    def clone(self, **params):
+        returnValue = ExternalGeneratorFilter.__new__(type(self))
+        returnValue.__init__(self._prod.clone())
+        return returnValue
+    def insertInto(self, parameterSet, myname):
+        newpset = parameterSet.newPSet()
+        newpset.addString(True, "@module_label", self.moduleLabel_(myname))
+        newpset.addString(True, "@module_type", self.type_())
+        newpset.addString(True, "@module_edm_type", cms.EDFilter.__name__)
+        newpset.addString(True, "@external_type", self._prod.type_())
+        newpset.addString(False,"@python_config", self._prod.dumpPython())
+        self._prod.insertContentsInto(newpset)
+        parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)

--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -1,14 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
 class ExternalGeneratorFilter(cms.EDFilter):
-    def __init__(self, prod):
+    def __init__(self, prod, _external_process_verbose_ = cms.untracked.bool(False)):
+        self.__dict__['_external_process_verbose_']=_external_process_verbose_
         self.__dict__['_prod'] = prod
         super(cms.EDFilter,self).__init__('ExternalGeneratorFilter')
     def __setattr__(self, name, value):
+        if name =='_external_process_verbose_':
+            return self.__dict__['_external_process_verbose_']
         setattr(self._prod, name, value)
     def __getattr__(self, name):
         if name =='_prod':
             return self.__dict__['_prod']
+        if name == '_external_process_verbose_':
+            return self.__dict__['_external_process_verbose_']
         return getattr(self._prod, name)
     def clone(self, **params):
         returnValue = ExternalGeneratorFilter.__new__(type(self))
@@ -21,5 +26,6 @@ class ExternalGeneratorFilter(cms.EDFilter):
         newpset.addString(True, "@module_edm_type", cms.EDFilter.__name__)
         newpset.addString(True, "@external_type", self._prod.type_())
         newpset.addString(False,"@python_config", self._prod.dumpPython())
+        newpset.addBool(False,"_external_process_verbose_", self._external_process_verbose_.value())
         self._prod.insertContentsInto(newpset)
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)

--- a/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
@@ -17,3 +17,7 @@
   <use name="FWCore/TestProcessor"/>
   <use name="catch2"/>
 </bin>
+
+<test name="TestGeneratorInterfacePythia8InterfaceCompareIdentical" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_identical_generators_cfg.py"/>
+<test name="TestGeneratorInterfacePythia8InterfaceCompareExternal" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_external_generators_cfg.py"/>
+<test name="TestGeneratorInterfacePythia8InterfaceCompareExternalStreams" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py"/>

--- a/GeneratorInterface/Pythia8Interface/test/compare_external_generators_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/compare_external_generators_cfg.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+process.source =cms.Source("EmptySource")
+
+process.maxEvents.input = 10
+
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.gen1 = process.RandomNumberGeneratorService.generator.clone()
+process.RandomNumberGeneratorService.gen2 = process.RandomNumberGeneratorService.generator.clone()
+process.gen1 = cms.EDFilter("Pythia8GeneratorFilter",
+                            comEnergy = cms.double(7000.),
+                            PythiaParameters = cms.PSet(
+                                pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                                                'PhaseSpace:pTHatMin = 20.'),
+                                parameterSets = cms.vstring('pythia8_example02')
+                            )
+                        )
+
+_pythia8 = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter
+process.gen2 = ExternalGeneratorFilter(_pythia8)
+
+process.compare = cms.EDAnalyzer("CompareGeneratorResultsAnalyzer", module1 = cms.untracked.string("gen1"), module2 =cms.untracked.string("gen2"))
+
+process.p = cms.Path(process.gen1+process.gen2+process.compare)

--- a/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py
@@ -32,6 +32,9 @@ process.gen2 = ExternalGeneratorFilter(_pythia8)
 
 process.sleeper = cms.EDProducer("timestudy::SleepingProducer", ivalue = cms.int32(1), consumes = cms.VInputTag(), eventTimes=cms.vdouble(1.))
 
-process.compare = cms.EDAnalyzer("CompareGeneratorResultsAnalyzer", module1 = cms.untracked.string("gen1"), module2 =cms.untracked.string("gen2"))
+process.compare = cms.EDAnalyzer("CompareGeneratorResultsAnalyzer", 
+                                 module1 = cms.untracked.string("gen1"), 
+                                 module2 =cms.untracked.string("gen2"),
+                                 allowXSecDifferences = cms.untracked.bool(True))
 
 process.p = cms.Path(process.sleeper+process.gen1+process.gen2+process.compare)

--- a/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+process.source =cms.Source("EmptySource")
+
+process.maxEvents.input = 10
+process.options.numberOfStreams = 2
+process.options.numberOfThreads = 2
+
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.gen1 = process.RandomNumberGeneratorService.generator.clone()
+process.RandomNumberGeneratorService.gen2 = process.RandomNumberGeneratorService.generator.clone()
+process.gen1 = cms.EDFilter("Pythia8GeneratorFilter",
+                            comEnergy = cms.double(7000.),
+                            PythiaParameters = cms.PSet(
+                                pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                                                'PhaseSpace:pTHatMin = 20.'),
+                                parameterSets = cms.vstring('pythia8_example02')
+                            )
+                        )
+
+_pythia8 = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter
+process.gen2 = ExternalGeneratorFilter(_pythia8)
+
+process.sleeper = cms.EDProducer("timestudy::SleepingProducer", ivalue = cms.int32(1), consumes = cms.VInputTag(), eventTimes=cms.vdouble(1.))
+
+process.compare = cms.EDAnalyzer("CompareGeneratorResultsAnalyzer", module1 = cms.untracked.string("gen1"), module2 =cms.untracked.string("gen2"))
+
+process.p = cms.Path(process.sleeper+process.gen1+process.gen2+process.compare)

--- a/GeneratorInterface/Pythia8Interface/test/compare_identical_generators_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/compare_identical_generators_cfg.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+process.source =cms.Source("EmptySource")
+
+process.maxEvents.input = 10
+
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.gen1 = process.RandomNumberGeneratorService.generator.clone()
+process.RandomNumberGeneratorService.gen2 = process.RandomNumberGeneratorService.generator.clone()
+process.gen1 = cms.EDFilter("Pythia8GeneratorFilter",
+                            comEnergy = cms.double(7000.),
+                            PythiaParameters = cms.PSet(
+                                pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                                                'PhaseSpace:pTHatMin = 20.'),
+                                parameterSets = cms.vstring('pythia8_example02')
+                            )
+                        )
+process.gen2 = cms.EDFilter("Pythia8GeneratorFilter",
+                            comEnergy = cms.double(7000.),
+                            PythiaParameters = cms.PSet(
+                                pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                                                'PhaseSpace:pTHatMin = 20.'),
+                                parameterSets = cms.vstring('pythia8_example02')
+                            )
+                        )
+process.compare = cms.EDAnalyzer("CompareGeneratorResultsAnalyzer", module1 = cms.untracked.string("gen1"), module2 =cms.untracked.string("gen2"))
+
+process.p = cms.Path(process.gen1+process.gen2+process.compare)

--- a/GeneratorInterface/Pythia8Interface/test/test_catch2_External_Pythia8GeneratorFilter.cc
+++ b/GeneratorInterface/Pythia8Interface/test/test_catch2_External_Pythia8GeneratorFilter.cc
@@ -1,0 +1,57 @@
+#include "catch.hpp"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+static constexpr auto s_tag = "[External Pythia8GeneratorFilter]";
+
+TEST_CASE("Standard checks of ExternalGeneratorFilter with Pythia8GeneratorFilter", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.toTest = process.RandomNumberGeneratorService.generator.clone()
+from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter
+_pythia8 = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+process.toTest = ExternalGeneratorFilter(_pythia8)
+
+process.add_(cms.Service('Tracer'))
+
+process.moduleToTest(process.toTest)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+  SECTION("base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+}
+
+//Add additional TEST_CASEs to exercise the modules capabilities

--- a/SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h
@@ -1,0 +1,21 @@
+#ifndef SimDataFormats_GeneratorProducts_ExternalGeneratorEventInfo_h
+#define SimDataFormats_GeneratorProducts_ExternalGeneratorEventInfo_h
+
+/** \class ExternalGeneratorEventInfo
+ *
+ * This class is an internal detail of the ExternalGeneratorFilter. It is the type
+ *  used to transfer from the external process to ExternalGeneratorFilter the 
+ *  event information.
+ */
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
+
+struct ExternalGeneratorEventInfo {
+  edm::HepMCProduct hepmc_;
+  GenEventInfoProduct eventInfo_;
+  edm::RandomNumberGeneratorState randomState_;
+  bool keepEvent_;
+};
+
+#endif

--- a/SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h
@@ -1,0 +1,18 @@
+#ifndef SimDataFormats_GeneratorProducts_ExternalGeneratorLumiInfo_h
+#define SimDataFormats_GeneratorProducts_ExternalGeneratorLumiInfo_h
+
+/** \class ExternalGeneratorLumiInfo
+ *
+ * This class is an internal detail of the ExternalGeneratorFilter. It is the type
+ *  used to transfer from the external process to ExternalGeneratorFilter the 
+ *  begin LuminosityBlock information.
+ */
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
+
+struct ExternalGeneratorLumiInfo {
+  GenLumiInfoHeader header_;
+  edm::RandomNumberGeneratorState randomState_;
+};
+
+#endif

--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
@@ -63,9 +63,12 @@ public:
     double sum2() const { return sum2_; }
 
     void add(const FinalStat &other) {
-      n_ += other.n();
-      sum_ += other.sum();
-      sum2_ += other.sum2();
+      //Hadronizers treat 0, -1., -1. to mean the value is not present
+      if (other.n() != 0 and other.sum_ != -1. and other.sum2() != -1.) {
+        n_ += other.n();
+        sum_ += other.sum();
+        sum2_ += other.sum2();
+      }
     }
 
     bool operator==(const FinalStat &other) const {

--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
@@ -2,6 +2,7 @@
 #define SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h
 
 #include <vector>
+#include <cmath>
 
 /** \class GenLumiInfoProduct
  *
@@ -89,21 +90,22 @@ public:
 
     // accessors
     int process() const { return process_; }
-    XSec lheXSec() const { return lheXSec_; }
+    XSec const &lheXSec() const { return lheXSec_; }
 
     unsigned int nPassPos() const { return nPassPos_; }
     unsigned int nPassNeg() const { return nPassNeg_; }
     unsigned int nTotalPos() const { return nTotalPos_; }
     unsigned int nTotalNeg() const { return nTotalNeg_; }
 
-    FinalStat tried() const { return tried_; }
-    FinalStat selected() const { return selected_; }
-    FinalStat killed() const { return killed_; }
-    FinalStat accepted() const { return accepted_; }
-    FinalStat acceptedBr() const { return acceptedBr_; }
+    FinalStat const &tried() const { return tried_; }
+    FinalStat const &selected() const { return selected_; }
+    FinalStat const &killed() const { return killed_; }
+    FinalStat const &accepted() const { return accepted_; }
+    FinalStat const &acceptedBr() const { return acceptedBr_; }
 
     // setters
     void addOthers(const ProcessInfo &other) {
+      mergeXSec(other.lheXSec(), other.selected().sum());
       nPassPos_ += other.nPassPos();
       nPassNeg_ += other.nPassNeg();
       nTotalPos_ += other.nTotalPos();
@@ -127,6 +129,21 @@ public:
     void setAcceptedBr(unsigned int n, double sum, double sum2) { acceptedBr_ = FinalStat(n, sum, sum2); }
 
   private:
+    void mergeXSec(XSec const &iXSec, double iWeight) {
+      if (iWeight <= 0.) {
+        return;
+      }
+      if (lheXSec_.value() <= 0.) {
+        lheXSec_ = iXSec;
+      } else {
+        bool useWeights = (lheXSec_.error() <= 0. || iXSec.error() <= 0.);
+        double wgt1 = useWeights ? selected().sum() : 1. / (lheXSec_.error() * lheXSec_.error());
+        double wgt2 = useWeights ? iWeight : 1. / (iXSec.error() * iXSec.error());
+        double xsec = (wgt1 * lheXSec_.value() + wgt2 * iXSec.value()) / (wgt1 + wgt2);
+        double err = useWeights ? 0. : 1.0 / std::sqrt(wgt1 + wgt2);
+        lheXSec_ = XSec(xsec, err);
+      }
+    }
     int process_;
     XSec lheXSec_;
     unsigned int nPassPos_;

--- a/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
@@ -57,7 +57,7 @@ const bool operator==(const GenLumiInfoProduct& lhs, const GenLumiInfoProduct& r
   unsigned int rhssize = rhsVector.size();
 
   bool condition = (lhs.getHEPIDWTUP() == rhs.getHEPIDWTUP()) && (lhssize == rhssize);
-  unsigned int passCounts = -999;
+  unsigned int passCounts = 0;
   if (condition) {
     for (unsigned int i = 0; i < lhssize; i++) {
       if (lhsVector[i] == rhsVector[i])

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -17,6 +17,9 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h"
+
 #include <HepMC/GenRanges.h>
 
 //needed for backward compatibility between HepMC 2.06.xx and 2.05.yy

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -241,4 +241,11 @@
    ]]>
  </ioread>        
 
+<class name="ExternalGeneratorLumiInfo" ClassVersion="3">
+  <version ClassVersion="3" checksum="2760887354"/>
+</class>
+<class name="ExternalGeneratorEventInfo" ClassVersion="3">
+  <version ClassVersion="3" checksum="2860722409"/>
+</class>
+
 </lcgdict>


### PR DESCRIPTION
#### PR description:

ExternalGeneratorFilter is a cmsRun module which can be configured to run a module built from GeneratorFilter<> in a separate process. This separate process is controlled by ExternalGeneratorFilter and cooperatively shares the CPU with cmsRun.

#### PR validation:

Additional unit tests were added to compare the output of Pythia8GeneratorFilter run directly within cmsRun and run via the ExternalGeneratorFilter. With just 1 stream/thread the output is identical. With multiple streams, the GenLumiInfoHeader, edm::HepMCProduct, GenEventInfoProduct and the GenRunInfoProduct are identical. The GenLumiInfoProduct is nearly identical exception the XSec value and errors are different.