### PR TITLE
Initialize YCUT to a negative value to avoid compilation warning

### DIFF
--- a/GeneratorInterface/PartonShowerVeto/src/ME2pythia.f
+++ b/GeneratorInterface/PartonShowerVeto/src/ME2pythia.f
@@ -608,6 +608,7 @@ c      endif
 c      write(*,*)'Entering MGVETO'
 c      write(*,*)'qcut is ',qcut,' and showerkt is ',showerkt
       IPVETO=0
+      YCUT=-1.0
 c     Return if not MLM matching (or non-matched subprocess)
       
       IF(ICKKW.LE.0.OR.IEXC.eq.-1) RETURN


### PR DESCRIPTION
#### PR description:

resolves #28928
As suggested https://github.com/cms-sw/cmssw/issues/28928 , initialize `YCUT` to `-1.0` to avoid compilation warnings in GCC9 and GCC 8.4 IBs.

#### PR validation:

Local build for GCC 9 and GCC 8.4 do not show any more the warnings.