### PR TITLE
Update eventcontent structure in RecoHI packages

### DIFF
--- a/RecoHI/Configuration/python/RecoHI_EventContent_cff.py
+++ b/RecoHI/Configuration/python/RecoHI_EventContent_cff.py
@@ -8,22 +8,24 @@ from RecoHI.HiCentralityAlgos.RecoHiCentrality_EventContent_cff import *
 from RecoHI.HiEvtPlaneAlgos.RecoHiEvtPlane_EventContent_cff import *
 from RecoHI.HiMuonAlgos.RecoHiMuon_EventContent_cff import *
 
-
 # combine RECO, AOD, FEVT content from all RecoHI packages
 # RecoHI event contents to be included by Configuration.EventContent.EventContentHeavyIons_cff
 
-RecoHIRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring()
-    )
-
+# AOD content
 RecoHIAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
-    )
+)
+RecoHIAOD.outputCommands.extend(RecoHiTrackerAOD.outputCommands)
+RecoHIAOD.outputCommands.extend(RecoHiJetsAOD.outputCommands)
+RecoHIAOD.outputCommands.extend(RecoHiEgammaAOD.outputCommands)
+RecoHIAOD.outputCommands.extend(RecoHiEvtPlaneAOD.outputCommands)
+RecoHIAOD.outputCommands.extend(RecoHiCentralityAOD.outputCommands)
+RecoHIAOD.outputCommands.extend(RecoHiMuonAOD.outputCommands)
 
-RecoHIFEVT = cms.PSet(
+# RECO content
+RecoHIRECO = cms.PSet(
     outputCommands = cms.untracked.vstring()
-    )
-
+)
 RecoHIRECO.outputCommands.extend(RecoHiTrackerRECO.outputCommands)
 RecoHIRECO.outputCommands.extend(RecoHiTrackerLocalRECO.outputCommands)
 RecoHIRECO.outputCommands.extend(RecoHiJetsRECO.outputCommands)
@@ -32,13 +34,10 @@ RecoHIRECO.outputCommands.extend(RecoHiEvtPlaneRECO.outputCommands)
 RecoHIRECO.outputCommands.extend(RecoHiCentralityRECO.outputCommands)
 RecoHIRECO.outputCommands.extend(RecoHiMuonRECO.outputCommands)
 
-RecoHIAOD.outputCommands.extend(RecoHiTrackerAOD.outputCommands)
-RecoHIAOD.outputCommands.extend(RecoHiJetsAOD.outputCommands)
-RecoHIAOD.outputCommands.extend(RecoHiEgammaAOD.outputCommands)
-RecoHIAOD.outputCommands.extend(RecoHiEvtPlaneAOD.outputCommands)
-RecoHIAOD.outputCommands.extend(RecoHiCentralityAOD.outputCommands)
-RecoHIAOD.outputCommands.extend(RecoHiMuonAOD.outputCommands)
-
+# FEVT content
+RecoHIFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
 RecoHIFEVT.outputCommands.extend(RecoHiTrackerFEVT.outputCommands)
 RecoHIFEVT.outputCommands.extend(RecoHiTrackerLocalFEVT.outputCommands)
 RecoHIFEVT.outputCommands.extend(RecoHiJetsFEVT.outputCommands)

--- a/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
+++ b/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
@@ -1,17 +1,20 @@
 import FWCore.ParameterSet.Config as cms
-
-RecoHiCentralityFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
-                                           'keep *_centralityBin_*_*',
-                                           'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
-    )
-RecoHiCentralityRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
-                                           'keep *_centralityBin_*_*',
-                                           'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
-    )
+# AOD content
 RecoHiCentralityAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
