### PR TITLE
Small fixes to special DB payload scripts

### DIFF
--- a/CondTools/Geometry/test/writehelpers/createExtended2017Plan1Payloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createExtended2017Plan1Payloads.sh
@@ -11,7 +11,7 @@ echo ${mytag}
 
 # Set the tag in all the scripts and the metadata text files
 sed -i {s/TagXX/${mytag}/g} *.py
-sed -i {s/TagXX/${mytag}/g} *.txt
+compgen -G "*.txt" > /dev/null && sed -i {s/TagXX/${mytag}/g} *.txt
 sed -i {s/TagXX/${mytag}/g} splitExtended2017Plan1Database.sh
 
 # First read in the little XML files and create the

--- a/CondTools/Geometry/test/writehelpers/createExtended2018Payloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createExtended2018Payloads.sh
@@ -11,7 +11,7 @@ echo ${mytag}
 
 # Set the tag in all the scripts and the metadata text files
 sed -i {s/TagXX/${mytag}/g} *.py
-sed -i {s/TagXX/${mytag}/g} *.txt
+compgen -G "*.txt" > /dev/null && sed -i {s/TagXX/${mytag}/g} *.txt
 sed -i {s/TagXX/${mytag}/g} splitExtended2018Database.sh
 
 # First read in the little XML files and create the

--- a/CondTools/Geometry/test/writehelpers/createExtended2021Payloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createExtended2021Payloads.sh
@@ -11,7 +11,7 @@ echo ${mytag}
 
 # Set the tag in all the scripts and the metadata text files
 sed -i {s/TagXX/${mytag}/g} *.py
-sed -i {s/TagXX/${mytag}/g} *.txt
+compgen -G "*.txt" > /dev/null && sed -i {s/TagXX/${mytag}/g} *.txt
 sed -i {s/TagXX/${mytag}/g} splitExtended2021Database.sh
 
 # First read in the little XML files and create the

--- a/CondTools/Geometry/test/writehelpers/createExtended2026Payloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createExtended2026Payloads.sh
@@ -11,7 +11,7 @@ echo ${mytag}
 
 # Set the tag in all the scripts and the metadata text files
 sed -i {s/TagXX/${mytag}/g} *.py
-sed -i {s/TagXX/${mytag}/g} *.txt
+compgen -G "*.txt" > /dev/null && sed -i {s/TagXX/${mytag}/g} *.txt
 sed -i {s/TagXX/${mytag}/g} splitExtended2026Database.sh
 
 # First read in the little XML files and create the

--- a/CondTools/Geometry/test/writehelpers/createRun1Payloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createRun1Payloads.sh
@@ -10,7 +10,7 @@ echo ${mytag}
 
 # Set the tag in all the scripts and the metadata text files
 sed -i {s/TagXX/${mytag}/g} *.py
-sed -i {s/TagXX/${mytag}/g} *.txt
+compgen -G "*.txt" > /dev/null && sed -i {s/TagXX/${mytag}/g} *.txt
 sed -i {s/TagXX/${mytag}/g} splitRun1Database.sh
 
 # First read in the little XML files and create the

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -23,7 +23,7 @@ echo geometry = ${geometry}
 #global tag gtag is assumed to be of the form GeometryWORD such as GeometryExtended or GeometryIdeal
 #as of 3.4.X loaded objects in the DB, these correspond to condlabels Extended, Ideal, etc...
 # Run 2 Extended condlabel corresponds to GeometryExtended2015 scenario. 
-set condlabel = `(echo $geometry | sed '{s/Geometry//g}' | sed '{s/2015//g}')`
+set condlabel = `(echo $geometry | sed -e '{s/Geometry//g}' -e '{s/Plan//g}' -e '{s/[0-9]*//g}')`
 echo ${condlabel} " geometry label from db"
 
 set workArea = `(echo $geometry)`
@@ -420,12 +420,12 @@ echo "Start Simulation geometry validation" | tee -a GeometryValidation.log
 # echo "After the GeoHistory in the output file dumpGeoHistoryOnRead you will see x, y, z, r11, r12, r13, r21, r22, r23, r31, r32, r33" >> readXML.expected
 # echo "finished" >> readXML.expected
 
-if ( ${geometry} == GeometryExtended ) then                                                               
+if ( ${geometry} == GeometryExtended2021 ) then                                                               
   cat > readXML.expected <<END_OF_TEXT  
 Here I am 
 Top Most LogicalPart =cms:OCMS 
  mat=materials:Air
