### PR TITLE
add track filter for N tracks with minimum pt

### DIFF
--- a/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
@@ -14,11 +14,12 @@
 
 typedef ObjectCountFilter<reco::TrackCollection, PtMinSelector>::type PtMinTrackCountFilter;
 
-template<>
+template <>
 void PtMinTrackCountFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("tracks"));
   desc.add<double>("ptMin", 0.);
+  desc.add<std::string>  ( "cut", "" );
   descriptions.add("ptMinTrackCountFilter", desc);
 }
 

--- a/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
@@ -19,7 +19,7 @@ void PtMinTrackCountFilter::fillDescriptions(edm::ConfigurationDescriptions& des
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("tracks"));
   desc.add<double>("ptMin", 0.);
-  desc.add<std::string>  ( "cut", "" );
+  desc.add<std::string>( "cut", "" );
   descriptions.add("ptMinTrackCountFilter", desc);
 }
 

--- a/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
@@ -19,7 +19,7 @@ void PtMinTrackCountFilter::fillDescriptions(edm::ConfigurationDescriptions& des
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("tracks"));
   desc.add<double>("ptMin", 0.);
-  desc.add<std::string>( "cut", "" );
+  desc.add<std::string>("cut", "");
   descriptions.add("ptMinTrackCountFilter", desc);
 }
 

--- a/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
@@ -1,0 +1,25 @@
+/* \class PtMinTrackCountFilter
+ *
+ * Filters events if at least N tracks above 
+ * a pt cut are present.
+ *
+ * \author: Antonio Vagnerini, DESY
+ *
+ */
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
+#include "CommonTools/UtilAlgos/interface/PtMinSelector.h"
+
+typedef ObjectCountFilter<reco::TrackCollection, PtMinSelector>::type PtMinTrackCountFilter;
+
+template<>
+void PtMinTrackCountFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("tracks"));
+  desc.add<double>("ptMin", 0.);
+  descriptions.add("ptMinTrackCountFilter", desc);
+}
+
+DEFINE_FWK_MODULE(PtMinTrackCountFilter);


### PR DESCRIPTION
EDFilter to be used in the cosmics during collision (CDC) trigger @HLT
It selects N tracks passing a certain pT cut. 

This PR is a follow-up of the PR https://github.com/cms-sw/cmssw/pull/21241 and it uses the template approach suggested previously.
