### PR TITLE
updated lost dictionaries mapping for L1T Phase2

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -38,6 +38,7 @@ equivDict = \
          {'TrackTriggerAssociation' : ['(TTClusterAssociationMap|TTStubAssociationMap|TTTrackAssociationMap|TrackingParticle).*Phase2TrackerDigi',
                                        '(TTStub|TTCluster|TTTrack).*Phase2TrackerDigi.*TrackingParticle']},
          {'L1TrackTrigger'        : ['(TTStub|TTCluster|TTTrack).*Phase2TrackerDigi']},
+         {'L1TCalorimeterPhase2'  : ['l1tp2::CaloTower.*']},
          {'L1TCalorimeter'        : ['l1t::CaloTower.*']},
          {'GsfTracking'           : ['reco::GsfTrack(Collection|).*(MomentumConstraint|VertexConstraint)', 'Trajectory.*reco::GsfTrack']},
          {'ParallelAnalysis'      : ['examples::TrackAnalysisAlgorithm']},


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/29348 introduced new dictionaries which are now wrongly mapped under CaloTowers ( https://cmssdt.cern.ch/SDT/cgi-bin/showDupDict.py//cc8_amd64_gcc8/www/tue/11.1-tue-23/CMSSW_11_1_X_2020-04-14-2300/testLogs/dupDict-lostDefs.log ). This PR proposes to update the dictionary mapping for L1T CalorimeterPhase2 (l1tp2) to be mapped under L1TCalorimeterPhase2

#### PR validation:

Locally built and ran `duplicateReflexLibrarySearch.py --lostDefs`
