### PR TITLE
Add time support to IPCutPFCandidateSelector

### DIFF
--- a/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
@@ -68,7 +68,7 @@ namespace pf2pat {
         double pfct = pfc->time();
         double pfcte = pfc->timeError();
         double dt = fabs(pfct - vt);
-        double dte = std::sqrt(pfcte*pfcte + vte*vte);
+        double dte = std::sqrt(pfcte * pfcte + vte * vte);
         if (dtCut_ > 0 && pfcte > 0 && vte > 0 && dt > dtCut_)
           passing = false;
         if (dtSigCut_ > 0 && pfcte > 0 && vte > 0 && dt / dte > dtSigCut_)

--- a/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
@@ -26,8 +26,10 @@ namespace pf2pat {
         : verticesToken_(iC.consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
           d0Cut_(cfg.getParameter<double>("d0Cut")),
           dzCut_(cfg.getParameter<double>("dzCut")),
+          dtCut_(cfg.getParameter<double>("dtCut")),
           d0SigCut_(cfg.getParameter<double>("d0SigCut")),
-          dzSigCut_(cfg.getParameter<double>("dzSigCut")) {}
+          dzSigCut_(cfg.getParameter<double>("dzSigCut")),
+          dtSigCut_(cfg.getParameter<double>("dtSigCut")) {}
 
     void select(const HandleToCollection &hc, const edm::Event &e, const edm::EventSetup &s) {
       selected_.clear();
@@ -37,6 +39,8 @@ namespace pf2pat {
       if (vertices->empty())
         return;
       const reco::Vertex &vtx = (*vertices)[0];
+      double vt = vtx.t();
+      double vte = vtx.tError();
 
       unsigned key = 0;
       for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
@@ -61,6 +65,14 @@ namespace pf2pat {
           if (dzSigCut_ > 0 && dze > 0 && dz / dze > dzSigCut_)
             passing = false;
         }
+        double pfct = pfc->time();
+        double pfcte = pfc->timeError();
+        double dt = fabs(pfct - vt);
+        double dte = std::sqrt(pfcte*pfcte + vte*vte);
+        if (dtCut_ > 0 && pfcte > 0 && vte > 0 && dt > dtCut_)
+          passing = false;
+        if (dtSigCut_ > 0 && pfcte > 0 && vte > 0 && dt / dte > dtSigCut_)
+          passing = false;
 
         if (passing) {
           selected_.push_back(reco::PFCandidate(*pfc));
@@ -79,8 +91,10 @@ namespace pf2pat {
     edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
     double d0Cut_;
     double dzCut_;
+    double dtCut_;
     double d0SigCut_;
     double dzSigCut_;
+    double dtSigCut_;
   };
 }  // namespace pf2pat
 

--- a/CommonTools/ParticleFlow/python/ParticleSelectors/pfElectronsFromVertex_cfi.py
+++ b/CommonTools/ParticleFlow/python/ParticleSelectors/pfElectronsFromVertex_cfi.py
@@ -6,6 +6,8 @@ pfElectronsFromVertex = cms.EDFilter(
     vertices = cms.InputTag("offlinePrimaryVertices"),  # vertices source
     d0Cut = cms.double(0.2),  # transverse IP
     dzCut = cms.double(0.5),  # longitudinal IP
+    dtCut = cms.double(-1.0), # time
     d0SigCut = cms.double(99.),  # transverse IP significance
     dzSigCut = cms.double(99.),  # longitudinal IP significance
+    dtSigCut = cms.double(-1.0), # time significance
     )

--- a/CommonTools/ParticleFlow/python/ParticleSelectors/pfMuonsFromVertex_cfi.py
+++ b/CommonTools/ParticleFlow/python/ParticleSelectors/pfMuonsFromVertex_cfi.py
@@ -6,6 +6,8 @@ pfMuonsFromVertex = cms.EDFilter(
     vertices = cms.InputTag("offlinePrimaryVertices"),  # vertices source
     d0Cut = cms.double(0.2),  # transverse IP
     dzCut = cms.double(0.5),  # longitudinal IP
+    dtCut = cms.double(-1.0), # time
     d0SigCut = cms.double(99.),  # transverse IP significance
     dzSigCut = cms.double(99.),  # longitudinal IP significance
+    dtSigCut = cms.double(-1.0), # time significance
     )


### PR DESCRIPTION
#### PR description:

This is a simple addition to the IPCutPFCandidateSelector to allow a filter on the delta time or time significance of particle flow candidates relative to the first primary vertex.

An example usage would be:

```
process.pfAllInTimeChargedHadrons = cms.EDFilter("IPCutPFCandidateSelector",
    d0Cut = cms.double(-1),
    d0SigCut = cms.double(-1),
    dtCut = cms.double(-1),
    dtSigCut = cms.double(3.0),
    dzCut = cms.double(-1),
    dzSigCut = cms.double(-1),
    src = cms.InputTag("pfAllChargedHadrons"),
    vertices = cms.InputTag("offlinePrimaryVertices4D")
)
```

This is a first part in adding timing to isolation sums.

#### PR validation:

Ran most of the following (before my kinit ran out, but its a simple change and the early ones succeeded):

```
runTheMatrix.py -l limited -i all --ibeos
```

Also ran on a phase-II sample with MTD timing available in particleFlow,
modifying the muon pfIsolation charged hadron inputs to be the in time charged hadrons
(rather than all charged hadrons) and correctly observe a reduction in PF isolation energy.
It is not yet decided if this will be used.