### PR TITLE
[LLVM10] PhysicsTools fix clang warnings

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc
@@ -90,7 +90,7 @@ void LeptonInJetProducer<T>::produce(edm::StreamID streamID, edm::Event &iEvent,
     std::vector<fastjet::PseudoJet> lClusterParticles;
     float lepPt(-1), lepEta(-1), lepPhi(-1);
     int lepId(-1);
-    for (auto const d : itJet.daughterPtrVector()) {
+    for (auto const &d : itJet.daughterPtrVector()) {
       fastjet::PseudoJet p(d->px(), d->py(), d->pz(), d->energy());
       lClusterParticles.emplace_back(p);
     }

--- a/PhysicsTools/NanoAOD/plugins/LeptonJetVarProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LeptonJetVarProducer.cc
@@ -162,7 +162,7 @@ std::tuple<float, float, float> LeptonJetVarProducer<T>::calculatePtRatioRel(edm
   auto ptrel = lepp4.Vect().Cross((jetp4 - lepp4).Vect().Unit()).R();
 
   unsigned int jndau = 0;
-  for (const auto _d : jet->daughterPtrVector()) {
+  for (const auto& _d : jet->daughterPtrVector()) {
     const auto d = dynamic_cast<const pat::PackedCandidate*>(_d.get());
     if (d->charge() == 0)
       continue;

--- a/PhysicsTools/ONNXRuntime/test/testONNXRuntime.cc
+++ b/PhysicsTools/ONNXRuntime/test/testONNXRuntime.cc
@@ -22,7 +22,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testONNXRuntime);
 void testONNXRuntime::checkAll() {
   std::string model_path = edm::FileInPath("PhysicsTools/ONNXRuntime/test/data/model.onnx").fullPath();
   ONNXRuntime rt(model_path);
-  for (const unsigned &batch_size : {1, 2, 4}) {
+  for (const unsigned batch_size : {1, 2, 4}) {
     FloatArrays input_values{
         std::vector<float>(batch_size * 2, 1),
     };

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
@@ -74,11 +74,13 @@ void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm:
     const reco::PFJet* jet_matched = nullptr;
     for (auto jet : selectedJets) {
       for (auto jetc : jet->getPFConstituents()) {
-        if (jet_matched)
-          break;
-        if (deltaR2(originalPFCandidate->p4(), jetc->p4()) < dR2Match)
+        if (deltaR2(originalPFCandidate->p4(), jetc->p4()) < dR2Match) {
           jet_matched = jet;
+          break;
+        }
       }
+      if (jet_matched)
+        break;
     }
 
     double shift = 0.;

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
@@ -72,12 +72,12 @@ void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm:
        originalPFCandidate != originalPFCandidates->end();
        ++originalPFCandidate) {
     const reco::PFJet* jet_matched = nullptr;
-    for (std::vector<const reco::PFJet*>::iterator jet = selectedJets.begin(); jet != selectedJets.end(); ++jet) {
-      for (std::vector<reco::PFCandidatePtr>::const_iterator jetConstituent = (*jet)->getPFConstituents().begin();
-           jetConstituent != (*jet)->getPFConstituents().end() && jet_matched == nullptr;
-           ++jetConstituent) {
-        if (deltaR2(originalPFCandidate->p4(), (*jetConstituent)->p4()) < dR2Match)
-          jet_matched = (*jet);
+    for (auto jet : selectedJets) {
+      for (auto jetc : jet->getPFConstituents()) {
+        if (jet_matched)
+          break;
+        if (deltaR2(originalPFCandidate->p4(), jetc->p4()) < dR2Match)
+          jet_matched = jet;
       }
     }
 


### PR DESCRIPTION
#### PR description:

Fix warnings in PhysicsTools, 
please see the  PhysicsTools/PatUtils one the others are trivial
the warning about it is here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc820/CMSSW_11_1_CLANG_X_2020-04-27-2300/PhysicsTools/PatUtils

#### PR validation:

Builds without warnings with the CLANG IB
