### PR TITLE
DT DQM legacy modules removal

### DIFF
--- a/DQM/DTMonitorClient/python/dtDQMOfflineCertification_cff.py
+++ b/DQM/DTMonitorClient/python/dtDQMOfflineCertification_cff.py
@@ -4,6 +4,6 @@ from DQM.DTMonitorClient.dtDAQInfo_cfi import *
 from DQM.DTMonitorClient.dtDCSByLumiSummary_cfi import *
 from DQM.DTMonitorClient.dtCertificationSummary_cfi import *
 
-dtCertification = cms.Sequence(dtDAQInfo + dtDCSByLumiSummary + dtCertificationSummary)
+dtCertification = cms.Sequence(dtDAQInfo + dtCertificationSummary)
 
 

--- a/DQM/DTMonitorClient/python/dtDQMOfflineCertification_cff.py
+++ b/DQM/DTMonitorClient/python/dtDQMOfflineCertification_cff.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.DTMonitorClient.dtDAQInfo_cfi import *
-from DQM.DTMonitorClient.dtDCSByLumiSummary_cfi import *
 from DQM.DTMonitorClient.dtCertificationSummary_cfi import *
 
 dtCertification = cms.Sequence(dtDAQInfo + dtCertificationSummary)

--- a/DQM/DTMonitorClient/python/dtDataIntegrityTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtDataIntegrityTest_cfi.py
@@ -2,10 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 dataIntegrityTest = DQMEDHarvester("DTDataIntegrityTest",
-                                   diagnosticPrescale = cms.untracked.int32(1),
-				   checkUros = cms.untracked.bool(False) 
+                                   diagnosticPrescale = cms.untracked.int32(1)
 )
 
-from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
-run2_DT_2018.toModify(dataIntegrityTest,checkUros=cms.untracked.bool(True))
 

--- a/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
+++ b/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
@@ -90,8 +90,8 @@ void DTDataIntegrityTest::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
 
   //Loop on FED id
   //Monitoring only real used FEDs
-  int  FEDIDmin = FEDNumbering::MINDTUROSFEDID;
-  int  FEDIDmax = FEDNumbering::MAXDTUROSFEDID;
+  int FEDIDmin = FEDNumbering::MINDTUROSFEDID;
+  int FEDIDmax = FEDNumbering::MAXDTUROSFEDID;
 
   for (int dduId = FEDIDmin; dduId <= FEDIDmax; ++dduId) {
     LogTrace("DTDQM|DTRawToDigi|DTMonitorClient|DTDataIntegrityTest") << "[DTDataIntegrityTest]:FED Id: " << dduId;
@@ -112,18 +112,18 @@ void DTDataIntegrityTest::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
     string fedSummaryName1 = "";
     string fedSummaryName2 = "";
     string sign = "-";
-      if (dduId == FEDIDmin || dduId == FEDIDmax) {
-        if (dduId == FEDIDmax)
-          sign = "";
-        fedSummaryName2 = "DT/00-DataIntegrity/ROSSummary_W" + sign + "2";
-        fedSummaryName1 = "DT/00-DataIntegrity/ROSSummary_W" + sign + "1";
-        FED_ROSSummary1 = igetter.get(fedSummaryName1);
-        FED_ROSSummary2 = igetter.get(fedSummaryName2);
-      } else {
-        fedSummaryName = "DT/00-DataIntegrity/ROSSummary_W0";
-        FED_ROSSummary1 = igetter.get(fedSummaryName);
-        FED_ROSSummary2 = igetter.get(fedSummaryName);  //for wheel compatibility...
-      }
+    if (dduId == FEDIDmin || dduId == FEDIDmax) {
+      if (dduId == FEDIDmax)
+        sign = "";
+      fedSummaryName2 = "DT/00-DataIntegrity/ROSSummary_W" + sign + "2";
+      fedSummaryName1 = "DT/00-DataIntegrity/ROSSummary_W" + sign + "1";
+      FED_ROSSummary1 = igetter.get(fedSummaryName1);
+      FED_ROSSummary2 = igetter.get(fedSummaryName2);
+    } else {
+      fedSummaryName = "DT/00-DataIntegrity/ROSSummary_W0";
+      FED_ROSSummary1 = igetter.get(fedSummaryName);
+      FED_ROSSummary2 = igetter.get(fedSummaryName);  //for wheel compatibility...
+    }
 
     // Get the event length plot (used to count # of processed evts)
     string fedEvLenName = "DT/00-DataIntegrity/FED" + dduId_s + "/FED" + dduId_s + "_EventLength";
@@ -133,113 +133,113 @@ void DTDataIntegrityTest::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
     string fedIntegrityFolder = "DT/00-DataIntegrity/";
     MonitorElement* hFEDEntry = igetter.get(fedIntegrityFolder + "FEDEntries");
 
-      if (hFEDEntry) {
-        int offsetFED = 1368;
-        // Check that the FED is in the ReadOut using the FEDIntegrity histos
-        bool fedNotReadout = (hFEDEntry->getBinContent(dduId - offsetFED)) == 0;
-        int wheel = dduId - offsetFED - 2;
-        if (FED_ROSSummary1 && FED_ROSSummary2 && FED_ROSStatus && FED_EvLength && !fedNotReadout) {
-          TH2F* histoFEDSummary1 = FED_ROSSummary1->getTH2F();
-          TH2F* histoFEDSummary2 = FED_ROSSummary2->getTH2F();  // same for central FED...
-          TH2F* histoROSStatus = FED_ROSStatus->getTH2F();
-          TH1F* histoEvLength = FED_EvLength->getTH1F();
+    if (hFEDEntry) {
+      int offsetFED = 1368;
+      // Check that the FED is in the ReadOut using the FEDIntegrity histos
+      bool fedNotReadout = (hFEDEntry->getBinContent(dduId - offsetFED)) == 0;
+      int wheel = dduId - offsetFED - 2;
+      if (FED_ROSSummary1 && FED_ROSSummary2 && FED_ROSStatus && FED_EvLength && !fedNotReadout) {
+        TH2F* histoFEDSummary1 = FED_ROSSummary1->getTH2F();
+        TH2F* histoFEDSummary2 = FED_ROSSummary2->getTH2F();  // same for central FED...
+        TH2F* histoROSStatus = FED_ROSStatus->getTH2F();
+        TH1F* histoEvLength = FED_EvLength->getTH1F();
 
-          int nFEDEvts = histoEvLength->Integral();
-          //if(dduId==FEDIDmin || dduId==FEDIDmax) nFEDEvts = nFEDEvts/2.; // split in 2 for external FEDs
-          if (!(nFEDEvts > 0))
+        int nFEDEvts = histoEvLength->Integral();
+        //if(dduId==FEDIDmin || dduId==FEDIDmax) nFEDEvts = nFEDEvts/2.; // split in 2 for external FEDs
+        if (!(nFEDEvts > 0))
+          continue;
+        int extraFEDevents1 = 0;
+        int extraFEDevents2 = 0;
+
+        for (int urosNumber = 1; urosNumber <= DOCESLOTS; ++urosNumber) {  // loop on the uROS
+          string urosNumber_s = to_string(urosNumber);
+          // Get the event length plot for this uROS (used to count # of processed evts)
+          string fedUrosEvLenName = "DT/00-DataIntegrity/FED" + dduId_s + "/uROS" + urosNumber_s + "/FED" + dduId_s +
+                                    "_uROS" + urosNumber_s + "_EventLength";
+          MonitorElement* FED_uROS_EvLength = igetter.get(fedUrosEvLenName);
+          TH1F* histoUrosEvLength = FED_uROS_EvLength->getTH1F();
+          int nFEDEvtsUros = histoUrosEvLength->Integral();
+
+          //station 4 sectors drievn by uROS 1 & 2
+          if (urosNumber == 1) {
+            extraFEDevents1 = nFEDEvtsUros;
             continue;
-          int extraFEDevents1 = 0;
-          int extraFEDevents2 = 0;
+          }
+          if (urosNumber == 2) {
+            extraFEDevents2 = nFEDEvtsUros;
+            continue;
+          }
 
-          for (int urosNumber = 1; urosNumber <= DOCESLOTS; ++urosNumber) {  // loop on the uROS
-            string urosNumber_s = to_string(urosNumber);
-            // Get the event length plot for this uROS (used to count # of processed evts)
-            string fedUrosEvLenName = "DT/00-DataIntegrity/FED" + dduId_s + "/uROS" + urosNumber_s + "/FED" + dduId_s +
-                                      "_uROS" + urosNumber_s + "_EventLength";
-            MonitorElement* FED_uROS_EvLength = igetter.get(fedUrosEvLenName);
-            TH1F* histoUrosEvLength = FED_uROS_EvLength->getTH1F();
-            int nFEDEvtsUros = histoUrosEvLength->Integral();
+          if (nFEDEvtsUros > 0) {                                                      //this uROS is active
+            nFEDEvtsUros = extraFEDevents1 + extraFEDevents2 + nFEDEvtsUros / 3.;      // split in 3 ROS
+            float nGErrors = histoROSStatus->Integral(1, 12, urosNumber, urosNumber);  //Only Global Errors,
+            //not possible to distinguish which ROS, so coumting them in the 3/12 ROSes
 
-            //station 4 sectors drievn by uROS 1 & 2
-            if (urosNumber == 1) {
-              extraFEDevents1 = nFEDEvtsUros;
-              continue;
-            }
-            if (urosNumber == 2) {
-              extraFEDevents2 = nFEDEvtsUros;
-              continue;
-            }
+            int ros = getROS(urosNumber, 0);
+            for (int iros = ros; iros < (ros + 3); ++iros) {
+              // -1,0,+1 wheels
+              float nROBErrors1 = histoFEDSummary1->Integral(1, 5, iros, iros);  //Errors and Not OK Flag
+              float nErrors1 = nROBErrors1 + nGErrors;
+              float result1 = 0.;
+              if (nFEDEvtsUros != 0)
+                result1 = max((float)0., ((float)nFEDEvtsUros - nROBErrors1) / (float)nFEDEvtsUros);
+              summaryHisto->setBinContent(iros, wheel + 3, result1);
+              double tdcResult1 = -2;
+              float nTDCErrors1 = histoFEDSummary1->Integral(6, 6, iros, iros);  //Only TDC fatal considered
+              if (nTDCErrors1 == 0) {                                            // no errors
+                tdcResult1 = 0.5;
+              } else {  // there are errors
+                tdcResult1 = 2.5;
+              }
+              summaryTDCHisto->setBinContent(iros, wheel + 3, tdcResult1);
 
-            if (nFEDEvtsUros > 0) {                                                      //this uROS is active
-              nFEDEvtsUros = extraFEDevents1 + extraFEDevents2 + nFEDEvtsUros / 3.;      // split in 3 ROS
-              float nGErrors = histoROSStatus->Integral(1, 12, urosNumber, urosNumber);  //Only Global Errors,
-              //not possible to distinguish which ROS, so coumting them in the 3/12 ROSes
+              // FIXME: different errors should have different weights
+              float sectPerc1 = 0.;
+              if (nFEDEvtsUros != 0)
+                sectPerc1 = max((float)0., ((float)nFEDEvtsUros - nErrors1) / (float)nFEDEvtsUros);
+              glbSummaryHisto->setBinContent(iros, wheel + 3, sectPerc1);
+              if (dduId == (FEDIDmax - 1))
+                continue;  //wheel 0 case
 
-              int ros = getROS(urosNumber, 0);
-              for (int iros = ros; iros < (ros + 3); ++iros) {
-                // -1,0,+1 wheels
-                float nROBErrors1 = histoFEDSummary1->Integral(1, 5, iros, iros);  //Errors and Not OK Flag
-                float nErrors1 = nROBErrors1 + nGErrors;
-                float result1 = 0.;
-                if (nFEDEvtsUros != 0)
-                  result1 = max((float)0., ((float)nFEDEvtsUros - nROBErrors1) / (float)nFEDEvtsUros);
-                summaryHisto->setBinContent(iros, wheel + 3, result1);
-                double tdcResult1 = -2;
-                float nTDCErrors1 = histoFEDSummary1->Integral(6, 6, iros, iros);  //Only TDC fatal considered
-                if (nTDCErrors1 == 0) {                                            // no errors
-                  tdcResult1 = 0.5;
-                } else {  // there are errors
-                  tdcResult1 = 2.5;
-                }
-                summaryTDCHisto->setBinContent(iros, wheel + 3, tdcResult1);
+              // -2,+2 wheels
+              float nROBErrors2 = histoFEDSummary2->Integral(1, 5, iros, iros);  //Errors and Not OK Flag
+              float nErrors2 = nROBErrors2 + nGErrors;
+              float result2 = 0.;
+              if (nFEDEvtsUros != 0)
+                result2 = max((float)0., ((float)nFEDEvtsUros - nROBErrors2) / (float)nFEDEvtsUros);
+              summaryHisto->setBinContent(iros, wheel * 2 + 3, result2);
 
-                // FIXME: different errors should have different weights
-                float sectPerc1 = 0.;
-                if (nFEDEvtsUros != 0)
-                  sectPerc1 = max((float)0., ((float)nFEDEvtsUros - nErrors1) / (float)nFEDEvtsUros);
-                glbSummaryHisto->setBinContent(iros, wheel + 3, sectPerc1);
-                if (dduId == (FEDIDmax - 1))
-                  continue;  //wheel 0 case
+              double tdcResult2 = -2;
+              float nTDCErrors2 = histoFEDSummary2->Integral(6, 6, iros, iros);  //Only TDC fatal considered
+              if (nTDCErrors2 == 0) {                                            // no errors
+                tdcResult2 = 0.5;
+              } else {  // there are errors
+                tdcResult2 = 2.5;
+              }
+              summaryTDCHisto->setBinContent(iros, wheel * 2 + 3, tdcResult2);
 
-                // -2,+2 wheels
-                float nROBErrors2 = histoFEDSummary2->Integral(1, 5, iros, iros);  //Errors and Not OK Flag
-                float nErrors2 = nROBErrors2 + nGErrors;
-                float result2 = 0.;
-                if (nFEDEvtsUros != 0)
-                  result2 = max((float)0., ((float)nFEDEvtsUros - nROBErrors2) / (float)nFEDEvtsUros);
-                summaryHisto->setBinContent(iros, wheel * 2 + 3, result2);
+              // FIXME: different errors should have different weights
+              float sectPerc2 = 0.;
+              if (nFEDEvtsUros != 0)
+                sectPerc2 = max((float)0., ((float)nFEDEvtsUros - nErrors2) / (float)nFEDEvtsUros);
+              glbSummaryHisto->setBinContent(iros, wheel * 2 + 3, sectPerc2);
+            }   //loop in three ros
+          }     // this uROS is active
+        }       //loop on uros
+      } else {  // no data in this FED: it is off, no ROS suummary/status or evLength and fedNotReadout
+        for (int i = 1; i <= DOCESLOTS; ++i) {
+          summaryHisto->setBinContent(i, wheel + 3, 0.5);
+          summaryTDCHisto->setBinContent(i, wheel + 3, 1.5);
+          glbSummaryHisto->setBinContent(i, wheel + 3, 0.5);
+          if (dduId == (FEDIDmax - 1))
+            continue;  //wheel 0 case
+          summaryHisto->setBinContent(i, wheel * 2 + 3, 0.5);
+          summaryTDCHisto->setBinContent(i, wheel * 2 + 3, 1.5);
+          glbSummaryHisto->setBinContent(i, wheel * 2 + 3, 0.5);
+        }  //loop on uros
+      }    // no data in this FED: it is off, no ROS suummary/status or evLength
 
-                double tdcResult2 = -2;
-                float nTDCErrors2 = histoFEDSummary2->Integral(6, 6, iros, iros);  //Only TDC fatal considered
-                if (nTDCErrors2 == 0) {                                            // no errors
-                  tdcResult2 = 0.5;
-                } else {  // there are errors
-                  tdcResult2 = 2.5;
-                }
-                summaryTDCHisto->setBinContent(iros, wheel * 2 + 3, tdcResult2);
-
-                // FIXME: different errors should have different weights
-                float sectPerc2 = 0.;
-                if (nFEDEvtsUros != 0)
-                  sectPerc2 = max((float)0., ((float)nFEDEvtsUros - nErrors2) / (float)nFEDEvtsUros);
-                glbSummaryHisto->setBinContent(iros, wheel * 2 + 3, sectPerc2);
-              }   //loop in three ros
-            }     // this uROS is active
-          }       //loop on uros
-        } else {  // no data in this FED: it is off, no ROS suummary/status or evLength and fedNotReadout
-          for (int i = 1; i <= DOCESLOTS; ++i) {
-            summaryHisto->setBinContent(i, wheel + 3, 0.5);
-            summaryTDCHisto->setBinContent(i, wheel + 3, 1.5);
-            glbSummaryHisto->setBinContent(i, wheel + 3, 0.5);
-            if (dduId == (FEDIDmax - 1))
-              continue;  //wheel 0 case
-            summaryHisto->setBinContent(i, wheel * 2 + 3, 0.5);
-            summaryTDCHisto->setBinContent(i, wheel * 2 + 3, 1.5);
-            glbSummaryHisto->setBinContent(i, wheel * 2 + 3, 0.5);
-          }  //loop on uros
-        }    // no data in this FED: it is off, no ROS suummary/status or evLength
-
-      }       //FEDentry
+    }  //FEDentry
 
   }  //  loop on dduIds
 }

--- a/DQM/DTMonitorClient/src/DTDataIntegrityTest.h
+++ b/DQM/DTMonitorClient/src/DTDataIntegrityTest.h
@@ -38,9 +38,6 @@ protected:
   /// Get the ME name
   std::string getMEName(std::string histoType, int FEDId);
 
-  /// Book the MEs
-  void bookHistos(DQMStore::IBooker &, std::string histoType, int dduId);
-
   /// DQM Client Diagnostic
   void dqmEndLuminosityBlock(DQMStore::IBooker &,
                              DQMStore::IGetter &,
@@ -57,9 +54,6 @@ private:
   // prescale on the # of LS to update the test
   int prescaleFactor;
 
-  // to use in 2018 with uROS
-  bool checkUros;
-
   //Counter between 0 and nTimeBin
   int counter;
 
@@ -73,12 +67,6 @@ private:
   edm::ESHandle<DTReadOutMapping> mapping;
 
   // Monitor Elements
-  std::map<std::string, std::map<int, MonitorElement *> > dduHistos;
-  std::map<std::string, std::map<int, std::vector<MonitorElement *> > > dduVectorHistos;
-
-  std::map<std::string, std::map<int, MonitorElement *> > fedHistos;
-  std::map<std::string, std::map<int, std::vector<MonitorElement *> > > fedVectorHistos;
-
   MonitorElement *summaryHisto;
   MonitorElement *summaryTDCHisto;
   MonitorElement *glbSummaryHisto;

--- a/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.cc
+++ b/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.cc
@@ -64,9 +64,10 @@ void DTSegmentAnalysisTest::beginRun(const Run& run, const EventSetup& context) 
   context.get<MuonGeometryRecord>().get(muonGeom);
 }
 
-void DTSegmentAnalysisTest::dqmBeginLuminosityBlock(LuminosityBlock const& lumiSeg, EventSetup const& ){
+void DTSegmentAnalysisTest::dqmBeginLuminosityBlock(LuminosityBlock const& lumiSeg, EventSetup const&) {
   nLSs++;
-  LogTrace("DTDQM|DTMonitorClient|DTSegmentAnalysisTest") << "DTSegmentAnalysisTest: analyzing LS" << lumiSeg.id().luminosityBlock() << " of " << nLSs <<endl; 
+  LogTrace("DTDQM|DTMonitorClient|DTSegmentAnalysisTest")
+      << "DTSegmentAnalysisTest: analyzing LS" << lumiSeg.id().luminosityBlock() << " of " << nLSs << endl;
 }
 
 void DTSegmentAnalysisTest::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,

--- a/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.cc
+++ b/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.cc
@@ -42,30 +42,31 @@ DTSegmentAnalysisTest::DTSegmentAnalysisTest(const ParameterSet& ps) {
 
   // get the cfi parameters
   detailedAnalysis = parameters.getUntrackedParameter<bool>("detailedAnalysis", false);
-  normalizeHistoPlots = parameters.getUntrackedParameter<bool>("normalizeHistoPlots", false);
   runOnline = parameters.getUntrackedParameter<bool>("runOnline", true);
   // top folder for the histograms in DQMStore
   topHistoFolder = ps.getUntrackedParameter<string>("topHistoFolder", "DT/02-Segments");
-  // hlt DQM mode
-
-  hltDQMMode = ps.getUntrackedParameter<bool>("hltDQMMode", false);
   nMinEvts = ps.getUntrackedParameter<int>("nEventsCert", 5000);
   maxPhiHit = ps.getUntrackedParameter<int>("maxPhiHit", 7);
   maxPhiZHit = ps.getUntrackedParameter<int>("maxPhiZHit", 11);
 
-  nevents = 0;
+  nLSs = 0;
 
   bookingdone = false;
 }
 
 DTSegmentAnalysisTest::~DTSegmentAnalysisTest() {
-  LogTrace("DTDQM|DTMonitorClient|DTSegmentAnalysisTest") << "DTSegmentAnalysisTest: analyzed " << nevents << " events";
+  LogTrace("DTDQM|DTMonitorClient|DTSegmentAnalysisTest") << "DTSegmentAnalysisTest: analyzed " << nLSs << " LS";
 }
 
 void DTSegmentAnalysisTest::beginRun(const Run& run, const EventSetup& context) {
   LogTrace("DTDQM|DTMonitorClient|DTSegmentAnalysisTest") << "[DTSegmentAnalysisTest]: BeginRun";
 
   context.get<MuonGeometryRecord>().get(muonGeom);
+}
+
+void DTSegmentAnalysisTest::dqmBeginLuminosityBlock(LuminosityBlock const& lumiSeg, EventSetup const& ){
+  nLSs++;
+  LogTrace("DTDQM|DTMonitorClient|DTSegmentAnalysisTest") << "DTSegmentAnalysisTest: analyzing LS" << lumiSeg.id().luminosityBlock() << " of " << nLSs <<endl; 
 }
 
 void DTSegmentAnalysisTest::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
@@ -90,47 +91,12 @@ void DTSegmentAnalysisTest::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
   }
 }
 
-void DTSegmentAnalysisTest::endRun(Run const& run, EventSetup const& context) {}
-
 void DTSegmentAnalysisTest::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (!runOnline) {
     LogTrace("DTDQM|DTMonitorClient|DTSegmentAnalysisTest")
         << "[DTSegmentAnalysisTest]: endJob. Client called in offline mode , perform DQM client operation";
 
     performClientDiagnostic(igetter);
-  }
-
-  if (normalizeHistoPlots) {
-    LogTrace("DTDQM|DTMonitorClient|DTSegmentAnalysisTest") << " Performing time-histo normalization" << endl;
-    MonitorElement* hNevtPerLS = nullptr;
-
-    if (hltDQMMode)
-      hNevtPerLS = igetter.get(topHistoFolder + "/NevtPerLS");
-    else
-      hNevtPerLS = igetter.get("DT/EventInfo/NevtPerLS");
-
-    if (hNevtPerLS != nullptr) {
-      for (int wheel = -2; wheel != 3; ++wheel) {       // loop over wheels
-        for (int sector = 1; sector <= 12; ++sector) {  // loop over sectors
-          stringstream wheelstr;
-          wheelstr << wheel;
-          stringstream sectorstr;
-          sectorstr << sector;
-          string sectorHistoName = topHistoFolder + "/Wheel" + wheelstr.str() + "/Sector" + sectorstr.str() +
-                                   "/NSegmPerEvent_W" + wheelstr.str() + "_Sec" + sectorstr.str();
-
-          //FR get the histo from here (igetter available!) ...
-          MonitorElement* histoGot = igetter.get(sectorHistoName);
-
-          //FR ...and just make with it a DTTimeEvolutionHisto
-          DTTimeEvolutionHisto hNSegmPerLS(histoGot);
-
-          hNSegmPerLS.normalizeTo(hNevtPerLS);
-        }
-      }
-    } else {
-      LogError("DTDQM|DTMonitorClient|DTSegmentAnalysisTest") << "Histo NevtPerLS not found!" << endl;
-    }
   }
 }
 

--- a/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.h
+++ b/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.h
@@ -54,7 +54,6 @@ public:
   /// Perform client diagnostic operations
   void performClientDiagnostic(DQMStore::IGetter &);
 
-
 protected:
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
   void dqmEndLuminosityBlock(DQMStore::IBooker &,
@@ -62,7 +61,7 @@ protected:
                              edm::LuminosityBlock const &,
                              edm::EventSetup const &) override;
 
-  void dqmBeginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const&);
+  void dqmBeginLuminosityBlock(edm::LuminosityBlock const &lumiSeg, edm::EventSetup const &);
 
 private:
   int nLSs;

--- a/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.h
+++ b/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.h
@@ -54,7 +54,6 @@ public:
   /// Perform client diagnostic operations
   void performClientDiagnostic(DQMStore::IGetter &);
 
-  void endRun(edm::Run const &run, edm::EventSetup const &c) override;
 
 protected:
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
@@ -63,8 +62,10 @@ protected:
                              edm::LuminosityBlock const &,
                              edm::EventSetup const &) override;
 
+  void dqmBeginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const&);
+
 private:
-  int nevents;
+  int nLSs;
   unsigned int nLumiSegs;
   // switch on for detailed analysis
   bool detailedAnalysis;
@@ -84,11 +85,8 @@ private:
   std::map<std::pair<int, int>, MonitorElement *> chi2Histos;
   std::map<std::pair<int, int>, MonitorElement *> segmRecHitHistos;
   std::map<int, MonitorElement *> summaryHistos;
-  bool normalizeHistoPlots;
   // top folder for the histograms in DQMStore
   std::string topHistoFolder;
-  // hlt DQM mode
-  bool hltDQMMode;
 };
 
 #endif

--- a/DQM/DTMonitorClient/src/DTSummaryClients.cc
+++ b/DQM/DTMonitorClient/src/DTSummaryClients.cc
@@ -103,7 +103,7 @@ void DTSummaryClients::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
     }
 
   } else {
-    LogError("DTDQM|DTMonitorClient|DTSummaryClients")
+    LogVerbatim("DTDQM|DTMonitorClient|DTSummaryClients")
         << "Data Integrity Summary not found with name: DT/00-DataIntegrity/DataIntegritySummary" << endl;
   }
 
@@ -140,7 +140,7 @@ void DTSummaryClients::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
       totalStatus += (48. - nFailingChambers) / 48.;
     } else {
       occupancyFound = false;
-      LogError("DTDQM|DTMonitorClient|DTSummaryClients")
+      LogVerbatim("DTDQM|DTMonitorClient|DTSummaryClients")
           << " Wheel Occupancy Summary not found with name: " << str.str() << endl;
     }
   }

--- a/DQM/DTMonitorModule/interface/DTDataIntegrityROSOffline.h
+++ b/DQM/DTMonitorModule/interface/DTDataIntegrityROSOffline.h
@@ -107,7 +107,6 @@ private:
   edm::EDGetTokenT<DTDDUCollection> dduToken;
 
   edm::EDGetTokenT<DTROS25Collection> ros25Token;
-
 };
 
 #endif

--- a/DQM/DTMonitorModule/interface/DTDataIntegrityROSOffline.h
+++ b/DQM/DTMonitorModule/interface/DTDataIntegrityROSOffline.h
@@ -1,0 +1,118 @@
+#ifndef DTDataIntegrityROSOffline_H
+#define DTDataIntegrityROSOffline_H
+
+/** \class DTDataIntegrityROSOffline
+ *
+ * Class for DT Data Integrity.
+ *
+ *
+ * \author Marco Zanetti (INFN Padova), Gianluca Cerminara (INFN Torino)
+ *
+ */
+
+#include "EventFilter/DTRawToDigi/interface/DTROChainCoding.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <DQMServices/Core/interface/DQMStore.h>
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+#include "DataFormats/DTDigi/interface/DTControlData.h"
+
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+#include <list>
+
+class DTROS25Data;
+class DTDDUData;
+
+class DTDataIntegrityROSOffline : public DQMEDAnalyzer {
+public:
+  DTDataIntegrityROSOffline(const edm::ParameterSet& ps);
+
+  ~DTDataIntegrityROSOffline() override;
+
+  void processROS25(DTROS25Data& data, int dduID, int ros);
+  void processFED(DTDDUData& dduData, const std::vector<DTROS25Data>& rosData, int dduID);
+
+  // log number of times the payload of each fed is unpacked
+  void fedEntry(int dduID);
+  // log number of times the payload of each fed is skipped (no ROS inside)
+  void fedFatal(int dduID);
+  // log number of times the payload of each fed is partially skipped (some ROS skipped)
+  void fedNonFatal(int dduID);
+
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+private:
+  void bookHistos(DQMStore::IBooker&, const int fedMin, const int fedMax);
+  void bookHistos(DQMStore::IBooker&, std::string folder, DTROChainCoding code);
+  void bookHistosROS25(DQMStore::IBooker&, DTROChainCoding code);
+
+  void channelsInCEROS(int cerosId, int chMask, std::vector<int>& channels);
+  void channelsInROS(int cerosMask, std::vector<int>& channels);
+
+  std::string topFolder(bool isFEDIntegrity) const;
+
+  // Plot quantities about SC
+  bool getSCInfo;
+
+  int nevents;
+
+  // Monitor Elements
+  MonitorElement* nEventMonitor;
+  // <histoType, <index , histo> >
+  std::map<std::string, std::map<int, MonitorElement*> > fedHistos;
+  // <histoType, histo> >
+  std::map<std::string, std::map<int, MonitorElement*> > summaryHistos;
+  // <histoType, <index , histo> >
+  std::map<std::string, std::map<int, MonitorElement*> > rosHistos;
+
+  // standard ME for monitoring of FED integrity
+  MonitorElement* hFEDEntry;
+  MonitorElement* hFEDFatal;
+  MonitorElement* hFEDNonFatal;
+  MonitorElement* hCorruptionSummary;
+
+  // one for all FEDS
+  MonitorElement* hTTSSummary;
+
+  int neventsFED;
+  int neventsROS;
+
+  // Number of ROS per FED
+  const int nROS = 12;
+
+  int FEDIDmin;
+  int FEDIDmax;
+
+  // event error flag: true when errors are detected
+  // can be used for the selection of the debug stream
+  bool eventErrorFlag;
+
+  std::map<int, std::set<int> > rosBxIdsPerFED;
+  std::set<int> fedBXIds;
+  std::map<int, std::set<int> > rosL1AIdsPerFED;
+
+  std::string fedIntegrityFolder;
+
+  // The label to retrieve the digis
+  edm::EDGetTokenT<DTDDUCollection> dduToken;
+
+  edm::EDGetTokenT<DTROS25Collection> ros25Token;
+
+};
+
+#endif
+
+/* Local Variables: */
+/* show-trailing-whitespace: t */
+/* truncate-lines: t */
+/* End: */

