### PR TITLE
Clean buildfiles after L1TriggerOffline in alphabet

### DIFF
--- a/CondCore/DBOutputService/bin/BuildFile.xml
+++ b/CondCore/DBOutputService/bin/BuildFile.xml
@@ -1,2 +1,0 @@
-<use   name="CondCore/DBOutputService"/>
-<use   name="boost_program_options"/>

--- a/MagneticField/Engine/BuildFile.xml
+++ b/MagneticField/Engine/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/GeometryVector"/>
 <use   name="FWCore/Utilities"/>
 <export>
   <lib   name="1"/>

--- a/MagneticField/GeomBuilder/BuildFile.xml
+++ b/MagneticField/GeomBuilder/BuildFile.xml
@@ -2,13 +2,10 @@
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DetectorDescription/Core"/>
 <use   name="DetectorDescription/DDCMS"/>
-<use   name="FWCore/Framework"/>
 <use   name="FWCore/Utilities"/>
-<use   name="MagneticField/Engine"/>
 <use   name="MagneticField/Interpolation"/>
 <use   name="MagneticField/Layers"/>
 <use   name="MagneticField/VolumeGeometry"/>
-<use   name="MagneticField/ParametrizedEngine"/>
 <use   name="Utilities/BinningTools"/>
 <use   name="CondFormats/MFObjects"/>
 <use   name="clhep"/>

--- a/MagneticField/GeomBuilder/plugins/BuildFile.xml
+++ b/MagneticField/GeomBuilder/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="MagneticField/GeomBuilder"/>
 <use   name="MagneticField/VolumeBasedEngine"/>
 <use   name="MagneticField/Records"/>
+<use   name="MagneticField/ParametrizedEngine"/>
 <use   name="CondFormats/RunInfo"/>
 <use   name="DetectorDescription/Parser"/>
 

--- a/MagneticField/Layers/BuildFile.xml
+++ b/MagneticField/Layers/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="boost"/>
-<use   name="DataFormats/GeometrySurface"/>
 <use   name="MagneticField/VolumeGeometry"/>
 <export>
   <lib   name="1"/>

--- a/MagneticField/ParametrizedEngine/BuildFile.xml
+++ b/MagneticField/ParametrizedEngine/BuildFile.xml
@@ -1,8 +1,7 @@
-<use   name="DataFormats/GeometryVector"/>
-<!--use   name="FWCore/Framework"/-->
+<use   name="DataFormats/Math"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="MagneticField/Engine"/>
-<use   name="MagneticField/Records"/>
+<use   name="MagneticField/UniformEngine"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/MagneticField/ParametrizedEngine/plugins/BuildFile.xml
+++ b/MagneticField/ParametrizedEngine/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="DataFormats/GeometryVector"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="MagneticField/Engine"/>

--- a/MagneticField/Records/BuildFile.xml
+++ b/MagneticField/Records/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="FWCore/Framework"/>
-<use   name="Geometry/Records"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="boost"/>
 <export>

--- a/MagneticField/UniformEngine/BuildFile.xml
+++ b/MagneticField/UniformEngine/BuildFile.xml
@@ -1,0 +1,1 @@
+<use   name="MagneticField/Engine"/>

--- a/MagneticField/UniformEngine/plugins/BuildFile.xml
+++ b/MagneticField/UniformEngine/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="DataFormats/GeometryVector"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="MagneticField/Engine"/>

--- a/MuonAnalysis/MomentumScaleCalibration/BuildFile.xml
+++ b/MuonAnalysis/MomentumScaleCalibration/BuildFile.xml
@@ -4,17 +4,11 @@
 <use   name="rootminuit"/>
 
 <use   name="roothistmatrix"/>
-<use   name="FWCore/Framework"/>
-<use   name="FWCore/Utilities"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="FWCore/PluginManager"/>
 <use   name="DataFormats/Candidate"/>
-<use   name="DataFormats/Common"/>
 <use   name="SimDataFormats/Track"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="CondFormats/RecoMuonObjects"/>
-<use   name="DataFormats/PatCandidates"/>
-<use   name="PhysicsTools/TagAndProbe"/>
 <export>
   <lib name="1"/>
 </export>

--- a/MuonAnalysis/MomentumScaleCalibration/bin/BuildFile.xml
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/BuildFile.xml
@@ -1,12 +1,7 @@
-<use   name="DataFormats/Luminosity"/>
 <use   name="DataFormats/FWLite"/>
