### PR TITLE
[LLVM10] Fix compilation warnings from CondCore

### DIFF
--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
@@ -67,6 +67,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<AlignmentErrorsExtended>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<AlignmentErrorsExtended> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
@@ -52,6 +52,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<AlignmentSurfaceDeformations>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
       for (auto const &iov : iovs) {
         std::shared_ptr<AlignmentSurfaceDeformations> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
@@ -56,6 +56,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalIntercalibConstantsMC>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -115,6 +116,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalIntercalibConstantsMC>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalIntercalibConstantsMC> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
@@ -56,6 +56,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalIntercalibConstants>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -105,6 +106,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalIntercalibConstants>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalIntercalibConstants> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
@@ -57,6 +57,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalIntercalibErrors>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -114,6 +115,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalIntercalibErrors>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalIntercalibErrors> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
@@ -56,6 +56,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalLaserAPDPNRatiosRef>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -113,6 +114,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalLaserAPDPNRatiosRef>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalLaserAPDPNRatiosRef> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatios_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatios_PayloadInspector.cc
@@ -56,6 +56,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalLaserAPDPNRatios>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -96,6 +97,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalLaserAPDPNRatios>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalLaserAPDPNRatios> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
@@ -56,6 +56,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalLaserAlphas>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -113,6 +114,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalLaserAlphas>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalLaserAlphas> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
@@ -56,6 +56,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPFRecHitThresholds>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -113,6 +114,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPFRecHitThresholds>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPFRecHitThresholds> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -704,6 +704,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -753,6 +754,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -797,6 +799,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -841,6 +844,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -893,6 +897,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -943,6 +948,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -993,6 +999,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -1041,6 +1048,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -1084,6 +1092,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -1127,6 +1136,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -1178,6 +1188,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -1227,6 +1238,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
@@ -57,6 +57,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalTimeCalibConstants>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -114,6 +115,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalTimeCalibConstants>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalTimeCalibConstants> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
@@ -57,6 +57,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalTimeCalibErrors>::fill;
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
@@ -114,6 +115,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<EcalTimeCalibErrors>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<EcalTimeCalibErrors> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
@@ -45,6 +45,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<RunInfo>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<RunInfo> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -44,6 +44,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiPixelLorentzAngle>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
       for (auto const &iov : iovs) {
         std::shared_ptr<SiPixelLorentzAngle> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -50,6 +50,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiPixelQuality>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiPixelQuality> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -53,6 +53,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripApvGain>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
@@ -92,6 +93,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripApvGain>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
@@ -155,6 +157,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<SiStripApvGain>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
@@ -200,6 +203,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripApvGain>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
@@ -269,6 +273,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripApvGain>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
@@ -340,6 +345,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<SiStripApvGain>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
@@ -399,6 +405,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram2D<SiStripApvGain>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
@@ -1162,6 +1169,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripApvGain>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
@@ -46,6 +46,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
       for (auto const &iov : iovs) {
         std::shared_ptr<SiStripBackPlaneCorrection> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -58,6 +58,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripBadStrip>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripBadStrip> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripConfObject_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripConfObject_PayloadInspector.cc
@@ -45,6 +45,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripConfObject>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripConfObject> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -160,6 +160,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripDetVOff>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripDetVOff> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
@@ -52,6 +52,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripLatency>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripLatency> payload = Base::fetchPayload(std::get<1>(iov));
@@ -75,6 +76,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripLatency>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripLatency> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -46,6 +46,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripLorentzAngle>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
       for (auto const &iov : iovs) {
         std::shared_ptr<SiStripLorentzAngle> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -59,6 +59,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripNoises>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripNoises> payload = Base::fetchPayload(std::get<1>(iov));
@@ -196,6 +197,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripNoises>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripNoises> payload = Base::fetchPayload(std::get<1>(iov));
@@ -231,6 +233,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripNoises>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripNoises> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -59,6 +59,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -197,6 +198,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripPedestals> payload = Base::fetchPayload(std::get<1>(iov));
@@ -232,6 +234,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripPedestals>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripPedestals> payload = Base::fetchPayload(std::get<1>(iov));

--- a/CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc
@@ -58,6 +58,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripThreshold>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       for (auto const& iov : iovs) {
         std::shared_ptr<SiStripThreshold> payload = Base::fetchPayload(std::get<1>(iov));
@@ -96,6 +97,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripThreshold>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
@@ -141,6 +143,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
+    using cond::payloadInspector::Histogram1D<SiStripThreshold>::fill;
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());


### PR DESCRIPTION
#### PR description:

Integration of https://github.com/cms-sw/cmssw/pull/29622 introducs new warnings in CLANG IB [a]. This PR explicitly adds `using Baseclase::fill;` to avoid this warnings.

FYI, @ggovi , please suggest if there is any better/simple way to avoid such warning.

[a]
```
CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc:70:10: warning: '(anonymous namespace)::TrackerAlignmentErrorExtendedValue<AlignmentPI::YY>::fill' hides overloaded virtual function [-Woverloaded-virtual]
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
CondCore/Utilities/interface/PayloadInspector.h:724:12: note: hidden overloaded virtual function 'cond::payloadInspector::Histogram1D<AlignmentErrorsExtended, cond::payloadInspector::UNSPECIFIED_IOV>::fill' declared here: different number of parameters (0 vs 1)
      bool fill() override {
```
#### PR validation:

Local build for both CLANG and normal IBs look good