### PR TITLE
[LLVM10] Fixing compilation warnings for Reco2

### DIFF
--- a/CommonTools/RecoAlgos/test/FKDTree_t.cpp
+++ b/CommonTools/RecoAlgos/test/FKDTree_t.cpp
@@ -35,9 +35,9 @@ void TestFKDTree::test2D() {
     unsigned int id = 0;
 
     for (unsigned int i = 0; i < numberOfPointsInTheBox; ++i) {
-      float x = minX + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxX - minX)));
+      float x = minX + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(maxX - minX));
 
-      float y = minY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxY - minY)));
+      float y = minY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(maxY - minY));
 
       points.emplace_back(x, y, id);
       id++;
@@ -47,7 +47,7 @@ void TestFKDTree::test2D() {
       float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
       float y;
       if (x <= maxX && x >= minX)
-        y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(1.f - maxY)));
+        y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(1.f - maxY));
 
       points.emplace_back(x, y, id);
       id++;
@@ -82,10 +82,10 @@ void TestFKDTree::test3D() {
     unsigned int id = 0;
 
     for (unsigned int i = 0; i < numberOfPointsInTheBox; ++i) {
-      float x = minX + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxX - minX)));
+      float x = minX + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(maxX - minX));
 
-      float y = minY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxY - minY)));
-      float z = minZ + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxZ - minZ)));
+      float y = minY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(maxY - minY));
+      float z = minZ + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(maxZ - minZ));
 
       points.emplace_back(x, y, z, id);
       id++;
@@ -95,8 +95,8 @@ void TestFKDTree::test3D() {
       float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
       float y;
       if (x <= maxX && x >= minX)
-        y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(1.f - maxY)));
-      float z = minZ + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxZ - minZ)));
+        y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(1.f - maxY));
+      float z = minZ + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(maxZ - minZ));
 
       points.emplace_back(x, y, z, id);
       id++;

--- a/DataFormats/Math/interface/approx_atan2.h
+++ b/DataFormats/Math/interface/approx_atan2.h
@@ -121,7 +121,7 @@ constexpr float unsafe_atan2f(float y, float x) {
 
 template <int DEGREE>
 constexpr float safe_atan2f(float y, float x) {
-  return unsafe_atan2f_impl<DEGREE>(y, (y == 0.f) & (x == 0.f) ? 0.2f : x);
+  return unsafe_atan2f_impl<DEGREE>(y, ((y == 0.f) & (x == 0.f)) ? 0.2f : x);
   // return (y==0.f)&(x==0.f) ? 0.f :  unsafe_atan2f_impl<DEGREE>( y, x);
 }
 

--- a/DataFormats/SiStripDigi/interface/SiStripDigi.h
+++ b/DataFormats/SiStripDigi/interface/SiStripDigi.h
@@ -14,7 +14,7 @@ public:
   SiStripDigi(const uint16_t& strip, const uint16_t& adc) : strip_(strip), adc_(adc) { ; }
 
   SiStripDigi() : strip_(0), adc_(0) { ; }
-  ~SiStripDigi() { ; }
+  ~SiStripDigi() = default;
 
   inline const uint16_t& strip() const;
   inline const uint16_t& adc() const;

--- a/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
+++ b/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
@@ -17,7 +17,7 @@ public:
   explicit SiStripRawDigi(uint16_t adc) : adc_(adc) {}
 
   SiStripRawDigi() : adc_(0) {}
-  ~SiStripRawDigi() {}
+  ~SiStripRawDigi() = default;
 
   inline uint16_t adc() const { return adc_; }
 

--- a/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxDigiToRaw.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxDigiToRaw.cc
@@ -95,7 +95,7 @@ void RPCTwinMuxDigiToRaw::produce(edm::Event& event, edm::EventSetup const& setu
 
   std::map<int, FEDRawData> fed_data;
   // Loop over the FEDs
-  for (std::pair<int, std::vector<RPCAMCLink> > const& fed_amcs : fed_amcs_) {
+  for (std::pair<const int, std::vector<RPCAMCLink> > const& fed_amcs : fed_amcs_) {
     FEDRawData& data = data_collection->FEDData(fed_amcs.first);
     unsigned int size(0);
 

--- a/RecoBTag/TensorFlow/plugins/DeepVertexTFJetTagsProducer.cc
+++ b/RecoBTag/TensorFlow/plugins/DeepVertexTFJetTagsProducer.cc
@@ -101,7 +101,7 @@ DeepVertexTFJetTagsProducer::DeepVertexTFJetTagsProducer(const edm::ParameterSet
 
   // get output names from flav_table
   const auto& flav_pset = iConfig.getParameter<edm::ParameterSet>("flav_table");
-  for (const auto flav_pair : flav_pset.tbl()) {
+  for (const auto& flav_pair : flav_pset.tbl()) {
     const auto& flav_name = flav_pair.first;
     flav_pairs_.emplace_back(flav_name, flav_pset.getParameter<std::vector<unsigned int>>(flav_name));
   }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -445,7 +445,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
   // muons first - no cleaning, take as is.
   if (muonCollectionHandle_.isValid()) {
-    for (const auto muon : *muonCollectionHandle_) {
+    for (const auto& muon : *muonCollectionHandle_) {
       outputMuons->push_back(muon);
     }
   }

--- a/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.cc
@@ -119,7 +119,7 @@ namespace {
     Stream ss;
     for (auto const& spansLayers : spansLayerSets) {
       ss << "Overlapping detGroups:\n";
-      for (auto const cspan : spansLayers.first) {
+      for (auto const& cspan : spansLayers.first) {
         detGroupSpanInfo(cspan, ss);
         ss << std::endl;
       }

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
@@ -43,7 +43,7 @@ void TrackProducerAlgorithm<T>::runWithCandidate(const TrackingGeometry* theG,
 
   int cont = 0;
   int ntc = 0;
-  for (auto const theTC : theTCCollection) {
+  for (auto const& theTC : theTCCollection) {
     PTrajectoryStateOnDet const& state = theTC.trajectoryStateOnDet();
     const TrackCandidate::range& recHitVec = theTC.recHits();
     const TrajectorySeed& seed = theTC.seed();

--- a/TrackingTools/DetLayers/src/GeomDetCompatibilityChecker.cc
+++ b/TrackingTools/DetLayers/src/GeomDetCompatibilityChecker.cc
@@ -73,7 +73,7 @@ std::pair<bool, TrajectoryStateOnSurface> GeomDetCompatibilityChecker::isCompati
   */
 
   bool isIn = false;
-  float sagitta = 99999999;
+  float sagitta = 99999999.0f;
   bool close = false;
   if
     LIKELY(sagCut > 0) {


### PR DESCRIPTION
#### PR description:

LLVM 10 integration in CLANG IBs shows new compilation warnings. This PR fixes few of these from reconstruction packages
- Avoid creating loop variable copy
- fix implicit conversion warnings

#### PR validation:

Local compilation for CLANG and normal IBs show no warnings.