### PR TITLE
MTD geometry: remove thermal screen from ETL D53

### DIFF
--- a/Geometry/MTDCommonData/data/etl/v4/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v4/etl.xml
@@ -2,12 +2,12 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
 
   <ConstantsSection label="etl.xml" eval="true/false">
-    <Constant name="ETLcenter" value="3024.5*mm"/> 
+    <Constant name="ETLrmin" value="[caloBase:Rmin100]"/>   <!-- 26.3 cm -->
+    <Constant name="ETLrmax" value="[caloBase:Rmax100]"/>   <!-- 125.525 cm -->
+    <Constant name="ETLthickness" value="7.7*cm"/>
+    <Constant name="ETLcenter" value="3024.5*mm"/>
     <Constant name="Disc1center" value="2999.62*mm"/>
     <Constant name="Disc2center" value="3029.62*mm"/>
-    <Constant name="ETLrmin" value="[caloBase:Rmin100]"/>   <!-- 26.3 cm -->
-    <Constant name="ETLrmax" value="[caloBase:Rmax100]"/>   <!-- 125.525 cm --> 
-    <Constant name="ETLthickness" value="7.7*cm"/> 
     <Constant name="Disc_thickness" value="1.894"/>  <!-- thickness of one Disc comprising modules, service hybrids on both faces, mounted on the Al and MIC6-Al rings. Fig 3.73 TDR and line 354 Ulascan ETLDetectorDimensions.cc -->
     <Constant name="DiscSector_thickness" value="0.585"/> <!-- this is the service hybrid height according to TDR table 3.9 -->
     <!-- LGAD and ETROC values taken from Ulascan code (line 103 on in ETLDetectorDimensions.cc), same values in the TDR -->
@@ -34,7 +34,6 @@
     <Constant name="DeltaY" value="0.05"/>
     <Constant name="DeltaY_ServiceLong_ServiceShort" value="19.57"/>
   </ConstantsSection>
-
 
   <SolidSection label="etl.xml">
     <Tubs name="EndcapTimingLayer" rMin="[ETLrmin]" rMax="[ETLrmax]" dz="0.5*[ETLthickness]*cm" startPhi="0*deg" deltaPhi="360*deg"/>
@@ -70,7 +69,6 @@
     <Rotation name="Reverse" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="270*deg" thetaZ="180*deg" phiZ="0*deg"/>
   </RotationSection>
 
-
   <LogicalPartSection label="etl.xml">
     <LogicalPart name="EndcapTimingLayer" category="unspecified">
       <rSolid name="etl:EndcapTimingLayer"/>
@@ -84,7 +82,7 @@
       <rSolid name="etl:Disc"/>
       <rMaterial name="materials:Air"/>
     </LogicalPart>
-	<LogicalPart name="Aluminium_Disc" category="unspecified">
+    <LogicalPart name="Aluminium_Disc" category="unspecified">
       <rSolid name="etl:Aluminium_Disc"/>
       <rMaterial name="materials:Aluminium"/>
     </LogicalPart>
@@ -173,27 +171,25 @@
     </LogicalPart>
   </LogicalPartSection>
 
-
-  
-  <PosPartSection label="etl.xml">                                     
-    <PosPart copyNumber="1">                                           
-      <rParent name="caloBase:CALOECFront"/>                         
-      <rChild name="etl:EndcapTimingLayer"/>  
-      <Translation x="0." y="0." z="[ETLcenter]" />  
+  <PosPartSection label="etl.xml">
+    <PosPart copyNumber="1">
+      <rParent name="caloBase:CALOECFront"/>
+      <rChild name="etl:EndcapTimingLayer"/>
+      <Translation x="0." y="0." z="[ETLcenter]" />
     </PosPart>
-    <PosPart copyNumber="1">                                           
-      <rParent name="etl:EndcapTimingLayer"/>                         
-      <rChild name="etl:Disc1Timing"/>  
-      <Translation x="0." y="0." z="[Disc1center]-[ETLcenter]" /> 
-    </PosPart> 
-    <PosPart copyNumber="1">                                           
-      <rParent name="etl:EndcapTimingLayer"/>                         
-      <rChild name="etl:Disc2Timing"/>  
-      <Translation x="0." y="0." z="[Disc2center]-[ETLcenter]" /> 
-    </PosPart> 
-    <PosPart copyNumber="1">                                           
-      <rParent name="etl:Disc1Timing"/>                         
-      <rChild name="etl:Aluminium_Disc"/>  
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Disc1Timing"/>
+      <Translation x="0." y="0." z="[Disc1center]-[ETLcenter]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Disc2Timing"/>
+      <Translation x="0." y="0." z="[Disc2center]-[ETLcenter]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:Aluminium_Disc"/>
       <Translation x="0." y="0." z="0.3175*cm" />
     </PosPart>
     <PosPart copyNumber="1">
@@ -202,15 +198,15 @@
       <Translation x="0." y="0." z="-0.0445*cm" />
     </PosPart>
     <!-- Sectors in both Disc1Timing and Disc2Timing (Front/Back faces) are placed anti-clockwise (Quarter 1 is on top right, Quarter 2 top left...) -->
-    <PosPart copyNumber="1">                                           
-      <rParent name="etl:Disc1Timing"/>                         
-      <rChild name="etl:DiscSector_Front"/> 
-      <rRotation name="etl:0"/> 
-      <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />  
-    </PosPart> 
-    <PosPart copyNumber="2">                                           
-      <rParent name="etl:Disc1Timing"/>                         
-      <rChild name="etl:DiscSector_Front"/>  
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Front"/>
+      <rRotation name="etl:0"/>
+      <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Front"/>
       <rRotation name="etl:270"/>
       <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />
     </PosPart>
@@ -467,12 +463,8 @@
     </PosPart>
   </PosPartSection>
 
-
-
-
-
   <!-- Algorithm Section begins -->
-    <!-- Disc1Timing Front face -->
+  <!-- Disc1Timing Front face -->
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
     <String name="ChildName" value="etl:SensorModule_Front_Left"/>
@@ -692,7 +684,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+ <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm> -->
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -1047,7 +1039,7 @@
   </Algorithm>
 
 
-    <!-- Disc1Timing Back face -->
+  <!-- Disc1Timing Back face -->
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Back"/>
     <String name="ChildName" value="etl:ServiceHybrid"/>
@@ -1634,7 +1626,7 @@
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
 
- 	<!-- Disc2Timing Front face -->
+  <!-- Disc2Timing Front face -->
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
     <String name="ChildName" value="etl:SensorModule_Front_Right"/>
@@ -2209,7 +2201,7 @@
   </Algorithm>
 
 
-    <!-- Disc2Timing Back face -->
+  <!-- Disc2Timing Back face -->
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Back_2"/>
     <String name="ChildName" value="etl:ServiceHybrid"/>
@@ -2795,8 +2787,5 @@
     <Numeric name="Theta_obj" value="90.*deg"/>
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
-
-
-
 
 </DDDefinition>

--- a/Geometry/MTDCommonData/data/etl/v4/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v4/etl.xml
@@ -4,7 +4,7 @@
   <ConstantsSection label="etl.xml" eval="true/false">
     <Constant name="ETLrmin" value="[caloBase:Rmin100]"/>   <!-- 26.3 cm -->
     <Constant name="ETLrmax" value="[caloBase:Rmax100]"/>   <!-- 125.525 cm -->
-    <Constant name="ETLthickness" value="7.7*cm"/>
+    <Constant name="ETLthickness" value="7.7"/>
     <Constant name="ETLcenter" value="3024.5*mm"/>
     <Constant name="Disc1center" value="2999.62*mm"/>
     <Constant name="Disc2center" value="3029.62*mm"/>

--- a/Geometry/MTDCommonData/data/etl/v4/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v4/etl.xml
@@ -2,92 +2,84 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
 
   <ConstantsSection label="etl.xml" eval="true/false">
