### PR TITLE
Add tracking particle |eta| > 2.7 validation plots for Phase 2 tracker

### DIFF
--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -48,6 +48,7 @@ _allTPEfficName = _allName+" (all TPs)"
 _fromPVName = "Tracks from PV"
 _fromPVAllTPName = "Tracks from PV (all TPs)"
 _tpPtLess09Name = "All tracks (TP pT &lt; 0.9 GeV)"
+_tpEtaGreater2p7Name = "All tracks (TP |eta| &gt; 2.7)"
 _conversionName = "Tracks for conversions"
 _gsfName = "Electron GSF tracks"
 _bhadronName = "All tracks (B-hadron TPs)"
@@ -85,6 +86,8 @@ _trackQualityNameOrder = collections.OrderedDict([
     ("tpPtLess09_highPurityByOriginalAlgo", _toOriAlgo(_allToHP(_tpPtLess09Name))),
     ("tpPtLess09_ByAlgoMask", _toAlgoMask(_tpPtLess09Name)),
     ("tpPtLess09_highPurityByAlgoMask", _toAlgoMask(_allToHP(_tpPtLess09Name))),
+    ("tpEtaGreater2p7_", _tpEtaGreater2p7Name),
+    ("tpEtaGreater2p7_highPurity", _allToHP(_tpEtaGreater2p7Name)),
     ("btvLike", _allToBTV(_allName)),
     ("ak4PFJets", "AK4 PF jets"),
     ("allTPEffic_", _allTPEfficName),
@@ -181,6 +184,8 @@ _sectionNameMapOrder = collections.OrderedDict([
     ("highPurityPt09", "High purity tracks (pT&gt;0.9 GeV)"),
     ("tpPtLess09", _tpPtLess09Name),
     ("tpPtLess09_highPurity", _allToHP(_tpPtLess09Name)),
+    ("tpEtaGreater2p7", _tpEtaGreater2p7Name),
+    ("tpEtaGreater2p7_highPurity", _allToHP(_tpEtaGreater2p7Name)),
     ("btvLike", "BTV-like"),
     ("ak4PFJets", "AK4 PF jets"),
     ("allTPEffic", _allTPEfficName),

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1363,6 +1363,7 @@ def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, only
         plotter.appendTable(summaryName, folders, TrackingSummaryTable(section="ak4PFJets", collection=TrackingSummaryTable.AK4PFJets))
 _appendTrackingPlots("Track", "", _simBasedPlots+_recoBasedPlots)
 _appendTrackingPlots("TrackTPPtLess09", "tpPtLess09", _simBasedPlots)
+_appendTrackingPlots("TrackTPEtaGreater2p7", "tpEtaGreater2p7", _simBasedPlots)
 _appendTrackingPlots("TrackAllTPEffic", "allTPEffic", _simBasedPlots, onlyForPileup=True)
 _appendTrackingPlots("TrackFromPV", "fromPV", _simBasedPlots+_recoBasedPlots, onlyForPileup=True)
 _appendTrackingPlots("TrackFromPVAllTP", "fromPVAllTP", _simBasedPlots+_recoBasedPlots, onlyForPileup=True)

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -632,8 +632,8 @@ def _mapCollectionToAlgoQuality(collName):
         collNameLow = collNameLow[:i_seeds]
 
     algo = None
-    prefixes = ["cutsreco", "cutsrecofrompv", "cutsrecofrompv2", "cutsrecofrompvalltp"]
-    if collNameLow in ["general", "generalfrompv"]+prefixes:
+    prefixes = ["cutsreco", "cutsrecofrompv", "cutsrecofrompv2", "cutsrecofrompvalltp", "cutsrecoetagreater2p7"]
+    if collNameLow in ["general", "generalfrompv", "generaletagreater2p7"]+prefixes:
         algo = "ootb"
     else:
         def testColl(coll):
@@ -1363,7 +1363,7 @@ def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, only
         plotter.appendTable(summaryName, folders, TrackingSummaryTable(section="ak4PFJets", collection=TrackingSummaryTable.AK4PFJets))
 _appendTrackingPlots("Track", "", _simBasedPlots+_recoBasedPlots)
 _appendTrackingPlots("TrackTPPtLess09", "tpPtLess09", _simBasedPlots)
-_appendTrackingPlots("TrackTPEtaGreater2p7", "tpEtaGreater2p7", _simBasedPlots)
+_appendTrackingPlots("TrackTPEtaGreater2p7", "tpEtaGreater2p7", _simBasedPlots+_recoBasedPlots)
 _appendTrackingPlots("TrackAllTPEffic", "allTPEffic", _simBasedPlots, onlyForPileup=True)
 _appendTrackingPlots("TrackFromPV", "fromPV", _simBasedPlots+_recoBasedPlots, onlyForPileup=True)
 _appendTrackingPlots("TrackFromPVAllTP", "fromPVAllTP", _simBasedPlots+_recoBasedPlots, onlyForPileup=True)

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -47,6 +47,7 @@ def main(opts):
             "fromPV": limitProcessing,
             "fromPVAllTP": limitProcessing,
             "tpPtLess09": limitProcessing,
+            "tpEtaGreater2p7": limitProcessing,
             "seeding": limitProcessing,
             "building": limitProcessing,
             "bhadron": limitProcessing,
@@ -60,6 +61,7 @@ def main(opts):
             "fromPV": ignore,
             "fromPVAllTP": ignore,
             "tpPtLess09": limitRelVal,
+            "tpEtaGreater2p7": limitRelVal,
             "seeding": ignore,
             "bhadron": limitRelVal,
         }

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -70,14 +70,15 @@ ignore09 = LimitTrackAlgo(None) # ignore Pt09 plots
 # "plot set" is not in the dictionary, full set of plots will be
 # produced for it
 limitSubFolders = {
-    "":            limit,  # The default set (signal TrackingParticles for efficiency, all TrackingParticles for fakes)
-    "tpPtLess09":  limit,  # Efficiency for TrackingParticles with pT < 0.9 GeV
-    "allTPEffic":  ignore, # Efficiency with all TrackingParticles
-    "bhadron":     limit,  # Efficiency with B-hadron TrackingParticles
-    "fromPV":      limit,  # Tracks from PV, signal TrackingParticles for efficiency and fakes
-    "fromPVAllTP": limit,  # Tracks from PV, all TrackingParticles for fakes
-    "building":    ignore, # Built tracks (as opposed to selected tracks in above)
-    "seeding":     ignore, # Seeds
+    "":                limit,  # The default set (signal TrackingParticles for efficiency, all TrackingParticles for fakes)
+    "tpPtLess09":      limit,  # Efficiency for TrackingParticles with pT < 0.9 GeV
+    "tpEtaGreater2p7": limit,  # Efficiency for TrackingParticles with |eta| > 2.7 (phase 2)
+    "allTPEffic":      ignore, # Efficiency with all TrackingParticles
+    "bhadron":         limit,  # Efficiency with B-hadron TrackingParticles
+    "fromPV":          limit,  # Tracks from PV, signal TrackingParticles for efficiency and fakes
+    "fromPVAllTP":     limit,  # Tracks from PV, all TrackingParticles for fakes
+    "building":        ignore, # Built tracks (as opposed to selected tracks in above)
+    "seeding":         ignore, # Seeds
 }
 # arguments to be passed to tracking val.doPlots() below
 kwargs_tracking["limitSubFoldersOnlyTo"]=limitSubFolders

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -206,6 +206,7 @@ kwargs_tracking = {
         # filter out the pT>0.9 GeV track selection
         "": limitRelVal,
         "tpPtLess09": limitRelVal,
+        "tpEtaGreater2p7": limitRelVal,
         "allTPEffic": limitRelVal,
         "fromPV": limitRelVal,
         "fromPVAllTP": limitRelVal,


### PR DESCRIPTION
#### PR description:

This PR adds plots such that they are created with the makeTrackValidationPlots.py script. The plots added are for when the tracking particle (TP) has |eta| > 2.7, which is a useful collection for the Phase 2 tracker.


#### PR validation:

The output here produces the desired plots:
http://jalimena.web.cern.ch/jalimena/plots/track_validation_plots_tpEtaGreater2p7_take4/

Basic tests run fine.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.


FYI @mtosi , @makortel , @mmusich , @emiglior 