### PR TITLE
Modify DQMHarvestUnit to multiRun when RD MC runs

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -512,6 +512,8 @@ class MatrixInjector(object):
                                 #print 't_second',pprint.pformat(t_second)
                                 if t_second['TaskName'].startswith('HARVEST'):
                                     chainDict.update(copy.deepcopy(self.defaultHarvest))
+                                    if "_RD" in t_second['TaskName']:
+                                        chainDict['DQMHarvestUnit'] = "multiRun"
                                     chainDict['DQMConfigCacheID']=t_second['ConfigCacheID']
                                     ## the info are not in the task specific dict but in the general dict
                                     #t_input.update(copy.deepcopy(self.defaultHarvest))


### PR DESCRIPTION
#### PR description:
Following the discussion in https://hypernews.cern.ch/HyperNews/CMS/get/wmDevelopment/808.html

When Multi-Run Harvesting is used, the workflow dictionary needs to be updated:
`"DQMHarvestUnit": "byRun",  ==> change to "multiRun"`

#### PR validation:
Local test or IB can't validate this PR as local harvesting is running fine. We need to test with submitted workflows. Two relvals have been submitted to test this update:

> srimanob_RVCMSSW_11_1_0_pre6ZEE_13UP18_RD_PUpmx25ns__RD_Harvesting_8_200416_161631_4812
> srimanob_RVCMSSW_11_1_0_pre6ZEE_13UP18_RD_PUpmx25ns__RD_Harvesting_8HS_200416_161423_9045

One can just trigger the test with RD workflow, i.e. 250200.182 just to see local run is fine.

In addition, the above workflows will validate also issue reported in https://github.com/cms-sw/cmssw/issues/29472 (Strange output when firstLuminosityBlockForEachRun is used for Run-Dependent MC)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
-
