### PR TITLE
Update offline GTs for Run 1 and Run 2 data, including special runs.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '111X_dataRun2_v2',
+    'run1_data'         :   '111X_dataRun2_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '111X_dataRun2_v2',
+    'run2_data'         :   '111X_dataRun2_v3',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '111X_dataRun2_HEfail_v2',
+    'run2_data_HEfail'  :   '111X_dataRun2_HEfail_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '111X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '111X_dataRun2_relval_v3',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR updates the offline data global tags to include updates for special runs from:

- beamspot
- PPS
- tracker alignment/APEs.

The global tag diffs are as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_v2/111X_dataRun2_v3

**Offline data (HEM 15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_HEfail_v2/111X_dataRun2_HEfail_v3

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_relval_v2/111X_dataRun2_relval_v3

#### PR validation:

See links found in the HN post at [1]. In addition, a technical test was performed: `runTheMatrix.py -l limited --ibeos`

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4292/2/1.html

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 11_0_X and 10_6_X.