### PR TITLE
re-add also SiPixelPhase1RecHitsAnalyzer to DQM offline for HI scenario

### DIFF
--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
@@ -23,8 +23,5 @@ siPixelPhase1OfflineDQM_harvesting_cosmics = siPixelPhase1OfflineDQM_harvesting.
 siPixelPhase1OfflineDQM_harvesting_cosmics.replace(RunQTests_offline, RunQTests_cosmics)
 siPixelPhase1OfflineDQM_harvesting_cosmics.replace(SiPixelPhase1SummaryOffline, SiPixelPhase1SummaryCosmics)
 
-siPixelPhase1OfflineDQM_harvesting_hi = siPixelPhase1OfflineDQM_harvesting.copyAndExclude([
-    SiPixelPhase1RecHitsHarvester,
-    SiPixelPhase1TrackResidualsHarvester
-])
+siPixelPhase1OfflineDQM_harvesting_hi = siPixelPhase1OfflineDQM_harvesting.copy()
 

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -67,9 +67,13 @@ siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1TrackClustersAnalyze
 
 #heavy ions config
 
-siPixelPhase1OfflineDQM_source_hi = siPixelPhase1OfflineDQM_source.copyAndExclude([
-    SiPixelPhase1RecHitsAnalyzer
-])
+siPixelPhase1OfflineDQM_source_hi = siPixelPhase1OfflineDQM_source.copy()
+
+SiPixelPhase1RecHitsAnalyzer_hi = SiPixelPhase1RecHitsAnalyzer.clone()
+SiPixelPhase1RecHitsAnalyzer_hi.src = "hiGeneralTracks"
+
+siPixelPhase1OfflineDQM_source_hi.replace(SiPixelPhase1RecHitsAnalyzer,
+                                          SiPixelPhase1RecHitsAnalyzer_hi)
 
 SiPixelPhase1TrackResidualsAnalyzer_hi = SiPixelPhase1TrackResidualsAnalyzer.clone()
 SiPixelPhase1TrackResidualsAnalyzer_hi.Tracks = "hiGeneralTracks"


### PR DESCRIPTION
#### PR description:

While reviewing the code for PR #29461 I noticed also that some other DQM modules (`SiPixelPhase1RecHitsAnalyzer`) were excluded from being run without apparent reason.
I re-add it here, together with the harvester for the residuals.

#### PR validation:

Standard limited matrix integration tests passed + 
```
runTheMatrix.py -l 150.0 -t 4 -j 8
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.
