### PR TITLE
Move muon SelectionType and Selector string to enum maps to muon namespace

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -197,6 +197,7 @@ namespace reco {
     ///
     /// ====================== STANDARD SELECTORS ===========================
     ///
+    // When adding new selectors, also update DataFormats/MuonReco/interface/MuonSelectors.h string to enum map
     enum Selector {
       CutBasedIdLoose = 1UL << 0,
       CutBasedIdMedium = 1UL << 1,

--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -142,7 +142,6 @@ namespace muon {
       {"LowPtMvaMedium", reco::Muon::LowPtMvaMedium},
       {nullptr, (reco::Muon::Selector)-1}};
 
-
   /// main GoodMuon wrapper call
   bool isGoodMuon(const reco::Muon& muon,
                   SelectionType type,

--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -63,7 +63,85 @@ namespace muon {
     const char* label;
     SelectionType value;
   };
+
+  static const SelectionTypeStringToEnum selectionTypeStringToEnumMap[] = {
+      {"All", All},
+      {"AllGlobalMuons", AllGlobalMuons},
+      {"AllStandAloneMuons", AllStandAloneMuons},
+      {"AllTrackerMuons", AllTrackerMuons},
+      {"TrackerMuonArbitrated", TrackerMuonArbitrated},
+      {"AllArbitrated", AllArbitrated},
+      {"GlobalMuonPromptTight", GlobalMuonPromptTight},
+      {"TMLastStationLoose", TMLastStationLoose},
+      {"TMLastStationTight", TMLastStationTight},
+      {"TM2DCompatibilityLoose", TM2DCompatibilityLoose},
+      {"TM2DCompatibilityTight", TM2DCompatibilityTight},
+      {"TMOneStationLoose", TMOneStationLoose},
+      {"TMOneStationTight", TMOneStationTight},
+      {"TMLastStationOptimizedLowPtLoose", TMLastStationOptimizedLowPtLoose},
+      {"TMLastStationOptimizedLowPtTight", TMLastStationOptimizedLowPtTight},
+      {"GMTkChiCompatibility", GMTkChiCompatibility},
+      {"GMStaChiCompatibility", GMStaChiCompatibility},
+      {"GMTkKinkTight", GMTkKinkTight},
+      {"TMLastStationAngLoose", TMLastStationAngLoose},
+      {"TMLastStationAngTight", TMLastStationAngTight},
+      {"TMOneStationAngLoose", TMOneStationAngLoose},
+      {"TMOneStationAngTight", TMOneStationAngTight},
+      {"TMLastStationOptimizedBarrelLowPtLoose", TMLastStationOptimizedBarrelLowPtLoose},
+      {"TMLastStationOptimizedBarrelLowPtTight", TMLastStationOptimizedBarrelLowPtTight},
+      {"RPCMuLoose", RPCMuLoose},
+      {"AllME0Muons", AllME0Muons},
+      {"ME0MuonArbitrated", ME0MuonArbitrated},
+      {"AllGEMMuons", AllGEMMuons},
+      {"GEMMuonArbitrated", GEMMuonArbitrated},
+      {"TriggerIdLoose", TriggerIdLoose},
+      {nullptr, (SelectionType)-1}};
+
   SelectionType selectionTypeFromString(const std::string& label);
+
+  // a map for string label to reco::Muon::Selector enum
+  struct SelectorStringToEnum {
+    const char* label;
+    reco::Muon::Selector value;
+  };
+
+  static const SelectorStringToEnum selectorStringToEnumMap[] = {
+      {"CutBasedIdLoose", reco::Muon::CutBasedIdLoose},
+      {"CutBasedIdMedium", reco::Muon::CutBasedIdMedium},
+      {"CutBasedIdMediumPrompt", reco::Muon::CutBasedIdMediumPrompt},
+      {"CutBasedIdTight", reco::Muon::CutBasedIdTight},
+      {"CutBasedIdGlobalHighPt", reco::Muon::CutBasedIdGlobalHighPt},
+      {"CutBasedIdTrkHighPt", reco::Muon::CutBasedIdTrkHighPt},
+      {"PFIsoVeryLoose", reco::Muon::PFIsoVeryLoose},
+      {"PFIsoLoose", reco::Muon::PFIsoLoose},
+      {"PFIsoMedium", reco::Muon::PFIsoMedium},
+      {"PFIsoTight", reco::Muon::PFIsoTight},
+      {"PFIsoVeryTight", reco::Muon::PFIsoVeryTight},
+      {"TkIsoLoose", reco::Muon::TkIsoLoose},
+      {"TkIsoTight", reco::Muon::TkIsoTight},
+      {"SoftCutBasedId", reco::Muon::SoftCutBasedId},
+      {"SoftMvaId", reco::Muon::SoftMvaId},
+      {"MvaLoose", reco::Muon::MvaLoose},
+      {"MvaMedium", reco::Muon::MvaMedium},
+      {"MvaTight", reco::Muon::MvaTight},
+      {"MiniIsoLoose", reco::Muon::MiniIsoLoose},
+      {"MiniIsoMedium", reco::Muon::MiniIsoMedium},
+      {"MiniIsoTight", reco::Muon::MiniIsoTight},
+      {"MiniIsoVeryTight", reco::Muon::MiniIsoVeryTight},
+      {"TriggerIdLoose", reco::Muon::TriggerIdLoose},
+      {"InTimeMuon", reco::Muon::InTimeMuon},
+      {"PFIsoVeryVeryTight", reco::Muon::PFIsoVeryVeryTight},
+      {"MultiIsoLoose", reco::Muon::MultiIsoLoose},
+      {"MultiIsoMedium", reco::Muon::MultiIsoMedium},
+      {"PuppiIsoLoose", reco::Muon::PuppiIsoLoose},
+      {"PuppiIsoMedium", reco::Muon::PuppiIsoMedium},
+      {"PuppiIsoTight", reco::Muon::PuppiIsoTight},
+      {"MvaVTight", reco::Muon::MvaVTight},
+      {"MvaVVTight", reco::Muon::MvaVVTight},
+      {"LowPtMvaLoose", reco::Muon::LowPtMvaLoose},
+      {"LowPtMvaMedium", reco::Muon::LowPtMvaMedium},
+      {nullptr, (reco::Muon::Selector)-1}};
+
 
   /// main GoodMuon wrapper call
   bool isGoodMuon(const reco::Muon& muon,

--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -142,6 +142,8 @@ namespace muon {
       {"LowPtMvaMedium", reco::Muon::LowPtMvaMedium},
       {nullptr, (reco::Muon::Selector)-1}};
 
+  reco::Muon::Selector selectorFromString(const std::string& label);
+
   /// main GoodMuon wrapper call
   bool isGoodMuon(const reco::Muon& muon,
                   SelectionType type,

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -20,6 +20,21 @@ namespace muon {
       throw cms::Exception("MuonSelectorError") << label << " is not a recognized SelectionType";
     return value;
   }
+
+  reco::Muon::Selector selectorFromString(const std::string& label) {
+    reco::Muon::Selector value = (reco::Muon::Selector)-1;
+    bool found = false;
+    for (int i = 0; selectorStringToEnumMap[i].label && (!found); ++i)
+      if (!strcmp(label.c_str(), selectorStringToEnumMap[i].label)) {
+        found = true;
+        value = selectorStringToEnumMap[i].value;
+      }
+
+    // in case of unrecognized selection type
+    if (!found)
+      throw cms::Exception("MuonSelectorError") << label << " is not a recognized reco::Muon::Selector";
+    return value;
+  }
 }  // namespace muon
 
 unsigned int muon::RequiredStationMask(const reco::Muon& muon,

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -7,39 +7,6 @@
 
 namespace muon {
   SelectionType selectionTypeFromString(const std::string& label) {
-    static const SelectionTypeStringToEnum selectionTypeStringToEnumMap[] = {
-        {"All", All},
-        {"AllGlobalMuons", AllGlobalMuons},
-        {"AllStandAloneMuons", AllStandAloneMuons},
-        {"AllTrackerMuons", AllTrackerMuons},
-        {"TrackerMuonArbitrated", TrackerMuonArbitrated},
-        {"AllArbitrated", AllArbitrated},
-        {"GlobalMuonPromptTight", GlobalMuonPromptTight},
-        {"TMLastStationLoose", TMLastStationLoose},
-        {"TMLastStationTight", TMLastStationTight},
-        {"TM2DCompatibilityLoose", TM2DCompatibilityLoose},
-        {"TM2DCompatibilityTight", TM2DCompatibilityTight},
-        {"TMOneStationLoose", TMOneStationLoose},
-        {"TMOneStationTight", TMOneStationTight},
-        {"TMLastStationOptimizedLowPtLoose", TMLastStationOptimizedLowPtLoose},
-        {"TMLastStationOptimizedLowPtTight", TMLastStationOptimizedLowPtTight},
-        {"GMTkChiCompatibility", GMTkChiCompatibility},
-        {"GMStaChiCompatibility", GMStaChiCompatibility},
-        {"GMTkKinkTight", GMTkKinkTight},
-        {"TMLastStationAngLoose", TMLastStationAngLoose},
-        {"TMLastStationAngTight", TMLastStationAngTight},
-        {"TMOneStationAngLoose", TMOneStationAngLoose},
-        {"TMOneStationAngTight", TMOneStationAngTight},
-        {"TMLastStationOptimizedBarrelLowPtLoose", TMLastStationOptimizedBarrelLowPtLoose},
-        {"TMLastStationOptimizedBarrelLowPtTight", TMLastStationOptimizedBarrelLowPtTight},
-        {"RPCMuLoose", RPCMuLoose},
-        {"AllME0Muons", AllME0Muons},
-        {"ME0MuonArbitrated", ME0MuonArbitrated},
-        {"AllGEMMuons", AllGEMMuons},
-        {"GEMMuonArbitrated", GEMMuonArbitrated},
-        {"TriggerIdLoose", TriggerIdLoose},
-        {nullptr, (SelectionType)-1}};
-
     SelectionType value = (SelectionType)-1;
     bool found = false;
     for (int i = 0; selectionTypeStringToEnumMap[i].label && (!found); ++i)


### PR DESCRIPTION
#### PR description:

The goal here is to make available the list of Selectors or SelectionType enums in a given release available as strings. Specifically for analysis based recipes (like TagAndProbe) that want to store all supported Selectors but not have to manually update the code when new IDs are released.

For example:

```
      // add reco::Muon::Selector
      for (auto selToEnum : muon::selectorStringToEnumMap) {
        if (selToEnum.label == nullptr) continue;
        branches_["muon_"+std::string(selToEnum.label)].push_back(muon.passed(selToEnum.value));
      }
```

#### PR validation:

runTheMatrix (so I didn't break anything) and the above example in a ntuplizer works as expected.