### PR TITLE
Add missing include to  TrackingRecHit.h

### DIFF
--- a/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 #include <memory>
+#include <cassert>
 
 class TkCloner;
 class TrajectoryStateOnSurface;


### PR DESCRIPTION
#### PR description:

The header now includes all symbols it references. This was spotted by the CXXMODULE IB.

#### PR validation:

The code compiles.