### PR TITLE
ElectronNHitSeedProducer modernization

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -164,10 +164,30 @@ def customiseFor2017DtUnpacking(process):
 
     return process
 
+def customiseFor29512(process):
+    """Refresh configuration of ElectronNHitSeedProducer instances.
+    
+    Loops over some parameters of ElectronNHitSeedProducer instances and changes their type from string to ESInputTag.
+
+    For PR https://github.com/cms-sw/cmssw/pull/29512 "ElectronNHitSeedProducer modernization"
+    """
+
+    for producer in producers_by_type(process, "ElectronNHitSeedProducer"):
+        matcherConfig = producer.matcherConfig
+        for parameter_name in ("detLayerGeom", "navSchool", "paramMagField"):
+            if hasattr(matcherConfig, parameter_name):
+                old_parameter = getattr(matcherConfig, parameter_name)
+                if old_parameter.pythonTypeName().endswith("string"):
+                    old_value = old_parameter.pythonValue()[1:-1]
+                    setattr(matcherConfig, parameter_name, cms.ESInputTag("", old_value))
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseFor29512(process)
 
     return process

--- a/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
@@ -51,46 +51,17 @@ class TrackingRecHit;
 
 class TrajSeedMatcher {
 public:
-  class SCHitMatch {
-  public:
-    SCHitMatch() {}
-
-    //does not set charge,et,nrclus
-    SCHitMatch(const GlobalPoint& vtxPos, const TrajectoryStateOnSurface& trajState, const TrackingRecHit& hit);
-    ~SCHitMatch() = default;
-
-    void setExtra(float et, float eta, float phi, int charge, int nrClus) {
-      et_ = et;
-      eta_ = eta;
-      phi_ = phi;
-      charge_ = charge;
-      nrClus_ = nrClus;
-    }
-
-    int subdetId() const { return detId_.subdetId(); }
-    DetId detId() const { return detId_; }
-    float dRZ() const { return dRZ_; }
-    float dPhi() const { return dPhi_; }
-    const GlobalPoint& hitPos() const { return hitPos_; }
-    float et() const { return et_; }
-    float eta() const { return eta_; }
-    float phi() const { return phi_; }
-    int charge() const { return charge_; }
-    int nrClus() const { return nrClus_; }
-    const TrackingRecHit* hit() const { return hit_; }
-
-  private:
-    DetId detId_ = 0;
-    GlobalPoint hitPos_;
-    float dRZ_ = std::numeric_limits<float>::max();
-    float dPhi_ = std::numeric_limits<float>::max();
-    const TrackingRecHit* hit_ = nullptr;  //we do not own this
-    //extra quanities which are set later
-    float et_ = 0.f;
-    float eta_ = 0.f;
-    float phi_ = 0.f;
-    int charge_ = 0;
-    int nrClus_ = 0;
+  struct SCHitMatch {
+    const DetId detId = 0;
+    const GlobalPoint hitPos;
+    const float dRZ = std::numeric_limits<float>::max();
+    const float dPhi = std::numeric_limits<float>::max();
+    const TrackingRecHit& hit;
+    const float et = 0.f;
+    const float eta = 0.f;
+    const float phi = 0.f;
+    const int charge = 0;
+    const int nrClus = 0;
   };
 
   struct MatchInfo {
@@ -186,7 +157,7 @@ public:
     const bool requireExactMatchCount;
     const bool useParamMagFieldIfDefined;
 
-    //these two varibles determine how hits we require
+    //these two variables determine how hits we require
     //based on how many valid layers we had
     //right now we always need atleast two hits
     //also highly dependent on the seeds you pass in
@@ -219,20 +190,6 @@ private:
   static float getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos,
                                         const GlobalPoint& hitPos,
                                         const GlobalPoint& candPos);
-
-  bool passTrajPreSel(const GlobalPoint& hitPos, const GlobalPoint& candPos) const;
-
-  TrajSeedMatcher::SCHitMatch matchFirstHit(const TrajectorySeed& seed,
-                                            const TrajectoryStateOnSurface& trajState,
-                                            const GlobalPoint& vtxPos,
-                                            const PropagatorWithMaterial& propagator);
-
-  TrajSeedMatcher::SCHitMatch match2ndToNthHit(const TrajectorySeed& seed,
-                                               const FreeTrajectoryState& trajState,
-                                               const size_t hitNr,
-                                               const GlobalPoint& prevHitPos,
-                                               const GlobalPoint& vtxPos,
-                                               const PropagatorWithMaterial& propagator);
 
   const TrajectoryStateOnSurface& getTrajStateFromVtx(const TrackingRecHit& hit,
                                                       const TrajectoryStateOnSurface& initialState,
@@ -274,7 +231,6 @@ private:
 
 private:
   static constexpr float kElectronMass_ = 0.000511;
-  static constexpr float kPhiCut_ = -0.801144;  //cos(2.5)
 
   Configuration const& cfg_;
 

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -10,49 +10,71 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
-#include "TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
-
-#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
 
 #include "TrackingTools/TrajectoryState/interface/ftsFromVertexToPoint.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
 constexpr float TrajSeedMatcher::kElectronMass_;
 
-TrajSeedMatcher::TrajSeedMatcher(const edm::ParameterSet& pset)
-    : cacheIDMagField_(0),
-      paramMagFieldLabel_(pset.getParameter<std::string>("paramMagField")),
-      navSchoolLabel_(pset.getParameter<std::string>("navSchool")),
-      detLayerGeomLabel_(pset.getParameter<std::string>("detLayerGeom")),
-      useRecoVertex_(pset.getParameter<bool>("useRecoVertex")),
-      enableHitSkipping_(pset.getParameter<bool>("enableHitSkipping")),
-      requireExactMatchCount_(pset.getParameter<bool>("requireExactMatchCount")),
-      useParamMagFieldIfDefined_(pset.getParameter<bool>("useParamMagFieldIfDefined")),
-      minNrHits_(pset.getParameter<std::vector<unsigned int> >("minNrHits")),
-      minNrHitsValidLayerBins_(pset.getParameter<std::vector<int> >("minNrHitsValidLayerBins")) {
-  const auto cutsPSets = pset.getParameter<std::vector<edm::ParameterSet> >("matchingCuts");
-  for (const auto& cutPSet : cutsPSets) {
-    int version = cutPSet.getParameter<int>("version");
-    switch (version) {
-      case 1:
-        matchingCuts_.emplace_back(std::make_unique<MatchingCutsV1>(cutPSet));
-        break;
-      case 2:
-        matchingCuts_.emplace_back(std::make_unique<MatchingCutsV2>(cutPSet));
-        break;
-      default:
-        throw cms::Exception("InvalidConfig") << " Error TrajSeedMatcher::TrajSeedMatcher pixel match cuts version "
-                                              << version << " not recognised" << std::endl;
-    }
-  }
+namespace {
+  auto makeMatchingCuts(std::vector<edm::ParameterSet> const& cutsPSets) {
+    std::vector<std::unique_ptr<TrajSeedMatcher::MatchingCuts> > matchingCuts;
 
-  if (minNrHitsValidLayerBins_.size() + 1 != minNrHits_.size()) {
+    for (const auto& cutPSet : cutsPSets) {
+      int version = cutPSet.getParameter<int>("version");
+      switch (version) {
+        case 1:
+          matchingCuts.emplace_back(std::make_unique<TrajSeedMatcher::MatchingCutsV1>(cutPSet));
+          break;
+        case 2:
+          matchingCuts.emplace_back(std::make_unique<TrajSeedMatcher::MatchingCutsV2>(cutPSet));
+          break;
+        default:
+          throw cms::Exception("InvalidConfig") << " Error TrajSeedMatcher::TrajSeedMatcher pixel match cuts version "
+                                                << version << " not recognised" << std::endl;
+      }
+    }
+
+    return matchingCuts;
+  }
+};  // namespace
+
+TrajSeedMatcher::Configuration::Configuration(const edm::ParameterSet& pset, edm::ConsumesCollector&& cc)
+    : magFieldToken{cc.esConsumes<MagneticField, IdealMagneticFieldRecord>()},
+      paramMagFieldToken{
+          cc.esConsumes<MagneticField, IdealMagneticFieldRecord>(pset.getParameter<edm::ESInputTag>("paramMagField"))},
+      navSchoolToken{
+          cc.esConsumes<NavigationSchool, NavigationSchoolRecord>(pset.getParameter<edm::ESInputTag>("navSchool"))},
+      detLayerGeomToken{
+          cc.esConsumes<DetLayerGeometry, RecoGeometryRecord>(pset.getParameter<edm::ESInputTag>("detLayerGeom"))},
+      useRecoVertex{pset.getParameter<bool>("useRecoVertex")},
+      enableHitSkipping{pset.getParameter<bool>("enableHitSkipping")},
+      requireExactMatchCount{pset.getParameter<bool>("requireExactMatchCount")},
+      useParamMagFieldIfDefined{pset.getParameter<bool>("useParamMagFieldIfDefined")},
+      minNrHits{pset.getParameter<std::vector<unsigned int> >("minNrHits")},
+      minNrHitsValidLayerBins{pset.getParameter<std::vector<int> >("minNrHitsValidLayerBins")},
+      matchingCuts{makeMatchingCuts(pset.getParameter<std::vector<edm::ParameterSet> >("matchingCuts"))} {
+  if (minNrHitsValidLayerBins.size() + 1 != minNrHits.size()) {
     throw cms::Exception("InvalidConfig")
         << " TrajSeedMatcher::TrajSeedMatcher minNrHitsValidLayerBins should be 1 less than minNrHits when its "
-        << minNrHitsValidLayerBins_.size() << " vs " << minNrHits_.size();
+        << minNrHitsValidLayerBins.size() << " vs " << minNrHits.size();
   }
 }
+
+TrajSeedMatcher::TrajSeedMatcher(TrajSeedMatcher::Configuration const& cfg,
+                                 edm::EventSetup const& iSetup,
+                                 MeasurementTrackerEvent const& measTkEvt)
+    : cfg_{cfg},
+      magField_{iSetup.getData(cfg_.magFieldToken)},
+      magFieldParam_{iSetup.getData(cfg_.paramMagFieldToken)},
+      measTkEvt_{measTkEvt},
+      navSchool_{iSetup.getData(cfg_.navSchoolToken)},
+      detLayerGeom_{iSetup.getData(cfg_.detLayerGeomToken)},
+      forwardPropagator_(alongMomentum, kElectronMass_, &magField_),
+      backwardPropagator_(oppositeToMomentum, kElectronMass_, &magField_) {}
 
 edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription() {
   edm::ParameterSetDescription desc;
@@ -60,9 +82,9 @@ edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription() {
   desc.add<bool>("enableHitSkipping", false);
   desc.add<bool>("requireExactMatchCount", true);
   desc.add<bool>("useParamMagFieldIfDefined", true);
-  desc.add<std::string>("paramMagField", "ParabolicMf");
-  desc.add<std::string>("navSchool", "SimpleNavigationSchool");
-  desc.add<std::string>("detLayerGeom", "hltESPGlobalDetLayerGeometry");
+  desc.add<edm::ESInputTag>("paramMagField", edm::ESInputTag{"", "ParabolicMf"});
+  desc.add<edm::ESInputTag>("navSchool", edm::ESInputTag{"", "SimpleNavigationSchool"});
+  desc.add<edm::ESInputTag>("detLayerGeom", edm::ESInputTag{"", "hltESPGlobalDetLayerGeometry"});
   desc.add<std::vector<int> >("minNrHitsValidLayerBins", {4});
   desc.add<std::vector<unsigned int> >("minNrHits", {2, 3});
 
@@ -70,10 +92,8 @@ edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription() {
   auto cutDescCases = 1 >> (edm::ParameterDescription<double>("dPhiMax", 0.04, true) and
                             edm::ParameterDescription<double>("dRZMax", 0.09, true) and
                             edm::ParameterDescription<double>("dRZMaxLowEtThres", 20., true) and
-                            edm::ParameterDescription<std::vector<double> >(
-                                "dRZMaxLowEtEtaBins", std::vector<double>{1., 1.5}, true) and
-                            edm::ParameterDescription<std::vector<double> >(
-                                "dRZMaxLowEt", std::vector<double>{0.09, 0.15, 0.09}, true)) or
+                            edm::ParameterDescription<std::vector<double> >("dRZMaxLowEtEtaBins", {1., 1.5}, true) and
+                            edm::ParameterDescription<std::vector<double> >("dRZMaxLowEt", {0.09, 0.15, 0.09}, true)) or
                       2 >> (edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEt", {0.003}, true) and
                             edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEtThres", {0.0}, true) and
                             edm::ParameterDescription<std::vector<double> >("dPhiMaxLowEtGrad", {0.0}, true) and
@@ -94,28 +114,10 @@ edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription() {
   return desc;
 }
 
-void TrajSeedMatcher::doEventSetup(const edm::EventSetup& iSetup) {
-  if (cacheIDMagField_ != iSetup.get<IdealMagneticFieldRecord>().cacheIdentifier()) {
-    iSetup.get<IdealMagneticFieldRecord>().get(magField_);
-    if (useParamMagFieldIfDefined_)
-      iSetup.get<IdealMagneticFieldRecord>().get(paramMagFieldLabel_, magFieldParam_);
-    cacheIDMagField_ = iSetup.get<IdealMagneticFieldRecord>().cacheIdentifier();
-    forwardPropagator_ = std::make_unique<PropagatorWithMaterial>(alongMomentum, kElectronMass_, &*(magField_));
-    backwardPropagator_ = std::make_unique<PropagatorWithMaterial>(oppositeToMomentum, kElectronMass_, &*(magField_));
-  }
-  iSetup.get<NavigationSchoolRecord>().get(navSchoolLabel_, navSchool_);
-  iSetup.get<RecoGeometryRecord>().get(detLayerGeomLabel_, detLayerGeom_);
-}
-
-std::vector<TrajSeedMatcher::SeedWithInfo> TrajSeedMatcher::compatibleSeeds(const TrajectorySeedCollection& seeds,
-                                                                            const GlobalPoint& candPos,
-                                                                            const GlobalPoint& vprim,
-                                                                            const float energy) {
-  if (!forwardPropagator_ || !backwardPropagator_ || !magField_.isValid()) {
-    throw cms::Exception("LogicError") << __FUNCTION__
-                                       << " can not make pixel seeds as event setup has not properly been called";
-  }
-
+std::vector<TrajSeedMatcher::SeedWithInfo> TrajSeedMatcher::operator()(const TrajectorySeedCollection& seeds,
+                                                                       const GlobalPoint& candPos,
+                                                                       const GlobalPoint& vprim,
+                                                                       const float energy) {
   clearCache();
 
   std::vector<SeedWithInfo> matchedSeeds;
@@ -140,7 +142,7 @@ std::vector<TrajSeedMatcher::SeedWithInfo> TrajSeedMatcher::compatibleSeeds(cons
     int nrValidLayers = std::max(nrValidLayersNeg, nrValidLayersPos);
     size_t nrHitsRequired = getNrHitsRequired(nrValidLayers);
     bool matchCountPasses;
-    if (requireExactMatchCount_) {
+    if (cfg_.requireExactMatchCount) {
       // If the input seed collection is not cross-cleaned, an exact match is necessary to
       // prevent redundant seeds.
       matchCountPasses = matchedHitsNeg.size() == nrHitsRequired || matchedHitsPos.size() == nrHitsRequired;
@@ -168,23 +170,23 @@ std::vector<TrajSeedMatcher::SCHitMatch> TrajSeedMatcher::processSeed(const Traj
   FreeTrajectoryState firstHitFreeTraj;
   GlobalPoint prevHitPos;
   GlobalPoint vertex;
-  for (size_t hitNr = 0; hitNr < matchingCuts_.size() && hitNr < seed.nHits(); hitNr++) {
+  for (size_t hitNr = 0; hitNr < cfg_.matchingCuts.size() && hitNr < seed.nHits(); hitNr++) {
     bool matched = false;
     if (matchedHits.empty()) {  // First hit is special
-      SCHitMatch firstHit = matchFirstHit(seed, initialTrajState, vprim, *backwardPropagator_);
+      SCHitMatch firstHit = matchFirstHit(seed, initialTrajState, vprim, backwardPropagator_);
       firstHit.setExtra(candEt, candEta, candPos.phi(), charge, 1);
       if (passesMatchSel(firstHit, 0)) {
         matched = true;
         matchedHits.push_back(firstHit);
         //now we can figure out the z vertex
-        double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim, firstHit.hitPos(), candPos);
+        double zVertex = cfg_.useRecoVertex ? vprim.z() : getZVtxFromExtrapolation(vprim, firstHit.hitPos(), candPos);
         vertex = GlobalPoint(vprim.x(), vprim.y(), zVertex);
         firstHitFreeTraj = trackingTools::ftsFromVertexToPoint(
             getMagField(firstHit.hitPos()), firstHit.hitPos(), vertex, energy, charge);
         prevHitPos = firstHit.hitPos();
       }
     } else {  // All subsequent hits are handled the same
-      SCHitMatch hit = match2ndToNthHit(seed, firstHitFreeTraj, hitNr, prevHitPos, vertex, *forwardPropagator_);
+      SCHitMatch hit = match2ndToNthHit(seed, firstHitFreeTraj, hitNr, prevHitPos, vertex, forwardPropagator_);
       hit.setExtra(candEt, candEta, candPos.phi(), charge, 1);
       if (passesMatchSel(hit, matchedHits.size())) {
         matched = true;
@@ -192,7 +194,7 @@ std::vector<TrajSeedMatcher::SCHitMatch> TrajSeedMatcher::processSeed(const Traj
         prevHitPos = hit.hitPos();
       }
     }
-    if (!matched and !enableHitSkipping_)
+    if (!matched and !cfg_.enableHitSkipping)
       break;
   }
   return matchedHits;
@@ -306,11 +308,11 @@ void TrajSeedMatcher::clearCache() {
 }
 
 bool TrajSeedMatcher::passesMatchSel(const TrajSeedMatcher::SCHitMatch& hit, const size_t hitNr) const {
-  if (hitNr < matchingCuts_.size()) {
-    return (*matchingCuts_[hitNr])(hit);
+  if (hitNr < cfg_.matchingCuts.size()) {
+    return (*cfg_.matchingCuts[hitNr])(hit);
   } else {
     throw cms::Exception("LogicError") << " Error, attempting to apply selection to hit " << hitNr
-                                       << " but only cuts for " << matchingCuts_.size() << " defined";
+                                       << " but only cuts for " << cfg_.matchingCuts.size() << " defined";
   }
 }
 
@@ -320,23 +322,23 @@ int TrajSeedMatcher::getNrValidLayersAlongTraj(const SCHitMatch& hit1,
                                                const GlobalPoint& vprim,
                                                const float energy,
                                                const int charge) {
-  double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim, hit1.hitPos(), candPos);
+  double zVertex = cfg_.useRecoVertex ? vprim.z() : getZVtxFromExtrapolation(vprim, hit1.hitPos(), candPos);
   GlobalPoint vertex(vprim.x(), vprim.y(), zVertex);
 
   auto firstHitFreeTraj =
       trackingTools::ftsFromVertexToPoint(getMagField(hit1.hitPos()), hit1.hitPos(), vertex, energy, charge);
-  auto const& secondHitTraj = getTrajStateFromPoint(*hit2.hit(), firstHitFreeTraj, hit1.hitPos(), *forwardPropagator_);
+  auto const& secondHitTraj = getTrajStateFromPoint(*hit2.hit(), firstHitFreeTraj, hit1.hitPos(), forwardPropagator_);
   return getNrValidLayersAlongTraj(hit2.hit()->geographicalId(), secondHitTraj);
 }
 
 int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId, const TrajectoryStateOnSurface& hitTrajState) const {
-  const DetLayer* detLayer = detLayerGeom_->idToLayer(hitId);
+  const DetLayer* detLayer = detLayerGeom_.idToLayer(hitId);
   if (detLayer == nullptr)
     return 0;
 
   const FreeTrajectoryState& hitFreeState = *hitTrajState.freeState();
-  auto const inLayers = navSchool_->compatibleLayers(*detLayer, hitFreeState, oppositeToMomentum);
-  const std::vector<const DetLayer*> outLayers = navSchool_->compatibleLayers(*detLayer, hitFreeState, alongMomentum);
+  auto const inLayers = navSchool_.compatibleLayers(*detLayer, hitFreeState, oppositeToMomentum);
+  const auto outLayers = navSchool_.compatibleLayers(*detLayer, hitFreeState, alongMomentum);
 
   int nrValidLayers = 1;  //because our current hit is also valid and wont be included in the count otherwise
   int nrPixInLayers = 0;
@@ -344,14 +346,14 @@ int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId, const Traject
   for (auto layer : inLayers) {
     if (GeomDetEnumerators::isTrackerPixel(layer->subDetector())) {
       nrPixInLayers++;
-      if (layerHasValidHits(*layer, hitTrajState, *backwardPropagator_))
+      if (layerHasValidHits(*layer, hitTrajState, backwardPropagator_))
         nrValidLayers++;
     }
   }
   for (auto layer : outLayers) {
     if (GeomDetEnumerators::isTrackerPixel(layer->subDetector())) {
       nrPixOutLayers++;
-      if (layerHasValidHits(*layer, hitTrajState, *forwardPropagator_))
+      if (layerHasValidHits(*layer, hitTrajState, forwardPropagator_))
         nrValidLayers++;
     }
   }
@@ -372,7 +374,7 @@ bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer,
     return false;
   else {
     DetId id = detWithState.front().first->geographicalId();
-    MeasurementDetWithData measDet = measTkEvt_->idToDet(id);
+    MeasurementDetWithData measDet = measTkEvt_.idToDet(id);
     if (measDet.isActive())
       return true;
     else
@@ -381,11 +383,11 @@ bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer,
 }
 
 size_t TrajSeedMatcher::getNrHitsRequired(const int nrValidLayers) const {
-  for (size_t binNr = 0; binNr < minNrHitsValidLayerBins_.size(); binNr++) {
-    if (nrValidLayers < minNrHitsValidLayerBins_[binNr])
-      return minNrHits_[binNr];
+  for (size_t binNr = 0; binNr < cfg_.minNrHitsValidLayerBins.size(); binNr++) {
+    if (nrValidLayers < cfg_.minNrHitsValidLayerBins[binNr])
+      return cfg_.minNrHits[binNr];
   }
-  return minNrHits_.back();
+  return cfg_.minNrHits.back();
 }
 
 TrajSeedMatcher::SCHitMatch::SCHitMatch(const GlobalPoint& vtxPos,

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
@@ -14,11 +14,10 @@
 //
 //*******************************************************************************
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -26,7 +25,6 @@
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
@@ -37,35 +35,29 @@
 
 #include "RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h"
 
-class ElectronNHitSeedProducer : public edm::stream::EDProducer<> {
+class ElectronNHitSeedProducer : public edm::global::EDProducer<> {
 public:
   explicit ElectronNHitSeedProducer(const edm::ParameterSet&);
-  ~ElectronNHitSeedProducer() override = default;
 
-  void produce(edm::Event&, const edm::EventSetup&) final;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const final;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  TrajSeedMatcher matcher_;
+  const TrajSeedMatcher::Configuration matcherConfiguration_;
 
   std::vector<edm::EDGetTokenT<std::vector<reco::SuperClusterRef>>> superClustersTokens_;
-  edm::EDGetTokenT<TrajectorySeedCollection> initialSeedsToken_;
-  edm::EDGetTokenT<std::vector<reco::Vertex>> verticesToken_;
-  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
-  edm::EDGetTokenT<MeasurementTrackerEvent> measTkEvtToken_;
+  const edm::EDGetTokenT<TrajectorySeedCollection> initialSeedsToken_;
+  const edm::EDGetTokenT<std::vector<reco::Vertex>> verticesToken_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  const edm::EDGetTokenT<MeasurementTrackerEvent> measTkEvtToken_;
+  const edm::EDPutTokenT<reco::ElectronSeedCollection> putToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
 };
 
 namespace {
   template <typename T>
-  edm::Handle<T> getHandle(const edm::Event& event, const edm::EDGetTokenT<T>& token) {
-    edm::Handle<T> handle;
-    event.getByToken(token, handle);
-    return handle;
-  }
-
-  template <typename T>
-  GlobalPoint convertToGP(const T& orgPoint) {
+  inline auto convertToGP(const T& orgPoint) {
     return GlobalPoint(orgPoint.x(), orgPoint.y(), orgPoint.z());
   }
 
@@ -92,56 +84,50 @@ namespace {
 }  // namespace
 
 ElectronNHitSeedProducer::ElectronNHitSeedProducer(const edm::ParameterSet& pset)
-    : matcher_(pset.getParameter<edm::ParameterSet>("matcherConfig")),
+    : matcherConfiguration_(pset.getParameter<edm::ParameterSet>("matcherConfig"), consumesCollector()),
       initialSeedsToken_(consumes<TrajectorySeedCollection>(pset.getParameter<edm::InputTag>("initialSeeds"))),
       verticesToken_(consumes<std::vector<reco::Vertex>>(pset.getParameter<edm::InputTag>("vertices"))),
       beamSpotToken_(consumes<reco::BeamSpot>(pset.getParameter<edm::InputTag>("beamSpot"))),
-      measTkEvtToken_(consumes<MeasurementTrackerEvent>(pset.getParameter<edm::InputTag>("measTkEvt"))) {
-  const auto superClusTags = pset.getParameter<std::vector<edm::InputTag>>("superClusters");
-  for (const auto& scTag : superClusTags) {
+      measTkEvtToken_(consumes<MeasurementTrackerEvent>(pset.getParameter<edm::InputTag>("measTkEvt"))),
+      putToken_{produces<reco::ElectronSeedCollection>()},
+      trackerTopologyToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()} {
+  for (const auto& scTag : pset.getParameter<std::vector<edm::InputTag>>("superClusters")) {
     superClustersTokens_.emplace_back(consumes<std::vector<reco::SuperClusterRef>>(scTag));
   }
-  produces<reco::ElectronSeedCollection>();
 }
 
 void ElectronNHitSeedProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("initialSeeds", edm::InputTag("hltElePixelSeedsCombined"));
-  desc.add<edm::InputTag>("vertices", edm::InputTag());
-  desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
-  desc.add<edm::InputTag>("measTkEvt", edm::InputTag("hltSiStripClusters"));
-  desc.add<std::vector<edm::InputTag>>("superClusters",
-                                       std::vector<edm::InputTag>{edm::InputTag{"hltEgammaSuperClustersToPixelMatch"}});
+  desc.add<edm::InputTag>("initialSeeds", {"hltElePixelSeedsCombined"});
+  desc.add<edm::InputTag>("vertices", {});
+  desc.add<edm::InputTag>("beamSpot", {"hltOnlineBeamSpot"});
+  desc.add<edm::InputTag>("measTkEvt", {"hltSiStripClusters"});
+  desc.add<std::vector<edm::InputTag>>("superClusters", {{"hltEgammaSuperClustersToPixelMatch"}});
   desc.add<edm::ParameterSetDescription>("matcherConfig", TrajSeedMatcher::makePSetDescription());
 
   descriptions.add("electronNHitSeedProducer", desc);
 }
 
-void ElectronNHitSeedProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerTopology> trackerTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(trackerTopoHandle);
+void ElectronNHitSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto const& trackerTopology = iSetup.getData(trackerTopologyToken_);
 
-  matcher_.doEventSetup(iSetup);
-  matcher_.setMeasTkEvtHandle(getHandle(iEvent, measTkEvtToken_));
+  TrajSeedMatcher matcher{matcherConfiguration_, iSetup, iEvent.get(measTkEvtToken_)};
 
-  auto eleSeeds = std::make_unique<reco::ElectronSeedCollection>();
-  auto initialSeedsHandle = getHandle(iEvent, initialSeedsToken_);
+  reco::ElectronSeedCollection eleSeeds{};
+  auto const& initialSeeds = iEvent.get(initialSeedsToken_);
 
-  auto beamSpotHandle = getHandle(iEvent, beamSpotToken_);
-  GlobalPoint primVtxPos = convertToGP(beamSpotHandle->position());
+  auto primVtxPos = convertToGP(iEvent.get(beamSpotToken_).position());
 
   // Loop over all super-cluster collections (typically barrel and forward are supplied separately)
   for (const auto& superClustersToken : superClustersTokens_) {
-    auto superClustersHandle = getHandle(iEvent, superClustersToken);
-    for (auto& superClusRef : *superClustersHandle) {
+    for (auto& superClusRef : iEvent.get(superClustersToken)) {
       //the eta of the supercluster when mustache clustered is slightly biased due to bending in magnetic field
       //the eta of its seed cluster is a better estimate of the orginal position
       GlobalPoint caloPosition(GlobalPoint::Polar(superClusRef->seed()->position().theta(),  //seed theta
                                                   superClusRef->position().phi(),            //supercluster phi
                                                   superClusRef->position().r()));            //supercluster r
 
-      const std::vector<TrajSeedMatcher::SeedWithInfo> matchedSeeds =
-          matcher_.compatibleSeeds(*initialSeedsHandle, caloPosition, primVtxPos, superClusRef->energy());
+      const auto matchedSeeds = matcher(initialSeeds, caloPosition, primVtxPos, superClusRef->energy());
 
       for (auto& matchedSeed : matchedSeeds) {
         reco::ElectronSeed eleSeed(matchedSeed.seed());
@@ -149,13 +135,14 @@ void ElectronNHitSeedProducer::produce(edm::Event& iEvent, const edm::EventSetup
         eleSeed.setCaloCluster(caloClusRef);
         eleSeed.setNrLayersAlongTraj(matchedSeed.nrValidLayers());
         for (auto& matchInfo : matchedSeed.matches()) {
-          eleSeed.addHitInfo(makeSeedPixelVar(matchInfo, *trackerTopoHandle));
+          eleSeed.addHitInfo(makeSeedPixelVar(matchInfo, trackerTopology));
         }
-        eleSeeds->emplace_back(eleSeed);
+        eleSeeds.emplace_back(eleSeed);
       }
     }
   }
-  iEvent.put(std::move(eleSeeds));
+  iEvent.emplace(putToken_, std::move(eleSeeds));
 }
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(ElectronNHitSeedProducer);


### PR DESCRIPTION
#### PR description:

In https://github.com/cms-sw/cmssw/pull/29304 it was discussed that the `ElectronSeedProducer` should be replaced at some point with the `ElectronNHitSeedProducer` which is already used at HLT. That's indeed a good idea, but it would be good if we update the `ElectronNHitSeedProducer` first to fulfil some good practices for producer plugins, which this PR implements:

1. Usage of `EDPutToken`
2. Usage of `ESGetToken` instead of caching the event setup objects manually (the framework does this efficiently for us)
3. Move from `stream` to `global` module to enforce good design practice (like `const` functions and immutable algorithm classes)

In particular, the move to a `global` module was achieved  by splitting the `TrajSeedMatcher` class up in a `const` configuration structure which is initialized in the constructor of the plugin, and an actual algorithm class which is instantiated for each event using a reference to the configuration. This pattern is already used in some other plugins (like the `GsfElectronAlgo`) and I think it makes sense.

#### PR validation:

CMSSW compiles and local matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.
