### PR TITLE
initialize std::array data member in TICLCandidate

### DIFF
--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -15,12 +15,12 @@ public:
   typedef ticl::Trackster::ParticleType ParticleType;
 
   TICLCandidate(Charge q, const LorentzVector& p4)
-      : LeafCandidate(q, p4), time_(0.f), timeError_(-1.f), rawEnergy_(0.f) {}
+      : LeafCandidate(q, p4), time_(0.f), timeError_(-1.f), rawEnergy_(0.f), idProbabilities_{} {}
 
-  TICLCandidate() : LeafCandidate(), time_(0.f), timeError_(-1.f), rawEnergy_(0.f) {}
+  TICLCandidate() : LeafCandidate(), time_(0.f), timeError_(-1.f), rawEnergy_(0.f), idProbabilities_{} {}
 
   TICLCandidate(const edm::Ptr<ticl::Trackster>& trackster)
-      : LeafCandidate(), time_(0.f), timeError_(-1.f), rawEnergy_(0.f), tracksters_({trackster}) {}
+      : LeafCandidate(), time_(0.f), timeError_(-1.f), rawEnergy_(0.f), tracksters_({trackster}), idProbabilities_{} {}
 
   inline float time() const { return time_; }
   inline float timeError() const { return timeError_; }


### PR DESCRIPTION
apparently arrays are not default-constructed and we get random values ```TICLCandidate::idProbabilities_``` presently, in absence of settings by the current version of ```TICLCandidateFromTrackstersProducer```.
I checked on wf 23234.0 that zeroes are now appearing instead of something random