-<use   name="FWCore/Framework"/>
 <use   name="FWCore/FWLite"/>
 <use   name="boost"/>
-<use   name="CommonTools/Utils"/>
-<use   name="PhysicsTools/Utilities"/>
 <use   name="PhysicsTools/FWLite"/>
-<use   name="PhysicsTools/SelectorUtils"/>
 <environment>
   <use   name="hepmc"/>
   <use   name="heppdt"/>

--- a/MuonAnalysis/MuonAssociators/BuildFile.xml
+++ b/MuonAnalysis/MuonAssociators/BuildFile.xml
@@ -7,16 +7,12 @@
 <use   name="DataFormats/Math"/>
 <use   name="DataFormats/RecoCandidate"/>
 <use   name="DataFormats/TrackReco"/>
-<use   name="DataFormats/CSCRecHit"/>
-<use   name="DataFormats/CSCDigi"/>
-<use   name="DataFormats/L1CSCTrackFinder"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="Geometry/Records"/>
-<use   name="L1Trigger/CSCTrackFinder"/>
 <use   name="MagneticField/Engine"/>
 <use   name="MagneticField/Records"/>
 <use   name="RecoMuon/DetLayers"/>

--- a/MuonAnalysis/MuonAssociators/plugins/BuildFile.xml
+++ b/MuonAnalysis/MuonAssociators/plugins/BuildFile.xml
@@ -1,9 +1,7 @@
 <use   name="CommonTools/Utils"/>
 <use   name="DataFormats/PatCandidates"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="SimMuon/MCTruth"/>
 <use   name="SimTracker/Records"/>
-<use   name="SimTracker/TrackAssociation"/>
 <use   name="SimDataFormats/Associations"/>
 <use   name="MuonAnalysis/MuonAssociators"/>
 <export>

--- a/OnlineDB/CSCCondDB/BuildFile.xml
+++ b/OnlineDB/CSCCondDB/BuildFile.xml
@@ -1,14 +1,9 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="FWCore/PluginManager"/>
-<use   name="FWCore/ServiceRegistry"/>
-<use   name="CondCore/DBOutputService"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/CSCDigi"/>
-<use   name="EventFilter/CSCRawToDigi"/>
 <use   name="CondFormats/CSCObjects"/>
 <use   name="CondFormats/DataRecord"/>
-<use   name="CondCore/PopCon"/>
 <use   name="clhep"/>
 <use   name="root"/>
 <use   name="OnlineDB/Oracle"/>

--- a/OnlineDB/CSCCondDB/test/BuildFile.xml
+++ b/OnlineDB/CSCCondDB/test/BuildFile.xml
@@ -1,8 +1,7 @@
-<use   name="CondFormats/Calibration"/>
-<use   name="CondFormats/DataRecord"/>
 <use   name="CondCore/PopCon"/>
 <use   name="CondFormats/CSCObjects"/>
 <use   name="OnlineDB/Oracle"/>
+<lib   name="occi"/>
 <library   name="OnlineDBCSCCondDB_TestPlugins" file="../src/CSCMap1.cc,../src/CSCCableRead.cc,stubs/*.cc">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/OnlineDB/EcalCondDB/test/BuildFile.xml
+++ b/OnlineDB/EcalCondDB/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="OnlineDB/EcalCondDB"/>
-<use   name="OnlineDB/Oracle"/>
 <use   name="CalibCalorimetry/EcalLaserAnalyzer"/>
 <use   name="root"/>
 <bin   file="LaserSeqToDB.cpp">

--- a/OnlineDB/SiStripConfigDb/BuildFile.xml
+++ b/OnlineDB/SiStripConfigDb/BuildFile.xml
@@ -2,7 +2,6 @@
 <use   name="DataFormats/SiStripCommon"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
 <use   name="tkonlineswdb"/>
 <use   name="boost"/>

--- a/OnlineDB/SiStripESSources/BuildFile.xml
+++ b/OnlineDB/SiStripESSources/BuildFile.xml
@@ -1,11 +1,9 @@
-<use   name="CalibTracker/Records"/>
 <use   name="CalibTracker/SiStripESProducers"/>
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CondFormats/SiStripObjects"/>
 <use   name="DataFormats/SiStripCommon"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="FWCore/PluginManager"/>
 <use   name="OnlineDB/SiStripConfigDb"/>
 <use   name="TkOnlineSwDB"/>
 <use   name="boost"/>

