### PR TITLE
[ROOT master] Add direct deps after ROOT cleanup

### DIFF
--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -42,6 +42,7 @@
 #include <TSystem.h>
 #include <TTimeStamp.h>
 #include <TStopwatch.h>
+#include <TObjString.h>
 //#include "Alignment/OfflineValidation/macros/TkAlStyle.cc"
 #include "Alignment/OfflineValidation/macros/CMS_lumi.h"
 #define PLOTTING_MACRO  // to remove message logger

--- a/Alignment/OfflineValidation/macros/FitPVResolution.C
+++ b/Alignment/OfflineValidation/macros/FitPVResolution.C
@@ -10,6 +10,7 @@
 #include "TStyle.h"
 #include "TClass.h"
 #include "TLegend.h"
+#include "TObjString.h"
 #include <string>
 #include <iomanip>
 #include "TPaveText.h"

--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
@@ -12,6 +12,7 @@
 #include "TTree.h"
 #include "TFile.h"
 #include "TClonesArray.h"
+#include "TObjString.h"
 #include <iostream>
 #include <vector>
 #include <set>

--- a/DQM/L1TMonitorClient/interface/L1TOccupancyClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TOccupancyClient.h
@@ -25,6 +25,7 @@
 #include <TProfile2D.h>
 #include <TNamed.h>
 #include <TRandom3.h>
+#include <TDirectory.h>
 
 class L1TOccupancyClient : public DQMEDHarvester {
 public:

--- a/Fireworks/Core/src/FWDetailViewManager.cc
+++ b/Fireworks/Core/src/FWDetailViewManager.cc
@@ -23,6 +23,7 @@
 #include "TEveWindowManager.h"
 #include "TEveWindow.h"
 #include "TQObject.h"
+#include "TObjString.h"
 
 #include "Fireworks/Core/interface/FWDetailViewManager.h"
 #include "Fireworks/Core/interface/FWColorManager.h"

--- a/Fireworks/Core/src/FWGeometry.cc
+++ b/Fireworks/Core/src/FWGeometry.cc
@@ -5,6 +5,7 @@
 #include "TSystem.h"
 #include "TGeoArb8.h"
 #include "TObjArray.h"
+#include "TObjString.h"
 #include "TPRegexp.h"
 
 #include "Fireworks/Core/interface/FWGeometry.h"

--- a/IOPool/Output/src/RootOutputTree.h
+++ b/IOPool/Output/src/RootOutputTree.h
@@ -9,7 +9,7 @@ RootOutputTree.h // used by ROOT output modules
 
 #include <string>
 #include <vector>
-
+#include <set>
 #include <memory>
 
 #include "FWCore/Utilities/interface/BranchType.h"

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron2.cc
@@ -20,6 +20,7 @@
 
 #include <TMath.h>
 #include "TPRegexp.h"
+#include <TObjString.h>
 
 #include <iostream>
 #include <sstream>

--- a/SimG4Core/HelpfulWatchers/src/G4StepStatistics.h
+++ b/SimG4Core/HelpfulWatchers/src/G4StepStatistics.h
@@ -38,7 +38,7 @@
 #include <TString.h>
 #include <TTree.h>
 #include <TVector.h>
-//#include<TObjString.h>
+#include <TObjString.h>
 
 // forward declarations
 class DDDWorld;

--- a/SimTransport/TotemRPProtonTransportParametrization/src/TMultiDimFet.cc
+++ b/SimTransport/TotemRPProtonTransportParametrization/src/TMultiDimFet.cc
@@ -18,6 +18,7 @@
 #include "TH2.h"
 #include "TROOT.h"
 #include "TDecompChol.h"
+#include "TDatime.h"
 #include <iostream>
 #include <map>
 


### PR DESCRIPTION
#### PR description:

Adds direct dependencies for used types namely TObjString, TFile and std::set
See: https://github.com/cms-sw/cmsdist/pull/5800 and https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-370a62/5988/build-logs/
We had the types present included indirectly by other headers (I'd guess)
I didn't want to open 10 PRs with one line change, hence the multiple categories

#### PR validation:

Builds with ROOT_X IB (given we have the GL installed, I copied it by hand for the test, it built)