### PR TITLE
Handle PseudoTraps in DD4hep MF geometry builder

### DIFF
--- a/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
+++ b/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
@@ -53,6 +53,10 @@ volumeHandle::volumeHandle(const cms::DDFilteredView &fv, bool expand2Pi, bool d
     case DDSolidShape::ddtubs:
       buildTubs();
       break;
+    case DDSolidShape::ddpseudotrap: {
+      vector<double> d = solid.volume().volume().solid().dimensions();
+      buildPseudoTrap(d[0], d[1], d[2], d[3], d[4], d[5], d[6]);
+    } break;
     case DDSolidShape::ddtrunctubs:
       buildTruncTubs();
       break;
@@ -148,11 +152,10 @@ void volumeHandle::referencePlane(const cms::DDFilteredView &fv) {
     // See comments above for the conventions for orientation.
     LocalVector globalZdir(0., 0., 1.);  // Local direction of the axis along global Z
 
-    /* Preserve in case pseudotrap is needed again
     if (theShape == DDSolidShape::ddpseudotrap) {
       globalZdir = LocalVector(0., 1., 0.);
     }
-    */
+
     if (refPlane->toGlobal(globalZdir).z() < 0.) {
       globalZdir = -globalZdir;
     }
@@ -198,4 +201,5 @@ using namespace cms::dd;
 #include "buildTrap.icc"
 #include "buildTubs.icc"
 #include "buildCons.icc"
+#include "buildPseudoTrap.icc"
 #include "buildTruncTubs.icc"

--- a/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.h
+++ b/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.h
@@ -47,6 +47,9 @@ namespace magneticfield {
     void buildTubs();
     // Build the surfaces for a ddcons shape
     void buildCons();
+    // Build the surfaces for a ddpseudotrap. This is not a supported
+    // shape in DD4hep; it is handled here to cope with legacy geometries.
+    void buildPseudoTrap(double x1, double x2, double y1, double y2, double halfZ, double radius, bool atMinusZ);
     // Build the surfaces for a ddtrunctubs shape
     void buildTruncTubs();
 

--- a/MagneticField/GeomBuilder/src/MagGeoBuilderFromDDD.cc
+++ b/MagneticField/GeomBuilder/src/MagGeoBuilderFromDDD.cc
@@ -186,7 +186,7 @@ void MagGeoBuilderFromDDD::build(const DDCompactView& cpva) {
     //       }
     //     }
 
-    volumeHandle* v = new volumeHandle(fv, expand);
+    volumeHandle* v = new volumeHandle(fv, expand, debug);
 
     if (theGridFiles != nullptr) {
       int key = (v->volumeno) * 100 + v->copyno;

--- a/MagneticField/GeomBuilder/src/buildPseudoTrap.icc
+++ b/MagneticField/GeomBuilder/src/buildPseudoTrap.icc
@@ -1,6 +1,7 @@
 /*
  *  Compute parameters for a pseudotrapezoid .
- *  NOTE: The pseudotrapezoid is no longer needed or support for DD4hep.
+ *  NOTE: The pseudotrapezoid is no longer supported in DD4hep.
+ *  It is handled here for legacy geonetries that are still in use.
  *  For pseudotraps the refPlane is parallel to beam line; transformation:
  *
  *  Global(for vol at pi/2)    Local 
@@ -11,20 +12,16 @@
  *  \author N. Amapane - INFN Torino
  */
 
-void volumeHandle::buildPseudoTrap() {
-  LogTrace("MagGeoBuilder") << "Building PseudoTrap surfaces...: ";
-
-  DDPseudoTrap ptrap(solid);
-
+void volumeHandle::buildPseudoTrap(
+    double x1_, double x2_, double y1_, double y2_, double halfZ_, double radius_, bool atMinusZ) {
   // Old DD needs mm to cm conversion, but DD4hep needs no conversion.
   // convertUnits should be defined appropriately.
-  double halfZ = convertUnits(ptrap.halfZ());
-  double x1 = convertUnits(ptrap.x1());
-  double x2 = convertUnits(ptrap.x2());
-  double y1 = convertUnits(ptrap.y1());
-  double y2 = convertUnits(ptrap.y2());
-  double radius = convertUnits(ptrap.radius());
-  bool atMinusZ = ptrap.atMinusZ();
+  double halfZ = convertUnits(halfZ_);
+  double x1 = convertUnits(x1_);
+  double x2 = convertUnits(x2_);
+  double y1 = convertUnits(y1_);
+  double y2 = convertUnits(y2_);
+  double radius = convertUnits(radius_);
 
   LogTrace("MagGeoBuilder") << "halfZ     " << halfZ << newln << "x1        " << x1 << newln << "x2        " << x2
                             << newln << "y1        " << y1 << newln << "y2        " << y2 << newln << "radius    "

--- a/MagneticField/GeomBuilder/src/volumeHandle.cc
+++ b/MagneticField/GeomBuilder/src/volumeHandle.cc
@@ -58,7 +58,8 @@ MagGeoBuilderFromDDD::volumeHandle::volumeHandle(const DDExpandedView &fv, bool 
   } else if (solid.shape() == DDSolidShape::ddtubs) {
     buildTubs();
   } else if (solid.shape() == DDSolidShape::ddpseudotrap) {
-    buildPseudoTrap();
+    DDPseudoTrap ptrap(solid);
+    buildPseudoTrap(ptrap.x1(), ptrap.x2(), ptrap.y1(), ptrap.y2(), ptrap.halfZ(), ptrap.radius(), ptrap.atMinusZ());
   } else if (solid.shape() == DDSolidShape::ddtrunctubs) {
     buildTruncTubs();
   } else {

--- a/MagneticField/GeomBuilder/src/volumeHandle.h
+++ b/MagneticField/GeomBuilder/src/volumeHandle.h
@@ -47,7 +47,7 @@ private:
   // Build the surfaces for a ddcons shape
   void buildCons();
   // Build the surfaces for a ddpseudotrap shape
-  void buildPseudoTrap();
+  void buildPseudoTrap(double x1, double x2, double y1, double y2, double halfZ, double radius, bool atMinusZ);
   // Build the surfaces for a ddtrunctubs shape
   void buildTruncTubs();
 


### PR DESCRIPTION
#### PR description:

Some legacy MF maps still use an old geometry that includes a few PseudoTrap shapes; notably, the  2T, which is in production and whose geometry is loaded into the DB. 
PseudoTraps are no longer supported in DD4hep, and for this reason these MF maps could not be created with the DD4hep-based MF builders.
This PR fixes this. It works by retrieving the vector of PseudoTrap parameters from the DDFilteredView without creating a DD4Hep shape object.

Recent and future geometries do not use PseudoTraps, so it is expected that it will be possible to drop support for it completely once all maps in production are updated to a recent geometry at some point in the future.

#### PR validation:
Checked for proper construction of the 2T geometry with DD4Hep against DDD, and regression-tested all maps in production against reference values.
