### PR TITLE
Protect ProcessCallGraph for module IDs larger than the number of modules 

### DIFF
--- a/HLTrigger/Timer/src/ProcessCallGraph.cc
+++ b/HLTrigger/Timer/src/ProcessCallGraph.cc
@@ -4,6 +4,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <numeric>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -72,7 +73,13 @@ void ProcessCallGraph::preBeginJob(edm::PathsAndConsumesOfModulesBase const& pat
   boost::get_property(graph, boost::graph_name) = context.processName();
 
   // create graph vertices associated to all modules in the process
-  auto size = pathsAndConsumes.allModules().size();
+  unsigned int size = 0;
+  if (auto const& allModules = pathsAndConsumes.allModules(); not allModules.empty()) {
+    size = std::accumulate(
+        allModules.begin(), allModules.end(), size, [](unsigned int s, edm::ModuleDescription const* module) {
+          return std::max(s, module->id());
+        });
+  }
   for (size_t i = 0; i < size; ++i)
     boost::add_vertex(graph);
 


### PR DESCRIPTION
#### PR description:

#29553 can make the number of modules at `beginJob()` (and thereafter) smaller than the largest module ID, which would lead to out-of-bound errors in `ProcessCallGraph::preBeginJob()` when using the module IDs as an index to a boost graph. This PR proposes, as a minimal fix, to look for the maximum module ID explicitly.

This PR fixes some of the crashes seen in #29553 tests, I'm submitting the fix in a separate PR to make the review a bit easier.

#### PR validation:

Limited matrix runs.