-                                           'keep *_centralityBin_*_*',
-                                           'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
-    )
+    outputCommands = cms.untracked.vstring(
+	'keep recoCentrality*_hiCentrality_*_*',
+        'keep *_centralityBin_*_*',
+        'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
+)
+
+# RECO content
+RecoHiCentralityRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoHiCentralityRECO.outputCommands.extend(RecoHiCentralityAOD.outputCommands)
+
+# FEVT content
+RecoHiCentralityFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoHiCentralityFEVT.outputCommands.extend(RecoHiCentralityRECO.outputCommands)

--- a/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
+++ b/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
@@ -1,17 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
-RecoHiEvtPlaneFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoEvtPlanes_hiEvtPlane_*_*')
-    )
-
-RecoHiEvtPlaneRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoEvtPlanes_hiEvtPlane_*_*')
-    )
-
+# AOD content
 RecoHiEvtPlaneAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoEvtPlanes_hiEvtPlane_*_*',
-                                           'keep ZDCRecHitsSorted_zdcreco_*_*',
-                                           'keep ZDCDataFramesSorted_hcalDigis_*_*',
-                                           'keep HFRecHitsSorted_hfreco_*_*'
-                                          )
-    )
+    outputCommands = cms.untracked.vstring(
+	'keep recoEvtPlanes_hiEvtPlane_*_*',
+        'keep ZDCRecHitsSorted_zdcreco_*_*',
+        'keep ZDCDataFramesSorted_hcalDigis_*_*',
+        'keep HFRecHitsSorted_hfreco_*_*')
+)
+
+# RECO content
+RecoHiEvtPlaneRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoHiEvtPlaneRECO.outputCommands.extend(RecoHiEvtPlaneAOD.outputCommands)
+
+# FEVT content
+RecoHiEvtPlaneFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoHiEvtPlaneFEVT.outputCommands.extend(RecoHiEvtPlaneRECO.outputCommands)

--- a/RecoHI/HiMuonAlgos/python/RecoHiMuon_EventContent_cff.py
+++ b/RecoHI/HiMuonAlgos/python/RecoHiMuon_EventContent_cff.py
@@ -4,9 +4,7 @@ import FWCore.ParameterSet.Config as cms
 RecoHiMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
     )
-#Add Isolation
-from RecoMuon.MuonIsolationProducers.muIsolation_EventContent_cff import *
-# AOD content for re-muons
+# for re-muons
 reRecoMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_remuons_*_*',

--- a/RecoHI/HiMuonAlgos/python/RecoHiMuon_EventContent_cff.py
+++ b/RecoHI/HiMuonAlgos/python/RecoHiMuon_EventContent_cff.py
@@ -1,54 +1,52 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content 
-RecoHiMuonFEVT = cms.PSet(
+#AOD content
+RecoHiMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
     )
+#Add Isolation
+from RecoMuon.MuonIsolationProducers.muIsolation_EventContent_cff import *
+# AOD content for re-muons
+reRecoMuonAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_remuons_*_*',
+        'keep *_*_remuons_*',
+        # Tracks known by the Muon obj
+        'keep recoTracks_standAloneMuons_*_*', 
+        'keep recoTrackExtras_standAloneMuons_*_*', 
+        'keep TrackingRecHitsOwned_standAloneMuons_*_*', 
+        'keep recoTracks_reglobalMuons_*_*', 
+        'keep recoTrackExtras_reglobalMuons_*_*', 
+        'keep recoTracks_retevMuons_*_*', 
+        'keep recoTrackExtras_retevMuons_*_*', 
+        'keep recoTracksToOnerecoTracksAssociation_retevMuons_*_*')
+)
+RecoHiMuonAOD.outputCommands.extend(reRecoMuonAOD.outputCommands)
 
 #RECO content
 RecoHiMuonRECO = cms.PSet(
     outputCommands = cms.untracked.vstring()
     )
 
