### PR TITLE
First version of DeepMET

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -184,7 +184,9 @@ namespace pat {
       RawCalo = 10,
       RawChs = 11,
       RawTrk = 12,
-      METCorrectionLevelSize = 13
+      RawDeepResponseTune = 13,
+      RawDeepResolutionTune = 14,
+      METCorrectionLevelSize = 15
     };
     enum METCorrectionType {
       None = 0,
@@ -199,7 +201,9 @@ namespace pat {
       Calo = 9,
       Chs = 10,
       Trk = 11,
-      METCorrectionTypeSize = 12
+      DeepResponseTune = 12,
+      DeepResolutionTune = 13,
+      METCorrectionTypeSize = 14
     };
 
     struct Vector2 {

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -193,6 +193,16 @@ void MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpRawTrk;
   tmpRawTrk.push_back(MET::Trk);
   corMap_[MET::RawTrk] = tmpRawTrk;
+
+  //specific deep response tune case
+  std::vector<MET::METCorrectionType> tmpDeepResponse;
+  tmpDeepResponse.push_back(MET::DeepResponseTune);
+  corMap_[MET::RawDeepResponseTune] = tmpDeepResponse;
+
+  //specific deep resolution tune case
+  std::vector<MET::METCorrectionType> tmpDeepResolution;
+  tmpDeepResolution.push_back(MET::DeepResolutionTune);
+  corMap_[MET::RawDeepResolutionTune] = tmpDeepResolution;
 }
 
 const MET::PackedMETUncertainty MET::findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const {

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -80,8 +80,10 @@ pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet &iConfig)
   maybeReadShifts(iConfig, "caloMET", pat::MET::Calo);
   maybeReadShifts(iConfig, "chsMET", pat::MET::Chs);
   maybeReadShifts(iConfig, "trkMET", pat::MET::Trk);
-  maybeReadShifts(iConfig, "deepMETResolutionTune", pat::MET::DeepResolutionTune);
-  maybeReadShifts(iConfig, "deepMETResponseTune", pat::MET::DeepResponseTune);
+  if (iConfig.getParameter<bool>("addDeepMETs")) {
+    maybeReadShifts(iConfig, "deepMETResolutionTune", pat::MET::DeepResolutionTune);
+    maybeReadShifts(iConfig, "deepMETResponseTune", pat::MET::DeepResponseTune);
+  }
 
   produces<std::vector<pat::MET>>();
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -80,6 +80,8 @@ pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet &iConfig)
   maybeReadShifts(iConfig, "caloMET", pat::MET::Calo);
   maybeReadShifts(iConfig, "chsMET", pat::MET::Chs);
   maybeReadShifts(iConfig, "trkMET", pat::MET::Trk);
+  maybeReadShifts(iConfig, "deepMETResolutionTune", pat::MET::DeepResolutionTune);
+  maybeReadShifts(iConfig, "deepMETResponseTune", pat::MET::DeepResponseTune);
 
   produces<std::vector<pat::MET>>();
 }

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -20,8 +20,6 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedMETs_*_*',
         'keep *_slimmedMETsNoHF_*_*',
         'keep *_slimmedMETsPuppi_*_*',
-        'keep *_slimmedMETsDeep_*_*',
-        'keep *_slimmedMETsDeepResp_*_*',
         'keep *_slimmedSecondaryVertices_*_*',
         'keep *_slimmedLambdaVertices_*_*',
         'keep *_slimmedKshortVertices_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -20,6 +20,8 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedMETs_*_*',
         'keep *_slimmedMETsNoHF_*_*',
         'keep *_slimmedMETsPuppi_*_*',
+        'keep *_slimmedMETsDeep_*_*',
+        'keep *_slimmedMETsDeepResp_*_*',
         'keep *_slimmedSecondaryVertices_*_*',
         'keep *_slimmedLambdaVertices_*_*',
         'keep *_slimmedKshortVertices_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -454,26 +454,25 @@ def miniAOD_customizeCommon(process):
 
     process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
 
