### PR TITLE
Run-3 ALCT and LCT data formats

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -36,14 +36,14 @@ public:
   void setValid(const int valid) { valid_ = valid; }
 
   /// return quality of a pattern
-  int getQuality() const { return quality_; }
+  uint16_t getQuality() const { return quality_; }
 
   /// set quality
   void setQuality(const int quality) { quality_ = quality; }
 
   /// return Accelerator bit
   /// 1-Accelerator pattern, 0-CollisionA or CollisionB pattern
-  int getAccelerator() const { return accel_; }
+  uint16_t getAccelerator() const { return accel_; }
 
   /// set accelerator bit
   void setAccelerator(const int accelerator) { accel_ = accelerator; }
@@ -51,31 +51,31 @@ public:
   /// return Collision Pattern B bit
   /// 1-CollisionB pattern (accel_ = 0),
   /// 0-CollisionA pattern (accel_ = 0)
-  int getCollisionB() const { return patternb_; }
+  uint16_t getCollisionB() const { return patternb_; }
 
   /// set Collision Pattern B bit
   void setCollisionB(const int collision) { patternb_ = collision; }
 
   /// return key wire group
-  int getKeyWG() const { return keywire_; }
+  uint16_t getKeyWG() const { return keywire_; }
 
   /// set key wire group
   void setKeyWG(const int keyWG) { keywire_ = keyWG; }
 
   /// return BX - five low bits of BXN counter tagged by the ALCT
-  int getBX() const { return bx_; }
+  uint16_t getBX() const { return bx_; }
 
   /// set BX
   void setBX(const int BX) { bx_ = BX; }
 
   /// return track number (1,2)
-  int getTrknmb() const { return trknmb_; }
+  uint16_t getTrknmb() const { return trknmb_; }
 
   /// Set track number (1,2) after sorting ALCTs.
   void setTrknmb(const uint16_t number) { trknmb_ = number; }
 
   /// return 12-bit full BX.
-  int getFullBX() const { return fullbx_; }
+  uint16_t getFullBX() const { return fullbx_; }
 
   /// Set 12-bit full BX.
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -109,7 +109,7 @@ public:
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3);
+  void setRun3(const bool isRun3);
 
 private:
   uint16_t valid_;

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -14,6 +14,8 @@
 
 class CSCALCTDigi {
 public:
+  enum class Version { Legacy = 0, Run3 };
+
   /// Constructors
   CSCALCTDigi(const int valid,
               const int quality,
@@ -22,7 +24,8 @@ public:
               const int keywire,
               const int bx,
               const int trknmb = 0,
-              const int hmt = 0);
+              const int hmt = 0,
+              const Version version = Version::Legacy);
   /// default
   CSCALCTDigi();
 
@@ -120,8 +123,6 @@ private:
   /// Note: In DN-20-016, 3 bits are allocated for HMT in the
   /// ALCT board. These bits are copied into the ALCT digi in CMSSW
   uint16_t hmt_;
-
-  enum class Version { Legacy = 0, Run3 };
 
   Version version_;
 };

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -14,8 +14,6 @@
 
 class CSCALCTDigi {
 public:
-  enum ALCTHMT { kIsRun3Mask = 0x1, kHMTMask = 0x7, kIsRun3Shift = 14, kHMTShift = 0 };
-
   /// Constructors
   CSCALCTDigi(const int valid,
               const int quality,
@@ -83,10 +81,10 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   /// return the high multiplicity bits
-  int getHMT() const;
+  int getHMT() const { return hmt_; }
 
   /// set the high multiplicity bits
-  void setHMT(const int hmt);
+  void setHMT(const int hmt) { hmt_ = hmt; }
 
   /// True if the first ALCT has a larger quality, or if it has the same
   /// quality but a larger wire group.
@@ -105,9 +103,9 @@ public:
   void setWireGroup(unsigned int wiregroup) { keywire_ = wiregroup; }
 
   /// Distinguish Run-1/2 from Run-3
-  bool isRun3() const;
+  bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3);
+  void setRun3(bool isRun3) { version_ = Version::Run3; }
 
 private:
   uint16_t valid_;
@@ -122,6 +120,10 @@ private:
   /// Note: In DN-20-016, 3 bits are allocated for HMT in the
   /// ALCT board. These bits are copied into the ALCT digi in CMSSW
   uint16_t hmt_;
+
+  enum class Version { Legacy = 0, Run3 };
+
+  Version version_;
 };
 
 std::ostream& operator<<(std::ostream& o, const CSCALCTDigi& digi);

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -81,10 +81,10 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   /// return the high multiplicity bits
-  uint16_t getHMT() const { return ( (version_ == Version::Run3 ) ? hmt_ : -1 ); }
+  uint16_t getHMT() const { return ((version_ == Version::Run3) ? hmt_ : -1); }
 
   /// set the high multiplicity bits
-  void setHMT(const int hmt) {version_ == Version::Run3 ? hmt_ = hmt : -1; }
+  void setHMT(const int hmt) { version_ == Version::Run3 ? hmt_ = hmt : -1; }
 
   /// True if the first ALCT has a larger quality, or if it has the same
   /// quality but a larger wire group.
@@ -105,7 +105,7 @@ public:
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { isRun3 ?  version_ = Version::Run3 : Version::Legacy; }
+  void setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
 
 private:
   uint16_t valid_;

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -81,10 +81,10 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   /// return the high multiplicity bits
-  int getHMT() const { return hmt_; }
+  uint16_t getHMT() const { return ( (version_ == Version::Run3 ) ? hmt_ : -1 ); }
 
   /// set the high multiplicity bits
-  void setHMT(const int hmt) { hmt_ = hmt; }
+  void setHMT(const int hmt) {version_ == Version::Run3 ? hmt_ = hmt : -1; }
 
   /// True if the first ALCT has a larger quality, or if it has the same
   /// quality but a larger wire group.
