### PR TITLE
Use LogTrace in IsolatedPixelTrackCandidateL1TProducer

### DIFF
--- a/Calibration/HcalIsolatedTrackReco/src/IsolatedPixelTrackCandidateL1TProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IsolatedPixelTrackCandidateL1TProducer.cc
@@ -100,7 +100,7 @@ void IsolatedPixelTrackCandidateL1TProducer::beginRun(const edm::Run& run, const
   const VolumeBasedMagneticField* vbfCPtr = dynamic_cast<const VolumeBasedMagneticField*>(&(*vbfField));
   GlobalVector BField = vbfCPtr->inTesla(GlobalPoint(0, 0, 0));
   bfVal_ = BField.mag();
-  edm::LogVerbatim("IsoTrack") << "rEB " << rEB_ << " zEE " << zEE_ << " B " << bfVal_ << std::endl;
+  LogTrace("IsoTrack") << "rEB " << rEB_ << " zEE " << zEE_ << " B " << bfVal_ << std::endl;
 }
 
 void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
@@ -152,8 +152,8 @@ void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const
       etaTriggered = p->eta();
     }
   }
-  edm::LogVerbatim("IsoTrack") << "Sizes " << l1tauobjref.size() << ":" << l1jetobjref.size() << " Trig " << ptTriggered
-                               << ":" << etaTriggered << ":" << phiTriggered << std::endl;
+  LogTrace("IsoTrack") << "Sizes " << l1tauobjref.size() << ":" << l1jetobjref.size() << " Trig " << ptTriggered << ":"
+                       << etaTriggered << ":" << phiTriggered << std::endl;
 
   double drMaxL1Track_ = tauAssocCone_;
   int ntr = 0;
@@ -179,12 +179,12 @@ void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const
     } else {
       vtxMatch = true;
     }
-    edm::LogVerbatim("IsoTrack") << "minZD " << minDZ << " Found " << found << ":" << vtxMatch << std::endl;
+    LogTrace("IsoTrack") << "minZD " << minDZ << " Found " << found << ":" << vtxMatch << std::endl;
 
     //select tracks not matched to triggered L1 jet
     double R = reco::deltaR(etaTriggered, phiTriggered, pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi());
-    edm::LogVerbatim("IsoTrack") << "Distance to L1 " << R << ":" << tauUnbiasCone_ << " Result "
-                                 << (R < tauUnbiasCone_) << std::endl;
+    LogTrace("IsoTrack") << "Distance to L1 " << R << ":" << tauUnbiasCone_ << " Result " << (R < tauUnbiasCone_)
+                         << std::endl;
     if (R < tauUnbiasCone_)
       continue;
 
@@ -200,7 +200,7 @@ void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const
       selj = tj;
       tmatch = true;
     }  //loop over L1 tau
-    edm::LogVerbatim("IsoTrack") << "tMatch " << tmatch << std::endl;
+    LogTrace("IsoTrack") << "tMatch " << tmatch << std::endl;
 
     //propagate seed track to ECAL surface:
     std::pair<double, double> seedCooAtEC;
@@ -220,7 +220,7 @@ void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const
                                     0);
     seedAtEC seed(iS, (tmatch || vtxMatch), seedCooAtEC.first, seedCooAtEC.second);
     VecSeedsatEC.push_back(seed);
-    edm::LogVerbatim("IsoTrack") << "Seed " << seedCooAtEC.first << seedCooAtEC.second << std::endl;
+    LogTrace("IsoTrack") << "Seed " << seedCooAtEC.first << seedCooAtEC.second << std::endl;
   }
   for (unsigned int i = 0; i < VecSeedsatEC.size(); i++) {
     unsigned int iSeed = VecSeedsatEC[i].index;
@@ -278,7 +278,7 @@ void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const
       ntr++;
     }
   }
-  edm::LogVerbatim("IsoTrack") << "Number of Isolated Track " << ntr << "\n";
+  LogTrace("IsoTrack") << "Number of Isolated Track " << ntr << "\n";
   // put the product in the event
   theEvent.put(std::move(trackCollection));
 }


### PR DESCRIPTION
#### PR description:

Changed edm::LogVerbatim to LogTrace to speed up code. IgProf traces of HLT jobs showed the edm::LogVerbatim calls from this module were taking about 0.7% of the entire event processing time.

#### PR validation:

The code compiles.