### PR TITLE
New BeamSpot Object and Records

### DIFF
--- a/CondCore/BeamSpotPlugins/src/plugin.cc
+++ b/CondCore/BeamSpotPlugins/src/plugin.cc
@@ -1,8 +1,13 @@
 #include "CondCore/ESSources/interface/registration_macros.h"
 #include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/SimBeamSpotObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
 
 REGISTER_PLUGIN(BeamSpotObjectsRcd, BeamSpotObjects);
 REGISTER_PLUGIN(SimBeamSpotObjectsRcd, SimBeamSpotObjects);
+REGISTER_PLUGIN(BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineObjects);
+REGISTER_PLUGIN(BeamSpotOnlineLegacyObjectsRcd, BeamSpotOnlineObjects);

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -9,6 +9,7 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(AlignmentSurfaceDeformations);
   PAYLOAD_2XML_CLASS(Alignments);
   PAYLOAD_2XML_CLASS(BeamSpotObjects);
+  PAYLOAD_2XML_CLASS(BeamSpotOnlineObjects);
   PAYLOAD_2XML_CLASS(CSCBadChambers);
   PAYLOAD_2XML_CLASS(CSCBadStrips);
   PAYLOAD_2XML_CLASS(CSCBadWires);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -34,6 +34,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE(Alignments)
       FETCH_PAYLOAD_CASE(AlignPCLThresholds)
       FETCH_PAYLOAD_CASE(BeamSpotObjects)
+      FETCH_PAYLOAD_CASE(BeamSpotOnlineObjects)
       FETCH_PAYLOAD_CASE(CSCBadChambers)
       FETCH_PAYLOAD_CASE(CSCBadStrips)
       FETCH_PAYLOAD_CASE(CSCBadWires)

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -54,6 +54,7 @@ namespace cond {
         IMPORT_PAYLOAD_CASE(Alignments)
         IMPORT_PAYLOAD_CASE(AlignPCLThresholds)
         IMPORT_PAYLOAD_CASE(BeamSpotObjects)
+        IMPORT_PAYLOAD_CASE(BeamSpotOnlineObjects)
         IMPORT_PAYLOAD_CASE(CSCBadChambers)
         IMPORT_PAYLOAD_CASE(CSCBadStrips)
         IMPORT_PAYLOAD_CASE(CSCBadWires)

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -7,6 +7,7 @@
 #include "CondFormats/Alignment/interface/AlignmentSurfaceDeformations.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
 #include "CondFormats/CastorObjects/interface/CastorElectronicsMap.h"
 #include "CondFormats/CastorObjects/interface/CastorSaturationCorrs.h"
 #include "CondFormats/HIObjects/interface/CentralityTable.h"

--- a/CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h
@@ -109,7 +109,7 @@ public:
   /// print beam spot parameters
   void print(std::stringstream& ss) const;
 
-private:
+protected:
   double position_[3];
   double sigmaZ_;
   double beamwidthX_;

--- a/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
@@ -31,7 +31,6 @@ public:
 
   ~BeamSpotOnlineObjects() override {}
 
-
   /// Setters Methods
   // set lastAnalyzedLumi_, last analyzed lumisection
   void SetLastAnalyzedLumi(int val) { lastAnalyzedLumi_ = val; }
@@ -41,7 +40,6 @@ public:
 
   // set lastAnalyzedFill_, fill of the last analyzed lumisection
   void SetLastAnalyzedFill(int val) { lastAnalyzedFill_ = val; }
-
 
   /// Getters Methods
   // get lastAnalyzedLumi_, last analyzed lumisection
@@ -53,10 +51,8 @@ public:
   // get lastAnalyzedFill_, fill of the last analyzed lumisection
   int GetLastAnalyzedFill() const { return lastAnalyzedFill_; }
 
-
   /// Print BeamSpotOnline parameters
   void print(std::stringstream& ss) const;
-
 
 private:
   int lastAnalyzedLumi_;

--- a/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
@@ -19,6 +19,8 @@
 #include <cmath>
 #include <sstream>
 #include <cstring>
+#include <vector>
+#include <string>
 
 class BeamSpotOnlineObjects : public BeamSpotObjects {
 public:
@@ -27,9 +29,13 @@ public:
     lastAnalyzedLumi_ = 0;
     lastAnalyzedRun_ = 0;
     lastAnalyzedFill_ = 0;
+    intParams_.resize(ISIZE, std::vector<int>(1, 0));
   }
 
   ~BeamSpotOnlineObjects() override {}
+
+  /// Enums
+  enum IntParamIndex { NUM_TRACKS = 0, NUM_PVS = 1, ISIZE = 2 };
 
   /// Setters Methods
   // set lastAnalyzedLumi_, last analyzed lumisection
@@ -41,6 +47,12 @@ public:
   // set lastAnalyzedFill_, fill of the last analyzed lumisection
   void SetLastAnalyzedFill(int val) { lastAnalyzedFill_ = val; }
 
+  // set number of tracks used in the BeamSpot fit
+  void SetNumTracks(int val);
+
+  // set number of Primary Vertices used in the BeamSpot fit
+  void SetNumPVs(int val);
+
   /// Getters Methods
   // get lastAnalyzedLumi_, last analyzed lumisection
   int GetLastAnalyzedLumi() const { return lastAnalyzedLumi_; }
@@ -51,6 +63,12 @@ public:
   // get lastAnalyzedFill_, fill of the last analyzed lumisection
   int GetLastAnalyzedFill() const { return lastAnalyzedFill_; }
 
+  // get number of tracks used in the BeamSpot fit
+  int GetNumTracks() const;
+
+  // get number of Primary Vertices used in the BeamSpot fit
+  int GetNumPVs() const;
+
   /// Print BeamSpotOnline parameters
   void print(std::stringstream& ss) const;
 
@@ -58,6 +76,9 @@ private:
   int lastAnalyzedLumi_;
   int lastAnalyzedRun_;
   int lastAnalyzedFill_;
+  std::vector<std::vector<int> > intParams_;
+  std::vector<std::vector<float> > floatParams_;
+  std::vector<std::vector<std::string> > stringParams_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
@@ -29,7 +29,7 @@ public:
     lastAnalyzedFill_ = 0;
   }
 
-  virtual ~BeamSpotOnlineObjects() {}
+  ~BeamSpotOnlineObjects() override {}
 
 
   /// Setters Methods

--- a/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
@@ -13,7 +13,7 @@
  */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
-
+#include "CondFormats/Common/interface/Time.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 
 #include <cmath>
@@ -30,12 +30,14 @@ public:
     lastAnalyzedRun_ = 0;
     lastAnalyzedFill_ = 0;
     intParams_.resize(ISIZE, std::vector<int>(1, 0));
+    timeParams_.resize(TSIZE, std::vector<unsigned long long>(1, 0ULL));
   }
 
   ~BeamSpotOnlineObjects() override {}
 
   /// Enums
   enum IntParamIndex { NUM_TRACKS = 0, NUM_PVS = 1, ISIZE = 2 };
+  enum TimeParamIndex { CREATE_TIME = 0, TSIZE = 1 };
 
   /// Setters Methods
   // set lastAnalyzedLumi_, last analyzed lumisection
@@ -53,6 +55,9 @@ public:
   // set number of Primary Vertices used in the BeamSpot fit
   void SetNumPVs(int val);
 
+  // set creation time of the payload
+  void SetCreationTime(cond::Time_t val);
+
   /// Getters Methods
   // get lastAnalyzedLumi_, last analyzed lumisection
   int GetLastAnalyzedLumi() const { return lastAnalyzedLumi_; }
@@ -69,6 +74,9 @@ public:
   // get number of Primary Vertices used in the BeamSpot fit
   int GetNumPVs() const;
 
+  // get creation time of the payload
+  cond::Time_t GetCreationTime() const;
+
   /// Print BeamSpotOnline parameters
   void print(std::stringstream& ss) const;
 
@@ -79,6 +87,7 @@ private:
   std::vector<std::vector<int> > intParams_;
   std::vector<std::vector<float> > floatParams_;
   std::vector<std::vector<std::string> > stringParams_;
+  std::vector<std::vector<unsigned long long> > timeParams_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
@@ -1,0 +1,71 @@
+#ifndef BEAMSPOTONLINEOBJECTS_H
+#define BEAMSPOTONLINEOBJECTS_H
+/** \class BeamSpotOnlineObjects
+ *
+ * Class inheriting from BeamSpotObjects. 
+ * New members of the class:
+ *  - lastAnalyzedLumi : last lumisection analyzed
+ *  - lastAnalyzedRun  : run of the last analyzed lumisection
+ *  - lastAnalyzedFill : fill of the last analyzed lumisection
+ *
+ * \author Francisco Brivio, Milano-Bicocca (francesco.brivio@cern.ch)
+ *
+ */
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+
+#include <cmath>
+#include <sstream>
+#include <cstring>
+
+class BeamSpotOnlineObjects : public BeamSpotObjects {
+public:
+  /// default constructor
+  BeamSpotOnlineObjects() {
+    lastAnalyzedLumi_ = 0;
+    lastAnalyzedRun_ = 0;
+    lastAnalyzedFill_ = 0;
+  }
+
+  virtual ~BeamSpotOnlineObjects() {}
+
+
+  /// Setters Methods
+  // set lastAnalyzedLumi_, last analyzed lumisection
+  void SetLastAnalyzedLumi(int val) { lastAnalyzedLumi_ = val; }
+
+  // set lastAnalyzedRun_, run of the last analyzed lumisection
+  void SetLastAnalyzedRun(int val) { lastAnalyzedRun_ = val; }
+
+  // set lastAnalyzedFill_, fill of the last analyzed lumisection
+  void SetLastAnalyzedFill(int val) { lastAnalyzedFill_ = val; }
+
+
+  /// Getters Methods
+  // get lastAnalyzedLumi_, last analyzed lumisection
+  int GetLastAnalyzedLumi() const { return lastAnalyzedLumi_; }
+
+  // get lastAnalyzedRun_, run of the last analyzed lumisection
+  int GetLastAnalyzedRun() const { return lastAnalyzedRun_; }
+
+  // get lastAnalyzedFill_, fill of the last analyzed lumisection
+  int GetLastAnalyzedFill() const { return lastAnalyzedFill_; }
+
+
+  /// Print BeamSpotOnline parameters
+  void print(std::stringstream& ss) const;
+
+
+private:
+  int lastAnalyzedLumi_;
+  int lastAnalyzedRun_;
+  int lastAnalyzedFill_;
+
+  COND_SERIALIZABLE;
+};
+
+std::ostream& operator<<(std::ostream&, BeamSpotOnlineObjects beam);
+
+#endif

--- a/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
@@ -51,12 +51,20 @@ int BeamSpotOnlineObjects::GetNumTracks() const {
 
 int BeamSpotOnlineObjects::GetNumPVs() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, NUM_PVS); }
 
+cond::Time_t BeamSpotOnlineObjects::GetCreationTime() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(timeParams_, CREATE_TIME);
+}
+
 // setters
 void BeamSpotOnlineObjects::SetNumTracks(int nTracks) {
   BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_TRACKS, nTracks);
 }
 
 void BeamSpotOnlineObjects::SetNumPVs(int nPVs) { BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_PVS, nPVs); }