@@ -105,7 +105,7 @@ public:
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { version_ = Version::Run3; }
+  void setRun3(bool isRun3) { isRun3 ?  version_ = Version::Run3 : Version::Legacy; }
 
 private:
   uint16_t valid_;

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -14,6 +14,8 @@
 
 class CSCALCTDigi {
 public:
+  enum ALCTHMT { kIsRun3Mask = 0x1, kHMTMask = 0x7, kIsRun3Shift = 14, kHMTShift = 0 };
+
   /// Constructors
   CSCALCTDigi(const int valid,
               const int quality,
@@ -81,10 +83,10 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   /// return the high multiplicity bits
-  int getHMT() const { return hmt_; }
+  int getHMT() const;
 
   /// set the high multiplicity bits
-  void setHMT(const int hmt) { hmt_ = hmt; }
+  void setHMT(const int hmt);
 
   /// True if the first ALCT has a larger quality, or if it has the same
   /// quality but a larger wire group.
@@ -101,6 +103,11 @@ public:
 
   /// set wiregroup number
   void setWireGroup(unsigned int wiregroup) { keywire_ = wiregroup; }
+
+  /// Distinguish Run-1/2 from Run-3
+  bool isRun3() const;
+
+  void setRun3(bool isRun3);
 
 private:
   uint16_t valid_;

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -11,20 +11,21 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <limits>
 
 class CSCALCTDigi {
 public:
   enum class Version { Legacy = 0, Run3 };
 
   /// Constructors
-  CSCALCTDigi(const int valid,
-              const int quality,
-              const int accel,
-              const int patternb,
-              const int keywire,
-              const int bx,
-              const int trknmb = 0,
-              const int hmt = 0,
+  CSCALCTDigi(const uint16_t valid,
+              const uint16_t quality,
+              const uint16_t accel,
+              const uint16_t patternb,
+              const uint16_t keywire,
+              const uint16_t bx,
+              const uint16_t trknmb = 0,
+              const uint16_t hmt = 0,
               const Version version = Version::Legacy);
   /// default
   CSCALCTDigi();
@@ -36,20 +37,20 @@ public:
   bool isValid() const { return valid_; }
 
   /// set valid
-  void setValid(const int valid) { valid_ = valid; }
+  void setValid(const uint16_t valid) { valid_ = valid; }
 
   /// return quality of a pattern
   uint16_t getQuality() const { return quality_; }
 
   /// set quality
-  void setQuality(const int quality) { quality_ = quality; }
+  void setQuality(const uint16_t quality) { quality_ = quality; }
 
   /// return Accelerator bit
   /// 1-Accelerator pattern, 0-CollisionA or CollisionB pattern
   uint16_t getAccelerator() const { return accel_; }
 
   /// set accelerator bit
-  void setAccelerator(const int accelerator) { accel_ = accelerator; }
+  void setAccelerator(const uint16_t accelerator) { accel_ = accelerator; }
 
   /// return Collision Pattern B bit
   /// 1-CollisionB pattern (accel_ = 0),
@@ -57,19 +58,19 @@ public:
   uint16_t getCollisionB() const { return patternb_; }
 
   /// set Collision Pattern B bit
-  void setCollisionB(const int collision) { patternb_ = collision; }
+  void setCollisionB(const uint16_t collision) { patternb_ = collision; }
 
   /// return key wire group
   uint16_t getKeyWG() const { return keywire_; }
 
   /// set key wire group
-  void setKeyWG(const int keyWG) { keywire_ = keyWG; }
+  void setKeyWG(const uint16_t keyWG) { keywire_ = keyWG; }
 
   /// return BX - five low bits of BXN counter tagged by the ALCT
   uint16_t getBX() const { return bx_; }
 
   /// set BX
-  void setBX(const int BX) { bx_ = BX; }
+  void setBX(const uint16_t BX) { bx_ = BX; }
 
   /// return track number (1,2)
   uint16_t getTrknmb() const { return trknmb_; }
@@ -84,10 +85,10 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   /// return the high multiplicity bits
-  uint16_t getHMT() const { return ((version_ == Version::Run3) ? hmt_ : -1); }
+  uint16_t getHMT() const;
 
   /// set the high multiplicity bits
-  void setHMT(const int hmt) { version_ == Version::Run3 ? hmt_ = hmt : -1; }
+  void setHMT(const uint16_t hmt);
 
   /// True if the first ALCT has a larger quality, or if it has the same
   /// quality but a larger wire group.
@@ -103,12 +104,12 @@ public:
   void print() const;
 
   /// set wiregroup number
-  void setWireGroup(unsigned int wiregroup) { keywire_ = wiregroup; }
+  void setWireGroup(uint16_t wiregroup) { keywire_ = wiregroup; }
 
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
+  void setRun3(bool isRun3);
 
 private:
   uint16_t valid_;

--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -21,7 +21,8 @@ public:
               const int patternb,
               const int keywire,
               const int bx,
-              const int trknmb = 0);
+              const int trknmb = 0,
+              const int hmt = 0);
   /// default
   CSCALCTDigi();
 
@@ -79,6 +80,12 @@ public:
   /// Set 12-bit full BX.
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
+  /// return the high multiplicity bits
+  int getHMT() const { return hmt_; }
+
+  /// set the high multiplicity bits
+  void setHMT(const int hmt) { hmt_ = hmt; }
+
   /// True if the first ALCT has a larger quality, or if it has the same
   /// quality but a larger wire group.
   bool operator>(const CSCALCTDigi&) const;
@@ -104,6 +111,10 @@ private:
   uint16_t bx_;
   uint16_t trknmb_;
   uint16_t fullbx_;
+  /// Run-3 introduces high-multiplicity bits for CSCs.
+  /// Note: In DN-20-016, 3 bits are allocated for HMT in the
+  /// ALCT board. These bits are copied into the ALCT digi in CMSSW
+  uint16_t hmt_;
 };
 
 std::ostream& operator<<(std::ostream& o, const CSCALCTDigi& digi);

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -119,7 +119,7 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   // 12-bit comparator code
-  int getCompCode() const { return compCode_; }
+  uint16_t getCompCode() const { return ( (version_ == Version::Run3 ) ? compCode_ : -1 ); }
 
   void setCompCode(const int16_t code) { compCode_ = code; }
 
@@ -145,14 +145,22 @@ public:
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { version_ = Version::Run3; }
+  void setRun3(bool isRun3) { isRun3 ?  version_ = Version::Run3 : Version::Legacy; }
 
 private:
   uint16_t valid_;
   uint16_t quality_;
+  // In Run-3, the 4-bit pattern number is reinterpreted as the
+  // 4-bit bending value. There will be 16 bending values * 2 (left/right)
   uint16_t pattern_;
   uint16_t striptype_;  // not used since mid-2008
+  // Common definition for left/right bending in Run-1, Run-2 and Run-3.
+  // 0: right; 1: left
   uint16_t bend_;
+  // In Run-3, the strip number receives two additional bits
+  // strip[4:0] -> 1/2 strip value
+  // strip[5]   -> 1/4 strip bit
+  // strip[6]   -> 1/8 strip bit
   uint16_t strip_;
   uint16_t cfeb_;
   uint16_t bx_;

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -142,6 +142,11 @@ public:
   /// Print content of digi.
   void print() const;
 
+  /// Distinguish Run-1/2 from Run-3
+  bool isRun3() const { return version_ == Version::Run3; }
+
+  void setRun3(bool isRun3) { version_ = Version::Run3; }
+
 private:
   uint16_t valid_;
   uint16_t quality_;
@@ -159,6 +164,10 @@ private:
   int16_t compCode_;
   // which hits are in this CLCT?
   ComparatorContainer hits_;
+
+  enum class Version { Legacy = 0, Run3 };
+
+  Version version_;
 };
 
 std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi);

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -148,7 +148,7 @@ public:
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
+  void setRun3(bool isRun3);
 
 private:
   uint16_t valid_;

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -119,7 +119,7 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   // 12-bit comparator code
-  uint16_t getCompCode() const { return ((version_ == Version::Run3) ? compCode_ : -1); }
+  int16_t getCompCode() const { return ((version_ == Version::Run3) ? compCode_ : -1); }
 
   void setCompCode(const int16_t code) { compCode_ = code; }
 

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -19,6 +19,7 @@ public:
 
   enum CLCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0x1f };
   enum CLCTKeyStripShifts { kEightStripShift = 6, kQuartStripShift = 5, kHalfStripShift = 0 };
+  enum class Version { Legacy = 0, Run3 };
 
   /// Constructors
   CSCCLCTDigi(const int valid,
@@ -31,7 +32,8 @@ public:
               const int bx,
               const int trknmb = 0,
               const int fullbx = 0,
-              const int compCode = -1);
+              const int compCode = -1,
+              const Version version = Version::Legacy);
   /// default
   CSCCLCTDigi();
 
@@ -173,8 +175,6 @@ private:
   int16_t compCode_;
   // which hits are in this CLCT?
   ComparatorContainer hits_;
-
-  enum class Version { Legacy = 0, Run3 };
 
   Version version_;
 };

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -45,31 +45,31 @@ public:
   void setValid(const int valid) { valid_ = valid; }
 
   /// return quality of a pattern (number of layers hit!)
-  int getQuality() const { return quality_; }
+  uint16_t getQuality() const { return quality_; }
 
   /// set quality
   void setQuality(const int quality) { quality_ = quality; }
 
   /// return pattern
-  int getPattern() const { return pattern_; }
+  uint16_t getPattern() const { return pattern_; }
 
   /// set pattern
   void setPattern(const int pattern) { pattern_ = pattern; }
 
   /// return striptype
-  int getStripType() const { return striptype_; }
+  uint16_t getStripType() const { return striptype_; }
 
   /// set stripType
   void setStripType(const int stripType) { striptype_ = stripType; }
 
   /// return bend
-  int getBend() const { return bend_; }
+  uint16_t getBend() const { return bend_; }
 
   /// set bend
   void setBend(const int bend) { bend_ = bend; }
 
   /// return halfstrip that goes from 0 to 31 in a (D)CFEB
-  int getStrip() const;
+  uint16_t getStrip() const;
 
   /// set strip
   void setStrip(const int strip) { strip_ = strip; }
@@ -87,19 +87,19 @@ public:
   bool getEightStrip() const;
 
   /// return Key CFEB ID
-  int getCFEB() const { return cfeb_; }
+  uint16_t getCFEB() const { return cfeb_; }
 
   /// set Key CFEB ID
   void setCFEB(const int cfeb) { cfeb_ = cfeb; }
 
   /// return BX
-  int getBX() const { return bx_; }
+  uint16_t getBX() const { return bx_; }
 
   /// set bx
   void setBX(const int bx) { bx_ = bx; }
 
   /// return track number (1,2)
-  int getTrknmb() const { return trknmb_; }
+  uint16_t getTrknmb() const { return trknmb_; }
 
   /// Convert strip_ and cfeb_ to keyStrip. Each CFEB has up to 16 strips
   /// (32 halfstrips). There are 5 cfebs.  The "strip_" variable is one
@@ -107,13 +107,13 @@ public:
   /// Halfstrip = (cfeb*32 + strip).
   /// This function can also return the quartstrip or eightstrip
   /// when the comparator code has been set
-  int getKeyStrip(int n = 2) const;
+  uint16_t getKeyStrip(int n = 2) const;
 
   /// Set track number (1,2) after sorting CLCTs.
   void setTrknmb(const uint16_t number) { trknmb_ = number; }
 
   /// return 12-bit full BX.
