### PR TITLE
Change Herwig7Interface to be consistent with Herwig 7.2.0

### DIFF
--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -23,13 +23,16 @@ Marco A. Harrendorf
 
 namespace ThePEG {
 
-  template <> struct HepMCTraits<HepMC::GenEvent> :
-                public HepMCTraitsBase<
-      HepMC::GenEvent, HepMC::GenParticle, HepMC::GenParticle *, 
-      HepMC::GenVertex, HepMC::GenVertex *, HepMC::Polarization,
-      HepMC::PdfInfo> {};
+  template <>
+  struct HepMCTraits<HepMC::GenEvent> : public HepMCTraitsBase<HepMC::GenEvent,
+                                                               HepMC::GenParticle,
+                                                               HepMC::GenParticle *,
+                                                               HepMC::GenVertex,
+                                                               HepMC::GenVertex *,
+                                                               HepMC::Polarization,
+                                                               HepMC::PdfInfo> {};
 
-}
+}  // namespace ThePEG
 
 namespace CLHEP {
   class HepRandomEngine;

--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -23,12 +23,13 @@ Marco A. Harrendorf
 
 namespace ThePEG {
 
-  template <>
-  struct HepMCTraits<HepMC::GenEvent>
-      : public HepMCTraitsBase<HepMC::GenEvent, HepMC::GenParticle, HepMC::GenVertex, HepMC::Polarization, HepMC::PdfInfo> {
-  };
+  template <> struct HepMCTraits<HepMC::GenEvent> :
+                public HepMCTraitsBase<
+      HepMC::GenEvent, HepMC::GenParticle, HepMC::GenParticle *, 
+      HepMC::GenVertex, HepMC::GenVertex *, HepMC::Polarization,
+      HepMC::PdfInfo> {};
 
-}  // namespace ThePEG
+}
 
 namespace CLHEP {
   class HepRandomEngine;


### PR DESCRIPTION
#### PR description:

Update of Herwig 7 interface to allow update of Herwig 7.1.4->7.2.0. 

#### PR validation:

Has been tested with runTheMatrix workflow 535, and the test commands on the Herwig twiki


