### PR TITLE
DQM: Use correct local MEs in DQMEDAnalyzer

### DIFF
--- a/DQMServices/Core/interface/DQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMEDAnalyzer.h
@@ -78,8 +78,8 @@ public:
     // if we run booking multiple times because there are multiple runs in a
     // job, this is needed to make sure all existing MEs are in a valid state
     // before the booking code runs.
-    edm::Service<DQMStore>()->initLumi(run.run(), /* lumi */ 0, this->moduleDescription().id());
-    edm::Service<DQMStore>()->enterLumi(run.run(), /* lumi */ 0, this->moduleDescription().id());
+    edm::Service<DQMStore>()->initLumi(run.run(), /* lumi */ 0, meId());
+    edm::Service<DQMStore>()->enterLumi(run.run(), /* lumi */ 0, meId());
     dqmBeginRun(run, setup);
     edm::Service<DQMStore>()->bookTransaction(
         [this, &run, &setup](DQMStore::IBooker& booker) {


### PR DESCRIPTION
#### PR description:

This is an attempt to fix #29743.

I added these calls as a precaution (there might be cases where user can can see invalid MEs otherwise) and got the code from `DQMOneEDAnalyzer`. Except `DQMEDAnalyzer` needs a different definition of moduleid... And screwing that up could lead to a thread safety problem like observed, since now we get enter/init lumi on different threads for the same MEs, and depending on the interleaving the set of MEs might have changed between initLumi and enterLumi, leading to the assertion failure.

This is a theory only though.

#### PR validation:

None, so far.

I can't reproduce the issue in #29743, so I can't tell if this fixes the issue. But it is very obviously a bug, and fixing it should not hurt.