### PR TITLE
Inclusion of Signal Shape Simulation for the Phase2 Tracker

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h
@@ -7,17 +7,37 @@
 #include <iostream>
 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
-#include "SimTracker/Common/interface/SimHitInfoForLinks.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 
 namespace DigitizerUtility {
+
+  class SimHitInfo {
+  public:
+    SimHitInfo(const PSimHit* hitp, float corrTime, size_t hitIndex, uint32_t tofBin)
+        : eventId_(hitp->eventId()), trackId_(hitp->trackId()), hitIndex_(hitIndex), tofBin_(tofBin), time_(corrTime) {}
+
+    uint32_t hitIndex() const { return hitIndex_; };
+    uint32_t tofBin() const { return tofBin_; };
+    EncodedEventId eventId() const { return eventId_; };
+    uint32_t trackId() const { return trackId_; };
+    float time() const { return time_; };
+
+  private:
+    EncodedEventId eventId_;
+    uint32_t trackId_;
+    uint32_t hitIndex_;
+    uint32_t tofBin_;
+    float time_;
+  };
+
   class Amplitude {
   public:
     Amplitude() : _amp(0.0) {}
-    Amplitude(float amp, const PSimHit* hitp, float frac = 0, size_t hitIndex = 0, uint32_t tofBin = 0) : _amp(amp) {
+    Amplitude(float amp, const PSimHit* hitp, float frac = 0, float tcor = 0, size_t hitIndex = 0, uint32_t tofBin = 0)
+        : _amp(amp) {
       if (frac > 0) {
         if (hitp != nullptr)
-          _simInfoList.push_back({frac, std::make_unique<SimHitInfoForLinks>(hitp, hitIndex, tofBin)});
+          _simInfoList.push_back({frac, std::make_unique<SimHitInfo>(hitp, tcor, hitIndex, tofBin)});
         else
           _simInfoList.push_back({frac, nullptr});
       }
@@ -26,16 +46,14 @@ namespace DigitizerUtility {
     // can be used as a float by convers.
     operator float() const { return _amp; }
     float ampl() const { return _amp; }
-    const std::vector<std::pair<float, std::unique_ptr<SimHitInfoForLinks> > >& simInfoList() const {
-      return _simInfoList;
-    }
+    const std::vector<std::pair<float, std::unique_ptr<SimHitInfo> > >& simInfoList() const { return _simInfoList; }
 
     void operator+=(const Amplitude& other) {
       _amp += other._amp;
       // in case of digi from the noise, the MC information need not be there
       for (auto const& ic : other.simInfoList()) {
         if (ic.first > -0.5)
-          _simInfoList.push_back({ic.first, std::make_unique<SimHitInfoForLinks>(*ic.second)});
+          _simInfoList.push_back({ic.first, std::make_unique<SimHitInfo>(*ic.second)});
       }
     }
     void operator+=(const float& amp) { _amp += amp; }
@@ -48,7 +66,7 @@ namespace DigitizerUtility {
 
   private:
     float _amp;
-    std::vector<std::pair<float, std::unique_ptr<SimHitInfoForLinks> > > _simInfoList;
+    std::vector<std::pair<float, std::unique_ptr<SimHitInfo> > > _simInfoList;
   };
 
   //*********************************************************
@@ -109,7 +127,7 @@ namespace DigitizerUtility {
   struct DigiSimInfo {
     int sig_tot;
     bool ot_bit;
-    std::vector<std::pair<float, SimHitInfoForLinks*> > simInfoList;
+    std::vector<std::pair<float, SimHitInfo*> > simInfoList;
   };
 }  // namespace DigitizerUtility
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -52,10 +52,9 @@ void PSPDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterat
     std::vector<DigitizerUtility::EnergyDepositUnit> ionization_points;
     std::vector<DigitizerUtility::SignalPoint> collection_points;
 
+    double signalScale = 1.0;
     // fill collection_points for this SimHit, indpendent of topology
-    // Check the TOF cut
-    if ((hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.) >= theTofLowerCut_ &&
-        (hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.) <= theTofUpperCut_) {
+    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.), signalScale)) {
       primary_ionization(hit, ionization_points);  // fills ionization_points
 
       // transforms ionization_points -> collection_points
@@ -67,4 +66,22 @@ void PSPDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterat
     }
     ++simHitGlobalIndex;
   }
+}
+//
+// -- Select the Hit for Digitization
+//
+bool PSPDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, double& sigScale) {
+  bool result = false;
+  sigScale = 1.0;
+  double toa = hit.tof() - tCorr;
+  if (toa > theTofLowerCut_ && toa < theTofUpperCut_)
+    result = true;
+
+  return result;
+}
+bool PSPDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) {
+  if (charge >= thr)
+    return true;
+  else
+    return false;
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -18,13 +18,13 @@ PSPDigitizerAlgorithm::PSPDigitizerAlgorithm(const edm::ParameterSet& conf)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<ParameterSet>("AlgorithmCommon"),
                                       conf.getParameter<ParameterSet>("PSPDigitizerAlgorithm")) {
   pixelFlag_ = false;
-  LogInfo("PSPDigitizerAlgorithm") << "Algorithm constructed "
-                                   << "Configuration parameters:"
-                                   << "Threshold/Gain = "
-                                   << "threshold in electron Endcap = " << theThresholdInE_Endcap_
-                                   << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " "
-                                   << theElectronPerADC_ << " " << theAdcFullScale_ << " The delta cut-off is set to "
-                                   << tMax_ << " pix-inefficiency " << addPixelInefficiency_;
+  LogDebug("PSPDigitizerAlgorithm") << "Algorithm constructed "
+                                    << "Configuration parameters:"
+                                    << "Threshold/Gain = "
+                                    << "threshold in electron Endcap = " << theThresholdInE_Endcap_
+                                    << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " "
+                                    << theElectronPerADC_ << " " << theAdcFullScale_ << " The delta cut-off is set to "
+                                    << tMax_ << " pix-inefficiency " << addPixelInefficiency_;
 }
 PSPDigitizerAlgorithm::~PSPDigitizerAlgorithm() { LogDebug("PSPDigitizerAlgorithm") << "Algorithm deleted"; }
 void PSPDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterator inputBegin,
