### PR TITLE
DQM: Use process.maxLuminosityBlocks in the unit test

### DIFF
--- a/DQMServices/Demo/test/run_analyzers_cfg.py
+++ b/DQMServices/Demo/test/run_analyzers_cfg.py
@@ -39,6 +39,7 @@ parser.register('numberEventsInRun',    100, one, int, "See EmptySource.")
 parser.register('numberEventsInLuminosityBlock', 20, one, int, "See EmptySource.")
 parser.register('processingMode',       'RunsLumisAndEvents', one, string, "See EmptySource.")
 parser.register('nEvents',              100, one, int, "Total number of events.")
+parser.register('nLumisections',        -1, one, int, "Total number of lumisections.")
 parser.register('nThreads',             1, one, int, "Number of threads and streams.")
 parser.register('nConcurrent',          1, one, int, "Number of concurrent runs/lumis.")
 parser.register('howmany',              1, one, int, "Number of MEs to book of each type.")
@@ -55,6 +56,9 @@ process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uin
                             processingMode = cms.untracked.string(args.processingMode))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(args.nEvents) )
+if args.nLumisections > 0:
+    process.maxLuminosityBlocks = cms.untracked.PSet( input = cms.untracked.int32(args.nLumisections) )
+
 
 process.options = cms.untracked.PSet(
   numberOfThreads = cms.untracked.uint32(args.nThreads),

--- a/DQMServices/Demo/test/runtests.sh
+++ b/DQMServices/Demo/test/runtests.sh
@@ -155,12 +155,8 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=empty.root nEvents=0
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=empty.root howmany=0
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=empty.root howmany=0 legacyoutput=True
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=empty.root howmany=0 protobufoutput=True
-# also try empty lumisections. EmptySource does not really support 'no events' mode (never terminates), so, a bit of a hack here.
-cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=noevents.root processingMode='RunsAndLumis' &
-PID=$!
-sleep 5
-kill -INT $PID
-wait
+# nLumisections might be a bit buggy (off by one) in EDM, but is fine here.
+cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=noevents.root processingMode='RunsAndLumis' nLumisections=20
 [ 66 = $(dqmiolistmes.py noevents.root -r 1 | wc -l) ]
 [ 66 = $(dqmiolistmes.py noevents.root -r 1 -l 1 | wc -l) ]
 [ 66 = $(dqmiolistmes.py noevents.root -r 2 | wc -l) ]


### PR DESCRIPTION
#### PR description:
As pointed out by @Dr15Jones in #29794 , this actually exists.

Much better than the previous 'solution'.

This should fix #29794 .

#### PR validation:

Unit tests pass. No other impact.
