### PR TITLE
Run3-sim66 Make ECAL geometry builder dd4hep ERA dependent

### DIFF
--- a/Geometry/EcalAlgo/python/EcalBarrelGeometry_cfi.py
+++ b/Geometry/EcalAlgo/python/EcalBarrelGeometry_cfi.py
@@ -4,3 +4,9 @@ EcalBarrelGeometryEP = cms.ESProducer( "EcalBarrelGeometryEP",
                                        applyAlignment = cms.bool(False)
                                       )
 
+_EcalBarrelGeometryEP_dd4hep = cms.ESProducer("EcalBarrelGeometryEPdd4hep",
+    applyAlignment = cms.bool(False)
+)
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+dd4hep.toReplaceWith(EcalBarrelGeometryEP, _EcalBarrelGeometryEP_dd4hep)

--- a/Geometry/EcalAlgo/python/EcalEndcapGeometry_cfi.py
+++ b/Geometry/EcalAlgo/python/EcalEndcapGeometry_cfi.py
@@ -3,3 +3,10 @@ import FWCore.ParameterSet.Config as cms
 EcalEndcapGeometryEP = cms.ESProducer( "EcalEndcapGeometryEP",
                                        applyAlignment = cms.bool(False)
                                        )
+
+_EcalEndcapGeometryEP_dd4hep = cms.ESProducer("EcalEndcapGeometryEPdd4hep",
+    applyAlignment = cms.bool(False)
+)
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+dd4hep.toReplaceWith(EcalEndcapGeometryEP, _EcalEndcapGeometryEP_dd4hep)

--- a/Geometry/EcalAlgo/python/EcalGeometry_cfi.py
+++ b/Geometry/EcalAlgo/python/EcalGeometry_cfi.py
@@ -1,3 +1,3 @@
-from Geometry.EcalAlgo.EcalEndcapGeometry_cfi import *
-from Geometry.EcalAlgo.EcalPreshowerGeometry_cfi import *
-from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *
+from Geometry.EcalAlgo.EcalEndcapGeometry_cfi import EcalEndcapGeometryEP
+from Geometry.EcalAlgo.EcalPreshowerGeometry_cfi import EcalPreshowerGeometryEP
+from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import EcalBarrelGeometryEP

--- a/Geometry/EcalAlgo/python/EcalPreshowerGeometry_cfi.py
+++ b/Geometry/EcalAlgo/python/EcalPreshowerGeometry_cfi.py
@@ -3,3 +3,10 @@ import FWCore.ParameterSet.Config as cms
 EcalPreshowerGeometryEP = cms.ESProducer( "EcalPreshowerGeometryEP",
                                           applyAlignment = cms.bool(False)
                                           )
+
+_EcalPreshowerGeometryEP_dd4hep = cms.ESProducer("EcalPreshowerGeometryEPdd4hep",
+    applyAlignment = cms.bool(False)
+)
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+dd4hep.toReplaceWith(EcalPreshowerGeometryEP, _EcalPreshowerGeometryEP_dd4hep)


### PR DESCRIPTION
#### PR description:

Use dd4hep ERA to choose the reconstruction geometry builder

#### PR validation:

runTheMatrix.py is used

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Nothing special