### PR TITLE
Decrease begin Run startup time for HLT

### DIFF
--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -30,7 +30,10 @@
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Common/interface/SecondaryEventIDAndFileInfo.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
+#include "DataFormats/Provenance/interface/ParameterSetBlob.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
 #include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
 
 #include <vector>
+#include <map>

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -190,5 +190,5 @@
  <class name="edm::RandomNumberGeneratorState" ClassVersion="3">
   <version ClassVersion="3" checksum="2237762164"/>
  </class>
-
+ <class name="edm::Wrapper<std::map<edm::ParameterSetID,edm::ParameterSetBlob>>"/>
 </lcgdict>

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -156,6 +156,7 @@
  <class name="std::vector<std::vector<edm::ParameterSetID > >"/>
  <class name="std::map<edm::ParameterSetID,edm::ParameterSetBlob>"/>
  <class name="std::pair<edm::ParameterSetID,edm::ParameterSetBlob>"/>
+ <class name="std::pair<const edm::ParameterSetID,edm::ParameterSetBlob>"/>
  <class name="edm::ProcessConfigurationID"/>
  <class name="std::vector<edm::ProcessConfigurationID>"/>
  <class name="edm::ParentageID"/>

--- a/EventFilter/Utilities/interface/EvFOutputModule.h
+++ b/EventFilter/Utilities/interface/EvFOutputModule.h
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "IOPool/Streamer/interface/StreamerOutputModuleCommon.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "DataFormats/Streamer/interface/StreamedProducts.h"
 
 #include "EventFilter/Utilities/interface/JsonMonitorable.h"
 #include "EventFilter/Utilities/interface/FastMonitor.h"