--- a/OnlineDB/SiStripESSources/test/BuildFile.xml
+++ b/OnlineDB/SiStripESSources/test/BuildFile.xml
@@ -1,15 +1,10 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="FWCore/Utilities"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="FWCore/PluginManager"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/SiStripObjects"/>
 <use   name="CalibFormats/SiStripObjects"/>
-<use   name="DataFormats/DetId"/>
 <use   name="DataFormats/SiStripCommon"/>
-<use   name="DataFormats/SiStripDetId"/>
-<use   name="Geometry/Records"/>
 <use   name="boost"/>
 <library   file="stubs/*.cc" name="testOnlineDBSiStripESSources">
   <flags   EDM_PLUGIN="1"/>

--- a/OnlineDB/SiStripO2O/plugins/BuildFile.xml
+++ b/OnlineDB/SiStripO2O/plugins/BuildFile.xml
@@ -4,12 +4,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="CondCore/PopCon"/>
-<use   name="CondCore/DBOutputService"/>
-<use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/SiStripObjects"/>
-<use   name="CalibFormats/SiStripObjects"/>
-<use   name="DataFormats/SiStripDetId"/>
-<use   name="CalibTracker/Records"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="OnlineDB/SiStripConfigDb"/>
 <use   name="OnlineDB/SiStripESSources"/>

--- a/PerfTools/EdmEvent/BuildFile.xml
+++ b/PerfTools/EdmEvent/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="FWCore/FWLite"/>
 <use   name="rootgraphics"/>
 <use   name="boost"/>
 <export>

--- a/PhysicsTools/CondLiteIO/plugins/BuildFile.xml
+++ b/PhysicsTools/CondLiteIO/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="FWCore/PluginManager"/>
 <use   name="DataFormats/FWLite"/>
 <use   name="PhysicsTools/CondLiteIO"/>
 <library   file="*.cc" name="PhysicsToolsCondLiteIOPlugins">

--- a/PhysicsTools/FWLite/BuildFile.xml
+++ b/PhysicsTools/FWLite/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="CommonTools/Utils"/>
 <use   name="DataFormats/FWLite"/>
 <use   name="DataFormats/PatCandidates"/>
+<use   name="PhysicsTools/SelectorUtils"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/PhysicsTools/FWLite/bin/BuildFile.xml
+++ b/PhysicsTools/FWLite/bin/BuildFile.xml
@@ -4,10 +4,7 @@
 <use   name="DataFormats/FWLite"/>
 <use   name="DataFormats/Luminosity"/>
 <use   name="FWCore/ParameterSetReader"/>
-<use   name="CommonTools/Utils"/>
 <use   name="PhysicsTools/FWLite"/>
-<use   name="PhysicsTools/Utilities"/>
-<use   name="PhysicsTools/SelectorUtils"/>
 <environment>
   <bin   file="FWLiteLumiAccess.cc"></bin>
   <bin   file="FWLiteHistograms.cc"></bin>

--- a/PhysicsTools/JetCharge/plugins/BuildFile.xml
+++ b/PhysicsTools/JetCharge/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="PhysicsTools/JetCharge"/>
 <use   name="DataFormats/JetReco"/>
-<use   name="DataFormats/TrackReco"/>
 <library   file="*.cc" name="PhysicsToolsJetChargePlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/PhysicsTools/JetCharge/test/BuildFile.xml
+++ b/PhysicsTools/JetCharge/test/BuildFile.xml
@@ -1,10 +1,8 @@
-<use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/JetReco"/>
-<use   name="PhysicsTools/JetCharge"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="root"/>
 <library   file="JetChargeAnalyzer.cc" name="JetChargeAnalyzer">

--- a/PhysicsTools/JetExamples/test/BuildFile.xml
+++ b/PhysicsTools/JetExamples/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="clhep"/>
-<use   name="DataFormats/BTauReco"/>
 <library   file="printJetFlavourInfo.cc">
   <flags   EDM_PLUGIN="1"/>
   <use   name="FWCore/Framework"/>
@@ -23,6 +22,7 @@
 </library>
 <library   file="printPartonJet.cc">
   <flags   EDM_PLUGIN="1"/>
