### PR TITLE
[HGC trigger] FE customization, OOT subtraction, separate HFNose sequence

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -85,6 +85,13 @@ public:
 
   static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
 
+  enum SubDetectorType {
+    hgcal_silicon_CEE,
+    hgcal_silicon_CEH,
+    hgcal_scintillator,
+  };
+  SubDetectorType getSubDetectorType(const DetId& id) const;
+
 private:
   const HGCalTriggerGeometryBase* geom_;
   unsigned eeLayers_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -13,7 +13,7 @@
 
 class HGCalConcentratorProcessorSelection : public HGCalConcentratorProcessorBase {
 private:
-  enum SelectionType { thresholdSelect, bestChoiceSelect, superTriggerCellSelect, mixedBestChoiceSuperTriggerCell };
+  enum SelectionType { thresholdSelect, bestChoiceSelect, superTriggerCellSelect, noSelection };
 
 public:
   HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf);
@@ -23,10 +23,12 @@ public:
            const edm::EventSetup& es) override;
 
 private:
-  SelectionType selectionType_;
   bool fixedDataSizePerHGCROC_;
-  bool coarsenTriggerCells_;
+  std::vector<unsigned> coarsenTriggerCells_;
   static constexpr int kHighDensityThickness_ = 0;
+  static constexpr int kNSubDetectors_ = 3;
+
+  std::vector<SelectionType> selectionType_;
 
   std::unique_ptr<HGCalConcentratorThresholdImpl> thresholdImpl_;
   std::unique_ptr<HGCalConcentratorBestChoiceImpl> bestChoiceImpl_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -29,13 +29,14 @@ private:
     oneBitFraction,
     equalShare,
   };
+
   EnergyDivisionType energyDivisionType_;
   static constexpr int kHighDensityThickness_ = 0;
   static constexpr int kOddNumberMask_ = 1;
 
   HGCalTriggerTools triggerTools_;
   bool fixedDataSizePerHGCROC_;
-  bool coarsenTriggerCells_;
+  std::vector<unsigned> coarsenTriggerCells_;
   HGCalCoarseTriggerCellMapping coarseTCmapping_;
   HGCalCoarseTriggerCellMapping superTCmapping_;
 

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFELinearizationImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFELinearizationImpl.h
@@ -39,6 +39,7 @@ private:
   //
   uint32_t linMax_;
   uint32_t linnBits_;
+  std::vector<double> oot_coefficients_;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/plugins/HFNoseVFEProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HFNoseVFEProducer.cc
@@ -16,28 +16,26 @@
 
 #include <memory>
 
-class HGCalVFEProducer : public edm::stream::EDProducer<> {
+class HFNoseVFEProducer : public edm::stream::EDProducer<> {
 public:
-  HGCalVFEProducer(const edm::ParameterSet&);
-  ~HGCalVFEProducer() override {}
+  HFNoseVFEProducer(const edm::ParameterSet&);
+  ~HFNoseVFEProducer() override {}
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   // inputs
-  edm::EDGetToken inputee_, inputfh_, inputbh_;
+  edm::EDGetToken inputnose_;
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
   std::unique_ptr<HGCalVFEProcessorBase> vfeProcess_;
 };
 
-DEFINE_FWK_MODULE(HGCalVFEProducer);
+DEFINE_FWK_MODULE(HFNoseVFEProducer);
 
-HGCalVFEProducer::HGCalVFEProducer(const edm::ParameterSet& conf)
-    : inputee_(consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("eeDigis"))),
-      inputfh_(consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("fhDigis"))),
-      inputbh_(consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("bhDigis"))) {
+HFNoseVFEProducer::HFNoseVFEProducer(const edm::ParameterSet& conf)
+    : inputnose_(consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("noseDigis"))) {
   // setup VFE parameters
   const edm::ParameterSet& vfeParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& vfeProcessorName = vfeParamConfig.getParameter<std::string>("ProcessorName");
@@ -48,39 +46,22 @@ HGCalVFEProducer::HGCalVFEProducer(const edm::ParameterSet& conf)
   produces<l1t::HGCalTriggerSumsBxCollection>(vfeProcess_->name());
 }
 
-void HGCalVFEProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
+void HFNoseVFEProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
   es.get<CaloGeometryRecord>().get(triggerGeometry_);
   vfeProcess_->setGeometry(triggerGeometry_.product());
 }
 