-	<Constant name="ETLrmin" value="[caloBase:Rmin100]"/>   <!-- 26.3 cm -->
-	<Constant name="ETLrmax" value="[caloBase:Rmax100]"/>   <!-- 125.525 cm -->
-	<Constant name="ETLzmin" value="-0.5*([caloBase:Zpos110]-[caloBase:Zpos10])"/>
-	<Constant name="ETLzmax" value="0.5*([caloBase:Zpos110]-[caloBase:Zpos10])-2*cm"/>
-
-	<Constant name="Disc_thickness" value="1.894"/>  <!-- thickness of one Disc comprising modules, service hybrids on both faces, mounted on the Al and MIC6-Al rings. Fig 3.73 TDR and line 354 Ulascan ETLDetectorDimensions.cc -->
-	<Constant name="DiscSector_thickness" value="0.585"/> <!-- this is the service hybrid height according to TDR table 3.9 -->
-	<!-- LGAD and ETROC values taken from Ulascan code (line 103 on in ETLDetectorDimensions.cc), same values in the TDR -->
-	<Constant name="LGADdx" value="2.12"/>
-	<Constant name="LGADdy" value="4.2"/>
-	<Constant name="EModule_Timingactive" value="0.005"/>
-	<Constant name="LGAD_Substrate" value="0.025"/>
-	<Constant name="LGADdz" value="0.03"/>
-	<Constant name="lgadSep_X" value="0.025"/>  <!-- x-offset between lgad in a 2SensorModule, line 232 ETLDetectorDimensions.cc -->
-	<Constant name="lgadSep_Y" value="0.05"/> <!-- y-offset between SensorModules and service hybrids, line 414 ETLDetectorDimensions.cc -->
-	<Constant name="ETROCdx" value="2.23"/>
-	<Constant name="ETROCdy" value="2.08"/>
-	<Constant name="ETROCdz" value="0.025"/>
-	<Constant name="etrocSep_X" value="0.03"/>  <!-- line 202 Ulascan ETLDetectorDimensions.cc -->
-	<Constant name="etrocSep_Y" value="0.01"/>
-
-	<Constant name="ServiceHybrid_X" value="3.4"/>  <!-- line 294 Ulascan ETLDetectorDimensions.cc -->
-	<Constant name="ServiceHybrid_Y" value="26.11"/> <!-- ORANGE 6x SensorModule_dy + 5x lgadSep_Y -->
-	<Constant name="ServiceHybrid_Y_short" value="13.03"/> <!-- RED 3x SensorModule_dy + 2x lgadSep_Y -->
-	<Constant name="ServiceHybrid_Z" value="0.585"/>
-	<Constant name="SensorModuledx" value="2.585"/>  <!-- Half of a 2-Sensor-Module line 181 Ulascan ETLDetectorDimensions.cc -->
-	<Constant name="SensorModuledy" value="4.31"/>
-	<Constant name="SensorModuledz" value="0.229"/>
-	<Constant name="DeltaX_ServiceModule" value="2.9925"/>
-	<Constant name="DeltaY" value="0.05"/>
-	<Constant name="DeltaY_ServiceLong_ServiceShort" value="19.57"/>
+    <Constant name="ETLcenter" value="3024.5*mm"/> 
+    <Constant name="Disc1center" value="2999.62*mm"/>
+    <Constant name="Disc2center" value="3029.62*mm"/>
+    <Constant name="ETLrmin" value="[caloBase:Rmin100]"/>   <!-- 26.3 cm -->
+    <Constant name="ETLrmax" value="[caloBase:Rmax100]"/>   <!-- 125.525 cm --> 
+    <Constant name="ETLthickness" value="7.7*cm"/> 
+    <Constant name="Disc_thickness" value="1.894"/>  <!-- thickness of one Disc comprising modules, service hybrids on both faces, mounted on the Al and MIC6-Al rings. Fig 3.73 TDR and line 354 Ulascan ETLDetectorDimensions.cc -->
+    <Constant name="DiscSector_thickness" value="0.585"/> <!-- this is the service hybrid height according to TDR table 3.9 -->
+    <!-- LGAD and ETROC values taken from Ulascan code (line 103 on in ETLDetectorDimensions.cc), same values in the TDR -->
+    <Constant name="LGADdx" value="2.12"/>
+    <Constant name="LGADdy" value="4.2"/>
+    <Constant name="EModule_Timingactive" value="0.005"/> <!-- LGAD_Timingactive? -->
+    <Constant name="LGAD_Substrate" value="0.025"/>
+    <Constant name="LGADdz" value="0.03"/>
+    <Constant name="lgadSep_X" value="0.025"/>  <!-- x-offset between lgad in a 2SensorModule, line 232 ETLDetectorDimensions.cc -->
+    <Constant name="lgadSep_Y" value="0.05"/> <!-- y-offset between SensorModules and service hybrids, line 414 ETLDetectorDimensions.cc -->
+    <Constant name="ETROCdx" value="2.23"/>
+    <Constant name="ETROCdy" value="2.08"/>
+    <Constant name="ETROCdz" value="0.025"/>
+    <Constant name="etrocSep_X" value="0.03"/>  <!-- line 202 Ulascan ETLDetectorDimensions.cc -->
+    <Constant name="etrocSep_Y" value="0.01"/>
+    <Constant name="ServiceHybrid_X" value="3.4"/>  <!-- line 294 Ulascan ETLDetectorDimensions.cc -->
+    <Constant name="ServiceHybrid_Y" value="26.11"/> <!-- ORANGE 6x SensorModule_dy + 5x lgadSep_Y -->
+    <Constant name="ServiceHybrid_Y_short" value="13.03"/> <!-- RED 3x SensorModule_dy + 2x lgadSep_Y -->
+    <Constant name="ServiceHybrid_Z" value="0.585"/>
+    <Constant name="SensorModuledx" value="2.585"/>  <!-- Half of a 2-Sensor-Module line 181 Ulascan ETLDetectorDimensions.cc -->
+    <Constant name="SensorModuledy" value="4.31"/>
+    <Constant name="SensorModuledz" value="0.229"/>
+    <Constant name="DeltaX_ServiceModule" value="2.9925"/>
+    <Constant name="DeltaY" value="0.05"/>
+    <Constant name="DeltaY_ServiceLong_ServiceShort" value="19.57"/>
   </ConstantsSection>
 
 
   <SolidSection label="etl.xml">
-	<Polycone name="EndcapTimingLayer" startPhi="0*deg" deltaPhi="360*deg">
-	  <ZSection z="[ETLzmin]"         rMin="[ETLrmin]"          rMax="[ETLrmax]" />
-	  <ZSection z="[ETLzmax]"         rMin="[ETLrmin]"          rMax="[ETLrmax]" />
-	</Polycone>
-	<!-- Aluminium rings: dimensions as defined by ulascan (line 345 ETLDetectorDimensions.cc). Note: epoxy not considered as single element but included in "Aluminium_Disc" (0.081 + 0.008 cm) -->
-	<Tubs name="ThermalScreen" rMin="26.3*cm" rMax="124.37*cm" dz="0.5*(2)*cm" startPhi="0*deg" deltaPhi="360*deg"/>
-	<Tubs name="Disc" rMin="31*cm" rMax="119*cm" dz="0.5*[Disc_thickness]*cm" startPhi="0*deg" deltaPhi="360*deg"/>
-	<Tubs name="Aluminium_Disc" rMin="31*cm" rMax="119*cm" dz="0.5*(0.089)*cm" startPhi="0*deg" deltaPhi="360*deg"/>
-	<Tubs name="MIC6_Aluminium_Disc" rMin="31*cm" rMax="119*cm" dz="0.5*(0.635)*cm" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="EndcapTimingLayer" rMin="[ETLrmin]" rMax="[ETLrmax]" dz="0.5*[ETLthickness]*cm" startPhi="0*deg" deltaPhi="360*deg"/>
+    <!-- Aluminium rings: dimensions as defined by ulascan (line 345 ETLDetectorDimensions.cc). Note: epoxy not considered as single element but included in "Aluminium_Disc" (0.081 + 0.008 cm) -->
+    <Tubs name="Disc" rMin="31*cm" rMax="119*cm" dz="0.5*[Disc_thickness]*cm" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="Aluminium_Disc" rMin="31*cm" rMax="119*cm" dz="0.5*(0.089)*cm" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="MIC6_Aluminium_Disc" rMin="31*cm" rMax="119*cm" dz="0.5*(0.635)*cm" startPhi="0*deg" deltaPhi="360*deg"/>
 
