### PR TITLE
Herwig7.2 upgrade 9 3

### DIFF
--- a/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
+++ b/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
@@ -1,0 +1,114 @@
+import FWCore.ParameterSet.Config as cms
+
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/TTBar/hvq_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_ttbar_new.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+generator = cms.EDFilter("Herwig7GeneratorFilter",
+
+    configFiles = cms.vstring(),
+                                                                                                                                                             
+   hw_nnpdf31 = cms.vstring(
+            'cd /Herwig/Partons',
+            'create ThePEG::LHAPDF PDFSet ThePEGLHAPDF.so',
+            'set PDFSet:PDFName NNPDF31_nnlo_as_0118.LHgrid',
+            'set PDFSet:RemnantHandler HadronRemnants',
+            'set /Herwig/Particles/p+:PDF PDFSet',
+            'set /Herwig/Particles/pbar-:PDF PDFSet',
+            'set /Herwig/Shower/ShowerHandler:PDFA PDFSet',
+            'set /Herwig/Shower/ShowerHandler:PDFB PDFSet',
+            'set /Herwig/DipoleShower/DipoleShowerHandler:PDFA PDFSet',
+            'set /Herwig/DipoleShower/DipoleShowerHandler:PDFB PDFSet',
+
+            'set /Herwig/Shower/ShowerHandler:PDFARemnant PDFSet',
+            'set /Herwig/Shower/ShowerHandler:PDFBRemnant PDFSet',
+            'set /Herwig/DipoleShower/DipoleShowerHandler:PDFARemnant PDFSet',
+            'set /Herwig/DipoleShower/DipoleShowerHandler:PDFBRemnant PDFSet',
+            'set /Herwig/Partons/MPIExtractor:FirstPDF PDFSet',
+            'set /Herwig/Partons/MPIExtractor:SecondPDF PDFSet',
+
+            'cd /',
+    ),
+    hw_alphas = cms.vstring(
+        'cd /Herwig/Shower',
+        'set AlphaQCD:AlphaMZ 0.118',
+        'cd /Herwig/DipoleShower',
+        'set NLOAlphaS:input_alpha_s 0.118'
+    ),
+    hw_LHEsettings = cms.vstring(
+            'read snippets/PPCollider.in',
+
+            'cd /Herwig/Generators',
+            'set EventGenerator:NumberOfEvents 10000000',
+            #'set EventGenerator:RandomNumberGenerator:Seed 31122001'
+            'set EventGenerator:DebugLevel 0',
+            'set EventGenerator:PrintEvent 10',
+            'set EventGenerator:MaxErrors 10000',
+
+            'cd /Herwig/EventHandlers',
+            'library LesHouches.so',
+            'create ThePEG::LesHouchesEventHandler LesHouchesHandler',
+
+            'set LesHouchesHandler:PartonExtractor /Herwig/Partons/PPExtractor',
+            'set LesHouchesHandler:CascadeHandler /Herwig/Shower/ShowerHandler',
+            'set LesHouchesHandler:DecayHandler /Herwig/Decays/DecayHandler',
+            'set LesHouchesHandler:HadronizationHandler /Herwig/Hadronization/ClusterHadHandler',
+
+            'set LesHouchesHandler:WeightOption VarNegWeight',
+
+            'set /Herwig/Generators/EventGenerator:EventHandler /Herwig/EventHandlers/LesHouchesHandler',
+
+            'create ThePEG::Cuts /Herwig/Cuts/NoCuts',
+
+            'create ThePEG::LHAPDF /Herwig/Partons/LHAPDF ThePEGLHAPDF.so',
+            'set /Herwig/Partons/LHAPDF:PDFName NNPDF30_nlo_as_0118',
+            'set /Herwig/Partons/LHAPDF:RemnantHandler /Herwig/Partons/HadronRemnants',
+            'set /Herwig/Particles/p+:PDF /Herwig/Partons/LHAPDF',
+            'set /Herwig/Particles/pbar-:PDF /Herwig/Partons/LHAPDF',
+            'set /Herwig/Partons/PPExtractor:FirstPDF  /Herwig/Partons/LHAPDF',
+            'set /Herwig/Partons/PPExtractor:SecondPDF /Herwig/Partons/LHAPDF',
+
+            'create ThePEG::LesHouchesFileReader LesHouchesReader',
+            'set LesHouchesReader:FileName cmsgrid_final.lhe',
+            'set LesHouchesReader:AllowedToReOpen No',
+            'set LesHouchesReader:InitPDFs 0',
+            'set LesHouchesReader:Cuts /Herwig/Cuts/NoCuts',
+
+            'set LesHouchesReader:MomentumTreatment RescaleEnergy',
+            'set LesHouchesReader:PDFA /Herwig/Partons/LHAPDF',
+            'set LesHouchesReader:PDFB /Herwig/Partons/LHAPDF',
+
+            'insert LesHouchesHandler:LesHouchesReaders 0 LesHouchesReader',
+
+            'set /Herwig/Shower/ShowerHandler:MaxPtIsMuF Yes',
+            'set /Herwig/Shower/ShowerHandler:RestrictPhasespace Yes',
+
+
+            'set /Herwig/Shower/PartnerFinder:PartnerMethod Random',
+            'set /Herwig/Shower/PartnerFinder:ScaleChoice Partner',
+
+            'set /Herwig/Shower/GtoQQbarSplitFn:AngularOrdered Yes',
+            'set /Herwig/Shower/GammatoQQbarSplitFn:AngularOrdered Yes',
+            'set /Herwig/Particles/t:NominalMass 172.5',
+            'cd /Herwig/Generators',
+            'saverun LHE EventGenerator'),                                                                                                                                                                         
+    parameterSets = cms.vstring('hw_LHEsettings', 'hw_nnpdf31','hw_alphas'),
+    crossSection = cms.untracked.double(-1),
+    dataLocation = cms.string('${HERWIGPATH:-6}'),
+    eventHandlers = cms.string('/Herwig/EventHandlers'),
+    filterEfficiency = cms.untracked.double(1.0),
+    generatorModule = cms.string('/Herwig/Generators/EventGenerator'),
+    repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
+    run = cms.string('InterfaceMatchboxTest'),
+    runModeList = cms.untracked.string("read,run"),
+    seed = cms.untracked.int32(12345)
+)
+
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -30,8 +30,8 @@ namespace ThePEG {
 
   template<> struct HepMCTraits<HepMC::GenEvent> :
                 public HepMCTraitsBase<
-    HepMC::GenEvent, HepMC::GenParticle,
-    HepMC::GenVertex, HepMC::Polarization,
+    HepMC::GenEvent, HepMC::GenParticle, HepMC::GenParticle *, 
+    HepMC::GenVertex, HepMC::GenVertex *, HepMC::Polarization,
     HepMC::PdfInfo> {};
 
 }


### PR DESCRIPTION
PR description:

Update of Herwig 7 interface to allow update of Herwig 7.1.4->7.2.0, and reintroduced cmssw/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py, which is needed for workflow 535, but seems to have been removed

PR validation:

Has been tested with runTheMatrix workflow 535, and the test commands on the Herwig twiki

If this PR is a backport please specify the original PR and why you need to backport that PR:

First part is a backport of #29523 to allow use of Herwig 7.2 for 2017 production