### PR TITLE
PUPPI tune v14 [10_6_X]

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -28,6 +28,7 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fUseFromPVLooseTight = iConfig.getParameter<bool>("UseFromPVLooseTight");
   fUseDZ     = iConfig.getParameter<bool>("UseDeltaZCut");
   fDZCut     = iConfig.getParameter<double>("DeltaZCut");
+  fEtaMinUseDZ = iConfig.getParameter<double>("EtaMinUseDeltaZ");
   fPtMaxCharged = iConfig.getParameter<double>("PtMaxCharged");
   fEtaMaxCharged = iConfig.getParameter<double>("EtaMaxCharged");
   fUseExistingWeights     = iConfig.getParameter<bool>("useExistingWeights");
@@ -154,7 +155,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             pReco.id = 1;
           else if (std::abs(pReco.eta) > fEtaMaxCharged)
             pReco.id = 1;
-          else if (fUseDZ)
+          else if ((fUseDZ) && (std::abs(pReco.eta) >= fEtaMinUseDZ))
             pReco.id = (std::abs(pDZ) < fDZCut) ? 1 : 2;
           else if (fUseFromPVLooseTight && tmpFromPV == 1)
             pReco.id = 2;
@@ -180,7 +181,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             pReco.id = 1;
           else if (std::abs(pReco.eta) > fEtaMaxCharged)
             pReco.id = 1;
-          else if (fUseDZ)
+          else if ((fUseDZ) && (std::abs(pReco.eta) >= fEtaMinUseDZ))
             pReco.id = (std::abs(pDZ) < fDZCut) ? 1 : 2;
           else if (fUseFromPVLooseTight && lPack->fromPV() == (pat::PackedCandidate::PVLoose))
             pReco.id = 2;
@@ -355,6 +356,7 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<bool>("UseFromPVLooseTight", false);
   desc.add<bool>("UseDeltaZCut", true);
   desc.add<double>("DeltaZCut", 0.3);
+  desc.add<double>("EtaMinUseDeltaZ", 0.);
   desc.add<double>("PtMaxCharged", 0.);
   desc.add<double>("EtaMaxCharged", 99999.);
   desc.add<double>("PtMaxNeutrals", 200.);

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.h
@@ -51,6 +51,7 @@ private:
         bool fUseFromPVLooseTight;
 	bool            fUseDZ;
 	float           fDZCut;
+	double fEtaMinUseDZ;
         double fPtMaxCharged;
 	double fEtaMaxCharged;
 	bool fUseExistingWeights;

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -29,6 +29,7 @@ puppi = cms.EDProducer("PuppiProducer",#cms.PSet(#"PuppiProducer",
                        puppiForLeptons = cms.bool(False),
                        UseFromPVLooseTight = cms.bool(False),
                        UseDeltaZCut   = cms.bool(True),
+                       EtaMinUseDeltaZ = cms.double(0.),
                        DeltaZCut      = cms.double(0.3),
 		       PtMaxCharged   = cms.double(0.),
 		       EtaMaxCharged   = cms.double(99999.),
@@ -113,4 +114,12 @@ phase2_common.toModify(
              puppiAlgos = puppiForward
        )
     )
+)
+
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+run2_miniAOD_devel.toModify(
+    puppi,
+    EtaMinUseDeltaZ = 2.4,
+    PtMaxCharged = 20.,
+    PtMaxNeutralsStartSlope = 20.
 )

--- a/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py
+++ b/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-def UpdatePuppiTuneV13(process):
+def UpdatePuppiTuneV14(process):
   #
   # Adapt for re-running PUPPI
   #
-  print("customizePuppiTune_cff::UpdatePuppiTuneV13: Recomputing PUPPI with Tune v13, slimmedJetsPuppi and slimmedMETsPuppi")
+  print("customizePuppiTune_cff::UpdatePuppiTuneV14: Recomputing PUPPI with Tune v14, slimmedJetsPuppi and slimmedMETsPuppi")
   from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
   task = getPatAlgosToolsTask(process)
   from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
@@ -26,15 +26,11 @@ def UpdatePuppiTuneV13(process):
   del process.updatedPatJetsPuppiJetSpecific
   process.puppiSequence = cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi+process.patPuppiJetSpecificProducer+process.slimmedJetsPuppi)
   #
-  # Adapt for PUPPI tune V13
+  # Adapt for PUPPI tune V14
   #
-  process.puppi.UseFromPVLooseTight = False
-  process.puppi.UseDeltaZCut = False
   process.puppi.PtMaxCharged = 20.
-  process.puppi.EtaMaxCharged = 2.5
+  process.puppi.EtaMinUseDeltaZ = 2.4
   process.puppi.PtMaxNeutralsStartSlope = 20.
-  process.puppiNoLep.UseFromPVLooseTight = False
-  process.puppiNoLep.UseDeltaZCut = False
   process.puppiNoLep.PtMaxCharged = 20.
-  process.puppiNoLep.EtaMaxCharged = 2.5
+  process.puppiNoLep.EtaMinUseDeltaZ = 2.4
   process.puppiNoLep.PtMaxNeutralsStartSlope = 20.


### PR DESCRIPTION
#### PR description:

Switch to PUPPI v14 for UL-re-MiniAOD.

Also update customizer function for PUPPI tune V14 for JME-extended-NanoAODs for UL.

#### PR validation:

Does not change defaults.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport from #29600 to 10_6 to include into UL-reminiAOD.