### PR TITLE
Fixed BUS error due to uninitialized MEs

### DIFF
--- a/DQM/RPCMonitorDigi/src/RPCMonitorDigi.cc
+++ b/DQM/RPCMonitorDigi/src/RPCMonitorDigi.cc
@@ -15,7 +15,13 @@
 
 const std::array<std::string, 3> RPCMonitorDigi::regionNames_ = {{"Endcap-", "Barrel", "Endcap+"}};
 
-RPCMonitorDigi::RPCMonitorDigi(const edm::ParameterSet& pset) : counter(0), numberOfDisks_(0), numberOfInnerRings_(0) {
+RPCMonitorDigi::RPCMonitorDigi(const edm::ParameterSet& pset)
+    : counter(0),
+      muonRPCEvents_(nullptr),
+      NumberOfRecHitMuon_(nullptr),
+      NumberOfMuon_(nullptr),
+      numberOfDisks_(0),
+      numberOfInnerRings_(0) {
   useMuonDigis_ = pset.getUntrackedParameter<bool>("UseMuon", true);
   useRollInfo_ = pset.getUntrackedParameter<bool>("UseRollInfo", false);
 
@@ -377,7 +383,7 @@ void RPCMonitorDigi::performSourceOperation(std::map<RPCDetId, std::vector<RPCRe
         }
       }
 
-      // ###################### Wheel/Disk Level #########################ààà
+      // ###################### Wheel/Disk Level #########################
       if (region == 0) {
         os.str("");
         os << "1DOccupancy_Wheel_" << wheelOrDiskNumber;


### PR DESCRIPTION
#### PR description:

Added `MonitorElement` pointer initializers to the constructor because booking logic is conditional and in some cases MEs are left uninitialized, pointing to random places in the memory. A BUS error because of this is observed by the new unit tests: https://github.com/cms-sw/cmssw/pull/29372

#### PR validation:

PR was validated locally.
