### PR TITLE
Extend ConfigBuilder to properly handle special import handling

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2298,6 +2298,14 @@ class ConfigBuilder(object):
         from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
         self.process = customiseEarlyDelete(self.process)
 
+        imports = cms.specialImportRegistry.getSpecialImports()
+        if len(imports) > 0:
+            #need to inject this at the top
+            index = self.pythonCfgCode.find("import FWCore.ParameterSet.Config")
+            #now find the end of line
+            index = self.pythonCfgCode.find("\n",index)
+            self.pythonCfgCode = self.pythonCfgCode[:index]+ "\n" + "\n".join(imports)+"\n" +self.pythonCfgCode[index:]
+
 
         # make the .io file
 


### PR DESCRIPTION
#### PR description:

The cms.Process object's dumpPython command allows specifying additional 'import' commands that are needed. The ConfigBuilder now includes those when creating a configuration.

#### PR validation:

Using a generator configuration fragment containing the use of an ExternalGeneratorFilter with cmsDriver.py now works where it was failing before.