- solid=cms:OCMS   Polycone_rrz:  startPhi[deg]=0 dPhi[deg]=360 Sizes[cm]=-45000 0 100 -2700 0 100 -2700 0 1750 2700 0 1750 2700 0 100 45000 0 100 
+ solid=cms:OCMS   Box:  xhalf[cm]=10100 yhalf[cm]=10100 zhalf[cm]=45000
 After the GeoHistory in the output file dumpGeoHistoryOnRead you will see x, y, z, r11, r12, r13, r21, r22, r23, r31, r32, r33
 finished
 END_OF_TEXT
@@ -436,7 +436,7 @@ else
 Here I am 
 Top Most LogicalPart =cms:OCMS 
  mat=materials:Air
- solid=cms:OCMS   Box:  xhalf[cm]=10100 yhalf[cm]=10100 zhalf[cm]=45000
+ solid=cms:OCMS   Polycone_rrz:  startPhi[deg]=0 dPhi[deg]=360 Sizes[cm]=-45000 0 100 -2700 0 100 -2700 0 1750 2700 0 1750 2700 0 100 45000 0 100 
 After the GeoHistory in the output file dumpGeoHistoryOnRead you will see x, y, z, r11, r12, r13, r21, r22, r23, r31, r32, r33
 finished
 END_OF_TEXT
@@ -452,8 +452,7 @@ cp $CMSSW_RELEASE_BASE/src/GeometryReaders/XMLIdealGeometryESSource/test/testRea
 sed -i "{/process.GlobalTag.globaltag/d}" testReadXMLFromGTDB.py >> GeometryValidation.log
 sed -i "{/process.XMLFromDBSource.label/d}" testReadXMLFromGTDB.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testReadXMLFromGTDB.py >> GeometryValidation.log
-set shortlabel = `(echo $condlabel | sed '{s/[0-9]*//g}')`
-sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${shortlabel}')" testReadXMLFromGTDB.py >> GeometryValidation.log
+sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testReadXMLFromGTDB.py >> GeometryValidation.log
 cmsRun testReadXMLFromGTDB.py > readXMLfromGTDB.log
 
 cp $CMSSW_RELEASE_BASE/src/GeometryReaders/XMLIdealGeometryESSource/test/testReadXMLFromDB.py .

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -420,7 +420,19 @@ echo "Start Simulation geometry validation" | tee -a GeometryValidation.log
 # echo "After the GeoHistory in the output file dumpGeoHistoryOnRead you will see x, y, z, r11, r12, r13, r21, r22, r23, r31, r32, r33" >> readXML.expected
 # echo "finished" >> readXML.expected
 
-cat > readXML.expected <<END_OF_TEXT  
+if ( ${geometry} == GeometryExtended ) then                                                               
+  cat > readXML.expected <<END_OF_TEXT  
+Here I am 
+Top Most LogicalPart =cms:OCMS 
+ mat=materials:Air
+ solid=cms:OCMS   Polycone_rrz:  startPhi[deg]=0 dPhi[deg]=360 Sizes[cm]=-45000 0 100 -2700 0 100 -2700 0 1750 2700 0 1750 2700 0 100 45000 0 100 
+After the GeoHistory in the output file dumpGeoHistoryOnRead you will see x, y, z, r11, r12, r13, r21, r22, r23, r31, r32, r33
+finished
+END_OF_TEXT
+
+else
+
+  cat > readXML.expected <<END_OF_TEXT  
 Here I am 
 Top Most LogicalPart =cms:OCMS 
  mat=materials:Air
@@ -428,6 +440,8 @@ Top Most LogicalPart =cms:OCMS
 After the GeoHistory in the output file dumpGeoHistoryOnRead you will see x, y, z, r11, r12, r13, r21, r22, r23, r31, r32, r33
 finished
 END_OF_TEXT
+
+endif
 
 cp $CMSSW_RELEASE_BASE/src/GeometryReaders/XMLIdealGeometryESSource/test/readExtendedAndDump.py .
 sed -i "{s/GeometryExtended/${geometry}/}" readExtendedAndDump.py >>  GeometryValidation.log


### PR DESCRIPTION
The scripts in this PR are used by experts to create DB payloads and to check their validity. While running these scripts, I noticed some minor issues I decided to fix.

The `create*Payloads.sh` scripts in this PR were issuing an unnecessary warning about a missing optional `txt` file. I added a test to silence it.

For the `runDDDvsDBGeometryValidation.sh` script, I added support for scenarios that have names like "Extended2017Plan1".

More fixes and enhancements could be added to these scripts, but those will have to wait for a later PR.

#### PR validation:

These scripts are only run manually, so they don't affect any workflows. I checked that the fixes in this PR do work.