### PR TITLE
Fix crashing bug  in reco when run with XML geometry

### DIFF
--- a/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
@@ -165,7 +165,7 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& event, const edm::EventSe
         lpArray[ptCounter] = etaPartition->centreOfPad(padArray[ptCounter]);
       }                     // end for
       if (ptCounter < 2) {  // Broke out of "for" loop
-        edm::LogError(kLogCategory_) << "Skipping a digi after " << (ptCounter + 1) << " tries.";
+        edm::LogError(kLogCategory_) << "Skipping a digi due to bad chamber " << (ptCounter + 1);
         continue;
       }
       const GlobalPoint& gp1 = surface.toGlobal(lpArray[0]);

--- a/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
@@ -26,22 +26,23 @@ void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
     for (const auto& station : region->stations()) {
       Int_t station_id = station->station();
-      const auto &superChamberVec = station->superChambers();
+      const auto& superChamberVec = station->superChambers();
       if (superChamberVec.empty() || superChamberVec[0] == nullptr) {
         edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
-          << " and station = " << station_id;
+                                     << " and station = " << station_id;
         continue;
       }
-      const auto &chamberVec = superChamberVec[0]->chambers();
+      const auto& chamberVec = superChamberVec[0]->chambers();
       if (chamberVec.empty() || chamberVec[0] == nullptr) {
-        edm::LogError(kLogCategory_) << "Chambers missing or null for region, station, super chamber = (" <<
-          region_id << ", " << station_id << ", " <<  superChamberVec[0]->id() << ")";
+        edm::LogError(kLogCategory_) << "Chambers missing or null for region, station, super chamber = (" << region_id
+                                     << ", " << station_id << ", " << superChamberVec[0]->id() << ")";
         continue;
       }
-      const auto &etaPartitionVec = chamberVec[0]->etaPartitions();
+      const auto& etaPartitionVec = chamberVec[0]->etaPartitions();
       if (etaPartitionVec.empty() || etaPartitionVec[0] == nullptr) {
-        edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = (" <<
-          region_id << ", " << station_id << ", " <<  superChamberVec[0]->id() << ", " << chamberVec[0]->id() << ")";
+        edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = ("
+                                     << region_id << ", " << station_id << ", " << superChamberVec[0]->id() << ", "
+                                     << chamberVec[0]->id() << ")";
         continue;
       }
       Int_t num_pads = etaPartitionVec[0]->npads();
@@ -149,19 +150,20 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& event, const edm::EventSe
       LocalPoint lpArray[2];
       int ptCounter = 0;
       for (; ptCounter < 2; ++ptCounter) {
-        const GEMChamber *const chamber = super_chamber->chamber(ptCounter + 1); // Fetch chambers 1 and 2
+        const GEMChamber* const chamber = super_chamber->chamber(ptCounter + 1);  // Fetch chambers 1 and 2
         if (chamber == nullptr) {
-          edm::LogError(kLogCategory_) << "Chamber " << (ptCounter + 1) << " is null for super chamber = " << super_chamber_id;
+          edm::LogError(kLogCategory_) << "Chamber " << (ptCounter + 1)
+                                       << " is null for super chamber = " << super_chamber_id;
           break;
         }
-        const GEMEtaPartition *const etaPartition = chamber->etaPartition(roll_id);
+        const GEMEtaPartition* const etaPartition = chamber->etaPartition(roll_id);
         if (etaPartition == nullptr) {
-          edm::LogError(kLogCategory_) << "Eta partition " << roll_id << " is null for chamber, super chamber = (" <<
-            (ptCounter + 1) << ", " << super_chamber_id << ")";
+          edm::LogError(kLogCategory_) << "Eta partition " << roll_id << " is null for chamber, super chamber = ("
+                                       << (ptCounter + 1) << ", " << super_chamber_id << ")";
           break;
         }
         lpArray[ptCounter] = etaPartition->centreOfPad(padArray[ptCounter]);
-      } // end for
+      }                     // end for
       if (ptCounter < 2) {  // Broke out of "for" loop
         edm::LogError(kLogCategory_) << "Skipping a digi after " << (ptCounter + 1) << " tries.";
         continue;

--- a/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
@@ -28,20 +28,22 @@ void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
       Int_t station_id = station->station();
       const auto &superChamberVec = station->superChambers();
       if (superChamberVec.empty() || superChamberVec[0] == nullptr) {
-        edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+        edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
+          << " and station = " << station_id;
         continue;
       }
       const auto &chamberVec = superChamberVec[0]->chambers();
       if (chamberVec.empty() || chamberVec[0] == nullptr) {
-        edm::LogError(kLogCategory_) << "Chambers missing or null. ";
+        edm::LogError(kLogCategory_) << "Chambers missing or null for region, station, super chamber = (" <<
+          region_id << ", " << station_id << ", " <<  superChamberVec[0]->id() << ")";
         continue;
       }
       const auto &etaPartitionVec = chamberVec[0]->etaPartitions();
       if (etaPartitionVec.empty() || etaPartitionVec[0] == nullptr) {
-        edm::LogError(kLogCategory_) << "Eta partition missing or null.";
+        edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = (" <<
+          region_id << ", " << station_id << ", " <<  superChamberVec[0]->id() << ", " << chamberVec[0]->id() << ")";
         continue;
       }
-      // Int_t num_pads = station->superChambers()[0]->chambers()[0]->etaPartitions()[0]->npads();
       Int_t num_pads = etaPartitionVec[0]->npads();
       ME2IdsKey key2{region_id, station_id};
 
@@ -129,7 +131,7 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& event, const edm::EventSe
       const BoundPlane& surface = geom_det->surface();
       const GEMSuperChamber* super_chamber = gem->superChamber(super_chamber_id);
       if (super_chamber == nullptr) {
-        edm::LogError(kLogCategory_) << "Super chamber is null.";
+        edm::LogError(kLogCategory_) << "Super chamber is null for super chamber ID = " << super_chamber_id;
         continue;
       }
       Int_t pad1 = digi->pad(1);
@@ -147,14 +149,15 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& event, const edm::EventSe
       LocalPoint lpArray[2];
       int ptCounter = 0;
       for (; ptCounter < 2; ++ptCounter) {
-        const GEMChamber *const chamber = super_chamber->chamber(ptCounter + 1);
+        const GEMChamber *const chamber = super_chamber->chamber(ptCounter + 1); // Fetch chambers 1 and 2
         if (chamber == nullptr) {
-          edm::LogError(kLogCategory_) << "Chamber " << (ptCounter + 1) << " is null.";
+          edm::LogError(kLogCategory_) << "Chamber " << (ptCounter + 1) << " is null for super chamber = " << super_chamber_id;
           break;
         }
         const GEMEtaPartition *const etaPartition = chamber->etaPartition(roll_id);
         if (etaPartition == nullptr) {
-          edm::LogError(kLogCategory_) << "Eta partition " << roll_id << " is null.";
+          edm::LogError(kLogCategory_) << "Eta partition " << roll_id << " is null for chamber, super chamber = (" <<
+            (ptCounter + 1) << ", " << super_chamber_id << ")";
           break;
         }
         lpArray[ptCounter] = etaPartition->centreOfPad(padArray[ptCounter]);
@@ -163,9 +166,6 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& event, const edm::EventSe
         edm::LogError(kLogCategory_) << "Skipping a digi after " << (ptCounter + 1) << " tries.";
         continue;
       }
-      // const LocalPoint& lp1 = super_chamber->chamber(1)->etaPartition(roll_id)->centreOfPad(pad1);
-      // const LocalPoint& lp2 = super_chamber->chamber(2)->etaPartition(roll_id)->centreOfPad(pad2);
-
       const GlobalPoint& gp1 = surface.toGlobal(lpArray[0]);
       const GlobalPoint& gp2 = surface.toGlobal(lpArray[1]);
 

--- a/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
@@ -26,7 +26,23 @@ void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
     for (const auto& station : region->stations()) {
       Int_t station_id = station->station();
-      Int_t num_pads = station->superChambers()[0]->chambers()[0]->etaPartitions()[0]->npads();
+      const auto &superChamberVec = station->superChambers();
+      if (superChamberVec.empty() || superChamberVec[0] == nullptr) {
+        edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+        continue;
+      }
+      const auto &chamberVec = superChamberVec[0]->chambers();
+      if (chamberVec.empty() || chamberVec[0] == nullptr) {
+        edm::LogError(kLogCategory_) << "Chambers missing or null. ";
+        continue;
+      }
+      const auto &etaPartitionVec = chamberVec[0]->etaPartitions();
+      if (etaPartitionVec.empty() || etaPartitionVec[0] == nullptr) {
+        edm::LogError(kLogCategory_) << "Eta partition missing or null.";
+        continue;
+      }
+      // Int_t num_pads = station->superChambers()[0]->chambers()[0]->etaPartitions()[0]->npads();
+      Int_t num_pads = etaPartitionVec[0]->npads();
       ME2IdsKey key2{region_id, station_id};
 
       me_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "copad", "CoPad");
@@ -112,7 +128,10 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& event, const edm::EventSe
 
       const BoundPlane& surface = geom_det->surface();
       const GEMSuperChamber* super_chamber = gem->superChamber(super_chamber_id);
-
+      if (super_chamber == nullptr) {
+        edm::LogError(kLogCategory_) << "Super chamber is null.";
+        continue;
+      }
       Int_t pad1 = digi->pad(1);
       Int_t pad2 = digi->pad(2);
       Int_t bx1 = digi->bx(1);
@@ -124,11 +143,31 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& event, const edm::EventSe
       if (bx2 < gem_bx_min_ or bx2 > gem_bx_max_)
         continue;
 
-      const LocalPoint& lp1 = super_chamber->chamber(1)->etaPartition(roll_id)->centreOfPad(pad1);
-      const LocalPoint& lp2 = super_chamber->chamber(2)->etaPartition(roll_id)->centreOfPad(pad2);
+      const Int_t padArray[] = {pad1, pad2};
+      LocalPoint lpArray[2];
+      int ptCounter = 0;
+      for (; ptCounter < 2; ++ptCounter) {
+        const GEMChamber *const chamber = super_chamber->chamber(ptCounter + 1);
+        if (chamber == nullptr) {
+          edm::LogError(kLogCategory_) << "Chamber " << (ptCounter + 1) << " is null.";
+          break;
+        }
+        const GEMEtaPartition *const etaPartition = chamber->etaPartition(roll_id);
+        if (etaPartition == nullptr) {
+          edm::LogError(kLogCategory_) << "Eta partition " << roll_id << " is null.";
+          break;
+        }
+        lpArray[ptCounter] = etaPartition->centreOfPad(padArray[ptCounter]);
+      } // end for
+      if (ptCounter < 2) {  // Broke out of "for" loop
+        edm::LogError(kLogCategory_) << "Skipping a digi after " << (ptCounter + 1) << " tries.";
+        continue;
+      }
+      // const LocalPoint& lp1 = super_chamber->chamber(1)->etaPartition(roll_id)->centreOfPad(pad1);
+      // const LocalPoint& lp2 = super_chamber->chamber(2)->etaPartition(roll_id)->centreOfPad(pad2);
 
-      const GlobalPoint& gp1 = surface.toGlobal(lp1);
-      const GlobalPoint& gp2 = surface.toGlobal(lp2);
+      const GlobalPoint& gp1 = surface.toGlobal(lpArray[0]);
+      const GlobalPoint& gp2 = surface.toGlobal(lpArray[1]);
 
       Float_t g_r1 = gp1.perp();
       Float_t g_r2 = gp2.perp();

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
@@ -26,26 +26,27 @@ void GEMPadDigiClusterValidation::bookHistograms(DQMStore::IBooker& booker,
 
       me_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "pad", "Pad Cluster");
 
-      const auto &superChamberVec = station->superChambers();
+      const auto& superChamberVec = station->superChambers();
       if (superChamberVec.empty()) {
         edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
-          << " and station = " << station_id;
+                                     << " and station = " << station_id;
         continue;
       }
       const GEMSuperChamber* super_chamber = superChamberVec.front();
       if (super_chamber == nullptr) {
         edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
-          << " and station = " << station_id;
+                                     << " and station = " << station_id;
         continue;
       }
       for (const auto& chamber : super_chamber->chambers()) {
         Int_t layer_id = chamber->id().layer();
         ME3IdsKey key3{region_id, station_id, layer_id};
 
-        const auto &etaPartitionVec = chamber->etaPartitions();
+        const auto& etaPartitionVec = chamber->etaPartitions();
         if (etaPartitionVec.empty() || etaPartitionVec.front() == nullptr) {
-        edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = (" <<
-          region_id << ", " << station_id << ", " <<  super_chamber->id() << ", " << chamber->id() << ")";
+          edm::LogError(kLogCategory_)
+              << "Eta partition missing or null for region, station, super chamber, chamber = (" << region_id << ", "
+              << station_id << ", " << super_chamber->id() << ", " << chamber->id() << ")";
           continue;
         }
         Int_t num_pads = etaPartitionVec.front()->npads();
@@ -82,16 +83,16 @@ void GEMPadDigiClusterValidation::bookHistograms(DQMStore::IBooker& booker,
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (superChamberVec.empty()) {
           edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
           continue;
         }
         const GEMSuperChamber* super_chamber = superChamberVec.front();
         if (super_chamber == nullptr) {
           edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
           continue;
         }
         for (const auto& chamber : super_chamber->chambers()) {
@@ -140,7 +141,7 @@ void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::Ev
     ME3IdsKey key3(region_id, station_id, layer_id);
 
     for (auto digi = range.first; digi != range.second; ++digi) {
-      const auto &padsVec = digi->pads();
+      const auto& padsVec = digi->pads();
       if (padsVec.empty()) {
         edm::LogError(kLogCategory_) << "Pads missing for digi from GEM ID = " << gemid;
         continue;

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
@@ -26,12 +26,28 @@ void GEMPadDigiClusterValidation::bookHistograms(DQMStore::IBooker& booker,
 
       me_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "pad", "Pad Cluster");
 
-      const GEMSuperChamber* super_chamber = station->superChambers().front();
+      const auto &superChamberVec = station->superChambers();
+      if (superChamberVec.empty()) {
+        edm::LogError(kLogCategory_) << "Super chambers missing.";
+        continue;
+      }
+      const GEMSuperChamber* super_chamber = superChamberVec.front();
+      if (super_chamber == nullptr) {
+        edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+        continue;
+      }
+      // const GEMSuperChamber* super_chamber = station->superChambers().front();
       for (const auto& chamber : super_chamber->chambers()) {
         Int_t layer_id = chamber->id().layer();
         ME3IdsKey key3{region_id, station_id, layer_id};
 
-        Int_t num_pads = chamber->etaPartitions().front()->npads();
+        const auto &etaPartitionVec = chamber->etaPartitions();
+        if (etaPartitionVec.empty() || etaPartitionVec.front() == nullptr) {
+          edm::LogError(kLogCategory_) << "Eta partition missing or null.";
+          continue;
+        }
+        Int_t num_pads = etaPartitionVec.front()->npads();
+        // Int_t num_pads = chamber->etaPartitions().front()->npads();
 
         if (detail_plot_) {
           me_detail_occ_xy_[key3] = bookXYOccupancy(booker, key3, "pad", "Pad Cluster");
@@ -65,7 +81,16 @@ void GEMPadDigiClusterValidation::bookHistograms(DQMStore::IBooker& booker,
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        const GEMSuperChamber* super_chamber = station->superChambers().front();
+        const auto &superChamberVec = station->superChambers();
+        if (superChamberVec.empty()) {
+          edm::LogError(kLogCategory_) << "Super chambers missing.";
+          continue;
+        }
+        const GEMSuperChamber* super_chamber = superChamberVec.front();
+        if (super_chamber == nullptr) {
+          edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+          continue;
+        }
         for (const auto& chamber : super_chamber->chambers()) {
           Int_t layer_id = chamber->id().layer();
           ME3IdsKey key3(region_id, station_id, layer_id);
@@ -112,7 +137,13 @@ void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::Ev
     ME3IdsKey key3(region_id, station_id, layer_id);
 
     for (auto digi = range.first; digi != range.second; ++digi) {
-      Int_t pad = digi->pads()[0];
+      const auto &padsVec = digi->pads();
+      if (padsVec.empty()) {
+        edm::LogError(kLogCategory_) << "Pads missing.";
+        continue;
+      }
+      Int_t pad = padsVec[0];
+      // Int_t pad = digi->pads()[0];
       // bunch crossing
       Int_t bx = digi->bx();
 

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
@@ -28,26 +28,27 @@ void GEMPadDigiClusterValidation::bookHistograms(DQMStore::IBooker& booker,
 
       const auto &superChamberVec = station->superChambers();
       if (superChamberVec.empty()) {
-        edm::LogError(kLogCategory_) << "Super chambers missing.";
+        edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
+          << " and station = " << station_id;
         continue;
       }
       const GEMSuperChamber* super_chamber = superChamberVec.front();
       if (super_chamber == nullptr) {
-        edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+        edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
+          << " and station = " << station_id;
         continue;
       }
-      // const GEMSuperChamber* super_chamber = station->superChambers().front();
       for (const auto& chamber : super_chamber->chambers()) {
         Int_t layer_id = chamber->id().layer();
         ME3IdsKey key3{region_id, station_id, layer_id};
 
         const auto &etaPartitionVec = chamber->etaPartitions();
         if (etaPartitionVec.empty() || etaPartitionVec.front() == nullptr) {
-          edm::LogError(kLogCategory_) << "Eta partition missing or null.";
+        edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = (" <<
+          region_id << ", " << station_id << ", " <<  super_chamber->id() << ", " << chamber->id() << ")";
           continue;
         }
         Int_t num_pads = etaPartitionVec.front()->npads();
-        // Int_t num_pads = chamber->etaPartitions().front()->npads();
 
         if (detail_plot_) {
           me_detail_occ_xy_[key3] = bookXYOccupancy(booker, key3, "pad", "Pad Cluster");
@@ -83,12 +84,14 @@ void GEMPadDigiClusterValidation::bookHistograms(DQMStore::IBooker& booker,
 
         const auto &superChamberVec = station->superChambers();
         if (superChamberVec.empty()) {
-          edm::LogError(kLogCategory_) << "Super chambers missing.";
+          edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
+            << " and station = " << station_id;
           continue;
         }
         const GEMSuperChamber* super_chamber = superChamberVec.front();
         if (super_chamber == nullptr) {
-          edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+          edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
+            << " and station = " << station_id;
           continue;
         }
         for (const auto& chamber : super_chamber->chambers()) {
@@ -139,11 +142,11 @@ void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::Ev
     for (auto digi = range.first; digi != range.second; ++digi) {
       const auto &padsVec = digi->pads();
       if (padsVec.empty()) {
-        edm::LogError(kLogCategory_) << "Pads missing.";
+        edm::LogError(kLogCategory_) << "Pads missing for digi from GEM ID = " << gemid;
         continue;
       }
       Int_t pad = padsVec[0];
-      // Int_t pad = digi->pads()[0];
+
       // bunch crossing
       Int_t bx = digi->bx();
 

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
@@ -28,22 +28,24 @@ void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
       const auto &superChamberVec = station->superChambers();
       if (superChamberVec.empty()) {
-        edm::LogError(kLogCategory_) << "Super chambers missing.";
+        edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
+          << " and station = " << station_id;
         continue;
       }
       const GEMSuperChamber* super_chamber = superChamberVec.front();
       if (super_chamber == nullptr) {
-        edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+        edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
+          << " and station = " << station_id;
         continue;
       }
-      // const GEMSuperChamber* super_chamber = station->superChambers().front();
       for (const auto& chamber : super_chamber->chambers()) {
         Int_t layer_id = chamber->id().layer();
         ME3IdsKey key3(region_id, station_id, layer_id);
 
         const auto &etaPartitionVec = chamber->etaPartitions();
         if (etaPartitionVec.empty() || etaPartitionVec.front() == nullptr) {
-          edm::LogError(kLogCategory_) << "Eta partition missing or null.";
+          edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = (" <<
+            region_id << ", " << station_id << ", " <<  super_chamber->id() << ", " << chamber->id() << ")";
           continue;
         }
         Int_t num_pads = etaPartitionVec.front()->npads();
@@ -82,12 +84,14 @@ void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
         const auto &superChamberVec = station->superChambers();
         if (superChamberVec.empty()) {
-          edm::LogError(kLogCategory_) << "Super chambers missing.";
+          edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
+            << " and station = " << station_id;
           continue;
         }
         const GEMSuperChamber* super_chamber = superChamberVec.front();
         if (super_chamber == nullptr) {
-          edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+          edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
+            << " and station = " << station_id;
           continue;
         }
         for (const auto& chamber : super_chamber->chambers()) {

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
@@ -26,26 +26,27 @@ void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
       me_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "pad", "Pad");
 
-      const auto &superChamberVec = station->superChambers();
+      const auto& superChamberVec = station->superChambers();
       if (superChamberVec.empty()) {
         edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
-          << " and station = " << station_id;
+                                     << " and station = " << station_id;
         continue;
       }
       const GEMSuperChamber* super_chamber = superChamberVec.front();
       if (super_chamber == nullptr) {
         edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
-          << " and station = " << station_id;
+                                     << " and station = " << station_id;
         continue;
       }
       for (const auto& chamber : super_chamber->chambers()) {
         Int_t layer_id = chamber->id().layer();
         ME3IdsKey key3(region_id, station_id, layer_id);
 
-        const auto &etaPartitionVec = chamber->etaPartitions();
+        const auto& etaPartitionVec = chamber->etaPartitions();
         if (etaPartitionVec.empty() || etaPartitionVec.front() == nullptr) {
-          edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = (" <<
-            region_id << ", " << station_id << ", " <<  super_chamber->id() << ", " << chamber->id() << ")";
+          edm::LogError(kLogCategory_)
+              << "Eta partition missing or null for region, station, super chamber, chamber = (" << region_id << ", "
+              << station_id << ", " << super_chamber->id() << ", " << chamber->id() << ")";
           continue;
         }
         Int_t num_pads = etaPartitionVec.front()->npads();
@@ -82,16 +83,16 @@ void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (superChamberVec.empty()) {
           edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
           continue;
         }
         const GEMSuperChamber* super_chamber = superChamberVec.front();
         if (super_chamber == nullptr) {
           edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
           continue;
         }
         for (const auto& chamber : super_chamber->chambers()) {

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
@@ -26,12 +26,27 @@ void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
       me_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "pad", "Pad");
 
-      const GEMSuperChamber* super_chamber = station->superChambers().front();
+      const auto &superChamberVec = station->superChambers();
+      if (superChamberVec.empty()) {
+        edm::LogError(kLogCategory_) << "Super chambers missing.";
+        continue;
+      }
+      const GEMSuperChamber* super_chamber = superChamberVec.front();
+      if (super_chamber == nullptr) {
+        edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+        continue;
+      }
+      // const GEMSuperChamber* super_chamber = station->superChambers().front();
       for (const auto& chamber : super_chamber->chambers()) {
         Int_t layer_id = chamber->id().layer();
         ME3IdsKey key3(region_id, station_id, layer_id);
 
-        Int_t num_pads = chamber->etaPartitions().front()->npads();
+        const auto &etaPartitionVec = chamber->etaPartitions();
+        if (etaPartitionVec.empty() || etaPartitionVec.front() == nullptr) {
+          edm::LogError(kLogCategory_) << "Eta partition missing or null.";
+          continue;
+        }
+        Int_t num_pads = etaPartitionVec.front()->npads();
 
         if (detail_plot_) {
           me_detail_occ_xy_[key3] = bookXYOccupancy(booker, key3, "pad", "Pad");
@@ -65,7 +80,16 @@ void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        const GEMSuperChamber* super_chamber = station->superChambers().front();
+        const auto &superChamberVec = station->superChambers();
+        if (superChamberVec.empty()) {
+          edm::LogError(kLogCategory_) << "Super chambers missing.";
+          continue;
+        }
+        const GEMSuperChamber* super_chamber = superChamberVec.front();
+        if (super_chamber == nullptr) {
+          edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+          continue;
+        }
         for (const auto& chamber : super_chamber->chambers()) {
           Int_t layer_id = chamber->id().layer();
           ME3IdsKey key3(region_id, station_id, layer_id);

--- a/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.cc
@@ -15,7 +15,6 @@ GEMStripDigiValidation::GEMStripDigiValidation(const edm::ParameterSet& pset)
 void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
                                             edm::Run const& run,
                                             edm::EventSetup const& setup) {
-  edm::LogError(kLogCategory_) << "About to init geom";
   const GEMGeometry* gem = initGeometry(setup);
   if (gem == nullptr) {
     edm::LogError(kLogCategory_) << "Failed to initialize GEM geometry.";
@@ -27,7 +26,6 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
   me_bx_ = booker.book1D("strip_bx", "Strip Digi Bunch Crossing", 5, -2.5, 2.5);
 
-  edm::LogError(kLogCategory_) << "before detail plot";
   if (detail_plot_) {
     for (const auto& region : gem->regions()) {
       if (region == nullptr) {
@@ -37,20 +35,21 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
       Int_t region_id = region->region();
       for (const auto& station : region->stations()) {
         if (station == nullptr) {
-          edm::LogError(kLogCategory_) << "Null region";
+          edm::LogError(kLogCategory_) << "Null station for region = " << region_id;
           continue;
         }
         Int_t station_id = station->station();
 
         const auto &superChamberVec = station->superChambers();
         if (superChamberVec.empty()) {
-          edm::LogError(kLogCategory_) << "Super chambers missing.";
+          edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
+            << " and station = " << station_id;
           continue;
         }
         const GEMSuperChamber* super_chamber = superChamberVec.front();
-        // const GEMSuperChamber* super_chamber = station->superChambers().front();
         if (super_chamber == nullptr) {
-          edm::LogError(kLogCategory_) << "Failed to find super chamber.";
+          edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
+            << " and station = " << station_id;
           continue;
         }
         for (const auto& chamber : super_chamber->chambers()) {
@@ -59,7 +58,7 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
           me_detail_bx_[key3] =
               bookHist1D(booker, key3, "strip_bx", "Strip Digi Bunch Crossing", 5, -2.5, 2.5, "Bunch crossing");
-        }// chamber loop
+        }  // chamber loop
       }    // station loop
     }      // region loop
   }        // detail plot
@@ -67,7 +66,6 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
   // NOTE Occupancy
   booker.setCurrentFolder("MuonGEMDigisV/GEMDigisTask/Strip/Occupancy");
 
-  edm::LogError(kLogCategory_) << "before regions ";
   for (const auto& region : gem->regions()) {
     Int_t region_id = region->region();
 
@@ -91,16 +89,11 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
                                               eta_range_[0],
                                               eta_range_[1],
                                               "|#eta|");
-
-    edm::LogError(kLogCategory_) << "before stations ";
     for (const auto& station : region->stations()) {
       Int_t station_id = station->station();
       ME2IdsKey key2{region_id, station_id};
-      edm::LogError(kLogCategory_) << "region ID = " << region_id << ", station ID = " << station_id;
 
-      edm::LogError(kLogCategory_) << "before book detector occupancy for strip";
       me_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "strip", "Strip Digi");
-      edm::LogError(kLogCategory_) << "after book detector occupancy for strip";
 
       me_simhit_occ_phi_[key2] =
           bookHist1D(booker, key2, "muon_simhit_occ_phi", "Muon SimHit Phi Occupancy", 51, -M_PI, M_PI, "#phi");
@@ -114,35 +107,29 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
       const auto &superChamberVec = station->superChambers();
       if (superChamberVec.empty() || superChamberVec[0] == nullptr) {
-        edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+        edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
+          << " and station = " << station_id;
       } else {
-        edm::LogError(kLogCategory_) << "before super chambers ";
-        // for (const auto& chamber : station->superChambers()[0]->chambers()) 
         for (const auto& chamber : superChamberVec[0]->chambers()) {
           if (chamber == nullptr) {
-            edm::LogError(kLogCategory_) << "Null chamber";
+            edm::LogError(kLogCategory_) << "Null chamber for region, station, super chamber = (" <<
+              region_id << ", " << station_id << ", " <<  superChamberVec[0]->id() << ")";
             continue;
           }
-          edm::LogError(kLogCategory_) << "got a chamber";
           Int_t layer_id = chamber->id().layer();
           ME3IdsKey key3{region_id, station_id, layer_id};
-          edm::LogError(kLogCategory_) << "region ID = " << region_id << ", station ID = " << station_id << ", layer ID = " << layer_id;
 
           if (detail_plot_) {
-            edm::LogError(kLogCategory_) << "before eta partitions ";
             const auto &etaPartitionsVec = chamber->etaPartitions();
             if (etaPartitionsVec.empty() || etaPartitionsVec.front() == nullptr) {
-              edm::LogError(kLogCategory_) << "Eta partitions missing.";
+              edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = (" <<
+                region_id << ", " << station_id << ", " <<  superChamberVec[0]->id() << ", " << chamber->id() << ")";
               continue;
             }
             Int_t num_strips = etaPartitionsVec.front()->nstrips();
-            // Int_t num_strips = chamber->etaPartitions().front()->nstrips();
-            edm::LogError(kLogCategory_) << "num strips = " << num_strips;
 
-            edm::LogError(kLogCategory_) << "before book XYOcc";
             me_detail_occ_xy_[key3] = bookXYOccupancy(booker, key3, "strip", "Strip Digi");
 
-            edm::LogError(kLogCategory_) << "before book hist1d";
             me_detail_occ_strip_[key3] = bookHist1D(booker,
                                                     key3,
                                                     "strip_occ_strip",
@@ -152,7 +139,6 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
                                                     num_strips + 0.5,
                                                     "strip number");
 
-            edm::LogError(kLogCategory_) << "before book hist2d";
             me_detail_occ_phi_strip_[key3] = bookHist2D(booker,
                                                         key3,
                                                         "strip_occ_phi_strip",
@@ -165,7 +151,6 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
                                                         num_strips,
                                                         "#phi [rad]",
                                                         "strip number");
-            edm::LogError(kLogCategory_) << "after book hist2d";
           }  // detail plot
         }   // chamber
       }    // end else

--- a/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.cc
@@ -40,16 +40,16 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
         }
         Int_t station_id = station->station();
 
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (superChamberVec.empty()) {
           edm::LogError(kLogCategory_) << "Super chambers missing for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
           continue;
         }
         const GEMSuperChamber* super_chamber = superChamberVec.front();
         if (super_chamber == nullptr) {
           edm::LogError(kLogCategory_) << "Failed to find super chamber for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
           continue;
         }
         for (const auto& chamber : super_chamber->chambers()) {
@@ -105,25 +105,26 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 
       me_strip_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "matched_strip", "Matched Strip Digi");
 
-      const auto &superChamberVec = station->superChambers();
+      const auto& superChamberVec = station->superChambers();
       if (superChamberVec.empty() || superChamberVec[0] == nullptr) {
         edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
-          << " and station = " << station_id;
+                                     << " and station = " << station_id;
       } else {
         for (const auto& chamber : superChamberVec[0]->chambers()) {
           if (chamber == nullptr) {
-            edm::LogError(kLogCategory_) << "Null chamber for region, station, super chamber = (" <<
-              region_id << ", " << station_id << ", " <<  superChamberVec[0]->id() << ")";
+            edm::LogError(kLogCategory_) << "Null chamber for region, station, super chamber = (" << region_id << ", "
+                                         << station_id << ", " << superChamberVec[0]->id() << ")";
             continue;
           }
           Int_t layer_id = chamber->id().layer();
           ME3IdsKey key3{region_id, station_id, layer_id};
 
           if (detail_plot_) {
-            const auto &etaPartitionsVec = chamber->etaPartitions();
+            const auto& etaPartitionsVec = chamber->etaPartitions();
             if (etaPartitionsVec.empty() || etaPartitionsVec.front() == nullptr) {
-              edm::LogError(kLogCategory_) << "Eta partition missing or null for region, station, super chamber, chamber = (" <<
-                region_id << ", " << station_id << ", " <<  superChamberVec[0]->id() << ", " << chamber->id() << ")";
+              edm::LogError(kLogCategory_)
+                  << "Eta partition missing or null for region, station, super chamber, chamber = (" << region_id
+                  << ", " << station_id << ", " << superChamberVec[0]->id() << ", " << chamber->id() << ")";
               continue;
             }
             Int_t num_strips = etaPartitionsVec.front()->nstrips();
@@ -152,10 +153,10 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
                                                         "#phi [rad]",
                                                         "strip number");
           }  // detail plot
-        }   // chamber
-      }    // end else
-    }      // station looop
-  }        // region loop
+        }    // chamber
+      }      // end else
+    }        // station looop
+  }          // region loop
 }
 
 GEMStripDigiValidation::~GEMStripDigiValidation() {}

--- a/Validation/MuonGEMHits/interface/GEMBaseValidation.h
+++ b/Validation/MuonGEMHits/interface/GEMBaseValidation.h
@@ -182,7 +182,7 @@ dqm::impl::MonitorElement* GEMBaseValidation::bookDetectorOccupancy(DQMStore::IB
   Int_t nbinsx = num_superchambers * num_chambers;
 
   if (nbinsx <= 0)
-    nbinsx = 20; // Ensure histogram is not zero size
+    nbinsx = 20;  // Ensure histogram is not zero size
   if (nbinsy <= 0)
     nbinsy = 20;
   auto hist = new TH2F(name, title, nbinsx, 1 - 0.5, nbinsx + 0.5, nbinsy, 1 - 0.5, nbinsy + 0.5);

--- a/Validation/MuonGEMHits/interface/GEMBaseValidation.h
+++ b/Validation/MuonGEMHits/interface/GEMBaseValidation.h
@@ -172,11 +172,19 @@ dqm::impl::MonitorElement* GEMBaseValidation::bookDetectorOccupancy(DQMStore::IB
   std::vector<const GEMSuperChamber*> superchambers = station->superChambers();
 
   Int_t num_superchambers = superchambers.size();
-  Int_t num_chambers = superchambers.front()->nChambers();
-
+  Int_t num_chambers = 0;
+  Int_t nbinsy = 0;
+  if (num_superchambers > 0) {
+    num_chambers = superchambers.front()->nChambers();
+    if (num_chambers > 0)
+      nbinsy = superchambers.front()->chambers().front()->nEtaPartitions();
+  }
   Int_t nbinsx = num_superchambers * num_chambers;
-  Int_t nbinsy = superchambers.front()->chambers().front()->nEtaPartitions();
 
+  if (nbinsx <= 0)
+    nbinsx = 20; // Ensure histogram is not zero size
+  if (nbinsy <= 0)
+    nbinsy = 20;
   auto hist = new TH2F(name, title, nbinsx, 1 - 0.5, nbinsx + 0.5, nbinsy, 1 - 0.5, nbinsy + 0.5);
   hist->GetXaxis()->SetTitle("Chamber-Layer");
   hist->GetYaxis()->SetTitle("Eta Partition");

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -28,7 +28,6 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
     return;
   } else {
     for (const auto& station : regionsVec[0]->stations()) {
-      // for (const auto& station : gem->regions()[0]->stations())
       Int_t station_id = station->station();
       const auto [tof_min, tof_max] = getTOFRange(station_id);
       auto tof_name = TString::Format("tof_muon_st%d", station_id);

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -22,21 +22,21 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
   TString tof_xtitle = "Time of flight [ns]";
   TString tof_ytitle = "Entries";
 
-  const auto &regionsVec = gem->regions();
+  const auto& regionsVec = gem->regions();
   if (regionsVec.empty() || regionsVec[0] == nullptr) {
     edm::LogError(kLogCategory_) << "Regions missing or null.";
     return;
   } else {
     for (const auto& station : regionsVec[0]->stations()) {
-    // for (const auto& station : gem->regions()[0]->stations()) 
+      // for (const auto& station : gem->regions()[0]->stations())
       Int_t station_id = station->station();
       const auto [tof_min, tof_max] = getTOFRange(station_id);
       auto tof_name = TString::Format("tof_muon_st%d", station_id);
       auto tof_title = TString::Format("SimHit Time Of Flight (Muon only) : Station %d", station_id);
 
       me_tof_mu_[station_id] = booker.book1D(tof_name, tof_title, 40, tof_min, tof_max);
-    } // end for
-  }   // end else
+    }  // end for
+  }    // end else
 
   if (detail_plot_) {
     for (const auto& region : gem->regions()) {
@@ -46,10 +46,10 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
         Int_t station_id = station->station();
 
         const auto [tof_min, tof_max] = getTOFRange(station_id);
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
           edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
         } else {
           const GEMSuperChamber* super_chamber = superChamberVec.front();
 
@@ -63,10 +63,10 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
             me_detail_tof_mu_[key3] = bookHist1D(
                 booker, key3, "tof_muon", "SimHit TOF (Muon only)", 40, tof_min, tof_max, tof_xtitle, tof_ytitle);
           }  // chamber loop
-        }   // end else
-      }    // station loop
-    }      // region loop
-  }        // detail plot
+        }    // end else
+      }      // station loop
+    }        // region loop
+  }          // detail plot
 
   // NOTE Energy Loss
   booker.setCurrentFolder("MuonGEMHitsV/GEMHitsTask/EnergyLoss");
@@ -89,10 +89,10 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       Int_t region_id = region->region();
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
           edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
         } else {
           for (const auto& chamber : superChamberVec.front()->chambers()) {
             Int_t layer_id = chamber->id().layer();
@@ -101,14 +101,21 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
             me_detail_eloss_[key3] =
                 bookHist1D(booker, key3, "eloss", "SimHit Energy Loss", 60, 0.0, 6000.0, eloss_xtitle, eloss_ytitle);
 
-            me_detail_eloss_mu_[key3] = bookHist1D(
-                booker, key3, "eloss_muon", "SimHit Energy Loss (Muon Only)", 60, 0.0, 6000.0, eloss_xtitle, eloss_ytitle);
+            me_detail_eloss_mu_[key3] = bookHist1D(booker,
+                                                   key3,
+                                                   "eloss_muon",
+                                                   "SimHit Energy Loss (Muon Only)",
+                                                   60,
+                                                   0.0,
+                                                   6000.0,
+                                                   eloss_xtitle,
+                                                   eloss_ytitle);
 
           }  // chamber loop
-        }   // end else
-      }    // station loop
-    }      // region loop
-  }        // detail plot
+        }    // end else
+      }      // station loop
+    }        // region loop
+  }          // detail plot
 
   // NOTE Occupancy
   booker.setCurrentFolder("MuonGEMHitsV/GEMHitsTask/Occupancy");
@@ -124,10 +131,10 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
 
       me_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "simhit", "SimHit");
 
-      const auto &superChamberVec = station->superChambers();
+      const auto& superChamberVec = station->superChambers();
       if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
         edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
-          << " and station = " << station_id;
+                                     << " and station = " << station_id;
       } else {
         const GEMSuperChamber* super_chamber = superChamberVec.front();
         for (const auto& chamber : super_chamber->chambers()) {
@@ -136,9 +143,9 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
 
           me_occ_xy_[key3] = bookXYOccupancy(booker, key3, "simhit", "SimHit");
         }  // layer loop
-      }   // end else
-    }    // station loop
-  }      // region loop
+      }    // end else
+    }      // station loop
+  }        // region loop
 }
 
 std::tuple<Double_t, Double_t> GEMSimHitValidation::getTOFRange(Int_t station_id) {

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -48,7 +48,8 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
         const auto [tof_min, tof_max] = getTOFRange(station_id);
         const auto &superChamberVec = station->superChambers();
         if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
-          edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+          edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
+            << " and station = " << station_id;
         } else {
           const GEMSuperChamber* super_chamber = superChamberVec.front();
 
@@ -90,7 +91,8 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
         Int_t station_id = station->station();
         const auto &superChamberVec = station->superChambers();
         if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
-          edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+          edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
+            << " and station = " << station_id;
         } else {
           for (const auto& chamber : superChamberVec.front()->chambers()) {
             Int_t layer_id = chamber->id().layer();
@@ -124,7 +126,8 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
 
       const auto &superChamberVec = station->superChambers();
       if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
-        edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+        edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
+          << " and station = " << station_id;
       } else {
         const GEMSuperChamber* super_chamber = superChamberVec.front();
         for (const auto& chamber : super_chamber->chambers()) {

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -22,14 +22,21 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
   TString tof_xtitle = "Time of flight [ns]";
   TString tof_ytitle = "Entries";
 
-  for (const auto& station : gem->regions()[0]->stations()) {
-    Int_t station_id = station->station();
-    const auto [tof_min, tof_max] = getTOFRange(station_id);
-    auto tof_name = TString::Format("tof_muon_st%d", station_id);
-    auto tof_title = TString::Format("SimHit Time Of Flight (Muon only) : Station %d", station_id);
+  const auto &regionsVec = gem->regions();
+  if (regionsVec.empty() || regionsVec[0] == nullptr) {
+    edm::LogError(kLogCategory_) << "Regions missing or null.";
+    return;
+  } else {
+    for (const auto& station : regionsVec[0]->stations()) {
+    // for (const auto& station : gem->regions()[0]->stations()) 
+      Int_t station_id = station->station();
+      const auto [tof_min, tof_max] = getTOFRange(station_id);
+      auto tof_name = TString::Format("tof_muon_st%d", station_id);
+      auto tof_title = TString::Format("SimHit Time Of Flight (Muon only) : Station %d", station_id);
 
-    me_tof_mu_[station_id] = booker.book1D(tof_name, tof_title, 40, tof_min, tof_max);
-  }
+      me_tof_mu_[station_id] = booker.book1D(tof_name, tof_title, 40, tof_min, tof_max);
+    } // end for
+  }   // end else
 
   if (detail_plot_) {
     for (const auto& region : gem->regions()) {
@@ -39,19 +46,23 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
         Int_t station_id = station->station();
 
         const auto [tof_min, tof_max] = getTOFRange(station_id);
-        const GEMSuperChamber* super_chamber = station->superChambers().front();
+        const auto &superChamberVec = station->superChambers();
+        if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
+          edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+        } else {
+          const GEMSuperChamber* super_chamber = superChamberVec.front();
 
-        for (const auto& chamber : super_chamber->chambers()) {
-          Int_t layer_id = chamber->id().layer();
-          ME3IdsKey key3{region_id, station_id, layer_id};
+          for (const auto& chamber : super_chamber->chambers()) {
+            Int_t layer_id = chamber->id().layer();
+            ME3IdsKey key3{region_id, station_id, layer_id};
 
-          me_detail_tof_[key3] = bookHist1D(
-              booker, key3, "tof", "Time of Flight of Muon SimHits", 40, tof_min, tof_max, tof_xtitle, tof_ytitle);
+            me_detail_tof_[key3] = bookHist1D(
+                booker, key3, "tof", "Time of Flight of Muon SimHits", 40, tof_min, tof_max, tof_xtitle, tof_ytitle);
 
-          me_detail_tof_mu_[key3] = bookHist1D(
-              booker, key3, "tof_muon", "SimHit TOF (Muon only)", 40, tof_min, tof_max, tof_xtitle, tof_ytitle);
-
-        }  // chamber loop
+            me_detail_tof_mu_[key3] = bookHist1D(
+                booker, key3, "tof_muon", "SimHit TOF (Muon only)", 40, tof_min, tof_max, tof_xtitle, tof_ytitle);
+          }  // chamber loop
+        }   // end else
       }    // station loop
     }      // region loop
   }        // detail plot
@@ -77,17 +88,22 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       Int_t region_id = region->region();
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
-        for (const auto& chamber : station->superChambers()[0]->chambers()) {
-          Int_t layer_id = chamber->id().layer();
-          ME3IdsKey key3{region_id, station_id, layer_id};
+        const auto &superChamberVec = station->superChambers();
+        if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
+          edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+        } else {
+          for (const auto& chamber : superChamberVec.front()->chambers()) {
+            Int_t layer_id = chamber->id().layer();
+            ME3IdsKey key3{region_id, station_id, layer_id};
 
-          me_detail_eloss_[key3] =
-              bookHist1D(booker, key3, "eloss", "SimHit Energy Loss", 60, 0.0, 6000.0, eloss_xtitle, eloss_ytitle);
+            me_detail_eloss_[key3] =
+                bookHist1D(booker, key3, "eloss", "SimHit Energy Loss", 60, 0.0, 6000.0, eloss_xtitle, eloss_ytitle);
 
-          me_detail_eloss_mu_[key3] = bookHist1D(
-              booker, key3, "eloss_muon", "SimHit Energy Loss (Muon Only)", 60, 0.0, 6000.0, eloss_xtitle, eloss_ytitle);
+            me_detail_eloss_mu_[key3] = bookHist1D(
+                booker, key3, "eloss_muon", "SimHit Energy Loss (Muon Only)", 60, 0.0, 6000.0, eloss_xtitle, eloss_ytitle);
 
-        }  // chamber loop
+          }  // chamber loop
+        }   // end else
       }    // station loop
     }      // region loop
   }        // detail plot
