### PR TITLE
Phase2 Updated Pixel Conditions and GenericCPE Seeding Errors Fix

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -17,10 +17,11 @@ allTags["DTCCabling"] = {
     "T6" :  ( ','.join( [ 'TrackerDetToDTCELinkCablingMap__OT614_200_IT404_layer2_10G__T6__OTOnly' ,TrackerDTCCablingRecord, connectionString, "", "2020-03-27 11:30:00.000"] ), ), # DTC cabling map provided for T6 geometry (taken from http://ghugo.web.cern.ch/ghugo/layouts/cabling/OT614_200_IT404_layer2_10G/cablingOuter.html)
 }
 
+#v6 versions of LA used to match versioning of pixel templates, but values are identical to v2
 allTags["LA"] = {
-    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v2_mc'  ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v2_mc' ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v2_mc' ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v6_mc'  ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v6_mc' ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v6_mc' ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T19' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T19_v1_mc' ,SiPixelLARecord,connectionString, "", "2020-02-23 14:00:00.000"] ), ),  #uH = 0.053/T (TBPX L3,L4), uH=0.0/T (TBPX L1,L2, TEPX+TFPX)
 }
 
@@ -38,10 +39,11 @@ allTags["LAfromAlignment"] = {
     'T19' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T19_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "fromAlignment", "2020-02-23 14:00:00.000"] ), ),  # uH=0.0/T (not in use)
 }
 
+#v6 versions of SimLA used to match versioning of pixel templates, but values are indentical to  v2
 allTags["SimLA"] = {
-    'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v2_mc'  ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v2_mc' ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v2_mc' ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v6_mc'  ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v6_mc' ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v6_mc' ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T19' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T19_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2020-02-23 14:00:00.000"] ), ), #uH = 0.053/T (TBPX L3,L4), uH=0.0/T (TBPX L1,L2, TEPX+TFPX)
 }
 

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -17,11 +17,11 @@ allTags["DTCCabling"] = {
     "T6" :  ( ','.join( [ 'TrackerDetToDTCELinkCablingMap__OT614_200_IT404_layer2_10G__T6__OTOnly' ,TrackerDTCCablingRecord, connectionString, "", "2020-03-27 11:30:00.000"] ), ), # DTC cabling map provided for T6 geometry (taken from http://ghugo.web.cern.ch/ghugo/layouts/cabling/OT614_200_IT404_layer2_10G/cablingOuter.html)
 }
 
-#v6 versions of LA used to match versioning of pixel templates, but values are identical to v2
+#v5 versions of LA used to match versioning of pixel templates, but values are identical to v2
 allTags["LA"] = {
-    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v6_mc'  ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v6_mc' ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v6_mc' ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v5_mc'  ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v5_mc' ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v5_mc' ,SiPixelLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T19' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T19_v1_mc' ,SiPixelLARecord,connectionString, "", "2020-02-23 14:00:00.000"] ), ),  #uH = 0.053/T (TBPX L3,L4), uH=0.0/T (TBPX L1,L2, TEPX+TFPX)
 }
 
@@ -39,11 +39,11 @@ allTags["LAfromAlignment"] = {
     'T19' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T19_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "fromAlignment", "2020-02-23 14:00:00.000"] ), ),  # uH=0.0/T (not in use)
 }
 