+  <use   name="DataFormats/Candidate"/>
   <use   name="FWCore/Framework"/>
 </library>
 <library   file="printTrackJet.cc">

--- a/PhysicsTools/JetMCAlgos/plugins/BuildFile.xml
+++ b/PhysicsTools/JetMCAlgos/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
-<use name="CommonTools/Utils"/>
 <use name="PhysicsTools/JetMCAlgos"/>
 <use name="PhysicsTools/JetMCUtils"/>
 <use name="PhysicsTools/HepMCCandAlgos"/>

--- a/PhysicsTools/JetMCAlgos/test/BuildFile.xml
+++ b/PhysicsTools/JetMCAlgos/test/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="clhep"/>
-<use   name="DataFormats/BTauReco"/>
 <library   file="printEvent.cc">
   <flags   EDM_PLUGIN="1"/>
+  <use   name="DataFormats/JetReco"/>
   <use   name="FWCore/Framework"/>
   <use   name="SimGeneral/HepPDTRecord"/>
   <use   name="PhysicsTools/JetMCUtils"/>
@@ -10,12 +10,14 @@
 </library>
 <library   file="jetMatch.cc">
   <flags   EDM_PLUGIN="1"/>
+  <use   name="DataFormats/Candidate"/>
   <use   name="FWCore/Framework"/>
   <use   name="rootmath"/>
   <use   name="root"/>
 </library>
 <library   file="matchOneToOne.cc">
   <flags   EDM_PLUGIN="1"/>
+  <use   name="DataFormats/Candidate"/>
   <use   name="FWCore/Framework"/>
   <use   name="rootmath"/>
   <use   name="root"/>

--- a/PhysicsTools/MVAComputer/test/BuildFile.xml
+++ b/PhysicsTools/MVAComputer/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/PhysicsTools/PatAlgos/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/BuildFile.xml
@@ -13,8 +13,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="PhysicsTools/PatUtils"/>
 <use   name="PhysicsTools/IsolationAlgos"/>
-<use   name="RecoTracker/DeDx"/>
-<use   name="CondFormats/HcalObjects"/>
 <use   name="clhep"/>
 <export>
   <lib   name="1"/>

--- a/PhysicsTools/PatAlgos/plugins/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/plugins/BuildFile.xml
@@ -19,6 +19,8 @@
   <use   name="DataFormats/HepMCCandidate"/>
   <use   name="PhysicsTools/PatUtils"/>
   <use   name="CondFormats/JetMETObjects"/>
+  <use   name="CondFormats/HcalObjects"/>
+  <use   name="CondFormats/DataRecord"/>
   <use   name="CommonTools/CandAlgos"/>
   <use   name="CommonTools/MVAUtils"/>
   <use   name="JetMETCorrections/Objects"/>
@@ -31,6 +33,7 @@
   <use   name="SimGeneral/HepPDTRecord"/>
   <use   name="RecoMET/METAlgorithms"/>
   <use   name="RecoEgamma/EgammaTools"/>
+  <use   name="RecoTracker/DeDx"/>
   <use   name="TrackingTools/IPTools"/>
   <use   name="root"/>
 </library>

--- a/PhysicsTools/PatExamples/bin/BuildFile.xml
+++ b/PhysicsTools/PatExamples/bin/BuildFile.xml
@@ -3,10 +3,7 @@
 <use   name="DataFormats/FWLite"/>
 <use   name="FWCore/ParameterSetReader"/>
 <use   name="DataFormats/PatCandidates"/>
-<use   name="CommonTools/Utils"/>
 <use   name="PhysicsTools/FWLite"/>
-<use   name="PhysicsTools/Utilities"/>
-<use   name="PhysicsTools/PatUtils"/>
 <use   name="PhysicsTools/PatExamples"/>
 <use   name="PhysicsTools/SelectorUtils"/>
 <environment>

--- a/PhysicsTools/RecoUtils/BuildFile.xml
+++ b/PhysicsTools/RecoUtils/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="RecoVertex/VertexPrimitives"/>
 <use   name="RecoVertex/KinematicFit"/>
 <use   name="TrackingTools/TransientTrack"/>
-<use   name="RecoTracker/Record" />
+<use   name="TrackingTools/Records"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="DataFormats/RecoCandidate"/>
 <use   name="HepPDT"/>