-	<!-- FRONT: face closest to IP, BACK: furthest from IP -->
-	<Tubs name="DiscSector_Back" rMin="31*cm" rMax="119*cm" dz="0.5*[DiscSector_thickness]*cm" startPhi="90*deg" deltaPhi="90*deg"/>
-	<Tubs name="DiscSector_Front" rMin="31*cm" rMax="119*cm" dz="0.5*[DiscSector_thickness]*cm" startPhi="90*deg" deltaPhi="90*deg"/>
-	<Tubs name="DiscSector_Back_2" rMin="31*cm" rMax="119*cm" dz="0.5*[DiscSector_thickness]*cm" startPhi="0*deg" deltaPhi="90*deg"/>
-	<Tubs name="DiscSector_Front_2" rMin="31*cm" rMax="119*cm" dz="0.5*[DiscSector_thickness]*cm" startPhi="0*deg" deltaPhi="90*deg"/>
-	<Box name="SensorModule" dx="0.5*[SensorModuledx]*cm" dy="0.5*[SensorModuledy]*cm" dz="0.5*[SensorModuledz]*cm"/>
-	<Box name="ServiceHybrid" dx="0.5*[ServiceHybrid_X]*cm" dy="0.5*[ServiceHybrid_Y]*cm" dz="0.5*[ServiceHybrid_Z]*cm"/>
-	<Box name="ServiceHybrid_short" dx="0.5*[ServiceHybrid_X]*cm" dy="0.5*[ServiceHybrid_Y_short]*cm" dz="0.5*[ServiceHybrid_Z]*cm"/>
+    <!-- FRONT: face closest to IP, BACK: furthest from IP -->
+    <Tubs name="DiscSector_Back" rMin="31*cm" rMax="119*cm" dz="0.5*[DiscSector_thickness]*cm" startPhi="90*deg" deltaPhi="90*deg"/>
+    <Tubs name="DiscSector_Front" rMin="31*cm" rMax="119*cm" dz="0.5*[DiscSector_thickness]*cm" startPhi="90*deg" deltaPhi="90*deg"/>
+    <Tubs name="DiscSector_Back_2" rMin="31*cm" rMax="119*cm" dz="0.5*[DiscSector_thickness]*cm" startPhi="0*deg" deltaPhi="90*deg"/>
+    <Tubs name="DiscSector_Front_2" rMin="31*cm" rMax="119*cm" dz="0.5*[DiscSector_thickness]*cm" startPhi="0*deg" deltaPhi="90*deg"/>
+    <Box name="SensorModule" dx="0.5*[SensorModuledx]*cm" dy="0.5*[SensorModuledy]*cm" dz="0.5*[SensorModuledz]*cm"/>
+    <Box name="ServiceHybrid" dx="0.5*[ServiceHybrid_X]*cm" dy="0.5*[ServiceHybrid_Y]*cm" dz="0.5*[ServiceHybrid_Z]*cm"/>
+    <Box name="ServiceHybrid_short" dx="0.5*[ServiceHybrid_X]*cm" dy="0.5*[ServiceHybrid_Y_short]*cm" dz="0.5*[ServiceHybrid_Z]*cm"/>
 
-	<Box name="ThermalPad" dx="0.5*[SensorModuledx]*cm" dy="0.5*[SensorModuledy]*cm" dz="0.5*(0.025)*cm"/>
-	<Box name="AlN_Carrier" dx="0.5*[SensorModuledx]*cm" dy="0.5*[SensorModuledy]*cm" dz="0.5*(0.079)*cm"/>
-	<Box name="LairdFilm" dx="0.5*([ETROCdx]+0.5*[etrocSep_X])*cm" dy="0.5*([ETROCdy]*2+[etrocSep_Y])*cm" dz="0.5*(0.008)*cm"/>
-	<Box name="ETROC" dx="0.5*[ETROCdx]*cm" dy="0.5*[ETROCdy]*cm" dz="0.5*(0.028)*cm"/>  <!-- solder bumps not considered, their thickness is included in that of the ETROC -->
-	<Box name="LGAD" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[LGADdz]*cm"/>
-	<Box name="EModule_Timingactive" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[EModule_Timingactive]*cm"/>
-	<Box name="LGAD_Substrate" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[LGAD_Substrate]*cm"/>
-	<Box name="AlN_Cover" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*(0.059)*cm"/>  <!-- epoxy included in the thickness of the AlN cover -->
+    <Box name="ThermalPad" dx="0.5*[SensorModuledx]*cm" dy="0.5*[SensorModuledy]*cm" dz="0.5*(0.025)*cm"/>
+    <Box name="AlN_Carrier" dx="0.5*[SensorModuledx]*cm" dy="0.5*[SensorModuledy]*cm" dz="0.5*(0.079)*cm"/>
+    <Box name="LairdFilm" dx="0.5*([ETROCdx]+0.5*[etrocSep_X])*cm" dy="0.5*([ETROCdy]*2+[etrocSep_Y])*cm" dz="0.5*(0.008)*cm"/>
+    <Box name="ETROC" dx="0.5*[ETROCdx]*cm" dy="0.5*[ETROCdy]*cm" dz="0.5*(0.028)*cm"/>  <!-- solder bumps not considered, their thickness is included in that of the ETROC -->
+    <Box name="LGAD" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[LGADdz]*cm"/>
+    <Box name="EModule_Timingactive" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[EModule_Timingactive]*cm"/>
+    <Box name="LGAD_Substrate" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*[LGAD_Substrate]*cm"/>
+    <Box name="AlN_Cover" dx="0.5*[LGADdx]*cm" dy="0.5*[LGADdy]*cm" dz="0.5*(0.059)*cm"/>  <!-- epoxy included in the thickness of the AlN cover -->
   </SolidSection>
 
   <RotationSection label="etl.xml">
     <Rotation name="0" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg" phiZ="0*deg"/>
-	<Rotation name="270" thetaX="90*deg" phiX="270*deg" thetaY="90*deg" phiY="0*deg" thetaZ="0*deg" phiZ="0*deg"/>
-	<Rotation name="180" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="270*deg" thetaZ="0*deg" phiZ="0*deg"/>
-	<Rotation name="90" thetaX="90*deg" phiX="90*deg" thetaY="90*deg" phiY="180*deg" thetaZ="0*deg" phiZ="0*deg"/>
-	<Rotation name="Reverse" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="270*deg" thetaZ="180*deg" phiZ="0*deg"/>
+    <Rotation name="270" thetaX="90*deg" phiX="270*deg" thetaY="90*deg" phiY="0*deg" thetaZ="0*deg" phiZ="0*deg"/>
+    <Rotation name="180" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="270*deg" thetaZ="0*deg" phiZ="0*deg"/>
+    <Rotation name="90" thetaX="90*deg" phiX="90*deg" thetaY="90*deg" phiY="180*deg" thetaZ="0*deg" phiZ="0*deg"/>
+    <Rotation name="Reverse" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="270*deg" thetaZ="180*deg" phiZ="0*deg"/>
   </RotationSection>
 
 
   <LogicalPartSection label="etl.xml">
-	<LogicalPart name="EndcapTimingLayer" category="unspecified">
-	  <rSolid name="etl:EndcapTimingLayer"/>
-	  <rMaterial name="materials:Air"/>
-	</LogicalPart>
-	<LogicalPart name="ThermalScreen" category="unspecified">
-	  <rSolid name="etl:ThermalScreen"/>
-	  <rMaterial name="mtdMaterial:ThermalScreenComposite"/>
-	</LogicalPart>
-	<LogicalPart name="Disc1Timing" category="unspecified">
-	  <rSolid name="etl:Disc"/>
-	  <rMaterial name="materials:Air"/>
-	</LogicalPart>
+    <LogicalPart name="EndcapTimingLayer" category="unspecified">
+      <rSolid name="etl:EndcapTimingLayer"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="Disc1Timing" category="unspecified">
+      <rSolid name="etl:Disc"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
     <LogicalPart name="Disc2Timing" category="unspecified">
       <rSolid name="etl:Disc"/>
       <rMaterial name="materials:Air"/>
@@ -100,7 +92,7 @@
       <rSolid name="etl:MIC6_Aluminium_Disc"/>
       <rMaterial name="materials:Aluminium"/>
     </LogicalPart>
-    <!-- Sectors on Disc1 -->
+    <!-- Sectors on Disc1Timing -->
     <LogicalPart name="DiscSector_Front" category="unspecified">
       <rSolid name="etl:DiscSector_Front"/>
       <rMaterial name="materials:Air"/>
