### PR TITLE
llvm warning: build with -O3 so that clang can unroll the loop

### DIFF
--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -86,6 +86,7 @@
 </bin>
 
 <bin file="CholeskyInvert_t.cpp" name="CholeskyInvert_t">
+  <flags CXXFLAGS="-O3"/>
 </bin>
 
 <bin file="testGraph.cpp">


### PR DESCRIPTION
#### PR description:

With LLVM 9 we have start seeing the warnings [a]. Looks like with `-O3` clang is able to unroll the loop. 

FYI, @VinInn  

[a]
```
DataFormats/Math/test/CholeskyInvert_t.cpp:48:6: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
 void go(bool soa) {
```

#### PR validation:

Local build for both CLANG and normal IBs look good