### PR TITLE
[LLVM10] Fix compilation warnings for RECO package

### DIFF
--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -1037,7 +1037,7 @@ void HcalNoiseInfoProducer::filldigis(edm::Event& iEvent,
       int ieta = laserMonIEtaList_[ich];
 
       // loop over digis, find the digi that matches this channel
-      for (const QIE10DataFrame& df : (*hLasermon)) {
+      for (const QIE10DataFrame df : (*hLasermon)) {
         HcalCalibDetId calibId(df.id());
 
         int ch_cboxch = calibId.cboxChannel();


### PR DESCRIPTION
#### PR description:

Fixed loop variable copy warnings. Looks like we need a copy anyway as `hLasermon` returns `edm::DataFrame` and we need to convert it to `QIE10DataFrame`

#### PR validation:

Local build for both CLANG and normal IBs look good