### PR TITLE
Update of the lostTrack collection for MUO (back-port of #29389)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -1,5 +1,6 @@
 #include <string>
 
+
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
@@ -26,43 +27,49 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 namespace {
-  bool passesQuality(const reco::Track& trk, const std::vector<reco::TrackBase::TrackQuality>& allowedQuals) {
-    for (const auto& qual : allowedQuals) {
-      if (trk.quality(qual))
-        return true;
+  bool passesQuality(const reco::Track& trk,const std::vector<reco::TrackBase::TrackQuality>& allowedQuals){
+    for(const auto& qual : allowedQuals){
+      if(trk.quality(qual)) return true;
     }
     return false;
   }
-}  // namespace
+}
 
 namespace pat {
   class PATLostTracks : public edm::global::EDProducer<> {
   public:
     explicit PATLostTracks(const edm::ParameterSet&);
     ~PATLostTracks() override;
-
+    
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-
-  private:
-    enum class TrkStatus { NOTUSED = 0, PFCAND, PFCANDNOTRKPROPS, PFELECTRON, PFPOSITRON, VTX };
-    bool passTrkCuts(const reco::Track& tr) const;
+   
+  private:  
+    enum class TrkStatus {
+      NOTUSED=0,
+      PFCAND,
+      PFCANDNOTRKPROPS,
+      PFELECTRON,
+      PFPOSITRON,
+      VTX
+    };
+    bool passTrkCuts(const reco::Track& tr)const;
     void addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
-                            const reco::TrackRef& trk,
-                            const reco::VertexRef& pvSlimmed,
-                            const reco::VertexRefProd& pvSlimmedColl,
-                            const reco::Vertex& pvOrig,
-                            const TrkStatus trkStatus,
+			    const reco::TrackRef& trk,
+			    const reco::VertexRef& pvSlimmed,
+			    const reco::VertexRefProd& pvSlimmedColl,
+			    const reco::Vertex& pvOrig,
+			    const TrkStatus trkStatus,
                             edm::Handle<reco::MuonCollection> muons) const;
-
+      
   private:
-    const edm::EDGetTokenT<reco::PFCandidateCollection> cands_;
-    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> map_;
-    const edm::EDGetTokenT<reco::TrackCollection> tracks_;
-    const edm::EDGetTokenT<reco::VertexCollection> vertices_;
-    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> kshorts_;
-    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> lambdas_;
-    const edm::EDGetTokenT<reco::VertexCollection> pv_;
-    const edm::EDGetTokenT<reco::VertexCollection> pvOrigs_;
+    const edm::EDGetTokenT<reco::PFCandidateCollection>    cands_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
+    const edm::EDGetTokenT<reco::TrackCollection>          tracks_;
+    const edm::EDGetTokenT<reco::VertexCollection>         vertices_;
+    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>         kshorts_;
+    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>         lambdas_;
+    const edm::EDGetTokenT<reco::VertexCollection>         pv_;
+    const edm::EDGetTokenT<reco::VertexCollection>         pvOrigs_;
     const double minPt_;
     const double minHits_;
     const double minPixelHits_;
@@ -73,199 +80,195 @@ namespace pat {
     const edm::EDGetTokenT<reco::MuonCollection> muons_;
     StringCutObjectSelector<reco::Track, false> passThroughCut_;
   };
-}  // namespace pat
+}
 
-pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
-    : cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
-      map_(consumes<edm::Association<pat::PackedCandidateCollection>>(
-          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-      tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTracks"))),
-      vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices"))),
-      kshorts_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("kshorts"))),
-      lambdas_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("lambdas"))),
-      pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
-      pvOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
-      minPt_(iConfig.getParameter<double>("minPt")),
-      minHits_(iConfig.getParameter<uint32_t>("minHits")),
-      minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")),
-      minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
-      covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
-      covarianceSchema_(iConfig.getParameter<int>("covarianceSchema")),
-      muons_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
-      passThroughCut_(iConfig.getParameter<std::string>("passThroughCut")) {
-  std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string>>("qualsToAutoAccept"));
-  std::transform(
-      trkQuals.begin(), trkQuals.end(), std::back_inserter(qualsToAutoAccept_), reco::TrackBase::qualityByName);
-
-  if (std::find(qualsToAutoAccept_.begin(), qualsToAutoAccept_.end(), reco::TrackBase::undefQuality) !=
-      qualsToAutoAccept_.end()) {
+pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
+  cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
+  map_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+  tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTracks"))),
+  vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices"))),
+  kshorts_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("kshorts"))),
+  lambdas_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("lambdas"))),
+  pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+  pvOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
+  minPt_(iConfig.getParameter<double>("minPt")),
+  minHits_(iConfig.getParameter<uint32_t>("minHits")),
+  minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")) ,
+  minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
+  covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
+  covarianceSchema_(iConfig.getParameter<int >("covarianceSchema")),
+  muons_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+  passThroughCut_(iConfig.getParameter<std::string>("passThroughCut")) {
+  std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string> >("qualsToAutoAccept"));
+  std::transform(trkQuals.begin(),trkQuals.end(),std::back_inserter(qualsToAutoAccept_),reco::TrackBase::qualityByName);
+  
+  if(std::find(qualsToAutoAccept_.begin(),qualsToAutoAccept_.end(),reco::TrackBase::undefQuality)!=qualsToAutoAccept_.end()){
     std::ostringstream msg;
-    msg << " PATLostTracks has a quality requirement which resolves to undefQuality. This usually means a typo and is "
-           "therefore treated a config error\nquality requirements:\n   ";
-    for (const auto& trkQual : trkQuals)
-      msg << trkQual << " ";
+    msg<<" PATLostTracks has a quality requirement which resolves to undefQuality. This usually means a typo and is therefore treated a config error\nquality requirements:\n   ";
+    for(const auto& trkQual : trkQuals) msg <<trkQual<<" ";
     throw cms::Exception("Configuration") << msg.str();
-  }
-
-  produces<std::vector<reco::Track>>();
-  produces<std::vector<pat::PackedCandidate>>();
-  produces<std::vector<pat::PackedCandidate>>("eleTracks");
-  produces<edm::Association<pat::PackedCandidateCollection>>();
+  } 
+    
+  produces< std::vector<reco::Track> > ();
+  produces< std::vector<pat::PackedCandidate> > (); produces< std::vector<pat::PackedCandidate> > ("eleTracks");
+  produces< edm::Association<pat::PackedCandidateCollection> > ();
 }
 
 pat::PATLostTracks::~PATLostTracks() {}
 
 void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-  edm::Handle<reco::PFCandidateCollection> cands;
-  iEvent.getByToken(cands_, cands);
 
-  edm::Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
-  iEvent.getByToken(map_, pf2pc);
+    edm::Handle<reco::PFCandidateCollection> cands;
+    iEvent.getByToken( cands_, cands );
 
-  edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByToken(tracks_, tracks);
+    edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
+    iEvent.getByToken(map_,pf2pc);
 
