### PR TITLE
[LLVM10] Fixing compilation warnings for ALCA/DB

### DIFF
--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -118,7 +118,9 @@ namespace edmtest {
         if ((it->second).hasExtraDOF()) {
           for (unsigned int j = 0; j < (it->second).extraDOFSize(); j++) {
             std::array<float, 4> extraDOFCuts = thresholds->getExtraDOFCutsForAlignable(it->first, j);
-            fprintf(pFile, "Extra DOF: %i with label %s \n ", j,
+            fprintf(pFile,
+                    "Extra DOF: %i with label %s \n ",
+                    j,
                     thresholds->getExtraDOFLabelForAlignable(it->first, j).c_str());
             fprintf(pFile, "- cut              : %8.3f        ", extraDOFCuts.at(0));
             fprintf(pFile, "| sigCut           : %8.3f        ", extraDOFCuts.at(1));

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -118,8 +118,8 @@ namespace edmtest {
         if ((it->second).hasExtraDOF()) {
           for (unsigned int j = 0; j < (it->second).extraDOFSize(); j++) {
             std::array<float, 4> extraDOFCuts = thresholds->getExtraDOFCutsForAlignable(it->first, j);
-            const char* theLabel = (thresholds->getExtraDOFLabelForAlignable(it->first, j)).c_str();
-            fprintf(pFile, "Extra DOF: %i with label %s \n ", j, theLabel);
+            fprintf(pFile, "Extra DOF: %i with label %s \n ", j,
+                    thresholds->getExtraDOFLabelForAlignable(it->first, j).c_str());
             fprintf(pFile, "- cut              : %8.3f        ", extraDOFCuts.at(0));
             fprintf(pFile, "| sigCut           : %8.3f        ", extraDOFCuts.at(1));
             fprintf(pFile, "| maxMoveCut       : %8.3f        ", extraDOFCuts.at(2));

--- a/CondFormats/RPCObjects/src/L1RPCConeBuilder.cc
+++ b/CondFormats/RPCObjects/src/L1RPCConeBuilder.cc
@@ -25,7 +25,8 @@ L1RPCConeBuilder::~L1RPCConeBuilder() {}
 
 std::pair<L1RPCConeBuilder::TStripConVec::const_iterator, L1RPCConeBuilder::TStripConVec::const_iterator>
 L1RPCConeBuilder::getConVec(uint32_t det, unsigned char strip) const {
-  L1RPCConeBuilder::TStripConVec::const_iterator itBeg = L1RPCConeBuilder::TStripConVec().end();
+  L1RPCConeBuilder::TStripConVec tmp;
+  L1RPCConeBuilder::TStripConVec::const_iterator itBeg = tmp.end();
   L1RPCConeBuilder::TStripConVec::const_iterator itEnd = itBeg;
 
   TConMap::const_iterator it1 = m_coneConnectionMap->find(det);
@@ -42,7 +43,8 @@ L1RPCConeBuilder::getConVec(uint32_t det, unsigned char strip) const {
 
 std::pair<L1RPCConeBuilder::TCompressedConVec::const_iterator, L1RPCConeBuilder::TCompressedConVec::const_iterator>
 L1RPCConeBuilder::getCompConVec(uint32_t det) const {
-  L1RPCConeBuilder::TCompressedConVec::const_iterator itBeg = L1RPCConeBuilder::TCompressedConVec().end();
+  L1RPCConeBuilder::TCompressedConVec tmp;
+  L1RPCConeBuilder::TCompressedConVec::const_iterator itBeg = tmp.end();
   L1RPCConeBuilder::TCompressedConVec::const_iterator itEnd = itBeg;
 
   if (m_compressedConeConnectionMap->find(det) != m_compressedConeConnectionMap->end()) {


### PR DESCRIPTION
#### PR description:

LLVM 10 (in CLANG IBs) complains about `object backing the pointer will be destroyed at the end of the full-expression`. These changes are to avoid such warnings.

#### PR validation:

Local compilation for CLANG and normal IBs show no warnings.