### PR TITLE
Update eventcontent structure in RecoPixelVertexing

### DIFF
--- a/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_EventContent_cff.py
+++ b/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_EventContent_cff.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content 
-RecoPixelVertexingFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_pixelTracks_*_*', 
-        'keep *_pixelVertices_*_*')
-)
 #RECO content
 RecoPixelVertexingRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_pixelTracks_*_*', 
         'keep *_pixelVertices_*_*')
 )
 
+#Full Event content 
+RecoPixelVertexingFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring() 
+)
+RecoPixelVertexingFEVT.outputCommands.extend(RecoPixelVertexingRECO.outputCommands)


### PR DESCRIPTION
#### PR description:  
Update event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. 1 file changed : 
+ RecoPixelVertexing_EventContent_cff.py 

(The previous tasks are [PR#29025](https://github.com/cms-sw/cmssw/pull/29025), [PR#29158](https://github.com/cms-sw/cmssw/pull/29158), [PR#29225](https://github.com/cms-sw/cmssw/pull/29225), [PR#29299](https://github.com/cms-sw/cmssw/pull/29299), [PR#29470](https://github.com/cms-sw/cmssw/pull/29470), and [PR#29517](https://github.com/cms-sw/cmssw/pull/29517))

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).