### PR TITLE
CPPF emulator refactoring

### DIFF
--- a/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
+++ b/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
@@ -7,7 +7,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 
-
 class EmulateCPPF {
 public:
   explicit EmulateCPPF(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iConsumes);

--- a/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
+++ b/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
@@ -5,6 +5,8 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+
 
 class EmulateCPPF {
 public:
@@ -24,7 +26,10 @@ private:
   // separate entities
   std::array<RecHitProcessor, 1> recHit_processors_;
 
+  const edm::EDGetToken rpcDigiToken_;
   const edm::EDGetToken recHitToken_;
+  const edm::EDGetToken rpcDigiSimLinkToken_;
+
   enum class CppfSource { File, EventSetup } cppfSource_;
   std::vector<RecHitProcessor::CppfItem> CppfVec_1;
   int MaxClusterSize_;

--- a/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
+++ b/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
@@ -13,6 +13,8 @@
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+#include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
+#include "SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h"
 
 #include "CondFormats/RPCObjects/interface/RPCDeadStrips.h"
 #include "CondFormats/RPCObjects/interface/RPCMaskedStrips.h"
@@ -20,6 +22,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "L1Trigger/L1TMuonEndCap/interface/TrackTools.h"
 
+#include <boost/cstdint.hpp>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -50,6 +53,8 @@ public:
       const edm::Event &iEvent,
       const edm::EventSetup &iSetup,
       const edm::EDGetToken &recHitToken,
+      const edm::EDGetToken &rpcDigiToken,
+      const edm::EDGetToken &rpcDigiSimLinkToken,
       std::vector<RecHitProcessor::CppfItem> &CppfVec1,
       // Output
       l1t::CPPFDigiCollection &cppfDigis,
@@ -60,6 +65,8 @@ public:
       const edm::Event &iEvent,
       const edm::EventSetup &iSetup,
       const edm::EDGetToken &recHitToken,
+      const edm::EDGetToken &rpcDigiToken,
+      const edm::EDGetToken &rpcDigiSimLinkToken,
       // Output
       l1t::CPPFDigiCollection &cppfDigis) const;
 

--- a/L1Trigger/L1TMuonCPPF/python/emulatorCppfDigis_cfi.py
+++ b/L1Trigger/L1TMuonCPPF/python/emulatorCppfDigis_cfi.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-emulatorCppfDigis = cms.EDProducer("L1TMuonCPPFDigiProducer",
-                                   
+emulatorCppfDigis = cms.EDProducer("L1TMuonCPPFDigiProducer",                                   
                                    ## Input collection
                                    recHitLabel = cms.InputTag("rpcRecHits"),
+                                   rpcDigiLabel = cms.InputTag("simMuonRPCDigis"),
+                                   rpcDigiSimLinkLabel = cms.InputTag("simMuonRPCDigis", "RPCDigiSimLink"),
 				   MaxClusterSize = cms.int32(3),
                                    #  cppfSource = cms.string('Geo'), #'File' for Look up table and 'Geo' for CMSSW Geometry 
                                    cppfSource = cms.string('File'), #'File' for Look up table and 'Geo' for CMSSW Geometry 

--- a/L1Trigger/L1TMuonCPPF/src/CPPFCluster.cc
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFCluster.cc
@@ -1,0 +1,72 @@
+#include "CPPFCluster.h"
+#include <iostream>
+#include <fstream>
+#include <cmath>
+
+using namespace std;
+
+CPPFCluster::CPPFCluster()
+    : fstrip(0), lstrip(0), bunchx(0), sumTime(0), sumTime2(0), nTime(0), sumY(0), sumY2(0), nY(0) {}
+
+CPPFCluster::CPPFCluster(int fs, int ls, int bx)
+    : fstrip(fs), lstrip(ls), bunchx(bx), sumTime(0), sumTime2(0), nTime(0), sumY(0), sumY2(0), nY(0) {}
+
+CPPFCluster::~CPPFCluster() {}
+
+int CPPFCluster::firstStrip() const { return fstrip; }
+int CPPFCluster::lastStrip() const { return lstrip; }
+int CPPFCluster::clusterSize() const { return lstrip - fstrip + 1; }
+int CPPFCluster::bx() const { return bunchx; }
+
+bool CPPFCluster::hasTime() const { return nTime > 0; }
+float CPPFCluster::time() const { return hasTime() ? sumTime / nTime : 0; }
+float CPPFCluster::timeRMS() const {
+  return hasTime() ? sqrt(max(0.F, sumTime2 * nTime - sumTime * sumTime)) / nTime : -1;
+}
+
+bool CPPFCluster::hasY() const { return nY > 0; }
+float CPPFCluster::y() const { return hasY() ? sumY / nY : 0; }
+float CPPFCluster::yRMS() const { return hasY() ? sqrt(max(0.F, sumY2 * nY - sumY * sumY)) / nY : -1; }
+
+bool CPPFCluster::isAdjacent(const CPPFCluster& cl) const {
+  return ((cl.firstStrip() == this->firstStrip() - 1) && (cl.bx() == this->bx()));
+}
+
+void CPPFCluster::addTime(const float time) {
+  ++nTime;
+  sumTime += time;
+  sumTime2 += time * time;
+}
+
+void CPPFCluster::addY(const float y) {
+  ++nY;
+  sumY += y;
+  sumY2 += y * y;
+}
+
+void CPPFCluster::merge(const CPPFCluster& cl) {
+  if (!this->isAdjacent(cl))
+    return;
+
+  fstrip = cl.firstStrip();
+
+  nTime += cl.nTime;
+  sumTime += cl.sumTime;
+  sumTime2 += cl.sumTime2;
+
+  nY += cl.nY;
+  sumY += cl.sumY;
+  sumY2 += cl.sumY2;
+}
+
+bool CPPFCluster::operator<(const CPPFCluster& cl) const {
+  if (cl.bx() == this->bx())
+    return cl.firstStrip() < this->firstStrip();
+
+  return cl.bx() < this->bx();
+}
+
+bool CPPFCluster::operator==(const CPPFCluster& cl) const {
+  return ((this->clusterSize() == cl.clusterSize()) && (this->bx() == cl.bx()) &&
+          (this->firstStrip() == cl.firstStrip()));
+}

--- a/L1Trigger/L1TMuonCPPF/src/CPPFCluster.h
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFCluster.h
@@ -1,0 +1,42 @@
+#include <cstdint>
+#ifndef L1Trigger_CPPFCluster_h
+#define L1Trigger_CPPFCluster_h
+class CPPFCluster {
+public:
+  CPPFCluster();
+  CPPFCluster(int fs, int ls, int bx);
+  ~CPPFCluster();
+
+  int firstStrip() const;
+  int lastStrip() const;
+  int clusterSize() const;
+  int bx() const;
+
+  bool hasTime() const;
+  float time() const;
+  float timeRMS() const;
+
+  bool hasY() const;
+  float y() const;
+  float yRMS() const;
+
+  void addTime(const float time);
+  void addY(const float y);
+  void merge(const CPPFCluster& cl);
+
+  bool operator<(const CPPFCluster& cl) const;
+  bool operator==(const CPPFCluster& cl) const;
+  bool isAdjacent(const CPPFCluster& cl) const;
+
+private:
+  uint16_t fstrip;
+  uint16_t lstrip;
+  int16_t bunchx;
+
+  float sumTime, sumTime2;
+  uint16_t nTime;
+
+  float sumY, sumY2;
+  uint16_t nY;
+};
+#endif

--- a/L1Trigger/L1TMuonCPPF/src/CPPFClusterContainer.h
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFClusterContainer.h
@@ -1,0 +1,6 @@
+#ifndef L1Trigger_CPPFClusterContainer_h
+#define L1Trigger_CPPFClusterContainer_h
+#include <set>
+class CPPFCluster;
+typedef std::set<CPPFCluster> CPPFClusterContainer;
+#endif

--- a/L1Trigger/L1TMuonCPPF/src/CPPFClusterizer.cc
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFClusterizer.cc
@@ -1,0 +1,43 @@
+#include "CPPFClusterizer.h"
+
+CPPFClusterContainer CPPFClusterizer::doAction(const RPCDigiCollection::Range& digiRange) {
+  CPPFClusterContainer initialCluster, finalCluster;
+  // Return empty container for null input
+  if (std::distance(digiRange.second, digiRange.first) == 0)
+    return finalCluster;
+
+  // Start from single digi recHits
+  for (auto digi = digiRange.first; digi != digiRange.second; ++digi) {
+    CPPFCluster cl(digi->strip(), digi->strip(), digi->bx());
+    if (digi->hasTime())
+      cl.addTime(digi->time());
+    if (digi->hasY())
+      cl.addY(digi->coordinateY());
+    initialCluster.insert(cl);
+  }
+  if (initialCluster.empty())
+    return finalCluster;  // Confirm the collection is valid
+
+  // Start from the first initial cluster
+  CPPFCluster prev = *initialCluster.begin();
+
+  // Loop over the remaining digis
+  // Note that the last one remains as open in this loop
+  for (auto cl = std::next(initialCluster.begin()); cl != initialCluster.end(); ++cl) {
+    if (prev.isAdjacent(*cl)) {
+      // Merged digi to the previous one
+      prev.merge(*cl);
+    } else {
+      // Close the previous cluster and start new cluster
+      finalCluster.insert(prev);
+      prev = *cl;
+    }
+  }
+
+  // Finalize by adding the last cluster
+  finalCluster.insert(prev);
+
+  return finalCluster;
+}
+
+

--- a/L1Trigger/L1TMuonCPPF/src/CPPFClusterizer.cc
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFClusterizer.cc
@@ -39,5 +39,3 @@ CPPFClusterContainer CPPFClusterizer::doAction(const RPCDigiCollection::Range& d
 
   return finalCluster;
 }
-
-

--- a/L1Trigger/L1TMuonCPPF/src/CPPFClusterizer.h
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFClusterizer.h
@@ -1,0 +1,17 @@
+#ifndef L1Trigger_CPPFClusterizer_h
+#define L1Trigger_CPPFClusterizer_h
+/** \class CPPFClusterizer
+ *  \author M. Maggi -- INFN Bari
+ */
+
+#include "CPPFClusterContainer.h"
+#include "CPPFCluster.h"
+#include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
+
+class CPPFClusterizer {
+public:
+  CPPFClusterizer(){};
+  ~CPPFClusterizer(){};
+  CPPFClusterContainer doAction(const RPCDigiCollection::Range& digiRange);
+};
+#endif

--- a/L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.cc
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.cc
@@ -1,0 +1,36 @@
+/** \Class CPPFMaskReClusterizer
+ *  \author R. Hadjiiska -- INRNE-BAS, Sofia
+ */
+
+#include "CPPFCluster.h"
+#include "CPPFClusterizer.h"
+#include "CPPFMaskReClusterizer.h"
+
+CPPFClusterContainer CPPFMaskReClusterizer::doAction(const RPCDetId& id,
+                                                   CPPFClusterContainer& initClusters,
+                                                   const CPPFRollMask& mask) const {
+  CPPFClusterContainer finClusters;
+  if (initClusters.empty())
+    return finClusters;
+
+  CPPFCluster prev = *initClusters.begin();
+  for (auto cl = std::next(initClusters.begin()); cl != initClusters.end(); ++cl) {
+    // Merge this cluster if it is adjacent by 1 masked strip
+    // Note that the CPPFClusterContainer collection is sorted in DECREASING ORDER of strip #
+    // So the prev. cluster is placed after the current cluster (check the < operator of CPPFCluster carefully)
+    if ((prev.firstStrip() - cl->lastStrip()) == 2 and this->get(mask, cl->lastStrip() + 1) and prev.bx() == cl->bx()) {
+      CPPFCluster merged(cl->firstStrip(), prev.lastStrip(), cl->bx());
+      prev = merged;
+    } else {
+      finClusters.insert(prev);
+      prev = *cl;
+    }
+  }
+
+  // Finalize by putting the last cluster to the collection
+  finClusters.insert(prev);
+
+  return finClusters;
+}
+
+bool CPPFMaskReClusterizer::get(const CPPFRollMask& mask, int strip) const { return mask.test(strip - 1); }

--- a/L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.cc
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.cc
@@ -7,8 +7,8 @@
 #include "CPPFMaskReClusterizer.h"
 
 CPPFClusterContainer CPPFMaskReClusterizer::doAction(const RPCDetId& id,
-                                                   CPPFClusterContainer& initClusters,
-                                                   const CPPFRollMask& mask) const {
+                                                     CPPFClusterContainer& initClusters,
+                                                     const CPPFRollMask& mask) const {
   CPPFClusterContainer finClusters;
   if (initClusters.empty())
     return finClusters;

--- a/L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.h
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.h
@@ -1,0 +1,20 @@
+#ifndef L1Trigger_CPPFMaskReClusterizer_h
+#define L1Trigger_CPPFMaskReClusterizer_h
+
+/** \Class CPPFMaskReClusterizer
+ *  \author R. Hadjiiska -- INRNE-BAS, Sofia
+ */
+
+#include "CPPFRPCRollMask.h"
+#include "CPPFClusterContainer.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+
+class CPPFMaskReClusterizer {
+public:
+  CPPFMaskReClusterizer(){};
+  ~CPPFMaskReClusterizer(){};
+  CPPFClusterContainer doAction(const RPCDetId& id, CPPFClusterContainer& initClusters, const CPPFRollMask& mask) const;
+  bool get(const CPPFRollMask& mask, int strip) const;
+};
+
+#endif

--- a/L1Trigger/L1TMuonCPPF/src/CPPFRPCRollMask.h
+++ b/L1Trigger/L1TMuonCPPF/src/CPPFRPCRollMask.h
@@ -1,0 +1,9 @@
+#ifndef L1Trigger_CPPFRPCRollMask_h
+#define L1Trigger_CPPFRPCRollMask_h
+
+#include <bitset>
+
+const int maskCPPFSIZE = 192;
+typedef std::bitset<maskCPPFSIZE> CPPFRollMask;
+
+#endif

--- a/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
+++ b/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
@@ -4,74 +4,66 @@
 #include "L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h"
 #include <fstream>
 #include <string>
+#include "L1Trigger/L1TMuonCPPF/src/CPPFClusterContainer.h"
+#include "L1Trigger/L1TMuonCPPF/src/CPPFCluster.h"
+#include "L1Trigger/L1TMuonCPPF/src/CPPFClusterizer.h"
+#include "L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.h"
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
 
-EmulateCPPF::EmulateCPPF(const edm::ParameterSet &iConfig,
-                         edm::ConsumesCollector &&iConsumes)
-    :  // rpcDigi_processors_(),
+EmulateCPPF::EmulateCPPF(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iConsumes):
       recHit_processors_(),
-      // rpcDigiToken_(
-      // iConsumes.consumes<RPCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))
-      // ),
+      rpcDigiToken_(iConsumes.consumes<RPCDigiCollection>(iConfig.getParameter<edm::InputTag>("rpcDigiLabel"))),
       recHitToken_(iConsumes.consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))),
+      rpcDigiSimLinkToken_(iConsumes.consumes<edm::DetSetVector<RPCDigiSimLink> >(iConfig.getParameter<edm::InputTag>("rpcDigiSimLinkLabel"))),
       cppfSource_(CppfSource::EventSetup),
       MaxClusterSize_(0) {
-  MaxClusterSize_ = iConfig.getParameter<int>("MaxClusterSize");
-
-  const std::string cppfSource = iConfig.getParameter<std::string>("cppfSource");
-  // Look up table
-  if (cppfSource == "File") {
-    cppfSource_ = CppfSource::File;
-    edm::FileInPath fp = iConfig.getParameter<edm::FileInPath>("cppfvecfile");
-    std::ifstream inputFile(fp.fullPath().c_str(), std::ios::in);
-    if (!inputFile) {
-      throw cms::Exception("No LUT") << "Error: CPPF look up table file cannot not be opened";
-      exit(1);
-    }
-    while (inputFile.good()) {
-      RecHitProcessor::CppfItem Item;
-      inputFile >> Item.rawId >> Item.strip >> Item.lb >> Item.halfchannel >> Item.int_phi >> Item.int_theta;
-      if (inputFile.good())
-        CppfVec_1.push_back(Item);
-    }
-    inputFile.close();
-  }
-
-  // RPC Geometry
-  else if (cppfSource == "Geo") {
-    cppfSource_ = CppfSource::EventSetup;
-  }
-  // Error for wrong input
-  else {
-    throw cms::Exception("Invalid option") << "Error: Specify in python/emulatorCppfDigis_cfi 'File' for look up  "
-                                              "table or 'Geo' for RPC Geometry";
-    exit(1);
-  }
-}
+        MaxClusterSize_ = iConfig.getParameter<int>("MaxClusterSize");
+        const std::string cppfSource = iConfig.getParameter<std::string>("cppfSource");
+//      Look up table
+        if (cppfSource == "File") {
+          cppfSource_ = CppfSource::File;
+          edm::FileInPath fp = iConfig.getParameter<edm::FileInPath>("cppfvecfile");
+          std::ifstream inputFile(fp.fullPath().c_str(), std::ios::in);
+            if (!inputFile) {
+            throw cms::Exception("No LUT") << "Error: CPPF look up table file cannot not be opened";
+            exit(1);
+            }
+            while (inputFile.good()) {
+              RecHitProcessor::CppfItem Item;
+              inputFile >> Item.rawId >> Item.strip >> Item.lb >> Item.halfchannel >> Item.int_phi >> Item.int_theta;
+              if (inputFile.good())
+                CppfVec_1.push_back(Item);
+            }
+          inputFile.close();
+        }
+//      RPC Geometry
+        else if (cppfSource == "Geo") {
+          cppfSource_ = CppfSource::EventSetup;
+        }
+//      Error for wrong input
+        else {
+          throw cms::Exception("Invalid option") << "Error: Specify in python/emulatorCppfDigis_cfi 'File' for look up table or 'Geo' for RPC Geometry";
+          exit(1);
+        }
+      }
 
 EmulateCPPF::~EmulateCPPF() {}
 
 void EmulateCPPF::process(const edm::Event &iEvent,
                           const edm::EventSetup &iSetup,
-                          // l1t::CPPFDigiCollection& cppf_rpcDigi,
                           l1t::CPPFDigiCollection &cppf_recHit) {
-  if (cppfSource_ == CppfSource::File) {
-    // Using the look up table to fill the information
+  if (cppfSource_ == CppfSource::File) {  // Using the look up table to fill the information
     cppf_recHit.clear();
     for (auto &recHit_processor : recHit_processors_) {
-      recHit_processor.processLook(iEvent, iSetup, recHitToken_, CppfVec_1, cppf_recHit, MaxClusterSize_);
-      //  recHit_processors_.at(recHit_processor).processLook( iEvent, iSetup,
-      //  recHitToken_, CppfVec_1, cppf_recHit );
+      recHit_processor.processLook(iEvent, iSetup, recHitToken_, rpcDigiToken_, rpcDigiSimLinkToken_, CppfVec_1, cppf_recHit, MaxClusterSize_);
     }
   } else if (cppfSource_ == CppfSource::EventSetup) {
     // Clear output collections
     // cppf_rpcDigi.clear();
     cppf_recHit.clear();
 
-    // // Get the RPCDigis from the event
-    // edm::Handle<RPCTag::digi_collection> rpcDigis;
-    // iEvent.getByToken(rpcDigiToken_, rpcDigis);
-
-    // _________________________________________________________________________________
+    //Get the RPCDigis from the event
     // Run the CPPF clusterization+coordinate conversion algo on RPCDigis and
     // RecHits
 
@@ -84,9 +76,9 @@ void EmulateCPPF::process(const edm::Event &iEvent,
     // cppf_rpcDigi );
     // }
     for (auto &recHit_processor : recHit_processors_) {
-      recHit_processor.process(iEvent, iSetup, recHitToken_, cppf_recHit);
-      // recHit_processors_.at(recHit_processor).process( iEvent, iSetup,
-      // recHitToken_, cppf_recHit );
+      recHit_processor.process(iEvent, iSetup, recHitToken_, rpcDigiToken_, rpcDigiSimLinkToken_, cppf_recHit);
     }
   }
 }  // End void EmulateCPPF::process()
+
+

--- a/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
+++ b/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
@@ -11,42 +11,44 @@
 #include "Geometry/RPCGeometry/interface/RPCRoll.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 
-EmulateCPPF::EmulateCPPF(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iConsumes):
-      recHit_processors_(),
+EmulateCPPF::EmulateCPPF(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iConsumes)
+    : recHit_processors_(),
       rpcDigiToken_(iConsumes.consumes<RPCDigiCollection>(iConfig.getParameter<edm::InputTag>("rpcDigiLabel"))),
       recHitToken_(iConsumes.consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))),
-      rpcDigiSimLinkToken_(iConsumes.consumes<edm::DetSetVector<RPCDigiSimLink> >(iConfig.getParameter<edm::InputTag>("rpcDigiSimLinkLabel"))),
+      rpcDigiSimLinkToken_(iConsumes.consumes<edm::DetSetVector<RPCDigiSimLink> >(
+          iConfig.getParameter<edm::InputTag>("rpcDigiSimLinkLabel"))),
       cppfSource_(CppfSource::EventSetup),
       MaxClusterSize_(0) {
-        MaxClusterSize_ = iConfig.getParameter<int>("MaxClusterSize");
-        const std::string cppfSource = iConfig.getParameter<std::string>("cppfSource");
-//      Look up table
-        if (cppfSource == "File") {
-          cppfSource_ = CppfSource::File;
-          edm::FileInPath fp = iConfig.getParameter<edm::FileInPath>("cppfvecfile");
-          std::ifstream inputFile(fp.fullPath().c_str(), std::ios::in);
-            if (!inputFile) {
-            throw cms::Exception("No LUT") << "Error: CPPF look up table file cannot not be opened";
-            exit(1);
-            }
-            while (inputFile.good()) {
-              RecHitProcessor::CppfItem Item;
-              inputFile >> Item.rawId >> Item.strip >> Item.lb >> Item.halfchannel >> Item.int_phi >> Item.int_theta;
-              if (inputFile.good())
-                CppfVec_1.push_back(Item);
-            }
-          inputFile.close();
-        }
-//      RPC Geometry
-        else if (cppfSource == "Geo") {
-          cppfSource_ = CppfSource::EventSetup;
-        }
-//      Error for wrong input
-        else {
-          throw cms::Exception("Invalid option") << "Error: Specify in python/emulatorCppfDigis_cfi 'File' for look up table or 'Geo' for RPC Geometry";
-          exit(1);
-        }
-      }
+  MaxClusterSize_ = iConfig.getParameter<int>("MaxClusterSize");
+  const std::string cppfSource = iConfig.getParameter<std::string>("cppfSource");
+  //      Look up table
+  if (cppfSource == "File") {
+    cppfSource_ = CppfSource::File;
+    edm::FileInPath fp = iConfig.getParameter<edm::FileInPath>("cppfvecfile");
+    std::ifstream inputFile(fp.fullPath().c_str(), std::ios::in);
+    if (!inputFile) {
+      throw cms::Exception("No LUT") << "Error: CPPF look up table file cannot not be opened";
+      exit(1);
+    }
+    while (inputFile.good()) {
+      RecHitProcessor::CppfItem Item;
+      inputFile >> Item.rawId >> Item.strip >> Item.lb >> Item.halfchannel >> Item.int_phi >> Item.int_theta;
+      if (inputFile.good())
+        CppfVec_1.push_back(Item);
+    }
+    inputFile.close();
+  }
+  //      RPC Geometry
+  else if (cppfSource == "Geo") {
+    cppfSource_ = CppfSource::EventSetup;
+  }
+  //      Error for wrong input
+  else {
+    throw cms::Exception("Invalid option")
+        << "Error: Specify in python/emulatorCppfDigis_cfi 'File' for look up table or 'Geo' for RPC Geometry";
+    exit(1);
+  }
+}
 
 EmulateCPPF::~EmulateCPPF() {}
 