@@ -106,17 +122,20 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
 
       me_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "simhit", "SimHit");
 
-      const GEMSuperChamber* super_chamber = station->superChambers().front();
-      for (const auto& chamber : super_chamber->chambers()) {
-        Int_t layer_id = chamber->id().layer();
-        ME3IdsKey key3{region_id, station_id, layer_id};
+      const auto &superChamberVec = station->superChambers();
+      if (superChamberVec.empty() || superChamberVec.front() == nullptr) {
+        edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+      } else {
+        const GEMSuperChamber* super_chamber = superChamberVec.front();
+        for (const auto& chamber : super_chamber->chambers()) {
+          Int_t layer_id = chamber->id().layer();
+          ME3IdsKey key3{region_id, station_id, layer_id};
 
-        me_occ_xy_[key3] = bookXYOccupancy(booker, key3, "simhit", "SimHit");
-      }  // layer loop
+          me_occ_xy_[key3] = bookXYOccupancy(booker, key3, "simhit", "SimHit");
+        }  // layer loop
+      }   // end else
     }    // station loop
   }      // region loop
-
-  return;
 }
 
 std::tuple<Double_t, Double_t> GEMSimHitValidation::getTOFRange(Int_t station_id) {

--- a/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
+++ b/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
@@ -34,10 +34,10 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (superChamberVec.empty() || superChamberVec[0] == nullptr) {
           edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
-            << " and station = " << station_id;
+                                       << " and station = " << station_id;
         } else {
           for (const auto& chamber : superChamberVec[0]->chambers()) {
             Int_t layer_id = chamber->id().layer();
@@ -45,10 +45,10 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
 
             me_detail_cls_[key3] = bookHist1D(booker, key3, "cls", cls_title, 11, -0.5, 10.5, cls_x_title);
           }  // chamber loop
-        }  // end else
-      }    // station loop
-    }      // region loop
-  }        // detail plot
+        }    // end else
+      }      // station loop
+    }        // region loop
+  }          // detail plot
 
   // NOTE Residual
   booker.setCurrentFolder("MuonGEMRecHitsV/GEMRecHitsTask/Residual");
