### PR TITLE
Handle retries in SONIC

### DIFF
--- a/HeterogeneousCore/SonicCore/README.md
+++ b/HeterogeneousCore/SonicCore/README.md
@@ -92,7 +92,8 @@ For the `Sync` and `PseudoAsync` modes, `finish()` should be called at the end o
 For the `Async` mode, `finish()` should be called inside the communication protocol callback function (implementations may vary).
 
 When `finish()` is called, the success or failure of the call should be conveyed.
-If a call fails, it can optionally be retried.
+If a call fails, it can optionally be retried. This is only allowed if the call failure does not cause an exception.
+Therefore, if retrying is desired, any exception should be converted to a `LogWarning` or `LogError` message by the client.
 To enable retries with a specified maximum number of allowed tries (possibly obtained from a Python configuration parameter), the client should implement the following:
 ```cpp
 protected:

--- a/HeterogeneousCore/SonicCore/README.md
+++ b/HeterogeneousCore/SonicCore/README.md
@@ -13,23 +13,23 @@ To implement a concrete derived producer class, the following skeleton can be us
 
 class MyProducer : public SonicEDProducer<Client>
 {
-	public:
-		explicit MyProducer(edm::ParameterSet const& cfg) : SonicEDProducer<Client>(cfg) {
-			//for debugging
-			setDebugName("MyProducer");
-		}
-		void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
-			//convert event data to client input format
-		}
-		void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
-			//convert client output to event data format
-		}
-		static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-			edm::ParameterSetDescription desc;
-			Client::fillPSetDescription(desc);
-			//add producer-specific parameters
-			descriptions.add("MyProducer",desc);
-		}
+public:
+  explicit MyProducer(edm::ParameterSet const& cfg) : SonicEDProducer<Client>(cfg) {
+    //for debugging
+    setDebugName("MyProducer");
+  }
+  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
+    //convert event data to client input format
+  }
+  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
+    //convert client output to event data format
+  }
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+    edm::ParameterSetDescription desc;
+    Client::fillPSetDescription(desc);
+    //add producer-specific parameters
+    descriptions.add("MyProducer",desc);
+  }
 };
 
 DEFINE_FWK_MODULE(MyProducer);
@@ -65,13 +65,13 @@ To implement a concrete client, the following skeleton can be used for the `.h` 
 #include "HeterogeneousCore/SonicCore/interface/SonicClient*.h"
 
 class MyClient : public SonicClient*<Input,Output> {
-	public:
-		MyClient(const edm::ParameterSet& params);
+public:
+  MyClient(const edm::ParameterSet& params);
 
-		static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
-	protected:
-		void evaluate() override;
+protected:
+  void evaluate() override;
 };
 
 #endif
@@ -102,9 +102,9 @@ protected:
 The client must also provide a static method `fillPSetDescription` to populate its parameters in the `fillDescriptions` for the producers that use the client:
 ```cpp
 void MyClient::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
