### PR TITLE
Simulate all ALCTs and CLCTs in the CSC trigger

### DIFF
--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -67,7 +67,8 @@ public:
     MAX_CLCTS_PER_PROCESSOR = 50,
     MAX_CLCTS_READOUT = 2,
     // Each ALCT processor can send up to 2 ALCTs to TMB per BX
-    MAX_ALCTS_PER_PROCESSOR = 2,
+    MAX_ALCTS_PER_PROCESSOR = 50,
+    MAX_ALCTS_READOUT = 2,
     // Each CSC can send up to 2 LCTs to the MPC per BX
     MAX_LCTS_PER_CSC = 2,
     // An MPC receives up to 18 LCTs from 9 CSCs in the trigger sector

--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -64,7 +64,8 @@ public:
     // Maximum allowed matching window size
     MAX_MATCH_WINDOW_SIZE = 15,
     // Each CLCT processor can send up to 2 CLCTs to TMB per BX
-    MAX_CLCTS_PER_PROCESSOR = 2,
+    MAX_CLCTS_PER_PROCESSOR = 50,
+    MAX_CLCTS_READOUT = 2,
     // Each ALCT processor can send up to 2 ALCTs to TMB per BX
     MAX_ALCTS_PER_PROCESSOR = 2,
     // Each CSC can send up to 2 LCTs to the MPC per BX

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -72,10 +72,10 @@ public:
   void run(const std::vector<int> wire[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES]);
 
   /** Returns vector of ALCTs in the read-out time window, if any. */
-  std::vector<CSCALCTDigi> readoutALCTs() const;
+  std::vector<CSCALCTDigi> readoutALCTs(int nMaxALCTs = CSCConstants::MAX_ALCTS_READOUT) const;
 
   /** Returns vector of all found ALCTs, if any. */
-  std::vector<CSCALCTDigi> getALCTs() const;
+  std::vector<CSCALCTDigi> getALCTs(int nMaxALCTs = CSCConstants::MAX_ALCTS_READOUT) const;
 
   /** read out pre-ALCTs */
   std::vector<CSCALCTPreTriggerDigi> preTriggerDigis() const { return thePreTriggerDigis; }
@@ -97,6 +97,9 @@ protected:
 
   /** Second best LCTs in this chamber, as found by the processor. */
   CSCALCTDigi secondALCT[CSCConstants::MAX_ALCT_TBINS];
+
+  /** LCTs in this chamber, as found by the processor. */
+  CSCALCTDigi ALCTContainer_[CSCConstants::MAX_ALCT_TBINS][CSCConstants::MAX_ALCTS_PER_PROCESSOR];
 
   /** Access routines to wire digis. */
   bool getDigis(const CSCWireDigiCollection* wiredc);

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -65,9 +65,9 @@ public:
   void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
   /** Returns vector of CLCTs in the read-out time window, if any. */
-  std::vector<CSCCLCTDigi> readoutCLCTs() const;
-  std::vector<CSCCLCTDigi> readoutCLCTsME1a() const;
-  std::vector<CSCCLCTDigi> readoutCLCTsME1b() const;
+  std::vector<CSCCLCTDigi> readoutCLCTs(int nMaxCLCTs = CSCConstants::MAX_CLCTS_READOUT) const;
+  std::vector<CSCCLCTDigi> readoutCLCTsME1a(int nMaxCLCTs = CSCConstants::MAX_CLCTS_READOUT) const;
+  std::vector<CSCCLCTDigi> readoutCLCTsME1b(int nMaxCLCTs = CSCConstants::MAX_CLCTS_READOUT) const;
 
   /** Returns vector of all found CLCTs, if any. */
   std::vector<CSCCLCTDigi> getCLCTs() const;
@@ -85,11 +85,8 @@ public:
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1b() const;
 
 protected:
