### PR TITLE
Make DQMRootOutputModule to depend on all DQM modules via DQMTokens

### DIFF
--- a/DQMServices/FwkIO/plugins/BuildFile.xml
+++ b/DQMServices/FwkIO/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/Histograms"/>
 <use   name="DQMServices/Core"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/Sources"/>

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -42,6 +42,8 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 
+#include "DataFormats/Histograms/interface/DQMToken.h"
+
 #include "format.h"
 
 namespace {
@@ -284,7 +286,15 @@ DQMRootOutputModule::DQMRootOutputModule(edm::ParameterSet const& pset)
       m_presentHistoryIndex(0),
       m_filterOnRun(pset.getUntrackedParameter<unsigned int>("filterOnRun")),
       m_fullNameBufferPtr(&m_fullNameBuffer),
-      m_indicesTree(nullptr) {}
+      m_indicesTree(nullptr) {
+  // Declare dependencies for all Lumi and Run tokens here. In
+  // principle could use the keep statements, but then DQMToken would
+  // have to be made persistent (transient products are ignored),
+  // which would lead to a need to (finally) remove underscores from
+  // DQM module labels.
+  consumesMany<DQMToken, edm::InLumi>();
+  consumesMany<DQMToken, edm::InRun>();
+}
 
 // DQMRootOutputModule::DQMRootOutputModule(const DQMRootOutputModule& rhs)
 // {


### PR DESCRIPTION
#### PR description:

#29553 implies that all data dependencies for modules in Tasks must be specified to keep those modules alive and running (in principle the proper dependencies should be declared anyway, that PR makes it necessary also in practice). It turned out that the `DQMRootOutputModule` currently does not declare dependencies on all the DQM analyzers. Easiest fix is to do `consumesMany<DQMToken, ...>` for both Lumi and Run products.

Actually I tried first to use the `outputCommands` (which by the for some reason is
https://github.com/cms-sw/cmssw/blob/3f89112fddb9bd4f384fa7acacc5fb81720bee16/Configuration/EventContent/python/EventContent_cff.py#L356-L357
which to me doesn't seem to make much sense), but that would require making `DQMToken` persistable, which would require an underscore a forbidden character for all modules producing `DQMToken`. An underscore appears to be in wide use for DQM modules, which is why I scrapped that approach (I did some amount of migration to no-underscore module labels, if DQM is interested I can make pull request(s) of what I did).

#### PR validation:

Limited matrix runs.