### PR TITLE
Update eventcontent structure for RecoHiJets

### DIFF
--- a/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
+++ b/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
@@ -1,45 +1,37 @@
 import FWCore.ParameterSet.Config as cms
 
-#Full Event content ---- temporary
-RecoHiJetsRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring( 'keep *_akPu3CaloJets_*_*',
-                                            'keep *_akPu4CaloJets_*_*', 
-                                            'keep *_akPu5CaloJets_*_*', 
-                                            'keep *_iterativeConePu5CaloJets_*_*', 
-                                            'keep *_akPu3PFJets_*_*',
-                                            'keep *_akPu4PFJets_*_*',
-                                            'keep *_akPu5PFJets_*_*',
-                                            'keep *_akCs3PFJets_*_*',
-                                            'keep *_akCs4PFJets_*_*',
-                                            'keep *_kt4PFJetsForRho_*_*',
-                                            'keep *_*HiGenJets_*_*',
-                                            'keep *_PFTowers_*_*',
-                                            'keep *_hiFJRhoProducer_*_*'
-
-                                           )
-    )
-
-RecoHiJetsFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_*CaloJets_*_*',
-                                           'keep *_*PFJets_*_*',
-                                           'keep *_*HiGenJets_*_*',
-                                           'keep *_*PFTowers_*_*',
-                                           'keep *_*hiFJRhoProducer_*_*'
-                                           )
-    )
-
+# AOD content
 RecoHiJetsAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_*CaloJets_*_*',
-                                           'keep *_*PFJets_*_*',
-                                           'keep *_*HiGenJets_*_*',
-                                           'keep *_*PFTowers_*_*',
-                                           'keep *_*hiFJRhoProducer_*_*',
-                                           'keep CaloTowersSorted_towerMaker_*_*',
-                                           'drop recoCandidatesOwned_caloTowers_*_*',
-                                           'keep recoPFCandidates_particleFlowTmp_*_*'
-                                           )
-    )
+    outputCommands = cms.untracked.vstring(
+        'keep *_ak4CaloJets_*_*',
+        'keep *_akPu4CaloJets_*_*', 
+        'keep *_ak4PFJets_*_*',
+        'keep *_akPu3PFJets_*_*',
+        'keep *_akPu4PFJets_*_*',
+        'keep *_akCs3PFJets_*_*',
+        'keep *_akCs4PFJets_*_*',
+        'keep *_PFTowers_*_*',
+        'keep *_hiFJRhoProducer_*_*',
+        'keep CaloTowersSorted_towerMaker_*_*',
+        'keep recoPFCandidates_particleFlowTmp_*_*')
+)
 
+# RECO content
+RecoHiJetsRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring( 
+        'keep *_akPu3CaloJets_*_*', 
+        'keep *_akPu5CaloJets_*_*', 
+        'keep *_iterativeConePu5CaloJets_*_*', 
+        'keep *_akPu5PFJets_*_*',
+        'keep recoCandidatesOwned_caloTowers_*_*',
+        'keep *_kt4PFJetsForRho_*_*')
+)
+RecoHiJetsRECO.outputCommands.extend(RecoHiJetsAOD.outputCommands)
 
-
-
+#Full Event content 
+RecoHiJetsFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep *_*CaloJets_*_*',
+        'keep *_*PFJets_*_*')
+)
+RecoHiJetsFEVT.outputCommands.extend(RecoHiJetsRECO.outputCommands)

--- a/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
+++ b/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
@@ -4,14 +4,19 @@ import FWCore.ParameterSet.Config as cms
 RecoHiJetsAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_ak4CaloJets_*_*',
+        'keep *_akPu3CaloJets_*_*', 
         'keep *_akPu4CaloJets_*_*', 
+        'keep *_akPu5CaloJets_*_*', 
+        'keep *_iterativeConePu5CaloJets_*_*', 
         'keep *_ak4PFJets_*_*',
         'keep *_akPu3PFJets_*_*',
         'keep *_akPu4PFJets_*_*',
+        'keep *_akPu5PFJets_*_*',
         'keep *_akCs3PFJets_*_*',
         'keep *_akCs4PFJets_*_*',
-        'keep *_PFTowers_*_*',
-        'keep *_hiFJRhoProducer_*_*',
+        'keep *_*HiGenJets_*_*',
+        'keep *_*PFTowers_*_*',
+        'keep *_*hiFJRhoProducer_*_*',
         'keep CaloTowersSorted_towerMaker_*_*',
         'keep recoPFCandidates_particleFlowTmp_*_*')
 )
@@ -19,11 +24,6 @@ RecoHiJetsAOD = cms.PSet(
 # RECO content
 RecoHiJetsRECO = cms.PSet(
     outputCommands = cms.untracked.vstring( 
-        'keep *_akPu3CaloJets_*_*', 
-        'keep *_akPu5CaloJets_*_*', 
-        'keep *_iterativeConePu5CaloJets_*_*', 
-        'keep *_akPu5PFJets_*_*',
-        'keep recoCandidatesOwned_caloTowers_*_*',
         'keep *_kt4PFJetsForRho_*_*')
 )
 RecoHiJetsRECO.outputCommands.extend(RecoHiJetsAOD.outputCommands)


### PR DESCRIPTION
#### PR description:  
Update event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. 1 file changed : 
+ `RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py`

(The previous tasks for RecoHI event content : [PR#29576](https://github.com/cms-sw/cmssw/pull/29576) and [PR#29746](https://github.com/cms-sw/cmssw/pull/29746). )

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).