### PR TITLE
improve exception reporting in HLTTauRefProducer

### DIFF
--- a/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
@@ -145,11 +145,11 @@ void HLTTauRefProducer::doPFTaus(edm::StreamID iID, edm::Event& iEvent) const {
       streamCache(iID)->first = iEvent.processHistoryID();
       streamCache(iID)->second.resize(PFTauDisContWPs_.size());
       for (size_t i = 0; i < PFTauDisCont_.size(); ++i) {
-        auto const aHandle =  iEvent.getHandle(PFTauDisCont_[i]);
+        auto const aHandle = iEvent.getHandle(PFTauDisCont_[i]);
         auto const aProv = aHandle.provenance();
         if (aProv == nullptr)
           aHandle.whyFailed()->raise();
-        const auto psetsFromProvenance = edm::parameterSet(*aProv, iEvent.processHistory());
+        const auto& psetsFromProvenance = edm::parameterSet(*aProv, iEvent.processHistory());
         if (psetsFromProvenance.exists("workingPoints")) {
           auto const idlist = psetsFromProvenance.getParameter<std::vector<std::string>>("workingPoints");
           bool found = false;

--- a/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
@@ -146,10 +146,10 @@ void HLTTauRefProducer::doPFTaus(edm::StreamID iID, edm::Event& iEvent) const {
       streamCache(iID)->second.resize(PFTauDisContWPs_.size());
       for (size_t i = 0; i < PFTauDisCont_.size(); ++i) {
         auto const aHandle =  iEvent.getHandle(PFTauDisCont_[i]);
-        if (aHandle.provenance() == nullptr)
+        auto const aProv = aHandle.provenance();
+        if (aProv == nullptr)
           aHandle.whyFailed()->raise();
-        const auto psetsFromProvenance =
-            edm::parameterSet(*(iEvent.getHandle(PFTauDisCont_[i]).provenance()), iEvent.processHistory());
+        const auto psetsFromProvenance = edm::parameterSet(*aProv, iEvent.processHistory());
         if (psetsFromProvenance.exists("workingPoints")) {
           auto const idlist = psetsFromProvenance.getParameter<std::vector<std::string>>("workingPoints");
           bool found = false;

--- a/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
@@ -145,6 +145,9 @@ void HLTTauRefProducer::doPFTaus(edm::StreamID iID, edm::Event& iEvent) const {
       streamCache(iID)->first = iEvent.processHistoryID();
       streamCache(iID)->second.resize(PFTauDisContWPs_.size());
       for (size_t i = 0; i < PFTauDisCont_.size(); ++i) {
+        auto const aHandle =  iEvent.getHandle(PFTauDisCont_[i]);
+        if (aHandle.provenance() == nullptr)
+          aHandle.whyFailed()->raise();
         const auto psetsFromProvenance =
             edm::parameterSet(*(iEvent.getHandle(PFTauDisCont_[i]).provenance()), iEvent.processHistory());
         if (psetsFromProvenance.exists("workingPoints")) {


### PR DESCRIPTION
The change is to raise whyFailed if tau ID container provenance is not available.
This way we will get an edm::Exception instead of a segfault

this will reclassify #29448 from a crash to an error