-
-    addToProcessAndTask('slimmedMETsDeep', process.deepMETProducer.clone(), process, task)
-    addToProcessAndTask('slimmedMETsDeepResp', process.deepMETProducer.clone(), process, task)
-    process.slimmedMETsDeepResp.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
+    addToProcessAndTask('deepMETsResolutionTune', process.deepMETProducer.clone(), process, task)
+    addToProcessAndTask('deepMETsResponseTune', process.deepMETProducer.clone(), process, task)
+    process.deepMETsResponseTune.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
 
     from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
     phase2_common.toModify(
-        process.slimmedMETsDeep,
+        process.deepMETsResolutionTune,
         max_n_pf=12500,
         graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb"
     )
     phase2_common.toModify(
-        process.slimmedMETsDeepResp,
+        process.deepMETsResponseTune,
         max_n_pf=12500,
         graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb"
     )
 
     from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
     run2_jme_2016.toModify(
-        process.slimmedMETsDeepResp,
+        process.deepMETsResponseTune,
         graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"
     )
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -462,19 +462,19 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
     phase2_common.toModify(
         process.slimmedMETsDeep,
-        max_n_pf=cms.uint32(12500),
-        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb")
+        max_n_pf=12500,
+        graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb"
     )
     phase2_common.toModify(
         process.slimmedMETsDeepResp,
-        max_n_pf=cms.uint32(12500),
-        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb")
+        max_n_pf=12500,
+        graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb"
     )
 
     from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
     run2_jme_2016.toModify(
         process.slimmedMETsDeepResp,
-        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb")
+        graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"
     )
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)
     process.load("TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff")

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -177,6 +177,8 @@ def miniAOD_customizeCommon(process):
 
     process.load('PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi')
     task.add(process.slimmedMETs)
+    process.slimmedMETs.addDeepMETs = True
+
     addToProcessAndTask('slimmedMETsNoHF', process.slimmedMETs.clone(), process, task)
     process.slimmedMETsNoHF.src = cms.InputTag("patMETsNoHF")
     process.slimmedMETsNoHF.rawVariation =  cms.InputTag("patPFMetNoHF")

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -452,6 +452,30 @@ def miniAOD_customizeCommon(process):
     process.slimmedMETsPuppi.tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxyPuppi")
     del process.slimmedMETsPuppi.caloMET
 
