### PR TITLE
small cleanup of CorrectedECALPFClusterProducer::fillDescriptions

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -183,11 +183,25 @@ def customiseFor29512(process):
 
     return process
 
+def customiseFor29XXX(process):
+    """small cleanup of CorrectedECALPFClusterProducer::fillDescriptions
+    Removes two unused parameters of CorrectedECALPFClusterProducer
+    PR: https://github.com/cms-sw/cmssw/pull/29XXX
+    """
+    for mod in producers_by_type(process, 'CorrectedECALPFClusterProducer'):
+        if hasattr(mod, 'energyCorrector'):
+           for parName in ['algoName', 'verticesLabel']:
+               if hasattr(mod.energyCorrector, parName):
+                  delattr(mod.energyCorrector, parName)
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
     process = customiseFor29512(process)
+    process = customiseFor29XXX(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -183,10 +183,10 @@ def customiseFor29512(process):
 
     return process
 
-def customiseFor29XXX(process):
+def customiseFor29658(process):
     """small cleanup of CorrectedECALPFClusterProducer::fillDescriptions
     Removes two unused parameters of CorrectedECALPFClusterProducer
-    PR: https://github.com/cms-sw/cmssw/pull/29XXX
+    PR: https://github.com/cms-sw/cmssw/pull/29658
     """
     for mod in producers_by_type(process, 'CorrectedECALPFClusterProducer'):
         if hasattr(mod, 'energyCorrector'):
@@ -202,6 +202,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
     process = customiseFor29512(process)
-    process = customiseFor29XXX(process)
+    process = customiseFor29658(process)
 
     return process

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -37,8 +37,6 @@ ootPhotons.isolationSumsCalculatorSet.trackProducer = cms.InputTag("hiGeneralTra
 
 from RecoParticleFlow.Configuration.RecoParticleFlow_cff import *
 
-particleFlowClusterECAL.energyCorrector.verticesLabel = cms.InputTag('hiPixelAdaptiveVertex')
-
 mvaElectrons.vertexTag = cms.InputTag("hiSelectedVertex")
 
 particleFlowBlock.elementImporters = cms.VPSet(

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -135,10 +135,8 @@ void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescript
     psd0.add<bool>("autoDetectBunchSpacing", true);
     psd0.add<int>("bunchSpacing", 25);
     psd0.add<double>("maxPtForMVAEvaluation", -99.);
-    psd0.add<std::string>("algoName", "PFClusterEMEnergyCorrector");
     psd0.add<edm::InputTag>("recHitsEBLabel", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
     psd0.add<edm::InputTag>("recHitsEELabel", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
-    psd0.add<edm::InputTag>("verticesLabel", edm::InputTag("offlinePrimaryVertices"));
     psd0.add<edm::InputTag>("ebSrFlagLabel", edm::InputTag("ecalDigis"));
     psd0.add<edm::InputTag>("eeSrFlagLabel", edm::InputTag("ecalDigis"));
     desc.add<edm::ParameterSetDescription>("energyCorrector", psd0);


### PR DESCRIPTION
#### PR description:

It seems that a couple of parameters specified in the `fillDescriptions` method of `CorrectedECALPFClusterProducer` are not really being used by the producer.

The two parameters are `algoName` and `verticesLabel`, and they are currently part of a PSet used to configure an instance of `PFClusterEMEnergyCorrector`.

As far as I can see, the primary vertices were used in previous versions of `PFClusterEMEnergyCorrector` (they were introduced in #7558), but then were later removed when the BDT training was updated (in #8872, which was a follow-up of #8818).

For the `algoName` parameter, in my understanding this was needed when `PFClusterEMEnergyCorrector` was inheriting from `PFClusterEnergyCorrectorBase`, but that is not the case anymore (since #7558).

The only change in `Reconstruction_hiPF_cff` is the removal of one line, which was modifying the value of one of these (unused) parameters.

No changes are expected.

#### PR validation:

Passed tests with `runTheMatrix.py -l limited -i all`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.