@@ -109,7 +101,7 @@
       <rSolid name="etl:DiscSector_Back"/>
       <rMaterial name="materials:Air"/>
     </LogicalPart>
-    <!-- Sectors on Disc2 -->
+    <!-- Sectors on Disc2Timing -->
     <LogicalPart name="DiscSector_Front_2" category="unspecified">
       <rSolid name="etl:DiscSector_Front_2"/>
       <rMaterial name="materials:Air"/>
@@ -182,88 +174,82 @@
   </LogicalPartSection>
 
 
-  <PosPartSection label="etl.xml">
-	<PosPart copyNumber="1">
-	  <rParent name="caloBase:CALOECFront"/>
-	  <rChild name="etl:EndcapTimingLayer"/>
-	  <Translation x="0." y="0." z="0.5*([caloBase:Zpos110]+[caloBase:Zpos10])+2*cm" />  <!-- 303.45*cm wrt IP-->
-	</PosPart>
-
-	<!-- ETL z-Positions wrt IP: endcap: 298.6*cm (2966) -> 306.3*cm  / Volume center 303.45*cm -->
-	<PosPart copyNumber="1">
-	  <rParent name="etl:EndcapTimingLayer"/>
-	  <rChild name="etl:ThermalScreen"/>
-	  <Translation x="0." y="0." z="-3.85*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:EndcapTimingLayer"/>
-	  <rChild name="etl:Disc1Timing"/>
-	  <Translation x="0." y="0." z="-1.788*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:EndcapTimingLayer"/>
-	  <rChild name="etl:Disc2Timing"/>
-	  <Translation x="0." y="0." z="1.212*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:Aluminium_Disc"/>
-	  <Translation x="0." y="0." z="0.3175*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:MIC6_Aluminium_Disc"/>
-	  <Translation x="0." y="0." z="-0.0445*cm" />
-	</PosPart>
-	<!-- Sectors in both Disc1 and Disc2 (Front/Back faces) are placed anti-clockwise (Quarter 1 is on top right, Quarter 2 top left...) -->
-	<PosPart copyNumber="1">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:DiscSector_Front"/>
-	  <rRotation name="etl:0"/>
-	  <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />  <!-- 1.2375 = 1.2 + 0.075/2 -->
-	</PosPart>
-	<PosPart copyNumber="2">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:DiscSector_Front"/>
-	  <rRotation name="etl:270"/>
-	  <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />
-	</PosPart>
-	<PosPart copyNumber="3">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:DiscSector_Front"/>
-	  <rRotation name="etl:180"/>
-	  <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />
-	</PosPart>
-	<PosPart copyNumber="4">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:DiscSector_Front"/>
-	  <rRotation name="etl:90"/>
-	  <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:DiscSector_Back"/>
-	  <rRotation name="etl:0"/>
-	  <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
-	</PosPart>
-	<PosPart copyNumber="2">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:DiscSector_Back"/>
-	  <rRotation name="etl:270"/>
-	  <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
-	</PosPart>
-	<PosPart copyNumber="3">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:DiscSector_Back"/>
-	  <rRotation name="etl:180"/>
-	  <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
-	</PosPart>
-	<PosPart copyNumber="4">
-	  <rParent name="etl:Disc1Timing"/>
-	  <rChild name="etl:DiscSector_Back"/>
-	  <rRotation name="etl:90"/>
-	  <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
-	</PosPart>
+  
+  <PosPartSection label="etl.xml">                                     
+    <PosPart copyNumber="1">                                           
+      <rParent name="caloBase:CALOECFront"/>                         
+      <rChild name="etl:EndcapTimingLayer"/>  
+      <Translation x="0." y="0." z="[ETLcenter]" />  
+    </PosPart>
+    <PosPart copyNumber="1">                                           
+      <rParent name="etl:EndcapTimingLayer"/>                         
+      <rChild name="etl:Disc1Timing"/>  
+      <Translation x="0." y="0." z="[Disc1center]-[ETLcenter]" /> 
+    </PosPart> 
+    <PosPart copyNumber="1">                                           
+      <rParent name="etl:EndcapTimingLayer"/>                         
+      <rChild name="etl:Disc2Timing"/>  
+      <Translation x="0." y="0." z="[Disc2center]-[ETLcenter]" /> 
+    </PosPart> 
+    <PosPart copyNumber="1">                                           
+      <rParent name="etl:Disc1Timing"/>                         
+      <rChild name="etl:Aluminium_Disc"/>  
+      <Translation x="0." y="0." z="0.3175*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:MIC6_Aluminium_Disc"/>
+      <Translation x="0." y="0." z="-0.0445*cm" />
+    </PosPart>
+    <!-- Sectors in both Disc1Timing and Disc2Timing (Front/Back faces) are placed anti-clockwise (Quarter 1 is on top right, Quarter 2 top left...) -->
+    <PosPart copyNumber="1">                                           
+      <rParent name="etl:Disc1Timing"/>                         
+      <rChild name="etl:DiscSector_Front"/> 
+      <rRotation name="etl:0"/> 
+      <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />  
+    </PosPart> 
+    <PosPart copyNumber="2">                                           
+      <rParent name="etl:Disc1Timing"/>                         
+      <rChild name="etl:DiscSector_Front"/>  
+      <rRotation name="etl:270"/>
+      <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Front"/>
+      <rRotation name="etl:180"/>
+      <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Front"/>
+      <rRotation name="etl:90"/>
+      <Translation x="0*cm" y="0*cm" z="-0.6545*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Back"/>
+      <rRotation name="etl:0"/>
+      <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Back"/>
+      <rRotation name="etl:270"/>
+      <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Back"/>
+      <rRotation name="etl:180"/>
+      <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Back"/>
+      <rRotation name="etl:90"/>
+      <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
+    </PosPart>
     <PosPart copyNumber="1">
       <rParent name="etl:Disc2Timing"/>
       <rChild name="etl:Aluminium_Disc"/>
@@ -274,7 +260,7 @@
       <rChild name="etl:MIC6_Aluminium_Disc"/>
       <Translation x="0." y="0." z="-0.0445*cm" />
     </PosPart>
-     <PosPart copyNumber="1">
+    <PosPart copyNumber="1">
       <rParent name="etl:Disc2Timing"/>
       <rChild name="etl:DiscSector_Front_2"/>
       <rRotation name="etl:0"/>
