### PR TITLE
Introduce a local cache for any caching MagneticField functions, and use them in Oscar(MT)Producer

### DIFF
--- a/MagneticField/Engine/interface/localMagneticField.h
+++ b/MagneticField/Engine/interface/localMagneticField.h
@@ -1,0 +1,55 @@
+#ifndef MagneticField_Engine_localMagneticField_h
+#define MagneticField_Engine_localMagneticField_h
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+namespace local {
+  /**
+   * A helper class for efficient thread-safe internal caching in
+   * classes deriving from ::MagneticField (where such caching is
+   * useful). This class is intended to provide the interface of
+   * MagneticField while passing the cache internally. It is intended
+   * as a straightforward replacement of ::MagneticField in the user
+   * code.
+   *
+   * Note that one local::MagneticField object should not be shared
+   * between threads. In case of doubt, copy the local::MagneticField
+   * object (e.g. for tbb::parallel_for);
+   */
+  class MagneticField {
+  public:
+    MagneticField() : field_(nullptr) {}
+    explicit MagneticField(::MagneticField const* field) : field_(field) {}
+
+    /// Field value ad specified global point, in Tesla
+    GlobalVector inTesla(const GlobalPoint& gp) { return field_->inTesla(gp, cache_); }
+
+    /// Field value ad specified global point, in KGauss
+    GlobalVector inKGauss(const GlobalPoint& gp) { return inTesla(gp) * 10.F; }
+
+    /// Field value ad specified global point, in 1/Gev
+    GlobalVector inInverseGeV(const GlobalPoint& gp) { return inTesla(gp) * 2.99792458e-3F; }
+
+    /// True if the point is within the region where the concrete field
+    // engine is defined.
+    bool isDefined(const GlobalPoint& gp) const { return field_->isDefined(gp); }
+
+    /// Optional implementation that derived classes can implement to provide faster query
+    /// by skipping the check to isDefined.
+    GlobalVector inTeslaUnchecked(const GlobalPoint& gp) { return field_->inTeslaUnchecked(gp, cache_); }
+
+    /// The nominal field value for this map in kGauss
+    int nominalValue() const { return field_->nominalValue(); }
+
+    void reset(::MagneticField const* iField) {
+      field_ = iField;
+      cache_.reset();
+    }
+
+  private:
+    ::MagneticField const* field_;
+    MagneticFieldCache cache_;
+  };
+}  // namespace local
+
+#endif

--- a/MagneticField/VolumeBasedEngine/interface/MagGeometry.h
+++ b/MagneticField/VolumeBasedEngine/interface/MagGeometry.h
@@ -15,6 +15,7 @@
 
 class MagBLayer;
 class MagESector;
+class MagneticFieldCache;
 class MagVolume;
 class MagVolume6Faces;
 template <class T>
@@ -42,9 +43,13 @@ public:
 
   /// Return field vector at the specified global point
   GlobalVector fieldInTesla(const GlobalPoint& gp) const;
+  /// Return field vector at the specified global point
+  GlobalVector fieldInTesla(const GlobalPoint& gp, MagneticFieldCache& cache) const;
 
   /// Find a volume
   MagVolume const* findVolume(const GlobalPoint& gp, double tolerance = 0.) const;
+  /// Find a volume
+  MagVolume const* findVolume(const GlobalPoint& gp, MagneticFieldCache& cache, double tolerance = 0.) const;
 
   // FIXME: only for temporary tests, should be removed.
   const std::vector<MagVolume6Faces const*>& barrelVolumes() const { return theBVolumes; }
@@ -55,6 +60,8 @@ private:
 
   // Linear search (for debug purposes only)
   MagVolume const* findVolume1(const GlobalPoint& gp, double tolerance = 0.) const;
+
+  MagVolume const* findVolumeImpl(const GlobalPoint& gp, double tolerance) const;
 
   bool inBarrel(const GlobalPoint& gp) const;
 

--- a/MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h
+++ b/MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h
@@ -40,8 +40,10 @@ public:
   MagneticField* clone() const override;
 
   GlobalVector inTesla(const GlobalPoint& g) const override;