-  edm::Handle<reco::VertexCollection> vertices;
-  iEvent.getByToken(vertices_, vertices);
+    edm::Handle<reco::TrackCollection> tracks;
+    iEvent.getByToken( tracks_, tracks );
+    
+    edm::Handle<reco::VertexCollection> vertices;
+    iEvent.getByToken( vertices_, vertices );
 
-  edm::Handle<reco::MuonCollection> muons;
-  iEvent.getByToken(muons_, muons);
+    edm::Handle<reco::MuonCollection> muons;
+    iEvent.getByToken(muons_, muons);
 
-  edm::Handle<reco::VertexCompositeCandidateCollection> kshorts;
-  iEvent.getByToken(kshorts_, kshorts);
-  edm::Handle<reco::VertexCompositeCandidateCollection> lambdas;
-  iEvent.getByToken(lambdas_, lambdas);
+    edm::Handle<reco::VertexCompositeCandidateCollection> kshorts;
+    iEvent.getByToken( kshorts_, kshorts );
+    edm::Handle<reco::VertexCompositeCandidateCollection> lambdas;
+    iEvent.getByToken( lambdas_, lambdas );
 
-  edm::Handle<reco::VertexCollection> pvs;
-  iEvent.getByToken(pv_, pvs);
-  reco::VertexRef pv(pvs.id());
-  reco::VertexRefProd pvRefProd(pvs);
-  if (!pvs->empty()) {
-    pv = reco::VertexRef(pvs, 0);
-  }
-  edm::Handle<reco::VertexCollection> pvOrigs;
-  iEvent.getByToken(pvOrigs_, pvOrigs);
-  const reco::Vertex& pvOrig = (*pvOrigs)[0];
-
-  auto outPtrTrks = std::make_unique<std::vector<reco::Track>>();
-  auto outPtrTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
-  auto outPtrEleTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
-
-  std::vector<TrkStatus> trkStatus(tracks->size(), TrkStatus::NOTUSED);
-  //Mark all tracks used in candidates
-  //check if packed candidates are storing the tracks by seeing if number of hits >0
-  //currently we dont use that information though
-  //electrons will never store their track (they store the GSF track)
-  for (unsigned int ic = 0, nc = cands->size(); ic < nc; ++ic) {
-    edm::Ref<reco::PFCandidateCollection> r(cands, ic);
-    const reco::PFCandidate& cand = (*cands)[ic];
-    if (cand.charge() && cand.trackRef().isNonnull() && cand.trackRef().id() == tracks.id()) {
-      if (cand.pdgId() == 11)
-        trkStatus[cand.trackRef().key()] = TrkStatus::PFELECTRON;
-      else if (cand.pdgId() == -11)
-        trkStatus[cand.trackRef().key()] = TrkStatus::PFPOSITRON;
-      else if ((*pf2pc)[r]->numberOfHits() > 0)
-        trkStatus[cand.trackRef().key()] = TrkStatus::PFCAND;
-      else
-        trkStatus[cand.trackRef().key()] = TrkStatus::PFCANDNOTRKPROPS;
+    edm::Handle<reco::VertexCollection> pvs;
+    iEvent.getByToken( pv_, pvs );
+    reco::VertexRef pv(pvs.id());
+    reco::VertexRefProd pvRefProd(pvs);
+    if (!pvs->empty()) {
+        pv = reco::VertexRef(pvs, 0);
     }
-  }
+    edm::Handle<reco::VertexCollection> pvOrigs;
+    iEvent.getByToken( pvOrigs_, pvOrigs );
+    const reco::Vertex & pvOrig = (*pvOrigs)[0];
 
-  //Mark all tracks used in secondary vertices
-  for (const auto& secVert : *vertices) {
-    for (auto trkIt = secVert.tracks_begin(); trkIt != secVert.tracks_end(); trkIt++) {
-      if (trkStatus[trkIt->key()] == TrkStatus::NOTUSED)
-        trkStatus[trkIt->key()] = TrkStatus::VTX;
+    auto outPtrTrks = std::make_unique<std::vector<reco::Track>>();
+    auto outPtrTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
+    auto outPtrEleTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
+  
+    std::vector<TrkStatus> trkStatus(tracks->size(),TrkStatus::NOTUSED);
+    //Mark all tracks used in candidates	
+    //check if packed candidates are storing the tracks by seeing if number of hits >0 	  
+    //currently we dont use that information though
+    //electrons will never store their track (they store the GSF track)
+    for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
+        edm::Ref<reco::PFCandidateCollection> r(cands,ic);
+        const reco::PFCandidate &cand=(*cands)[ic]; 
+	if(cand.charge() && cand.trackRef().isNonnull() && cand.trackRef().id() == tracks.id() ) { 
+	  
+	  if(cand.pdgId()==11) trkStatus[cand.trackRef().key()]=TrkStatus::PFELECTRON;	  
+	  else if(cand.pdgId()==-11) trkStatus[cand.trackRef().key()]=TrkStatus::PFPOSITRON;
+	  else if((*pf2pc)[r]->numberOfHits() > 0) trkStatus[cand.trackRef().key()]=TrkStatus::PFCAND; 
+	  else trkStatus[cand.trackRef().key()]=TrkStatus::PFCANDNOTRKPROPS; 
+	}
     }
-  }
-  for (const auto& v0 : *kshorts) {
-    for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
-      size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
-      if (trkStatus[key] == TrkStatus::NOTUSED)
-        trkStatus[key] = TrkStatus::VTX;
+        
+    //Mark all tracks used in secondary vertices
+    for(const auto& secVert : *vertices){
+        for(auto trkIt = secVert.tracks_begin();trkIt!=secVert.tracks_end();trkIt++){
+	    if(trkStatus[trkIt->key()]==TrkStatus::NOTUSED)  trkStatus[trkIt->key()]=TrkStatus::VTX;
+	}
     }
-  }
-  for (const auto& v0 : *lambdas) {
-    for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
-      size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
-      if (trkStatus[key] == TrkStatus::NOTUSED)
-        trkStatus[key] = TrkStatus::VTX;
+    for(const auto& v0 : *kshorts){
+        for(size_t dIdx=0;dIdx<v0.numberOfDaughters(); dIdx++){
+	    size_t key= (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
+	    if(trkStatus[key]==TrkStatus::NOTUSED)  trkStatus[key]=TrkStatus::VTX;
+	}
     }
-  }
-  std::vector<int> mapping(tracks->size(), -1);
-  int lostTrkIndx = 0;
-  for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
-    reco::TrackRef trk(tracks, trkIndx);
-    if (trkStatus[trkIndx] == TrkStatus::VTX || (trkStatus[trkIndx] == TrkStatus::NOTUSED && passTrkCuts(*trk))) {
-      outPtrTrks->emplace_back(*trk);
-      addPackedCandidate(*outPtrTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
+    for(const auto& v0 : *lambdas){
+        for(size_t dIdx=0;dIdx<v0.numberOfDaughters(); dIdx++){
+	    size_t key= (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
+	    if(trkStatus[key]==TrkStatus::NOTUSED)  trkStatus[key]=TrkStatus::VTX;
+	}
+    }
+    std::vector<int> mapping(tracks->size(),-1);  
+    int lostTrkIndx=0;
+    for(unsigned int trkIndx=0; trkIndx < tracks->size(); trkIndx++){
+        reco::TrackRef trk(tracks,trkIndx);
+	if( trkStatus[trkIndx] == TrkStatus::VTX || 
+	   (trkStatus[trkIndx]==TrkStatus::NOTUSED && passTrkCuts(*trk)) ) { 
+	
+	    outPtrTrks->emplace_back(*trk);
+	    addPackedCandidate(*outPtrTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
+	
+	    //for creating the reco::Track -> pat::PackedCandidate map
+	    //not done for the lostTrack:eleTracks collection
+	    mapping[trkIndx]=lostTrkIndx;
+	    lostTrkIndx++;
+	}else if( (trkStatus[trkIndx]==TrkStatus::PFELECTRON || trkStatus[trkIndx]==TrkStatus::PFPOSITRON ) 
+		  && passTrkCuts(*trk) ) {
+             addPackedCandidate(*outPtrEleTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
 
-      //for creating the reco::Track -> pat::PackedCandidate map
-      //not done for the lostTrack:eleTracks collection
-      mapping[trkIndx] = lostTrkIndx;
-      lostTrkIndx++;
-    } else if ((trkStatus[trkIndx] == TrkStatus::PFELECTRON || trkStatus[trkIndx] == TrkStatus::PFPOSITRON) &&
-               passTrkCuts(*trk)) {
-      addPackedCandidate(*outPtrEleTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
-    }
-  }
-
-  iEvent.put(std::move(outPtrTrks));
-  iEvent.put(std::move(outPtrEleTrksAsCands), "eleTracks");
-  edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrTrksAsCands));
-  auto tk2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
-  edm::Association<pat::PackedCandidateCollection>::Filler tk2pcFiller(*tk2pc);
-  tk2pcFiller.insert(tracks, mapping.begin(), mapping.end());
-  tk2pcFiller.fill();
-  iEvent.put(std::move(tk2pc));
+	
+      }	      
+    } 
+    
+    iEvent.put(std::move(outPtrTrks));
+    iEvent.put(std::move(outPtrEleTrksAsCands),"eleTracks");
+    edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrTrksAsCands));
+    auto tk2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
+    edm::Association<pat::PackedCandidateCollection>::Filler tk2pcFiller(*tk2pc);
+    tk2pcFiller.insert(tracks, mapping.begin(), mapping.end());
+    tk2pcFiller.fill() ; 
+    iEvent.put(std::move(tk2pc));   
 }
 
-bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr) const {
-  const bool passTrkHits = tr.pt() > minPt_ && tr.numberOfValidHits() >= minHits_ &&
-                           tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
-  const bool passTrkQual = passesQuality(tr, qualsToAutoAccept_);
+bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr)const
+{
+    const bool passTrkHits = tr.pt() > minPt_ && 
+                             tr.numberOfValidHits() >= minHits_ && 
+                             tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
+    const bool passTrkQual = passesQuality(tr,qualsToAutoAccept_);
 
-  return passTrkHits || passTrkQual || passThroughCut_(tr);
+    return passTrkHits || passTrkQual || passThroughCut_(tr);
 }
 
 void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