@@ -56,7 +58,8 @@ void EmulateCPPF::process(const edm::Event &iEvent,
   if (cppfSource_ == CppfSource::File) {  // Using the look up table to fill the information
     cppf_recHit.clear();
     for (auto &recHit_processor : recHit_processors_) {
-      recHit_processor.processLook(iEvent, iSetup, recHitToken_, rpcDigiToken_, rpcDigiSimLinkToken_, CppfVec_1, cppf_recHit, MaxClusterSize_);
+      recHit_processor.processLook(
+          iEvent, iSetup, recHitToken_, rpcDigiToken_, rpcDigiSimLinkToken_, CppfVec_1, cppf_recHit, MaxClusterSize_);
     }
   } else if (cppfSource_ == CppfSource::EventSetup) {
     // Clear output collections
@@ -80,5 +83,3 @@ void EmulateCPPF::process(const edm::Event &iEvent,
     }
   }
 }  // End void EmulateCPPF::process()
-
-

--- a/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
+++ b/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
@@ -7,7 +7,6 @@
 #include "L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
 
-
 RecHitProcessor::RecHitProcessor() {}
 
 RecHitProcessor::~RecHitProcessor() {}
@@ -20,7 +19,6 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
                                   std::vector<RecHitProcessor::CppfItem> &CppfVec1,
                                   l1t::CPPFDigiCollection &cppfDigis,
                                   const int MaxClusterSize) const {
-
   edm::Handle<RPCRecHitCollection> recHits;
   iEvent.getByToken(recHitToken, recHits);
 
@@ -33,10 +31,11 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
   edm::ESHandle<RPCGeometry> rpcGeom;
   iSetup.get<MuonGeometryRecord>().get(rpcGeom);
 
-  for (const auto&& rpcdgIt : (*rpcDigis)) {
-    const RPCDetId& rpcId = rpcdgIt.first;
-    const RPCDigiCollection::Range& range = rpcdgIt.second;
-    if (rpcId.region()==0) continue;
+  for (const auto &&rpcdgIt : (*rpcDigis)) {
+    const RPCDetId &rpcId = rpcdgIt.first;
+    const RPCDigiCollection::Range &range = rpcdgIt.second;
+    if (rpcId.region() == 0)
+      continue;
 
     CPPFClusterizer clizer;
     CPPFClusterContainer tcls = clizer.doAction(range);
@@ -44,7 +43,7 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
     CPPFRollMask mask;
     CPPFClusterContainer cls = mrclizer.doAction(rpcId, tcls, mask);
 
-    for (auto cl : cls){
+    for (auto cl : cls) {
       int isValid = rpcDigis.isValid();
       int rawId = rpcId.rawId();
       int Bx = cl.bx();
@@ -59,7 +58,7 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
       const double y = cl.hasY() ? cl.y() : 0;
       LocalPoint lPos(centreOfCluster, y, 0);
       if (roll->id().region() != 0) {
-        const auto& topo = dynamic_cast<const TrapezoidalStripTopology&>(roll->topology());
+        const auto &topo = dynamic_cast<const TrapezoidalStripTopology &>(roll->topology());
         const double angle = topo.stripAngle((firststrip + laststrip) / 2.);
         const double x = centreOfCluster - y * std::tan(angle);
         lPos = LocalPoint(x, y, 0);
@@ -94,25 +93,21 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
       if ((global_phi > 15.) && (global_phi <= 16.3)) {
         EMTFsector1 = 1;
         EMTFsector2 = 6;
-      }
-      else if ((global_phi > 16.3) && (global_phi <= 53.)) {
+      } else if ((global_phi > 16.3) && (global_phi <= 53.)) {
         EMTFsector1 = 1;
         EMTFsector2 = 0;
-      }
-      else if ((global_phi > 53.) && (global_phi <= 75.)) {
+      } else if ((global_phi > 53.) && (global_phi <= 75.)) {
         EMTFsector1 = 1;
         EMTFsector2 = 2;
       }
-        // sector 2
+      // sector 2
       else if ((global_phi > 75.) && (global_phi <= 76.3)) {
         EMTFsector1 = 1;
         EMTFsector2 = 2;
-      }
-      else if ((global_phi > 76.3) && (global_phi <= 113.)) {
+      } else if ((global_phi > 76.3) && (global_phi <= 113.)) {
         EMTFsector1 = 2;
         EMTFsector2 = 0;
-      }
-      else if ((global_phi > 113.) && (global_phi <= 135.)) {
+      } else if ((global_phi > 113.) && (global_phi <= 135.)) {
         EMTFsector1 = 2;
         EMTFsector2 = 3;
       }
@@ -159,12 +154,10 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
       else if ((global_phi > -45.) && (global_phi <= -43.7)) {
         EMTFsector1 = 5;
         EMTFsector2 = 6;
-      }
-      else if ((global_phi > -43.7) && (global_phi <= -7.)) {
+      } else if ((global_phi > -43.7) && (global_phi <= -7.)) {
         EMTFsector1 = 6;
         EMTFsector2 = 0;
-      }
-      else if ((global_phi > -7.) && (global_phi <= 15.)) {
+      } else if ((global_phi > -7.) && (global_phi <= 15.)) {
         EMTFsector1 = 6;
         EMTFsector2 = 1;
       }
@@ -196,8 +189,7 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
                 cppf = (cppf1 - 1);
               else if (before > after)
                 cppf = (cppf1 + 1);
-            }
-            else if (firststrip > 1) {
+            } else if (firststrip > 1) {
               if (before < after)
                 cppf = (cppf1 + 1);
               else if (before > after)
@@ -235,12 +227,10 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
 
             if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
               cppfDigis.push_back(*MainVariables1.get());
-            }
-            else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
+            } else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
               cppfDigis.push_back(*MainVariables1.get());
               cppfDigis.push_back(*MainVariables2.get());
-            }
-            else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
+            } else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
               continue;
             }
           }  // Geo is true