-void HGCalVFEProducer::produce(edm::Event& e, const edm::EventSetup& es) {
+void HFNoseVFEProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   // Output collections
   auto vfe_trigcell_output = std::make_unique<l1t::HGCalTriggerCellBxCollection>();
   auto vfe_trigsums_output = std::make_unique<l1t::HGCalTriggerSumsBxCollection>();
 
-  // Input collections
-  edm::Handle<HGCalDigiCollection> ee_digis_h;
-  edm::Handle<HGCalDigiCollection> fh_digis_h;
-  edm::Handle<HGCalDigiCollection> bh_digis_h;
+  edm::Handle<HGCalDigiCollection> nose_digis_h;
+  e.getByToken(inputnose_, nose_digis_h);
 
-  e.getByToken(inputee_, ee_digis_h);
-  e.getByToken(inputfh_, fh_digis_h);
-  e.getByToken(inputbh_, bh_digis_h);
-
-  // Processing DigiCollections and putting the results into the HGCalTriggerCellBxCollectio
-  if (ee_digis_h.isValid()) {
-    const HGCalDigiCollection& ee_digis = *ee_digis_h;
-    vfeProcess_->run(ee_digis, *vfe_trigcell_output, es);
-  }
-
-  if (fh_digis_h.isValid()) {
-    const HGCalDigiCollection& fh_digis = *fh_digis_h;
-    vfeProcess_->run(fh_digis, *vfe_trigcell_output, es);
-  }
-
-  if (bh_digis_h.isValid()) {
-    const HGCalDigiCollection& bh_digis = *bh_digis_h;
-    vfeProcess_->run(bh_digis, *vfe_trigcell_output, es);
+  if (nose_digis_h.isValid()) {
+    const HGCalDigiCollection& nose_digis = *nose_digis_h;
+    vfeProcess_->run(nose_digis, *vfe_trigcell_output, es);
   }
 
   // Put in the event

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, coarsetc_equalshare_proc, bestchoice_ndata_decentralized, mixedbcstc_conc_proc
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, coarsetc_equalshare_proc, bestchoice_ndata_decentralized, custom_conc_proc
 
 def custom_triggercellselect_supertriggercell(process,
                                               stcSize=supertc_conc_proc.stcSize,
@@ -73,16 +73,17 @@ def custom_coarsetc_equalshare(process,
     return process
     
 def custom_triggercellselect_mixedBestChoiceSuperTriggerCell(process,
-                                              stcSize=mixedbcstc_conc_proc.stcSize,
-                                              type_energy_division=mixedbcstc_conc_proc.type_energy_division,
-                                              fixedDataSizePerHGCROC=mixedbcstc_conc_proc.fixedDataSizePerHGCROC,
-                                              triggercells=mixedbcstc_conc_proc.NData
+                                              stcSize=custom_conc_proc.stcSize,
+                                              type_energy_division=custom_conc_proc.type_energy_division,
+                                              fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+                                              triggercells=custom_conc_proc.NData
                                               ):
-    parameters = mixedbcstc_conc_proc.clone(stcSize = stcSize,
-                                         type_energy_division = type_energy_division,
-                                         fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-                                         NData=triggercells
-                                         )
+    parameters = custom_conc_proc.clone(stcSize = stcSize,
+                                        type_energy_division = type_energy_division,
+                                        fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+                                        NData=triggercells,
+                                        Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),        
+    )
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
 

--- a/L1Trigger/L1THGCal/python/customVFE.py
+++ b/L1Trigger/L1THGCal/python/customVFE.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
+from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import vfe_proc
+
+def custom_hgcroc_oot(process,
+                      oot_coefficients=vfe_proc.oot_coefficients
+                      ):
+    parameters = vfe_proc.clone(oot_coefficients = oot_coefficients)
+    process.hgcalVFEProducer.ProcessorParameters = parameters
+    return process

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -67,3 +67,6 @@ hgcalBackEndLayer1Producer = cms.EDProducer(
     InputTriggerCells = cms.InputTag('hgcalConcentratorProducer:HGCalConcentratorProcessorSelection'),
     ProcessorParameters = be_proc.clone()
     )
+
+hgcalBackEndLayer1ProducerHFNose = hgcalBackEndLayer1Producer.clone()
+hgcalBackEndLayer1ProducerHFNose.InputTriggerCells = cms.InputTag('hgcalConcentratorProducerHFNose:HGCalConcentratorProcessorSelection')

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -68,5 +68,6 @@ hgcalBackEndLayer1Producer = cms.EDProducer(
     ProcessorParameters = be_proc.clone()
     )
 
-hgcalBackEndLayer1ProducerHFNose = hgcalBackEndLayer1Producer.clone()
-hgcalBackEndLayer1ProducerHFNose.InputTriggerCells = cms.InputTag('hgcalConcentratorProducerHFNose:HGCalConcentratorProcessorSelection')
+hgcalBackEndLayer1ProducerHFNose = hgcalBackEndLayer1Producer.clone(
+    InputTriggerCells = cms.InputTag('hgcalConcentratorProducerHFNose:HGCalConcentratorProcessorSelection')
+)

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1_cff.py
@@ -6,3 +6,5 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import *
 
 hgcalBackEndLayer1 = cms.Task(hgcalBackEndLayer1Producer)
 
+hgcalBackEndLayer1HFNose = cms.Task(hgcalBackEndLayer1ProducerHFNose)
+

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -169,15 +169,17 @@ hgcalBackEndLayer2Producer = cms.EDProducer(
     )
 
 
-hgcalBackEndLayer2ProducerHFNose = hgcalBackEndLayer2Producer.clone()
-hgcalBackEndLayer2ProducerHFNose.InputCluster = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering')
-
-binSumsNose = cms.vuint32(13,11,9,9)
-
-hgcalBackEndLayer2ProducerHFNose.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = dict(
-    ## note in #Phi same bin size for HGCAL and HFNose
-    nBins_X1_histo_multicluster = 4, # R bin size: 5 FullModules * 8 TP
-    binSumsHisto = binSumsNose,
-    kROverZMin = 0.025,
-    kROverZMax = 0.1
+hgcalBackEndLayer2ProducerHFNose = hgcalBackEndLayer2Producer.clone(
+    InputCluster = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering'),
+    ProcessorParameters = dict(
+        C3d_parameters = dict(
+            histoMax_C3d_seeding_parameters = dict(
+                ## note in #Phi same bin size for HGCAL and HFNose
+                nBins_X1_histo_multicluster = 4, # R bin size: 5 FullModules * 8 TP
+                binSumsHisto = cms.vuint32(13,11,9,9),
+                kROverZMin = 0.025,
+                kROverZMax = 0.1
+            )
+        )
+    )
 )

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -17,15 +17,6 @@ binSums = cms.vuint32(13,               # 0
                       3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 28 - 41
                       )
 
-binSumsNose = cms.vuint32(13,               # 0
-                          13,               # 1
-                          11, 11, 11,       # 2 - 4
-                          9, 9, 9,          # 5 - 7
-                          7, 7, 7, 7, 7, 7,  # 8 - 13
-                          5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 14 - 28
-                          3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 29 - 42
-)
-
 EE_DR_GROUP = 7
 FH_DR_GROUP = 6
 BH_DR_GROUP = 12
@@ -97,14 +88,6 @@ histoMax_C3d_seeding_params = cms.PSet(type_histoalgo=cms.string('HistoMaxC3d'),
                                seed_smoothing_ecal=seed_smoothing_ecal,
                                seed_smoothing_hcal=seed_smoothing_hcal,
                               )
-
-## Note: this customization change both HGC and HFnose, to be revised
-phase2_hfnose.toModify(histoMax_C3d_seeding_params,
-                       nBins_X1_histo_multicluster=cms.uint32(43),
-                       binSumsHisto=binSumsNose,
-                       kROverZMin=cms.double(0.025),
-                       kROverZMax=cms.double(0.58),
-                       )
 
 histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
                                dR_multicluster_byLayer_coefficientA=cms.vdouble(),
@@ -184,3 +167,17 @@ hgcalBackEndLayer2Producer = cms.EDProducer(
     InputCluster = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering'),
     ProcessorParameters = be_proc.clone()
     )
+
+
+hgcalBackEndLayer2ProducerHFNose = hgcalBackEndLayer2Producer.clone()
+hgcalBackEndLayer2ProducerHFNose.InputCluster = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering')
+
+binSumsNose = cms.vuint32(13,11,9,9)
+
+hgcalBackEndLayer2ProducerHFNose.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = dict(
+    ## note in #Phi same bin size for HGCAL and HFNose
+    nBins_X1_histo_multicluster = 4, # R bin size: 5 FullModules * 8 TP
+    binSumsHisto = binSumsNose,
+    kROverZMin = 0.025,
+    kROverZMax = 0.1
+)

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2_cff.py
@@ -6,3 +6,5 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import *
 
 hgcalBackEndLayer2 = cms.Task(hgcalBackEndLayer2Producer)
 
+hgcalBackEndLayer2HFNose = cms.Task(hgcalBackEndLayer2ProducerHFNose)
+

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -27,10 +27,10 @@ STC_SIZE =  ( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*3 )
 
 
 threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                               Method = cms.string('thresholdSelect'),
+                               Method = cms.vstring(['thresholdSelect']*3),
                                threshold_silicon = cms.double(2.), # MipT
                                threshold_scintillator = cms.double(2.), # MipT
-                               coarsenTriggerCells = cms.bool(False),
+                               coarsenTriggerCells = cms.vuint32(0,0,0),
                                fixedDataSizePerHGCROC = cms.bool(False),
                                ctcSize = cms.vuint32(CTC_SIZE),
                                )
@@ -75,9 +75,9 @@ coarseTCCompression_proc = cms.PSet(exponentBits = cms.uint32(4),
 
 from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import vfe_proc
 best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                          Method = cms.string('bestChoiceSelect'),
+                          Method = cms.vstring(['bestChoiceSelect']*3),
                           NData = cms.vuint32(bestchoice_ndata_centralized),
-                          coarsenTriggerCells = cms.bool(False),
+                          coarsenTriggerCells = cms.vuint32(0,0,0),
                           fixedDataSizePerHGCROC = cms.bool(False),
                           coarseTCCompression = coarseTCCompression_proc.clone(),
                           superTCCalibration = vfe_proc.clone(),
@@ -85,39 +85,40 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
                           )
 
 supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                             Method = cms.string('superTriggerCellSelect'),
+                             Method = cms.vstring(['superTriggerCellSelect']*3),
                              type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                              stcSize = cms.vuint32(STC_SIZE),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(False),
-                             coarsenTriggerCells = cms.bool(False),
+                             coarsenTriggerCells = cms.vuint32(0,0,0),
                              superTCCompression = superTCCompression_proc.clone(),
                              coarseTCCompression = coarseTCCompression_proc.clone(),
                              superTCCalibration = vfe_proc.clone(),
                              )
 
-
-mixedbcstc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                          Method = cms.string('mixedBestChoiceSuperTriggerCell'),
+custom_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                          Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),
                           NData = cms.vuint32(bestchoice_ndata_centralized),
-                          coarsenTriggerCells = cms.bool(False),
+                          threshold_silicon = cms.double(2.), # MipT
+                          threshold_scintillator = cms.double(2.), # MipT
+                          coarsenTriggerCells = cms.vuint32(0,0,0),
                           fixedDataSizePerHGCROC = cms.bool(False),
                           type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                           stcSize = cms.vuint32(STC_SIZE),
                           ctcSize = cms.vuint32(CTC_SIZE),
-                          supertccompression = superTCCompression_proc.clone(),
+                          superTCCompression = superTCCompression_proc.clone(),
                           coarseTCCompression = coarseTCCompression_proc.clone(),
                           superTCCalibration = vfe_proc.clone(),
                           )
 
 
 coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                             Method = cms.string('superTriggerCellSelect'),
