### PR TITLE
[LLVM10] Fixing compilation warnings for SIM/GEOM

### DIFF
--- a/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
+++ b/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
@@ -10,7 +10,7 @@ using namespace edm;
 string_view DDSpecPar::strValue(const string& key) const {
   auto const& item = spars.find(key);
   if (item == end(spars))
-    return string();
+    return string_view();
   return *begin(item->second);
 }
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_MaterialAccountingGroup.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_MaterialAccountingGroup.cc
@@ -33,7 +33,7 @@ DD4hep_MaterialAccountingGroup::DD4hep_MaterialAccountingGroup(const std::string
   edm::LogVerbatim("TrackingMaterialAnalysis") << "Elements within: " << name;
 
   for (const auto j : fv.specpars()) {
-    for (const auto k : j->paths) {
+    for (const auto &k : j->paths) {
       if (firstChild) {
         std::vector<std::vector<cms::Node*>> children = fv.children(k);
         for (auto const& path : children) {

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_MaterialAccountingGroup.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_MaterialAccountingGroup.cc
@@ -17,7 +17,8 @@
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingDetector.h"
 #include "DD4hep_MaterialAccountingGroup.h"
 
-DD4hep_MaterialAccountingGroup::DD4hep_MaterialAccountingGroup(const std::string& name, const cms::DDCompactView& geometry)
+DD4hep_MaterialAccountingGroup::DD4hep_MaterialAccountingGroup(const std::string& name,
+                                                               const cms::DDCompactView& geometry)
     : m_name(name),
       m_elements(),
       m_boundingbox(),
@@ -33,7 +34,7 @@ DD4hep_MaterialAccountingGroup::DD4hep_MaterialAccountingGroup(const std::string
   edm::LogVerbatim("TrackingMaterialAnalysis") << "Elements within: " << name;
 
   for (const auto j : fv.specpars()) {
-    for (const auto &k : j->paths) {
+    for (const auto& k : j->paths) {
       if (firstChild) {
         std::vector<std::vector<cms::Node*>> children = fv.children(k);
         for (auto const& path : children) {
@@ -211,7 +212,9 @@ MaterialAccountingStep DD4hep_MaterialAccountingGroup::average(void) const {
   return m_tracks ? m_accounting / m_tracks : MaterialAccountingStep();
 }
 
-double DD4hep_MaterialAccountingGroup::averageLength(void) const { return m_tracks ? m_accounting.length() / m_tracks : 0.; }
+double DD4hep_MaterialAccountingGroup::averageLength(void) const {
+  return m_tracks ? m_accounting.length() / m_tracks : 0.;
+}
 
 double DD4hep_MaterialAccountingGroup::averageEnergyLoss(void) const {
   return m_tracks ? m_accounting.energyLoss() / m_tracks : 0.;


### PR DESCRIPTION
#### PR description:

- DetectorDescription/DDCMS/src/DDSpecparRegistry.cc: Return `string_view` instead of address of local temporary string object.
- SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_MaterialAccountingGroup.cc :  Avoid loop variable copy.

#### PR validation:

Local compilation for CLANG and normal IBs show no warnings.