### PR TITLE
Fix phase2 tracker premixed digis

### DIFF
--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -224,7 +224,8 @@ phase2_tracker.toModify(mixData,
             pixelPileInputTag = cms.InputTag("simSiPixelDigis:Pixel"),
             trackerLabelSig = cms.InputTag("simSiPixelDigis:Tracker"),
             trackerPileInputTag = cms.InputTag("simSiPixelDigis:Tracker"),
-            premixStage1ElectronPerAdc = cms.double(_phase2TrackerPremixStage1ModifyDict["PixelDigitizerAlgorithm"]["ElectronPerAdc"])
+            pixelPmxStage1ElectronPerAdc = cms.double(phase2TrackerDigitizer.PixelDigitizerAlgorithm.ElectronPerAdc.value()),
+            trackerPmxStage1ElectronPerAdc = cms.double(phase2TrackerDigitizer.PSPDigitizerAlgorithm.ElectronPerAdc.value())
         ),
         pixelSimLink = dict(
             labelSig = "simSiPixelDigis:Pixel",

--- a/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
@@ -31,7 +31,7 @@ public:
   void put(edm::Event& e, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bs) override;
 
 private:
-  void accumulate(const edm::DetSetVector<PixelDigi>& digis,const float electronsPerADC);
+  void accumulate(const edm::DetSetVector<PixelDigi>& digis, const float electronsPerADC);
 
   cms::Phase2TrackerDigitizer digitizer_;
 
@@ -70,22 +70,22 @@ void PreMixingPhase2TrackerWorker::initializeEvent(edm::Event const& e, edm::Eve
 void PreMixingPhase2TrackerWorker::addSignals(edm::Event const& e, edm::EventSetup const& es) {
   edm::Handle<edm::DetSetVector<PixelDigi>> hdigis;
   e.getByToken(pixelSignalToken_, hdigis);
-  accumulate(*hdigis,pixelElectronPerAdc_);
+  accumulate(*hdigis, pixelElectronPerAdc_);
 
   e.getByToken(trackerSignalToken_, hdigis);
-  accumulate(*hdigis,trackerElectronPerAdc_);
+  accumulate(*hdigis, trackerElectronPerAdc_);
 }
 
 void PreMixingPhase2TrackerWorker::addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& es) {
   edm::Handle<edm::DetSetVector<PixelDigi>> hdigis;
   pep.getByLabel(pixelPileupLabel_, hdigis);
-  accumulate(*hdigis,pixelElectronPerAdc_);
+  accumulate(*hdigis, pixelElectronPerAdc_);
 
   pep.getByLabel(trackerPileupLabel_, hdigis);
-  accumulate(*hdigis,trackerElectronPerAdc_);
+  accumulate(*hdigis, trackerElectronPerAdc_);
 }
 
-void PreMixingPhase2TrackerWorker::accumulate(const edm::DetSetVector<PixelDigi>& digis,const float electronPerADC) {
+void PreMixingPhase2TrackerWorker::accumulate(const edm::DetSetVector<PixelDigi>& digis, const float electronPerADC) {
   for (const auto& detset : digis) {
     auto& accDet = accumulator_[detset.detId()];
     for (const auto& digi : detset) {

--- a/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
@@ -31,7 +31,7 @@ public:
   void put(edm::Event& e, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bs) override;
 
 private:
-  void accumulate(const edm::DetSetVector<PixelDigi>& digis);
+  void accumulate(const edm::DetSetVector<PixelDigi>& digis,const float electronsPerADC);
 
   cms::Phase2TrackerDigitizer digitizer_;
 
@@ -39,7 +39,8 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> trackerSignalToken_;
   edm::InputTag pixelPileupLabel_;
   edm::InputTag trackerPileupLabel_;
-  float electronPerAdc_;
+  float pixelElectronPerAdc_;
+  float trackerElectronPerAdc_;
 
   // Maybe map of maps is not that bad for this add once, update once,
   // read once workflow?
@@ -55,7 +56,8 @@ PreMixingPhase2TrackerWorker::PreMixingPhase2TrackerWorker(const edm::ParameterS
       trackerSignalToken_(iC.consumes<edm::DetSetVector<PixelDigi>>(ps.getParameter<edm::InputTag>("trackerLabelSig"))),
       pixelPileupLabel_(ps.getParameter<edm::InputTag>("pixelPileInputTag")),
       trackerPileupLabel_(ps.getParameter<edm::InputTag>("trackerPileInputTag")),
-      electronPerAdc_(ps.getParameter<double>("premixStage1ElectronPerAdc")) {}
+      pixelElectronPerAdc_(ps.getParameter<double>("pixelPmxStage1ElectronPerAdc")),
+      trackerElectronPerAdc_(ps.getParameter<double>("trackerPmxStage1ElectronPerAdc")) {}
 
 void PreMixingPhase2TrackerWorker::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& es) {
   digitizer_.beginLuminosityBlock(lumi, es);
@@ -68,29 +70,29 @@ void PreMixingPhase2TrackerWorker::initializeEvent(edm::Event const& e, edm::Eve
 void PreMixingPhase2TrackerWorker::addSignals(edm::Event const& e, edm::EventSetup const& es) {
   edm::Handle<edm::DetSetVector<PixelDigi>> hdigis;
   e.getByToken(pixelSignalToken_, hdigis);
-  accumulate(*hdigis);
+  accumulate(*hdigis,pixelElectronPerAdc_);
 
   e.getByToken(trackerSignalToken_, hdigis);
-  accumulate(*hdigis);
+  accumulate(*hdigis,trackerElectronPerAdc_);
 }
 
 void PreMixingPhase2TrackerWorker::addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& es) {
   edm::Handle<edm::DetSetVector<PixelDigi>> hdigis;
   pep.getByLabel(pixelPileupLabel_, hdigis);
-  accumulate(*hdigis);
+  accumulate(*hdigis,pixelElectronPerAdc_);
 
   pep.getByLabel(trackerPileupLabel_, hdigis);
-  accumulate(*hdigis);
+  accumulate(*hdigis,trackerElectronPerAdc_);
 }
 
-void PreMixingPhase2TrackerWorker::accumulate(const edm::DetSetVector<PixelDigi>& digis) {
+void PreMixingPhase2TrackerWorker::accumulate(const edm::DetSetVector<PixelDigi>& digis,const float electronPerADC) {
   for (const auto& detset : digis) {
     auto& accDet = accumulator_[detset.detId()];
     for (const auto& digi : detset) {
       // note: according to C++ standard operator[] does
       // value-initializiation, which for float means initial value of 0
       auto& acc = accDet[digi.channel()];
-      acc += digi.adc() * electronPerAdc_;
+      acc += digi.adc() * electronPerADC;
     }
   }
 }

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -221,9 +221,6 @@ phase2TrackerDigitizer = cms.PSet(
 # - do not apply inefficiency (to be done in stage2)
 # - disable threshold smearing
 #
-# For inner pixel
-# - extend the dynamic range of ADCs
-#
 # For outer tracker
 # - force analog readout to get the ADCs
 #
@@ -235,8 +232,6 @@ _premixStage1ModifyDict = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
-        ElectronPerAdc = phase2TrackerDigitizer.PSPDigitizerAlgorithm.ElectronPerAdc.value(),
-        AdcFullScale = phase2TrackerDigitizer.PSPDigitizerAlgorithm.AdcFullScale.value(),
     ),
     PSPDigitizerAlgorithm = dict(
         AddNoisyPixels = False,

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -242,6 +242,7 @@ _premixStage1ModifyDict = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
+        Phase2ReadoutMode = -1
     ),
     SSDigitizerAlgorithm = dict(
         AddNoisyPixels = False,


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/29563

#### PR description:

Solves the two issues reported at https://github.com/cms-sw/cmssw/issues/29563 by:
1. allowing the collections of `PixelDigi`s produced by the premixing stage-1 and the signal digitization in step2 with two different conversion factor for IT and OT and then let the PreMixingPhase2TrackerWorker to undo the conversion separately for IT and OT.
2.  configuring the Phase-2 digitizer to have analog readout for OT (for the PSS layers) at step 1 of pre-mixing, as actual charge information is essential.

#### PR validation:

Validation has been run twice:
  *  I tested wf 23461.99 (SingleNu gun - premixed, PU=200, Geometry = D49) and compared it with the same workflow run in a vanilla CMSSW_11_1_0_pre6 release and with the equivalent standard mixing workflow 23461.0 (SingleNu gun - standard mixing, PU=200, Geometry = D49).
  * @suchandradutta tested also the changes with a signal TTbar + PU=200 sample and obtained the results below:

1. IT digis issue: 
![image](https://user-images.githubusercontent.com/5082376/80355896-f2d94600-8878-11ea-94ee-87a52dd5c32b.png)

2. OT digis issue:
![image](https://user-images.githubusercontent.com/5082376/80355977-11d7d800-8879-11ea-8945-b7093b30da11.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.
@suchandradutta @emiglior @skinnari @tsusa 