-                                            const reco::TrackRef& trk,
-                                            const reco::VertexRef& pvSlimmed,
-                                            const reco::VertexRefProd& pvSlimmedColl,
-                                            const reco::Vertex& pvOrig,
-                                            const pat::PATLostTracks::TrkStatus trkStatus,
-                                            edm::Handle<reco::MuonCollection> muons) const {
-  const float mass = 0.13957018;
+					    const reco::TrackRef& trk,
+					    const reco::VertexRef& pvSlimmed,
+					    const reco::VertexRefProd& pvSlimmedColl,
+					    const reco::Vertex& pvOrig,
+					    const pat::PATLostTracks::TrkStatus trkStatus,
+                                            edm::Handle<reco::MuonCollection> muons) const
+{
+    const float mass = 0.13957018;
+    
+    int id=211*trk->charge();
+    if(trkStatus==TrkStatus::PFELECTRON) id=11;
+    else if(trkStatus==TrkStatus::PFPOSITRON) id=-11; 
 
-  int id = 211 * trk->charge();
-  if (trkStatus == TrkStatus::PFELECTRON)
-    id = 11;
-  else if (trkStatus == TrkStatus::PFPOSITRON)
-    id = -11;
-
-  // assign the proper pdgId for tracks that are reconstructed as a muon
-  for (auto& mu : *muons) {
-    if (reco::TrackRef(mu.innerTrack()) == trk) {
-      id = -13 * trk->charge();
-      break;
+    // assign the proper pdgId for tracks that are reconstructed as a muon
+    for (auto& mu : *muons) {
+      if (reco::TrackRef(mu.innerTrack()) == trk) {
+        id = -13 * trk->charge();
+        break;
+      }
     }
-  }
 
-  reco::Candidate::PolarLorentzVector p4(trk->pt(), trk->eta(), trk->phi(), mass);
-  cands.emplace_back(
-      pat::PackedCandidate(p4, trk->vertex(), trk->pt(), trk->eta(), trk->phi(), id, pvSlimmedColl, pvSlimmed.key()));
-
-  if (trk->quality(reco::TrackBase::highPurity))
-    cands.back().setTrackHighPurity(true);
-  else
-    cands.back().setTrackHighPurity(false);
-
-  if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX)
-    cands.back().setTrackProperties(*trk, covarianceSchema_, covarianceVersion_);
-  if (pvOrig.trackWeight(trk) > 0.5) {
-    cands.back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
-  }
+    reco::Candidate::PolarLorentzVector p4(trk->pt(),trk->eta(),trk->phi(),mass);
+    cands.emplace_back(pat::PackedCandidate(p4,trk->vertex(),
+					    trk->pt(),trk->eta(),trk->phi(),
+					    id,pvSlimmedColl,pvSlimmed.key()));
+ 
+   if (trk->quality(reco::TrackBase::highPurity))
+       cands.back().setTrackHighPurity(true);
+    else
+       cands.back().setTrackHighPurity(false);
+              
+    if(trk->pt()>minPtToStoreProps_ || trkStatus==TrkStatus::VTX) cands.back().setTrackProperties(*trk,covarianceSchema_,covarianceVersion_);
+    if(pvOrig.trackWeight(trk) > 0.5) {
+         cands.back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
+    }
 }
