### PR TITLE
Turn on New Truth Matching

### DIFF
--- a/SimTracker/TrackTriggerAssociation/python/TTTrackAssociation_cfi.py
+++ b/SimTracker/TrackTriggerAssociation/python/TTTrackAssociation_cfi.py
@@ -6,6 +6,6 @@ TTTrackAssociatorFromPixelDigis = cms.EDProducer("TTTrackAssociator_Phase2Tracke
     ),
     TTClusterTruth = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
     TTStubTruth = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),
-    TTTrackAllowOneFalse2SStub = cms.bool(False),
+    TTTrackAllowOneFalse2SStub = cms.bool(True),
 )
 


### PR DESCRIPTION
#### PR description:

A new MC truth matching is set as our default option, expected consequences are:

-Tracking efficiency goes up by 1.3% 
-Almost no impact on eta, z0 resolution
-Modest impact on phi, pT resolution

This is a relevant talk I gave at L1TK algo meeting:
[https://indico.cern.ch/event/907491/contributions/3827940/attachments/2020524/3378294/AlgoMeeting_April_15.pdf]()