@@ -93,6 +94,7 @@ namespace evf {
     edm::ParameterSet const& ps_;
     std::string streamLabel_;
     edm::EDGetTokenT<edm::TriggerResults> trToken_;
+    edm::EDGetTokenT<edm::SendJobHeader::ParameterSetMap> psetToken_;
 
     evf::FastMonitoringService* fms_;
 

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -109,7 +109,9 @@ namespace evf {
         EvFOutputModuleType(ps),
         ps_(ps),
         streamLabel_(ps.getParameter<std::string>("@module_label")),
-        trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))) {
+        trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
+        psetToken_(consumes<edm::SendJobHeader::ParameterSetMap, edm::InRun>(
+            ps.getUntrackedParameter<edm::InputTag>("psetMap"))) {
     //replace hltOutoputA with stream if the HLT menu uses this convention
     std::string testPrefix = "hltOutput";
     if (streamLabel_.find(testPrefix) == 0)
@@ -138,6 +140,8 @@ namespace evf {
     edm::ParameterSetDescription desc;
     edm::StreamerOutputModuleCommon::fillDescription(desc);
     EvFOutputModuleType::fillDescription(desc);
+    desc.addUntracked<edm::InputTag>("psetMap", {"psetMap"})
+        ->setComment("Optionally allow the map of ParameterSets to be calculated externally.");
     descriptions.addDefault(desc);
   }
 
@@ -153,13 +157,16 @@ namespace evf {
     uint32 preamble_adler32 = 1;
     edm::BranchIDLists const* bidlPtr = branchIDLists();
 
+    auto psetMapHandle = run.getHandle(psetToken_);
+
     std::unique_ptr<InitMsgBuilder> init_message =
         jsonWriter_->streamerCommon_.serializeRegistry(*jsonWriter_->streamerCommon_.getSerializerBuffer(),
                                                        *bidlPtr,
                                                        *thinnedAssociationsHelper(),
                                                        OutputModule::processName(),
                                                        description().moduleLabel(),
-                                                       moduleDescription().mainParameterSetID());
+                                                       moduleDescription().mainParameterSetID(),
+                                                       psetMapHandle.isValid() ? psetMapHandle.product() : nullptr);
 
     //Let us turn it into a View
     InitMsgView view(init_message->startAddress());

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -16,6 +16,7 @@
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
+#include "DataFormats/Streamer/interface/StreamedProducts.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 // Data structure to be shared by all output modules for event serialization
@@ -75,6 +76,11 @@ namespace edm {
     int serializeRegistry(SerializeDataBuffer &data_buffer,
                           const BranchIDLists &branchIDLists,
                           ThinnedAssociationsHelper const &thinnedAssociationsHelper);
+
+    int serializeRegistry(SerializeDataBuffer &data_buffer,
+                          const BranchIDLists &branchIDLists,
+                          ThinnedAssociationsHelper const &thinnedAssociationsHelper,
+                          SendJobHeader::ParameterSetMap const &psetMap);
 
     int serializeEvent(SerializeDataBuffer &data_buffer,
                        EventForOutput const &event,

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
+#include "DataFormats/Streamer/interface/StreamedProducts.h"
 //#include "IOPool/Streamer/interface/StreamSerializer.h"
 //#include <memory>
 //#include <vector>
@@ -41,6 +42,7 @@ namespace edm {
 
   private:
     edm::EDGetTokenT<edm::TriggerResults> trToken_;
+    edm::EDGetTokenT<SendJobHeader::ParameterSetMap> psetToken_;
 
   };  //end-of-class-def
 

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -5,6 +5,7 @@
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "IOPool/Streamer/interface/StreamSerializer.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Streamer/interface/StreamedProducts.h"
 #include <memory>
 #include <vector>
 
@@ -28,7 +29,8 @@ namespace edm {
                                                       ThinnedAssociationsHelper const& helper,
                                                       std::string const& processName,
                                                       std::string const& moduleLabel,
-                                                      ParameterSetID const& toplevel);
+                                                      ParameterSetID const& toplevel,
+                                                      SendJobHeader::ParameterSetMap const* psetMap);
 
     std::unique_ptr<EventMsgBuilder> serializeEvent(SerializeDataBuffer& sbuf,
                                                     EventForOutput const& e,

--- a/IOPool/Streamer/plugins/BuildFile.xml
+++ b/IOPool/Streamer/plugins/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="IOPool/Streamer"/>
-<library   file="Module.cc" name="IOPoolStreamerPlugins">
+<library   file="*.cc" name="IOPoolStreamerPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/IOPool/Streamer/plugins/ParameterSetBlobProducer.cc
+++ b/IOPool/Streamer/plugins/ParameterSetBlobProducer.cc
@@ -1,0 +1,36 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "DataFormats/Provenance/interface/ParameterSetBlob.h"
+
+class ParameterSetBlobProducer : public edm::global::EDProducer<edm::BeginRunProducer> {
+public:
+  ParameterSetBlobProducer(edm::ParameterSet const&);
+
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
+
+  void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const final;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&) {}
+
+private:
+  edm::EDPutTokenT<std::map<edm::ParameterSetID, edm::ParameterSetBlob>> const token_;
+};
+
+ParameterSetBlobProducer::ParameterSetBlobProducer(edm::ParameterSet const&)
+    : token_{produces<std::map<edm::ParameterSetID, edm::ParameterSetBlob>, edm::Transition::BeginRun>()} {}
+
+void ParameterSetBlobProducer::produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const {}
+
+void ParameterSetBlobProducer::globalBeginRunProduce(edm::Run& iRun, edm::EventSetup const&) const {
+  std::map<edm::ParameterSetID, edm::ParameterSetBlob> psetMap;
+  edm::pset::Registry::instance()->fillMap(psetMap);
+
+  iRun.emplace(token_, std::move(psetMap));
+}
+
+DEFINE_FWK_MODULE(ParameterSetBlobProducer);

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -42,10 +42,18 @@ namespace edm {
    * Serializes the product registry (that was specified to the constructor)
    * into the specified InitMessage.
    */
-
   int StreamSerializer::serializeRegistry(SerializeDataBuffer &data_buffer,
                                           const BranchIDLists &branchIDLists,
                                           ThinnedAssociationsHelper const &thinnedAssociationsHelper) {
+    SendJobHeader::ParameterSetMap psetMap;
+    pset::Registry::instance()->fillMap(psetMap);
+    return serializeRegistry(data_buffer, branchIDLists, thinnedAssociationsHelper, psetMap);
+  }
+
+  int StreamSerializer::serializeRegistry(SerializeDataBuffer &data_buffer,
+                                          const BranchIDLists &branchIDLists,
+                                          ThinnedAssociationsHelper const &thinnedAssociationsHelper,
+                                          SendJobHeader::ParameterSetMap const &psetMap) {
     FDEBUG(6) << "StreamSerializer::serializeRegistry" << std::endl;
     SendJobHeader sd;
 
@@ -58,9 +66,6 @@ namespace edm {
     Service<ConstProductRegistry> reg;
     sd.setBranchIDLists(branchIDLists);
     sd.setThinnedAssociationsHelper(thinnedAssociationsHelper);
-    SendJobHeader::ParameterSetMap psetMap;
-
-    pset::Registry::instance()->fillMap(psetMap);
     sd.setParameterSetMap(psetMap);
 
     data_buffer.rootbuf_.Reset();

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -17,19 +17,25 @@ namespace edm {
       : one::OutputModuleBase::OutputModuleBase(ps),
         one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks>(ps),
         StreamerOutputModuleCommon(ps, &keptProducts()[InEvent]),
-        trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))) {}
+        trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
+        psetToken_(
+            consumes<SendJobHeader::ParameterSetMap, edm::InRun>(ps.getUntrackedParameter<edm::InputTag>("psetMap"))) {}
 
   StreamerOutputModuleBase::~StreamerOutputModuleBase() {}
 
-  void StreamerOutputModuleBase::beginRun(RunForOutput const&) {
+  void StreamerOutputModuleBase::beginRun(RunForOutput const& iRun) {
     start();
 
-    std::unique_ptr<InitMsgBuilder> init_message = serializeRegistry(*getSerializerBuffer(),
-                                                                     *branchIDLists(),
-                                                                     *thinnedAssociationsHelper(),
-                                                                     OutputModule::processName(),
-                                                                     description().moduleLabel(),
-                                                                     moduleDescription().mainParameterSetID());
+    auto psetMapHandle = iRun.getHandle(psetToken_);
+
+    std::unique_ptr<InitMsgBuilder> init_message =
+        serializeRegistry(*getSerializerBuffer(),
+                          *branchIDLists(),
+                          *thinnedAssociationsHelper(),
+                          OutputModule::processName(),
+                          description().moduleLabel(),
+                          moduleDescription().mainParameterSetID(),
+                          psetMapHandle.isValid() ? psetMapHandle.product() : nullptr);
 
     doOutputHeader(*init_message);
     serializerBuffer_->clearHeaderBuffer();
@@ -62,5 +68,7 @@ namespace edm {
   void StreamerOutputModuleBase::fillDescription(ParameterSetDescription& desc) {
     StreamerOutputModuleCommon::fillDescription(desc);
     OutputModule::fillDescription(desc);
+    desc.addUntracked<edm::InputTag>("psetMap", {"psetMap"})
+        ->setComment("Optionally allow the map of ParameterSets to be calculated externally.");
   }
 }  // namespace edm

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -88,14 +88,19 @@ namespace edm {
 
   StreamerOutputModuleCommon::~StreamerOutputModuleCommon() {}
 
-  std::unique_ptr<InitMsgBuilder> StreamerOutputModuleCommon::serializeRegistry(SerializeDataBuffer& sbuf,
-                                                                                const BranchIDLists& branchLists,
-                                                                                ThinnedAssociationsHelper const& helper,
-                                                                                std::string const& processName,
-                                                                                std::string const& moduleLabel,
-                                                                                ParameterSetID const& toplevel) {
-    serializer_.serializeRegistry(sbuf, branchLists, helper);
-
+  std::unique_ptr<InitMsgBuilder> StreamerOutputModuleCommon::serializeRegistry(
+      SerializeDataBuffer& sbuf,
+      const BranchIDLists& branchLists,
+      ThinnedAssociationsHelper const& helper,
+      std::string const& processName,
+      std::string const& moduleLabel,
+      ParameterSetID const& toplevel,
+      SendJobHeader::ParameterSetMap const* psetMap) {
+    if (psetMap) {
+      serializer_.serializeRegistry(sbuf, branchLists, helper, *psetMap);
+    } else {
+      serializer_.serializeRegistry(sbuf, branchLists, helper);
+    }
     // resize header_buf_ to reflect space used in serializer_ + header
     // I just added an overhead for header of 50000 for now
     unsigned int src_size = sbuf.currentSpaceUsed();


### PR DESCRIPTION
#### PR description:

Running igprof on an example HLT configuration uncovered that the vast amount of time spent in the begin Run transition was all the ShmStreamConsumer OutputModules calculating the ParameterSetBlobs to be stored in the files. This pull request adds the option to run ParameterSetBlobProducer at begin Run to create the ParameterSetBlobs once and then have all the OutputModules use that information. This decreased the time spent making the blobs from 147s in the orginal job to 4s.

#### PR validation:

The test configuration I was using ran fine both with and without ParameterSetBlobProducer added.