+
+
 
 using pat::PATLostTracks;
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -24,6 +24,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 namespace {
   bool passesQuality(const reco::Track& trk,const std::vector<reco::TrackBase::TrackQuality>& allowedQuals){
@@ -57,7 +58,8 @@ namespace pat {
 			    const reco::VertexRef& pvSlimmed,
 			    const reco::VertexRefProd& pvSlimmedColl,
 			    const reco::Vertex& pvOrig,
-			    const TrkStatus trkStatus)const;
+			    const TrkStatus trkStatus,
+                            edm::Handle<reco::MuonCollection> muons) const;
       
   private:
     const edm::EDGetTokenT<reco::PFCandidateCollection>    cands_;
@@ -92,9 +94,9 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
   minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")) ,
   minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
   covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
-  covarianceSchema_(iConfig.getParameter<int >("covarianceSchema"))
-
-{ 
+  covarianceSchema_(iConfig.getParameter<int >("covarianceSchema")),
+  muons_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+  passThroughCut_(iConfig.getParameter<std::string>("passThroughCut")) {
   std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string> >("qualsToAutoAccept"));
   std::transform(trkQuals.begin(),trkQuals.end(),std::back_inserter(qualsToAutoAccept_),reco::TrackBase::qualityByName);
   
@@ -125,6 +127,9 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     
     edm::Handle<reco::VertexCollection> vertices;
     iEvent.getByToken( vertices_, vertices );
+
+    edm::Handle<reco::MuonCollection> muons;
+    iEvent.getByToken(muons_, muons);
 
     edm::Handle<reco::VertexCompositeCandidateCollection> kshorts;
     iEvent.getByToken( kshorts_, kshorts );
@@ -189,7 +194,7 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 	   (trkStatus[trkIndx]==TrkStatus::NOTUSED && passTrkCuts(*trk)) ) { 
 	
 	    outPtrTrks->emplace_back(*trk);
-	    addPackedCandidate(*outPtrTrksAsCands,trk,pv,pvRefProd,pvOrig,trkStatus[trkIndx]);
+	    addPackedCandidate(*outPtrTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
 	
 	    //for creating the reco::Track -> pat::PackedCandidate map
 	    //not done for the lostTrack:eleTracks collection
@@ -197,7 +202,7 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 	    lostTrkIndx++;
 	}else if( (trkStatus[trkIndx]==TrkStatus::PFELECTRON || trkStatus[trkIndx]==TrkStatus::PFPOSITRON ) 
 		  && passTrkCuts(*trk) ) {
-   	    addPackedCandidate(*outPtrEleTrksAsCands,trk,pv,pvRefProd,pvOrig,trkStatus[trkIndx]);
+             addPackedCandidate(*outPtrEleTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
 
 	
       }	      
@@ -220,7 +225,7 @@ bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr)const
                              tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
     const bool passTrkQual = passesQuality(tr,qualsToAutoAccept_);
 
-    return passTrkHits || passTrkQual;
+    return passTrkHits || passTrkQual || passThroughCut_(tr);
 }
 
 void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
@@ -235,7 +240,15 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
     int id=211*trk->charge();
     if(trkStatus==TrkStatus::PFELECTRON) id=11;
     else if(trkStatus==TrkStatus::PFPOSITRON) id=-11; 
-    
+
+    // assign the proper pdgId for tracks that are reconstructed as a muon
+    for (auto& mu : *muons) {
+      if (reco::TrackRef(mu.innerTrack()) == trk) {
+        id = -13 * trk->charge();
+        break;
+      }
+    }
+
     reco::Candidate::PolarLorentzVector p4(trk->pt(),trk->eta(),trk->phi(),mass);
     cands.emplace_back(pat::PackedCandidate(p4,trk->vertex(),
 					    trk->pt(),trk->eta(),trk->phi(),

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -77,6 +77,8 @@ namespace pat {
     const int covarianceVersion_;
     const int covarianceSchema_;
     std::vector<reco::TrackBase::TrackQuality> qualsToAutoAccept_;
+    const edm::EDGetTokenT<reco::MuonCollection> muons_;
+    StringCutObjectSelector<reco::Track, false> passThroughCut_;
   };
 }
 
@@ -233,7 +235,8 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
 					    const reco::VertexRef& pvSlimmed,
 					    const reco::VertexRefProd& pvSlimmedColl,
 					    const reco::Vertex& pvOrig,
-					    const pat::PATLostTracks::TrkStatus trkStatus)const
+					    const pat::PATLostTracks::TrkStatus trkStatus,
+                                            edm::Handle<reco::MuonCollection> muons) const
 {
     const float mass = 0.13957018;
     

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -79,7 +79,7 @@ namespace pat {
     std::vector<reco::TrackBase::TrackQuality> qualsToAutoAccept_;
     const edm::EDGetTokenT<reco::MuonCollection> muons_;
     StringCutObjectSelector<reco::Track, false> passThroughCut_;
-    bool allowPassThroughAndMuonId_;
+    bool allowMuonId_;
   };
 }
 
@@ -100,7 +100,7 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
   covarianceSchema_(iConfig.getParameter<int >("covarianceSchema")),
   muons_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
   passThroughCut_(iConfig.getParameter<std::string>("passThroughCut")),
-  allowPassThroughAndMuonId_(iConfig.getParameter<bool>("allowPassThroughAndMuonId")){
+  allowMuonId_(iConfig.getParameter<bool>("allowMuonId")){
   std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string> >("qualsToAutoAccept"));
   std::transform(trkQuals.begin(),trkQuals.end(),std::back_inserter(qualsToAutoAccept_),reco::TrackBase::qualityByName);
   
@@ -229,7 +229,7 @@ bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr)const
                              tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
     const bool passTrkQual = passesQuality(tr,qualsToAutoAccept_);
 
-    return passTrkHits || passTrkQual || (passThroughCut_(tr) && allowPassThroughAndMuonId_);
+    return passTrkHits || passTrkQual || passThroughCut_(tr) ;
 }
 
 void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
@@ -247,7 +247,7 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
     else if(trkStatus==TrkStatus::PFPOSITRON) id=-11; 
 
     // assign the proper pdgId for tracks that are reconstructed as a muon