@@ -275,20 +265,18 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
                                                                             global_theta));
             if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
               cppfDigis.push_back(*MainVariables1.get());
-            }
-            else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
+            } else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
               cppfDigis.push_back(*MainVariables1.get());
               cppfDigis.push_back(*MainVariables2.get());
-            }
-            else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
+            } else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
               continue;
             }
           }
         }  // Condition to save the CPPFDigi
-      }// Loop over the LUTVector
-    }//end loop over cludters
-  }//end loop over digis
-}//end processlook function
+      }    // Loop over the LUTVector
+    }      //end loop over cludters
+  }        //end loop over digis
+}  //end processlook function
 
 void RecHitProcessor::process(const edm::Event &iEvent,
                               const edm::EventSetup &iSetup,
@@ -296,7 +284,6 @@ void RecHitProcessor::process(const edm::Event &iEvent,
                               const edm::EDGetToken &rpcDigiToken,
                               const edm::EDGetToken &rpcDigiSimLinkToken,
                               l1t::CPPFDigiCollection &cppfDigis) const {
-
   // Get the RPC Geometry
   edm::ESHandle<RPCGeometry> rpcGeom;
   iSetup.get<MuonGeometryRecord>().get(rpcGeom);
@@ -308,10 +295,11 @@ void RecHitProcessor::process(const edm::Event &iEvent,
   edm::Handle<RPCRecHitCollection> recHits;
   iEvent.getByToken(recHitToken, recHits);
 
-  for (const auto&& rpcdgIt : (*rpcDigis)) {
-    const RPCDetId& rpcId = rpcdgIt.first;
-    const RPCDigiCollection::Range& range = rpcdgIt.second;
-    if (rpcId.region()==0) continue;
+  for (const auto &&rpcdgIt : (*rpcDigis)) {
+    const RPCDetId &rpcId = rpcdgIt.first;
+    const RPCDigiCollection::Range &range = rpcdgIt.second;
+    if (rpcId.region() == 0)
+      continue;
 
     CPPFClusterizer clizer;
     CPPFClusterContainer tcls = clizer.doAction(range);
@@ -319,10 +307,10 @@ void RecHitProcessor::process(const edm::Event &iEvent,
     CPPFRollMask mask;
     CPPFClusterContainer cls = mrclizer.doAction(rpcId, tcls, mask);
 
-    for (auto cl : cls){
+    for (auto cl : cls) {
       int region = rpcId.region();
       int isValid = rpcDigis.isValid();
-//      int rawId = rpcId.rawId();
+      //      int rawId = rpcId.rawId();
       int Bx = cl.bx();
       const int firststrip = cl.firstStrip();
       const int clustersize = cl.clusterSize();
@@ -335,7 +323,7 @@ void RecHitProcessor::process(const edm::Event &iEvent,
       const double y = cl.hasY() ? cl.y() : 0;
       LocalPoint lPos(centreOfCluster, y, 0);
       if (roll->id().region() != 0) {
-        const auto& topo = dynamic_cast<const TrapezoidalStripTopology&>(roll->topology());
+        const auto &topo = dynamic_cast<const TrapezoidalStripTopology &>(roll->topology());
         const double angle = topo.stripAngle((firststrip + laststrip) / 2.);
         const double x = centreOfCluster - y * std::tan(angle);
         lPos = LocalPoint(x, y, 0);
@@ -347,14 +335,14 @@ void RecHitProcessor::process(const edm::Event &iEvent,
 
       // Endcap region only
       if (region != 0) {
-        int int_theta = (region == -1 ? 180. * 32. / 36.5 : 0.) + (float)region * global_theta * 32. / 36.5 - 8.5 * 32 / 36.5;
+        int int_theta =
+            (region == -1 ? 180. * 32. / 36.5 : 0.) + (float)region * global_theta * 32. / 36.5 - 8.5 * 32 / 36.5;
         if (region == 1) {
           if (global_theta < 8.5)
             int_theta = 0;
           if (global_theta > 45.)
             int_theta = 31;
-        }
-        else if (region == -1) {
+        } else if (region == -1) {
           if (global_theta < 135.)
             int_theta = 31;
           if (global_theta > 171.5)
@@ -370,13 +358,11 @@ void RecHitProcessor::process(const edm::Event &iEvent,
           local_phi = global_phi - 15.;
           EMTFsector1 = 1;
           EMTFsector2 = 6;
-        }
-        else if ((global_phi > 16.3) && (global_phi <= 53.)) {
+        } else if ((global_phi > 16.3) && (global_phi <= 53.)) {
           local_phi = global_phi - 15.;
           EMTFsector1 = 1;
           EMTFsector2 = 0;
-        }
-        else if ((global_phi > 53.) && (global_phi <= 75.)) {
+        } else if ((global_phi > 53.) && (global_phi <= 75.)) {
           local_phi = global_phi - 15.;
           EMTFsector1 = 1;
           EMTFsector2 = 2;
@@ -386,13 +372,11 @@ void RecHitProcessor::process(const edm::Event &iEvent,
           local_phi = global_phi - 15.;
           EMTFsector1 = 1;
           EMTFsector2 = 2;
-        }
-        else if ((global_phi > 76.3) && (global_phi <= 113.)) {
+        } else if ((global_phi > 76.3) && (global_phi <= 113.)) {
           local_phi = global_phi - 75.;
           EMTFsector1 = 2;
           EMTFsector2 = 0;
-        }
-        else if ((global_phi > 113.) && (global_phi <= 135.)) {
+        } else if ((global_phi > 113.) && (global_phi <= 135.)) {
           local_phi = global_phi - 75.;
           EMTFsector1 = 2;
           EMTFsector2 = 3;
@@ -403,13 +387,11 @@ void RecHitProcessor::process(const edm::Event &iEvent,
           local_phi = global_phi - 75.;
           EMTFsector1 = 2;
           EMTFsector2 = 3;
-        }
-        else if ((global_phi > 136.3) && (global_phi <= 173.)) {
+        } else if ((global_phi > 136.3) && (global_phi <= 173.)) {
           local_phi = global_phi - 135.;
           EMTFsector1 = 3;
           EMTFsector2 = 0;
-        }
-        else if ((global_phi > 173.) && (global_phi <= 180.)) {
+        } else if ((global_phi > 173.) && (global_phi <= 180.)) {
           local_phi = global_phi - 135.;
           EMTFsector1 = 3;
           EMTFsector2 = 4;
@@ -425,13 +407,11 @@ void RecHitProcessor::process(const edm::Event &iEvent,
           local_phi = global_phi + 225.;
           EMTFsector1 = 3;
           EMTFsector2 = 4;
-        }
-        else if ((global_phi > -163.7) && (global_phi <= -127.)) {
+        } else if ((global_phi > -163.7) && (global_phi <= -127.)) {
           local_phi = global_phi + 165.;
           EMTFsector1 = 4;
           EMTFsector2 = 0;
-        }
-        else if ((global_phi > -127.) && (global_phi <= -105.)) {
+        } else if ((global_phi > -127.) && (global_phi <= -105.)) {
           local_phi = global_phi + 165.;
           EMTFsector1 = 4;
           EMTFsector2 = 5;
@@ -441,13 +421,11 @@ void RecHitProcessor::process(const edm::Event &iEvent,
           local_phi = global_phi + 165.;
           EMTFsector1 = 4;
           EMTFsector2 = 5;
-        }
-        else if ((global_phi > -103.7) && (global_phi <= -67.)) {
+        } else if ((global_phi > -103.7) && (global_phi <= -67.)) {
           local_phi = global_phi + 105.;
           EMTFsector1 = 5;
           EMTFsector2 = 0;
-        }
-        else if ((global_phi > -67.) && (global_phi <= -45.)) {
+        } else if ((global_phi > -67.) && (global_phi <= -45.)) {
           local_phi = global_phi + 105.;
           EMTFsector1 = 5;
           EMTFsector2 = 6;
@@ -457,13 +435,11 @@ void RecHitProcessor::process(const edm::Event &iEvent,
           local_phi = global_phi + 105.;
           EMTFsector1 = 5;
           EMTFsector2 = 6;
-        }
-        else if ((global_phi > -43.7) && (global_phi <= -7.)) {
+        } else if ((global_phi > -43.7) && (global_phi <= -7.)) {
           local_phi = global_phi + 45.;
           EMTFsector1 = 6;
           EMTFsector2 = 0;
-        }
-        else if ((global_phi > -7.) && (global_phi <= 15.)) {
+        } else if ((global_phi > -7.) && (global_phi <= 15.)) {
           local_phi = global_phi + 45.;
           EMTFsector1 = 6;
           EMTFsector2 = 1;
@@ -520,7 +496,7 @@ void RecHitProcessor::process(const edm::Event &iEvent,
         if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
           continue;
         }
-      }// No barrel hits
-    }//end loop over clusters
-  }//end loop over digis
-}// End function: void RecHitProcessor::process()
+      }  // No barrel hits
+    }    //end loop over clusters
+  }      //end loop over digis
+}  // End function: void RecHitProcessor::process()

--- a/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
+++ b/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
@@ -1,4 +1,12 @@
 #include "L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h"
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "L1Trigger/L1TMuonCPPF/src/CPPFClusterContainer.h"
+#include "L1Trigger/L1TMuonCPPF/src/CPPFCluster.h"
+#include "L1Trigger/L1TMuonCPPF/src/CPPFClusterizer.h"
+#include "L1Trigger/L1TMuonCPPF/src/CPPFMaskReClusterizer.h"
+#include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
+
 
 RecHitProcessor::RecHitProcessor() {}
 
@@ -7,504 +15,512 @@ RecHitProcessor::~RecHitProcessor() {}
 void RecHitProcessor::processLook(const edm::Event &iEvent,
                                   const edm::EventSetup &iSetup,
                                   const edm::EDGetToken &recHitToken,
+                                  const edm::EDGetToken &rpcDigiToken,
+                                  const edm::EDGetToken &rpcDigiSimLinkToken,
                                   std::vector<RecHitProcessor::CppfItem> &CppfVec1,
                                   l1t::CPPFDigiCollection &cppfDigis,
                                   const int MaxClusterSize) const {
+
   edm::Handle<RPCRecHitCollection> recHits;
   iEvent.getByToken(recHitToken, recHits);
+
+  edm::Handle<RPCDigiCollection> rpcDigis;
+  iEvent.getByToken(rpcDigiToken, rpcDigis);
+
+  edm::Handle<edm::DetSetVector<RPCDigiSimLink>> theSimlinkDigis;
+  iEvent.getByToken(rpcDigiSimLinkToken, theSimlinkDigis);
 
   edm::ESHandle<RPCGeometry> rpcGeom;
   iSetup.get<MuonGeometryRecord>().get(rpcGeom);
 
-  // The loop is over the detector container in the rpc geometry collection. We
-  // are interested in the RPDdetID (inside of RPCChamber vectors),
-  // specifically, the RPCrechits. to assignment the CPPFDigis.
-  for (TrackingGeometry::DetContainer::const_iterator iDet = rpcGeom->dets().begin(); iDet < rpcGeom->dets().end();
-       iDet++) {
-    //  we do a cast over the class RPCChamber to obtain the RPCroll vectors,
-    //  inside of them, the RPCRechits are found. in other words, the method
-    //  ->rolls() does not exist for other kind of vector within DetContainer
-    //  and we can not obtain the rpcrechits in a suitable way.
-    if (dynamic_cast<const RPCChamber *>(*iDet) == nullptr)
-      continue;
+  for (const auto&& rpcdgIt : (*rpcDigis)) {
+    const RPCDetId& rpcId = rpcdgIt.first;
+    const RPCDigiCollection::Range& range = rpcdgIt.second;
+    if (rpcId.region()==0) continue;
 
-    auto chamb = dynamic_cast<const RPCChamber *>(*iDet);
+    CPPFClusterizer clizer;
+    CPPFClusterContainer tcls = clizer.doAction(range);
+    CPPFMaskReClusterizer mrclizer;
+    CPPFRollMask mask;
+    CPPFClusterContainer cls = mrclizer.doAction(rpcId, tcls, mask);
 
-    std::vector<const RPCRoll *> rolls = (chamb->rolls());
+    for (auto cl : cls){
+      int isValid = rpcDigis.isValid();
+      int rawId = rpcId.rawId();
+      int Bx = cl.bx();
+      const int firststrip = cl.firstStrip();
+      const int clustersize = cl.clusterSize();
+      const int laststrip = cl.lastStrip();
+      const RPCRoll *roll = rpcGeom->roll(rpcId);
+      // Get Average Strip position
+      const float fstrip = (roll->centreOfStrip(firststrip)).x();
+      const float lstrip = (roll->centreOfStrip(laststrip)).x();
+      const float centreOfCluster = (fstrip + lstrip) / 2;
+      const double y = cl.hasY() ? cl.y() : 0;
+      LocalPoint lPos(centreOfCluster, y, 0);
+      if (roll->id().region() != 0) {
+        const auto& topo = dynamic_cast<const TrapezoidalStripTopology&>(roll->topology());
+        const double angle = topo.stripAngle((firststrip + laststrip) / 2.);
+        const double x = centreOfCluster - y * std::tan(angle);
+        lPos = LocalPoint(x, y, 0);
+      }
+      const BoundPlane &rollSurface = roll->surface();
+      GlobalPoint gPos = rollSurface.toGlobal(lPos);
+      float global_theta = emtf::rad_to_deg(gPos.theta().value());
+      float global_phi = emtf::rad_to_deg(gPos.phi().value());
 
-    // Loop over rolls in the chamber
-    for (auto &iRoll : rolls) {
-      RPCDetId rpcId = (*iRoll).id();
+      // Establish the average position of the rechit
+      int rechitstrip = firststrip;
 
-      typedef std::pair<RPCRecHitCollection::const_iterator, RPCRecHitCollection::const_iterator> rangeRecHits;
-      rangeRecHits recHitCollection = recHits->get(rpcId);
+      if (clustersize > 2) {
+        int medium = 0;
+        if (clustersize % 2 == 0)
+          medium = 0.5 * (clustersize);
+        else
+          medium = 0.5 * (clustersize - 1);
+        rechitstrip += medium;
+      }
+      if (clustersize > MaxClusterSize)
+        continue;
+      // This is just for test CPPFDigis with the RPC Geometry, It must be
+      // "true" in the normal runs
+      bool Geo = true;
+      ////:::::::::::::::::::::::::::::::::::::::::::::::::
+      // Set the EMTF Sector
+      int EMTFsector1 = 0;
+      int EMTFsector2 = 0;
 
-      // Loop over the RPC digis
-      for (RPCRecHitCollection::const_iterator rechit_it = recHitCollection.first; rechit_it != recHitCollection.second;
-           rechit_it++) {
-        // const RPCDetId& rpcId = rechit_it->rpcId();
-        int rawId = rpcId.rawId();
-        // int station = rpcId.station();
-        int Bx = rechit_it->BunchX();
-        int isValid = rechit_it->isValid();
-        int firststrip = rechit_it->firstClusterStrip();
-        int clustersize = rechit_it->clusterSize();
-        LocalPoint lPos = rechit_it->localPosition();
-        const RPCRoll *roll = rpcGeom->roll(rpcId);
-        const BoundPlane &rollSurface = roll->surface();
-        GlobalPoint gPos = rollSurface.toGlobal(lPos);
-        float global_theta = emtf::rad_to_deg(gPos.theta().value());
-        float global_phi = emtf::rad_to_deg(gPos.phi().value());
-        //::::::::::::::::::::::::::::
-        // Establish the average position of the rechit
-        int rechitstrip = firststrip;
+      // sector 1
+      if ((global_phi > 15.) && (global_phi <= 16.3)) {
+        EMTFsector1 = 1;
+        EMTFsector2 = 6;
+      }
+      else if ((global_phi > 16.3) && (global_phi <= 53.)) {
+        EMTFsector1 = 1;
+        EMTFsector2 = 0;
+      }
+      else if ((global_phi > 53.) && (global_phi <= 75.)) {
+        EMTFsector1 = 1;
+        EMTFsector2 = 2;
+      }
+        // sector 2
+      else if ((global_phi > 75.) && (global_phi <= 76.3)) {
+        EMTFsector1 = 1;
+        EMTFsector2 = 2;
+      }
+      else if ((global_phi > 76.3) && (global_phi <= 113.)) {
+        EMTFsector1 = 2;
+        EMTFsector2 = 0;
+      }
+      else if ((global_phi > 113.) && (global_phi <= 135.)) {
+        EMTFsector1 = 2;
+        EMTFsector2 = 3;
+      }
+      // sector 3
+      // less than 180
+      else if ((global_phi > 135.) && (global_phi <= 136.3)) {
+        EMTFsector1 = 2;
+        EMTFsector2 = 3;
+      } else if ((global_phi > 136.3) && (global_phi <= 173.)) {
+        EMTFsector1 = 3;
+        EMTFsector2 = 0;
+      } else if ((global_phi > 173.) && (global_phi <= 180.)) {
+        EMTFsector1 = 3;
+        EMTFsector2 = 4;
+      }
+      // Greater than -180
+      else if ((global_phi < -165.) && (global_phi >= -180.)) {
+        EMTFsector1 = 3;
+        EMTFsector2 = 4;
+      }
+      // Fourth sector
+      else if ((global_phi > -165.) && (global_phi <= -163.7)) {
+        EMTFsector1 = 3;
+        EMTFsector2 = 4;
+      } else if ((global_phi > -163.7) && (global_phi <= -127.)) {
+        EMTFsector1 = 4;
+        EMTFsector2 = 0;
+      } else if ((global_phi > -127.) && (global_phi <= -105.)) {
+        EMTFsector1 = 4;
+        EMTFsector2 = 5;
+      }
+      // fifth sector
+      else if ((global_phi > -105.) && (global_phi <= -103.7)) {
+        EMTFsector1 = 4;
+        EMTFsector2 = 5;
+      } else if ((global_phi > -103.7) && (global_phi <= -67.)) {
+        EMTFsector1 = 5;
+        EMTFsector2 = 0;
+      } else if ((global_phi > -67.) && (global_phi <= -45.)) {
+        EMTFsector1 = 5;
+        EMTFsector2 = 6;
+      }
+      // sixth sector
+      else if ((global_phi > -45.) && (global_phi <= -43.7)) {
+        EMTFsector1 = 5;
+        EMTFsector2 = 6;
+      }
+      else if ((global_phi > -43.7) && (global_phi <= -7.)) {
+        EMTFsector1 = 6;
+        EMTFsector2 = 0;
+      }
+      else if ((global_phi > -7.) && (global_phi <= 15.)) {
+        EMTFsector1 = 6;
+        EMTFsector2 = 1;
+      }
 
-        if (clustersize > 2) {
-          int medium = 0;
-          if (clustersize % 2 == 0)
-            medium = 0.5 * (clustersize);
-          else
-            medium = 0.5 * (clustersize - 1);
-          rechitstrip += medium;
+      double EMTFLink1 = 0.;
+      double EMTFLink2 = 0.;
+      std::vector<RecHitProcessor::CppfItem>::iterator cppf1;
+      std::vector<RecHitProcessor::CppfItem>::iterator cppf;
+      for (cppf1 = CppfVec1.begin(); cppf1 != CppfVec1.end(); cppf1++) {
+        // Condition to save the CPPFDigi
+        if (((*cppf1).rawId == rawId) && ((*cppf1).strip == rechitstrip)) {
+          int old_strip = (*cppf1).strip;
+          int before = 0;
+          int after = 0;
+
+          if (cppf1 != CppfVec1.begin())
+            before = (*(cppf1 - 2)).strip;
+          else if (cppf1 == CppfVec1.begin())
+            before = (*cppf1).strip;
+          if (cppf1 != CppfVec1.end())
+            after = (*(cppf1 + 2)).strip;
+          else if (cppf1 == CppfVec1.end())
+            after = (*cppf1).strip;
+          cppf = cppf1;
+
+          if (clustersize == 2) {
+            if (firststrip == 1) {
+              if (before < after)
+                cppf = (cppf1 - 1);
+              else if (before > after)
+                cppf = (cppf1 + 1);
+            }
+            else if (firststrip > 1) {
+              if (before < after)
+                cppf = (cppf1 + 1);
+              else if (before > after)
+                cppf = (cppf1 - 1);
+            }
+          }
+          // Using the RPCGeometry
+          if (Geo) {
+            std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
+                                                                            Bx,
+                                                                            (*cppf).int_phi,
+                                                                            (*cppf).int_theta,
+                                                                            isValid,
+                                                                            (*cppf).lb,
+                                                                            (*cppf).halfchannel,
+                                                                            EMTFsector1,
+                                                                            EMTFLink1,
+                                                                            old_strip,
+                                                                            clustersize,
+                                                                            global_phi,
+                                                                            global_theta));
+            std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
+                                                                            Bx,
+                                                                            (*cppf).int_phi,
+                                                                            (*cppf).int_theta,
+                                                                            isValid,
+                                                                            (*cppf).lb,
+                                                                            (*cppf).halfchannel,
+                                                                            EMTFsector2,
+                                                                            EMTFLink2,
+                                                                            old_strip,
+                                                                            clustersize,
+                                                                            global_phi,
+                                                                            global_theta));
+
+            if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
+              cppfDigis.push_back(*MainVariables1.get());
+            }
+            else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
+              cppfDigis.push_back(*MainVariables1.get());
+              cppfDigis.push_back(*MainVariables2.get());
+            }
+            else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
+              continue;
+            }
+          }  // Geo is true
+          else {
+            global_phi = 0.;
+            global_theta = 0.;
+            std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
+                                                                            Bx,
+                                                                            (*cppf).int_phi,
+                                                                            (*cppf).int_theta,
+                                                                            isValid,
+                                                                            (*cppf).lb,
+                                                                            (*cppf).halfchannel,
+                                                                            EMTFsector1,
+                                                                            EMTFLink1,
+                                                                            old_strip,
+                                                                            clustersize,
+                                                                            global_phi,
+                                                                            global_theta));
+            std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
+                                                                            Bx,
+                                                                            (*cppf).int_phi,
+                                                                            (*cppf).int_theta,
+                                                                            isValid,
+                                                                            (*cppf).lb,
+                                                                            (*cppf).halfchannel,
+                                                                            EMTFsector2,
+                                                                            EMTFLink2,
+                                                                            old_strip,
+                                                                            clustersize,
+                                                                            global_phi,
+                                                                            global_theta));
+            if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
+              cppfDigis.push_back(*MainVariables1.get());
+            }
+            else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
+              cppfDigis.push_back(*MainVariables1.get());
+              cppfDigis.push_back(*MainVariables2.get());
+            }
+            else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
+              continue;
+            }
+          }
+        }  // Condition to save the CPPFDigi
+      }// Loop over the LUTVector
+    }//end loop over cludters
+  }//end loop over digis
+}//end processlook function
+
+void RecHitProcessor::process(const edm::Event &iEvent,
+                              const edm::EventSetup &iSetup,
+                              const edm::EDGetToken &recHitToken,
+                              const edm::EDGetToken &rpcDigiToken,
+                              const edm::EDGetToken &rpcDigiSimLinkToken,
+                              l1t::CPPFDigiCollection &cppfDigis) const {
+
+  // Get the RPC Geometry
+  edm::ESHandle<RPCGeometry> rpcGeom;
+  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+
+  edm::Handle<RPCDigiCollection> rpcDigis;
+  iEvent.getByToken(rpcDigiToken, rpcDigis);
+
+  // Get the RecHits from the event
+  edm::Handle<RPCRecHitCollection> recHits;
+  iEvent.getByToken(recHitToken, recHits);
+
+  for (const auto&& rpcdgIt : (*rpcDigis)) {
+    const RPCDetId& rpcId = rpcdgIt.first;
+    const RPCDigiCollection::Range& range = rpcdgIt.second;
+    if (rpcId.region()==0) continue;
+
+    CPPFClusterizer clizer;
+    CPPFClusterContainer tcls = clizer.doAction(range);
+    CPPFMaskReClusterizer mrclizer;
+    CPPFRollMask mask;
+    CPPFClusterContainer cls = mrclizer.doAction(rpcId, tcls, mask);
+
+    for (auto cl : cls){
+      int region = rpcId.region();
+      int isValid = rpcDigis.isValid();
+//      int rawId = rpcId.rawId();
+      int Bx = cl.bx();
+      const int firststrip = cl.firstStrip();
+      const int clustersize = cl.clusterSize();
+      const int laststrip = cl.lastStrip();
+      const RPCRoll *roll = rpcGeom->roll(rpcId);
+      // Get Average Strip position
+      const float fstrip = (roll->centreOfStrip(firststrip)).x();
+      const float lstrip = (roll->centreOfStrip(laststrip)).x();
+      const float centreOfCluster = (fstrip + lstrip) / 2;
+      const double y = cl.hasY() ? cl.y() : 0;
+      LocalPoint lPos(centreOfCluster, y, 0);
+      if (roll->id().region() != 0) {
+        const auto& topo = dynamic_cast<const TrapezoidalStripTopology&>(roll->topology());
+        const double angle = topo.stripAngle((firststrip + laststrip) / 2.);
+        const double x = centreOfCluster - y * std::tan(angle);
+        lPos = LocalPoint(x, y, 0);
+      }
+      const BoundPlane &rollSurface = roll->surface();
+      GlobalPoint gPos = rollSurface.toGlobal(lPos);
+      float global_theta = emtf::rad_to_deg(gPos.theta().value());
+      float global_phi = emtf::rad_to_deg(gPos.phi().value());
+
+      // Endcap region only
+      if (region != 0) {
+        int int_theta = (region == -1 ? 180. * 32. / 36.5 : 0.) + (float)region * global_theta * 32. / 36.5 - 8.5 * 32 / 36.5;
+        if (region == 1) {
+          if (global_theta < 8.5)
+            int_theta = 0;
+          if (global_theta > 45.)
+            int_theta = 31;
         }
-
-        if (clustersize > MaxClusterSize)
-          continue;
-        // This is just for test CPPFDigis with the RPC Geometry, It must be
-        // "true" in the normal runs
-        bool Geo = true;
-        ////:::::::::::::::::::::::::::::::::::::::::::::::::
-        // Set the EMTF Sector
+        else if (region == -1) {
+          if (global_theta < 135.)
+            int_theta = 31;
+          if (global_theta > 171.5)
+            int_theta = 0;
+        }
+        // Local EMTF
+        double local_phi = 0.;
         int EMTFsector1 = 0;
         int EMTFsector2 = 0;
 
         // sector 1
         if ((global_phi > 15.) && (global_phi <= 16.3)) {
+          local_phi = global_phi - 15.;
           EMTFsector1 = 1;
           EMTFsector2 = 6;
-        } else if ((global_phi > 16.3) && (global_phi <= 53.)) {
+        }
+        else if ((global_phi > 16.3) && (global_phi <= 53.)) {
+          local_phi = global_phi - 15.;
           EMTFsector1 = 1;
           EMTFsector2 = 0;
-        } else if ((global_phi > 53.) && (global_phi <= 75.)) {
+        }
+        else if ((global_phi > 53.) && (global_phi <= 75.)) {
+          local_phi = global_phi - 15.;
           EMTFsector1 = 1;
           EMTFsector2 = 2;
         }
         // sector 2
         else if ((global_phi > 75.) && (global_phi <= 76.3)) {
+          local_phi = global_phi - 15.;
           EMTFsector1 = 1;
           EMTFsector2 = 2;
-        } else if ((global_phi > 76.3) && (global_phi <= 113.)) {
+        }
+        else if ((global_phi > 76.3) && (global_phi <= 113.)) {
+          local_phi = global_phi - 75.;
           EMTFsector1 = 2;
           EMTFsector2 = 0;
-        } else if ((global_phi > 113.) && (global_phi <= 135.)) {
+        }
+        else if ((global_phi > 113.) && (global_phi <= 135.)) {
+          local_phi = global_phi - 75.;
           EMTFsector1 = 2;
           EMTFsector2 = 3;
         }
         // sector 3
         // less than 180
         else if ((global_phi > 135.) && (global_phi <= 136.3)) {
+          local_phi = global_phi - 75.;
           EMTFsector1 = 2;
           EMTFsector2 = 3;
-        } else if ((global_phi > 136.3) && (global_phi <= 173.)) {
+        }
+        else if ((global_phi > 136.3) && (global_phi <= 173.)) {
+          local_phi = global_phi - 135.;
           EMTFsector1 = 3;
           EMTFsector2 = 0;
-        } else if ((global_phi > 173.) && (global_phi <= 180.)) {
+        }
+        else if ((global_phi > 173.) && (global_phi <= 180.)) {
+          local_phi = global_phi - 135.;
           EMTFsector1 = 3;
           EMTFsector2 = 4;
         }
         // Greater than -180
         else if ((global_phi < -165.) && (global_phi >= -180.)) {
+          local_phi = global_phi + 225.;
           EMTFsector1 = 3;
           EMTFsector2 = 4;
         }
         // Fourth sector
         else if ((global_phi > -165.) && (global_phi <= -163.7)) {
+          local_phi = global_phi + 225.;
           EMTFsector1 = 3;
           EMTFsector2 = 4;
-        } else if ((global_phi > -163.7) && (global_phi <= -127.)) {
+        }
+        else if ((global_phi > -163.7) && (global_phi <= -127.)) {
+          local_phi = global_phi + 165.;
           EMTFsector1 = 4;
           EMTFsector2 = 0;
-        } else if ((global_phi > -127.) && (global_phi <= -105.)) {
+        }
+        else if ((global_phi > -127.) && (global_phi <= -105.)) {
+          local_phi = global_phi + 165.;
           EMTFsector1 = 4;
           EMTFsector2 = 5;
         }
         // fifth sector
         else if ((global_phi > -105.) && (global_phi <= -103.7)) {
+          local_phi = global_phi + 165.;
           EMTFsector1 = 4;
           EMTFsector2 = 5;
-        } else if ((global_phi > -103.7) && (global_phi <= -67.)) {
+        }
+        else if ((global_phi > -103.7) && (global_phi <= -67.)) {
+          local_phi = global_phi + 105.;
           EMTFsector1 = 5;
           EMTFsector2 = 0;
-        } else if ((global_phi > -67.) && (global_phi <= -45.)) {
+        }
+        else if ((global_phi > -67.) && (global_phi <= -45.)) {
+          local_phi = global_phi + 105.;
           EMTFsector1 = 5;
           EMTFsector2 = 6;
         }
         // sixth sector
         else if ((global_phi > -45.) && (global_phi <= -43.7)) {
+          local_phi = global_phi + 105.;
           EMTFsector1 = 5;
           EMTFsector2 = 6;
-        } else if ((global_phi > -43.7) && (global_phi <= -7.)) {
+        }
+        else if ((global_phi > -43.7) && (global_phi <= -7.)) {
+          local_phi = global_phi + 45.;
           EMTFsector1 = 6;
           EMTFsector2 = 0;
-        } else if ((global_phi > -7.) && (global_phi <= 15.)) {
+        }
+        else if ((global_phi > -7.) && (global_phi <= 15.)) {
+          local_phi = global_phi + 45.;
           EMTFsector1 = 6;
           EMTFsector2 = 1;
         }
 
-        // std::vector<RecHitProcessor::CppfItem>::iterator it;
-        // for(it = CppfVec1.begin(); it != CppfVec1.end(); it++){
-        //	if( (*it).rawId == rawId) if(Geo_true) std::cout << (*it).rawId
-        //<< "rawid" << rawId << std::endl;
-        //	}
-        // Loop over the look up table
+        int int_phi = int((local_phi + 22.0) * 15. + .5);
         double EMTFLink1 = 0.;
         double EMTFLink2 = 0.;
+        double lb = 0.;
+        double halfchannel = 0.;
 
-        std::vector<RecHitProcessor::CppfItem>::iterator cppf1;
-        std::vector<RecHitProcessor::CppfItem>::iterator cppf;
-        for (cppf1 = CppfVec1.begin(); cppf1 != CppfVec1.end(); cppf1++) {
-          // Condition to save the CPPFDigi
-          if (((*cppf1).rawId == rawId) && ((*cppf1).strip == rechitstrip)) {
-            int old_strip = (*cppf1).strip;
-            int before = 0;
-            int after = 0;
+        // Invalid hit
+        if (isValid == 0)
+          int_phi = 2047;
+        // Right integers range
+        assert(0 <= int_phi && int_phi < 1250);
+        assert(0 <= int_theta && int_theta < 32);
 
-            if (cppf1 != CppfVec1.begin())
-              before = (*(cppf1 - 2)).strip;
-
-            else if (cppf1 == CppfVec1.begin())
-              before = (*cppf1).strip;
-
-            if (cppf1 != CppfVec1.end())
-              after = (*(cppf1 + 2)).strip;
-
-            else if (cppf1 == CppfVec1.end())
-              after = (*cppf1).strip;
-
-            cppf = cppf1;
-
-            if (clustersize == 2) {
-              if (firststrip == 1) {
-                if (before < after)
-                  cppf = (cppf1 - 1);
-                else if (before > after)
-                  cppf = (cppf1 + 1);
-              } else if (firststrip > 1) {
-                if (before < after)
-                  cppf = (cppf1 + 1);
-                else if (before > after)
-                  cppf = (cppf1 - 1);
-              }
-            }
-            // Using the RPCGeometry
-            if (Geo) {
-              std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
-                                                                              Bx,
-                                                                              (*cppf).int_phi,
-                                                                              (*cppf).int_theta,
-                                                                              isValid,
-                                                                              (*cppf).lb,
-                                                                              (*cppf).halfchannel,
-                                                                              EMTFsector1,
-                                                                              EMTFLink1,
-                                                                              old_strip,
-                                                                              clustersize,
-                                                                              global_phi,
-                                                                              global_theta));
-              std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
-                                                                              Bx,
-                                                                              (*cppf).int_phi,
-                                                                              (*cppf).int_theta,
-                                                                              isValid,
-                                                                              (*cppf).lb,
-                                                                              (*cppf).halfchannel,
-                                                                              EMTFsector2,
-                                                                              EMTFLink2,
-                                                                              old_strip,
-                                                                              clustersize,
-                                                                              global_phi,
-                                                                              global_theta));
-
-              if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
-                cppfDigis.push_back(*MainVariables1.get());
-              } else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
-                cppfDigis.push_back(*MainVariables1.get());
-                cppfDigis.push_back(*MainVariables2.get());
-              } else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
-                continue;
-              }
-            }  // Geo is true
-            else {
-              global_phi = 0.;
-              global_theta = 0.;
-              std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
-                                                                              Bx,
-                                                                              (*cppf).int_phi,
-                                                                              (*cppf).int_theta,
-                                                                              isValid,
-                                                                              (*cppf).lb,
-                                                                              (*cppf).halfchannel,
-                                                                              EMTFsector1,
-                                                                              EMTFLink1,
-                                                                              old_strip,
-                                                                              clustersize,
-                                                                              global_phi,
-                                                                              global_theta));
-              std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
-                                                                              Bx,
-                                                                              (*cppf).int_phi,
-                                                                              (*cppf).int_theta,
-                                                                              isValid,
-                                                                              (*cppf).lb,
-                                                                              (*cppf).halfchannel,
-                                                                              EMTFsector2,
-                                                                              EMTFLink2,
-                                                                              old_strip,
-                                                                              clustersize,
-                                                                              global_phi,
-                                                                              global_theta));
-              if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
-                cppfDigis.push_back(*MainVariables1.get());
-              } else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
-                cppfDigis.push_back(*MainVariables1.get());
-                cppfDigis.push_back(*MainVariables2.get());
-              } else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
-                continue;
-              }
-            }
-          }  // Condition to save the CPPFDigi
-        }    // Loop over the LUTVector
-      }      // Loop over the recHits
-    }        // End loop: for (std::vector<const RPCRoll*>::const_iterator r =
-             // rolls.begin(); r != rolls.end(); ++r)
-  }          // End loop: for (TrackingGeometry::DetContainer::const_iterator iDet =
-             // rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++)
-}
-
-void RecHitProcessor::process(const edm::Event &iEvent,
-                              const edm::EventSetup &iSetup,
-                              const edm::EDGetToken &recHitToken,
-                              l1t::CPPFDigiCollection &cppfDigis) const {
-  // Get the RPC Geometry
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
-
-  // Get the RecHits from the event
-  edm::Handle<RPCRecHitCollection> recHits;
-  iEvent.getByToken(recHitToken, recHits);
-
-  // The loop is over the detector container in the rpc geometry collection. We
-  // are interested in the RPDdetID (inside of RPCChamber vectors),
-  // specifically, the RPCrechits. to assignment the CPPFDigis.
-  for (TrackingGeometry::DetContainer::const_iterator iDet = rpcGeom->dets().begin(); iDet < rpcGeom->dets().end();
-       iDet++) {
-    //  we do a cast over the class RPCChamber to obtain the RPCroll vectors,
-    //  inside of them, the RPCRechits are found. in other words, the method
-    //  ->rolls() does not exist for other kind of vector within DetContainer
-    //  and we can not obtain the rpcrechits in a suitable way.
-    if (dynamic_cast<const RPCChamber *>(*iDet) == nullptr)
-      continue;
-
-    auto chamb = dynamic_cast<const RPCChamber *>(*iDet);
-    std::vector<const RPCRoll *> rolls = (chamb->rolls());
-
-    // Loop over rolls in the chamber
-    for (auto &iRoll : rolls) {
-      RPCDetId rpcId = (*iRoll).id();
-
-      typedef std::pair<RPCRecHitCollection::const_iterator, RPCRecHitCollection::const_iterator> rangeRecHits;
-      rangeRecHits recHitCollection = recHits->get(rpcId);
-
-      for (RPCRecHitCollection::const_iterator rechit_it = recHitCollection.first; rechit_it != recHitCollection.second;
-           rechit_it++) {
-        // const RPCDetId& rpcId = rechit_it->rpcId();
-        // int rawId = rpcId.rawId();
-        int region = rpcId.region();
-        // int station = rpcId.station();
-        int Bx = rechit_it->BunchX();
-        int isValid = rechit_it->isValid();
-        int firststrip = rechit_it->firstClusterStrip();
-        int clustersize = rechit_it->clusterSize();
-        LocalPoint lPos = rechit_it->localPosition();
-        const RPCRoll *roll = rpcGeom->roll(rpcId);
-        const BoundPlane &rollSurface = roll->surface();
-        GlobalPoint gPos = rollSurface.toGlobal(lPos);
-        float global_theta = emtf::rad_to_deg(gPos.theta().value());
-        float global_phi = emtf::rad_to_deg(gPos.phi().value());
-        // Endcap region only
-
-        if (region != 0) {
-          int int_theta =
-              (region == -1 ? 180. * 32. / 36.5 : 0.) + (float)region * global_theta * 32. / 36.5 - 8.5 * 32 / 36.5;
-
-          if (region == 1) {
-            if (global_theta < 8.5)
-              int_theta = 0;
-            if (global_theta > 45.)
-              int_theta = 31;
-          } else if (region == -1) {
-            if (global_theta < 135.)
-              int_theta = 31;
-            if (global_theta > 171.5)
-              int_theta = 0;
-          }
-
-          // Local EMTF
-          double local_phi = 0.;
-          int EMTFsector1 = 0;
-          int EMTFsector2 = 0;
-
-          // sector 1
-          if ((global_phi > 15.) && (global_phi <= 16.3)) {
-            local_phi = global_phi - 15.;
-            EMTFsector1 = 1;
-            EMTFsector2 = 6;
-          } else if ((global_phi > 16.3) && (global_phi <= 53.)) {
-            local_phi = global_phi - 15.;
-            EMTFsector1 = 1;
-            EMTFsector2 = 0;
-          } else if ((global_phi > 53.) && (global_phi <= 75.)) {
-            local_phi = global_phi - 15.;
-            EMTFsector1 = 1;
-            EMTFsector2 = 2;
-          }
-          // sector 2
-          else if ((global_phi > 75.) && (global_phi <= 76.3)) {
-            local_phi = global_phi - 15.;
-            EMTFsector1 = 1;
-            EMTFsector2 = 2;
-          } else if ((global_phi > 76.3) && (global_phi <= 113.)) {
-            local_phi = global_phi - 75.;
-            EMTFsector1 = 2;
-            EMTFsector2 = 0;
-          } else if ((global_phi > 113.) && (global_phi <= 135.)) {
-            local_phi = global_phi - 75.;
-            EMTFsector1 = 2;
-            EMTFsector2 = 3;
-          }
-          // sector 3
-          // less than 180
-          else if ((global_phi > 135.) && (global_phi <= 136.3)) {
-            local_phi = global_phi - 75.;
-            EMTFsector1 = 2;
-            EMTFsector2 = 3;
-          } else if ((global_phi > 136.3) && (global_phi <= 173.)) {
-            local_phi = global_phi - 135.;
-            EMTFsector1 = 3;
-            EMTFsector2 = 0;
-          } else if ((global_phi > 173.) && (global_phi <= 180.)) {
-            local_phi = global_phi - 135.;
-            EMTFsector1 = 3;
-            EMTFsector2 = 4;
-          }
-          // Greater than -180
-          else if ((global_phi < -165.) && (global_phi >= -180.)) {
-            local_phi = global_phi + 225.;
-            EMTFsector1 = 3;
-            EMTFsector2 = 4;
-          }
-          // Fourth sector
-          else if ((global_phi > -165.) && (global_phi <= -163.7)) {
-            local_phi = global_phi + 225.;
-            EMTFsector1 = 3;
-            EMTFsector2 = 4;
-          } else if ((global_phi > -163.7) && (global_phi <= -127.)) {
-            local_phi = global_phi + 165.;
-            EMTFsector1 = 4;
-            EMTFsector2 = 0;
-          } else if ((global_phi > -127.) && (global_phi <= -105.)) {
-            local_phi = global_phi + 165.;
-            EMTFsector1 = 4;
-            EMTFsector2 = 5;
-          }
-          // fifth sector
-          else if ((global_phi > -105.) && (global_phi <= -103.7)) {
-            local_phi = global_phi + 165.;
-            EMTFsector1 = 4;
-            EMTFsector2 = 5;
-          } else if ((global_phi > -103.7) && (global_phi <= -67.)) {
-            local_phi = global_phi + 105.;
-            EMTFsector1 = 5;
-            EMTFsector2 = 0;
-          } else if ((global_phi > -67.) && (global_phi <= -45.)) {
-            local_phi = global_phi + 105.;
-            EMTFsector1 = 5;
-            EMTFsector2 = 6;
-          }
-          // sixth sector
-          else if ((global_phi > -45.) && (global_phi <= -43.7)) {
-            local_phi = global_phi + 105.;
-            EMTFsector1 = 5;
-            EMTFsector2 = 6;
-          } else if ((global_phi > -43.7) && (global_phi <= -7.)) {
-            local_phi = global_phi + 45.;
-            EMTFsector1 = 6;
-            EMTFsector2 = 0;
-          } else if ((global_phi > -7.) && (global_phi <= 15.)) {
-            local_phi = global_phi + 45.;
-            EMTFsector1 = 6;
-            EMTFsector2 = 1;
-          }
-
-          int int_phi = int((local_phi + 22.0) * 15. + .5);
-
-          double EMTFLink1 = 0.;
-          double EMTFLink2 = 0.;
-          double lb = 0.;
-          double halfchannel = 0.;
-
-          // Invalid hit
-          if (isValid == 0)
-            int_phi = 2047;
-          // Right integers range
-          assert(0 <= int_phi && int_phi < 1250);
-          assert(0 <= int_theta && int_theta < 32);
-
-          std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
-                                                                          Bx,
-                                                                          int_phi,
-                                                                          int_theta,
-                                                                          isValid,
-                                                                          lb,
-                                                                          halfchannel,
-                                                                          EMTFsector1,
-                                                                          EMTFLink1,
-                                                                          firststrip,
-                                                                          clustersize,
-                                                                          global_phi,
-                                                                          global_theta));
-          std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
-                                                                          Bx,
-                                                                          int_phi,
-                                                                          int_theta,
-                                                                          isValid,
-                                                                          lb,
-                                                                          halfchannel,
-                                                                          EMTFsector2,
-                                                                          EMTFLink2,
-                                                                          firststrip,
-                                                                          clustersize,
-                                                                          global_phi,
-                                                                          global_theta));
-          if (int_theta == 31)
-            continue;
-          if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
-            cppfDigis.push_back(*MainVariables1.get());
-          }
-          if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
-            cppfDigis.push_back(*MainVariables1.get());
-            cppfDigis.push_back(*MainVariables2.get());
-          }
-          if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
-            continue;
-          }
-        }  // No barrel rechits
-
-      }  // End loop: for (RPCRecHitCollection::const_iterator recHit =
-         // recHitCollection.first; recHit != recHitCollection.second; recHit++)
-
-    }  // End loop: for (std::vector<const RPCRoll*>::const_iterator r =
-       // rolls.begin(); r != rolls.end(); ++r)
-  }    // End loop: for (TrackingGeometry::DetContainer::const_iterator iDet =
-       // rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++)
-}  // End function: void RecHitProcessor::process()
+        std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
+                                                                        Bx,
+                                                                        int_phi,
+                                                                        int_theta,
+                                                                        isValid,
+                                                                        lb,
+                                                                        halfchannel,
+                                                                        EMTFsector1,
+                                                                        EMTFLink1,
+                                                                        firststrip,
+                                                                        clustersize,
+                                                                        global_phi,
+                                                                        global_theta));
+        std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
+                                                                        Bx,
+                                                                        int_phi,
+                                                                        int_theta,
+                                                                        isValid,
+                                                                        lb,
+                                                                        halfchannel,
+                                                                        EMTFsector2,
+                                                                        EMTFLink2,
+                                                                        firststrip,
+                                                                        clustersize,
+                                                                        global_phi,
+                                                                        global_theta));
+        if (int_theta == 31)
+          continue;
+        if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
+          cppfDigis.push_back(*MainVariables1.get());
+        }
+        if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
+          cppfDigis.push_back(*MainVariables1.get());
+          cppfDigis.push_back(*MainVariables2.get());
+        }
+        if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
+          continue;
+        }
+      }// No barrel hits
+    }//end loop over clusters
+  }//end loop over digis
+}// End function: void RecHitProcessor::process()

