### PR TITLE
DQM BeamPixel Online client ME double reset fix

### DIFF
--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -73,7 +73,7 @@ Vx3DHLTAnalyzer::Vx3DHLTAnalyzer(const ParameterSet& iConfig) {
   // ##############################
 }
 
-Vx3DHLTAnalyzer::~Vx3DHLTAnalyzer() { reset("scratch"); }
+Vx3DHLTAnalyzer::~Vx3DHLTAnalyzer() {}
 
 void Vx3DHLTAnalyzer::analyze(const Event& iEvent, const EventSetup& iSetup) {
   Handle<VertexCollection> Vx3DCollection;


### PR DESCRIPTION
#### PR description:

By the time the module destructor is being called, MEs no longer have backing MonitorElementData and practically any access to them throws.

#### PR validation:

PR was validated locally.
