### PR TITLE
add a fast and simple rounding function with given precision

### DIFF
--- a/DataFormats/Math/interface/roundAtPrecision.h
+++ b/DataFormats/Math/interface/roundAtPrecision.h
@@ -1,0 +1,34 @@
+#ifndef DataFormatsMathroundAtPrecision_H
+#define DataFormatsMathroundAtPrecision_H
+
+#include "FWCore/Utilities/interface/isFinite.h"
+#include<cstring>
+#include<cstdint>
+
+// round with N significant bits
+template<int N>
+float roundAtPrecision(float x) {
+
+  if (edm::isNotFinite(x)) return x;
+
+  static_assert(N<23);
+  constexpr auto shift = 23-N;
+  constexpr uint32_t mask = 1<<(shift-1);
+
+  uint32_t i; memcpy(&i, &x, sizeof(x));
+
+  i += mask;
+  i>>=shift; i<<=shift;
+  memcpy(&x, &i, sizeof(x));
+
+  return x;
+
+}
+
+
+template<>
+float roundAtPrecision<23>(float x) { return x;}
+
+
+
+#endif  // DataFormatsMathroundAtPrecision_H

--- a/DataFormats/Math/interface/roundAtPrecision.h
+++ b/DataFormats/Math/interface/roundAtPrecision.h
@@ -2,33 +2,33 @@
 #define DataFormatsMathroundAtPrecision_H
 
 #include "FWCore/Utilities/interface/isFinite.h"
-#include<cstring>
-#include<cstdint>
+#include <cstring>
+#include <cstdint>
 
 // round with N significant bits
-template<int N>
+template <int N>
 float roundAtPrecision(float x) {
+  if (edm::isNotFinite(x))
+    return x;
 
-  if (edm::isNotFinite(x)) return x;
+  static_assert(N < 23);
+  constexpr auto shift = 23 - N;
+  constexpr uint32_t mask = 1 << (shift - 1);
 
-  static_assert(N<23);
-  constexpr auto shift = 23-N;
-  constexpr uint32_t mask = 1<<(shift-1);
-
-  uint32_t i; memcpy(&i, &x, sizeof(x));
+  uint32_t i;
+  memcpy(&i, &x, sizeof(x));
 
   i += mask;
-  i>>=shift; i<<=shift;
+  i >>= shift;
+  i <<= shift;
   memcpy(&x, &i, sizeof(x));
 
   return x;
-
 }
 
-
-template<>
-float roundAtPrecision<23>(float x) { return x;}
-
-
+template <>
+float roundAtPrecision<23>(float x) {
+  return x;
+}
 
 #endif  // DataFormatsMathroundAtPrecision_H

--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -53,6 +53,9 @@
 <bin file="arc.cpp" name="DataFormatsAsin_t">
 </bin>
 
+<bin file="roundAtPrecision_t.cpp" name="DataFormatsRoundAtPrecision_t">
+</bin>
+
 <bin file="testAtan2.cpp">
   <flags CXXFLAGS="-fwrapv"/>
 </bin>

--- a/DataFormats/Math/test/roundAtPrecision_t.cpp
+++ b/DataFormats/Math/test/roundAtPrecision_t.cpp
@@ -2,33 +2,24 @@
 
 #include <cmath>
 
-#include<cassert>
-
+#include <cassert>
 
 int main() {
+  float almost05m = std::nextafter(0.5f, 0.f);
+  float almost05p = std::nextafter(0.5f, 1.f);
 
+  assert(roundAtPrecision<8>(almost05m) == 0.5f);
+  assert(roundAtPrecision<8>(almost05p) == 0.5f);
+  assert(roundAtPrecision<8>(-almost05m) == -0.5f);
+  assert(roundAtPrecision<8>(-almost05p) == -0.5f);
 
+  assert(roundAtPrecision<0>(M_PI) == 4.f);
+  assert(roundAtPrecision<0>(2.9) == 2.f);
+  assert(roundAtPrecision<0>(-M_PI) == -4.f);
+  assert(roundAtPrecision<0>(-2.9) == -2.f);
 
-  float almost05m = std::nextafter(0.5f,0.f);
-  float almost05p = std::nextafter(0.5f,1.f);
-
-  assert(roundAtPrecision<8>(almost05m)==0.5f);
-  assert(roundAtPrecision<8>(almost05p)==0.5f);
-  assert(roundAtPrecision<8>(-almost05m)==-0.5f);
-  assert(roundAtPrecision<8>(-almost05p)==-0.5f);
-
-  assert(roundAtPrecision<0>(M_PI)==4.f);
-  assert(roundAtPrecision<0>(2.9)==2.f);
-  assert(roundAtPrecision<0>(-M_PI)==-4.f);
-  assert(roundAtPrecision<0>(-2.9)==-2.f);
-
-
-  assert(roundAtPrecision<23>(M_PI)==float(M_PI));
-  assert(roundAtPrecision<23>(-M_PI)==float(-M_PI));
-
-
+  assert(roundAtPrecision<23>(M_PI) == float(M_PI));
+  assert(roundAtPrecision<23>(-M_PI) == float(-M_PI));
 
   return 0;
-
 }
-

--- a/DataFormats/Math/test/roundAtPrecision_t.cpp
+++ b/DataFormats/Math/test/roundAtPrecision_t.cpp
@@ -1,0 +1,34 @@
+#include "DataFormats/Math/interface/roundAtPrecision.h"
+
+#include <cmath>
+
+#include<cassert>
+
+
+int main() {
+
+
+
+  float almost05m = std::nextafter(0.5f,0.f);
+  float almost05p = std::nextafter(0.5f,1.f);
+
+  assert(roundAtPrecision<8>(almost05m)==0.5f);
+  assert(roundAtPrecision<8>(almost05p)==0.5f);
+  assert(roundAtPrecision<8>(-almost05m)==-0.5f);
+  assert(roundAtPrecision<8>(-almost05p)==-0.5f);
+
+  assert(roundAtPrecision<0>(M_PI)==4.f);
+  assert(roundAtPrecision<0>(2.9)==2.f);
+  assert(roundAtPrecision<0>(-M_PI)==-4.f);
+  assert(roundAtPrecision<0>(-2.9)==-2.f);
+
+
+  assert(roundAtPrecision<23>(M_PI)==float(M_PI));
+  assert(roundAtPrecision<23>(-M_PI)==float(-M_PI));
+
+
+
+  return 0;
+
+}
+


### PR DESCRIPTION
As discussed in #29513 it would be useful to have a fast and simple function to round a floating point number to a given precision of N bits.

here is it!

compiler will simplify it in just 2 integer instructions
https://godbolt.org/z/rpBkVS