@@ -323,89 +309,89 @@
       <Translation x="0*cm" y="0*cm" z="0.6545*cm" />
     </PosPart>
     <!-- Elements composing SensorModule_Front_Right -->
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Right"/>
-	  <rChild name="etl:ThermalPad"/>
-	  <Translation x="0." y="0." z="0.102*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Right"/>
-	  <rChild name="etl:AlN_Carrier"/>
-	  <Translation x="0." y="0." z="0.05*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Right"/>
-	  <rChild name="etl:LairdFilm"/>
-	  <Translation x="0.17" y="0." z="0.0065*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Right"/>
-	  <rChild name="etl:ETROC"/>
-	  <Translation x="0.1625*cm" y="1.045*cm" z="-0.0115*cm" />
-	</PosPart>
-	<PosPart copyNumber="2">
-	  <rParent name="etl:SensorModule_Front_Right"/>
-	  <rChild name="etl:ETROC"/>
-	  <Translation x="0.1625*cm" y="-1.045*cm" z="-0.0115*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Right"/>
-	  <rChild name="etl:LGAD"/>
-	  <Translation x="0.22*cm" y="0." z="-0.0405*cm" />
-	</PosPart>
-	<!-- definition of LGAD active/substrate volumes -->
-	<PosPart copyNumber="1">
-	  <rParent name="etl:LGAD"/>
-	  <rChild name="etl:EModule_Timingactive"/>
-	  <Translation x="0.*cm" y="0.*cm" z="-0.0125*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:LGAD"/>
-	  <rChild name="etl:LGAD_Substrate"/>
-	  <Translation x="0.*cm" y="0.*cm" z="0.0025*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Right"/>
-	  <rChild name="etl:AlN_Cover"/>
-	  <Translation x="0.22*cm" y="0." z="-0.085*cm" />
-	</PosPart>
-	 <!-- Elements composing SensorModule_Front_Left -->
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Left"/>
-	  <rChild name="etl:ThermalPad"/>
-	  <Translation x="0." y="0." z="0.102*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Left"/>
-	  <rChild name="etl:AlN_Carrier"/>
-	  <Translation x="0." y="0." z="0.05*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Left"/>
-	  <rChild name="etl:LairdFilm"/>
-	  <Translation x="-0.17" y="0." z="0.0065*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Left"/>
-	  <rChild name="etl:ETROC"/>
-	  <Translation x="-0.1625*cm" y="1.045*cm" z="-0.0115*cm" />
-	</PosPart>
-	<PosPart copyNumber="2">
-	  <rParent name="etl:SensorModule_Front_Left"/>
-	  <rChild name="etl:ETROC"/>
-	  <Translation x="-0.1625*cm" y="-1.045*cm" z="-0.0115*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Left"/>
-	  <rChild name="etl:LGAD"/>
-	  <Translation x="-0.22*cm" y="0." z="-0.0405*cm" />
-	</PosPart>
-	<PosPart copyNumber="1">
-	  <rParent name="etl:SensorModule_Front_Left"/>
-	  <rChild name="etl:AlN_Cover"/>
-	  <Translation x="-0.22*cm" y="0." z="-0.085*cm" />
-	</PosPart>
-	<!-- Elements composing SensorModule_Back_Left -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ThermalPad"/>
+      <Translation x="0." y="0." z="0.102*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:AlN_Carrier"/>
+      <Translation x="0." y="0." z="0.05*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:LairdFilm"/>
+      <Translation x="0.17" y="0." z="0.0065*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="0.1625*cm" y="1.045*cm" z="-0.0115*cm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="0.1625*cm" y="-1.045*cm" z="-0.0115*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:LGAD"/>
+      <Translation x="0.22*cm" y="0." z="-0.0405*cm" />
+    </PosPart>
+    <!-- definition of LGAD active/substrate volumes -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:LGAD"/>
+      <rChild name="etl:EModule_Timingactive"/>
+      <Translation x="0.*cm" y="0.*cm" z="-0.0125*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:LGAD"/>
+      <rChild name="etl:LGAD_Substrate"/>
+      <Translation x="0.*cm" y="0.*cm" z="0.0025*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:AlN_Cover"/>
+      <Translation x="0.22*cm" y="0." z="-0.085*cm" />
+    </PosPart>
+    <!-- Elements composing SensorModule_Front_Left -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ThermalPad"/>
+      <Translation x="0." y="0." z="0.102*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:AlN_Carrier"/>
+      <Translation x="0." y="0." z="0.05*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:LairdFilm"/>
+      <Translation x="-0.17" y="0." z="0.0065*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="-0.1625*cm" y="1.045*cm" z="-0.0115*cm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="-0.1625*cm" y="-1.045*cm" z="-0.0115*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:LGAD"/>
+      <Translation x="-0.22*cm" y="0." z="-0.0405*cm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:AlN_Cover"/>
+      <Translation x="-0.22*cm" y="0." z="-0.085*cm" />
+    </PosPart>
+    <!-- Elements composing SensorModule_Back_Left -->
     <PosPart copyNumber="1">
       <rParent name="etl:SensorModule_Back_Left"/>
       <rChild name="etl:ThermalPad"/>
@@ -486,19 +472,19 @@
 
 
   <!-- Algorithm Section begins -->
-    <!-- Disc1 Front face -->
+    <!-- Disc1Timing Front face -->
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Front"/>
-	<String name="ChildName" value="etl:SensorModule_Front_Left"/>
-	<Numeric name="N" value="8"/>
-	<Numeric name="StartCopyNo" value="1"/>
+    <rParent name="etl:DiscSector_Front"/>
+    <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+    <Numeric name="N" value="8"/>
+    <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
     <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
     <Vector  name="Base" type="numeric" nEntries="3"> -111.93*cm, 2.2925*cm, 0.178*cm </Vector>
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -511,7 +497,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -524,7 +510,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -537,7 +523,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -550,7 +536,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -563,7 +549,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -576,7 +562,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -589,7 +575,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -602,7 +588,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -615,7 +601,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -628,7 +614,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -641,7 +627,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -654,7 +640,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -667,7 +653,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -680,7 +666,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">  <!-- y start changed from 13.1925 to 13.0925 to avoid extrusion -->
     <rParent name="etl:DiscSector_Front"/>
@@ -693,7 +679,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <!-- <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -719,7 +705,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -732,7 +718,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -745,7 +731,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -758,7 +744,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -771,7 +757,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -784,7 +770,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -797,7 +783,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -810,7 +796,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -823,7 +809,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -836,7 +822,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -849,7 +835,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -862,7 +848,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -875,7 +861,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -888,7 +874,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -901,7 +887,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -914,7 +900,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
    <Algorithm name="mtd:DDMTDLinear">  <!-- y-pos of 1st SH module moved from 13.1925 to 16.2 to avoid module extrusion -->
     <rParent name="etl:DiscSector_Front"/>