@@ -66,7 +66,7 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (!superChamberVec.empty() && superChamberVec[0] != nullptr) {
           for (const auto& chamber : superChamberVec[0]->chambers()) {
             Int_t layer_id = chamber->id().layer();
@@ -80,10 +80,10 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
                 bookHist1D(booker, key3, "residual_y", "Residual in Y", 600, -15, 15, "Residual in Y [cm]");
 
           }  // chamber loop
-        }  // end if
-      }    // station loop
-    }      // detail_plot
-  }        // region loop
+        }    // end if
+      }      // station loop
+    }        // detail_plot
+  }          // region loop
 
   // NOTE Pull
   booker.setCurrentFolder("MuonGEMRecHitsV/GEMRecHitsTask/Pull");
@@ -99,7 +99,7 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (!superChamberVec.empty() && superChamberVec[0] != nullptr) {
           for (const auto& chamber : superChamberVec[0]->chambers()) {
             Int_t layer_id = chamber->id().layer();
@@ -110,10 +110,10 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
             me_detail_pull_y_[key3] = bookHist1D(booker, key3, "pull_y", "Pull in Y", 100, -3, 3);
 
           }  // chamber loop
-        }  // end if
-      }    // station loop
-    }      // detail plot
-  }        // region loop
+        }    // end if
+      }      // station loop
+    }        // detail plot
+  }          // region loop
 
   // NOTE Occupancy
   booker.setCurrentFolder("MuonGEMRecHitsV/GEMRecHitsTask/Occupancy");