-  int getFullBX() const { return fullbx_; }
+  uint16_t getFullBX() const { return fullbx_; }
 
   /// Set 12-bit full BX.
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
@@ -162,6 +162,7 @@ private:
   // strip[5]   -> 1/4 strip bit
   // strip[6]   -> 1/8 strip bit
   uint16_t strip_;
+  // There are up to 7 (D)CFEBs in a chamber
   uint16_t cfeb_;
   uint16_t bx_;
   uint16_t trknmb_;

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -119,7 +119,7 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   // 12-bit comparator code
-  uint16_t getCompCode() const { return ( (version_ == Version::Run3 ) ? compCode_ : -1 ); }
+  uint16_t getCompCode() const { return ((version_ == Version::Run3) ? compCode_ : -1); }
 
   void setCompCode(const int16_t code) { compCode_ = code; }
 
@@ -145,7 +145,7 @@ public:
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { isRun3 ?  version_ = Version::Run3 : Version::Legacy; }
+  void setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
 
 private:
   uint16_t valid_;

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <vector>
+#include <limits>
 
 class CSCCLCTDigi {
 public:
@@ -22,17 +23,17 @@ public:
   enum class Version { Legacy = 0, Run3 };
 
   /// Constructors
-  CSCCLCTDigi(const int valid,
-              const int quality,
-              const int pattern,
-              const int striptype,
-              const int bend,
-              const int strip,
-              const int cfeb,
-              const int bx,
-              const int trknmb = 0,
-              const int fullbx = 0,
-              const int compCode = -1,
+  CSCCLCTDigi(const uint16_t valid,
+              const uint16_t quality,
+              const uint16_t pattern,
+              const uint16_t striptype,
+              const uint16_t bend,
+              const uint16_t strip,
+              const uint16_t cfeb,
+              const uint16_t bx,
+              const uint16_t trknmb = 0,
+              const uint16_t fullbx = 0,
+              const int16_t compCode = -1,
               const Version version = Version::Legacy);
   /// default
   CSCCLCTDigi();
@@ -44,37 +45,37 @@ public:
   bool isValid() const { return valid_; }
 
   /// set valid
-  void setValid(const int valid) { valid_ = valid; }
+  void setValid(const uint16_t valid) { valid_ = valid; }
 
   /// return quality of a pattern (number of layers hit!)
   uint16_t getQuality() const { return quality_; }
 
   /// set quality
-  void setQuality(const int quality) { quality_ = quality; }
+  void setQuality(const uint16_t quality) { quality_ = quality; }
 
   /// return pattern
   uint16_t getPattern() const { return pattern_; }
 
   /// set pattern
-  void setPattern(const int pattern) { pattern_ = pattern; }
+  void setPattern(const uint16_t pattern) { pattern_ = pattern; }
 
   /// return striptype
   uint16_t getStripType() const { return striptype_; }
 
   /// set stripType
-  void setStripType(const int stripType) { striptype_ = stripType; }
+  void setStripType(const uint16_t stripType) { striptype_ = stripType; }
 
   /// return bend
   uint16_t getBend() const { return bend_; }
 
   /// set bend
-  void setBend(const int bend) { bend_ = bend; }
+  void setBend(const uint16_t bend) { bend_ = bend; }
 
   /// return halfstrip that goes from 0 to 31 in a (D)CFEB
   uint16_t getStrip() const;
 
   /// set strip
-  void setStrip(const int strip) { strip_ = strip; }
+  void setStrip(const uint16_t strip) { strip_ = strip; }
 
   /// set single quart strip bit
   void setQuartStrip(const bool quartStrip);
@@ -92,13 +93,13 @@ public:
   uint16_t getCFEB() const { return cfeb_; }
 
   /// set Key CFEB ID
-  void setCFEB(const int cfeb) { cfeb_ = cfeb; }
+  void setCFEB(const uint16_t cfeb) { cfeb_ = cfeb; }
 
   /// return BX
   uint16_t getBX() const { return bx_; }
 
   /// set bx
-  void setBX(const int bx) { bx_ = bx; }
+  void setBX(const uint16_t bx) { bx_ = bx; }
 
   /// return track number (1,2)
   uint16_t getTrknmb() const { return trknmb_; }
@@ -109,7 +110,7 @@ public:
   /// Halfstrip = (cfeb*32 + strip).
   /// This function can also return the quartstrip or eightstrip
   /// when the comparator code has been set
-  uint16_t getKeyStrip(int n = 2) const;
+  uint16_t getKeyStrip(uint16_t n = 2) const;
 
   /// Set track number (1,2) after sorting CLCTs.
   void setTrknmb(const uint16_t number) { trknmb_ = number; }

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -122,7 +122,7 @@ public:
   void setFullBX(const uint16_t fullbx) { fullbx_ = fullbx; }
 
   // 12-bit comparator code
-  int16_t getCompCode() const { return ((version_ == Version::Run3) ? compCode_ : -1); }
+  int16_t getCompCode() const { return (isRun3() ? compCode_ : -1); }
 
   void setCompCode(const int16_t code) { compCode_ = code; }
 

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -32,7 +32,8 @@ public:
                        const int mpclink = 0,
                        const uint16_t bx0 = 0,
                        const uint16_t syncErr = 0,
-                       const uint16_t cscID = 0);
+                       const uint16_t cscID = 0,
+                       const uint16_t hmt = 0);
   CSCCorrelatedLCTDigi();  /// default
 
   /// clear this LCT
@@ -78,6 +79,7 @@ public:
   int getBX() const { return bx; }
 
   /// return CLCT pattern number (in use again Feb 2011)
+  /// This function should not be used for Run-3
   int getCLCTPattern() const { return (pattern & 0xF); }
 
   /// return strip type (obsolete since mid-2008)
@@ -89,6 +91,12 @@ public:
   uint16_t getCSCID() const { return cscID; }
   uint16_t getBX0() const { return bx0; }
   uint16_t getSyncErr() const { return syncErr; }
+
+  /// Run-3 introduces high-multiplicity bits for CSCs.
+  /// The allocation is different for ME1/1 and non-ME1/1
+  /// chambers. Both LCTs in a chamber are needed for the complete
+  /// high-multiplicity trigger information
+  uint16_t getHMT() const { return hmt; }
 
   /// Set track number (1,2) after sorting LCTs.
   void setTrknmb(const uint16_t number) { trknmb = number; }
@@ -133,6 +141,9 @@ public:
   /// set cscID
   void setCSCID(unsigned int c) { cscID = c; }
 