-  /** Best LCT in this chamber, as found by the processor. */
-  CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_TBINS];
-
-  /** Second best LCT in this chamber, as found by the processor. */
-  CSCCLCTDigi secondCLCT[CSCConstants::MAX_CLCT_TBINS];
+  /** LCTs in this chamber, as found by the processor. */
+  CSCCLCTDigi CLCTContainer_[CSCConstants::MAX_CLCT_TBINS][CSCConstants::MAX_CLCTS_PER_PROCESSOR];
 
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -72,9 +72,11 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   if (writeOutAllALCTs_) {
     produces<CSCALCTDigiCollection>("All");
   }
-  produces<CSCCLCTPreTriggerDigiCollection>();
   produces<CSCCLCTPreTriggerCollection>();
-  produces<CSCALCTPreTriggerDigiCollection>();
+  if (savePreTriggers_) {
+    produces<CSCCLCTPreTriggerDigiCollection>();
+    produces<CSCALCTPreTriggerDigiCollection>();
+  }
   produces<CSCCorrelatedLCTDigiCollection>();
   produces<CSCCorrelatedLCTDigiCollection>("MPCSORTED");
   if (runME11ILT_ or runME21ILT_)

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -75,11 +75,9 @@ private:
   bool checkBadChambers_;
 
   // write out all CLCTs
-  // only relevant when CSCConstants::MAX_CLCTS_PER_PROCESSOR is > 2
   bool writeOutAllCLCTs_;
 
   // write out all ALCTs
-  // only relevant when CSCConstants::MAX_ALCTS_PER_PROCESSOR is > 2
   bool writeOutAllALCTs_;
 
   // Write out pre-triggers

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1142,7 +1142,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs(int nMaxCLCTs) con
   }
 
   // remove the CLCTs with an index larger than nMaxCLCTs
