### PR TITLE
Add TICLPFValidation sequence

### DIFF
--- a/Validation/Configuration/python/hgcalSimValid_cff.py
+++ b/Validation/Configuration/python/hgcalSimValid_cff.py
@@ -8,6 +8,9 @@ from Validation.HGCalValidation.hgcalHitValidation_cfi  import *
 from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
 from Validation.RecoParticleFlow.PFJetValidation_cff import pfJetValidation1 as _hgcalPFJetValidation
 
+from Validation.HGCalValidation.ticlPFValidation_cfi import ticlPFValidation
+hgcalTiclPFValidation = cms.Sequence(ticlPFValidation)
+
 hgcalValidatorSequence = cms.Sequence(hgcalValidator)
 hgcalPFJetValidation = _hgcalPFJetValidation.clone(BenchmarkLabel = 'PFJetValidation/HGCAlCompWithGenJet',
     VariablePtBins=[10., 30., 80., 120., 250., 600.],
@@ -24,4 +27,5 @@ hgcalValidation = cms.Sequence(hgcalSimHitValidationEE
                                + hgcalRecHitValidationHEB
                                + hgcalHitValidationSequence
                                + hgcalValidatorSequence
+                               + hgcalTiclPFValidation
                                + hgcalPFJetValidation)

--- a/Validation/HGCalValidation/plugins/TICLPFValidation.cc
+++ b/Validation/HGCalValidation/plugins/TICLPFValidation.cc
@@ -129,7 +129,7 @@ void TICLPFValidation::fillDescriptions(edm::ConfigurationDescriptions& descript
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.add<std::string>("folder", "HGCAL/");  // Please keep the trailing '/'
-  desc.add<edm::InputTag>("ticlPFCandidates", edm::InputTag("pfTICLProducer"));
+  desc.add<edm::InputTag>("ticlPFCandidates", edm::InputTag("pfTICL"));
   descriptions.add("ticlPFValidationDefault", desc);
 }
 

--- a/Validation/HGCalValidation/python/ticlPFValidation_cfi.py
+++ b/Validation/HGCalValidation/python/ticlPFValidation_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.HGCalValidation.ticlPFValidationDefault_cfi import ticlPFValidationDefault as _ticlPFValidationDefault
+ticlPFValidation = _ticlPFValidationDefault.clone()
+


### PR DESCRIPTION
#### PR description:

Now that TICL is part of the Phase2 reconstruction sequence, we activate
the corresponding validation module to monitor the performance of the
PFCandidates produces by TICL.

#### PR validation:

`runTheMatrix.py -l limited`