+  GlobalVector inTesla(const GlobalPoint& g, MagneticFieldCache& cache) const override;
 
   GlobalVector inTeslaUnchecked(const GlobalPoint& g) const override;
+  GlobalVector inTeslaUnchecked(const GlobalPoint& g, MagneticFieldCache& cache) const override;
 
   const MagVolume* findVolume(const GlobalPoint& gp) const;
 

--- a/MagneticField/VolumeBasedEngine/src/VolumeBasedMagneticField.cc
+++ b/MagneticField/VolumeBasedEngine/src/VolumeBasedMagneticField.cc
@@ -49,11 +49,30 @@ GlobalVector VolumeBasedMagneticField::inTesla(const GlobalPoint& gp) const {
   return field->fieldInTesla(gp);
 }
 
+GlobalVector VolumeBasedMagneticField::inTesla(const GlobalPoint& gp, MagneticFieldCache& cache) const {
+  // If parametrization of the inner region is available, use it.
+  if (paramField && paramField->isDefined(gp))
+    return paramField->inTeslaUnchecked(gp, cache);
+
+  // If point is outside magfield map, return 0 field (not an error)
+  if (!isDefined(gp))
+    return GlobalVector();
+
+  return field->fieldInTesla(gp, cache);
+}
+
 GlobalVector VolumeBasedMagneticField::inTeslaUnchecked(const GlobalPoint& gp) const {
   //same as above, but do not check range
   if (paramField && paramField->isDefined(gp))
     return paramField->inTeslaUnchecked(gp);
   return field->fieldInTesla(gp);
+}
+
+GlobalVector VolumeBasedMagneticField::inTeslaUnchecked(const GlobalPoint& gp, MagneticFieldCache& cache) const {
+  //same as above, but do not check range
+  if (paramField && paramField->isDefined(gp))
+    return paramField->inTeslaUnchecked(gp, cache);
+  return field->fieldInTesla(gp, cache);
 }
 
 const MagVolume* VolumeBasedMagneticField::findVolume(const GlobalPoint& gp) const { return field->findVolume(gp); }

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -25,6 +25,7 @@
 #include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Engine/interface/localMagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "SimG4Core/Notification/interface/G4SimEvent.h"
