### PR TITLE
Handle Depth 7-only Signal in HcalTriggerPrimitiveAlgo

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -95,7 +95,7 @@ private:
   bool validUpgradeFG(const HcalTrigTowerDetId& id, int depth) const;
   bool validChannel(const QIE10DataFrame& digi, int ts) const;
   bool needLegacyFG(const HcalTrigTowerDetId& id) const;
-  bool needUpgradeFG(const HcalTrigTowerDetId& id, int depth) const;
+  bool needUpgradeID(const HcalTrigTowerDetId& id, int depth) const;
 
   /// adds the actual digis
   void analyze(IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result);

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -95,6 +95,7 @@ private:
   bool validUpgradeFG(const HcalTrigTowerDetId& id, int depth) const;
   bool validChannel(const QIE10DataFrame& digi, int ts) const;
   bool needLegacyFG(const HcalTrigTowerDetId& id) const;
+  bool needUpgradeFG(const HcalTrigTowerDetId& id, int depth) const;
 
   /// adds the actual digis
   void analyze(IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result);
@@ -205,6 +206,7 @@ private:
 
   // HE constants
   static const int HBHE_OVERLAP_TOWER = 16;
+  static const int FIRST_DEPTH7_TOWER = 26;
   static const int LAST_FINEGRAIN_DEPTH = 6;
   static const int LAST_FINEGRAIN_TOWER = 28;
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -788,9 +788,9 @@ bool HcalTriggerPrimitiveAlgo::needLegacyFG(const HcalTrigTowerDetId& id) const 
   return false;
 }
 
-bool HcalTriggerPrimitiveAlgo::needUpgradeFG(const HcalTrigTowerDetId& id, int depth) const {
+bool HcalTriggerPrimitiveAlgo::needUpgradeID(const HcalTrigTowerDetId& id, int depth) const {
 
-   // Depth 7 for ieta 26, 27, and 28 is not considered a fine grain depth.
+   // Depth 7 for TT 26, 27, and 28 is not considered a fine grain depth.
    // However, the trigger tower for these ieta should still be added to the fgUpgradeMap_
    // Otherwise, depth 7-only signal will not be analyzed.
    unsigned int aieta = id.ietaAbs();
@@ -807,7 +807,7 @@ void HcalTriggerPrimitiveAlgo::addUpgradeFG(const HcalTrigTowerDetId& id,
     if (needLegacyFG(id)) {
       std::vector<bool> pseudo(bits.size(), false);
       addFG(id, pseudo);
-    } else if (needUpgradeFG(id, depth)) {
+    } else if (needUpgradeID(id, depth)) {
 
        // If the tower id is not in the map yet
        // then for safety's sake add it, otherwise, no need

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -789,16 +789,14 @@ bool HcalTriggerPrimitiveAlgo::needLegacyFG(const HcalTrigTowerDetId& id) const 
 }
 
 bool HcalTriggerPrimitiveAlgo::needUpgradeID(const HcalTrigTowerDetId& id, int depth) const {
-
-   // Depth 7 for TT 26, 27, and 28 is not considered a fine grain depth.
-   // However, the trigger tower for these ieta should still be added to the fgUpgradeMap_
-   // Otherwise, depth 7-only signal will not be analyzed.
-   unsigned int aieta = id.ietaAbs();
-   if (aieta >= FIRST_DEPTH7_TOWER and aieta <= LAST_FINEGRAIN_TOWER and depth > LAST_FINEGRAIN_DEPTH)
-      return true;
-   return false;
+  // Depth 7 for TT 26, 27, and 28 is not considered a fine grain depth.
+  // However, the trigger tower for these ieta should still be added to the fgUpgradeMap_
+  // Otherwise, depth 7-only signal will not be analyzed.
+  unsigned int aieta = id.ietaAbs();
+  if (aieta >= FIRST_DEPTH7_TOWER and aieta <= LAST_FINEGRAIN_TOWER and depth > LAST_FINEGRAIN_DEPTH)
+    return true;
+  return false;
 }
-
 
 void HcalTriggerPrimitiveAlgo::addUpgradeFG(const HcalTrigTowerDetId& id,
                                             int depth,
@@ -808,16 +806,15 @@ void HcalTriggerPrimitiveAlgo::addUpgradeFG(const HcalTrigTowerDetId& id,
       std::vector<bool> pseudo(bits.size(), false);
       addFG(id, pseudo);
     } else if (needUpgradeID(id, depth)) {
-
-       // If the tower id is not in the map yet
-       // then for safety's sake add it, otherwise, no need
-       // Likewise, we're here with non-fg depth 7 so the bits are not to be added
-       auto it = fgUpgradeMap_.find(id);
-       if (it == fgUpgradeMap_.end()) {
-          FGUpgradeContainer element;
-          element.resize(bits.size());
-          fgUpgradeMap_.insert(std::make_pair(id, element)).first;
-       }
+      // If the tower id is not in the map yet
+      // then for safety's sake add it, otherwise, no need
+      // Likewise, we're here with non-fg depth 7 so the bits are not to be added
+      auto it = fgUpgradeMap_.find(id);
+      if (it == fgUpgradeMap_.end()) {
+        FGUpgradeContainer element;
+        element.resize(bits.size());
+        fgUpgradeMap_.insert(std::make_pair(id, element)).first;
+      }
     }
 
     return;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -813,7 +813,7 @@ void HcalTriggerPrimitiveAlgo::addUpgradeFG(const HcalTrigTowerDetId& id,
       if (it == fgUpgradeMap_.end()) {
         FGUpgradeContainer element;
         element.resize(bits.size());
-        fgUpgradeMap_.insert(std::make_pair(id, element)).first;
+        fgUpgradeMap_.insert(std::make_pair(id, element));
       }
     }
 


### PR DESCRIPTION
#### PR description:

This PR addresses the issue described in JIRA ticket [CMSHCALTRG-9](https://its.cern.ch/jira/browse/CMSHCALTRG-9). When a signal is only in depth 7 of HCAL TT26, TT27, or TT28, the corresponding `HcalTriggerPrimitiveDigi` is not fully formed.

#### PR validation:

To understand this fix, the `HcalTriggerPrimitiveAlgo` code was run before and after and these depth 7 special cases were investigated. Example printout is provided below:

Prefix
```
EVENT 7227 | (HcalTrigTower v0: 27,37) | size() 0 | presamples() 0
```
Here, since the TP is not fully formed, its `size()` and `presamples()` members are left initialized at 0.

Postfix
```
EVENT 7227 | (HcalTrigTower v0: 27,37) | size() 4 | presamples() 2
  Value=0, FG=0
  Value=0, FG=0
  Value=0, FG=0
  Value=0, FG=0
```

After the fix, when the TP is fully constructed, it has valid `size()` and `presamples()` values. Likewise, there are non-zero number of `HcalTriggerPrimitiveSamples`.

Only one additional `static const` variable is added to the code.