### PR TITLE
Fix fillDescription of PFRecoTauDiscriminationByIsolation

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -662,7 +662,7 @@ void PFRecoTauDiscriminationByIsolation::fillDescriptions(edm::ConfigurationDesc
     edm::ParameterSetDescription vpsd1;
     vpsd1.add<std::string>("selection");
     vpsd1.add<std::string>("offset");
-    desc.addVPSet("footprintCorrections", vpsd1);
+    desc.addVPSet("footprintCorrections", vpsd1, {});
   }
 
   desc.add<std::string>("deltaBetaFactor", "0.38");


### PR DESCRIPTION
#### PR description:

Fix fillDescription of PFRecoTauDiscriminationByIsolation
Based on CMSSW_11_1_0_pre6

Before the fix, the generated cfi file contained the line:
```
  footprintCorrections = cms.required.VPSet
```
which lets ConfDB parsing remove the parameter completely!

With the fix it contains:
```
  footprintCorrections = cms.VPSet(
  ),
```

#### PR validation:

fillDescription generated cfi file now correct for ConfDB parsing.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A