### PR TITLE
Have EcalSimParametersESModule only consume what is needed

### DIFF
--- a/Geometry/EcalCommonData/plugins/EcalSimParametersESModule.cc
+++ b/Geometry/EcalCommonData/plugins/EcalSimParametersESModule.cc
@@ -33,8 +33,11 @@ private:
 EcalSimParametersESModule::EcalSimParametersESModule(const edm::ParameterSet& ps)
     : fromDD4Hep_(ps.getParameter<bool>("fromDD4Hep")), name_(ps.getParameter<std::string>("name")) {
   auto cc = setWhatProduced(this, name_);
-  cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
-  cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  if (fromDD4Hep_) {
+    cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  } else {
+    cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  }
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("EcalGeom") << "EcalSimParametersESModule::EcalSimParametersESModule called with dd4hep: "


### PR DESCRIPTION
#### PR description:

At configuration time we know which of the two data products we will actually be consuming. Only call `consumesFrom` on that one. This avoids trying to do a prefetch on something we know we will not actually want.

#### PR validation:

The code compiles.