--- a/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
+++ b/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
@@ -3,14 +3,14 @@
 
 /** \class DTDataIntegrityTask
  *
- * Class for DT Data Integrity.
+ * Class for DT Data Integrity
+ * at Online DQM (Single Thread)
+ * expected to monitor uROS
+ * Class with MEs vs Time/LS
  *
- *
- * \author Marco Zanetti (INFN Padova), Gianluca Cerminara (INFN Torino)
+ * \author Javier Fernandez (Uni. Oviedo) 
  *
  */
-
-#include "EventFilter/DTRawToDigi/interface/DTROChainCoding.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -20,7 +20,6 @@
 #include <DQMServices/Core/interface/DQMStore.h>
 #include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 
-#include "DataFormats/DTDigi/interface/DTControlData.h"
 #include "DataFormats/DTDigi/interface/DTuROSControlData.h"
 
 #include <fstream>
@@ -29,9 +28,6 @@
 #include <vector>
 #include <list>
 
-class DTROS25Data;
-class DTDDUData;
-//to remove
 class DTuROSROSData;
 class DTuROSFEDData;
 class DTTimeEvolutionHisto;
@@ -46,17 +42,6 @@ public:
 
   void processuROS(DTuROSROSData& data, int fed, int uRos);
   void processFED(DTuROSFEDData& data, int fed);
-  void processROS25(DTROS25Data& data, int dduID, int ros);
-  void processFED(DTDDUData& dduData, const std::vector<DTROS25Data>& rosData, int dduID);
-
-  // log number of times the payload of each fed is unpacked
-  void fedEntry(int dduID);
-  // log number of times the payload of each fed is skipped (no ROS inside)
-  void fedFatal(int dduID);
-  // log number of times the payload of each fed is partially skipped (some ROS skipped)
-  void fedNonFatal(int dduID);
-
-  bool eventHasErrors() const;
 
   void beginLuminosityBlock(const edm::LuminosityBlock& ls, const edm::EventSetup& es) override;
   void endLuminosityBlock(const edm::LuminosityBlock& ls, const edm::EventSetup& es) override;
@@ -68,21 +53,12 @@ protected:
 
 private:
   void bookHistos(DQMStore::IBooker&, const int fedMin, const int fedMax);
-  void bookHistos(DQMStore::IBooker&, std::string folder, DTROChainCoding code);
   void bookHistos(DQMStore::IBooker&, std::string folder, const int fed);
-  void bookHistosROS25(DQMStore::IBooker&, DTROChainCoding code);
   void bookHistosuROS(DQMStore::IBooker&, const int fed, const int uRos);
   void bookHistosROS(DQMStore::IBooker&, const int wheel, const int ros);
 
-  void channelsInCEROS(int cerosId, int chMask, std::vector<int>& channels);
-  void channelsInROS(int cerosMask, std::vector<int>& channels);
 
   std::string topFolder(bool isFEDIntegrity) const;
-
-  std::multimap<std::string, std::string> names;
-  std::multimap<std::string, std::string>::iterator it;
-
-  edm::ParameterSet parameters;
 
   //conversions
   int theDDU(int crate, int slot, int link, bool tenDDU);
@@ -90,14 +66,8 @@ private:
 
   //If you want info VS time histos
   bool doTimeHisto;
-  // Plot quantities about SC
-  bool getSCInfo;
-  // Check FEDs from uROS, otherwise standard ROS
-  bool checkUros;
 
   int nevents;
-
-  DTROChainCoding coding;
 
   // Monitor Elements
   MonitorElement* nEventMonitor;
@@ -105,12 +75,8 @@ private:
   std::map<std::string, std::map<int, MonitorElement*> > fedHistos;
   // <histoType, histo> >
   std::map<std::string, std::map<int, MonitorElement*> > summaryHistos;
-  // <histoType, <index , histo> >
-  std::map<std::string, std::map<int, MonitorElement*> > rosHistos;
   // <key , histo> >
   std::map<unsigned int, MonitorElement*> urosHistos;
-  // <histoType, <tdcID, histo> >
-  std::map<std::string, std::map<int, MonitorElement*> > robHistos;
 
   //enum histoTypes for reduced map of MEs urosHistos
   // key = stringEnum*1000 + (fed-minFED)#*100 + (uROS-minuROS)#
@@ -118,16 +84,9 @@ private:
 
   // standard ME for monitoring of FED integrity
   MonitorElement* hFEDEntry;
-  MonitorElement* hFEDFatal;
-  MonitorElement* hFEDNonFatal;
-  MonitorElement* hCorruptionSummary;
 
-  // one for all FEDS
-  MonitorElement* hTTSSummary;
-
-  //time histos for DDU/ROS
+  //time histos for FEDs/uROS
   std::map<std::string, std::map<int, DTTimeEvolutionHisto*> > fedTimeHistos;
-  std::map<std::string, std::map<int, DTTimeEvolutionHisto*> > rosTimeHistos;
   // <key, histo> >
   std::map<unsigned int, DTTimeEvolutionHisto*> urosTimeHistos;
   //key =  (fed-minFED)#*100 + (uROS-minuROS)#
@@ -137,42 +96,17 @@ private:
   int neventsFED;
   int neventsuROS;
 
-  float trigger_counter;
-  std::string outputFile;
-  double rob_max[25];
-  double link_max[72];
-
   int FEDIDmin;
   int FEDIDmax;
 
-  // Number of ROS/uROS per FED
+  // Number of uROS per FED
   const int NuROS = 12;
-
-  //Event counter for the graphs VS time
-  int myPrevEv;
-
-  //Monitor TTS,ROS,FIFO VS time
-  int myPrevTtsVal;
-  int myPrevRosVal;
-  int myPrevFifoVal[7];
-
-  // event error flag: true when errors are detected
-  // can be used for the selection of the debug stream
-  bool eventErrorFlag;
-
-  std::map<int, std::set<int> > rosBxIdsPerFED;
-  std::set<int> fedBXIds;
-  std::map<int, std::set<int> > rosL1AIdsPerFED;
 
   // flag to toggle the creation of only the summaries (for HLT running)
   int mode;
   std::string fedIntegrityFolder;
 
   // The label to retrieve the digis
-  edm::EDGetTokenT<DTDDUCollection> dduToken;
-
-  edm::EDGetTokenT<DTROS25Collection> ros25Token;
-
   edm::EDGetTokenT<DTuROSFEDDataCollection> fedToken;
 };
 

--- a/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
+++ b/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
@@ -57,7 +57,6 @@ private:
   void bookHistosuROS(DQMStore::IBooker&, const int fed, const int uRos);
   void bookHistosROS(DQMStore::IBooker&, const int wheel, const int ros);
 
-
   std::string topFolder(bool isFEDIntegrity) const;
 
   //conversions

--- a/DQM/DTMonitorModule/interface/DTDataIntegrityUrosOffline.h
+++ b/DQM/DTMonitorModule/interface/DTDataIntegrityUrosOffline.h
@@ -1,0 +1,99 @@
+#ifndef DTDataIntegrityUrosOffline_H
+#define DTDataIntegrityUrosOffline_H
+
+/** \class DTDataIntegrityUrosOffline
+ *
+ * Class for DT Data Integrity Offline
+ * expected to monitor uROS
+ * to follow DTDataIntegrityTask
+ * which contains also MEs vs Time/LS
+ *
+ * \author Javier Fernandez (Uni. Oviedo)
+ *
+ */
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <DQMServices/Core/interface/DQMStore.h>
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+#include "DataFormats/DTDigi/interface/DTuROSControlData.h"
+
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+#include <list>
+
+class DTuROSROSData;
+class DTuROSFEDData;
+
+class DTDataIntegrityUrosOffline : public DQMEDAnalyzer {
+public:
+  DTDataIntegrityUrosOffline(const edm::ParameterSet& ps);
+
+  ~DTDataIntegrityUrosOffline() override;
+
+  void processuROS(DTuROSROSData& data, int fed, int uRos);
+  void processFED(DTuROSFEDData& data, int fed);
+
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+private:
+  void bookHistos(DQMStore::IBooker&, const int fedMin, const int fedMax);
+  void bookHistos(DQMStore::IBooker&, std::string folder, const int fed);
+  void bookHistosuROS(DQMStore::IBooker&, const int fed, const int uRos);
+  void bookHistosROS(DQMStore::IBooker&, const int wheel, const int ros);
+
+  std::string topFolder(bool isFEDIntegrity) const;
+
+  //conversions
+  int theDDU(int crate, int slot, int link, bool tenDDU);
+  int theROS(int slot, int link);
+
+  int nevents;
+
+  // Monitor Elements
+  MonitorElement* nEventMonitor;
+  // <histoType, <index , histo> >
+  std::map<std::string, std::map<int, MonitorElement*> > fedHistos;
+  // <histoType, histo> >
+  std::map<std::string, std::map<int, MonitorElement*> > summaryHistos;
+  // <key , histo> >
+  std::map<unsigned int, MonitorElement*> urosHistos;
+
+  //enum histoTypes for reduced map of MEs urosHistos
+  // key = stringEnum*1000 + (fed-minFED)#*100 + (uROS-minuROS)#
+  enum histoTypes { uROSEventLength = 0, uROSError = 1, TDCError = 4, TTSValues = 7 };
+
+  // standard ME for monitoring of FED integrity
+  MonitorElement* hFEDEntry;
+
+  int nEventsLS;
+
+  int neventsFED;
+  int neventsuROS;
+
+  int FEDIDmin;
+  int FEDIDmax;
+
+  // Number of uROS per FED
+  const int NuROS = 12;
+
+  std::string fedIntegrityFolder;
+
+  // The label to retrieve the digis
+  edm::EDGetTokenT<DTuROSFEDDataCollection> fedToken;
+};
+
+#endif
+
+/* Local Variables: */
+/* show-trailing-whitespace: t */
+/* truncate-lines: t */
+/* End: */

--- a/DQM/DTMonitorModule/plugins/plugins.cc
+++ b/DQM/DTMonitorModule/plugins/plugins.cc
@@ -54,6 +54,12 @@ DEFINE_FWK_MODULE(DTDCSByLumiTask);
 #include <DQM/DTMonitorModule/interface/DTDataIntegrityTask.h>
 DEFINE_FWK_MODULE(DTDataIntegrityTask);
 
