### PR TITLE
DataFormats/Math: Fix segfault in deltaPhi when run under cmsRunVDT

### DIFF
--- a/DataFormats/Math/interface/deltaPhi.h
+++ b/DataFormats/Math/interface/deltaPhi.h
@@ -9,6 +9,12 @@
  */
 
 #include <cmath>
+#include <iostream>
+#include <limits>
+#include <iomanip>
+#include <iostream>
+#include <type_traits>
+#include <algorithm>
 #include "DataFormats/Math/interface/angle_units.h"
 
 namespace reco {
@@ -38,7 +44,8 @@ namespace reco {
 
   template <typename T>
   constexpr T deltaPhi(T phi1, T phi2) {
-    constexpr T epsilon = 1.e-13;
+    std::cout << std::fixed << std::setprecision(20) << "phi1=" << phi1 << "\nphi2=" << phi2 << '\n';
+    constexpr T epsilon = std::numeric_limits<T>::epsilon();
     constexpr T diff = phi1 - phi2;
     if (std::abs(diff) <= epsilon)
       return (0.);
@@ -72,7 +79,7 @@ namespace angle0to2pi {
   inline constexpr valType make0To2pi(valType angle) {
     constexpr valType twoPi = 2._pi;
     constexpr valType oneOverTwoPi = 1. / twoPi;
-    constexpr valType epsilon = 1.e-13;
+    constexpr valType epsilon = std::numeric_limits<valType>::epsilon();
 
     if ((std::abs(angle) <= epsilon) || (std::abs(twoPi - std::abs(angle)) <= epsilon))
       return (0.);

--- a/DataFormats/Math/interface/deltaPhi.h
+++ b/DataFormats/Math/interface/deltaPhi.h
@@ -38,7 +38,12 @@ namespace reco {
 
   template <typename T>
   constexpr T deltaPhi(T phi1, T phi2) {
-    return reduceRange(phi1 - phi2);
+    constexpr T epsilon = 1.e-13;
+    constexpr T diff = phi1 - phi2;
+    if (std::abs(diff) <= epsilon)
+      return (0.);
+    else
+      return reduceRange(diff);
   }
 }  // namespace reco
 


### PR DESCRIPTION
DataFormats/Math: Check if diff of floats passed to reco::deltaPhi is less than the precision of floats.

This should address a segfault seen in Phase2EndcapRing::computeCrossings when running with cmsRunVDT.

#### PR description:
Attempt to address this segfault seen when running RECO with cmsRunVDT
```
Thread 3 (Thread 0x7f6c69152700 (LWP 30111)):
#0  0x00007f6c9c418bed in poll () from /lib64/libc.so.6
#1  0x00007f6c93791947 in full_read.constprop () from /cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_1_X_2020-04-19-2300/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#2  0x00007f6c9379205c in edm::service::InitRootHandlers::stacktraceFromThread() () from /cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_1_X_2020-04-19-2300/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#3  0x00007f6c93792d84 in sig_dostack_then_abort () from /cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_1_X_2020-04-19-2300/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#4  <signal handler called>
#5  0x00007f6c7cc1e2fa in Phase2EndcapRing::computeCrossings (this=this@entry=0x7f6c4a9fd820, startingState=..., propDir=<optimized out>) at /home/users/gartung/CMSSW_11_1_X_2020-04-19-2300/src/DataFormats/Math/interface/deltaPhi.h:32
#6  0x00007f6c7cc1ec55 in Phase2EndcapRing::groupedCompatibleDetsV(TrajectoryStateOnSurface const&, Propagator const&, MeasurementEstimator const&, std::vector<DetGroup, std::allocator<DetGroup> >&) const () at /cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc900
/cms/cmssw/CMSSW_11_1_X_2020-04-19-2300/src/TrackingTools/GeomPropagators/interface/Propagator.h:139
```
