### PR TITLE
Improve Validation for unphysical CaloParticles

### DIFF
--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -59,6 +59,7 @@ protected:
   std::vector<edm::InputTag> label_mcl;
   const bool SaveGeneralInfo_;
   const bool doCaloParticlePlots_;
+  const bool doCaloParticleSelection_;
   const bool dolayerclustersPlots_;
   const bool domulticlustersPlots_;
   const edm::FileInPath cummatbudinxo_;

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -11,6 +11,7 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
       label_mcl(pset.getParameter<std::vector<edm::InputTag>>("label_mcl")),
       SaveGeneralInfo_(pset.getUntrackedParameter<bool>("SaveGeneralInfo")),
       doCaloParticlePlots_(pset.getUntrackedParameter<bool>("doCaloParticlePlots")),
+      doCaloParticleSelection_(pset.getUntrackedParameter<bool>("doCaloParticleSelection")),
       dolayerclustersPlots_(pset.getUntrackedParameter<bool>("dolayerclustersPlots")),
       domulticlustersPlots_(pset.getUntrackedParameter<bool>("domulticlustersPlots")),
       cummatbudinxo_(pset.getParameter<edm::FileInPath>("cummatbudinxo")) {
@@ -146,7 +147,7 @@ void HGCalValidator::cpParametersAndSelection(const Histograms& histograms,
   for (auto const caloParticle : cPeff) {
     int id = caloParticle.pdgId();
 
-    if (cpSelector(caloParticle, simVertices)) {
+    if (!doCaloParticleSelection_ || (doCaloParticleSelection_ && cpSelector(caloParticle, simVertices))) {
       selected_cPeff.push_back(j);
       if (doCaloParticlePlots_) {
         histoProducerAlgo_->fill_caloparticle_histos(histograms.histoProducerAlgo, id, caloParticle, simVertices);

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -24,6 +24,8 @@ hgcalValidator = DQMEDAnalyzer(
     SaveGeneralInfo = cms.untracked.bool(True),
     #CaloParticle related plots
     doCaloParticlePlots = cms.untracked.bool(True),
+    #Select caloParticles for efficiency or pass through
+    doCaloParticleSelection = cms.untracked.bool(True),
     #Layer Cluster related plots
     dolayerclustersPlots = cms.untracked.bool(True),
     #Multi Cluster related plots


### PR DESCRIPTION
In the special case of CaloParticles shot parallel to the beamline,
all the checks and selection on the caloParticles collection are turned
off via a configuration parameter, so that the usual plots of
efficiencies, fake, merge and duplicate rate for both layerClusters and
tracksters can be produced.

#### PR validation:

`runTheMatrix.py -l limited`
