### PR TITLE
Strip hybrid zero suppression: do less work if the APV is already zero-suppressed

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -396,10 +396,8 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
                                                              lmode,
                                                              pCode);
             if (fedchannelunpacker::StatusCode::SUCCESS == st_ch) {
-              SiStripRawProcessingAlgorithms::digivector_t workRawDigis;
-              rawAlgos.convertHybridDigiToRawDigiVector(unpDigis, workRawDigis);
               edm::DetSet<SiStripDigi> suppDigis{id};
-              rawAlgos.suppressHybridData(id, ipair * 2, workRawDigis, suppDigis);
+              rawAlgos.suppressHybridData_faster(unpDigis, suppDigis, ipair * 2);
               std::copy(std::begin(suppDigis), std::end(suppDigis), perStripAdder);
             }
           }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -397,7 +397,7 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
                                                              pCode);
             if (fedchannelunpacker::StatusCode::SUCCESS == st_ch) {
               edm::DetSet<SiStripDigi> suppDigis{id};
-              rawAlgos.suppressHybridData_faster(unpDigis, suppDigis, ipair * 2);
+              rawAlgos.suppressHybridData(unpDigis, suppDigis, ipair * 2);
               std::copy(std::begin(suppDigis), std::end(suppDigis), perStripAdder);
             }
           }

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
@@ -24,8 +24,7 @@ public:
   uint16_t suppressHybridData_faster(const edm::DetSet<SiStripDigi>& inDigis,
                                      edm::DetSet<SiStripDigi>& suppressedDigis);
   uint16_t suppressHybridData(const edm::DetSet<SiStripDigi>& inDigis,
-                              edm::DetSet<SiStripDigi>& suppressedDigis,
-                              digivector_t& rawDigis);
+                              edm::DetSet<SiStripDigi>& suppressedDigis);
   uint16_t suppressHybridData(uint32_t detId,
                               uint16_t firstAPV,
                               digivector_t& processedRawDigis,

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
@@ -21,15 +21,9 @@ public:
   void initialize(const edm::EventSetup&);
   void initialize(const edm::EventSetup&, const edm::Event&);
 
-  uint16_t suppressHybridData_faster(const edm::DetSet<SiStripDigi>& inDigis,
-                                     edm::DetSet<SiStripDigi>& suppressedDigis,
-                                     uint16_t firstAPV = 0);
   uint16_t suppressHybridData(const edm::DetSet<SiStripDigi>& inDigis,
-                              edm::DetSet<SiStripDigi>& suppressedDigis);
-  uint16_t suppressHybridData(uint32_t detId,
-                              uint16_t firstAPV,
-                              digivector_t& processedRawDigis,
-                              edm::DetSet<SiStripDigi>& suppressedDigis);
+                              edm::DetSet<SiStripDigi>& suppressedDigis,
+                              uint16_t firstAPV = 0);
 
   uint16_t suppressVirginRawData(uint32_t detId,
                                  uint16_t firstAPV,
@@ -49,8 +43,6 @@ public:
                                     edm::DetSet<SiStripDigi>& rawDigis);
   uint16_t convertVirginRawToHybrid(const edm::DetSet<SiStripRawDigi>& rawDigis,
                                     edm::DetSet<SiStripDigi>& suppressedDigis);