-	edm::ParameterSetDescription descClient;
-	//add parameters
-	iDesc.add<edm::ParameterSetDescription>("Client",descClient);
+  edm::ParameterSetDescription descClient;
+  //add parameters
+  iDesc.add<edm::ParameterSetDescription>("Client",descClient);
 }
 ```
 

--- a/HeterogeneousCore/SonicCore/README.md
+++ b/HeterogeneousCore/SonicCore/README.md
@@ -91,6 +91,14 @@ In all cases, the implementation of `evaluate()` must call `finish()`.
 For the `Sync` and `PseudoAsync` modes, `finish()` should be called at the end of `evaluate()`.
 For the `Async` mode, `finish()` should be called inside the communication protocol callback function (implementations may vary).
 
+When `finish()` is called, the success or failure of the call should be conveyed.
+If a call fails, it can optionally be retried.
+To enable retries with a specified maximum number of allowed tries (possibly obtained from a Python configuration parameter), the client should implement the following:
+```cpp
+protected:
+  unsigned allowedTries() const override;
+```
+
 The client must also provide a static method `fillPSetDescription` to populate its parameters in the `fillDescriptions` for the producers that use the client:
 ```cpp
 void MyClient::fillPSetDescription(edm::ParameterSetDescription& iDesc) {

--- a/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
@@ -36,7 +36,8 @@ protected:
   }
 
   void finish(bool success, std::exception_ptr eptr = std::exception_ptr{}) {
-    if (!success) {
+    //retries are only allowed if no exception was raised
+    if (!success and !eptr) {
       ++tries_;
       //if max retries has not been exceeded, call evaluate again
       if (tries_ < allowedTries()) {
@@ -44,8 +45,8 @@ protected:
         //avoid calling doneWaiting() twice
         return;
       }
-      //prepare an exception if there isn't one already
-      else if (!eptr) {
+      //prepare an exception if exceeded
+      else {
         cms::Exception ex("SonicCallFailed");
         ex << "call failed after max " << tries_ << " tries";
         eptr = make_exception_ptr(ex);

--- a/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
@@ -10,6 +10,9 @@
 
 class SonicClientBase {
 public:
+  //constructor
+  SonicClientBase() : tries_(0) {}
+
   //destructor
   virtual ~SonicClientBase() = default;
 
@@ -22,13 +25,32 @@ public:
 protected:
   virtual void evaluate() = 0;
 
+  //this should be overridden by clients that allow retries
+  virtual unsigned allowedTries() const { return 0; }
+
   void setStartTime() {
+    tries_ = 0;
     if (debugName_.empty())
       return;
     t0_ = std::chrono::high_resolution_clock::now();
   }
 
-  void finish(std::exception_ptr eptr = std::exception_ptr{}) {
+  void finish(bool success, std::exception_ptr eptr = std::exception_ptr{}) {
+    if (!success) {
+      ++tries_;
+      //if max retries has not been exceeded, call evaluate again
+      if (tries_ < allowedTries()) {
+        evaluate();
+        //avoid calling doneWaiting() twice
+        return;
+      }
+      //prepare an exception if there isn't one already
+      else if (!eptr) {
+        cms::Exception ex("SonicCallFailed");
+        ex << "call failed after max " << tries_ << " tries";
+        eptr = make_exception_ptr(ex);
+      }
+    }
     if (!debugName_.empty()) {
       auto t1 = std::chrono::high_resolution_clock::now();
       edm::LogInfo(debugName_) << "Client time: "
@@ -38,6 +60,7 @@ protected:
   }
 
   //members
+  unsigned tries_;
   edm::WaitingTaskWithArenaHolder holder_;
 
   //for logging/debugging

--- a/HeterogeneousCore/SonicCore/test/DummyClient.h
+++ b/HeterogeneousCore/SonicCore/test/DummyClient.h
@@ -15,12 +15,11 @@ template <typename Client>
 class DummyClient : public Client {
 public:
   //constructor
-  DummyClient(const edm::ParameterSet& params) :
-    factor_(params.getParameter<int>("factor")),
-    wait_(params.getParameter<int>("wait")),
-    allowedTries_(params.getParameter<unsigned>("allowedTries")),
-    fails_(params.getParameter<unsigned>("fails"))
-  {}
+  DummyClient(const edm::ParameterSet& params)
+      : factor_(params.getParameter<int>("factor")),
+        wait_(params.getParameter<int>("wait")),
+        allowedTries_(params.getParameter<unsigned>("allowedTries")),
+        fails_(params.getParameter<unsigned>("fails")) {}
 
   //for fillDescriptions
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
@@ -42,8 +41,10 @@ protected:
     this->output_ = this->input_ * factor_;
 
     //simulate a failure
-    if(this->tries_ < fails_) this->finish(false);
-    else this->finish(true);
+    if (this->tries_ < fails_)
+      this->finish(false);
+    else
+      this->finish(true);
   }
 
   //members

--- a/HeterogeneousCore/SonicCore/test/DummyClient.h
+++ b/HeterogeneousCore/SonicCore/test/DummyClient.h
@@ -15,29 +15,42 @@ template <typename Client>
 class DummyClient : public Client {
 public:
   //constructor
-  DummyClient(const edm::ParameterSet& params)
-      : factor_(params.getParameter<int>("factor")), wait_(params.getParameter<int>("wait")) {}
+  DummyClient(const edm::ParameterSet& params) :
+    factor_(params.getParameter<int>("factor")),
+    wait_(params.getParameter<int>("wait")),
+    allowedTries_(params.getParameter<unsigned>("allowedTries")),
+    fails_(params.getParameter<unsigned>("fails"))
+  {}
 
   //for fillDescriptions
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     edm::ParameterSetDescription descClient;
     descClient.add<int>("factor", -1);
     descClient.add<int>("wait", 10);
+    descClient.add<unsigned>("allowedTries", 0);
+    descClient.add<unsigned>("fails", 0);
     iDesc.add<edm::ParameterSetDescription>("Client", descClient);
   }
 
 protected:
+  unsigned allowedTries() const override { return allowedTries_; }
+
   void evaluate() override {
     //simulate a blocking call
     std::this_thread::sleep_for(std::chrono::seconds(wait_));
 
     this->output_ = this->input_ * factor_;
-    this->finish();
+
+    //simulate a failure
+    if(this->tries_ < fails_) this->finish(false);
+    else this->finish(true);
   }
 
   //members
   int factor_;
   int wait_;
+  unsigned allowedTries_;
+  unsigned fails_;
 };
 
 typedef DummyClient<SonicClientSync<int>> DummyClientSync;

--- a/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
+++ b/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
@@ -14,8 +14,8 @@ process.dummySync = cms.EDProducer("SonicDummyProducerSync",
     Client = cms.PSet(
         factor = cms.int32(-1),
         wait = cms.int32(10),
-        allowedTries = cms.uint32(3),
-        fails = cms.uint32(2),
+        allowedTries = cms.uint32(0),
+        fails = cms.uint32(0),
     ),
 )
 
@@ -39,7 +39,34 @@ process.dummyAsync = cms.EDProducer("SonicDummyProducerAsync",
     ),
 )
 
-process.task = cms.Task(process.dummySync,process.dummyPseudoAsync,process.dummyAsync)
+process.dummySyncRetry = process.dummySync.clone(
+    Client = dict(
+        wait = 2,
+        allowedTries = 2,
+        fails = 1,
+    )
+)
+
+process.dummyPseudoAsyncRetry = process.dummyPseudoAsync.clone(
+    Client = dict(
+        wait = 2,
+        allowedTries = 2,
+        fails = 1,
+    )
+)
+
+process.dummyAsyncRetry = process.dummyAsync.clone(
+    Client = dict(
+        wait = 2,
+        allowedTries = 2,
+        fails = 1,
+    )
+)
+
+process.task = cms.Task(
+    process.dummySync,process.dummyPseudoAsync,process.dummyAsync,
+    process.dummySyncRetry,process.dummyPseudoAsyncRetry,process.dummyAsyncRetry,
+)
 
 process.testerSync = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(-1),
@@ -56,6 +83,21 @@ process.testerAsync = cms.EDAnalyzer("IntTestAnalyzer",
     moduleLabel = cms.untracked.string("dummyAsync"),
 )
 
+process.testerSyncRetry = process.testerSync.clone(
+    moduleLabel = cms.untracked.string("dummySyncRetry")
+)
+
+process.testerPseudoAsyncRetry = process.testerPseudoAsync.clone(
+    moduleLabel = cms.untracked.string("dummyPseudoAsyncRetry")
+)
+
+process.testerAsyncRetry = process.testerAsync.clone(
+    moduleLabel = cms.untracked.string("dummyAsyncRetry")
+)
+
 process.p1 = cms.Path(process.testerSync, process.task)
 process.p2 = cms.Path(process.testerPseudoAsync, process.task)
 process.p3 = cms.Path(process.testerAsync, process.task)
+process.p4 = cms.Path(process.testerSyncRetry, process.task)
+process.p5 = cms.Path(process.testerPseudoAsyncRetry, process.task)
+process.p6 = cms.Path(process.testerAsyncRetry, process.task)

--- a/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
+++ b/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
@@ -14,6 +14,8 @@ process.dummySync = cms.EDProducer("SonicDummyProducerSync",
     Client = cms.PSet(
         factor = cms.int32(-1),
         wait = cms.int32(10),
+        allowedTries = cms.uint32(3),
+        fails = cms.uint32(2),
     ),
 )
 
@@ -22,6 +24,8 @@ process.dummyPseudoAsync = cms.EDProducer("SonicDummyProducerPseudoAsync",
     Client = cms.PSet(
         factor = cms.int32(2),
         wait = cms.int32(10),
+        allowedTries = cms.uint32(0),
+        fails = cms.uint32(0),
     ),
 )
 
@@ -30,6 +34,8 @@ process.dummyAsync = cms.EDProducer("SonicDummyProducerAsync",
     Client = cms.PSet(
         factor = cms.int32(5),
         wait = cms.int32(10),
+        allowedTries = cms.uint32(0),
+        fails = cms.uint32(0),
     ),
 )
 


### PR DESCRIPTION
#### PR description:

In some cases, the connection a remote server could be temporarily interrupted. It may be desirable to try the request again, rather than failing immediately. This PR adds that functionality to the SONIC core framework, in such a way that it can be enabled (or not) by specific clients. The documentation is also updated.

#### PR validation:

Separate unit tests are added for this feature.

The case where the number of failures exceeds the number of allowed tries is not included in the unit tests, as it emits an exception. It has been tested privately, and the expected output was observed:
```
----- Begin Fatal Exception 10-Apr-2020 14:34:40 CDT-----------------------
An exception of category 'SonicCallFailed' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
   [1] Running path 'p3'
   [2] Prefetching for module IntTestAnalyzer/'testerAsync'
   [3] Calling method for module SonicDummyProducerAsync/'dummyAsync'
Exception Message:
call failed after max 3 tries
----- End Fatal Exception -------------------------------------------------
```