-    if (allowPassThroughAndMuonId_){
+    if (allowMuonId_){
       for (auto& mu : *muons) {
         if (reco::TrackRef(mu.innerTrack()) == trk) {
           id = -13 * trk->charge();

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -1,6 +1,5 @@
 #include <string>
 
-
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
@@ -27,49 +26,43 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 namespace {
-  bool passesQuality(const reco::Track& trk,const std::vector<reco::TrackBase::TrackQuality>& allowedQuals){
-    for(const auto& qual : allowedQuals){
-      if(trk.quality(qual)) return true;
+  bool passesQuality(const reco::Track& trk, const std::vector<reco::TrackBase::TrackQuality>& allowedQuals) {
+    for (const auto& qual : allowedQuals) {
+      if (trk.quality(qual))
+        return true;
     }
     return false;
   }
-}
+}  // namespace
 
 namespace pat {
   class PATLostTracks : public edm::global::EDProducer<> {
   public:
     explicit PATLostTracks(const edm::ParameterSet&);
     ~PATLostTracks() override;
-    
+
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-   
-  private:  
-    enum class TrkStatus {
-      NOTUSED=0,
-      PFCAND,
-      PFCANDNOTRKPROPS,
-      PFELECTRON,
-      PFPOSITRON,
-      VTX
-    };
-    bool passTrkCuts(const reco::Track& tr)const;
-    void addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
-			    const reco::TrackRef& trk,
-			    const reco::VertexRef& pvSlimmed,
-			    const reco::VertexRefProd& pvSlimmedColl,
-			    const reco::Vertex& pvOrig,
-			    const TrkStatus trkStatus,
-                            edm::Handle<reco::MuonCollection> muons) const;
-      
+
   private:
-    const edm::EDGetTokenT<reco::PFCandidateCollection>    cands_;
-    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
-    const edm::EDGetTokenT<reco::TrackCollection>          tracks_;
-    const edm::EDGetTokenT<reco::VertexCollection>         vertices_;
-    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>         kshorts_;
-    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>         lambdas_;
-    const edm::EDGetTokenT<reco::VertexCollection>         pv_;
-    const edm::EDGetTokenT<reco::VertexCollection>         pvOrigs_;
+    enum class TrkStatus { NOTUSED = 0, PFCAND, PFCANDNOTRKPROPS, PFELECTRON, PFPOSITRON, VTX };
+    bool passTrkCuts(const reco::Track& tr) const;
+    void addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
+                            const reco::TrackRef& trk,
+                            const reco::VertexRef& pvSlimmed,
+                            const reco::VertexRefProd& pvSlimmedColl,
+                            const reco::Vertex& pvOrig,
+                            const TrkStatus trkStatus,
+                            edm::Handle<reco::MuonCollection> muons) const;
+
+  private:
+    const edm::EDGetTokenT<reco::PFCandidateCollection> cands_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> map_;
+    const edm::EDGetTokenT<reco::TrackCollection> tracks_;
+    const edm::EDGetTokenT<reco::VertexCollection> vertices_;
+    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> kshorts_;
+    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> lambdas_;
+    const edm::EDGetTokenT<reco::VertexCollection> pv_;
+    const edm::EDGetTokenT<reco::VertexCollection> pvOrigs_;
     const double minPt_;
     const double minHits_;
     const double minPixelHits_;
@@ -80,195 +73,199 @@ namespace pat {
     const edm::EDGetTokenT<reco::MuonCollection> muons_;
     StringCutObjectSelector<reco::Track, false> passThroughCut_;
   };
-}
+}  // namespace pat
 
-pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
-  cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
-  map_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-  tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTracks"))),
-  vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices"))),
-  kshorts_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("kshorts"))),
-  lambdas_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("lambdas"))),
-  pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
-  pvOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
-  minPt_(iConfig.getParameter<double>("minPt")),
-  minHits_(iConfig.getParameter<uint32_t>("minHits")),
-  minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")) ,
-  minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
-  covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
-  covarianceSchema_(iConfig.getParameter<int >("covarianceSchema")),
-  muons_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
-  passThroughCut_(iConfig.getParameter<std::string>("passThroughCut")) {
-  std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string> >("qualsToAutoAccept"));
-  std::transform(trkQuals.begin(),trkQuals.end(),std::back_inserter(qualsToAutoAccept_),reco::TrackBase::qualityByName);
-  
-  if(std::find(qualsToAutoAccept_.begin(),qualsToAutoAccept_.end(),reco::TrackBase::undefQuality)!=qualsToAutoAccept_.end()){
+pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
+    : cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
+      map_(consumes<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTracks"))),
+      vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices"))),
+      kshorts_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("kshorts"))),
+      lambdas_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("lambdas"))),
+      pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+      pvOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
+      minPt_(iConfig.getParameter<double>("minPt")),
+      minHits_(iConfig.getParameter<uint32_t>("minHits")),
+      minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")),
+      minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
+      covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
+      covarianceSchema_(iConfig.getParameter<int>("covarianceSchema")),
+      muons_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+      passThroughCut_(iConfig.getParameter<std::string>("passThroughCut")) {
+  std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string>>("qualsToAutoAccept"));
+  std::transform(
+      trkQuals.begin(), trkQuals.end(), std::back_inserter(qualsToAutoAccept_), reco::TrackBase::qualityByName);
+
+  if (std::find(qualsToAutoAccept_.begin(), qualsToAutoAccept_.end(), reco::TrackBase::undefQuality) !=
+      qualsToAutoAccept_.end()) {
     std::ostringstream msg;
-    msg<<" PATLostTracks has a quality requirement which resolves to undefQuality. This usually means a typo and is therefore treated a config error\nquality requirements:\n   ";
-    for(const auto& trkQual : trkQuals) msg <<trkQual<<" ";
+    msg << " PATLostTracks has a quality requirement which resolves to undefQuality. This usually means a typo and is "
+           "therefore treated a config error\nquality requirements:\n   ";
+    for (const auto& trkQual : trkQuals)
+      msg << trkQual << " ";
     throw cms::Exception("Configuration") << msg.str();
-  } 
-    
-  produces< std::vector<reco::Track> > ();
-  produces< std::vector<pat::PackedCandidate> > (); produces< std::vector<pat::PackedCandidate> > ("eleTracks");
-  produces< edm::Association<pat::PackedCandidateCollection> > ();
+  }
+
+  produces<std::vector<reco::Track>>();
+  produces<std::vector<pat::PackedCandidate>>();
+  produces<std::vector<pat::PackedCandidate>>("eleTracks");
+  produces<edm::Association<pat::PackedCandidateCollection>>();
 }
 
 pat::PATLostTracks::~PATLostTracks() {}
 
 void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  edm::Handle<reco::PFCandidateCollection> cands;
+  iEvent.getByToken(cands_, cands);
 
-    edm::Handle<reco::PFCandidateCollection> cands;
-    iEvent.getByToken( cands_, cands );
+  edm::Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
+  iEvent.getByToken(map_, pf2pc);
 
-    edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
-    iEvent.getByToken(map_,pf2pc);
+  edm::Handle<reco::TrackCollection> tracks;
+  iEvent.getByToken(tracks_, tracks);
 
-    edm::Handle<reco::TrackCollection> tracks;
-    iEvent.getByToken( tracks_, tracks );
-    
-    edm::Handle<reco::VertexCollection> vertices;
-    iEvent.getByToken( vertices_, vertices );
+  edm::Handle<reco::VertexCollection> vertices;
+  iEvent.getByToken(vertices_, vertices);
 
-    edm::Handle<reco::MuonCollection> muons;
-    iEvent.getByToken(muons_, muons);
+  edm::Handle<reco::MuonCollection> muons;
+  iEvent.getByToken(muons_, muons);
 
-    edm::Handle<reco::VertexCompositeCandidateCollection> kshorts;
-    iEvent.getByToken( kshorts_, kshorts );
-    edm::Handle<reco::VertexCompositeCandidateCollection> lambdas;
-    iEvent.getByToken( lambdas_, lambdas );
+  edm::Handle<reco::VertexCompositeCandidateCollection> kshorts;
+  iEvent.getByToken(kshorts_, kshorts);
+  edm::Handle<reco::VertexCompositeCandidateCollection> lambdas;
+  iEvent.getByToken(lambdas_, lambdas);
 