-
-  void convertHybridDigiToRawDigiVector(const edm::DetSet<SiStripDigi>& inDigis, digivector_t& rawDigis);
 
   inline const std::vector<bool>& getAPVFlags() const { return restorer->getAPVFlags(); }
   inline const SiStripAPVRestorer::baselinemap_t& getBaselineMap() const { return restorer->getBaselineMap(); }

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
@@ -22,7 +22,8 @@ public:
   void initialize(const edm::EventSetup&, const edm::Event&);
 
   uint16_t suppressHybridData_faster(const edm::DetSet<SiStripDigi>& inDigis,
-                                     edm::DetSet<SiStripDigi>& suppressedDigis);
+                                     edm::DetSet<SiStripDigi>& suppressedDigis,
+                                     uint16_t firstAPV = 0);
   uint16_t suppressHybridData(const edm::DetSet<SiStripDigi>& inDigis,
                               edm::DetSet<SiStripDigi>& suppressedDigis);
   uint16_t suppressHybridData(uint32_t detId,

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
@@ -21,6 +21,8 @@ public:
   void initialize(const edm::EventSetup&);
   void initialize(const edm::EventSetup&, const edm::Event&);
 
+  uint16_t suppressHybridData_faster(const edm::DetSet<SiStripDigi>& inDigis,
+                                     edm::DetSet<SiStripDigi>& suppressedDigis);
   uint16_t suppressHybridData(const edm::DetSet<SiStripDigi>& inDigis,
                               edm::DetSet<SiStripDigi>& suppressedDigis,
                               digivector_t& rawDigis);

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
@@ -19,8 +19,7 @@ SiStripZeroSuppression::SiStripZeroSuppression(edm::ParameterSet const& conf)
       produceCalculatedBaseline(conf.getParameter<bool>("produceCalculatedBaseline")),
       produceBaselinePoints(conf.getParameter<bool>("produceBaselinePoints")),
       storeInZScollBadAPV(conf.getParameter<bool>("storeInZScollBadAPV")),
-      produceHybridFormat(conf.getParameter<bool>("produceHybridFormat")),
-      fasterHybridZS(conf.getUntrackedParameter<bool>("fasterHybridZS", false)) {
+      produceHybridFormat(conf.getParameter<bool>("produceHybridFormat")) {
   for (const auto& inputTag : conf.getParameter<std::vector<edm::InputTag>>("RawDigiProducersList")) {
     const auto& tagName = inputTag.instance();
     produces<edm::DetSetVector<SiStripDigi>>(tagName);
@@ -152,11 +151,7 @@ inline void SiStripZeroSuppression::processHybrid(const edm::DetSetVector<SiStri
     edm::DetSet<SiStripDigi> suppressedDigis(inDigis.id);
 
     uint16_t nAPVflagged = 0;
-    if (fasterHybridZS) {
-      nAPVflagged = algorithms->suppressHybridData_faster(inDigis, suppressedDigis);
-    } else {
-      nAPVflagged = algorithms->suppressHybridData(inDigis, suppressedDigis);
-    }
+    nAPVflagged = algorithms->suppressHybridData(inDigis, suppressedDigis);
 
     storeExtraOutput(inDigis.id, nAPVflagged);
     if (!suppressedDigis.empty())

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
@@ -62,7 +62,7 @@ SiStripZeroSuppression::SiStripZeroSuppression(edm::ParameterSet const& conf)
                                               "configured with APVInspectMode='HybridEmulation'";
 
   if ((!hybridInputs.empty()) && produceRawDigis) {
-    edm::LogWarning("SiStripZeroSuppression") << "Raw digis will not be saved for hybrid inputs";
+    edm::LogInfo("SiStripZeroSuppression") << "Raw digis will not be saved for hybrid inputs";
   }
 
   if (!(rawInputs.empty() && hybridInputs.empty())) {

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
@@ -43,6 +43,7 @@ private:
   bool produceBaselinePoints;
   bool storeInZScollBadAPV;
   bool produceHybridFormat;
+  bool fasterHybridZS;
 
   using rawtoken_t = edm::EDGetTokenT<edm::DetSetVector<SiStripRawDigi>>;
   using zstoken_t = edm::EDGetTokenT<edm::DetSetVector<SiStripDigi>>;

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
@@ -43,7 +43,6 @@ private:
   bool produceBaselinePoints;
   bool storeInZScollBadAPV;
   bool produceHybridFormat;
-  bool fasterHybridZS;
 
   using rawtoken_t = edm::EDGetTokenT<edm::DetSetVector<SiStripRawDigi>>;
   using zstoken_t = edm::EDGetTokenT<edm::DetSetVector<SiStripDigi>>;

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
@@ -140,8 +140,8 @@ uint16_t SiStripRawProcessingAlgorithms::suppressHybridData_faster(const edm::De
 }
 
 uint16_t SiStripRawProcessingAlgorithms::suppressHybridData(const edm::DetSet<SiStripDigi>& hybridDigis,
-                                                            edm::DetSet<SiStripDigi>& suppressedDigis,
-                                                            digivector_t& rawDigis) {
+                                                            edm::DetSet<SiStripDigi>& suppressedDigis) {
+  std::vector<int16_t> rawDigis;
   convertHybridDigiToRawDigiVector(hybridDigis, rawDigis);
   return suppressHybridData(hybridDigis.id, 0, rawDigis, suppressedDigis);
 }

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
@@ -46,53 +46,6 @@ void SiStripRawProcessingAlgorithms::initialize(const edm::EventSetup& es, const
  * Zero-suppress "hybrid" raw data
  *
  * Subtracts common-mode noise, and inspects the digis then.
- * If flagged by the APV inspector, the zero-suppression is performed as usual;
- * otherwise the positive inputs are copied.
- *
- * @param id module DetId
- * @param firstAPV index of the first APV considered
- * @param procRawDigis input (processed raw) ADCs. Note that this means that
- * ADCs for all strips are expected, so zero-suppressed data should be filled with zeros for the suppressed strips.
- * Output: the ADCs after all subtractions, but before zero-suppression.
- * @param output zero-suppressed digis
- * @return number of restored APVs
- */
-//IMPORTANT: don't forget the conversion from  hybrids on the bad APVs (*2 -1024)
-uint16_t SiStripRawProcessingAlgorithms::suppressHybridData(uint32_t id,
-                                                            uint16_t firstAPV,
-                                                            digivector_t& procRawDigis,
-                                                            edm::DetSet<SiStripDigi>& suppressedDigis) {
-  digivector_t procRawDigisPedSubtracted(procRawDigis);
-
-  subtractorCMN->subtract(id, firstAPV, procRawDigis);
-
-  const auto nAPVFlagged =
-      restorer->inspectAndRestore(id, firstAPV, procRawDigisPedSubtracted, procRawDigis, subtractorCMN->getAPVsCM());
-
-  const std::vector<bool>& apvf = getAPVFlags();
-  const std::size_t nAPVs = procRawDigis.size() / 128;
-  for (uint16_t iAPV = firstAPV; iAPV < firstAPV + nAPVs; ++iAPV) {
-    if (apvf[iAPV]) {
-      const auto firstDigiIt = std::begin(procRawDigis) + 128 * (iAPV - firstAPV);
-      std::vector<int16_t> singleAPVdigi(firstDigiIt, firstDigiIt + 128);
-      suppressor->suppress(singleAPVdigi, iAPV, suppressedDigis);
-    } else {
-      for (uint16_t i = 0; i < 128; ++i) {
-        const int16_t digi = procRawDigisPedSubtracted[128 * (iAPV - firstAPV) + i];
-        if (digi > 0) {
-          suppressedDigis.push_back(SiStripDigi(iAPV * 128 + i, suppressor->truncate(digi)));
-        }
-      }
-    }
-  }
-
-  return nAPVFlagged;
-}
-
-/**
- * Zero-suppress "hybrid" raw data
- *
- * Subtracts common-mode noise, and inspects the digis then.
  * If flagged by the APV inspector, the zero-suppression is performed as usual.
  * Otherwise, the positive inputs are copied.
  *
@@ -102,13 +55,14 @@ uint16_t SiStripRawProcessingAlgorithms::suppressHybridData(uint32_t id,
  *
  * @return number of restored APVs
  */
-// NOTE replaces both suppressHybridData methods and convertVirginRawToHybrid
-uint16_t SiStripRawProcessingAlgorithms::suppressHybridData_faster(const edm::DetSet<SiStripDigi>& hybridDigis, edm::DetSet<SiStripDigi>& suppressedDigis, uint16_t firstAPV) {
+uint16_t SiStripRawProcessingAlgorithms::suppressHybridData(const edm::DetSet<SiStripDigi>& hybridDigis,
+                                                            edm::DetSet<SiStripDigi>& suppressedDigis,
+                                                            uint16_t firstAPV) {
   uint16_t nAPVFlagged = 0;
   auto beginAPV = hybridDigis.begin();
   const auto indigis_end = hybridDigis.end();
   auto iAPV = firstAPV;
-  while ( beginAPV != indigis_end ) {
+  while (beginAPV != indigis_end) {
     const auto endAPV = std::lower_bound(beginAPV, indigis_end, SiStripDigi((iAPV + 1) * 128, 0));
     const auto nDigisInAPV = std::distance(beginAPV, endAPV);
     if (nDigisInAPV > 64) {
@@ -118,14 +72,15 @@ uint16_t SiStripRawProcessingAlgorithms::suppressHybridData_faster(const edm::De
       }
       digivector_t workDigisPedSubtracted(workDigis);
       subtractorCMN->subtract(hybridDigis.id, iAPV, workDigis);
-      const auto apvFlagged = restorer->inspectAndRestore(hybridDigis.id, iAPV, workDigisPedSubtracted, workDigis, subtractorCMN->getAPVsCM());
+      const auto apvFlagged = restorer->inspectAndRestore(
+          hybridDigis.id, iAPV, workDigisPedSubtracted, workDigis, subtractorCMN->getAPVsCM());
       nAPVFlagged += apvFlagged;
-      if ( getAPVFlags()[iAPV] ) {
+      if (getAPVFlags()[iAPV]) {
         suppressor->suppress(workDigis, iAPV, suppressedDigis);
-      } else { // bad APV: more than 64 but not flagged
-        for ( uint16_t i = 0; i != 128; ++i ) {
+      } else {  // bad APV: more than 64 but not flagged
+        for (uint16_t i = 0; i != 128; ++i) {
           const auto digi = workDigisPedSubtracted[i];
-          if ( digi > 0 ) {
+          if (digi > 0) {
             suppressedDigis.push_back(SiStripDigi(iAPV * 128 + i, suppressor->truncate(digi)));
           }
         }
@@ -139,45 +94,6 @@ uint16_t SiStripRawProcessingAlgorithms::suppressHybridData_faster(const edm::De
     ++iAPV;
   }
   return nAPVFlagged;
-}
-
-uint16_t SiStripRawProcessingAlgorithms::suppressHybridData(const edm::DetSet<SiStripDigi>& hybridDigis,
-                                                            edm::DetSet<SiStripDigi>& suppressedDigis) {
-  std::vector<int16_t> rawDigis;
-  convertHybridDigiToRawDigiVector(hybridDigis, rawDigis);
-  return suppressHybridData(hybridDigis.id, 0, rawDigis, suppressedDigis);
-}
-
-/**
- * Convert hybrid digis to a list of processed raw ADCs
- *
- * Non-zero-suppressed APVs are identified by the number of ADCs found (above 64),
- * and the ADCs converted into normal processed format (x->x*2-1024).
- * For zero-supppressed APVs the absent strips are set to zero ADC.
- *
- * @param inDigis input (non-ZS hybrid or ZS) data
- * @param RawDigis processed raw (or zero-filled ZS) ADCs
- */
-void SiStripRawProcessingAlgorithms::convertHybridDigiToRawDigiVector(const edm::DetSet<SiStripDigi>& inDigis,
-                                                                      digivector_t& rawDigis) {
-  const auto stripModuleGeom = dynamic_cast<const StripGeomDetUnit*>(trGeo->idToDetUnit(inDigis.id));
-  const std::size_t nStrips = stripModuleGeom->specificTopology().nstrips();
-  const std::size_t nAPVs = nStrips / 128;
-
-  rawDigis.assign(nStrips, 0);
-  std::vector<uint16_t> stripsPerAPV(nAPVs, 0);
-
-  for (SiStripDigi digi : inDigis) {
-    rawDigis[digi.strip()] = digi.adc();
-    ++stripsPerAPV[digi.strip() / 128];
-  }
-
-  for (uint16_t iAPV = 0; iAPV < nAPVs; ++iAPV) {
-    if (stripsPerAPV[iAPV] > 64) {
-      for (uint16_t strip = iAPV * 128; strip < (iAPV + 1) * 128; ++strip)
-        rawDigis[strip] = rawDigis[strip] * 2 - 1024;
-    }
-  }
 }
 
 /**

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
@@ -111,7 +111,6 @@ uint16_t SiStripRawProcessingAlgorithms::suppressHybridData_faster(const edm::De
   const std::size_t nStrips = stripModuleGeom->specificTopology().nstrips();
   const std::size_t nAPVs = nStrips / 128;
 
-  std::vector<bool> apvFlags(nAPVs, false);
 
   uint16_t nAPVFlagged = 0;
   auto beginAPV = std::cbegin(hybridDigis);
@@ -121,14 +120,11 @@ uint16_t SiStripRawProcessingAlgorithms::suppressHybridData_faster(const edm::De
                             : std::cend(hybridDigis);
     const auto nDigisInAPV = std::distance(beginAPV, endAPV);
     if (nDigisInAPV > 64) {
-      apvFlags[iAPV] = true;
       digivector_t procRawDigis(128, -1024);
       for (auto it = beginAPV; it != endAPV; ++it) {
         procRawDigis[it->strip() - 128 * iAPV] = it->adc() * 2 - 1024;
       }
-      // hybrid reusing previous code - my be able to sve a bit more
-      const auto nFlag = suppressHybridData(hybridDigis.id, iAPV, procRawDigis, suppressedDigis);
-      nAPVFlagged += nFlag;
+      nAPVFlagged += suppressHybridData(hybridDigis.id, iAPV, procRawDigis, suppressedDigis);
     } else {  // already zero-suppressed, copy and truncate
       std::transform(beginAPV, endAPV, std::back_inserter(suppressedDigis), [this](const SiStripDigi inDigi) {
         return SiStripDigi(inDigi.strip(), suppressor->truncate(inDigi.adc()));


### PR DESCRIPTION
#### PR description:

Changed the implementation of the zero-suppression for hybrid strip tracker data, where most of the APVs are zero-suppressed in the FED, and some detected as having a non-flat or shifted baseline, and fully read out. When the software zero-suppression processes these data, the digis for APVs that were already zero-suppressed can simply be copied, but the current implementation would still recalculate the common mode (and ignore the result from that).
The time gain for a 2021 HI scenario is difficult to estimate (it depends on occupancy and the number of APVs that is not zero-suppressed by the FEDs), but should be significant, about an order of magnitude less time spent in the ZS (on the 2015 VR file I used for validation a factor 14).
With the changes above it didn't really make sense anymore to have different "convert hybrid to raw digis" and two suppressHybridData methods, so I made it one that can handle the calls from both the ZS module and the regional unpacker; I also removed the option to write the raw digis out again from the ZS for hybrid inputs (it was not used anywhere, and keeping this would have made the rest more complicated and inefficient).

#### PR validation:

No changes are expected. I did a digi-to-digi comparison by adding a flag to switch between the old and new implementation (removed only in the last commit), on 2018 repacked data (as in the HI benchmarks), [config](https://github.com/pieterdavid/SiStripLocalRecoDebugging/blob/master/test/test_hybridZSSpeedup_2018.py), and 2015 VR data with hybrid emulation, [config](https://github.com/pieterdavid/SiStripLocalRecoDebugging/blob/master/test/test_hybridZSSpeedup_2015VR.py); I also checked that the digis are the same between the full sequence and the regional unpacker (which calls the zero-suppression in a slightly different way, I think it may have been wrong before, but was not used).

Could this be tested with workflow 140.55? I think that's the only one that uses this code.

CC: @icali @CesarBernardes 