### PR TITLE
Delete unscheduled modules that are not consumed by any scheduled module

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -20,7 +20,6 @@
 
 // system include files
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
 #include <array>
@@ -107,7 +106,7 @@ namespace edm {
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
 
     void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modulesAll,
-                                         std::set<ModuleProcessName>& modulesInPreviousProcesses,
+                                         std::vector<ModuleProcessName>& modulesInPreviousProcesses,
                                          ProductRegistry const& preg,
                                          std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                          std::string const& processName) const;

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -106,8 +106,7 @@ namespace edm {
     typedef ProductLabels Labels;
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
 
-    void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
-                                         std::vector<ModuleDescription const*>& modulesLumiRun,
+    void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modulesAll,
                                          std::set<ModuleProcessName>& modulesInPreviousProcesses,
                                          ProductRegistry const& preg,
                                          std::map<std::string, ModuleDescription const*> const& labelsToDesc,

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -20,6 +20,7 @@
 
 // system include files
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 #include <array>
@@ -50,6 +51,7 @@
 
 namespace edm {
   class ModuleDescription;
+  class ModuleProcessName;
   class ProductResolverIndexHelper;
   class ProductRegistry;
   class ConsumesCollector;
@@ -106,6 +108,7 @@ namespace edm {
 
     void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
                                          std::vector<ModuleDescription const*>& modulesLumiRun,
+                                         std::set<ModuleProcessName>& modulesInPreviousProcesses,
                                          ProductRegistry const& preg,
                                          std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                          std::string const& processName) const;

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -104,7 +104,8 @@ namespace edm {
     typedef ProductLabels Labels;
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
 
-    void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+    void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
+                                         std::vector<ModuleDescription const*>& modulesLumiRun,
                                          ProductRegistry const& preg,
                                          std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                          std::string const& processName) const;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -362,6 +362,7 @@ namespace edm {
     ExcludedDataMap eventSetupDataToExcludeFromPrefetching_;
 
     bool printDependencies_ = false;
+    bool deleteNonConsumedUnscheduledModules_ = true;
   };  // class EventProcessor
 
   //--------------------------------------------------------------------

--- a/FWCore/Framework/interface/ModuleProcessName.h
+++ b/FWCore/Framework/interface/ModuleProcessName.h
@@ -1,0 +1,30 @@
+#ifndef FWCore_Framework_ModuleProcessName_h
+#define FWCore_Framework_ModuleProcessName_h
+
+#include <string_view>
+
+namespace edm {
+  /**
+   * Helper class to hold a module label and a process name
+   *
+   * Note: does NOT own the string storage, be careful to use.
+   */
+  class ModuleProcessName {
+  public:
+    explicit ModuleProcessName(std::string_view module, std::string_view process)
+        : moduleLabel_{module}, processName_{process} {}
+
+    std::string_view moduleLabel() const { return moduleLabel_; }
+    std::string_view processName() const { return processName_; }
+
+  private:
+    std::string_view moduleLabel_;
+    std::string_view processName_;
+  };
+
+  inline bool operator<(ModuleProcessName const& a, ModuleProcessName const& b) {
+    return a.processName() == b.processName() ? a.moduleLabel() < b.moduleLabel() : a.processName() < b.processName();
+  }
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -15,7 +15,10 @@
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 #include "FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h"
 
+#include "FWCore/Framework/interface/ModuleProcessName.h"
+
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -28,11 +31,14 @@ namespace edm {
 
   class PathsAndConsumesOfModules : public PathsAndConsumesOfModulesBase {
   public:
+    PathsAndConsumesOfModules();
     ~PathsAndConsumesOfModules() override;
 
     void initialize(Schedule const*, std::shared_ptr<ProductRegistry const>);
 
     void removeModules(std::vector<ModuleDescription const*> const& modules);
+
+    std::set<ModuleProcessName> const& modulesInPreviousProcessesWhoseProductsAreConsumedBy(unsigned int moduleID) const;
 
   private:
     std::vector<std::string> const& doPaths() const override { return paths_; }
@@ -68,12 +74,14 @@ namespace edm {
 
     std::vector<std::vector<ModuleDescription const*> > modulesWhoseProductsAreConsumedByEvent_;
     std::vector<std::vector<ModuleDescription const*> > modulesWhoseProductsAreConsumedByLumiRun_;
+    std::vector<std::set<ModuleProcessName> > modulesInPreviousProcessesWhoseProductsAreConsumedBy_;
 
     Schedule const* schedule_;
     std::shared_ptr<ProductRegistry const> preg_;
   };
 
-  std::vector<ModuleDescription const*> nonConsumedUnscheduledModules(edm::PathsAndConsumesOfModulesBase const& iPnC);
+  std::vector<ModuleDescription const*> nonConsumedUnscheduledModules(edm::PathsAndConsumesOfModulesBase const& iPnC,
+                                                                      std::set<ModuleProcessName>& consumedByChildren);
 
   void checkForModuleDependencyCorrectness(edm::PathsAndConsumesOfModulesBase const& iPnC, bool iPrintDependencies);
 }  // namespace edm

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -16,6 +16,7 @@
 #include "FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h"
 
 #include "FWCore/Framework/interface/ModuleProcessName.h"
+#include "FWCore/Utilities/interface/BranchType.h"
 
 #include <memory>
 #include <set>
@@ -50,9 +51,7 @@ namespace edm {
     std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const override;
     std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const override;
     std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(
-        unsigned int moduleID) const override;
-    std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedByLumiRun(
-        unsigned int moduleID) const override;
+        unsigned int moduleID, BranchType branchType = InEvent) const override;
 
     std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const override;
 
@@ -72,8 +71,7 @@ namespace edm {
     // following data member
     std::vector<std::pair<unsigned int, unsigned int> > moduleIDToIndex_;
 
-    std::vector<std::vector<ModuleDescription const*> > modulesWhoseProductsAreConsumedByEvent_;
-    std::vector<std::vector<ModuleDescription const*> > modulesWhoseProductsAreConsumedByLumiRun_;
+    std::array<std::vector<std::vector<ModuleDescription const*> >, NumBranchTypes> modulesWhoseProductsAreConsumedBy_;
     std::vector<std::set<ModuleProcessName> > modulesInPreviousProcessesWhoseProductsAreConsumedBy_;
 
     Schedule const* schedule_;

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -19,7 +19,6 @@
 #include "FWCore/Utilities/interface/BranchType.h"
 
 #include <memory>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -39,7 +38,8 @@ namespace edm {
 
     void removeModules(std::vector<ModuleDescription const*> const& modules);
 
-    std::set<ModuleProcessName> const& modulesInPreviousProcessesWhoseProductsAreConsumedBy(unsigned int moduleID) const;
+    std::vector<ModuleProcessName> const& modulesInPreviousProcessesWhoseProductsAreConsumedBy(
+        unsigned int moduleID) const;
 
   private:
     std::vector<std::string> const& doPaths() const override { return paths_; }
@@ -72,14 +72,14 @@ namespace edm {
     std::vector<std::pair<unsigned int, unsigned int> > moduleIDToIndex_;
 
     std::array<std::vector<std::vector<ModuleDescription const*> >, NumBranchTypes> modulesWhoseProductsAreConsumedBy_;
-    std::vector<std::set<ModuleProcessName> > modulesInPreviousProcessesWhoseProductsAreConsumedBy_;
+    std::vector<std::vector<ModuleProcessName> > modulesInPreviousProcessesWhoseProductsAreConsumedBy_;
 
     Schedule const* schedule_;
     std::shared_ptr<ProductRegistry const> preg_;
   };
 
-  std::vector<ModuleDescription const*> nonConsumedUnscheduledModules(edm::PathsAndConsumesOfModulesBase const& iPnC,
-                                                                      std::set<ModuleProcessName>& consumedByChildren);
+  std::vector<ModuleDescription const*> nonConsumedUnscheduledModules(
+      edm::PathsAndConsumesOfModulesBase const& iPnC, std::vector<ModuleProcessName>& consumedByChildren);
 
   void checkForModuleDependencyCorrectness(edm::PathsAndConsumesOfModulesBase const& iPnC, bool iPrintDependencies);
 }  // namespace edm

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -32,6 +32,8 @@ namespace edm {
 
     void initialize(Schedule const*, std::shared_ptr<ProductRegistry const>);
 
+    void removeModules(std::vector<ModuleDescription const*> const& modules);
+
   private:
     std::vector<std::string> const& doPaths() const override { return paths_; }
     std::vector<std::string> const& doEndPaths() const override { return endPaths_; }
@@ -42,6 +44,8 @@ namespace edm {
     std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const override;
     std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const override;
     std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(
+        unsigned int moduleID) const override;
+    std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedByLumiRun(
         unsigned int moduleID) const override;
 
     std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const override;
@@ -62,11 +66,14 @@ namespace edm {
     // following data member
     std::vector<std::pair<unsigned int, unsigned int> > moduleIDToIndex_;
 
-    std::vector<std::vector<ModuleDescription const*> > modulesWhoseProductsAreConsumedBy_;
+    std::vector<std::vector<ModuleDescription const*> > modulesWhoseProductsAreConsumedByEvent_;
+    std::vector<std::vector<ModuleDescription const*> > modulesWhoseProductsAreConsumedByLumiRun_;
 
     Schedule const* schedule_;
     std::shared_ptr<ProductRegistry const> preg_;
   };
+
+  std::vector<ModuleDescription const*> nonConsumedUnscheduledModules(edm::PathsAndConsumesOfModulesBase const& iPnC);
 
   void checkForModuleDependencyCorrectness(edm::PathsAndConsumesOfModulesBase const& iPnC, bool iPrintDependencies);
 }  // namespace edm

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -55,6 +55,8 @@ namespace edm {
 
     std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const override;
 
+    unsigned int doLargestModuleID() const override;
+
     unsigned int moduleIndex(unsigned int moduleID) const;
 
     // data members

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -281,7 +281,7 @@ namespace edm {
                       eventsetup::ESRecordsToProxyIndices const&);
 
     /// Deletes module with label iLabel
-    void deleteModule(std::string const& iLabel);
+    void deleteModule(std::string const& iLabel, ActivityRegistry* areg);
 
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkers() const;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -230,10 +230,12 @@ namespace edm {
                                      std::vector<ModuleDescription const*>& descriptions,
                                      unsigned int hint) const;
 
-    void fillModuleAndConsumesInfo(std::vector<ModuleDescription const*>& allModuleDescriptions,
-                                   std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
-                                   std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedBy,
-                                   ProductRegistry const& preg) const;
+    void fillModuleAndConsumesInfo(
+        std::vector<ModuleDescription const*>& allModuleDescriptions,
+        std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
+        std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedByEvent,
+        std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedByLumiRun,
+        ProductRegistry const& preg) const;
 
     /// Return the number of events this Schedule has tried to process
     /// (inclues both successes and failures, including failures due
@@ -276,6 +278,9 @@ namespace edm {
                       ParameterSet const& iPSet,
                       const ProductRegistry& iRegistry,
                       eventsetup::ESRecordsToProxyIndices const&);
+
+    /// Deletes module with label iLabel
+    void deleteModule(std::string const& iLabel);
 
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkers() const;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -233,8 +233,8 @@ namespace edm {
     void fillModuleAndConsumesInfo(
         std::vector<ModuleDescription const*>& allModuleDescriptions,
         std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
-        std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedByEvent,
-        std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedByLumiRun,
+        std::array<std::vector<std::vector<ModuleDescription const*>>, NumBranchTypes>&
+            modulesWhoseProductsAreConsumedBy,
         std::vector<std::set<ModuleProcessName>>& modulesInPreviousProcessesWhoseProductsAreConsumedBy,
         ProductRegistry const& preg) const;
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -235,6 +235,7 @@ namespace edm {
         std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
         std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedByEvent,
         std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedByLumiRun,
+        std::vector<std::set<ModuleProcessName>>& modulesInPreviousProcessesWhoseProductsAreConsumedBy,
         ProductRegistry const& preg) const;
 
     /// Return the number of events this Schedule has tried to process

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -235,7 +235,7 @@ namespace edm {
         std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
         std::array<std::vector<std::vector<ModuleDescription const*>>, NumBranchTypes>&
             modulesWhoseProductsAreConsumedBy,
-        std::vector<std::set<ModuleProcessName>>& modulesInPreviousProcessesWhoseProductsAreConsumedBy,
+        std::vector<std::vector<ModuleProcessName>>& modulesInPreviousProcessesWhoseProductsAreConsumedBy,
         ProductRegistry const& preg) const;
 
     /// Return the number of events this Schedule has tried to process

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -51,6 +51,13 @@ namespace edm {
       }
     }
 
+    void removeWorker(Worker const* worker) {
+      unscheduledWorkers_.erase(std::remove(unscheduledWorkers_.begin(), unscheduledWorkers_.end(), worker),
+                                unscheduledWorkers_.end());
+      accumulatorWorkers_.erase(std::remove(accumulatorWorkers_.begin(), accumulatorWorkers_.end(), worker),
+                                accumulatorWorkers_.end());
+    }
+
     void setEventTransitionInfo(EventTransitionInfo const& info) { aux_.setEventTransitionInfo(info); }
 
     UnscheduledAuxiliary const& auxiliary() const { return aux_; }

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -41,6 +41,9 @@ namespace edm {
     WorkerManager(std::shared_ptr<ModuleRegistry> modReg,
                   std::shared_ptr<ActivityRegistry> actReg,
                   ExceptionToActionTable const& actions);
+
+    void deleteModuleIfExists(std::string const& moduleLabel);
+
     void addToUnscheduledWorkers(ParameterSet& pset,
                                  ProductRegistry& preg,
                                  PreallocationConfiguration const* prealloc,

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -111,8 +111,7 @@ namespace edm {
 
       const EDConsumerBase* consumer() const;
 
-      void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
-                                           std::vector<ModuleDescription const*>& modulesLumiRun,
+      void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
                                            std::set<ModuleProcessName>& modulesInPreviousProcesses,
                                            ProductRegistry const& preg,
                                            std::map<std::string, ModuleDescription const*> const& labelsToDesc,

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -20,6 +20,7 @@
 
 // system include files
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -40,6 +41,7 @@
 
 namespace edm {
   class ModuleCallingContext;
+  class ModuleProcessName;
   class ProductResolverIndexHelper;
   class EDConsumerBase;
   class PreallocationConfiguration;
@@ -111,6 +113,7 @@ namespace edm {
 
       void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
                                            std::vector<ModuleDescription const*>& modulesLumiRun,
+                                           std::set<ModuleProcessName>& modulesInPreviousProcesses,
                                            ProductRegistry const& preg,
                                            std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                            std::string const& processName) const;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -109,7 +109,8 @@ namespace edm {
 
       const EDConsumerBase* consumer() const;
 
-      void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+      void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
+                                           std::vector<ModuleDescription const*>& modulesLumiRun,
                                            ProductRegistry const& preg,
                                            std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                            std::string const& processName) const;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -20,7 +20,6 @@
 
 // system include files
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -112,7 +111,7 @@ namespace edm {
       const EDConsumerBase* consumer() const;
 
       void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-                                           std::set<ModuleProcessName>& modulesInPreviousProcesses,
+                                           std::vector<ModuleProcessName>& modulesInPreviousProcesses,
                                            ProductRegistry const& preg,
                                            std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                            std::string const& processName) const;

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -100,7 +100,8 @@ namespace edm {
       void updateLookup(BranchType iBranchType, ProductResolverIndexHelper const&, bool iPrefetchMayGet);
       void updateLookup(eventsetup::ESRecordsToProxyIndices const&);
 
-      void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+      void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
+                                           std::vector<ModuleDescription const*>& modulesLumiRun,
                                            ProductRegistry const& preg,
                                            std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                            std::string const& processName) const;

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -101,8 +101,7 @@ namespace edm {
       void updateLookup(BranchType iBranchType, ProductResolverIndexHelper const&, bool iPrefetchMayGet);
       void updateLookup(eventsetup::ESRecordsToProxyIndices const&);
 
-      void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
-                                           std::vector<ModuleDescription const*>& modulesLumiRun,
+      void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
                                            std::set<ModuleProcessName>& modulesInPreviousProcesses,
                                            ProductRegistry const& preg,
                                            std::map<std::string, ModuleDescription const*> const& labelsToDesc,

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -102,7 +102,7 @@ namespace edm {
       void updateLookup(eventsetup::ESRecordsToProxyIndices const&);
 
       void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-                                           std::set<ModuleProcessName>& modulesInPreviousProcesses,
+                                           std::vector<ModuleProcessName>& modulesInPreviousProcesses,
                                            ProductRegistry const& preg,
                                            std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                            std::string const& processName) const;

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -45,6 +45,7 @@
 namespace edm {
   class Event;
   class ModuleCallingContext;
+  class ModuleProcessName;
   class ProductResolverIndexHelper;
   class EDConsumerBase;
   class PreallocationConfiguration;
@@ -102,6 +103,7 @@ namespace edm {
 
       void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modulesEvent,
                                            std::vector<ModuleDescription const*>& modulesLumiRun,
+                                           std::set<ModuleProcessName>& modulesInPreviousProcesses,
                                            ProductRegistry const& preg,
                                            std::map<std::string, ModuleDescription const*> const& labelsToDesc,
                                            std::string const& processName) const;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -547,10 +547,15 @@ namespace edm {
     actReg_->preallocateSignal_(bounds);
     schedule_->convertCurrentProcessAlias(processConfiguration_->processName());
     pathsAndConsumesOfModules_.initialize(schedule_.get(), preg());
+    std::set<ModuleProcessName> consumedBySubProcesses;
+    for_all(subProcesses_, [&consumedBySubProcesses](auto& subProcess) {
+      auto c = subProcess.keepOnlyConsumedUnscheduledModules();
+      consumedBySubProcesses.insert(c.begin(), c.end());
+    });
 
     // Note: all these may throw
     checkForModuleDependencyCorrectness(pathsAndConsumesOfModules_, printDependencies_);
-    if (auto const unusedModules = nonConsumedUnscheduledModules(pathsAndConsumesOfModules_);
+    if (auto const unusedModules = nonConsumedUnscheduledModules(pathsAndConsumesOfModules_, consumedBySubProcesses);
         not unusedModules.empty()) {
       pathsAndConsumesOfModules_.removeModules(unusedModules);
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -567,7 +567,7 @@ namespace edm {
         }
       });
       for (auto const& description : unusedModules) {
-        schedule_->deleteModule(description->moduleLabel());
+        schedule_->deleteModule(description->moduleLabel(), actReg_.get());
       }
     }
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1914,7 +1914,7 @@ namespace edm {
           s = std::make_unique<LogSystem>("ModulesSynchingOnLumis");
           (*s) << "The following modules require synchronizing on LuminosityBlock boundaries:";
         }
-        (*s) << "\n  " << worker->description().moduleName() << " " << worker->description().moduleLabel();
+        (*s) << "\n  " << worker->description()->moduleName() << " " << worker->description()->moduleLabel();
       }
     }
   }

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -113,6 +113,12 @@ namespace edm {
     }
   }
 
+  void GlobalSchedule::deleteModule(std::string const& iLabel) {
+    for (auto& wm : workerManagers_) {
+      wm.deleteModuleIfExists(iLabel);
+    }
+  }
+
   std::vector<ModuleDescription const*> GlobalSchedule::getAllModuleDescriptions() const {
     std::vector<ModuleDescription const*> result;
     result.reserve(allWorkers().size());

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -99,7 +99,7 @@ namespace edm {
     Worker* found = nullptr;
     for (auto& wm : workerManagers_) {
       for (auto const& worker : wm.allWorkers()) {
-        if (worker->description().moduleLabel() == iLabel) {
+        if (worker->description()->moduleLabel() == iLabel) {
           found = worker;
           break;
         }
@@ -118,7 +118,7 @@ namespace edm {
     result.reserve(allWorkers().size());
 
     for (auto const& worker : allWorkers()) {
-      ModuleDescription const* p = worker->descPtr();
+      ModuleDescription const* p = worker->description();
       result.push_back(p);
     }
     return result;

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -121,6 +121,9 @@ namespace edm {
     /// clone the type of module with label iLabel but configure with iPSet.
     void replaceModule(maker::ModuleHolder* iMod, std::string const& iLabel);
 
+    /// Delete the module with label iLabel
+    void deleteModule(std::string const& iLabel);
+
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkers() const { return workerManagers_[0].allWorkers(); }
 

--- a/FWCore/Framework/src/ModuleRegistry.cc
+++ b/FWCore/Framework/src/ModuleRegistry.cc
@@ -49,4 +49,14 @@ namespace edm {
     modItr->second = modPtr;
     return modItr->second.get();
   }
+
+  void ModuleRegistry::deleteModule(std::string const& iModuleLabel /* TODO: signals */) {
+    auto modItr = labelToModule_.find(iModuleLabel);
+    if (modItr == labelToModule_.end()) {
+      throw cms::Exception("LogicError")
+          << "Trying to delete module " << iModuleLabel
+          << " but it does not exist in the ModuleRegistry. Please contact framework developers.";
+    }
+    labelToModule_.erase(modItr);
+  }
 }  // namespace edm

--- a/FWCore/Framework/src/ModuleRegistry.cc
+++ b/FWCore/Framework/src/ModuleRegistry.cc
@@ -50,13 +50,34 @@ namespace edm {
     return modItr->second.get();
   }
 
-  void ModuleRegistry::deleteModule(std::string const& iModuleLabel /* TODO: signals */) {
+  void ModuleRegistry::deleteModule(std::string const& iModuleLabel,
+                                    signalslot::Signal<void(ModuleDescription const&)>& iPre,
+                                    signalslot::Signal<void(ModuleDescription const&)>& iPost) {
     auto modItr = labelToModule_.find(iModuleLabel);
     if (modItr == labelToModule_.end()) {
       throw cms::Exception("LogicError")
           << "Trying to delete module " << iModuleLabel
           << " but it does not exist in the ModuleRegistry. Please contact framework developers.";
     }
-    labelToModule_.erase(modItr);
+    // If iPost throws and exception, let it propagate
+    // If deletion throws an exception, capture it and call iPost before throwing an exception
+    // If iPost throws an exception, let it propagate
+    auto md = modItr->second->moduleDescription();
+    iPre(modItr->second->moduleDescription());
+    bool postCalled = false;
+    // exception is rethrown
+    CMS_SA_ALLOW try {
+      labelToModule_.erase(modItr);
+      // if exception then post will be called in the catch block
+      postCalled = true;
+      iPost(md);
+    } catch (...) {
+      if (not postCalled) {
+        // we're already handling exception, nothing we can do if iPost throws
+        CMS_SA_ALLOW try { iPost(md); } catch (...) {
+        }
+      }
+      throw;
+    }
   }
 }  // namespace edm

--- a/FWCore/Framework/src/ModuleRegistry.h
+++ b/FWCore/Framework/src/ModuleRegistry.h
@@ -48,7 +48,9 @@ namespace edm {
                                        edm::ParameterSet const& iPSet,
                                        edm::PreallocationConfiguration const&);
 
-    void deleteModule(std::string const& iModuleLabel /* TODO: signals */);
+    void deleteModule(std::string const& iModuleLabel,
+                      signalslot::Signal<void(ModuleDescription const&)>& iPre,
+                      signalslot::Signal<void(ModuleDescription const&)>& iPost);
 
     template <typename F>
     void forAllModuleHolders(F iFunc) {

--- a/FWCore/Framework/src/ModuleRegistry.h
+++ b/FWCore/Framework/src/ModuleRegistry.h
@@ -48,6 +48,8 @@ namespace edm {
                                        edm::ParameterSet const& iPSet,
                                        edm::PreallocationConfiguration const&);
 
+    void deleteModule(std::string const& iModuleLabel /* TODO: signals */);
+
     template <typename F>
     void forAllModuleHolders(F iFunc) {
       for (auto& labelMod : labelToModule_) {

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -266,12 +266,14 @@ namespace edm {
       CMS_SA_ALLOW try {
         std::ostringstream ost;
         ost << iEP.id();
+        ModuleDescription const* desc = worker.getWorker()->description();
+        assert(desc != nullptr);
         shouldContinue = handleWorkerFailure(*pEx,
                                              iModuleIndex,
                                              /*isEvent*/ true,
                                              /*isBegin*/ true,
                                              InEvent,
-                                             worker.getWorker()->description(),
+                                             *desc,
                                              ost.str());
         //If we didn't rethrow, then we effectively skipped
         worker.skipWorker(iEP);

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -123,6 +123,11 @@ namespace edm {
     return worker->consumesInfo();
   }
 
+  unsigned int PathsAndConsumesOfModules::doLargestModuleID() const {
+    // moduleIDToIndex_ is sorted, so last element has the largest ID
+    return moduleIDToIndex_.empty() ? 0 : moduleIDToIndex_.back().first;
+  }
+
   unsigned int PathsAndConsumesOfModules::moduleIndex(unsigned int moduleID) const {
     unsigned int dummy = 0;
     auto target = std::make_pair(moduleID, dummy);

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -87,7 +87,7 @@ namespace edm {
     }
   }
 
-  std::set<ModuleProcessName> const& PathsAndConsumesOfModules::modulesInPreviousProcessesWhoseProductsAreConsumedBy(
+  std::vector<ModuleProcessName> const& PathsAndConsumesOfModules::modulesInPreviousProcessesWhoseProductsAreConsumedBy(
       unsigned int moduleID) const {
     return modulesInPreviousProcessesWhoseProductsAreConsumedBy_.at(moduleIndex(moduleID));
   }
@@ -157,8 +157,8 @@ namespace {
 }  // namespace
 
 namespace edm {
-  std::vector<ModuleDescription const*> nonConsumedUnscheduledModules(edm::PathsAndConsumesOfModulesBase const& iPnC,
-                                                                      std::set<ModuleProcessName>& consumedByChildren) {
+  std::vector<ModuleDescription const*> nonConsumedUnscheduledModules(
+      edm::PathsAndConsumesOfModulesBase const& iPnC, std::vector<ModuleProcessName>& consumedByChildren) {
     const std::string kTriggerResults("TriggerResults");
 
     std::vector<std::string> pathNames = iPnC.paths();
@@ -191,10 +191,12 @@ namespace edm {
       if (description->moduleLabel() == kTriggerResults or
           std::find(pathNames.begin(), pathNames.end(), description->moduleLabel()) != pathNames.end()) {
         consumerModules.push_back(description);
-      } else if (consumedByChildren.find(ModuleProcessName{description->moduleLabel(), description->processName()}) !=
-                     consumedByChildren.end() or
-                 consumedByChildren.find(ModuleProcessName{description->moduleLabel(), ""}) !=
-                     consumedByChildren.end()) {
+      } else if (std::binary_search(consumedByChildren.begin(),
+                                    consumedByChildren.end(),
+                                    ModuleProcessName{description->moduleLabel(), description->processName()}) or
+                 std::binary_search(consumedByChildren.begin(),
+                                    consumedByChildren.end(),
+                                    ModuleProcessName{description->moduleLabel(), ""})) {
         consumerModules.push_back(description);
       }
     }

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -381,7 +381,6 @@ namespace edm {
   void UnscheduledProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
     aux_ = iConfigure.auxiliary();
     worker_ = iConfigure.findWorker(branchDescription().moduleLabel());
-    assert(worker_ != nullptr);
   }
 
   ProductResolverBase::Resolution UnscheduledProductResolver::resolveProduct_(Principal const&,
@@ -430,6 +429,10 @@ namespace edm {
                                                   ModuleCallingContext const* mcc) const {
     if (skipCurrentProcess) {
       return;
+    }
+    if (worker_ == nullptr) {
+      throw cms::Exception("LogicError") << "UnscheduledProductResolver::prefetchAsync_()  called with null worker_. "
+                                            "This should not happen, please contact framework developers.";
     }
     //need to try changing prefetchRequested_ before adding to waitingTasks_
     bool expected = false;

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -412,8 +412,8 @@ namespace edm {
 
         } catch (cms::Exception& ex) {
           std::ostringstream ost;
-          ost << "Calling produce method for unscheduled module " << worker_->description().moduleName() << "/'"
-              << worker_->description().moduleLabel() << "'";
+          ost << "Calling produce method for unscheduled module " << worker_->description()->moduleName() << "/'"
+              << worker_->description()->moduleLabel() << "'";
           ex.addContext(ost.str());
           throw;
         }

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -182,7 +182,7 @@ namespace edm {
   class UnscheduledProductResolver : public ProducedProductResolver {
   public:
     explicit UnscheduledProductResolver(std::shared_ptr<BranchDescription const> bd)
-        : ProducedProductResolver(bd, ProductStatus::ResolveNotRun), aux_(nullptr), prefetchRequested_(false) {}
+        : ProducedProductResolver(bd, ProductStatus::ResolveNotRun) {}
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
 
@@ -202,9 +202,9 @@ namespace edm {
     void resetProductData_(bool deleteEarly) override;
 
     CMS_THREAD_SAFE mutable WaitingTaskList waitingTasks_;
-    UnscheduledAuxiliary const* aux_;
-    Worker* worker_;
-    mutable std::atomic<bool> prefetchRequested_;
+    UnscheduledAuxiliary const* aux_ = nullptr;
+    Worker* worker_ = nullptr;
+    mutable std::atomic<bool> prefetchRequested_ = false;
   };
 
   class AliasProductResolver : public DataManagingOrAliasProductResolver {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1478,16 +1478,19 @@ namespace edm {
       std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
       std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedByEvent,
       std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedByLumiRun,
+      std::vector<std::set<ModuleProcessName>>& modulesInPreviousProcessesWhoseProductsAreConsumedBy,
       ProductRegistry const& preg) const {
     allModuleDescriptions.clear();
     moduleIDToIndex.clear();
     modulesWhoseProductsAreConsumedByEvent.clear();
     modulesWhoseProductsAreConsumedByLumiRun.clear();
+    modulesInPreviousProcessesWhoseProductsAreConsumedBy.clear();
 
     allModuleDescriptions.reserve(allWorkers().size());
     moduleIDToIndex.reserve(allWorkers().size());
     modulesWhoseProductsAreConsumedByEvent.resize(allWorkers().size());
     modulesWhoseProductsAreConsumedByLumiRun.resize(allWorkers().size());
+    modulesInPreviousProcessesWhoseProductsAreConsumedBy.resize(allWorkers().size());
 
     std::map<std::string, ModuleDescription const*> labelToDesc;
     unsigned int i = 0;
@@ -1504,8 +1507,11 @@ namespace edm {
     for (auto const& worker : allWorkers()) {
       std::vector<ModuleDescription const*>& modulesEvent = modulesWhoseProductsAreConsumedByEvent.at(i);
       std::vector<ModuleDescription const*>& modulesLumiRun = modulesWhoseProductsAreConsumedByLumiRun.at(i);
+      std::set<ModuleProcessName>& modulesInPreviousProcesses =
+          modulesInPreviousProcessesWhoseProductsAreConsumedBy.at(i);
       try {
-        worker->modulesWhoseProductsAreConsumed(modulesEvent, modulesLumiRun, preg, labelToDesc);
+        worker->modulesWhoseProductsAreConsumed(
+            modulesEvent, modulesLumiRun, modulesInPreviousProcesses, preg, labelToDesc);
       } catch (cms::Exception& ex) {
         ex.addContext("Calling Worker::modulesWhoseProductsAreConsumed() for module " +
                       worker->description()->moduleLabel());

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1479,7 +1479,7 @@ namespace edm {
       std::vector<ModuleDescription const*>& allModuleDescriptions,
       std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
       std::array<std::vector<std::vector<ModuleDescription const*>>, NumBranchTypes>& modulesWhoseProductsAreConsumedBy,
-      std::vector<std::set<ModuleProcessName>>& modulesInPreviousProcessesWhoseProductsAreConsumedBy,
+      std::vector<std::vector<ModuleProcessName>>& modulesInPreviousProcessesWhoseProductsAreConsumedBy,
       ProductRegistry const& preg) const {
     allModuleDescriptions.clear();
     moduleIDToIndex.clear();
@@ -1513,7 +1513,7 @@ namespace edm {
         modules[iBranchType] = &modulesWhoseProductsAreConsumedBy[iBranchType].at(i);
       }
 
-      std::set<ModuleProcessName>& modulesInPreviousProcesses =
+      std::vector<ModuleProcessName>& modulesInPreviousProcesses =
           modulesInPreviousProcessesWhoseProductsAreConsumedBy.at(i);
       try {
         worker->modulesWhoseProductsAreConsumed(modules, modulesInPreviousProcesses, preg, labelToDesc);

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1422,12 +1422,12 @@ namespace edm {
     return true;
   }
 
-  void Schedule::deleteModule(std::string const& iLabel) {
+  void Schedule::deleteModule(std::string const& iLabel, ActivityRegistry* areg) {
     globalSchedule_->deleteModule(iLabel);
     for (auto& stream : streamSchedules_) {
       stream->deleteModule(iLabel);
     }
-    moduleRegistry_->deleteModule(iLabel);
+    moduleRegistry_->deleteModule(iLabel, areg->preModuleDestructionSignal_, areg->postModuleDestructionSignal_);
   }
 
   std::vector<ModuleDescription const*> Schedule::getAllModuleDescriptions() const {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -847,6 +847,8 @@ namespace edm {
       summaryTimeKeeper_ = std::make_unique<SystemTimeKeeper>(prealloc.numberOfStreams(), modDesc, tns, processContext);
       auto timeKeeperPtr = summaryTimeKeeper_.get();
 
+      areg->watchPreModuleDestruction(timeKeeperPtr, &SystemTimeKeeper::removeModuleIfExists);
+
       areg->watchPreModuleEvent(timeKeeperPtr, &SystemTimeKeeper::startModuleEvent);
       areg->watchPostModuleEvent(timeKeeperPtr, &SystemTimeKeeper::stopModuleEvent);
       areg->watchPreModuleEventAcquire(timeKeeperPtr, &SystemTimeKeeper::restartModuleEvent);

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -719,8 +719,8 @@ namespace edm {
     std::vector<std::string> modulesToUse;
     modulesToUse.reserve(streamSchedules_[0]->allWorkers().size());
     for (auto const& worker : streamSchedules_[0]->allWorkers()) {
-      if (worker->description().moduleLabel() != kTriggerResults) {
-        modulesToUse.push_back(worker->description().moduleLabel());
+      if (worker->description()->moduleLabel() != kTriggerResults) {
+        modulesToUse.push_back(worker->description()->moduleLabel());
       }
     }
     //The unscheduled modules are at the end of the list, but we want them at the front
@@ -752,8 +752,8 @@ namespace edm {
     // reduceParameterSet would fail to find it. Just remove it up front.
     std::set<std::string> usedModuleLabels;
     for (auto const& worker : allWorkers()) {
-      if (worker->description().moduleLabel() != kTriggerResults) {
-        usedModuleLabels.insert(worker->description().moduleLabel());
+      if (worker->description()->moduleLabel() != kTriggerResults) {
+        usedModuleLabels.insert(worker->description()->moduleLabel());
       }
     }
     std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string>>("@all_modules"));
@@ -841,7 +841,7 @@ namespace edm {
       std::transform(workers.begin(),
                      workers.end(),
                      std::back_inserter(modDesc),
-                     [](const Worker* iWorker) -> const ModuleDescription* { return iWorker->descPtr(); });
+                     [](const Worker* iWorker) -> const ModuleDescription* { return iWorker->description(); });
 
       // propagate_const<T> has no reset() function
       summaryTimeKeeper_ = std::make_unique<SystemTimeKeeper>(prealloc.numberOfStreams(), modDesc, tns, processContext);
@@ -1379,7 +1379,7 @@ namespace edm {
                               eventsetup::ESRecordsToProxyIndices const& iIndices) {
     Worker* found = nullptr;
     for (auto const& worker : allWorkers()) {
-      if (worker->description().moduleLabel() == iLabel) {
+      if (worker->description()->moduleLabel() == iLabel) {
         found = worker;
         break;
       }
@@ -1427,7 +1427,7 @@ namespace edm {
     result.reserve(allWorkers().size());
 
     for (auto const& worker : allWorkers()) {
-      ModuleDescription const* p = worker->descPtr();
+      ModuleDescription const* p = worker->description();
       result.push_back(p);
     }
     return result;
@@ -1481,7 +1481,7 @@ namespace edm {
     std::map<std::string, ModuleDescription const*> labelToDesc;
     unsigned int i = 0;
     for (auto const& worker : allWorkers()) {
-      ModuleDescription const* p = worker->descPtr();
+      ModuleDescription const* p = worker->description();
       allModuleDescriptions.push_back(p);
       moduleIDToIndex.push_back(std::pair<unsigned int, unsigned int>(p->id(), i));
       labelToDesc[p->moduleLabel()] = p;
@@ -1496,7 +1496,7 @@ namespace edm {
         worker->modulesWhoseProductsAreConsumed(modules, preg, labelToDesc);
       } catch (cms::Exception& ex) {
         ex.addContext("Calling Worker::modulesWhoseProductsAreConsumed() for module " +
-                      worker->description().moduleLabel());
+                      worker->description()->moduleLabel());
         throw;
       }
       ++i;

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -547,6 +547,8 @@ namespace edm {
     found->beginStream(streamID_, streamContext_);
   }
 
+  void StreamSchedule::deleteModule(std::string const& iLabel) { workerManager_.deleteModuleIfExists(iLabel); }
+
   std::vector<ModuleDescription const*> StreamSchedule::getAllModuleDescriptions() const {
     std::vector<ModuleDescription const*> result;
     result.reserve(allWorkers().size());

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -198,7 +198,7 @@ namespace edm {
     //See if all modules were used
     std::set<std::string> usedWorkerLabels;
     for (auto const& worker : allWorkers()) {
-      usedWorkerLabels.insert(worker->description().moduleLabel());
+      usedWorkerLabels.insert(worker->description()->moduleLabel());
     }
     std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string>>("@all_modules"));
     std::set<std::string> modulesInConfigSet(modulesInConfig.begin(), modulesInConfig.end());
@@ -291,7 +291,7 @@ namespace edm {
 
     for (auto w : allWorkers()) {
       //determine if this module could read a branch we want to delete early
-      auto pset = pset::Registry::instance()->getMapped(w->description().parameterSetID());
+      auto pset = pset::Registry::instance()->getMapped(w->description()->parameterSetID());
       if (nullptr != pset) {
         auto branches = pset->getUntrackedParameter<std::vector<std::string>>("mightGet", kEmpty);
         if (not branches.empty()) {
@@ -446,10 +446,10 @@ namespace edm {
         // We have a filter on an end path, and the filter is not explicitly ignored.
         // See if the filter is allowed.
         std::vector<std::string> allowed_filters = proc_pset.getUntrackedParameter<vstring>("@filters_on_endpaths");
-        if (!search_all(allowed_filters, worker->description().moduleName())) {
+        if (!search_all(allowed_filters, worker->description()->moduleName())) {
           // Filter is not allowed. Ignore the result, and issue a warning.
           filterAction = WorkerInPath::Ignore;
-          LogWarning("FilterOnEndPath") << "The EDFilter '" << worker->description().moduleName()
+          LogWarning("FilterOnEndPath") << "The EDFilter '" << worker->description()->moduleName()
                                         << "' with module label '" << moduleLabel << "' appears on EndPath '"
                                         << pathName << "'.\n"
                                         << "The return value of the filter will be ignored.\n"
@@ -534,7 +534,7 @@ namespace edm {
   void StreamSchedule::replaceModule(maker::ModuleHolder* iMod, std::string const& iLabel) {
     Worker* found = nullptr;
     for (auto const& worker : allWorkers()) {
-      if (worker->description().moduleLabel() == iLabel) {
+      if (worker->description()->moduleLabel() == iLabel) {
         found = worker;
         break;
       }
@@ -552,7 +552,7 @@ namespace edm {
     result.reserve(allWorkers().size());
 
     for (auto const& worker : allWorkers()) {
-      ModuleDescription const* p = worker->descPtr();
+      ModuleDescription const* p = worker->description();
       result.push_back(p);
     }
     return result;
@@ -764,7 +764,7 @@ namespace edm {
     if (itFound != trig_paths_.end()) {
       oLabelsToFill.reserve(itFound->size());
       for (size_t i = 0; i < itFound->size(); ++i) {
-        oLabelsToFill.push_back(itFound->getWorker(i)->description().moduleLabel());
+        oLabelsToFill.push_back(itFound->getWorker(i)->description()->moduleLabel());
       }
     }
   }
@@ -793,7 +793,7 @@ namespace edm {
     if (found) {
       descriptions.reserve(itFound->size());
       for (size_t i = 0; i < itFound->size(); ++i) {
-        descriptions.push_back(itFound->getWorker(i)->descPtr());
+        descriptions.push_back(itFound->getWorker(i)->description());
       }
     }
   }
@@ -822,7 +822,7 @@ namespace edm {
     if (found) {
       descriptions.reserve(itFound->size());
       for (size_t i = 0; i < itFound->size(); ++i) {
-        descriptions.push_back(itFound->getWorker(i)->descPtr());
+        descriptions.push_back(itFound->getWorker(i)->description());
       }
     }
   }
@@ -836,7 +836,7 @@ namespace edm {
     sum.timesPassed += path.timesPassed(which);
     sum.timesFailed += path.timesFailed(which);
     sum.timesExcept += path.timesExcept(which);
-    sum.moduleLabel = path.getWorker(which)->description().moduleLabel();
+    sum.moduleLabel = path.getWorker(which)->description()->moduleLabel();
   }
 
   static void fillPathSummary(Path const& path, PathSummary& sum) {
@@ -868,7 +868,7 @@ namespace edm {
     sum.timesPassed += w.timesPassed();
     sum.timesFailed += w.timesFailed();
     sum.timesExcept += w.timesExcept();
-    sum.moduleLabel = w.description().moduleLabel();
+    sum.moduleLabel = w.description()->moduleLabel();
   }
 
   static void fillWorkerSummary(Worker const* pw, WorkerSummary& sum) { fillWorkerSummaryAux(*pw, sum); }

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -251,6 +251,9 @@ namespace edm {
     /// clone the type of module with label iLabel but configure with iPSet.
     void replaceModule(maker::ModuleHolder* iMod, std::string const& iLabel);
 
+    /// Delete the module with label iLabel
+    void deleteModule(std::string const& iLabel);
+
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkers() const { return workerManager_.allWorkers(); }
 

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -249,7 +249,7 @@ namespace edm {
         }
       });
       for (auto const& description : unusedModules) {
-        schedule_->deleteModule(description->moduleLabel());
+        schedule_->deleteModule(description->moduleLabel(), actReg_.get());
       }
     }
 

--- a/FWCore/Framework/src/SubProcess.h
+++ b/FWCore/Framework/src/SubProcess.h
@@ -78,7 +78,7 @@ namespace edm {
 
     // Returns the set of modules whose products may be consumed by
     // modules in this SubProcess or its child SubProcesses
-    std::set<ModuleProcessName> keepOnlyConsumedUnscheduledModules();
+    std::vector<ModuleProcessName> keepOnlyConsumedUnscheduledModules();
 
     void doBeginJob();
     void doEndJob();

--- a/FWCore/Framework/src/SubProcess.h
+++ b/FWCore/Framework/src/SubProcess.h
@@ -78,7 +78,7 @@ namespace edm {
 
     // Returns the set of modules whose products may be consumed by
     // modules in this SubProcess or its child SubProcesses
-    std::vector<ModuleProcessName> keepOnlyConsumedUnscheduledModules();
+    std::vector<ModuleProcessName> keepOnlyConsumedUnscheduledModules(bool deleteModules);
 
     void doBeginJob();
     void doEndJob();

--- a/FWCore/Framework/src/SubProcess.h
+++ b/FWCore/Framework/src/SubProcess.h
@@ -76,6 +76,10 @@ namespace edm {
 
     SelectedProductsForBranchType const& keptProducts() const { return keptProducts_; }
 
+    // Returns the set of modules whose products may be consumed by
+    // modules in this SubProcess or its child SubProcesses
+    std::set<ModuleProcessName> keepOnlyConsumedUnscheduledModules();
+
     void doBeginJob();
     void doEndJob();
 

--- a/FWCore/Framework/src/SystemTimeKeeper.cc
+++ b/FWCore/Framework/src/SystemTimeKeeper.cc
@@ -27,6 +27,12 @@
 #include "SystemTimeKeeper.h"
 
 using namespace edm;
+
+namespace {
+  bool lessModuleDescription(const ModuleDescription* iLHS, const ModuleDescription* iRHS) {
+    return iLHS->id() < iRHS->id();
+  }
+}  // namespace
 //
 // constants, enums and typedefs
 //
@@ -48,10 +54,7 @@ SystemTimeKeeper::SystemTimeKeeper(unsigned int iNumStreams,
       m_processContext(iProcessContext),
       m_minModuleID(0),
       m_numberOfEvents(0) {
-  std::sort(
-      m_modules.begin(), m_modules.end(), [](const ModuleDescription* iLHS, const ModuleDescription* iRHS) -> bool {
-        return iLHS->id() < iRHS->id();
-      });
+  std::sort(m_modules.begin(), m_modules.end(), lessModuleDescription);
   if (not m_modules.empty()) {
     m_minModuleID = m_modules.front()->id();
     unsigned int numModuleSlots = m_modules.back()->id() - m_minModuleID + 1;
@@ -103,6 +106,15 @@ SystemTimeKeeper::SystemTimeKeeper(unsigned int iNumStreams,
 //
 // member functions
 //
+void SystemTimeKeeper::removeModuleIfExists(ModuleDescription const& module) {
+  // The deletion of a module is signaled to all (Sub)Processes, even
+  // though the module exists in only one of them.
+  auto found = std::lower_bound(m_modules.begin(), m_modules.end(), &module, lessModuleDescription);
+  if (*found == &module) {
+    m_modules.erase(found);
+  }
+}
+
 SystemTimeKeeper::PathTiming& SystemTimeKeeper::pathTiming(StreamContext const& iStream, PathContext const& iPath) {
   unsigned int offset = 0;
   if (iPath.isEndPath()) {

--- a/FWCore/Framework/src/SystemTimeKeeper.h
+++ b/FWCore/Framework/src/SystemTimeKeeper.h
@@ -58,6 +58,8 @@ namespace edm {
     // ---------- static member functions --------------------
 
     // ---------- member functions ---------------------------
+    void removeModuleIfExists(ModuleDescription const& module);
+
     void startProcessingLoop();
     void stopProcessingLoop();
 

--- a/FWCore/Framework/src/UnscheduledConfigurator.h
+++ b/FWCore/Framework/src/UnscheduledConfigurator.h
@@ -34,7 +34,7 @@ namespace edm {
     template <typename IT>
     UnscheduledConfigurator(IT iBegin, IT iEnd, UnscheduledAuxiliary const* iAux) : m_aux(iAux) {
       for (auto it = iBegin; it != iEnd; ++it) {
-        m_labelToWorker.emplace((*it)->description().moduleLabel(), *it);
+        m_labelToWorker.emplace((*it)->description()->moduleLabel(), *it);
       }
     }
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -180,7 +180,7 @@ namespace edm {
         return true;
       }
 
-      ModuleCallingContext tempContext(&description(), ModuleCallingContext::State::kInvalid, parentContext, nullptr);
+      ModuleCallingContext tempContext(description(), ModuleCallingContext::State::kInvalid, parentContext, nullptr);
 
       // If we are processing an endpath and the module was scheduled, treat SkipEvent or FailPath
       // as IgnoreCompletely, so any subsequent OutputModules are still run.
@@ -349,13 +349,14 @@ namespace edm {
   void Worker::beginJob() {
     try {
       convertException::wrap([&]() {
-        ModuleBeginJobSignalSentry cpp(actReg_.get(), description());
+        ModuleBeginJobSignalSentry cpp(actReg_.get(), *description());
         implBeginJob();
       });
     } catch (cms::Exception& ex) {
       state_ = Exception;
       std::ostringstream ost;
-      ost << "Calling beginJob for module " << description().moduleName() << "/'" << description().moduleLabel() << "'";
+      ost << "Calling beginJob for module " << description()->moduleName() << "/'" << description()->moduleLabel()
+          << "'";
       ex.addContext(ost.str());
       throw;
     }
@@ -364,13 +365,15 @@ namespace edm {
   void Worker::endJob() {
     try {
       convertException::wrap([&]() {
-        ModuleEndJobSignalSentry cpp(actReg_.get(), description());
+        ModuleDescription const* desc = description();
+        assert(desc != nullptr);
+        ModuleEndJobSignalSentry cpp(actReg_.get(), *desc);
         implEndJob();
       });
     } catch (cms::Exception& ex) {
       state_ = Exception;
       std::ostringstream ost;
-      ost << "Calling endJob for module " << description().moduleName() << "/'" << description().moduleLabel() << "'";
+      ost << "Calling endJob for module " << description()->moduleName() << "/'" << description()->moduleLabel() << "'";
       ex.addContext(ost.str());
       throw;
     }
@@ -393,7 +396,7 @@ namespace edm {
     } catch (cms::Exception& ex) {
       state_ = Exception;
       std::ostringstream ost;
-      ost << "Calling beginStream for module " << description().moduleName() << "/'" << description().moduleLabel()
+      ost << "Calling beginStream for module " << description()->moduleName() << "/'" << description()->moduleLabel()
           << "'";
       ex.addContext(ost.str());
       throw;
@@ -417,7 +420,7 @@ namespace edm {
     } catch (cms::Exception& ex) {
       state_ = Exception;
       std::ostringstream ost;
-      ost << "Calling endStream for module " << description().moduleName() << "/'" << description().moduleLabel()
+      ost << "Calling endStream for module " << description()->moduleName() << "/'" << description()->moduleLabel()
           << "'";
       ex.addContext(ost.str());
       throw;
@@ -428,7 +431,7 @@ namespace edm {
     try {
       implRegisterThinnedAssociations(registry, helper);
     } catch (cms::Exception& ex) {
-      ex.addContext("Calling registerThinnedAssociations() for module " + description().moduleLabel());
+      ex.addContext("Calling registerThinnedAssociations() for module " + description()->moduleLabel());
       throw ex;
     }
   }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -213,7 +213,7 @@ namespace edm {
 
     virtual void modulesWhoseProductsAreConsumed(
         std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-        std::set<ModuleProcessName>& modulesInPreviousProcesses,
+        std::vector<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc) const = 0;
 

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -212,8 +212,7 @@ namespace edm {
             iIndicies) = 0;
 
     virtual void modulesWhoseProductsAreConsumed(
-        std::vector<ModuleDescription const*>& modulesEvent,
-        std::vector<ModuleDescription const*>& modulesLumiRun,
+        std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
         std::set<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc) const = 0;

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -70,6 +70,7 @@ namespace edm {
   class EventPrincipal;
   class EventSetupImpl;
   class EarlyDeleteHelper;
+  class ModuleProcessName;
   class ProductResolverIndexHelper;
   class ProductResolverIndexAndSkipBit;
   class StreamID;
@@ -213,6 +214,7 @@ namespace edm {
     virtual void modulesWhoseProductsAreConsumed(
         std::vector<ModuleDescription const*>& modulesEvent,
         std::vector<ModuleDescription const*>& modulesLumiRun,
+        std::set<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc) const = 0;
 

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -185,8 +185,7 @@ namespace edm {
 
     void postDoEvent(EventPrincipal const&);
 
-    ModuleDescription const& description() const { return *(moduleCallingContext_.moduleDescription()); }
-    ModuleDescription const* descPtr() const { return moduleCallingContext_.moduleDescription(); }
+    ModuleDescription const* description() const { return moduleCallingContext_.moduleDescription(); }
     ///The signals are required to live longer than the last call to 'doWork'
     /// this was done to improve performance based on profiling
     void setActivityRegistry(std::shared_ptr<ActivityRegistry> areg);

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -30,6 +30,16 @@ namespace edm {
         unscheduled_(*areg),
         lastSetupEventPrincipal_(nullptr) {}  // WorkerManager::WorkerManager
 
+  void WorkerManager::deleteModuleIfExists(std::string const& moduleLabel) {
+    auto worker = workerReg_.get(moduleLabel);
+    if (worker != nullptr) {
+      auto eraseBeg = std::remove(allWorkers_.begin(), allWorkers_.end(), worker);
+      allWorkers_.erase(eraseBeg, allWorkers_.end());
+      unscheduled_.removeWorker(worker);
+      workerReg_.deleteModule(moduleLabel);
+    }
+  }
+
   Worker* WorkerManager::getWorker(ParameterSet& pset,
                                    ProductRegistry& preg,
                                    PreallocationConfiguration const* prealloc,

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -85,7 +85,7 @@ namespace edm {
     auto const lumiLookup = iRegistry.productLookup(InLumi);
     auto const eventLookup = iRegistry.productLookup(InEvent);
     if (!allWorkers_.empty()) {
-      auto const& processName = allWorkers_[0]->description().processName();
+      auto const& processName = allWorkers_[0]->description()->processName();
       auto processBlockModuleToIndicies = processBlockLookup->indiciesForModulesInProcess(processName);
       auto runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
       auto lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);

--- a/FWCore/Framework/src/WorkerRegistry.cc
+++ b/FWCore/Framework/src/WorkerRegistry.cc
@@ -44,4 +44,23 @@ namespace edm {
     }
     return (workerIt->second.get());
   }
+
+  Worker const* WorkerRegistry::get(std::string const& moduleLabel) const {
+    WorkerMap::const_iterator workerIt = m_workerMap.find(moduleLabel);
+    if (workerIt != m_workerMap.end()) {
+      return workerIt->second;
+    }
+    return nullptr;
+  }
+
+  void WorkerRegistry::deleteModule(std::string const& moduleLabel) {
+    WorkerMap::iterator workerIt = m_workerMap.find(moduleLabel);
+    if (workerIt == m_workerMap.end()) {
+      throw cms::Exception("LogicError")
+          << "WorkerRegistry::deleteModule() Trying to delete the module of a Worker with label " << moduleLabel
+          << " but no such Worker exists in the WorkerRegistry. Please contact framework developers.";
+    }
+    workerIt->second->clearModule();
+  }
+
 }  // namespace edm

--- a/FWCore/Framework/src/WorkerRegistry.h
+++ b/FWCore/Framework/src/WorkerRegistry.h
@@ -50,6 +50,14 @@ namespace edm {
         create it
         @note Workers are owned by this class, do not delete them*/
     Worker* getWorker(WorkerParams const& p, std::string const& moduleLabel);
+
+    /// Retrieve particular instance of the worker without creating it
+    /// If one doesn't exist, returns nullptr
+    Worker const* get(std::string const& moduleLabel) const;
+
+    /// Deletes the module of the Worker, but the Worker continues to exist.
+    void deleteModule(std::string const& moduleLabel);
+
     void clear();
 
   private:

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -685,7 +685,7 @@ namespace edm {
       BranchType iBranchType,
       std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const&
           iIndicies) {
-    resolvePutIndiciesImpl(&module(), iBranchType, iIndicies, description().moduleLabel());
+    resolvePutIndiciesImpl(&module(), iBranchType, iIndicies, description()->moduleLabel());
   }
 
   template <typename T>

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -110,17 +110,12 @@ namespace edm {
     TaskQueueAdaptor serializeRunModule() override;
 
     void modulesWhoseProductsAreConsumed(
-        std::vector<ModuleDescription const*>& modulesEvent,
-        std::vector<ModuleDescription const*>& modulesLumiRun,
+        std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
         std::set<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
-      module_->modulesWhoseProductsAreConsumed(modulesEvent,
-                                               modulesLumiRun,
-                                               modulesInPreviousProcesses,
-                                               preg,
-                                               labelsToDesc,
-                                               module_->moduleDescription().processName());
+      module_->modulesWhoseProductsAreConsumed(
+          modules, modulesInPreviousProcesses, preg, labelsToDesc, module_->moduleDescription().processName());
     }
 
     void convertCurrentProcessAlias(std::string const& processName) override {

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -111,7 +111,7 @@ namespace edm {
 
     void modulesWhoseProductsAreConsumed(
         std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-        std::set<ModuleProcessName>& modulesInPreviousProcesses,
+        std::vector<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
       module_->modulesWhoseProductsAreConsumed(

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -22,6 +22,7 @@ WorkerT: Code common to all workers.
 namespace edm {
 
   class ModuleCallingContext;
+  class ModuleProcessName;
   class ProductResolverIndexAndSkipBit;
   class ThinnedAssociationsHelper;
   class WaitingTaskWithArenaHolder;
@@ -111,10 +112,15 @@ namespace edm {
     void modulesWhoseProductsAreConsumed(
         std::vector<ModuleDescription const*>& modulesEvent,
         std::vector<ModuleDescription const*>& modulesLumiRun,
+        std::set<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
-      module_->modulesWhoseProductsAreConsumed(
-          modulesEvent, modulesLumiRun, preg, labelsToDesc, module_->moduleDescription().processName());
+      module_->modulesWhoseProductsAreConsumed(modulesEvent,
+                                               modulesLumiRun,
+                                               modulesInPreviousProcesses,
+                                               preg,
+                                               labelsToDesc,
+                                               module_->moduleDescription().processName());
     }
 
     void convertCurrentProcessAlias(std::string const& processName) override {

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -77,6 +77,8 @@ namespace edm {
     T const& module() const { return *module_; }
 
   private:
+    void doClearModule() override { get_underlying_safe(module_).reset(); }
+
     bool implDo(EventTransitionInfo const&, ModuleCallingContext const*) override;
 
     void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const final;
@@ -107,10 +109,12 @@ namespace edm {
     TaskQueueAdaptor serializeRunModule() override;
 
     void modulesWhoseProductsAreConsumed(
-        std::vector<ModuleDescription const*>& modules,
+        std::vector<ModuleDescription const*>& modulesEvent,
+        std::vector<ModuleDescription const*>& modulesLumiRun,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
-      module_->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, module_->moduleDescription().processName());
+      module_->modulesWhoseProductsAreConsumed(
+          modulesEvent, modulesLumiRun, preg, labelsToDesc, module_->moduleDescription().processName());
     }
 
     void convertCurrentProcessAlias(std::string const& processName) override {

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -122,15 +122,14 @@ void EDAnalyzerAdaptorBase::updateLookup(eventsetup::ESRecordsToProxyIndices con
 const edm::EDConsumerBase* EDAnalyzerAdaptorBase::consumer() const { return m_streamModules[0]; }
 
 void EDAnalyzerAdaptorBase::modulesWhoseProductsAreConsumed(
-    std::vector<ModuleDescription const*>& modulesEvent,
-    std::vector<ModuleDescription const*>& modulesLumiRun,
+    std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
     std::set<ModuleProcessName>& modulesInPreviousProcesses,
     ProductRegistry const& preg,
     std::map<std::string, ModuleDescription const*> const& labelsToDesc,
     std::string const& processName) const {
   assert(not m_streamModules.empty());
   return m_streamModules[0]->modulesWhoseProductsAreConsumed(
-      modulesEvent, modulesLumiRun, modulesInPreviousProcesses, preg, labelsToDesc, processName);
+      modules, modulesInPreviousProcesses, preg, labelsToDesc, processName);
 }
 
 void EDAnalyzerAdaptorBase::convertCurrentProcessAlias(std::string const& processName) {

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -122,12 +122,14 @@ void EDAnalyzerAdaptorBase::updateLookup(eventsetup::ESRecordsToProxyIndices con
 const edm::EDConsumerBase* EDAnalyzerAdaptorBase::consumer() const { return m_streamModules[0]; }
 
 void EDAnalyzerAdaptorBase::modulesWhoseProductsAreConsumed(
-    std::vector<ModuleDescription const*>& modules,
+    std::vector<ModuleDescription const*>& modulesEvent,
+    std::vector<ModuleDescription const*>& modulesLumiRun,
     ProductRegistry const& preg,
     std::map<std::string, ModuleDescription const*> const& labelsToDesc,
     std::string const& processName) const {
   assert(not m_streamModules.empty());
-  return m_streamModules[0]->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, processName);
+  return m_streamModules[0]->modulesWhoseProductsAreConsumed(
+      modulesEvent, modulesLumiRun, preg, labelsToDesc, processName);
 }
 
 void EDAnalyzerAdaptorBase::convertCurrentProcessAlias(std::string const& processName) {

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -123,7 +123,7 @@ const edm::EDConsumerBase* EDAnalyzerAdaptorBase::consumer() const { return m_st
 
 void EDAnalyzerAdaptorBase::modulesWhoseProductsAreConsumed(
     std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-    std::set<ModuleProcessName>& modulesInPreviousProcesses,
+    std::vector<ModuleProcessName>& modulesInPreviousProcesses,
     ProductRegistry const& preg,
     std::map<std::string, ModuleDescription const*> const& labelsToDesc,
     std::string const& processName) const {

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -124,12 +124,13 @@ const edm::EDConsumerBase* EDAnalyzerAdaptorBase::consumer() const { return m_st
 void EDAnalyzerAdaptorBase::modulesWhoseProductsAreConsumed(
     std::vector<ModuleDescription const*>& modulesEvent,
     std::vector<ModuleDescription const*>& modulesLumiRun,
+    std::set<ModuleProcessName>& modulesInPreviousProcesses,
     ProductRegistry const& preg,
     std::map<std::string, ModuleDescription const*> const& labelsToDesc,
     std::string const& processName) const {
   assert(not m_streamModules.empty());
   return m_streamModules[0]->modulesWhoseProductsAreConsumed(
-      modulesEvent, modulesLumiRun, preg, labelsToDesc, processName);
+      modulesEvent, modulesLumiRun, modulesInPreviousProcesses, preg, labelsToDesc, processName);
 }
 
 void EDAnalyzerAdaptorBase::convertCurrentProcessAlias(std::string const& processName) {

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -118,12 +118,14 @@ namespace edm {
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::modulesWhoseProductsAreConsumed(
-        std::vector<ModuleDescription const*>& modules,
+        std::vector<ModuleDescription const*>& modulesEvent,
+        std::vector<ModuleDescription const*>& modulesLumiRun,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
         std::string const& processName) const {
       assert(not m_streamModules.empty());
-      return m_streamModules[0]->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, processName);
+      return m_streamModules[0]->modulesWhoseProductsAreConsumed(
+          modulesEvent, modulesLumiRun, preg, labelsToDesc, processName);
     }
 
     template <typename T>

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -120,12 +120,13 @@ namespace edm {
     void ProducingModuleAdaptorBase<T>::modulesWhoseProductsAreConsumed(
         std::vector<ModuleDescription const*>& modulesEvent,
         std::vector<ModuleDescription const*>& modulesLumiRun,
+        std::set<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
         std::string const& processName) const {
       assert(not m_streamModules.empty());
       return m_streamModules[0]->modulesWhoseProductsAreConsumed(
-          modulesEvent, modulesLumiRun, preg, labelsToDesc, processName);
+          modulesEvent, modulesLumiRun, modulesInPreviousProcesses, preg, labelsToDesc, processName);
     }
 
     template <typename T>

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -119,7 +119,7 @@ namespace edm {
     template <typename T>
     void ProducingModuleAdaptorBase<T>::modulesWhoseProductsAreConsumed(
         std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-        std::set<ModuleProcessName>& modulesInPreviousProcesses,
+        std::vector<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
         std::string const& processName) const {

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -118,15 +118,14 @@ namespace edm {
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::modulesWhoseProductsAreConsumed(
-        std::vector<ModuleDescription const*>& modulesEvent,
-        std::vector<ModuleDescription const*>& modulesLumiRun,
+        std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
         std::set<ModuleProcessName>& modulesInPreviousProcesses,
         ProductRegistry const& preg,
         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
         std::string const& processName) const {
       assert(not m_streamModules.empty());
       return m_streamModules[0]->modulesWhoseProductsAreConsumed(
-          modulesEvent, modulesLumiRun, modulesInPreviousProcesses, preg, labelsToDesc, processName);
+          modules, modulesInPreviousProcesses, preg, labelsToDesc, processName);
     }
 
     template <typename T>

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -180,6 +180,13 @@
   <use name="FWCore/ParameterSet"/>
 </library>
 
+<library file="stubs/TestModuleDelete.cc" name="FWCoreFrameworkTestModuleDelete">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+</library>
+
 <bin name="TestFWCoreFramework" file="testRunner.cpp,maker2_t.cppunit.cc,maker_t.cppunit.cc,productregistry.cppunit.cc,edproducer_productregistry_callback.cc,event_getrefbeforeput_t.cppunit.cc,generichandle_t.cppunit.cc,edconsumerbase_t.cppunit.cc,global_producer_t.cppunit.cc,global_filter_t.cppunit.cc,one_outputmodule_t.cppunit.cc,global_outputmodule_t.cppunit.cc,stream_producer_t.cppunit.cc,stream_filter_t.cppunit.cc,limited_producer_t.cppunit.cc,limited_filter_t.cppunit.cc,limited_outputmodule_t.cppunit.cc,throwIfImproperDependencies_t.cppunit.cc">
   <use name="DataFormats/Common"/>
   <use name="DataFormats/Provenance"/>
@@ -385,3 +392,4 @@
 
 <test name="testFWCoreFrameworkNonEventOrdering" command="test_non_event_ordering.sh"/>
 <test name="testFWCoreFramework1ThreadESPrefetch" command="run_test_1_thread_es_prefetching.sh"/>
+<test name="testFWCoreFrameworkModuleDeletion" command="run_module_delete_tests.sh"/>

--- a/FWCore/Framework/test/run_module_delete_tests.sh
+++ b/FWCore/Framework/test/run_module_delete_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+TEST_DIR=src/FWCore/Framework/test
+
+cmsRun $TEST_DIR/test_module_delete_cfg.py || die "module deletion test failed" $?
+echo "module deletion test succeeded"

--- a/FWCore/Framework/test/run_module_delete_tests.sh
+++ b/FWCore/Framework/test/run_module_delete_tests.sh
@@ -7,3 +7,5 @@ TEST_DIR=src/FWCore/Framework/test
 
 cmsRun $TEST_DIR/test_module_delete_cfg.py || die "module deletion test failed" $?
 echo "module deletion test succeeded"
+cmsRun $TEST_DIR/test_module_delete_subprocess_cfg.py || die "module deletion test with subprocess failed" $?
+echo "module deletion test with subprocess succeeded"

--- a/FWCore/Framework/test/run_module_delete_tests.sh
+++ b/FWCore/Framework/test/run_module_delete_tests.sh
@@ -11,3 +11,5 @@ cmsRun $TEST_DIR/test_module_delete_subprocess_cfg.py || die "module deletion te
 echo "module deletion test with subprocess succeeded"
 cmsRun $TEST_DIR/test_module_delete_improperDependencies_cfg.py && die "module deletion with improper module ordering test failed" $?
 echo "module deletion test with improper module ordering succeeded"
+cmsRun $TEST_DIR/test_module_delete_looper_cfg.py || die "module deletetion test with looper failed" $?
+echo "module deletion test with looper succeeded"

--- a/FWCore/Framework/test/run_module_delete_tests.sh
+++ b/FWCore/Framework/test/run_module_delete_tests.sh
@@ -9,3 +9,5 @@ cmsRun $TEST_DIR/test_module_delete_cfg.py || die "module deletion test failed" 
 echo "module deletion test succeeded"
 cmsRun $TEST_DIR/test_module_delete_subprocess_cfg.py || die "module deletion test with subprocess failed" $?
 echo "module deletion test with subprocess succeeded"
+cmsRun $TEST_DIR/test_module_delete_improperDependencies_cfg.py && die "module deletion with improper module ordering test failed" $?
+echo "module deletion test with improper module ordering succeeded"

--- a/FWCore/Framework/test/run_module_delete_tests.sh
+++ b/FWCore/Framework/test/run_module_delete_tests.sh
@@ -13,3 +13,5 @@ cmsRun $TEST_DIR/test_module_delete_improperDependencies_cfg.py && die "module d
 echo "module deletion test with improper module ordering succeeded"
 cmsRun $TEST_DIR/test_module_delete_looper_cfg.py || die "module deletetion test with looper failed" $?
 echo "module deletion test with looper succeeded"
+cmsRun $TEST_DIR/test_module_delete_dependencygraph_cfg.py || die "module deletetion test with DependencyGraph failed" $?
+echo "module deletion test with DependencyGraph succeeded"

--- a/FWCore/Framework/test/run_module_delete_tests.sh
+++ b/FWCore/Framework/test/run_module_delete_tests.sh
@@ -15,3 +15,5 @@ cmsRun $TEST_DIR/test_module_delete_looper_cfg.py || die "module deletetion test
 echo "module deletion test with looper succeeded"
 cmsRun $TEST_DIR/test_module_delete_dependencygraph_cfg.py || die "module deletetion test with DependencyGraph failed" $?
 echo "module deletion test with DependencyGraph succeeded"
+cmsRun $TEST_DIR/test_module_delete_disable_cfg.py || die "module deletetion test with disabling the deletion failed" $?
+echo "module deletion test with disabling the deletion succeeded"

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -158,7 +158,13 @@ namespace edmtest {
     class LumiIntAnalyzer : public edm::global::EDAnalyzer<edm::LuminosityBlockCache<Cache>> {
     public:
       explicit LumiIntAnalyzer(edm::ParameterSet const& p)
-          : trans_(p.getParameter<int>("transitions")), cvalue_(p.getParameter<int>("cachevalue")) {}
+          : trans_(p.getParameter<int>("transitions")), cvalue_(p.getParameter<int>("cachevalue")) {
+        // just to create a data dependence
+        auto const& tag = p.getParameter<edm::InputTag>("moduleLabel");
+        if (not tag.label().empty()) {
+          consumes<unsigned int, edm::InLumi>(tag);
+        }
+      }
       const unsigned int trans_;
       const unsigned int cvalue_;
       mutable std::atomic<unsigned int> m_count{0};

--- a/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
@@ -167,7 +167,13 @@ namespace edmtest {
           : edm::limited::EDAnalyzerBase(p),
             edm::limited::EDAnalyzer<edm::LuminosityBlockCache<Cache>>(p),
             trans_(p.getParameter<int>("transitions")),
-            cvalue_(p.getParameter<int>("cachevalue")) {}
+            cvalue_(p.getParameter<int>("cachevalue")) {
+        // just to create a data dependence
+        auto const& tag = p.getParameter<edm::InputTag>("moduleLabel");
+        if (not tag.label().empty()) {
+          consumes<unsigned int, edm::InLumi>(tag);
+        }
+      }
       const unsigned int trans_;
       const unsigned int cvalue_;
       mutable std::atomic<unsigned int> m_count{0};

--- a/FWCore/Framework/test/stubs/TestModuleDelete.cc
+++ b/FWCore/Framework/test/stubs/TestModuleDelete.cc
@@ -29,10 +29,26 @@ namespace edmtest {
   public:
     explicit TestModuleDeleteProducer(edm::ParameterSet const& p)
         : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun")) {
+        consumes<IntProduct, edm::InRun>(tag);
+      }
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginLumi")) {
+        consumes<IntProduct, edm::InLumi>(tag);
+      }
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcEvent")) {
+        consumes<IntProduct>(tag);
+      }
       produces<IntProduct>();
       g_constructed.push_back(moduleLabel_);
     }
     ~TestModuleDeleteProducer() override { g_destructed.push_back(moduleLabel_); }
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginRun", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginLumi", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcEvent", std::vector<edm::InputTag>{});
+      descriptions.addDefault(desc);
+    }
     void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override {
       throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
     }
@@ -45,10 +61,26 @@ namespace edmtest {
   public:
     explicit TestModuleDeleteInLumiProducer(edm::ParameterSet const& p)
         : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun")) {
+        consumes<IntProduct, edm::InRun>(tag);
+      }
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginLumi")) {
+        consumes<IntProduct, edm::InLumi>(tag);
+      }
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcEvent")) {
+        consumes<IntProduct, edm::InRun>(tag);
+      }
       produces<IntProduct, edm::Transition::BeginLuminosityBlock>();
       g_lumi_constructed.push_back(moduleLabel_);
     }
     ~TestModuleDeleteInLumiProducer() override { g_lumi_destructed.push_back(moduleLabel_); }
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginRun", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginLumi", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcEvent", std::vector<edm::InputTag>{});
+      descriptions.addDefault(desc);
+    }
     void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
       throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
     }
@@ -64,10 +96,26 @@ namespace edmtest {
   public:
     explicit TestModuleDeleteInRunProducer(edm::ParameterSet const& p)
         : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun")) {
+        consumes<IntProduct, edm::InRun>(tag);
+      }
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginLumi")) {
+        consumes<IntProduct, edm::InLumi>(tag);
+      }
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcEvent")) {
+        consumes<IntProduct, edm::InRun>(tag);
+      }
       produces<IntProduct, edm::Transition::BeginRun>();
       g_run_constructed.push_back(moduleLabel_);
     }
     ~TestModuleDeleteInRunProducer() override { g_run_destructed.push_back(moduleLabel_); }
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginRun", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginLumi", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcEvent", std::vector<edm::InputTag>{});
+      descriptions.addDefault(desc);
+    }
     void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
       throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
     }

--- a/FWCore/Framework/test/stubs/TestModuleDelete.cc
+++ b/FWCore/Framework/test/stubs/TestModuleDelete.cc
@@ -1,0 +1,149 @@
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace {
+  // No need to protect, all access is serialized by the framework
+  std::vector<std::string> g_constructed;
+  std::vector<std::string> g_destructed;
+
+  std::vector<std::string> g_lumi_constructed;
+  std::vector<std::string> g_lumi_destructed;
+
+  std::vector<std::string> g_run_constructed;
+  std::vector<std::string> g_run_destructed;
+}  // namespace
+
+namespace edmtest {
+  // Similar to FailingProducer, but set a flag when deleted
+  class TestModuleDeleteProducer : public edm::global::EDProducer<> {
+  public:
+    explicit TestModuleDeleteProducer(edm::ParameterSet const& p)
+        : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      produces<IntProduct>();
+      g_constructed.push_back(moduleLabel_);
+    }
+    ~TestModuleDeleteProducer() override { g_destructed.push_back(moduleLabel_); }
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override {
+      throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
+    }
+
+  private:
+    std::string moduleLabel_;
+  };
+
+  class TestModuleDeleteInLumiProducer : public edm::global::EDProducer<edm::BeginLuminosityBlockProducer> {
+  public:
+    explicit TestModuleDeleteInLumiProducer(edm::ParameterSet const& p)
+        : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      produces<IntProduct, edm::Transition::BeginLuminosityBlock>();
+      g_lumi_constructed.push_back(moduleLabel_);
+    }
+    ~TestModuleDeleteInLumiProducer() override { g_lumi_destructed.push_back(moduleLabel_); }
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
+    }
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override {
+      throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
+    }
+
+  private:
+    std::string moduleLabel_;
+  };
+
+  class TestModuleDeleteInRunProducer : public edm::global::EDProducer<edm::BeginRunProducer> {
+  public:
+    explicit TestModuleDeleteInRunProducer(edm::ParameterSet const& p)
+        : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      produces<IntProduct, edm::Transition::BeginRun>();
+      g_run_constructed.push_back(moduleLabel_);
+    }
+    ~TestModuleDeleteInRunProducer() override { g_run_destructed.push_back(moduleLabel_); }
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
+    }
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override {
+      throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
+    }
+
+  private:
+    std::string moduleLabel_;
+  };
+
+  class TestModuleDeleteAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit TestModuleDeleteAnalyzer(edm::ParameterSet const& /*p*/){};
+
+    void beginJob() override {
+      if (g_constructed.size() == 0) {
+        throw cms::Exception("LogicError")
+            << "No TestModuleDeleteProducer modules constructed in this job, the test is meaningless";
+      }
+
+      auto formatException =
+          [](std::vector<std::string>& constructed, std::vector<std::string>& destructed, cms::Exception& ex) {
+            ex << " Modules constructed but not destructed:\n";
+            auto newEnd = std::remove_if(constructed.begin(), constructed.end(), [&](const std::string& label) {
+              auto found = std::find(destructed.begin(), destructed.end(), label);
+              if (found != destructed.end()) {
+                destructed.erase(found);
+                return true;
+              }
+              return false;
+            });
+            constructed.erase(newEnd, constructed.end());
+            for (const auto& lab : constructed) {
+              ex << " " << lab << "\n";
+            }
+          };
+
+      if (g_constructed.size() != g_destructed.size()) {
+        cms::Exception ex("Assert");
+        ex << "Number of TestModuleDeleteProducer constructors " << g_constructed.size()
+           << " differs from the number of destructors " << g_destructed.size() << ".";
+        formatException(g_constructed, g_destructed, ex);
+        throw ex;
+      }
+
+      if (g_lumi_constructed.size() == 0) {
+        throw cms::Exception("LogicError")
+            << "No TestModuleDeleteInLumiProducer modules constructed in this job, the test is meaningless";
+      }
+      if (g_lumi_constructed.size() != g_lumi_destructed.size()) {
+        cms::Exception ex("Assert");
+        ex << "Number of TestModuleDeleteInLumiProducer constructors " << g_lumi_constructed.size()
+           << " differs from the number of destructors " << g_lumi_destructed.size() << ".";
+        formatException(g_lumi_constructed, g_lumi_destructed, ex);
+        throw ex;
+      }
+
+      if (g_run_constructed.size() == 0) {
+        throw cms::Exception("LogicError")
+            << "No TestModuleDeleteInRunProducer modules constructed in this job, the test is meaningless";
+      }
+      if (g_run_constructed.size() != g_run_destructed.size()) {
+        cms::Exception ex("Assert");
+        ex << "Number of TestModuleDeleteInRunProducer constructors " << g_run_constructed.size()
+           << " differs from the number of destructors " << g_run_destructed.size() << ".";
+        formatException(g_run_constructed, g_run_destructed, ex);
+        throw ex;
+      }
+    }
+
+    void analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const& c) const override {}
+  };
+}  // namespace edmtest
+
+DEFINE_FWK_MODULE(edmtest::TestModuleDeleteProducer);
+DEFINE_FWK_MODULE(edmtest::TestModuleDeleteInLumiProducer);
+DEFINE_FWK_MODULE(edmtest::TestModuleDeleteInRunProducer);
+DEFINE_FWK_MODULE(edmtest::TestModuleDeleteAnalyzer);

--- a/FWCore/Framework/test/stubs/TestModuleDelete.cc
+++ b/FWCore/Framework/test/stubs/TestModuleDelete.cc
@@ -21,6 +21,9 @@ namespace {
 
   std::vector<std::string> g_run_constructed;
   std::vector<std::string> g_run_destructed;
+
+  std::vector<std::string> g_process_constructed;
+  std::vector<std::string> g_process_destructed;
 }  // namespace
 
 namespace edmtest {
@@ -29,6 +32,9 @@ namespace edmtest {
   public:
     explicit TestModuleDeleteProducer(edm::ParameterSet const& p)
         : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginProcess")) {
+        consumes<IntProduct, edm::InProcess>(tag);
+      }
       for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun")) {
         consumes<IntProduct, edm::InRun>(tag);
       }
@@ -44,6 +50,7 @@ namespace edmtest {
     ~TestModuleDeleteProducer() override { g_destructed.push_back(moduleLabel_); }
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginProcess", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcBeginRun", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcBeginLumi", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcEvent", std::vector<edm::InputTag>{});
@@ -61,6 +68,9 @@ namespace edmtest {
   public:
     explicit TestModuleDeleteInLumiProducer(edm::ParameterSet const& p)
         : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginProcess")) {
+        consumes<IntProduct, edm::InProcess>(tag);
+      }
       for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun")) {
         consumes<IntProduct, edm::InRun>(tag);
       }
@@ -76,6 +86,7 @@ namespace edmtest {
     ~TestModuleDeleteInLumiProducer() override { g_lumi_destructed.push_back(moduleLabel_); }
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginProcess", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcBeginRun", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcBeginLumi", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcEvent", std::vector<edm::InputTag>{});
@@ -96,6 +107,9 @@ namespace edmtest {
   public:
     explicit TestModuleDeleteInRunProducer(edm::ParameterSet const& p)
         : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginProcess")) {
+        consumes<IntProduct, edm::InProcess>(tag);
+      }
       for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun")) {
         consumes<IntProduct, edm::InRun>(tag);
       }
@@ -111,12 +125,48 @@ namespace edmtest {
     ~TestModuleDeleteInRunProducer() override { g_run_destructed.push_back(moduleLabel_); }
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginProcess", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcBeginRun", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcBeginLumi", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcEvent", std::vector<edm::InputTag>{});
       descriptions.addDefault(desc);
     }
     void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
+    }
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override {
+      throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
+    }
+
+  private:
+    std::string moduleLabel_;
+  };
+
+  class TestModuleDeleteInProcessProducer : public edm::global::EDProducer<edm::BeginProcessBlockProducer> {
+  public:
+    explicit TestModuleDeleteInProcessProducer(edm::ParameterSet const& p)
+        : moduleLabel_{p.getParameter<std::string>("@module_label")} {
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun")) {
+        consumes<IntProduct, edm::InRun>(tag);
+      }
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginLumi")) {
+        consumes<IntProduct, edm::InLumi>(tag);
+      }
+      for (const auto& tag : p.getUntrackedParameter<std::vector<edm::InputTag>>("srcEvent")) {
+        consumes<IntProduct, edm::InRun>(tag);
+      }
+      produces<IntProduct, edm::Transition::BeginProcessBlock>();
+      g_process_constructed.push_back(moduleLabel_);
+    }
+    ~TestModuleDeleteInProcessProducer() override { g_process_destructed.push_back(moduleLabel_); }
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginRun", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginLumi", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcEvent", std::vector<edm::InputTag>{});
+      descriptions.addDefault(desc);
+    }
+    void beginProcessBlockProduce(edm::ProcessBlock&) const override {
       throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
     }
     void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override {
@@ -185,6 +235,18 @@ namespace edmtest {
         formatException(g_run_constructed, g_run_destructed, ex);
         throw ex;
       }
+
+      if (g_process_constructed.size() == 0) {
+        throw cms::Exception("LogicError")
+            << "No TestModuleDeleteInProcessProducer modules constructed in this job, the test is meaningless";
+      }
+      if (g_process_constructed.size() != g_process_destructed.size()) {
+        cms::Exception ex("Assert");
+        ex << "Number of TestModuleDeleteInProcessProducer constructors " << g_process_constructed.size()
+           << " differs from the number of destructors " << g_process_destructed.size() << ".";
+        formatException(g_process_constructed, g_process_destructed, ex);
+        throw ex;
+      }
     }
 
     void analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const& c) const override {}
@@ -194,4 +256,5 @@ namespace edmtest {
 DEFINE_FWK_MODULE(edmtest::TestModuleDeleteProducer);
 DEFINE_FWK_MODULE(edmtest::TestModuleDeleteInLumiProducer);
 DEFINE_FWK_MODULE(edmtest::TestModuleDeleteInRunProducer);
+DEFINE_FWK_MODULE(edmtest::TestModuleDeleteInProcessProducer);
 DEFINE_FWK_MODULE(edmtest::TestModuleDeleteAnalyzer);

--- a/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
@@ -93,7 +93,13 @@ namespace edmtest {
 
     class WatchLumiBlocksAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
     public:
-      explicit WatchLumiBlocksAnalyzer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {}
+      explicit WatchLumiBlocksAnalyzer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
+        // just to create a data dependence
+        auto const& tag = p.getParameter<edm::InputTag>("moduleLabel");
+        if (not tag.label().empty()) {
+          consumes<unsigned int, edm::InLumi>(tag);
+        }
+      }
       const unsigned int trans_;
       bool bl = false;
       bool el = false;

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -177,6 +177,11 @@ namespace edmtest {
         trans_ = p.getParameter<int>("transitions");
         cvalue_ = p.getParameter<int>("cachevalue");
         m_count = 0;
+        // just to create a data dependence
+        auto const& tag = p.getParameter<edm::InputTag>("moduleLabel");
+        if (not tag.label().empty()) {
+          consumes<unsigned int, edm::InLumi>(tag);
+        }
       }
 
       void analyze(edm::Event const&, edm::EventSetup const&) override {

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -105,24 +105,24 @@ namespace edmtest {
 
   //--------------------------------------------------------------------
   //
-  class GenericIntsAnalyzer : public edm::global::EDAnalyzer<> {
+  template <typename T>
+  class GenericAnalyzerT : public edm::global::EDAnalyzer<> {
   public:
-    GenericIntsAnalyzer(edm::ParameterSet const& iPSet)
-        : tokensBeginRun_(edm::vector_transform(
-              iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun"),
-              [this](edm::InputTag const& tag) { return this->consumes<IntProduct, edm::InRun>(tag); })),
-          tokensBeginLumi_(edm::vector_transform(
-              iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginLumi"),
-              [this](edm::InputTag const& tag) { return this->consumes<IntProduct, edm::InLumi>(tag); })),
-          tokensEvent_(
-              edm::vector_transform(iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcEvent"),
-                                    [this](edm::InputTag const& tag) { return this->consumes<IntProduct>(tag); })),
-          tokensEndLumi_(edm::vector_transform(
-              iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcEndLumi"),
-              [this](edm::InputTag const& tag) { return this->consumes<IntProduct, edm::InLumi>(tag); })),
-          tokensEndRun_(edm::vector_transform(
-              iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcEndRun"),
-              [this](edm::InputTag const& tag) { return this->consumes<IntProduct, edm::InRun>(tag); })),
+    GenericAnalyzerT(edm::ParameterSet const& iPSet)
+        : tokensBeginRun_(
+              edm::vector_transform(iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun"),
+                                    [this](edm::InputTag const& tag) { return this->consumes<T, edm::InRun>(tag); })),
+          tokensBeginLumi_(
+              edm::vector_transform(iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginLumi"),
+                                    [this](edm::InputTag const& tag) { return this->consumes<T, edm::InLumi>(tag); })),
+          tokensEvent_(edm::vector_transform(iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcEvent"),
+                                             [this](edm::InputTag const& tag) { return this->consumes<T>(tag); })),
+          tokensEndLumi_(
+              edm::vector_transform(iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcEndLumi"),
+                                    [this](edm::InputTag const& tag) { return this->consumes<T, edm::InLumi>(tag); })),
+          tokensEndRun_(
+              edm::vector_transform(iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcEndRun"),
+                                    [this](edm::InputTag const& tag) { return this->consumes<T, edm::InRun>(tag); })),
           shouldExist_(iPSet.getUntrackedParameter<bool>("inputShouldExist")),
           shouldBeMissing_(iPSet.getUntrackedParameter<bool>("inputShouldBeMissing")) {
       if (shouldExist_ and shouldBeMissing_) {
@@ -161,14 +161,16 @@ namespace edmtest {
     }
 
   private:
-    const std::vector<edm::EDGetTokenT<IntProduct>> tokensBeginRun_;
-    const std::vector<edm::EDGetTokenT<IntProduct>> tokensBeginLumi_;
-    const std::vector<edm::EDGetTokenT<IntProduct>> tokensEvent_;
-    const std::vector<edm::EDGetTokenT<IntProduct>> tokensEndLumi_;
-    const std::vector<edm::EDGetTokenT<IntProduct>> tokensEndRun_;
+    const std::vector<edm::EDGetTokenT<T>> tokensBeginRun_;
+    const std::vector<edm::EDGetTokenT<T>> tokensBeginLumi_;
+    const std::vector<edm::EDGetTokenT<T>> tokensEvent_;
+    const std::vector<edm::EDGetTokenT<T>> tokensEndLumi_;
+    const std::vector<edm::EDGetTokenT<T>> tokensEndRun_;
     const bool shouldExist_;
     const bool shouldBeMissing_;
   };
+  using GenericIntsAnalyzer = GenericAnalyzerT<IntProduct>;
+  using GenericUInt64Analyzer = GenericAnalyzerT<UInt64Product>;
 
   //--------------------------------------------------------------------
   //
@@ -396,6 +398,7 @@ DEFINE_FWK_MODULE(NonAnalyzer);
 DEFINE_FWK_MODULE(IntTestAnalyzer);
 DEFINE_FWK_MODULE(MultipleIntsAnalyzer);
 DEFINE_FWK_MODULE(edmtest::GenericIntsAnalyzer);
+DEFINE_FWK_MODULE(edmtest::GenericUInt64Analyzer);
 DEFINE_FWK_MODULE(IntConsumingAnalyzer);
 DEFINE_FWK_MODULE(edmtest::IntFromRunConsumingAnalyzer);
 DEFINE_FWK_MODULE(ConsumingStreamAnalyzer);

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -109,7 +109,10 @@ namespace edmtest {
   class GenericAnalyzerT : public edm::global::EDAnalyzer<> {
   public:
     GenericAnalyzerT(edm::ParameterSet const& iPSet)
-        : tokensBeginRun_(
+        : tokensBeginProcess_(edm::vector_transform(
+              iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginProcess"),
+              [this](edm::InputTag const& tag) { return this->consumes<T, edm::InProcess>(tag); })),
+          tokensBeginRun_(
               edm::vector_transform(iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcBeginRun"),
                                     [this](edm::InputTag const& tag) { return this->consumes<T, edm::InRun>(tag); })),
           tokensBeginLumi_(
@@ -123,6 +126,9 @@ namespace edmtest {
           tokensEndRun_(
               edm::vector_transform(iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcEndRun"),
                                     [this](edm::InputTag const& tag) { return this->consumes<T, edm::InRun>(tag); })),
+          tokensEndProcess_(edm::vector_transform(
+              iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("srcEndProcess"),
+              [this](edm::InputTag const& tag) { return this->consumes<T, edm::InProcess>(tag); })),
           shouldExist_(iPSet.getUntrackedParameter<bool>("inputShouldExist")),
           shouldBeMissing_(iPSet.getUntrackedParameter<bool>("inputShouldBeMissing")) {
       if (shouldExist_ and shouldBeMissing_) {
@@ -150,22 +156,26 @@ namespace edmtest {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
+      desc.addUntracked<std::vector<edm::InputTag>>("srcBeginProcess", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcBeginRun", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcBeginLumi", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcEvent", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcEndLumi", std::vector<edm::InputTag>{});
       desc.addUntracked<std::vector<edm::InputTag>>("srcEndRun", std::vector<edm::InputTag>{});
+      desc.addUntracked<std::vector<edm::InputTag>>("srcEndProcess", std::vector<edm::InputTag>{});
       desc.addUntracked<bool>("inputShouldExist", false);
       desc.addUntracked<bool>("inputShouldBeMissing", false);
       descriptions.addDefault(desc);
     }
 
   private:
+    const std::vector<edm::EDGetTokenT<T>> tokensBeginProcess_;
     const std::vector<edm::EDGetTokenT<T>> tokensBeginRun_;
     const std::vector<edm::EDGetTokenT<T>> tokensBeginLumi_;
     const std::vector<edm::EDGetTokenT<T>> tokensEvent_;
     const std::vector<edm::EDGetTokenT<T>> tokensEndLumi_;
     const std::vector<edm::EDGetTokenT<T>> tokensEndRun_;
+    const std::vector<edm::EDGetTokenT<T>> tokensEndProcess_;
     const bool shouldExist_;
     const bool shouldBeMissing_;
   };

--- a/FWCore/Framework/test/test_emptyEndPathWithTask_cfg.py
+++ b/FWCore/Framework/test/test_emptyEndPathWithTask_cfg.py
@@ -7,6 +7,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(3)
 )
 
+# note that these modules get deleted, but the module dependence check is made first
 process.intProducer1 = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
 process.intProducer2 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer1"))
 

--- a/FWCore/Framework/test/test_emptyPathWithTask_cfg.py
+++ b/FWCore/Framework/test/test_emptyPathWithTask_cfg.py
@@ -7,6 +7,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(3)
 )
 
+# note that these modules get deleted, but the module dependence check is made first
 process.intProducer1 = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
 process.intProducer2 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer1"))
 

--- a/FWCore/Framework/test/test_global_modules_cfg.py
+++ b/FWCore/Framework/test/test_global_modules_cfg.py
@@ -15,7 +15,6 @@ process.options = cms.untracked.PSet(
     numberOfThreads = cms.untracked.uint32(nStreams)
 )
 
-
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(nEvt)
 )
@@ -107,6 +106,8 @@ process.RunIntAn= cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
 process.LumiIntAn = cms.EDAnalyzer("edmtest::global::LumiIntAnalyzer",
     transitions = cms.int32(int(nEvt+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
+    # needed to avoid deleting TestAccumulator1
+    ,moduleLabel = cms.InputTag("TestAccumulator1")
 )
 
 process.RunSumIntAn = cms.EDAnalyzer("edmtest::global::RunSummaryIntAnalyzer",

--- a/FWCore/Framework/test/test_limited_modules_cfg.py
+++ b/FWCore/Framework/test/test_limited_modules_cfg.py
@@ -124,6 +124,8 @@ process.LumiIntAn = cms.EDAnalyzer("edmtest::limited::LumiIntAnalyzer",
                                    concurrencyLimit = cms.untracked.uint32(1),
     transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
+    # needed to avoid deleting TestAccumulator1
+    ,moduleLabel = cms.InputTag("TestAccumulator1")
 )
 
 process.RunSumIntAn = cms.EDAnalyzer("edmtest::limited::RunSummaryIntAnalyzer",

--- a/FWCore/Framework/test/test_module_delete_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_cfg.py
@@ -52,6 +52,7 @@ process.consumerEndRun = nonEventConsumer("endRun", "producer%sConsumed", 5)
 process.producerEventNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteProducer")
 process.producerBeginLumiNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer")
 process.producerBeginRunNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer")
+process.producerBeginProcessNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInProcessProducer")
 
 process.producerEventNotConsumedChain1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
 process.producerEventNotConsumedChain2 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
@@ -69,11 +70,17 @@ process.producerEventNotConsumedChain5 = cms.EDProducer("edmtest::TestModuleDele
 process.producerEventNotConsumedChain6 = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer",
     srcBeginLumi = cms.untracked.VInputTag("producerEventNotConsumedChain5")
 )
-process.producerEventNotConsumedChain7 = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+process.producerEventNotConsumedChain7 = cms.EDProducer("edmtest::TestModuleDeleteInProcessProducer",
     srcBeginRun = cms.untracked.VInputTag("producerEventNotConsumedChain6")
 )
-process.producerEventNotConsumedChain8 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+process.producerEventNotConsumedChain8 = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer",
     srcBeginLumi = cms.untracked.VInputTag("producerEventNotConsumedChain7")
+)
+process.producerEventNotConsumedChain9 = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcBeginRun = cms.untracked.VInputTag("producerEventNotConsumedChain8")
+)
+process.producerEventNotConsumedChain10 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcBeginLumi = cms.untracked.VInputTag("producerEventNotConsumedChain9")
 )
 
 process.producerEventPartiallyConsumedChain1 = intEventProducerMustRun.clone()
@@ -123,6 +130,10 @@ process.producerEventSwitchProducer = SwitchProducerTest(
 
 process.consumerNotExist = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer",
     inputShouldBeMissing = cms.untracked.bool(True),
+    srcBeginProcess = cms.untracked.VInputTag(
+        "producerBeginProcessNotConsumed:doesNotExist",
+        cms.InputTag("producerBeginProcessNotConsumed", "", cms.InputTag.skipCurrentProcess())
+    ),
     srcBeginRun = cms.untracked.VInputTag(
         "producerBeginRunNotConsumed:doesNotExist",
         cms.InputTag("producerBeginRunNotConsumed", "", cms.InputTag.skipCurrentProcess())
@@ -149,6 +160,7 @@ process.t = cms.Task(
     process.producerEventNotConsumed,
     process.producerBeginLumiNotConsumed,
     process.producerBeginRunNotConsumed,
+    process.producerBeginProcessNotConsumed,
     #
     process.producerEventNotConsumedChain1,
     process.producerEventNotConsumedChain2,
@@ -158,6 +170,8 @@ process.t = cms.Task(
     process.producerEventNotConsumedChain6,
     process.producerEventNotConsumedChain7,
     process.producerEventNotConsumedChain8,
+    process.producerEventNotConsumedChain9,
+    process.producerEventNotConsumedChain10,
     #
     process.producerEventPartiallyConsumedChain1,
     process.producerEventPartiallyConsumedChain3,

--- a/FWCore/Framework/test/test_module_delete_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_cfg.py
@@ -13,6 +13,8 @@ process.source = cms.Source("EmptySource")
 # - event product not consumed but module in Path, module kept
 # - event/lumi/run product with the same module label but different instance name, module deleted
 # - event/lumi/run product with the same module label and instance name but with skipCurrentProcess, module deleted
+# - DAG of event/lumi/run producers that are not consumed by an always-running module, whole DAG deleted
+# - DAG of event(/lumi/run) producers that are partly consumed (kept) and partly non-consumed (delete)
 
 intEventProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
 intNonEventProducer = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
@@ -49,6 +51,38 @@ process.producerEventNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteProd
 process.producerBeginLumiNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer")
 process.producerBeginRunNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer")
 
+process.producerEventNotConsumedChain1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerEventNotConsumedChain2 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventNotConsumedChain1")
+)
+process.producerEventNotConsumedChain3 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventNotConsumedChain1")
+)
+process.producerEventNotConsumedChain4 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventNotConsumedChain2", "producerEventNotConsumedChain3")
+)
+process.producerEventNotConsumedChain5 = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventNotConsumedChain1")
+)
+process.producerEventNotConsumedChain6 = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer",
+    srcBeginLumi = cms.untracked.VInputTag("producerEventNotConsumedChain5")
+)
+process.producerEventNotConsumedChain7 = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcBeginRun = cms.untracked.VInputTag("producerEventNotConsumedChain6")
+)
+process.producerEventNotConsumedChain8 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcBeginLumi = cms.untracked.VInputTag("producerEventNotConsumedChain7")
+)
+
+process.producerEventPartiallyConsumedChain1 = intEventProducerMustRun.clone()
+process.producerEventPartiallyConsumedChain2 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("producerEventPartiallyConsumedChain1"))
+process.producerEventPartiallyConsumedChain3 = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventPartiallyConsumedChain1")
+)
+process.producerEventPartiallyConsumedChain4 = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventPartiallyConsumedChain2", "producerEventPartiallyConsumedChain4")
+)
+
 process.consumerNotExist = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer",
     inputShouldBeMissing = cms.untracked.bool(True),
     srcBeginRun = cms.untracked.VInputTag(
@@ -73,19 +107,38 @@ process.t = cms.Task(
     process.producerEndLumiConsumed,
     process.producerBeginRunConsumed,
     process.producerEndRunConsumed,
+    #
     process.producerEventNotConsumed,
     process.producerBeginLumiNotConsumed,
     process.producerBeginRunNotConsumed,
+    #
+    process.producerEventNotConsumedChain1,
+    process.producerEventNotConsumedChain2,
+    process.producerEventNotConsumedChain3,
+    process.producerEventNotConsumedChain4,
+    process.producerEventNotConsumedChain5,
+    process.producerEventNotConsumedChain6,
+    process.producerEventNotConsumedChain7,
+    process.producerEventNotConsumedChain8,
+    #
+    process.producerEventPartiallyConsumedChain1,
+    process.producerEventPartiallyConsumedChain3,
+    process.producerEventPartiallyConsumedChain4,
 )
 
 process.p = cms.Path(
     process.producerEventNotConsumedInPath+
+    #
     process.consumerEvent+
     process.consumerBeginLumi+
     process.consumerEndLumi+
     process.consumerBeginRun+
     process.consumerEndRun+
+    #
     process.consumerNotExist+
+    #
+    process.producerEventPartiallyConsumedChain2+
+    #
     process.intAnalyzerDelete
     ,
     process.t

--- a/FWCore/Framework/test/test_module_delete_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_cfg.py
@@ -1,0 +1,92 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTMODULEDELETE")
+
+process.maxEvents.input = 8
+process.source = cms.Source("EmptySource")
+
+#process.Tracer = cms.Service("Tracer")
+
+# Cases to test
+# - event/lumi/run product consumed, module kept
+# - event/lumi/run product not consumed, module deleted
+# - event product not consumed but module in Path, module kept
+# - event/lumi/run product with the same module label but different instance name, module deleted
+# - event/lumi/run product with the same module label and instance name but with skipCurrentProcess, module deleted
+
+intEventProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+intNonEventProducer = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
+intEventProducerMustRun = cms.EDProducer("edmtest::MustRunIntProducer", ivalue = cms.int32(1))
+intEventConsumer = cms.EDAnalyzer("IntTestAnalyzer",
+    moduleLabel = cms.untracked.InputTag("producerEventConsumed"),
+    valueMustMatch = cms.untracked.int32(1)
+)
+def nonEventConsumer(transition, sourcePattern, expected):
+    transCap = transition[0].upper() + transition[1:]
+    runOrLumiBlock = transCap
+    if "Lumi" in runOrLumiBlock:
+        runOrLumiBlock = runOrLumiBlock+"nosityBlock"
+    ret = intNonEventProducer.clone()
+    setattr(ret, "consumes%s"%runOrLumiBlock, cms.InputTag(sourcePattern%transCap, transition))
+    setattr(ret, "expect%s"%runOrLumiBlock, cms.untracked.int32(expected))
+    return ret
+
+process.producerEventConsumed = intEventProducer.clone(ivalue = 1)
+process.producerBeginLumiConsumed = intNonEventProducer.clone(ivalue = 2)
+process.producerEndLumiConsumed = intNonEventProducer.clone(ivalue = 3)
+process.producerBeginRunConsumed = intNonEventProducer.clone(ivalue = 4)
+process.producerEndRunConsumed = intNonEventProducer.clone(ivalue = 5)
+
+process.producerEventNotConsumedInPath = intEventProducerMustRun.clone()
+
+process.consumerEvent = intEventConsumer.clone(moduleLabel = "producerEventConsumed", valueMustMatch = 1)
+process.consumerBeginLumi = nonEventConsumer("beginLumi", "producer%sConsumed", 2)
+process.consumerEndLumi = nonEventConsumer("endLumi", "producer%sConsumed", 3)
+process.consumerBeginRun = nonEventConsumer("beginRun", "producer%sConsumed", 4)
+process.consumerEndRun = nonEventConsumer("endRun", "producer%sConsumed", 5)
+
+process.producerEventNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerBeginLumiNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer")
+process.producerBeginRunNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer")
+
+process.consumerNotExist = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer",
+    inputShouldBeMissing = cms.untracked.bool(True),
+    srcBeginRun = cms.untracked.VInputTag(
+        "producerBeginRunNotConsumed:doesNotExist",
+        cms.InputTag("producerBeginRunNotConsumed", "", cms.InputTag.skipCurrentProcess())
+    ),
+    srcBeginLumi = cms.untracked.VInputTag(
+        "producerBeginLumiNotConsumed:doesNotExist",
+        cms.InputTag("producerBeginLumiNotConsumed", "", cms.InputTag.skipCurrentProcess())
+    ),
+    srcEvent = cms.untracked.VInputTag(
+        "producerEventNotConsumed:doesNotExist",
+        cms.InputTag("producerEventNotConsumed", "", cms.InputTag.skipCurrentProcess())
+    ),
+)
+
+process.intAnalyzerDelete = cms.EDAnalyzer("edmtest::TestModuleDeleteAnalyzer")
+
+process.t = cms.Task(
+    process.producerEventConsumed,
+    process.producerBeginLumiConsumed,
+    process.producerEndLumiConsumed,
+    process.producerBeginRunConsumed,
+    process.producerEndRunConsumed,
+    process.producerEventNotConsumed,
+    process.producerBeginLumiNotConsumed,
+    process.producerBeginRunNotConsumed,
+)
+
+process.p = cms.Path(
+    process.producerEventNotConsumedInPath+
+    process.consumerEvent+
+    process.consumerBeginLumi+
+    process.consumerEndLumi+
+    process.consumerBeginRun+
+    process.consumerEndRun+
+    process.consumerNotExist+
+    process.intAnalyzerDelete
+    ,
+    process.t
+)

--- a/FWCore/Framework/test/test_module_delete_dependencygraph_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_dependencygraph_cfg.py
@@ -1,0 +1,184 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("A")
+
+process.maxEvents.input = 1
+process.source = cms.Source("EmptySource")
+
+process.load("FWCore.Services.DependencyGraph_cfi")
+process.DependencyGraph.fileName = "test_module_delete_dependencygraph.gv"
+
+intEventProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+intEventProducerMustRun = cms.EDProducer("edmtest::MustRunIntProducer", ivalue = cms.int32(1), mustRunEvent = cms.bool(True))
+intEventConsumer = cms.EDAnalyzer("IntTestAnalyzer",
+    moduleLabel = cms.untracked.InputTag("producerEventConsumed"),
+    valueMustMatch = cms.untracked.int32(1)
+)
+intGenericConsumer = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer",
+    srcEvent = cms.untracked.VInputTag(),
+    inputShouldExist = cms.untracked.bool(True)
+)
+
+process.producerAEventConsumedInB = intEventProducer.clone(ivalue = 1)
+process.producerAEventConsumedInBA = intEventProducer.clone(ivalue = 10)
+
+process.producerEventNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerBeginLumiNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer")
+process.producerBeginRunNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer")
+
+# These producers do not get the event transitions for the events
+# where the same-name producers in the SubProcesses produce a product.
+# Nevertheless, these producers must not be deleted early, because
+# their event transitions might get called.
+process.producerEventMaybeConsumedInB = intEventProducerMustRun.clone(mustRunEvent=False)
+process.producerEventMaybeConsumedInBA = intEventProducerMustRun.clone(mustRunEvent=False)
+
+process.producerAEventNotConsumedInB = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerAEventNotConsumedInBA = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+
+process.producerEventConsumedInB1 = intEventProducerMustRun.clone()
+process.producerEventConsumedInB2 = intEventProducerMustRun.clone()
+process.producerEventConsumedInBA1 = intEventProducerMustRun.clone()
+process.producerEventConsumedInBA2 = intEventProducerMustRun.clone()
+
+process.intAnalyzerDelete = cms.EDAnalyzer("edmtest::TestModuleDeleteAnalyzer")
+
+process.t = cms.Task(
+    process.producerAEventConsumedInB,
+    #
+    process.producerAEventConsumedInBA,
+    #
+    process.producerEventNotConsumed,
+    process.producerBeginLumiNotConsumed,
+    process.producerBeginRunNotConsumed,
+    #
+    process.producerEventMaybeConsumedInB,
+    process.producerEventMaybeConsumedInBA,
+    #
+    process.producerAEventNotConsumedInB,
+    process.producerAEventNotConsumedInBA,
+    #
+    process.producerEventConsumedInB1,
+    process.producerEventConsumedInB2,
+    process.producerEventConsumedInBA1,
+    process.producerEventConsumedInBA2,
+)
+
+process.p = cms.Path(process.intAnalyzerDelete, process.t)
+
+####################
+subprocessB = cms.Process("B")
+process.addSubProcess( cms.SubProcess(
+    process = subprocessB,
+    SelectEvents = cms.untracked.PSet(),
+    outputCommands = cms.untracked.vstring()
+) )
+
+subprocessB.consumerEventFromA = intEventConsumer.clone(moduleLabel = "producerAEventConsumedInB", valueMustMatch = 1)
+
+subprocessB.producerEventNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+
+subprocessB.producerEventMaybeConsumedInB = intEventProducerMustRun.clone()
+subprocessB.producerEventMaybeConsumedInBA = intEventProducerMustRun.clone(mustRunEvent=False)
+subprocessB.consumerEventMaybeInB = intGenericConsumer.clone(srcEvent = ["producerEventMaybeConsumedInB"])
+
+subprocessB.producerAEventNotConsumedInB = intEventProducerMustRun.clone()
+subprocessB.producerAEventNotConsumedInBA = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessB.consumerAEventNotConsumedInB = intGenericConsumer.clone(srcEvent = ["producerAEventNotConsumedInB::B"])
+
+subprocessB.producerEventConsumedInB1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessB.producerEventConsumedInB2 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessB.consumerEventNotConsumedInB1 = intGenericConsumer.clone(srcEvent = ["producerEventConsumedInB1::A"])
+subprocessB.consumerEventNotConsumedInB2 = intGenericConsumer.clone(srcEvent = [cms.InputTag("producerEventConsumedInB2", "", cms.InputTag.skipCurrentProcess())])
+subprocessB.producerBEventConsumedInBA1 = intEventProducerMustRun.clone()
+subprocessB.producerBEventConsumedInBA2 = intEventProducerMustRun.clone()
+
+subprocessB.producerBEventConsumedInB1 = intEventProducerMustRun.clone()
+subprocessB.producerBEventConsumedInB2 = intEventProducerMustRun.clone()
+subprocessB.producerBEventConsumedInB3 = intEventProducerMustRun.clone()
+subprocessB.consumerBEventConsumedInB1 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInB1"])
+subprocessB.consumerBEventConsumedInB2 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInB2::B"])
+subprocessB.consumerBEventConsumedInB3 = intGenericConsumer.clone(srcEvent = [cms.InputTag("producerBEventConsumedInB3", "", cms.InputTag.currentProcess())])
+
+
+subprocessB.t = cms.Task(
+    subprocessB.producerEventNotConsumed,
+    #
+    subprocessB.producerEventMaybeConsumedInB,
+    subprocessB.producerEventMaybeConsumedInBA,
+    #
+    subprocessB.producerAEventNotConsumedInB,
+    subprocessB.producerAEventNotConsumedInBA,
+    #
+    subprocessB.producerEventConsumedInB1,
+    subprocessB.producerEventConsumedInB2,
+    subprocessB.producerBEventConsumedInBA1,
+    subprocessB.producerBEventConsumedInBA2,
+    #
+    subprocessB.producerBEventConsumedInB1,
+    subprocessB.producerBEventConsumedInB2,
+    subprocessB.producerBEventConsumedInB3,
+)
+subprocessB.p = cms.Path(
+    subprocessB.consumerEventFromA+
+    #
+    subprocessB.consumerEventMaybeInB+
+    #
+    subprocessB.consumerAEventNotConsumedInB+
+    subprocessB.consumerEventNotConsumedInB1+
+    subprocessB.consumerEventNotConsumedInB2+
+    #
+    subprocessB.consumerBEventConsumedInB1+
+    subprocessB.consumerBEventConsumedInB2+
+    subprocessB.consumerBEventConsumedInB3
+    ,subprocessB.t
+)
+
+####################
+subprocessBA = cms.Process("BA")
+subprocessB.addSubProcess( cms.SubProcess(
+    process = subprocessBA,
+    SelectEvents = cms.untracked.PSet(),
+    outputCommands = cms.untracked.vstring()
+) )
+
+subprocessBA.consumerEventFromA = intEventConsumer.clone(moduleLabel = "producerAEventConsumedInBA", valueMustMatch = 10)
+
+subprocessBA.producerEventMaybeConsumedInBA = intEventProducerMustRun.clone()
+subprocessBA.consumerEventMaybeInBA = intGenericConsumer.clone(srcEvent = ["producerEventMaybeConsumedInBA"])
+
+subprocessBA.producerAEventNotConsumedInBA = intEventProducerMustRun.clone()
+subprocessBA.consumerAEventNotConsumedInBA = intGenericConsumer.clone(srcEvent = ["producerAEventNotConsumedInBA::BA"])
+
+subprocessBA.producerEventConsumedInBA1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessBA.producerEventConsumedInBA2 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessBA.producerBEventConsumedInBA1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessBA.producerBEventConsumedInBA2 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessBA.consumerEventNotConsumedInBA1 = intGenericConsumer.clone(srcEvent = ["producerEventConsumedInBA1::A",
+                                                                                  "producerBEventConsumedInBA1::B"])
+subprocessBA.consumerEventNotConsumedInBA2 = intGenericConsumer.clone(srcEvent = [
+    cms.InputTag("producerEventConsumedInBA2", "", cms.InputTag.skipCurrentProcess()),
+    cms.InputTag("producerBEventConsumedInBA2", "", cms.InputTag.skipCurrentProcess())
+])
+
+subprocessBA.t = cms.Task(
+    subprocessBA.producerEventMaybeConsumedInBA,
+    #
+    subprocessBA.producerAEventNotConsumedInBA,
+    #
+    subprocessBA.producerEventConsumedInBA1,
+    subprocessBA.producerEventConsumedInBA2,
+    subprocessBA.producerBEventConsumedInBA1,
+    subprocessBA.producerBEventConsumedInBA2,
+)
+subprocessBA.p = cms.Path(
+    subprocessBA.consumerEventFromA+
+    #
+    subprocessBA.consumerEventMaybeInBA+
+    #
+    subprocessBA.consumerAEventNotConsumedInBA+
+    #
+    subprocessBA.consumerEventNotConsumedInBA1+
+    subprocessBA.consumerEventNotConsumedInBA2
+    , subprocessBA.t
+)

--- a/FWCore/Framework/test/test_module_delete_dependencygraph_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_dependencygraph_cfg.py
@@ -25,6 +25,7 @@ process.producerAEventConsumedInBA = intEventProducer.clone(ivalue = 10)
 process.producerEventNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteProducer")
 process.producerBeginLumiNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer")
 process.producerBeginRunNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer")
+process.producerBeginProcessNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInProcessProducer")
 
 # These producers do not get the event transitions for the events
 # where the same-name producers in the SubProcesses produce a product.
@@ -51,6 +52,7 @@ process.t = cms.Task(
     process.producerEventNotConsumed,
     process.producerBeginLumiNotConsumed,
     process.producerBeginRunNotConsumed,
+    process.producerBeginProcessNotConsumed,
     #
     process.producerEventMaybeConsumedInB,
     process.producerEventMaybeConsumedInBA,

--- a/FWCore/Framework/test/test_module_delete_disable_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_disable_cfg.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTMODULEDELETE")
+
+process.maxEvents.input = 1
+process.options.deleteNonConsumedUnscheduledModules = False
+process.source = cms.Source("EmptySource")
+
+process.intEventProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.intEventConsumer = cms.EDAnalyzer("IntTestAnalyzer",
+    moduleLabel = cms.untracked.InputTag("intEventProducer"),
+    valueMustMatch = cms.untracked.int32(1)
+)
+process.intProducerNotConsumed = cms.EDProducer("edmtest::MustRunIntProducer",
+    ivalue = cms.int32(1),
+    mustRunEvent = cms.bool(False)
+)
+
+process.t = cms.Task(
+    process.intEventProducer,
+    process.intProducerNotConsumed
+)
+process.p = cms.Path(
+    process.intEventConsumer,
+    process.t
+)

--- a/FWCore/Framework/test/test_module_delete_improperDependencies_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_improperDependencies_cfg.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTMODULEDELETE")
+
+process.maxEvents.input = 8
+process.source = cms.Source("EmptySource")
+
+process.producerEventNotConsumed1 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventNotConsumed2")
+)
+process.producerEventNotConsumed2 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventNotConsumed3")
+)
+process.producerEventNotConsumed3 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcEvent = cms.untracked.VInputTag("producerEventNotConsumed1")
+)
+process.consumerEvent = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer",
+    srcEvent = cms.untracked.VInputTag("producerEventNotConsumed3")
+)
+
+process.t = cms.Task(
+    process.producerEventNotConsumed1,
+    process.producerEventNotConsumed2,
+    process.producerEventNotConsumed3,
+)
+process.p = cms.Path(
+    process.consumerEvent,
+    process.t
+)

--- a/FWCore/Framework/test/test_module_delete_looper_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_looper_cfg.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTMODULEDELETE")
+
+process.maxEvents.input = 4
+process.source = cms.Source("EmptySource")
+
+# In presence of looper nothing is deleted
+process.producerEventNotConsumed = cms.EDProducer("edmtest::MustRunIntProducer", ivalue = cms.int32(1), mustRunEvent = cms.bool(False))
+
+process.pInt = cms.EDProducer("IntProducer",
+    ivalue = cms.int32(1)
+)
+#Dummy looper will loop twice
+process.looper = cms.Looper("TestModuleChangeLooper",
+    startingValue = cms.untracked.int32(1),
+    tag = cms.untracked.InputTag("pInt")
+)
+
+process.t1 = cms.Task(process.producerEventNotConsumed)
+process.p1 = cms.Path(process.pInt, process.t1)

--- a/FWCore/Framework/test/test_module_delete_subprocess_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_subprocess_cfg.py
@@ -93,6 +93,14 @@ process.producerEventConsumedInBA2 = intEventProducerMustRun.clone()
 process.producerEventConsumedInC1 = intEventProducerMustRun.clone()
 process.producerEventConsumedInC2 = intEventProducerMustRun.clone()
 
+process.producerANotConsumedChainEvent = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerANotConsumedChainLumi = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcEvent = cms.untracked.VInputTag("producerANotConsumedChainEvent")
+)
+process.producerANotConsumedChainRun = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer",
+    srcEvent = cms.untracked.VInputTag("producerANotConsumedChainEvent")
+)
+
 process.intAnalyzerDelete = cms.EDAnalyzer("edmtest::TestModuleDeleteAnalyzer")
 
 process.t = cms.Task(
@@ -126,6 +134,10 @@ process.t = cms.Task(
     process.producerEventConsumedInBA2,
     process.producerEventConsumedInC1,
     process.producerEventConsumedInC2,
+    #
+    process.producerANotConsumedChainEvent,
+    process.producerANotConsumedChainLumi,
+    process.producerANotConsumedChainRun,
 )
 
 process.p = cms.Path(
@@ -191,6 +203,16 @@ subprocessB.consumerBEventConsumedInB1 = intGenericConsumer.clone(srcEvent = ["p
 subprocessB.consumerBEventConsumedInB2 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInB2::B"])
 subprocessB.consumerBEventConsumedInB3 = intGenericConsumer.clone(srcEvent = [cms.InputTag("producerBEventConsumedInB3", "", cms.InputTag.currentProcess())])
 
+subprocessB.producerBNotConsumedChainEvent = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcBeginRun = cms.untracked.VInputTag("producerANotConsumedChainRun")
+)
+subprocessB.producerBNotConsumedChainLumi = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcEvent = cms.untracked.VInputTag("producerANotConsumedChainEvent")
+)
+subprocessB.producerBNotConsumedChainRun = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer",
+    srcBeginLumi = cms.untracked.VInputTag("producerANotConsumedChainLumi")
+)
+
 subprocessB.t = cms.Task(
     subprocessB.producerEventNotConsumed,
     subprocessB.producerBeginLumiNotConsumed,
@@ -213,6 +235,10 @@ subprocessB.t = cms.Task(
     subprocessB.producerBEventConsumedInB1,
     subprocessB.producerBEventConsumedInB2,
     subprocessB.producerBEventConsumedInB3,
+    #
+    subprocessB.producerBNotConsumedChainEvent,
+    subprocessB.producerBNotConsumedChainLumi,
+    subprocessB.producerBNotConsumedChainRun,
 )
 subprocessB.p = cms.Path(
     subprocessB.consumerEventFromA+
@@ -284,6 +310,22 @@ subprocessBA.consumerEventNotConsumedInBA2 = intGenericConsumer.clone(srcEvent =
     cms.InputTag("producerBEventConsumedInBA2", "", cms.InputTag.skipCurrentProcess())
 ])
 
+subprocessBA.producerBANotConsumedChainEvent = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcBeginLumi = cms.untracked.VInputTag("producerBNotConsumedChainLumi")
+)
+subprocessBA.producerBANotConsumedChainLumi = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcBeginRun = cms.untracked.VInputTag("producerBNotConsumedChainRun")
+)
+subprocessBA.producerBANotConsumedChainRun = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer",
+    srcEvent = cms.untracked.VInputTag("producerBNotConsumedChainEvent")
+)
+subprocessBA.producerBANotConsumedChainEvent2 = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcBeginRun = cms.untracked.VInputTag("producerANotConsumedChainRun"),
+    srcBeginLumi = cms.untracked.VInputTag("producerANotConsumedChainLumi"),
+    srcEvent = cms.untracked.VInputTag("producerANotConsumedChainEvent"),
+)
+
+
 subprocessBA.t = cms.Task(
     subprocessBA.producerEventMaybeConsumedInBA,
     #
@@ -293,6 +335,11 @@ subprocessBA.t = cms.Task(
     subprocessBA.producerEventConsumedInBA2,
     subprocessBA.producerBEventConsumedInBA1,
     subprocessBA.producerBEventConsumedInBA2,
+    #
+    subprocessBA.producerBANotConsumedChainEvent,
+    subprocessBA.producerBANotConsumedChainLumi,
+    subprocessBA.producerBANotConsumedChainRun,
+    subprocessBA.producerBANotConsumedChainEvent2,
 )
 subprocessBA.p = cms.Path(
     subprocessBA.consumerEventFromA+
@@ -355,6 +402,16 @@ subprocessC.consumerEventNotConsumedInC2 = intGenericConsumer.clone(srcEvent = [
 subprocessC.consumerBEventConsumedInC1 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInC1"], inputShouldExist=False)
 subprocessC.consumerBEventConsumedInC2 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInC1::B"], inputShouldExist=False)
 
+subprocessC.producerCNotConsumedChainEvent = cms.EDProducer("edmtest::TestModuleDeleteProducer",
+    srcEvent = cms.untracked.VInputTag("producerANotConsumedChainEvent")
+)
+subprocessC.producerCNotConsumedChainLumi = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer",
+    srcBeginLumi = cms.untracked.VInputTag("producerANotConsumedChainLumi")
+)
+subprocessC.producerCNotConsumedChainRun = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer",
+    srcBeginRun = cms.untracked.VInputTag("producerANotConsumedChainRun")
+)
+
 subprocessC.t = cms.Task(
     subprocessC.producerEventMaybeConsumedInC,
     #
@@ -362,6 +419,10 @@ subprocessC.t = cms.Task(
     #
     subprocessC.producerEventConsumedInC1,
     subprocessC.producerEventConsumedInC2,
+    #
+    subprocessC.producerCNotConsumedChainEvent,
+    subprocessC.producerCNotConsumedChainLumi,
+    subprocessC.producerCNotConsumedChainRun,
 )
 subprocessC.p = cms.Path(
     subprocessC.consumerEndLumiFromA+
@@ -437,7 +498,18 @@ subprocessDA.consumerDEventNotConsumedInDA = intGenericConsumer.clone(
     inputShouldExist = False,
 )
 
+subprocessDA.producerDNotConsumedChainRun = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer",
+    srcBeginRun = cms.untracked.VInputTag("producerANotConsumedChainRun"),
+    srcBeginLumi = cms.untracked.VInputTag("producerANotConsumedChainLumi"),
+    srcEvent = cms.untracked.VInputTag("producerANotConsumedChainEvent"),
+)
+
+subprocessDA.t = cms.Task(
+    subprocessDA.producerDNotConsumedChainRun
+)
+
 subprocessDA.p = cms.Path(
     subprocessDA.consumerAEventNotConsumedInD+
-    subprocessDA.consumerDEventNotConsumedInDA
+    subprocessDA.consumerDEventNotConsumedInDA,
+    subprocessDA.t
 )

--- a/FWCore/Framework/test/test_module_delete_subprocess_cfg.py
+++ b/FWCore/Framework/test/test_module_delete_subprocess_cfg.py
@@ -1,0 +1,443 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("A")
+
+process.maxEvents.input = 8
+process.source = cms.Source("EmptySource")
+
+#process.Tracer = cms.Service("Tracer")
+
+# Process tree
+# A (Process)
+# ^
+# \- B
+# |  ^
+# |  \- BA
+# |
+# \- C
+# |
+# \- D
+#    ^
+#    \- DA
+
+# Cases to test
+# - event/lumi/run product consumed in a B or C, module kept
+# - event/lumi/run product consumed in BA, module kept
+# - event/lumi/run product not consumed anywhere, module deleted
+# - event(/lumi/run) product produced in A and any SubProcess, consumed with empty process name, module kept
+# - event(/lumi/run) product produced in A and any SubProcess, consumed with SubProcess name, A module deleted
+# - event(/lumi/run) product produced in A and any SubProcess, consumed with A name or skipProcess, SubProcess module deleted
+# - event(/lumi/run) product produced in B and consumed in BA, module kept
+# - event(/lumi/run) product produced in B and consumed in C, module deleted (and product not found)
+# - event(/lumi/run) product producer in A and dropped for SubProcess, module deleted
+
+intEventProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+intNonEventProducer = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
+intEventProducerMustRun = cms.EDProducer("edmtest::MustRunIntProducer", ivalue = cms.int32(1), mustRunEvent = cms.bool(True))
+intEventConsumer = cms.EDAnalyzer("IntTestAnalyzer",
+    moduleLabel = cms.untracked.InputTag("producerEventConsumed"),
+    valueMustMatch = cms.untracked.int32(1)
+)
+intGenericConsumer = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer",
+    srcEvent = cms.untracked.VInputTag(),
+    inputShouldExist = cms.untracked.bool(True)
+)
+uint64GenericConsumer = cms.EDAnalyzer("edmtest::GenericUInt64Analyzer",
+    srcEvent = cms.untracked.VInputTag(),
+    inputShouldExist = cms.untracked.bool(True)
+)
+
+def nonEventConsumer(transition, sourcePattern, expected):
+    transCap = transition[0].upper() + transition[1:]
+    runOrLumiBlock = transCap
+    if "Lumi" in runOrLumiBlock:
+        runOrLumiBlock = runOrLumiBlock+"nosityBlock"
+    ret = intNonEventProducer.clone()
+    setattr(ret, "consumes%s"%runOrLumiBlock, cms.InputTag(sourcePattern%transCap, transition))
+    setattr(ret, "expect%s"%runOrLumiBlock, cms.untracked.int32(expected))
+    return ret
+
+process.producerAEventConsumedInB = intEventProducer.clone(ivalue = 1)
+process.producerABeginLumiConsumedInB = intNonEventProducer.clone(ivalue = 2)
+process.producerAEndRunConsumedInB = intNonEventProducer.clone(ivalue = 5)
+process.producerAEndLumiConsumedInC = intNonEventProducer.clone(ivalue = 3)
+process.producerABeginRunConsumedInC = intNonEventProducer.clone(ivalue = 4)
+
+process.producerAEventConsumedInBA = intEventProducer.clone(ivalue = 10)
+process.producerABeginLumiConsumedInBA = intNonEventProducer.clone(ivalue = 20)
+process.producerAEndLumiConsumedInBA = intNonEventProducer.clone(ivalue = 30)
+process.producerABeginRunConsumedInBA = intNonEventProducer.clone(ivalue = 40)
+process.producerAEndRunConsumedInBA = intNonEventProducer.clone(ivalue = 50)
+
+process.producerEventNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerBeginLumiNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer")
+process.producerBeginRunNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer")
+
+# These producers do not get the event transitions for the events
+# where the same-name producers in the SubProcesses produce a product.
+# Nevertheless, these producers must not be deleted early, because
+# their event transitions might get called.
+process.producerEventMaybeConsumedInB = intEventProducerMustRun.clone(mustRunEvent=False)
+process.producerEventMaybeConsumedInBA = intEventProducerMustRun.clone(mustRunEvent=False)
+process.producerEventMaybeConsumedInC = intEventProducerMustRun.clone(mustRunEvent=False)
+
+process.producerAEventNotConsumedInB = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerAEventNotConsumedInBA = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerAEventNotConsumedInC = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+process.producerAEventNotConsumedInD = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+
+process.producerEventConsumedInB1 = intEventProducerMustRun.clone()
+process.producerEventConsumedInB2 = intEventProducerMustRun.clone()
+process.producerEventConsumedInBA1 = intEventProducerMustRun.clone()
+process.producerEventConsumedInBA2 = intEventProducerMustRun.clone()
+process.producerEventConsumedInC1 = intEventProducerMustRun.clone()
+process.producerEventConsumedInC2 = intEventProducerMustRun.clone()
+
+process.intAnalyzerDelete = cms.EDAnalyzer("edmtest::TestModuleDeleteAnalyzer")
+
+process.t = cms.Task(
+    process.producerAEventConsumedInB,
+    process.producerABeginLumiConsumedInB,
+    process.producerAEndRunConsumedInB,
+    process.producerAEndLumiConsumedInC,
+    process.producerABeginRunConsumedInC,
+    #
+    process.producerAEventConsumedInBA,
+    process.producerABeginLumiConsumedInBA,
+    process.producerAEndLumiConsumedInBA,
+    process.producerABeginRunConsumedInBA,
+    process.producerAEndRunConsumedInBA,
+    #
+    process.producerEventNotConsumed,
+    process.producerBeginLumiNotConsumed,
+    process.producerBeginRunNotConsumed,
+    #
+    process.producerEventMaybeConsumedInB,
+    process.producerEventMaybeConsumedInBA,
+    process.producerEventMaybeConsumedInC,
+    #
+    process.producerAEventNotConsumedInB,
+    process.producerAEventNotConsumedInBA,
+    process.producerAEventNotConsumedInC,
+    #
+    process.producerEventConsumedInB1,
+    process.producerEventConsumedInB2,
+    process.producerEventConsumedInBA1,
+    process.producerEventConsumedInBA2,
+    process.producerEventConsumedInC1,
+    process.producerEventConsumedInC2,
+)
+
+process.p = cms.Path(
+    process.intAnalyzerDelete
+    ,
+    process.t
+)
+
+####################
+subprocessB = cms.Process("B")
+process.addSubProcess( cms.SubProcess(
+    process = subprocessB,
+    SelectEvents = cms.untracked.PSet(),
+    outputCommands = cms.untracked.vstring()
+) )
+
+subprocessB.consumerEventFromA = intEventConsumer.clone(moduleLabel = "producerAEventConsumedInB", valueMustMatch = 1)
+subprocessB.consumerBeginLumiFromA = nonEventConsumer("beginLumi", "producerA%sConsumedInB", 2)
+subprocessB.consumerEndRunFromA = nonEventConsumer("endRun", "producerA%sConsumedInB", 5)
+
+subprocessB.consumerAEventNotConsumed = intGenericConsumer.clone(
+    srcEvent = [
+        "producerEventNotConsumed:doesNotExist",
+        "producerEventNotConsumed:doesNotExist:A",
+        cms.InputTag("producerEventNotConsumed", "doesNotExist", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+subprocessB.consumerAEventNotConsumed2 = uint64GenericConsumer.clone(
+    srcEvent = [
+        "producerEventNotConsumed",
+        "producerEventNotConsumed::A",
+        cms.InputTag("producerEventNotConsumed", "", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+subprocessB.producerEventNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessB.producerBeginLumiNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInLumiProducer")
+subprocessB.producerBeginRunNotConsumed = cms.EDProducer("edmtest::TestModuleDeleteInRunProducer")
+
+subprocessB.producerEventMaybeConsumedInB = intEventProducerMustRun.clone()
+subprocessB.producerEventMaybeConsumedInBA = intEventProducerMustRun.clone(mustRunEvent=False)
+subprocessB.consumerEventMaybeInB = intGenericConsumer.clone(srcEvent = ["producerEventMaybeConsumedInB"])
+
+subprocessB.producerAEventNotConsumedInB = intEventProducerMustRun.clone()
+subprocessB.producerAEventNotConsumedInBA = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessB.consumerAEventNotConsumedInB = intGenericConsumer.clone(srcEvent = ["producerAEventNotConsumedInB::B"])
+
+subprocessB.producerEventConsumedInB1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessB.producerEventConsumedInB2 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessB.consumerEventNotConsumedInB1 = intGenericConsumer.clone(srcEvent = ["producerEventConsumedInB1::A"])
+subprocessB.consumerEventNotConsumedInB2 = intGenericConsumer.clone(srcEvent = [cms.InputTag("producerEventConsumedInB2", "", cms.InputTag.skipCurrentProcess())])
+subprocessB.producerBEventConsumedInBA1 = intEventProducerMustRun.clone()
+subprocessB.producerBEventConsumedInBA2 = intEventProducerMustRun.clone()
+
+subprocessB.producerBEventConsumedInC1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessB.producerBEventConsumedInC2 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+
+subprocessB.producerBEventConsumedInB1 = intEventProducerMustRun.clone()
+subprocessB.producerBEventConsumedInB2 = intEventProducerMustRun.clone()
+subprocessB.producerBEventConsumedInB3 = intEventProducerMustRun.clone()
+subprocessB.consumerBEventConsumedInB1 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInB1"])
+subprocessB.consumerBEventConsumedInB2 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInB2::B"])
+subprocessB.consumerBEventConsumedInB3 = intGenericConsumer.clone(srcEvent = [cms.InputTag("producerBEventConsumedInB3", "", cms.InputTag.currentProcess())])
+
+subprocessB.t = cms.Task(
+    subprocessB.producerEventNotConsumed,
+    subprocessB.producerBeginLumiNotConsumed,
+    subprocessB.producerBeginRunNotConsumed,
+    #
+    subprocessB.producerEventMaybeConsumedInB,
+    subprocessB.producerEventMaybeConsumedInBA,
+    #
+    subprocessB.producerAEventNotConsumedInB,
+    subprocessB.producerAEventNotConsumedInBA,
+    #
+    subprocessB.producerEventConsumedInB1,
+    subprocessB.producerEventConsumedInB2,
+    subprocessB.producerBEventConsumedInBA1,
+    subprocessB.producerBEventConsumedInBA2,
+    #
+    subprocessB.producerBEventConsumedInC1,
+    subprocessB.producerBEventConsumedInC2,
+    #
+    subprocessB.producerBEventConsumedInB1,
+    subprocessB.producerBEventConsumedInB2,
+    subprocessB.producerBEventConsumedInB3,
+)
+subprocessB.p = cms.Path(
+    subprocessB.consumerEventFromA+
+    subprocessB.consumerBeginLumiFromA+
+    subprocessB.consumerEndRunFromA+
+    #
+    subprocessB.consumerAEventNotConsumed+
+    subprocessB.consumerAEventNotConsumed2+
+    #
+    subprocessB.consumerEventMaybeInB+
+    #
+    subprocessB.consumerAEventNotConsumedInB+
+    subprocessB.consumerEventNotConsumedInB1+
+    subprocessB.consumerEventNotConsumedInB2+
+    #
+    subprocessB.consumerBEventConsumedInB1+
+    subprocessB.consumerBEventConsumedInB2+
+    subprocessB.consumerBEventConsumedInB3
+    ,subprocessB.t
+)
+
+####################
+subprocessBA = cms.Process("BA")
+subprocessB.addSubProcess( cms.SubProcess(
+    process = subprocessBA,
+    SelectEvents = cms.untracked.PSet(),
+    outputCommands = cms.untracked.vstring()
+) )
+
+subprocessBA.consumerEventFromA = intEventConsumer.clone(moduleLabel = "producerAEventConsumedInBA", valueMustMatch = 10)
+subprocessBA.consumerBeginLumiFromA = nonEventConsumer("beginLumi", "producerA%sConsumedInBA", 20)
+subprocessBA.consumerEndLumiFromA = nonEventConsumer("endLumi", "producerA%sConsumedInBA", 30)
+subprocessBA.consumerBeginRunFromA = nonEventConsumer("beginRun", "producerA%sConsumedInBA", 40)
+subprocessBA.consumerEndRunFromA = nonEventConsumer("endRun", "producerA%sConsumedInBA", 50)
+
+subprocessBA.consumerABEventNotConsumed = intGenericConsumer.clone(
+    srcEvent = [
+        "producerEventNotConsumed:doesNotExist",
+        "producerEventNotConsumed:doesNotExist:A",
+        "producerEventNotConsumed:doesNotExist:B",
+        cms.InputTag("producerEventNotConsumed", "doesNotExist", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+subprocessBA.consumerABEventNotConsumed2 = uint64GenericConsumer.clone(
+    srcEvent = [
+        "producerEventNotConsumed",
+        "producerEventNotConsumed::A",
+        "producerEventNotConsumed::B",
+        cms.InputTag("producerEventNotConsumed", "", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+
+subprocessBA.producerEventMaybeConsumedInBA = intEventProducerMustRun.clone()
+subprocessBA.consumerEventMaybeInBA = intGenericConsumer.clone(srcEvent = ["producerEventMaybeConsumedInBA"])
+
+subprocessBA.producerAEventNotConsumedInBA = intEventProducerMustRun.clone()
+subprocessBA.consumerAEventNotConsumedInBA = intGenericConsumer.clone(srcEvent = ["producerAEventNotConsumedInBA::BA"])
+
+subprocessBA.producerEventConsumedInBA1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessBA.producerEventConsumedInBA2 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessBA.producerBEventConsumedInBA1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessBA.producerBEventConsumedInBA2 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessBA.consumerEventNotConsumedInBA1 = intGenericConsumer.clone(srcEvent = ["producerEventConsumedInBA1::A",
+                                                                                  "producerBEventConsumedInBA1::B"])
+subprocessBA.consumerEventNotConsumedInBA2 = intGenericConsumer.clone(srcEvent = [
+    cms.InputTag("producerEventConsumedInBA2", "", cms.InputTag.skipCurrentProcess()),
+    cms.InputTag("producerBEventConsumedInBA2", "", cms.InputTag.skipCurrentProcess())
+])
+
+subprocessBA.t = cms.Task(
+    subprocessBA.producerEventMaybeConsumedInBA,
+    #
+    subprocessBA.producerAEventNotConsumedInBA,
+    #
+    subprocessBA.producerEventConsumedInBA1,
+    subprocessBA.producerEventConsumedInBA2,
+    subprocessBA.producerBEventConsumedInBA1,
+    subprocessBA.producerBEventConsumedInBA2,
+)
+subprocessBA.p = cms.Path(
+    subprocessBA.consumerEventFromA+
+    subprocessBA.consumerBeginLumiFromA+
+    subprocessBA.consumerEndLumiFromA+
+    subprocessBA.consumerBeginRunFromA+
+    subprocessBA.consumerEndRunFromA+
+    #
+    subprocessBA.consumerABEventNotConsumed+
+    subprocessBA.consumerABEventNotConsumed2+
+    #
+    subprocessBA.consumerEventMaybeInBA+
+    #
+    subprocessBA.consumerAEventNotConsumedInBA+
+    #
+    subprocessBA.consumerEventNotConsumedInBA1+
+    subprocessBA.consumerEventNotConsumedInBA2
+    , subprocessBA.t
+)
+
+####################
+subprocessC = cms.Process("C")
+process.addSubProcess( cms.SubProcess(
+    process = subprocessC,
+    SelectEvents = cms.untracked.PSet(),
+    outputCommands = cms.untracked.vstring()
+) )
+
+subprocessC.consumerEndLumiFromA = nonEventConsumer("endLumi", "producerA%sConsumedInC", 3)
+subprocessC.consumerBeginRunFromA = nonEventConsumer("beginRun", "producerA%sConsumedInC", 4)
+
+subprocessC.consumerAEventNotConsumed = intGenericConsumer.clone(
+    srcEvent = [
+        "producerEventNotConsumed:doesNotExist",
+        "producerEventNotConsumed:doesNotExist:A",
+        cms.InputTag("producerEventNotConsumed", "doesNotExist", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+subprocessC.consumerAEventNotConsumed2 = uint64GenericConsumer.clone(
+    srcEvent = [
+        "producerEventNotConsumed",
+        "producerEventNotConsumed::A",
+        cms.InputTag("producerEventNotConsumed", "", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+
+subprocessC.producerEventMaybeConsumedInC = intEventProducerMustRun.clone()
+subprocessC.consumerEventMaybeInC = intGenericConsumer.clone(srcEvent = ["producerEventMaybeConsumedInC"])
+
+subprocessC.producerAEventNotConsumedInC = intEventProducerMustRun.clone()
+subprocessC.consumerAEventNotConsumedInC = intGenericConsumer.clone(srcEvent = ["producerAEventNotConsumedInC::C"])
+
+subprocessC.producerEventConsumedInC1 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessC.producerEventConsumedInC2 = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+subprocessC.consumerEventNotConsumedInC1 = intGenericConsumer.clone(srcEvent = ["producerEventConsumedInC1::A"])
+subprocessC.consumerEventNotConsumedInC2 = intGenericConsumer.clone(srcEvent = [cms.InputTag("producerEventConsumedInC2", "", cms.InputTag.skipCurrentProcess())])
+
+subprocessC.consumerBEventConsumedInC1 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInC1"], inputShouldExist=False)
+subprocessC.consumerBEventConsumedInC2 = intGenericConsumer.clone(srcEvent = ["producerBEventConsumedInC1::B"], inputShouldExist=False)
+
+subprocessC.t = cms.Task(
+    subprocessC.producerEventMaybeConsumedInC,
+    #
+    subprocessC.producerAEventNotConsumedInC,
+    #
+    subprocessC.producerEventConsumedInC1,
+    subprocessC.producerEventConsumedInC2,
+)
+subprocessC.p = cms.Path(
+    subprocessC.consumerEndLumiFromA+
+    subprocessC.consumerBeginRunFromA+
+    #
+    subprocessC.consumerAEventNotConsumed+
+    subprocessC.consumerAEventNotConsumed2+
+    #
+    subprocessC.consumerEventMaybeInC+
+    subprocessC.consumerAEventNotConsumedInC+
+    #
+    subprocessC.consumerEventNotConsumedInC1+
+    subprocessC.consumerEventNotConsumedInC2+
+    #
+    subprocessC.consumerBEventConsumedInC1+
+    subprocessC.consumerBEventConsumedInC2
+    , subprocessC.t
+)
+
+####################
+subprocessD = cms.Process("D")
+process.addSubProcess( cms.SubProcess(
+    process = subprocessD,
+    SelectEvents = cms.untracked.PSet(),
+    outputCommands = cms.untracked.vstring(
+        "drop *_producerAEventNotConsumedInD_*_*",
+    )
+) )
+
+subprocessD.consumerAEventNotConsumedInD = intGenericConsumer.clone(
+    srcEvent = [
+        "producerAEvenNotConsumedInD",
+        "producerAEvenNotConsumedInD::A",
+        cms.InputTag("producerEventANotConsumedInD", "", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+
+subprocessD.producerDEventNotConsumedInDA = cms.EDProducer("edmtest::TestModuleDeleteProducer")
+
+subprocessD.t = cms.Task(
+    subprocessD.producerDEventNotConsumedInDA
+)
+subprocessD.p = cms.Path(
+    subprocessD.consumerAEventNotConsumedInD,
+    subprocessD.t
+)
+
+####################
+subprocessDA = cms.Process("BA")
+subprocessD.addSubProcess( cms.SubProcess(
+    process = subprocessDA,
+    SelectEvents = cms.untracked.PSet(),
+    outputCommands = cms.untracked.vstring(
+        "drop *_producerDEventNotConsumedInDA_*_*",
+    )
+) )
+
+subprocessDA.consumerAEventNotConsumedInD = intGenericConsumer.clone(
+    srcEvent = [
+        "producerAEvenNotConsumedInD",
+        "producerAEvenNotConsumedInD::A",
+        cms.InputTag("producerEventANotConsumedInD", "", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+subprocessDA.consumerDEventNotConsumedInDA = intGenericConsumer.clone(
+    srcEvent = [
+        "producerDEvenNotConsumedInDA",
+        "producerDEvenNotConsumedInDA::D",
+        cms.InputTag("producerEventDNotConsumedInDA", "", cms.InputTag.skipCurrentProcess())
+    ],
+    inputShouldExist = False,
+)
+
+subprocessDA.p = cms.Path(
+    subprocessDA.consumerAEventNotConsumedInD+
+    subprocessDA.consumerDEventNotConsumedInDA
+)

--- a/FWCore/Framework/test/test_non_event_ordering_beginLumi_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_beginLumi_cfg.py
@@ -6,13 +6,13 @@ process.source = cms.Source("EmptySource")
 
 process.maxEvents.input = 3
 
-process.a = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
+process.d = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
 process.b = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(2),
                            consumesBeginLuminosityBlock = cms.InputTag("c","beginLumi"),
                            expectBeginLuminosityBlock = cms.untracked.int32(3) )
 process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3),
-                           consumesBeginLuminosityBlock = cms.InputTag("a", "beginLumi"),
+                           consumesBeginLuminosityBlock = cms.InputTag("d", "beginLumi"),
                            expectBeginLuminosityBlock = cms.untracked.int32(1))
 
-process.t = cms.Task(process.a, process.c)
+process.t = cms.Task(process.d, process.c)
 process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_beginLumi_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_beginLumi_cfg.py
@@ -14,4 +14,5 @@ process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3),
                            consumesBeginLuminosityBlock = cms.InputTag("a", "beginLumi"),
                            expectBeginLuminosityBlock = cms.untracked.int32(1))
 
-process.schedule = cms.Schedule(tasks=cms.Task(process.a,process.b,process.c))
+process.t = cms.Task(process.a, process.c)
+process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_beginRun_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_beginRun_cfg.py
@@ -14,4 +14,5 @@ process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3),
                            consumesBeginRun = cms.InputTag("a", "beginRun"),
                            expectBeginRun = cms.untracked.int32(1))
 
-process.schedule = cms.Schedule(tasks=cms.Task(process.a,process.b,process.c))
+process.t = cms.Task(process.a, process.c)
+process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_beginRun_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_beginRun_cfg.py
@@ -6,13 +6,13 @@ process.source = cms.Source("EmptySource")
 
 process.maxEvents.input = 3
 
-process.a = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
+process.d = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
 process.b = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(2),
                            consumesBeginRun = cms.InputTag("c","beginRun"),
                            expectBeginRun = cms.untracked.int32(3) )
 process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3),
-                           consumesBeginRun = cms.InputTag("a", "beginRun"),
+                           consumesBeginRun = cms.InputTag("d", "beginRun"),
                            expectBeginRun = cms.untracked.int32(1))
 
-process.t = cms.Task(process.a, process.c)
+process.t = cms.Task(process.d, process.c)
 process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_endLumi_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_endLumi_cfg.py
@@ -6,13 +6,13 @@ process.source = cms.Source("EmptySource")
 
 process.maxEvents.input = 3
 
-process.a = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
+process.d = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
 process.b = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(2),
                            consumesEndLuminosityBlock = cms.InputTag("c","endLumi"),
                            expectEndLuminosityBlock = cms.untracked.int32(3) )
 process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3),
-                           consumesEndLuminosityBlock = cms.InputTag("a", "endLumi"),
+                           consumesEndLuminosityBlock = cms.InputTag("d", "endLumi"),
                            expectEndLuminosityBlock = cms.untracked.int32(1))
 
-process.t = cms.Task(process.a, process.c)
+process.t = cms.Task(process.d, process.c)
 process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_endLumi_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_endLumi_cfg.py
@@ -14,4 +14,5 @@ process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3),
                            consumesEndLuminosityBlock = cms.InputTag("a", "endLumi"),
                            expectEndLuminosityBlock = cms.untracked.int32(1))
 
-process.schedule = cms.Schedule(tasks=cms.Task(process.a,process.b,process.c))
+process.t = cms.Task(process.a, process.c)
+process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_endRun_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_endRun_cfg.py
@@ -6,9 +6,9 @@ process.source = cms.Source("EmptySource")
 
 process.maxEvents.input = 3
 
-process.a = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
+process.d = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
 process.b = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(2), consumesEndRun = cms.InputTag("c","endRun"), expectEndRun = cms.untracked.int32(3) )
-process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3), consumesEndRun = cms.InputTag("a", "endRun"), expectEndRun = cms.untracked.int32(1) )
+process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3), consumesEndRun = cms.InputTag("d", "endRun"), expectEndRun = cms.untracked.int32(1) )
 
-process.t = cms.Task(process.a, process.c)
+process.t = cms.Task(process.d, process.c)
 process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_endRun_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_endRun_cfg.py
@@ -10,4 +10,5 @@ process.a = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
 process.b = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(2), consumesEndRun = cms.InputTag("c","endRun"), expectEndRun = cms.untracked.int32(3) )
 process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3), consumesEndRun = cms.InputTag("a", "endRun"), expectEndRun = cms.untracked.int32(1) )
 
-process.schedule = cms.Schedule(tasks=cms.Task(process.a,process.b,process.c))
+process.t = cms.Task(process.a, process.c)
+process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_one_modules_cfg.py
+++ b/FWCore/Framework/test/test_one_modules_cfg.py
@@ -101,6 +101,8 @@ process.WatchRunAn = cms.EDAnalyzer("edmtest::one::WatchRunsAnalyzer",
 
 process.WatchLumiBlockAn = cms.EDAnalyzer("edmtest::one::WatchLumiBlocksAnalyzer",
     transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
+    # needed to avoid deleting TestAccumulator1
+    ,moduleLabel = cms.InputTag("TestAccumulator1")
 )
 
 process.RunCacheAn = cms.EDAnalyzer("edmtest::one::RunCacheAnalyzer",

--- a/FWCore/Framework/test/test_stream_modules_cfg.py
+++ b/FWCore/Framework/test/test_stream_modules_cfg.py
@@ -117,6 +117,8 @@ process.RunIntAn= cms.EDAnalyzer("edmtest::stream::RunIntAnalyzer",
 process.LumiIntAn = cms.EDAnalyzer("edmtest::stream::LumiIntAnalyzer",
     transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
+    # needed to avoid deleting TestAccumulator1
+    ,moduleLabel = cms.InputTag("TestAccumulator1")
 )
 
 process.RunSumIntAn = cms.EDAnalyzer("edmtest::stream::RunSummaryIntAnalyzer",

--- a/FWCore/Integration/test/testSubProcessUnscheduled_cfg.py
+++ b/FWCore/Integration/test/testSubProcessUnscheduled_cfg.py
@@ -17,6 +17,7 @@ process.two = cms.EDProducer("BusyWaitIntProducer", ivalue = cms.int32(2), itera
 
 # producer
 process.four = cms.EDProducer("BusyWaitIntProducer", ivalue = cms.int32(4), iterations=cms.uint32(10*1000))
+process.fourConsumer = cms.EDAnalyzer("MultipleIntsAnalyzer", getFromModules=cms.untracked.VInputTag("four"))
 
 # producer
 process.ten = cms.EDProducer("BusyWaitIntProducer", ivalue = cms.int32(10), iterations=cms.uint32(2*1000))
@@ -25,7 +26,7 @@ process.adder = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag('two','
 
 process.task = cms.Task(process.two, process.four, process.ten, process.adder)
 
-process.path = cms.Path(process.task)
+process.path = cms.Path(process.fourConsumer, process.task)
 
 subprocess = cms.Process("SUB")
 process.addSubProcess( cms.SubProcess(

--- a/FWCore/MessageService/interface/MessageLogger.h
+++ b/FWCore/MessageService/interface/MessageLogger.h
@@ -73,6 +73,9 @@ namespace edm {
       void preModuleConstruction(ModuleDescription const&);
       void postModuleConstruction(ModuleDescription const&);
 
+      void preModuleDestruction(ModuleDescription const&);
+      void postModuleDestruction(ModuleDescription const&);
+
       void preSourceConstruction(ModuleDescription const&);
       void postSourceConstruction(ModuleDescription const&);
 

--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -283,6 +283,9 @@ namespace edm {
       iRegistry.watchPostSourceConstruction(this, &MessageLogger::postSourceConstruction);
       // change log 3
 
+      iRegistry.watchPreModuleDestruction(this, &MessageLogger::preModuleDestruction);
+      iRegistry.watchPostModuleDestruction(this, &MessageLogger::postModuleDestruction);
+
       iRegistry.watchPreModuleEvent(this, &MessageLogger::preModuleEvent);
       iRegistry.watchPostModuleEvent(this, &MessageLogger::postModuleEvent);
 
@@ -543,10 +546,15 @@ namespace edm {
       }
       establishModule(desc, "@ctor");  // ChangeLog 16
     }
-    void MessageLogger::postModuleConstruction(
-        const ModuleDescription&
-            iDescription) {  //it is now guaranteed that this will be called even if the module throws
+    //it is now guaranteed that this will be called even if the module throws
+    void MessageLogger::postModuleConstruction(const ModuleDescription& iDescription) {
       unEstablishModule(iDescription, "AfterModConstruction");
+    }
+
+    void MessageLogger::preModuleDestruction(const ModuleDescription& desc) { establishModule(desc, "@dtor"); }
+    //it is guaranteed that this will be called even if the module throws
+    void MessageLogger::postModuleDestruction(const ModuleDescription& iDescription) {
+      unEstablishModule(iDescription, "AfterModDestruction");
     }
 
     void MessageLogger::preModuleBeginJob(const ModuleDescription& desc) {

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -227,6 +227,7 @@ class Process(object):
                               forceEventSetupCacheClearOnNewRun = untracked.bool(False),
                               throwIfIllegalParameter = untracked.bool(True),
                               printDependencies = untracked.bool(False),
+                              deleteNonConsumedUnscheduledModules = untracked.bool(True),
                               sizeOfStackForThreadsInKB = optional.untracked.uint32,
                               Rethrow = untracked.vstring(),
                               SkipEvent = untracked.vstring(),
@@ -2008,6 +2009,7 @@ process.options = cms.untracked.PSet(
     SkipEvent = cms.untracked.vstring(),
     allowUnscheduled = cms.obsolete.untracked.bool,
     canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
     emptyRunLumiMode = cms.obsolete.untracked.string,
     eventSetup = cms.untracked.PSet(
         forceNumberOfConcurrentIOVs = cms.untracked.PSet(

--- a/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
+++ b/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
@@ -41,6 +41,10 @@ namespace edm {
     description.addUntracked<bool>("throwIfIllegalParameter", true)
         ->setComment("Set false to disable exception throws when configuration validation detects illegal parameters");
     description.addUntracked<bool>("printDependencies", false)->setComment("Print data dependencies between modules");
+    description.addUntracked<bool>("deleteNonConsumedUnscheduledModules", true)
+        ->setComment(
+            "Delete modules that are unscheduled, i.e. only in Tasks, whose products are not consumed by any other "
+            "otherwise-running module");
 
     // No default for this one because the parameter value is
     // actually used in the main function in cmsRun.cpp before

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -678,6 +678,24 @@ namespace edm {
     // WARNING - ModuleDescription is not in fixed place.  See note M above.
     AR_WATCH_USING_METHOD_1(watchPostModuleConstruction)
 
+    /// signal is emitted before the module is destructed, only for modules deleted before beginJob
+    typedef signalslot::Signal<void(ModuleDescription const&)> PreModuleDestruction;
+    PreModuleDestruction preModuleDestructionSignal_;
+    void watchPreModuleDestruction(PreModuleDestruction::slot_type const& iSlot) {
+      preModuleDestructionSignal_.connect(iSlot);
+    }
+    // note: ModuleDescription IS in the fixed place. See note M above.
+    AR_WATCH_USING_METHOD_1(watchPreModuleDestruction)
+
+    /// signal is emitted after the module is destructed, only for modules deleted before beginJob
+    typedef signalslot::Signal<void(ModuleDescription const&)> PostModuleDestruction;
+    PostModuleDestruction postModuleDestructionSignal_;
+    void watchPostModuleDestruction(PostModuleDestruction::slot_type const& iSlot) {
+      postModuleDestructionSignal_.connect_front(iSlot);
+    }
+    // WARNING - ModuleDescription is not in fixed place.  See note M above.
+    AR_WATCH_USING_METHOD_1(watchPostModuleDestruction)
+
     /// signal is emitted before the module does beginJob
     typedef signalslot::Signal<void(ModuleDescription const&)> PreModuleBeginJob;
     PreModuleBeginJob preModuleBeginJobSignal_;

--- a/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
+++ b/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
@@ -23,6 +23,7 @@
 //         Created: 11/5/2014
 
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
+#include "FWCore/Utilities/interface/BranchType.h"
 
 #include <string>
 #include <vector>
@@ -60,12 +61,9 @@ namespace edm {
     // it consumes a module label that is an EDAlias, the corresponding module
     // description will be included in the returned vector (but the label in the
     // module description is not the EDAlias label).
-    std::vector<ModuleDescription const*> const& modulesWhoseProductsAreConsumedBy(unsigned int moduleID) const {
-      return doModulesWhoseProductsAreConsumedBy(moduleID);
-    }
-
-    std::vector<ModuleDescription const*> const& modulesWhoseProductsAreConsumedByLumiRun(unsigned int moduleID) const {
-      return doModulesWhoseProductsAreConsumedByLumiRun(moduleID);
+    std::vector<ModuleDescription const*> const& modulesWhoseProductsAreConsumedBy(
+        unsigned int moduleID, BranchType branchType = InEvent) const {
+      return doModulesWhoseProductsAreConsumedBy(moduleID, branchType);
     }
 
     // This returns the declared consumes information for a module.
@@ -85,9 +83,7 @@ namespace edm {
     virtual std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const = 0;
     virtual std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const = 0;
     virtual std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(
-        unsigned int moduleID) const = 0;
-    virtual std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedByLumiRun(
-        unsigned int moduleID) const = 0;
+        unsigned int moduleID, BranchType branchType) const = 0;
     virtual std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const = 0;
   };
 }  // namespace edm

--- a/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
+++ b/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
@@ -75,6 +75,8 @@ namespace edm {
     // than just a pointer.
     std::vector<ConsumesInfo> consumesInfo(unsigned int moduleID) const { return doConsumesInfo(moduleID); }
 
+    unsigned int largestModuleID() const { return doLargestModuleID(); }
+
   private:
     virtual std::vector<std::string> const& doPaths() const = 0;
     virtual std::vector<std::string> const& doEndPaths() const = 0;
@@ -85,6 +87,7 @@ namespace edm {
     virtual std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(
         unsigned int moduleID, BranchType branchType) const = 0;
     virtual std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const = 0;
+    virtual unsigned int doLargestModuleID() const = 0;
   };
 }  // namespace edm
 #endif

--- a/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
+++ b/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
@@ -64,6 +64,10 @@ namespace edm {
       return doModulesWhoseProductsAreConsumedBy(moduleID);
     }
 
+    std::vector<ModuleDescription const*> const& modulesWhoseProductsAreConsumedByLumiRun(unsigned int moduleID) const {
+      return doModulesWhoseProductsAreConsumedByLumiRun(moduleID);
+    }
+
     // This returns the declared consumes information for a module.
     // Note the other functions above return a reference to an object
     // that is held in memory throughout the job, while the following
@@ -81,6 +85,8 @@ namespace edm {
     virtual std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const = 0;
     virtual std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const = 0;
     virtual std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(
+        unsigned int moduleID) const = 0;
+    virtual std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedByLumiRun(
         unsigned int moduleID) const = 0;
     virtual std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const = 0;
   };

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -209,6 +209,9 @@ namespace edm {
     preModuleConstructionSignal_.connect(std::cref(iOther.preModuleConstructionSignal_));
     postModuleConstructionSignal_.connect(std::cref(iOther.postModuleConstructionSignal_));
 
+    preModuleDestructionSignal_.connect(std::cref(iOther.preModuleDestructionSignal_));
+    postModuleDestructionSignal_.connect(std::cref(iOther.postModuleDestructionSignal_));
+
     preModuleBeginJobSignal_.connect(std::cref(iOther.preModuleBeginJobSignal_));
     postModuleBeginJobSignal_.connect(std::cref(iOther.postModuleBeginJobSignal_));
 
@@ -413,6 +416,9 @@ namespace edm {
 */
     copySlotsToFrom(preModuleConstructionSignal_, iOther.preModuleConstructionSignal_);
     copySlotsToFromReverse(postModuleConstructionSignal_, iOther.postModuleConstructionSignal_);
+
+    copySlotsToFrom(preModuleDestructionSignal_, iOther.preModuleDestructionSignal_);
+    copySlotsToFromReverse(postModuleDestructionSignal_, iOther.postModuleDestructionSignal_);
 
     copySlotsToFrom(preModuleBeginJobSignal_, iOther.preModuleBeginJobSignal_);
     copySlotsToFromReverse(postModuleBeginJobSignal_, iOther.postModuleBeginJobSignal_);

--- a/FWCore/Services/plugins/ConcurrentModuleTimer.cc
+++ b/FWCore/Services/plugins/ConcurrentModuleTimer.cc
@@ -86,6 +86,12 @@ ConcurrentModuleTimer::ConcurrentModuleTimer(edm::ParameterSet const& iConfig, e
         }
       }
     });
+    iReg.watchPreModuleDestruction([this](ModuleDescription const& iMod) {
+      auto found = std::find(m_excludedModuleIds.begin(), m_excludedModuleIds.end(), iMod.id());
+      if (found != m_excludedModuleIds.end()) {
+        m_excludedModuleIds.erase(found);
+      }
+    });
     iReg.watchPreModuleEvent([this](StreamContext const&, ModuleCallingContext const& iContext) {
       if (trackModule(iContext)) {
         start();

--- a/FWCore/Services/plugins/ConcurrentModuleTimer.cc
+++ b/FWCore/Services/plugins/ConcurrentModuleTimer.cc
@@ -9,6 +9,8 @@
 // Original Author:  Chris Jones
 //         Created:  Tue, 10 Dec 2013 21:16:00 GMT
 //
+#include <memory>
+
 #include <vector>
 #include <atomic>
 #include <chrono>
@@ -148,7 +150,7 @@ ConcurrentModuleTimer::ConcurrentModuleTimer(edm::ParameterSet const& iConfig, e
 
   iReg.watchPreallocate([this](edm::service::SystemBounds const& iBounds) {
     m_nTimeSums = iBounds.maxNumberOfThreads() + 1 + m_padding;
-    m_timeSums.reset(new std::atomic<std::chrono::high_resolution_clock::rep>[m_nTimeSums]);
+    m_timeSums = std::make_unique<std::atomic<std::chrono::high_resolution_clock::rep>[]>(m_nTimeSums);
     for (unsigned int i = 0; i < m_nTimeSums; ++i) {
       m_timeSums[i] = 0;
     }

--- a/FWCore/Services/plugins/DependencyGraph.cc
+++ b/FWCore/Services/plugins/DependencyGraph.cc
@@ -222,7 +222,7 @@ void DependencyGraph::preBeginJob(PathsAndConsumesOfModulesBase const &pathsAndC
     boost::get_property(m_graph, boost::graph_graph_attribute)["labelloc"] = "top";
 
     // create graph vertices associated to all modules in the process
-    auto size = pathsAndConsumes.allModules().size();
+    auto size = pathsAndConsumes.largestModuleID() - boost::num_vertices(m_graph) + 1;
     for (size_t i = 0; i < size; ++i)
       boost::add_vertex(m_graph);
 
@@ -237,7 +237,7 @@ void DependencyGraph::preBeginJob(PathsAndConsumesOfModulesBase const &pathsAndC
     boost::get_property(graph, boost::graph_graph_attribute)["labelloc"] = "top";
 
     // create graph vertices associated to all modules in the subprocess
-    auto size = pathsAndConsumes.allModules().size();
+    auto size = pathsAndConsumes.largestModuleID() - boost::num_vertices(m_graph) + 1;
     for (size_t i = 0; i < size; ++i)
       boost::add_vertex(graph);
   }

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -263,6 +263,9 @@ namespace edm {
         iRegistry.watchPreModuleConstruction(this, &Timing::preModule);
         iRegistry.watchPostModuleConstruction(this, &Timing::postModule);
 
+        iRegistry.watchPreModuleDestruction(this, &Timing::preModule);
+        iRegistry.watchPostModuleDestruction(this, &Timing::postModule);
+
         iRegistry.watchPreModuleBeginJob(this, &Timing::preModule);
         iRegistry.watchPostModuleBeginJob(this, &Timing::postModule);
 

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -147,6 +147,9 @@ namespace edm {
       void preModuleConstruction(ModuleDescription const& md);
       void postModuleConstruction(ModuleDescription const& md);
 
+      void preModuleDestruction(ModuleDescription const& md);
+      void postModuleDestruction(ModuleDescription const& md);
+
       void preModuleBeginJob(ModuleDescription const& md);
       void postModuleBeginJob(ModuleDescription const& md);
 
@@ -321,6 +324,9 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry& iRegistry)
 
   iRegistry.watchPreModuleConstruction(this, &Tracer::preModuleConstruction);
   iRegistry.watchPostModuleConstruction(this, &Tracer::postModuleConstruction);
+
+  iRegistry.watchPreModuleDestruction(this, &Tracer::preModuleDestruction);
+  iRegistry.watchPostModuleDestruction(this, &Tracer::postModuleDestruction);
 
   iRegistry.watchPreModuleBeginJob(this, &Tracer::preModuleBeginJob);
   iRegistry.watchPostModuleBeginJob(this, &Tracer::postModuleBeginJob);
@@ -974,6 +980,26 @@ void Tracer::postModuleConstruction(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: constructing module with label '" << desc.moduleLabel()
+      << "' id = " << desc.id();
+  if (dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
+    out << "\n" << desc;
+  }
+}
+
+void Tracer::preModuleDestruction(ModuleDescription const& desc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  out << indention_ << indention_ << " starting: destructing module with label '" << desc.moduleLabel()
+      << "' id = " << desc.id();
+  if (dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
+    out << "\n" << desc;
+  }
+}
+
+void Tracer::postModuleDestruction(ModuleDescription const& desc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  out << indention_ << indention_ << " finished: destructing module with label '" << desc.moduleLabel()
       << "' id = " << desc.id();
   if (dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << desc;

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -87,7 +87,7 @@ namespace edm {
 
       // The saveFileName must correspond to a file name without any path specification.
       // Throw if that is not true.
-      if (!saveFileName_.empty() && (saveFileName_.find("/") != std::string::npos)) {
+      if (!saveFileName_.empty() && (saveFileName_.find('/') != std::string::npos)) {
         throw Exception(errors::Configuration)
             << "The saveFileName parameter must be a simple file name with no path\n"
             << "specification. In the configuration, it was given the value \"" << saveFileName_ << "\"\n";

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -187,6 +187,7 @@ namespace edm {
         }
       }
       activityRegistry.watchPreModuleConstruction(this, &RandomNumberGeneratorService::preModuleConstruction);
+      activityRegistry.watchPreModuleDestruction(this, &RandomNumberGeneratorService::preModuleDestruction);
 
       activityRegistry.watchPreallocate(this, &RandomNumberGeneratorService::preallocate);
 
@@ -379,6 +380,13 @@ namespace edm {
       std::map<std::string, SeedsAndName>::iterator iter = seedsAndNameMap_.find(description.moduleLabel());
       if (iter != seedsAndNameMap_.end()) {
         iter->second.setModuleID(description.id());
+      }
+    }
+
+    void RandomNumberGeneratorService::preModuleDestruction(ModuleDescription const& description) {
+      std::map<std::string, SeedsAndName>::iterator iter = seedsAndNameMap_.find(description.moduleLabel());
+      if (iter != seedsAndNameMap_.end()) {
+        iter->second.setModuleID(SeedsAndName::kInvalid);
       }
     }
 

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -81,6 +81,7 @@ namespace edm {
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
       void preModuleConstruction(ModuleDescription const& description);
+      void preModuleDestruction(ModuleDescription const& description);
       void preallocate(SystemBounds const&);
 
       void preBeginLumi(LuminosityBlock const& lumi) override;
@@ -234,8 +235,10 @@ namespace edm {
       // It is left as max unsigned if the module is never constructed and not in the process
       class SeedsAndName {
       public:
+        static constexpr unsigned int kInvalid = std::numeric_limits<unsigned int>::max();
+
         SeedsAndName(VUint32 const& theSeeds, std::string const& theEngineName)
-            : seeds_(theSeeds), engineName_(theEngineName), moduleID_(std::numeric_limits<unsigned int>::max()) {}
+            : seeds_(theSeeds), engineName_(theEngineName), moduleID_(kInvalid) {}
         VUint32 const& seeds() const { return seeds_; }
         std::string const& engineName() const { return engineName_; }
         unsigned int moduleID() const { return moduleID_; }


### PR DESCRIPTION
#### PR description:

This PR makes the framework to delete unscheduled EDModules whose output products are not consumed by any scheduled EDModule. For motivation see https://github.com/cms-sw/cmssw/issues/26438 (which this PR mostly resolves).

Here "unscheduled" means that such EDModules are only in `Task`s, i.e. not directly in any `Path` or `EndPath`, and "scheduled" means an EDModule in a `Path` or `EndPath`. If the module data dependence graph has a subgraph of unscheduled modules whose output products are not consumed by any scheduled module, those unscheduled modules are deleted.

A possible data dependence from a scheduled module from a SubProcess is also enough to keep an otherwise non-consumed EDModule alive. For example, if the Process and its SubProcess both have a module `foo`, and only the SubProcess has a consumer with an `InputTag("foo")`, the module `foo` in the Process is kept as well for the case that the SubProcess's `foo` would not produce a product for some events (assuming the product types and instance names also match).

The data dependencies are checked also for Lumi and Run products in addition of Event products, for which the `EDConsumerBase::modulesWhoseProductsAreConsumed()` and `PathsAndConsumesOfModules` were extended. They were extended also to carry the dependencies from the SubProcesses (it turned out that passing pairs of module label and process name are sufficient, the product type and instance name get handled automatically).

The non-consumed modules are deleted after `preallocate` signal and before `beginJob()` signal. Two new signals, `preModuleDestruction` and `postModuleDestruction` are added for those deletions (the "normal" module deletion at the end of the `cmsRun` process do not emit these signals). I took a look of all modules watching either `preModuleConstruction` or `postModuleConstruction` signals, and added watch for the destruction signals if it seemed to make sense.

Note that even if the modules are deleted, the corresponding Workers are kept alive. The Workers are removed from the containers of unscheduled and accumulator modules, so they won't get any further framework transitions after the deletion.

Resolves https://github.com/cms-sw/cmssw/issues/26438.

#### PR validation:

Framework unit tests run.