### PR TITLE
Fix skipping of LuminosityBlock with firstLuminosityBlockForEachRun

### DIFF
--- a/FWCore/Modules/src/EventIDChecker.cc
+++ b/FWCore/Modules/src/EventIDChecker.cc
@@ -18,7 +18,7 @@
 
 // user include files
 #include "DataFormats/Provenance/interface/EventID.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -34,7 +34,7 @@
 // class decleration
 //
 
-class EventIDChecker : public edm::EDAnalyzer {
+class EventIDChecker : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit EventIDChecker(edm::ParameterSet const&);
   ~EventIDChecker() override;
@@ -42,12 +42,18 @@ public:
 
 private:
   void beginJob() override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void endJob() override;
 
   // ----------member data ---------------------------
   std::vector<edm::EventID> ids_;
   unsigned int index_;
+  edm::RunNumber_t presentRun_ = 0;
+  edm::LuminosityBlockNumber_t presentLumi_ = 0;
 
   unsigned int multiProcessSequentialEvents_;
   unsigned int numberOfEventsLeftBeforeSearch_;
@@ -117,7 +123,42 @@ void EventIDChecker::analyze(edm::Event const& iEvent, edm::EventSetup const&) {
     throw cms::Exception("WrongEvent") << "Was expecting event " << ids_[index_] << " but was given " << iEvent.id()
                                        << "\n";
   }
+
+  if (presentRun_ != iEvent.run()) {
+    throw cms::Exception("MissingRunTransitionForEvent")
+        << "at event expected Run " << presentRun_ << " but got " << iEvent.run();
+  }
+  if (presentLumi_ != iEvent.luminosityBlock()) {
+    throw cms::Exception("MissingLuminosityBlockTransitionForEvent")
+        << "expected LuminosityBlock " << presentLumi_ << " but got " << iEvent.luminosityBlock();
+  }
+
   ++index_;
+}
+
+void EventIDChecker::beginRun(edm::Run const& iRun, edm::EventSetup const&) { presentRun_ = iRun.run(); }
+void EventIDChecker::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
+  if (presentRun_ != iLumi.run()) {
+    throw cms::Exception("WrongRunForLuminosityBlock")
+        << "at beginLuminosityBlock expected Run " << presentRun_ << " but got " << iLumi.run();
+  }
+  presentLumi_ = iLumi.luminosityBlock();
+}
+
+void EventIDChecker::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
+  if (presentRun_ != iLumi.run()) {
+    throw cms::Exception("WrongRunForLuminosityBlock")
+        << "at endLuminosityBlock expected Run " << presentRun_ << " but got " << iLumi.run();
+  }
+  if (presentLumi_ != iLumi.luminosityBlock()) {
+    throw cms::Exception("WrongEndLuminosityBlock")
+        << "expected LuminosityBlock " << presentLumi_ << " but got " << iLumi.luminosityBlock();
+  }
+}
+void EventIDChecker::endRun(edm::Run const& iRun, edm::EventSetup const&) {
+  if (presentRun_ != iRun.run()) {
+    throw cms::Exception("WrongEndRun") << "expected Run " << presentRun_ << " but got " << iRun.run();
+  }
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/FWCore/Sources/src/EventSkipperByID.cc
+++ b/FWCore/Sources/src/EventSkipperByID.cc
@@ -23,7 +23,7 @@ namespace edm {
             pset.getUntrackedParameter<std::vector<EventRange> >("eventsToSkip", std::vector<EventRange>())),
         whichEventsToProcess_(
             pset.getUntrackedParameter<std::vector<EventRange> >("eventsToProcess", std::vector<EventRange>())),
-        skippingLumis_(!(whichLumisToSkip_.empty() && whichLumisToProcess_.empty())),
+        skippingLumis_(!(whichLumisToSkip_.empty() && whichLumisToProcess_.empty() && firstLumi_ == 0)),
         skippingEvents_(!(whichEventsToSkip_.empty() && whichEventsToProcess_.empty())),
         somethingToSkip_(skippingLumis_ || skippingEvents_ ||
                          !(firstRun_ <= 1U && firstLumi_ <= 1U && firstEvent_ <= 1U)) {

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -65,7 +65,6 @@
 
 #include <algorithm>
 #include <list>
-#include <iostream>
 
 namespace edm {
 

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -65,6 +65,7 @@
 
 #include <algorithm>
 #include <list>
+#include <iostream>
 
 namespace edm {
 
@@ -748,6 +749,7 @@ namespace edm {
     if (indexIntoFileIter_ == indexIntoFileEnd_) {
       return false;
     }
+
     if (eventSkipperByID_ && eventSkipperByID_->somethingToSkip()) {
       // See first if the entire lumi or run is skipped, so we won't have to read the event Auxiliary in that case.
       if (eventSkipperByID_->skipIt(indexIntoFileIter_.run(), indexIntoFileIter_.lumi(), 0U)) {
@@ -764,18 +766,16 @@ namespace edm {
 
       // Skip runs with no lumis if either lumisToSkip or lumisToProcess have been set to select lumis
       if (indexIntoFileIter_.getEntryType() == IndexIntoFile::kRun && eventSkipperByID_->skippingLumis()) {
-        IndexIntoFile::IndexIntoFileItr iterLumi = indexIntoFileIter_;
-
         // There are no lumis in this run, not even ones we will skip
-        if (iterLumi.peekAheadAtLumi() == IndexIntoFile::invalidLumi) {
+        if (indexIntoFileIter_.peekAheadAtLumi() == IndexIntoFile::invalidLumi) {
           return true;
         }
         // If we get here there are lumis in the run, check to see if we are skipping all of them
         do {
-          if (!eventSkipperByID_->skipIt(iterLumi.run(), iterLumi.peekAheadAtLumi(), 0U)) {
+          if (!eventSkipperByID_->skipIt(indexIntoFileIter_.run(), indexIntoFileIter_.peekAheadAtLumi(), 0U)) {
             return false;
           }
-        } while (iterLumi.skipLumiInRun());
+        } while (indexIntoFileIter_.skipLumiInRun());
         return true;
       }
     }
@@ -828,7 +828,6 @@ namespace edm {
     if (entryType == IndexIntoFile::kLumi) {
       run = indexIntoFileIter_.run();
       lumi = indexIntoFileIter_.lumi();
-      runHelper_->checkForNewRun(run, lumi);
       return IndexIntoFile::kLumi;
     } else if (processingMode_ == InputSource::RunsAndLumis) {
       indexIntoFileIter_.advanceToNextLumiOrRun();

--- a/IOPool/Input/test/RunPerLumiTest_cfg.py
+++ b/IOPool/Input/test/RunPerLumiTest_cfg.py
@@ -8,24 +8,32 @@ from sys import argv
 process = cms.Process("TESTRECO")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(int(argv[2]))
-)
+process.maxEvents.input = int(argv[2])
+
+runToLumi = [111,222,333,444,555]
 
 process.OtherThing = cms.EDProducer("OtherThingProducer")
 
 process.Analysis = cms.EDAnalyzer("OtherThingAnalyzer")
 
 process.source = cms.Source("PoolSource",
-    setRunNumberForEachLumi = cms.untracked.vuint32(111,222,333,444,555),
-    fileNames = cms.untracked.vstring('file:RunPerLumiTest.root')
+                            setRunNumberForEachLumi = cms.untracked.vuint32(*runToLumi),
+                            fileNames = cms.untracked.vstring('file:RunPerLumiTest.root')
 )
 
 process.output = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('OutputRunPerLumiTest.root')
 )
 
+numberOfEventsInLumi = 5
+ids = cms.VEventID()
+for l,r in enumerate(runToLumi):
+    for e in range(numberOfEventsInLumi):
+        ids.append(cms.EventID(r, l+1,l*5+e+1))
+
+process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(ids))
+
+
 process.p = cms.Path(process.OtherThing*process.Analysis)
 
-process.e = cms.EndPath(process.output)
-
+process.e = cms.EndPath(process.check+process.output)

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -75,6 +75,10 @@ cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py 'f
 cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py 'file:firstLumiTest1.root' 4 || die 'Failure using firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py with first lumi 4' $?
 cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py 'file:firstLumiTest1.root' 3 || die 'Failure using firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py with first lumi 3' $?
 
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py 'file:firstLumiTest1.root' 2 || die 'Failure using firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py with first lumi 2' $?
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py 'file:firstLumiTest1.root' 4 || die 'Failure using firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py with first lumi 4' $?
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py 'file:firstLumiTest1.root' 3 || die 'Failure using firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py with first lumi 3' $?
+
 
 #test merging of heterogeneous files with extra provenenace in subsequent files
 

--- a/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py
+++ b/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py
@@ -5,8 +5,6 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-import sys
-
 #ignore script name and anything before it
 argv = []
 foundpy = False
@@ -64,4 +62,3 @@ process.source = cms.Source("PoolSource",
 )
 
 process.e = cms.EndPath(process.check)
-

--- a/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py
+++ b/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py
@@ -1,0 +1,67 @@
+# The following comments couldn't be translated into the new config version:
+
+# Configuration file for PoolInputTest
+
+import FWCore.ParameterSet.Config as cms
+import sys
+
+import sys
+
+#ignore script name and anything before it
+argv = []
+foundpy = False
+for a in sys.argv:
+    if foundpy:
+        argv.append(a)
+    if ".py" in a:
+        foundpy = True
+
+
+process = cms.Process("TESTRECO")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents.input = -1
+
+#have first run of second file be a new run
+runToLumi = ((2,1),(10,3),(20,5))
+
+def findRunForLumi( lumi) :
+  lastRun = runToLumi[0][0]
+  for r,l in runToLumi:
+    if l > lumi:
+      break
+    lastRun = r
+  return lastRun
+
+ids = cms.VEventID()
+numberOfEventsInLumi = 0
+numberOfEventsPerLumi = 5
+lumi = int(argv[1])
+event= numberOfEventsPerLumi*(lumi-1)
+oldRun = 2
+numberOfFiles = 1
+numberOfEventsInFile = 15
+for i in range(numberOfEventsPerLumi*(6-lumi)):
+   numberOfEventsInLumi +=1
+   event += 1
+   run = findRunForLumi(lumi)
+#   if event > numberOfEventsInFile:
+#    event = 1
+   if numberOfEventsInLumi > numberOfEventsPerLumi:
+      numberOfEventsInLumi=1
+      lumi += 1
+      run = findRunForLumi(lumi)
+      if run != oldRun:
+        oldRun = run
+   ids.append(cms.EventID(run,lumi,event))
+process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(ids))
+
+
+process.source = cms.Source("PoolSource",
+                            lumisToProcess = cms.untracked.VLuminosityBlockRange('1:'+str(int(argv[1]))+'-1:'+str(runToLumi[-1][1])),
+    firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(x,y) for x,y in runToLumi]),
+    fileNames = cms.untracked.vstring(argv[0].split(","))
+)
+
+process.e = cms.EndPath(process.check)
+


### PR DESCRIPTION
#### PR description:

CMSSW_11_1_0_pre6 showed that the tests for Run dependent MC had failed. This adds tests which exhibit the problem and provides changes which allow those tests to pass.

#### PR validation:

The code compiles and the new (and extended) tests all pass.