### PR TITLE
Update eventcontent structure for RecoBTag and RecoBTau

### DIFF
--- a/RecoBTag/Configuration/python/RecoBTag_EventContent_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_EventContent_cff.py
@@ -1,77 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content
-RecoBTagFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_softPFMuonsTagInfos_*_*',
-        'keep *_softPFElectronsTagInfos_*_*',
-        'keep *_softPFElectronBJetTags_*_*',
-        'keep *_softPFMuonBJetTags_*_*',
-        'keep *_pfImpactParameterTagInfos_*_*',
-        'keep *_pfTrackCountingHighEffBJetTags_*_*',
-        'keep *_pfJetProbabilityBJetTags_*_*',
-        'keep *_pfJetBProbabilityBJetTags_*_*',
-        'keep *_pfSecondaryVertexTagInfos_*_*',
-        'keep *_pfInclusiveSecondaryVertexFinderTagInfos_*_*',
-        'keep *_pfSimpleSecondaryVertexHighEffBJetTags_*_*',
-        'keep *_pfSimpleInclusiveSecondaryVertexHighEffBJetTags_*_*',
-        'keep *_pfCombinedSecondaryVertexV2BJetTags_*_*',
-        'keep *_pfCombinedInclusiveSecondaryVertexV2BJetTags_*_*',
-        'keep *_pfGhostTrackVertexTagInfos_*_*',
-        'keep *_pfGhostTrackBJetTags_*_*',
-        'keep *_pfCombinedMVAV2BJetTags_*_*',
-        'keep *_inclusiveCandidateSecondaryVertices_*_*',
-        # CTagging
-        'keep *_inclusiveCandidateSecondaryVerticesCvsL_*_*',
-        'keep *_pfInclusiveSecondaryVertexFinderCvsLTagInfos_*_*',
-        'keep *_pfCombinedCvsLJetTags_*_*',
-        'keep *_pfCombinedCvsBJetTags_*_*',
-        # ChargeTag
-        'keep *_pfChargeBJetTags_*_*',
-        # DeepFlavour
-        'keep *_pfDeepCSVJetTags_*_*',
-        # DeepCMVA
-        'keep *_pfDeepCMVAJetTags_*_*',
-        # Pixel Cluster
-        'keep *_pixelClusterTagInfos_*_*',
-    )
-)
-#RECO content
-RecoBTagRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_softPFMuonsTagInfos_*_*',
-        'keep *_softPFElectronsTagInfos_*_*',
-        'keep *_softPFElectronBJetTags_*_*',
-        'keep *_softPFMuonBJetTags_*_*',
-        'keep *_pfImpactParameterTagInfos_*_*',
-        'keep *_pfTrackCountingHighEffBJetTags_*_*',
-        'keep *_pfJetProbabilityBJetTags_*_*',
-        'keep *_pfJetBProbabilityBJetTags_*_*',
-        'keep *_pfSecondaryVertexTagInfos_*_*',
-        'keep *_pfInclusiveSecondaryVertexFinderTagInfos_*_*',
-        'keep *_pfSimpleSecondaryVertexHighEffBJetTags_*_*',
-        'keep *_pfSimpleInclusiveSecondaryVertexHighEffBJetTags_*_*',
-        'keep *_pfCombinedSecondaryVertexV2BJetTags_*_*',
-        'keep *_pfCombinedInclusiveSecondaryVertexV2BJetTags_*_*',
-        'keep *_pfGhostTrackVertexTagInfos_*_*',
-        'keep *_pfGhostTrackBJetTags_*_*',
-        'keep *_pfCombinedMVAV2BJetTags_*_*',
-        'keep *_inclusiveCandidateSecondaryVertices_*_*',
-        # CTagging
-        'keep *_inclusiveCandidateSecondaryVerticesCvsL_*_*',
-        'keep *_pfInclusiveSecondaryVertexFinderCvsLTagInfos_*_*',
-        'keep *_pfCombinedCvsLJetTags_*_*',
-        'keep *_pfCombinedCvsBJetTags_*_*',
-        # ChargeTag
-        'keep *_pfChargeBJetTags_*_*',
-        # DeepFlavour
-        'keep *_pfDeepCSVJetTags_*_*',
-        # DeepCMVA
-        'keep *_pfDeepCMVAJetTags_*_*',
-        # Pixel Cluster
-        'keep *_pixelClusterTagInfos_*_*',
-    )
-)
 #AOD content
 RecoBTagAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -98,6 +26,25 @@ RecoBTagAOD = cms.PSet(
         # DeepCMVA
         'keep *_pfDeepCMVAJetTags_*_*',
         # Pixel Cluster
-        'keep *_pixelClusterTagInfos_*_*',
-    )
+        'keep *_pixelClusterTagInfos_*_*')
 )
+
+#RECO content
+RecoBTagRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_softPFMuonsTagInfos_*_*',
+        'keep *_softPFElectronsTagInfos_*_*',
+        'keep *_pfImpactParameterTagInfos_*_*',
+        'keep *_pfSecondaryVertexTagInfos_*_*',
+        'keep *_pfInclusiveSecondaryVertexFinderTagInfos_*_*',
+        'keep *_pfGhostTrackVertexTagInfos_*_*',
+        'keep *_pfInclusiveSecondaryVertexFinderCvsLTagInfos_*_*')
+)
+RecoBTagRECO.outputCommands.extend(RecoBTagAOD.outputCommands)
+
+
+#Full Event content
+RecoBTagFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoBTagFEVT.outputCommands.extend(RecoBTagRECO.outputCommands)

--- a/RecoBTau/Configuration/python/RecoBTau_EventContent_cff.py
+++ b/RecoBTau/Configuration/python/RecoBTau_EventContent_cff.py
@@ -9,9 +9,10 @@ RecoBTauAOD = cms.PSet(
 RecoBTauRECO = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
+RecoBTauRECO.outputCommands.extend(RecoBTauAOD.outputCommands)
 
 #Full Event content 
 RecoBTauFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
-
+RecoBTauFEVT.outputCommands.extend(RecoBTauRECO.outputCommands)

--- a/RecoBTau/Configuration/python/RecoBTau_EventContent_cff.py
+++ b/RecoBTau/Configuration/python/RecoBTau_EventContent_cff.py
@@ -1,15 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content 
-RecoBTauFEVT = cms.PSet(
+#AOD content
+RecoBTauAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
+
 #RECO content
 RecoBTauRECO = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
-#AOD content
-RecoBTauAOD = cms.PSet(
+
+#Full Event content 
+RecoBTauFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 


### PR DESCRIPTION
#### PR description:  
Update event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. 2 files changed : 
+ RecoBTag_EventContent_cff.py 
+ RecoBTau_EventContent_cff.py

(The previous tasks are [PR#29025](https://github.com/cms-sw/cmssw/pull/29025), [PR#29158](https://github.com/cms-sw/cmssw/pull/29158), [PR#29225](https://github.com/cms-sw/cmssw/pull/29225), [PR#29299](https://github.com/cms-sw/cmssw/pull/29299), and [PR#29470](https://github.com/cms-sw/cmssw/pull/29470).)

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).