### PR TITLE
MTD geometry: update of ideal geometry tests 

### DIFF
--- a/Geometry/MTDCommonData/test/TestMTDNumbering.cc
+++ b/Geometry/MTDCommonData/test/TestMTDNumbering.cc
@@ -134,10 +134,12 @@ void TestMTDNumbering::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       bool isSens = false;
 
       if (fv.geoHistory()[num - 1].logicalPart().specifics().size() > 0) {
-        for (auto elem : *(fv.geoHistory()[num - 1].logicalPart().specifics()[0])) {
-          if (elem.second.name() == "SensitiveDetector") {
-            isSens = true;
-            break;
+        for (auto vec : fv.geoHistory()[num - 1].logicalPart().specifics()) {
+          for (auto elem : *vec) {
+            if (elem.second.name() == "SensitiveDetector") {
+              isSens = true;
+              break;
+            }
           }
         }
       }

--- a/Geometry/MTDCommonData/test/TestMTDPosition.cc
+++ b/Geometry/MTDCommonData/test/TestMTDPosition.cc
@@ -126,10 +126,12 @@ void TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       bool isSens = false;
 
       if (fv.geoHistory()[num - 1].logicalPart().specifics().size() > 0) {
-        for (auto elem : *(fv.geoHistory()[num - 1].logicalPart().specifics()[0])) {
-          if (elem.second.name() == "SensitiveDetector") {
-            isSens = true;
-            break;
+        for (auto vec : fv.geoHistory()[num - 1].logicalPart().specifics()) {
+          for (auto elem : *vec) {
+            if (elem.second.name() == "SensitiveDetector") {
+              isSens = true;
+              break;
+            }
           }
         }
       }


### PR DESCRIPTION
#### PR description:

In this PR there are two updates/fixes concerning tests of ideal geometry in ```MTDCommonData```:

- the DD4hep test is refreshed by using the new ```geoHistory``` added by @ianna . This makes the code more stable and the printout consistent with the DDD version;

- the DDD tests are updated so as to prepare them for an update of ```specifics``` needed by the new ETL for DD4hep (but that need to cohexist with DDD for a while).


#### PR validation:

Test runs and provide fully consistent output on both D50 and D53, with the only residual exception of 

```
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/^A^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR264Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/^B^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR361Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/^C^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR452Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/^D^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR537Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/^E^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR629Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/^F^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR713Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/^G^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR805Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR887Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/     ^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR979Z2666[1]/
%MSG
%MSG-i DD4hep_TestMTDPath:  DD4hep_TestMTDIdealGeometry:testETL  24-Apr-2020 11:21:13 CEST Run: 1 Event: 1
 - OCMS[0]/CMSE[1]/
^@^@^@[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/serviceR1059Z2666[1]/
%MSG
```

where still spurious characters are printed at the end of the loop on the first ETL. This appears for D50 only, in any case the DetId and position sequences is consistent.