### PR TITLE
Backport of #28753 (fix the sign of pat::Muon dxy to take the one from the track)

### DIFF
--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -327,7 +327,13 @@ public:
     
     /// error on beta
     double betaError() const;
-    
+   
+    /// error on dxy with respect to a user-given reference point + uncertainty (i.e. reco::Vertex position)
+    double dxyError(Point const &vtx, math::Error<3>::type const &vertexCov) const;
+
+    /// error on dxy with respect to a user-given beamspot
+    double dxyError(const BeamSpot &theBeamSpot) const;
+
     /// fill SMatrix
     CovarianceMatrix &fill(CovarianceMatrix &v) const;
 
@@ -883,6 +889,12 @@ inline double TrackBase::t0Error() const
 inline double TrackBase::betaError() const
 {
     return std::sqrt(covbetabeta_);
+}
+
+// error on dxy with respect to a given beamspot
+inline double TrackBase::dxyError(const BeamSpot &theBeamSpot) const
+{
+    return dxyError(theBeamSpot.position(vz()), theBeamSpot.rotatedCovariance3D());
 }
 
 // number of valid hits found

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -154,3 +154,20 @@ TrackBase::TrackAlgorithm TrackBase::algoByName(const std::string &name)
     // cast
     return TrackAlgorithm(index);
 }
+
+double TrackBase::dxyError(Point const &vtx, math::Error<3>::type const &vertexCov) const {
+  // Gradient of TrackBase::dxy(const Point &myBeamSpot) with respect to track parameters
+  TrackBase::ParameterVector trackGrad =
+      TrackBase::ParameterVector(0,
+                                 0,
+                                 (vtx.x() * px() + vtx.y() * py()) / pt(),  // x_vert * cos(phi) + y_vert * sin(phi)
+                                 1,
+                                 0);
+  // Gradient with respect to point parameters
+  math::Vector<3>::type pointGrad = math::Vector<3>::type(py() / pt(),   // sin(phi)
+                                                          -px() / pt(),  // -cos(phi)
+                                                          0);
+  // Propagate covariance assuming cross-terms of the covariance between track and vertex parameters are 0
+  return std::sqrt(ROOT::Math::Dot(trackGrad, covariance() * trackGrad) +
+                   ROOT::Math::Dot(pointGrad, vertexCov * pointGrad));
+}

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -984,6 +984,9 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   iDesc.add<edm::InputTag>("sourceInverseBeta", edm::InputTag("muons", "combined"))
       ->setComment("source of inverse beta values");
 
+  // switch to get the IP from the best track instead of running IPTools
+  iDesc.add<bool>("getdBFromTrack", false)->setComment("switch IP2D computation to use the best track one");
+ 
   // MC matching configurables
   iDesc.add<bool>("addGenMatch", true)->setComment("add MC matching");
   iDesc.add<bool>("embedGenMatch", false)->setComment("embed MC matched MC information");
@@ -1098,6 +1101,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
                                      bool beamspotIsValid) {
   // Generic variable to store measurements
   std::pair<bool,Measurement1D> result;
+  double d0_corr;
+  double d0_err;
 
   // Correct to PV
 
@@ -1106,14 +1111,9 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
     aMuon.setDB(track->dxy(primaryVertex.position()),
                 track->dxyError(primaryVertex.position(), primaryVertex.covariance()),
                 pat::Muon::PV2D);
-  }
-  else{
+  } else{
     result =
-      IPTools::signedTransverseImpactParameter(tt,
-                                               GlobalVector(track->px(),
-                                                            track->py(),
-                                                            track->pz()),
-                                               primaryVertex);
+      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
     double d0_corr = result.second.value();
     double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
     aMuon.setDB( d0_corr, d0_err, pat::Muon::PV2D);
@@ -1122,8 +1122,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   // PV3D
   result =
       IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
-  double d0_corr = result.second.value();
-  double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
+  d0_corr = result.second.value();
+  d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV3D);
 
   // Correct to beam spot