@@ -54,7 +54,7 @@ void PSPDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterat
 
     double signalScale = 1.0;
     // fill collection_points for this SimHit, indpendent of topology
-    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.), signalScale)) {
+    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv), signalScale)) {
       primary_ionization(hit, ionization_points);  // fills ionization_points
 
       // transforms ionization_points -> collection_points
@@ -68,20 +68,15 @@ void PSPDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterat
   }
 }
 //
-// -- Select the Hit for Digitization
+// -- Select the Hit for Digitization (sigScale will be implemented in future)
 //
 bool PSPDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, double& sigScale) {
-  bool result = false;
-  sigScale = 1.0;
   double toa = hit.tof() - tCorr;
-  if (toa > theTofLowerCut_ && toa < theTofUpperCut_)
-    result = true;
-
-  return result;
+  return (toa > theTofLowerCut_ && toa < theTofUpperCut_);
 }
+//
+// -- Compare Signal with Threshold
+//
 bool PSPDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) {
-  if (charge >= thr)
-    return true;
-  else
-    return false;
+  return (charge >= thr);
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
@@ -19,5 +19,7 @@ public:
                          const uint32_t tofBin,
                          const Phase2TrackerGeomDetUnit* pixdet,
                          const GlobalVector& bfield) override;
+  bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) override;
+  bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) override;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
@@ -18,13 +18,13 @@ PSSDigitizerAlgorithm::PSSDigitizerAlgorithm(const edm::ParameterSet& conf)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<ParameterSet>("AlgorithmCommon"),
                                       conf.getParameter<ParameterSet>("PSSDigitizerAlgorithm")) {
   pixelFlag_ = false;
-  LogInfo("PSSDigitizerAlgorithm") << "Algorithm constructed "
-                                   << "Configuration parameters: "
-                                   << "Threshold/Gain = "
-                                   << "threshold in electron Endcap = " << theThresholdInE_Endcap_
-                                   << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " "
-                                   << theElectronPerADC_ << " " << theAdcFullScale_ << " The delta cut-off is set to "
-                                   << tMax_ << " pix-inefficiency " << addPixelInefficiency_;
+  LogDebug("PSSDigitizerAlgorithm") << "Algorithm constructed "
+                                    << "Configuration parameters: "
+                                    << "Threshold/Gain = "
+                                    << "threshold in electron Endcap = " << theThresholdInE_Endcap_
+                                    << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " "
+                                    << theElectronPerADC_ << " " << theAdcFullScale_ << " The delta cut-off is set to "
+                                    << tMax_ << " pix-inefficiency " << addPixelInefficiency_;
 }
 PSSDigitizerAlgorithm::~PSSDigitizerAlgorithm() { LogDebug("PSSDigitizerAlgorithm") << "Algorithm deleted"; }
 void PSSDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterator inputBegin,
@@ -54,7 +54,7 @@ void PSSDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterat
 
     double signalScale = 1.0;
     // fill collection_points for this SimHit, indpendent of topology
-    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.), signalScale)) {
+    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv), signalScale)) {
       primary_ionization(hit, ionization_points);  // fills ionization_points
 
       // transforms ionization_points -> collection_points
@@ -68,22 +68,17 @@ void PSSDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterat
   }
 }
 //
-// -- Select the Hit for Digitization
+// -- Select the Hit for Digitization (sigScale will be implemented in future)
 //
 bool PSSDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, double& sigScale) {
-  bool result = false;
-  sigScale = 1.0;
   double toa = hit.tof() - tCorr;
-  if (toa > theTofLowerCut_ && toa < theTofUpperCut_)
-    result = true;
-
-  return result;
+  return (toa > theTofLowerCut_ && toa < theTofUpperCut_);
 }