@@ -155,7 +155,7 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       me_rechit_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "matched_rechit", "Matched RecHit");
 
       if (detail_plot_) {
-        const auto &superChamberVec = station->superChambers();
+        const auto& superChamberVec = station->superChambers();
         if (!superChamberVec.empty() && superChamberVec[0] != nullptr) {
           for (const auto& chamber : superChamberVec[0]->chambers()) {
             Int_t layer_id = chamber->id().layer();
@@ -166,10 +166,10 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
             me_detail_occ_polar_[key3] = bookPolarOccupancy(booker, key3, "rechit", "RecHit");
 
           }  // chamber loop
-        }  // end if
-      }    // detail plot
-    }      // station loop
-  }        // region_loop
+        }    // end if
+      }      // detail plot
+    }        // station loop
+  }          // region_loop
 }
 
 Bool_t GEMRecHitValidation::matchRecHitAgainstSimHit(GEMRecHitCollection::const_iterator rechit, Int_t simhit_strip) {

--- a/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
+++ b/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
@@ -36,9 +36,9 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
 
         const auto &superChamberVec = station->superChambers();
         if (superChamberVec.empty() || superChamberVec[0] == nullptr) {
-          edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+          edm::LogError(kLogCategory_) << "Super chambers missing or null for region = " << region_id
+            << " and station = " << station_id;
         } else {
-          // for (const auto& chamber : station->superChambers()[0]->chambers()) 
           for (const auto& chamber : superChamberVec[0]->chambers()) {
             Int_t layer_id = chamber->id().layer();
             ME3IdsKey key3{region_id, station_id, layer_id};

--- a/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
+++ b/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
@@ -34,13 +34,18 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        for (const auto& chamber : station->superChambers()[0]->chambers()) {
-          Int_t layer_id = chamber->id().layer();
-          ME3IdsKey key3{region_id, station_id, layer_id};
+        const auto &superChamberVec = station->superChambers();
+        if (superChamberVec.empty() || superChamberVec[0] == nullptr) {
+          edm::LogError(kLogCategory_) << "Super chambers missing or null.";
+        } else {
+          // for (const auto& chamber : station->superChambers()[0]->chambers()) 
+          for (const auto& chamber : superChamberVec[0]->chambers()) {
+            Int_t layer_id = chamber->id().layer();
+            ME3IdsKey key3{region_id, station_id, layer_id};
 
-          me_detail_cls_[key3] = bookHist1D(booker, key3, "cls", cls_title, 11, -0.5, 10.5, cls_x_title);
-
-        }  // chamber loop
+            me_detail_cls_[key3] = bookHist1D(booker, key3, "cls", cls_title, 11, -0.5, 10.5, cls_x_title);
+          }  // chamber loop
+        }  // end else
       }    // station loop
     }      // region loop
   }        // detail plot