-#v6 versions of SimLA used to match versioning of pixel templates, but values are indentical to  v2
+#v5 versions of SimLA used to match versioning of pixel templates, but values are indentical to  v2
 allTags["SimLA"] = {
-    'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v6_mc'  ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v6_mc' ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v6_mc' ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v5_mc'  ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v5_mc' ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v5_mc' ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T19' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T19_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2020-02-23 14:00:00.000"] ), ), #uH = 0.053/T (TBPX L3,L4), uH=0.0/T (TBPX L1,L2, TEPX+TFPX)
 }
 

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -46,15 +46,15 @@ allTags["SimLA"] = {
 }
 
 allTags["GenError"] = {
-    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v4_mc_bugfix'  ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v4_mc_bugfix' ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v4_mc_bugfix' ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v5_mc'  ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
 }
 
 allTags["Template"] = {
-    'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v4_mc_bugfix' ,SiPixelTemplatesRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v4_mc_bugfix',SiPixelTemplatesRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v4_mc_bugfix',SiPixelTemplatesRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v5_mc' ,SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
 }
 
 ##

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -46,9 +46,9 @@ allTags["SimLA"] = {
 }
 
 allTags["GenError"] = {
-    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v5_mc'  ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-03-04 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v5_mc'  ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
 }
 
 allTags["Template"] = {

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -146,8 +146,6 @@ public:
     //std::cout<<" in PixelCPEBase:localParameters(all) - "<<nRecHitsTotal_<<std::endl;  //dk
 #endif
 
-    printf("det angle\n");
-
     DetParam const& theDetParam = detParam(det);
     std::unique_ptr<ClusterParam> theClusterParam = createClusterParam(cl);
     setTheClu(theDetParam, *theClusterParam);

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -174,8 +174,6 @@ public:
     //std::cout<<" in PixelCPEBase:localParameters(on track) - "<<nRecHitsTotal_<<std::endl;  //dk
 #endif
 
-    printf("track angle\n");
-
     DetParam const& theDetParam = detParam(det);
     std::unique_ptr<ClusterParam> theClusterParam = createClusterParam(cl);
     setTheClu(theDetParam, *theClusterParam);

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -146,6 +146,8 @@ public:
     //std::cout<<" in PixelCPEBase:localParameters(all) - "<<nRecHitsTotal_<<std::endl;  //dk
 #endif
 
+    printf("det angle\n");
+
     DetParam const& theDetParam = detParam(det);
     std::unique_ptr<ClusterParam> theClusterParam = createClusterParam(cl);
     setTheClu(theDetParam, *theClusterParam);
@@ -171,6 +173,8 @@ public:
     nRecHitsTotal_++;
     //std::cout<<" in PixelCPEBase:localParameters(on track) - "<<nRecHitsTotal_<<std::endl;  //dk
 #endif
+
+    printf("track angle\n");
 
     DetParam const& theDetParam = detParam(det);
     std::unique_ptr<ClusterParam> theClusterParam = createClusterParam(cl);

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -121,7 +121,6 @@ private:
 
   bool UseErrorsFromTemplates_;
   bool DoCosmics_;
-  //bool LoadTemplatesFromDB_;
   bool TruncatePixelCharge_;
   bool IrradiationBiasCorrection_;
   bool isUpgrade_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -125,6 +125,7 @@ private:
   bool TruncatePixelCharge_;
   bool IrradiationBiasCorrection_;
   bool isUpgrade_;
+  bool NoTemplateErrorsWhenNoTrkAngles_;
 
   float EdgeClusterErrorX_;
   float EdgeClusterErrorY_;

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -8,16 +8,6 @@ PixelCPEGenericESProducer = _generic_default.clone()
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True)
 
-# customize CPE Generic to not use any template information for 3d sensors
-from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
-phase2_PixelCPEGeneric.toModify(PixelCPEGenericESProducer,
-   UseErrorsFromTemplates = False,    # no GenErrors
-   LoadTemplatesFromDB = False,       # do not load templates
-  TruncatePixelCharge = False,
-  IrradiationBiasCorrection = False, # set IBC off (needs GenErrors)
-  DoCosmics = False,
-  Upgrade = True                     # use hard-coded CPE errors (for Upgrade)
-)
 
 # customize the Pixel CPE generic producer for phase2
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
@@ -29,4 +19,12 @@ phase2_tracker.toModify(PixelCPEGenericESProducer,
   IrradiationBiasCorrection = False, # set IBC off
   DoCosmics = False,
   Upgrade = True                     # use 'upgrade' version of hardcoded CPE errors
+)
+
+
+# customize the Pixel CPE generic producer in order not to use any  template information
+from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
+phase2_PixelCPEGeneric.toModify(PixelCPEGenericESProducer,
+  UseErrorsFromTemplates = False,    # no GenErrors
+  LoadTemplatesFromDB = False,       # do not load templates
 )

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -8,6 +8,17 @@ PixelCPEGenericESProducer = _generic_default.clone()
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True)
 