+  /// set high-multiplicity bits
+  void setHMT(unsigned int h) { hmt = h; }
+
   /// SIMULATION ONLY ////
   enum Type {
     CLCTALCT,      // CLCT-centric
@@ -158,18 +169,45 @@ public:
   const GEMPadDigi& getGEM2() const { return gem2_; }
 
 private:
+  // Note: The Run-3 data format is substantially different than the
+  // Run-1/2 data format. Some explanation is provided below. For
+  // more information, please check "DN-20-016".
+
+  // Run-1, Run-2 and Run-3 trknmb is either 1 or 2.
   uint16_t trknmb;
+  // In Run-3, the valid will be encoded as a quality
+  // value "000" or "00".
   uint16_t valid;
+  // In Run-3, the LCT quality number will be 2 or 3 bits
+  // For ME1/1 chambers: 3 bits
+  // For non-ME1/1 chambers: 2 bits
   uint16_t quality;
+  // 7-bit key wire
   uint16_t keywire;
+  // In Run-3, the strip number receives two additional bits
+  // strip[7:0] -> 1/2 strip value
+  // strip[8]   -> 1/4 strip bit
+  // strip[9]   -> 1/8 strip bit
   uint16_t strip;
+  // In Run-3, the 4-bit pattern number is reinterpreted as the
+  // 4-bit bending value. There will be 16 bending values * 2 (left/right)
   uint16_t pattern;
+  // Common definition for left/right bending in Run-1, Run-2 and Run-3.
+  // 0: right; 1: left
   uint16_t bend;
   uint16_t bx;
   uint16_t mpclink;
   uint16_t bx0;
+  // The synchronization bit is actually not used by MPC or EMTF
   uint16_t syncErr;
+  // 4-bit CSC chamber identifier
   uint16_t cscID;
+  // In Run-3, LCT data will be carrying the high-multiplicity bits
+  // for chamber. These bits may indicate the observation of "exotic" events
+  // Depending on the chamber type 2 or 3 bits will be repurposed
+  // in the 32-bit LCT data word from the synchronization bit and
+  // quality bits.
+  uint16_t hmt;
 
   /// SIMULATION ONLY ////
   int type_;

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -19,7 +19,6 @@ class CSCCorrelatedLCTDigi {
 public:
   enum LCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
   enum LCTKeyStripShifts { kEightStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
-  enum LCTHMT { kIsRun3Mask = 0x1, kHMTMask = 0x7, kIsRun3Shift = 14, kHMTShift = 0 };
 
   /// Constructors
   CSCCorrelatedLCTDigi(const int trknmb,
@@ -97,7 +96,7 @@ public:
   /// The allocation is different for ME1/1 and non-ME1/1
   /// chambers. Both LCTs in a chamber are needed for the complete
   /// high-multiplicity trigger information
-  uint16_t getHMT() const;
+  uint16_t getHMT() const { return hmt; }
 
   /// Set track number (1,2) after sorting LCTs.
   void setTrknmb(const uint16_t number) { trknmb = number; }
@@ -143,7 +142,12 @@ public:
   void setCSCID(unsigned int c) { cscID = c; }
 
   /// set high-multiplicity bits
-  void setHMT(const unsigned int h);
+  void setHMT(const unsigned int h) { hmt = h; }
+
+  /// Distinguish Run-1/2 from Run-3
+  bool isRun3() const { return version_ == Version::Run3; }
+
+  void setRun3(bool isRun3) { version_ = Version::Run3; }
 
   /// SIMULATION ONLY ////
   enum Type {
@@ -160,11 +164,6 @@ public:
   int getType() const { return type_; }
 
   void setType(int type) { type_ = type; }
-
-  /// Distinguish Run-1/2 from Run-3
-  bool isRun3() const;
-
-  void setRun3(const bool isRun3);
 
   void setALCT(const CSCALCTDigi& alct) { alct_ = alct; }
   void setCLCT(const CSCCLCTDigi& clct) { clct_ = clct; }
@@ -223,6 +222,10 @@ private:
   CSCCLCTDigi clct_;
   GEMPadDigi gem1_;
   GEMPadDigi gem2_;
+
+  enum class Version { Legacy = 0, Run3 };
+
+  Version version_;
 };
 
 std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi);

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <limits>
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
@@ -22,15 +23,15 @@ public:
   enum class Version { Legacy = 0, Run3 };
 
   /// Constructors
-  CSCCorrelatedLCTDigi(const int trknmb,
-                       const int valid,
-                       const int quality,
-                       const int keywire,
-                       const int strip,
-                       const int pattern,
-                       const int bend,
-                       const int bx,
-                       const int mpclink = 0,
+  CSCCorrelatedLCTDigi(const uint16_t trknmb,
+                       const uint16_t valid,
+                       const uint16_t quality,
+                       const uint16_t keywire,
+                       const uint16_t strip,
+                       const uint16_t pattern,
+                       const uint16_t bend,
+                       const uint16_t bx,
+                       const uint16_t mpclink = 0,
                        const uint16_t bx0 = 0,
                        const uint16_t syncErr = 0,
                        const uint16_t cscID = 0,
@@ -43,19 +44,19 @@ public:
   void clear();
 
   /// return track number
-  int getTrknmb() const { return trknmb; }
+  uint16_t getTrknmb() const { return trknmb; }
 
   /// return valid pattern bit
   bool isValid() const { return valid; }
 
   /// return the Quality
-  int getQuality() const { return quality; }
+  uint16_t getQuality() const { return quality; }
 
   /// return the key wire group. counts from 0.
-  int getKeyWG() const { return keywire; }
+  uint16_t getKeyWG() const { return keywire; }
 
   /// return the key halfstrip from 0,159
-  int getStrip(int n = 2) const;
+  uint16_t getStrip(uint16_t n = 2) const;
 
   /// set single quart strip bit
   void setQuartStrip(const bool quartStrip);
@@ -70,27 +71,27 @@ public:
   bool getEightStrip() const;
 
   /// return the fractional strip. counts from 0.25
-  float getFractionalStrip(int n = 2) const;
+  float getFractionalStrip(uint16_t n = 2) const;
 
   /// Legacy: return pattern ID
   /// Run-3: return the bending angle value
-  int getPattern() const { return pattern; }
+  uint16_t getPattern() const { return pattern; }
 
   /// return left/right bending
-  int getBend() const { return bend; }
+  uint16_t getBend() const { return bend; }
 
   /// return BX
-  int getBX() const { return bx; }
+  uint16_t getBX() const { return bx; }
 
   /// return CLCT pattern number (in use again Feb 2011)
   /// This function should not be used for Run-3
-  int getCLCTPattern() const { return ((version_ == Version::Legacy) ? (pattern & 0xF) : -1); }
+  uint16_t getCLCTPattern() const;
 
   /// return strip type (obsolete since mid-2008)
-  int getStripType() const { return ((pattern & 0x8) >> 3); }
+  uint16_t getStripType() const { return ((pattern & 0x8) >> 3); }
 
   /// return MPC link number, 0 means not sorted, 1-3 give MPC sorting rank
-  int getMPCLink() const { return mpclink; }
+  uint16_t getMPCLink() const { return mpclink; }
 
   uint16_t getCSCID() const { return cscID; }
   uint16_t getBX0() const { return bx0; }
@@ -100,7 +101,7 @@ public:
   /// The allocation is different for ME1/1 and non-ME1/1
   /// chambers. Both LCTs in a chamber are needed for the complete
   /// high-multiplicity trigger information
-  uint16_t getHMT() const { return ((version_ == Version::Run3) ? hmt : -1); }
+  uint16_t getHMT() const;
 
   /// Set track number (1,2) after sorting LCTs.
   void setTrknmb(const uint16_t number) { trknmb = number; }
@@ -116,42 +117,42 @@ public:
   bool operator!=(const CSCCorrelatedLCTDigi& rhs) const { return !(this->operator==(rhs)); }
 
   /// set wiregroup number
-  void setWireGroup(unsigned int wiregroup) { keywire = wiregroup; }
+  void setWireGroup(const uint16_t wiregroup) { keywire = wiregroup; }
 
   /// set quality code
-  void setQuality(unsigned int q) { quality = q; }
+  void setQuality(const uint16_t q) { quality = q; }
 
   /// set valid
-  void setValid(unsigned int v) { valid = v; }
+  void setValid(const uint16_t v) { valid = v; }
 
   /// set strip
-  void setStrip(unsigned int s) { strip = s; }
+  void setStrip(const uint16_t s) { strip = s; }
 
   /// set pattern
-  void setPattern(unsigned int p) { pattern = p; }
+  void setPattern(const uint16_t p) { pattern = p; }
 
   /// set bend
-  void setBend(unsigned int b) { bend = b; }
+  void setBend(const uint16_t b) { bend = b; }
 
   /// set bx
-  void setBX(unsigned int b) { bx = b; }
+  void setBX(const uint16_t b) { bx = b; }
 
   /// set bx0
-  void setBX0(unsigned int b) { bx0 = b; }
+  void setBX0(const uint16_t b) { bx0 = b; }
 
   /// set syncErr
-  void setSyncErr(unsigned int s) { syncErr = s; }
+  void setSyncErr(const uint16_t s) { syncErr = s; }
 
   /// set cscID
-  void setCSCID(unsigned int c) { cscID = c; }
+  void setCSCID(const uint16_t c) { cscID = c; }
 
   /// set high-multiplicity bits
-  void setHMT(const unsigned int h) { version_ == Version::Run3 ? hmt = h : -1; }
+  void setHMT(const uint16_t h);
 
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
+  void setRun3(bool isRun3);
 
   /// SIMULATION ONLY ////
   enum Type {

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -152,7 +152,7 @@ public:
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3);
+  void setRun3(const bool isRun3);
 
   /// SIMULATION ONLY ////
   enum Type {

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -19,6 +19,7 @@ class CSCCorrelatedLCTDigi {
 public:
   enum LCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
   enum LCTKeyStripShifts { kEightStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
+  enum class Version { Legacy = 0, Run3 };
 
   /// Constructors
   CSCCorrelatedLCTDigi(const int trknmb,
@@ -33,8 +34,10 @@ public:
                        const uint16_t bx0 = 0,
                        const uint16_t syncErr = 0,
                        const uint16_t cscID = 0,
-                       const uint16_t hmt = 0);
-  CSCCorrelatedLCTDigi();  /// default
+                       const uint16_t hmt = 0,
+                       const Version version = Version::Legacy);
+  /// default
+  CSCCorrelatedLCTDigi();
 
   /// clear this LCT
   void clear();
@@ -223,8 +226,6 @@ private:
   CSCCLCTDigi clct_;
   GEMPadDigi gem1_;
   GEMPadDigi gem2_;
-
-  enum class Version { Legacy = 0, Run3 };
 
   Version version_;
 };

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -19,6 +19,7 @@ class CSCCorrelatedLCTDigi {
 public:
   enum LCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
   enum LCTKeyStripShifts { kEightStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
+  enum LCTHMT { kIsRun3Mask = 0x1, kHMTMask = 0x7, kIsRun3Shift = 14, kHMTShift = 0 };
 
   /// Constructors
   CSCCorrelatedLCTDigi(const int trknmb,
@@ -96,7 +97,7 @@ public:
   /// The allocation is different for ME1/1 and non-ME1/1
   /// chambers. Both LCTs in a chamber are needed for the complete
   /// high-multiplicity trigger information
-  uint16_t getHMT() const { return hmt; }
+  uint16_t getHMT() const;
 
   /// Set track number (1,2) after sorting LCTs.
   void setTrknmb(const uint16_t number) { trknmb = number; }
@@ -142,7 +143,7 @@ public:
   void setCSCID(unsigned int c) { cscID = c; }
 
   /// set high-multiplicity bits
-  void setHMT(unsigned int h) { hmt = h; }
+  void setHMT(const unsigned int h);
 
   /// SIMULATION ONLY ////
   enum Type {
@@ -157,7 +158,13 @@ public:
   };
 
   int getType() const { return type_; }
+
   void setType(int type) { type_ = type; }
+
+  /// Distinguish Run-1/2 from Run-3
+  bool isRun3() const;
+
+  void setRun3(const bool isRun3);
 
   void setALCT(const CSCALCTDigi& alct) { alct_ = alct; }
   void setCLCT(const CSCCLCTDigi& clct) { clct_ = clct; }

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -69,10 +69,11 @@ public:
   /// return the fractional strip. counts from 0.25
   float getFractionalStrip(int n = 2) const;
 
-  /// return pattern
+  /// Legacy: return pattern ID
+  /// Run-3: return the bending angle value
   int getPattern() const { return pattern; }
 
-  /// return bend
+  /// return left/right bending
   int getBend() const { return bend; }
 
   /// return BX
@@ -80,7 +81,7 @@ public:
 
   /// return CLCT pattern number (in use again Feb 2011)
   /// This function should not be used for Run-3
-  int getCLCTPattern() const { return (pattern & 0xF); }
+  int getCLCTPattern() const { return ( (version_ == Version::Legacy) ? (pattern & 0xF) : -1 ); }
 
   /// return strip type (obsolete since mid-2008)
   int getStripType() const { return ((pattern & 0x8) >> 3); }
@@ -96,7 +97,7 @@ public:
   /// The allocation is different for ME1/1 and non-ME1/1
   /// chambers. Both LCTs in a chamber are needed for the complete
   /// high-multiplicity trigger information
-  uint16_t getHMT() const { return hmt; }
+  uint16_t getHMT() const { return ( (version_ == Version::Run3 ) ? hmt : -1 ); }
 
   /// Set track number (1,2) after sorting LCTs.
   void setTrknmb(const uint16_t number) { trknmb = number; }
@@ -142,12 +143,12 @@ public:
   void setCSCID(unsigned int c) { cscID = c; }
 
   /// set high-multiplicity bits
-  void setHMT(const unsigned int h) { hmt = h; }
+  void setHMT(const unsigned int h) { version_ == Version::Run3 ? hmt = h : -1 ; }
 
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { version_ = Version::Run3; }
+  void setRun3(bool isRun3) { isRun3 ?  version_ = Version::Run3 : Version::Legacy; }
 
   /// SIMULATION ONLY ////
   enum Type {

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -81,7 +81,7 @@ public:
 
   /// return CLCT pattern number (in use again Feb 2011)
   /// This function should not be used for Run-3
-  int getCLCTPattern() const { return ( (version_ == Version::Legacy) ? (pattern & 0xF) : -1 ); }
+  int getCLCTPattern() const { return ((version_ == Version::Legacy) ? (pattern & 0xF) : -1); }
 
   /// return strip type (obsolete since mid-2008)
   int getStripType() const { return ((pattern & 0x8) >> 3); }
@@ -97,7 +97,7 @@ public:
   /// The allocation is different for ME1/1 and non-ME1/1
   /// chambers. Both LCTs in a chamber are needed for the complete
   /// high-multiplicity trigger information
-  uint16_t getHMT() const { return ( (version_ == Version::Run3 ) ? hmt : -1 ); }
+  uint16_t getHMT() const { return ((version_ == Version::Run3) ? hmt : -1); }
 
   /// Set track number (1,2) after sorting LCTs.
   void setTrknmb(const uint16_t number) { trknmb = number; }
@@ -143,12 +143,12 @@ public:
   void setCSCID(unsigned int c) { cscID = c; }
 
   /// set high-multiplicity bits
-  void setHMT(const unsigned int h) { version_ == Version::Run3 ? hmt = h : -1 ; }
+  void setHMT(const unsigned int h) { version_ == Version::Run3 ? hmt = h : -1; }
 
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(bool isRun3) { isRun3 ?  version_ = Version::Run3 : Version::Legacy; }
+  void setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
 
   /// SIMULATION ONLY ////
   enum Type {

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -74,6 +74,26 @@ bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {
   return returnValue;
 }
 
+int CSCALCTDigi::getHMT() const { return hmt_ & kIsRun3Mask; }
+
+void CSCALCTDigi::setHMT(const int newHmt) {
+  // clear the old value
+  hmt_ &= ~(kHMTMask << kHMTShift);
+
+  // set the new value
+  hmt_ |= newHmt << kHMTShift;
+}
+
+bool CSCALCTDigi::isRun3() const { return (hmt_ >> kIsRun3Shift) & kIsRun3Mask; }
+
+void CSCALCTDigi::setRun3(const bool isRun3) {
+  // clear the old value
+  hmt_ &= ~(kIsRun3Mask << kIsRun3Shift);
+
+  // set the new value
+  hmt_ |= isRun3 << kIsRun3Shift;
+}
+
 bool CSCALCTDigi::operator==(const CSCALCTDigi& rhs) const {
   // Exact equality.
   bool returnValue = false;

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -14,14 +14,14 @@
 using namespace std;
 
 /// Constructors
-CSCALCTDigi::CSCALCTDigi(const int valid,
-                         const int quality,
-                         const int accel,
-                         const int patternb,
-                         const int keywire,
-                         const int bx,
-                         const int trknmb,
-                         const int hmt,
+CSCALCTDigi::CSCALCTDigi(const uint16_t valid,
+                         const uint16_t quality,
+                         const uint16_t accel,
+                         const uint16_t patternb,
+                         const uint16_t keywire,
+                         const uint16_t bx,
+                         const uint16_t trknmb,
+                         const uint16_t hmt,
                          const Version version)
     : valid_(valid),
       quality_(quality),
@@ -52,6 +52,13 @@ void CSCALCTDigi::clear() {
   hmt_ = 0;
 }
 
+uint16_t CSCALCTDigi::getHMT() const { return ((version_ == Version::Run3) ? hmt_ : std::numeric_limits<uint16_t>::max()); }
+
+void CSCALCTDigi::setHMT(const uint16_t hmt) { version_ == Version::Run3 ? hmt_ = hmt : std::numeric_limits<uint16_t>::max(); }
+
+void CSCALCTDigi::setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
+
+
 bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {
   bool returnValue = false;
 
@@ -66,8 +73,8 @@ bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {
   // The > operator then checks the quality of ALCTs.
   // If two qualities are equal, the ALCT furthest from the beam axis
   // (lowest eta, highest wire group number) is selected.
-  int quality1 = getQuality();
-  int quality2 = rhs.getQuality();
+  uint16_t quality1 = getQuality();
+  uint16_t quality2 = rhs.getQuality();
   if (quality1 > quality2) {
     returnValue = true;
   } else if (quality1 == quality2 && getKeyWG() > rhs.getKeyWG()) {

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -52,13 +52,9 @@ void CSCALCTDigi::clear() {
   hmt_ = 0;
 }
 
-uint16_t CSCALCTDigi::getHMT() const {
-  return ((version_ == Version::Run3) ? hmt_ : std::numeric_limits<uint16_t>::max());
-}
+uint16_t CSCALCTDigi::getHMT() const { return (isRun3() ? hmt_ : std::numeric_limits<uint16_t>::max()); }
 
-void CSCALCTDigi::setHMT(const uint16_t h) {
-  hmt_ = (version_ == Version::Run3) ? h : std::numeric_limits<uint16_t>::max();
-}
+void CSCALCTDigi::setHMT(const uint16_t h) { hmt_ = isRun3() ? h : std::numeric_limits<uint16_t>::max(); }
 
 void CSCALCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
 

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -21,20 +21,22 @@ CSCALCTDigi::CSCALCTDigi(const int valid,
                          const int keywire,
                          const int bx,
                          const int trknmb,
-                         const int hmt) {
-  valid_ = valid;
-  quality_ = quality;
-  accel_ = accel;
-  patternb_ = patternb;
-  keywire_ = keywire;
-  bx_ = bx;
-  trknmb_ = trknmb;
-  hmt_ = hmt;
-}
+                         const int hmt,
+                         const Version version)
+    : valid_(valid),
+      quality_(quality),
+      accel_(accel),
+      patternb_(patternb),
+      keywire_(keywire),
+      bx_(bx),
+      trknmb_(trknmb),
+      hmt_(hmt),
+      version_(version) {}
 
 /// Default
 CSCALCTDigi::CSCALCTDigi() {
   clear();  // set contents to zero
+  version_ = Version::Legacy;
 }
 
 /// Clears this ALCT.

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -52,12 +52,15 @@ void CSCALCTDigi::clear() {
   hmt_ = 0;
 }
 
-uint16_t CSCALCTDigi::getHMT() const { return ((version_ == Version::Run3) ? hmt_ : std::numeric_limits<uint16_t>::max()); }
+uint16_t CSCALCTDigi::getHMT() const {
+  return ((version_ == Version::Run3) ? hmt_ : std::numeric_limits<uint16_t>::max());
+}
 
-void CSCALCTDigi::setHMT(const uint16_t h) { hmt_ = (version_ == Version::Run3) ? h : std::numeric_limits<uint16_t>::max(); }
+void CSCALCTDigi::setHMT(const uint16_t h) {
+  hmt_ = (version_ == Version::Run3) ? h : std::numeric_limits<uint16_t>::max();
+}
 
 void CSCALCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
-
 
 bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {
   bool returnValue = false;

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -74,26 +74,6 @@ bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {
   return returnValue;
 }
 
-int CSCALCTDigi::getHMT() const { return hmt_ & kIsRun3Mask; }
-
-void CSCALCTDigi::setHMT(const int newHmt) {
-  // clear the old value
-  hmt_ &= ~(kHMTMask << kHMTShift);
-
-  // set the new value
-  hmt_ |= newHmt << kHMTShift;
-}
-
-bool CSCALCTDigi::isRun3() const { return (hmt_ >> kIsRun3Shift) & kIsRun3Mask; }
-
-void CSCALCTDigi::setRun3(const bool isRun3) {
-  // clear the old value
-  hmt_ &= ~(kIsRun3Mask << kIsRun3Shift);
-
-  // set the new value
-  hmt_ |= isRun3 << kIsRun3Shift;
-}
-
 bool CSCALCTDigi::operator==(const CSCALCTDigi& rhs) const {
   // Exact equality.
   bool returnValue = false;

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -20,7 +20,8 @@ CSCALCTDigi::CSCALCTDigi(const int valid,
                          const int patternb,
                          const int keywire,
                          const int bx,
-                         const int trknmb) {
+                         const int trknmb,
+                         const int hmt) {
   valid_ = valid;
   quality_ = quality;
   accel_ = accel;
@@ -28,6 +29,7 @@ CSCALCTDigi::CSCALCTDigi(const int valid,
   keywire_ = keywire;
   bx_ = bx;
   trknmb_ = trknmb;
+  hmt_ = hmt;
 }
 
 /// Default
@@ -45,6 +47,7 @@ void CSCALCTDigi::clear() {
   bx_ = 0;
   trknmb_ = 0;
   fullbx_ = 0;
+  hmt_ = 0;
 }
 
 bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {
@@ -75,7 +78,8 @@ bool CSCALCTDigi::operator==(const CSCALCTDigi& rhs) const {
   // Exact equality.
   bool returnValue = false;
   if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getAccelerator() == rhs.getAccelerator() &&
-      getCollisionB() == rhs.getCollisionB() && getKeyWG() == rhs.getKeyWG() && getBX() == rhs.getBX()) {
+      getCollisionB() == rhs.getCollisionB() && getKeyWG() == rhs.getKeyWG() && getBX() == rhs.getBX() &&
+      getHMT() == rhs.getHMT()) {
     returnValue = true;
   }
   return returnValue;
@@ -96,7 +100,8 @@ void CSCALCTDigi::print() const {
                                 << " Quality = " << setw(2) << getQuality() << " Accel. = " << setw(1)
                                 << getAccelerator() << " PatternB = " << setw(1) << getCollisionB()
                                 << " Key wire group = " << setw(3) << getKeyWG() << " BX = " << setw(2) << getBX()
-                                << " Full BX= " << std::setw(1) << getFullBX();
+                                << " Full BX = " << std::setw(1) << getFullBX() << " HMT = " << std::setw(1)
+                                << getHMT();
   } else {
     edm::LogVerbatim("CSCDigi") << "Not a valid Anode LCT.";
   }
@@ -105,5 +110,5 @@ void CSCALCTDigi::print() const {
 std::ostream& operator<<(std::ostream& o, const CSCALCTDigi& digi) {
   return o << "CSC ALCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
            << " Accel. = " << digi.getAccelerator() << " PatternB = " << digi.getCollisionB()
-           << " Key wire group = " << digi.getKeyWG() << " BX = " << digi.getBX();
+           << " Key wire group = " << digi.getKeyWG() << " BX = " << digi.getBX() << " HMT = " << digi.getHMT();
 }

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -54,9 +54,9 @@ void CSCALCTDigi::clear() {
 
 uint16_t CSCALCTDigi::getHMT() const { return ((version_ == Version::Run3) ? hmt_ : std::numeric_limits<uint16_t>::max()); }
 
-void CSCALCTDigi::setHMT(const uint16_t hmt) { version_ == Version::Run3 ? hmt_ = hmt : std::numeric_limits<uint16_t>::max(); }
+void CSCALCTDigi::setHMT(const uint16_t h) { hmt_ = (version_ == Version::Run3) ? h : std::numeric_limits<uint16_t>::max(); }
 
-void CSCALCTDigi::setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
+void CSCALCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
 
 
 bool CSCALCTDigi::operator>(const CSCALCTDigi& rhs) const {

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -24,7 +24,8 @@ CSCCLCTDigi::CSCCLCTDigi(const int valid,
                          const int bx,
                          const int trknmb,
                          const int fullbx,
-                         const int compCode)
+                         const int compCode,
+                         const Version version)
     : valid_(valid),
       quality_(quality),
       pattern_(pattern),
@@ -35,7 +36,8 @@ CSCCLCTDigi::CSCCLCTDigi(const int valid,
       bx_(bx),
       trknmb_(trknmb),
       fullbx_(fullbx),
-      compCode_(compCode) {
+      compCode_(compCode),
+      version_(version) {
   hits_.resize(NUM_LAYERS);
   for (auto& p : hits_) {
     p.resize(CLCT_PATTERN_WIDTH);
@@ -54,7 +56,8 @@ CSCCLCTDigi::CSCCLCTDigi()
       bx_(0),
       trknmb_(0),
       fullbx_(0),
-      compCode_(-1) {
+      compCode_(-1),
+      version_(Version::Legacy) {
   hits_.resize(NUM_LAYERS);
   for (auto& p : hits_) {
     p.resize(CLCT_PATTERN_WIDTH);

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -121,6 +121,8 @@ void CSCCLCTDigi::setEightStrip(const bool eightStrip) {
   strip_ |= eightStrip << kEightStripShift;
 }
 
+void CSCCLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
+
 bool CSCCLCTDigi::operator>(const CSCCLCTDigi& rhs) const {
   // Several versions of CLCT sorting criteria were used before 2008.
   // They are available in CMSSW versions prior to 3_1_0; here we only keep

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -81,7 +81,7 @@ void CSCCLCTDigi::clear() {
   }
 }
 
-int CSCCLCTDigi::getKeyStrip(int n) const {
+uint16_t CSCCLCTDigi::getKeyStrip(int n) const {
   // 10-bit case for strip data word
   if (compCode_ != -1 and n == 8) {
     return getKeyStrip(4) * 2 + getEightStrip();
@@ -96,7 +96,7 @@ int CSCCLCTDigi::getKeyStrip(int n) const {
   }
 }
 
-int CSCCLCTDigi::getStrip() const { return strip_ & kHalfStripMask; }
+uint16_t CSCCLCTDigi::getStrip() const { return strip_ & kHalfStripMask; }
 
 bool CSCCLCTDigi::getQuartStrip() const { return (strip_ >> kQuartStripShift) & kQuartStripMask; }
 

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -106,26 +106,6 @@ float CSCCorrelatedLCTDigi::getFractionalStrip(int n) const {
   }
 }
 
-uint16_t CSCCorrelatedLCTDigi::getHMT() const { return hmt & kIsRun3Mask; }
-
-void CSCCorrelatedLCTDigi::setHMT(const unsigned int newHmt) {
-  // clear the old value
-  hmt &= ~(kHMTMask << kHMTShift);
-
-  // set the new value
-  hmt |= newHmt << kHMTShift;
-}
-
-bool CSCCorrelatedLCTDigi::isRun3() const { return (hmt >> kIsRun3Shift) & kIsRun3Mask; }
-
-void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) {
-  // clear the old value
-  hmt &= ~(kIsRun3Mask << kIsRun3Shift);
-
-  // set the new value
-  hmt |= isRun3 << kIsRun3Shift;
-}
-
 /// Comparison
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {
   return ((trknmb == rhs.trknmb) && (quality == rhs.quality) && (keywire == rhs.keywire) && (strip == rhs.strip) &&

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -11,15 +11,15 @@
 #include <iostream>
 
 /// Constructors
-CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const int itrknmb,
-                                           const int ivalid,
-                                           const int iquality,
-                                           const int ikeywire,
-                                           const int istrip,
-                                           const int ipattern,
-                                           const int ibend,
-                                           const int ibx,
-                                           const int impclink,
+CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
+                                           const uint16_t ivalid,
+                                           const uint16_t iquality,
+                                           const uint16_t ikeywire,
+                                           const uint16_t istrip,
+                                           const uint16_t ipattern,
+                                           const uint16_t ibend,
+                                           const uint16_t ibx,
+                                           const uint16_t impclink,
                                            const uint16_t ibx0,
                                            const uint16_t isyncErr,
                                            const uint16_t icscID,
@@ -63,7 +63,7 @@ void CSCCorrelatedLCTDigi::clear() {
   hmt = 0;
 }
 
-int CSCCorrelatedLCTDigi::getStrip(int n) const {
+uint16_t CSCCorrelatedLCTDigi::getStrip(const uint16_t n) const {
   // all 10 bits
   if (n == 8) {
     return 2 * getStrip(4) + getEightStrip();
@@ -99,7 +99,7 @@ bool CSCCorrelatedLCTDigi::getQuartStrip() const { return (strip >> kQuartStripS
 bool CSCCorrelatedLCTDigi::getEightStrip() const { return (strip >> kEightStripShift) & kEightStripMask; }
 
 /// return the fractional strip
-float CSCCorrelatedLCTDigi::getFractionalStrip(int n) const {
+float CSCCorrelatedLCTDigi::getFractionalStrip(const uint16_t n) const {
   if (n == 8) {
     return 0.125f * (getStrip() + 1) - 0.0625f;
   } else if (n == 4) {
@@ -108,6 +108,14 @@ float CSCCorrelatedLCTDigi::getFractionalStrip(int n) const {
     return 0.5f * (getStrip() + 1) - 0.25f;
   }
 }
+
+uint16_t CSCCorrelatedLCTDigi::getCLCTPattern() const { return ((version_ == Version::Legacy) ? (pattern & 0xF) : std::numeric_limits<uint16_t>::max()); }
+
+uint16_t CSCCorrelatedLCTDigi::getHMT() const { return ((version_ == Version::Run3) ? hmt : std::numeric_limits<uint16_t>::max()); }
+
+void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { version_ == Version::Run3 ? hmt = h : std::numeric_limits<uint16_t>::max(); }
+
+void CSCCorrelatedLCTDigi::setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
 
 /// Comparison
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -22,7 +22,8 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const int itrknmb,
                                            const int impclink,
                                            const uint16_t ibx0,
                                            const uint16_t isyncErr,
-                                           const uint16_t icscID)
+                                           const uint16_t icscID,
+                                           const uint16_t ihmt)
     : trknmb(itrknmb),
       valid(ivalid),
       quality(iquality),
@@ -34,7 +35,8 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const int itrknmb,
       mpclink(impclink),
       bx0(ibx0),
       syncErr(isyncErr),
-      cscID(icscID) {}
+      cscID(icscID),
+      hmt(ihmt) {}
 
 /// Default
 CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi() {
@@ -55,6 +57,7 @@ void CSCCorrelatedLCTDigi::clear() {
   bx0 = 0;
   syncErr = 0;
   cscID = 0;
+  hmt = 0;
 }
 
 int CSCCorrelatedLCTDigi::getStrip(int n) const {
@@ -107,7 +110,7 @@ float CSCCorrelatedLCTDigi::getFractionalStrip(int n) const {
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {
   return ((trknmb == rhs.trknmb) && (quality == rhs.quality) && (keywire == rhs.keywire) && (strip == rhs.strip) &&
           (pattern == rhs.pattern) && (bend == rhs.bend) && (bx == rhs.bx) && (valid == rhs.valid) &&
-          (mpclink == rhs.mpclink));
+          (mpclink == rhs.mpclink) && (hmt == rhs.hmt));
 }
 
 /// Debug
@@ -117,7 +120,7 @@ void CSCCorrelatedLCTDigi::print() const {
                                 << " Quality = " << getQuality() << " Key Wire = " << getKeyWG()
                                 << " Strip = " << getStrip() << " Pattern = " << getPattern()
                                 << " Bend = " << ((getBend() == 0) ? 'L' : 'R') << " BX = " << getBX()
-                                << " MPC Link = " << getMPCLink();
+                                << " MPC Link = " << getMPCLink() << " HMT Bit = " << getHMT();
   } else {
     edm::LogVerbatim("CSCDigi") << "Not a valid correlated LCT.";
   }
@@ -129,5 +132,5 @@ std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
            << "  cathode info: Strip = " << digi.getStrip() << " Pattern = " << digi.getPattern()
            << " Bend = " << ((digi.getBend() == 0) ? 'L' : 'R') << "\n"
            << "    anode info: Key wire = " << digi.getKeyWG() << " BX = " << digi.getBX() << " bx0 = " << digi.getBX0()
-           << " syncErr = " << digi.getSyncErr() << "\n";
+           << " syncErr = " << digi.getSyncErr() << " HMT Bit = " << digi.getHMT() << "\n";
 }

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -23,7 +23,8 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const int itrknmb,
                                            const uint16_t ibx0,
                                            const uint16_t isyncErr,
                                            const uint16_t icscID,
-                                           const uint16_t ihmt)
+                                           const uint16_t ihmt,
+                                           const Version version)
     : trknmb(itrknmb),
       valid(ivalid),
       quality(iquality),
@@ -36,11 +37,13 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const int itrknmb,
       bx0(ibx0),
       syncErr(isyncErr),
       cscID(icscID),
-      hmt(ihmt) {}
+      hmt(ihmt),
+      version_(version) {}
 
 /// Default
 CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi() {
   clear();  // set contents to zero
+  version_ = Version::Legacy;
 }
 
 /// Clears this LCT.

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -106,6 +106,26 @@ float CSCCorrelatedLCTDigi::getFractionalStrip(int n) const {
   }
 }
 
+uint16_t CSCCorrelatedLCTDigi::getHMT() const { return hmt & kIsRun3Mask; }
+
+void CSCCorrelatedLCTDigi::setHMT(const unsigned int newHmt) {
+  // clear the old value
+  hmt &= ~(kHMTMask << kHMTShift);
+
+  // set the new value
+  hmt |= newHmt << kHMTShift;
+}
+
+bool CSCCorrelatedLCTDigi::isRun3() const { return (hmt >> kIsRun3Shift) & kIsRun3Mask; }
+
+void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) {
+  // clear the old value
+  hmt &= ~(kIsRun3Mask << kIsRun3Shift);
+
+  // set the new value
+  hmt |= isRun3 << kIsRun3Shift;
+}
+
 /// Comparison
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {
   return ((trknmb == rhs.trknmb) && (quality == rhs.quality) && (keywire == rhs.keywire) && (strip == rhs.strip) &&

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -109,11 +109,17 @@ float CSCCorrelatedLCTDigi::getFractionalStrip(const uint16_t n) const {
   }
 }
 
-uint16_t CSCCorrelatedLCTDigi::getCLCTPattern() const { return ((version_ == Version::Legacy) ? (pattern & 0xF) : std::numeric_limits<uint16_t>::max()); }
+uint16_t CSCCorrelatedLCTDigi::getCLCTPattern() const {
+  return ((version_ == Version::Legacy) ? (pattern & 0xF) : std::numeric_limits<uint16_t>::max());
+}
 
-uint16_t CSCCorrelatedLCTDigi::getHMT() const { return ((version_ == Version::Run3) ? hmt : std::numeric_limits<uint16_t>::max()); }
+uint16_t CSCCorrelatedLCTDigi::getHMT() const {
+  return ((version_ == Version::Run3) ? hmt : std::numeric_limits<uint16_t>::max());
+}
 
-void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { hmt = (version_ == Version::Run3) ? h : std::numeric_limits<uint16_t>::max(); }
+void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) {
+  hmt = (version_ == Version::Run3) ? h : std::numeric_limits<uint16_t>::max();
+}
 
 void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
 

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -113,9 +113,9 @@ uint16_t CSCCorrelatedLCTDigi::getCLCTPattern() const { return ((version_ == Ver
 
 uint16_t CSCCorrelatedLCTDigi::getHMT() const { return ((version_ == Version::Run3) ? hmt : std::numeric_limits<uint16_t>::max()); }
 
-void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { version_ == Version::Run3 ? hmt = h : std::numeric_limits<uint16_t>::max(); }
+void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { hmt = (version_ == Version::Run3) ? h : std::numeric_limits<uint16_t>::max(); }
 
-void CSCCorrelatedLCTDigi::setRun3(bool isRun3) { isRun3 ? version_ = Version::Run3 : Version::Legacy; }
+void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
 
 /// Comparison
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -110,7 +110,7 @@ float CSCCorrelatedLCTDigi::getFractionalStrip(const uint16_t n) const {
 }
 
 uint16_t CSCCorrelatedLCTDigi::getCLCTPattern() const {
-  return (isRun3() ? (pattern & 0xF) : std::numeric_limits<uint16_t>::max());
+  return (isRun3() ? std::numeric_limits<uint16_t>::max() : (pattern & 0xF));
 }
 
 uint16_t CSCCorrelatedLCTDigi::getHMT() const { return (isRun3() ? hmt : std::numeric_limits<uint16_t>::max()); }

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -110,16 +110,12 @@ float CSCCorrelatedLCTDigi::getFractionalStrip(const uint16_t n) const {
 }
 
 uint16_t CSCCorrelatedLCTDigi::getCLCTPattern() const {
-  return ((version_ == Version::Legacy) ? (pattern & 0xF) : std::numeric_limits<uint16_t>::max());
+  return (isRun3() ? (pattern & 0xF) : std::numeric_limits<uint16_t>::max());
 }
 
-uint16_t CSCCorrelatedLCTDigi::getHMT() const {
-  return ((version_ == Version::Run3) ? hmt : std::numeric_limits<uint16_t>::max());
-}
+uint16_t CSCCorrelatedLCTDigi::getHMT() const { return (isRun3() ? hmt : std::numeric_limits<uint16_t>::max()); }
 
-void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) {
-  hmt = (version_ == Version::Run3) ? h : std::numeric_limits<uint16_t>::max();
-}
+void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { hmt = isRun3() ? h : std::numeric_limits<uint16_t>::max(); }
 
 void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
 

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -12,24 +12,25 @@
     <version ClassVersion="10" checksum="656608282"/>
    </class>
    <class name="CSCCorrelatedLCTDigi" ClassVersion="12">
-    <version ClassVersion="12" checksum="3887645155"/>
+    <version ClassVersion="12" checksum="1516836035"/>
     <version ClassVersion="11" checksum="2118578151"/>
     <version ClassVersion="10" checksum="1301481852"/>
    </class>
    <class name="GEMCSCLCTDigi" ClassVersion="11">
-    <version ClassVersion="10" checksum="967689346"/>
     <version ClassVersion="11" checksum="56593764"/>
+    <version ClassVersion="10" checksum="967689346"/>
    </class>
-   <class name="CSCCLCTDigi" ClassVersion="11">
-    <version ClassVersion="10" checksum="3910057547"/>
+   <class name="CSCCLCTDigi" ClassVersion="12">
+    <version ClassVersion="12" checksum="1002733592"/>
     <version ClassVersion="11" checksum="511203876"/>
+    <version ClassVersion="10" checksum="3910057547"/>
    </class>
    <ioread sourceClass="CSCCLCTDigi"  targetClass="CSCCLCTDigi" version="[-10]" target="compCode_" source=""> <![CDATA[ compCode_ = -1; ]]> </ioread>
    <class name="CSCCLCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="1207676078"/>
    </class>
    <class name="CSCALCTDigi" ClassVersion="11">
-     <version ClassVersion="11" checksum="2721753237"/>
+     <version ClassVersion="11" checksum="4162193785"/>
      <version ClassVersion="10" checksum="817473300"/>
    </class>
    <class name="CSCALCTPreTriggerDigi" ClassVersion="10">

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -11,7 +11,8 @@
    <class name="CSCComparatorDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="656608282"/>
    </class>
-   <class name="CSCCorrelatedLCTDigi" ClassVersion="11">
+   <class name="CSCCorrelatedLCTDigi" ClassVersion="12">
+    <version ClassVersion="12" checksum="3887645155"/>
     <version ClassVersion="11" checksum="2118578151"/>
     <version ClassVersion="10" checksum="1301481852"/>
    </class>
@@ -27,8 +28,9 @@
    <class name="CSCCLCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="1207676078"/>
    </class>
-   <class name="CSCALCTDigi" ClassVersion="10">
-    <version ClassVersion="10" checksum="817473300"/>
+   <class name="CSCALCTDigi" ClassVersion="11">
+     <version ClassVersion="11" checksum="2721753237"/>
+     <version ClassVersion="10" checksum="817473300"/>
    </class>
    <class name="CSCALCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="2925979693"/>

--- a/DataFormats/L1CSCTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1CSCTrackFinder/src/classes_def.xml
@@ -13,7 +13,8 @@
     <version ClassVersion="10" checksum="3445513287"/>
    </class>
 
-   <class name="csctf::TrackStub" ClassVersion="12">
+   <class name="csctf::TrackStub" ClassVersion="13">
+    <version ClassVersion="13" checksum="3107461083"/>
     <version ClassVersion="12" checksum="1100843423"/>
     <version ClassVersion="11" checksum="2137081572"/>
     <version ClassVersion="10" checksum="2767475416"/>

--- a/DataFormats/L1CSCTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1CSCTrackFinder/src/classes_def.xml
@@ -14,7 +14,7 @@
    </class>
 
    <class name="csctf::TrackStub" ClassVersion="13">
-    <version ClassVersion="13" checksum="3107461083"/>
+    <version ClassVersion="13" checksum="1877810363"/>
     <version ClassVersion="12" checksum="1100843423"/>
     <version ClassVersion="11" checksum="2137081572"/>
     <version ClassVersion="10" checksum="2767475416"/>

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -270,7 +270,7 @@ void CSCDigiToRaw::add(const CSCCLCTDigiCollection& clctDigis, FindEventDataInfo
     if (me11a && fedInfo.formatVersion_ == 2013) {
       std::vector<CSCCLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
       for (std::vector<CSCCLCTDigi>::iterator iC = shiftedDigis.begin(); iC != shiftedDigis.end(); ++iC) {
-        if (iC->getCFEB() >= 0 && iC->getCFEB() < 3) {  //sanity check, mostly
+        if (iC->getCFEB() < 3) {  //sanity check, mostly
           (*iC) = CSCCLCTDigi(iC->isValid(),
                               iC->getQuality(),
                               iC->getPattern(),
@@ -302,7 +302,7 @@ void CSCDigiToRaw::add(const CSCCorrelatedLCTDigiCollection& corrLCTDigis, FindE
     if (me11a && fedInfo.formatVersion_ == 2013) {
       std::vector<CSCCorrelatedLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
       for (std::vector<CSCCorrelatedLCTDigi>::iterator iC = shiftedDigis.begin(); iC != shiftedDigis.end(); ++iC) {
-        if (iC->getStrip() >= 0 && iC->getStrip() < 96) {  //sanity check, mostly
+        if (iC->getStrip() < 96) {  //sanity check, mostly
           (*iC) = CSCCorrelatedLCTDigi(iC->getTrknmb(),
                                        iC->isValid(),
                                        iC->getQuality(),


### PR DESCRIPTION
#### PR description:

This PR extends the ALCT and LCT data formats for Run-3. Detailed information can be found in this note: https://gitlab.cern.ch/tdr/notes/DN-20-016/blob/master/temp/DN-20-016_temp.pdf

Edited Summary:

**ALCT changes** (section 3.1 in DN-20-016)
- 3 highest bits in BXN[4:0], BXN[4:2], will be reassigned for high-multiplicity triggering
- a new high-multiplicity trigger member `hmt_` was added
- a new member `version_` that indicates Run3 or Legacy was added

**CLCT changes**
- a new member `version_` that indicates Run3 or Legacy was added

**LCT changes** (section 3.2 in DN-20-016)
- 2 bits are reallocated to encode the 1/4 and 1/8 strip bit (see also #29205 )
- 4-bit quality becomes a 3-bit for ME1/1, or 2-bit for non-ME1/1
- 4-bit pattern ID is reinterpreted as 4-bit bending value
- 2-bit (3-bit) high-multiplicity trigger word for each ME1/1 (non-ME1/1) chamber
- a new high-multiplicity trigger member `hmt` was added
- a new member `version_` that indicates Run3 or Legacy was added

#### PR validation:

Tested with WF 22034.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