@@ -61,18 +66,21 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        for (const auto& chamber : station->superChambers()[0]->chambers()) {
-          Int_t layer_id = chamber->id().layer();
-          ME3IdsKey key3{region_id, station_id, layer_id};
+        const auto &superChamberVec = station->superChambers();
+        if (!superChamberVec.empty() && superChamberVec[0] != nullptr) {
+          for (const auto& chamber : superChamberVec[0]->chambers()) {
+            Int_t layer_id = chamber->id().layer();
+            ME3IdsKey key3{region_id, station_id, layer_id};
 
-          // Occupancy histograms of SimHits and RecHits for Efficiency
-          me_detail_residual_x_[key3] =
-              bookHist1D(booker, key3, "residual_x", "Residual in X", 120, -3, 3, "Residual in X [cm]");
+            // Occupancy histograms of SimHits and RecHits for Efficiency
+            me_detail_residual_x_[key3] =
+                bookHist1D(booker, key3, "residual_x", "Residual in X", 120, -3, 3, "Residual in X [cm]");
 
-          me_detail_residual_y_[key3] =
-              bookHist1D(booker, key3, "residual_y", "Residual in Y", 600, -15, 15, "Residual in Y [cm]");
+            me_detail_residual_y_[key3] =
+                bookHist1D(booker, key3, "residual_y", "Residual in Y", 600, -15, 15, "Residual in Y [cm]");
 
-        }  // chamber loop
+          }  // chamber loop
+        }  // end if
       }    // station loop
     }      // detail_plot
   }        // region loop
