### PR TITLE
MTD validation: fixed python test config file

### DIFF
--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -1,10 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("mtdSimHitsValidation")
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+process = cms.Process('mtdValidation',Phase2C9)
+
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
-process.load("Configuration.Geometry.GeometryExtended2023D38_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D49_cff")
+
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi")
 process.load("Geometry.MTDNumberingBuilder.mtdTopology_cfi")
@@ -30,20 +35,26 @@ process.source = cms.Source("PoolSource",
     )
 )
 
+process.mix.digitizers = cms.PSet()
+for a in process.aliases: delattr(process, a)
+
 # --- BTL Validation
 process.load("Validation.MtdValidation.btlSimHits_cfi")
 process.load("Validation.MtdValidation.btlDigiHits_cfi")
-process.load("Validation.MtdValidation.btlRecHits_cfi")
-btlValidation = cms.Sequence(process.btlSimHits + process.btlDigiHits + process.btlRecHits)
+process.load("Validation.MtdValidation.btlLocalReco_cfi")
+btlValidation = cms.Sequence(process.btlSimHits + process.btlDigiHits + process.btlLocalReco)
 
 # --- ETL Validation
 process.load("Validation.MtdValidation.etlSimHits_cfi")
 process.load("Validation.MtdValidation.etlDigiHits_cfi")
-process.load("Validation.MtdValidation.etlRecHits_cfi")
-etlValidation = cms.Sequence(process.etlSimHits + process.etlDigiHits + process.etlRecHits)
+process.load("Validation.MtdValidation.etlLocalReco_cfi")
+etlValidation = cms.Sequence(process.etlSimHits + process.etlDigiHits + process.etlLocalReco)
+
+# --- Global Validation
+process.load("Validation.MtdValidation.globalReco_cfi")
 
 process.DQMStore = cms.Service("DQMStore")
 
 process.load("DQMServices.FileIO.DQMFileSaverOnline_cfi")
 
-process.p = cms.Path( btlValidation + etlValidation + process.dqmSaver )
+process.p = cms.Path( process.mix + btlValidation + etlValidation + process.globalReco + process.dqmSaver)


### PR DESCRIPTION
#### PR description:

The python config file to run the MTD validation stand-alone has been updated in order to read the MTD SimHits from the CrossingFrames and to be compatible with the latest developments (#29074 and #29275).