-    edm::Handle<reco::VertexCollection> pvs;
-    iEvent.getByToken( pv_, pvs );
-    reco::VertexRef pv(pvs.id());
-    reco::VertexRefProd pvRefProd(pvs);
-    if (!pvs->empty()) {
-        pv = reco::VertexRef(pvs, 0);
+  edm::Handle<reco::VertexCollection> pvs;
+  iEvent.getByToken(pv_, pvs);
+  reco::VertexRef pv(pvs.id());
+  reco::VertexRefProd pvRefProd(pvs);
+  if (!pvs->empty()) {
+    pv = reco::VertexRef(pvs, 0);
+  }
+  edm::Handle<reco::VertexCollection> pvOrigs;
+  iEvent.getByToken(pvOrigs_, pvOrigs);
+  const reco::Vertex& pvOrig = (*pvOrigs)[0];
+
+  auto outPtrTrks = std::make_unique<std::vector<reco::Track>>();
+  auto outPtrTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
+  auto outPtrEleTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
+
+  std::vector<TrkStatus> trkStatus(tracks->size(), TrkStatus::NOTUSED);
+  //Mark all tracks used in candidates
+  //check if packed candidates are storing the tracks by seeing if number of hits >0
+  //currently we dont use that information though
+  //electrons will never store their track (they store the GSF track)
+  for (unsigned int ic = 0, nc = cands->size(); ic < nc; ++ic) {
+    edm::Ref<reco::PFCandidateCollection> r(cands, ic);
+    const reco::PFCandidate& cand = (*cands)[ic];
+    if (cand.charge() && cand.trackRef().isNonnull() && cand.trackRef().id() == tracks.id()) {
+      if (cand.pdgId() == 11)
+        trkStatus[cand.trackRef().key()] = TrkStatus::PFELECTRON;
+      else if (cand.pdgId() == -11)
+        trkStatus[cand.trackRef().key()] = TrkStatus::PFPOSITRON;
+      else if ((*pf2pc)[r]->numberOfHits() > 0)
+        trkStatus[cand.trackRef().key()] = TrkStatus::PFCAND;
+      else
+        trkStatus[cand.trackRef().key()] = TrkStatus::PFCANDNOTRKPROPS;
     }
-    edm::Handle<reco::VertexCollection> pvOrigs;
-    iEvent.getByToken( pvOrigs_, pvOrigs );
-    const reco::Vertex & pvOrig = (*pvOrigs)[0];
+  }
 
-    auto outPtrTrks = std::make_unique<std::vector<reco::Track>>();
-    auto outPtrTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
-    auto outPtrEleTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
-  
-    std::vector<TrkStatus> trkStatus(tracks->size(),TrkStatus::NOTUSED);
-    //Mark all tracks used in candidates	
-    //check if packed candidates are storing the tracks by seeing if number of hits >0 	  
-    //currently we dont use that information though
-    //electrons will never store their track (they store the GSF track)
-    for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
-        edm::Ref<reco::PFCandidateCollection> r(cands,ic);
-        const reco::PFCandidate &cand=(*cands)[ic]; 
-	if(cand.charge() && cand.trackRef().isNonnull() && cand.trackRef().id() == tracks.id() ) { 
-	  
-	  if(cand.pdgId()==11) trkStatus[cand.trackRef().key()]=TrkStatus::PFELECTRON;	  
-	  else if(cand.pdgId()==-11) trkStatus[cand.trackRef().key()]=TrkStatus::PFPOSITRON;
-	  else if((*pf2pc)[r]->numberOfHits() > 0) trkStatus[cand.trackRef().key()]=TrkStatus::PFCAND; 
-	  else trkStatus[cand.trackRef().key()]=TrkStatus::PFCANDNOTRKPROPS; 
-	}
+  //Mark all tracks used in secondary vertices
+  for (const auto& secVert : *vertices) {
+    for (auto trkIt = secVert.tracks_begin(); trkIt != secVert.tracks_end(); trkIt++) {
+      if (trkStatus[trkIt->key()] == TrkStatus::NOTUSED)
+        trkStatus[trkIt->key()] = TrkStatus::VTX;
     }
-        
-    //Mark all tracks used in secondary vertices
-    for(const auto& secVert : *vertices){
-        for(auto trkIt = secVert.tracks_begin();trkIt!=secVert.tracks_end();trkIt++){
-	    if(trkStatus[trkIt->key()]==TrkStatus::NOTUSED)  trkStatus[trkIt->key()]=TrkStatus::VTX;
-	}
+  }
+  for (const auto& v0 : *kshorts) {
+    for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
+      size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
+      if (trkStatus[key] == TrkStatus::NOTUSED)
+        trkStatus[key] = TrkStatus::VTX;
     }
-    for(const auto& v0 : *kshorts){
-        for(size_t dIdx=0;dIdx<v0.numberOfDaughters(); dIdx++){
-	    size_t key= (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
-	    if(trkStatus[key]==TrkStatus::NOTUSED)  trkStatus[key]=TrkStatus::VTX;
-	}
+  }
+  for (const auto& v0 : *lambdas) {
+    for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
+      size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
+      if (trkStatus[key] == TrkStatus::NOTUSED)
+        trkStatus[key] = TrkStatus::VTX;
     }
-    for(const auto& v0 : *lambdas){
-        for(size_t dIdx=0;dIdx<v0.numberOfDaughters(); dIdx++){
-	    size_t key= (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
-	    if(trkStatus[key]==TrkStatus::NOTUSED)  trkStatus[key]=TrkStatus::VTX;
-	}
-    }
-    std::vector<int> mapping(tracks->size(),-1);  
-    int lostTrkIndx=0;
-    for(unsigned int trkIndx=0; trkIndx < tracks->size(); trkIndx++){
-        reco::TrackRef trk(tracks,trkIndx);
-	if( trkStatus[trkIndx] == TrkStatus::VTX || 
-	   (trkStatus[trkIndx]==TrkStatus::NOTUSED && passTrkCuts(*trk)) ) { 
-	
-	    outPtrTrks->emplace_back(*trk);
-	    addPackedCandidate(*outPtrTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
-	
-	    //for creating the reco::Track -> pat::PackedCandidate map
-	    //not done for the lostTrack:eleTracks collection
-	    mapping[trkIndx]=lostTrkIndx;
-	    lostTrkIndx++;
-	}else if( (trkStatus[trkIndx]==TrkStatus::PFELECTRON || trkStatus[trkIndx]==TrkStatus::PFPOSITRON ) 
-		  && passTrkCuts(*trk) ) {
-             addPackedCandidate(*outPtrEleTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
+  }
+  std::vector<int> mapping(tracks->size(), -1);
+  int lostTrkIndx = 0;
+  for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
+    reco::TrackRef trk(tracks, trkIndx);
+    if (trkStatus[trkIndx] == TrkStatus::VTX || (trkStatus[trkIndx] == TrkStatus::NOTUSED && passTrkCuts(*trk))) {
+      outPtrTrks->emplace_back(*trk);
+      addPackedCandidate(*outPtrTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
 
-	
-      }	      
-    } 
-    
-    iEvent.put(std::move(outPtrTrks));
-    iEvent.put(std::move(outPtrEleTrksAsCands),"eleTracks");
-    edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrTrksAsCands));
-    auto tk2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
-    edm::Association<pat::PackedCandidateCollection>::Filler tk2pcFiller(*tk2pc);
-    tk2pcFiller.insert(tracks, mapping.begin(), mapping.end());
-    tk2pcFiller.fill() ; 
-    iEvent.put(std::move(tk2pc));   
+      //for creating the reco::Track -> pat::PackedCandidate map
+      //not done for the lostTrack:eleTracks collection
+      mapping[trkIndx] = lostTrkIndx;
+      lostTrkIndx++;
+    } else if ((trkStatus[trkIndx] == TrkStatus::PFELECTRON || trkStatus[trkIndx] == TrkStatus::PFPOSITRON) &&
+               passTrkCuts(*trk)) {
+      addPackedCandidate(*outPtrEleTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx], muons);
+    }
+  }
+
+  iEvent.put(std::move(outPtrTrks));
+  iEvent.put(std::move(outPtrEleTrksAsCands), "eleTracks");
+  edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrTrksAsCands));
+  auto tk2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
+  edm::Association<pat::PackedCandidateCollection>::Filler tk2pcFiller(*tk2pc);
+  tk2pcFiller.insert(tracks, mapping.begin(), mapping.end());
+  tk2pcFiller.fill();
+  iEvent.put(std::move(tk2pc));
 }
 
-bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr)const
-{
-    const bool passTrkHits = tr.pt() > minPt_ && 
-                             tr.numberOfValidHits() >= minHits_ && 
-                             tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
-    const bool passTrkQual = passesQuality(tr,qualsToAutoAccept_);
+bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr) const {
+  const bool passTrkHits = tr.pt() > minPt_ && tr.numberOfValidHits() >= minHits_ &&
+                           tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
+  const bool passTrkQual = passesQuality(tr, qualsToAutoAccept_);
 
-    return passTrkHits || passTrkQual || passThroughCut_(tr);
+  return passTrkHits || passTrkQual || passThroughCut_(tr);
 }
 
 void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
-					    const reco::TrackRef& trk,
-					    const reco::VertexRef& pvSlimmed,
-					    const reco::VertexRefProd& pvSlimmedColl,
-					    const reco::Vertex& pvOrig,
-					    const pat::PATLostTracks::TrkStatus trkStatus,
-                                            edm::Handle<reco::MuonCollection> muons) const
-{
-    const float mass = 0.13957018;
-    
-    int id=211*trk->charge();
-    if(trkStatus==TrkStatus::PFELECTRON) id=11;
-    else if(trkStatus==TrkStatus::PFPOSITRON) id=-11; 
+                                            const reco::TrackRef& trk,
+                                            const reco::VertexRef& pvSlimmed,
+                                            const reco::VertexRefProd& pvSlimmedColl,
+                                            const reco::Vertex& pvOrig,
+                                            const pat::PATLostTracks::TrkStatus trkStatus,
+                                            edm::Handle<reco::MuonCollection> muons) const {
+  const float mass = 0.13957018;
 
-    // assign the proper pdgId for tracks that are reconstructed as a muon
-    for (auto& mu : *muons) {
-      if (reco::TrackRef(mu.innerTrack()) == trk) {
-        id = -13 * trk->charge();
-        break;
-      }
-    }
+  int id = 211 * trk->charge();
+  if (trkStatus == TrkStatus::PFELECTRON)
+    id = 11;
+  else if (trkStatus == TrkStatus::PFPOSITRON)
+    id = -11;
 
-    reco::Candidate::PolarLorentzVector p4(trk->pt(),trk->eta(),trk->phi(),mass);
-    cands.emplace_back(pat::PackedCandidate(p4,trk->vertex(),
-					    trk->pt(),trk->eta(),trk->phi(),
-					    id,pvSlimmedColl,pvSlimmed.key()));
- 
-   if (trk->quality(reco::TrackBase::highPurity))
-       cands.back().setTrackHighPurity(true);
-    else
-       cands.back().setTrackHighPurity(false);
-              
-    if(trk->pt()>minPtToStoreProps_ || trkStatus==TrkStatus::VTX) cands.back().setTrackProperties(*trk,covarianceSchema_,covarianceVersion_);
-    if(pvOrig.trackWeight(trk) > 0.5) {
-         cands.back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
+  // assign the proper pdgId for tracks that are reconstructed as a muon
+  for (auto& mu : *muons) {
+    if (reco::TrackRef(mu.innerTrack()) == trk) {
+      id = -13 * trk->charge();
+      break;
     }
+  }
+
+  reco::Candidate::PolarLorentzVector p4(trk->pt(), trk->eta(), trk->phi(), mass);
+  cands.emplace_back(
+      pat::PackedCandidate(p4, trk->vertex(), trk->pt(), trk->eta(), trk->phi(), id, pvSlimmedColl, pvSlimmed.key()));
+
+  if (trk->quality(reco::TrackBase::highPurity))
+    cands.back().setTrackHighPurity(true);
+  else
+    cands.back().setTrackHighPurity(false);
+
+  if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX)
+    cands.back().setTrackProperties(*trk, covarianceSchema_, covarianceVersion_);
+  if (pvOrig.trackWeight(trk) > 0.5) {
+    cands.back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
+  }
 }
