### PR TITLE
Update PR #28417, TauSkimPFTausSelectedForMuTau reading anti-muon ID from new data format

### DIFF
--- a/DPGAnalysis/Skims/python/MuTauSkim_cff.py
+++ b/DPGAnalysis/Skims/python/MuTauSkim_cff.py
@@ -74,15 +74,20 @@ TauSkimPFTausSelectedForMuTau.discriminators = cms.VPSet(
 #              selectionCut=cms.double(0.5)
 #              ),
 
-    cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByLooseMuonRejection3"), #HTT 2015 TWIKI 
-              selectionCut=cms.double(0.5)
-              ),
     #cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByElectronVLooseMVA5"), #HTT 2015 TWIKI (not working!)
     #          selectionCut=cms.double(0.5)
     #          ),
 
 
     )
+
+TauSkimPFTausSelectedForMuTau.discriminatorContainers = cms.VPSet(
+    cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByMuonRejection3"),
+              workingPoints=cms.vstring("ByLooseMuonRejection3"),
+              rawValues=cms.vstring(),
+              selectionCuts=cms.vdouble()
+    )
+)
 
 ## MODULE IN 53X ONLY  
 #TauSkimPFTausSelectedForMuTau.cut = cms.string('pt > 18. && abs(eta) < 2.3') #75X

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2Container.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2Container.cc
@@ -243,6 +243,8 @@ void PFRecoTauDiscriminationAgainstMuon2Container::fillDescriptions(edm::Configu
   std::vector<edm::ParameterSet> vpsd_wp;
   vpsd_wp.push_back(pset_wp);
   desc.addVPSet("IDWPdefinitions", desc_wp, vpsd_wp);
+  //add empty raw value config to simplify subsequent provenance searches
+  desc.addVPSet("IDdefinitions", edm::ParameterSetDescription(), {});
 
   descriptions.add("pfRecoTauDiscriminationAgainstMuon2Container", desc);
 }


### PR DESCRIPTION
## PR description:

- make TauSkimPFTausSelectedForMuTau read loose anti-muon discriminator via the new data format which solves the problem reported in #29447 
- adding a default config set for raw values to PFRecoTauDiscriminationAgainstMuon2Container. It is technically not needed for this particular producer but fulfils the convention that is expected by subsequent producers when reading from provenance.

#### PR validation:

Ran 136.787 successfully.
