### PR TITLE
[LLVM10] GeneratorInterface fix warning

### DIFF
--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyAnalyzer.cc
@@ -31,7 +31,7 @@ namespace gfea {
   struct Empty {};
 };  // namespace gfea
 
-class GenFilterEfficiencyAnalyzer : public edm::global::EDAnalyzer<edm::LuminosityBlockCache<gfea::Empty>> {
+class GenFilterEfficiencyAnalyzer final : public edm::global::EDAnalyzer<edm::LuminosityBlockCache<gfea::Empty>> {
 public:
   explicit GenFilterEfficiencyAnalyzer(const edm::ParameterSet&);
   ~GenFilterEfficiencyAnalyzer() final;


### PR DESCRIPTION
#### PR description:

Fixes warning in clang 10

#### PR validation:

Builds without warning with CLANG IB