@@ -1133,14 +1133,9 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   reco::Vertex vBeamspot(beamspot.position(), beamspot.rotatedCovariance3D());
   if (getdBFromTrack_){
     aMuon.setDB(track->dxy(beamspot), track->dxyError(beamspot), pat::Muon::BS2D);
-  }
-  else{
+  } else{
     result =
-      IPTools::signedTransverseImpactParameter(tt,
-                                               GlobalVector(track->px(),
-                                                            track->py(),
-                                                            track->pz()),
-                                               vBeamspot);
+      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
     d0_corr = result.second.value();
     d0_err = beamspotIsValid ? result.second.error() : -1.0;
     aMuon.setDB( d0_corr, d0_err, pat::Muon::BS2D);

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1102,7 +1102,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy() > 0 ? 1 : -1)*fabs(d0_corr);
+  d0_corr = (track->dxy(primaryVertex.position()) > 0 ? 1 : -1)*fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1102,7 +1102,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy(primaryVertex.position()) > 0 ? 1 : -1)*fabs(d0_corr);
+  d0_corr = (track->dxy(primaryVertex.position()) > 0 ? 1 : -1) * fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D
@@ -1120,7 +1120,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy(beamspot) > 0 ? 1 : -1)*fabs(d0_corr);
+  d0_corr = (track->dxy(beamspot) > 0 ? 1 : -1) * fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
 
   // BS3D

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1102,7 +1102,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy(primaryVertex.position()) > 0 ? 1 : -1) * fabs(d0_corr);
+  d0_corr = std::copysign(d0_corr, track->dxy(primaryVertex.position()));
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D
@@ -1120,7 +1120,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy(beamspot) > 0 ? 1 : -1) * fabs(d0_corr);
+  d0_corr = std::copysign(d0_corr, track->dxy(beamspot)); 
   aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
 
   // BS3D

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1101,6 +1101,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
       IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
+  // Now correct the sign using information from the track
+  d0_corr = (track->dxy() > 0 ? 1 : -1)*fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D
@@ -1117,6 +1119,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
+  // Now correct the sign using information from the track
+  d0_corr = (track->dxy(beamspot) > 0 ? 1 : -1)*fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
 
   // BS3D

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1120,8 +1120,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   }
 
   // PV3D
-  result =
-      IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   d0_corr = result.second.value();
   d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV3D);
@@ -1134,8 +1133,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   if (getdBFromTrack_){
     aMuon.setDB(track->dxy(beamspot), track->dxyError(beamspot), pat::Muon::BS2D);
   } else{
-    result =
-      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
+    result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
     d0_corr = result.second.value();
     d0_err = beamspotIsValid ? result.second.error() : -1.0;
     aMuon.setDB( d0_corr, d0_err, pat::Muon::BS2D);

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1125,8 +1125,6 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   // PVDZ
   aMuon.setDB(
       track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ);
-
-              pat::Muon::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1097,31 +1097,24 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   // Correct to PV
 
   // PV2D
-  std::pair<bool, Measurement1D> result =
-      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
-  double d0_corr = result.second.value();
-  double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  // Now correct the sign using information from the track
-  d0_corr = std::copysign(d0_corr, track->dxy(primaryVertex.position()));
-  aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
+  aMuon.setDB(track->dxy(primaryVertex.position()),
+              track->dxyError(primaryVertex.position(), primaryVertex.covariance()),
+              pat::Muon::PV2D);
 
   // PV3D
-  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
-  d0_corr = result.second.value();
-  d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
+  std::pair<bool, Measurement1D> result =
+      IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
+  double d0_corr = result.second.value();
+  double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV3D);
 
   // Correct to beam spot
-  // make a fake vertex out of beam spot
-  reco::Vertex vBeamspot(beamspot.position(), beamspot.rotatedCovariance3D());
 
   // BS2D
