### PR TITLE
Run3-hcx253 Make additional tests for DetId setting in SIM/RECO

### DIFF
--- a/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdTester.cc
@@ -27,7 +27,8 @@ private:
 HcalGeometryDetIdTester::HcalGeometryDetIdTester(const edm::ParameterSet& iConfig) {
   detMin_ = std::min(ndetMax_, std::max(iConfig.getParameter<int>("DetectorMin"), 1));
   detMax_ = std::min(ndetMax_, std::max(iConfig.getParameter<int>("DetectorMax"), 1));
-  if (detMin_ > detMax_) detMin_ = detMax_;
+  if (detMin_ > detMax_)
+    detMin_ = detMax_;
   std::cout << "Study DetIds for SubDetId in the range " << detMin_ << ":" << detMax_ << std::endl;
 }
 
@@ -56,17 +57,19 @@ void HcalGeometryDetIdTester::analyze(const edm::Event& /*iEvent*/, const edm::E
 
   for (int subd = (detMin_ - 1); subd < detMax_; ++subd) {
     std::cout << "\n\nStudy Detector = Hcal SubDetector = " << subdets[subd]
-	      << "\n======================================\n\n";
+              << "\n======================================\n\n";
     int nall(0), nbad(0);
     const std::vector<DetId>& ids = hcalGeom->getValidDetIds(DetId::Hcal, subdetd[subd]);
     for (auto id : ids) {
       ++nall;
       if (!(topology.valid(id))) {
-	++nbad;
-	std::cout << "Check " << HcalDetId(id) << " *****\n";
+        ++nbad;
+        std::cout << "Check " << HcalDetId(id) << " *****\n";
       }
     }
-    std::cout << "\n" << nbad << " bad out of " << nall << " detIds\n========================\n\nNow List All IDs\n================\n" ;
+    std::cout << "\n"
+              << nbad << " bad out of " << nall
+              << " detIds\n========================\n\nNow List All IDs\n================\n";
     int k(0);
     for (auto id : ids) {
       std::cout << "[ " << std::setw(4) << k << "] " << HcalDetId(id) << "\n";
@@ -77,16 +80,15 @@ void HcalGeometryDetIdTester::analyze(const edm::Event& /*iEvent*/, const edm::E
     std::cout << "\nNow List all IDs declared valid by Topology\n===========================================\n\n";
     for (int ieta = ietaMin[subd]; ieta <= ietaMax[subd]; ++ieta) {
       for (int depth = depthMin[subd]; depth <= depthMax[subd]; ++depth) {
-	HcalDetId id(subdetd[subd], ieta, 1, depth);
-	if (topology.validHcal(id)) {
-	  std::cout << "[ " << std::setw(2) << n << "] " << id << "\n";
-	  ++n;
-	}
+        HcalDetId id(subdetd[subd], ieta, 1, depth);
+        if (topology.validHcal(id)) {
+          std::cout << "[ " << std::setw(2) << n << "] " << id << "\n";
+          ++n;
+        }
       }
     }
     std::cout << "\nFinds a total of " << n << " IDs\n";
   }
-
 }
 
 DEFINE_FWK_MODULE(HcalGeometryDetIdTester);

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdTester.cc
@@ -1,0 +1,92 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+#include <iostream>
+
+class HcalGeometryDetIdTester : public edm::one::EDAnalyzer<> {
+public:
+  explicit HcalGeometryDetIdTester(const edm::ParameterSet&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void beginJob() override {}
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void endJob() override {}
+
+private:
+  static const int ndetMax_ = 4;
+  int detMin_, detMax_;
+};
+
+HcalGeometryDetIdTester::HcalGeometryDetIdTester(const edm::ParameterSet& iConfig) {
+  detMin_ = std::min(ndetMax_, std::max(iConfig.getParameter<int>("DetectorMin"), 1));
+  detMax_ = std::min(ndetMax_, std::max(iConfig.getParameter<int>("DetectorMax"), 1));
+  if (detMin_ > detMax_) detMin_ = detMax_;
+  std::cout << "Study DetIds for SubDetId in the range " << detMin_ << ":" << detMax_ << std::endl;
+}
+
+void HcalGeometryDetIdTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<int>("DetectorMin", 1);
+  desc.add<int>("DetectorMax", 4);
+  descriptions.add("hcalGeometryDetIdTester", desc);
+}
+
+void HcalGeometryDetIdTester::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+  edm::ESHandle<HcalTopology> topologyHandle;
+  iSetup.get<HcalRecNumberingRecord>().get(topologyHandle);
+  const HcalTopology topology = (*topologyHandle);
+  edm::ESHandle<CaloGeometry> pG;
+  iSetup.get<CaloGeometryRecord>().get(pG);
+  const CaloGeometry* geo = pG.product();
+  const HcalGeometry* hcalGeom = static_cast<const HcalGeometry*>(geo->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
+
+  std::string subdets[ndetMax_] = {"HB", "HE", "HO", "HF"};
+  HcalSubdetector subdetd[ndetMax_] = {HcalBarrel, HcalEndcap, HcalOuter, HcalForward};
+  int ietaMin[ndetMax_] = {1, 16, 1, 29};
+  int ietaMax[ndetMax_] = {16, 29, 15, 41};
+  int depthMin[ndetMax_] = {1, 1, 4, 1};
+  int depthMax[ndetMax_] = {4, 7, 4, 4};
+
+  for (int subd = (detMin_ - 1); subd < detMax_; ++subd) {
+    std::cout << "\n\nStudy Detector = Hcal SubDetector = " << subdets[subd]
+	      << "\n======================================\n\n";
+    int nall(0), nbad(0);
+    const std::vector<DetId>& ids = hcalGeom->getValidDetIds(DetId::Hcal, subdetd[subd]);
+    for (auto id : ids) {
+      ++nall;
+      if (!(topology.valid(id))) {
+	++nbad;
+	std::cout << "Check " << HcalDetId(id) << " *****\n";
+      }
+    }
+    std::cout << "\n" << nbad << " bad out of " << nall << " detIds\n========================\n\nNow List All IDs\n================\n" ;
+    int k(0);
+    for (auto id : ids) {
+      std::cout << "[ " << std::setw(4) << k << "] " << HcalDetId(id) << "\n";
+      ++k;
+    }
+
+    int n(0);
+    std::cout << "\nNow List all IDs declared valid by Topology\n===========================================\n\n";
+    for (int ieta = ietaMin[subd]; ieta <= ietaMax[subd]; ++ieta) {
+      for (int depth = depthMin[subd]; depth <= depthMax[subd]; ++depth) {
+	HcalDetId id(subdetd[subd], ieta, 1, depth);
+	if (topology.validHcal(id)) {
+	  std::cout << "[ " << std::setw(2) << n << "] " << id << "\n";
+	  ++n;
+	}
+      }
+    }
+    std::cout << "\nFinds a total of " << n << " IDs\n";
+  }
+
+}
+
+DEFINE_FWK_MODULE(HcalGeometryDetIdTester);

--- a/Geometry/HcalTowerAlgo/test/runHcalGeometryDetIdTester_cfg.py
+++ b/Geometry/HcalTowerAlgo/test/runHcalGeometryDetIdTester_cfg.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+#from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+from Configuration.Eras.Era_Run3_cff import Run3
+
+#process = cms.Process('HcalGeometryTest',Run2_2018)
+process = cms.Process('HcalGeometryTest',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+#process.load('Configuration.Geometry.GeometryExtended2018Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2021Reco_cff')
+process.load('Geometry.HcalTowerAlgo.hcalGeometryDetIdTester_cfi')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.hcalGeometryDetIdTester.DetectorMin = 1
+#process.hcalGeometryDetIdTester.DetectorMin = 2
+process.hcalGeometryDetIdTester.DetectorMax = 2
+
+process.Timing = cms.Service("Timing")
+process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")
+
+process.p1 = cms.Path(process.hcalGeometryDetIdTester)

--- a/SimG4CMS/Calo/plugins/HcalTestSimHitID.cc
+++ b/SimG4CMS/Calo/plugins/HcalTestSimHitID.cc
@@ -1,0 +1,114 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalTestNumbering.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
+#include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+
+#include <memory>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+
+class HcalTestSimHitID : public edm::EDAnalyzer {
+public:
+  HcalTestSimHitID(const edm::ParameterSet& ps);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void beginJob() override {}
+  void endJob() override {}
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+
+private:
+  const std::string g4Label_, hitLab_;
+  const bool testN_, dumpHits_;
+  const int maxEvent_;
+  int nevt_;
+  edm::EDGetTokenT<edm::PCaloHitContainer> toks_calo_;
+};
+
+HcalTestSimHitID::HcalTestSimHitID(const edm::ParameterSet& ps) : 
+  g4Label_(ps.getUntrackedParameter<std::string>("moduleLabel", "g4SimHits")),
+  hitLab_(ps.getUntrackedParameter<std::string>("hcCollection", "HcalHits")),
+  testN_(ps.getUntrackedParameter<bool>("testNumbering", false)),
+  dumpHits_(ps.getUntrackedParameter<bool>("dumpHits", false)),
+  maxEvent_(ps.getUntrackedParameter<int>("maxEvent", 100)), nevt_(0) {
+
+  // register for data access
+  toks_calo_ = consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_, hitLab_));
+
+  std::cout << "HcalTestSimHitID::Module Label: " << g4Label_ << "   Hits: " << hitLab_ << " MaxEvent: " << maxEvent_ << " Numbering scheme: " << testN_ << " (0 normal; 1 test)\n";
+}
+
+void HcalTestSimHitID::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("moduleLabel", "g4SimHits");
+  desc.addUntracked<std::string>("hcCollection", "HcalHits");
+  desc.addUntracked<bool>("testNumbering", false);
+  desc.addUntracked<bool>("dumpHits", false);
+  desc.addUntracked<int>("maxEvent", 100);
+  descriptions.add("hcalGeometryDetIdTester", desc);
+}
+
+void HcalTestSimHitID::analyze(const edm::Event& e, const edm::EventSetup& iS) {
+  ++nevt_;
+  std::cout << "HcalTestSimHitID::Serial # " << nevt_ << " Run # " << e.id().run() << " Event # " << e.id().event() << std::endl;
+  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
+  iS.get<HcalRecNumberingRecord>().get(pHRNDC);
+  const HcalDDDRecConstants* hcr = static_cast<const HcalDDDRecConstants*>(&(*pHRNDC));
+  edm::ESHandle<HcalTopology> htopo;
+  iS.get<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology* theHBHETopology = htopo.product();
+
+  if (nevt_ <= maxEvent_) {
+    std::vector<PCaloHit> hcHits;
+    edm::Handle<edm::PCaloHitContainer> hitsCalo;
+    e.getByToken(toks_calo_, hitsCalo);
+    if (hitsCalo.isValid()) {
+      std::vector<PCaloHit> hits;
+      hits.insert(hits.end(), hitsCalo->begin(), hitsCalo->end());
+      std::cout << "HcalValidation: Hit buffer " << hits.size() << std::endl;
+
+      //Now the testing
+      unsigned int good(0);
+      for (unsigned int i = 0; i < hits.size(); i++) {
+	unsigned int id = hits[i].id();
+	HcalDetId hid;
+	if (testN_) {
+	  hid = HcalDetId(HcalHitRelabeller::relabel(id, hcr));
+	} else {
+	  hid = HcalDetId(id);
+	}
+	if (theHBHETopology->validHcal(hid)) {
+	  ++good;
+	  if (dumpHits_)
+	    std::cout << "Hit[" << i << "] " << hid << " \n";
+	} else {
+	  std::cout << "Hit[" << i << "] " << hid << " ***** ERROR *****\n";
+	}
+      }
+      std::cout << "HcalTestSimHitID:: " << good << " among " << hits.size() << " hits\n";
+    }
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalTestSimHitID);

--- a/SimG4CMS/Calo/plugins/HcalTestSimHitID.cc
+++ b/SimG4CMS/Calo/plugins/HcalTestSimHitID.cc
@@ -45,17 +45,18 @@ private:
   edm::EDGetTokenT<edm::PCaloHitContainer> toks_calo_;
 };
 
