### PR TITLE
[LLVM10] EventFilter fix warnings for clang 10

### DIFF
--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
@@ -111,12 +111,6 @@ bool CSCDigiValidator::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   CSCALCTDigiCollection::DigiRangeIterator alct = _alct->begin(), salct = _salct->begin();
   CSCCorrelatedLCTDigiCollection::DigiRangeIterator lct = _lct->begin(), slct = _slct->begin();
   L1CSCTrackCollection::const_iterator trk = _trk->begin(), strk = _strk->begin();
-  std::vector<csctf::TrackStub>::const_iterator dt = _dt->get().begin(), sdt = _sdt->get().begin();
-  // WARNING 5_0_X
-  dt++;
-  dt--;
-  sdt++;
-  sdt--;
 
   //per detID, create lists of various digi types
   matchingDetWireCollection wires;

--- a/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxDigiToRaw.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxDigiToRaw.cc
@@ -95,7 +95,7 @@ void RPCTwinMuxDigiToRaw::produce(edm::Event& event, edm::EventSetup const& setu
 
   std::map<int, FEDRawData> fed_data;
   // Loop over the FEDs
-  for (std::pair<int, std::vector<RPCAMCLink> > const& fed_amcs : fed_amcs_) {
+  for (std::pair<int, std::vector<RPCAMCLink> > const fed_amcs : fed_amcs_) {
     FEDRawData& data = data_collection->FEDData(fed_amcs.first);
     unsigned int size(0);
 

--- a/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxDigiToRaw.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxDigiToRaw.cc
@@ -95,7 +95,7 @@ void RPCTwinMuxDigiToRaw::produce(edm::Event& event, edm::EventSetup const& setu
 
   std::map<int, FEDRawData> fed_data;
   // Loop over the FEDs
-  for (std::pair<int, std::vector<RPCAMCLink> > const fed_amcs : fed_amcs_) {
+  for (std::pair<int, std::vector<RPCAMCLink> > const& fed_amcs : fed_amcs_) {
     FEDRawData& data = data_collection->FEDData(fed_amcs.first);
     unsigned int size(0);
 

--- a/EventFilter/Utilities/src/json_reader.cpp
+++ b/EventFilter/Utilities/src/json_reader.cpp
@@ -430,7 +430,7 @@ namespace Json {
       while (token.type_ == tokenComment && ok) {
         ok = readToken(token);
       }
-      bool badTokenType = (token.type_ == tokenArraySeparator && token.type_ == tokenArrayEnd);
+      bool badTokenType = (token.type_ == tokenArraySeparator || token.type_ == tokenArrayEnd);
       if (!ok || badTokenType) {
         return addErrorAndRecover("Missing ',' or ']' in array declaration", token, tokenArrayEnd);
       }


### PR DESCRIPTION
#### PR description:

Fixes warnings in clang 10

#### PR validation:

Builds without warnings with CLANG IB
tokenArraySeparator and tokenArrayEnd belong to the same enum so thats probably or not and
