### PR TITLE
ECAL Digitization: fix logical bug in protection against unwanted gainId values in trivial zero suppression

### DIFF
--- a/SimCalorimetry/EcalZeroSuppressionAlgos/interface/TrivialAmplitudeAlgo.icc
+++ b/SimCalorimetry/EcalZeroSuppressionAlgos/interface/TrivialAmplitudeAlgo.icc
@@ -31,7 +31,7 @@ double TrivialAmplitudeAlgo<C>::energy(const C &frame) {
 
   for (int sample = 0; sample < frame.size(); ++sample) {
     int gain = (frame.sample(sample).gainId());
-    if (gain >= 1 || gain <= 3) {
+    if (gain >= 1 && gain <= 3) {
       Erec = Erec + theWeights[sample] * (frame.sample(sample).adc()) * theGainFactors[gain];
     } else {
       edm::LogWarning("EcalAmplitudeError") << "Wrong gain in frame " << sample << " \n" << frame;


### PR DESCRIPTION
#### PR description:

This PR addresses the issue #29569 . A logical protection against unwated values of gain identifier is incorrect in the ```TrivialAmplitudeAlgo``` class. As far as I can see the fix is simply replacing ```||``` with ```&&```, i.e. the gain id must be between 1 and 3 included. This class is very old, and practically unused in production workflows as far as I can see (the ECAL selective readout mechanism is used). 

#### PR validation:

Code compiles, wf 11634.0 runs without apparent effect.