+//
+// -- Compare Signal with Threshold
+//
 bool PSSDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo* const hisInfo,
                                              float charge,
                                              float thr) {
-  if (charge >= thr)
-    return true;
-  else
-    return false;
+  return (charge >= thr);
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
@@ -52,10 +52,9 @@ void PSSDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterat
     std::vector<DigitizerUtility::EnergyDepositUnit> ionization_points;
     std::vector<DigitizerUtility::SignalPoint> collection_points;
 
+    double signalScale = 1.0;
     // fill collection_points for this SimHit, indpendent of topology
-    // Check the TOF cut
-    if ((hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.) >= theTofLowerCut_ &&
-        (hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.) <= theTofUpperCut_) {
+    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.), signalScale)) {
       primary_ionization(hit, ionization_points);  // fills ionization_points
 
       // transforms ionization_points -> collection_points
@@ -67,4 +66,24 @@ void PSSDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterat
     }
     ++simHitGlobalIndex;
   }
+}
+//
+// -- Select the Hit for Digitization
+//
+bool PSSDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, double& sigScale) {
+  bool result = false;
+  sigScale = 1.0;
+  double toa = hit.tof() - tCorr;
+  if (toa > theTofLowerCut_ && toa < theTofUpperCut_)
+    result = true;
+
+  return result;
+}
+bool PSSDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo* const hisInfo,
+                                             float charge,
+                                             float thr) {
+  if (charge >= thr)
+    return true;
+  else
+    return false;
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
@@ -19,5 +19,7 @@ public:
                          const uint32_t tofBin,
                          const Phase2TrackerGeomDetUnit* pixdet,
                          const GlobalVector& bfield) override;
