### PR TITLE
Herwig 7.2 Interface backport to CMSSW_10_2_X

### DIFF
--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -28,13 +28,16 @@ Marco A. Harrendorf
 
 namespace ThePEG {
 
-  template<> struct HepMCTraits<HepMC::GenEvent> :
-                public HepMCTraitsBase<
-    HepMC::GenEvent, HepMC::GenParticle,
-    HepMC::GenVertex, HepMC::Polarization,
-    HepMC::PdfInfo> {};
+  template <>
+  struct HepMCTraits<HepMC::GenEvent> : public HepMCTraitsBase<HepMC::GenEvent,
+                                                               HepMC::GenParticle,
+                                                               HepMC::GenParticle *,
+                                                               HepMC::GenVertex,
+                                                               HepMC::GenVertex *,
+                                                               HepMC::Polarization,
+                                                               HepMC::PdfInfo> {};
 
-}
+}  // namespace ThePEG
 
 namespace CLHEP {
   class HepRandomEngine;


### PR DESCRIPTION
#### PR description:

Update of Herwig 7 interface to allow update of Herwig 7.1.4->7.2.0.

#### PR validation:

Has been tested with runTheMatrix workflow 535, and the test commands on the Herwig twiki

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/29523 to allow use of Herwig 7.2 for 2018 production 