### PR TITLE
Update eventcontent structure in RecoTauTag RecoMTD

### DIFF
--- a/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
+++ b/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
@@ -4,12 +4,17 @@ import FWCore.ParameterSet.Config as cms
 RecoMTDAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_trackExtenderWithMTD_*_*',
-        'keep *_mtdTrackQualityMVA_*_*'
-        )
+        'keep *_mtdTrackQualityMVA_*_*')
 )
 
 #RECO content
-RecoMTDRECO = RecoMTDAOD.copy()
+RecoMTDRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring() 
+)
+RecoMTDRECO.outputCommands.extend(RecoMTDAOD.outputCommands)
 
 #FEVT content
-RecoMTDFEVT = RecoMTDRECO.copy()
+RecoMTDFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring() 
+)
+RecoMTDFEVT.outputCommands.extend(RecoMTDRECO.outputCommands)

--- a/RecoTauTag/Configuration/python/RecoTauTag_EventContent_cff.py
+++ b/RecoTauTag/Configuration/python/RecoTauTag_EventContent_cff.py
@@ -1,38 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content
-RecoTauTagFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_ak4PFJetsRecoTauPiZeros_*_*',
-        'keep *_hpsPFTauProducer_*_*',
-        'keep *_hpsPFTauDiscrimination*_*_*',
-        'keep *_hpsPFTau*PtSum_*_*',
-        'keep *_hpsPFTauTransverseImpactParameters_*_*'
-    )
-)
-#RECO content
-RecoTauTagRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep recoRecoTauPiZeros_hpsPFTauProducer_pizeros_*',
-        'keep recoPFTaus_hpsPFTauProducer_*_*',
-        'keep *_hpsPFTauBasicDiscriminators_*_*',
-        'keep *_hpsPFTauBasicDiscriminatorsdR03_*_*',
-        'keep *_hpsPFTauDiscriminationByDeadECALElectronRejection_*_*',
-        'keep *_hpsPFTauDiscriminationByDecayModeFinding_*_*',
-        'keep *_hpsPFTauDiscriminationByDecayModeFindingNewDMs_*_*',
-        'keep *_hpsPFTauDiscriminationByDecayModeFindingOldDMs_*_*',
-        'keep *_hpsPFTauDiscriminationByLooseElectronRejection_*_*',
-        'keep *_hpsPFTauDiscriminationByMuonRejection3_*_*',
-        'keep *_hpsPFTauTransverseImpactParameters_*_*',
-        'keep *_hpsPFTauDiscriminationByMVA6ElectronRejection_*_*',
-        'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT_*_*',
-        'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLT_*_*',
-        'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1PWoldDMwLT_*_*',
-        'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1PWnewDMwLT_*_*',
-        'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLT_*_*',
-        'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLT_*_*',
-    )
-)
 #AOD content
 RecoTauTagAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -52,7 +19,22 @@ RecoTauTagAOD = cms.PSet(
         'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1PWoldDMwLT_*_*',
         'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1PWnewDMwLT_*_*',
         'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLT_*_*',
-        'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLT_*_*',
-    )
+        'keep *_hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLT_*_*')
 )
 
+#RECO content
+RecoTauTagRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_hpsPFTauDiscriminationByLooseElectronRejection_*_*')
+)
+RecoTauTagRECO.outputCommands.extend(RecoTauTagAOD.outputCommands)
+
+#Full Event content
+RecoTauTagFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_ak4PFJetsRecoTauPiZeros_*_*',
+        'keep *_hpsPFTauProducer_*_*',
+        'keep *_hpsPFTauDiscrimination*_*_*',
+        'keep *_hpsPFTau*PtSum_*_*')
+)
+RecoTauTagFEVT.outputCommands.extend(RecoTauTagRECO.outputCommands)


### PR DESCRIPTION
#### PR description:  
Update event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. 2 file changed : 
+ RecoTauTag_EventContent_cff.py 
+ RecoMTD_EventContent_cff.py 

(The previous tasks are [PR#29025](https://github.com/cms-sw/cmssw/pull/29025), [PR#29158](https://github.com/cms-sw/cmssw/pull/29158), [PR#29225](https://github.com/cms-sw/cmssw/pull/29225), [PR#29299](https://github.com/cms-sw/cmssw/pull/29299), [PR#29470](https://github.com/cms-sw/cmssw/pull/29470), [PR#29517](https://github.com/cms-sw/cmssw/pull/29517), and  [PR#29535](https://github.com/cms-sw/cmssw/pull/29535))

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).