### PR TITLE
PoolSource's firstLuminosityBlockForEachRun properly skips Lumis

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -828,6 +828,7 @@ namespace edm {
     if (entryType == IndexIntoFile::kLumi) {
       run = indexIntoFileIter_.run();
       lumi = indexIntoFileIter_.lumi();
+      runHelper_->checkForNewRun(run, lumi);
       return IndexIntoFile::kLumi;
     } else if (processingMode_ == InputSource::RunsAndLumis) {
       indexIntoFileIter_.advanceToNextLumiOrRun();

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -71,6 +71,9 @@ cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py firstLumiTest1.root 25 1 100 1 
 cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py firstLumiTest2.root 25 1 100 6 5 || die 'Failure using PrePoolInputTest_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRunTest_cfg.py 'file:firstLumiTest1.root,file:firstLumiTest2.root' 50 1 25 1 5 || die 'Failure using firstLuminosityBlockForEachRunTest_cfg.py with 2 files' $?
 cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRunTest_cfg.py 'file:firstLumiTest1.root,file:firstLumiTest2.root' 50 1 25 1 5 shareRun || die 'Failure using firstLuminosityBlockForEachRunTest_cfg.py with 2 files which share a run' $?
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py 'file:firstLumiTest1.root' 2 || die 'Failure using firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py with first lumi 2' $?
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py 'file:firstLumiTest1.root' 4 || die 'Failure using firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py with first lumi 4' $?
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py 'file:firstLumiTest1.root' 3 || die 'Failure using firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py with first lumi 3' $?
 
 
 #test merging of heterogeneous files with extra provenenace in subsequent files

--- a/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py
+++ b/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py
@@ -1,0 +1,67 @@
+# The following comments couldn't be translated into the new config version:
+
+# Configuration file for PoolInputTest
+
+import FWCore.ParameterSet.Config as cms
+import sys
+
+import sys
+
+#ignore script name and anything before it
+argv = []
+foundpy = False
+for a in sys.argv:
+    if foundpy:
+        argv.append(a)
+    if ".py" in a:
+        foundpy = True
+
+
+process = cms.Process("TESTRECO")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents.input = -1
+
+#have first run of second file be a new run
+runToLumi = ((2,1),(10,3),(20,5))
+
+def findRunForLumi( lumi) :
+  lastRun = runToLumi[0][0]
+  for r,l in runToLumi:
+    if l > lumi:
+      break
+    lastRun = r
+  return lastRun
+
+ids = cms.VEventID()
+numberOfEventsInLumi = 0
+numberOfEventsPerLumi = 5
+lumi = int(argv[1])
+event= numberOfEventsPerLumi*(lumi-1)
+oldRun = 2
+numberOfFiles = 1
+numberOfEventsInFile = 15
+for i in range(numberOfEventsPerLumi*(6-lumi)):
+   numberOfEventsInLumi +=1
+   event += 1
+   run = findRunForLumi(lumi)
+#   if event > numberOfEventsInFile:
+#    event = 1
+   if numberOfEventsInLumi > numberOfEventsPerLumi:
+      numberOfEventsInLumi=1
+      lumi += 1
+      run = findRunForLumi(lumi)
+      if run != oldRun:
+        oldRun = run
+   ids.append(cms.EventID(run,lumi,event))
+process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(ids))
+
+
+process.source = cms.Source("PoolSource",
+                            firstLuminosityBlock = cms.untracked.uint32(int(argv[1])),
+    firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(x,y) for x,y in runToLumi]),
+    fileNames = cms.untracked.vstring(argv[0].split(","))
+)
+
+process.e = cms.EndPath(process.check)
+


### PR DESCRIPTION
#### PR description:

When skipping Lumis while using firstLuminosityBlockForEachRun could cause the first Run number used to be incorrect.

#### PR validation:

The newly added unit tests checking correctness after skipping passes.