### PR TITLE
Fix a TrackerDTCProducer input tag in SLHCUpgradeSimulations/Geometry unit test

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -151,3 +151,5 @@ process.TFileService = cms.Service('TFileService',
 fileName = cms.string("pixelntuple.root")
 )
 
+if hasattr(process, "TrackerDTCProducer"):
+    process.TrackerDTCProducer.ParamsED.ProcessName = process.process


### PR DESCRIPTION
This is a trivial way to solve #29474.
I would prefer the L1T experts fix `L1Trigger/TrackerDTC/src/Settings.cc` to avoid this kind of error.
Please note that special InputTag such as `@currentProcess` does not work because of `Settings::checkConfiguration()` in  `L1Trigger/TrackerDTC/src/Settings.cc`


#### PR validation:
`cmsRun SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py`