### PR TITLE
Fix dead assignments in L1TStage2RegionalMuonCandComp L1 muon DQM module.

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
@@ -497,10 +497,6 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
           errorSummaryNum->Fill(RTRACKADDR);
       }
 
-      if (incBin[RMUON] && muonSelMismatch) {
-        errorSummaryNum->Fill(RMUON);
-      }
-
       if (isBmtf) {
         if (muonIt1->hwDXY() != muonIt2->hwDXY()) {
           muonMismatch = true;
@@ -518,6 +514,10 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
             errorSummaryNum->Fill(RPT2);
           }
         }
+      }
+
+      if (incBin[RMUON] && muonSelMismatch) {
+        errorSummaryNum->Fill(RMUON);
       }
 
       if (muonMismatch) {


### PR DESCRIPTION
#### PR description:

Fixes two dead assignments found by the static analyzer. The BMTF dxy and pt2 tests should happen before the summary histogram is filled.

https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_11_1_X_2020-05-06-2300/slc7_amd64_gcc820/llvm-analysis/report-721356.html
https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_11_1_X_2020-05-06-2300/slc7_amd64_gcc820/llvm-analysis/report-749ec7.html#EndPath

#### PR validation:

`runTheMatrix.py -l 136.793 -i all --ibeos`