+    process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
+
+
+    addToProcessAndTask('slimmedMETsDeep', process.deepMETProducer.clone(), process, task)
+    addToProcessAndTask('slimmedMETsDeepResp', process.deepMETProducer.clone(), process, task)
+    process.slimmedMETsDeepResp.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
+
+    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+    phase2_common.toModify(
+        process.slimmedMETsDeep,
+        max_n_pf=cms.uint32(12500),
+        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb")
+    )
+    phase2_common.toModify(
+        process.slimmedMETsDeepResp,
+        max_n_pf=cms.uint32(12500),
+        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb")
+    )
+
+    from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
+    run2_jme_2016.toModify(
+        process.slimmedMETsDeepResp,
+        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb")
+    )
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)
     process.load("TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff")
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
@@ -19,6 +19,8 @@ slimmedMETs = cms.EDProducer("PATMETSlimmer",
    #adding CHS and Track MET for the Jet/MET studies
    chsMET = cms.InputTag("patCHSMet"),
    trkMET = cms.InputTag("patTrkMet"),
+   deepMETResolutionTune = cms.InputTag("deepMETsResolutionTune"),
+   deepMETResponseTune = cms.InputTag("deepMETsResponseTune"),
 
    #switch to read the type0 correction from the existing slimmedMET
    #when running on top of miniAOD (type0 cannot be redone at the miniAOD level

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
@@ -19,6 +19,9 @@ slimmedMETs = cms.EDProducer("PATMETSlimmer",
    #adding CHS and Track MET for the Jet/MET studies
    chsMET = cms.InputTag("patCHSMet"),
    trkMET = cms.InputTag("patTrkMet"),
+
+   #adding DeepMET variants
+   addDeepMETs = cms.bool(False),
    deepMETResolutionTune = cms.InputTag("deepMETsResolutionTune"),
    deepMETResponseTune = cms.InputTag("deepMETsResponseTune"),
 

--- a/RecoMET/METPUSubtraction/plugins/BuildFile.xml
+++ b/RecoMET/METPUSubtraction/plugins/BuildFile.xml
@@ -17,6 +17,7 @@
   <use name="JetMETCorrections/Objects"/>
   <use name="RecoMET/METPUSubtraction"/>
   <use name="RecoJets/JetProducers"/>
+  <use name="PhysicsTools/TensorFlow"/>
   <use name="root"/>
   <use name="roottmva"/>
 </library>

--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -1,0 +1,163 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+
+struct DeepMETCache {
+  std::atomic<tensorflow::GraphDef*> graph_def;
+};
+
+class DeepMETProducer : public edm::stream::EDProducer<edm::GlobalCache<DeepMETCache> > {
+public:
+  explicit DeepMETProducer(const edm::ParameterSet&, const DeepMETCache*);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  // static methods for handling the global cache
+  static std::unique_ptr<DeepMETCache> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(DeepMETCache*);
+private:
+  const edm::EDGetTokenT<std::vector<pat::PackedCandidate> > pf_token_;
+  float norm_;
+  bool ignore_leptons_;
+  unsigned int max_n_pf_;
+
+  tensorflow::Session* session_;
+
+  std::unordered_map<int, int32_t> charge_embedding_;
+  std::unordered_map<int, int32_t> pdg_id_embedding_;
+};
+
+
+namespace {
+  float divide_and_rm_outlier(float val, float norm) {
+    float ret_val = val/norm;
+    if (ret_val > 1e6 || ret_val < -1e6)
+      return 0.;
+    return ret_val;
+  }
+}
+
+DeepMETProducer::DeepMETProducer(const edm::ParameterSet& cfg, const DeepMETCache* cache) :
+  pf_token_(consumes<std::vector<pat::PackedCandidate> >(cfg.getParameter<edm::InputTag>("pf_src"))),
+  norm_(cfg.getParameter<double>("norm_factor")), 
+  ignore_leptons_(cfg.getParameter<bool>("ignore_leptons")),
+  max_n_pf_(cfg.getParameter<unsigned int>("max_n_pf")) {
+    session_ = tensorflow::createSession(cache->graph_def);
+    produces<pat::METCollection>();
+    charge_embedding_ = {{-1, 0}, {0, 1}, {1, 2}};
+    pdg_id_embedding_ = {{-211, 0}, {-13, 1}, {-11, 2}, {0, 3}, {1, 4}, {2, 5}, {11, 6}, {13, 7}, {22, 8}, {130, 9}, {211, 10}};;
+}
+
+void DeepMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+  edm::Handle<std::vector<pat::PackedCandidate> > pf_h;
+  event.getByToken(pf_token_, pf_h);
+
+  // PF keys [b'PF_dxy', b'PF_dz', b'PF_eta', b'PF_mass', b'PF_pt', b'PF_puppiWeight', b'PF_px', b'PF_py']
+  tensorflow::TensorShape shape({1, max_n_pf_, 8});
+  tensorflow::TensorShape cat_shape({1, max_n_pf_, 1});
+  tensorflow::Tensor input(tensorflow::DT_FLOAT, shape);
+  tensorflow::Tensor input_cat0(tensorflow::DT_FLOAT, cat_shape);
+  tensorflow::Tensor input_cat1(tensorflow::DT_FLOAT, cat_shape);
+  tensorflow::Tensor input_cat2(tensorflow::DT_FLOAT, cat_shape);
+
+  tensorflow::TensorShape out_shape({1, 2});
+  tensorflow::Tensor output(tensorflow::DT_FLOAT, out_shape);
+
+  tensorflow::NamedTensorList input_list = {{"input", input}, {"input_cat0", input_cat0}, {"input_cat1", input_cat1}, {"input_cat2", input_cat2}};
+
+  // Set all inputs to zero
+  input.flat<float>().setZero();
+  input_cat0.flat<float>().setZero();
+  input_cat1.flat<float>().setZero();
+  input_cat2.flat<float>().setZero();
+
+  size_t i_pf = 0;
+  float px_leptons = 0.;
+  float py_leptons = 0.;
+  for (const auto& pf : *pf_h) {
+
+    if (ignore_leptons_) {
+      int pdg_id = std::abs(pf.pdgId());
+      if (pdg_id == 11 || pdg_id == 13) {
+        px_leptons += pf.px();
+        py_leptons += pf.py();
+        continue;
+      }
+    } 
+
+    // fill the tensor
+    float* ptr = &input.tensor<float, 3>()(0, i_pf, 0);
+    *ptr = pf.dxy();
+    *(++ptr) = pf.dz();
+    *(++ptr) = pf.eta();
+    *(++ptr) = pf.mass();
+    *(++ptr) = divide_and_rm_outlier(pf.pt(), norm_);
+    *(++ptr) = pf.puppiWeight();
+    *(++ptr) = divide_and_rm_outlier(pf.px(), norm_);
+    *(++ptr) = divide_and_rm_outlier(pf.py(), norm_);
+    input_cat0.tensor<float, 3>()(0, i_pf, 0) = charge_embedding_[pf.charge()];
+    input_cat1.tensor<float, 3>()(0, i_pf, 0) = pdg_id_embedding_[pf.pdgId()];
+    input_cat2.tensor<float, 3>()(0, i_pf, 0) = pf.fromPV();
+
+    ++i_pf;
+    if (i_pf > max_n_pf_)
+    {
+      break; // output a warning?
+    }
+  }
+
+  std::vector<tensorflow::Tensor> outputs;
+  std::vector<std::string> output_names = {"output/BiasAdd"};
+
+  // run the inference and return met
+  tensorflow::run(session_, input_list, output_names, &outputs);
+
+  // The DNN directly estimates the missing px and py, not the recoil
+  float px = outputs[0].tensor<float, 2>()(0, 0) * norm_;
+  float py = outputs[0].tensor<float, 2>()(0, 1) * norm_;
+
+  px -= px_leptons;
+  py -= py_leptons;
+
+  auto pf_mets = std::make_unique<pat::METCollection>();
+  reco::LeafCandidate::LorentzVector p4(px, py, 0., std::sqrt(px*px + py*py));
+  const reco::Candidate::Point vtx(0.0, 0.0, 0.0);
+  pf_mets->emplace_back(reco::MET(p4, vtx));
+  event.put(std::move(pf_mets));
+}
+
+std::unique_ptr<DeepMETCache> DeepMETProducer::initializeGlobalCache(const edm::ParameterSet& params) {
+  // this method is supposed to create, initialize and return a DeepMETCache instance
+  std::unique_ptr<DeepMETCache> cache = std::make_unique<DeepMETCache>();
+
+  // load the graph def and save it
+  std::string graphPath = params.getParameter<std::string>("graph_path");
+  if (!graphPath.empty()) {
+    graphPath = edm::FileInPath(graphPath).fullPath();
+    cache->graph_def = tensorflow::loadGraphDef(graphPath);
+  }
+
+  return cache;
+}
+
+void DeepMETProducer::globalEndJob(DeepMETCache* cache) {
+  delete cache->graph_def;
+}
+
+void DeepMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("pf_src", edm::InputTag("packedPFCandidates"));
+  desc.add<bool>("ignore_leptons", false);
+  desc.add<double>("norm_factor", 50.);
+  desc.add<unsigned int>("max_n_pf", 4500);
+  desc.add<std::string>("graph_path", "RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_2018.pb");
+  descriptions.add("deepMETProducer", desc);
+}
+
+DEFINE_FWK_MODULE(DeepMETProducer);