@@ -91,15 +99,18 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       for (const auto& station : region->stations()) {
         Int_t station_id = station->station();
 
-        for (const auto& chamber : station->superChambers()[0]->chambers()) {
-          Int_t layer_id = chamber->id().layer();
-          ME3IdsKey key3{region_id, station_id, layer_id};
+        const auto &superChamberVec = station->superChambers();
+        if (!superChamberVec.empty() && superChamberVec[0] != nullptr) {
+          for (const auto& chamber : superChamberVec[0]->chambers()) {
+            Int_t layer_id = chamber->id().layer();
+            ME3IdsKey key3{region_id, station_id, layer_id};
 
-          me_detail_pull_x_[key3] = bookHist1D(booker, key3, "pull_x", "Pull in X", 100, -3, 3);
+            me_detail_pull_x_[key3] = bookHist1D(booker, key3, "pull_x", "Pull in X", 100, -3, 3);
 
-          me_detail_pull_y_[key3] = bookHist1D(booker, key3, "pull_y", "Pull in Y", 100, -3, 3);
+            me_detail_pull_y_[key3] = bookHist1D(booker, key3, "pull_y", "Pull in Y", 100, -3, 3);
 
-        }  // chamber loop
+          }  // chamber loop
+        }  // end if
       }    // station loop
     }      // detail plot
   }        // region loop