--- a/L1Trigger/L1TMuonCPPF/test/step2_DIGI_L1_DIGI2RAW_HLT.py
+++ b/L1Trigger/L1TMuonCPPF/test/step2_DIGI_L1_DIGI2RAW_HLT.py
@@ -1,0 +1,148 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: step2 --conditions auto:phase1_2018_realistic -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2018 --datatier GEN-SIM-DIGI-RAW -n 10 --geometry DB:Extended --era Run2_2018 --eventcontent FEVTDEBUGHLT --filein file:step1.root --fileout file:step2.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+
+process = cms.Process('HLT',Run2_2018)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('HLTrigger.Configuration.HLT_Fake2_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
+    fileNames = cms.untracked.vstring(
+'file:/eos/cms/store/relval/CMSSW_11_1_0_pre5/RelValZMM_13UP18_RD_test/GEN-SIM/110X_upgrade2018_realistic_v9_RD_Harvesting_4-v1/10000/05AE6B11-E993-584E-8C59-DF931E8635D6.root'
+#'file:step1.root'
+),
+    inputCommands = cms.untracked.vstring(
+        'keep *', 
+        'drop *_genParticles_*_*', 
+        'drop *_genParticlesForJets_*_*', 
+        'drop *_kt4GenJets_*_*', 
+        'drop *_kt6GenJets_*_*', 
+        'drop *_iterativeCone5GenJets_*_*', 
+        'drop *_ak4GenJets_*_*', 
+        'drop *_ak7GenJets_*_*', 
+        'drop *_ak8GenJets_*_*', 
+        'drop *_ak4GenJetsNoNu_*_*', 
+        'drop *_ak8GenJetsNoNu_*_*', 
+        'drop *_genCandidatesForMET_*_*', 
+        'drop *_genParticlesForMETAllVisible_*_*', 
+        'drop *_genMetCalo_*_*', 
+        'drop *_genMetCaloAndNonPrompt_*_*', 
+        'drop *_genMetTrue_*_*', 
+        'drop *_genMetIC5GenJs_*_*'
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(1)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step2 nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+process.load('L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi')
+from L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi import *
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:step2.root'),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.mix.digitizers = cms.PSet(process.theDigitizersValid)
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic', '')
+
+# Path and EndPath definitions
+process.digitisation_step = cms.Path(process.pdigi_valid)
+process.emulatorCppfDigis_step = cms.Path(process.emulatorCppfDigis)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.digi2raw_step = cms.Path(process.DigiToRaw)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.digitisation_step,process.emulatorCppfDigis_step,process.L1simulation_step,process.digi2raw_step)
+#process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.digi2raw_step)
+process.schedule.extend(process.HLTSchedule)
+process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforMC
+from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC 
+
+#call to customisation function customizeHLTforMC imported from HLTrigger.Configuration.customizeHLTforMC
+process = customizeHLTforMC(process)
+
+# End of customisation functions
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
#### PR description:

CPPF Emulator Refactoring

Currently, the CPPF emulator calls RecoLocalMuon.RPCRecHit.rpcRecHits_cfi in order to produce clusters.
The proposed branch aims to avoid callind the LocalReco code on a early stage like emulation
and from the other side to separate the two clusterizers - RPC Rechits and CPPF clusters 
and thus to ensure a possibility for further independent work on both the packages.

#### PR validation:

tested with: runTheMatrix.py -l 10806.0
output: 10806.0_SingleMuPt1+SingleMuPt1_pythia8_2018_GenSimFull+DigiFull_2018+RecoFull_2018+HARVESTFull_2018+ALCAFull_2018+NanoFull_2018 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED  - time date Thu Apr 30 16:10:55 2020-date Thu Apr 30 15:59:15 2020; exit: 0 0 0 0 0 0
1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 failed

local test:
cmsRun L1Trigger/L1TMuonCPPF/test/step2_DIGI_L1_DIGI2RAW_HLT.py

Other tests and slides:
MC data produced with the current and new clusterizer comparison - matched in 100%
Experimetnal data comparison: CPPF emulator calling current (RPCRechit) clusterizer and the new CPPF clusterizer - matched in 100%

Slides:
https://indico.cern.ch/event/892112/contributions/3762940/attachments/1993832/3325539/cppfEmulatorWithDigi.pdf
https://indico.cern.ch/event/907310/contributions/3817691/attachments/2017161/3371674/cppfEmulatorWithDigi_8April.pdf

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

 @BrieucF @ftorresd
