### PR TITLE
Remove TICL dedicated wfs, and adjust the name for the pfTICLProducer automatic config

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -19,7 +19,6 @@ numWFIB.extend([20661.97]) # 2026D41 premixing stage1 (NuGun+PU)
 numWFIB.extend([20634.99]) # 2026D41 premixing combined stage1+stage2 (ttbar+PU)
 numWFIB.extend([20434.21,20634.21]) #2026D41 prodlike, prodlike PU
 numWFIB.extend([20434.103]) #2026D41 aging
-numWFIB.extend([20493.52]) #2026D41+TICL
 numWFIB.extend([20834.0]) #2026D43
 numWFIB.extend([21234.0]) #2026D44
 numWFIB.extend([21634.0]) #2026D45

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -474,47 +474,6 @@ upgradeWFs['JMENano'] = UpgradeWorkflow_JMENano(
 )
 
 
-class UpgradeWorkflow_TICLOnly(UpgradeWorkflow):
-    def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
-    def condition(self, fragment, stepList, key, hasHarvest):
-        result = (fragment=="CloseByParticleGun") and ('2026' in key)
-        if result:
-            skipList = [s for s in stepList if ("HARVEST" in s)]
-            for skip in skipList:
-                stepList.remove(skip)
-        return result
-upgradeWFs['TICLOnly'] = UpgradeWorkflow_TICLOnly(
-    steps = [
-        'RecoFull',
-        'RecoFullGlobal',
-    ],
-    PU = [],
-    suffix = '_TICLOnly',
-    offset = 0.51,
-)
-upgradeWFs['TICLOnly'].step3 = {
-    '--customise' : 'RecoHGCal/TICL/ticl_iterations.TICL_iterations'
-}
-
-class UpgradeWorkflow_TICLFullReco(UpgradeWorkflow):
-    def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
-    def condition(self, fragment, stepList, key, hasHarvest):
-        return (fragment=="CloseByParticleGun") and ('2026' in key)
-upgradeWFs['TICLFullReco'] = UpgradeWorkflow_TICLFullReco(
-    steps = [
-        'RecoFull',
-        'RecoFullGlobal',
-    ],
-    PU = [],
-    suffix = '_TICLFullReco',
-    offset = 0.52,
-)
-upgradeWFs['TICLFullReco'].step3 = {
-    '--customise' : 'RecoHGCal/TICL/ticl_iterations.TICL_iterations_withReco'
-}
-
 # common operations for aging workflows
 class UpgradeWorkflowAging(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -37,7 +37,7 @@ PFTICLProducer::PFTICLProducer(const edm::ParameterSet& conf)
 void PFTICLProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("ticlCandidateSrc", edm::InputTag("ticlCandidateFromTracksters"));
-  descriptions.add("pfTICL", desc);
+  descriptions.add("pfTICLProducer", desc);
 }
 
 void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const {

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -6,7 +6,7 @@ from RecoHGCal.TICL.EMStep_cff import *
 from RecoHGCal.TICL.HADStep_cff import *
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer
 from RecoHGCal.TICL.ticlCandidateFromTrackstersProducer_cfi import ticlCandidateFromTrackstersProducer as _ticlCandidateFromTrackstersProducer
-from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer as pfTICL
+from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer as _pfTICLProducer
 from RecoHGCal.TICL.trackstersMergeProducer_cfi import trackstersMergeProducer as _trackstersMergeProducer
 from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 
@@ -24,6 +24,7 @@ ticlCandidateFromTracksters = _ticlCandidateFromTrackstersProducer.clone(
       # A possible alternative for momentum computation:
       # momentumPlugin = dict(plugin="TracksterP4FromTrackAndPCA")
     )
+pfTICL = _pfTICLProducer.clone()
 ticlPFTask = cms.Task(ticlCandidateFromTracksters, pfTICL)
 
 iterTICLTask = cms.Task(ticlLayerTileTask

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -6,7 +6,7 @@ from RecoHGCal.TICL.EMStep_cff import *
 from RecoHGCal.TICL.HADStep_cff import *
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer
 from RecoHGCal.TICL.ticlCandidateFromTrackstersProducer_cfi import ticlCandidateFromTrackstersProducer as _ticlCandidateFromTrackstersProducer
-from RecoHGCal.TICL.pfTICL_cfi import pfTICL
+from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer as pfTICL
 from RecoHGCal.TICL.trackstersMergeProducer_cfi import trackstersMergeProducer as _trackstersMergeProducer
 from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 


### PR DESCRIPTION
This is a fix proposed to solve the issue #29446 (credit to @rovere for the suggestion)

The failing workflows are the ones that were customized to run TICL. Now that TICL is part of the official reconstruction, there's no need to have them as separate workflows.
This PR removes the wf 20493.52 and its customization from runTheMatrix

In addition, the config automatically created with fillDescriptions for the PFTiclProducer producer is here renamed according to the name of the producer itself.