-
-
 
 using pat::PATLostTracks;
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMuonMerger.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonMerger.cc
@@ -1,0 +1,134 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/Common/interface/getRef.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+namespace pat {
+  typedef edm::Ptr<pat::PackedCandidate> PackedCandidatePtr;
+}
+
+class PATMuonMerger : public edm::stream::EDProducer<> {
+public:
+  explicit PATMuonMerger(const edm::ParameterSet& iConfig);
+  ~PATMuonMerger() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  edm::InputTag muons_;
+  StringCutObjectSelector<pat::Muon, false> muonsCut_;
+  edm::InputTag pfCandidate_;
+  StringCutObjectSelector<pat::PackedCandidate, false> pfCandidateCut_;
+  edm::InputTag lostTrack_;
+  StringCutObjectSelector<pat::PackedCandidate, false> lostTrackCut_;
+
+  edm::EDGetTokenT<std::vector<pat::Muon>> muonToken_;
+  edm::EDGetTokenT<std::vector<pat::PackedCandidate>> pfCandToken_;
+  edm::EDGetTokenT<std::vector<pat::PackedCandidate>> lostTrackToken_;
+};
+
+PATMuonMerger::PATMuonMerger(const edm::ParameterSet& iConfig)
+    : muons_(iConfig.getParameter<edm::InputTag>("muons")),
+      muonsCut_(iConfig.getParameter<std::string>("muonCut")),
+      pfCandidate_(iConfig.getParameter<edm::InputTag>("pfCandidates")),
+      pfCandidateCut_(iConfig.getParameter<std::string>("pfCandidatesCut")),
+      lostTrack_(iConfig.getParameter<edm::InputTag>("otherTracks")),
+      lostTrackCut_(iConfig.getParameter<std::string>("lostTrackCut")) {
+  muonToken_ = consumes<std::vector<pat::Muon>>(muons_);
+  pfCandToken_ = consumes<std::vector<pat::PackedCandidate>>(pfCandidate_);
+  lostTrackToken_ = consumes<std::vector<pat::PackedCandidate>>(lostTrack_);
+  produces<std::vector<pat::Muon>>();
+}
+
+void PATMuonMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // mergedMuons
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("muonCut", "");
+  desc.add<edm::InputTag>("otherTracks", edm::InputTag("lostTracks"));
+  desc.add<edm::InputTag>("pfCandidates", edm::InputTag("packedPFCandidates"));
+  desc.add<std::string>("pfCandidatesCut", "");
+  desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
+  desc.add<std::string>("lostTrackCut", "");
+  descriptions.add("mergedMuonsNoCuts", desc);
+}
+
+void PATMuonMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<std::vector<pat::Muon>> muons;
+  edm::Handle<std::vector<pat::PackedCandidate>> pfCands;
+  edm::Handle<std::vector<pat::PackedCandidate>> lostTracks;
+
+  iEvent.getByToken(muonToken_, muons);
+  iEvent.getByToken(pfCandToken_, pfCands);
+  iEvent.getByToken(lostTrackToken_, lostTracks);
+
+  auto out = std::make_unique<std::vector<pat::Muon>>();
+  out->reserve(muons->size() + pfCands->size() + lostTracks->size());
+
+  // copy all muons
+  for (auto& muon : *muons) {
+    if (!muonsCut_(muon))
+      continue;
+    out->push_back(muon);
+  }
+
+  // add other pfCandidates, removing duplicates
+  for (unsigned int pf = 0; pf < pfCands->size(); ++pf) {
+    auto pfCand = pfCands->at(pf);
+    if (!pfCandidateCut_(pfCand))
+      continue;
+    reco::CandidatePtr pfCandPtr(pfCands, pf);
+    bool isPFMuon = false;
+    for (auto& muon : *muons) {
+      for (unsigned int i = 0, n = muon.numberOfSourceCandidatePtrs(); i < n; ++i) {
+        reco::CandidatePtr ptr = muon.sourceCandidatePtr(i);
+        if (ptr.isNonnull() && ptr == pfCandPtr) {
+          isPFMuon = true;
+          break;
+        }
+      }
+      if (isPFMuon)
+        break;
+    }
+    if (isPFMuon) {
+      continue;
+    }
+
+    // now make a reco::Muon and recast to pat::Muon
+    double energy = sqrt(pfCand.p() * pfCand.p() + 0.011163691);
+    math::XYZTLorentzVector p4(pfCand.px(), pfCand.py(), pfCand.pz(), energy);
+    reco::Muon mu(pfCand.charge(), p4, pfCand.vertex());
+    pat::Muon aMu(mu);
+    out->push_back(aMu);
+  }
+
+  // adding now lost tracks, removing duplicates
+  for (auto& lostTrack : *lostTracks) {
+    if (!lostTrackCut_(lostTrack))
+      continue;
+    if (std::abs(lostTrack.pdgId()) == 13)
+      continue;
+
+    // now make a reco::Muon and recast to pat::Muon
+    double energy = sqrt(lostTrack.p() * lostTrack.p() + 0.011163691);
+    math::XYZTLorentzVector p4(lostTrack.px(), lostTrack.py(), lostTrack.pz(), energy);
+    reco::Muon mu(lostTrack.charge(), p4, lostTrack.vertex());
+    pat::Muon aMu(mu);
+    out->push_back(aMu);
+  }
+  iEvent.put(std::move(out));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATMuonMerger);

--- a/PhysicsTools/PatAlgos/python/patMuonMerger_cfi.py
+++ b/PhysicsTools/PatAlgos/python/patMuonMerger_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+mergedMuons = cms.EDProducer("PATMuonMerger",
+                             muons     = cms.InputTag("slimmedMuons"), 
+                             pfCandidates=cms.InputTag("packedPFCandidates"),
+                             otherTracks = cms.InputTag("lostTracks"),
+                             muonCut = cms.string("pt>15 && abs(eta)<2.4"),
+                             pfCandidatesCut = cms.string("pt>15 && abs(eta)<2.4"),
+                             lostTrackCut = cms.string("pt>15 && abs(eta)<2.4")
+                         )

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -9,13 +9,15 @@ lostTracks = cms.EDProducer("PATLostTracks",
     lambdas=cms.InputTag("generalV0Candidates","Lambda"),
     primaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     originalVertices = cms.InputTag("offlinePrimaryVertices"),
+    muons = cms.InputTag("muons"),
     minPt = cms.double(0.95),	
     minHits = cms.uint32(8),	
     minPixelHits = cms.uint32(1),  
     covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1   
     covarianceSchema = cms.int32(0), #old miniaod like
     qualsToAutoAccept = cms.vstring("highPurity"),
-    minPtToStoreProps = cms.double(0.95)	
+    minPtToStoreProps = cms.double(0.95),
+    passThroughCut = cms.string("pt>2")
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -17,8 +17,11 @@ lostTracks = cms.EDProducer("PATLostTracks",
     covarianceSchema = cms.int32(0), #old miniaod like
     qualsToAutoAccept = cms.vstring("highPurity"),
     minPtToStoreProps = cms.double(0.95),
-    passThroughCut = cms.string("pt>2")
+    passThroughCut = cms.string("pt>2"),
+    allowPassThroughAndMuonId = cms.bool(False)
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )
 
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+run2_miniAOD_devel.toModify(lostTracks, allowPassThroughAndMuonId=True)

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -17,11 +17,12 @@ lostTracks = cms.EDProducer("PATLostTracks",
     covarianceSchema = cms.int32(0), #old miniaod like
     qualsToAutoAccept = cms.vstring("highPurity"),
     minPtToStoreProps = cms.double(0.95),
-    passThroughCut = cms.string("pt>2"),
-    allowPassThroughAndMuonId = cms.bool(False)
+    passThroughCut = cms.string("0"),
+    allowMuonId = cms.bool(False)
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )
 
 from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-run2_miniAOD_devel.toModify(lostTracks, allowPassThroughAndMuonId=True)
+run2_miniAOD_devel.toModify(lostTracks, passThroughCut="pt>2", allowMuonId=True)
+


### PR DESCRIPTION
#### PR description:

Backport from #29389, update of the lostTrack collection for MUO 
https://github.com/cms-sw/cmssw/issues/27889
#### PR validation:

This PR has been validated with 136.8311

This PR is back-port from #29389, needs to be in 10_6_X for the UL re-miniAOD