### PR TITLE
Make it possible to pass command line arguments to python config file…

### DIFF
--- a/FWCore/PythonParameterSet/interface/MakePyBind11ParameterSets.h
+++ b/FWCore/PythonParameterSet/interface/MakePyBind11ParameterSets.h
@@ -26,6 +26,7 @@ namespace edm {
        python commands. These PSets are bundled into a top level PSet from which they can be retrieved
     */
     std::unique_ptr<ParameterSet> readPSetsFrom(std::string const& fileOrString);
+    std::unique_ptr<ParameterSet> readPSetsFrom(std::string const& fileOrString, int argc, char* argv[]);
   }  // namespace cmspybind11
 }  // namespace edm
 #endif

--- a/FWCore/PythonParameterSet/src/MakePyBind11ParameterSets.cc
+++ b/FWCore/PythonParameterSet/src/MakePyBind11ParameterSets.cc
@@ -15,7 +15,24 @@ static void makePSetsFromFile(std::string const& fileName) {
   pybind11::exec("makeCppPSet(locals(), topPSet)");
 }
 
+static void makePSetsFromFile(std::string const& fileName, int argc, char* argv[]) {
+  PySys_SetArgv(argc, argv);//This is the magic line that gives you access to command line arguments in the python config which contains the PSets
+  std::string initCommand(
+      "from FWCore.ParameterSet.Types import makeCppPSet\n"
+      "exec(open('");
+  initCommand += fileName + "').read())";
+  pybind11::exec(initCommand);
+  pybind11::exec("makeCppPSet(locals(), topPSet)");
+}
+
 static void makePSetsFromString(std::string const& module) {
+  std::string command = module;
+  command += "\nfrom FWCore.ParameterSet.Types import makeCppPSet\nmakeCppPSet(locals(), topPSet)";
+  pybind11::exec(command);
+}
+
+static void makePSetsFromString(std::string const& module, int argc, char* argv[]) {
+  PySys_SetArgv(argc, argv);//This is the magic line that gives you access to command line arguments in the python config which contains the PSets
   std::string command = module;
   command += "\nfrom FWCore.ParameterSet.Types import makeCppPSet\nmakeCppPSet(locals(), topPSet)";
   pybind11::exec(command);
@@ -53,6 +70,30 @@ namespace edm {
             makePSetsFromFile(module);
           } else {
             makePSetsFromString(module);
+          }
+        } catch (pybind11::error_already_set const& e) {
+          pythonToCppException("Configuration", e.what());
+        }
+        retVal = std::make_unique<edm::ParameterSet>(ParameterSet(theProcessPSet.pset()));
+      }
+      return retVal;
+    }
+
+    std::unique_ptr<ParameterSet> readPSetsFrom(std::string const& module, int argc, char* argv[]) {
+      pybind11::scoped_interpreter guard{};
+      python::initializePyBind11Module();
+      std::unique_ptr<ParameterSet> retVal;
+      {
+        Python11ParameterSet theProcessPSet;
+        pybind11::object mainModule = pybind11::module::import("__main__");
+        mainModule.attr("topPSet") = pybind11::cast(&theProcessPSet);
+
+        try {
+          // if it ends with py, it's a file
+          if (module.substr(module.size() - 3) == ".py") {
+            makePSetsFromFile(module, argc, argv);
+          } else {
+            makePSetsFromString(module, argc, argv);
           }
         } catch (pybind11::error_already_set const& e) {
           pythonToCppException("Configuration", e.what());


### PR DESCRIPTION
… for c++ process

#### PR description:

It is now possible to modify a python parameterSet in a python config file based on command line arguments for a c++ analysis. 

Previously one would load a PSet from a python config file **fileName** with:
`const edm::ParameterSet& process    = edm::cmspybind11::readPSetsFrom(argv[1])->getParameter<edm::ParameterSet>("process"); `

but this is very inflexible, not allowing a single python config to be modified by command line arguments and forcing the user to do all the manipulation in the bin/analysis.cc. 

Now one can load a PSet from a python config file and let the python config file have access to the command line arguments:
`const edm::ParameterSet& process    = edm::cmspybind11::readPSetsFrom(argv[1], argc, argv)->getParameter<edm::ParameterSet>("process");`

This is a trivial improvement that simply requires the line
`PySys_SetArgv(argc, argv);`
prior to the pybind11::exec calls in makePSetsFromFile.

#### PR validation:

I have checked that my analysis code operates as expected.