@@ -927,7 +913,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -940,7 +926,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -953,7 +939,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -966,7 +952,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -979,7 +965,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -992,7 +978,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -1005,7 +991,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -1018,7 +1004,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -1031,7 +1017,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -1044,7 +1030,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front"/>
@@ -1057,610 +1043,610 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
 
 
-    <!-- Disc1 Back face -->
+    <!-- Disc1Timing Back face -->
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="1"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> -113.555*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/> <!-- translation along y -->
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> -113.555*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/> <!-- translation along y -->
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="6"/>
-	<Numeric name="StartCopyNo" value="1"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+[DeltaX_ServiceModule])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="6"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+[DeltaX_ServiceModule])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="10"/>
-	<Numeric name="StartCopyNo" value="1"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+[DeltaX_ServiceModule]+[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="10"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+[DeltaX_ServiceModule]+[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="2"/>
-	<Numeric name="StartCopyNo" value="2"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+2*[DeltaX_ServiceModule]+[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="2"/>
+    <Numeric name="StartCopyNo" value="2"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+2*[DeltaX_ServiceModule]+[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="12"/>
-	<Numeric name="StartCopyNo" value="7"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+3*[DeltaX_ServiceModule]+[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="12"/>
+    <Numeric name="StartCopyNo" value="7"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+3*[DeltaX_ServiceModule]+[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="14"/>
-	<Numeric name="StartCopyNo" value="11"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+3*[DeltaX_ServiceModule]+2*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="14"/>
+    <Numeric name="StartCopyNo" value="11"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+3*[DeltaX_ServiceModule]+2*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="2"/>
-	<Numeric name="StartCopyNo" value="4"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+4*[DeltaX_ServiceModule]+2*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="2"/>
+    <Numeric name="StartCopyNo" value="4"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+4*[DeltaX_ServiceModule]+2*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">  <!-- 1st placement of a short service hybrid -->
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="1"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+4*[DeltaX_ServiceModule]+2*[SensorModuledx])*cm, (13.1925+[ServiceHybrid_Y]+2*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+4*[DeltaX_ServiceModule]+2*[SensorModuledx])*cm, (13.1925+[ServiceHybrid_Y]+2*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="15"/>
-	<Numeric name="StartCopyNo" value="19"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+5*[DeltaX_ServiceModule]+2*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="15"/>
+    <Numeric name="StartCopyNo" value="19"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+5*[DeltaX_ServiceModule]+2*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="17"/>
-	<Numeric name="StartCopyNo" value="25"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+5*[DeltaX_ServiceModule]+3*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="17"/>
+    <Numeric name="StartCopyNo" value="25"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+5*[DeltaX_ServiceModule]+3*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">  <!-- y start pos 13.0925 instead of 13.1925 to avoid extrusion -->
     <rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="2"/>  <!-- "3" -->
-	<Numeric name="StartCopyNo" value="6"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+6*[DeltaX_ServiceModule]+3*[SensorModuledx])*cm, 13.0925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="2"/>  <!-- "3" -->
+    <Numeric name="StartCopyNo" value="6"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+6*[DeltaX_ServiceModule]+3*[SensorModuledx])*cm, 13.0925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="34"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+7*[DeltaX_ServiceModule]+3*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="34"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+7*[DeltaX_ServiceModule]+3*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="42"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+7*[DeltaX_ServiceModule]+4*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="42"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+7*[DeltaX_ServiceModule]+4*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="9"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+8*[DeltaX_ServiceModule]+4*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="9"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+8*[DeltaX_ServiceModule]+4*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="52"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+9*[DeltaX_ServiceModule]+4*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="52"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+9*[DeltaX_ServiceModule]+4*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="21"/>
-	<Numeric name="StartCopyNo" value="60"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+9*[DeltaX_ServiceModule]+5*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="21"/>
+    <Numeric name="StartCopyNo" value="60"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+9*[DeltaX_ServiceModule]+5*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="12"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+10*[DeltaX_ServiceModule]+5*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="12"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+10*[DeltaX_ServiceModule]+5*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="2"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+10*[DeltaX_ServiceModule]+5*[SensorModuledx])*cm, (13.1925+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="2"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+10*[DeltaX_ServiceModule]+5*[SensorModuledx])*cm, (13.1925+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="21"/>
-	<Numeric name="StartCopyNo" value="70"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+11*[DeltaX_ServiceModule]+5*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="21"/>
+    <Numeric name="StartCopyNo" value="70"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+11*[DeltaX_ServiceModule]+5*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="21"/>
-	<Numeric name="StartCopyNo" value="81"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+11*[DeltaX_ServiceModule]+6*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="21"/>
+    <Numeric name="StartCopyNo" value="81"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+11*[DeltaX_ServiceModule]+6*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="15"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+12*[DeltaX_ServiceModule]+6*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="15"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+12*[DeltaX_ServiceModule]+6*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="3"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+12*[DeltaX_ServiceModule]+6*[SensorModuledx])*cm, (13.1925+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="3"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+12*[DeltaX_ServiceModule]+6*[SensorModuledx])*cm, (13.1925+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="21"/>
-	<Numeric name="StartCopyNo" value="91"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+13*[DeltaX_ServiceModule]+6*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="21"/>
+    <Numeric name="StartCopyNo" value="91"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+13*[DeltaX_ServiceModule]+6*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="23"/>
-	<Numeric name="StartCopyNo" value="102"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+13*[DeltaX_ServiceModule]+7*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="23"/>
+    <Numeric name="StartCopyNo" value="102"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+13*[DeltaX_ServiceModule]+7*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="4"/>
-	<Numeric name="StartCopyNo" value="18"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+14*[DeltaX_ServiceModule]+7*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="4"/>
+    <Numeric name="StartCopyNo" value="18"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+14*[DeltaX_ServiceModule]+7*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="112"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+15*[DeltaX_ServiceModule]+7*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="112"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+15*[DeltaX_ServiceModule]+7*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="125"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+15*[DeltaX_ServiceModule]+8*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="125"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+15*[DeltaX_ServiceModule]+8*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="4"/>
-	<Numeric name="StartCopyNo" value="22"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+16*[DeltaX_ServiceModule]+8*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="4"/>
+    <Numeric name="StartCopyNo" value="22"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+16*[DeltaX_ServiceModule]+8*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="136"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+17*[DeltaX_ServiceModule]+8*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="136"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+17*[DeltaX_ServiceModule]+8*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="149"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+17*[DeltaX_ServiceModule]+9*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="149"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+17*[DeltaX_ServiceModule]+9*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="4"/>
-	<Numeric name="StartCopyNo" value="26"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+18*[DeltaX_ServiceModule]+9*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="4"/>
+    <Numeric name="StartCopyNo" value="26"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+18*[DeltaX_ServiceModule]+9*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="160"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+19*[DeltaX_ServiceModule]+9*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="160"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+19*[DeltaX_ServiceModule]+9*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="20"/>
-	<Numeric name="StartCopyNo" value="173"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+19*[DeltaX_ServiceModule]+10*[SensorModuledx])*cm, (2.2925+4*[SensorModuledy]+4*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="20"/>
+    <Numeric name="StartCopyNo" value="173"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+19*[DeltaX_ServiceModule]+10*[SensorModuledx])*cm, (2.2925+4*[SensorModuledy]+4*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="30"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+20*[DeltaX_ServiceModule]+10*[SensorModuledx])*cm, (13.1925+4*[SensorModuledy]+4*[DeltaY])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="30"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+20*[DeltaX_ServiceModule]+10*[SensorModuledx])*cm, (13.1925+4*[SensorModuledy]+4*[DeltaY])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="4"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+20*[DeltaX_ServiceModule]+10*[SensorModuledx])*cm, (13.1925+4*[SensorModuledy]+4*[DeltaY]+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="4"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+20*[DeltaX_ServiceModule]+10*[SensorModuledx])*cm, (13.1925+4*[SensorModuledy]+4*[DeltaY]+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="20"/>
-	<Numeric name="StartCopyNo" value="184"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+21*[DeltaX_ServiceModule]+10*[SensorModuledx])*cm, (2.2925+5*[SensorModuledy]+5*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="20"/>
+    <Numeric name="StartCopyNo" value="184"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+21*[DeltaX_ServiceModule]+10*[SensorModuledx])*cm, (2.2925+5*[SensorModuledy]+5*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="20"/>
-	<Numeric name="StartCopyNo" value="193"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+21*[DeltaX_ServiceModule]+11*[SensorModuledx])*cm, (2.2925+6*[SensorModuledy]+6*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="20"/>
+    <Numeric name="StartCopyNo" value="193"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+21*[DeltaX_ServiceModule]+11*[SensorModuledx])*cm, (2.2925+6*[SensorModuledy]+6*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
    <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="33"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+22*[DeltaX_ServiceModule]+11*[SensorModuledx])*cm, (13.1925+6*[SensorModuledy]+6*[DeltaY])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="33"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+22*[DeltaX_ServiceModule]+11*[SensorModuledx])*cm, (13.1925+6*[SensorModuledy]+6*[DeltaY])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <!--<Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="5"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+22*[DeltaX_ServiceModule]+11*[SensorModuledx])*cm, (13.1925+6*[SensorModuledy]+6*[DeltaY]+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="5"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+22*[DeltaX_ServiceModule]+11*[SensorModuledx])*cm, (13.1925+6*[SensorModuledy]+6*[DeltaY]+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm> -->
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="19"/>   <!-- "20" -->
-	<Numeric name="StartCopyNo" value="204"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+23*[DeltaX_ServiceModule]+11*[SensorModuledx])*cm, (2.2925+7*[SensorModuledy]+7*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="19"/>   <!-- "20" -->
+    <Numeric name="StartCopyNo" value="204"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+23*[DeltaX_ServiceModule]+11*[SensorModuledx])*cm, (2.2925+7*[SensorModuledy]+7*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="213"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+23*[DeltaX_ServiceModule]+12*[SensorModuledx])*cm, (2.2925+7*[SensorModuledy]+7*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="213"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+23*[DeltaX_ServiceModule]+12*[SensorModuledx])*cm, (2.2925+7*[SensorModuledy]+7*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="36"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+24*[DeltaX_ServiceModule]+12*[SensorModuledx])*cm, (13.1925+7*[SensorModuledy]+7*[DeltaY])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="36"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+24*[DeltaX_ServiceModule]+12*[SensorModuledx])*cm, (13.1925+7*[SensorModuledy]+7*[DeltaY])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="17"/>
-	<Numeric name="StartCopyNo" value="224"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+25*[DeltaX_ServiceModule]+12*[SensorModuledx])*cm, (2.2925+8*[SensorModuledy]+8*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="17"/>
+    <Numeric name="StartCopyNo" value="224"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+25*[DeltaX_ServiceModule]+12*[SensorModuledx])*cm, (2.2925+8*[SensorModuledy]+8*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="231"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+25*[DeltaX_ServiceModule]+13*[SensorModuledx])*cm, (2.2925+8*[SensorModuledy]+8*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="231"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+25*[DeltaX_ServiceModule]+13*[SensorModuledx])*cm, (2.2925+8*[SensorModuledy]+8*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="39"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (-113.555+26*[DeltaX_ServiceModule]+13*[SensorModuledx])*cm, (13.1925+8*[SensorModuledy]+8*[DeltaY])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="39"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (-113.555+26*[DeltaX_ServiceModule]+13*[SensorModuledx])*cm, (13.1925+8*[SensorModuledy]+8*[DeltaY])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
 
- 	<!-- Disc2 Front face -->
+ 	<!-- Disc2Timing Front face -->
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Front_2"/>
-	<String name="ChildName" value="etl:SensorModule_Front_Right"/>
-	<Numeric name="N" value="8"/>
-	<Numeric name="StartCopyNo" value="1"/>
+    <rParent name="etl:DiscSector_Front_2"/>
+    <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+    <Numeric name="N" value="8"/>
+    <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
     <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
     <Vector  name="Base" type="numeric" nEntries="3"> 111.93*cm, 2.2925*cm, 0.178*cm </Vector>
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1673,7 +1659,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1686,7 +1672,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1699,7 +1685,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1712,7 +1698,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1725,7 +1711,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1738,7 +1724,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1751,7 +1737,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1764,7 +1750,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1777,7 +1763,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1790,7 +1776,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1803,7 +1789,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1816,7 +1802,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1829,7 +1815,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1842,7 +1828,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear"> <!-- y start changed from 13.1925 to 13.0925 to avoid extrusion -->
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1855,7 +1841,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <!-- <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1868,7 +1854,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm> -->
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1881,7 +1867,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1894,7 +1880,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1907,7 +1893,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1920,7 +1906,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1933,7 +1919,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1946,7 +1932,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1959,7 +1945,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1972,7 +1958,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1985,7 +1971,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -1998,7 +1984,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2011,7 +1997,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2024,7 +2010,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2037,7 +2023,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2050,7 +2036,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2063,7 +2049,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2076,7 +2062,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
    <Algorithm name="mtd:DDMTDLinear"> <!-- y-pos of 1st SH module moved from 13.1925 to 16 to avoid module extrusion -->
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2089,7 +2075,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2102,7 +2088,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2115,7 +2101,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2128,7 +2114,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2141,7 +2127,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2154,7 +2140,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2167,7 +2153,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2180,7 +2166,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2193,7 +2179,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2206,7 +2192,7 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
     <rParent name="etl:DiscSector_Front_2"/>
@@ -2219,595 +2205,595 @@
     <Numeric name="Theta" value="90.*deg"/>
     <Numeric name="Phi" value="90.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
 
 
-    <!-- Disc2 Back face -->
+    <!-- Disc2Timing Back face -->
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="1"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> 113.555*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/> <!-- translation along y -->
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> 113.555*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/> <!-- translation along y -->
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="6"/>
-	<Numeric name="StartCopyNo" value="1"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-[DeltaX_ServiceModule])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="6"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-[DeltaX_ServiceModule])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="10"/>
-	<Numeric name="StartCopyNo" value="1"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-[DeltaX_ServiceModule]-[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="10"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-[DeltaX_ServiceModule]-[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="2"/>
-	<Numeric name="StartCopyNo" value="2"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-2*[DeltaX_ServiceModule]-[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="2"/>
+    <Numeric name="StartCopyNo" value="2"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-2*[DeltaX_ServiceModule]-[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="12"/>
-	<Numeric name="StartCopyNo" value="7"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-3*[DeltaX_ServiceModule]-[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="12"/>
+    <Numeric name="StartCopyNo" value="7"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-3*[DeltaX_ServiceModule]-[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="14"/>
-	<Numeric name="StartCopyNo" value="11"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-3*[DeltaX_ServiceModule]-2*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="14"/>
+    <Numeric name="StartCopyNo" value="11"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-3*[DeltaX_ServiceModule]-2*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="2"/>
-	<Numeric name="StartCopyNo" value="4"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-4*[DeltaX_ServiceModule]-2*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="2"/>
+    <Numeric name="StartCopyNo" value="4"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-4*[DeltaX_ServiceModule]-2*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">  <!-- 1st placement of a short service hybrid -->
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="1"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-4*[DeltaX_ServiceModule]-2*[SensorModuledx])*cm, (13.1925+[ServiceHybrid_Y]+2*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-4*[DeltaX_ServiceModule]-2*[SensorModuledx])*cm, (13.1925+[ServiceHybrid_Y]+2*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="15"/>
-	<Numeric name="StartCopyNo" value="19"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-5*[DeltaX_ServiceModule]-2*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="15"/>
+    <Numeric name="StartCopyNo" value="19"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-5*[DeltaX_ServiceModule]-2*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="17"/>
-	<Numeric name="StartCopyNo" value="25"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-5*[DeltaX_ServiceModule]-3*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="17"/>
+    <Numeric name="StartCopyNo" value="25"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-5*[DeltaX_ServiceModule]-3*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear"> <!-- y start pos 13.0925 instead of 13.1925 to avoid extrusion -->
     <rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="2"/>  <!-- "3" -->
-	<Numeric name="StartCopyNo" value="6"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-6*[DeltaX_ServiceModule]-3*[SensorModuledx])*cm, 13.0925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="2"/>  <!-- "3" -->
+    <Numeric name="StartCopyNo" value="6"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-6*[DeltaX_ServiceModule]-3*[SensorModuledx])*cm, 13.0925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="34"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-7*[DeltaX_ServiceModule]-3*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="34"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-7*[DeltaX_ServiceModule]-3*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="42"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-7*[DeltaX_ServiceModule]-4*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="42"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-7*[DeltaX_ServiceModule]-4*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="9"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-8*[DeltaX_ServiceModule]-4*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="9"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-8*[DeltaX_ServiceModule]-4*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="52"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-9*[DeltaX_ServiceModule]-4*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="52"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-9*[DeltaX_ServiceModule]-4*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="21"/>
-	<Numeric name="StartCopyNo" value="60"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-9*[DeltaX_ServiceModule]-5*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="21"/>
+    <Numeric name="StartCopyNo" value="60"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-9*[DeltaX_ServiceModule]-5*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="12"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-10*[DeltaX_ServiceModule]-5*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="12"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-10*[DeltaX_ServiceModule]-5*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="2"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-10*[DeltaX_ServiceModule]-5*[SensorModuledx])*cm, (13.1925+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="2"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-10*[DeltaX_ServiceModule]-5*[SensorModuledx])*cm, (13.1925+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="21"/>
-	<Numeric name="StartCopyNo" value="70"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-11*[DeltaX_ServiceModule]-5*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="21"/>
+    <Numeric name="StartCopyNo" value="70"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-11*[DeltaX_ServiceModule]-5*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="21"/>
-	<Numeric name="StartCopyNo" value="81"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-11*[DeltaX_ServiceModule]-6*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="21"/>
+    <Numeric name="StartCopyNo" value="81"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-11*[DeltaX_ServiceModule]-6*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="15"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-12*[DeltaX_ServiceModule]-6*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="15"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-12*[DeltaX_ServiceModule]-6*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="3"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-12*[DeltaX_ServiceModule]-6*[SensorModuledx])*cm, (13.1925+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="3"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-12*[DeltaX_ServiceModule]-6*[SensorModuledx])*cm, (13.1925+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="21"/>
-	<Numeric name="StartCopyNo" value="91"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-13*[DeltaX_ServiceModule]-6*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="21"/>
+    <Numeric name="StartCopyNo" value="91"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-13*[DeltaX_ServiceModule]-6*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="23"/>
-	<Numeric name="StartCopyNo" value="102"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-13*[DeltaX_ServiceModule]-7*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="23"/>
+    <Numeric name="StartCopyNo" value="102"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-13*[DeltaX_ServiceModule]-7*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="4"/>
-	<Numeric name="StartCopyNo" value="18"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-14*[DeltaX_ServiceModule]-7*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="4"/>
+    <Numeric name="StartCopyNo" value="18"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-14*[DeltaX_ServiceModule]-7*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="112"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-15*[DeltaX_ServiceModule]-7*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="112"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-15*[DeltaX_ServiceModule]-7*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="125"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-15*[DeltaX_ServiceModule]-8*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="125"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-15*[DeltaX_ServiceModule]-8*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="4"/>
-	<Numeric name="StartCopyNo" value="22"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-16*[DeltaX_ServiceModule]-8*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="4"/>
+    <Numeric name="StartCopyNo" value="22"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-16*[DeltaX_ServiceModule]-8*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="136"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-17*[DeltaX_ServiceModule]-8*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="136"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-17*[DeltaX_ServiceModule]-8*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="149"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-17*[DeltaX_ServiceModule]-9*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="149"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-17*[DeltaX_ServiceModule]-9*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="4"/>
-	<Numeric name="StartCopyNo" value="26"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-18*[DeltaX_ServiceModule]-9*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="4"/>
+    <Numeric name="StartCopyNo" value="26"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-18*[DeltaX_ServiceModule]-9*[SensorModuledx])*cm, 13.1925*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="24"/>
-	<Numeric name="StartCopyNo" value="160"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-19*[DeltaX_ServiceModule]-9*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="24"/>
+    <Numeric name="StartCopyNo" value="160"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-19*[DeltaX_ServiceModule]-9*[SensorModuledx])*cm, 2.2925*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="20"/>
-	<Numeric name="StartCopyNo" value="173"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-19*[DeltaX_ServiceModule]-10*[SensorModuledx])*cm, (2.2925+4*[SensorModuledy]+4*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="20"/>
+    <Numeric name="StartCopyNo" value="173"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-19*[DeltaX_ServiceModule]-10*[SensorModuledx])*cm, (2.2925+4*[SensorModuledy]+4*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="30"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-20*[DeltaX_ServiceModule]-10*[SensorModuledx])*cm, (13.1925+4*[SensorModuledy]+4*[DeltaY])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="30"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-20*[DeltaX_ServiceModule]-10*[SensorModuledx])*cm, (13.1925+4*[SensorModuledy]+4*[DeltaY])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="4"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-20*[DeltaX_ServiceModule]-10*[SensorModuledx])*cm, (13.1925+4*[SensorModuledy]+4*[DeltaY]+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="4"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-20*[DeltaX_ServiceModule]-10*[SensorModuledx])*cm, (13.1925+4*[SensorModuledy]+4*[DeltaY]+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="20"/>
-	<Numeric name="StartCopyNo" value="184"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-21*[DeltaX_ServiceModule]-10*[SensorModuledx])*cm, (2.2925+5*[SensorModuledy]+5*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="20"/>
+    <Numeric name="StartCopyNo" value="184"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-21*[DeltaX_ServiceModule]-10*[SensorModuledx])*cm, (2.2925+5*[SensorModuledy]+5*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="20"/>
-	<Numeric name="StartCopyNo" value="193"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-21*[DeltaX_ServiceModule]-11*[SensorModuledx])*cm, (2.2925+6*[SensorModuledy]+6*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="20"/>
+    <Numeric name="StartCopyNo" value="193"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-21*[DeltaX_ServiceModule]-11*[SensorModuledx])*cm, (2.2925+6*[SensorModuledy]+6*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
-   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="33"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-22*[DeltaX_ServiceModule]-11*[SensorModuledx])*cm, (13.1925+6*[SensorModuledy]+6*[DeltaY])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+  <Algorithm name="mtd:DDMTDLinear">
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="33"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-22*[DeltaX_ServiceModule]-11*[SensorModuledx])*cm, (13.1925+6*[SensorModuledy]+6*[DeltaY])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <!-- <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid_short"/>
-	<Numeric name="N" value="1"/>
-	<Numeric name="StartCopyNo" value="5"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-22*[DeltaX_ServiceModule]-11*[SensorModuledx])*cm, (13.1925+6*[SensorModuledy]+6*[DeltaY]+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid_short"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="5"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y_short]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-22*[DeltaX_ServiceModule]-11*[SensorModuledx])*cm, (13.1925+6*[SensorModuledy]+6*[DeltaY]+2*[ServiceHybrid_Y]+3*[DeltaY]+[DeltaY_ServiceLong_ServiceShort])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm> -->
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="19"/>  <!-- "20" -->
-	<Numeric name="StartCopyNo" value="204"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-23*[DeltaX_ServiceModule]-11*[SensorModuledx])*cm, (2.2925+7*[SensorModuledy]+7*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="19"/>  <!-- "20" -->
+    <Numeric name="StartCopyNo" value="204"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-23*[DeltaX_ServiceModule]-11*[SensorModuledx])*cm, (2.2925+7*[SensorModuledy]+7*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="213"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-23*[DeltaX_ServiceModule]-12*[SensorModuledx])*cm, (2.2925+7*[SensorModuledy]+7*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="213"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-23*[DeltaX_ServiceModule]-12*[SensorModuledx])*cm, (2.2925+7*[SensorModuledy]+7*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="36"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-24*[DeltaX_ServiceModule]-12*[SensorModuledx])*cm, (13.1925+7*[SensorModuledy]+7*[DeltaY])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="36"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-24*[DeltaX_ServiceModule]-12*[SensorModuledx])*cm, (13.1925+7*[SensorModuledy]+7*[DeltaY])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Right"/>
-	<Numeric name="N" value="17"/>
-	<Numeric name="StartCopyNo" value="224"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-25*[DeltaX_ServiceModule]-12*[SensorModuledx])*cm, (2.2925+8*[SensorModuledy]+8*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+    <Numeric name="N" value="17"/>
+    <Numeric name="StartCopyNo" value="224"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-25*[DeltaX_ServiceModule]-12*[SensorModuledx])*cm, (2.2925+8*[SensorModuledy]+8*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:SensorModule_Back_Left"/>
-	<Numeric name="N" value="18"/>
-	<Numeric name="StartCopyNo" value="231"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-25*[DeltaX_ServiceModule]-13*[SensorModuledx])*cm, (2.2925+8*[SensorModuledy]+8*[DeltaY])*cm, -0.178*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+    <Numeric name="N" value="18"/>
+    <Numeric name="StartCopyNo" value="231"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([SensorModuledy]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-25*[DeltaX_ServiceModule]-13*[SensorModuledx])*cm, (2.2925+8*[SensorModuledy]+8*[DeltaY])*cm, -0.178*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
   <Algorithm name="mtd:DDMTDLinear">