+# customize CPE Generic to not use any template information for 3d sensors
+from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
+phase2_PixelCPEGeneric.toModify(PixelCPEGenericESProducer,
+   UseErrorsFromTemplates = False,    # no GenErrors
+   LoadTemplatesFromDB = False,       # do not load templates
+  TruncatePixelCharge = False,
+  IrradiationBiasCorrection = False, # set IBC off (needs GenErrors)
+  DoCosmics = False,
+  Upgrade = True                     # use hard-coded CPE errors (for Upgrade)
+)
+
 # customize the Pixel CPE generic producer for phase2
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(PixelCPEGenericESProducer,
@@ -17,5 +28,5 @@ phase2_tracker.toModify(PixelCPEGenericESProducer,
   TruncatePixelCharge = False,
   IrradiationBiasCorrection = False, # set IBC off
   DoCosmics = False,
-  Upgrade = True                     # use hard-coded CPE errors (for Upgrade)
+  Upgrade = True                     # use 'upgrade' version of hardcoded CPE errors
 )

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -8,14 +8,14 @@ PixelCPEGenericESProducer = _generic_default.clone()
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True)
 
-# customize the Pixel CPE generic producer in order not to use any
-# template information
-from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
-phase2_PixelCPEGeneric.toModify(PixelCPEGenericESProducer,
-  UseErrorsFromTemplates = False,    # no GenErrors
-  LoadTemplatesFromDB = False,       # do not load templates
+# customize the Pixel CPE generic producer for phase2
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(PixelCPEGenericESProducer,
+  UseErrorsFromTemplates = True,    
+  LoadTemplatesFromDB = True,       
+  NoTemplateErrorsWhenNoTrkAngles = True,
   TruncatePixelCharge = False,
-  IrradiationBiasCorrection = False, # set IBC off (needs GenErrors)
+  IrradiationBiasCorrection = False, # set IBC off
   DoCosmics = False,
   Upgrade = True                     # use hard-coded CPE errors (for Upgrade)
 )

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -641,7 +641,7 @@ void PixelCPEGeneric::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<double>("EdgeClusterErrorX", 50.0);
   desc.add<double>("EdgeClusterErrorY", 85.0);
   desc.add<bool>("inflate_errors", false);
-  desc.add<bool>("inflate_all_errors_no_trk_angle", true);
+  desc.add<bool>("inflate_all_errors_no_trk_angle", false);
   desc.add<bool>("NoTemplateErrorsWhenNoTrkAngles", false);
   desc.add<bool>("UseErrorsFromTemplates", true);
   desc.add<bool>("TruncatePixelCharge", true);

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -59,15 +59,11 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
   TruncatePixelCharge_ = conf.getParameter<bool>("TruncatePixelCharge");
   IrradiationBiasCorrection_ = conf.getParameter<bool>("IrradiationBiasCorrection");
   DoCosmics_ = conf.getParameter<bool>("DoCosmics");
-  //LoadTemplatesFromDB_       = conf.getParameter<bool>("LoadTemplatesFromDB");
 
   // Upgrade means phase 2
-  isUpgrade_ = false;
-  if (conf.getParameter<bool>("Upgrade"))
-    isUpgrade_ = true;
+  isUpgrade_ = conf.getParameter<bool>("Upgrade");
 
-  // Select the position error source
-  // For upgrde and cosmics force the use simple errors
+  // For cosmics force the use of simple errors
   if ((DoCosmics_))
     UseErrorsFromTemplates_ = false;
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -54,20 +54,21 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
   inflate_errors = conf.getParameter<bool>("inflate_errors");
   inflate_all_errors_no_trk_angle = conf.getParameter<bool>("inflate_all_errors_no_trk_angle");
 
+  NoTemplateErrorsWhenNoTrkAngles_ = conf.getParameter<bool>("NoTemplateErrorsWhenNoTrkAngles");
   UseErrorsFromTemplates_ = conf.getParameter<bool>("UseErrorsFromTemplates");
   TruncatePixelCharge_ = conf.getParameter<bool>("TruncatePixelCharge");
   IrradiationBiasCorrection_ = conf.getParameter<bool>("IrradiationBiasCorrection");
   DoCosmics_ = conf.getParameter<bool>("DoCosmics");
   //LoadTemplatesFromDB_       = conf.getParameter<bool>("LoadTemplatesFromDB");
 
-  // no clear what upgrade means, is it phase1, phase2? Probably delete.
+  // Upgrade means phase 2
   isUpgrade_ = false;
   if (conf.getParameter<bool>("Upgrade"))
     isUpgrade_ = true;
 
   // Select the position error source
   // For upgrde and cosmics force the use simple errors
-  if (isUpgrade_ || (DoCosmics_))
+  if ((DoCosmics_))
     UseErrorsFromTemplates_ = false;
 
   if (!UseErrorsFromTemplates_ && (TruncatePixelCharge_ || IrradiationBiasCorrection_ || LoadTemplatesFromDB_)) {
@@ -494,11 +495,13 @@ LocalError PixelCPEGeneric::localError(DetParam const& theDetParam, ClusterParam
            << endl;
   }
 
+  bool useTempErrors =
+      UseErrorsFromTemplates_ && (!NoTemplateErrorsWhenNoTrkAngles_ || theClusterParam.with_track_angle);
+
   if
-    LIKELY(UseErrorsFromTemplates_) {
+    LIKELY(useTempErrors) {
       //
       // Use template errors
-      //cout << "Track angles are known. We can use either errors from templates or the error parameterization from DB." << endl;
 
       if (!edgex) {  // Only use this for non-edge clusters
         if (sizex == 1) {
@@ -638,7 +641,8 @@ void PixelCPEGeneric::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<double>("EdgeClusterErrorX", 50.0);
   desc.add<double>("EdgeClusterErrorY", 85.0);
   desc.add<bool>("inflate_errors", false);
-  desc.add<bool>("inflate_all_errors_no_trk_angle", false);
+  desc.add<bool>("inflate_all_errors_no_trk_angle", true);
+  desc.add<bool>("NoTemplateErrorsWhenNoTrkAngles", false);
   desc.add<bool>("UseErrorsFromTemplates", true);
   desc.add<bool>("TruncatePixelCharge", true);
   desc.add<bool>("IrradiationBiasCorrection", false);

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -14,3 +14,7 @@ trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.s
 # uncomment these two lines to turn on Cluster Repair CPE
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRepair')
+
+# Turn off template reco for phase 2d, 3d sensors
+from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
+phase2_PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -15,6 +15,6 @@ trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.s
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRepair')
 
-# Turn off template reco for phase 2d, 3d sensors
+# Turn off template reco for phase 2 (when not supported)
 from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
 phase2_PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -14,8 +14,3 @@ trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.s
 # uncomment these two lines to turn on Cluster Repair CPE
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRepair')
-
-# uncomment these two lines to turn on Cluster Repair CPE
-from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
-phase2_PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')
-


### PR DESCRIPTION
This is the PR intending to fix the loss in the phase 2 tracking performance (efficiency and fakerate) since the 11_1_0 and later releases.

We presented about the ongoing issues in several places, most recently at the Tracking POG meeting [here](https://indico.cern.ch/event/912823/contributions/3841072/attachments/2027324/3391939/phase2_det_angle_update_april26.pdf)

The PR contains updated template and genError conditions that fix a slight Lorentz Angle mismatch that was introduced in the last conditions.

It also introduces a new configuration option for the generic CPE which allows one to use the hardcoded errors when the CPE is called without local track angles (ie in the seeding step) the database values (genErrors) when called with local track angles. This option is turned on only for the phase 2 configuration of the generic CPE. 

There should be no changes in any phase 1 workflows. 

We have run the tracking validation comparing the performance of the current CMSSW, the performance before the introduction of the templates for phase 2 and this proposed fix. The plots are [here](http://cmantill.web.cern.ch/cmantill/phase2/PU200_ComparisonCMSSW_11_1_0_pre6/plots/). We see that this fix does indeed fix the efficiency loss and fakerate increase seen in the current release as compared to the 11_0_0 releases. 
There is still an increase in the chi^2 observed for eta > 1.5 or so as compared to the 11_0_0 releases. This has been traced back to the templates having a smaller error for FPIX local x than the hardcoded values, but looking at the pull distributions it seems this is actually the more correct error (RMS with template is ~1 and with hardcoded errors ~0.75). It is believed that the reason the chi^/2dof is larger than 1 is due to a known issue, that the material budget is underestimated, not the CPE's. 

@mmusich @tsusa @mtosi @emiglior @cmantill @tvami @pmaksim1 @JanFSchulte @jalimena @perrotta @slava77 