+  bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) override;
+  bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) override;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -216,7 +216,7 @@ namespace cms {
   }
 
   void Phase2TrackerDigitizer::finalizeEvent(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-    // Decide if we want analog readout for Outer Tracker.
+    //Decide if we want analog readout for Outer Tracker.
     addPixelCollection(iEvent, iSetup, isOuterTrackerReadoutAnalog_);
     if (!isOuterTrackerReadoutAnalog_) {
       if (premixStage1_)
@@ -285,7 +285,7 @@ namespace cms {
       if (fiter == algomap_.end())
         continue;
 
-      //Decide if we want analog readout for Outer Tracker.
+      // Decide if we want analog readout for Outer Tracker.
       if (!ot_analog && (algotype != AlgorithmType::InnerPixel && algotype != AlgorithmType::InnerPixel3D)) {
         continue;
       }
@@ -350,13 +350,12 @@ namespace cms {
       uint32_t rawId = det_u->geographicalId().rawId();
       auto algotype = getAlgoType(rawId);
 
-      if (algomap_.find(algotype) == algomap_.end() || algotype == AlgorithmType::InnerPixel ||
-          algotype == AlgorithmType::InnerPixel3D) {
+      auto fiter = algomap_.find(algotype);
+      if (fiter == algomap_.end() || algotype == AlgorithmType::InnerPixel || algotype == AlgorithmType::InnerPixel3D) {
         continue;
       }
-
       std::map<int, DigitizerUtility::DigiSimInfo> digi_map;
-      algomap_[algotype]->digitize(dynamic_cast<const Phase2TrackerGeomDetUnit*>(det_u), digi_map, tTopo);
+      fiter->second->digitize(dynamic_cast<const Phase2TrackerGeomDetUnit*>(det_u), digi_map, tTopo);
 
       edm::DetSet<DigiType> collector(rawId);
       edm::DetSet<PixelDigiSimLink> linkcollector(rawId);

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -73,7 +73,7 @@ namespace cms {
 
     // constants of different algorithm types
     enum class AlgorithmType { InnerPixel, InnerPixel3D, PixelinPS, StripinPS, TwoStrip, Unknown };
-    AlgorithmType getAlgoType(unsigned int idet);
+    AlgorithmType getAlgoType(uint32_t idet);
 
     void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >, size_t globalSimHitIndex, const uint32_t tofBin);
     void addPixelCollection(edm::Event& iEvent, const edm::EventSetup& iSetup, const bool ot_analog);

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -156,7 +156,7 @@ Phase2TrackerDigitizerAlgorithm::Phase2TrackerDigitizerAlgorithm(const edm::Para
       theSiPixelGainCalibrationService_(
           use_ineff_from_db_ ? std::make_unique<SiPixelGainCalibrationOfflineSimService>(conf_specific) : nullptr),
       subdetEfficiencies_(conf_specific) {
-  LogInfo("Phase2TrackerDigitizerAlgorithm")
+  LogDebug("Phase2TrackerDigitizerAlgorithm")
       << "Phase2TrackerDigitizerAlgorithm constructed\n"
       << "Configuration parameters:\n"
       << "Threshold/Gain = "
@@ -532,7 +532,7 @@ void Phase2TrackerDigitizerAlgorithm::induce_signal(
     }
   }
   // Fill the global map with all hit pixels from this event
-  float corr_time = hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.;
+  float corr_time = hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv;
   for (auto const& hit_s : hit_signal) {
     int chan = hit_s.first;
     theSignal[chan] +=
@@ -983,7 +983,7 @@ int Phase2TrackerDigitizerAlgorithm::convertSignalToAdc(uint32_t detID, float si
         temp_signal = std::floor((temp_signal - kink_point) / (pow(2, dualslope_param - 1))) + kink_point;
     }
     signal_in_adc = std::min(temp_signal, theAdcFullScale_);
-    LogInfo("Phase2TrackerDigitizerAlgorithm")
+    LogTrace("Phase2TrackerDigitizerAlgorithm")
         << " DetId " << detID << " signal_in_elec " << signal_in_elec << " threshold " << threshold
         << " signal_above_thr " << signal_in_elec - threshold << " temp conversion "
         << std::floor((signal_in_elec - threshold) / theElectronPerADC_) + 1 << " signal after slope correction "

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -16,6 +16,11 @@
 #include "SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
 
+// Units and Constants
+#include "DataFormats/Math/interface/CMSUnits.h"
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
 // forward declarations
 // For the random numbers
 namespace CLHEP {
@@ -38,6 +43,17 @@ class SiPixelLorentzAngle;
 class SiPixelQuality;
 class TrackerGeometry;
 class TrackerTopology;
+
+// REMEMBER CMS conventions:
+// -- Energy: GeV
+// -- momentum: GeV/c
+// -- mass: GeV/c^2
+// -- Distance, position: cm
+// -- Time: ns
+// -- Angles: radian
+// Some constants in convenient units
+constexpr double c_cm_ns = CLHEP::c_light * CLHEP::ns / CLHEP::cm;
+constexpr double c_inv = 1.0 / c_cm_ns;
 
 class Phase2TrackerDigitizerAlgorithm {
 public:

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -58,6 +58,8 @@ public:
   virtual void digitize(const Phase2TrackerGeomDetUnit* pixdet,
                         std::map<int, DigitizerUtility::DigiSimInfo>& digi_map,
                         const TrackerTopology* tTopo);
+  virtual bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) { return true; }
+  virtual bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) { return true; }
 
   // For premixing
   void loadAccumulator(uint32_t detId, const std::map<int, float>& accumulator);

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -16,11 +16,6 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 
-// Units and Constants
-#include "DataFormats/Math/interface/CMSUnits.h"
-#include "CLHEP/Units/GlobalPhysicalConstants.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
-
 //#include <iostream>
 #include <cmath>
 #include <vector>
@@ -28,16 +23,6 @@
 
 using namespace sipixelobjects;
 
-// REMEMBER CMS conventions:
-// -- Energy: GeV
-// -- momentum: GeV/c
-// -- mass: GeV/c^2
-// -- Distance, position: cm
-// -- Time: ns
-// -- Angles: radian
-// Some constants in convenient units
-constexpr double c_cm_ns = CLHEP::c_light * CLHEP::ns / CLHEP::cm;
-constexpr double c_inv = 1.0 / c_cm_ns;
 // Analogously to CMSUnits (no um defined)
 constexpr double operator""_um(long double length) { return length * 1e-4; }
 constexpr double operator""_um_inv(long double length) { return length * 1e4; }

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -49,7 +49,10 @@ PixelDigitizerAlgorithm::PixelDigitizerAlgorithm(const edm::ParameterSet& conf)
               .getParameter<double>("Odd_column_interchannelCoupling_next_column")),
       even_column_interchannelCoupling_next_column_(
           conf.getParameter<ParameterSet>("PixelDigitizerAlgorithm")
-              .getParameter<double>("Even_column_interchannelCoupling_next_column")) {
+              .getParameter<double>("Even_column_interchannelCoupling_next_column")),
+      apply_timewalk_(conf.getParameter<ParameterSet>("PixelDigitizerAlgorithm").getParameter<bool>("ApplyTimeWalk")),
+      timewalk_model_(
+          conf.getParameter<ParameterSet>("PixelDigitizerAlgorithm").getParameter<edm::ParameterSet>("TimewalkModel")) {
   pixelFlag_ = true;
   LogInfo("PixelDigitizerAlgorithm") << "Algorithm constructed "
                                      << "Configuration parameters:"
@@ -85,10 +88,9 @@ void PixelDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iter
     std::vector<DigitizerUtility::EnergyDepositUnit> ionization_points;
     std::vector<DigitizerUtility::SignalPoint> collection_points;
 
+    double signalScale = 1.0;
     // fill collection_points for this SimHit, indpendent of topology
-    // Check the TOF cut
-    if ((hit.tof() - pixdet->surface().toGlobal((hit).localPosition()).mag() / 30.) >= theTofLowerCut_ &&
-        (hit.tof() - pixdet->surface().toGlobal((hit).localPosition()).mag() / 30.) <= theTofUpperCut_) {
+    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.), signalScale)) {
       primary_ionization(hit, ionization_points);  // fills ionization_points
 
       // transforms ionization_points -> collection_points
@@ -101,6 +103,12 @@ void PixelDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iter
     ++simHitGlobalIndex;
   }
 }
+
+bool PixelDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, double& sigScale) {
+  double time = hit.tof() - tCorr;
+  return (time >= theTofLowerCut_ && time < theTofUpperCut_);
+}
+
 // ======================================================================
 //
 //  Add  Cross-talk contribution
@@ -202,4 +210,63 @@ void PixelDigitizerAlgorithm::add_cross_talk(const Phase2TrackerGeomDetUnit* pix
       theSignal.emplace(chan, DigitizerUtility::Amplitude(l.second.ampl(), nullptr, -1.0));
     }
   }
+}
+
+PixelDigitizerAlgorithm::TimewalkCurve::TimewalkCurve(const edm::ParameterSet& pset)
+    : x_(pset.getParameter<std::vector<double>>("charge")), y_(pset.getParameter<std::vector<double>>("delay")) {
+  if (x_.size() != y_.size())
+    throw cms::Exception("Configuration") << "Timewalk model error: Invalid curve.";
+}
+
+double PixelDigitizerAlgorithm::TimewalkCurve::operator()(double x) const {
+  auto it = std::lower_bound(x_.begin(), x_.end(), x);
+  if (it == x_.begin())
+    return y_.front();
+  if (it == x_.end())
+    return y_.back();
+  int index = std::distance(x_.begin(), it);
+  double x_high = *it;
+  double x_low = *(--it);
+  double p = (x - x_low) / (x_high - x_low);
+  return p * y_[index] + (1 - p) * y_[index - 1];
+}
+
+PixelDigitizerAlgorithm::TimewalkModel::TimewalkModel(const edm::ParameterSet& pset) {
+  threshold_values = pset.getParameter<std::vector<double>>("ThresholdValues");
+  const auto& curve_psetvec = pset.getParameter<std::vector<edm::ParameterSet>>("Curves");
+  if (threshold_values.size() != curve_psetvec.size())
+    throw cms::Exception("Configuration")
+        << "Timewalk model error: the number of threshold values does not match the number of curves.";
+  for (const auto& curve_pset : curve_psetvec)
+    curves.emplace_back(curve_pset);
+}
+
+double PixelDigitizerAlgorithm::TimewalkModel::operator()(double q_in, double q_threshold) const {
+  auto index = find_closest_index(threshold_values, q_threshold);
+  return curves[index](q_in);
+}
+
+std::size_t PixelDigitizerAlgorithm::TimewalkModel::find_closest_index(const std::vector<double>& vec,
+                                                                       double value) const {
+  auto it = std::lower_bound(vec.begin(), vec.end(), value);
+  if (it == vec.begin())
+    return 0;
+  else if (it == vec.end())
+    return vec.size() - 1;
+  else {
+    auto it_upper = it;
+    auto it_lower = --it;
+    auto closest = (value - *it_lower > *it_upper - value) ? it_upper : it_lower;
+    return std::distance(vec.begin(), closest);
+  }
+}
+bool PixelDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) {
+  if (charge < thr)
+    return false;
+  if (apply_timewalk_ && hitInfo) {
+    float corrected_time = hitInfo->time();
+    double time = corrected_time + timewalk_model_(charge, thr);
+    return (time >= theTofLowerCut_ && time < theTofUpperCut_);
+  } else
+    return true;
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
@@ -4,6 +4,36 @@
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
 
 class PixelDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
+private:
+  // A list of 2d points
+  class TimewalkCurve {
+  public:
+    // pset must contain "charge" and "delay" of type vdouble
+    TimewalkCurve(const edm::ParameterSet& pset);
+
+    // linear interpolation
+    double operator()(double x) const;
+
+  private:
+    std::vector<double> x_;
+    std::vector<double> y_;
+  };
+
+  // Holds the timewalk model data
+  class TimewalkModel {
+  public:
+    TimewalkModel(const edm::ParameterSet& pset);
+
+    // returns the delay for given input charge and threshold
+    double operator()(double q_in, double q_threshold) const;
+
+  private:
+    std::size_t find_closest_index(const std::vector<double>& vec, double value) const;
+
+    std::vector<double> threshold_values;
+    std::vector<TimewalkCurve> curves;
+  };
+
 public:
   PixelDigitizerAlgorithm(const edm::ParameterSet& conf);
   ~PixelDigitizerAlgorithm() override;
@@ -19,6 +49,8 @@ public:
                          const uint32_t tofBin,
                          const Phase2TrackerGeomDetUnit* pixdet,
                          const GlobalVector& bfield) override;
