### PR TITLE
added missing dependency; header cleanup

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/BuildFile.xml
+++ b/CalibCalorimetry/EcalTrivialCondModules/BuildFile.xml
@@ -10,4 +10,5 @@
 <use   name="CondFormats/ESObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="DataFormats/EcalDetId"/>
+<use   name="DataFormats/EcalDigi"/>
 <use   name="clhep"/>

--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h
@@ -113,6 +113,7 @@
 #include "SimG4CMS/Calo/interface/EnergyResolutionVsLumi.h"
 #include "SimG4CMS/Calo/interface/EvolutionECAL.h"
 
+#include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
 // forward declarations
 
 namespace edm {

--- a/CondFormats/EcalObjects/BuildFile.xml
+++ b/CondFormats/EcalObjects/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="CondFormats/Alignment"/>
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="DataFormats/EcalDetId"/>
+<use   name="DataFormats/EcalDigi"/>
 <use   name="DataFormats/Math"/>
 <use   name="boost"/>
 <use   name="boost_serialization"/>

--- a/CondFormats/EcalObjects/interface/EcalWeightSet.h
+++ b/CondFormats/EcalObjects/interface/EcalWeightSet.h
@@ -11,7 +11,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "CondFormats/EcalObjects/interface/EcalWeight.h"
-#include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
 #include "DataFormats/Math/interface/Matrix.h"
 #include <iostream>
 


### PR DESCRIPTION
Adding missing dependency on `DataFormats/EcalDigi` which is used by [a]. Although it is header only dependency but by definition we should have it in BuildFile too.
Cleanup unused include header too.

[a]
```
CondFormats/EcalObjects/src/EcalSampleMask.cc:#include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
CondFormats/EcalObjects/src/EcalSampleMask.cc:  sampleMaskEB_ = pow(2, EcalDataFrame::MAXSAMPLES) - 1;
CondFormats/EcalObjects/src/EcalSampleMask.cc:  sampleMaskEE_ = pow(2, EcalDataFrame::MAXSAMPLES) - 1;
```