### PR TITLE
adapt tau validation for miniAOD-only workflows

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -36,7 +36,9 @@ prevalidationNoHLT = cms.Sequence( cms.SequencePlaceholder("mix") * globalPreval
 prevalidation = cms.Sequence( cms.SequencePlaceholder("mix") * globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
-prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * photonMiniAODValidationSequence * egammaValidationMiniAOD)
+prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence 
+                                    * photonMiniAODValidationSequence * egammaValidationMiniAOD
+                                    * produceDenoms)
 
 _prevalidation_fastsim = prevalidation.copy()
 for _entry in [hltassociation]:

--- a/Validation/RecoTau/BuildFile.xml
+++ b/Validation/RecoTau/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/TauReco"/>

--- a/Validation/RecoTau/src/TauValidationMiniAOD.cc
+++ b/Validation/RecoTau/src/TauValidationMiniAOD.cc
@@ -17,6 +17,7 @@
 //         Created:  August 13, 2019
 
 #include "Validation/RecoTau/interface/TauValidationMiniAOD.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace edm;
 using namespace std;
@@ -129,14 +130,14 @@ void TauValidationMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSet
   edm::Handle<pat::TauCollection> taus;
   bool isTau = iEvent.getByToken(tauCollection_, taus);
   if (!isTau) {
-    std::cerr << " Tau collection not found while running TauValidationMiniAOD.cc " << std::endl;
+    edm::LogWarning("TauValidationMiniAOD") << " Tau collection not found while running TauValidationMiniAOD.cc ";
     return;
   }
   typedef edm::View<reco::Candidate> refCandidateCollection;
   Handle<refCandidateCollection> ReferenceCollection;
   bool isRef = iEvent.getByToken(refCollectionInputTagToken_, ReferenceCollection);
   if (!isRef) {
-    std::cerr << " Reference collection not found while running TauValidationMiniAOD.cc " << std::endl;
+    edm::LogWarning("TauValidationMiniAOD") << " Reference collection not found while running TauValidationMiniAOD.cc ";
     return;
   }
   for (refCandidateCollection::const_iterator RefJet = ReferenceCollection->begin();


### PR DESCRIPTION
this PR was initially triggered by observation of numerous printouts in re-miniAOD workflows like
```
 Reference collection not found while running TauValidationMiniAOD.cc
```
This PR replaces cerr (not allowed for production/centrally running code) with a LogWarning.
It looks like the fix to the underlying issue is simple, to add the ```produceDenoms``` to the prevalidationMiniAOD.