--- a/RecoMET/METPUSubtraction/test/testDeepMET_cfg.py
+++ b/RecoMET/METPUSubtraction/test/testDeepMET_cfg.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+from RecoMET.METPUSubtraction.deepMETProducer_cfi import deepMETProducer
+
+process = cms.Process('DeepMET')
+
+process.task = cms.Task()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load(
+    'Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input=cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+                            secondaryFileNames=cms.untracked.vstring(),
+                            fileNames=cms.untracked.vstring(
+                                # '/store/relval/CMSSW_11_0_0_pre7/RelValTTbar_13/MINIAODSIM/PUpmx25ns_110X_mc2017_realistic_v1_rsb-v1/10000/A745F01B-D6C3-A843-97B7-2B12C7C0DD4E.root'),
+                                '/store/mc/RunIIAutumn18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/270000/9E5D0032-E9FB-6646-B1AB-67EA8B95FCCD.root'),
+                            skipEvents=cms.untracked.uint32(0)
+                            )
+
+process.deepMETProducer = deepMETProducer.clone()
+
+process.sequence = cms.Sequence(process.deepMETProducer)
+process.p = cms.Path(process.sequence)
+process.output = cms.OutputModule("PoolOutputModule",
+                                  outputCommands=cms.untracked.vstring(
+                                      'keep *'),
+                                  fileName=cms.untracked.string(
+                                      "DeepMETTest.root")
+                                  )
+process.outpath  = cms.EndPath(process.output)