@@ -144,15 +155,18 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       me_rechit_occ_det_[key2] = bookDetectorOccupancy(booker, key2, station, "matched_rechit", "Matched RecHit");
 
       if (detail_plot_) {
-        for (const auto& chamber : station->superChambers()[0]->chambers()) {
-          Int_t layer_id = chamber->id().layer();
-          ME3IdsKey key3{region_id, station_id, layer_id};
+        const auto &superChamberVec = station->superChambers();
+        if (!superChamberVec.empty() && superChamberVec[0] != nullptr) {
+          for (const auto& chamber : superChamberVec[0]->chambers()) {
+            Int_t layer_id = chamber->id().layer();
+            ME3IdsKey key3{region_id, station_id, layer_id};
 
-          me_detail_occ_xy_[key3] = bookXYOccupancy(booker, key3, "rechit", "RecHit");
+            me_detail_occ_xy_[key3] = bookXYOccupancy(booker, key3, "rechit", "RecHit");
 
-          me_detail_occ_polar_[key3] = bookPolarOccupancy(booker, key3, "rechit", "RecHit");
+            me_detail_occ_polar_[key3] = bookPolarOccupancy(booker, key3, "rechit", "RecHit");
 
-        }  // chamber loop
+          }  // chamber loop
+        }  // end if
       }    // detail plot
     }      // station loop
   }        // region_loop


### PR DESCRIPTION
When reco for the Extended2021 scenario was run with geometry from XML instead of the DB, it was crashing due to missing GEM super chambers. The validation code was referencing GEM super chambers even if they didn't exist, thus causing the crash.

This bug fix adds protection in the validation code to make sure that null or empty objects are not dereferenced.

The issue of the missing GEM super chambers requires further investigation. This PR is just a first step that allows reco to run to completion without crashing. The next step is to examine the plots derived from reco to try to understand what is missing from the GEMs.

#### PR validation:

The 11634.0_TTbar_14TeV+TTbar_14TeV_TuneCP5_2021 reco step was tested using XML geometry and a second time with DB geometry, and it ran successfully.

No backport is needed.