+#include <DQM/DTMonitorModule/interface/DTDataIntegrityUrosOffline.h>
+DEFINE_FWK_MODULE(DTDataIntegrityUrosOffline);
+
+#include <DQM/DTMonitorModule/interface/DTDataIntegrityROSOffline.h>
+DEFINE_FWK_MODULE(DTDataIntegrityROSOffline);
+
 #include <DQM/DTMonitorModule/src/DTOccupancyEfficiency.h>
 DEFINE_FWK_MODULE(DTOccupancyEfficiency);
 

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_Cosmics_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_Cosmics_cff.py
@@ -45,7 +45,6 @@ from DQM.DTMonitorModule.dtTriggerEfficiencyTask_cfi import *
 
 dtSourcesCosmics = cms.Sequence(dtDataIntegrityUnpacker  +
                                 DTDataIntegrityTask +
-                                dtDCSByLumiMonitor + 
                                 dtRunConditionVar + 
                                 dtSegmentAnalysisMonitor +
                                 dtResolutionAnalysisMonitor +

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_Cosmics_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_Cosmics_cff.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.DTMonitorModule.dtChamberEfficiency_Cosmics_cfi import *
-from DQM.DTMonitorModule.dtDCSByLumiTask_cfi import *
 from DQM.DTMonitorModule.dtOccupancyEfficiency_cfi import *
 from DQM.DTMonitorModule.dtSegmentTask_cfi import *
 from DQM.DTMonitorModule.dtRunConditionVar_cfi import *
@@ -39,12 +38,11 @@ dtDataIntegrityUnpacker = cms.EDProducer("DTUnpackingModule",
 )
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "Offline"
 
 from DQM.DTMonitorModule.dtTriggerEfficiencyTask_cfi import *
 
 dtSourcesCosmics = cms.Sequence(dtDataIntegrityUnpacker  +
-                                DTDataIntegrityTask +
+                                dtDataIntegrityTaskOffline +
                                 dtRunConditionVar + 
                                 dtSegmentAnalysisMonitor +
                                 dtResolutionAnalysisMonitor +

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_Cosmics_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_Cosmics_cff.py
@@ -5,8 +5,6 @@ from DQM.DTMonitorModule.dtOccupancyEfficiency_cfi import *
 from DQM.DTMonitorModule.dtSegmentTask_cfi import *
 from DQM.DTMonitorModule.dtRunConditionVar_cfi import *
 dtSegmentAnalysisMonitor.detailedAnalysis = True
-dtSegmentAnalysisMonitor.slideTimeBins = False
-dtSegmentAnalysisMonitor.nLSTimeBin = 5
 
 from DQM.DTMonitorModule.dtResolutionTask_cfi import *
 

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_HI_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_HI_cff.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from DQM.DTMonitorModule.dtChamberEfficiencyHI_cfi import *
 from DQM.DTMonitorModule.dtOccupancyEfficiency_cfi import *
 from DQM.DTMonitorModule.dtSegmentTask_cfi import *
-from DQM.DTMonitorModule.dtDCSByLumiTask_cfi import *
 from DQM.DTMonitorModule.dtRunConditionVar_cfi import *
 dtSegmentAnalysisMonitor.detailedAnalysis = True
 dtSegmentAnalysisMonitor.slideTimeBins = False
@@ -39,12 +38,11 @@ dtDataIntegrityUnpacker = cms.EDProducer("DTUnpackingModule",
 )
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "Offline"
 
 from DQM.DTMonitorModule.dtTriggerEfficiencyTask_cfi import *
 
 dtSources = cms.Sequence(dtDataIntegrityUnpacker  +
-                         DTDataIntegrityTask +
+                         dtDataIntegrityTaskOffline +
                          dtRunConditionVar + 
                          dtSegmentAnalysisMonitor +
                          dtResolutionAnalysisMonitor +

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_HI_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_HI_cff.py
@@ -45,7 +45,6 @@ from DQM.DTMonitorModule.dtTriggerEfficiencyTask_cfi import *
 
 dtSources = cms.Sequence(dtDataIntegrityUnpacker  +
                          DTDataIntegrityTask +
-                         dtDCSByLumiMonitor + 
                          dtRunConditionVar + 
                          dtSegmentAnalysisMonitor +
                          dtResolutionAnalysisMonitor +

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_HI_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_HI_cff.py
@@ -5,8 +5,6 @@ from DQM.DTMonitorModule.dtOccupancyEfficiency_cfi import *
 from DQM.DTMonitorModule.dtSegmentTask_cfi import *
 from DQM.DTMonitorModule.dtRunConditionVar_cfi import *
 dtSegmentAnalysisMonitor.detailedAnalysis = True
-dtSegmentAnalysisMonitor.slideTimeBins = False
-dtSegmentAnalysisMonitor.nLSTimeBin = 5
 
 from DQM.DTMonitorModule.dtResolutionTask_cfi import *
 

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_cff.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from DQM.DTMonitorModule.dtChamberEfficiency_cfi import *
 from DQM.DTMonitorModule.dtOccupancyEfficiency_cfi import *
 from DQM.DTMonitorModule.dtSegmentTask_cfi import *
-from DQM.DTMonitorModule.dtDCSByLumiTask_cfi import *
 from DQM.DTMonitorModule.dtRunConditionVar_cfi import *
 dtSegmentAnalysisMonitor.detailedAnalysis = True
 dtSegmentAnalysisMonitor.slideTimeBins = False
@@ -40,12 +39,11 @@ dtDataIntegrityUnpacker = cms.EDProducer("DTUnpackingModule",
 
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "Offline"
 
 from DQM.DTMonitorModule.dtTriggerEfficiencyTask_cfi import *
 
 dtSources = cms.Sequence(dtDataIntegrityUnpacker  +
-                         DTDataIntegrityTask +
+                         dtDataIntegrityTaskOffline +
                          dtRunConditionVar + 
                          dtSegmentAnalysisMonitor +
                          dtResolutionAnalysisMonitor +

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_cff.py
@@ -5,8 +5,6 @@ from DQM.DTMonitorModule.dtOccupancyEfficiency_cfi import *
 from DQM.DTMonitorModule.dtSegmentTask_cfi import *
 from DQM.DTMonitorModule.dtRunConditionVar_cfi import *
 dtSegmentAnalysisMonitor.detailedAnalysis = True
-dtSegmentAnalysisMonitor.slideTimeBins = False
-dtSegmentAnalysisMonitor.nLSTimeBin = 5
 
 from DQM.DTMonitorModule.dtResolutionTask_cfi import *
 

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_cff.py
@@ -46,7 +46,6 @@ from DQM.DTMonitorModule.dtTriggerEfficiencyTask_cfi import *
 
 dtSources = cms.Sequence(dtDataIntegrityUnpacker  +
                          DTDataIntegrityTask +
-                         dtDCSByLumiMonitor + 
                          dtRunConditionVar + 
                          dtSegmentAnalysisMonitor +
                          dtResolutionAnalysisMonitor +

--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_EvF_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_EvF_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "HLT"
-DTDataIntegrityTask.fedIntegrityFolder = "DT/FEDIntegrity_EvF"
+dtDataIntegrityTask.processingMode = "HLT"
+dtDataIntegrityTask.fedIntegrityFolder = "DT/FEDIntegrity_EvF"
 

--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
@@ -1,16 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-DTDataIntegrityTask = DQMEDAnalyzer('DTDataIntegrityTask',
-                                     getSCInfo = cms.untracked.bool(True),
-                                     checkUros  = cms.untracked.bool(False),
+dtDataIntegrityTask = DQMEDAnalyzer('DTDataIntegrityTask',
                                      fedIntegrityFolder = cms.untracked.string("DT/FEDIntegrity"),
                                      processingMode     = cms.untracked.string("Online"),
-                                     dtDDULabel         = cms.InputTag("dtDataIntegrityUnpacker"),
-                                     dtROS25Label       = cms.InputTag("dtDataIntegrityUnpacker"),
 				     dtFEDlabel         =  cms.InputTag("dtDataIntegrityUnpacker")
 )
 
+dtDataIntegrityTaskOffline = DQMEDAnalyzer('DTDataIntegrityROSOffline',
+                                     getSCInfo = cms.untracked.bool(True),
+                                     fedIntegrityFolder = cms.untracked.string("DT/FEDIntegrity"),
+                                     dtDDULabel         = cms.InputTag("dtDataIntegrityUnpacker"),
+                                     dtROS25Label       = cms.InputTag("dtDataIntegrityUnpacker"),
+)
+
+dtDataIntegrityUrosOffline = DQMEDAnalyzer('DTDataIntegrityUrosOffline',
+                                     fedIntegrityFolder = cms.untracked.string("DT/FEDIntegrity"),
+                                     dtFEDlabel         =  cms.InputTag("dtDataIntegrityUnpacker")
+)
+
 from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
-run2_DT_2018.toModify(DTDataIntegrityTask,checkUros=cms.untracked.bool(True))
+run2_DT_2018.toReplaceWith(dtDataIntegrityTaskOffline, dtDataIntegrityUrosOffline)
 

--- a/DQM/DTMonitorModule/python/dtSegmentTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtSegmentTask_cfi.py
@@ -10,12 +10,6 @@ dtSegmentAnalysisMonitor = DQMEDAnalyzer('DTSegmentAnalysisTask',
                                           checkNoisyChannels = cms.untracked.bool(True),
                                           # switch off uneeded histograms
                                           detailedAnalysis = cms.untracked.bool(False),
-                                          # # of bins in the time histos
-                                          nTimeBins = cms.untracked.int32(100),
-                                          # # of LS per bin in the time histos
-                                          nLSTimeBin = cms.untracked.int32(15),
-                                          # switch on/off sliding bins in time histos
-                                          slideTimeBins = cms.untracked.bool(True),
                                           # top folder for the histograms in DQMStore
                                           topHistoFolder = cms.untracked.string("DT/02-Segments"),
                                           # hlt DQM mode

--- a/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
+++ b/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
@@ -46,11 +46,9 @@ from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
 from DQM.DTMonitorClient.dtDataIntegrityTest_cfi import *
 from DQM.DTMonitorClient.dtBlockedROChannelsTest_cfi import *
-DTDataIntegrityTask.processingMode = 'Online'
-DTDataIntegrityTask.dtFEDlabel     = 'dtunpacker'
-DTDataIntegrityTask.checkUros      = True
+dtDataIntegrityTask.processingMode = 'Online'
+dtDataIntegrityTask.dtFEDlabel     = 'dtunpacker'
 blockedROChannelTest.checkUros      = True
-dataIntegrityTest.checkUros      = True
 
 # Digi task
 from DQM.DTMonitorModule.dtDigiTask_cfi import *
@@ -112,7 +110,7 @@ unpackers = cms.Sequence(dtunpacker + twinMuxStage2Digis + scalersRawToDigi)
 reco = cms.Sequence(dt1DRecHits + dt4DSegments)
 
 # sequence of DQM tasks to be run on physics events only
-dtDQMTask = cms.Sequence(DTDataIntegrityTask + dtDigiMonitor + dtSegmentAnalysisMonitor + dtTriggerBaseMonitor + dtTriggerLutMonitor + dtNoiseMonitor + dtResolutionAnalysisMonitor)
+dtDQMTask = cms.Sequence(dtDataIntegrityTask + dtDigiMonitor + dtSegmentAnalysisMonitor + dtTriggerBaseMonitor + dtTriggerLutMonitor + dtNoiseMonitor + dtResolutionAnalysisMonitor)
 
 # DQM clients to be run on physics event only
 dtDQMTest = cms.Sequence(dataIntegrityTest + blockedROChannelTest + triggerLutTest + triggerTest + dtOccupancyTest + dtOccupancyTestML + segmentTest + dtNoiseAnalysisMonitor + dtSummaryClients + dtqTester)

--- a/DQM/DTMonitorModule/src/DTDataIntegrityROSOffline.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityROSOffline.cc
@@ -1,0 +1,768 @@
+/*
+ * \file DTDataIntegrityROSOffline.cc
+ *
+ * \author M. Zanetti (INFN Padova), S. Bolognesi (INFN Torino), G. Cerminara (INFN Torino)
+ *
+ */
+
+#include "DQM/DTMonitorModule/interface/DTDataIntegrityROSOffline.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/DTDigi/interface/DTControlData.h"
+#include "DataFormats/DTDigi/interface/DTDDUWords.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <cmath>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace std;
+using namespace edm;
+
+DTDataIntegrityROSOffline::DTDataIntegrityROSOffline(const edm::ParameterSet& ps) : nevents(0) {
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline") << "[DTDataIntegrityROSOffline]: Constructor" << endl;
+
+    dduToken = consumes<DTDDUCollection>(ps.getParameter<InputTag>("dtDDULabel"));
+    ros25Token = consumes<DTROS25Collection>(ps.getParameter<InputTag>("dtROS25Label"));
+    FEDIDmin = FEDNumbering::MINDTFEDID;
+    FEDIDmax = FEDNumbering::MAXDTFEDID;
+
+  neventsFED = 0;
+
+  //   Plot quantities about SC
+  getSCInfo = ps.getUntrackedParameter<bool>("getSCInfo", false);
+
+  fedIntegrityFolder = ps.getUntrackedParameter<string>("fedIntegrityFolder", "DT/FEDIntegrity");
+
+}
+
+DTDataIntegrityROSOffline::~DTDataIntegrityROSOffline() {
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << "[DTDataIntegrityROSOffline]: Destructor. Analyzed " << neventsFED << " events" << endl;
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << "[DTDataIntegrityROSOffline]: postEndJob called!" << endl;
+}
+
+/*
+  Folder Structure (ROS Legacy):
+  - One folder for each DDU, named FEDn
+  - Inside each DDU folder the DDU histos and the ROSn folder
+  - Inside each ROS folder the ROS histos and the ROBn folder
+  - Inside each ROB folder one occupancy plot and the TimeBoxes
+  with the chosen granularity (simply change the histo name)
+*/
+
+void DTDataIntegrityROSOffline::bookHistograms(DQMStore::IBooker& ibooker,
+                                         edm::Run const& iRun,
+                                         edm::EventSetup const& iSetup) {
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline") << "[DTDataIntegrityROSOffline]: postBeginJob" << endl;
+
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << "[DTDataIntegrityROSOffline] Get DQMStore service" << endl;
+
+  // Loop over the DT FEDs
+
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << " FEDS: " << FEDIDmin << " to " << FEDIDmax << " in the RO" << endl;
+
+  // book FED integrity histos
+  bookHistos(ibooker, FEDIDmin, FEDIDmax);
+
+  //Legacy ROS
+
+      // static booking of the histograms
+
+      for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
+        DTROChainCoding code;
+        code.setDDU(fed);
+        bookHistos(ibooker, string("ROS_S"), code);
+
+        bookHistos(ibooker, string("DDU"), code);
+
+        for (int ros = 1; ros <= nROS; ++ros) {  // loop over all ROS
+          code.setROS(ros);
+          bookHistosROS25(ibooker, code);
+        }
+      }
+}
+
+void DTDataIntegrityROSOffline::bookHistos(DQMStore::IBooker& ibooker, const int fedMin, const int fedMax) {
+  ibooker.setCurrentFolder("DT/EventInfo/Counters");
+  nEventMonitor = ibooker.bookFloat("nProcessedEventsDataIntegrity");
+
+  // Standard FED integrity histos
+  ibooker.setCurrentFolder(topFolder(true));
+
+  int nFED = (fedMax - fedMin) + 1;
+
+  hFEDEntry = ibooker.book1D("FEDEntries", "# entries per DT FED", nFED, fedMin, fedMax + 1);
+
+    hFEDFatal = ibooker.book1D("FEDFatal", "# fatal errors DT FED", nFED, fedMin, fedMax + 1);
+    hFEDNonFatal = ibooker.book1D("FEDNonFatal", "# NON fatal errors DT FED", nFED, fedMin, fedMax + 1);
+
+    ibooker.setCurrentFolder(topFolder(false));
+    hTTSSummary = ibooker.book2D("TTSSummary", "Summary Status TTS", nFED, fedMin, fedMax + 1, 9, 1, 10);
+    hTTSSummary->setAxisTitle("FED", 1);
+    hTTSSummary->setBinLabel(1, "ROS PAF", 2);
+    hTTSSummary->setBinLabel(2, "DDU PAF", 2);
+    hTTSSummary->setBinLabel(3, "ROS PAF", 2);
+    hTTSSummary->setBinLabel(4, "DDU PAF", 2);
+    hTTSSummary->setBinLabel(5, "DDU Full", 2);
+    hTTSSummary->setBinLabel(6, "L1A Mism.", 2);
+    hTTSSummary->setBinLabel(7, "ROS Error", 2);
+    hTTSSummary->setBinLabel(8, "BX Mism.", 2);
+    hTTSSummary->setBinLabel(9, "DDU Logic Err.", 2);
+
+    // bookkeeping of the histos
+    hCorruptionSummary =
+        ibooker.book2D("DataCorruptionSummary", "Data Corruption Sources", nFED, fedMin, fedMax + 1, 8, 1, 9);
+    hCorruptionSummary->setAxisTitle("FED", 1);
+    hCorruptionSummary->setBinLabel(1, "Miss Ch.", 2);
+    hCorruptionSummary->setBinLabel(2, "ROS BX mism", 2);
+    hCorruptionSummary->setBinLabel(3, "DDU BX mism", 2);
+    hCorruptionSummary->setBinLabel(4, "ROS L1A mism", 2);
+    hCorruptionSummary->setBinLabel(5, "Miss Payload", 2);
+    hCorruptionSummary->setBinLabel(6, "FCRC bit", 2);
+    hCorruptionSummary->setBinLabel(7, "Header check", 2);
+    hCorruptionSummary->setBinLabel(8, "Trailer Check", 2);
+}
+
+void DTDataIntegrityROSOffline::bookHistos(DQMStore::IBooker& ibooker, string folder, DTROChainCoding code) {
+  string dduID_s = to_string(code.getDDU());
+  string rosID_s = to_string(code.getROS());
+  string robID_s = to_string(code.getROB());
+  int wheel = (code.getDDUID() - 770) % 5 - 2;
+  string wheel_s = to_string(wheel);
+
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << " Booking histos for FED: " << code.getDDU() << " ROS: " << code.getROS() << " ROB: " << code.getROB()
+      << " folder: " << folder << endl;
+
+  string histoType;
+  string histoName;
+  string histoTitle;
+  MonitorElement* histo = nullptr;
+
+  // DDU Histograms
+  if (folder == "DDU") {
+    ibooker.setCurrentFolder(topFolder(false) + "FED" + dduID_s);
+
+    histoType = "EventLength";
+    histoName = "FED" + dduID_s + "_" + histoType;
+    histoTitle = "Event Length (Bytes) FED " + dduID_s;
+    (fedHistos[histoType])[code.getDDUID()] = ibooker.book1D(histoName, histoTitle, 501, 0, 16032);
+
+    histoType = "ROSStatus";
+    histoName = "FED" + dduID_s + "_" + histoType;
+    (fedHistos[histoType])[code.getDDUID()] = ibooker.book2D(histoName, histoName, 12, 0, 12, 12, 0, 12);
+    histo = (fedHistos[histoType])[code.getDDUID()];
+    histo->setBinLabel(1, "ch.enabled", 1);
+    histo->setBinLabel(2, "timeout", 1);
+    histo->setBinLabel(3, "ev.trailer lost", 1);
+    histo->setBinLabel(4, "opt.fiber lost", 1);
+    histo->setBinLabel(5, "tlk.prop.error", 1);
+    histo->setBinLabel(6, "tlk.pattern error", 1);
+    histo->setBinLabel(7, "tlk.sign.lost", 1);
+    histo->setBinLabel(8, "error from ROS", 1);
+    histo->setBinLabel(9, "if ROS in events", 1);
+    histo->setBinLabel(10, "Miss. Evt.", 1);
+    histo->setBinLabel(11, "Evt. ID Mismatch", 1);
+    histo->setBinLabel(12, "BX Mismatch", 1);
+
+    histo->setBinLabel(1, "ROS 1", 2);
+    histo->setBinLabel(2, "ROS 2", 2);
+    histo->setBinLabel(3, "ROS 3", 2);
+    histo->setBinLabel(4, "ROS 4", 2);
+    histo->setBinLabel(5, "ROS 5", 2);
+    histo->setBinLabel(6, "ROS 6", 2);
+    histo->setBinLabel(7, "ROS 7", 2);
+    histo->setBinLabel(8, "ROS 8", 2);
+    histo->setBinLabel(9, "ROS 9", 2);
+    histo->setBinLabel(10, "ROS 10", 2);
+    histo->setBinLabel(11, "ROS 11", 2);
+    histo->setBinLabel(12, "ROS 12", 2);
+
+  }
+
+  // ROS Histograms
+  if (folder == "ROS_S") {  // The summary of the error of the ROS on the same FED
+    ibooker.setCurrentFolder(topFolder(false));
+
+    histoType = "ROSSummary";
+    histoName = "FED" + dduID_s + "_ROSSummary";
+    string histoTitle = "Summary Wheel" + wheel_s + " (FED " + dduID_s + ")";
+
+    ((summaryHistos[histoType])[code.getDDUID()]) = ibooker.book2D(histoName, histoTitle, 20, 0, 20, 12, 1, 13);
+    MonitorElement* histo = ((summaryHistos[histoType])[code.getDDUID()]);
+    // ROS error bins
+    histo->setBinLabel(1, "Link TimeOut", 1);
+    histo->setBinLabel(2, "Ev.Id.Mis.", 1);
+    histo->setBinLabel(3, "FIFO almost full", 1);
+    histo->setBinLabel(4, "FIFO full", 1);
+    histo->setBinLabel(5, "CEROS timeout", 1);
+    histo->setBinLabel(6, "Max. wds", 1);
+    histo->setBinLabel(7, "WO L1A FIFO", 1);
+    histo->setBinLabel(8, "TDC parity err.", 1);
+    histo->setBinLabel(9, "BX ID Mis.", 1);
+    histo->setBinLabel(10, "TXP", 1);
+    histo->setBinLabel(11, "L1A almost full", 1);
+    histo->setBinLabel(12, "Ch. blocked", 1);
+    histo->setBinLabel(13, "Ev. Id. Mis.", 1);
+    histo->setBinLabel(14, "CEROS blocked", 1);
+    // TDC error bins
+    histo->setBinLabel(15, "TDC Fatal", 1);
+    histo->setBinLabel(16, "TDC RO FIFO ov.", 1);
+    histo->setBinLabel(17, "TDC L1 buf. ov.", 1);
+    histo->setBinLabel(18, "TDC L1A FIFO ov.", 1);
+    histo->setBinLabel(19, "TDC hit err.", 1);
+    histo->setBinLabel(20, "TDC hit rej.", 1);
+
+    histo->setBinLabel(1, "ROS1", 2);
+    histo->setBinLabel(2, "ROS2", 2);
+    histo->setBinLabel(3, "ROS3", 2);
+    histo->setBinLabel(4, "ROS4", 2);
+    histo->setBinLabel(5, "ROS5", 2);
+    histo->setBinLabel(6, "ROS6", 2);
+    histo->setBinLabel(7, "ROS7", 2);
+    histo->setBinLabel(8, "ROS8", 2);
+    histo->setBinLabel(9, "ROS9", 2);
+    histo->setBinLabel(10, "ROS10", 2);
+    histo->setBinLabel(11, "ROS11", 2);
+    histo->setBinLabel(12, "ROS12", 2);
+  }
+
+  if (folder == "ROS") {
+    ibooker.setCurrentFolder(topFolder(false) + "FED" + dduID_s + "/" + folder + rosID_s);
+
+    histoType = "ROSError";
+    histoName = "FED" + dduID_s + "_" + folder + rosID_s + "_ROSError";
+    histoTitle = histoName + " (ROBID error summary)";
+    (rosHistos[histoType])[code.getROSID()] = ibooker.book2D(histoName, histoTitle, 11, 0, 11, 26, 0, 26);
+
+    MonitorElement* histo = (rosHistos[histoType])[code.getROSID()];
+    // ROS error bins
+    histo->setBinLabel(1, "Link TimeOut", 1);
+    histo->setBinLabel(2, "Ev.Id.Mis.", 1);
+    histo->setBinLabel(3, "FIFO almost full", 1);
+    histo->setBinLabel(4, "FIFO full", 1);
+    histo->setBinLabel(5, "CEROS timeout", 1);
+    histo->setBinLabel(6, "Max. wds", 1);
+    histo->setBinLabel(7, "TDC parity err.", 1);
+    histo->setBinLabel(8, "BX ID Mis.", 1);
+    histo->setBinLabel(9, "Ch. blocked", 1);
+    histo->setBinLabel(10, "Ev. Id. Mis.", 1);
+    histo->setBinLabel(11, "CEROS blocked", 1);
+
+    histo->setBinLabel(1, "ROB0", 2);
+    histo->setBinLabel(2, "ROB1", 2);
+    histo->setBinLabel(3, "ROB2", 2);
+    histo->setBinLabel(4, "ROB3", 2);
+    histo->setBinLabel(5, "ROB4", 2);
+    histo->setBinLabel(6, "ROB5", 2);
+    histo->setBinLabel(7, "ROB6", 2);
+    histo->setBinLabel(8, "ROB7", 2);
+    histo->setBinLabel(9, "ROB8", 2);
+    histo->setBinLabel(10, "ROB9", 2);
+    histo->setBinLabel(11, "ROB10", 2);
+    histo->setBinLabel(12, "ROB11", 2);
+    histo->setBinLabel(13, "ROB12", 2);
+    histo->setBinLabel(14, "ROB13", 2);
+    histo->setBinLabel(15, "ROB14", 2);
+    histo->setBinLabel(16, "ROB15", 2);
+    histo->setBinLabel(17, "ROB16", 2);
+    histo->setBinLabel(18, "ROB17", 2);
+    histo->setBinLabel(19, "ROB18", 2);
+    histo->setBinLabel(20, "ROB19", 2);
+    histo->setBinLabel(21, "ROB20", 2);
+    histo->setBinLabel(22, "ROB21", 2);
+    histo->setBinLabel(23, "ROB22", 2);
+    histo->setBinLabel(24, "ROB23", 2);
+    histo->setBinLabel(25, "ROB24", 2);
+    histo->setBinLabel(26, "SC", 2);
+
+  }
+
+  // SC Histograms
+  if (folder == "SC") {
+    // The plots are per wheel
+    ibooker.setCurrentFolder(topFolder(false) + "FED" + dduID_s);
+
+    // SC data Size
+    histoType = "SCSizeVsROSSize";
+    histoName = "FED" + dduID_s + "_SCSizeVsROSSize";
+    histoTitle = "SC size vs SC (FED " + dduID_s + ")";
+    rosHistos[histoType][code.getSCID()] = ibooker.book2D(histoName, histoTitle, 12, 1, 13, 51, -1, 50);
+    rosHistos[histoType][code.getSCID()]->setAxisTitle("SC", 1);
+  }
+}
+
+void DTDataIntegrityROSOffline::bookHistosROS25(DQMStore::IBooker& ibooker, DTROChainCoding code) {
+  bookHistos(ibooker, string("ROS"), code);
+}
+
+
+void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros) {
+  neventsROS++;  
+
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << "[DTDataIntegrityROSOffline]: " << neventsROS << " events analyzed by processROS25" << endl;
+
+  // The ID of the RO board (used to map the histos)
+  DTROChainCoding code;
+  code.setDDU(ddu);
+  code.setROS(ros);
+
+  MonitorElement* ROSSummary = summaryHistos["ROSSummary"][code.getDDUID()];
+
+  // Summary of all ROB errors
+  MonitorElement* ROSError = nullptr;
+    ROSError = rosHistos["ROSError"][code.getROSID()];
+
+  if ((!ROSError)) {
+    LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+        << "Trying to access non existing ME at ROSID " << code.getROSID() << std::endl;
+    return;
+  }
+
+  // L1A ids to be checked against FED one
+  rosL1AIdsPerFED[ddu].insert(data.getROSHeader().TTCEventCounter());
+
+  // ROS errors
+
+  // check for TPX errors
+  if (data.getROSTrailer().TPX() != 0) {
+    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline") << " TXP error en ROS " << code.getROS() << endl;
+    ROSSummary->Fill(9, code.getROS());
+  }
+
+  // L1 Buffer almost full (non-critical error!)
+  if (data.getROSTrailer().l1AFifoOccupancy() > 31) {
+    ROSSummary->Fill(10, code.getROS());
+  }
+
+  for (vector<DTROSErrorWord>::const_iterator error_it = data.getROSErrors().begin();
+       error_it != data.getROSErrors().end();
+       error_it++) {  // Loop over ROS error words
+
+    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+        << " Error in ROS " << code.getROS() << " ROB Id " << (*error_it).robID() << " Error type "
+        << (*error_it).errorType() << endl;
+
+    // Fill the ROSSummary (1 per FED) histo
+    ROSSummary->Fill((*error_it).errorType(), code.getROS());
+    if ((*error_it).errorType() <= 11) {  // set error flag
+      eventErrorFlag = true;
+    }
+
+      // Fill the ROB Summary (1 per ROS) histo
+      if ((*error_it).robID() != 31) {
+        ROSError->Fill((*error_it).errorType(), (*error_it).robID());
+      } else if ((*error_it).errorType() == 4) {
+        vector<int> channelBins;
+        channelsInROS((*error_it).cerosID(), channelBins);
+        vector<int>::const_iterator channelIt = channelBins.begin();
+        vector<int>::const_iterator channelEnd = channelBins.end();
+        for (; channelIt != channelEnd; ++channelIt) {
+          ROSError->Fill(4, (*channelIt));
+        }
+      }
+  }
+
+  int ROSDebug_BunchNumber = -1;
+
+  for (vector<DTROSDebugWord>::const_iterator debug_it = data.getROSDebugs().begin();
+       debug_it != data.getROSDebugs().end();
+       debug_it++) {  // Loop over ROS debug words
+
+    int debugROSSummary = 0;
+    int debugROSError = 0;
+    vector<int> debugBins;
+    bool hasEvIdMis = false;
+    vector<int> evIdMisBins;
+
+    if ((*debug_it).debugType() == 0) {
+      ROSDebug_BunchNumber = (*debug_it).debugMessage();
+    } else if ((*debug_it).debugType() == 1) {
+      // not used
+      // ROSDebug_BcntResCntLow = (*debug_it).debugMessage();
+    } else if ((*debug_it).debugType() == 2) {
+      // not used
+      // ROSDebug_BcntResCntHigh = (*debug_it).debugMessage();
+    } else if ((*debug_it).debugType() == 3) {
+      if ((*debug_it).dontRead()) {
+        debugROSSummary = 11;
+        debugROSError = 8;
+        channelsInCEROS((*debug_it).cerosIdCerosStatus(), (*debug_it).dontRead(), debugBins);
+      }
+      if ((*debug_it).evIdMis()) {
+        hasEvIdMis = true;
+        channelsInCEROS((*debug_it).cerosIdCerosStatus(), (*debug_it).evIdMis(), evIdMisBins);
+      }
+    } else if ((*debug_it).debugType() == 4 && (*debug_it).cerosIdRosStatus()) {
+      debugROSSummary = 13;
+      debugROSError = 10;
+      channelsInROS((*debug_it).cerosIdRosStatus(), debugBins);
+    }
+
+    if (debugROSSummary) {
+      ROSSummary->Fill(debugROSSummary, code.getROS());
+        vector<int>::const_iterator channelIt = debugBins.begin();
+        vector<int>::const_iterator channelEnd = debugBins.end();
+        for (; channelIt != channelEnd; ++channelIt) {
+          ROSError->Fill(debugROSError, (*channelIt));
+        }
+    }
+
+    if (hasEvIdMis) {
+      ROSSummary->Fill(12, code.getROS());
+        vector<int>::const_iterator channelIt = evIdMisBins.begin();
+        vector<int>::const_iterator channelEnd = evIdMisBins.end();
+        for (; channelIt != channelEnd; ++channelIt) {
+          ROSError->Fill(9, (*channelIt));
+        }
+    }
+  }
+
+  // ROB Group Header
+  // Check the BX of the ROB headers against the BX of the ROS
+  for (vector<DTROBHeader>::const_iterator rob_it = data.getROBHeaders().begin(); rob_it != data.getROBHeaders().end();
+       rob_it++) {  // loop over ROB headers
+
+    code.setROB((*rob_it).first);
+    DTROBHeaderWord robheader = (*rob_it).second;
+
+    rosBxIdsPerFED[ddu].insert(ROSDebug_BunchNumber);
+
+    if (robheader.bunchID() != ROSDebug_BunchNumber) {
+      // fill ROS Summary plot
+      ROSSummary->Fill(8, code.getROS());
+      eventErrorFlag = true;
+
+      // fill ROB Summary plot for that particular ROS
+        ROSError->Fill(7, robheader.robID());
+    }
+  }
+
+  // TDC Data
+  for (vector<DTTDCData>::const_iterator tdc_it = data.getTDCData().begin(); tdc_it != data.getTDCData().end();
+       tdc_it++) {  // loop over TDC data
+
+    DTTDCMeasurementWord tdcDatum = (*tdc_it).second;
+
+    if (tdcDatum.PC() != 0) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+          << " PC error in ROS " << code.getROS() << " TDC " << (*tdc_it).first << endl;
+      //     fill ROS Summary plot
+      ROSSummary->Fill(7, code.getROS());
+
+      eventErrorFlag = true;
+
+      // fill ROB Summary plot for that particular ROS
+        ROSError->Fill(6, (*tdc_it).first);
+    }
+  }
+
+  // TDC Error
+  for (vector<DTTDCError>::const_iterator tdc_it = data.getTDCError().begin(); tdc_it != data.getTDCError().end();
+       tdc_it++) {  // loop over TDC errors
+
+    code.setROB((*tdc_it).first);
+
+    int tdcError_ROSSummary = 0;
+    int tdcError_ROSError = 0;
+
+    if (((*tdc_it).second).tdcError() & 0x4000) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+          << " ROS " << code.getROS() << " ROB " << code.getROB() << " Internal fatal Error 4000 in TDC "
+          << (*tdc_it).first << endl;
+
+      tdcError_ROSSummary = 14;
+      tdcError_ROSError = 11;
+
+    } else if (((*tdc_it).second).tdcError() & 0x0249) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC FIFO overflow in TDC " << (*tdc_it).first
+          << endl;
+
+      tdcError_ROSSummary = 15;
+      tdcError_ROSError = 12;
+
+    } else if (((*tdc_it).second).tdcError() & 0x0492) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC L1 buffer overflow in TDC "
+          << (*tdc_it).first << endl;
+
+      tdcError_ROSSummary = 16;
+      tdcError_ROSError = 13;
+
+    } else if (((*tdc_it).second).tdcError() & 0x2000) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC L1A FIFO overflow in TDC " << (*tdc_it).first
+          << endl;
+
+      tdcError_ROSSummary = 17;
+      tdcError_ROSError = 14;
+
+    } else if (((*tdc_it).second).tdcError() & 0x0924) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC hit error in TDC " << (*tdc_it).first
+          << endl;
+
+      tdcError_ROSSummary = 18;
+      tdcError_ROSError = 15;
+
+    } else if (((*tdc_it).second).tdcError() & 0x1000) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC hit rejected in TDC " << (*tdc_it).first
+          << endl;
+
+      tdcError_ROSSummary = 19;
+      tdcError_ROSError = 16;
+
+    } else {
+      LogWarning("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+          << " TDC error code not known " << ((*tdc_it).second).tdcError() << endl;
+    }
+
+    ROSSummary->Fill(tdcError_ROSSummary, code.getROS());
+
+    if (tdcError_ROSSummary <= 15) {
+      eventErrorFlag = true;
+    }
+
+      ROSError->Fill(tdcError_ROSError, (*tdc_it).first);
+  }
+
+}
+
+void DTDataIntegrityROSOffline::processFED(DTDDUData& data, const std::vector<DTROS25Data>& rosData, int ddu) {
+  neventsFED++;
+  if (neventsFED % 1000 == 0)
+    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+        << "[DTDataIntegrityROSOffline]: " << neventsFED << " events analyzed by processFED" << endl;
+
+  DTROChainCoding code;
+  code.setDDU(ddu);
+  if (code.getDDUID() < FEDIDmin || code.getDDUID() > FEDIDmax)
+    return;
+
+  hFEDEntry->Fill(code.getDDUID());
+
+  const FEDTrailer& trailer = data.getDDUTrailer();
+  const FEDHeader& header = data.getDDUHeader();
+
+  // check consistency of header and trailer
+  if (!header.check()) {
+    // error code 7
+    hFEDFatal->Fill(code.getDDUID());
+    hCorruptionSummary->Fill(code.getDDUID(), 7);
+  }
+
+  if (!trailer.check()) {
+    // error code 8
+    hFEDFatal->Fill(code.getDDUID());
+    hCorruptionSummary->Fill(code.getDDUID(), 8);
+  }
+
+  // check CRC error bit set by DAQ before sending data on SLink
+  if (data.crcErrorBit()) {
+    // error code 6
+    hFEDFatal->Fill(code.getDDUID());
+    hCorruptionSummary->Fill(code.getDDUID(), 6);
+  }
+
+  const DTDDUSecondStatusWord& secondWord = data.getSecondStatusWord();
+
+  //2D HISTO: ROS VS STATUS (8 BIT = 8 BIN) from 1st-2nd status words (9th BIN FROM LIST OF ROS in 2nd status word)
+  MonitorElement* hROSStatus = fedHistos["ROSStatus"][code.getDDUID()];
+  //1D HISTO: NUMBER OF ROS IN THE EVENTS from 2nd status word
+
+  int rosList = secondWord.rosList();
+  set<int> rosPositions;
+  for (int i = 0; i < 12; i++) {
+    if (rosList & 0x1) {
+      rosPositions.insert(i);
+      //9th BIN FROM LIST OF ROS in 2nd status word
+      hROSStatus->Fill(8, i, 1);
+    }
+    rosList >>= 1;
+  }
+
+  int channel = 0;
+  for (vector<DTDDUFirstStatusWord>::const_iterator fsw_it = data.getFirstStatusWord().begin();
+       fsw_it != data.getFirstStatusWord().end();
+       fsw_it++) {
+    // assuming association one-to-one between DDU channel and ROS
+      hROSStatus->Fill(0, channel, (*fsw_it).channelEnabled());
+      hROSStatus->Fill(1, channel, (*fsw_it).timeout());
+      hROSStatus->Fill(2, channel, (*fsw_it).eventTrailerLost());
+      hROSStatus->Fill(3, channel, (*fsw_it).opticalFiberSignalLost());
+      hROSStatus->Fill(4, channel, (*fsw_it).tlkPropagationError());
+      hROSStatus->Fill(5, channel, (*fsw_it).tlkPatternError());
+      hROSStatus->Fill(6, channel, (*fsw_it).tlkSignalLost());
+      hROSStatus->Fill(7, channel, (*fsw_it).errorFromROS());
+    // check that the enabled channel was also in the read-out
+    if ((*fsw_it).channelEnabled() == 1 && rosPositions.find(channel) == rosPositions.end()) {
+      hROSStatus->Fill(9, channel, 1);
+      // error code 1
+      hFEDFatal->Fill(code.getDDUID());
+      hCorruptionSummary->Fill(code.getDDUID(), 1);
+    }
+    channel++;
+  }
+
+  // ---------------------------------------------------------------------
+  // cross checks between FED and ROS data
+  // check the BX ID against the ROSs
+  set<int> rosBXIds = rosBxIdsPerFED[ddu];
+  if ((rosBXIds.size() > 1 || rosBXIds.find(header.bxID()) == rosBXIds.end()) &&
+      !rosBXIds.empty()) {  // in this case look for faulty ROSs
+    for (vector<DTROS25Data>::const_iterator rosControlData = rosData.begin(); rosControlData != rosData.end();
+         ++rosControlData) {  // loop over the ROS data
+      for (vector<DTROSDebugWord>::const_iterator debug_it = (*rosControlData).getROSDebugs().begin();
+           debug_it != (*rosControlData).getROSDebugs().end();
+           debug_it++) {                                                                    // Loop over ROS debug words
+        if ((*debug_it).debugType() == 0 && (*debug_it).debugMessage() != header.bxID()) {  // check the BX
+          int ros = (*rosControlData).getROSID();
+          // fill the error bin
+            hROSStatus->Fill(11, ros - 1);
+          // error code 2
+          hFEDFatal->Fill(code.getDDUID());
+          hCorruptionSummary->Fill(code.getDDUID(), 2);
+        }
+      }
+    }
+  }
+
+  // check the BX ID against other FEDs
+  fedBXIds.insert(header.bxID());
+  if (fedBXIds.size() != 1) {
+    LogWarning("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+        << "ERROR: FED " << ddu << " BX ID different from other feds: " << header.bxID() << endl;
+    // error code 3
+    hFEDFatal->Fill(code.getDDUID());
+    hCorruptionSummary->Fill(code.getDDUID(), 3);
+  }
+
+  // check the L1A ID against the ROSs
+  set<int> rosL1AIds = rosL1AIdsPerFED[ddu];
+  if ((rosL1AIds.size() > 1 || rosL1AIds.find(header.lvl1ID() - 1) == rosL1AIds.end()) &&
+      !rosL1AIds.empty()) {  // in this case look for faulty ROSs
+    //If L1A_ID error identify which ROS has wrong L1A
+    for (vector<DTROS25Data>::const_iterator rosControlData = rosData.begin(); rosControlData != rosData.end();
+         rosControlData++) {  // loop over the ROS data
+      unsigned int ROSHeader_TTCCount =
+          ((*rosControlData).getROSHeader().TTCEventCounter() + 1) %
+          0x1000000;  // fix comparison in case of last counting bin in ROS /first one in DDU
+      if (ROSHeader_TTCCount != header.lvl1ID()) {
+        int ros = (*rosControlData).getROSID();
+        hROSStatus->Fill(10, ros - 1);
+        // error code 4
+        hFEDFatal->Fill(code.getDDUID());
+        hCorruptionSummary->Fill(code.getDDUID(), 4);
+      }
+    }
+  }
+
+  //1D HISTOS: EVENT LENGHT from trailer
+  int fedEvtLength = trailer.fragmentLength() * 8;
+  //   if(fedEvtLength > 16000) fedEvtLength = 16000; // overflow bin
+  fedHistos["EventLength"][code.getDDUID()]->Fill(fedEvtLength);
+
+}
+
+// log number of times the payload of each fed is unpacked
+void DTDataIntegrityROSOffline::fedEntry(int dduID) { hFEDEntry->Fill(dduID); }
+
+// log number of times the payload of each fed is skipped (no ROS inside)
+void DTDataIntegrityROSOffline::fedFatal(int dduID) { hFEDFatal->Fill(dduID); }
+
+// log number of times the payload of each fed is partially skipped (some ROS skipped)
+void DTDataIntegrityROSOffline::fedNonFatal(int dduID) { hFEDNonFatal->Fill(dduID); }
+
+std::string DTDataIntegrityROSOffline::topFolder(bool isFEDIntegrity) const {
+  string folder = "DT/00-DataIntegrity/";  
+
+  return folder;
+}
+
+void DTDataIntegrityROSOffline::channelsInCEROS(int cerosId, int chMask, vector<int>& channels) {
+  for (int iCh = 0; iCh < 6; ++iCh) {
+    if ((chMask >> iCh) & 0x1) {
+      channels.push_back(cerosId * 6 + iCh);
+    }
+  }
+  return;
+}
+
+void DTDataIntegrityROSOffline::channelsInROS(int cerosMask, vector<int>& channels) {
+  for (int iCeros = 0; iCeros < 5; ++iCeros) {
+    if ((cerosMask >> iCeros) & 0x1) {
+      for (int iCh = 0; iCh < 6; ++iCh) {
+        channels.push_back(iCeros * 6 + iCh);
+      }
+    }
+  }
+  return;
+}
+
+void DTDataIntegrityROSOffline::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  nevents++;
+  nEventMonitor->Fill(nevents);
+
+  LogTrace("DTRawToDigi|TDQM|DTMonitorModule|DTDataIntegrityROSOffline") << "[DTDataIntegrityROSOffline]: preProcessEvent" << endl;
+
+  //Legacy ROS
+    // clear the set of BXids from the ROSs
+    for (map<int, set<int> >::iterator rosBxIds = rosBxIdsPerFED.begin(); rosBxIds != rosBxIdsPerFED.end();
+         ++rosBxIds) {
+      (*rosBxIds).second.clear();
+    }
+
+    fedBXIds.clear();
+
+    for (map<int, set<int> >::iterator rosL1AIds = rosL1AIdsPerFED.begin(); rosL1AIds != rosL1AIdsPerFED.end();
+         ++rosL1AIds) {
+      (*rosL1AIds).second.clear();
+    }
+
+    // reset the error flag
+    eventErrorFlag = false;
+
+    // Digi collection
+    edm::Handle<DTDDUCollection> dduProduct;
+    e.getByToken(dduToken, dduProduct);
+    edm::Handle<DTROS25Collection> ros25Product;
+    e.getByToken(ros25Token, ros25Product);
+
+    DTDDUData dduData;
+    std::vector<DTROS25Data> ros25Data;
+    if (dduProduct.isValid() && ros25Product.isValid()) {
+      for (unsigned int i = 0; i < dduProduct->size(); ++i) {
+        dduData = dduProduct->at(i);
+        ros25Data = ros25Product->at(i);
+        FEDHeader header = dduData.getDDUHeader();
+        int id = header.sourceID();
+        if (id > FEDIDmax || id < FEDIDmin)
+          continue;  //SIM uses extra FEDs not monitored
+
+        processFED(dduData, ros25Data, id);
+        for (unsigned int j = 0; j < ros25Data.size(); ++j) {
+          int rosid = j + 1;
+          processROS25(ros25Data[j], id, rosid);
+        }
+      }
+    }
+}
+
+// Local Variables:
+// show-trailing-whitespace: t
+// truncate-lines: t
+// End:

--- a/DQM/DTMonitorModule/src/DTDataIntegrityROSOffline.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityROSOffline.cc
@@ -27,12 +27,13 @@ using namespace std;
 using namespace edm;
 
 DTDataIntegrityROSOffline::DTDataIntegrityROSOffline(const edm::ParameterSet& ps) : nevents(0) {
-  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline") << "[DTDataIntegrityROSOffline]: Constructor" << endl;
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << "[DTDataIntegrityROSOffline]: Constructor" << endl;
 
-    dduToken = consumes<DTDDUCollection>(ps.getParameter<InputTag>("dtDDULabel"));
-    ros25Token = consumes<DTROS25Collection>(ps.getParameter<InputTag>("dtROS25Label"));
-    FEDIDmin = FEDNumbering::MINDTFEDID;
-    FEDIDmax = FEDNumbering::MAXDTFEDID;
+  dduToken = consumes<DTDDUCollection>(ps.getParameter<InputTag>("dtDDULabel"));
+  ros25Token = consumes<DTROS25Collection>(ps.getParameter<InputTag>("dtROS25Label"));
+  FEDIDmin = FEDNumbering::MINDTFEDID;
+  FEDIDmax = FEDNumbering::MAXDTFEDID;
 
   neventsFED = 0;
 
@@ -40,7 +41,6 @@ DTDataIntegrityROSOffline::DTDataIntegrityROSOffline(const edm::ParameterSet& ps
   getSCInfo = ps.getUntrackedParameter<bool>("getSCInfo", false);
 
   fedIntegrityFolder = ps.getUntrackedParameter<string>("fedIntegrityFolder", "DT/FEDIntegrity");
-
 }
 
 DTDataIntegrityROSOffline::~DTDataIntegrityROSOffline() {
@@ -60,9 +60,10 @@ DTDataIntegrityROSOffline::~DTDataIntegrityROSOffline() {
 */
 
 void DTDataIntegrityROSOffline::bookHistograms(DQMStore::IBooker& ibooker,
-                                         edm::Run const& iRun,
-                                         edm::EventSetup const& iSetup) {
-  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline") << "[DTDataIntegrityROSOffline]: postBeginJob" << endl;
+                                               edm::Run const& iRun,
+                                               edm::EventSetup const& iSetup) {
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << "[DTDataIntegrityROSOffline]: postBeginJob" << endl;
 
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
       << "[DTDataIntegrityROSOffline] Get DQMStore service" << endl;
@@ -77,20 +78,20 @@ void DTDataIntegrityROSOffline::bookHistograms(DQMStore::IBooker& ibooker,
 
   //Legacy ROS
 
-      // static booking of the histograms
+  // static booking of the histograms
 
-      for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
-        DTROChainCoding code;
-        code.setDDU(fed);
-        bookHistos(ibooker, string("ROS_S"), code);
+  for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
+    DTROChainCoding code;
+    code.setDDU(fed);
+    bookHistos(ibooker, string("ROS_S"), code);
 
-        bookHistos(ibooker, string("DDU"), code);
+    bookHistos(ibooker, string("DDU"), code);
 
-        for (int ros = 1; ros <= nROS; ++ros) {  // loop over all ROS
-          code.setROS(ros);
-          bookHistosROS25(ibooker, code);
-        }
-      }
+    for (int ros = 1; ros <= nROS; ++ros) {  // loop over all ROS
+      code.setROS(ros);
+      bookHistosROS25(ibooker, code);
+    }
+  }
 }
 
 void DTDataIntegrityROSOffline::bookHistos(DQMStore::IBooker& ibooker, const int fedMin, const int fedMax) {
@@ -104,34 +105,34 @@ void DTDataIntegrityROSOffline::bookHistos(DQMStore::IBooker& ibooker, const int
 
   hFEDEntry = ibooker.book1D("FEDEntries", "# entries per DT FED", nFED, fedMin, fedMax + 1);
 
-    hFEDFatal = ibooker.book1D("FEDFatal", "# fatal errors DT FED", nFED, fedMin, fedMax + 1);
-    hFEDNonFatal = ibooker.book1D("FEDNonFatal", "# NON fatal errors DT FED", nFED, fedMin, fedMax + 1);
+  hFEDFatal = ibooker.book1D("FEDFatal", "# fatal errors DT FED", nFED, fedMin, fedMax + 1);
+  hFEDNonFatal = ibooker.book1D("FEDNonFatal", "# NON fatal errors DT FED", nFED, fedMin, fedMax + 1);
 
-    ibooker.setCurrentFolder(topFolder(false));
-    hTTSSummary = ibooker.book2D("TTSSummary", "Summary Status TTS", nFED, fedMin, fedMax + 1, 9, 1, 10);
-    hTTSSummary->setAxisTitle("FED", 1);
-    hTTSSummary->setBinLabel(1, "ROS PAF", 2);
-    hTTSSummary->setBinLabel(2, "DDU PAF", 2);
-    hTTSSummary->setBinLabel(3, "ROS PAF", 2);
-    hTTSSummary->setBinLabel(4, "DDU PAF", 2);
-    hTTSSummary->setBinLabel(5, "DDU Full", 2);
-    hTTSSummary->setBinLabel(6, "L1A Mism.", 2);
-    hTTSSummary->setBinLabel(7, "ROS Error", 2);
-    hTTSSummary->setBinLabel(8, "BX Mism.", 2);
-    hTTSSummary->setBinLabel(9, "DDU Logic Err.", 2);
+  ibooker.setCurrentFolder(topFolder(false));
+  hTTSSummary = ibooker.book2D("TTSSummary", "Summary Status TTS", nFED, fedMin, fedMax + 1, 9, 1, 10);
+  hTTSSummary->setAxisTitle("FED", 1);
+  hTTSSummary->setBinLabel(1, "ROS PAF", 2);
+  hTTSSummary->setBinLabel(2, "DDU PAF", 2);
+  hTTSSummary->setBinLabel(3, "ROS PAF", 2);
+  hTTSSummary->setBinLabel(4, "DDU PAF", 2);
+  hTTSSummary->setBinLabel(5, "DDU Full", 2);
+  hTTSSummary->setBinLabel(6, "L1A Mism.", 2);
+  hTTSSummary->setBinLabel(7, "ROS Error", 2);
+  hTTSSummary->setBinLabel(8, "BX Mism.", 2);
+  hTTSSummary->setBinLabel(9, "DDU Logic Err.", 2);
 
-    // bookkeeping of the histos
-    hCorruptionSummary =
-        ibooker.book2D("DataCorruptionSummary", "Data Corruption Sources", nFED, fedMin, fedMax + 1, 8, 1, 9);
-    hCorruptionSummary->setAxisTitle("FED", 1);
-    hCorruptionSummary->setBinLabel(1, "Miss Ch.", 2);
-    hCorruptionSummary->setBinLabel(2, "ROS BX mism", 2);
-    hCorruptionSummary->setBinLabel(3, "DDU BX mism", 2);
-    hCorruptionSummary->setBinLabel(4, "ROS L1A mism", 2);
-    hCorruptionSummary->setBinLabel(5, "Miss Payload", 2);
-    hCorruptionSummary->setBinLabel(6, "FCRC bit", 2);
-    hCorruptionSummary->setBinLabel(7, "Header check", 2);
-    hCorruptionSummary->setBinLabel(8, "Trailer Check", 2);
+  // bookkeeping of the histos
+  hCorruptionSummary =
+      ibooker.book2D("DataCorruptionSummary", "Data Corruption Sources", nFED, fedMin, fedMax + 1, 8, 1, 9);
+  hCorruptionSummary->setAxisTitle("FED", 1);
+  hCorruptionSummary->setBinLabel(1, "Miss Ch.", 2);
+  hCorruptionSummary->setBinLabel(2, "ROS BX mism", 2);
+  hCorruptionSummary->setBinLabel(3, "DDU BX mism", 2);
+  hCorruptionSummary->setBinLabel(4, "ROS L1A mism", 2);
+  hCorruptionSummary->setBinLabel(5, "Miss Payload", 2);
+  hCorruptionSummary->setBinLabel(6, "FCRC bit", 2);
+  hCorruptionSummary->setBinLabel(7, "Header check", 2);
+  hCorruptionSummary->setBinLabel(8, "Trailer Check", 2);
 }
 
 void DTDataIntegrityROSOffline::bookHistos(DQMStore::IBooker& ibooker, string folder, DTROChainCoding code) {
@@ -188,7 +189,6 @@ void DTDataIntegrityROSOffline::bookHistos(DQMStore::IBooker& ibooker, string fo
     histo->setBinLabel(10, "ROS 10", 2);
     histo->setBinLabel(11, "ROS 11", 2);
     histo->setBinLabel(12, "ROS 12", 2);
-
   }
 
   // ROS Histograms
@@ -286,7 +286,6 @@ void DTDataIntegrityROSOffline::bookHistos(DQMStore::IBooker& ibooker, string fo
     histo->setBinLabel(24, "ROB23", 2);
     histo->setBinLabel(25, "ROB24", 2);
     histo->setBinLabel(26, "SC", 2);
-
   }
 
   // SC Histograms
@@ -307,9 +306,8 @@ void DTDataIntegrityROSOffline::bookHistosROS25(DQMStore::IBooker& ibooker, DTRO
   bookHistos(ibooker, string("ROS"), code);
 }
 
-
 void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros) {
-  neventsROS++;  
+  neventsROS++;
 
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
       << "[DTDataIntegrityROSOffline]: " << neventsROS << " events analyzed by processROS25" << endl;
@@ -323,7 +321,7 @@ void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros
 
   // Summary of all ROB errors
   MonitorElement* ROSError = nullptr;
-    ROSError = rosHistos["ROSError"][code.getROSID()];
+  ROSError = rosHistos["ROSError"][code.getROSID()];
 
   if ((!ROSError)) {
     LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
@@ -338,7 +336,8 @@ void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros
 
   // check for TPX errors
   if (data.getROSTrailer().TPX() != 0) {
-    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline") << " TXP error en ROS " << code.getROS() << endl;
+    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+        << " TXP error en ROS " << code.getROS() << endl;
     ROSSummary->Fill(9, code.getROS());
   }
 
@@ -361,18 +360,18 @@ void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros
       eventErrorFlag = true;
     }
 
-      // Fill the ROB Summary (1 per ROS) histo
-      if ((*error_it).robID() != 31) {
-        ROSError->Fill((*error_it).errorType(), (*error_it).robID());
-      } else if ((*error_it).errorType() == 4) {
-        vector<int> channelBins;
-        channelsInROS((*error_it).cerosID(), channelBins);
-        vector<int>::const_iterator channelIt = channelBins.begin();
-        vector<int>::const_iterator channelEnd = channelBins.end();
-        for (; channelIt != channelEnd; ++channelIt) {
-          ROSError->Fill(4, (*channelIt));
-        }
+    // Fill the ROB Summary (1 per ROS) histo
+    if ((*error_it).robID() != 31) {
+      ROSError->Fill((*error_it).errorType(), (*error_it).robID());
+    } else if ((*error_it).errorType() == 4) {
+      vector<int> channelBins;
+      channelsInROS((*error_it).cerosID(), channelBins);
+      vector<int>::const_iterator channelIt = channelBins.begin();
+      vector<int>::const_iterator channelEnd = channelBins.end();
+      for (; channelIt != channelEnd; ++channelIt) {
+        ROSError->Fill(4, (*channelIt));
       }
+    }
   }
 
   int ROSDebug_BunchNumber = -1;
@@ -413,20 +412,20 @@ void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros
 
     if (debugROSSummary) {
       ROSSummary->Fill(debugROSSummary, code.getROS());
-        vector<int>::const_iterator channelIt = debugBins.begin();
-        vector<int>::const_iterator channelEnd = debugBins.end();
-        for (; channelIt != channelEnd; ++channelIt) {
-          ROSError->Fill(debugROSError, (*channelIt));
-        }
+      vector<int>::const_iterator channelIt = debugBins.begin();
+      vector<int>::const_iterator channelEnd = debugBins.end();
+      for (; channelIt != channelEnd; ++channelIt) {
+        ROSError->Fill(debugROSError, (*channelIt));
+      }
     }
 
     if (hasEvIdMis) {
       ROSSummary->Fill(12, code.getROS());
-        vector<int>::const_iterator channelIt = evIdMisBins.begin();
-        vector<int>::const_iterator channelEnd = evIdMisBins.end();
-        for (; channelIt != channelEnd; ++channelIt) {
-          ROSError->Fill(9, (*channelIt));
-        }
+      vector<int>::const_iterator channelIt = evIdMisBins.begin();
+      vector<int>::const_iterator channelEnd = evIdMisBins.end();
+      for (; channelIt != channelEnd; ++channelIt) {
+        ROSError->Fill(9, (*channelIt));
+      }
     }
   }
 
@@ -446,7 +445,7 @@ void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros
       eventErrorFlag = true;
 
       // fill ROB Summary plot for that particular ROS
-        ROSError->Fill(7, robheader.robID());
+      ROSError->Fill(7, robheader.robID());
     }
   }
 
@@ -465,7 +464,7 @@ void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros
       eventErrorFlag = true;
 
       // fill ROB Summary plot for that particular ROS
-        ROSError->Fill(6, (*tdc_it).first);
+      ROSError->Fill(6, (*tdc_it).first);
     }
   }
 