@@ -248,7 +249,7 @@ void RunManager::initG4(const edm::EventSetup& es) {
     es.get<IdealMagneticFieldRecord>().get(pMF);
     const GlobalPoint g(0., 0., 0.);
 
-    sim::FieldBuilder fieldBuilder(pMF.product(), m_pField);
+    sim::FieldBuilder fieldBuilder(local::MagneticField(pMF.product()), m_pField);
     CMSFieldManager* fieldManager = new CMSFieldManager();
     G4TransportationManager* tM = G4TransportationManager::GetTransportationManager();
     tM->SetFieldManager(fieldManager);

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -39,6 +39,7 @@
 #include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Engine/interface/localMagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -290,7 +291,7 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
     edm::ESHandle<MagneticField> pMF;
     es.get<IdealMagneticFieldRecord>().get(pMF);
 
-    sim::FieldBuilder fieldBuilder(pMF.product(), m_pField);
+    sim::FieldBuilder fieldBuilder(local::MagneticField(pMF.product()), m_pField);
     CMSFieldManager* fieldManager = new CMSFieldManager();
     tM->SetFieldManager(fieldManager);
     fieldBuilder.build(fieldManager, tM->GetPropagatorInField());

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -18,6 +18,7 @@
 #include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Engine/interface/localMagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -87,7 +88,7 @@ void GeometryProducer::updateMagneticField(edm::EventSetup const &es) {
     const GlobalPoint g(0., 0., 0.);
     edm::LogInfo("GeometryProducer") << "B-field(T) at (0,0,0)(cm): " << pMF->inTesla(g);
 
-    sim::FieldBuilder fieldBuilder(pMF.product(), m_pField);
+    sim::FieldBuilder fieldBuilder(local::MagneticField(pMF.product()), m_pField);
     CMSFieldManager *fieldManager = new CMSFieldManager();
     G4TransportationManager *tM = G4TransportationManager::GetTransportationManager();
     tM->SetFieldManager(fieldManager);

--- a/SimG4Core/MagneticField/interface/Field.h
+++ b/SimG4Core/MagneticField/interface/Field.h
@@ -3,17 +3,17 @@
 
 #include "G4MagneticField.hh"
 
-class MagneticField;
+#include "MagneticField/Engine/interface/localMagneticField.h"
 
 namespace sim {
   class Field : public G4MagneticField {
   public:
-    Field(const MagneticField *f, double d);
+    Field(local::MagneticField f, double d);
     ~Field() override;
     void GetFieldValue(const G4double p[4], G4double b[3]) const override;
 
   private:
-    const MagneticField *theCMSMagneticField;
+    mutable local::MagneticField theCMSMagneticField;
     double theDelta;
 
     mutable double oldx[3];

--- a/SimG4Core/MagneticField/interface/FieldBuilder.h
+++ b/SimG4Core/MagneticField/interface/FieldBuilder.h
@@ -4,17 +4,20 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <memory>
 
-class MagneticField;
 class CMSFieldManager;
 class G4Mag_UsualEqRhs;
 class G4PropagatorInField;
 class G4LogicalVolume;
 
+namespace local {
+  class MagneticField;
+}
+
 namespace sim {
   class Field;
   class FieldBuilder {
   public:
-    FieldBuilder(const MagneticField *, const edm::ParameterSet &);
+    FieldBuilder(local::MagneticField, const edm::ParameterSet &);
 
     ~FieldBuilder();
 

--- a/SimG4Core/MagneticField/src/Field.cc
+++ b/SimG4Core/MagneticField/src/Field.cc
@@ -1,4 +1,4 @@
-#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Engine/interface/localMagneticField.h"
 #include "SimG4Core/MagneticField/interface/Field.h"
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
@@ -8,7 +8,7 @@
 
 using namespace sim;
 
-Field::Field(const MagneticField *f, double d) : G4MagneticField(), theCMSMagneticField(f), theDelta(d) {
+Field::Field(local::MagneticField f, double d) : G4MagneticField(), theCMSMagneticField(std::move(f)), theDelta(d) {
   for (int i = 0; i < 3; ++i) {
     oldx[i] = 1.0e12;
     oldb[i] = 0.0;
@@ -22,7 +22,7 @@ void Field::GetFieldValue(const G4double xyz[4], G4double bfield[3]) const {
       std::abs(oldx[2] - xyz[2]) > theDelta) {
     static const float lunit = (float)(1.0 / CLHEP::cm);
     GlobalPoint ggg((float)(xyz[0]) * lunit, (float)(xyz[1]) * lunit, (float)(xyz[2]) * lunit);
-    GlobalVector v = theCMSMagneticField->inTesla(ggg);
+    GlobalVector v = theCMSMagneticField.inTesla(ggg);
 
     static const float btesla = (float)CLHEP::tesla;
     oldb[0] = (G4double)(v.x() * btesla);

--- a/SimG4Core/MagneticField/src/FieldBuilder.cc
+++ b/SimG4Core/MagneticField/src/FieldBuilder.cc
@@ -20,9 +20,9 @@
 
 using namespace sim;
 
-FieldBuilder::FieldBuilder(const MagneticField *f, const edm::ParameterSet &p) : theTopVolume(nullptr), thePSet(p) {
+FieldBuilder::FieldBuilder(local::MagneticField f, const edm::ParameterSet &p) : theTopVolume(nullptr), thePSet(p) {
   theDelta = p.getParameter<double>("delta") * CLHEP::mm;
-  theField = new Field(f, theDelta);
+  theField = new Field(std::move(f), theDelta);
   theFieldEquation = new G4Mag_UsualEqRhs(theField);
 }
 


### PR DESCRIPTION
#### PR description:

Following the discussion #28180 this PR proposes a local cache for the caching of "previous volume" in `MagGeometry` following the sketch in https://github.com/cms-sw/cmssw/pull/28180#issuecomment-617817229, and `local::MagneticField` as an easy replacement of `MagneticField const*`.

This PR also migrates Oscar(MT)Producer to use the `local::MagneticField` to enable testing for the most affected use case.

#### PR validation:

Limited matrix runs. I also tested with one workflow that the SIM step runs with multiple threads.