### PR TITLE
keeping METsumPtUnclustered (backport of #28370)

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -75,6 +75,10 @@ namespace pat {
       void setMETSignificance(const double& metSig);
       // get the MET significance
       double metSignificance() const;
+      // set the MET sumPtUnclustered for MET Significance
+      void setMETSumPtUnclustered(const double& sumPtUnclustered);
+      // get the MET sumPtUnclustered
+      double metSumPtUnclustered() const;
 
       // ---- methods for uncorrected MET ----
       // Methods not yet defined
@@ -250,7 +254,9 @@ namespace pat {
 
       // MET significance
       double metSig_;
-      
+      // MET sumPtUnclustered for MET Significance
+      double sumPtUnclustered_;
+
       const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
    
       std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> > corMap_;

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -23,6 +23,7 @@ MET::MET(const reco::MET & aMET) : PATObject<reco::MET>(aMET) {
     if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
+    sumPtUnclustered_ = 0.;
     initCorMap();
 }
 
@@ -37,6 +38,7 @@ MET::MET(const edm::RefToBase<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETR
     if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
+    sumPtUnclustered_ = 0.;
     initCorMap();
 }
 
@@ -50,6 +52,7 @@ MET::MET(const edm::Ptr<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
     if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
+    sumPtUnclustered_ = 0.;
     initCorMap();
 }
 
@@ -60,6 +63,7 @@ genMET_(iOther.genMET_),
 caloMET_(iOther.caloMET_),
 pfMET_(iOther.pfMET_),
 metSig_(iOther.metSig_),
+sumPtUnclustered_(iOther.sumPtUnclustered_),
 uncertaintiesRaw_(iOther.uncertaintiesRaw_), //74X reading compatibility
 uncertaintiesType1_(iOther.uncertaintiesType1_), //74X compatibility
 uncertaintiesType1p2_(iOther.uncertaintiesType1p2_), //74X compatibility
@@ -78,6 +82,7 @@ genMET_(srcMET.genMET_),
 caloMET_(srcMET.caloMET_),
 pfMET_(srcMET.pfMET_),
 metSig_(srcMET.metSig_),
+sumPtUnclustered_(srcMET.sumPtUnclustered_),
 caloPackedMet_(srcMET.caloPackedMet_) {
 
   setSignificanceMatrix(srcMET.getSignificanceMatrix());
@@ -101,6 +106,7 @@ MET& MET::operator=(MET const& iOther) {
    uncertainties_ = iOther.uncertainties_;
    corrections_ = iOther.corrections_;
    metSig_ = iOther.metSig_;
+   sumPtUnclustered_ = iOther.sumPtUnclustered_;
    caloPackedMet_ = iOther.caloPackedMet_;
 
    return *this;
@@ -126,6 +132,10 @@ void MET::setMETSignificance(const double& metSig) {
 double MET::metSignificance() const {
   return metSig_;
 }
+
+void MET::setMETSumPtUnclustered(const double &sumPtUnclustered) { sumPtUnclustered_ = sumPtUnclustered; }
+
+double MET::metSumPtUnclustered() const { return sumPtUnclustered_; }
 
 void
 MET::initCorMap() {

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -276,9 +276,10 @@
   <ioread sourceClass = "pat::Jet" version="[1-]" targetClass="pat::Jet" source="" target="daughtersTemp_">
     <![CDATA[daughtersTemp_.reset();]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="15">
-    <version ClassVersion="15" checksum="428901429"/>
+  <class name="pat::MET"  ClassVersion="16">
+    <version ClassVersion="16" checksum="2416242778"/>
     <field name="corMap_" transient="true"/>
+   <version ClassVersion="15" checksum="428901429"/>
    <version ClassVersion="14" checksum="1795935545"/>
    <version ClassVersion="13" checksum="2368359386"/>
    <version ClassVersion="12" checksum="1474251442"/>

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -98,10 +98,12 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 
     //add the MET significance
     if(calculateMETSignificance_) {
-      const reco::METCovMatrix& sigcov = getMETCovMatrix(iEvent, iSetup);
+      double sumPtUnclustered=0;
+      const reco::METCovMatrix& sigcov = getMETCovMatrix(iEvent, iSetup, sumPtUnclustered);
       amet.setSignificanceMatrix(sigcov);
       double metSig=metSigAlgo_->getSignificance(sigcov, amet);
       amet.setMETSignificance(metSig);
+      amet.setMETSumPtUnclustered(sumPtUnclustered);
     }
 
     if (efficiencyLoader_.enabled()) {
@@ -163,8 +165,8 @@ void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
 
 }
 
-const reco::METCovMatrix 
-PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const {
+const reco::METCovMatrix
+PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup, double &sumPtUnclustered) const {
   std::vector< edm::Handle<reco::CandidateView> > leptons;
   for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
 	srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
@@ -189,7 +191,7 @@ PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& 
 
   //Compute the covariance matrix and fill it
   reco::METCovMatrix cov = metSigAlgo_->getCovariance( *inputJets, leptons, inputCands,
-						       *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
+						       *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPtUnclustered);
 
   return cov;
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -78,7 +78,7 @@ namespace pat {
     std::string jetSFType_;
 
     const reco::METCovMatrix getMETCovMatrix(const edm::Event& event, 
-					     const edm::EventSetup& iSetup) const;
+					     const edm::EventSetup& iSetup, double &sumPtUnclustered) const;
 
   };
 

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -44,7 +44,8 @@ namespace metsig {
 					  JME::JetResolution & resPtObj,
 					  JME::JetResolution & resPhiObj,
 					  JME::JetResolutionScaleFactor & resSFObj,
-					  bool isRealData);
+					  bool isRealData,
+					  double &sumPtUnclustered);
 
      static double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met );
 

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -55,7 +55,8 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 				       JME::JetResolution& resPtObj,
 				       JME::JetResolution& resPhiObj,
 				       JME::JetResolutionScaleFactor& resSFObj,
-				       bool isRealData) {
+				       bool isRealData,
+				       double& sumPtUnclustered) {
 
   //pfcandidates
   const edm::View<reco::Candidate>* pfCandidates=pfCandidatesH.product();
@@ -68,7 +69,7 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
    // for lepton and jet subtraction
    std::unordered_set<reco::CandidatePtr,ptr_hash> footprint;
 
-   // subtract leptons out of sumPt
+   // subtract leptons out of sumPtUnclustered
    for ( const auto& lep_i : leptons ) {
      for( const auto& lep : *lep_i ) {
        if( lep.pt() > 10 ){
@@ -80,7 +81,7 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
        }
      }
    }
-   // subtract jets out of sumPt
+   // subtract jets out of sumPtUnclustered
    for(const auto& jet : jets) {
 
      // disambiguate jets and leptons
@@ -93,8 +94,7 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 
    }
 
-   // calculate sumPt
-   double sumPt = 0;
+   // calculate sumPtUnclustered
    for(size_t i = 0; i< pfCandidates->size();  ++i) {
      
      // check if candidate exists in a lepton or jet
@@ -111,14 +111,14 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 	   break;
 	 }
        }
-       // if not, add to sumPt
+       // if not, add to sumPtUnclustered
        if( cleancand ){
-	 sumPt += (*pfCandidates)[i].pt();
+	 sumPtUnclustered += (*pfCandidates)[i].pt();
        }
      }
    }
 
-   // add jets to metsig covariance matrix and subtract them from sumPt
+   // add jets to metsig covariance matrix and subtract them from sumPtUnclustered
    for(const auto& jet : jets) {
      
      // disambiguate jets and leptons
@@ -160,19 +160,19 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
 
       } else {
 
-         // add the (corrected) jet to the sumPt
-         sumPt += jpt;
+         // add the (corrected) jet to the sumPtUnclustered
+         sumPtUnclustered += jpt;
 
       }
 
    }
 
    //protection against unphysical events
-   if(sumPt<0) sumPt=0;
+   if(sumPtUnclustered<0) sumPtUnclustered=0;
  
    // add pseudo-jet to metsig covariance matrix
-   cov_xx += pjetParams_[0]*pjetParams_[0] + pjetParams_[1]*pjetParams_[1]*sumPt;
-   cov_yy += pjetParams_[0]*pjetParams_[0] + pjetParams_[1]*pjetParams_[1]*sumPt;
+   cov_xx += pjetParams_[0]*pjetParams_[0] + pjetParams_[1]*pjetParams_[1]*sumPtUnclustered;
+   cov_yy += pjetParams_[0]*pjetParams_[0] + pjetParams_[1]*pjetParams_[1]*sumPtUnclustered;
 
    reco::METCovMatrix cov;
    cov(0,0) = cov_xx;

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -89,7 +89,8 @@ namespace cms
    //
    // compute the significance
    //
-   const reco::METCovMatrix cov = metSigAlgo_->getCovariance( *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData() );
+   double sumPtUnclustered = 0;
+   const reco::METCovMatrix cov = metSigAlgo_->getCovariance( *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPtUnclustered);
    double sig  = metSigAlgo_->getSignificance(cov, met);
 
    auto significance = std::make_unique<double>();

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -99,7 +99,8 @@ namespace cms
 	event.getByToken(rhoToken_, rho);
 
 	//Compute the covariance matrix and fill it
-	reco::METCovMatrix cov = metSigAlgo_->getCovariance( *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData() );
+	double sumPtUnclustered = 0;
+	reco::METCovMatrix cov = metSigAlgo_->getCovariance( *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPtUnclustered);
 
 	return cov;
   }


### PR DESCRIPTION
#### PR description:

The sum of the unclustered energy is one of the inputs to MET significance, but is currently not stored in miniAOD, making recomputation of the significance and the MET covariance matrix difficult. With this PR, the calculated sum of the pTs of the unclustered particles is stored, and can be accessed with metSumPtUnclustered(), similar to metSignificance().

#### PR validation:

Tests passed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #28370 
