### PR TITLE
Have EmptySource properly handle RunsAndLumis mode

### DIFF
--- a/FWCore/Modules/test/BuildFile.xml
+++ b/FWCore/Modules/test/BuildFile.xml
@@ -5,6 +5,7 @@
   </bin>
 
   <test name="TestFWCoreModulesEmptySourceLumiForRuns" command="cmsRun ${LOCALTOP}/src/FWCore/Modules/test/emptysource_firstLuminosityBlockForEachRun_cfg.py"/>
+  <test name="TestFWCoreModulesEmptySourceRunsAndLumis" command="cmsRun ${LOCALTOP}/src/FWCore/Modules/test/emptysource_RunsAndLumis_cfg.py"/>
   <bin file="test_catch2_*.cc" name="TestFWCoreModulesTP">
     <use name="FWCore/TestProcessor"/>
     <use name="catch2"/>

--- a/FWCore/Modules/test/emptysource_RunsAndLumis_cfg.py
+++ b/FWCore/Modules/test/emptysource_RunsAndLumis_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Test")
+process.source = cms.Source("EmptySource", 
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(2), 
+                            processingMode=cms.untracked.string('RunsAndLumis'))
+
+process.maxLuminosityBlocks.input = 3
+
+ids = cms.untracked.VPSet()
+ids.append(cms.PSet(type = cms.untracked.string("IsFile"),
+                    id = cms.untracked.EventID(0,0,0)))
+for i in range(0,4):
+    if(i==0) :
+        ids.append(cms.PSet(type = cms.untracked.string("IsRun"),
+                                id = cms.untracked.EventID(1,0,0)))
+    else:
+        ids.append(cms.PSet(type = cms.untracked.string("IsLumi"),
+                                id = cms.untracked.EventID(1,i,0)))
+
+ids.append(cms.PSet(type = cms.untracked.string("IsStop"),
+                    id = cms.untracked.EventID(0,0,0)))
+
+#print ids.dumpPython()
+process.add_(cms.Service("CheckTransitions",
+                         transitions = ids))
+

--- a/FWCore/Sources/src/IDGeneratorSourceBase.cc
+++ b/FWCore/Sources/src/IDGeneratorSourceBase.cc
@@ -164,12 +164,6 @@ namespace edm {
       BASE::setNewLumi();
       return newFile ? BASE::IsFile : BASE::IsRun;
     }
-    if (BASE::processingMode() == BASE::Runs) {
-      return newFile ? BASE::IsFile : BASE::IsRun;
-    }
-    if (BASE::processingMode() == BASE::RunsAndLumis) {
-      return newFile ? BASE::IsFile : BASE::IsLumi;
-    }
     // Same Run
     if (BASE::newLumi() || eventID_.luminosityBlock() != oldEventID.luminosityBlock()) {
       // New Lumi


### PR DESCRIPTION
#### PR description:

One too few LuminosityBlocks were being generated in RunsAndLumis mode.

#### PR validation:
The code compiles and the newly added unit test (and all old unit tests) pass.