--- a/PhysicsTools/SelectorUtils/bin/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/bin/BuildFile.xml
@@ -1,12 +1,9 @@
-<use   name="DataFormats/PatCandidates"/>
 <use   name="DataFormats/FWLite"/>
 <use   name="FWCore/FWLite"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ParameterSetReader"/>
 <use   name="root"/>
 <use   name="boost"/>
-<use   name="CommonTools/Utils"/>
-<use   name="PhysicsTools/Utilities"/>
 <use   name="PhysicsTools/FWLite"/>
 <use   name="PhysicsTools/SelectorUtils"/>
 <environment>

--- a/PhysicsTools/TensorFlow/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="tensorflow-cc" />
 
 <use name="FWCore/Utilities" />
-<use name="FWCore/Concurrency" />
 <use name="FWCore/MessageLogger" />
 
 <export>

--- a/PhysicsTools/UtilAlgos/BuildFile.xml
+++ b/PhysicsTools/UtilAlgos/BuildFile.xml
@@ -4,11 +4,14 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Common"/>
+<use   name="FWCore/FWLite"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="DataFormats/MuonReco"/>
 <use   name="DataFormats/PatCandidates"/>
+<use   name="DataFormats/FWLite"/>
+<use   name="PhysicsTools/FWLite"/>
 <use   name="root"/>
 <export>
   <lib   name="1"/>

--- a/PhysicsTools/UtilAlgos/bin/BuildFile.xml
+++ b/PhysicsTools/UtilAlgos/bin/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="root"/>
 <use   name="boost_program_options"/>
-<use   name="PhysicsTools/FWLite"/>
 <use   name="PhysicsTools/UtilAlgos"/>
 <use   name="FWCore/ParameterSetReader"/>
 
@@ -8,4 +7,3 @@
   <bin   file="FWLiteWithBasicAnalyzer.cc"></bin>
   <bin   file="mergeTFileServiceHistograms.cpp"></bin>
 </environment>
-

--- a/PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h
@@ -1,15 +1,12 @@
 #ifndef StringBasedNTupler_NTupler_H
 #define StringBasedNTupler_NTupler_H
 
-//#include "PhysicsTools/UtilAlgos/interface/UpdaterService.h"
-
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 
-//#include "PhysicsTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "TTree.h"
 #include "TBranch.h"
@@ -28,8 +25,6 @@
 
 #include "DataFormats/PatCandidates/interface/PFParticle.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
-
-//#define StringBasedNTuplerPrecision float;
 
 #include <memory>
 #include <string>

--- a/PhysicsTools/UtilAlgos/interface/VariableNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/VariableNTupler.h
@@ -2,7 +2,6 @@
 #define VariableNtupler_NTupler_H
 
 #include "PhysicsTools/UtilAlgos/interface/VariableHelper.h"
-//#include "PhysicsTools/UtilAlgos/interface/UpdaterService.h"
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -10,7 +9,6 @@
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 
-//#include "PhysicsTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "TTree.h"
 #include "TBranch.h"

--- a/PhysicsTools/Utilities/plugins/BuildFile.xml
+++ b/PhysicsTools/Utilities/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
 <use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <flags EDM_PLUGIN="1"/>

--- a/QCDAnalysis/Skimming/BuildFile.xml
+++ b/QCDAnalysis/Skimming/BuildFile.xml
@@ -2,12 +2,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
-<use   name="Geometry/Records"/>
-<use   name="SimDataFormats/GeneratorProducts"/>
-<use   name="DataFormats/EgammaCandidates"/>
-<use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/JetReco"/>
 <use   name="clhep"/>
 <use   name="root"/>

--- a/QCDAnalysis/Skimming/plugins/BuildFile.xml
+++ b/QCDAnalysis/Skimming/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="FWCore/Framework"/>
-<use   name="FWCore/ParameterSet"/>
 <use   name="QCDAnalysis/Skimming"/>
 <library   file="*.cc" name="QCDAnalysisSkimmingPlugins">
   <flags   EDM_PLUGIN="1"/>

--- a/QCDAnalysis/UEAnalysis/BuildFile.xml
+++ b/QCDAnalysis/UEAnalysis/BuildFile.xml
@@ -4,7 +4,6 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/HepMCCandidate"/>
-<use   name="DataFormats/TrackCandidate"/>
 <use   name="DataFormats/HLTReco"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="FWCore/Framework"/>

