### PR TITLE
Update PR #28417, add era modifier to TauRefProducer to read old data format from existing files

### DIFF
--- a/Configuration/ProcessModifiers/python/tau_readOldDiscriminatorFormat_cff.py
+++ b/Configuration/ProcessModifiers/python/tau_readOldDiscriminatorFormat_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is used to adapt input configurations of tau producers if input files with old tau ID format are used.
+
+tau_readOldDiscriminatorFormat =  cms.Modifier()
+

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2676,6 +2676,7 @@ steps['DQMHLTonAOD_2017']={
     '--datatier':'DQMIO',
     '--era':'Run2_2017',
     '--fileout':'DQMHLTonAOD.root',
+    '--procModifiers':'tau_readOldDiscriminatorFormat',
     }
 steps['DQMHLTonAODextra_2017'] = merge([ {'-s':'DQM:offlineHLTSourceOnAODextra'}, steps['DQMHLTonAOD_2017'] ])
 
@@ -2690,6 +2691,7 @@ steps['DQMHLTonRAWAOD_2017']={
     '--secondfilein':'filelist:step1_dasparentquery.log',
     '--customise_commands':'"process.HLTAnalyzerEndpath.remove(process.hltL1TGlobalSummary)"',
     '--fileout':'DQMHLTonAOD.root',
+    '--procModifiers':'tau_readOldDiscriminatorFormat',
     }
 
 steps['HARVESTDQMHLTonAOD_2017'] = merge([ {'--filein':'file:DQMHLTonAOD.root','-s':'HARVESTING:hltOfflineDQMClient'}, steps['HARVEST2017'] ]) ### Harvesting step for the DQM-only workflow

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.tau_readOldDiscriminatorFormat_cff import tau_readOldDiscriminatorFormat
 
 hltTauDQMofflineProcess = "HLT"
 
@@ -77,6 +78,18 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                     PhiMin = cms.untracked.double(-3.15),
                     PhiMax = cms.untracked.double(3.15)
                   )
+
+tau_readOldDiscriminatorFormat.toModify(TauRefProducer.PFTaus,
+              PFTauDiscriminators = cms.untracked.VInputTag(
+                                    cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding"),
+                                    cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),
+                                    cms.InputTag("hpsPFTauDiscriminationByLooseMuonRejection3"),
+                                    cms.InputTag("hpsPFTauDiscriminationByMVA6TightElectronRejection"),
+                                    cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding")
+                            ),
+              PFTauDiscriminatorContainers = cms.untracked.VInputTag(),
+              PFTauDiscriminatorContainerWPs = cms.untracked.vstring()
+)
 
 #----------------------------------MONITORS--------------------------------------------------------------------------
 


### PR DESCRIPTION
#### PR description:

Addressing issue #29448 
Given workflows read root files with old tauID format which requires an era modifier to adapt the configuration accordingly which is done in this PR.

#### PR validation:

Ran 136.7801 successfully