### PR TITLE
Fix features order

### DIFF
--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -333,7 +333,7 @@ void PatternRecognitionbyCA::energyRegressionAndID(const std::vector<reco::CaloC
         float *features = &input.tensor<float, 4>()(i, j, seenClusters[j], 0);
 
         // fill features
-        *(features++) = float(cluster.energy()/float(trackster.vertex_multiplicity(k)));
+        *(features++) = float(cluster.energy() / float(trackster.vertex_multiplicity(k)));
         *(features++) = float(std::abs(cluster.eta()));
         *(features) = float(cluster.phi());
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -333,7 +333,7 @@ void PatternRecognitionbyCA::energyRegressionAndID(const std::vector<reco::CaloC
         float *features = &input.tensor<float, 4>()(i, j, seenClusters[j], 0);
 
         // fill features
-        *(features++) = float(cluster.energy());
+        *(features++) = float(cluster.energy()/float(trackster.vertex_multiplicity(k)));
         *(features++) = float(std::abs(cluster.eta()));
         *(features) = float(cluster.phi());
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -333,9 +333,9 @@ void PatternRecognitionbyCA::energyRegressionAndID(const std::vector<reco::CaloC
         float *features = &input.tensor<float, 4>()(i, j, seenClusters[j], 0);
 
         // fill features
+        *(features++) = float(cluster.energy());
         *(features++) = float(std::abs(cluster.eta()));
-        *(features++) = float(cluster.phi());
-        *features = float(cluster.energy());
+        *(features) = float(cluster.phi());
 
         // increment seen clusters
         seenClusters[j]++;

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -440,7 +440,7 @@ void TrackstersMergeProducer::energyRegressionAndID(const std::vector<reco::Calo
         float *features = &input.tensor<float, inputDimension>()(i, j, seenClusters[j], 0);
 
         // fill features
-        *(features++) = float(cluster.energy()/float(trackster.vertex_multiplicity(k)));
+        *(features++) = float(cluster.energy() / float(trackster.vertex_multiplicity(k)));
         *(features++) = float(std::abs(cluster.eta()));
         *(features) = float(cluster.phi());
 

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -287,7 +287,7 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
             << track.eta() << ", " << track.phi() << std::endl;
       }
       result->push_back(t);
-      usedTrackstersTRK[tracksterTRK_idx] = 1;
+      usedTrackstersTRK[tracksterTRK_idx] = true;
       tracksterTRK_idx++;
     }
   }
@@ -440,9 +440,9 @@ void TrackstersMergeProducer::energyRegressionAndID(const std::vector<reco::Calo
         float *features = &input.tensor<float, inputDimension>()(i, j, seenClusters[j], 0);
 
         // fill features
+        *(features++) = float(cluster.energy());
         *(features++) = float(std::abs(cluster.eta()));
-        *(features++) = float(cluster.phi());
-        *features = float(cluster.energy());
+        *(features) = float(cluster.phi());
 
         // increment seen clusters
         seenClusters[j]++;

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -440,7 +440,7 @@ void TrackstersMergeProducer::energyRegressionAndID(const std::vector<reco::Calo
         float *features = &input.tensor<float, inputDimension>()(i, j, seenClusters[j], 0);
 
         // fill features
-        *(features++) = float(cluster.energy());
+        *(features++) = float(cluster.energy()/float(trackster.vertex_multiplicity(k)));
         *(features++) = float(std::abs(cluster.eta()));
         *(features) = float(cluster.phi());
 


### PR DESCRIPTION
#### PR description:

In recent meetings at the Upgrade HLT TDR, strange distribution of PFCandidates produced from TICL have been reported: [JetMET](https://indico.cern.ch/event/909498/contributions/3843607/attachments/2028099/3393510/200428_hltupg_jme.pdf) [BTV](https://indico.cern.ch/event/909499/contributions/3826040/subcontributions/304057/attachments/2032345/3401691/05_05_20_HLTUpgradeBTV.pdf).
After some debugging, this has been traced back to the way in which we pass features to ML model for PID and energy regression. This PR reshuffle them in the correct order. Local tests show no more dependency on phi.

#### PR validation:

Besides checking that the strange phi behaviour is gone:

`runTheMatrix.py -l limited`