-  if (tmpV.size() > nMaxCLCTs) {
+  if (tmpV.size() > unsigned(nMaxCLCTs)) {
     tmpV.erase(tmpV.begin() + nMaxCLCTs, tmpV.end());
   }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -358,12 +358,13 @@ void CSCCathodeLCTProcessor::run(
   for (int bx = 0; bx < CSCConstants::MAX_CLCT_TBINS; bx++) {
     for (int iCLCT = 0; iCLCT < CSCConstants::MAX_CLCTS_PER_PROCESSOR; iCLCT++) {
       if (CLCTContainer_[bx][iCLCT].isValid()) {
-        CLCTContainer_[bx][iCLCT].setTrknmb(iCLCT+1);
+        CLCTContainer_[bx][iCLCT].setTrknmb(iCLCT + 1);
         if (infoV > 0) {
           LogDebug("CSCCathodeLCTProcessor")
-            << CLCTContainer_[bx][iCLCT] << " found in " << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
-            << " (sector " << theSector << " subsector " << theSubsector << " trig id. " << theTrigChamber << ")"
-            << "\n";
+              << CLCTContainer_[bx][iCLCT] << " found in "
+              << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber) << " (sector " << theSector
+              << " subsector " << theSubsector << " trig id. " << theTrigChamber << ")"
+              << "\n";
         }
       }
     }
@@ -615,10 +616,9 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
 
       // If 1st best CLCT is found, look for other CLCTs!
       if (best_halfstrip[0] >= 0) {
-
         for (int ilct = 1; ilct < CSCConstants::MAX_CLCTS_PER_PROCESSOR; ilct++) {
           // Mark keys near best CLCT as busy by setting their quality to zero, and repeat the search.
-          markBusyKeys(best_halfstrip[ilct-1], best_pid[best_halfstrip[ilct-1]], quality);
+          markBusyKeys(best_halfstrip[ilct - 1], best_pid[best_halfstrip[ilct - 1]], quality);
 
           for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
             if (quality[hstrip] > best_quality[ilct]) {
@@ -627,10 +627,10 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
             }
             if (infoV > 1 && quality[hstrip] > 0) {
               LogTrace("CSCCathodeLCTProcessor")
-                << "CLCT " << ilct+1 << ": halfstrip = " << std::setw(3) << hstrip << " quality = " << std::setw(3)
-                << quality[hstrip] << " nhits = " << std::setw(3) << nhits[hstrip] << " pid = " << std::setw(3)
-                << best_pid[hstrip] << " best halfstrip = " << std::setw(3) << best_halfstrip[1]
-                << " best quality = " << std::setw(3) << best_quality[1];
+                  << "CLCT " << ilct + 1 << ": halfstrip = " << std::setw(3) << hstrip << " quality = " << std::setw(3)
+                  << quality[hstrip] << " nhits = " << std::setw(3) << nhits[hstrip] << " pid = " << std::setw(3)
+                  << best_pid[hstrip] << " best halfstrip = " << std::setw(3) << best_halfstrip[1]
+                  << " best quality = " << std::setw(3) << best_quality[1];
             }
           }
         }
@@ -649,7 +649,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
             keystrip_data[ilct][CLCT_QUALITY] = nhits[best_hs];
             keystrip_data[ilct][CLCT_CFEB] = keystrip_data[ilct][CLCT_STRIP] / CSCConstants::NUM_HALF_STRIPS_PER_CFEB;
             const uint16_t halfstrip_in_cfeb = keystrip_data[ilct][CLCT_STRIP] -
-              CSCConstants::NUM_HALF_STRIPS_PER_CFEB * keystrip_data[ilct][CLCT_CFEB];
+                                               CSCConstants::NUM_HALF_STRIPS_PER_CFEB * keystrip_data[ilct][CLCT_CFEB];
 
             CSCCLCTDigi thisLCT(1,
                                 keystrip_data[ilct][CLCT_QUALITY],
@@ -671,8 +671,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
 
             // useful debugging
             if (infoV > 1) {
-              LogTrace("CSCCathodeLCTProcessor")
-                << " Final selection: ilct " << ilct << " " << thisLCT << std::endl;
+              LogTrace("CSCCathodeLCTProcessor") << " Final selection: ilct " << ilct << " " << thisLCT << std::endl;
             }
 
             // put the CLCT into the collection
@@ -1106,13 +1105,13 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs(int nMaxCLCTs) con
   int bx_readout = -1;
   const std::vector<CSCCLCTDigi>& all_lcts = getCLCTs();
   for (const auto& p : all_lcts) {
-
     // only consider valid CLCTs
     if (!p.isValid())
       continue;
 
     //ignore the CLCTs with an index larger than nMaxCLCTs
-    if (p.getTrknmb() > nMaxCLCTs) break;
+    if (p.getTrknmb() > nMaxCLCTs)
+      break;
 
     const int bx = p.getBX();
     // Skip CLCTs found too early relative to L1Accept.

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1109,10 +1109,6 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs(int nMaxCLCTs) con
     if (!p.isValid())
       continue;
 
-    //ignore the CLCTs with an index larger than nMaxCLCTs
-    if (p.getTrknmb() > nMaxCLCTs)
-      break;
-
     const int bx = p.getBX();
     // Skip CLCTs found too early relative to L1Accept.
     if (bx <= early_tbins) {
@@ -1144,6 +1140,12 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs(int nMaxCLCTs) con
     } else
       tmpV.push_back(p);
   }
+
+  // remove the CLCTs with an index larger than nMaxCLCTs
+  if (tmpV.size() > nMaxCLCTs) {
+    tmpV.erase(tmpV.begin() + nMaxCLCTs, tmpV.end());
+  }
+
   return tmpV;
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -177,7 +177,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = tmb11->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = tmb11->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11->clctProc->readoutCLCTsME1b();
-              const std::vector<CSCCLCTDigi>& clctV_all = tmb11->clctProc->readoutCLCTsME1b(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
+              const std::vector<CSCCLCTDigi>& clctV_all =
+                  tmb11->clctProc->readoutCLCTsME1b(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = tmb11->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11->clctProc->preTriggerDigisME1b();
               const std::vector<CSCCLCTDigi>& clctV1a = tmb11->clctProc->readoutCLCTsME1a();
@@ -246,7 +247,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = tmb11GEM->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = tmb11GEM->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11GEM->clctProc->readoutCLCTsME1b();
-              const std::vector<CSCCLCTDigi>& clctV_all = tmb11GEM->clctProc->readoutCLCTsME1b(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
+              const std::vector<CSCCLCTDigi>& clctV_all =
+                  tmb11GEM->clctProc->readoutCLCTsME1b(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = tmb11GEM->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11GEM->clctProc->preTriggerDigisME1b();
               const std::vector<CSCCLCTDigi>& clctV1a = tmb11GEM->clctProc->readoutCLCTsME1a();
@@ -307,7 +309,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = tmb21GEM->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = tmb21GEM->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb21GEM->clctProc->readoutCLCTs();
-              const std::vector<CSCCLCTDigi>& clctV_all = tmb21GEM->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
+              const std::vector<CSCCLCTDigi>& clctV_all =
+                  tmb21GEM->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = tmb21GEM->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb21GEM->clctProc->preTriggerDigis();
               const std::vector<GEMCoPadDigi>& copads = tmb21GEM->coPadProcessor->readoutCoPads();
@@ -340,7 +343,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = utmb->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = utmb->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = utmb->clctProc->readoutCLCTs();
-              const std::vector<CSCCLCTDigi>& clctV_all = utmb->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
+              const std::vector<CSCCLCTDigi>& clctV_all =
+                  utmb->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = utmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = utmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = utmb->alctProc->preTriggerDigis();
@@ -370,7 +374,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = tmb->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = tmb->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb->clctProc->readoutCLCTs();
-              const std::vector<CSCCLCTDigi>& clctV_all = tmb->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
+              const std::vector<CSCCLCTDigi>& clctV_all =
+                  tmb->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = tmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb->alctProc->preTriggerDigis();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -175,7 +175,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb11->readoutLCTs1b();
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11->readoutLCTs1a();
               const std::vector<CSCALCTDigi>& alctV = tmb11->alctProc->readoutALCTs();
-              const std::vector<CSCALCTDigi>& alctV_all = tmb11->alctProc->getALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all =
+                  tmb11->alctProc->readoutALCTs(CSCConstants::MAX_ALCTS_PER_PROCESSOR);
               const std::vector<CSCCLCTDigi>& clctV = tmb11->clctProc->readoutCLCTsME1b();
               const std::vector<CSCCLCTDigi>& clctV_all =
                   tmb11->clctProc->readoutCLCTsME1b(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
@@ -245,7 +246,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb11GEM->readoutLCTs1b();
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11GEM->readoutLCTs1a();
               const std::vector<CSCALCTDigi>& alctV = tmb11GEM->alctProc->readoutALCTs();
-              const std::vector<CSCALCTDigi>& alctV_all = tmb11GEM->alctProc->getALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all =
+                  tmb11GEM->alctProc->readoutALCTs(CSCConstants::MAX_ALCTS_PER_PROCESSOR);
               const std::vector<CSCCLCTDigi>& clctV = tmb11GEM->clctProc->readoutCLCTsME1b();
               const std::vector<CSCCLCTDigi>& clctV_all =
                   tmb11GEM->clctProc->readoutCLCTsME1b(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
@@ -307,7 +309,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb21GEM->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = tmb21GEM->alctProc->readoutALCTs();
-              const std::vector<CSCALCTDigi>& alctV_all = tmb21GEM->alctProc->getALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all =
+                  tmb21GEM->alctProc->readoutALCTs(CSCConstants::MAX_ALCTS_PER_PROCESSOR);
               const std::vector<CSCCLCTDigi>& clctV = tmb21GEM->clctProc->readoutCLCTs();
               const std::vector<CSCCLCTDigi>& clctV_all =
                   tmb21GEM->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
@@ -341,7 +344,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = utmb->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = utmb->alctProc->readoutALCTs();
-              const std::vector<CSCALCTDigi>& alctV_all = utmb->alctProc->getALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all =
+                  utmb->alctProc->readoutALCTs(CSCConstants::MAX_ALCTS_PER_PROCESSOR);
               const std::vector<CSCCLCTDigi>& clctV = utmb->clctProc->readoutCLCTs();
               const std::vector<CSCCLCTDigi>& clctV_all =
                   utmb->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
@@ -372,7 +376,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = tmb->alctProc->readoutALCTs();
-              const std::vector<CSCALCTDigi>& alctV_all = tmb->alctProc->getALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all =
+                  tmb->alctProc->readoutALCTs(CSCConstants::MAX_ALCTS_PER_PROCESSOR);
               const std::vector<CSCCLCTDigi>& clctV = tmb->clctProc->readoutCLCTs();
               const std::vector<CSCCLCTDigi>& clctV_all =
                   tmb->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -177,8 +177,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = tmb11->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = tmb11->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11->clctProc->readoutCLCTsME1b();
-              const std::vector<CSCCLCTDigi>& clctV_all = tmb11->clctProc->getCLCTs();
-              const std::vector<int> preTriggerBXs = tmb11->clctProc->preTriggerBXs();
+              const std::vector<CSCCLCTDigi>& clctV_all = tmb11->clctProc->readoutCLCTsME1b(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
+              const std::vector<int>& preTriggerBXs = tmb11->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11->clctProc->preTriggerDigisME1b();
               const std::vector<CSCCLCTDigi>& clctV1a = tmb11->clctProc->readoutCLCTsME1a();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11->clctProc->preTriggerDigisME1a();
@@ -246,7 +246,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = tmb11GEM->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = tmb11GEM->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11GEM->clctProc->readoutCLCTsME1b();
-              const std::vector<CSCCLCTDigi>& clctV_all = tmb11GEM->clctProc->getCLCTs();
+              const std::vector<CSCCLCTDigi>& clctV_all = tmb11GEM->clctProc->readoutCLCTsME1b(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = tmb11GEM->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11GEM->clctProc->preTriggerDigisME1b();
               const std::vector<CSCCLCTDigi>& clctV1a = tmb11GEM->clctProc->readoutCLCTsME1a();
@@ -307,7 +307,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = tmb21GEM->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = tmb21GEM->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb21GEM->clctProc->readoutCLCTs();
-              const std::vector<CSCCLCTDigi>& clctV_all = tmb21GEM->clctProc->getCLCTs();
+              const std::vector<CSCCLCTDigi>& clctV_all = tmb21GEM->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = tmb21GEM->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb21GEM->clctProc->preTriggerDigis();
               const std::vector<GEMCoPadDigi>& copads = tmb21GEM->coPadProcessor->readoutCoPads();
@@ -340,7 +340,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = utmb->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = utmb->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = utmb->clctProc->readoutCLCTs();
-              const std::vector<CSCCLCTDigi>& clctV_all = utmb->clctProc->getCLCTs();
+              const std::vector<CSCCLCTDigi>& clctV_all = utmb->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = utmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = utmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = utmb->alctProc->preTriggerDigis();
@@ -370,7 +370,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCALCTDigi>& alctV = tmb->alctProc->readoutALCTs();
               const std::vector<CSCALCTDigi>& alctV_all = tmb->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb->clctProc->readoutCLCTs();
-              const std::vector<CSCCLCTDigi>& clctV_all = tmb->clctProc->getCLCTs();
+              const std::vector<CSCCLCTDigi>& clctV_all = tmb->clctProc->readoutCLCTs(CSCConstants::MAX_CLCTS_PER_PROCESSOR);
               const std::vector<int>& preTriggerBXs = tmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb->alctProc->preTriggerDigis();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -272,10 +272,9 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
 
       // If 1st best CLCT is found, look for the 2nd best.
       if (best_halfstrip[0] >= 0) {
-
         for (int ilct = 1; ilct < CSCConstants::MAX_CLCTS_PER_PROCESSOR; ilct++) {
           // Mark keys near best CLCT as busy by setting their quality to zero, and repeat the search.
-          markBusyKeys(best_halfstrip[ilct-1], best_pid[best_halfstrip[ilct-1]], quality);
+          markBusyKeys(best_halfstrip[ilct - 1], best_pid[best_halfstrip[ilct - 1]], quality);
 
           for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
             if (quality[hstrip] > best_quality[ilct] && pretrig_zone[hstrip] && !busyMap[hstrip][first_bx]) {
@@ -283,10 +282,10 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
               best_quality[ilct] = quality[hstrip];
               if (infoV > 1) {
                 LogTrace("CSCCathodeLCTProcessor")
-                  << "CLCT " << ilct+1 << ": halfstrip = " << std::setw(3) << hstrip << " quality = " << std::setw(3)
-                  << quality[hstrip] << " nhits = " << std::setw(3) << nhits[hstrip] << " pid = " << std::setw(3)
-                  << best_pid[hstrip] << " best halfstrip = " << std::setw(3) << best_halfstrip[ilct]
-                  << " best quality = " << std::setw(3) << best_quality[ilct];
+                    << "CLCT " << ilct + 1 << ": halfstrip = " << std::setw(3) << hstrip
+                    << " quality = " << std::setw(3) << quality[hstrip] << " nhits = " << std::setw(3) << nhits[hstrip]
+                    << " pid = " << std::setw(3) << best_pid[hstrip] << " best halfstrip = " << std::setw(3)
+                    << best_halfstrip[ilct] << " best quality = " << std::setw(3) << best_quality[ilct];
               }
             }
           }
@@ -325,8 +324,7 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
                                 keystrip_data[ilct][CLCT_CFEB],
                                 keystrip_data[ilct][CLCT_BX]);
             if (infoV > 1) {
-              LogTrace("CSCCathodeLCTProcessor")
-                << " Final selection: ilct " << ilct << " " << thisLCT << std::endl;
+              LogTrace("CSCCathodeLCTProcessor") << " Final selection: ilct " << ilct << " " << thisLCT << std::endl;
             }
             thisLCT.setFullBX(fbx);
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -278,15 +278,15 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
           markBusyKeys(best_halfstrip[ilct-1], best_pid[best_halfstrip[ilct-1]], quality);
 
           for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
-            if (quality[hstrip] > best_quality[1] && pretrig_zone[hstrip] && !busyMap[hstrip][first_bx]) {
+            if (quality[hstrip] > best_quality[ilct] && pretrig_zone[hstrip] && !busyMap[hstrip][first_bx]) {
               best_halfstrip[ilct] = hstrip;
               best_quality[ilct] = quality[hstrip];
               if (infoV > 1) {
                 LogTrace("CSCCathodeLCTProcessor")
                   << "CLCT " << ilct+1 << ": halfstrip = " << std::setw(3) << hstrip << " quality = " << std::setw(3)
                   << quality[hstrip] << " nhits = " << std::setw(3) << nhits[hstrip] << " pid = " << std::setw(3)
-                  << best_pid[hstrip] << " best halfstrip = " << std::setw(3) << best_halfstrip[1]
-                  << " best quality = " << std::setw(3) << best_quality[1];
+                  << best_pid[hstrip] << " best halfstrip = " << std::setw(3) << best_halfstrip[ilct]
+                  << " best quality = " << std::setw(3) << best_quality[ilct];
               }
             }
           }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -272,20 +272,22 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
 
       // If 1st best CLCT is found, look for the 2nd best.
       if (best_halfstrip[0] >= 0) {
-        // Mark keys near best CLCT as busy by setting their quality to zero, and repeat the search.
-        markBusyKeys(best_halfstrip[0], best_pid[best_halfstrip[0]], quality);
 
-        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
-          if (quality[hstrip] > best_quality[1] && pretrig_zone[hstrip] && !busyMap[hstrip][first_bx])
-          //!busyMap[hstrip][latch_bx] )
-          {
-            best_halfstrip[1] = hstrip;
-            best_quality[1] = quality[hstrip];
-            if (infoV > 1) {
-              LogTrace("CSCUpgradeCathodeLCTProcessor")
-                  << " 2nd CLCT: halfstrip = " << std::setw(3) << hstrip << " quality = " << std::setw(3)
-                  << quality[hstrip] << " best halfstrip = " << std::setw(3) << best_halfstrip[1]
+        for (int ilct = 1; ilct < CSCConstants::MAX_CLCTS_PER_PROCESSOR; ilct++) {
+          // Mark keys near best CLCT as busy by setting their quality to zero, and repeat the search.
+          markBusyKeys(best_halfstrip[ilct-1], best_pid[best_halfstrip[ilct-1]], quality);
+
+          for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+            if (quality[hstrip] > best_quality[1] && pretrig_zone[hstrip] && !busyMap[hstrip][first_bx]) {
+              best_halfstrip[ilct] = hstrip;
+              best_quality[ilct] = quality[hstrip];
+              if (infoV > 1) {
+                LogTrace("CSCCathodeLCTProcessor")
+                  << "CLCT " << ilct+1 << ": halfstrip = " << std::setw(3) << hstrip << " quality = " << std::setw(3)
+                  << quality[hstrip] << " nhits = " << std::setw(3) << nhits[hstrip] << " pid = " << std::setw(3)
+                  << best_pid[hstrip] << " best halfstrip = " << std::setw(3) << best_halfstrip[1]
                   << " best quality = " << std::setw(3) << best_quality[1];
+              }
             }
           }
         }
@@ -314,12 +316,6 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
             int halfstrip_in_cfeb = keystrip_data[ilct][CLCT_STRIP] -
                                     CSCConstants::NUM_HALF_STRIPS_PER_CFEB * keystrip_data[ilct][CLCT_CFEB];
 
-            if (infoV > 1)
-              LogTrace("CSCUpgradeCathodeLCTProcessor")
-                  << " Final selection: ilct " << ilct << " key halfstrip " << keystrip_data[ilct][CLCT_STRIP]
-                  << " quality " << keystrip_data[ilct][CLCT_QUALITY] << " pattern "
-                  << keystrip_data[ilct][CLCT_PATTERN] << " bx " << keystrip_data[ilct][CLCT_BX];
-
             CSCCLCTDigi thisLCT(1,
                                 keystrip_data[ilct][CLCT_QUALITY],
                                 keystrip_data[ilct][CLCT_PATTERN],
@@ -328,6 +324,10 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
                                 halfstrip_in_cfeb,
                                 keystrip_data[ilct][CLCT_CFEB],
                                 keystrip_data[ilct][CLCT_BX]);
+            if (infoV > 1) {
+              LogTrace("CSCCathodeLCTProcessor")
+                << " Final selection: ilct " << ilct << " " << thisLCT << std::endl;
+            }
             thisLCT.setFullBX(fbx);
 
             // get the comparator hits for this pattern


### PR DESCRIPTION
#### PR description:

The CSC trigger, more specific the ALCT and CLCT processors, consider all possible patterns for each wire-group and half-strip. However, this is in fact never done in the simulation. This pull request addresses that for the CLCT processor. In another PR, I'll do the same for the ALCT processor. Note that the correlation of ALCT and CLCT still only considers the best/second best of ALCT and CLCT.

Edit: I added an updated for the ALCT processor, simulating all ALCTs. 

#### PR validation:

I made a few validation plots (see below) by re-emulating the ALCT/CLCT and LCT on 25000 events in the file block ```/ZeroBias/Run2018D-v1/RAW#5dd68d0d-5a62-4bfe-9065-cc0cd92e3f3e``` (```/store/data/Run2018D/ZeroBias/RAW/v1/000/324/022/00000/```). 
- For CLCTs: Black are the unpacked CLCTs. Red are the re-emulated CLCTs from RAW digis. 
- For LCTs: Black are the unpacked LCTs. Blue and red are the re-emulated LCTs from RAW digis.

Plots look good. You will notice slightly bigger differences from the positive endcap ("pAll"). This is because we were testing newer firmware during the 2018D period on a few ME+1/1 chambers.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 