@@ -537,9 +536,8 @@ void DTDataIntegrityROSOffline::processROS25(DTROS25Data& data, int ddu, int ros
       eventErrorFlag = true;
     }
 
-      ROSError->Fill(tdcError_ROSError, (*tdc_it).first);
+    ROSError->Fill(tdcError_ROSError, (*tdc_it).first);
   }
-
 }
 
 void DTDataIntegrityROSOffline::processFED(DTDDUData& data, const std::vector<DTROS25Data>& rosData, int ddu) {
@@ -600,14 +598,14 @@ void DTDataIntegrityROSOffline::processFED(DTDDUData& data, const std::vector<DT
        fsw_it != data.getFirstStatusWord().end();
        fsw_it++) {
     // assuming association one-to-one between DDU channel and ROS
-      hROSStatus->Fill(0, channel, (*fsw_it).channelEnabled());
-      hROSStatus->Fill(1, channel, (*fsw_it).timeout());
-      hROSStatus->Fill(2, channel, (*fsw_it).eventTrailerLost());
-      hROSStatus->Fill(3, channel, (*fsw_it).opticalFiberSignalLost());
-      hROSStatus->Fill(4, channel, (*fsw_it).tlkPropagationError());
-      hROSStatus->Fill(5, channel, (*fsw_it).tlkPatternError());
-      hROSStatus->Fill(6, channel, (*fsw_it).tlkSignalLost());
-      hROSStatus->Fill(7, channel, (*fsw_it).errorFromROS());
+    hROSStatus->Fill(0, channel, (*fsw_it).channelEnabled());
+    hROSStatus->Fill(1, channel, (*fsw_it).timeout());
+    hROSStatus->Fill(2, channel, (*fsw_it).eventTrailerLost());
+    hROSStatus->Fill(3, channel, (*fsw_it).opticalFiberSignalLost());
+    hROSStatus->Fill(4, channel, (*fsw_it).tlkPropagationError());
+    hROSStatus->Fill(5, channel, (*fsw_it).tlkPatternError());
+    hROSStatus->Fill(6, channel, (*fsw_it).tlkSignalLost());
+    hROSStatus->Fill(7, channel, (*fsw_it).errorFromROS());
     // check that the enabled channel was also in the read-out
     if ((*fsw_it).channelEnabled() == 1 && rosPositions.find(channel) == rosPositions.end()) {
       hROSStatus->Fill(9, channel, 1);
@@ -632,7 +630,7 @@ void DTDataIntegrityROSOffline::processFED(DTDDUData& data, const std::vector<DT
         if ((*debug_it).debugType() == 0 && (*debug_it).debugMessage() != header.bxID()) {  // check the BX
           int ros = (*rosControlData).getROSID();
           // fill the error bin
-            hROSStatus->Fill(11, ros - 1);
+          hROSStatus->Fill(11, ros - 1);
           // error code 2
           hFEDFatal->Fill(code.getDDUID());
           hCorruptionSummary->Fill(code.getDDUID(), 2);
@@ -675,7 +673,6 @@ void DTDataIntegrityROSOffline::processFED(DTDDUData& data, const std::vector<DT
   int fedEvtLength = trailer.fragmentLength() * 8;
   //   if(fedEvtLength > 16000) fedEvtLength = 16000; // overflow bin
   fedHistos["EventLength"][code.getDDUID()]->Fill(fedEvtLength);
-
 }
 
 // log number of times the payload of each fed is unpacked
@@ -688,7 +685,7 @@ void DTDataIntegrityROSOffline::fedFatal(int dduID) { hFEDFatal->Fill(dduID); }
 void DTDataIntegrityROSOffline::fedNonFatal(int dduID) { hFEDNonFatal->Fill(dduID); }
 
 std::string DTDataIntegrityROSOffline::topFolder(bool isFEDIntegrity) const {
-  string folder = "DT/00-DataIntegrity/";  
+  string folder = "DT/00-DataIntegrity/";
 
   return folder;
 }
@@ -717,49 +714,49 @@ void DTDataIntegrityROSOffline::analyze(const edm::Event& e, const edm::EventSet
   nevents++;
   nEventMonitor->Fill(nevents);
 
-  LogTrace("DTRawToDigi|TDQM|DTMonitorModule|DTDataIntegrityROSOffline") << "[DTDataIntegrityROSOffline]: preProcessEvent" << endl;
+  LogTrace("DTRawToDigi|TDQM|DTMonitorModule|DTDataIntegrityROSOffline")
+      << "[DTDataIntegrityROSOffline]: preProcessEvent" << endl;
 
   //Legacy ROS
-    // clear the set of BXids from the ROSs
-    for (map<int, set<int> >::iterator rosBxIds = rosBxIdsPerFED.begin(); rosBxIds != rosBxIdsPerFED.end();
-         ++rosBxIds) {
-      (*rosBxIds).second.clear();
-    }
+  // clear the set of BXids from the ROSs
+  for (map<int, set<int> >::iterator rosBxIds = rosBxIdsPerFED.begin(); rosBxIds != rosBxIdsPerFED.end(); ++rosBxIds) {
+    (*rosBxIds).second.clear();
+  }
 
-    fedBXIds.clear();
+  fedBXIds.clear();
 
-    for (map<int, set<int> >::iterator rosL1AIds = rosL1AIdsPerFED.begin(); rosL1AIds != rosL1AIdsPerFED.end();
-         ++rosL1AIds) {
-      (*rosL1AIds).second.clear();
-    }
+  for (map<int, set<int> >::iterator rosL1AIds = rosL1AIdsPerFED.begin(); rosL1AIds != rosL1AIdsPerFED.end();
+       ++rosL1AIds) {
+    (*rosL1AIds).second.clear();
+  }
 
-    // reset the error flag
-    eventErrorFlag = false;
+  // reset the error flag
+  eventErrorFlag = false;
 
-    // Digi collection
-    edm::Handle<DTDDUCollection> dduProduct;
-    e.getByToken(dduToken, dduProduct);
-    edm::Handle<DTROS25Collection> ros25Product;
-    e.getByToken(ros25Token, ros25Product);
+  // Digi collection
+  edm::Handle<DTDDUCollection> dduProduct;
+  e.getByToken(dduToken, dduProduct);
+  edm::Handle<DTROS25Collection> ros25Product;
+  e.getByToken(ros25Token, ros25Product);
 
-    DTDDUData dduData;
-    std::vector<DTROS25Data> ros25Data;
-    if (dduProduct.isValid() && ros25Product.isValid()) {
-      for (unsigned int i = 0; i < dduProduct->size(); ++i) {
-        dduData = dduProduct->at(i);
-        ros25Data = ros25Product->at(i);
-        FEDHeader header = dduData.getDDUHeader();
-        int id = header.sourceID();
-        if (id > FEDIDmax || id < FEDIDmin)
-          continue;  //SIM uses extra FEDs not monitored
+  DTDDUData dduData;
+  std::vector<DTROS25Data> ros25Data;
+  if (dduProduct.isValid() && ros25Product.isValid()) {
+    for (unsigned int i = 0; i < dduProduct->size(); ++i) {
+      dduData = dduProduct->at(i);
+      ros25Data = ros25Product->at(i);
+      FEDHeader header = dduData.getDDUHeader();
+      int id = header.sourceID();
+      if (id > FEDIDmax || id < FEDIDmin)
+        continue;  //SIM uses extra FEDs not monitored
 
-        processFED(dduData, ros25Data, id);
-        for (unsigned int j = 0; j < ros25Data.size(); ++j) {
-          int rosid = j + 1;
-          processROS25(ros25Data[j], id, rosid);
-        }
+      processFED(dduData, ros25Data, id);
+      for (unsigned int j = 0; j < ros25Data.size(); ++j) {
+        int rosid = j + 1;
+        processROS25(ros25Data[j], id, rosid);
       }
     }
+  }
 }
 
 // Local Variables:

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -33,9 +33,9 @@ using namespace edm;
 DTDataIntegrityTask::DTDataIntegrityTask(const edm::ParameterSet& ps) : nevents(0) {
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask") << "[DTDataIntegrityTask]: Constructor" << endl;
 
-    fedToken = consumes<DTuROSFEDDataCollection>(ps.getParameter<InputTag>("dtFEDlabel"));
-    FEDIDmin = FEDNumbering::MINDTUROSFEDID;
-    FEDIDmax = FEDNumbering::MAXDTUROSFEDID;
+  fedToken = consumes<DTuROSFEDDataCollection>(ps.getParameter<InputTag>("dtFEDlabel"));
+  FEDIDmin = FEDNumbering::MINDTUROSFEDID;
+  FEDIDmax = FEDNumbering::MAXDTUROSFEDID;
 
   neventsFED = 0;
   neventsuROS = 0;
@@ -51,8 +51,8 @@ DTDataIntegrityTask::DTDataIntegrityTask(const edm::ParameterSet& ps) : nevents(
     mode = 1;
   } else if (processingMode == "Offline") {
     throw cms::Exception("WrongParameter") << "[DTDataIntegrityTask]: processingMode :" << processingMode
-                                             << " invalid! Must be Online, SM or HLT !" << endl
-                                             << " Offline mode is covered on DTDataIntegrityuROSOffline"<< endl;
+                                           << " invalid! Must be Online, SM or HLT !" << endl
+                                           << " Offline mode is covered on DTDataIntegrityuROSOffline" << endl;
   } else if (processingMode == "HLT") {
     mode = 3;
   } else {
@@ -93,27 +93,27 @@ void DTDataIntegrityTask::bookHistograms(DQMStore::IBooker& ibooker,
   // book FED integrity histos
   bookHistos(ibooker, FEDIDmin, FEDIDmax);
 
-    // static booking of the histograms
+  // static booking of the histograms
 
-    if (mode == 0 ) {
-      for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
+  if (mode == 0) {
+    for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
 
-        bookHistos(ibooker, string("FED"), fed);
+      bookHistos(ibooker, string("FED"), fed);
 
-        bookHistos(ibooker, string("CRATE"), fed);
+      bookHistos(ibooker, string("CRATE"), fed);
 
-        for (int uRos = 1; uRos <= NuROS; ++uRos) {  // loop over all ROS
-          bookHistosuROS(ibooker, fed, uRos);
-        }
+      for (int uRos = 1; uRos <= NuROS; ++uRos) {  // loop over all ROS
+        bookHistosuROS(ibooker, fed, uRos);
       }
+    }
 
-      for (int wheel = -2; wheel < 3; ++wheel) {
-        for (int ros = 1; ros <= NuROS; ++ros) {  // loop over all ROS
-          bookHistosROS(ibooker, wheel, ros);
-        }
+    for (int wheel = -2; wheel < 3; ++wheel) {
+      for (int ros = 1; ros <= NuROS; ++ros) {  // loop over all ROS
+        bookHistosROS(ibooker, wheel, ros);
       }
+    }
 
-    }  //Not in HLT or SM mode
+  }  //Not in HLT or SM mode
 }
 
 void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, const int fedMin, const int fedMax) {
@@ -127,45 +127,45 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, const int fedMi
 
   hFEDEntry = ibooker.book1D("FEDEntries", "# entries per DT FED", nFED, fedMin, fedMax + 1);
 
-    string histoType = "ROSSummary";
-    for (int wheel = -2; wheel < 3; ++wheel) {
-      string wheel_s = to_string(wheel);
-      string histoName = "ROSSummary_W" + wheel_s;
-      string fed_s = to_string(FEDIDmin + 1);  //3 FEDs from 2018 onwards
-      if (wheel < 0)
-        fed_s = to_string(FEDIDmin);
-      else if (wheel > 0)
-        fed_s = to_string(FEDIDmax);
-      string histoTitle = "Summary Wheel" + wheel_s + " (FED " + fed_s + ")";
+  string histoType = "ROSSummary";
+  for (int wheel = -2; wheel < 3; ++wheel) {
+    string wheel_s = to_string(wheel);
+    string histoName = "ROSSummary_W" + wheel_s;
+    string fed_s = to_string(FEDIDmin + 1);  //3 FEDs from 2018 onwards
+    if (wheel < 0)
+      fed_s = to_string(FEDIDmin);
+    else if (wheel > 0)
+      fed_s = to_string(FEDIDmax);
+    string histoTitle = "Summary Wheel" + wheel_s + " (FED " + fed_s + ")";
 
-      ((summaryHistos[histoType])[wheel]) = ibooker.book2D(histoName, histoTitle, 11, 0, 11, 12, 1, 13);
-      MonitorElement* histo = ((summaryHistos[histoType])[wheel]);
-      histo->setBinLabel(1, "Error 1", 1);
-      histo->setBinLabel(2, "Error 2", 1);
-      histo->setBinLabel(3, "Error 3", 1);
-      histo->setBinLabel(4, "Error 4", 1);
-      histo->setBinLabel(5, "Not OKflag", 1);
-      // TDC error bins
-      histo->setBinLabel(6, "TDC Fatal", 1);
-      histo->setBinLabel(7, "TDC RO FIFO ov.", 1);
-      histo->setBinLabel(8, "TDC L1 buf. ov.", 1);
-      histo->setBinLabel(9, "TDC L1A FIFO ov.", 1);
-      histo->setBinLabel(10, "TDC hit err.", 1);
-      histo->setBinLabel(11, "TDC hit rej.", 1);
+    ((summaryHistos[histoType])[wheel]) = ibooker.book2D(histoName, histoTitle, 11, 0, 11, 12, 1, 13);
+    MonitorElement* histo = ((summaryHistos[histoType])[wheel]);
+    histo->setBinLabel(1, "Error 1", 1);
+    histo->setBinLabel(2, "Error 2", 1);
+    histo->setBinLabel(3, "Error 3", 1);
+    histo->setBinLabel(4, "Error 4", 1);
+    histo->setBinLabel(5, "Not OKflag", 1);
+    // TDC error bins
+    histo->setBinLabel(6, "TDC Fatal", 1);
+    histo->setBinLabel(7, "TDC RO FIFO ov.", 1);
+    histo->setBinLabel(8, "TDC L1 buf. ov.", 1);
+    histo->setBinLabel(9, "TDC L1A FIFO ov.", 1);
+    histo->setBinLabel(10, "TDC hit err.", 1);
+    histo->setBinLabel(11, "TDC hit rej.", 1);
 
-      histo->setBinLabel(1, "ROS1", 2);
-      histo->setBinLabel(2, "ROS2", 2);
-      histo->setBinLabel(3, "ROS3", 2);
-      histo->setBinLabel(4, "ROS4", 2);
-      histo->setBinLabel(5, "ROS5", 2);
-      histo->setBinLabel(6, "ROS6", 2);
-      histo->setBinLabel(7, "ROS7", 2);
-      histo->setBinLabel(8, "ROS8", 2);
-      histo->setBinLabel(9, "ROS9", 2);
-      histo->setBinLabel(10, "ROS10", 2);
-      histo->setBinLabel(11, "ROS11", 2);
-      histo->setBinLabel(12, "ROS12", 2);
-    }
+    histo->setBinLabel(1, "ROS1", 2);
+    histo->setBinLabel(2, "ROS2", 2);
+    histo->setBinLabel(3, "ROS3", 2);
+    histo->setBinLabel(4, "ROS4", 2);
+    histo->setBinLabel(5, "ROS5", 2);
+    histo->setBinLabel(6, "ROS6", 2);
+    histo->setBinLabel(7, "ROS7", 2);
+    histo->setBinLabel(8, "ROS8", 2);
+    histo->setBinLabel(9, "ROS9", 2);
+    histo->setBinLabel(10, "ROS10", 2);
+    histo->setBinLabel(11, "ROS11", 2);
+    histo->setBinLabel(12, "ROS12", 2);
+  }
 }
 
 void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, string folder, const int fed) {
@@ -422,7 +422,7 @@ void DTDataIntegrityTask::bookHistosuROS(DQMStore::IBooker& ibooker, const int f
 }
 
 void DTDataIntegrityTask::processuROS(DTuROSROSData& data, int fed, int uRos) {
-  neventsuROS++; 
+  neventsuROS++;
 
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
       << "[DTDataIntegrityTask]: " << neventsuROS << " events analyzed by processuROS" << endl;
@@ -678,7 +678,7 @@ void DTDataIntegrityTask::processuROS(DTuROSROSData& data, int fed, int uRos) {
     default: {
       LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
           << "[DTDataIntegrityTask] FED User control: wrong TTS value " << value << " in FED " << fed << " uROS "
-          << uRos << endl; 
+          << uRos << endl;
       ttsCodeValue = 7;
     }
   }
@@ -770,7 +770,6 @@ void DTDataIntegrityTask::processFED(DTuROSFEDData& data, int fed) {
     fedHistos["TTSValues"][fed]->Fill(ttsCodeValue);
 }
 
-
 std::string DTDataIntegrityTask::topFolder(bool isFEDIntegrity) const {
   string folder = isFEDIntegrity ? fedIntegrityFolder : "DT/00-DataIntegrity/";
 
@@ -787,21 +786,21 @@ void DTDataIntegrityTask::beginLuminosityBlock(const edm::LuminosityBlock& ls, c
 void DTDataIntegrityTask::endLuminosityBlock(const edm::LuminosityBlock& ls, const edm::EventSetup& es) {
   int lumiBlock = ls.luminosityBlock();
 
-    map<string, map<int, DTTimeEvolutionHisto*> >::iterator fedIt = fedTimeHistos.begin();
-    map<string, map<int, DTTimeEvolutionHisto*> >::iterator fedEnd = fedTimeHistos.end();
-    for (; fedIt != fedEnd; ++fedIt) {
-      map<int, DTTimeEvolutionHisto*>::iterator histoIt = fedIt->second.begin();
-      map<int, DTTimeEvolutionHisto*>::iterator histoEnd = fedIt->second.end();
-      for (; histoIt != histoEnd; ++histoIt) {
-        histoIt->second->updateTimeSlot(lumiBlock, nEventsLS);
-      }
+  map<string, map<int, DTTimeEvolutionHisto*> >::iterator fedIt = fedTimeHistos.begin();
+  map<string, map<int, DTTimeEvolutionHisto*> >::iterator fedEnd = fedTimeHistos.end();
+  for (; fedIt != fedEnd; ++fedIt) {
+    map<int, DTTimeEvolutionHisto*>::iterator histoIt = fedIt->second.begin();
+    map<int, DTTimeEvolutionHisto*>::iterator histoEnd = fedIt->second.end();
+    for (; histoIt != histoEnd; ++histoIt) {
+      histoIt->second->updateTimeSlot(lumiBlock, nEventsLS);
     }
+  }
 
-    map<unsigned int, DTTimeEvolutionHisto*>::iterator urosIt = urosTimeHistos.begin();
-    map<unsigned int, DTTimeEvolutionHisto*>::iterator urosEnd = urosTimeHistos.end();
-    for (; urosIt != urosEnd; ++urosIt) {
-      urosIt->second->updateTimeSlot(lumiBlock, nEventsLS);
-    }
+  map<unsigned int, DTTimeEvolutionHisto*>::iterator urosIt = urosTimeHistos.begin();
+  map<unsigned int, DTTimeEvolutionHisto*>::iterator urosEnd = urosTimeHistos.end();
+  for (; urosIt != urosEnd; ++urosIt) {
+    urosIt->second->updateTimeSlot(lumiBlock, nEventsLS);
+  }
 }
 
 void DTDataIntegrityTask::analyze(const edm::Event& e, const edm::EventSetup& c) {
@@ -812,34 +811,34 @@ void DTDataIntegrityTask::analyze(const edm::Event& e, const edm::EventSetup& c)
 
   LogTrace("DTRawToDigi|TDQM|DTMonitorModule|DTDataIntegrityTask") << "[DTDataIntegrityTask]: preProcessEvent" << endl;
 
-    // Digi collection
-    edm::Handle<DTuROSFEDDataCollection> fedCol;
-    e.getByToken(fedToken, fedCol);
-    DTuROSFEDData fedData;
-    DTuROSROSData urosData;
+  // Digi collection
+  edm::Handle<DTuROSFEDDataCollection> fedCol;
+  e.getByToken(fedToken, fedCol);
+  DTuROSFEDData fedData;
+  DTuROSROSData urosData;
 
-    if (fedCol.isValid()) {
-      for (unsigned int j = 0; j < fedCol->size(); ++j) {
-        fedData = fedCol->at(j);
-        int fed = fedData.getfed();  //argument should be void
-        if (fed > FEDIDmax || fed < FEDIDmin) {
-          LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-              << "[DTDataIntegrityTask]: analyze, FED ID " << fed << " not expected." << endl;
+  if (fedCol.isValid()) {
+    for (unsigned int j = 0; j < fedCol->size(); ++j) {
+      fedData = fedCol->at(j);
+      int fed = fedData.getfed();  //argument should be void
+      if (fed > FEDIDmax || fed < FEDIDmin) {
+        LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
+            << "[DTDataIntegrityTask]: analyze, FED ID " << fed << " not expected." << endl;
+        continue;
+      }
+      processFED(fedData, fed);
+
+      if (mode == 3 || mode == 1)
+        continue;  //Not needed for FEDIntegrity_EvF
+
+      for (int slot = 1; slot <= DOCESLOTS; ++slot) {
+        urosData = fedData.getuROS(slot);
+        if (fedData.getslotsize(slot) == 0 || urosData.getslot() == -1)
           continue;
-        }
-        processFED(fedData, fed);
-
-        if (mode == 3 || mode == 1)
-          continue;  //Not needed for FEDIntegrity_EvF
-
-        for (int slot = 1; slot <= DOCESLOTS; ++slot) {
-          urosData = fedData.getuROS(slot);
-          if (fedData.getslotsize(slot) == 0 || urosData.getslot() == -1)
-            continue;
-          processuROS(urosData, fed, slot);
-        }
+        processuROS(urosData, fed, slot);
       }
     }
+  }
 }
 
 // Conversions

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -1,7 +1,12 @@
 /*
  * \file DTDataIntegrityTask.cc
  *
- * \author M. Zanetti (INFN Padova), S. Bolognesi (INFN Torino), G. Cerminara (INFN Torino)
+ * Class for DT Data Integrity
+ * at Online DQM (Single Thread)
+ * expected to monitor uROS
+ * Class with MEs vs Time/LS
+ *
+ * \author Javier Fernandez (Uni. Oviedo) 
  *
  */
 
@@ -9,8 +14,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/DTDigi/interface/DTControlData.h"
-#include "DataFormats/DTDigi/interface/DTDDUWords.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <DQM/DTMonitorModule/interface/DTTimeEvolutionHisto.h>
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -30,26 +33,12 @@ using namespace edm;
 DTDataIntegrityTask::DTDataIntegrityTask(const edm::ParameterSet& ps) : nevents(0) {
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask") << "[DTDataIntegrityTask]: Constructor" << endl;
 
-  checkUros = ps.getUntrackedParameter<bool>("checkUros", true);
-
-  if (checkUros) {
     fedToken = consumes<DTuROSFEDDataCollection>(ps.getParameter<InputTag>("dtFEDlabel"));
     FEDIDmin = FEDNumbering::MINDTUROSFEDID;
     FEDIDmax = FEDNumbering::MAXDTUROSFEDID;
-  } else {
-    dduToken = consumes<DTDDUCollection>(ps.getParameter<InputTag>("dtDDULabel"));
-    ros25Token = consumes<DTROS25Collection>(ps.getParameter<InputTag>("dtROS25Label"));
-    FEDIDmin = FEDNumbering::MINDTFEDID;
-    FEDIDmax = FEDNumbering::MAXDTFEDID;
-  }
 
   neventsFED = 0;
   neventsuROS = 0;
-
-  //   If you want info VS time histos
-  //   doTimeHisto =  ps.getUntrackedParameter<bool>("doTimeHisto", false);
-  //   Plot quantities about SC
-  getSCInfo = ps.getUntrackedParameter<bool>("getSCInfo", false);
 
   fedIntegrityFolder = ps.getUntrackedParameter<string>("fedIntegrityFolder", "DT/FEDIntegrity");
 
@@ -61,7 +50,9 @@ DTDataIntegrityTask::DTDataIntegrityTask(const edm::ParameterSet& ps) : nevents(
   } else if (processingMode == "SM") {
     mode = 1;
   } else if (processingMode == "Offline") {
-    mode = 2;
+    throw cms::Exception("WrongParameter") << "[DTDataIntegrityTask]: processingMode :" << processingMode
+                                             << " invalid! Must be Online, SM or HLT !" << endl
+                                             << " Offline mode is covered on DTDataIntegrityuROSOffline"<< endl;
   } else if (processingMode == "HLT") {
     mode = 3;
   } else {
@@ -78,14 +69,7 @@ DTDataIntegrityTask::~DTDataIntegrityTask() {
 }
 
 /*
-  Folder Structure (ROS Legacy):
-  - One folder for each DDU, named FEDn
-  - Inside each DDU folder the DDU histos and the ROSn folder
-  - Inside each ROS folder the ROS histos and the ROBn folder
-  - Inside each ROB folder one occupancy plot and the TimeBoxes
-  with the chosen granularity (simply change the histo name)
- 
-  uROS (starting 2018):
+  Folder Structure uROS:
   - 3 uROS Summary plots: Wheel-1/-2 (FED1369), Wheel0 (FED1370), Wheel+1/+2 (FED1371)
   - One folder for each FED
   - Inside each FED folder the uROSStatus histos, FED histos
@@ -109,10 +93,9 @@ void DTDataIntegrityTask::bookHistograms(DQMStore::IBooker& ibooker,
   // book FED integrity histos
   bookHistos(ibooker, FEDIDmin, FEDIDmax);
 
-  if (checkUros) {  //uROS starting on 2018
     // static booking of the histograms
 
-    if (mode == 0 || mode == 2) {
+    if (mode == 0 ) {
       for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
 
         bookHistos(ibooker, string("FED"), fed);
@@ -131,27 +114,6 @@ void DTDataIntegrityTask::bookHistograms(DQMStore::IBooker& ibooker,
       }
 
     }  //Not in HLT or SM mode
-  }    //uROS
-
-  else {  //Legacy ROS
-
-    if (mode == 0 || mode == 2) {
-      // static booking of the histograms
-
-      for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
-        DTROChainCoding code;
-        code.setDDU(fed);
-        bookHistos(ibooker, string("ROS_S"), code);
-
-        bookHistos(ibooker, string("DDU"), code);
-
-        for (int ros = 1; ros <= NuROS; ++ros) {  // loop over all ROS
-          code.setROS(ros);
-          bookHistosROS25(ibooker, code);
-        }
-      }
-    }  //Not in HLT or SM mode
-  }    //Legacy ROS
 }
 
 void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, const int fedMin, const int fedMax) {
@@ -164,15 +126,6 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, const int fedMi
   int nFED = (fedMax - fedMin) + 1;
 
   hFEDEntry = ibooker.book1D("FEDEntries", "# entries per DT FED", nFED, fedMin, fedMax + 1);
-
-  if (checkUros) {
-    if (mode == 3 || mode == 1) {
-      //Booked for completion in general CMS FED test. Not filled
-      hFEDFatal = ibooker.book1D("FEDFatal", "# fatal errors DT FED", nFED, fedMin, fedMax + 1);  //No available in uROS
-      hFEDNonFatal =
-          ibooker.book1D("FEDNonFatal", "# NON fatal errors DT FED", nFED, fedMin, fedMax + 1);  //No available in uROS
-      return;  //Avoid duplication of Info in FEDIntegrity_EvF
-    }
 
     string histoType = "ROSSummary";
     for (int wheel = -2; wheel < 3; ++wheel) {
@@ -213,44 +166,8 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, const int fedMi
       histo->setBinLabel(11, "ROS11", 2);
       histo->setBinLabel(12, "ROS12", 2);
     }
-  }
-
-  else {  //if(!checkUros){
-    hFEDFatal = ibooker.book1D("FEDFatal", "# fatal errors DT FED", nFED, fedMin, fedMax + 1);
-    hFEDNonFatal = ibooker.book1D("FEDNonFatal", "# NON fatal errors DT FED", nFED, fedMin, fedMax + 1);
-
-    if (mode == 3 || mode == 1)
-      return;  //Avoid duplication of Info in FEDIntegrity_EvF
-
-    ibooker.setCurrentFolder(topFolder(false));
-    hTTSSummary = ibooker.book2D("TTSSummary", "Summary Status TTS", nFED, fedMin, fedMax + 1, 9, 1, 10);
-    hTTSSummary->setAxisTitle("FED", 1);
-    hTTSSummary->setBinLabel(1, "ROS PAF", 2);
-    hTTSSummary->setBinLabel(2, "DDU PAF", 2);
-    hTTSSummary->setBinLabel(3, "ROS PAF", 2);
-    hTTSSummary->setBinLabel(4, "DDU PAF", 2);
-    hTTSSummary->setBinLabel(5, "DDU Full", 2);
-    hTTSSummary->setBinLabel(6, "L1A Mism.", 2);
-    hTTSSummary->setBinLabel(7, "ROS Error", 2);
-    hTTSSummary->setBinLabel(8, "BX Mism.", 2);
-    hTTSSummary->setBinLabel(9, "DDU Logic Err.", 2);
-
-    // bookkeeping of the
-    hCorruptionSummary =
-        ibooker.book2D("DataCorruptionSummary", "Data Corruption Sources", nFED, fedMin, fedMax + 1, 8, 1, 9);
-    hCorruptionSummary->setAxisTitle("FED", 1);
-    hCorruptionSummary->setBinLabel(1, "Miss Ch.", 2);
-    hCorruptionSummary->setBinLabel(2, "ROS BX mism", 2);
-    hCorruptionSummary->setBinLabel(3, "DDU BX mism", 2);
-    hCorruptionSummary->setBinLabel(4, "ROS L1A mism", 2);
-    hCorruptionSummary->setBinLabel(5, "Miss Payload", 2);
-    hCorruptionSummary->setBinLabel(6, "FCRC bit", 2);
-    hCorruptionSummary->setBinLabel(7, "Header check", 2);
-    hCorruptionSummary->setBinLabel(8, "Trailer Check", 2);
-  }  //!checkUros
 }
 
-// ******************uROS******************** //
 void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, string folder, const int fed) {
   string wheel = "ZERO";
   if (fed == FEDIDmin)
@@ -383,339 +300,7 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, string folder, 
     histo->setBinLabel(12, "uROS12", 2);
   }
 }
-// ******************End uROS******************** //
 
-void DTDataIntegrityTask::bookHistos(DQMStore::IBooker& ibooker, string folder, DTROChainCoding code) {
-  string dduID_s = to_string(code.getDDU());
-  string rosID_s = to_string(code.getROS());
-  string robID_s = to_string(code.getROB());
-  int wheel = (code.getDDUID() - 770) % 5 - 2;
-  string wheel_s = to_string(wheel);
-
-  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-      << " Booking histos for FED: " << code.getDDU() << " ROS: " << code.getROS() << " ROB: " << code.getROB()
-      << " folder: " << folder << endl;
-
-  string histoType;
-  string histoName;
-  string histoTitle;
-  MonitorElement* histo = nullptr;
-
-  // DDU Histograms
-  if (folder == "DDU") {
-    ibooker.setCurrentFolder(topFolder(false) + "FED" + dduID_s);
-
-    histoType = "EventLength";
-    histoName = "FED" + dduID_s + "_" + histoType;
-    histoTitle = "Event Length (Bytes) FED " + dduID_s;
-    (fedHistos[histoType])[code.getDDUID()] = ibooker.book1D(histoName, histoTitle, 501, 0, 16032);
-
-    if (mode == 3 || mode == 1)
-      return;  //Avoid duplication of Info in FEDIntegrity_EvF
-
-    histoType = "ROSStatus";
-    histoName = "FED" + dduID_s + "_" + histoType;
-    (fedHistos[histoType])[code.getDDUID()] = ibooker.book2D(histoName, histoName, 12, 0, 12, 12, 0, 12);
-    histo = (fedHistos[histoType])[code.getDDUID()];
-    histo->setBinLabel(1, "ch.enabled", 1);
-    histo->setBinLabel(2, "timeout", 1);
-    histo->setBinLabel(3, "ev.trailer lost", 1);
-    histo->setBinLabel(4, "opt.fiber lost", 1);
-    histo->setBinLabel(5, "tlk.prop.error", 1);
-    histo->setBinLabel(6, "tlk.pattern error", 1);
-    histo->setBinLabel(7, "tlk.sign.lost", 1);
-    histo->setBinLabel(8, "error from ROS", 1);
-    histo->setBinLabel(9, "if ROS in events", 1);
-    histo->setBinLabel(10, "Miss. Evt.", 1);
-    histo->setBinLabel(11, "Evt. ID Mismatch", 1);
-    histo->setBinLabel(12, "BX Mismatch", 1);
-
-    histo->setBinLabel(1, "ROS 1", 2);
-    histo->setBinLabel(2, "ROS 2", 2);
-    histo->setBinLabel(3, "ROS 3", 2);
-    histo->setBinLabel(4, "ROS 4", 2);
-    histo->setBinLabel(5, "ROS 5", 2);
-    histo->setBinLabel(6, "ROS 6", 2);
-    histo->setBinLabel(7, "ROS 7", 2);
-    histo->setBinLabel(8, "ROS 8", 2);
-    histo->setBinLabel(9, "ROS 9", 2);
-    histo->setBinLabel(10, "ROS 10", 2);
-    histo->setBinLabel(11, "ROS 11", 2);
-    histo->setBinLabel(12, "ROS 12", 2);
-
-    if (mode > 0)
-      return;  //Info for Online only
-
-    histoType = "FEDAvgEvLengthvsLumi";
-    histoName = "FED" + dduID_s + "_" + histoType;
-    histoTitle = "Avg Event Length (Bytes) vs LumiSec FED " + dduID_s;
-    fedTimeHistos[histoType][code.getDDUID()] =
-        new DTTimeEvolutionHisto(ibooker, histoName, histoTitle, 200, 10, true, 0);
-
-    histoType = "TTSValues";
-    histoName = "FED" + dduID_s + "_" + histoType;
-    (fedHistos[histoType])[code.getDDUID()] = ibooker.book1D(histoName, histoName, 8, 0, 8);
-    histo = (fedHistos[histoType])[code.getDDUID()];
-    histo->setBinLabel(1, "disconnected", 1);
-    histo->setBinLabel(2, "warning overflow", 1);
-    histo->setBinLabel(3, "out of synch", 1);
-    histo->setBinLabel(4, "busy", 1);
-    histo->setBinLabel(5, "ready", 1);
-    histo->setBinLabel(6, "error", 1);
-    histo->setBinLabel(7, "disconnected", 1);
-    histo->setBinLabel(8, "unknown", 1);
-
-    histoType = "EventType";
-    histoName = "FED" + dduID_s + "_" + histoType;
-    (fedHistos[histoType])[code.getDDUID()] = ibooker.book1D(histoName, histoName, 2, 1, 3);
-    histo = (fedHistos[histoType])[code.getDDUID()];
-    histo->setBinLabel(1, "physics", 1);
-    histo->setBinLabel(2, "calibration", 1);
-
-    histoType = "ROSList";
-    histoName = "FED" + dduID_s + "_" + histoType;
-    histoTitle = "# of ROS in the FED payload (FED" + dduID_s + ")";
-    (fedHistos[histoType])[code.getDDUID()] = ibooker.book1D(histoName, histoTitle, 13, 0, 13);
-
-    histoType = "FIFOStatus";
-    histoName = "FED" + dduID_s + "_" + histoType;
-    (fedHistos[histoType])[code.getDDUID()] = ibooker.book2D(histoName, histoName, 7, 0, 7, 3, 0, 3);
-    histo = (fedHistos[histoType])[code.getDDUID()];
-    histo->setBinLabel(1, "Input ch1-4", 1);
-    histo->setBinLabel(2, "Input ch5-8", 1);
-    histo->setBinLabel(3, "Input ch9-12", 1);
-    histo->setBinLabel(4, "Error/L1A ch1-4", 1);
-    histo->setBinLabel(5, "Error/L1A ch5-8", 1);
-    histo->setBinLabel(6, "Error/L1A ch9-12", 1);
-    histo->setBinLabel(7, "Output", 1);
-    histo->setBinLabel(1, "Full", 2);
-    histo->setBinLabel(2, "Almost Full", 2);
-    histo->setBinLabel(3, "Not Full", 2);
-
-    histoType = "BXID";
-    histoName = "FED" + dduID_s + "_BXID";
-    histoTitle = "Distrib. BX ID (FED" + dduID_s + ")";
-    (fedHistos[histoType])[code.getDDUID()] = ibooker.book1D(histoName, histoTitle, 3600, 0, 3600);
-  }
-
-  // ROS Histograms
-  if (folder == "ROS_S") {  // The summary of the error of the ROS on the same FED
-    ibooker.setCurrentFolder(topFolder(false));
-
-    if (mode == 3 || mode == 1)
-      return;  //Avoid duplication of Info in FEDIntegrity_EvF
-
-    histoType = "ROSSummary";
-    histoName = "FED" + dduID_s + "_ROSSummary";
-    string histoTitle = "Summary Wheel" + wheel_s + " (FED " + dduID_s + ")";
-
-    ((summaryHistos[histoType])[code.getDDUID()]) = ibooker.book2D(histoName, histoTitle, 20, 0, 20, 12, 1, 13);
-    MonitorElement* histo = ((summaryHistos[histoType])[code.getDDUID()]);
-    // ROS error bins
-    histo->setBinLabel(1, "Link TimeOut", 1);
-    histo->setBinLabel(2, "Ev.Id.Mis.", 1);
-    histo->setBinLabel(3, "FIFO almost full", 1);
-    histo->setBinLabel(4, "FIFO full", 1);
-    histo->setBinLabel(5, "CEROS timeout", 1);
-    histo->setBinLabel(6, "Max. wds", 1);
-    histo->setBinLabel(7, "WO L1A FIFO", 1);
-    histo->setBinLabel(8, "TDC parity err.", 1);
-    histo->setBinLabel(9, "BX ID Mis.", 1);
-    histo->setBinLabel(10, "TXP", 1);
-    histo->setBinLabel(11, "L1A almost full", 1);
-    histo->setBinLabel(12, "Ch. blocked", 1);
-    histo->setBinLabel(13, "Ev. Id. Mis.", 1);
-    histo->setBinLabel(14, "CEROS blocked", 1);
-    // TDC error bins
-    histo->setBinLabel(15, "TDC Fatal", 1);
-    histo->setBinLabel(16, "TDC RO FIFO ov.", 1);
-    histo->setBinLabel(17, "TDC L1 buf. ov.", 1);
-    histo->setBinLabel(18, "TDC L1A FIFO ov.", 1);
-    histo->setBinLabel(19, "TDC hit err.", 1);
-    histo->setBinLabel(20, "TDC hit rej.", 1);
-
-    histo->setBinLabel(1, "ROS1", 2);
-    histo->setBinLabel(2, "ROS2", 2);
-    histo->setBinLabel(3, "ROS3", 2);
-    histo->setBinLabel(4, "ROS4", 2);
-    histo->setBinLabel(5, "ROS5", 2);
-    histo->setBinLabel(6, "ROS6", 2);
-    histo->setBinLabel(7, "ROS7", 2);
-    histo->setBinLabel(8, "ROS8", 2);
-    histo->setBinLabel(9, "ROS9", 2);
-    histo->setBinLabel(10, "ROS10", 2);
-    histo->setBinLabel(11, "ROS11", 2);
-    histo->setBinLabel(12, "ROS12", 2);
-  }
-
-  if (folder == "ROS") {
-    ibooker.setCurrentFolder(topFolder(false) + "FED" + dduID_s + "/" + folder + rosID_s);
-
-    if (mode == 3 || mode == 1)
-      return;  //Avoid duplication of Info in FEDIntegrity_EvF
-
-    histoType = "ROSError";
-    histoName = "FED" + dduID_s + "_" + folder + rosID_s + "_ROSError";
-    histoTitle = histoName + " (ROBID error summary)";
-    if (mode < 1)  //Online only
-      (rosHistos[histoType])[code.getROSID()] = ibooker.book2D(histoName, histoTitle, 17, 0, 17, 26, 0, 26);
-    else
-      (rosHistos[histoType])[code.getROSID()] = ibooker.book2D(histoName, histoTitle, 11, 0, 11, 26, 0, 26);
-
-    MonitorElement* histo = (rosHistos[histoType])[code.getROSID()];
-    // ROS error bins
-    histo->setBinLabel(1, "Link TimeOut", 1);
-    histo->setBinLabel(2, "Ev.Id.Mis.", 1);
-    histo->setBinLabel(3, "FIFO almost full", 1);
-    histo->setBinLabel(4, "FIFO full", 1);
-    histo->setBinLabel(5, "CEROS timeout", 1);
-    histo->setBinLabel(6, "Max. wds", 1);
-    histo->setBinLabel(7, "TDC parity err.", 1);
-    histo->setBinLabel(8, "BX ID Mis.", 1);
-    histo->setBinLabel(9, "Ch. blocked", 1);
-    histo->setBinLabel(10, "Ev. Id. Mis.", 1);
-    histo->setBinLabel(11, "CEROS blocked", 1);
-    if (mode < 1) {  //Online only
-      // TDC error bins
-      histo->setBinLabel(12, "TDC Fatal", 1);
-      histo->setBinLabel(13, "TDC RO FIFO ov.", 1);
-      histo->setBinLabel(14, "TDC L1 buf. ov.", 1);
-      histo->setBinLabel(15, "TDC L1A FIFO ov.", 1);
-      histo->setBinLabel(16, "TDC hit err.", 1);
-      histo->setBinLabel(17, "TDC hit rej.", 1);
-    }
-    histo->setBinLabel(1, "ROB0", 2);
-    histo->setBinLabel(2, "ROB1", 2);
-    histo->setBinLabel(3, "ROB2", 2);
-    histo->setBinLabel(4, "ROB3", 2);
-    histo->setBinLabel(5, "ROB4", 2);
-    histo->setBinLabel(6, "ROB5", 2);
-    histo->setBinLabel(7, "ROB6", 2);
-    histo->setBinLabel(8, "ROB7", 2);
-    histo->setBinLabel(9, "ROB8", 2);
-    histo->setBinLabel(10, "ROB9", 2);
-    histo->setBinLabel(11, "ROB10", 2);
-    histo->setBinLabel(12, "ROB11", 2);
-    histo->setBinLabel(13, "ROB12", 2);
-    histo->setBinLabel(14, "ROB13", 2);
-    histo->setBinLabel(15, "ROB14", 2);
-    histo->setBinLabel(16, "ROB15", 2);
-    histo->setBinLabel(17, "ROB16", 2);
-    histo->setBinLabel(18, "ROB17", 2);
-    histo->setBinLabel(19, "ROB18", 2);
-    histo->setBinLabel(20, "ROB19", 2);
-    histo->setBinLabel(21, "ROB20", 2);
-    histo->setBinLabel(22, "ROB21", 2);
-    histo->setBinLabel(23, "ROB22", 2);
-    histo->setBinLabel(24, "ROB23", 2);
-    histo->setBinLabel(25, "ROB24", 2);
-    histo->setBinLabel(26, "SC", 2);
-
-    if (mode > 1)
-      return;
-
-    histoType = "ROSEventLength";
-    histoName = "FED" + dduID_s + "_" + folder + rosID_s + "_ROSEventLength";
-    histoTitle = "Event Length (Bytes) FED " + dduID_s + " ROS " + rosID_s;
-    (rosHistos[histoType])[code.getROSID()] = ibooker.book1D(histoName, histoTitle, 101, 0, 1616);
-
-    histoType = "ROSAvgEventLengthvsLumi";
-    histoName = "FED" + dduID_s + "_" + folder + rosID_s + histoType;
-    histoTitle = "Event Length (Bytes) FED " + dduID_s + " ROS " + rosID_s;
-    rosTimeHistos[histoType][code.getROSID()] =
-        new DTTimeEvolutionHisto(ibooker, histoName, histoTitle, 200, 10, true, 0);
-
-    histoType = "TDCError";
-    histoName = "FED" + dduID_s + "_" + folder + rosID_s + "_TDCError";
-    histoTitle = histoName + " (ROBID error summary)";
-    (rosHistos[histoType])[code.getROSID()] = ibooker.book2D(histoName, histoTitle, 24, 0, 24, 25, 0, 25);
-    histo = (rosHistos[histoType])[code.getROSID()];
-    // TDC error bins
-    histo->setBinLabel(1, "Fatal", 1);
-    histo->setBinLabel(2, "RO FIFO ov.", 1);
-    histo->setBinLabel(3, "L1 buf. ov.", 1);
-    histo->setBinLabel(4, "L1A FIFO ov.", 1);
-    histo->setBinLabel(5, "hit err.", 1);
-    histo->setBinLabel(6, "hit rej.", 1);
-    histo->setBinLabel(7, "Fatal", 1);
-    histo->setBinLabel(8, "RO FIFO ov.", 1);
-    histo->setBinLabel(9, "L1 buf. ov.", 1);
-    histo->setBinLabel(10, "L1A FIFO ov.", 1);
-    histo->setBinLabel(11, "hit err.", 1);
-    histo->setBinLabel(12, "hit rej.", 1);
-    histo->setBinLabel(13, "Fatal", 1);
-    histo->setBinLabel(14, "RO FIFO ov.", 1);
-    histo->setBinLabel(15, "L1 buf. ov.", 1);
-    histo->setBinLabel(16, "L1A FIFO ov.", 1);
-    histo->setBinLabel(17, "hit err.", 1);
-    histo->setBinLabel(18, "hit rej.", 1);
-    histo->setBinLabel(19, "Fatal", 1);
-    histo->setBinLabel(20, "RO FIFO ov.", 1);
-    histo->setBinLabel(21, "L1 buf. ov.", 1);
-    histo->setBinLabel(22, "L1A FIFO ov.", 1);
-    histo->setBinLabel(23, "hit err.", 1);
-    histo->setBinLabel(24, "hit rej.", 1);
-
-    histo->setBinLabel(1, "ROB0", 2);
-    histo->setBinLabel(2, "ROB1", 2);
-    histo->setBinLabel(3, "ROB2", 2);
-    histo->setBinLabel(4, "ROB3", 2);
-    histo->setBinLabel(5, "ROB4", 2);
-    histo->setBinLabel(6, "ROB5", 2);
-    histo->setBinLabel(7, "ROB6", 2);
-    histo->setBinLabel(8, "ROB7", 2);
-    histo->setBinLabel(9, "ROB8", 2);
-    histo->setBinLabel(10, "ROB9", 2);
-    histo->setBinLabel(11, "ROB10", 2);
-    histo->setBinLabel(12, "ROB11", 2);
-    histo->setBinLabel(13, "ROB12", 2);
-    histo->setBinLabel(14, "ROB13", 2);
-    histo->setBinLabel(15, "ROB14", 2);
-    histo->setBinLabel(16, "ROB15", 2);
-    histo->setBinLabel(17, "ROB16", 2);
-    histo->setBinLabel(18, "ROB17", 2);
-    histo->setBinLabel(19, "ROB18", 2);
-    histo->setBinLabel(20, "ROB19", 2);
-    histo->setBinLabel(21, "ROB20", 2);
-    histo->setBinLabel(22, "ROB21", 2);
-    histo->setBinLabel(23, "ROB22", 2);
-    histo->setBinLabel(24, "ROB23", 2);
-    histo->setBinLabel(25, "ROB24", 2);
-
-    histoType = "ROB_mean";
-    histoName = "FED" + dduID_s + "_" + "ROS" + rosID_s + "_ROB_mean";
-    string fullName = topFolder(false) + "FED" + dduID_s + "/" + folder + rosID_s + "/" + histoName;
-    names.insert(pair<std::string, std::string>(histoType, string(fullName)));
-    (rosHistos[histoType])[code.getROSID()] = ibooker.book2D(histoName, histoName, 25, 0, 25, 100, 0, 100);
-    (rosHistos[histoType])[code.getROSID()]->setAxisTitle("ROB #", 1);
-    (rosHistos[histoType])[code.getROSID()]->setAxisTitle("ROB wordcounts", 2);
-  }
-
-  // SC Histograms
-  if (folder == "SC") {
-    // The plots are per wheel
-    ibooker.setCurrentFolder(topFolder(false) + "FED" + dduID_s);
-    if (mode == 3 || mode == 1)
-      return;  //Avoid duplication of Info in FEDIntegrity_EvF
-
-    // SC data Size
-    histoType = "SCSizeVsROSSize";
-    histoName = "FED" + dduID_s + "_SCSizeVsROSSize";
-    histoTitle = "SC size vs SC (FED " + dduID_s + ")";
-    rosHistos[histoType][code.getSCID()] = ibooker.book2D(histoName, histoTitle, 12, 1, 13, 51, -1, 50);
-    rosHistos[histoType][code.getSCID()]->setAxisTitle("SC", 1);
-  }
-}
-
-void DTDataIntegrityTask::bookHistosROS25(DQMStore::IBooker& ibooker, DTROChainCoding code) {
-  bookHistos(ibooker, string("ROS"), code);
-
-  if (mode < 1)
-    if (getSCInfo)
-      bookHistos(ibooker, string("SC"), code);
-}
-
-// ******************uROS******************** //
 void DTDataIntegrityTask::bookHistosROS(DQMStore::IBooker& ibooker, const int wheel, const int ros) {
   string wheel_s = to_string(wheel);
   string ros_s = to_string(ros);
@@ -835,11 +420,9 @@ void DTDataIntegrityTask::bookHistosuROS(DQMStore::IBooker& ibooker, const int f
   histo->setBinLabel(7, "Disconnected", 1);
   histo->setBinLabel(8, "Unknown", 1);
 }
-// ******************End uROS******************** //
 
-// ******************uROS******************** //
 void DTDataIntegrityTask::processuROS(DTuROSROSData& data, int fed, int uRos) {
-  neventsuROS++;  // FIXME: implement a counter which makes sense
+  neventsuROS++; 
 
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
       << "[DTDataIntegrityTask]: " << neventsuROS << " events analyzed by processuROS" << endl;
@@ -1095,7 +678,7 @@ void DTDataIntegrityTask::processuROS(DTuROSROSData& data, int fed, int uRos) {
     default: {
       LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
           << "[DTDataIntegrityTask] FED User control: wrong TTS value " << value << " in FED " << fed << " uROS "
-          << uRos << endl;  //FIXME
+          << uRos << endl; 
       ttsCodeValue = 7;
     }
   }
@@ -1112,294 +695,6 @@ void DTDataIntegrityTask::processuROS(DTuROSROSData& data, int fed, int uRos) {
   }
 }
 
-// *****************End uROS ******************//
-
-void DTDataIntegrityTask::processROS25(DTROS25Data& data, int ddu, int ros) {
-  neventsuROS++;  // FIXME: implement a counter which makes sense
-
-  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-      << "[DTDataIntegrityTask]: " << neventsuROS << " events analyzed by processROS25" << endl;
-
-  // The ID of the RO board (used to map the histos)
-  DTROChainCoding code;
-  code.setDDU(ddu);
-  code.setROS(ros);
-
-  if (mode == 3 || mode == 1)
-    return;  //Avoid duplication of Info in FEDIntegrity_EvF
-
-  MonitorElement* ROSSummary = summaryHistos["ROSSummary"][code.getDDUID()];
-
-  // Summary of all ROB errors
-  MonitorElement* ROSError = nullptr;
-  if (mode <= 2)
-    ROSError = rosHistos["ROSError"][code.getROSID()];
-
-  if ((mode <= 2) && (!ROSError)) {
-    LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-        << "Trying to access non existing ME at ROSID " << code.getROSID() << std::endl;
-    return;
-  }
-
-  // L1A ids to be checked against FED one
-  rosL1AIdsPerFED[ddu].insert(data.getROSHeader().TTCEventCounter());
-
-  // ROS errors
-
-  // check for TPX errors
-  if (data.getROSTrailer().TPX() != 0) {
-    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask") << " TXP error en ROS " << code.getROS() << endl;
-    ROSSummary->Fill(9, code.getROS());
-  }
-
-  // L1 Buffer almost full (non-critical error!)
-  if (data.getROSTrailer().l1AFifoOccupancy() > 31) {
-    ROSSummary->Fill(10, code.getROS());
-  }
-
-  for (vector<DTROSErrorWord>::const_iterator error_it = data.getROSErrors().begin();
-       error_it != data.getROSErrors().end();
-       error_it++) {  // Loop over ROS error words
-
-    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-        << " Error in ROS " << code.getROS() << " ROB Id " << (*error_it).robID() << " Error type "
-        << (*error_it).errorType() << endl;
-
-    // Fill the ROSSummary (1 per FED) histo
-    ROSSummary->Fill((*error_it).errorType(), code.getROS());
-    if ((*error_it).errorType() <= 11) {  // set error flag
-      eventErrorFlag = true;
-    }
-
-    if (mode <= 2) {
-      // Fill the ROB Summary (1 per ROS) histo
-      if ((*error_it).robID() != 31) {
-        ROSError->Fill((*error_it).errorType(), (*error_it).robID());
-      } else if ((*error_it).errorType() == 4) {
-        vector<int> channelBins;
-        channelsInROS((*error_it).cerosID(), channelBins);
-        vector<int>::const_iterator channelIt = channelBins.begin();
-        vector<int>::const_iterator channelEnd = channelBins.end();
-        for (; channelIt != channelEnd; ++channelIt) {
-          ROSError->Fill(4, (*channelIt));
-        }
-      }
-    }
-  }
-
-  int ROSDebug_BunchNumber = -1;
-
-  for (vector<DTROSDebugWord>::const_iterator debug_it = data.getROSDebugs().begin();
-       debug_it != data.getROSDebugs().end();
-       debug_it++) {  // Loop over ROS debug words
-
-    int debugROSSummary = 0;
-    int debugROSError = 0;
-    vector<int> debugBins;
-    bool hasEvIdMis = false;
-    vector<int> evIdMisBins;
-
-    if ((*debug_it).debugType() == 0) {
-      ROSDebug_BunchNumber = (*debug_it).debugMessage();
-    } else if ((*debug_it).debugType() == 1) {
-      // not used
-      // ROSDebug_BcntResCntLow = (*debug_it).debugMessage();
-    } else if ((*debug_it).debugType() == 2) {
-      // not used
-      // ROSDebug_BcntResCntHigh = (*debug_it).debugMessage();
-    } else if ((*debug_it).debugType() == 3) {
-      if ((*debug_it).dontRead()) {
-        debugROSSummary = 11;
-        debugROSError = 8;
-        if (mode <= 2)
-          channelsInCEROS((*debug_it).cerosIdCerosStatus(), (*debug_it).dontRead(), debugBins);
-      }
-      if ((*debug_it).evIdMis()) {
-        hasEvIdMis = true;
-        if (mode <= 2)
-          channelsInCEROS((*debug_it).cerosIdCerosStatus(), (*debug_it).evIdMis(), evIdMisBins);
-      }
-    } else if ((*debug_it).debugType() == 4 && (*debug_it).cerosIdRosStatus()) {
-      debugROSSummary = 13;
-      debugROSError = 10;
-      if (mode <= 2)
-        channelsInROS((*debug_it).cerosIdRosStatus(), debugBins);
-    }
-
-    if (debugROSSummary) {
-      ROSSummary->Fill(debugROSSummary, code.getROS());
-      if (mode <= 2) {
-        vector<int>::const_iterator channelIt = debugBins.begin();
-        vector<int>::const_iterator channelEnd = debugBins.end();
-        for (; channelIt != channelEnd; ++channelIt) {
-          ROSError->Fill(debugROSError, (*channelIt));
-        }
-      }
-    }
-
-    if (hasEvIdMis) {
-      ROSSummary->Fill(12, code.getROS());
-      if (mode <= 2) {
-        vector<int>::const_iterator channelIt = evIdMisBins.begin();
-        vector<int>::const_iterator channelEnd = evIdMisBins.end();
-        for (; channelIt != channelEnd; ++channelIt) {
-          ROSError->Fill(9, (*channelIt));
-        }
-      }
-    }
-  }
-
-  // ROB Group Header
-  // Check the BX of the ROB headers against the BX of the ROS
-  for (vector<DTROBHeader>::const_iterator rob_it = data.getROBHeaders().begin(); rob_it != data.getROBHeaders().end();
-       rob_it++) {  // loop over ROB headers
-
-    code.setROB((*rob_it).first);
-    DTROBHeaderWord robheader = (*rob_it).second;
-
-    rosBxIdsPerFED[ddu].insert(ROSDebug_BunchNumber);
-
-    if (robheader.bunchID() != ROSDebug_BunchNumber) {
-      // fill ROS Summary plot
-      ROSSummary->Fill(8, code.getROS());
-      eventErrorFlag = true;
-
-      // fill ROB Summary plot for that particular ROS
-      if (mode <= 2)
-        ROSError->Fill(7, robheader.robID());
-    }
-  }
-
-  if (mode < 1) {  // produce only when not in HLT or SM
-    // ROB Trailer
-    for (vector<DTROBTrailerWord>::const_iterator robt_it = data.getROBTrailers().begin();
-         robt_it != data.getROBTrailers().end();
-         robt_it++) {  // loop over ROB trailers
-      float wCount = (*robt_it).wordCount() < 100. ? (*robt_it).wordCount() : 99.9;
-      rosHistos["ROB_mean"][code.getROSID()]->Fill((*robt_it).robID(), wCount);
-    }
-
-    // Plot the event length //NOHLT
-    int rosEventLength = data.getROSTrailer().EventWordCount() * 4;
-    rosTimeHistos["ROSAvgEventLengthvsLumi"][code.getROSID()]->accumulateValueTimeSlot(rosEventLength);
-
-    if (rosEventLength > 1600)
-      rosEventLength = 1600;
-    rosHistos["ROSEventLength"][code.getROSID()]->Fill(rosEventLength);
-  }
-
-  // TDC Data
-  for (vector<DTTDCData>::const_iterator tdc_it = data.getTDCData().begin(); tdc_it != data.getTDCData().end();
-       tdc_it++) {  // loop over TDC data
-
-    DTTDCMeasurementWord tdcDatum = (*tdc_it).second;
-
-    if (tdcDatum.PC() != 0) {
-      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << " PC error in ROS " << code.getROS() << " TDC " << (*tdc_it).first << endl;
-      //     fill ROS Summary plot
-      ROSSummary->Fill(7, code.getROS());
-
-      eventErrorFlag = true;
-
-      // fill ROB Summary plot for that particular ROS
-      if (mode <= 2)
-        ROSError->Fill(6, (*tdc_it).first);
-    }
-  }
-
-  // TDC Error
-  for (vector<DTTDCError>::const_iterator tdc_it = data.getTDCError().begin(); tdc_it != data.getTDCError().end();
-       tdc_it++) {  // loop over TDC errors
-
-    code.setROB((*tdc_it).first);
-
-    int tdcError_ROSSummary = 0;
-    int tdcError_ROSError = 0;
-    int tdcError_TDCHisto = 0;
-
-    if (((*tdc_it).second).tdcError() & 0x4000) {
-      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << " ROS " << code.getROS() << " ROB " << code.getROB() << " Internal fatal Error 4000 in TDC "
-          << (*tdc_it).first << endl;
-
-      tdcError_ROSSummary = 14;
-      tdcError_ROSError = 11;
-      tdcError_TDCHisto = 0;
-
-    } else if (((*tdc_it).second).tdcError() & 0x0249) {
-      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC FIFO overflow in TDC " << (*tdc_it).first
-          << endl;
-
-      tdcError_ROSSummary = 15;
-      tdcError_ROSError = 12;
-      tdcError_TDCHisto = 1;
-
-    } else if (((*tdc_it).second).tdcError() & 0x0492) {
-      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC L1 buffer overflow in TDC "
-          << (*tdc_it).first << endl;
-
-      tdcError_ROSSummary = 16;
-      tdcError_ROSError = 13;
-      tdcError_TDCHisto = 2;
-
-    } else if (((*tdc_it).second).tdcError() & 0x2000) {
-      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC L1A FIFO overflow in TDC " << (*tdc_it).first
-          << endl;
-
-      tdcError_ROSSummary = 17;
-      tdcError_ROSError = 14;
-      tdcError_TDCHisto = 3;
-
-    } else if (((*tdc_it).second).tdcError() & 0x0924) {
-      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC hit error in TDC " << (*tdc_it).first
-          << endl;
-
-      tdcError_ROSSummary = 18;
-      tdcError_ROSError = 15;
-      tdcError_TDCHisto = 4;
-
-    } else if (((*tdc_it).second).tdcError() & 0x1000) {
-      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << " ROS " << code.getROS() << " ROB " << code.getROB() << " TDC hit rejected in TDC " << (*tdc_it).first
-          << endl;
-
-      tdcError_ROSSummary = 19;
-      tdcError_ROSError = 16;
-      tdcError_TDCHisto = 5;
-
-    } else {
-      LogWarning("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << " TDC error code not known " << ((*tdc_it).second).tdcError() << endl;
-    }
-
-    ROSSummary->Fill(tdcError_ROSSummary, code.getROS());
-
-    if (tdcError_ROSSummary <= 15) {
-      eventErrorFlag = true;
-    }
-
-    if (mode <= 2) {
-      ROSError->Fill(tdcError_ROSError, (*tdc_it).first);
-      if (mode <= 1)
-        rosHistos["TDCError"][code.getROSID()]->Fill(tdcError_TDCHisto + 6 * ((*tdc_it).second).tdcID(),
-                                                     (*tdc_it).first);
-    }
-  }
-
-  // Read SC data
-  if (mode < 1 && getSCInfo) {
-    // NumberOf16bitWords counts the # of words + 1 subheader
-    // the SC includes the SC "private header" and the ROS header and trailer (= NumberOf16bitWords +3)
-    rosHistos["SCSizeVsROSSize"][code.getSCID()]->Fill(ros, data.getSCTrailer().wordCount());
-  }
-}
-
-// ******************uROS******************** //
 void DTDataIntegrityTask::processFED(DTuROSFEDData& data, int fed) {
   neventsFED++;
   if (neventsFED % 1000 == 0)
@@ -1474,332 +769,15 @@ void DTDataIntegrityTask::processFED(DTuROSFEDData& data, int fed) {
   if (mode < 1)
     fedHistos["TTSValues"][fed]->Fill(ttsCodeValue);
 }
-// *****************End uROS ******************//
 
-void DTDataIntegrityTask::processFED(DTDDUData& data, const std::vector<DTROS25Data>& rosData, int ddu) {
-  neventsFED++;
-  if (neventsFED % 1000 == 0)
-    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-        << "[DTDataIntegrityTask]: " << neventsFED << " events analyzed by processFED" << endl;
-
-  DTROChainCoding code;
-  code.setDDU(ddu);
-  if (code.getDDUID() < FEDIDmin || code.getDDUID() > FEDIDmax)
-    return;
-
-  hFEDEntry->Fill(code.getDDUID());
-
-  const FEDTrailer& trailer = data.getDDUTrailer();
-  const FEDHeader& header = data.getDDUHeader();
-
-  // check consistency of header and trailer
-  if (!header.check()) {
-    // error code 7
-    hFEDFatal->Fill(code.getDDUID());
-    hCorruptionSummary->Fill(code.getDDUID(), 7);
-  }
-
-  if (!trailer.check()) {
-    // error code 8
-    hFEDFatal->Fill(code.getDDUID());
-    hCorruptionSummary->Fill(code.getDDUID(), 8);
-  }
-
-  // check CRC error bit set by DAQ before sending data on SLink
-  if (data.crcErrorBit()) {
-    // error code 6
-    hFEDFatal->Fill(code.getDDUID());
-    hCorruptionSummary->Fill(code.getDDUID(), 6);
-  }
-
-  if (mode == 3 || mode == 1)
-    return;  //Avoid duplication of Info in FEDIntegrity_EvF
-
-  const DTDDUSecondStatusWord& secondWord = data.getSecondStatusWord();
-
-  // Fill the status summary of the TTS
-
-  //1D HISTO WITH TTS VALUES form trailer (7 bins = 7 values)
-  int ttsCodeValue = -1;
-  int ttsSummaryBin = -1;
-
-  switch (trailer.ttsBits()) {
-    case 0: {  //disconnected
-      ttsCodeValue = 0;
-      break;
-    }
-    case 1: {  //warning overflow
-      ttsCodeValue = 1;
-      if (secondWord.warningROSPAF()) {  // ROS PAF
-        ttsSummaryBin = 1;
-      } else {  // DDU PAF
-        ttsSummaryBin = 2;
-      }
-
-      break;
-    }
-    case 2: {  //out of sinch
-      ttsCodeValue = 2;
-      bool knownOrigin = false;
-      if (secondWord.outOfSynchROSError()) {  // ROS Error
-        ttsSummaryBin = 7;
-        knownOrigin = true;
-      }
-      if (secondWord.l1AIDError()) {  // L1A Mism.
-        ttsSummaryBin = 6;
-        knownOrigin = true;
-      }
-      if (secondWord.bxIDError()) {  // BX Mism.
-        ttsSummaryBin = 8;
-        knownOrigin = true;
-      }
-      if (secondWord.outputFifoFull() || secondWord.inputFifoFull() || secondWord.fifoFull()) {  // DDU Full
-        ttsSummaryBin = 5;
-        knownOrigin = true;
-      }
-      if (!knownOrigin)
-        ttsSummaryBin = 9;  // Error in DDU logic
-
-      break;
-    }
-    case 4: {  //busy
-      ttsCodeValue = 3;
-      bool knownOrigin = false;
-      if (secondWord.busyROSPAF()) {  // ROS PAF
-        ttsSummaryBin = 3;
-        knownOrigin = true;
-      }
-      if (secondWord.outputFifoAlmostFull() || secondWord.inputFifoAlmostFull() ||
-          secondWord.fifoAlmostFull()) {  // DDU PAF
-        ttsSummaryBin = 4;
-        knownOrigin = true;
-      }
-      if (!knownOrigin)
-        ttsSummaryBin = 9;  // Error in DDU logic
-      break;
-    }
-    case 8: {  //ready
-      ttsCodeValue = 4;
-      break;
-    }
-    case 12: {  //error
-      ttsCodeValue = 5;
-      break;
-    }
-    case 16: {  //disconnected
-      ttsCodeValue = 6;
-      break;
-    }
-    default: {
-      LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-          << "[DTDataIntegrityTask] DDU control: wrong TTS value " << trailer.ttsBits() << endl;
-      ttsCodeValue = 7;
-    }
-  }
-  if (mode < 1)
-    fedHistos["TTSValues"][code.getDDUID()]->Fill(ttsCodeValue);
-  if (ttsSummaryBin != -1) {
-    hTTSSummary->Fill(ddu, ttsSummaryBin);
-  }
-
-  //2D HISTO: ROS VS STATUS (8 BIT = 8 BIN) from 1st-2nd status words (9th BIN FROM LIST OF ROS in 2nd status word)
-  MonitorElement* hROSStatus = fedHistos["ROSStatus"][code.getDDUID()];
-  //1D HISTO: NUMBER OF ROS IN THE EVENTS from 2nd status word
-
-  int rosList = secondWord.rosList();
-  set<int> rosPositions;
-  for (int i = 0; i < 12; i++) {
-    if (rosList & 0x1) {
-      rosPositions.insert(i);
-      //9th BIN FROM LIST OF ROS in 2nd status word
-      if (mode <= 2)
-        hROSStatus->Fill(8, i, 1);
-    }
-    rosList >>= 1;
-  }
-
-  int channel = 0;
-  for (vector<DTDDUFirstStatusWord>::const_iterator fsw_it = data.getFirstStatusWord().begin();
-       fsw_it != data.getFirstStatusWord().end();
-       fsw_it++) {
-    // assuming association one-to-one between DDU channel and ROS
-    if (mode <= 2) {
-      hROSStatus->Fill(0, channel, (*fsw_it).channelEnabled());
-      hROSStatus->Fill(1, channel, (*fsw_it).timeout());
-      hROSStatus->Fill(2, channel, (*fsw_it).eventTrailerLost());
-      hROSStatus->Fill(3, channel, (*fsw_it).opticalFiberSignalLost());
-      hROSStatus->Fill(4, channel, (*fsw_it).tlkPropagationError());
-      hROSStatus->Fill(5, channel, (*fsw_it).tlkPatternError());
-      hROSStatus->Fill(6, channel, (*fsw_it).tlkSignalLost());
-      hROSStatus->Fill(7, channel, (*fsw_it).errorFromROS());
-    }
-    // check that the enabled channel was also in the read-out
-    if ((*fsw_it).channelEnabled() == 1 && rosPositions.find(channel) == rosPositions.end()) {
-      if (mode <= 2)
-        hROSStatus->Fill(9, channel, 1);
-      // error code 1
-      hFEDFatal->Fill(code.getDDUID());
-      hCorruptionSummary->Fill(code.getDDUID(), 1);
-    }
-    channel++;
-  }
-
-  // ---------------------------------------------------------------------
-  // cross checks between FED and ROS data
-  // check the BX ID against the ROSs
-  set<int> rosBXIds = rosBxIdsPerFED[ddu];
-  if ((rosBXIds.size() > 1 || rosBXIds.find(header.bxID()) == rosBXIds.end()) &&
-      !rosBXIds.empty()) {  // in this case look for faulty ROSs
-    for (vector<DTROS25Data>::const_iterator rosControlData = rosData.begin(); rosControlData != rosData.end();
-         ++rosControlData) {  // loop over the ROS data
-      for (vector<DTROSDebugWord>::const_iterator debug_it = (*rosControlData).getROSDebugs().begin();
-           debug_it != (*rosControlData).getROSDebugs().end();
-           debug_it++) {                                                                    // Loop over ROS debug words
-        if ((*debug_it).debugType() == 0 && (*debug_it).debugMessage() != header.bxID()) {  // check the BX
-          int ros = (*rosControlData).getROSID();
-          // fill the error bin
-          if (mode <= 2)
-            hROSStatus->Fill(11, ros - 1);
-          // error code 2
-          hFEDFatal->Fill(code.getDDUID());
-          hCorruptionSummary->Fill(code.getDDUID(), 2);
-        }
-      }
-    }
-  }
-
-  // check the BX ID against other FEDs
-  fedBXIds.insert(header.bxID());
-  if (fedBXIds.size() != 1) {
-    LogWarning("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask")
-        << "ERROR: FED " << ddu << " BX ID different from other feds: " << header.bxID() << endl;
-    // error code 3
-    hFEDFatal->Fill(code.getDDUID());
-    hCorruptionSummary->Fill(code.getDDUID(), 3);
-  }
-
-  // check the L1A ID against the ROSs
-  set<int> rosL1AIds = rosL1AIdsPerFED[ddu];
-  if ((rosL1AIds.size() > 1 || rosL1AIds.find(header.lvl1ID() - 1) == rosL1AIds.end()) &&
-      !rosL1AIds.empty()) {  // in this case look for faulty ROSs
-    //If L1A_ID error identify which ROS has wrong L1A
-    for (vector<DTROS25Data>::const_iterator rosControlData = rosData.begin(); rosControlData != rosData.end();
-         rosControlData++) {  // loop over the ROS data
-      unsigned int ROSHeader_TTCCount =
-          ((*rosControlData).getROSHeader().TTCEventCounter() + 1) %
-          0x1000000;  // fix comparison in case of last counting bin in ROS /first one in DDU
-      if (ROSHeader_TTCCount != header.lvl1ID()) {
-        int ros = (*rosControlData).getROSID();
-        if (mode <= 2)
-          hROSStatus->Fill(10, ros - 1);
-        // error code 4
-        hFEDFatal->Fill(code.getDDUID());
-        hCorruptionSummary->Fill(code.getDDUID(), 4);
-      }
-    }
-  }
-
-  //1D HISTOS: EVENT LENGHT from trailer
-  int fedEvtLength = trailer.fragmentLength() * 8;
-  //   if(fedEvtLength > 16000) fedEvtLength = 16000; // overflow bin
-  fedHistos["EventLength"][code.getDDUID()]->Fill(fedEvtLength);
-
-  if (mode > 1)
-    return;
-
-  fedTimeHistos["FEDAvgEvLengthvsLumi"][code.getDDUID()]->accumulateValueTimeSlot(fedEvtLength);
-
-  // size of the list of ROS in the Read-Out
-  fedHistos["ROSList"][code.getDDUID()]->Fill(rosPositions.size());
-
-  //2D HISTO: FIFO STATUS from 2nd status word
-  MonitorElement* hFIFOStatus = fedHistos["FIFOStatus"][code.getDDUID()];
-  int inputFifoFull = secondWord.inputFifoFull();
-  int inputFifoAlmostFull = secondWord.inputFifoAlmostFull();
-  int fifoFull = secondWord.fifoFull();
-  int fifoAlmostFull = secondWord.fifoAlmostFull();
-  int outputFifoFull = secondWord.outputFifoFull();
-  int outputFifoAlmostFull = secondWord.outputFifoAlmostFull();
-  for (int i = 0; i < 3; i++) {
-    if (inputFifoFull & 0x1) {
-      hFIFOStatus->Fill(i, 0);
-    }
-    if (inputFifoAlmostFull & 0x1) {
-      hFIFOStatus->Fill(i, 1);
-    }
-    if (fifoFull & 0x1) {
-      hFIFOStatus->Fill(3 + i, 0);
-    }
-    if (fifoAlmostFull & 0x1) {
-      hFIFOStatus->Fill(3 + i, 1);
-    }
-    if (!(inputFifoFull & 0x1) && !(inputFifoAlmostFull & 0x1)) {
-      hFIFOStatus->Fill(i, 2);
-    }
-    if (!(fifoFull & 0x1) && !(fifoAlmostFull & 0x1)) {
-      hFIFOStatus->Fill(3 + i, 2);
-    }
-    inputFifoFull >>= 1;
-    inputFifoAlmostFull >>= 1;
-    fifoFull >>= 1;
-    fifoAlmostFull >>= 1;
-  }
-
-  if (outputFifoFull) {
-    hFIFOStatus->Fill(6, 0);
-  }
-  if (outputFifoAlmostFull) {
-    hFIFOStatus->Fill(6, 1);
-  }
-  if (!outputFifoFull && !outputFifoAlmostFull) {
-    hFIFOStatus->Fill(6, 2);
-  }
-
-  //1D HISTO: EVENT TYPE from header
-  fedHistos["EventType"][code.getDDUID()]->Fill(header.triggerType());
-
-  // fill the distribution of the BX ids
-  fedHistos["BXID"][code.getDDUID()]->Fill(header.bxID());
-}
-
-bool DTDataIntegrityTask::eventHasErrors() const { return eventErrorFlag; }
-
-// log number of times the payload of each fed is unpacked
-void DTDataIntegrityTask::fedEntry(int dduID) { hFEDEntry->Fill(dduID); }
-
-// log number of times the payload of each fed is skipped (no ROS inside)
-void DTDataIntegrityTask::fedFatal(int dduID) { hFEDFatal->Fill(dduID); }
-
-// log number of times the payload of each fed is partially skipped (some ROS skipped)
-void DTDataIntegrityTask::fedNonFatal(int dduID) { hFEDNonFatal->Fill(dduID); }
 
 std::string DTDataIntegrityTask::topFolder(bool isFEDIntegrity) const {
   string folder = isFEDIntegrity ? fedIntegrityFolder : "DT/00-DataIntegrity/";
 
-  if (mode == 0 || mode == 2)
+  if (mode == 0)
     folder = "DT/00-DataIntegrity/";  //Move everything from FEDIntegrity except for SM and HLT modes
 
   return folder;
-}
-
-void DTDataIntegrityTask::channelsInCEROS(int cerosId, int chMask, vector<int>& channels) {
-  for (int iCh = 0; iCh < 6; ++iCh) {
-    if ((chMask >> iCh) & 0x1) {
-      channels.push_back(cerosId * 6 + iCh);
-    }
-  }
-  return;
-}
-
-void DTDataIntegrityTask::channelsInROS(int cerosMask, vector<int>& channels) {
-  for (int iCeros = 0; iCeros < 5; ++iCeros) {
-    if ((cerosMask >> iCeros) & 0x1) {
-      for (int iCh = 0; iCh < 6; ++iCh) {
-        channels.push_back(iCeros * 6 + iCh);
-      }
-    }
-  }
-  return;
 }
 
 void DTDataIntegrityTask::beginLuminosityBlock(const edm::LuminosityBlock& ls, const edm::EventSetup& es) {
@@ -1809,7 +787,6 @@ void DTDataIntegrityTask::beginLuminosityBlock(const edm::LuminosityBlock& ls, c
 void DTDataIntegrityTask::endLuminosityBlock(const edm::LuminosityBlock& ls, const edm::EventSetup& es) {
   int lumiBlock = ls.luminosityBlock();
 
-  if (checkUros) {
     map<string, map<int, DTTimeEvolutionHisto*> >::iterator fedIt = fedTimeHistos.begin();
     map<string, map<int, DTTimeEvolutionHisto*> >::iterator fedEnd = fedTimeHistos.end();
     for (; fedIt != fedEnd; ++fedIt) {
@@ -1825,29 +802,6 @@ void DTDataIntegrityTask::endLuminosityBlock(const edm::LuminosityBlock& ls, con
     for (; urosIt != urosEnd; ++urosIt) {
       urosIt->second->updateTimeSlot(lumiBlock, nEventsLS);
     }
-
-  }  //uROS starting on 2018
-  else {
-    map<string, map<int, DTTimeEvolutionHisto*> >::iterator dduIt = fedTimeHistos.begin();
-    map<string, map<int, DTTimeEvolutionHisto*> >::iterator dduEnd = fedTimeHistos.end();
-    for (; dduIt != dduEnd; ++dduIt) {
-      map<int, DTTimeEvolutionHisto*>::iterator histoIt = dduIt->second.begin();
-      map<int, DTTimeEvolutionHisto*>::iterator histoEnd = dduIt->second.end();
-      for (; histoIt != histoEnd; ++histoIt) {
-        histoIt->second->updateTimeSlot(lumiBlock, nEventsLS);
-      }
-    }
-
-    map<string, map<int, DTTimeEvolutionHisto*> >::iterator rosIt = rosTimeHistos.begin();
-    map<string, map<int, DTTimeEvolutionHisto*> >::iterator rosEnd = rosTimeHistos.end();
-    for (; rosIt != rosEnd; ++rosIt) {
-      map<int, DTTimeEvolutionHisto*>::iterator histoIt = rosIt->second.begin();
-      map<int, DTTimeEvolutionHisto*>::iterator histoEnd = rosIt->second.end();
-      for (; histoIt != histoEnd; ++histoIt) {
-        histoIt->second->updateTimeSlot(lumiBlock, nEventsLS);
-      }
-    }
-  }  //ROS Legacy
 }
 
 void DTDataIntegrityTask::analyze(const edm::Event& e, const edm::EventSetup& c) {
@@ -1858,7 +812,6 @@ void DTDataIntegrityTask::analyze(const edm::Event& e, const edm::EventSetup& c)
 
   LogTrace("DTRawToDigi|TDQM|DTMonitorModule|DTDataIntegrityTask") << "[DTDataIntegrityTask]: preProcessEvent" << endl;
 
-  if (checkUros) {  //uROS starting on 2018
     // Digi collection
     edm::Handle<DTuROSFEDDataCollection> fedCol;
     e.getByToken(fedToken, fedCol);
@@ -1887,50 +840,6 @@ void DTDataIntegrityTask::analyze(const edm::Event& e, const edm::EventSetup& c)
         }
       }
     }
-  }       // checkUros
-  else {  //Legacy ROS
-    // clear the set of BXids from the ROSs
-    for (map<int, set<int> >::iterator rosBxIds = rosBxIdsPerFED.begin(); rosBxIds != rosBxIdsPerFED.end();
-         ++rosBxIds) {
-      (*rosBxIds).second.clear();
-    }
-
-    fedBXIds.clear();
-
-    for (map<int, set<int> >::iterator rosL1AIds = rosL1AIdsPerFED.begin(); rosL1AIds != rosL1AIdsPerFED.end();
-         ++rosL1AIds) {
-      (*rosL1AIds).second.clear();
-    }
-
-    // reset the error flag
-    eventErrorFlag = false;
-
-    // Digi collection
-    edm::Handle<DTDDUCollection> dduProduct;
-    e.getByToken(dduToken, dduProduct);
-    edm::Handle<DTROS25Collection> ros25Product;
-    e.getByToken(ros25Token, ros25Product);
-
-    DTDDUData dduData;
-    std::vector<DTROS25Data> ros25Data;
-    if (dduProduct.isValid() && ros25Product.isValid()) {
-      for (unsigned int i = 0; i < dduProduct->size(); ++i) {
-        dduData = dduProduct->at(i);
-        ros25Data = ros25Product->at(i);
-        // FIXME: passing id variable is not needed anymore - change processFED interface for next release!
-        FEDHeader header = dduData.getDDUHeader();
-        int id = header.sourceID();
-        if (id > FEDIDmax || id < FEDIDmin)
-          continue;  //SIM uses extra FEDs not monitored
-
-        processFED(dduData, ros25Data, id);
-        for (unsigned int j = 0; j < ros25Data.size(); ++j) {
-          int rosid = j + 1;
-          processROS25(ros25Data[j], id, rosid);
-        }
-      }
-    }
-  }
 }
 
 // Conversions

--- a/DQM/DTMonitorModule/src/DTDataIntegrityUrosOffline.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityUrosOffline.cc
@@ -25,7 +25,8 @@ using namespace std;
 using namespace edm;
 
 DTDataIntegrityUrosOffline::DTDataIntegrityUrosOffline(const edm::ParameterSet& ps) : nevents(0) {
-  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline") << "[DTDataIntegrityUrosOffline]: Constructor" << endl;
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << "[DTDataIntegrityUrosOffline]: Constructor" << endl;
 
   fedToken = consumes<DTuROSFEDDataCollection>(ps.getParameter<InputTag>("dtFEDlabel"));
   FEDIDmin = FEDNumbering::MINDTUROSFEDID;
@@ -35,7 +36,6 @@ DTDataIntegrityUrosOffline::DTDataIntegrityUrosOffline(const edm::ParameterSet& 
   neventsuROS = 0;
 
   fedIntegrityFolder = ps.getUntrackedParameter<string>("fedIntegrityFolder", "DT/FEDIntegrity");
-
 }
 
 DTDataIntegrityUrosOffline::~DTDataIntegrityUrosOffline() {
@@ -55,9 +55,10 @@ DTDataIntegrityUrosOffline::~DTDataIntegrityUrosOffline() {
 */
 
 void DTDataIntegrityUrosOffline::bookHistograms(DQMStore::IBooker& ibooker,
-                                         edm::Run const& iRun,
-                                         edm::EventSetup const& iSetup) {
-  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline") << "[DTDataIntegrityUrosOffline]: postBeginJob" << endl;
+                                                edm::Run const& iRun,
+                                                edm::EventSetup const& iSetup) {
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << "[DTDataIntegrityUrosOffline]: postBeginJob" << endl;
 
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
       << "[DTDataIntegrityUrosOffline] Get DQMStore service" << endl;
@@ -70,24 +71,24 @@ void DTDataIntegrityUrosOffline::bookHistograms(DQMStore::IBooker& ibooker,
   // book FED integrity histos
   bookHistos(ibooker, FEDIDmin, FEDIDmax);
 
-    // static booking of the histograms
+  // static booking of the histograms
 
-      for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
+  for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
 
-        bookHistos(ibooker, string("FED"), fed);
+    bookHistos(ibooker, string("FED"), fed);
 
-        bookHistos(ibooker, string("CRATE"), fed);
+    bookHistos(ibooker, string("CRATE"), fed);
 
-        for (int uRos = 1; uRos <= NuROS; ++uRos) {  // loop over all ROS
-          bookHistosuROS(ibooker, fed, uRos);
-        }
-      }
+    for (int uRos = 1; uRos <= NuROS; ++uRos) {  // loop over all ROS
+      bookHistosuROS(ibooker, fed, uRos);
+    }
+  }
 
-      for (int wheel = -2; wheel < 3; ++wheel) {
-        for (int ros = 1; ros <= NuROS; ++ros) {  // loop over all ROS
-          bookHistosROS(ibooker, wheel, ros);
-        }
-      }
+  for (int wheel = -2; wheel < 3; ++wheel) {
+    for (int ros = 1; ros <= NuROS; ++ros) {  // loop over all ROS
+      bookHistosROS(ibooker, wheel, ros);
+    }
+  }
 }
 
 void DTDataIntegrityUrosOffline::bookHistos(DQMStore::IBooker& ibooker, const int fedMin, const int fedMax) {
@@ -101,45 +102,45 @@ void DTDataIntegrityUrosOffline::bookHistos(DQMStore::IBooker& ibooker, const in
 
   hFEDEntry = ibooker.book1D("FEDEntries", "# entries per DT FED", nFED, fedMin, fedMax + 1);
 
-    string histoType = "ROSSummary";
-    for (int wheel = -2; wheel < 3; ++wheel) {
-      string wheel_s = to_string(wheel);
-      string histoName = "ROSSummary_W" + wheel_s;
-      string fed_s = to_string(FEDIDmin + 1);  //3 FEDs from 2018 onwards
-      if (wheel < 0)
-        fed_s = to_string(FEDIDmin);
-      else if (wheel > 0)
-        fed_s = to_string(FEDIDmax);
-      string histoTitle = "Summary Wheel" + wheel_s + " (FED " + fed_s + ")";
+  string histoType = "ROSSummary";
+  for (int wheel = -2; wheel < 3; ++wheel) {
+    string wheel_s = to_string(wheel);
+    string histoName = "ROSSummary_W" + wheel_s;
+    string fed_s = to_string(FEDIDmin + 1);  //3 FEDs from 2018 onwards
+    if (wheel < 0)
+      fed_s = to_string(FEDIDmin);
+    else if (wheel > 0)
+      fed_s = to_string(FEDIDmax);
+    string histoTitle = "Summary Wheel" + wheel_s + " (FED " + fed_s + ")";
 
-      ((summaryHistos[histoType])[wheel]) = ibooker.book2D(histoName, histoTitle, 11, 0, 11, 12, 1, 13);
-      MonitorElement* histo = ((summaryHistos[histoType])[wheel]);
-      histo->setBinLabel(1, "Error 1", 1);
-      histo->setBinLabel(2, "Error 2", 1);
-      histo->setBinLabel(3, "Error 3", 1);
-      histo->setBinLabel(4, "Error 4", 1);
-      histo->setBinLabel(5, "Not OKflag", 1);
-      // TDC error bins
-      histo->setBinLabel(6, "TDC Fatal", 1);
-      histo->setBinLabel(7, "TDC RO FIFO ov.", 1);
-      histo->setBinLabel(8, "TDC L1 buf. ov.", 1);
-      histo->setBinLabel(9, "TDC L1A FIFO ov.", 1);
-      histo->setBinLabel(10, "TDC hit err.", 1);
-      histo->setBinLabel(11, "TDC hit rej.", 1);
+    ((summaryHistos[histoType])[wheel]) = ibooker.book2D(histoName, histoTitle, 11, 0, 11, 12, 1, 13);
+    MonitorElement* histo = ((summaryHistos[histoType])[wheel]);
+    histo->setBinLabel(1, "Error 1", 1);
+    histo->setBinLabel(2, "Error 2", 1);
+    histo->setBinLabel(3, "Error 3", 1);
+    histo->setBinLabel(4, "Error 4", 1);
+    histo->setBinLabel(5, "Not OKflag", 1);
+    // TDC error bins
+    histo->setBinLabel(6, "TDC Fatal", 1);
+    histo->setBinLabel(7, "TDC RO FIFO ov.", 1);
+    histo->setBinLabel(8, "TDC L1 buf. ov.", 1);
+    histo->setBinLabel(9, "TDC L1A FIFO ov.", 1);
+    histo->setBinLabel(10, "TDC hit err.", 1);
+    histo->setBinLabel(11, "TDC hit rej.", 1);
 
-      histo->setBinLabel(1, "ROS1", 2);
-      histo->setBinLabel(2, "ROS2", 2);
-      histo->setBinLabel(3, "ROS3", 2);
-      histo->setBinLabel(4, "ROS4", 2);
-      histo->setBinLabel(5, "ROS5", 2);
-      histo->setBinLabel(6, "ROS6", 2);
-      histo->setBinLabel(7, "ROS7", 2);
-      histo->setBinLabel(8, "ROS8", 2);
-      histo->setBinLabel(9, "ROS9", 2);
-      histo->setBinLabel(10, "ROS10", 2);
-      histo->setBinLabel(11, "ROS11", 2);
-      histo->setBinLabel(12, "ROS12", 2);
-    }
+    histo->setBinLabel(1, "ROS1", 2);
+    histo->setBinLabel(2, "ROS2", 2);
+    histo->setBinLabel(3, "ROS3", 2);
+    histo->setBinLabel(4, "ROS4", 2);
+    histo->setBinLabel(5, "ROS5", 2);
+    histo->setBinLabel(6, "ROS6", 2);
+    histo->setBinLabel(7, "ROS7", 2);
+    histo->setBinLabel(8, "ROS8", 2);
+    histo->setBinLabel(9, "ROS9", 2);
+    histo->setBinLabel(10, "ROS10", 2);
+    histo->setBinLabel(11, "ROS11", 2);
+    histo->setBinLabel(12, "ROS12", 2);
+  }
 }
 
 void DTDataIntegrityUrosOffline::bookHistos(DQMStore::IBooker& ibooker, string folder, const int fed) {
@@ -196,7 +197,6 @@ void DTDataIntegrityUrosOffline::bookHistos(DQMStore::IBooker& ibooker, string f
     histo->setBinLabel(10, "uROS 10", 2);
     histo->setBinLabel(11, "uROS 11", 2);
     histo->setBinLabel(12, "uROS 12", 2);
-
   }
 
   // uROS Histograms
@@ -276,7 +276,7 @@ void DTDataIntegrityUrosOffline::bookHistosuROS(DQMStore::IBooker& ibooker, cons
 }
 
 void DTDataIntegrityUrosOffline::processuROS(DTuROSROSData& data, int fed, int uRos) {
-  neventsuROS++; 
+  neventsuROS++;
 
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
       << "[DTDataIntegrityUrosOffline]: " << neventsuROS << " events analyzed by processuROS" << endl;
@@ -309,68 +309,68 @@ void DTDataIntegrityUrosOffline::processuROS(DTuROSROSData& data, int fed, int u
 
   int errorX[5][12] = {{0}};  //5th is notOK flag
 
-    if (uRos > 2) {  //sectors 1-12
+  if (uRos > 2) {  //sectors 1-12
 
-      uROSError0 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros - 1)];  //links 0-23
-      uROSError1 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros)];      //links 24-47
-      uROSError2 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros + 1)];  //links 48-71
+    uROSError0 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros - 1)];  //links 0-23
+    uROSError1 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros)];      //links 24-47
+    uROSError2 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros + 1)];  //links 48-71
 
-      if ((!uROSError2) || (!uROSError1) || (!uROSError0)) {
-        LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
-            << "Trying to access non existing ME at uROS " << uRos << std::endl;
-        return;
-      }
+    if ((!uROSError2) || (!uROSError1) || (!uROSError0)) {
+      LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+          << "Trying to access non existing ME at uROS " << uRos << std::endl;
+      return;
+    }
 
-      // uROS errors
-      for (unsigned int link = 0; link < 72; ++link) {
-        for (unsigned int flag = 0; flag < 5; ++flag) {
-          if ((data.getokxflag(link) >> flag) & 0x1) {  // Undefined Flag 1-4 64bits word for each MTP (12 channels)
-            int value = flag;
-            if (flag == 0)
-              value = 5;  //move it to the 5th bin
+    // uROS errors
+    for (unsigned int link = 0; link < 72; ++link) {
+      for (unsigned int flag = 0; flag < 5; ++flag) {
+        if ((data.getokxflag(link) >> flag) & 0x1) {  // Undefined Flag 1-4 64bits word for each MTP (12 channels)
+          int value = flag;
+          if (flag == 0)
+            value = 5;  //move it to the 5th bin
 
-            if (value > 0) {
-              if (link < 24) {
-                errorX[value - 1][ros - 1] += 1;
-                uROSError0->Fill(value - 1, link);  //bins start at 0 despite labelin
-              } else if (link < 48) {
-                errorX[value - 1][ros] += 1;
-                uROSError1->Fill(value - 1, link - 23);
-              } else if (link < 72) {
-                errorX[value - 1][ros + 1] += 1;
-                uROSError2->Fill(value - 1, link - 47);
-              }
-            }  //value>0
-          }    //flag value
-        }      //loop on flags
-      }        //loop on links
-    }          //uROS>2
-
-    else {  //uRos<3
-
-      for (unsigned int link = 0; link < 12; ++link) {
-        for (unsigned int flag = 0; flag < 5; ++flag) {
-          if ((data.getokxflag(link) >> flag) & 0x1) {  // Undefined Flag 1-4 64bits word for each MTP (12 channels)
-            int value = flag;
-            int sc = 24;
-            if (flag == 0)
-              value = 5;  //move it to the 5th bin
-
-            if (value > 0) {
-              unsigned int keyHisto = (uROSError)*1000 + (wheel + 2) * 100 + link;  //ros -1 = link in this case
-              uROSError0 = urosHistos[keyHisto];
-              if (!uROSError0) {
-                LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
-                    << "Trying to access non existing ME at uROS " << uRos << std::endl;
-                return;
-              }
-              errorX[value - 1][link] += 1;     // ros-1=link in this case
-              uROSError0->Fill(value - 1, sc);  //bins start at 0 despite labeling, this is the old SC
+          if (value > 0) {
+            if (link < 24) {
+              errorX[value - 1][ros - 1] += 1;
+              uROSError0->Fill(value - 1, link);  //bins start at 0 despite labelin
+            } else if (link < 48) {
+              errorX[value - 1][ros] += 1;
+              uROSError1->Fill(value - 1, link - 23);
+            } else if (link < 72) {
+              errorX[value - 1][ros + 1] += 1;
+              uROSError2->Fill(value - 1, link - 47);
             }
-          }  //flag values
-        }    //loop on flags
-      }      //loop on links
-    }        //else uRos<3
+          }  //value>0
+        }    //flag value
+      }      //loop on flags
+    }        //loop on links
+  }          //uROS>2
+
+  else {  //uRos<3
+
+    for (unsigned int link = 0; link < 12; ++link) {
+      for (unsigned int flag = 0; flag < 5; ++flag) {
+        if ((data.getokxflag(link) >> flag) & 0x1) {  // Undefined Flag 1-4 64bits word for each MTP (12 channels)
+          int value = flag;
+          int sc = 24;
+          if (flag == 0)
+            value = 5;  //move it to the 5th bin
+
+          if (value > 0) {
+            unsigned int keyHisto = (uROSError)*1000 + (wheel + 2) * 100 + link;  //ros -1 = link in this case
+            uROSError0 = urosHistos[keyHisto];
+            if (!uROSError0) {
+              LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+                  << "Trying to access non existing ME at uROS " << uRos << std::endl;
+              return;
+            }
+            errorX[value - 1][link] += 1;     // ros-1=link in this case
+            uROSError0->Fill(value - 1, sc);  //bins start at 0 despite labeling, this is the old SC
+          }
+        }  //flag values
+      }    //loop on flags
+    }      //loop on links
+  }        //else uRos<3
 
   // Fill the ROSSummary (1 per wheel) histo
   for (unsigned int iros = 0; iros < 12; ++iros) {
@@ -445,23 +445,21 @@ void DTDataIntegrityUrosOffline::processuROS(DTuROSROSData& data, int fed, int u
     if (uRos < 3) {
       ROSSummary->Fill(tdcError_ROSSummary, link + 1);  //link 0 = ROS 1
       int sc = 24;
-        urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (link)]->Fill(tdcError_ROSError, sc);
-    }                                                                          //uRos<3
-    else {                                                                     //uRos>2
-      if (link < 24){
+      urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (link)]->Fill(tdcError_ROSError, sc);
+    }       //uRos<3
+    else {  //uRos>2
+      if (link < 24) {
         ROSSummary->Fill(tdcError_ROSSummary, ros);
         uROSError0->Fill(tdcError_ROSError, link);
-      }
-      else if (link < 48){
+      } else if (link < 48) {
         ROSSummary->Fill(tdcError_ROSSummary, ros + 1);
         uROSError1->Fill(tdcError_ROSError, link - 23);
-      }
-      else if (link < 72){
+      } else if (link < 72) {
         ROSSummary->Fill(tdcError_ROSSummary, ros + 2);
         uROSError2->Fill(tdcError_ROSError, link - 47);
       }
-    }      //uROS>2
-  }        //loop on errors
+    }  //uROS>2
+  }    //loop on errors
 }
 
 void DTDataIntegrityUrosOffline::processFED(DTuROSFEDData& data, int fed) {
@@ -479,11 +477,10 @@ void DTDataIntegrityUrosOffline::processFED(DTuROSFEDData& data, int fed) {
   int fedEvtLength = data.getevtlgth() * 8;  //1 word = 8 bytes
   //   if(fedEvtLength > 16000) fedEvtLength = 16000; // overflow bin
   fedHistos["EventLength"][fed]->Fill(fedEvtLength);
-
 }
 
 std::string DTDataIntegrityUrosOffline::topFolder(bool isFEDIntegrity) const {
-  string folder = "DT/00-DataIntegrity/";  
+  string folder = "DT/00-DataIntegrity/";
 
   return folder;
 }
@@ -492,33 +489,34 @@ void DTDataIntegrityUrosOffline::analyze(const edm::Event& e, const edm::EventSe
   nevents++;
   nEventMonitor->Fill(nevents);
 
-  LogTrace("DTRawToDigi|TDQM|DTMonitorModule|DTDataIntegrityUrosOffline") << "[DTDataIntegrityUrosOffline]: preProcessEvent" << endl;
+  LogTrace("DTRawToDigi|TDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << "[DTDataIntegrityUrosOffline]: preProcessEvent" << endl;
 
-    // Digi collection
-    edm::Handle<DTuROSFEDDataCollection> fedCol;
-    e.getByToken(fedToken, fedCol);
-    DTuROSFEDData fedData;
-    DTuROSROSData urosData;
+  // Digi collection
+  edm::Handle<DTuROSFEDDataCollection> fedCol;
+  e.getByToken(fedToken, fedCol);
+  DTuROSFEDData fedData;
+  DTuROSROSData urosData;
 
-    if (fedCol.isValid()) {
-      for (unsigned int j = 0; j < fedCol->size(); ++j) {
-        fedData = fedCol->at(j);
-        int fed = fedData.getfed();  //argument should be void
-        if (fed > FEDIDmax || fed < FEDIDmin) {
-          LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
-              << "[DTDataIntegrityUrosOffline]: analyze, FED ID " << fed << " not expected." << endl;
+  if (fedCol.isValid()) {
+    for (unsigned int j = 0; j < fedCol->size(); ++j) {
+      fedData = fedCol->at(j);
+      int fed = fedData.getfed();  //argument should be void
+      if (fed > FEDIDmax || fed < FEDIDmin) {
+        LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+            << "[DTDataIntegrityUrosOffline]: analyze, FED ID " << fed << " not expected." << endl;
+        continue;
+      }
+      processFED(fedData, fed);
+
+      for (int slot = 1; slot <= DOCESLOTS; ++slot) {
+        urosData = fedData.getuROS(slot);
+        if (fedData.getslotsize(slot) == 0 || urosData.getslot() == -1)
           continue;
-        }
-        processFED(fedData, fed);
-
-        for (int slot = 1; slot <= DOCESLOTS; ++slot) {
-          urosData = fedData.getuROS(slot);
-          if (fedData.getslotsize(slot) == 0 || urosData.getslot() == -1)
-            continue;
-          processuROS(urosData, fed, slot);
-        }
+        processuROS(urosData, fed, slot);
       }
     }
+  }
 }
 
 // Conversions

--- a/DQM/DTMonitorModule/src/DTDataIntegrityUrosOffline.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityUrosOffline.cc
@@ -1,0 +1,567 @@
+/*
+ * \file DTDataIntegrityUrosOffline.cc
+ *
+ * \author Javier Fernandez (Uni. Oviedo) 
+ *
+ */
+
+#include "DQM/DTMonitorModule/interface/DTDataIntegrityUrosOffline.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <cmath>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace std;
+using namespace edm;
+
+DTDataIntegrityUrosOffline::DTDataIntegrityUrosOffline(const edm::ParameterSet& ps) : nevents(0) {
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline") << "[DTDataIntegrityUrosOffline]: Constructor" << endl;
+
+  fedToken = consumes<DTuROSFEDDataCollection>(ps.getParameter<InputTag>("dtFEDlabel"));
+  FEDIDmin = FEDNumbering::MINDTUROSFEDID;
+  FEDIDmax = FEDNumbering::MAXDTUROSFEDID;
+
+  neventsFED = 0;
+  neventsuROS = 0;
+
+  fedIntegrityFolder = ps.getUntrackedParameter<string>("fedIntegrityFolder", "DT/FEDIntegrity");
+
+}
+
+DTDataIntegrityUrosOffline::~DTDataIntegrityUrosOffline() {
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << "[DTDataIntegrityUrosOffline]: Destructor. Analyzed " << neventsFED << " events" << endl;
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << "[DTDataIntegrityUrosOffline]: postEndJob called!" << endl;
+}
+
+/*
+  Folder Structure uROS (starting 2018):
+  - 3 uROS Summary plots: Wheel-1/-2 (FED1369), Wheel0 (FED1370), Wheel+1/+2 (FED1371)
+  - One folder for each FED
+  - Inside each FED folder the uROSStatus histos, FED histos
+  - One folder for each wheel and the corresponding ROSn folders
+  - Inside each ROS folder the TDC and ROS errors histos, 24 Links/plot
+*/
+
+void DTDataIntegrityUrosOffline::bookHistograms(DQMStore::IBooker& ibooker,
+                                         edm::Run const& iRun,
+                                         edm::EventSetup const& iSetup) {
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline") << "[DTDataIntegrityUrosOffline]: postBeginJob" << endl;
+
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << "[DTDataIntegrityUrosOffline] Get DQMStore service" << endl;
+
+  // Loop over the DT FEDs
+
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << " FEDS: " << FEDIDmin << " to " << FEDIDmax << " in the RO" << endl;
+
+  // book FED integrity histos
+  bookHistos(ibooker, FEDIDmin, FEDIDmax);
+
+    // static booking of the histograms
+
+      for (int fed = FEDIDmin; fed <= FEDIDmax; ++fed) {  // loop over the FEDs in the readout
+
+        bookHistos(ibooker, string("FED"), fed);
+
+        bookHistos(ibooker, string("CRATE"), fed);
+
+        for (int uRos = 1; uRos <= NuROS; ++uRos) {  // loop over all ROS
+          bookHistosuROS(ibooker, fed, uRos);
+        }
+      }
+
+      for (int wheel = -2; wheel < 3; ++wheel) {
+        for (int ros = 1; ros <= NuROS; ++ros) {  // loop over all ROS
+          bookHistosROS(ibooker, wheel, ros);
+        }
+      }
+}
+
+void DTDataIntegrityUrosOffline::bookHistos(DQMStore::IBooker& ibooker, const int fedMin, const int fedMax) {
+  ibooker.setCurrentFolder("DT/EventInfo/Counters");
+  nEventMonitor = ibooker.bookFloat("nProcessedEventsDataIntegrity");
+
+  // Standard FED integrity histos
+  ibooker.setCurrentFolder(topFolder(true));
+
+  int nFED = (fedMax - fedMin) + 1;
+
+  hFEDEntry = ibooker.book1D("FEDEntries", "# entries per DT FED", nFED, fedMin, fedMax + 1);
+
+    string histoType = "ROSSummary";
+    for (int wheel = -2; wheel < 3; ++wheel) {
+      string wheel_s = to_string(wheel);
+      string histoName = "ROSSummary_W" + wheel_s;
+      string fed_s = to_string(FEDIDmin + 1);  //3 FEDs from 2018 onwards
+      if (wheel < 0)
+        fed_s = to_string(FEDIDmin);
+      else if (wheel > 0)
+        fed_s = to_string(FEDIDmax);
+      string histoTitle = "Summary Wheel" + wheel_s + " (FED " + fed_s + ")";
+
+      ((summaryHistos[histoType])[wheel]) = ibooker.book2D(histoName, histoTitle, 11, 0, 11, 12, 1, 13);
+      MonitorElement* histo = ((summaryHistos[histoType])[wheel]);
+      histo->setBinLabel(1, "Error 1", 1);
+      histo->setBinLabel(2, "Error 2", 1);
+      histo->setBinLabel(3, "Error 3", 1);
+      histo->setBinLabel(4, "Error 4", 1);
+      histo->setBinLabel(5, "Not OKflag", 1);
+      // TDC error bins
+      histo->setBinLabel(6, "TDC Fatal", 1);
+      histo->setBinLabel(7, "TDC RO FIFO ov.", 1);
+      histo->setBinLabel(8, "TDC L1 buf. ov.", 1);
+      histo->setBinLabel(9, "TDC L1A FIFO ov.", 1);
+      histo->setBinLabel(10, "TDC hit err.", 1);
+      histo->setBinLabel(11, "TDC hit rej.", 1);
+
+      histo->setBinLabel(1, "ROS1", 2);
+      histo->setBinLabel(2, "ROS2", 2);
+      histo->setBinLabel(3, "ROS3", 2);
+      histo->setBinLabel(4, "ROS4", 2);
+      histo->setBinLabel(5, "ROS5", 2);
+      histo->setBinLabel(6, "ROS6", 2);
+      histo->setBinLabel(7, "ROS7", 2);
+      histo->setBinLabel(8, "ROS8", 2);
+      histo->setBinLabel(9, "ROS9", 2);
+      histo->setBinLabel(10, "ROS10", 2);
+      histo->setBinLabel(11, "ROS11", 2);
+      histo->setBinLabel(12, "ROS12", 2);
+    }
+}
+
+void DTDataIntegrityUrosOffline::bookHistos(DQMStore::IBooker& ibooker, string folder, const int fed) {
+  string wheel = "ZERO";
+  if (fed == FEDIDmin)
+    wheel = "NEG";
+  else if (fed == FEDIDmax)
+    wheel = "POS";
+  string fed_s = to_string(fed);
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << " Booking histos for FED: " << fed_s << " folder: " << folder << endl;
+
+  string histoType;
+  string histoName;
+  string histoTitle;
+  MonitorElement* histo = nullptr;
+
+  // Crate (old DDU) Histograms
+  if (folder == "CRATE") {
+    ibooker.setCurrentFolder(topFolder(false) + "FED" + fed_s);
+
+    histoType = "EventLength";
+    histoName = "FED" + fed_s + "_" + histoType;
+    histoTitle = "Event Length (Bytes) FED " + fed_s;
+    (fedHistos[histoType])[fed] = ibooker.book1D(histoName, histoTitle, 501, 0, 30000);
+
+    histoType = "uROSStatus";
+    histoName = "FED" + fed_s + "_" + histoType;
+    (fedHistos[histoType])[fed] = ibooker.book2D(histoName, histoName, 12, 0, 12, 12, 1, 13);
+    histo = (fedHistos[histoType])[fed];
+    // only placeholders for the moment
+    histo->setBinLabel(1, "Error G 1", 1);
+    histo->setBinLabel(2, "Error G 2", 1);
+    histo->setBinLabel(3, "Error G 3", 1);
+    histo->setBinLabel(4, "Error G 4", 1);
+    histo->setBinLabel(5, "Error G 5", 1);
+    histo->setBinLabel(6, "Error G 6", 1);
+    histo->setBinLabel(7, "Error G 7", 1);
+    histo->setBinLabel(8, "Error G 8", 1);
+    histo->setBinLabel(9, "Error G 9", 1);
+    histo->setBinLabel(10, "Error G 10", 1);
+    histo->setBinLabel(11, "Error G 11", 1);
+    histo->setBinLabel(12, "Error G 12", 1);
+
+    histo->setBinLabel(1, "uROS 1", 2);
+    histo->setBinLabel(2, "uROS 2", 2);
+    histo->setBinLabel(3, "uROS 3", 2);
+    histo->setBinLabel(4, "uROS 4", 2);
+    histo->setBinLabel(5, "uROS 5", 2);
+    histo->setBinLabel(6, "uROS 6", 2);
+    histo->setBinLabel(7, "uROS 7", 2);
+    histo->setBinLabel(8, "uROS 8", 2);
+    histo->setBinLabel(9, "uROS 9", 2);
+    histo->setBinLabel(10, "uROS 10", 2);
+    histo->setBinLabel(11, "uROS 11", 2);
+    histo->setBinLabel(12, "uROS 12", 2);
+
+  }
+
+  // uROS Histograms
+  if (folder == "FED") {  // The summary of the error of the ROS on the same FED
+    ibooker.setCurrentFolder(topFolder(false));
+
+    histoType = "uROSSummary";
+    histoName = "FED" + fed_s + "_uROSSummary";
+    string histoTitle = "Summary Wheel" + wheel + " (FED " + fed_s + ")";
+
+    ((summaryHistos[histoType])[fed]) = ibooker.book2D(histoName, histoTitle, 12, 0, 12, 12, 1, 13);
+    MonitorElement* histo = ((summaryHistos[histoType])[fed]);
+    // ROS error bins
+    // Placeholders for Global Errors for the moment
+    histo->setBinLabel(1, "Error G 1", 1);
+    histo->setBinLabel(2, "Error G 2", 1);
+    histo->setBinLabel(3, "Error G 3", 1);
+    histo->setBinLabel(4, "Error G 4", 1);
+    histo->setBinLabel(5, "Error G 5", 1);
+    histo->setBinLabel(6, "Error G 6", 1);
+    histo->setBinLabel(7, "Error G 7", 1);
+    histo->setBinLabel(8, "Error G 8", 1);
+    histo->setBinLabel(9, "Error G 9", 1);
+    histo->setBinLabel(10, "Error G 10", 1);
+    histo->setBinLabel(11, "Error G 11", 1);
+    histo->setBinLabel(12, "Error G 12", 1);
+
+    histo->setBinLabel(1, "uROS1", 2);
+    histo->setBinLabel(2, "uROS2", 2);
+    histo->setBinLabel(3, "uROS3", 2);
+    histo->setBinLabel(4, "uROS4", 2);
+    histo->setBinLabel(5, "uROS5", 2);
+    histo->setBinLabel(6, "uROS6", 2);
+    histo->setBinLabel(7, "uROS7", 2);
+    histo->setBinLabel(8, "uROS8", 2);
+    histo->setBinLabel(9, "uROS9", 2);
+    histo->setBinLabel(10, "uROS10", 2);
+    histo->setBinLabel(11, "uROS11", 2);
+    histo->setBinLabel(12, "uROS12", 2);
+  }
+}
+
+void DTDataIntegrityUrosOffline::bookHistosROS(DQMStore::IBooker& ibooker, const int wheel, const int ros) {
+  string wheel_s = to_string(wheel);
+  string ros_s = to_string(ros);
+  ibooker.setCurrentFolder(topFolder(false) + "Wheel" + wheel_s + "/ROS" + ros_s);
+
+  string histoType = "ROSError";
+  int linkDown = 0;
+  string linkDown_s = to_string(linkDown);
+  int linkUp = linkDown + 24;
+  string linkUp_s = to_string(linkUp);
+  string histoName = "W" + wheel_s + "_" + "ROS" + ros_s + "_" + histoType;
+  string histoTitle = histoName + " (Link " + linkDown_s + "-" + linkUp_s + " error summary)";
+  unsigned int keyHisto = (uROSError)*1000 + (wheel + 2) * 100 + (ros - 1);
+  urosHistos[keyHisto] = ibooker.book2D(histoName, histoTitle, 5, 0, 5, 25, 0, 25);
+
+  MonitorElement* histo = urosHistos[keyHisto];
+  // uROS error bins
+  // Placeholders for the moment
+  histo->setBinLabel(1, "Error 1", 1);
+  histo->setBinLabel(2, "Error 2", 1);
+  histo->setBinLabel(3, "Error 3", 1);
+  histo->setBinLabel(4, "Error 4", 1);
+  histo->setBinLabel(5, "Not OKFlag", 1);
+  for (int link = linkDown; link < (linkUp + 1); ++link) {
+    string link_s = to_string(link);
+    histo->setBinLabel(link + 1, "Link" + link_s, 2);
+  }
+
+}  //bookHistosROS
+
+void DTDataIntegrityUrosOffline::bookHistosuROS(DQMStore::IBooker& ibooker, const int fed, const int uRos) {
+  string fed_s = to_string(fed);
+  string uRos_s = to_string(uRos);
+  ibooker.setCurrentFolder(topFolder(false) + "FED" + fed_s + "/uROS" + uRos_s);
+}
+
+void DTDataIntegrityUrosOffline::processuROS(DTuROSROSData& data, int fed, int uRos) {
+  neventsuROS++; 
+
+  LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+      << "[DTDataIntegrityUrosOffline]: " << neventsuROS << " events analyzed by processuROS" << endl;
+
+  MonitorElement* uROSSummary = nullptr;
+  uROSSummary = summaryHistos["uROSSummary"][fed];
+
+  MonitorElement* uROSStatus = nullptr;
+  uROSStatus = fedHistos["uROSStatus"][fed];
+
+  if (!uROSSummary) {
+    LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+        << "Trying to access non existing ME at FED " << fed << std::endl;
+    return;
+  }
+
+  unsigned int slotMap = (data.getboardId()) & 0xF;
+  if (slotMap == 0)
+    return;                      //prevention for Simulation empty uROS data
+  int ros = theROS(slotMap, 0);  //first sector correspondign to link 0
+  int ddu = theDDU(fed, slotMap, 0, false);
+  int wheel = (ddu - 770) % 5 - 2;
+  MonitorElement* ROSSummary = nullptr;
+  ROSSummary = summaryHistos["ROSSummary"][wheel];
+
+  // Summary of all Link errors
+  MonitorElement* uROSError0 = nullptr;
+  MonitorElement* uROSError1 = nullptr;
+  MonitorElement* uROSError2 = nullptr;
+
+  int errorX[5][12] = {{0}};  //5th is notOK flag
+
+    if (uRos > 2) {  //sectors 1-12
+
+      uROSError0 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros - 1)];  //links 0-23
+      uROSError1 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros)];      //links 24-47
+      uROSError2 = urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (ros + 1)];  //links 48-71
+
+      if ((!uROSError2) || (!uROSError1) || (!uROSError0)) {
+        LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+            << "Trying to access non existing ME at uROS " << uRos << std::endl;
+        return;
+      }
+
+      // uROS errors
+      for (unsigned int link = 0; link < 72; ++link) {
+        for (unsigned int flag = 0; flag < 5; ++flag) {
+          if ((data.getokxflag(link) >> flag) & 0x1) {  // Undefined Flag 1-4 64bits word for each MTP (12 channels)
+            int value = flag;
+            if (flag == 0)
+              value = 5;  //move it to the 5th bin
+
+            if (value > 0) {
+              if (link < 24) {
+                errorX[value - 1][ros - 1] += 1;
+                uROSError0->Fill(value - 1, link);  //bins start at 0 despite labelin
+              } else if (link < 48) {
+                errorX[value - 1][ros] += 1;
+                uROSError1->Fill(value - 1, link - 23);
+              } else if (link < 72) {
+                errorX[value - 1][ros + 1] += 1;
+                uROSError2->Fill(value - 1, link - 47);
+              }
+            }  //value>0
+          }    //flag value
+        }      //loop on flags
+      }        //loop on links
+    }          //uROS>2
+
+    else {  //uRos<3
+
+      for (unsigned int link = 0; link < 12; ++link) {
+        for (unsigned int flag = 0; flag < 5; ++flag) {
+          if ((data.getokxflag(link) >> flag) & 0x1) {  // Undefined Flag 1-4 64bits word for each MTP (12 channels)
+            int value = flag;
+            int sc = 24;
+            if (flag == 0)
+              value = 5;  //move it to the 5th bin
+
+            if (value > 0) {
+              unsigned int keyHisto = (uROSError)*1000 + (wheel + 2) * 100 + link;  //ros -1 = link in this case
+              uROSError0 = urosHistos[keyHisto];
+              if (!uROSError0) {
+                LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+                    << "Trying to access non existing ME at uROS " << uRos << std::endl;
+                return;
+              }
+              errorX[value - 1][link] += 1;     // ros-1=link in this case
+              uROSError0->Fill(value - 1, sc);  //bins start at 0 despite labeling, this is the old SC
+            }
+          }  //flag values
+        }    //loop on flags
+      }      //loop on links
+    }        //else uRos<3
+
+  // Fill the ROSSummary (1 per wheel) histo
+  for (unsigned int iros = 0; iros < 12; ++iros) {
+    for (unsigned int bin = 0; bin < 5; ++bin) {
+      if (errorX[bin][iros] != 0)
+        ROSSummary->Fill(bin, iros + 1);  //bins start at 1
+    }
+  }
+
+  // Global Errors for uROS
+  for (unsigned int flag = 4; flag < 16; ++flag) {
+    if ((data.getuserWord() >> flag) & 0x1) {
+      uROSSummary->Fill(flag - 4, uRos);
+      uROSStatus->Fill(flag - 4, uRos);  //duplicated info?
+    }
+  }
+
+  // ROS error
+  for (unsigned int icounter = 0; icounter < data.geterrors().size(); ++icounter) {
+    int link = data.geterrorROBID(icounter);
+    int error = data.geterror(icounter);
+    int tdcError_ROSSummary = 0;
+    int tdcError_ROSError = 0;
+
+    if (error & 0x4000) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+          << " ROS " << uRos << " ROB " << link << " Internal fatal Error 4000 in TDC " << error << endl;
+
+      tdcError_ROSSummary = 5;
+      tdcError_ROSError = 5;
+
+    } else if (error & 0x0249) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+          << " ROS " << uRos << " ROB " << link << " TDC FIFO overflow in TDC " << error << endl;
+
+      tdcError_ROSSummary = 6;
+      tdcError_ROSError = 6;
+
+    } else if (error & 0x0492) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+          << " ROS " << uRos << " ROB " << link << " TDC L1 buffer overflow in TDC " << error << endl;
+
+      tdcError_ROSSummary = 7;
+      tdcError_ROSError = 7;
+
+    } else if (error & 0x2000) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+          << " ROS " << uRos << " ROB " << link << " TDC L1A FIFO overflow in TDC " << error << endl;
+
+      tdcError_ROSSummary = 8;
+      tdcError_ROSError = 8;
+
+    } else if (error & 0x0924) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+          << " uROS " << uRos << " ROB " << link << " TDC hit error in TDC " << error << endl;
+
+      tdcError_ROSSummary = 9;
+      tdcError_ROSError = 9;
+
+    } else if (error & 0x1000) {
+      LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+          << " uROS " << uRos << " ROB " << link << " TDC hit rejected in TDC " << error << endl;
+
+      tdcError_ROSSummary = 10;
+      tdcError_ROSError = 10;
+
+    } else {
+      LogWarning("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+          << " TDC error code not known " << error << endl;
+    }
+
+    if (uRos < 3) {
+      ROSSummary->Fill(tdcError_ROSSummary, link + 1);  //link 0 = ROS 1
+      int sc = 24;
+        urosHistos[(uROSError)*1000 + (wheel + 2) * 100 + (link)]->Fill(tdcError_ROSError, sc);
+    }                                                                          //uRos<3
+    else {                                                                     //uRos>2
+      if (link < 24){
+        ROSSummary->Fill(tdcError_ROSSummary, ros);
+        uROSError0->Fill(tdcError_ROSError, link);
+      }
+      else if (link < 48){
+        ROSSummary->Fill(tdcError_ROSSummary, ros + 1);
+        uROSError1->Fill(tdcError_ROSError, link - 23);
+      }
+      else if (link < 72){
+        ROSSummary->Fill(tdcError_ROSSummary, ros + 2);
+        uROSError2->Fill(tdcError_ROSError, link - 47);
+      }
+    }      //uROS>2
+  }        //loop on errors
+}
+
+void DTDataIntegrityUrosOffline::processFED(DTuROSFEDData& data, int fed) {
+  neventsFED++;
+  if (neventsFED % 1000 == 0)
+    LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+        << "[DTDataIntegrityUrosOffline]: " << neventsFED << " events analyzed by processFED" << endl;
+
+  if (fed < FEDIDmin || fed > FEDIDmax)
+    return;
+
+  hFEDEntry->Fill(fed);
+
+  //1D HISTOS: EVENT LENGHT from trailer
+  int fedEvtLength = data.getevtlgth() * 8;  //1 word = 8 bytes
+  //   if(fedEvtLength > 16000) fedEvtLength = 16000; // overflow bin
+  fedHistos["EventLength"][fed]->Fill(fedEvtLength);
+
+}
+
+std::string DTDataIntegrityUrosOffline::topFolder(bool isFEDIntegrity) const {
+  string folder = "DT/00-DataIntegrity/";  
+
+  return folder;
+}
+
+void DTDataIntegrityUrosOffline::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  nevents++;
+  nEventMonitor->Fill(nevents);
+
+  LogTrace("DTRawToDigi|TDQM|DTMonitorModule|DTDataIntegrityUrosOffline") << "[DTDataIntegrityUrosOffline]: preProcessEvent" << endl;
+
+    // Digi collection
+    edm::Handle<DTuROSFEDDataCollection> fedCol;
+    e.getByToken(fedToken, fedCol);
+    DTuROSFEDData fedData;
+    DTuROSROSData urosData;
+
+    if (fedCol.isValid()) {
+      for (unsigned int j = 0; j < fedCol->size(); ++j) {
+        fedData = fedCol->at(j);
+        int fed = fedData.getfed();  //argument should be void
+        if (fed > FEDIDmax || fed < FEDIDmin) {
+          LogError("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityUrosOffline")
+              << "[DTDataIntegrityUrosOffline]: analyze, FED ID " << fed << " not expected." << endl;
+          continue;
+        }
+        processFED(fedData, fed);
+
+        for (int slot = 1; slot <= DOCESLOTS; ++slot) {
+          urosData = fedData.getuROS(slot);
+          if (fedData.getslotsize(slot) == 0 || urosData.getslot() == -1)
+            continue;
+          processuROS(urosData, fed, slot);
+        }
+      }
+    }
+}
+
+// Conversions
+int DTDataIntegrityUrosOffline::theDDU(int crate, int slot, int link, bool tenDDU) {
+  int ros = theROS(slot, link);
+
+  int ddu = 772;
+  //if (crate == 1368) { ddu = 775; }
+  //Needed just in case this FED should be used due to fibers length
+
+  if (crate == FEDNumbering::MINDTUROSFEDID) {
+    if (slot < 7)
+      ddu = 770;
+    else
+      ddu = 771;
+  }
+
+  if (crate == (FEDNumbering::MINDTUROSFEDID + 1)) {
+    ddu = 772;
+  }
+
+  if (crate == FEDNumbering::MAXDTUROSFEDID) {
+    if (slot < 7)
+      ddu = 773;
+    else
+      ddu = 774;
+  }
+
+  if (ros > 6 && tenDDU && ddu < 775)
+    ddu += 5;
+
+  return ddu;
+}
+
+int DTDataIntegrityUrosOffline::theROS(int slot, int link) {
+  if (slot % 6 == 5)
+    return link + 1;
+
+  int ros = (link / 24) + 3 * (slot % 6) - 2;
+  return ros;
+}
+
+// Local Variables:
+// show-trailing-whitespace: t
+// truncate-lines: t
+// End:

--- a/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.cc
+++ b/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.cc
@@ -11,7 +11,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
+//#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -72,7 +72,7 @@ void DTResolutionAnalysisTask::bookHistograms(DQMStore::IBooker& ibooker,
     }
   }
 }
-
+/*
 void DTResolutionAnalysisTask::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const EventSetup& context) {
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTResolutionAnalysisTask")
       << "[DTResolutionTask]: Begin of LS transition" << endl;
@@ -88,7 +88,7 @@ void DTResolutionAnalysisTask::beginLuminosityBlock(const LuminosityBlock& lumiS
     }
   }
 }
-
+*/
 void DTResolutionAnalysisTask::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTResolutionAnalysisTask")
       << "[DTResolutionAnalysisTask] Analyze #Run: " << event.id().run() << " #Event: " << event.id().event() << endl;

--- a/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.h
@@ -44,8 +44,8 @@ public:
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
   /// To reset the MEs
-//  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) override;
-//  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) final {}
+  //  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) override;
+  //  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) final {}
 
   // Operations
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override;

--- a/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.h
@@ -29,7 +29,7 @@
 
 class DTGeometry;
 
-class DTResolutionAnalysisTask : public DQMOneEDAnalyzer<edm::one::WatchLuminosityBlocks> {
+class DTResolutionAnalysisTask : public DQMOneEDAnalyzer<> {
 public:
   /// Constructor
   DTResolutionAnalysisTask(const edm::ParameterSet& pset);
@@ -44,8 +44,8 @@ public:
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
   /// To reset the MEs
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) override;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) final {}
+//  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) override;
+//  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) final {}
 
   // Operations
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override;

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.cc
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.cc
@@ -10,7 +10,6 @@
 // Framework
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -27,7 +26,6 @@
 #include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
 #include "CondFormats/DTObjects/interface/DTStatusFlag.h"
 
-#include "DQM/DTMonitorModule/interface/DTTimeEvolutionHisto.h"
 
 #include <iterator>
 #include <TMath.h>
@@ -36,7 +34,7 @@ using namespace edm;
 using namespace std;
 
 DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset)
-    : nevents(0), nEventsInLS(0), hNevtPerLS(nullptr) {
+    : nevents(0) {
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTSegmentAnalysisTask") << "[DTSegmentAnalysisTask] Constructor called!";
 
   // switch for detailed analysis
@@ -45,12 +43,6 @@ DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset)
   recHits4DToken_ = consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getParameter<string>("recHits4DLabel")));
   // Get the map of noisy channels
   checkNoisyChannels = pset.getUntrackedParameter<bool>("checkNoisyChannels", false);