+
+void BeamSpotOnlineObjects::SetCreationTime(cond::Time_t createTime) {
+  BeamSpotOnlineObjectsImpl::setOneParam(timeParams_, CREATE_TIME, createTime);
+}
 
 // printers
 void BeamSpotOnlineObjects::print(std::stringstream& ss) const {

--- a/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
@@ -2,6 +2,63 @@
 
 #include <iostream>
 
+namespace BeamSpotOnlineObjectsImpl {
+  template <typename T>
+  const T& getParams(const std::vector<T>& params, size_t index) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    return params[index];
+  }
+
+  template <typename T>
+  T& accessParams(std::vector<T>& params, size_t index) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    return params[index];
+  }
+
+  template <typename T>
+  const T& getOneParam(const std::vector<std::vector<T> >& params, size_t index) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    const std::vector<T>& inner = params[index];
+    if (inner.empty())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " type=" + typeid(T).name() +
+                              " has no value stored.");
+    return inner[0];
+  }
+
+  template <typename T>
+  void setOneParam(std::vector<std::vector<T> >& params, size_t index, const T& value) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    params[index] = std::vector<T>(1, value);
+  }
+
+  template <typename T>
+  void setParams(std::vector<T>& params, size_t index, const T& value) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    params[index] = value;
+  }
+
+}  //namespace BeamSpotOnlineObjectsImpl
+
+// getters
+int BeamSpotOnlineObjects::GetNumTracks() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, NUM_TRACKS);
+}
+
+int BeamSpotOnlineObjects::GetNumPVs() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, NUM_PVS); }
+
+// setters
+void BeamSpotOnlineObjects::SetNumTracks(int nTracks) {
+  BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_TRACKS, nTracks);
+}
+
+void BeamSpotOnlineObjects::SetNumPVs(int nPVs) { BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_PVS, nPVs); }
+
+// printers
 void BeamSpotOnlineObjects::print(std::stringstream& ss) const {
   ss << "-----------------------------------------------------\n"
      << "              BeamSpotOnline Data\n\n"

--- a/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
@@ -1,0 +1,31 @@
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+
+#include <iostream>
+
+void BeamSpotOnlineObjects::print(std::stringstream& ss) const {
+  ss << "-----------------------------------------------------\n"
+     << "              BeamSpotOnline Data\n\n"
+     << " Beam type    = " << GetBeamType() << "\n"
+     << "       X0     = " << GetX() << " +/- " << GetXError() << " [cm]\n"
+     << "       Y0     = " << GetY() << " +/- " << GetYError() << " [cm]\n"
+     << "       Z0     = " << GetZ() << " +/- " << GetZError() << " [cm]\n"
+     << " Sigma Z0     = " << GetSigmaZ() << " +/- " << GetSigmaZError() << " [cm]\n"
+     << " dxdz         = " << Getdxdz() << " +/- " << GetdxdzError() << " [radians]\n"
+     << " dydz         = " << Getdydz() << " +/- " << GetdydzError() << " [radians]\n"
+     << " Beam Width X = " << GetBeamWidthX() << " +/- " << GetBeamWidthXError() << " [cm]\n"
+     << " Beam Width Y = " << GetBeamWidthY() << " +/- " << GetBeamWidthYError() << " [cm]\n"
+     << " Emittance X  = " << GetEmittanceX() << " [cm]\n"
+     << " Emittance Y  = " << GetEmittanceY() << " [cm]\n"
+     << " Beta star    = " << GetBetaStar() << " [cm]\n"
+     << " Last Lumi    = " << GetLastAnalyzedLumi() << "\n"
+     << " Last Run     = " << GetLastAnalyzedRun() << "\n"
+     << " Last Fill    = " << GetLastAnalyzedFill() << "\n"
+     << "-----------------------------------------------------\n\n";
+}
+
+std::ostream& operator<<(std::ostream& os, BeamSpotOnlineObjects beam) {
+  std::stringstream ss;
+  beam.print(ss);
+  os << ss.str();
+  return os;
+}

--- a/CondFormats/BeamSpotObjects/src/T_EventSetup_BeamSpotOnlineObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/T_EventSetup_BeamSpotOnlineObjects.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(BeamSpotOnlineObjects);

--- a/CondFormats/BeamSpotObjects/src/classes_def.xml
+++ b/CondFormats/BeamSpotObjects/src/classes_def.xml
@@ -1,4 +1,5 @@
 <lcgdict>
        <class name="BeamSpotObjects"/>       
        <class name="SimBeamSpotObjects"/>       
+       <class name="BeamSpotOnlineObjects"/>
 </lcgdict>  

--- a/CondFormats/BeamSpotObjects/src/headers.h
+++ b/CondFormats/BeamSpotObjects/src/headers.h
@@ -1,2 +1,3 @@
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"

--- a/CondFormats/BeamSpotObjects/test/testSerializationBeamSpotObjects.cpp
+++ b/CondFormats/BeamSpotObjects/test/testSerializationBeamSpotObjects.cpp
@@ -5,6 +5,7 @@
 int main() {
   testSerialization<BeamSpotObjects>();
   testSerialization<SimBeamSpotObjects>();
+  testSerialization<BeamSpotOnlineObjects>();
 
   return 0;
 }

--- a/CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h
@@ -21,6 +21,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
-class BeamSpotOnlineHLTObjectsRcd : public edm::eventsetup::EventSetupRecordImplementation<BeamSpotOnlineHLTObjectsRcd> {};
+class BeamSpotOnlineHLTObjectsRcd
+    : public edm::eventsetup::EventSetupRecordImplementation<BeamSpotOnlineHLTObjectsRcd> {};
 
 #endif

--- a/CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h
@@ -1,0 +1,26 @@
+#ifndef DataRecord_BeamSpotOnlineHLTObjectsRcd_h
+#define DataRecord_BeamSpotOnlineHLTObjectsRcd_h
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     BeamSpotOnlineHLTObjectsRcd
+//
+/**\class BeamSpotOnlineHLTObjectsRcd BeamSpotOnlineHLTObjectsRcd.h CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:
+// Created:     Tue Mar  6 19:34:33 CST 2007
+// $Id$
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class BeamSpotOnlineHLTObjectsRcd : public edm::eventsetup::EventSetupRecordImplementation<BeamSpotOnlineHLTObjectsRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h
@@ -21,6 +21,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
-class BeamSpotOnlineLegacyObjectsRcd : public edm::eventsetup::EventSetupRecordImplementation<BeamSpotOnlineLegacyObjectsRcd> {};
+class BeamSpotOnlineLegacyObjectsRcd
+    : public edm::eventsetup::EventSetupRecordImplementation<BeamSpotOnlineLegacyObjectsRcd> {};
 
 #endif

--- a/CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h
@@ -1,0 +1,26 @@
+#ifndef DataRecord_BeamSpotOnlineLegacyObjectsRcd_h
+#define DataRecord_BeamSpotOnlineLegacyObjectsRcd_h
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     BeamSpotOnlineLegacyObjectsRcd
+//
+/**\class BeamSpotOnlineLegacyObjectsRcd BeamSpotOnlineLegacyObjectsRcd.h CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:
+// Created:     Tue Mar  6 19:34:33 CST 2007
+// $Id$
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class BeamSpotOnlineLegacyObjectsRcd : public edm::eventsetup::EventSetupRecordImplementation<BeamSpotOnlineLegacyObjectsRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
@@ -23,7 +23,9 @@
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
 
-class BeamSpotTransientObjectsRcd : public edm::eventsetup::DependentRecordImplementation<BeamSpotTransientObjectsRcd,
-                                    boost::mpl::vector<BeamSpotOnlineHLTObjectsRcd,BeamSpotOnlineLegacyObjectsRcd> > {};
+class BeamSpotTransientObjectsRcd
+    : public edm::eventsetup::DependentRecordImplementation<
+          BeamSpotTransientObjectsRcd,
+          boost::mpl::vector<BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineLegacyObjectsRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
@@ -1,0 +1,29 @@
+#ifndef DataRecord_BeamSpotTransientObjectsRcd_h
+#define DataRecord_BeamSpotTransientObjectsRcd_h
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     BeamSpotTransientObjectsRcd
+//
+/**\class BeamSpotTransientObjectsRcd BeamSpotTransientObjectsRcd.h CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:
+// Created:     Tue Mar  6 19:34:33 CST 2007
+// $Id$
+//
+#include "boost/mpl/vector.hpp"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+
+class BeamSpotTransientObjectsRcd : public edm::eventsetup::DependentRecordImplementation<BeamSpotTransientObjectsRcd,
+                                    boost::mpl::vector<BeamSpotOnlineHLTObjectsRcd,BeamSpotOnlineLegacyObjectsRcd> > {};
+
+#endif

--- a/CondFormats/DataRecord/src/BeamSpotOnlineHLTObjectsRcd.cc
+++ b/CondFormats/DataRecord/src/BeamSpotOnlineHLTObjectsRcd.cc
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     BeamSpotOnlineHLTObjectsRcd
+//
+// Implementation:
+//     <Notes on implementation>
+//
+// Author:
+// Created:     Tue Mar  6 19:34:33 CST 2007
+// $Id$
+
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(BeamSpotOnlineHLTObjectsRcd);

--- a/CondFormats/DataRecord/src/BeamSpotOnlineLegacyObjectsRcd.cc
+++ b/CondFormats/DataRecord/src/BeamSpotOnlineLegacyObjectsRcd.cc
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     BeamSpotOnlineLegacyObjectsRcd
+//
+// Implementation:
+//     <Notes on implementation>
+//
+// Author:
+// Created:     Tue Mar  6 19:34:33 CST 2007
+// $Id$
+
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(BeamSpotOnlineLegacyObjectsRcd);

--- a/CondFormats/DataRecord/src/BeamSpotTransientObjectsRcd.cc
+++ b/CondFormats/DataRecord/src/BeamSpotTransientObjectsRcd.cc
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     BeamSpotTransientObjectsRcd
+//
+// Implementation:
+//     <Notes on implementation>
+//
+// Author:
+// Created:     Tue Mar  6 19:34:33 CST 2007
+// $Id$
+
+#include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(BeamSpotTransientObjectsRcd);

--- a/CondTools/BeamSpot/data/BeamFitResults_Run306171.txt
+++ b/CondTools/BeamSpot/data/BeamFitResults_Run306171.txt
@@ -1,0 +1,23 @@
+Runnumber 306171
+BeginTimeOfFit 2017.11.07 05:54:26 GMT 1510034066
+EndTimeOfFit 2017.11.07 05:56:12 GMT 1510034172
+LumiRange 497 - 497
+Type 2
+X0 0.0820524
+Y0 -0.029357
+Z0 0.975028
+sigmaZ0 3.71505
+dxdz 4.96284e-05
+dydz 4.20814e-05
+BeamWidthX 0.00307016
+BeamWidthY 0.00317594    
+Cov(0,j) 4.79157e-09 -1.43662e-10 0 0 0 0 0     
+Cov(1,j) -1.43662e-10 4.934e-09 0 0 0 0 0 
+Cov(2,j) 0 0 0.00818113 0 0 0 0 
+Cov(3,j) 0 0 0 0.00409049 0 0 0 
+Cov(4,j) 0 0 0 0 3.14283e-10 -1.12097e-11 0 
+Cov(5,j) 0 0 0 0 -1.12097e-11 3.3278e-10 0 
+Cov(6,j) 0 0 0 0 0 0 1.12526e-08
+EmittanceX 0
+EmittanceY 0
+BetaStar 0

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdReader.cc
@@ -50,15 +50,15 @@
 class BeamSpotOnlineHLTRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
    public:
       explicit BeamSpotOnlineHLTRcdReader(const edm::ParameterSet&);
-      ~BeamSpotOnlineHLTRcdReader();
+      ~BeamSpotOnlineHLTRcdReader() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 
    private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override;
 
   struct theBSOfromDB {
     int ls;

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdReader.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <sstream>
@@ -47,18 +46,17 @@
 // class declaration
 //
 
-class BeamSpotOnlineHLTRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
-   public:
-      explicit BeamSpotOnlineHLTRcdReader(const edm::ParameterSet&);
-      ~BeamSpotOnlineHLTRcdReader() override;
+class BeamSpotOnlineHLTRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit BeamSpotOnlineHLTRcdReader(const edm::ParameterSet&);
+  ~BeamSpotOnlineHLTRcdReader() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   struct theBSOfromDB {
     int ls;
@@ -70,12 +68,12 @@ class BeamSpotOnlineHLTRcdReader : public edm::one::EDAnalyzer<edm::one::SharedR
     float Beamdxdz_;
     float BeamWidthX_;
     float BeamWidthY_;
-    int   lastAnalyzedLumi_;
-    int   lastAnalyzedRun_;
-    int   lastAnalyzedFill_;
+    int lastAnalyzedLumi_;
+    int lastAnalyzedRun_;
+    int lastAnalyzedFill_;
     void init();
   } theBSOfromDB_;
-  
+
   edm::Service<TFileService> tFileService;
   TTree* bstree_;
 
@@ -100,12 +98,10 @@ BeamSpotOnlineHLTRcdReader::BeamSpotOnlineHLTRcdReader(const edm::ParameterSet& 
   }
 }
 
-BeamSpotOnlineHLTRcdReader::~BeamSpotOnlineHLTRcdReader()
-{
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+BeamSpotOnlineHLTRcdReader::~BeamSpotOnlineHLTRcdReader() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -116,24 +112,22 @@ void BeamSpotOnlineHLTRcdReader::theBSOfromDB::init() {
   int dummy_int = -999;
 
   run = dummy_int;
-  ls  = dummy_int;
+  ls = dummy_int;
   BSx0_ = dummy_float;
   BSy0_ = dummy_float;
   BSz0_ = dummy_float;
   Beamsigmaz_ = dummy_float;
-  Beamdxdz_   = dummy_float;
+  Beamdxdz_ = dummy_float;
   BeamWidthX_ = dummy_float;
   BeamWidthY_ = dummy_float;
   lastAnalyzedLumi_ = dummy_int;
-  lastAnalyzedRun_  = dummy_int;
+  lastAnalyzedRun_ = dummy_int;
   lastAnalyzedFill_ = dummy_int;
 }
 
 // ------------ method called for each event  ------------
-void
-BeamSpotOnlineHLTRcdReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void BeamSpotOnlineHLTRcdReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
   std::ostringstream output;
 
   // initialize the ntuple
@@ -149,16 +143,16 @@ BeamSpotOnlineHLTRcdReader::analyze(const edm::Event& iEvent, const edm::EventSe
     const BeamSpotOnlineObjects* mybeamspot = beamhandle.product();
 
     theBSOfromDB_.run = iEvent.id().run();
-    theBSOfromDB_.ls  = iEvent.id().luminosityBlock();
+    theBSOfromDB_.ls = iEvent.id().luminosityBlock();
     theBSOfromDB_.BSx0_ = mybeamspot->GetX();
     theBSOfromDB_.BSy0_ = mybeamspot->GetY();
     theBSOfromDB_.BSz0_ = mybeamspot->GetZ();
     theBSOfromDB_.Beamsigmaz_ = mybeamspot->GetSigmaZ();
-    theBSOfromDB_.Beamdxdz_   = mybeamspot->Getdxdz();
+    theBSOfromDB_.Beamdxdz_ = mybeamspot->Getdxdz();
     theBSOfromDB_.BeamWidthX_ = mybeamspot->GetBeamWidthX();
     theBSOfromDB_.BeamWidthY_ = mybeamspot->GetBeamWidthY();
     theBSOfromDB_.lastAnalyzedLumi_ = mybeamspot->GetLastAnalyzedLumi();
-    theBSOfromDB_.lastAnalyzedRun_  = mybeamspot->GetLastAnalyzedRun();
+    theBSOfromDB_.lastAnalyzedRun_ = mybeamspot->GetLastAnalyzedRun();
     theBSOfromDB_.lastAnalyzedFill_ = mybeamspot->GetLastAnalyzedFill();
 
     bstree_->Fill();
@@ -173,37 +167,30 @@ BeamSpotOnlineHLTRcdReader::analyze(const edm::Event& iEvent, const edm::EventSe
     edm::LogInfo("") << output.str();
 }
 
-
 // ------------ method called once each job just before starting event loop  ------------
-void
-BeamSpotOnlineHLTRcdReader::beginJob()
-{
+void BeamSpotOnlineHLTRcdReader::beginJob() {
   bstree_ = tFileService->make<TTree>("BSONtuple", "BeamSpotOnline analyzer ntuple");
 
   //Tree Branches
   bstree_->Branch("run", &theBSOfromDB_.run, "run/I");
-  bstree_->Branch("ls" , &theBSOfromDB_.ls , "ls/I");
+  bstree_->Branch("ls", &theBSOfromDB_.ls, "ls/I");
   bstree_->Branch("BSx0", &theBSOfromDB_.BSx0_, "BSx0/F");
   bstree_->Branch("BSy0", &theBSOfromDB_.BSy0_, "BSy0/F");
   bstree_->Branch("BSz0", &theBSOfromDB_.BSz0_, "BSz0/F");
   bstree_->Branch("Beamsigmaz", &theBSOfromDB_.Beamsigmaz_, "Beamsigmaz/F");
-  bstree_->Branch("Beamdxdz"  , &theBSOfromDB_.Beamdxdz_  , "Beamdxdz/F");
+  bstree_->Branch("Beamdxdz", &theBSOfromDB_.Beamdxdz_, "Beamdxdz/F");
   bstree_->Branch("BeamWidthX", &theBSOfromDB_.BeamWidthX_, "BeamWidthX/F");
   bstree_->Branch("BeamWidthY", &theBSOfromDB_.BeamWidthY_, "BeamWidthY/F");
   bstree_->Branch("LastAnalyzedLumi", &theBSOfromDB_.lastAnalyzedLumi_, "LastAnalyzedLumi/I");
-  bstree_->Branch("LastAnalyzedRun" , &theBSOfromDB_.lastAnalyzedRun_ , "LastAnalyzedRun/I");
+  bstree_->Branch("LastAnalyzedRun", &theBSOfromDB_.lastAnalyzedRun_, "LastAnalyzedRun/I");
   bstree_->Branch("LastAnalyzedFill", &theBSOfromDB_.lastAnalyzedFill_, "LastAnalyzedFill/I");
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-BeamSpotOnlineHLTRcdReader::endJob()
-{
-}
+void BeamSpotOnlineHLTRcdReader::endJob() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-BeamSpotOnlineHLTRcdReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void BeamSpotOnlineHLTRcdReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdReader.cc
@@ -1,0 +1,215 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/BeamSpot
+// Class:      BeamSpotOnlineHLTRcdReader
+//
+/**\class BeamSpotOnlineHLTRcdReader BeamSpotOnlineHLTRcdReader.cc CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdReader.cc
+
+ Description: EDAnalyzer to create a BeamSpotOnlineHLTObjectsRcd payload from a txt file and dump it in a db file
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Francesco Brivio
+//         Created:  Tue, 11 Feb 2020 08:39:14 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <sstream>
+#include <fstream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+
+// For ROOT
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include <TTree.h>
+
+//
+// class declaration
+//
+
+class BeamSpotOnlineHLTRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+   public:
+      explicit BeamSpotOnlineHLTRcdReader(const edm::ParameterSet&);
+      ~BeamSpotOnlineHLTRcdReader();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+
+  struct theBSOfromDB {
+    int ls;
+    int run;
+    float BSx0_;
+    float BSy0_;
+    float BSz0_;
+    float Beamsigmaz_;
+    float Beamdxdz_;
+    float BeamWidthX_;
+    float BeamWidthY_;
+    int   lastAnalyzedLumi_;
+    int   lastAnalyzedRun_;
+    int   lastAnalyzedFill_;
+    void init();
+  } theBSOfromDB_;
+  
+  edm::Service<TFileService> tFileService;
+  TTree* bstree_;
+
+  // ----------member data ---------------------------
+  edm::ESWatcher<BeamSpotOnlineHLTObjectsRcd> watcher_;
+  std::unique_ptr<std::ofstream> output_;
+};
+
+//
+// constructors and destructor
+//
+BeamSpotOnlineHLTRcdReader::BeamSpotOnlineHLTRcdReader(const edm::ParameterSet& iConfig) : bstree_(nullptr) {
+  //now do what ever initialization is needed
+  usesResource("TFileService");
+  std::string fileName(iConfig.getUntrackedParameter<std::string>("rawFileName"));
+  if (!fileName.empty()) {
+    output_.reset(new std::ofstream(fileName.c_str()));
+    if (!output_->good()) {
+      edm::LogError("IOproblem") << "Could not open output file " << fileName << ".";
+      output_.reset();
+    }
+  }
+}
+
+BeamSpotOnlineHLTRcdReader::~BeamSpotOnlineHLTRcdReader()
+{
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+void BeamSpotOnlineHLTRcdReader::theBSOfromDB::init() {
+  float dummy_float = -999.0;
+  int dummy_int = -999;
+
+  run = dummy_int;
+  ls  = dummy_int;
+  BSx0_ = dummy_float;
+  BSy0_ = dummy_float;
+  BSz0_ = dummy_float;
+  Beamsigmaz_ = dummy_float;
+  Beamdxdz_   = dummy_float;
+  BeamWidthX_ = dummy_float;
+  BeamWidthY_ = dummy_float;
+  lastAnalyzedLumi_ = dummy_int;
+  lastAnalyzedRun_  = dummy_int;
+  lastAnalyzedFill_ = dummy_int;
+}
+
+// ------------ method called for each event  ------------
+void
+BeamSpotOnlineHLTRcdReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+  std::ostringstream output;
+
+  // initialize the ntuple
+  theBSOfromDB_.init();
+
+  if (watcher_.check(iSetup)) {  // check for new IOV for this run / LS
+
+    output << " for runs: " << iEvent.id().run() << " - " << iEvent.id().luminosityBlock() << std::endl;
+
+    // Get BeamSpot from EventSetup:
+    edm::ESHandle<BeamSpotOnlineObjects> beamhandle;
+    iSetup.get<BeamSpotOnlineHLTObjectsRcd>().get(beamhandle);
+    const BeamSpotOnlineObjects* mybeamspot = beamhandle.product();
+
+    theBSOfromDB_.run = iEvent.id().run();
+    theBSOfromDB_.ls  = iEvent.id().luminosityBlock();
+    theBSOfromDB_.BSx0_ = mybeamspot->GetX();
+    theBSOfromDB_.BSy0_ = mybeamspot->GetY();
+    theBSOfromDB_.BSz0_ = mybeamspot->GetZ();
+    theBSOfromDB_.Beamsigmaz_ = mybeamspot->GetSigmaZ();
+    theBSOfromDB_.Beamdxdz_   = mybeamspot->Getdxdz();
+    theBSOfromDB_.BeamWidthX_ = mybeamspot->GetBeamWidthX();
+    theBSOfromDB_.BeamWidthY_ = mybeamspot->GetBeamWidthY();
+    theBSOfromDB_.lastAnalyzedLumi_ = mybeamspot->GetLastAnalyzedLumi();
+    theBSOfromDB_.lastAnalyzedRun_  = mybeamspot->GetLastAnalyzedRun();
+    theBSOfromDB_.lastAnalyzedFill_ = mybeamspot->GetLastAnalyzedFill();
+
+    bstree_->Fill();
+
+    output << *mybeamspot << std::endl;
+  }
+
+  // Final output - either message logger or output file:
+  if (output_.get())
+    *output_ << output.str();
+  else
+    edm::LogInfo("") << output.str();
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+BeamSpotOnlineHLTRcdReader::beginJob()
+{
+  bstree_ = tFileService->make<TTree>("BSONtuple", "BeamSpotOnline analyzer ntuple");
+
+  //Tree Branches
+  bstree_->Branch("run", &theBSOfromDB_.run, "run/I");
+  bstree_->Branch("ls" , &theBSOfromDB_.ls , "ls/I");
+  bstree_->Branch("BSx0", &theBSOfromDB_.BSx0_, "BSx0/F");
+  bstree_->Branch("BSy0", &theBSOfromDB_.BSy0_, "BSy0/F");
+  bstree_->Branch("BSz0", &theBSOfromDB_.BSz0_, "BSz0/F");
+  bstree_->Branch("Beamsigmaz", &theBSOfromDB_.Beamsigmaz_, "Beamsigmaz/F");
+  bstree_->Branch("Beamdxdz"  , &theBSOfromDB_.Beamdxdz_  , "Beamdxdz/F");
+  bstree_->Branch("BeamWidthX", &theBSOfromDB_.BeamWidthX_, "BeamWidthX/F");
+  bstree_->Branch("BeamWidthY", &theBSOfromDB_.BeamWidthY_, "BeamWidthY/F");
+  bstree_->Branch("LastAnalyzedLumi", &theBSOfromDB_.lastAnalyzedLumi_, "LastAnalyzedLumi/I");
+  bstree_->Branch("LastAnalyzedRun" , &theBSOfromDB_.lastAnalyzedRun_ , "LastAnalyzedRun/I");
+  bstree_->Branch("LastAnalyzedFill", &theBSOfromDB_.lastAnalyzedFill_, "LastAnalyzedFill/I");
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+BeamSpotOnlineHLTRcdReader::endJob()
+{
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+BeamSpotOnlineHLTRcdReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamSpotOnlineHLTRcdReader);

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdWriter.cc
@@ -45,15 +45,15 @@
 class BeamSpotOnlineHLTRcdWriter : public edm::one::EDAnalyzer<>  {
    public:
       explicit BeamSpotOnlineHLTRcdWriter(const edm::ParameterSet&);
-      ~BeamSpotOnlineHLTRcdWriter();
+      ~BeamSpotOnlineHLTRcdWriter() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
       cond::Time_t pack(uint32_t, uint32_t);
 
    private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override;
 
       std::ifstream fasciiFile;
       std::string fasciiFileName;

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdWriter.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <string>
@@ -42,116 +41,100 @@
 // class declaration
 //
 
-class BeamSpotOnlineHLTRcdWriter : public edm::one::EDAnalyzer<>  {
-   public:
-      explicit BeamSpotOnlineHLTRcdWriter(const edm::ParameterSet&);
-      ~BeamSpotOnlineHLTRcdWriter() override;
+class BeamSpotOnlineHLTRcdWriter : public edm::one::EDAnalyzer<> {
+public:
+  explicit BeamSpotOnlineHLTRcdWriter(const edm::ParameterSet&);
+  ~BeamSpotOnlineHLTRcdWriter() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-      cond::Time_t pack(uint32_t, uint32_t);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  cond::Time_t pack(uint32_t, uint32_t);
 
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-      std::ifstream fasciiFile;
-      std::string fasciiFileName;
-      uint32_t fIOVStartRun;
-      uint32_t fIOVStartLumi;
-      cond::Time_t fnewSince;
-      bool fuseNewSince;
+  std::ifstream fasciiFile;
+  std::string fasciiFileName;
+  uint32_t fIOVStartRun;
+  uint32_t fIOVStartLumi;
+  cond::Time_t fnewSince;
+  bool fuseNewSince;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 //
 // constructors and destructor
 //
-BeamSpotOnlineHLTRcdWriter::BeamSpotOnlineHLTRcdWriter(const edm::ParameterSet& iConfig)
-{
+BeamSpotOnlineHLTRcdWriter::BeamSpotOnlineHLTRcdWriter(const edm::ParameterSet& iConfig) {
   //now do what ever initialization is needed
   fasciiFileName = iConfig.getUntrackedParameter<std::string>("InputFileName");
   fasciiFile.open(fasciiFileName.c_str());
-  if (iConfig.exists("IOVStartRun") && iConfig.exists("IOVStartLumi"))
-  {
-    fIOVStartRun  = iConfig.getUntrackedParameter<uint32_t>("IOVStartRun");
+  if (iConfig.exists("IOVStartRun") && iConfig.exists("IOVStartLumi")) {
+    fIOVStartRun = iConfig.getUntrackedParameter<uint32_t>("IOVStartRun");
     fIOVStartLumi = iConfig.getUntrackedParameter<uint32_t>("IOVStartLumi");
-    fnewSince  = BeamSpotOnlineHLTRcdWriter::pack(fIOVStartRun, fIOVStartLumi);
+    fnewSince = BeamSpotOnlineHLTRcdWriter::pack(fIOVStartRun, fIOVStartLumi);
     fuseNewSince = true;
-  }
-  else
-  {
+  } else {
     fuseNewSince = false;
   }
 }
 
-BeamSpotOnlineHLTRcdWriter::~BeamSpotOnlineHLTRcdWriter()
-{
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+BeamSpotOnlineHLTRcdWriter::~BeamSpotOnlineHLTRcdWriter() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ Create a since object (cond::Time_t) by packing Run and LS (both uint32_t)  ------------
-cond::Time_t BeamSpotOnlineHLTRcdWriter::pack(uint32_t fIOVStartRun, uint32_t fIOVStartLumi)
-{
-  return ( (uint64_t) fIOVStartRun << 32 | fIOVStartLumi);
+cond::Time_t BeamSpotOnlineHLTRcdWriter::pack(uint32_t fIOVStartRun, uint32_t fIOVStartLumi) {
+  return ((uint64_t)fIOVStartRun << 32 | fIOVStartLumi);
 }
 
 // ------------ method called for each event  ------------
-void
-BeamSpotOnlineHLTRcdWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-}
-
+void BeamSpotOnlineHLTRcdWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {}
 
 // ------------ method called once each job just before starting event loop  ------------
-void
-BeamSpotOnlineHLTRcdWriter::beginJob()
-{
-}
+void BeamSpotOnlineHLTRcdWriter::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-BeamSpotOnlineHLTRcdWriter::endJob()
-{
+void BeamSpotOnlineHLTRcdWriter::endJob() {
   std::cout << "Reading BeamSpotOnlineHLTRcd data from text file: " << fasciiFileName << std::endl;
 
   // extract from file
-	double x, y, z, sigmaZ, dxdz, dydz, beamWidthX, beamWidthY, emittanceX, emittanceY, betastar;
-	double cov[7][7];
-	int type, lastAnalyzedLumi, firstAnalyzedLumi, lastAnalyzedRun, lastAnalyzedFill;
+  double x, y, z, sigmaZ, dxdz, dydz, beamWidthX, beamWidthY, emittanceX, emittanceY, betastar;
+  double cov[7][7];
+  int type, lastAnalyzedLumi, firstAnalyzedLumi, lastAnalyzedRun, lastAnalyzedFill;
   std::string tag;
-	
+
   fasciiFile >> tag >> lastAnalyzedRun;
-  fasciiFile >> tag >> tag >> tag >> tag >> tag; // BeginTimeOfFit parsing (not used in payload)
-  fasciiFile >> tag >> tag >> tag >> tag >> tag; // EndTimeOfFit parsing (not used in payload)
-	fasciiFile >> tag >> firstAnalyzedLumi;
-	fasciiFile >> tag >> lastAnalyzedLumi;
-	fasciiFile >> tag >> type;
-	fasciiFile >> tag >> x;
-	fasciiFile >> tag >> y;
-	fasciiFile >> tag >> z;
-	fasciiFile >> tag >> sigmaZ;
-	fasciiFile >> tag >> dxdz;
-	fasciiFile >> tag >> dydz;
-	fasciiFile >> tag >> beamWidthX;
-	fasciiFile >> tag >> beamWidthY;
-	fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2]>> cov[0][3] >> cov[0][4]>> cov[0][5] >> cov[0][6];
-	fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3]>> cov[1][4] >> cov[1][5]>> cov[1][6];
-	fasciiFile >> tag >> cov[2][0]  >> cov[2][1] >> cov[2][2] >> cov[2][3]>> cov[2][4] >> cov[2][5]>> cov[2][6];
-	fasciiFile >> tag >> cov[3][0]  >> cov[3][1] >> cov[3][2] >> cov[3][3]>> cov[3][4] >> cov[3][5]>> cov[3][6];
-	fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3]>> cov[4][4] >> cov[4][5]>> cov[4][6];
-	fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3]>> cov[5][4] >> cov[5][5]>> cov[5][6];
-	fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3]>> cov[6][4] >> cov[6][5]>> cov[6][6];
-	fasciiFile >> tag >> emittanceX;
-	fasciiFile >> tag >> emittanceY;
-	fasciiFile >> tag >> betastar;
+  fasciiFile >> tag >> tag >> tag >> tag >> tag;  // BeginTimeOfFit parsing (not used in payload)
+  fasciiFile >> tag >> tag >> tag >> tag >> tag;  // EndTimeOfFit parsing (not used in payload)
+  fasciiFile >> tag >> firstAnalyzedLumi;
+  fasciiFile >> tag >> lastAnalyzedLumi;
+  fasciiFile >> tag >> type;
+  fasciiFile >> tag >> x;
+  fasciiFile >> tag >> y;
+  fasciiFile >> tag >> z;
+  fasciiFile >> tag >> sigmaZ;
+  fasciiFile >> tag >> dxdz;
+  fasciiFile >> tag >> dydz;
+  fasciiFile >> tag >> beamWidthX;
+  fasciiFile >> tag >> beamWidthY;
+  fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2] >> cov[0][3] >> cov[0][4] >> cov[0][5] >> cov[0][6];
+  fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3] >> cov[1][4] >> cov[1][5] >> cov[1][6];
+  fasciiFile >> tag >> cov[2][0] >> cov[2][1] >> cov[2][2] >> cov[2][3] >> cov[2][4] >> cov[2][5] >> cov[2][6];
+  fasciiFile >> tag >> cov[3][0] >> cov[3][1] >> cov[3][2] >> cov[3][3] >> cov[3][4] >> cov[3][5] >> cov[3][6];
+  fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3] >> cov[4][4] >> cov[4][5] >> cov[4][6];
+  fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3] >> cov[5][4] >> cov[5][5] >> cov[5][6];
+  fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3] >> cov[6][4] >> cov[6][5] >> cov[6][6];
+  fasciiFile >> tag >> emittanceX;
+  fasciiFile >> tag >> emittanceY;
+  fasciiFile >> tag >> betastar;
 
   lastAnalyzedFill = -999;
 
@@ -169,13 +152,20 @@ BeamSpotOnlineHLTRcdWriter::endJob()
   std::cout << " dydz              : " << dydz << std::endl;
   std::cout << " beamWidthX        : " << beamWidthX << std::endl;
   std::cout << " beamWidthY        : " << beamWidthY << std::endl;
-  std::cout << " Cov(0,j)          : " << cov[0][0] << " " << cov[0][1] << " " << cov[0][2] << " " << cov[0][3] << " " << cov[0][4] << " " << cov[0][5] << " " << cov[0][6] << std::endl;
-  std::cout << " Cov(1,j)          : " << cov[1][0] << " " << cov[1][1] << " " << cov[1][2] << " " << cov[1][3] << " " << cov[1][4] << " " << cov[1][5] << " " << cov[1][6] << std::endl;
-  std::cout << " Cov(2,j)          : " << cov[2][0] << " " << cov[2][1] << " " << cov[2][2] << " " << cov[2][3] << " " << cov[2][4] << " " << cov[2][5] << " " << cov[2][6] << std::endl;
-  std::cout << " Cov(3,j)          : " << cov[3][0] << " " << cov[3][1] << " " << cov[3][2] << " " << cov[3][3] << " " << cov[3][4] << " " << cov[3][5] << " " << cov[3][6] << std::endl;
-  std::cout << " Cov(4,j)          : " << cov[4][0] << " " << cov[4][1] << " " << cov[4][2] << " " << cov[4][3] << " " << cov[4][4] << " " << cov[4][5] << " " << cov[4][6] << std::endl;
-  std::cout << " Cov(5,j)          : " << cov[5][0] << " " << cov[5][1] << " " << cov[5][2] << " " << cov[5][3] << " " << cov[5][4] << " " << cov[5][5] << " " << cov[5][6] << std::endl;
-  std::cout << " Cov(6,j)          : " << cov[6][0] << " " << cov[6][1] << " " << cov[6][2] << " " << cov[6][3] << " " << cov[6][4] << " " << cov[6][5] << " " << cov[6][6] << std::endl;
+  std::cout << " Cov(0,j)          : " << cov[0][0] << " " << cov[0][1] << " " << cov[0][2] << " " << cov[0][3] << " "
+            << cov[0][4] << " " << cov[0][5] << " " << cov[0][6] << std::endl;
+  std::cout << " Cov(1,j)          : " << cov[1][0] << " " << cov[1][1] << " " << cov[1][2] << " " << cov[1][3] << " "
+            << cov[1][4] << " " << cov[1][5] << " " << cov[1][6] << std::endl;
+  std::cout << " Cov(2,j)          : " << cov[2][0] << " " << cov[2][1] << " " << cov[2][2] << " " << cov[2][3] << " "
+            << cov[2][4] << " " << cov[2][5] << " " << cov[2][6] << std::endl;
+  std::cout << " Cov(3,j)          : " << cov[3][0] << " " << cov[3][1] << " " << cov[3][2] << " " << cov[3][3] << " "
+            << cov[3][4] << " " << cov[3][5] << " " << cov[3][6] << std::endl;
+  std::cout << " Cov(4,j)          : " << cov[4][0] << " " << cov[4][1] << " " << cov[4][2] << " " << cov[4][3] << " "
+            << cov[4][4] << " " << cov[4][5] << " " << cov[4][6] << std::endl;
+  std::cout << " Cov(5,j)          : " << cov[5][0] << " " << cov[5][1] << " " << cov[5][2] << " " << cov[5][3] << " "
+            << cov[5][4] << " " << cov[5][5] << " " << cov[5][6] << std::endl;
+  std::cout << " Cov(6,j)          : " << cov[6][0] << " " << cov[6][1] << " " << cov[6][2] << " " << cov[6][3] << " "
+            << cov[6][4] << " " << cov[6][5] << " " << cov[6][6] << std::endl;
   std::cout << " emittanceX        : " << emittanceX << std::endl;
   std::cout << " emittanceY        : " << emittanceY << std::endl;
   std::cout << " betastar          : " << betastar << std::endl;
@@ -186,49 +176,45 @@ BeamSpotOnlineHLTRcdWriter::endJob()
   abeam->SetLastAnalyzedLumi(lastAnalyzedLumi);
   abeam->SetLastAnalyzedRun(lastAnalyzedRun);
   abeam->SetLastAnalyzedFill(lastAnalyzedFill);
-	abeam->SetType(type);
-	abeam->SetPosition(x,y,z);
-	abeam->SetSigmaZ(sigmaZ);
-	abeam->Setdxdz(dxdz);
-	abeam->Setdydz(dydz);
-	abeam->SetBeamWidthX(beamWidthX);
-	abeam->SetBeamWidthY(beamWidthY);
-	abeam->SetEmittanceX(emittanceX);
-	abeam->SetEmittanceY(emittanceY);
-	abeam->SetBetaStar(betastar);
+  abeam->SetType(type);
+  abeam->SetPosition(x, y, z);
+  abeam->SetSigmaZ(sigmaZ);
+  abeam->Setdxdz(dxdz);
+  abeam->Setdydz(dydz);
+  abeam->SetBeamWidthX(beamWidthX);
+  abeam->SetBeamWidthY(beamWidthY);
+  abeam->SetEmittanceX(emittanceX);
+  abeam->SetEmittanceY(emittanceY);
+  abeam->SetBetaStar(betastar);
 
-	for (int i=0; i<7; ++i) {
-	  for (int j=0; j<7; ++j) {
-	    abeam->SetCovariance(i,j,cov[i][j]);
-	  }
-	}
+  for (int i = 0; i < 7; ++i) {
+    for (int j = 0; j < 7; ++j) {
+      abeam->SetCovariance(i, j, cov[i][j]);
+    }
+  }
 
   std::cout << " Writing results to DB..." << std::endl;
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
     std::cout << "poolDBService available" << std::endl;
-    if (poolDbService->isNewTagRequest("BeamSpotOnlineHLTObjectsRcd"))
-    {
+    if (poolDbService->isNewTagRequest("BeamSpotOnlineHLTObjectsRcd")) {
       std::cout << "new tag requested" << std::endl;
-      if (fuseNewSince)
-      {
+      if (fuseNewSince) {
         std::cout << "Using a new Since: " << fnewSince << std::endl;
-        poolDbService->createNewIOV<BeamSpotOnlineObjects>(abeam, fnewSince, poolDbService->endOfTime(), "BeamSpotOnlineHLTObjectsRcd");
-      }
-      else
-        poolDbService->createNewIOV<BeamSpotOnlineObjects>(abeam, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotOnlineHLTObjectsRcd");
-    }
-    else
-    {
+        poolDbService->createNewIOV<BeamSpotOnlineObjects>(
+            abeam, fnewSince, poolDbService->endOfTime(), "BeamSpotOnlineHLTObjectsRcd");
+      } else
+        poolDbService->createNewIOV<BeamSpotOnlineObjects>(
+            abeam, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotOnlineHLTObjectsRcd");
+    } else {
       std::cout << "no new tag requested" << std::endl;
-      if (fuseNewSince)
-      {
+      if (fuseNewSince) {
         std::cout << "Using a new Since: " << fnewSince << std::endl;
         poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam, fnewSince, "BeamSpotOnlineHLTObjectsRcd");
-      }
-      else
-        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam, poolDbService->currentTime(), "BeamSpotOnlineHLTObjectsRcd");
+      } else
+        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(
+            abeam, poolDbService->currentTime(), "BeamSpotOnlineHLTObjectsRcd");
     }
   }
 
@@ -236,14 +222,12 @@ BeamSpotOnlineHLTRcdWriter::endJob()
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-BeamSpotOnlineHLTRcdWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void BeamSpotOnlineHLTRcdWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
-
 }
 
 //define this as a plug-in

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdWriter.cc
@@ -1,0 +1,250 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/BeamSpot
+// Class:      BeamSpotOnlineHLTRcdWriter
+//
+/**\class BeamSpotOnlineHLTRcdWriter BeamSpotOnlineHLTRcdWriter.cc CondTools/BeamSpot/plugins/BeamSpotOnlineHLTRcdWriter.cc
+
+ Description: EDAnalyzer to read the BeamSpotOnlineHLTObjectsRcd and dump it into a txt and root file
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Francesco Brivio
+//         Created:  Tue, 11 Feb 2020 11:10:12 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <string>
+#include <fstream>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+//
+// class declaration
+//
+
+class BeamSpotOnlineHLTRcdWriter : public edm::one::EDAnalyzer<>  {
+   public:
+      explicit BeamSpotOnlineHLTRcdWriter(const edm::ParameterSet&);
+      ~BeamSpotOnlineHLTRcdWriter();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+      cond::Time_t pack(uint32_t, uint32_t);
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+
+      std::ifstream fasciiFile;
+      std::string fasciiFileName;
+      uint32_t fIOVStartRun;
+      uint32_t fIOVStartLumi;
+      cond::Time_t fnewSince;
+      bool fuseNewSince;
+
+      // ----------member data ---------------------------
+};
+
+//
+// constructors and destructor
+//
+BeamSpotOnlineHLTRcdWriter::BeamSpotOnlineHLTRcdWriter(const edm::ParameterSet& iConfig)
+{
+  //now do what ever initialization is needed
+  fasciiFileName = iConfig.getUntrackedParameter<std::string>("InputFileName");
+  fasciiFile.open(fasciiFileName.c_str());
+  if (iConfig.exists("IOVStartRun") && iConfig.exists("IOVStartLumi"))
+  {
+    fIOVStartRun  = iConfig.getUntrackedParameter<uint32_t>("IOVStartRun");
+    fIOVStartLumi = iConfig.getUntrackedParameter<uint32_t>("IOVStartLumi");
+    fnewSince  = BeamSpotOnlineHLTRcdWriter::pack(fIOVStartRun, fIOVStartLumi);
+    fuseNewSince = true;
+  }
+  else
+  {
+    fuseNewSince = false;
+  }
+}
+
+BeamSpotOnlineHLTRcdWriter::~BeamSpotOnlineHLTRcdWriter()
+{
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ Create a since object (cond::Time_t) by packing Run and LS (both uint32_t)  ------------
+cond::Time_t BeamSpotOnlineHLTRcdWriter::pack(uint32_t fIOVStartRun, uint32_t fIOVStartLumi)
+{
+  return ( (uint64_t) fIOVStartRun << 32 | fIOVStartLumi);
+}
+
+// ------------ method called for each event  ------------
+void
+BeamSpotOnlineHLTRcdWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+BeamSpotOnlineHLTRcdWriter::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+BeamSpotOnlineHLTRcdWriter::endJob()
+{
+  std::cout << "Reading BeamSpotOnlineHLTRcd data from text file: " << fasciiFileName << std::endl;
+
+  // extract from file
+	double x, y, z, sigmaZ, dxdz, dydz, beamWidthX, beamWidthY, emittanceX, emittanceY, betastar;
+	double cov[7][7];
+	int type, lastAnalyzedLumi, firstAnalyzedLumi, lastAnalyzedRun, lastAnalyzedFill;
+  std::string tag;
+	
+  fasciiFile >> tag >> lastAnalyzedRun;
+  fasciiFile >> tag >> tag >> tag >> tag >> tag; // BeginTimeOfFit parsing (not used in payload)
+  fasciiFile >> tag >> tag >> tag >> tag >> tag; // EndTimeOfFit parsing (not used in payload)
+	fasciiFile >> tag >> firstAnalyzedLumi;
+	fasciiFile >> tag >> lastAnalyzedLumi;
+	fasciiFile >> tag >> type;
+	fasciiFile >> tag >> x;
+	fasciiFile >> tag >> y;
+	fasciiFile >> tag >> z;
+	fasciiFile >> tag >> sigmaZ;
+	fasciiFile >> tag >> dxdz;
+	fasciiFile >> tag >> dydz;
+	fasciiFile >> tag >> beamWidthX;
+	fasciiFile >> tag >> beamWidthY;
+	fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2]>> cov[0][3] >> cov[0][4]>> cov[0][5] >> cov[0][6];
+	fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3]>> cov[1][4] >> cov[1][5]>> cov[1][6];
+	fasciiFile >> tag >> cov[2][0]  >> cov[2][1] >> cov[2][2] >> cov[2][3]>> cov[2][4] >> cov[2][5]>> cov[2][6];
+	fasciiFile >> tag >> cov[3][0]  >> cov[3][1] >> cov[3][2] >> cov[3][3]>> cov[3][4] >> cov[3][5]>> cov[3][6];
+	fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3]>> cov[4][4] >> cov[4][5]>> cov[4][6];
+	fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3]>> cov[5][4] >> cov[5][5]>> cov[5][6];
+	fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3]>> cov[6][4] >> cov[6][5]>> cov[6][6];
+	fasciiFile >> tag >> emittanceX;
+	fasciiFile >> tag >> emittanceY;
+	fasciiFile >> tag >> betastar;
+
+  lastAnalyzedFill = -999;
+
+  std::cout << "---- Parsed these parameters from input txt file ----" << std::endl;
+  std::cout << " lastAnalyzedRun   : " << lastAnalyzedRun << std::endl;
+  std::cout << " lastAnalyzedFill  : " << lastAnalyzedFill << std::endl;
+  std::cout << " firstAnalyzedLumi : " << firstAnalyzedLumi << std::endl;
+  std::cout << " lastAnalyzedLumi  : " << lastAnalyzedLumi << std::endl;
+  std::cout << " type              : " << type << std::endl;
+  std::cout << " x                 : " << x << std::endl;
+  std::cout << " y                 : " << y << std::endl;
+  std::cout << " z                 : " << z << std::endl;
+  std::cout << " sigmaZ            : " << sigmaZ << std::endl;
+  std::cout << " dxdz              : " << dxdz << std::endl;
+  std::cout << " dydz              : " << dydz << std::endl;
+  std::cout << " beamWidthX        : " << beamWidthX << std::endl;
+  std::cout << " beamWidthY        : " << beamWidthY << std::endl;
+  std::cout << " Cov(0,j)          : " << cov[0][0] << " " << cov[0][1] << " " << cov[0][2] << " " << cov[0][3] << " " << cov[0][4] << " " << cov[0][5] << " " << cov[0][6] << std::endl;
+  std::cout << " Cov(1,j)          : " << cov[1][0] << " " << cov[1][1] << " " << cov[1][2] << " " << cov[1][3] << " " << cov[1][4] << " " << cov[1][5] << " " << cov[1][6] << std::endl;
+  std::cout << " Cov(2,j)          : " << cov[2][0] << " " << cov[2][1] << " " << cov[2][2] << " " << cov[2][3] << " " << cov[2][4] << " " << cov[2][5] << " " << cov[2][6] << std::endl;
+  std::cout << " Cov(3,j)          : " << cov[3][0] << " " << cov[3][1] << " " << cov[3][2] << " " << cov[3][3] << " " << cov[3][4] << " " << cov[3][5] << " " << cov[3][6] << std::endl;
+  std::cout << " Cov(4,j)          : " << cov[4][0] << " " << cov[4][1] << " " << cov[4][2] << " " << cov[4][3] << " " << cov[4][4] << " " << cov[4][5] << " " << cov[4][6] << std::endl;
+  std::cout << " Cov(5,j)          : " << cov[5][0] << " " << cov[5][1] << " " << cov[5][2] << " " << cov[5][3] << " " << cov[5][4] << " " << cov[5][5] << " " << cov[5][6] << std::endl;
+  std::cout << " Cov(6,j)          : " << cov[6][0] << " " << cov[6][1] << " " << cov[6][2] << " " << cov[6][3] << " " << cov[6][4] << " " << cov[6][5] << " " << cov[6][6] << std::endl;
+  std::cout << " emittanceX        : " << emittanceX << std::endl;
+  std::cout << " emittanceY        : " << emittanceY << std::endl;
+  std::cout << " betastar          : " << betastar << std::endl;
+  std::cout << "-----------------------------------------------------" << std::endl;
+
+  BeamSpotOnlineObjects* abeam = new BeamSpotOnlineObjects();
+
+  abeam->SetLastAnalyzedLumi(lastAnalyzedLumi);
+  abeam->SetLastAnalyzedRun(lastAnalyzedRun);
+  abeam->SetLastAnalyzedFill(lastAnalyzedFill);
+	abeam->SetType(type);
+	abeam->SetPosition(x,y,z);
+	abeam->SetSigmaZ(sigmaZ);
+	abeam->Setdxdz(dxdz);
+	abeam->Setdydz(dydz);
+	abeam->SetBeamWidthX(beamWidthX);
+	abeam->SetBeamWidthY(beamWidthY);
+	abeam->SetEmittanceX(emittanceX);
+	abeam->SetEmittanceY(emittanceY);
+	abeam->SetBetaStar(betastar);
+
+	for (int i=0; i<7; ++i) {
+	  for (int j=0; j<7; ++j) {
+	    abeam->SetCovariance(i,j,cov[i][j]);
+	  }
+	}
+
+  std::cout << " Writing results to DB..." << std::endl;
+
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if (poolDbService.isAvailable()) {
+    std::cout << "poolDBService available" << std::endl;
+    if (poolDbService->isNewTagRequest("BeamSpotOnlineHLTObjectsRcd"))
+    {
+      std::cout << "new tag requested" << std::endl;
+      if (fuseNewSince)
+      {
+        std::cout << "Using a new Since: " << fnewSince << std::endl;
+        poolDbService->createNewIOV<BeamSpotOnlineObjects>(abeam, fnewSince, poolDbService->endOfTime(), "BeamSpotOnlineHLTObjectsRcd");
+      }
+      else
+        poolDbService->createNewIOV<BeamSpotOnlineObjects>(abeam, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotOnlineHLTObjectsRcd");
+    }
+    else
+    {
+      std::cout << "no new tag requested" << std::endl;
+      if (fuseNewSince)
+      {
+        std::cout << "Using a new Since: " << fnewSince << std::endl;
+        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam, fnewSince, "BeamSpotOnlineHLTObjectsRcd");
+      }
+      else
+        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam, poolDbService->currentTime(), "BeamSpotOnlineHLTObjectsRcd");
+    }
+  }
+
+  std::cout << "[BeamSpotOnlineHLTRcdWriter] endJob done \n" << std::endl;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+BeamSpotOnlineHLTRcdWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamSpotOnlineHLTRcdWriter);

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdReader.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <sstream>
@@ -47,18 +46,17 @@
 // class declaration
 //
 
-class BeamSpotOnlineLegacyRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
-   public:
-      explicit BeamSpotOnlineLegacyRcdReader(const edm::ParameterSet&);
-      ~BeamSpotOnlineLegacyRcdReader() override;
+class BeamSpotOnlineLegacyRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit BeamSpotOnlineLegacyRcdReader(const edm::ParameterSet&);
+  ~BeamSpotOnlineLegacyRcdReader() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   struct theBSOfromDB {
     int ls;
@@ -70,12 +68,12 @@ class BeamSpotOnlineLegacyRcdReader : public edm::one::EDAnalyzer<edm::one::Shar
     float Beamdxdz_;
     float BeamWidthX_;
     float BeamWidthY_;
-    int   lastAnalyzedLumi_;
-    int   lastAnalyzedRun_;
-    int   lastAnalyzedFill_;
+    int lastAnalyzedLumi_;
+    int lastAnalyzedRun_;
+    int lastAnalyzedFill_;
     void init();
   } theBSOfromDB_;
-  
+
   edm::Service<TFileService> tFileService;
   TTree* bstree_;
 
@@ -100,12 +98,10 @@ BeamSpotOnlineLegacyRcdReader::BeamSpotOnlineLegacyRcdReader(const edm::Paramete
   }
 }
 
-BeamSpotOnlineLegacyRcdReader::~BeamSpotOnlineLegacyRcdReader()
-{
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+BeamSpotOnlineLegacyRcdReader::~BeamSpotOnlineLegacyRcdReader() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -116,24 +112,22 @@ void BeamSpotOnlineLegacyRcdReader::theBSOfromDB::init() {
   int dummy_int = -999;
 
   run = dummy_int;
-  ls  = dummy_int;
+  ls = dummy_int;
   BSx0_ = dummy_float;
   BSy0_ = dummy_float;
   BSz0_ = dummy_float;
   Beamsigmaz_ = dummy_float;
-  Beamdxdz_   = dummy_float;
+  Beamdxdz_ = dummy_float;
   BeamWidthX_ = dummy_float;
   BeamWidthY_ = dummy_float;
   lastAnalyzedLumi_ = dummy_int;
-  lastAnalyzedRun_  = dummy_int;
+  lastAnalyzedRun_ = dummy_int;
   lastAnalyzedFill_ = dummy_int;
 }
 
 // ------------ method called for each event  ------------
-void
-BeamSpotOnlineLegacyRcdReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void BeamSpotOnlineLegacyRcdReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
   std::ostringstream output;
 
   // initialize the ntuple
@@ -149,16 +143,16 @@ BeamSpotOnlineLegacyRcdReader::analyze(const edm::Event& iEvent, const edm::Even
     const BeamSpotOnlineObjects* mybeamspot = beamhandle.product();
 
     theBSOfromDB_.run = iEvent.id().run();
-    theBSOfromDB_.ls  = iEvent.id().luminosityBlock();
+    theBSOfromDB_.ls = iEvent.id().luminosityBlock();
     theBSOfromDB_.BSx0_ = mybeamspot->GetX();
     theBSOfromDB_.BSy0_ = mybeamspot->GetY();
     theBSOfromDB_.BSz0_ = mybeamspot->GetZ();
     theBSOfromDB_.Beamsigmaz_ = mybeamspot->GetSigmaZ();
-    theBSOfromDB_.Beamdxdz_   = mybeamspot->Getdxdz();
+    theBSOfromDB_.Beamdxdz_ = mybeamspot->Getdxdz();
     theBSOfromDB_.BeamWidthX_ = mybeamspot->GetBeamWidthX();
     theBSOfromDB_.BeamWidthY_ = mybeamspot->GetBeamWidthY();
     theBSOfromDB_.lastAnalyzedLumi_ = mybeamspot->GetLastAnalyzedLumi();
-    theBSOfromDB_.lastAnalyzedRun_  = mybeamspot->GetLastAnalyzedRun();
+    theBSOfromDB_.lastAnalyzedRun_ = mybeamspot->GetLastAnalyzedRun();
     theBSOfromDB_.lastAnalyzedFill_ = mybeamspot->GetLastAnalyzedFill();
 
     bstree_->Fill();
@@ -173,37 +167,30 @@ BeamSpotOnlineLegacyRcdReader::analyze(const edm::Event& iEvent, const edm::Even
     edm::LogInfo("") << output.str();
 }
 
-
 // ------------ method called once each job just before starting event loop  ------------
-void
-BeamSpotOnlineLegacyRcdReader::beginJob()
-{
+void BeamSpotOnlineLegacyRcdReader::beginJob() {
   bstree_ = tFileService->make<TTree>("BSONtuple", "BeamSpotOnline analyzer ntuple");
 
   //Tree Branches
   bstree_->Branch("run", &theBSOfromDB_.run, "run/I");
-  bstree_->Branch("ls" , &theBSOfromDB_.ls , "ls/I");
+  bstree_->Branch("ls", &theBSOfromDB_.ls, "ls/I");
   bstree_->Branch("BSx0", &theBSOfromDB_.BSx0_, "BSx0/F");
   bstree_->Branch("BSy0", &theBSOfromDB_.BSy0_, "BSy0/F");
   bstree_->Branch("BSz0", &theBSOfromDB_.BSz0_, "BSz0/F");
   bstree_->Branch("Beamsigmaz", &theBSOfromDB_.Beamsigmaz_, "Beamsigmaz/F");
-  bstree_->Branch("Beamdxdz"  , &theBSOfromDB_.Beamdxdz_  , "Beamdxdz/F");
+  bstree_->Branch("Beamdxdz", &theBSOfromDB_.Beamdxdz_, "Beamdxdz/F");
   bstree_->Branch("BeamWidthX", &theBSOfromDB_.BeamWidthX_, "BeamWidthX/F");
   bstree_->Branch("BeamWidthY", &theBSOfromDB_.BeamWidthY_, "BeamWidthY/F");
   bstree_->Branch("LastAnalyzedLumi", &theBSOfromDB_.lastAnalyzedLumi_, "LastAnalyzedLumi/I");
-  bstree_->Branch("LastAnalyzedRun" , &theBSOfromDB_.lastAnalyzedRun_ , "LastAnalyzedRun/I");
+  bstree_->Branch("LastAnalyzedRun", &theBSOfromDB_.lastAnalyzedRun_, "LastAnalyzedRun/I");
   bstree_->Branch("LastAnalyzedFill", &theBSOfromDB_.lastAnalyzedFill_, "LastAnalyzedFill/I");
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-BeamSpotOnlineLegacyRcdReader::endJob()
-{
-}
+void BeamSpotOnlineLegacyRcdReader::endJob() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-BeamSpotOnlineLegacyRcdReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void BeamSpotOnlineLegacyRcdReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdReader.cc
@@ -50,15 +50,15 @@
 class BeamSpotOnlineLegacyRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
    public:
       explicit BeamSpotOnlineLegacyRcdReader(const edm::ParameterSet&);
-      ~BeamSpotOnlineLegacyRcdReader();
+      ~BeamSpotOnlineLegacyRcdReader() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 
    private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override;
 
   struct theBSOfromDB {
     int ls;

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdReader.cc
@@ -1,0 +1,215 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/BeamSpot
+// Class:      BeamSpotOnlineLegacyRcdReader
+//
+/**\class BeamSpotOnlineLegacyRcdReader BeamSpotOnlineLegacyRcdReader.cc CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdReader.cc
+
+ Description: EDAnalyzer to create a BeamSpotOnlineLegacyObjectsRcd payload from a txt file and dump it in a db file
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Francesco Brivio
+//         Created:  Tue, 11 Feb 2020 08:39:14 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <sstream>
+#include <fstream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+
+// For ROOT
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include <TTree.h>
+
+//
+// class declaration
+//
+
+class BeamSpotOnlineLegacyRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+   public:
+      explicit BeamSpotOnlineLegacyRcdReader(const edm::ParameterSet&);
+      ~BeamSpotOnlineLegacyRcdReader();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+
+  struct theBSOfromDB {
+    int ls;
+    int run;
+    float BSx0_;
+    float BSy0_;
+    float BSz0_;
+    float Beamsigmaz_;
+    float Beamdxdz_;
+    float BeamWidthX_;
+    float BeamWidthY_;
+    int   lastAnalyzedLumi_;
+    int   lastAnalyzedRun_;
+    int   lastAnalyzedFill_;
+    void init();
+  } theBSOfromDB_;
+  
+  edm::Service<TFileService> tFileService;
+  TTree* bstree_;
+
+  // ----------member data ---------------------------
+  edm::ESWatcher<BeamSpotOnlineLegacyObjectsRcd> watcher_;
+  std::unique_ptr<std::ofstream> output_;
+};
+
+//
+// constructors and destructor
+//
+BeamSpotOnlineLegacyRcdReader::BeamSpotOnlineLegacyRcdReader(const edm::ParameterSet& iConfig) : bstree_(nullptr) {
+  //now do what ever initialization is needed
+  usesResource("TFileService");
+  std::string fileName(iConfig.getUntrackedParameter<std::string>("rawFileName"));
+  if (!fileName.empty()) {
+    output_.reset(new std::ofstream(fileName.c_str()));
+    if (!output_->good()) {
+      edm::LogError("IOproblem") << "Could not open output file " << fileName << ".";
+      output_.reset();
+    }
+  }
+}
+
+BeamSpotOnlineLegacyRcdReader::~BeamSpotOnlineLegacyRcdReader()
+{
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+void BeamSpotOnlineLegacyRcdReader::theBSOfromDB::init() {
+  float dummy_float = -999.0;
+  int dummy_int = -999;
+
+  run = dummy_int;
+  ls  = dummy_int;
+  BSx0_ = dummy_float;
+  BSy0_ = dummy_float;
+  BSz0_ = dummy_float;
+  Beamsigmaz_ = dummy_float;
+  Beamdxdz_   = dummy_float;
+  BeamWidthX_ = dummy_float;
+  BeamWidthY_ = dummy_float;
+  lastAnalyzedLumi_ = dummy_int;
+  lastAnalyzedRun_  = dummy_int;
+  lastAnalyzedFill_ = dummy_int;
+}
+
+// ------------ method called for each event  ------------
+void
+BeamSpotOnlineLegacyRcdReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+  std::ostringstream output;
+
+  // initialize the ntuple
+  theBSOfromDB_.init();
+
+  if (watcher_.check(iSetup)) {  // check for new IOV for this run / LS
+
+    output << " for runs: " << iEvent.id().run() << " - " << iEvent.id().luminosityBlock() << std::endl;
+
+    // Get BeamSpot from EventSetup:
+    edm::ESHandle<BeamSpotOnlineObjects> beamhandle;
+    iSetup.get<BeamSpotOnlineLegacyObjectsRcd>().get(beamhandle);
+    const BeamSpotOnlineObjects* mybeamspot = beamhandle.product();
+
+    theBSOfromDB_.run = iEvent.id().run();
+    theBSOfromDB_.ls  = iEvent.id().luminosityBlock();
+    theBSOfromDB_.BSx0_ = mybeamspot->GetX();
+    theBSOfromDB_.BSy0_ = mybeamspot->GetY();
+    theBSOfromDB_.BSz0_ = mybeamspot->GetZ();
+    theBSOfromDB_.Beamsigmaz_ = mybeamspot->GetSigmaZ();
+    theBSOfromDB_.Beamdxdz_   = mybeamspot->Getdxdz();
+    theBSOfromDB_.BeamWidthX_ = mybeamspot->GetBeamWidthX();
+    theBSOfromDB_.BeamWidthY_ = mybeamspot->GetBeamWidthY();
+    theBSOfromDB_.lastAnalyzedLumi_ = mybeamspot->GetLastAnalyzedLumi();
+    theBSOfromDB_.lastAnalyzedRun_  = mybeamspot->GetLastAnalyzedRun();
+    theBSOfromDB_.lastAnalyzedFill_ = mybeamspot->GetLastAnalyzedFill();
+
+    bstree_->Fill();
+
+    output << *mybeamspot << std::endl;
+  }
+
+  // Final output - either message logger or output file:
+  if (output_.get())
+    *output_ << output.str();
+  else
+    edm::LogInfo("") << output.str();
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+BeamSpotOnlineLegacyRcdReader::beginJob()
+{
+  bstree_ = tFileService->make<TTree>("BSONtuple", "BeamSpotOnline analyzer ntuple");
+
+  //Tree Branches
+  bstree_->Branch("run", &theBSOfromDB_.run, "run/I");
+  bstree_->Branch("ls" , &theBSOfromDB_.ls , "ls/I");
+  bstree_->Branch("BSx0", &theBSOfromDB_.BSx0_, "BSx0/F");
+  bstree_->Branch("BSy0", &theBSOfromDB_.BSy0_, "BSy0/F");
+  bstree_->Branch("BSz0", &theBSOfromDB_.BSz0_, "BSz0/F");
+  bstree_->Branch("Beamsigmaz", &theBSOfromDB_.Beamsigmaz_, "Beamsigmaz/F");
+  bstree_->Branch("Beamdxdz"  , &theBSOfromDB_.Beamdxdz_  , "Beamdxdz/F");
+  bstree_->Branch("BeamWidthX", &theBSOfromDB_.BeamWidthX_, "BeamWidthX/F");
+  bstree_->Branch("BeamWidthY", &theBSOfromDB_.BeamWidthY_, "BeamWidthY/F");
+  bstree_->Branch("LastAnalyzedLumi", &theBSOfromDB_.lastAnalyzedLumi_, "LastAnalyzedLumi/I");
+  bstree_->Branch("LastAnalyzedRun" , &theBSOfromDB_.lastAnalyzedRun_ , "LastAnalyzedRun/I");
+  bstree_->Branch("LastAnalyzedFill", &theBSOfromDB_.lastAnalyzedFill_, "LastAnalyzedFill/I");
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+BeamSpotOnlineLegacyRcdReader::endJob()
+{
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+BeamSpotOnlineLegacyRcdReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamSpotOnlineLegacyRcdReader);

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdWriter.cc
@@ -45,15 +45,15 @@
 class BeamSpotOnlineLegacyRcdWriter : public edm::one::EDAnalyzer<>  {
    public:
       explicit BeamSpotOnlineLegacyRcdWriter(const edm::ParameterSet&);
-      ~BeamSpotOnlineLegacyRcdWriter();
+      ~BeamSpotOnlineLegacyRcdWriter() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
       cond::Time_t pack(uint32_t, uint32_t);
 
    private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override;
 
       std::ifstream fasciiFile;
       std::string fasciiFileName;

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdWriter.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <string>
@@ -42,116 +41,100 @@
 // class declaration
 //
 
-class BeamSpotOnlineLegacyRcdWriter : public edm::one::EDAnalyzer<>  {
-   public:
-      explicit BeamSpotOnlineLegacyRcdWriter(const edm::ParameterSet&);
-      ~BeamSpotOnlineLegacyRcdWriter() override;
+class BeamSpotOnlineLegacyRcdWriter : public edm::one::EDAnalyzer<> {
+public:
+  explicit BeamSpotOnlineLegacyRcdWriter(const edm::ParameterSet&);
+  ~BeamSpotOnlineLegacyRcdWriter() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-      cond::Time_t pack(uint32_t, uint32_t);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  cond::Time_t pack(uint32_t, uint32_t);
 
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-      std::ifstream fasciiFile;
-      std::string fasciiFileName;
-      uint32_t fIOVStartRun;
-      uint32_t fIOVStartLumi;
-      cond::Time_t fnewSince;
-      bool fuseNewSince;
+  std::ifstream fasciiFile;
+  std::string fasciiFileName;
+  uint32_t fIOVStartRun;
+  uint32_t fIOVStartLumi;
+  cond::Time_t fnewSince;
+  bool fuseNewSince;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 //
 // constructors and destructor
 //
-BeamSpotOnlineLegacyRcdWriter::BeamSpotOnlineLegacyRcdWriter(const edm::ParameterSet& iConfig)
-{
+BeamSpotOnlineLegacyRcdWriter::BeamSpotOnlineLegacyRcdWriter(const edm::ParameterSet& iConfig) {
   //now do what ever initialization is needed
   fasciiFileName = iConfig.getUntrackedParameter<std::string>("InputFileName");
   fasciiFile.open(fasciiFileName.c_str());
-  if (iConfig.exists("IOVStartRun") && iConfig.exists("IOVStartLumi"))
-  {
-    fIOVStartRun  = iConfig.getUntrackedParameter<uint32_t>("IOVStartRun");
+  if (iConfig.exists("IOVStartRun") && iConfig.exists("IOVStartLumi")) {
+    fIOVStartRun = iConfig.getUntrackedParameter<uint32_t>("IOVStartRun");
     fIOVStartLumi = iConfig.getUntrackedParameter<uint32_t>("IOVStartLumi");
-    fnewSince  = BeamSpotOnlineLegacyRcdWriter::pack(fIOVStartRun, fIOVStartLumi);
+    fnewSince = BeamSpotOnlineLegacyRcdWriter::pack(fIOVStartRun, fIOVStartLumi);
     fuseNewSince = true;
-  }
-  else
-  {
+  } else {
     fuseNewSince = false;
   }
 }
 
-BeamSpotOnlineLegacyRcdWriter::~BeamSpotOnlineLegacyRcdWriter()
-{
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+BeamSpotOnlineLegacyRcdWriter::~BeamSpotOnlineLegacyRcdWriter() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ Create a since object (cond::Time_t) by packing Run and LS (both uint32_t)  ------------
-cond::Time_t BeamSpotOnlineLegacyRcdWriter::pack(uint32_t fIOVStartRun, uint32_t fIOVStartLumi)
-{
-  return ( (uint64_t) fIOVStartRun << 32 | fIOVStartLumi);
+cond::Time_t BeamSpotOnlineLegacyRcdWriter::pack(uint32_t fIOVStartRun, uint32_t fIOVStartLumi) {
+  return ((uint64_t)fIOVStartRun << 32 | fIOVStartLumi);
 }
 
 // ------------ method called for each event  ------------
-void
-BeamSpotOnlineLegacyRcdWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-}
-
+void BeamSpotOnlineLegacyRcdWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {}
 
 // ------------ method called once each job just before starting event loop  ------------
-void
-BeamSpotOnlineLegacyRcdWriter::beginJob()
-{
-}
+void BeamSpotOnlineLegacyRcdWriter::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-BeamSpotOnlineLegacyRcdWriter::endJob()
-{
+void BeamSpotOnlineLegacyRcdWriter::endJob() {
   std::cout << "Reading BeamSpotOnlineLegacyObjectsRcd data from text file: " << fasciiFileName << std::endl;
 
   // extract from file
-	double x,y,z,sigmaZ,dxdz,dydz,beamWidthX,beamWidthY,emittanceX,emittanceY,betastar;
-	double cov[7][7];
-	int type, lastAnalyzedLumi, firstAnalyzedLumi, lastAnalyzedRun, lastAnalyzedFill;
+  double x, y, z, sigmaZ, dxdz, dydz, beamWidthX, beamWidthY, emittanceX, emittanceY, betastar;
+  double cov[7][7];
+  int type, lastAnalyzedLumi, firstAnalyzedLumi, lastAnalyzedRun, lastAnalyzedFill;
   std::string tag;
-	
+
   fasciiFile >> tag >> lastAnalyzedRun;
-  fasciiFile >> tag >> tag >> tag >> tag >> tag; // BeginTimeOfFit parsing (not used in payload)
-  fasciiFile >> tag >> tag >> tag >> tag >> tag; // EndTimeOfFit parsing (not used in payload)
-	fasciiFile >> tag >> firstAnalyzedLumi;
-	fasciiFile >> tag >> lastAnalyzedLumi;
-	fasciiFile >> tag >> type;
-	fasciiFile >> tag >> x;
-	fasciiFile >> tag >> y;
-	fasciiFile >> tag >> z;
-	fasciiFile >> tag >> sigmaZ;
-	fasciiFile >> tag >> dxdz;
-	fasciiFile >> tag >> dydz;
-	fasciiFile >> tag >> beamWidthX;
-	fasciiFile >> tag >> beamWidthY;
-	fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2]>> cov[0][3] >> cov[0][4]>> cov[0][5] >> cov[0][6];
-	fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3]>> cov[1][4] >> cov[1][5]>> cov[1][6];
-	fasciiFile >> tag >> cov[2][0]  >> cov[2][1] >> cov[2][2] >> cov[2][3]>> cov[2][4] >> cov[2][5]>> cov[2][6];
-	fasciiFile >> tag >> cov[3][0]  >> cov[3][1] >> cov[3][2] >> cov[3][3]>> cov[3][4] >> cov[3][5]>> cov[3][6];
-	fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3]>> cov[4][4] >> cov[4][5]>> cov[4][6];
-	fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3]>> cov[5][4] >> cov[5][5]>> cov[5][6];
-	fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3]>> cov[6][4] >> cov[6][5]>> cov[6][6];
-	fasciiFile >> tag >> emittanceX;
-	fasciiFile >> tag >> emittanceY;
-	fasciiFile >> tag >> betastar;
+  fasciiFile >> tag >> tag >> tag >> tag >> tag;  // BeginTimeOfFit parsing (not used in payload)
+  fasciiFile >> tag >> tag >> tag >> tag >> tag;  // EndTimeOfFit parsing (not used in payload)
+  fasciiFile >> tag >> firstAnalyzedLumi;
+  fasciiFile >> tag >> lastAnalyzedLumi;
+  fasciiFile >> tag >> type;
+  fasciiFile >> tag >> x;
+  fasciiFile >> tag >> y;
+  fasciiFile >> tag >> z;
+  fasciiFile >> tag >> sigmaZ;
+  fasciiFile >> tag >> dxdz;
+  fasciiFile >> tag >> dydz;
+  fasciiFile >> tag >> beamWidthX;
+  fasciiFile >> tag >> beamWidthY;
+  fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2] >> cov[0][3] >> cov[0][4] >> cov[0][5] >> cov[0][6];
+  fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3] >> cov[1][4] >> cov[1][5] >> cov[1][6];
+  fasciiFile >> tag >> cov[2][0] >> cov[2][1] >> cov[2][2] >> cov[2][3] >> cov[2][4] >> cov[2][5] >> cov[2][6];
+  fasciiFile >> tag >> cov[3][0] >> cov[3][1] >> cov[3][2] >> cov[3][3] >> cov[3][4] >> cov[3][5] >> cov[3][6];
+  fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3] >> cov[4][4] >> cov[4][5] >> cov[4][6];
+  fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3] >> cov[5][4] >> cov[5][5] >> cov[5][6];
+  fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3] >> cov[6][4] >> cov[6][5] >> cov[6][6];
+  fasciiFile >> tag >> emittanceX;
+  fasciiFile >> tag >> emittanceY;
+  fasciiFile >> tag >> betastar;
 
   lastAnalyzedFill = -999;
 
@@ -169,13 +152,20 @@ BeamSpotOnlineLegacyRcdWriter::endJob()
   std::cout << " dydz              : " << dydz << std::endl;
   std::cout << " beamWidthX        : " << beamWidthX << std::endl;
   std::cout << " beamWidthY        : " << beamWidthY << std::endl;
-  std::cout << " Cov(0,j)          : " << cov[0][0] << " " << cov[0][1] << " " << cov[0][2] << " " << cov[0][3] << " " << cov[0][4] << " " << cov[0][5] << " " << cov[0][6] << std::endl;
-  std::cout << " Cov(1,j)          : " << cov[1][0] << " " << cov[1][1] << " " << cov[1][2] << " " << cov[1][3] << " " << cov[1][4] << " " << cov[1][5] << " " << cov[1][6] << std::endl;
-  std::cout << " Cov(2,j)          : " << cov[2][0] << " " << cov[2][1] << " " << cov[2][2] << " " << cov[2][3] << " " << cov[2][4] << " " << cov[2][5] << " " << cov[2][6] << std::endl;
-  std::cout << " Cov(3,j)          : " << cov[3][0] << " " << cov[3][1] << " " << cov[3][2] << " " << cov[3][3] << " " << cov[3][4] << " " << cov[3][5] << " " << cov[3][6] << std::endl;
-  std::cout << " Cov(4,j)          : " << cov[4][0] << " " << cov[4][1] << " " << cov[4][2] << " " << cov[4][3] << " " << cov[4][4] << " " << cov[4][5] << " " << cov[4][6] << std::endl;
-  std::cout << " Cov(5,j)          : " << cov[5][0] << " " << cov[5][1] << " " << cov[5][2] << " " << cov[5][3] << " " << cov[5][4] << " " << cov[5][5] << " " << cov[5][6] << std::endl;
-  std::cout << " Cov(6,j)          : " << cov[6][0] << " " << cov[6][1] << " " << cov[6][2] << " " << cov[6][3] << " " << cov[6][4] << " " << cov[6][5] << " " << cov[6][6] << std::endl;
+  std::cout << " Cov(0,j)          : " << cov[0][0] << " " << cov[0][1] << " " << cov[0][2] << " " << cov[0][3] << " "
+            << cov[0][4] << " " << cov[0][5] << " " << cov[0][6] << std::endl;
+  std::cout << " Cov(1,j)          : " << cov[1][0] << " " << cov[1][1] << " " << cov[1][2] << " " << cov[1][3] << " "
+            << cov[1][4] << " " << cov[1][5] << " " << cov[1][6] << std::endl;
+  std::cout << " Cov(2,j)          : " << cov[2][0] << " " << cov[2][1] << " " << cov[2][2] << " " << cov[2][3] << " "
+            << cov[2][4] << " " << cov[2][5] << " " << cov[2][6] << std::endl;
+  std::cout << " Cov(3,j)          : " << cov[3][0] << " " << cov[3][1] << " " << cov[3][2] << " " << cov[3][3] << " "
+            << cov[3][4] << " " << cov[3][5] << " " << cov[3][6] << std::endl;
+  std::cout << " Cov(4,j)          : " << cov[4][0] << " " << cov[4][1] << " " << cov[4][2] << " " << cov[4][3] << " "
+            << cov[4][4] << " " << cov[4][5] << " " << cov[4][6] << std::endl;
+  std::cout << " Cov(5,j)          : " << cov[5][0] << " " << cov[5][1] << " " << cov[5][2] << " " << cov[5][3] << " "
+            << cov[5][4] << " " << cov[5][5] << " " << cov[5][6] << std::endl;
+  std::cout << " Cov(6,j)          : " << cov[6][0] << " " << cov[6][1] << " " << cov[6][2] << " " << cov[6][3] << " "
+            << cov[6][4] << " " << cov[6][5] << " " << cov[6][6] << std::endl;
   std::cout << " emittanceX        : " << emittanceX << std::endl;
   std::cout << " emittanceY        : " << emittanceY << std::endl;
   std::cout << " betastar          : " << betastar << std::endl;
@@ -186,49 +176,45 @@ BeamSpotOnlineLegacyRcdWriter::endJob()
   abeam->SetLastAnalyzedLumi(lastAnalyzedLumi);
   abeam->SetLastAnalyzedRun(lastAnalyzedRun);
   abeam->SetLastAnalyzedFill(lastAnalyzedFill);
-	abeam->SetType(type);
-	abeam->SetPosition(x,y,z);
-	abeam->SetSigmaZ(sigmaZ);
-	abeam->Setdxdz(dxdz);
-	abeam->Setdydz(dydz);
-	abeam->SetBeamWidthX(beamWidthX);
-	abeam->SetBeamWidthY(beamWidthY);
-	abeam->SetEmittanceX(emittanceX);
-	abeam->SetEmittanceY(emittanceY);
-	abeam->SetBetaStar(betastar);
+  abeam->SetType(type);
+  abeam->SetPosition(x, y, z);
+  abeam->SetSigmaZ(sigmaZ);
+  abeam->Setdxdz(dxdz);
+  abeam->Setdydz(dydz);
+  abeam->SetBeamWidthX(beamWidthX);
+  abeam->SetBeamWidthY(beamWidthY);
+  abeam->SetEmittanceX(emittanceX);
+  abeam->SetEmittanceY(emittanceY);
+  abeam->SetBetaStar(betastar);
 
-	for (int i=0; i<7; ++i) {
-	  for (int j=0; j<7; ++j) {
-	    abeam->SetCovariance(i,j,cov[i][j]);
-	  }
-	}
+  for (int i = 0; i < 7; ++i) {
+    for (int j = 0; j < 7; ++j) {
+      abeam->SetCovariance(i, j, cov[i][j]);
+    }
+  }
 
   std::cout << " Writing results to DB..." << std::endl;
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
     std::cout << "poolDBService available" << std::endl;
-    if (poolDbService->isNewTagRequest("BeamSpotOnlineLegacyObjectsRcd"))
-    {
+    if (poolDbService->isNewTagRequest("BeamSpotOnlineLegacyObjectsRcd")) {
       std::cout << "new tag requested" << std::endl;
-      if (fuseNewSince)
-      {
+      if (fuseNewSince) {
         std::cout << "Using a new Since: " << fnewSince << std::endl;
-        poolDbService->createNewIOV<BeamSpotOnlineObjects>(abeam, fnewSince, poolDbService->endOfTime(), "BeamSpotOnlineLegacyObjectsRcd");
-      }
-      else
-        poolDbService->createNewIOV<BeamSpotOnlineObjects>(abeam, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotOnlineLegacyObjectsRcd");
-    }
-    else
-    {
+        poolDbService->createNewIOV<BeamSpotOnlineObjects>(
+            abeam, fnewSince, poolDbService->endOfTime(), "BeamSpotOnlineLegacyObjectsRcd");
+      } else
+        poolDbService->createNewIOV<BeamSpotOnlineObjects>(
+            abeam, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotOnlineLegacyObjectsRcd");
+    } else {
       std::cout << "no new tag requested" << std::endl;
-      if (fuseNewSince)
-      {
+      if (fuseNewSince) {
         std::cout << "Using a new Since: " << fnewSince << std::endl;
         poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam, fnewSince, "BeamSpotOnlineLegacyObjectsRcd");
-      }
-      else
-        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam, poolDbService->currentTime(), "BeamSpotOnlineLegacyObjectsRcd");
+      } else
+        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(
+            abeam, poolDbService->currentTime(), "BeamSpotOnlineLegacyObjectsRcd");
     }
   }
 
@@ -236,14 +222,12 @@ BeamSpotOnlineLegacyRcdWriter::endJob()
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-BeamSpotOnlineLegacyRcdWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void BeamSpotOnlineLegacyRcdWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
-
 }
 
 //define this as a plug-in

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdWriter.cc
@@ -1,0 +1,250 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/BeamSpot
+// Class:      BeamSpotOnlineLegacyRcdWriter
+//
+/**\class BeamSpotOnlineLegacyRcdWriter BeamSpotOnlineLegacyRcdWriter.cc CondTools/BeamSpot/plugins/BeamSpotOnlineLegacyRcdWriter.cc
+
+ Description: EDAnalyzer to read the BeamSpotOnlineLegacyObjectsRcd and dump it into a txt and root file
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Francesco Brivio
+//         Created:  Tue, 11 Feb 2020 11:10:12 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <string>
+#include <fstream>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+//
+// class declaration
+//
+
+class BeamSpotOnlineLegacyRcdWriter : public edm::one::EDAnalyzer<>  {
+   public:
+      explicit BeamSpotOnlineLegacyRcdWriter(const edm::ParameterSet&);
+      ~BeamSpotOnlineLegacyRcdWriter();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+      cond::Time_t pack(uint32_t, uint32_t);
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+
+      std::ifstream fasciiFile;
+      std::string fasciiFileName;
+      uint32_t fIOVStartRun;
+      uint32_t fIOVStartLumi;
+      cond::Time_t fnewSince;
+      bool fuseNewSince;
+
+      // ----------member data ---------------------------
+};
+
+//
+// constructors and destructor
+//
+BeamSpotOnlineLegacyRcdWriter::BeamSpotOnlineLegacyRcdWriter(const edm::ParameterSet& iConfig)
+{
+  //now do what ever initialization is needed
+  fasciiFileName = iConfig.getUntrackedParameter<std::string>("InputFileName");
+  fasciiFile.open(fasciiFileName.c_str());
+  if (iConfig.exists("IOVStartRun") && iConfig.exists("IOVStartLumi"))
+  {
+    fIOVStartRun  = iConfig.getUntrackedParameter<uint32_t>("IOVStartRun");
+    fIOVStartLumi = iConfig.getUntrackedParameter<uint32_t>("IOVStartLumi");
+    fnewSince  = BeamSpotOnlineLegacyRcdWriter::pack(fIOVStartRun, fIOVStartLumi);
+    fuseNewSince = true;
+  }
+  else
+  {
+    fuseNewSince = false;
+  }
+}
+
+BeamSpotOnlineLegacyRcdWriter::~BeamSpotOnlineLegacyRcdWriter()
+{
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ Create a since object (cond::Time_t) by packing Run and LS (both uint32_t)  ------------
+cond::Time_t BeamSpotOnlineLegacyRcdWriter::pack(uint32_t fIOVStartRun, uint32_t fIOVStartLumi)
+{
+  return ( (uint64_t) fIOVStartRun << 32 | fIOVStartLumi);
+}
+
+// ------------ method called for each event  ------------
+void
+BeamSpotOnlineLegacyRcdWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+BeamSpotOnlineLegacyRcdWriter::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+BeamSpotOnlineLegacyRcdWriter::endJob()
+{
+  std::cout << "Reading BeamSpotOnlineLegacyObjectsRcd data from text file: " << fasciiFileName << std::endl;
+
+  // extract from file
+	double x,y,z,sigmaZ,dxdz,dydz,beamWidthX,beamWidthY,emittanceX,emittanceY,betastar;
+	double cov[7][7];
+	int type, lastAnalyzedLumi, firstAnalyzedLumi, lastAnalyzedRun, lastAnalyzedFill;
+  std::string tag;
+	
+  fasciiFile >> tag >> lastAnalyzedRun;
+  fasciiFile >> tag >> tag >> tag >> tag >> tag; // BeginTimeOfFit parsing (not used in payload)
+  fasciiFile >> tag >> tag >> tag >> tag >> tag; // EndTimeOfFit parsing (not used in payload)
+	fasciiFile >> tag >> firstAnalyzedLumi;
+	fasciiFile >> tag >> lastAnalyzedLumi;
+	fasciiFile >> tag >> type;
+	fasciiFile >> tag >> x;
+	fasciiFile >> tag >> y;
+	fasciiFile >> tag >> z;
+	fasciiFile >> tag >> sigmaZ;
+	fasciiFile >> tag >> dxdz;
+	fasciiFile >> tag >> dydz;
+	fasciiFile >> tag >> beamWidthX;
+	fasciiFile >> tag >> beamWidthY;
+	fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2]>> cov[0][3] >> cov[0][4]>> cov[0][5] >> cov[0][6];
+	fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3]>> cov[1][4] >> cov[1][5]>> cov[1][6];
+	fasciiFile >> tag >> cov[2][0]  >> cov[2][1] >> cov[2][2] >> cov[2][3]>> cov[2][4] >> cov[2][5]>> cov[2][6];
+	fasciiFile >> tag >> cov[3][0]  >> cov[3][1] >> cov[3][2] >> cov[3][3]>> cov[3][4] >> cov[3][5]>> cov[3][6];
+	fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3]>> cov[4][4] >> cov[4][5]>> cov[4][6];
+	fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3]>> cov[5][4] >> cov[5][5]>> cov[5][6];
+	fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3]>> cov[6][4] >> cov[6][5]>> cov[6][6];
+	fasciiFile >> tag >> emittanceX;
+	fasciiFile >> tag >> emittanceY;
+	fasciiFile >> tag >> betastar;
+
+  lastAnalyzedFill = -999;
+
+  std::cout << "---- Parsed these parameters from input txt file ----" << std::endl;
+  std::cout << " lastAnalyzedRun   : " << lastAnalyzedRun << std::endl;
+  std::cout << " lastAnalyzedFill  : " << lastAnalyzedFill << std::endl;
+  std::cout << " firstAnalyzedLumi : " << firstAnalyzedLumi << std::endl;
+  std::cout << " lastAnalyzedLumi  : " << lastAnalyzedLumi << std::endl;
+  std::cout << " type              : " << type << std::endl;
+  std::cout << " x                 : " << x << std::endl;
+  std::cout << " y                 : " << y << std::endl;
+  std::cout << " z                 : " << z << std::endl;
+  std::cout << " sigmaZ            : " << sigmaZ << std::endl;
+  std::cout << " dxdz              : " << dxdz << std::endl;
+  std::cout << " dydz              : " << dydz << std::endl;
+  std::cout << " beamWidthX        : " << beamWidthX << std::endl;
+  std::cout << " beamWidthY        : " << beamWidthY << std::endl;
+  std::cout << " Cov(0,j)          : " << cov[0][0] << " " << cov[0][1] << " " << cov[0][2] << " " << cov[0][3] << " " << cov[0][4] << " " << cov[0][5] << " " << cov[0][6] << std::endl;
+  std::cout << " Cov(1,j)          : " << cov[1][0] << " " << cov[1][1] << " " << cov[1][2] << " " << cov[1][3] << " " << cov[1][4] << " " << cov[1][5] << " " << cov[1][6] << std::endl;
+  std::cout << " Cov(2,j)          : " << cov[2][0] << " " << cov[2][1] << " " << cov[2][2] << " " << cov[2][3] << " " << cov[2][4] << " " << cov[2][5] << " " << cov[2][6] << std::endl;
+  std::cout << " Cov(3,j)          : " << cov[3][0] << " " << cov[3][1] << " " << cov[3][2] << " " << cov[3][3] << " " << cov[3][4] << " " << cov[3][5] << " " << cov[3][6] << std::endl;
+  std::cout << " Cov(4,j)          : " << cov[4][0] << " " << cov[4][1] << " " << cov[4][2] << " " << cov[4][3] << " " << cov[4][4] << " " << cov[4][5] << " " << cov[4][6] << std::endl;
+  std::cout << " Cov(5,j)          : " << cov[5][0] << " " << cov[5][1] << " " << cov[5][2] << " " << cov[5][3] << " " << cov[5][4] << " " << cov[5][5] << " " << cov[5][6] << std::endl;
+  std::cout << " Cov(6,j)          : " << cov[6][0] << " " << cov[6][1] << " " << cov[6][2] << " " << cov[6][3] << " " << cov[6][4] << " " << cov[6][5] << " " << cov[6][6] << std::endl;
+  std::cout << " emittanceX        : " << emittanceX << std::endl;
+  std::cout << " emittanceY        : " << emittanceY << std::endl;
+  std::cout << " betastar          : " << betastar << std::endl;
+  std::cout << "-----------------------------------------------------" << std::endl;
+
+  BeamSpotOnlineObjects* abeam = new BeamSpotOnlineObjects();
+
+  abeam->SetLastAnalyzedLumi(lastAnalyzedLumi);
+  abeam->SetLastAnalyzedRun(lastAnalyzedRun);
+  abeam->SetLastAnalyzedFill(lastAnalyzedFill);
+	abeam->SetType(type);
+	abeam->SetPosition(x,y,z);
+	abeam->SetSigmaZ(sigmaZ);
+	abeam->Setdxdz(dxdz);
+	abeam->Setdydz(dydz);
+	abeam->SetBeamWidthX(beamWidthX);
+	abeam->SetBeamWidthY(beamWidthY);
+	abeam->SetEmittanceX(emittanceX);
+	abeam->SetEmittanceY(emittanceY);
+	abeam->SetBetaStar(betastar);
+
+	for (int i=0; i<7; ++i) {
+	  for (int j=0; j<7; ++j) {
+	    abeam->SetCovariance(i,j,cov[i][j]);
+	  }
+	}
+
+  std::cout << " Writing results to DB..." << std::endl;
+
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if (poolDbService.isAvailable()) {
+    std::cout << "poolDBService available" << std::endl;
+    if (poolDbService->isNewTagRequest("BeamSpotOnlineLegacyObjectsRcd"))
+    {
+      std::cout << "new tag requested" << std::endl;
+      if (fuseNewSince)
+      {
+        std::cout << "Using a new Since: " << fnewSince << std::endl;
+        poolDbService->createNewIOV<BeamSpotOnlineObjects>(abeam, fnewSince, poolDbService->endOfTime(), "BeamSpotOnlineLegacyObjectsRcd");
+      }
+      else
+        poolDbService->createNewIOV<BeamSpotOnlineObjects>(abeam, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotOnlineLegacyObjectsRcd");
+    }
+    else
+    {
+      std::cout << "no new tag requested" << std::endl;
+      if (fuseNewSince)
+      {
+        std::cout << "Using a new Since: " << fnewSince << std::endl;
+        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam, fnewSince, "BeamSpotOnlineLegacyObjectsRcd");
+      }
+      else
+        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam, poolDbService->currentTime(), "BeamSpotOnlineLegacyObjectsRcd");
+    }
+  }
+
+  std::cout << "[BeamSpotOnlineLegacyRcdWriter] endJob done \n" << std::endl;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+BeamSpotOnlineLegacyRcdWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamSpotOnlineLegacyRcdWriter);

--- a/CondTools/BeamSpot/plugins/BuildFile.xml
+++ b/CondTools/BeamSpot/plugins/BuildFile.xml
@@ -5,4 +5,5 @@
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="CondCore/CondDB"/>
+<use name="CondCore/DBOutputService"/>
 <flags EDM_PLUGIN="1"/>

--- a/CondTools/BeamSpot/test/BeamSpotOnlineHLTRcdReader_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineHLTRcdReader_cfg.py
@@ -1,0 +1,69 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.destinations = ['cout', 'cerr']
+process.MessageLogger.cerr.FwkReport.reportEvery = 100000                         # do not clog output with IO
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000000) )   # large number of events is needed since we probe 5000LS for run (see below)
+
+####################################################################
+# Empty source 
+####################################################################
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(306171),                  # Run in ../data/BeamFitResults_Run306171.txt
+                            firstLuminosityBlock = cms.untracked.uint32(497),         # Lumi in ../data/BeamFitResults_Run306171.txt
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(1),  # probe one event per LS
+                            numberEventsInRun = cms.untracked.uint32(5000),           # a number of events > the number of LS possible in a real run (5000 s ~ 32 h)
+                            )
+
+####################################################################
+# Connect to conditions DB
+####################################################################
+
+# either from Global Tag
+# process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+# from Configuration.AlCa.GlobalTag import GlobalTag
+# process.GlobalTag = GlobalTag(process.GlobalTag,"auto:run2_data")
+
+# ...or specify database connection and tag:  
+#from CondCore.CondDB.CondDB_cfi import *
+#CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
+#process.dbInput = cms.ESSource("PoolDBESSource",
+#                               CondDBBeamSpotObjects,
+#                               toGet = cms.VPSet(cms.PSet(record = cms.string('BeamSpotOnlineHLTObjectsRcd'), # BeamSpotOnlineHLT record
+#                                                          tag = cms.string('BSHLT_tag')                       # choose your favourite tag
+#                                                          )
+#                                                 )
+#                               )
+# ...or from a local db file
+# input database (in this case the local sqlite file)
+from CondCore.CondDB.CondDB_cfi import *
+CondDBBeamSpotOnlineHLT = CondDB.clone(connect = cms.string("sqlite_file:test.db")) # customize with input db file
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    CondDBBeamSpotOnlineHLT,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('BeamSpotOnlineHLTObjectsRcd'),  # BeamSpotOnlineHLT record
+        tag = cms.string('BSHLT_tag')                        # choose your favourite tag
+    ))
+)
+
+####################################################################
+# Load and configure analyzer
+####################################################################
+process.beamspotonlinereader = cms.EDAnalyzer("BeamSpotOnlineHLTRcdReader",
+                              rawFileName = cms.untracked.string("test.txt") # choose an output name
+                              )
+
+####################################################################
+# Output file
+####################################################################
+process.TFileService = cms.Service("TFileService",
+                                   fileName=cms.string("test.root") # choose an output name
+                                   )
+
+# Put module in path:
+process.p = cms.Path(process.beamspotonlinereader)

--- a/CondTools/BeamSpot/test/BeamSpotOnlineHLTRcdWriter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineHLTRcdWriter_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("write2DB")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+from CondCore.CondDB.CondDB_cfi import *
+
+#################################
+# Produce a SQLITE FILE
+#
+CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test.db')) # choose an output name
+
+#################################
+#
+# upload conditions to orcon
+#
+#process.CondDBCommon.connect = "oracle://cms_orcoff_prep/CMS_COND_BEAMSPOT"
+#process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+#process.GlobalTag.globaltag = 'MC_31X_V2::All'
+
+#################################
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          #process.CondDBCommon,
+                                          CondDBBeamSpotObjects,
+                                          timetype = cms.untracked.string('lumiid'), #('lumiid'), #('runnumber')
+                                          toPut = cms.VPSet(cms.PSet(
+    record = cms.string('BeamSpotOnlineHLTObjectsRcd'), # BeamSpotOnlineHLT record
+    tag = cms.string('BSHLT_tag') )),                    # choose your favourite tag
+    loadBlobStreamer = cms.untracked.bool(False)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+            input = cms.untracked.int32(1)
+                    )
+
+process.beamspotonlinewriter = cms.EDAnalyzer("BeamSpotOnlineHLTRcdWriter",
+                        InputFileName = cms.untracked.string('../data/BeamFitResults_Run306171.txt'),  # choose your input file
+                        #IOVStartRun = cms.untracked.uint32(306171), # Customize your Run
+                        #IOVStartLumi = cms.untracked.uint32(497),   # Customize your Lumi
+                   )
+
+process.p = cms.Path(process.beamspotonlinewriter)

--- a/CondTools/BeamSpot/test/BeamSpotOnlineLegacyRcdReader_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineLegacyRcdReader_cfg.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.destinations = ['cout', 'cerr']
+process.MessageLogger.cerr.FwkReport.reportEvery = 100000                         # do not clog output with IO
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000000) )   # large number of events is needed since we probe 5000LS for run (see below)
+
+####################################################################
+# Empty source 
+####################################################################
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(306171),                  # Run in ../data/BeamFitResults_Run306171.txt
+                            firstLuminosityBlock = cms.untracked.uint32(497),         # Lumi in ../data/BeamFitResults_Run306171.txt
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(1),  # probe one event per LS
+                            numberEventsInRun = cms.untracked.uint32(5000),           # a number of events > the number of LS possible in a real run (5000 s ~ 32 h)
+                            )
+
+####################################################################
+# Connect to conditions DB
+####################################################################
+
+# either from Global Tag
+# process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+# from Configuration.AlCa.GlobalTag import GlobalTag
+# process.GlobalTag = GlobalTag(process.GlobalTag,"auto:run2_data")
+
+# ...or specify database connection and tag:  
+#from CondCore.CondDB.CondDB_cfi import *
+#CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
+#process.dbInput = cms.ESSource("PoolDBESSource",
+#                               CondDBBeamSpotObjects,
+#                               toGet = cms.VPSet(cms.PSet(record = cms.string('BeamSpotOnlineLegacyObjectsRcd'), # BeamSpotOnlineLegacy record
+#                                                          tag = cms.string('BSLegacy_tag')                       # choose your favourite tag
+#                                                          )
+#                                                 )
+#                               )
+# ...or from a local db file
+# input database (in this case the local sqlite file)
+from CondCore.CondDB.CondDB_cfi import *
+CondDBBeamSpotOnlineLegacy = CondDB.clone(connect = cms.string("sqlite_file:test.db")) # customize with input db file
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    CondDBBeamSpotOnlineLegacy,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),  # BeamSpotOnlineLegacy record
+        tag = cms.string('BSLegacy_tag')                        # choose your favourite tag
+    ))
+)
+
+
+####################################################################
+# Load and configure analyzer
+####################################################################
+process.beamspotonlinereader = cms.EDAnalyzer("BeamSpotOnlineLegacyRcdReader",
+                              rawFileName = cms.untracked.string("test.txt") # choose an output name
+                              )
+
+####################################################################
+# Output file
+####################################################################
+process.TFileService = cms.Service("TFileService",
+                                   fileName=cms.string("test.root") # choose an output name
+                                   )
+
+# Put module in path:
+process.p = cms.Path(process.beamspotonlinereader)

--- a/CondTools/BeamSpot/test/BeamSpotOnlineLegacyRcdWriter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineLegacyRcdWriter_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("write2DB")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+from CondCore.CondDB.CondDB_cfi import *
+
+#################################
+# Produce a SQLITE FILE
+#
+CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test.db')) # choose an output name
+
+#################################
+#
+# upload conditions to orcon
+#
+#process.CondDBCommon.connect = "oracle://cms_orcoff_prep/CMS_COND_BEAMSPOT"
+#process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+#process.GlobalTag.globaltag = 'MC_31X_V2::All'
+
+#################################
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          #process.CondDBCommon,
+                                          CondDBBeamSpotObjects,
+                                          timetype = cms.untracked.string('lumiid'), #('lumiid'), #('runnumber')
+                                          toPut = cms.VPSet(cms.PSet(
+    record = cms.string('BeamSpotOnlineLegacyObjectsRcd'), # BeamSpotOnlineLegacy record
+    tag = cms.string('BSLegacy_tag') )),                    # choose your favourite tag
+    loadBlobStreamer = cms.untracked.bool(False)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+            input = cms.untracked.int32(1)
+                    )
+
+process.beamspotonlinewriter = cms.EDAnalyzer("BeamSpotOnlineLegacyRcdWriter",
+                        InputFileName = cms.untracked.string('../data/BeamFitResults_Run306171.txt'),  # choose your input file
+                        #IOVStartRun = cms.untracked.uint32(306171), # Customize your Run
+                        #IOVStartLumi = cms.untracked.uint32(497),   # Customize your Lumi
+                   )
+
+process.p = cms.Path(process.beamspotonlinewriter)


### PR DESCRIPTION
#### PR description:
This PR introduces one new BeamSpot object and three new BeamSpot records that will be used to pass the BeamSpot information to the HLT on a lumi-by-lumi basis.
Newly introduced objets:
- `BeamSpotOnlineObjects` inherits from the already existing `BeamSpotObjects` and contains few new members (last analyzed lumi, run and fill)
- `BeamSpotOnlineHLTObjectsRcd` and `BeamSpotOnlineLegacyObjectsRcd` are two new records based on the `BeamSpotOnlineObjects` that will hold the information from the two running BeamSpot DQM clients
- `BeamSpotTransientObjectsRcd` is a dependent record that depends on `BeamSpotOnlineHLTObjectsRcd` and `BeamSpotOnlineLegacyObjectsRcd` and holds the final beamspot that will be passed to HLT
- Few new plugins for writing and reading the new BeamSpot records are placed under `CondTools/BeamSpot`

 
#### Coming next
This PR will be followed by two other PRs:
1. To include the production of the new BeamSpot records in the DQM BeamSpot clients (under `DQM/BeamMonitor` and `DQM/Integration`)
2. ESProducer and all necessary code to pass the final BeamSpot value to the HLT