+  bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) override;
+  bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) override;
   void add_cross_talk(const Phase2TrackerGeomDetUnit* pixdet) override;
 
   // Addition four xtalk-related parameters to PixelDigitizerAlgorithm specific parameters initialized in Phase2TrackerDigitizerAlgorithm
@@ -26,5 +58,9 @@ public:
   const double even_row_interchannelCoupling_next_row_;
   const double odd_column_interchannelCoupling_next_column_;
   const double even_column_interchannelCoupling_next_column_;
+
+  // Timewalk parameters
+  bool apply_timewalk_;
+  const TimewalkModel timewalk_model_;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
@@ -10,13 +10,18 @@
 // Geometry
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 using namespace edm;
 
 void SSDigitizerAlgorithm::init(const edm::EventSetup& es) { es.get<TrackerDigiGeometryRecord>().get(geom_); }
 SSDigitizerAlgorithm::SSDigitizerAlgorithm(const edm::ParameterSet& conf)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<ParameterSet>("AlgorithmCommon"),
-                                      conf.getParameter<ParameterSet>("SSDigitizerAlgorithm")) {
+                                      conf.getParameter<ParameterSet>("SSDigitizerAlgorithm")),
+      hitDetectionMode_(conf.getParameter<ParameterSet>("SSDigitizerAlgorithm").getParameter<int>("HitDetectionMode")),
+      pulseShapeParameters_(conf.getParameter<ParameterSet>("SSDigitizerAlgorithm")
+                                .getParameter<std::vector<double> >("PulseShapeParameters")),
+      deadTime_(conf.getParameter<ParameterSet>("SSDigitizerAlgorithm").getParameter<double>("CBCDeadTime")) {
   pixelFlag_ = false;
   LogInfo("SSDigitizerAlgorithm ") << "SSDigitizerAlgorithm constructed "
                                    << "Configuration parameters:"
@@ -25,6 +30,7 @@ SSDigitizerAlgorithm::SSDigitizerAlgorithm(const edm::ParameterSet& conf)
                                    << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " "
                                    << theElectronPerADC_ << " " << theAdcFullScale_ << " The delta cut-off is set to "
                                    << tMax_ << " pix-inefficiency " << addPixelInefficiency_;
+  storeSignalShape();
 }
 SSDigitizerAlgorithm::~SSDigitizerAlgorithm() { LogDebug("SSDigitizerAlgorithm") << "SSDigitizerAlgorithm deleted"; }
 void SSDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterator inputBegin,