-HcalTestSimHitID::HcalTestSimHitID(const edm::ParameterSet& ps) : 
-  g4Label_(ps.getUntrackedParameter<std::string>("moduleLabel", "g4SimHits")),
-  hitLab_(ps.getUntrackedParameter<std::string>("hcCollection", "HcalHits")),
-  testN_(ps.getUntrackedParameter<bool>("testNumbering", false)),
-  dumpHits_(ps.getUntrackedParameter<bool>("dumpHits", false)),
-  maxEvent_(ps.getUntrackedParameter<int>("maxEvent", 100)), nevt_(0) {
-
+HcalTestSimHitID::HcalTestSimHitID(const edm::ParameterSet& ps)
+    : g4Label_(ps.getUntrackedParameter<std::string>("moduleLabel", "g4SimHits")),
+      hitLab_(ps.getUntrackedParameter<std::string>("hcCollection", "HcalHits")),
+      testN_(ps.getUntrackedParameter<bool>("testNumbering", false)),
+      dumpHits_(ps.getUntrackedParameter<bool>("dumpHits", false)),
+      maxEvent_(ps.getUntrackedParameter<int>("maxEvent", 100)),
+      nevt_(0) {
   // register for data access
   toks_calo_ = consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_, hitLab_));
 
-  std::cout << "HcalTestSimHitID::Module Label: " << g4Label_ << "   Hits: " << hitLab_ << " MaxEvent: " << maxEvent_ << " Numbering scheme: " << testN_ << " (0 normal; 1 test)\n";
+  std::cout << "HcalTestSimHitID::Module Label: " << g4Label_ << "   Hits: " << hitLab_ << " MaxEvent: " << maxEvent_
+            << " Numbering scheme: " << testN_ << " (0 normal; 1 test)\n";
 }
 
 void HcalTestSimHitID::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -70,7 +71,8 @@ void HcalTestSimHitID::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 void HcalTestSimHitID::analyze(const edm::Event& e, const edm::EventSetup& iS) {
   ++nevt_;
-  std::cout << "HcalTestSimHitID::Serial # " << nevt_ << " Run # " << e.id().run() << " Event # " << e.id().event() << std::endl;
+  std::cout << "HcalTestSimHitID::Serial # " << nevt_ << " Run # " << e.id().run() << " Event # " << e.id().event()
+            << std::endl;
   edm::ESHandle<HcalDDDRecConstants> pHRNDC;
   iS.get<HcalRecNumberingRecord>().get(pHRNDC);
   const HcalDDDRecConstants* hcr = static_cast<const HcalDDDRecConstants*>(&(*pHRNDC));
@@ -90,20 +92,20 @@ void HcalTestSimHitID::analyze(const edm::Event& e, const edm::EventSetup& iS) {
       //Now the testing
       unsigned int good(0);
       for (unsigned int i = 0; i < hits.size(); i++) {
-	unsigned int id = hits[i].id();
-	HcalDetId hid;
-	if (testN_) {
-	  hid = HcalDetId(HcalHitRelabeller::relabel(id, hcr));
-	} else {
-	  hid = HcalDetId(id);
-	}
-	if (theHBHETopology->validHcal(hid)) {
-	  ++good;
-	  if (dumpHits_)
-	    std::cout << "Hit[" << i << "] " << hid << " \n";
-	} else {
-	  std::cout << "Hit[" << i << "] " << hid << " ***** ERROR *****\n";
-	}
+        unsigned int id = hits[i].id();
+        HcalDetId hid;
+        if (testN_) {
+          hid = HcalDetId(HcalHitRelabeller::relabel(id, hcr));
+        } else {
+          hid = HcalDetId(id);
+        }
+        if (theHBHETopology->validHcal(hid)) {
+          ++good;
+          if (dumpHits_)
+            std::cout << "Hit[" << i << "] " << hid << " \n";
+        } else {
+          std::cout << "Hit[" << i << "] " << hid << " ***** ERROR *****\n";
+        }
       }
       std::cout << "HcalTestSimHitID:: " << good << " among " << hits.size() << " hits\n";
     }

--- a/SimG4CMS/Calo/test/python/runDetID_cfg.py
+++ b/SimG4CMS/Calo/test/python/runDetID_cfg.py
@@ -1,0 +1,66 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+process.load("SimG4CMS.Calo.pythiapdt_cfi")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load("IOMC.EventVertexGenerators.VtxSmearedGauss_cfi")
+#process.load("Configuration.Geometry.GeometryExtended2018Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2021Reco_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.EventContent.EventContent_cff")
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load("SimG4CMS.Calo.hcalGeometryDetIdTester_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag = autoCond['run2_mc']
+
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.categories.append('G4cerr')
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
+process.RandomNumberGeneratorService.VtxSmeared.initialSeed = 123456789
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100)
+)
+
+process.source = cms.Source("EmptySource",
+    firstRun        = cms.untracked.uint32(1),
+    firstEvent      = cms.untracked.uint32(1)
+)
+
+process.generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(13),
+        MinEta = cms.double(1.22),
+        MaxEta = cms.double(1.70),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinPt  = cms.double(100.),
+        MaxPt  = cms.double(100.)
+    ),
+    Verbosity       = cms.untracked.int32(0),
+    AddAntiParticle = cms.bool(True)
+)
+
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.analysis_step   = cms.Path(process.hcalGeometryDetIdTester)
+
+process.g4SimHits.Physics.type = 'SimG4Core/Physics/FTFP_BERT_EMM'
+process.g4SimHits.HCalSD.TestNumberingScheme  = True
+process.hcalGeometryDetIdTester.testNumbering = True
+process.hcalGeometryDetIdTester.dumpHits      = True
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,
+                                process.simulation_step,
+                                process.analysis_step,
+                                )
+
+# filter all path with the production filter sequence
+for path in process.paths:
+        getattr(process,path)._seq = process.generator * getattr(process,path)._seq


### PR DESCRIPTION
#### PR description:

There was doubt about DetId for comparison between RecHit ID's with those from calibration constants. Some tests are introduced at the level of geometry/topology as well as in numbering schemes to test these 

#### PR validation:

Utilize specific cfg files in the test directories of Geometry/HcalTowerAlgo and SimG4CMS/Calo

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special