-  result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
-  d0_corr = result.second.value();
-  d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  // Now correct the sign using information from the track
-  d0_corr = std::copysign(d0_corr, track->dxy(beamspot)); 
-  aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
+  aMuon.setDB(track->dxy(beamspot), track->dxyError(beamspot), pat::Muon::BS2D);
+
+  // make a fake vertex out of beam spot
+  reco::Vertex vBeamspot(beamspot.position(), beamspot.rotatedCovariance3D());
 
   // BS3D
   result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
@@ -1132,6 +1125,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   // PVDZ
   aMuon.setDB(
       track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ);
+
+              pat::Muon::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1114,8 +1114,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   } else{
     result =
       IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
-    double d0_corr = result.second.value();
-    double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
+    d0_corr = result.second.value();
+    d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
     aMuon.setDB( d0_corr, d0_err, pat::Muon::PV2D);
   }
 

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -175,6 +175,8 @@ namespace pat {
     bool embedDytMuon_;
     /// add combined inverse beta measurement into the muon
     bool addInverseBeta_;
+    /// switch on reading the dB information from the track
+    bool getdBFromTrack_;
     /// input tag for reading inverse beta
     edm::EDGetTokenT<edm::ValueMap<reco::MuonTimeExtra>> muonTimeExtraToken_;
     /// add generator match information

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -74,6 +74,10 @@ patMuons = cms.EDProducer("PATMuonProducer",
     # Read and store combined inverse beta
     addInverseBeta    = cms.bool(True),  
     sourceMuonTimeExtra = cms.InputTag("muons","combined"), #Use combined info, not only csc or dt
+
+    # Get 2D-IP from the best track instead of using IPTools
+    getdBFromTrack = cms.bool(False),
+
     # mc matching
     addGenMatch   = cms.bool(True),
     embedGenMatch = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -30,6 +30,7 @@ def miniAOD_customizeCommon(process):
     process.patMuons.computeSoftMuonMVA = True
 
     process.patMuons.addTriggerMatching = True
+    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
     from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
     from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
     from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
@@ -37,7 +38,7 @@ def miniAOD_customizeCommon(process):
     run2_muon_2017.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
     run2_muon_2018.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
     run2_muon_2016.toModify( process.patMuons, mvaTrainingFile = "RecoMuon/MuonIdentification/data/mu_2016_BDTG.weights.xml")
-
+    run2_miniAOD_devel.toModify( process.patMuons, getdBFromTrack = True) 
     process.patMuons.computePuppiCombinedIso = True
     #
     # disable embedding of electron and photon associated objects already stored by the ReducedEGProducer
@@ -373,7 +374,6 @@ def miniAOD_customizeCommon(process):
     process.deepTau2017v2p1.taus = _noUpdatedTauName
     deepTauIDTaskNew_ = cms.Task(process.deepTau2017v2p1,process.slimmedTaus)
 
-    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
     from Configuration.Eras.Modifier_run2_tau_ul_2016_cff import run2_tau_ul_2016
     from Configuration.Eras.Modifier_run2_tau_ul_2018_cff import run2_tau_ul_2018
     for era in [run2_miniAOD_devel,run2_tau_ul_2016,run2_tau_ul_2018]:


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/28753 to include it in the UL reminiAOD production (tagging https://github.com/cms-sw/cmssw/issues/27889 ) . The original PR included the fix to the computation of the impact parameter of the pat::Muon to take the one from the best track, whose sign makes more physical sense. 

This backport also includes an additional switch to activate/deactivate this behavior which off by default, only activated by the proper era modifier.

#### PR validation:

Tested locally in a couple of Z->mumu RelVal AOD samples reproducing the results from the master branch implementation.
Minimal integration checks from runTheMatrix.py -l limited -i all

I did not include the clang code format changes (took them out in the rebasing) as discussed in the RECO meeting to improve readability of the changes but I can do so if needed.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/28753