+                             Method = cms.vstring(['superTriggerCellSelect']*3),
                              type_energy_division = cms.string('oneBitFraction'),
                              stcSize = cms.vuint32([4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*3),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(True),
-                             coarsenTriggerCells = cms.bool(False),
+                             coarsenTriggerCells = cms.vuint32(0,0,0),
                              oneBitFractionThreshold = cms.double(0.125),
                              oneBitFractionLowValue = cms.double(0.0625),
                              oneBitFractionHighValue = cms.double(0.25),
@@ -128,12 +129,12 @@ coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcen
 
 
 coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                             Method = cms.string('superTriggerCellSelect'),
+                             Method = cms.vstring(['superTriggerCellSelect']*3),
                              type_energy_division = cms.string('equalShare'),
                              stcSize = cms.vuint32([4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*3),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(True),
-                             coarsenTriggerCells = cms.bool(False),
+                             coarsenTriggerCells = cms.vuint32(0,0,0),
                              superTCCompression = superTCCompression_proc.clone(),
                              coarseTCCompression = coarseTCCompression_proc.clone(),
                              superTCCalibration = vfe_proc.clone(),

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -163,7 +163,8 @@ hgcalConcentratorProducer = cms.EDProducer(
     )
 
 
-hgcalConcentratorProducerHFNose = hgcalConcentratorProducer.clone()
-hgcalConcentratorProducerHFNose.InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HGCalVFEProcessorSums')
-hgcalConcentratorProducerHFNose.InputTriggerSums = cms.InputTag('hfnoseVFEProducer:HGCalVFEProcessorSums')
+hgcalConcentratorProducerHFNose = hgcalConcentratorProducer.clone(
+    InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HGCalVFEProcessorSums'),
+    InputTriggerSums = cms.InputTag('hfnoseVFEProducer:HGCalVFEProcessorSums')
+)
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -161,3 +161,9 @@ hgcalConcentratorProducer = cms.EDProducer(
     InputTriggerSums = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
     ProcessorParameters = threshold_conc_proc.clone()
     )
+
+
+hgcalConcentratorProducerHFNose = hgcalConcentratorProducer.clone()
+hgcalConcentratorProducerHFNose.InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HGCalVFEProcessorSums')
+hgcalConcentratorProducerHFNose.InputTriggerSums = cms.InputTag('hfnoseVFEProducer:HGCalVFEProcessorSums')
+

--- a/L1Trigger/L1THGCal/python/hgcalConcentrator_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentrator_cff.py
@@ -5,4 +5,5 @@ from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import *
 
 
 hgcalConcentrator = cms.Task(hgcalConcentratorProducer)
+hgcalConcentratorHFNose = cms.Task(hgcalConcentratorProducerHFNose)
 

--- a/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
@@ -25,3 +25,6 @@ hgcalTowerMapProducer = cms.EDProducer(
     InputTriggerCells = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
     ProcessorParameters = tower_map.clone()
     )
+
+hgcalTowerMapProducerHFNose = hgcalTowerMapProducer.clone()
+hgcalTowerMapProducerHFNose.InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HFNoseVFEProcessorSums')

--- a/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
@@ -26,5 +26,6 @@ hgcalTowerMapProducer = cms.EDProducer(
     ProcessorParameters = tower_map.clone()
     )
 
-hgcalTowerMapProducerHFNose = hgcalTowerMapProducer.clone()
-hgcalTowerMapProducerHFNose.InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HFNoseVFEProcessorSums')
+hgcalTowerMapProducerHFNose = hgcalTowerMapProducer.clone(
+    InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HFNoseVFEProcessorSums')
+)

--- a/L1Trigger/L1THGCal/python/hgcalTowerMap_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMap_cff.py
@@ -6,3 +6,5 @@ from L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi import *
 
 hgcalTowerMap = cms.Task(hgcalTowerMapProducer)
 
+hgcalTowerMapHFNose = cms.Task(hgcalTowerMapProducerHFNose)
+

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -8,3 +8,8 @@ hgcalTowerProducer = cms.EDProducer(
     InputTowerMaps = cms.InputTag('hgcalTowerMapProducer:HGCalTowerMapProcessor'), 
     ProcessorParameters = tower.clone()
     )
+
+
+hgcalTowerProducerHFNose = hgcalTowerProducer.clone()
+hgcalTowerProducerHFNose.InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor')
+

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -10,6 +10,7 @@ hgcalTowerProducer = cms.EDProducer(
     )
 
 
-hgcalTowerProducerHFNose = hgcalTowerProducer.clone()
-hgcalTowerProducerHFNose.InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor')
+hgcalTowerProducerHFNose = hgcalTowerProducer.clone(
+    InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor')
+)
 

--- a/L1Trigger/L1THGCal/python/hgcalTower_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTower_cff.py
@@ -6,3 +6,5 @@ from L1Trigger.L1THGCal.hgcalTowerProducer_cfi import *
 
 hgcalTower = cms.Task(hgcalTowerProducer)
 
+hgcalTowerHFNose = cms.Task(hgcalTowerProducerHFNose)
+

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -8,9 +8,15 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer2_cff import *
 from L1Trigger.L1THGCal.hgcalTowerMap_cff import *
 from L1Trigger.L1THGCal.hgcalTower_cff import *
 
-
 hgcalTriggerPrimitivesTask = cms.Task(hgcalVFE, hgcalConcentrator, hgcalBackEndLayer1, hgcalBackEndLayer2, hgcalTowerMap, hgcalTower)
 hgcalTriggerPrimitives = cms.Sequence(hgcalTriggerPrimitivesTask)
+
+_hfnose_hgcalTriggerPrimitivesTask = hgcalTriggerPrimitivesTask.copy()
+_hfnose_hgcalTriggerPrimitivesTask.add(hfnoseVFE, hgcalConcentratorHFNose, hgcalBackEndLayer1HFNose, hgcalBackEndLayer2HFNose, hgcalTowerMapHFNose, hgcalTowerHFNose)
+
+from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
+phase2_hfnose.toReplaceWith(
+        hgcalTriggerPrimitivesTask, _hfnose_hgcalTriggerPrimitivesTask )
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11

--- a/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
@@ -59,6 +59,7 @@ vfe_proc = cms.PSet( ProcessorName = cms.string('HGCalVFEProcessorSums'),
                      adcnBits_sc = adcNbits_sc,
                      tdcsaturation_sc = tdcSaturation_sc,
                      linnBits = cms.uint32(16),
+                     oot_coefficients = cms.vdouble(0., 0.), # (bx-2, bx-1)
                      siliconCellLSB_fC =  cms.double( triggerCellLsbBeforeCompression*(2**triggerCellTruncationBits) ),
                      scintillatorCellLSB_MIP = cms.double(float(adcSaturation_sc.value())/(2**float(adcNbits_sc.value()))),
                      noiseSilicon = cms.PSet(),

--- a/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
@@ -59,7 +59,7 @@ vfe_proc = cms.PSet( ProcessorName = cms.string('HGCalVFEProcessorSums'),
                      adcnBits_sc = adcNbits_sc,
                      tdcsaturation_sc = tdcSaturation_sc,
                      linnBits = cms.uint32(16),
-                     oot_coefficients = cms.vdouble(0., 0.), # (bx-2, bx-1)
+                     oot_coefficients = cms.vdouble(0., 0.), # OOT PU subtraction coeffs for samples (bx-2, bx-1). (0,0) = no OOT PU subtraction
                      siliconCellLSB_fC =  cms.double( triggerCellLsbBeforeCompression*(2**triggerCellTruncationBits) ),
                      scintillatorCellLSB_MIP = cms.double(float(adcSaturation_sc.value())/(2**float(adcNbits_sc.value()))),
                      noiseSilicon = cms.PSet(),

--- a/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
@@ -93,7 +93,14 @@ hgcalVFEProducer = cms.EDProducer(
         eeDigis = cms.InputTag('simHGCalUnsuppressedDigis:EE'),
         fhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEfront'),
         bhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEback'),
+        ProcessorParameters = vfe_proc.clone()
+       )
+
+hfnoseVFEProducer = cms.EDProducer(
+        "HFNoseVFEProducer",
         noseDigis = cms.InputTag('simHFNoseUnsuppressedDigis:HFNose'),
         ProcessorParameters = vfe_proc.clone()
        )
+
+
 

--- a/L1Trigger/L1THGCal/python/hgcalVFE_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalVFE_cff.py
@@ -4,4 +4,5 @@ from L1Trigger.L1THGCal.hgcalTriggerGeometryESProducer_cfi import *
 from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import *
 
 hgcalVFE = cms.Task(hgcalVFEProducer)
+hfnoseVFE = cms.Task(hfnoseVFEProducer)
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -195,6 +195,18 @@ bool HGCalTriggerTools::isSilicon(const DetId& id) const {
   return silicon;
 }
 
+HGCalTriggerTools::SubDetectorType HGCalTriggerTools::getSubDetectorType(const DetId& id) const {
+  SubDetectorType subdet;
+  if (!isScintillator(id)) {
+    if (isEm(id))
+      subdet = HGCalTriggerTools::hgcal_silicon_CEE;
+    else
+      subdet = HGCalTriggerTools::hgcal_silicon_CEH;
+  } else
+    subdet = HGCalTriggerTools::hgcal_scintillator;
+  return subdet;
+}
+
 int HGCalTriggerTools::zside(const DetId& id) const {
   int zside = 0;
   if (id.det() == DetId::Forward && id.subdetId() != ForwardSubdetector::HFNose) {

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -2,7 +2,7 @@
 
 HGCalConcentratorSuperTriggerCellImpl::HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
     : fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC")),
-      coarsenTriggerCells_(conf.getParameter<bool>("coarsenTriggerCells")),
+      coarsenTriggerCells_(conf.getParameter<std::vector<unsigned>>("coarsenTriggerCells")),
       coarseTCmapping_(conf.getParameter<std::vector<unsigned>>("ctcSize")),
       superTCmapping_(conf.getParameter<std::vector<unsigned>>("stcSize")),
       calibration_(conf.getParameterSet("superTCCalibration")),
@@ -40,11 +40,12 @@ void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(
     if (output_ids.empty())
       continue;
 
+    HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(output_ids.at(0));
     int thickness = (!output_ids.empty() ? triggerTools_.thicknessIndex(output_ids.at(0), true) : 0);
 
     for (const auto& id : output_ids) {
-      if (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_ &&
-          id != coarseTCmapping_.getRepresentativeDetId(id)) {
+      if (((fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_) || coarsenTriggerCells_[subdet]) &&
+          (id != coarseTCmapping_.getRepresentativeDetId(id))) {
         continue;
       }
 
@@ -72,9 +73,7 @@ void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(
           continue;
         }
       }
-
       trigCellVecOutput.push_back(triggerCell);
-
       if (energyDivisionType_ == oneBitFraction) {  //Get the 1 bit fractions
 
         if (id != s.second.getMaxId()) {
@@ -84,7 +83,6 @@ void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(
       }
     }
   }
-
   // assign energy
   for (l1t::HGCalTriggerCell& tc : trigCellVecOutput) {
     const auto& stc = STCs[superTCmapping_.getCoarseTriggerCellId(tc.detId())];
@@ -97,10 +95,11 @@ void HGCalConcentratorSuperTriggerCellImpl::assignSuperTriggerCellEnergyAndPosit
   //Compress and recalibrate STC energy
   uint32_t compressed_value = getCompressedSTCEnergy(stc);
 
+  HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(c.detId());
   int thickness = triggerTools_.thicknessIndex(c.detId(), true);
 
   GlobalPoint point;
-  if ((fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_) || coarsenTriggerCells_) {
+  if ((fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_) || coarsenTriggerCells_[subdet]) {
     point = coarseTCmapping_.getCoarseTriggerCellPosition(coarseTCmapping_.getCoarseTriggerCellId(c.detId()));
   } else {
     point = triggerTools_.getTCPosition(c.detId());
@@ -120,7 +119,7 @@ void HGCalConcentratorSuperTriggerCellImpl::assignSuperTriggerCellEnergyAndPosit
     }
   } else if (energyDivisionType_ == equalShare) {
     double coarseTriggerCellSize =
-        coarsenTriggerCells_
+        coarsenTriggerCells_[subdet]
             ? double(
                   coarseTCmapping_.getConstituentTriggerCells(coarseTCmapping_.getCoarseTriggerCellId(stc.getMaxId()))
                       .size())

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFELinearizationImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFELinearizationImpl.cc
@@ -19,10 +19,10 @@ HGCalVFELinearizationImpl::HGCalVFELinearizationImpl(const edm::ParameterSet& co
   if (oot_coefficients_.size() != kOot_order) {
     throw cms::Exception("BadConfiguration") << "OOT subtraction needs " << kOot_order << " coefficients";
   }
-  adcLSB_si_ = adcsaturation_si_ / pow(2., adcnBits_si_);
-  tdcLSB_si_ = tdcsaturation_si_ / pow(2., tdcnBits_si_);
-  adcLSB_sc_ = adcsaturation_sc_ / pow(2., adcnBits_sc_);
-  tdcLSB_sc_ = tdcsaturation_sc_ / pow(2., tdcnBits_sc_);
+  adcLSB_si_ = ldexp(adcsaturation_si_, -adcnBits_si_);
+  tdcLSB_si_ = ldexp(tdcsaturation_si_, -tdcnBits_si_);
+  adcLSB_sc_ = ldexp(adcsaturation_sc_, -adcnBits_sc_);
+  tdcLSB_sc_ = ldexp(tdcsaturation_sc_, -tdcnBits_sc_);
   linMax_ = (0x1 << linnBits_) - 1;
 }
 

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFELinearizationImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFELinearizationImpl.cc
@@ -15,7 +15,7 @@ HGCalVFELinearizationImpl::HGCalVFELinearizationImpl(const edm::ParameterSet& co
       tdcsaturation_sc_(conf.getParameter<double>("tdcsaturation_sc")),
       linnBits_(conf.getParameter<uint32_t>("linnBits")),
       oot_coefficients_(conf.getParameter<std::vector<double>>("oot_coefficients")) {
-  const int kOot_order = 2;
+  constexpr int kOot_order = 2;
   if (oot_coefficients_.size() != kOot_order) {
     throw cms::Exception("BadConfiguration") << "OOT subtraction needs " << kOot_order << " coefficients";
   }
@@ -28,7 +28,9 @@ HGCalVFELinearizationImpl::HGCalVFELinearizationImpl(const edm::ParameterSet& co
 
 void HGCalVFELinearizationImpl::linearize(const std::vector<HGCDataFrame<DetId, HGCSample>>& dataframes,
                                           std::vector<std::pair<DetId, uint32_t>>& linearized_dataframes) {
-  const int kIntimeSample = 2;
+  constexpr int kIntimeSample = 2;
+  constexpr int kOuttime1Sample = 1;  // in time - 1;
+  constexpr int kOuttime2Sample = 0;  // in time - 2;
 
   for (const auto& frame : dataframes) {  //loop on DIGI
     double amplitude = 0.;
@@ -48,10 +50,10 @@ void HGCalVFELinearizationImpl::linearize(const std::vector<HGCDataFrame<DetId, 
       } else {  //ADC mode
         double data = frame[kIntimeSample].data();
         // applies OOT PU subtraction only in the ADC mode
-        if (!frame[kIntimeSample - 1].mode()) {
-          data += oot_coefficients_[kIntimeSample - 1] * frame[kIntimeSample - 1].data();
-          if (!frame[kIntimeSample - 2].mode()) {
-            data += oot_coefficients_[kIntimeSample - 2] * frame[kIntimeSample - 2].data();
+        if (!frame[kOuttime1Sample].mode()) {
+          data += oot_coefficients_[kOuttime1Sample] * frame[kOuttime1Sample].data();
+          if (!frame[kOuttime2Sample].mode()) {
+            data += oot_coefficients_[kOuttime2Sample] * frame[kOuttime2Sample].data();
           }
         }
         amplitude = std::max(0., data) * adcLSB;

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9Imp2_Nose_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9Imp2_Nose_cfg.py
@@ -68,8 +68,8 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
     outputCommands = cms.untracked.vstring(
         'keep *_genParticles_*_*',
-        'keep *_hgcalBackEndLayer1Producer_*_*',
-        'keep *_hgcalBackEndLayer2Producer_*_*',
+        'keep *_*hgcalBackEndLayer1Producer*_*_*',
+        'keep *_*hgcalBackEndLayer2Producer*_*_*',
         'keep *_hgcalTowerProducer_*_*',
     ),
     fileName = cms.untracked.string('file:/tmp/dalfonso/test.root')

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -199,7 +199,7 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     vector<int> hgcdigi_isadc(digi.size());
     for (int i = 0; i < digi.size(); i++) {
       hgcdigi_data[i] = digi[i].data();
-      hgcdigi_isadc[i] = (digi[i].mode() ? 0 : 1);
+      hgcdigi_isadc[i] = !digi[i].mode();
     }
     hgcdigi_data_.emplace_back(hgcdigi_data);
     hgcdigi_isadc_.emplace_back(hgcdigi_isadc);
@@ -239,7 +239,7 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     vector<int> hgcdigi_isadc(digi.size());
     for (int i = 0; i < digi.size(); i++) {
       hgcdigi_data[i] = digi[i].data();
-      hgcdigi_isadc[i] = (digi[i].mode() ? 0 : 1);
+      hgcdigi_isadc[i] = !digi[i].mode();
     }
     hgcdigi_data_.emplace_back(hgcdigi_data);
     hgcdigi_isadc_.emplace_back(hgcdigi_isadc);
@@ -280,7 +280,7 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     vector<int> bhdigi_isadc(digi.size());
     for (int i = 0; i < digi.size(); i++) {
       bhdigi_data[i] = digi[i].data();
-      bhdigi_isadc[i] = (digi[i].mode() ? 0 : 1);
+      bhdigi_isadc[i] = !digi[i].mode();
     }
     bhdigi_data_.emplace_back(bhdigi_data);
     bhdigi_isadc_.emplace_back(bhdigi_isadc);

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -42,8 +42,8 @@ private:
   std::vector<float> hgcdigi_eta_;
   std::vector<float> hgcdigi_phi_;
   std::vector<float> hgcdigi_z_;
-  std::vector<uint32_t> hgcdigi_data_;
-  std::vector<int> hgcdigi_isadc_;
+  std::vector<std::vector<uint32_t>> hgcdigi_data_;
+  std::vector<std::vector<int>> hgcdigi_isadc_;
   std::vector<float> hgcdigi_simenergy_;
   // V8 detid scheme
   std::vector<int> hgcdigi_wafer_;
@@ -64,7 +64,8 @@ private:
   std::vector<float> bhdigi_eta_;
   std::vector<float> bhdigi_phi_;
   std::vector<float> bhdigi_z_;
-  std::vector<uint32_t> bhdigi_data_;
+  std::vector<std::vector<uint32_t>> bhdigi_data_;
+  std::vector<std::vector<int>> bhdigi_isadc_;
   std::vector<float> bhdigi_simenergy_;
 
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
@@ -120,6 +121,7 @@ void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
   tree.Branch("bhdigi_phi", &bhdigi_phi_);
   tree.Branch("bhdigi_z", &bhdigi_z_);
   tree.Branch("bhdigi_data", &bhdigi_data_);
+  tree.Branch("bhdigi_isadc", &bhdigi_isadc_);
   if (is_Simhit_comp_)
     tree.Branch("bhdigi_simenergy", &bhdigi_simenergy_);
 }
@@ -183,7 +185,6 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
   if (is_Simhit_comp_)
     bhdigi_simenergy_.reserve(bhdigi_n_);
 
-  const int kIntimeSample = 2;
   for (const auto& digi : ee_digis) {
     const DetId id(digi.id());
     hgcdigi_id_.emplace_back(id.rawId());
@@ -194,7 +195,14 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     hgcdigi_eta_.emplace_back(cellpos.eta());
     hgcdigi_phi_.emplace_back(cellpos.phi());
     hgcdigi_z_.emplace_back(cellpos.z());
-    hgcdigi_data_.emplace_back(digi[kIntimeSample].data());
+    vector<uint32_t> hgcdigi_data(digi.size());
+    vector<int> hgcdigi_isadc(digi.size());
+    for (int i = 0; i < digi.size(); i++) {
+      hgcdigi_data[i] = digi[i].data();
+      hgcdigi_isadc[i] = (digi[i].mode() ? 0 : 1);
+    }
+    hgcdigi_data_.emplace_back(hgcdigi_data);
+    hgcdigi_isadc_.emplace_back(hgcdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCSiliconDetId idv9(digi.id());
       hgcdigi_waferu_.emplace_back(idv9.waferU());
@@ -208,10 +216,6 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
       hgcdigi_wafertype_.emplace_back(idv8.waferType());
       hgcdigi_cell_.emplace_back(idv8.cell());
     }
-    int is_adc = 0;
-    if (!(digi[kIntimeSample].mode()))
-      is_adc = 1;
-    hgcdigi_isadc_.emplace_back(is_adc);
     if (is_Simhit_comp_) {
       double hit_energy = 0;
       auto itr = simhits_ee.find(id);
@@ -231,7 +235,14 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     hgcdigi_eta_.emplace_back(cellpos.eta());
     hgcdigi_phi_.emplace_back(cellpos.phi());
     hgcdigi_z_.emplace_back(cellpos.z());
-    hgcdigi_data_.emplace_back(digi[kIntimeSample].data());
+    vector<uint32_t> hgcdigi_data(digi.size());
+    vector<int> hgcdigi_isadc(digi.size());
+    for (int i = 0; i < digi.size(); i++) {
+      hgcdigi_data[i] = digi[i].data();
+      hgcdigi_isadc[i] = (digi[i].mode() ? 0 : 1);
+    }
+    hgcdigi_data_.emplace_back(hgcdigi_data);
+    hgcdigi_isadc_.emplace_back(hgcdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCSiliconDetId idv9(digi.id());
       hgcdigi_waferu_.emplace_back(idv9.waferU());
@@ -245,10 +256,6 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
       hgcdigi_wafertype_.emplace_back(idv8.waferType());
       hgcdigi_cell_.emplace_back(idv8.cell());
     }
-    int is_adc = 0;
-    if (!(digi[kIntimeSample].mode()))
-      is_adc = 1;
-    hgcdigi_isadc_.emplace_back(is_adc);
     if (is_Simhit_comp_) {
       double hit_energy = 0;
       auto itr = simhits_fh.find(id);
@@ -269,7 +276,14 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     bhdigi_eta_.emplace_back(cellpos.eta());
     bhdigi_phi_.emplace_back(cellpos.phi());
     bhdigi_z_.emplace_back(cellpos.z());
-    bhdigi_data_.emplace_back(digi[kIntimeSample].data());
+    vector<uint32_t> bhdigi_data(digi.size());
+    vector<int> bhdigi_isadc(digi.size());
+    for (int i = 0; i < digi.size(); i++) {
+      bhdigi_data[i] = digi[i].data();
+      bhdigi_isadc[i] = (digi[i].mode() ? 0 : 1);
+    }
+    bhdigi_data_.emplace_back(bhdigi_data);
+    bhdigi_isadc_.emplace_back(bhdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCScintillatorDetId idv9(digi.id());
       bhdigi_ieta_.emplace_back(idv9.ietaAbs());
@@ -363,6 +377,7 @@ void HGCalTriggerNtupleHGCDigis::clear() {
   bhdigi_phi_.clear();
   bhdigi_z_.clear();
   bhdigi_data_.clear();
+  bhdigi_isadc_.clear();
   if (is_Simhit_comp_)
     bhdigi_simenergy_.clear();
 }

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -1,7 +1,7 @@
 
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, mixedbcstc_conc_proc
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, custom_conc_proc
 
 
 def create_supertriggercell(process, inputs,
@@ -73,20 +73,50 @@ def create_onebitfraction(process, inputs,
 
 
 def create_mixedfeoptions(process, inputs,
-                            stcSize=supertc_conc_proc.stcSize,
-                            type_energy_division=supertc_conc_proc.type_energy_division,
-                            fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC,
-                            triggercells=best_conc_proc.NData
+                            stcSize=custom_conc_proc.stcSize,
+                            type_energy_division=custom_conc_proc.type_energy_division,
+                            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+                            triggercells=custom_conc_proc.NData
                             ):
     producer = process.hgcalConcentratorProducer.clone(
             InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
             InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
             )
-    producer.ProcessorParameters = mixedbcstc_conc_proc.clone(
+    producer.ProcessorParameters = custom_conc_proc.clone(
             stcSize = stcSize,
             type_energy_division = type_energy_division,
             fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-            NData = triggercells
+            NData = triggercells,
+            Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),        
+            )
+    return producer
+
+
+def create_custom(process, inputs,
+                            stcSize=custom_conc_proc.stcSize,
+                            type_energy_division=custom_conc_proc.type_energy_division,
+                            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+                            triggercells=custom_conc_proc.NData,
+                            threshold_silicon=custom_conc_proc.threshold_silicon,  # in mipT
+                            threshold_scintillator=custom_conc_proc.threshold_scintillator,  # in mipT
+                            Method = custom_conc_proc.Method,
+                            coarsenTriggerCells=custom_conc_proc.coarsenTriggerCells,
+                            ctcSize=custom_conc_proc.ctcSize,
+                            ):
+    producer = process.hgcalConcentratorProducer.clone(
+            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
+            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+            )
+    producer.ProcessorParameters = custom_conc_proc.clone(
+            stcSize = stcSize,
+            type_energy_division = type_energy_division,
+            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+            NData = triggercells,
+            threshold_silicon = threshold_silicon,  # MipT
+            threshold_scintillator = threshold_scintillator,  # MipT
+            Method = Method,
+            coarsenTriggerCells=coarsenTriggerCells,
+            ctcSize = ctcSize,
             )
     return producer
 

--- a/L1Trigger/L1THGCalUtilities/python/vfe.py
+++ b/L1Trigger/L1THGCalUtilities/python/vfe.py
@@ -8,11 +8,12 @@ def create_compression(process,
        rounding=vfe_proc.rounding,
        oot_coefficients=vfe_proc.oot_coefficients
         ):
-    producer = process.hgcalVFEProducer.clone() 
-    producer.ProcessorParameters = vfe_proc.clone(
+    producer = process.hgcalVFEProducer.clone(
+        ProcessorParameters = vfe_proc.clone(
             exponentBits = exponent,
             mantissaBits = mantissa,
             rounding = rounding,
             oot_coefficients = oot_coefficients
-            )
+        )
+    )
     return producer

--- a/L1Trigger/L1THGCalUtilities/python/vfe.py
+++ b/L1Trigger/L1THGCalUtilities/python/vfe.py
@@ -1,13 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
+from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import vfe_proc
 
 def create_compression(process,
-       exponent=4,
-       mantissa=4,
-       rounding=True
+       exponent=vfe_proc.exponentBits,
+       mantissa=vfe_proc.mantissaBits,
+       rounding=vfe_proc.rounding,
+       oot_coefficients=vfe_proc.oot_coefficients
         ):
     producer = process.hgcalVFEProducer.clone() 
-    producer.ProcessorParameters.exponentBits = cms.uint32(exponent)
-    producer.ProcessorParameters.mantissaBits = cms.uint32(mantissa)
-    producer.ProcessorParameters.rounding = cms.bool(rounding)
+    producer.ProcessorParameters = vfe_proc.clone(
+            exponentBits = exponent,
+            mantissaBits = mantissa,
+            rounding = rounding,
+            oot_coefficients = oot_coefficients
+            )
     return producer


### PR DESCRIPTION
#### PR description:
- More customisable frontend selection in the CEE, CEH-si and CEH-sci (@snwebb)
- Possibility to configure out-of-time PU subtraction, switched off by default (@jbsauvan)
- Separate HFNose and HGCAL in different sequences (@mariadalfonso)
- Optimization of pow(2) in floating point compression initialization (@imranyusuff )

#### PR validation:
- Each item in this PR has been validated separately looking at standard distributions. Physics performance studies were also performed when necessary.
- Standard tests with V9, V10 and V11 worflows have been run
```
runTheMatrix.py -w upgrade -l 20034.0 --maxSteps=2
runTheMatrix.py -w upgrade -l 20434.0 --maxSteps=2
runTheMatrix.py -w upgrade -l 22034.0 --maxSteps=2
```


