### PR TITLE
DetectorDescription FilteredView: remove debugging printouts

### DIFF
--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -126,8 +126,6 @@ const RotationMatrix DDFilteredView::rotation() const {
     return RotationMatrix();
   }
 
-  LogVerbatim("DDFilteredView") << "Rotation matrix components (1st 3) = " << rotation[0] << ", " << rotation[1] << ", "
-                                << rotation[2];
   RotationMatrix rotMatrix;
   rotMatrix.SetComponents(rotation[0],
                           rotation[1],
@@ -147,8 +145,6 @@ void DDFilteredView::rot(dd4hep::Rotation3D& matrixOut) const {
     LogError("DDFilteredView") << "Current node has no valid rotation matrix.";
     return;
   }
-  LogVerbatim("DDFilteredView") << "Rotation matrix components (1st 3) = " << rotation[0] << ", " << rotation[1] << ", "
-                                << rotation[2];
   matrixOut.SetComponents(rotation[0],
                           rotation[1],
                           rotation[2],


### PR DESCRIPTION
#### PR description:

In the ```DetectorDescription FilteredView``` methods about rotation there are some debugging ```LogVerbatim``` instructions, partially printing the rotation matrix, which were overlooked in the code at the time of the integration (by me as a release manager). They turn to be quite annoying while enabling Info/Verbatim level verbosity for development/debugging. I suggest to remove them. Alternatively they could be downgraded to ```LogDebug``` if deemed still necessary.

#### PR validation:

Code compiles and unit tests run.