### PR TITLE
Run3-sim69 Add a few cfi files which defines transition energies for standard G4 versions

### DIFF
--- a/SimG4Core/PhysicsLists/python/physicsFTFP_BERT_G4104_cfi.py
+++ b/SimG4Core/PhysicsLists/python/physicsFTFP_BERT_G4104_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from SimG4Core.Configuration.SimG4Core_cff import *
+
+g4SimHits.Physics.EmaxBERT   = cms.double(12.) # in GeV
+g4SimHits.Physics.EmaxBERTpi = cms.double(12.) # in GeV
+g4SimHits.Physics.EminFTFP   = cms.double(3.)  # in GeV

--- a/SimG4Core/PhysicsLists/python/physicsFTFP_BERT_G4106_cfi.py
+++ b/SimG4Core/PhysicsLists/python/physicsFTFP_BERT_G4106_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from SimG4Core.Configuration.SimG4Core_cff import *
+
+g4SimHits.Physics.EmaxBERT   = cms.double(6.)  # in GeV
+g4SimHits.Physics.EmaxBERTpi = cms.double(6.)  # in GeV
+g4SimHits.Physics.EminFTFP   = cms.double(3.)  # in GeV

--- a/SimG4Core/PhysicsLists/python/physicsQGSP_BERT_G4104_cfi.py
+++ b/SimG4Core/PhysicsLists/python/physicsQGSP_BERT_G4104_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from SimG4Core.Configuration.SimG4Core_cff import *
+
+g4SimHits.Physics.EmaxBERT   = cms.double(8.)  # in GeV
+g4SimHits.Physics.EmaxBERTpi = cms.double(8.)  # in GeV
+g4SimHits.Physics.EminFTFP   = cms.double(6.)  # in GeV
+g4SimHits.Physics.EmaxFTFP   = cms.double(25.) # in GeV
+g4SimHits.Physics.EminQGSP   = cms.double(12.) # in GeV

--- a/SimG4Core/PhysicsLists/python/physicsQGSP_FTFP_BERT_G4104_cfi.py
+++ b/SimG4Core/PhysicsLists/python/physicsQGSP_FTFP_BERT_G4104_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from SimG4Core.Configuration.SimG4Core_cff import *
+
+g4SimHits.Physics.EmaxBERT   = cms.double(9.9) # in GeV
+g4SimHits.Physics.EmaxBERTpi = cms.double(9.9) # in GeV
+g4SimHits.Physics.EminFTFP   = cms.double(9.5) # in GeV
+g4SimHits.Physics.EmaxFTFP   = cms.double(25.) # in GeV
+g4SimHits.Physics.EminQGSP   = cms.double(12.) # in GeV

--- a/SimG4Core/PhysicsLists/python/physicsQGSP_FTFP_BERT_G4106_cfi.py
+++ b/SimG4Core/PhysicsLists/python/physicsQGSP_FTFP_BERT_G4106_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from SimG4Core.Configuration.SimG4Core_cff import *
+
+g4SimHits.Physics.EmaxBERT   = cms.double(6.)  # in GeV
+g4SimHits.Physics.EmaxBERTpi = cms.double(6.)  # in GeV
+g4SimHits.Physics.EminFTFP   = cms.double(3.)  # in GeV
+g4SimHits.Physics.EmaxFTFP   = cms.double(25.) # in GeV
+g4SimHits.Physics.EminQGSP   = cms.double(12.) # in GeV

--- a/SimG4Core/PhysicsLists/test/minbias_cfg.py
+++ b/SimG4Core/PhysicsLists/test/minbias_cfg.py
@@ -12,7 +12,8 @@ process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
-process.load('SimG4CMS.Calo.PythiaMinBias_cfi')
+process.load('Configuration.Generator.MinBias_14TeV_pythia8_TuneCUETP8M1_cfi')
+#process.load('SimG4CMS.Calo.PythiaMinBias_cfi')
 process.load('SimG4Core.PhysicsLists.physicsQGSP_FTFP_BERT_G4106_cfi')
 #process.load('SimG4Core.PhysicsLists.physicsQGSP_FTFP_BERT_G4104_cfi')
 #process.load('SimG4Core.PhysicsLists.physicsQGSP_BERT_G4104_cfi')
@@ -39,8 +40,8 @@ process.rndmStore = cms.EDProducer("RandomEngineStateProducer")
 process.generation_step = cms.Path(process.pgen)
 process.simulation_step = cms.Path(process.psim)
 
-process.generator.pythiaHepMCVerbosity = False
-process.generator.pythiaPylistVerbosity = 0
+#process.generator.pythiaHepMCVerbosity = False
+#process.generator.pythiaPylistVerbosity = 0
 process.g4SimHits.Physics.type = 'SimG4Core/Physics/QGSP_FTFP_BERT_EMM'
 
 # Schedule definition                                                          

--- a/SimG4Core/PhysicsLists/test/minbias_cfg.py
+++ b/SimG4Core/PhysicsLists/test/minbias_cfg.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('SIM',Run3)
+
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('IOMC.EventVertexGenerators.VtxSmearedGauss_cfi')
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('SimG4CMS.Calo.PythiaMinBias_cfi')
+process.load('SimG4Core.PhysicsLists.physicsQGSP_FTFP_BERT_G4106_cfi')
+#process.load('SimG4Core.PhysicsLists.physicsQGSP_FTFP_BERT_G4104_cfi')
+#process.load('SimG4Core.PhysicsLists.physicsQGSP_BERT_G4104_cfi')
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.categories.append('PhysicsList')
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(2)
+)
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
+process.RandomNumberGeneratorService.VtxSmeared.initialSeed = 123456789
+process.rndmStore = cms.EDProducer("RandomEngineStateProducer")
+
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+
+process.generator.pythiaHepMCVerbosity = False
+process.generator.pythiaPylistVerbosity = 0
+process.g4SimHits.Physics.type = 'SimG4Core/Physics/QGSP_FTFP_BERT_EMM'
+
+# Schedule definition                                                          
+process.schedule = cms.Schedule(process.generation_step,
+                                process.simulation_step,
+                                )
+
+# filter all path with the production filter sequence                          
+for path in process.paths:
+        getattr(process,path)._seq = process.generator * getattr(process,path)._seq
+


### PR DESCRIPTION
#### PR description:

Add a few cfi files which defines transition energies for standard G4 versions

#### PR validation:

Use the cfg file in the test area to check this 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special