### PR DESCRIPTION
#### PR description:

This PR introduces a producer for DeepMET, a deep-learning-based missing pT estimator. The producer creates a new MET collection, and a test configuration is included. The plan is to create a separate PR for possible inclusion in central sequences, e.g. for the upcoming ReMiniAOD campaign.

The tensorflow models for this PR are proposed in a separate PR to cms-data/RecoMET-METPUSubtraction https://github.com/cms-data/RecoMET-METPUSubtraction/pull/5

There are different trainings for different years/conditions (2016, 2018, phase 2), and for 2018 and phase 2 also non-response-corrected trainings. 

Presentations:
https://indico.cern.ch/event/912067/contributions/3835851/ (most recent update)
https://indico.cern.ch/event/883809/contributions/3733818/ (CMS week JetMET meeting)
https://indico.cern.ch/event/854654/contributions/3594579/ (first presentation in MET meeting)

Note that an alternative implementation would be to store additional weights for each PFCandidate and calculate MET and possibly jets in a subsequent step. However, we prefer to leave this option to future studies given that we have not checked the performance on jets (and assume some non-trivial effects) and that this would lead to an increase in complexity of the integration and the additional storage required, in particular if we want to have different METs (e.g. response and non-response-corrected) for a single campaigns.

#### PR validation:

The code has been validated by running it in large-scale checks with simulated and data events to evaluate the performance of the algorithm. A test configuration is included. We have not run any memory or timing tests but we suspect that it runs fast and consumes little memory given the models are small compared to most other tensorflow models.

CPU and memory reports can be found under the following links, obtained on 1000 events from the 136.8311_RunJetHT2017F workflow:
https://steggema.web.cern.ch/steggema/cgi-bin/igprof-navigator/deepmet_cpu_reminiaod
https://steggema.web.cern.ch/steggema/cgi-bin/igprof-navigator/deepmet_mem_reminiaod (note that DeepMET does not seem to appear here, supposedly because it's not in the top 1000, see the text file linked below)

Text dumps are also available here: /afs/cern.ch/user/s/steggema/public/DeepMETIntegration/

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

-

@intrepid42 @yongbinfeng 