### PR TITLE
decrease event size by storing PFCandidates with half precision float…

### DIFF
--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -156,13 +156,16 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
           ++index_counter;
         }
 
-	if(storeWithHalfPrecisionFloatingPoint) {
-	   outPFCandidates->emplace_back(MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(cand.pt())), MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(cand.eta())), MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(cand.phi())), MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(cand.mass())), cand.pdgId(), vertex_index);
-	} 
-	else {
-	   outPFCandidates->emplace_back(cand.pt(), cand.eta(), cand.phi(), cand.mass(), cand.pdgId(), vertex_index);
-	}
-
+        if (storeWithHalfPrecisionFloatingPoint) {
+          outPFCandidates->emplace_back(MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(cand.pt())),
+                                        MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(cand.eta())),
+                                        MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(cand.phi())),
+                                        MiniFloatConverter::float16to32(MiniFloatConverter::float32to16(cand.mass())),
+                                        cand.pdgId(),
+                                        vertex_index);
+        } else {
+          outPFCandidates->emplace_back(cand.pt(), cand.eta(), cand.phi(), cand.mass(), cand.pdgId(), vertex_index);
+        }
       }
     }
   }


### PR DESCRIPTION
… point format

#### PR description:

As mentioned in a TSG on Jan. 15th:
https://indico.cern.ch/event/878772/contributions/3703563/attachments/1969842/3276766/ScoutingGroup.pdf

The PFScouting event size is reduced by 40% when PFCandidate 4-vectors are stored in Hal precision floating point format. I used the libminifloat class in CMSSW and convert back to float32 (the type returned by float32to16 is uint16_t) and let the compression reduce the information being stored.

#### PR validation:

I was running with and without the change and compared the output, and it looks the same. The per event size of the corresponding collection is indeed reduced after checking via edmEventSize.

File outputScoutingPF.root Events 10
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event)
**float16:** ScoutingParticles_hltScoutingPFPacker__HLT2018. 24530.5 7804.4
**float32:** ScoutingParticles_hltScoutingPFPacker__HLT2018. 24530.5 12444.5

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)