### PR TITLE
Add warning if WF name will be too long for submission

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -59,7 +59,7 @@ class MatrixInjector(object):
         self.batchTime = str(int(time.time()))
         if(opt.batchName):
             self.batchName = '__'+opt.batchName+'-'+self.batchTime
-
+        
         #wagemt stuff
         if not self.wmagent:
             self.wmagent=os.getenv('WMAGENT_REQMGR')
@@ -83,7 +83,8 @@ class MatrixInjector(object):
         self.speciallabel=''
         if opt.label:
             self.speciallabel= '_'+opt.label
-
+        self.countLongWFName = 0
+        self.longWFName = ''
 
         if not os.getenv('WMCORE_ROOT'):
             print('\n\twmclient is not setup properly. Will not be able to upload or submit requests.\n')
@@ -477,6 +478,11 @@ class MatrixInjector(object):
                     chainDict['RequestString']='RV'+chainDict['CMSSWVersion']+s[1].split('+')[0]
                     if processStrPrefix or thisLabel:
                         chainDict['RequestString']+='_'+processStrPrefix+thisLabel
+                    #check candidate WF name
+                    self.candidateWFName = self.user+'_'+chainDict['RequestString']
+                    if (len(self.candidateWFName)>81):
+                        self.countLongWFName+=1
+                        self.longWFName+=self.candidateWFName+' ('+str(len(self.candidateWFName))+' characters) \n'
 
 ### PrepID
                     chainDict['PrepID'] = chainDict['CMSSWVersion']+'__'+self.batchTime+'-'+s[1].split('+')[0]
@@ -647,6 +653,6 @@ class MatrixInjector(object):
                 workFlow=makeRequest(self.wmagent,d,encodeDict=True)
                 print("...........",n,"submitted")
                 random_sleep()
-            
-
-        
+        if self.testMode and self.countLongWFName>0:
+            print("\n*** FIX NEEDED BEFORE INJECTION: "+str(self.countLongWFName)+" candidate workflows have too long name (>81 characters) ***")
+            print(self.longWFName)


### PR DESCRIPTION
#### PR description:
The character length of computing workflow is limited to 100 characters. The workflow name composes of 3 main parts:
- username
- RequestString
- data/time of submission; This part is added during the submission, max. characters are 19, e.g. `_200425_064221_5181`.

This PR is to check if len(username_RequestString) is longer than 81 characters or not, then print the warning at the end when `--wm init` is used. 

The goal is not to break the `--wm init` process, as one may need to just dump config for testing using any release (including IB). This PR just provides the warning in case someone would like to inject workflows later. Without this test, the injection will break when `--wm force` is used. However, some of the workflows will be submitted if they come before problematic workflows.

#### PR validation:
Test with 11_1_0_pre6:
runTheMatrix.py --what standard -l 136.886,136.7611,136.756 -t 8 -b 'DQM8CoresData' --label 'DQM8CoresData1234567890' --wm init

```
*** FIX NEEDED BEFORE INJECTION: 2 candidate workflows have too long name (>81 characters) ***
srimanob_RVCMSSW_11_1_0_pre6RunJetHT2016E_reminiaod__DQM8CoresData1234567890_RelVal_2016Ermaod (94 characters) 
srimanob_RVCMSSW_11_1_0_pre6RunZeroBias2016D__DQM8CoresData1234567890_RelVal_2016D (82 characters) 
```

workflow 136.866 is OK in this test,
> srimanob_RVCMSSW_11_1_0_pre6RunEGamma2018D__DQM8CoresData1234567890_RelVal_2018D (80 characters long)

During injection, 136.866 will pass the injection, then break when 136.7611 injection is done.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No need to backport.