-#AOD content
-RecoHiMuonAOD = cms.PSet(
+reRecoMuonRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep *_MuonSeed_*_*',
+        'keep *_ancientMuonSeed_*_*',
+        'keep *_mergedStandAloneMuonSeeds_*_*',
+        'keep TrackingRecHitsOwned_reglobalMuons_*_*', 
+        'keep TrackingRecHitsOwned_retevMuons_*_*',
+        'keep recoCaloMuons_recalomuons_*_*')
+)
+reRecoMuonRECO.outputCommands.extend(reRecoMuonAOD.outputCommands)
+RecoHiMuonRECO.outputCommands.extend(reRecoMuonRECO.outputCommands)
+
+#Full Event content 
+RecoHiMuonFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()
     )
 
-#Add Isolation
-from RecoMuon.MuonIsolationProducers.muIsolation_EventContent_cff import *
-# AOD content for re-muons
-reRecoMuonAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_remuons_*_*',
-                                           'keep *_*_remuons_*',
-                                           # Tracks known by the Muon obj
-                                           'keep recoTracks_standAloneMuons_*_*', 
-                                           'keep recoTrackExtras_standAloneMuons_*_*', 
-                                           'keep TrackingRecHitsOwned_standAloneMuons_*_*', 
-                                           'keep recoTracks_reglobalMuons_*_*', 
-                                           'keep recoTrackExtras_reglobalMuons_*_*', 
-                                           'keep recoTracks_retevMuons_*_*', 
-                                           'keep recoTrackExtras_retevMuons_*_*', 
-                                           'keep recoTracksToOnerecoTracksAssociation_retevMuons_*_*'
-                                           )
-)
-# RECO content
-reRecoMuonRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_MuonSeed_*_*',
-                                           'keep *_ancientMuonSeed_*_*',
-                                           'keep *_mergedStandAloneMuonSeeds_*_*',
-                                           'keep TrackingRecHitsOwned_reglobalMuons_*_*', 
-                                           'keep TrackingRecHitsOwned_retevMuons_*_*',
-                                           'keep recoCaloMuons_recalomuons_*_*')
-)
-# Full Event content 
 reRecoMuonFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
-reRecoMuonRECO.outputCommands.extend(reRecoMuonAOD.outputCommands)
 reRecoMuonFEVT.outputCommands.extend(reRecoMuonRECO.outputCommands)
-
-RecoHiMuonAOD.outputCommands.extend(reRecoMuonAOD.outputCommands)
-RecoHiMuonRECO.outputCommands.extend(reRecoMuonRECO.outputCommands)
 RecoHiMuonFEVT.outputCommands.extend(reRecoMuonFEVT.outputCommands)
-

--- a/RecoHI/HiTracking/python/RecoHiTracker_EventContent_cff.py
+++ b/RecoHI/HiTracking/python/RecoHiTracker_EventContent_cff.py
@@ -1,54 +1,43 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content 
-RecoHiTrackerFEVT = cms.PSet(
+#AOD content
+RecoHiTrackerAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
-		'keep *_hiGeneralTracks_*_*', 
-                'keep *_hiGeneralAndPixelTracks_*_*',
-		'keep *_hiPixel3PrimTracks_*_*', 
-		'keep *_hiPixel3ProtoTracks_*_*',	
-		'keep *_hiSelectedProtoTracks_*_*',	
-		'keep recoVertexs_hiPixelMedianVertex_*_*',
-		'keep recoVertexs_hiPixelAdaptiveVertex_*_*',
-		'keep recoVertexs_hiSelectedVertex_*_*',
-		'keep recoVertexs_hiSelectedPixelVertex_*_*',
-                'keep recoVertexs_hiPixelClusterVertex_*_*'	
-    )
-)
-
-RecoHiTrackerLocalFEVT = cms.PSet(
-   outputCommands = cms.untracked.vstring(
-   'keep *_*_APVCM_*',
-   'keep *_siStripZeroSuppression_BADAPVBASELINE_*',
-   'keep SiStripRawDigiedmDetSetVector_siStripZeroSuppression_VirginRaw_*'
-   )
+        'keep recoTracks_hiGeneralTracks_*_*',
+        'keep recoTracks_hiGeneralAndPixelTracks_*_*',
+        'keep recoVertexs_hiSelectedVertex_*_*')
 )
 
 #RECO content
 RecoHiTrackerRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