@@ -52,10 +58,9 @@ void SSDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterato
     std::vector<DigitizerUtility::EnergyDepositUnit> ionization_points;
     std::vector<DigitizerUtility::SignalPoint> collection_points;
 
+    double signalScale = 1.0;
     // fill collection_points for this SimHit, indpendent of topology
-    // Check the TOF cut
-    if ((hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.) >= theTofLowerCut_ &&
-        (hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.) <= theTofUpperCut_) {
+    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.), signalScale)) {
       primary_ionization(hit, ionization_points);  // fills ionization_points
 
       // transforms ionization_points -> collection_points
@@ -67,4 +72,147 @@ void SSDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterato
     }
     ++simHitGlobalIndex;
   }
+}
+//
+// -- Select the Hit for Digitization
+//
+bool SSDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, double& sigScale) {
+  bool result = false;
+  if (hitDetectionMode_ == SSDigitizerAlgorithm::SampledMode)
+    result = select_hit_sampledMode(hit, tCorr, sigScale);
+  else if (hitDetectionMode_ == SSDigitizerAlgorithm::LatchedMode)
+    result = select_hit_latchedMode(hit, tCorr, sigScale);
+  else {
+    double toa = hit.tof() - tCorr;
+    if (toa > theTofLowerCut_ && toa < theTofUpperCut_)
+      result = true;
+  }
+  return result;
+}
+//
+// -- Select Hits in Sampled Mode
+//
+bool SSDigitizerAlgorithm::select_hit_sampledMode(const PSimHit& hit, double tCorr, double& sigScale) {
+  double toa = hit.tof() - tCorr;
+  double sampling_time = bx_time;
+
+  DetId det_id = DetId(hit.detUnitId());
+  float theThresholdInE =
+      (det_id.subdetId() == StripSubdetector::TOB) ? theThresholdInE_Barrel_ : theThresholdInE_Endcap_;
+
+  sigScale = getSignalScale(sampling_time - toa);
+  if (sigScale * hit.energyLoss() / GeVperElectron_ > theThresholdInE)
+    return true;
+
+  return false;
+}
+//
+// -- Select Hits in Hit Detection Mode
+//
+bool SSDigitizerAlgorithm::select_hit_latchedMode(const PSimHit& hit, double tCorr, double& sigScale) {
+  float toa = hit.tof() - tCorr;
+  toa -= hit.eventId().bunchCrossing() * bx_time;
+
+  float sampling_time = (-1) * (hit.eventId().bunchCrossing() + 1) * bx_time;
+
+  DetId det_id = DetId(hit.detUnitId());
+  float theThresholdInE =
+      (det_id.subdetId() == StripSubdetector::TOB) ? theThresholdInE_Barrel_ : theThresholdInE_Endcap_;
+
+  bool lastPulse = true;
+  bool aboveThr = false;
+  for (float i = deadTime_; i <= bx_time; i++) {
+    sigScale = getSignalScale(sampling_time - toa + i);
+
+    if (sigScale * hit.energyLoss() / GeVperElectron_ > theThresholdInE)
+      aboveThr = true;
+    else
+      aboveThr = false;
+    if (!lastPulse && aboveThr) {
+      return true;
+    }
+    lastPulse = aboveThr;
+  }
+  return false;
+}
+
+double SSDigitizerAlgorithm::nFactorial(int n) { return TMath::Gamma(n + 1); }
+double SSDigitizerAlgorithm::aScalingConstant(int N, int i) {
+  return std::pow(-1, (double)i) * nFactorial(N) * nFactorial(N + 2) /
+         (nFactorial(N - i) * nFactorial(N + 2 - i) * nFactorial(i));
+}
+double SSDigitizerAlgorithm::cbc3PulsePolarExpansion(double x) {
+  if (pulseShapeParameters_.size() < 6)
+    return -1;
+  double xOffset = pulseShapeParameters_[0];
+  double tau = pulseShapeParameters_[1];
+  double r = pulseShapeParameters_[2];
+  double theta = pulseShapeParameters_[3];
+  int nTerms = static_cast<int>(pulseShapeParameters_[4]);
+
+  double fN = 0;
+  double xx = x - xOffset;
+  if (xx < 0)
+    return 0;
+
+  for (int i = 0; i < nTerms; i++) {
+    double angularTerm = 0;
+    double temporalTerm = 0;
+    double rTerm = std::pow(r, i) / (std::pow(tau, 2. * i) * nFactorial(i + 2));
+    for (int j = 0; j <= i; j++) {
+      double aij = nFactorial(i) * nFactorial(i + 2) / (nFactorial(i - j) * nFactorial(i + 2 - j) * nFactorial(j));
+      angularTerm += std::pow(std::cos(theta), (double)(i - j)) * std::pow(std::sin(theta), (double)j);
+      temporalTerm += std::pow(-1., (double)j) * aij * std::pow(xx, (double)(i - j)) * std::pow(tau, (double)j);
+    }
+    double fi = rTerm * angularTerm * temporalTerm;
+
+    fN += fi;
+  }
+  return fN;
+}
+double SSDigitizerAlgorithm::signalShape(double x) {
+  double xOffset = pulseShapeParameters_[0];
+  double tau = pulseShapeParameters_[1];
+  //  double r = pulseShapeParameters_[2];
+  //  double theta = pulseShapeParameters_[3];
+  //  double nTerms = pulseShapeParameters_[4];
+  double maxCharge = pulseShapeParameters_[5];
+
+  double xx = x - xOffset;
+  return maxCharge * (TMath::Exp(-xx / tau) * std::pow(xx / tau, 2.) * cbc3PulsePolarExpansion(x));
+}
+void SSDigitizerAlgorithm::storeSignalShape() {
+  for (int i = 0; i < 1000; i++) {
+    float val = i * 0.1;
+
+    pulseShapeVec_.push_back(signalShape(val));
+  }
+}
+double SSDigitizerAlgorithm::getSignalScale(double xval) {
+  double res = 0.0;
+  int len = pulseShapeVec_.size();
+
+  if (xval * 10 >= len)
+    return res;
+  if (xval < 0.0)
+    return res;
+
+  unsigned int lower = std::floor(xval) * 10;
+  unsigned int upper = std::ceil(xval) * 10;
+  for (size_t i = lower + 1; i < upper * 10; i++) {
+    float val = i * 0.1;
+    if (val > xval) {
+      res = pulseShapeVec_[i - 1];
+      break;
+    }
+  }
+  return res;
+}
+bool SSDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo* const hisInfo,
+                                            float charge,
+                                            float thr) {
+  if (charge >= thr)
+    return true;
+  else
+    return false;
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
@@ -37,5 +37,7 @@ private:
   std::vector<double> pulseShapeParameters_;
   float deadTime_;
   static constexpr float bx_time{25};
+  static constexpr size_t interpolationPoints{1000};
+  static constexpr int interpolationStep{10};
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
@@ -18,5 +18,24 @@ public:
                          const uint32_t tofBin,
                          const Phase2TrackerGeomDetUnit* pixdet,
                          const GlobalVector& bfield) override;
