### PR TITLE
Initialize SpatialRange to avoid compilation warnings on PPC64LE

### DIFF
--- a/RecoPPS/Local/interface/CTPPSTimingTrackRecognition.h
+++ b/RecoPPS/Local/interface/CTPPSTimingTrackRecognition.h
@@ -197,7 +197,7 @@ template <class TRACK_TYPE, class HIT_TYPE>
 inline typename CTPPSTimingTrackRecognition<TRACK_TYPE, HIT_TYPE>::SpatialRange
 CTPPSTimingTrackRecognition<TRACK_TYPE, HIT_TYPE>::getHitSpatialRange(const HitVector& hits) {
   bool initialized = false;
-  SpatialRange result;
+  SpatialRange result = {};
 
   for (const auto& hit : hits) {
     const float xBegin = hit.x() - 0.5f * hit.xWidth(), xEnd = hit.x() + 0.5f * hit.xWidth();


### PR DESCRIPTION
#### PR description:

In Power IBs, we have few compilation warnings [a]. This could happen if there are no hits and https://cmssdt.cern.ch/lxr/source/RecoPPS/Local/interface/CTPPSTimingTrackRecognition.h#0198 return the un-initialized  SpatialRange. This PR propose to initialize  SpatialRange with default values.

[a]
```
RecoPPS/Local/src/TotemTimingTrackRecognition.cc: In member function 'virtual int TotemTimingTrackRecognition::produceTracks(edm::DetSet<TotemTimingLocalTrack>&)':
  RecoPPS/Local/src/TotemTimingTrackRecognition.cc:66:96: warning: 'result.CTPPSTimingTrackRecognition<TotemTimingLocalTrack, TotemTimingRecHit>::SpatialRange::zEnd' may be used uninitialized in this function [-Wmaybe-uninitialized]
          math::XYZPoint positionSigma(xTrack.x0Sigma(), yTrack.y0Sigma(), 0.5f * (hitRange.zEnd - hitRange.zBegin));
                                                                                 ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
  RecoPPS/Local/src/TotemTimingTrackRecognition.cc:66:96: warning: 'result.CTPPSTimingTrackRecognition<TotemTimingLocalTrack, TotemTimingRecHit>::SpatialRange::zBegin' may be used uninitialized in this function [-Wmaybe-uninitialized]
 In file included from RecoPPS/Local/interface/TotemTimingTrackRecognition.h:18,
                 from RecoPPS/Local/src/TotemTimingTrackRecognition.cc:11:
  RecoPPS/Local/interface/CTPPSTimingTrackRecognition.h:131:15: warning: 'result.CTPPSTimingTrackRecognition<TotemTimingLocalTrack, TotemTimingRecHit>::SpatialRange::yEnd' may be used uninitialized in this function [-Wmaybe-uninitialized]
    const float profileRangeEnd = param.rangeEnd + profileRangeMargin;
               ^~~~~~~~~~~~~~~
 ```
#### PR validation:

Local compilation with both normal amd64 and ppc64le IBs is successful (without any warnings).