--- a/RecoCaloTools/Selectors/BuildFile.xml
+++ b/RecoCaloTools/Selectors/BuildFile.xml
@@ -1,4 +1,3 @@
 <use   name="Geometry/CaloGeometry"/>
 <export>
-  <lib   name="1"/>
 </export>

--- a/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
@@ -14,7 +14,6 @@
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/CaloGeometry"/>
 <use   name="RecoTracker/MeasurementDet"/>
-<use   name="RecoTracker/TkSeedGenerator"/>
 <use   name="TrackingTools/DetLayers"/>
 <use   name="TrackingTools/GsfTools"/>
 <use   name="TrackingTools/GsfTracking"/>
@@ -23,7 +22,6 @@
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="RecoEgamma/EgammaIsolationAlgos"/>
 <use   name="RecoEgamma/ElectronIdentification"/>
-<use   name="RecoTracker/TkTrackingRegions"/>
 <use   name="CondFormats/EgammaObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <export>

--- a/RecoEgamma/EgammaElectronProducers/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronProducers/plugins/BuildFile.xml
@@ -10,7 +10,6 @@
 <use   name="DataFormats/Math"/>
 <use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="DataFormats/ParticleFlowReco"/>
-<use   name="DataFormats/TrackingRecHit"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="CommonTools/BaseParticlePropagator"/>
 <use   name="FWCore/Framework"/>
@@ -23,6 +22,7 @@
 <use   name="RecoEgamma/EgammaElectronAlgos"/>
 <use   name="RecoEgamma/EgammaIsolationAlgos"/>
 <use   name="RecoParticleFlow/PFClusterTools"/>
+<use   name="RecoTracker/TkTrackingRegions"/>
 <use   name="RecoTracker/TransientTrackingRecHit"/>
 <use   name="TrackingTools/PatternTools"/>
 <use   name="TrackingTools/Records"/>

--- a/RecoTracker/TkNavigation/BuildFile.xml
+++ b/RecoTracker/TkNavigation/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="RecoTracker/TkDetLayers"/>
 <use name="TrackingTools/DetLayers"/>
 <export>
-  <lib   name="1"/>
 </export>

--- a/SimG4CMS/CherenkovAnalysis/plugins/BuildFile.xml
+++ b/SimG4CMS/CherenkovAnalysis/plugins/BuildFile.xml
@@ -5,11 +5,7 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="SimG4Core/SensitiveDetector"/>
-<use   name="SimG4Core/Notification"/>
-<use   name="SimG4CMS/Calo"/>
-<use   name="SimDataFormats/SimHitMaker"/>
 <use   name="SimDataFormats/CaloHit"/>
-<use   name="DetectorDescription/Core"/>
 <use   name="geant4core"/>
 <use   name="root"/>
 <library   file="*.cc" name="SimG4CMSCherenkovAnalysisPlugins">

--- a/SimG4CMS/HcalTestBeam/plugins/BuildFile.xml
+++ b/SimG4CMS/HcalTestBeam/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="DataFormats/HcalDetId"/>
 <use   name="DataFormats/Math"/>
 <use   name="Geometry/EcalCommonData"/>
-<use   name="Geometry/HcalCommonData"/>
 <use   name="Geometry/HcalTestBeamData"/>
 <use   name="SimDataFormats/HcalTestBeam"/>
 <use   name="SimG4Core/Notification"/>

--- a/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
@@ -5,6 +5,7 @@
  *  \author M. Strang SUNY-Buffalo
  */
 
+#include "CondFormats/EcalObjects/interface/EcalMGPAGainRatio.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"

--- a/Validation/GlobalDigis/src/GlobalDigisProducer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisProducer.cc
@@ -5,6 +5,7 @@
  *  \author M. Strang SUNY-Buffalo
  */
 
+#include "CondFormats/EcalObjects/interface/EcalMGPAGainRatio.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Validation/GlobalDigis/interface/GlobalDigisProducer.h"


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example #29485), this time covering all subsystems that come after Reco in the alphabet.

This one mainly focuses on the few subsystems that are between *L1TriggerOffline* and *Reco* in the alphabet. It also does what was promised in https://github.com/cms-sw/cmssw/pull/29485#discussion_r410666531: removing the library export of two header-only packages.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.