### PR TITLE
[LLVM10] Fix compilation warnings for DAQ/RECO packages

### DIFF
--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
@@ -111,7 +111,6 @@ bool CSCDigiValidator::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   CSCALCTDigiCollection::DigiRangeIterator alct = _alct->begin(), salct = _salct->begin();
   CSCCorrelatedLCTDigiCollection::DigiRangeIterator lct = _lct->begin(), slct = _slct->begin();
   L1CSCTrackCollection::const_iterator trk = _trk->begin(), strk = _strk->begin();
-  //std::vector<csctf::TrackStub>::const_iterator dt = _dt->get().begin(), sdt = _sdt->get().begin();
 
   //per detID, create lists of various digi types
   matchingDetWireCollection wires;

--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
@@ -111,12 +111,7 @@ bool CSCDigiValidator::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   CSCALCTDigiCollection::DigiRangeIterator alct = _alct->begin(), salct = _salct->begin();
   CSCCorrelatedLCTDigiCollection::DigiRangeIterator lct = _lct->begin(), slct = _slct->begin();
   L1CSCTrackCollection::const_iterator trk = _trk->begin(), strk = _strk->begin();
-  std::vector<csctf::TrackStub>::const_iterator dt = _dt->get().begin(), sdt = _sdt->get().begin();
-  // WARNING 5_0_X
-  dt++;
-  dt--;
-  sdt++;
-  sdt--;
+  //std::vector<csctf::TrackStub>::const_iterator dt = _dt->get().begin(), sdt = _sdt->get().begin();
 
   //per detID, create lists of various digi types
   matchingDetWireCollection wires;

--- a/EventFilter/Utilities/src/json_reader.cpp
+++ b/EventFilter/Utilities/src/json_reader.cpp
@@ -430,7 +430,7 @@ namespace Json {
       while (token.type_ == tokenComment && ok) {
         ok = readToken(token);
       }
-      bool badTokenType = (token.type_ == tokenArraySeparator && token.type_ == tokenArrayEnd);
+      bool badTokenType = (token.type_ == tokenArraySeparator || token.type_ == tokenArrayEnd);
       if (!ok || badTokenType) {
         return addErrorAndRecover("Missing ',' or ']' in array declaration", token, tokenArrayEnd);
       }

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -1037,7 +1037,7 @@ void HcalNoiseInfoProducer::filldigis(edm::Event& iEvent,
       int ieta = laserMonIEtaList_[ich];
 
       // loop over digis, find the digi that matches this channel
-      for (const QIE10DataFrame& df : (*hLasermon)) {
+      for (const QIE10DataFrame df : (*hLasermon)) {
         HcalCalibDetId calibId(df.id());
 
         int ch_cboxch = calibId.cboxChannel();


### PR DESCRIPTION
#### PR description:

- EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc:  Removed unused code.
- EventFilter/Utilities/src/json_reader.cpp:  Fixed logic, it was always returning false.
- RecoMET/METProducers/src/HcalNoiseInfoProducer.cc: Fixed loop variable copy warnings. Looks like we need a copy anyway as `hLasermon` returns `edm::DataFrame` and we need to convert it to `QIE10DataFrame`

#### PR validation:

Local build for both CLANG and normal IBs look good