### PR TITLE
Fix moduleLabelsInSequences to support modules with a "label" parameter

### DIFF
--- a/FWCore/ParameterSet/python/Utilities.py
+++ b/FWCore/ParameterSet/python/Utilities.py
@@ -162,7 +162,7 @@ def modulesInSequences(* sequences):
 
 
 def moduleLabelsInSequences(* sequences):
-  return [module.label() for module in modulesInSequences(* sequences)]
+  return [module.label_() for module in modulesInSequences(* sequences)]
 
 def createTaskWithAllProducersAndFilters(process):
   from FWCore.ParameterSet.Config import Task


### PR DESCRIPTION
#### PR description:

Fix `moduleLabelsInSequences()` to support paths and sequences that include modules that define a `label` top level parameter.

#### PR validation:

Run with
```python
from FWCore.ParameterSet.Utilities import moduleLabelsInSequences
process.DependencyGraph = cms.Service("DependencyGraph",
    highlightModules = cms.untracked.vstring(moduleLabelsInSequences(process.raw2digi_step, process.reconstruction_step))
)
```
on top of the 10824.512 workflow.