-	<rParent name="etl:DiscSector_Back_2"/>
-	<String name="ChildName" value="etl:ServiceHybrid"/>
-	<Numeric name="N" value="3"/>
-	<Numeric name="StartCopyNo" value="39"/>
-	<Numeric name="IncrCopyNo" value="1"/>
-	<Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
-	<Vector  name="Base" type="numeric" nEntries="3"> (113.555-26*[DeltaX_ServiceModule]-13*[SensorModuledx])*cm, (13.1925+8*[SensorModuledy]+8*[DeltaY])*cm, 0.*cm </Vector>
-	<Numeric name="Theta" value="90.*deg"/>
-	<Numeric name="Phi" value="90.*deg"/>
-	<Numeric name="Theta_obj" value="90.*deg"/>
-	<Numeric name="Phi_obj" value="0.*deg"/>
+    <rParent name="etl:DiscSector_Back_2"/>
+    <String name="ChildName" value="etl:ServiceHybrid"/>
+    <Numeric name="N" value="3"/>
+    <Numeric name="StartCopyNo" value="39"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="Delta" value="([ServiceHybrid_Y]+[DeltaY])*cm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (113.555-26*[DeltaX_ServiceModule]-13*[SensorModuledx])*cm, (13.1925+8*[SensorModuledy]+8*[DeltaY])*cm, 0.*cm </Vector>
+    <Numeric name="Theta" value="90.*deg"/>
+    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Theta_obj" value="90.*deg"/>
+    <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
 
 