-  // # of bins in the time histos
-  nTimeBins = pset.getUntrackedParameter<int>("nTimeBins", 100);
-  // # of LS per bin in the time histos
-  nLSTimeBin = pset.getUntrackedParameter<int>("nLSTimeBin", 2);
-  // switch on/off sliding bins in time histos
-  slideTimeBins = pset.getUntrackedParameter<bool>("slideTimeBins", true);
   phiSegmCut = pset.getUntrackedParameter<double>("phiSegmCut", 30.);
   nhitsCut = pset.getUntrackedParameter<int>("nhitsCut", 12);
 
@@ -62,7 +54,6 @@ DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset)
 
 DTSegmentAnalysisTask::~DTSegmentAnalysisTask() {
   //FR moved fron endjob
-  delete hNevtPerLS;
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTSegmentAnalysisTask") << "[DTSegmentAnalysisTask] Destructor called!";
 }
 
@@ -112,41 +103,12 @@ void DTSegmentAnalysisTask::bookHistograms(DQMStore::IBooker& ibooker,
   for (; ch_it != ch_end; ++ch_it) {
     bookHistos(ibooker, (*ch_it)->id());
   }
-
-  // book sector time-evolution histos
-  int modeTimeHisto = 0;
-  if (!slideTimeBins)
-    modeTimeHisto = 1;
-  for (int wheel = -2; wheel != 3; ++wheel) {       // loop over wheels
-    for (int sector = 1; sector <= 12; ++sector) {  // loop over sectors
-
-      stringstream wheelstr;
-      wheelstr << wheel;
-      stringstream sectorstr;
-      sectorstr << sector;
-      string sectorHistoName = "NSegmPerEvent_W" + wheelstr.str() + "_Sec" + sectorstr.str();
-      string sectorHistoTitle = "# segm. W" + wheelstr.str() + " Sect." + sectorstr.str();
-
-      ibooker.setCurrentFolder(topHistoFolder + "/Wheel" + wheelstr.str() + "/Sector" + sectorstr.str());
-
-      histoTimeEvol[wheel][sector] = new DTTimeEvolutionHisto(
-          ibooker, sectorHistoName, sectorHistoTitle, nTimeBins, nLSTimeBin, slideTimeBins, modeTimeHisto);
-    }
-  }
-
-  if (hltDQMMode)
-    ibooker.setCurrentFolder(topHistoFolder);
-  else
-    ibooker.setCurrentFolder("DT/EventInfo/");
-
-  hNevtPerLS = new DTTimeEvolutionHisto(ibooker, "NevtPerLS", "# evt.", nTimeBins, nLSTimeBin, slideTimeBins, 2);
 }
 
 void DTSegmentAnalysisTask::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   nevents++;
   nEventMonitor->Fill(nevents);
 
