### PR TITLE
Migrate legacy output modules to be 'one' types

### DIFF
--- a/FWCore/Framework/test/stubs/TestOutputModule.cc
+++ b/FWCore/Framework/test/stubs/TestOutputModule.cc
@@ -1,5 +1,5 @@
 
-#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -19,6 +19,8 @@
 #include <iterator>
 
 using namespace edm;
+
+typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
 
 namespace {
 
@@ -53,12 +55,14 @@ namespace {
 }  // namespace
 namespace edmtest {
 
-  class TestOutputModule : public edm::OutputModule {
+  class TestOutputModule : public edm::one::OutputModule<> {
   public:
     explicit TestOutputModule(edm::ParameterSet const&);
     virtual ~TestOutputModule();
 
   private:
+    Trig getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventForOutput const& e) const;
+
     virtual void write(edm::EventForOutput const& e) override;
     virtual void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
     virtual void writeRun(edm::RunForOutput const&) override;
@@ -74,7 +78,8 @@ namespace edmtest {
   // -----------------------------------------------------------------
 
   TestOutputModule::TestOutputModule(edm::ParameterSet const& ps)
-      : edm::OutputModule(ps),
+      : edm::one::OutputModuleBase(ps),
+        edm::one::OutputModule<>(ps),
         name_(ps.getParameter<std::string>("name")),
         bitMask_(ps.getParameter<int>("bitMask")),
         hltbits_(0),
@@ -82,6 +87,12 @@ namespace edmtest {
         resultsToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))) {}
 
   TestOutputModule::~TestOutputModule() {}
+
+  Trig TestOutputModule::getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventForOutput const& e) const {
+    Trig result;
+    e.getByToken<TriggerResults>(token, result);
+    return result;
+  }
 
   void TestOutputModule::write(edm::EventForOutput const& e) {
     assert(e.moduleCallingContext()->moduleDescription()->moduleLabel() == description().moduleLabel());

--- a/FWCore/Framework/test/stubs/TestOutputModule.cc
+++ b/FWCore/Framework/test/stubs/TestOutputModule.cc
@@ -88,10 +88,9 @@ namespace edmtest {
 
   TestOutputModule::~TestOutputModule() {}
 
-  Trig TestOutputModule::getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventForOutput const& e) const {
-    Trig result;
-    e.getByToken<TriggerResults>(token, result);
-    return result;
+  Trig TestOutputModule::getTriggerResults(EDGetTokenT<TriggerResults> const& token,
+                                           EventForOutput const& event) const {
+    return event.getHandle(token);
   }
 
   void TestOutputModule::write(edm::EventForOutput const& e) {

--- a/FWCore/Framework/test/stubs/TestOutputModule.cc
+++ b/FWCore/Framework/test/stubs/TestOutputModule.cc
@@ -20,7 +20,7 @@
 
 using namespace edm;
 
-typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
+using Trig = detail::TriggerResultsBasedEventSelector::handle_t;
 
 namespace {
 

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -15,7 +15,7 @@
 #include <sstream>
 
 // user include files
-#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
@@ -29,7 +29,7 @@ namespace edm {
   class ModuleCallingContext;
   class ParameterSet;
 
-  class GetProductCheckerOutputModule : public OutputModule {
+  class GetProductCheckerOutputModule : public one::OutputModule<> {
   public:
     // We do not take ownership of passed stream.
     explicit GetProductCheckerOutputModule(ParameterSet const& pset);
@@ -53,7 +53,8 @@ namespace edm {
   //
   // constructors and destructor
   //
-  GetProductCheckerOutputModule::GetProductCheckerOutputModule(ParameterSet const& iPSet) : OutputModule(iPSet) {}
+  GetProductCheckerOutputModule::GetProductCheckerOutputModule(ParameterSet const& iPSet)
+      : one::OutputModuleBase(iPSet), one::OutputModule<>(iPSet) {}
 
   // GetProductCheckerOutputModule::GetProductCheckerOutputModule(GetProductCheckerOutputModule const& rhs) {
   //    // do actual copying here;
@@ -118,7 +119,7 @@ namespace edm {
 
   void GetProductCheckerOutputModule::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
-    OutputModule::fillDescription(desc);
+    one::OutputModule<>::fillDescription(desc);
     descriptions.add("productChecker", desc);
   }
 }  // namespace edm

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
-#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -29,7 +29,7 @@ namespace edm {
   class ModuleCallingContext;
   class ParameterSet;
 
-  class ProvenanceCheckerOutputModule : public OutputModule {
+  class ProvenanceCheckerOutputModule : public one::OutputModule<> {
   public:
     // We do not take ownership of passed stream.
     explicit ProvenanceCheckerOutputModule(ParameterSet const& pset);
@@ -53,7 +53,8 @@ namespace edm {
   //
   // constructors and destructor
   //
-  ProvenanceCheckerOutputModule::ProvenanceCheckerOutputModule(ParameterSet const& pset) : OutputModule(pset) {}
+  ProvenanceCheckerOutputModule::ProvenanceCheckerOutputModule(ParameterSet const& pset)
+      : one::OutputModuleBase(pset), one::OutputModule<>(pset) {}
 
   // ProvenanceCheckerOutputModule::ProvenanceCheckerOutputModule(ProvenanceCheckerOutputModule const& rhs)
   // {
@@ -185,7 +186,7 @@ namespace edm {
   //
   void ProvenanceCheckerOutputModule::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
-    OutputModule::fillDescription(desc);
+    one::OutputModule<>::fillDescription(desc);
     descriptions.add("provenanceChecker", desc);
   }
 }  // namespace edm

--- a/IOPool/Input/test/IOExerciser.cc
+++ b/IOPool/Input/test/IOExerciser.cc
@@ -24,7 +24,7 @@ to use this plugin.
 // user include files
 #include "DataFormats/Provenance/interface/StableProvenance.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/GenericHandle.h"
@@ -41,7 +41,7 @@ to use this plugin.
 
 #include "ProductInfo.h"
 
-class IOExerciser : public edm::OutputModule {
+class IOExerciser : public edm::one::OutputModule<edm::WatchInputFiles> {
 public:
   explicit IOExerciser(const edm::ParameterSet&);
   ~IOExerciser() override;
@@ -58,6 +58,7 @@ private:
   void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {}
 
   void respondToOpenInputFile(edm::FileBlock const& fb) override;
+  void respondToCloseInputFile(edm::FileBlock const& fb) override {}
 
   // ----------internal implementation functions---------------------------
   void computeProducts(edm::EventForOutput const& e, TokenMap const& tokens);
@@ -82,7 +83,8 @@ private:
 // constructors and destructor
 //
 IOExerciser::IOExerciser(const edm::ParameterSet& pset)
-    : OutputModule(pset),
+    : edm::one::OutputModuleBase(pset),
+      edm::one::OutputModule<edm::WatchInputFiles>(pset),
       m_tokens(),
       m_fetchedProducts(false),
       m_eventsTree(nullptr),
@@ -290,7 +292,7 @@ void IOExerciser::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
           "will read out all event data, not just the selected branches.  Setting to 10\n"
           "will cause it to read out one event in 10.  Setting it to zero would mean to\n"
           "disable trigger behavior completely.  Defaults to 0.");
-  OutputModule::fillDescription(desc);
+  edm::one::OutputModule<edm::WatchInputFiles>::fillDescription(desc);
   descriptions.add("IOExerciser", desc);
 }
 


### PR DESCRIPTION
#### PR description:

Migrate 4 output modules from using the legacy OutputModule base class to use the 'one' type OutputModule base class. These are the last 4 output modules using the legacy base class in CMSSW. Soon after this is approved and merged I will submit another PR deleting the legacy OutputModule base class entirely. Note that these 4 output modules are only used in tests.

#### PR validation:

Existing unit tests run and pass. I manually ran 3 of these with some added print commands inserted to verify they were running properly and compared the output before and after the changes. IOExerciser is a module available for benchmarking tests, but was already broken . Probably it is easily fixable, but I didn't spend the time as nothing in CMSSW appears to be using it anyway. I migrated it and don't think the migration made its existing problems better or worse. (Maybe it is just calling selectEvents too early ...).