-		'keep *_hiGeneralTracks_*_*', 
-                'keep *_hiGeneralAndPixelTracks_*_*',
-		'keep recoVertexs_hiPixelMedianVertex_*_*',  
-		'keep recoVertexs_hiPixelAdaptiveVertex_*_*',  
-		'keep recoVertexs_hiSelectedVertex_*_*',
-		'keep recoVertexs_hiSelectedPixelVertex_*_*',
-                'keep recoVertexs_hiPixelClusterVertex_*_*'		
-    )
+	'keep *_hiGeneralTracks_*_*', 
+        'keep *_hiGeneralAndPixelTracks_*_*',
+	'keep recoVertexs_hiPixelMedianVertex_*_*',  
+	'keep recoVertexs_hiPixelAdaptiveVertex_*_*',  
+	'keep recoVertexs_hiSelectedPixelVertex_*_*',
+        'keep recoVertexs_hiPixelClusterVertex_*_*')
 )
+RecoHiTrackerRECO.outputCommands.extend(RecoHiTrackerAOD.outputCommands)
 
 RecoHiTrackerLocalRECO = cms.PSet(
    outputCommands = cms.untracked.vstring(
-   'keep *_*_APVCM_*'
-   #'keep *_siStripZeroSuppression_BADAPVBASELINE_*',
-   #'keep SiStripRawDigiedmDetSetVector_siStripZeroSuppression_VirginRaw_*'
-   )
+       'keep *_*_APVCM_*')
 )
 
-#AOD content
-RecoHiTrackerAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_hiGeneralTracks_*_*',
-                                           'keep recoTracks_hiGeneralAndPixelTracks_*_*',
-                                           'keep recoVertexs_hiSelectedVertex_*_*',		
-    )
+#Full Event content 
+RecoHiTrackerFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep *_hiPixel3PrimTracks_*_*', 
+	'keep *_hiPixel3ProtoTracks_*_*',	
+	'keep *_hiSelectedProtoTracks_*_*',	
+	'keep recoVertexs_hiSelectedVertex_*_*')
 )
+RecoHiTrackerFEVT.outputCommands.extend(RecoHiTrackerRECO.outputCommands)
+
+RecoHiTrackerLocalFEVT = cms.PSet(
+   outputCommands = cms.untracked.vstring(
+       'keep *_siStripZeroSuppression_BADAPVBASELINE_*',
+       'keep SiStripRawDigiedmDetSetVector_siStripZeroSuppression_VirginRaw_*')
+)
+RecoHiTrackerLocalFEVT.outputCommands.extend(RecoHiTrackerLocalRECO.outputCommands)


### PR DESCRIPTION
#### PR description:  
Update event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. 5 files changed : 
+ `RecoHI/Configuration/python/RecoHI_EventContent_cff.py`
+ `RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py `
+ `RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py` 
+ `RecoHI/HiMuonAlgos/python/RecoHiMuon_EventContent_cff.py `
+ `RecoHI/HiTracking/python/RecoHiTracker_EventContent_cff.py `

FYI, `RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py`, `RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py` files are work in progress and they will be updated in new PRs later (maybe separately).

(The previous tasks are [PR#29025](https://github.com/cms-sw/cmssw/pull/29025), [PR#29158](https://github.com/cms-sw/cmssw/pull/29158), [PR#29225](https://github.com/cms-sw/cmssw/pull/29225), [PR#29299](https://github.com/cms-sw/cmssw/pull/29299), [PR#29470](https://github.com/cms-sw/cmssw/pull/29470), [PR#29517](https://github.com/cms-sw/cmssw/pull/29517),  [PR#29535](https://github.com/cms-sw/cmssw/pull/29535), and  [PR#29571](https://github.com/cms-sw/cmssw/pull/29571) )

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).