-  nEventsInLS++;
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTSegmentAnalysisTask")
       << "[DTSegmentAnalysisTask] Analyze #Run: " << event.id().run() << " #Event: " << event.id().event();
   if (!(event.id().event() % 1000))
@@ -317,27 +279,12 @@ void DTSegmentAnalysisTask::fillHistos(DTChamberId chamberId, int nHits, float c
   }
 
   summaryHistos[chamberId.wheel()]->Fill(sector, chamberId.station());
-  histoTimeEvol[chamberId.wheel()][sector]->accumulateValueTimeSlot(1);
 
   vector<MonitorElement*> histos = histosPerCh[chamberId];
   histos[0]->Fill(nHits);
   if (detailedAnalysis) {
     histos[1]->Fill(chi2);
   }
-}
-
-void DTSegmentAnalysisTask::endLuminosityBlock(LuminosityBlock const& lumiSeg, EventSetup const& eSetup) {
-  hNevtPerLS->updateTimeSlot(lumiSeg.luminosityBlock(), nEventsInLS);
-  // book sector time-evolution histos
-  for (int wheel = -2; wheel != 3; ++wheel) {
-    for (int sector = 1; sector <= 12; ++sector) {
-      histoTimeEvol[wheel][sector]->updateTimeSlot(lumiSeg.luminosityBlock(), nEventsInLS);
-    }
-  }
-}
-
-void DTSegmentAnalysisTask::beginLuminosityBlock(LuminosityBlock const& lumiSeg, EventSetup const& eSetup) {
-  nEventsInLS = 0;
 }
 
 // Local Variables:

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.cc
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.cc
@@ -33,7 +33,7 @@
 using namespace edm;
 using namespace std;
 
-DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset){
+DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset) {
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTSegmentAnalysisTask") << "[DTSegmentAnalysisTask] Constructor called!";
 
   // switch for detailed analysis
@@ -98,7 +98,6 @@ void DTSegmentAnalysisTask::bookHistograms(DQMStore::IBooker& ibooker,
 }
 
 void DTSegmentAnalysisTask::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTSegmentAnalysisTask")
       << "[DTSegmentAnalysisTask] Analyze #Run: " << event.id().run() << " #Event: " << event.id().event();
   if (!(event.id().event() % 1000))

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.cc
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.cc
@@ -10,6 +10,7 @@
 // Framework
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -26,15 +27,13 @@
 #include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
 #include "CondFormats/DTObjects/interface/DTStatusFlag.h"
 
-
 #include <iterator>
 #include <TMath.h>
 
 using namespace edm;
 using namespace std;
 
-DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset)
-    : nevents(0) {
+DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset){
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTSegmentAnalysisTask") << "[DTSegmentAnalysisTask] Constructor called!";
 
   // switch for detailed analysis
@@ -48,8 +47,6 @@ DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset)
 
   // top folder for the histograms in DQMStore
   topHistoFolder = pset.getUntrackedParameter<string>("topHistoFolder", "DT/02-Segments");
-  // hlt DQM mode
-  hltDQMMode = pset.getUntrackedParameter<bool>("hltDQMMode", false);
 }
 
 DTSegmentAnalysisTask::~DTSegmentAnalysisTask() {
@@ -65,11 +62,6 @@ void DTSegmentAnalysisTask::dqmBeginRun(const Run& run, const edm::EventSetup& c
 void DTSegmentAnalysisTask::bookHistograms(DQMStore::IBooker& ibooker,
                                            edm::Run const& iRun,
                                            edm::EventSetup const& context) {
-  if (!hltDQMMode) {
-    ibooker.setCurrentFolder("DT/EventInfo/Counters");
-    nEventMonitor = ibooker.bookFloat("nProcessedEventsSegment");
-  }
-
   for (int wh = -2; wh <= 2; wh++) {
     stringstream wheel;
     wheel << wh;
@@ -106,8 +98,6 @@ void DTSegmentAnalysisTask::bookHistograms(DQMStore::IBooker& ibooker,
 }
 
 void DTSegmentAnalysisTask::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-  nevents++;
-  nEventMonitor->Fill(nevents);
 
   edm::LogVerbatim("DTDQM|DTMonitorModule|DTSegmentAnalysisTask")
       << "[DTSegmentAnalysisTask] Analyze #Run: " << event.id().run() << " #Event: " << event.id().event();

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
@@ -35,7 +35,7 @@
 
 class DTGeometry;
 
-class DTSegmentAnalysisTask : public DQMEDAnalyzer{
+class DTSegmentAnalysisTask : public DQMEDAnalyzer {
 public:
   /// Constructor
   DTSegmentAnalysisTask(const edm::ParameterSet& pset);
@@ -57,16 +57,14 @@ private:
   // Switch for detailed analysis
   bool detailedAnalysis;
 
-  // Get the DT Geometry
+ // Get the DT Geometry
   edm::ESHandle<DTGeometry> dtGeom;
 
-  // Lable of 4D segments in the event
+  // Label of 4D segments in the event
   edm::EDGetTokenT<DTRecSegment4DCollection> recHits4DToken_;
 
   // Get the map of noisy channels
   bool checkNoisyChannels;
-
-  edm::ParameterSet parameters;
 
   // book the histos
   void bookHistos(DQMStore::IBooker& ibooker, DTChamberId chamberId);
@@ -77,19 +75,13 @@ private:
   std::map<DTChamberId, std::vector<MonitorElement*> > histosPerCh;
   std::map<int, MonitorElement*> summaryHistos;
 
-  int nevents;
-  int nEventsInLS;
-
   // top folder for the histograms in DQMStore
   std::string topHistoFolder;
-  // hlt DQM mode
-  bool hltDQMMode;
   // max phi angle of reconstructed segments
   double phiSegmCut;
   // min # hits of segment used to validate a segment in WB+-2/SecX/MB1
   int nhitsCut;
 
-  MonitorElement* nEventMonitor;
 };
 #endif
 

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
@@ -57,7 +57,7 @@ private:
   // Switch for detailed analysis
   bool detailedAnalysis;
 
- // Get the DT Geometry
+  // Get the DT Geometry
   edm::ESHandle<DTGeometry> dtGeom;
 
   // Label of 4D segments in the event
@@ -81,7 +81,6 @@ private:
   double phiSegmCut;
   // min # hits of segment used to validate a segment in WB+-2/SecX/MB1
   int nhitsCut;
-
 };
 #endif
 

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
@@ -24,7 +24,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
 //RecHit
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
@@ -34,9 +34,8 @@
 #include <vector>
 
 class DTGeometry;
-class DTTimeEvolutionHisto;
 
-class DTSegmentAnalysisTask : public DQMOneEDAnalyzer<edm::one::WatchLuminosityBlocks> {
+class DTSegmentAnalysisTask : public DQMEDAnalyzer{
 public:
   /// Constructor
   DTSegmentAnalysisTask(const edm::ParameterSet& pset);
@@ -49,10 +48,6 @@ public:
 
   // Operations
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
-
-  /// Summary
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup) override;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup) override;
 
 protected:
   // Book the histograms
@@ -81,18 +76,10 @@ private:
   //  the histos
   std::map<DTChamberId, std::vector<MonitorElement*> > histosPerCh;
   std::map<int, MonitorElement*> summaryHistos;
-  std::map<int, std::map<int, DTTimeEvolutionHisto*> > histoTimeEvol;
 
   int nevents;
   int nEventsInLS;
-  DTTimeEvolutionHisto* hNevtPerLS;
 
-  // # of bins in the time histos
-  int nTimeBins;
-  // # of LS per bin in the time histos
-  int nLSTimeBin;
-  // switch on/off sliding bins in time histos
-  bool slideTimeBins;
   // top folder for the histograms in DQMStore
   std::string topHistoFolder;
   // hlt DQM mode

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
@@ -75,12 +75,17 @@ private:
   std::map<DTChamberId, std::vector<MonitorElement*> > histosPerCh;
   std::map<int, MonitorElement*> summaryHistos;
 
+  int nevents;
   // top folder for the histograms in DQMStore
   std::string topHistoFolder;
+  // hlt DQM mode
+  bool hltDQMMode;
   // max phi angle of reconstructed segments
   double phiSegmCut;
   // min # hits of segment used to validate a segment in WB+-2/SecX/MB1
   int nhitsCut;
+
+  MonitorElement* nEventMonitor;
 };
 #endif
 

--- a/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
@@ -62,11 +62,10 @@ process.ecalFEDMonitor.folderName = cms.untracked.string(folder_name)
 process.load('EventFilter.HcalRawToDigi.HcalRawToDigi_cfi')
 # DT sequence:
 process.load('DQM.DTMonitorModule.dtDataIntegrityTask_EvF_cff')
-process.DTDataIntegrityTask.processingMode = 'SM'
+process.dtDataIntegrityTask.processingMode = 'SM'
 path = 'DT/%s/' % folder_name
-process.DTDataIntegrityTask.fedIntegrityFolder = path
-process.DTDataIntegrityTask.checkUros = True
-process.DTDataIntegrityTask.dtFEDlabel     = 'dtunpacker'
+process.dtDataIntegrityTask.fedIntegrityFolder = path
+process.dtDataIntegrityTask.dtFEDlabel     = 'dtunpacker'
 # RPC sequence:
 process.load('EventFilter.RPCRawToDigi.rpcUnpacker_cfi')
 process.load('DQM.RPCMonitorClient.RPCFEDIntegrity_cfi')
@@ -124,7 +123,7 @@ process.FEDModulesPath = cms.Path(
 			                      + process.hcalDigis
                                   + process.cscDQMEvF
  			                      + process.dtunpacker
-                                  + process.DTDataIntegrityTask
+                                  + process.dtDataIntegrityTask
 			                      + process.rpcunpacker
                                   + process.rpcFEDIntegrity
 

--- a/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
@@ -23,7 +23,7 @@ DQMCertEGamma = cms.Sequence(egammaDataCertificationTask)
 DQMCertTrigger = cms.Sequence(dqmOfflineTriggerCert)
 
 DQMCertMuon = cms.Sequence(dtDAQInfo * rpcDaqInfo * cscDaqInfo *
-                           dtDCSByLumiSummary * rpcDCSSummary * cscDcsInfo *
+                           rpcDCSSummary * cscDcsInfo *
                            dtCertificationSummary * rpcDataCertification * cscCertificationInfo)
 
 DQMCertEcal = cms.Sequence(ecalDaqInfoTask * ecalPreshowerDaqInfoTask *

--- a/DQMOffline/Configuration/python/DQMOffline_DCS_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_DCS_cff.py
@@ -3,10 +3,9 @@ import FWCore.ParameterSet.Config as cms
 siStripDcsInfo = cms.EDAnalyzer("SiStripDcsInfo")
 from DQM.SiPixelCommon.SiPixelOfflineDQM_client_cff import *
 from DQM.EcalMonitorClient.EcalDcsInfoTask_cfi import *
-from DQM.DTMonitorClient.dtDCSByLumiSummary_cfi import *
 from DQM.RPCMonitorClient.RPCDCSSummary_cfi import *
 from DQM.CSCMonitorModule.csc_dcs_info_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESDcsInfoTask_cfi import *
 
-dcs_dqmoffline = cms.Sequence(siStripDcsInfo*sipixelDcsInfo*ecalDcsInfoTask*dtDCSByLumiSummary*rpcDCSSummary*cscDcsInfo*ecalPreshowerDcsInfoTask)
+dcs_dqmoffline = cms.Sequence(siStripDcsInfo*sipixelDcsInfo*ecalDcsInfoTask*rpcDCSSummary*cscDcsInfo*ecalPreshowerDcsInfoTask)
 


### PR DESCRIPTION
#### PR description:

This PR tries to asses the issue https://github.com/cms-sw/cmssw/issues/25090  in what concerns DT DQM Legacy modules.

The four conflicting classes:

DTDataIntegrityTask
DTDCSByLumiTask
DTResolutionAnalysisTask
DTSegmentAnalysisTask

are reconfigured to clear any conflicting module with concurrent LS or dropped their usage from DQM Offline configurations, leaving all the vs LS plots ONLY for DQM Online and removing them from DQM Offline.

The results imply a drop of 71 plots from workflows. Some other cleaning of the code has been done in parallel

#### PR validation:

Tested for DQM Online stand alone and with:

runTheMatrix.py -l limited

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport is foreseen

(Partially) Resolves #25090