+  bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) override;
+  bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) override;
+
+private:
+  enum { SquareWindow, SampledMode, LatchedMode, SampledOrLachedMode, HIPFindingMode };
+  double nFactorial(int n);
+  double aScalingConstant(int N, int i);
+  double cbc3PulsePolarExpansion(double x);
+  double signalShape(double x);
+  double getSignalScale(double xval);
+  void storeSignalShape();
+  bool select_hit_sampledMode(const PSimHit& hit, double tCorr, double& sigScale);
+  bool select_hit_latchedMode(const PSimHit& hit, double tCorr, double& sigScale);
+
+  int hitDetectionMode_;
+  std::vector<double> pulseShapeVec_;
+  std::vector<double> pulseShapeParameters_;
+  float deadTime_;
+  static constexpr float bx_time{25};
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -58,7 +58,7 @@ phase2TrackerDigitizer = cms.PSet(
       EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
       0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
       CellsToKill = cms.VPSet(),
-      ApplyTimeWalk = cms.bool(False),
+      ApplyTimewalk = cms.bool(False),
       TimewalkModel = cms.PSet(
         ThresholdValues = cms.vdouble(1000, 1200, 1500, 3000),
         Curves = cms.VPSet(

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -57,7 +57,29 @@ phase2TrackerDigitizer = cms.PSet(
       EfficiencyFactors_Barrel = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999 ),
       EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
       0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
-      CellsToKill = cms.VPSet()
+      CellsToKill = cms.VPSet(),
+      ApplyTimeWalk = cms.bool(False),
+      TimewalkModel = cms.PSet(
+        ThresholdValues = cms.vdouble(1000, 1200, 1500, 3000),
+        Curves = cms.VPSet(
+          cms.PSet(
+            charge = cms.vdouble(1000, 1025, 1050, 1100, 1200, 1500, 2000, 6000, 10000, 15000, 20000, 30000),
+            delay = cms.vdouble(26.8, 23.73, 21.92, 19.46, 16.52, 12.15, 8.88, 3.03, 1.69, 0.95, 0.56, 0.19)
+          ),
+          cms.PSet(
+            charge = cms.vdouble(1200, 1225, 1250, 1500, 2000, 6000, 10000, 15000, 20000, 30000),
+            delay = cms.vdouble(26.28, 23.5, 21.79, 14.92, 10.27, 3.33, 1.86, 1.07, 0.66, 0.27)
+          ),
+          cms.PSet(
+            charge = cms.vdouble(1500, 1525, 1550, 1600, 2000, 6000, 10000, 15000, 20000, 30000),
+            delay = cms.vdouble(25.36, 23.05, 21.6, 19.56, 12.94, 3.79, 2.14, 1.26, 0.81, 0.39)
+          ),
+          cms.PSet(
+            charge = cms.vdouble(3000, 3025, 3050, 3100, 3500, 6000, 10000, 15000, 20000, 30000),
+            delay = cms.vdouble(25.63, 23.63, 22.35, 20.65, 14.92, 6.7, 3.68, 2.29, 1.62, 1.02)
+          )
+        )
+      )
     ),
 #Pixel-3D Digitizer Algorithm
     Pixel3DDigitizerAlgorithm = cms.PSet(
@@ -211,7 +233,10 @@ phase2TrackerDigitizer = cms.PSet(
       EfficiencyFactors_Barrel = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999 ),
       EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
       0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
-      CellsToKill = cms.VPSet()
+      CellsToKill = cms.VPSet(),
+      HitDetectionMode = cms.int32(0),  # (0/1/2/3/4 => SquareWindow/SampledMode/LatchedMode/SampledOrLachedMode/HIPFindingMode)
+      PulseShapeParameters = cms.vdouble(-3.0, 16.043703, 99.999857, 40.571650, 2.0, 1.2459094),
+        CBCDeadTime = cms.double(0.0) # (2.7 ns deadtime in latched mode)
     )
 )
 


### PR DESCRIPTION
#### PR description:
Inclusion of  Time dependence of Signal shape
 - Time dependent Signal Shape correction added for SSDigitizerAlgorithm 

 - Pixel Timewalk correction added for PixelDigitizer Algorithm

 - DigitizerUtility::Amplitude class updated to use newly introduced SimHitInfo class where Time of   Flight information of SimHit is stored so that it can be accessed at the 
Phase2DigitizerAlgorithm::digitize step

  - Configuration parameters are set to switch off the Signal Shape Simulation. So output should be identical with the current code

  -  Integer and float literals are defined as constant. For example, we are now using
     constexpr double c_cm_ns = CLHEP::c_light * CLHEP::ns / CLHEP::cm;
     constexpr double c_inv = 1.0 / c_cm_ns;
      .....
      float corr_time = hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv;
      instead of
      float corr_time = hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() / 30.;
     in SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc and in other    places. Minor changes observed in DQM histograms due to such improved accuracy in unit conversions.

  - Does not depend on other PRs or externals

#### PR validation:

Code tested with Particle gun Muon + 200 PU (RelVal) events and the results can be found here
https://indico.cern.ch/event/879031/contributions/3823579/attachments/2018881/3376562/SignalShape_validation_14042020.pdf 

code-checks    done
code-format     done

@emiglior @skinnari @subirsarkar