### PR DESCRIPTION
#### PR description:

This PR, based on the work by @icosivi as discussed and agreed with @bsunanda and N. Koss, removes from the ETL TDR description as implemented in scenario D53 the front thermal screen, which is already included in the volume outside ```EndcapTimingLayer```.

I have taken the opportunity to move the main volume from a polycone to a tubs (i.e. a cyclindrical shell), which is simpler for the geometry navigation.

This PR fully embeds #29647, it may be rebased after the integration of that.

#### PR validation:

@icosivi has verified the positions and checked that no overlap is present after this update. I have checked that the volume paths and DetIds are identical after the update (as they should), just longitudinal positions are shifted along z (as expected). The initial part of the dump differences is:

```
6815271a6815272
>  - OCMS[0]/CMSE[1]/CALO[1]/CALOEC[1]/CALOECTSFront[1]/CALOECFront[1]/EndcapTimingLayer[1]/ThermalScreen[1]/
6815298c6815299
< Translation vector components:   -1121.500000      22.925000    2994.325000 
---
> Translation vector components:   -1121.500000      22.925000    3011.325000 
6815300c6815301
< Center global   =   -1121.500000     22.925000   2994.325000 r =    1121.734285 phi =     178.828959
---
> Center global   =   -1121.500000     22.925000   3011.325000 r =    1121.734285 phi =     178.828959
6815302c6815303
< Corner 1 global =   -1110.900000     43.925000   2994.350000 DeltaR =      23.523618
---
> Corner 1 global =   -1110.900000     43.925000   3011.350000 DeltaR =      23.523618
```