### PR TITLE
Backport of #29567 (biased tau decayer) to CMSSW_10_6_X

### DIFF
--- a/GeneratorInterface/Pythia8Interface/interface/BiasedTauDecayer.h
+++ b/GeneratorInterface/Pythia8Interface/interface/BiasedTauDecayer.h
@@ -1,0 +1,30 @@
+#include "Pythia8/ParticleDecays.h"
+#include "Pythia8/Pythia.h"
+
+//==========================================================================
+
+// Specialized decayer for resonance decays to taus to allowing biasing to
+// leptonic decays
+//
+class BiasedTauDecayer : public Pythia8::DecayHandler {
+public:
+  BiasedTauDecayer(Pythia8::Info* infoPtr,
+                   Pythia8::Settings* settingsPtr,
+                   Pythia8::ParticleData* particleDataPtr,
+                   Pythia8::Rndm* rndmPtr,
+                   Pythia8::Couplings* couplingsPtr);
+
+  bool decay(std::vector<int>& idProd,
+             std::vector<double>& mProd,
+             std::vector<Pythia8::Vec4>& pProd,
+             int iDec,
+             const Pythia8::Event& event) override;
+
+private:
+  Pythia8::TauDecays decayer;
+  bool filter_;
+  bool eMuDecays_;
+  std::vector<int> idProdSave;
+  std::vector<double> mProdSave;
+  std::vector<Pythia8::Vec4> pProdSave;
+};

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -74,478 +74,455 @@ namespace CLHEP {
 
 using namespace gen;
 
-
 class Pythia8Hadronizer : public Py8InterfaceBase {
+public:
+  Pythia8Hadronizer(const edm::ParameterSet &params);
+  ~Pythia8Hadronizer() override;
 
-  public:
+  bool initializeForInternalPartons() override;
+  bool initializeForExternalPartons();
 
-    Pythia8Hadronizer(const edm::ParameterSet &params);
-   ~Pythia8Hadronizer() override;
- 
-    bool initializeForInternalPartons() override;
-    bool initializeForExternalPartons();
-	
-    bool generatePartonsAndHadronize() override;
-    bool hadronize();
+  bool generatePartonsAndHadronize() override;
+  bool hadronize();
 
-    virtual bool residualDecay();
+  virtual bool residualDecay();
 
-    void finalizeEvent() override;
+  void finalizeEvent() override;
 
-    void statistics() override;
+  void statistics() override;
 
-    const char *classname() const override { return "Pythia8Hadronizer"; }
-    
+  const char *classname() const override { return "Pythia8Hadronizer"; }
+
   std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const override;
-    
-  private:
 
-    std::unique_ptr<Vincia::VinciaPlugin> fvincia;
-    std::unique_ptr<Pythia8::Dire> fDire;
+private:
+  std::unique_ptr<Vincia::VinciaPlugin> fvincia;
+  std::unique_ptr<Pythia8::Dire> fDire;
 
-    void doSetRandomEngine(CLHEP::HepRandomEngine* v) override { p8SetRandomEngine(v); }
-    std::vector<std::string> const& doSharedResources() const override { return p8SharedResources; }
+  void doSetRandomEngine(CLHEP::HepRandomEngine *v) override { p8SetRandomEngine(v); }
+  std::vector<std::string> const &doSharedResources() const override { return p8SharedResources; }
 
-    /// Center-of-Mass energy
-    double       comEnergy;
+  /// Center-of-Mass energy
+  double comEnergy;
 
-    std::string LHEInputFileName;
-    std::unique_ptr<LHAupLesHouches>  lhaUP;
+  std::string LHEInputFileName;
+  std::unique_ptr<LHAupLesHouches> lhaUP;
 
-    enum { PP, PPbar, ElectronPositron };
-    int  fInitialState ; // pp, ppbar, or e-e+
+  enum { PP, PPbar, ElectronPositron };
+  int fInitialState;  // pp, ppbar, or e-e+
 
-    double fBeam1PZ;
-    double fBeam2PZ;
+  double fBeam1PZ;
+  double fBeam2PZ;
 
-    //helper class to allow multiple user hooks simultaneously
-    std::unique_ptr<MultiUserHook> fMultiUserHook;
-    
-    // Reweight user hooks
-    //
-    std::unique_ptr<UserHooks> fReweightUserHook;
-    std::unique_ptr<UserHooks> fReweightEmpUserHook;
-    std::unique_ptr<UserHooks> fReweightRapUserHook;  
-    std::unique_ptr<UserHooks> fReweightPtHatRapUserHook;
-        
-    // PS matching prototype
-    //
-    std::unique_ptr<JetMatchingHook> fJetMatchingHook;
-    std::unique_ptr<Pythia8::JetMatchingMadgraph> fJetMatchingPy8InternalHook;
-    std::unique_ptr<Pythia8::amcnlo_unitarised_interface> fMergingHook;
-    
-    // Emission Veto Hooks
-    //
-    std::unique_ptr<PowhegHooks> fEmissionVetoHook;
-    std::unique_ptr<EmissionVetoHook1> fEmissionVetoHook1;
-    
-    // Resonance scale hook
-    std::unique_ptr<PowhegResHook> fPowhegResHook;
-    std::unique_ptr<PowhegHooksBB4L> fPowhegHooksBB4L;
-    
-    // biased tau decayer
-    std::unique_ptr<BiasedTauDecayer> fBiasedTauDecayer;
-    
-    //resonance decay filter hook
-    std::unique_ptr<ResonanceDecayFilterHook> fResonanceDecayFilterHook;
- 
-    //PT filter hook
-    std::unique_ptr<PTFilterHook> fPTFilterHook;
-   
-    int  EV1_nFinal;
-    bool EV1_vetoOn;
-    int  EV1_maxVetoCount;
-    int  EV1_pThardMode;
-    int  EV1_pTempMode;
-    int  EV1_emittedMode;
-    int  EV1_pTdefMode;
-    bool EV1_MPIvetoOn;   
-    int  EV1_QEDvetoMode;
-    int  EV1_nFinalMode;
+  //helper class to allow multiple user hooks simultaneously
+  std::unique_ptr<MultiUserHook> fMultiUserHook;
 
-    static const std::vector<std::string> p8SharedResources;
-    
-    vector<float> DJR;
-    int nME;
-    int nMEFiltered;
+  // Reweight user hooks
+  //
+  std::unique_ptr<UserHooks> fReweightUserHook;
+  std::unique_ptr<UserHooks> fReweightEmpUserHook;
+  std::unique_ptr<UserHooks> fReweightRapUserHook;
+  std::unique_ptr<UserHooks> fReweightPtHatRapUserHook;
 
-    int nISRveto;
-    int nFSRveto;
-    
+  // PS matching prototype
+  //
+  std::unique_ptr<JetMatchingHook> fJetMatchingHook;
+  std::unique_ptr<Pythia8::JetMatchingMadgraph> fJetMatchingPy8InternalHook;
+  std::unique_ptr<Pythia8::amcnlo_unitarised_interface> fMergingHook;
+
+  // Emission Veto Hooks
+  //
+  std::unique_ptr<PowhegHooks> fEmissionVetoHook;
+  std::unique_ptr<EmissionVetoHook1> fEmissionVetoHook1;
+
+  // Resonance scale hook
+  std::unique_ptr<PowhegResHook> fPowhegResHook;
+  std::unique_ptr<PowhegHooksBB4L> fPowhegHooksBB4L;
+
+  // biased tau decayer
+  std::unique_ptr<BiasedTauDecayer> fBiasedTauDecayer;
+
+  //resonance decay filter hook
+  std::unique_ptr<ResonanceDecayFilterHook> fResonanceDecayFilterHook;
+
+  //PT filter hook
+  std::unique_ptr<PTFilterHook> fPTFilterHook;
+
+  int EV1_nFinal;
+  bool EV1_vetoOn;
+  int EV1_maxVetoCount;
+  int EV1_pThardMode;
+  int EV1_pTempMode;
+  int EV1_emittedMode;
+  int EV1_pTdefMode;
+  bool EV1_MPIvetoOn;
+  int EV1_QEDvetoMode;
+  int EV1_nFinalMode;
+
+  static const std::vector<std::string> p8SharedResources;
+
+  vector<float> DJR;
+  int nME;
+  int nMEFiltered;
+
+  int nISRveto;
+  int nFSRveto;
 };
 
-const std::vector<std::string> Pythia8Hadronizer::p8SharedResources = { edm::SharedResourceNames::kPythia8 };
+const std::vector<std::string> Pythia8Hadronizer::p8SharedResources = {edm::SharedResourceNames::kPythia8};
 
-Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params) :
-  Py8InterfaceBase(params),
-  comEnergy(params.getParameter<double>("comEnergy")),
-  LHEInputFileName(params.getUntrackedParameter<std::string>("LHEInputFileName","")),
-  fInitialState(PP),
-  nME(-1), nMEFiltered(-1), nISRveto(0), nFSRveto(0)
-{
-
+Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
+    : Py8InterfaceBase(params),
+      comEnergy(params.getParameter<double>("comEnergy")),
+      LHEInputFileName(params.getUntrackedParameter<std::string>("LHEInputFileName", "")),
+      fInitialState(PP),
+      nME(-1),
+      nMEFiltered(-1),
+      nISRveto(0),
+      nFSRveto(0) {
   // J.Y.: the following 3 parameters are hacked "for a reason"
   //
-  if ( params.exists( "PPbarInitialState" ) )
-  {
-    if ( fInitialState == PP )
-    {
+  if (params.exists("PPbarInitialState")) {
+    if (fInitialState == PP) {
       fInitialState = PPbar;
       edm::LogImportant("GeneratorInterface|Pythia8Interface")
-      << "Pythia8 will be initialized for PROTON-ANTIPROTON INITIAL STATE. "
-      << "This is a user-request change from the DEFAULT PROTON-PROTON initial state.";
-    }
-    else
-    {   
+          << "Pythia8 will be initialized for PROTON-ANTIPROTON INITIAL STATE. "
+          << "This is a user-request change from the DEFAULT PROTON-PROTON initial state.";
+    } else {
       // probably need to throw on attempt to override ?
     }
-  }   
-  else if ( params.exists( "ElectronPositronInitialState" ) )
-  {
-    if ( fInitialState == PP )
-    {
+  } else if (params.exists("ElectronPositronInitialState")) {
+    if (fInitialState == PP) {
       fInitialState = ElectronPositron;
       edm::LogInfo("GeneratorInterface|Pythia8Interface")
-      << "Pythia8 will be initialized for ELECTRON-POSITRON INITIAL STATE. "
-      << "This is a user-request change from the DEFAULT PROTON-PROTON initial state.";
+          << "Pythia8 will be initialized for ELECTRON-POSITRON INITIAL STATE. "
+          << "This is a user-request change from the DEFAULT PROTON-PROTON initial state.";
+    } else {
+      // probably need to throw on attempt to override ?
     }
-    else
-    {   
-       // probably need to throw on attempt to override ?
-    }
-  }
-  else if ( params.exists( "ElectronProtonInitialState" ) || params.exists( "PositronProtonInitialState" ) )
-  {
+  } else if (params.exists("ElectronProtonInitialState") || params.exists("PositronProtonInitialState")) {
     // throw on unknown initial state !
-    throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-      <<" UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
+    throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
+        << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
   }
 
   // Reweight user hook
   //
-  if( params.exists( "reweightGen" ) )
-  {
+  if (params.exists("reweightGen")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGen";
-    edm::ParameterSet rgParams =
-       params.getParameter<edm::ParameterSet>("reweightGen");
+    edm::ParameterSet rgParams = params.getParameter<edm::ParameterSet>("reweightGen");
     fReweightUserHook.reset(
-       new PtHatReweightUserHook(rgParams.getParameter<double>("pTRef"),
-                                 rgParams.getParameter<double>("power"))
-       );
+        new PtHatReweightUserHook(rgParams.getParameter<double>("pTRef"), rgParams.getParameter<double>("power")));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGen";
   }
-  if( params.exists( "reweightGenEmp" ) )
-  {
+  if (params.exists("reweightGenEmp")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenEmp";
-    edm::ParameterSet rgeParams =
-       params.getParameter<edm::ParameterSet>("reweightGenEmp");
+    edm::ParameterSet rgeParams = params.getParameter<edm::ParameterSet>("reweightGenEmp");
 
     std::string tuneName = "";
-    if(rgeParams.exists("tune"))
-        tuneName =  rgeParams.getParameter<std::string>("tune");
+    if (rgeParams.exists("tune"))
+      tuneName = rgeParams.getParameter<std::string>("tune");
     fReweightEmpUserHook.reset(new PtHatEmpReweightUserHook(tuneName));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenEmp";
   }
-  if( params.exists( "reweightGenRap" ) )
-  {
+  if (params.exists("reweightGenRap")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenRap";
-    edm::ParameterSet rgrParams =
-      params.getParameter<edm::ParameterSet>("reweightGenRap");
-    fReweightRapUserHook.reset(
-      new RapReweightUserHook(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
-                              rgrParams.getParameter<double>("yLabPower"),
-                              rgrParams.getParameter<std::string>("yCMSigmaFunc"),
-                              rgrParams.getParameter<double>("yCMPower"),
-                              rgrParams.getParameter<double>("pTHatMin"),
-                              rgrParams.getParameter<double>("pTHatMax"))
-                         );
+    edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenRap");
+    fReweightRapUserHook.reset(new RapReweightUserHook(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
+                                                       rgrParams.getParameter<double>("yLabPower"),
+                                                       rgrParams.getParameter<std::string>("yCMSigmaFunc"),
+                                                       rgrParams.getParameter<double>("yCMPower"),
+                                                       rgrParams.getParameter<double>("pTHatMin"),
+                                                       rgrParams.getParameter<double>("pTHatMax")));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenRap";
   }
-  if( params.exists( "reweightGenPtHatRap" ) )
-  {
+  if (params.exists("reweightGenPtHatRap")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenPtHatRap";
-    edm::ParameterSet rgrParams =
-      params.getParameter<edm::ParameterSet>("reweightGenPtHatRap");
-    fReweightPtHatRapUserHook.reset(
-      new PtHatRapReweightUserHook(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
-                                   rgrParams.getParameter<double>("yLabPower"),
-                                   rgrParams.getParameter<std::string>("yCMSigmaFunc"),
-                                   rgrParams.getParameter<double>("yCMPower"),
-                                   rgrParams.getParameter<double>("pTHatMin"),
-                                   rgrParams.getParameter<double>("pTHatMax"))
-                              );
+    edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenPtHatRap");
+    fReweightPtHatRapUserHook.reset(new PtHatRapReweightUserHook(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
+                                                                 rgrParams.getParameter<double>("yLabPower"),
+                                                                 rgrParams.getParameter<std::string>("yCMSigmaFunc"),
+                                                                 rgrParams.getParameter<double>("yCMPower"),
+                                                                 rgrParams.getParameter<double>("pTHatMin"),
+                                                                 rgrParams.getParameter<double>("pTHatMax")));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenPtHatRap";
   }
 
-  if( params.exists( "useUserHook" ) )
-    throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-      <<" Obsolete parameter: useUserHook \n Please use the actual one instead \n";
+  if (params.exists("useUserHook"))
+    throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
+        << " Obsolete parameter: useUserHook \n Please use the actual one instead \n";
 
   // PS matching prototype
   //
-  if ( params.exists("jetMatching") )
-  {
-    edm::ParameterSet jmParams =
-      params.getUntrackedParameter<edm::ParameterSet>("jetMatching");
-      std::string scheme = jmParams.getParameter<std::string>("scheme");
-      if ( scheme == "Madgraph" || scheme == "MadgraphFastJet" )
-      {
-         fJetMatchingHook.reset(new JetMatchingHook( jmParams, &fMasterGen->info ));
-      }
+  if (params.exists("jetMatching")) {
+    edm::ParameterSet jmParams = params.getUntrackedParameter<edm::ParameterSet>("jetMatching");
+    std::string scheme = jmParams.getParameter<std::string>("scheme");
+    if (scheme == "Madgraph" || scheme == "MadgraphFastJet") {
+      fJetMatchingHook.reset(new JetMatchingHook(jmParams, &fMasterGen->info));
+    }
   }
 
   // Pythia8Interface emission veto
   //
-  if ( params.exists("emissionVeto1") )
-  {
+  if (params.exists("emissionVeto1")) {
     EV1_nFinal = -1;
-    if(params.exists("EV1_nFinal")) EV1_nFinal = params.getParameter<int>("EV1_nFinal");
+    if (params.exists("EV1_nFinal"))
+      EV1_nFinal = params.getParameter<int>("EV1_nFinal");
     EV1_vetoOn = true;
-    if(params.exists("EV1_vetoOn")) EV1_vetoOn = params.getParameter<bool>("EV1_vetoOn");
+    if (params.exists("EV1_vetoOn"))
+      EV1_vetoOn = params.getParameter<bool>("EV1_vetoOn");
     EV1_maxVetoCount = 10;
-    if(params.exists("EV1_maxVetoCount")) EV1_maxVetoCount = params.getParameter<int>("EV1_maxVetoCount");
+    if (params.exists("EV1_maxVetoCount"))
+      EV1_maxVetoCount = params.getParameter<int>("EV1_maxVetoCount");
     EV1_pThardMode = 1;
-    if(params.exists("EV1_pThardMode")) EV1_pThardMode = params.getParameter<int>("EV1_pThardMode");
+    if (params.exists("EV1_pThardMode"))
+      EV1_pThardMode = params.getParameter<int>("EV1_pThardMode");
     EV1_pTempMode = 0;
-    if(params.exists("EV1_pTempMode")) EV1_pTempMode = params.getParameter<int>("EV1_pTempMode");
-    if(EV1_pTempMode > 2 || EV1_pTempMode < 0)
-      throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-        <<" Wrong value for EV1_pTempMode code\n";
+    if (params.exists("EV1_pTempMode"))
+      EV1_pTempMode = params.getParameter<int>("EV1_pTempMode");
+    if (EV1_pTempMode > 2 || EV1_pTempMode < 0)
+      throw edm::Exception(edm::errors::Configuration, "Pythia8Interface") << " Wrong value for EV1_pTempMode code\n";
     EV1_emittedMode = 0;
-    if(params.exists("EV1_emittedMode")) EV1_emittedMode = params.getParameter<int>("EV1_emittedMode");
+    if (params.exists("EV1_emittedMode"))
+      EV1_emittedMode = params.getParameter<int>("EV1_emittedMode");
     EV1_pTdefMode = 1;
-    if(params.exists("EV1_pTdefMode")) EV1_pTdefMode = params.getParameter<int>("EV1_pTdefMode");
+    if (params.exists("EV1_pTdefMode"))
+      EV1_pTdefMode = params.getParameter<int>("EV1_pTdefMode");
     EV1_MPIvetoOn = false;
-    if(params.exists("EV1_MPIvetoOn")) EV1_MPIvetoOn = params.getParameter<bool>("EV1_MPIvetoOn");
+    if (params.exists("EV1_MPIvetoOn"))
+      EV1_MPIvetoOn = params.getParameter<bool>("EV1_MPIvetoOn");
     EV1_QEDvetoMode = 0;
-    if(params.exists("EV1_QEDvetoMode")) EV1_QEDvetoMode = params.getParameter<int>("EV1_QEDvetoMode");
+    if (params.exists("EV1_QEDvetoMode"))
+      EV1_QEDvetoMode = params.getParameter<int>("EV1_QEDvetoMode");
     EV1_nFinalMode = 0;
-    if(params.exists("EV1_nFinalMode")) EV1_nFinalMode = params.getParameter<int>("EV1_nFinalMode");
-    fEmissionVetoHook1.reset(new EmissionVetoHook1(EV1_nFinal, EV1_vetoOn,
-                               EV1_maxVetoCount, EV1_pThardMode, EV1_pTempMode,
-                               EV1_emittedMode, EV1_pTdefMode, 
-			       EV1_MPIvetoOn, EV1_QEDvetoMode, EV1_nFinalMode, 0));
+    if (params.exists("EV1_nFinalMode"))
+      EV1_nFinalMode = params.getParameter<int>("EV1_nFinalMode");
+    fEmissionVetoHook1.reset(new EmissionVetoHook1(EV1_nFinal,
+                                                   EV1_vetoOn,
+                                                   EV1_maxVetoCount,
+                                                   EV1_pThardMode,
+                                                   EV1_pTempMode,
+                                                   EV1_emittedMode,
+                                                   EV1_pTdefMode,
+                                                   EV1_MPIvetoOn,
+                                                   EV1_QEDvetoMode,
+                                                   EV1_nFinalMode,
+                                                   0));
   }
-  
-  if( params.exists( "VinciaPlugin" ) ) {
+
+  if (params.exists("VinciaPlugin")) {
     fMasterGen.reset(new Pythia);
     fvincia.reset(new Vincia::VinciaPlugin(fMasterGen.get()));
   }
-  if( params.exists( "DirePlugin" ) ) {
+  if (params.exists("DirePlugin")) {
     fMasterGen.reset(new Pythia);
     fDire.reset(new Pythia8::Dire());
     fDire->initSettings(*fMasterGen.get());
     fDire->initShowersAndWeights(*fMasterGen.get(), nullptr, nullptr);
   }
-
 }
 
+Pythia8Hadronizer::~Pythia8Hadronizer() {}
 
-Pythia8Hadronizer::~Pythia8Hadronizer()
-{
-  
-}
-
-bool Pythia8Hadronizer::initializeForInternalPartons()
-{
-  
+bool Pythia8Hadronizer::initializeForInternalPartons() {
   bool status = false, status1 = false;
-  
+
   if (lheFile_.empty()) {
-    if ( fInitialState == PP ) // default
+    if (fInitialState == PP)  // default
     {
       fMasterGen->settings.mode("Beams:idA", 2212);
       fMasterGen->settings.mode("Beams:idB", 2212);
-    }
-    else if ( fInitialState == PPbar )
-    {
+    } else if (fInitialState == PPbar) {
       fMasterGen->settings.mode("Beams:idA", 2212);
       fMasterGen->settings.mode("Beams:idB", -2212);
-    }
-    else if ( fInitialState == ElectronPositron )
-    {
+    } else if (fInitialState == ElectronPositron) {
       fMasterGen->settings.mode("Beams:idA", 11);
       fMasterGen->settings.mode("Beams:idB", -11);
-    }    
-    else 
-    {
+    } else {
       // throw on unknown initial state !
-      throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-        <<" UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
+      throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
+          << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
     }
     fMasterGen->settings.parm("Beams:eCM", comEnergy);
-  }
-  else {
+  } else {
     fMasterGen->settings.mode("Beams:frameType", 4);
     fMasterGen->settings.word("Beams:LHEF", lheFile_);
   }
-  
+
   fMultiUserHook.reset(new MultiUserHook);
-  
-  if(fReweightUserHook.get()) fMultiUserHook->addHook(fReweightUserHook.get());
-  if(fReweightEmpUserHook.get()) fMultiUserHook->addHook(fReweightEmpUserHook.get());
-  if(fReweightRapUserHook.get()) fMultiUserHook->addHook(fReweightRapUserHook.get());
-  if(fReweightPtHatRapUserHook.get()) fMultiUserHook->addHook(fReweightPtHatRapUserHook.get());
-  if(fJetMatchingHook.get()) fMultiUserHook->addHook(fJetMatchingHook.get());
-  if(fEmissionVetoHook1.get()) { 
+
+  if (fReweightUserHook.get())
+    fMultiUserHook->addHook(fReweightUserHook.get());
+  if (fReweightEmpUserHook.get())
+    fMultiUserHook->addHook(fReweightEmpUserHook.get());
+  if (fReweightRapUserHook.get())
+    fMultiUserHook->addHook(fReweightRapUserHook.get());
+  if (fReweightPtHatRapUserHook.get())
+    fMultiUserHook->addHook(fReweightPtHatRapUserHook.get());
+  if (fJetMatchingHook.get())
+    fMultiUserHook->addHook(fJetMatchingHook.get());
+  if (fEmissionVetoHook1.get()) {
     edm::LogInfo("Pythia8Interface") << "Turning on Emission Veto Hook 1 from CMSSW Pythia8Interface";
     fMultiUserHook->addHook(fEmissionVetoHook1.get());
   }
-  
-  if (fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) {
 
-    if(fJetMatchingHook.get() || fEmissionVetoHook1.get())
-      throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-      <<" Attempt to turn on PowhegHooks by pythia8 settings but there are incompatible hooks on \n Incompatible are : jetMatching, emissionVeto1 \n";
+  if (fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) {
+    if (fJetMatchingHook.get() || fEmissionVetoHook1.get())
+      throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
+          << " Attempt to turn on PowhegHooks by pythia8 settings but there are incompatible hooks on \n Incompatible "
+             "are : jetMatching, emissionVeto1 \n";
 
     fEmissionVetoHook.reset(new PowhegHooks());
 
     edm::LogInfo("Pythia8Interface") << "Turning on Emission Veto Hook from pythia8 code";
     fMultiUserHook->addHook(fEmissionVetoHook.get());
   }
-  
+
   bool PowhegRes = fMasterGen->settings.flag("POWHEGres:calcScales");
   if (PowhegRes) {
     edm::LogInfo("Pythia8Interface") << "Turning on resonance scale setting from CMSSW Pythia8Interface";
     fPowhegResHook.reset(new PowhegResHook());
     fMultiUserHook->addHook(fPowhegResHook.get());
   }
-  
+
   bool PowhegBB4L = fMasterGen->settings.flag("POWHEG:bb4l");
   if (PowhegBB4L) {
     edm::LogInfo("Pythia8Interface") << "Turning on BB4l hook from CMSSW Pythia8Interface";
     fPowhegHooksBB4L.reset(new PowhegHooksBB4L());
     fMultiUserHook->addHook(fPowhegHooksBB4L.get());
   }
-  
+
   //adapted from main89.cc in pythia8 examples
   bool internalMatching = fMasterGen->settings.flag("JetMatching:merge");
-  bool internalMerging = !(fMasterGen->settings.word("Merging:Process")=="void");
-  
+  bool internalMerging = !(fMasterGen->settings.word("Merging:Process") == "void");
+
   if (internalMatching && internalMerging) {
-    throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-      <<" Only one jet matching/merging scheme can be used at a time. \n";
+    throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
+        << " Only one jet matching/merging scheme can be used at a time. \n";
   }
-  
+
   if (internalMatching) {
     fJetMatchingPy8InternalHook.reset(new Pythia8::JetMatchingMadgraph);
     fMultiUserHook->addHook(fJetMatchingPy8InternalHook.get());
   }
-  
+
   if (internalMerging) {
-    int scheme = ( fMasterGen->settings.flag("Merging:doUMEPSTree")
-                || fMasterGen->settings.flag("Merging:doUMEPSSubt")) ?
-                1 :
-                 ( ( fMasterGen->settings.flag("Merging:doUNLOPSTree")
-                || fMasterGen->settings.flag("Merging:doUNLOPSSubt")
-                || fMasterGen->settings.flag("Merging:doUNLOPSLoop")
-                || fMasterGen->settings.flag("Merging:doUNLOPSSubtNLO")) ?
-                2 :
-                0 );
+    int scheme = (fMasterGen->settings.flag("Merging:doUMEPSTree") || fMasterGen->settings.flag("Merging:doUMEPSSubt"))
+                     ? 1
+                     : ((fMasterGen->settings.flag("Merging:doUNLOPSTree") ||
+                         fMasterGen->settings.flag("Merging:doUNLOPSSubt") ||
+                         fMasterGen->settings.flag("Merging:doUNLOPSLoop") ||
+                         fMasterGen->settings.flag("Merging:doUNLOPSSubtNLO"))
+                            ? 2
+                            : 0);
     fMergingHook.reset(new Pythia8::amcnlo_unitarised_interface(scheme));
     fMultiUserHook->addHook(fMergingHook.get());
   }
-  
+
   bool biasedTauDecayer = fMasterGen->settings.flag("BiasedTauDecayer:filter");
   if (biasedTauDecayer) {
-    fBiasedTauDecayer.reset(new BiasedTauDecayer(&(fMasterGen->info), &(fMasterGen->settings),
-	&(fMasterGen->particleData), &(fMasterGen->rndm), &(fMasterGen->couplings) ) );
+    fBiasedTauDecayer.reset(new BiasedTauDecayer(&(fMasterGen->info),
+                                                 &(fMasterGen->settings),
+                                                 &(fMasterGen->particleData),
+                                                 &(fMasterGen->rndm),
+                                                 &(fMasterGen->couplings)));
     std::vector<int> handledParticles;
     handledParticles.push_back(15);
-    fMasterGen->setDecayPtr(fBiasedTauDecayer.get(),handledParticles);
+    fMasterGen->setDecayPtr(fBiasedTauDecayer.get(), handledParticles);
   }
-  
+
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
   if (resonanceDecayFilter) {
     fResonanceDecayFilterHook.reset(new ResonanceDecayFilterHook);
     fMultiUserHook->addHook(fResonanceDecayFilterHook.get());
   }
- 
+
   bool PTFilter = fMasterGen->settings.flag("PTFilter:filter");
   if (PTFilter) {
     fPTFilterHook.reset(new PTFilterHook);
     fMultiUserHook->addHook(fPTFilterHook.get());
   }
- 
-  if (fMultiUserHook->nHooks()>0) {
+
+  if (fMultiUserHook->nHooks() > 0) {
     fMasterGen->setUserHooksPtr(fMultiUserHook.get());
   }
 
   edm::LogInfo("Pythia8Interface") << "Initializing MasterGen";
-  if( fvincia.get() ) {
-    fvincia->init(); status = true;
-  }
-  else if( fDire.get() ) {
+  if (fvincia.get()) {
+    fvincia->init();
+    status = true;
+  } else if (fDire.get()) {
     //fDire->initTune(*fMasterGen.get());
     fDire->weightsPtr->setup();
     fMasterGen->init();
     fDire->setup(*fMasterGen.get());
     status = true;
-  }
-  else {
+  } else {
     status = fMasterGen->init();
   }
-  
+
   //clean up temp file
   if (!slhafile_.empty()) {
     std::remove(slhafile_.c_str());
-  }  
+  }
 
-  if ( pythiaPylistVerbosity > 10 )
-  {
-    if ( pythiaPylistVerbosity == 11 || pythiaPylistVerbosity == 13 )
-           fMasterGen->settings.listAll();
-    if ( pythiaPylistVerbosity == 12 || pythiaPylistVerbosity == 13 )
-           fMasterGen->particleData.listAll();
+  if (pythiaPylistVerbosity > 10) {
+    if (pythiaPylistVerbosity == 11 || pythiaPylistVerbosity == 13)
+      fMasterGen->settings.listAll();
+    if (pythiaPylistVerbosity == 12 || pythiaPylistVerbosity == 13)
+      fMasterGen->particleData.listAll();
   }
 
   // init decayer
-  fDecayer->settings.flag("ProcessLevel:all", false ); // trick
-  fDecayer->settings.flag("ProcessLevel:resonanceDecays", true );
+  fDecayer->settings.flag("ProcessLevel:all", false);  // trick
+  fDecayer->settings.flag("ProcessLevel:resonanceDecays", true);
   edm::LogInfo("Pythia8Interface") << "Initializing Decayer";
   status1 = fDecayer->init();
 
   if (useEvtGen) {
     edm::LogInfo("Pythia8Hadronizer") << "Creating and initializing pythia8 EvtGen plugin";
     evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile, evtgenPdlFile));
-    for (unsigned int i=0; i<evtgenUserFiles.size(); i++) evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
+    for (unsigned int i = 0; i < evtgenUserFiles.size(); i++)
+      evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
   }
 
-  return (status&&status1);
+  return (status && status1);
 }
 
-
-bool Pythia8Hadronizer::initializeForExternalPartons()
-{
-
+bool Pythia8Hadronizer::initializeForExternalPartons() {
   edm::LogInfo("Pythia8Interface") << "Initializing for external partons";
 
   bool status = false, status1 = false;
-  
+
   fMultiUserHook.reset(new MultiUserHook);
-  
-  if(fReweightUserHook.get()) fMultiUserHook->addHook(fReweightUserHook.get());
-  if(fReweightEmpUserHook.get()) fMultiUserHook->addHook(fReweightEmpUserHook.get());
-  if(fReweightRapUserHook.get()) fMultiUserHook->addHook(fReweightRapUserHook.get());
-  if(fReweightPtHatRapUserHook.get()) fMultiUserHook->addHook(fReweightPtHatRapUserHook.get());
-  if(fJetMatchingHook.get()) fMultiUserHook->addHook(fJetMatchingHook.get());
-  if(fEmissionVetoHook1.get()) { 
+
+  if (fReweightUserHook.get())
+    fMultiUserHook->addHook(fReweightUserHook.get());
+  if (fReweightEmpUserHook.get())
+    fMultiUserHook->addHook(fReweightEmpUserHook.get());
+  if (fReweightRapUserHook.get())
+    fMultiUserHook->addHook(fReweightRapUserHook.get());
+  if (fReweightPtHatRapUserHook.get())
+    fMultiUserHook->addHook(fReweightPtHatRapUserHook.get());
+  if (fJetMatchingHook.get())
+    fMultiUserHook->addHook(fJetMatchingHook.get());
+  if (fEmissionVetoHook1.get()) {
     edm::LogInfo("Pythia8Interface") << "Turning on Emission Veto Hook 1 from CMSSW Pythia8Interface";
     fMultiUserHook->addHook(fEmissionVetoHook1.get());
   }
-  
-  if (fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) {
 
-    if(fJetMatchingHook.get() || fEmissionVetoHook1.get())
-      throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-      <<" Attempt to turn on PowhegHooks by pythia8 settings but there are incompatible hooks on \n Incompatible are : jetMatching, emissionVeto1 \n";
+  if (fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) {
+    if (fJetMatchingHook.get() || fEmissionVetoHook1.get())
+      throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
+          << " Attempt to turn on PowhegHooks by pythia8 settings but there are incompatible hooks on \n Incompatible "
+             "are : jetMatching, emissionVeto1 \n";
 
     fEmissionVetoHook.reset(new PowhegHooks());
 
     edm::LogInfo("Pythia8Interface") << "Turning on Emission Veto Hook from pythia8 code";
     fMultiUserHook->addHook(fEmissionVetoHook.get());
   }
-  
+
   bool PowhegRes = fMasterGen->settings.flag("POWHEGres:calcScales");
   if (PowhegRes) {
     edm::LogInfo("Pythia8Interface") << "Turning on resonance scale setting from CMSSW Pythia8Interface";
@@ -559,255 +536,245 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
     fPowhegHooksBB4L.reset(new PowhegHooksBB4L());
     fMultiUserHook->addHook(fPowhegHooksBB4L.get());
   }
-  
+
   //adapted from main89.cc in pythia8 examples
   bool internalMatching = fMasterGen->settings.flag("JetMatching:merge");
-  bool internalMerging = !(fMasterGen->settings.word("Merging:Process")=="void");
-  
+  bool internalMerging = !(fMasterGen->settings.word("Merging:Process") == "void");
+
   if (internalMatching && internalMerging) {
-    throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-      <<" Only one jet matching/merging scheme can be used at a time. \n";
+    throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
+        << " Only one jet matching/merging scheme can be used at a time. \n";
   }
-  
+
   if (internalMatching) {
     fJetMatchingPy8InternalHook.reset(new Pythia8::JetMatchingMadgraph);
     fMultiUserHook->addHook(fJetMatchingPy8InternalHook.get());
   }
-  
+
   if (internalMerging) {
-    int scheme = ( fMasterGen->settings.flag("Merging:doUMEPSTree")
-                || fMasterGen->settings.flag("Merging:doUMEPSSubt")) ?
-                1 :
-                 ( ( fMasterGen->settings.flag("Merging:doUNLOPSTree")
-                || fMasterGen->settings.flag("Merging:doUNLOPSSubt")
-                || fMasterGen->settings.flag("Merging:doUNLOPSLoop")
-                || fMasterGen->settings.flag("Merging:doUNLOPSSubtNLO")) ?
-                2 :
-                0 );
+    int scheme = (fMasterGen->settings.flag("Merging:doUMEPSTree") || fMasterGen->settings.flag("Merging:doUMEPSSubt"))
+                     ? 1
+                     : ((fMasterGen->settings.flag("Merging:doUNLOPSTree") ||
+                         fMasterGen->settings.flag("Merging:doUNLOPSSubt") ||
+                         fMasterGen->settings.flag("Merging:doUNLOPSLoop") ||
+                         fMasterGen->settings.flag("Merging:doUNLOPSSubtNLO"))
+                            ? 2
+                            : 0);
     fMergingHook.reset(new Pythia8::amcnlo_unitarised_interface(scheme));
     fMultiUserHook->addHook(fMergingHook.get());
   }
-  
+
   bool biasedTauDecayer = fMasterGen->settings.flag("BiasedTauDecayer:filter");
   if (biasedTauDecayer) {
-    fBiasedTauDecayer.reset(new BiasedTauDecayer(&(fMasterGen->info), &(fMasterGen->settings),
-	&(fMasterGen->particleData), &(fMasterGen->rndm), &(fMasterGen->couplings) ) );
+    fBiasedTauDecayer.reset(new BiasedTauDecayer(&(fMasterGen->info),
+                                                 &(fMasterGen->settings),
+                                                 &(fMasterGen->particleData),
+                                                 &(fMasterGen->rndm),
+                                                 &(fMasterGen->couplings)));
     std::vector<int> handledParticles;
     handledParticles.push_back(15);
-    fMasterGen->setDecayPtr(fBiasedTauDecayer.get(),handledParticles);
+    fMasterGen->setDecayPtr(fBiasedTauDecayer.get(), handledParticles);
   }
-  
+
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
   if (resonanceDecayFilter) {
     fResonanceDecayFilterHook.reset(new ResonanceDecayFilterHook);
     fMultiUserHook->addHook(fResonanceDecayFilterHook.get());
   }
- 
+
   bool PTFilter = fMasterGen->settings.flag("PTFilter:filter");
   if (PTFilter) {
     fPTFilterHook.reset(new PTFilterHook);
     fMultiUserHook->addHook(fPTFilterHook.get());
   }
- 
-  if (fMultiUserHook->nHooks()>0) {
-    fMasterGen->setUserHooksPtr(fMultiUserHook.get());
-  }  
-  
-  if(!LHEInputFileName.empty()) {
 
-    edm::LogInfo("Pythia8Interface") << "Initialize direct pythia8 reading from LHE file "
-                                     << LHEInputFileName;
+  if (fMultiUserHook->nHooks() > 0) {
+    fMasterGen->setUserHooksPtr(fMultiUserHook.get());
+  }
+
+  if (!LHEInputFileName.empty()) {
+    edm::LogInfo("Pythia8Interface") << "Initialize direct pythia8 reading from LHE file " << LHEInputFileName;
     edm::LogInfo("Pythia8Interface") << "Some LHE information can be not stored";
     fMasterGen->settings.mode("Beams:frameType", 4);
     fMasterGen->settings.word("Beams:LHEF", LHEInputFileName);
     status = fMasterGen->init();
 
   } else {
-
     lhaUP.reset(new LHAupLesHouches());
     lhaUP->setScalesFromLHEF(fMasterGen->settings.flag("Beams:setProductionScalesFromLHEF"));
     lhaUP->loadRunInfo(lheRunInfo());
-    
-    if ( fJetMatchingHook.get() )
-    {
-       fJetMatchingHook->init ( lheRunInfo() );
+
+    if (fJetMatchingHook.get()) {
+      fJetMatchingHook->init(lheRunInfo());
     }
-    
+
     fMasterGen->settings.mode("Beams:frameType", 5);
     fMasterGen->setLHAupPtr(lhaUP.get());
     edm::LogInfo("Pythia8Interface") << "Initializing MasterGen";
     status = fMasterGen->init();
   }
-  
+
   //clean up temp file
   if (!slhafile_.empty()) {
     std::remove(slhafile_.c_str());
-  }  
-  
-  if ( pythiaPylistVerbosity > 10 )
-  {
-    if ( pythiaPylistVerbosity == 11 || pythiaPylistVerbosity == 13 )
-           fMasterGen->settings.listAll();
-    if ( pythiaPylistVerbosity == 12 || pythiaPylistVerbosity == 13 )
-           fMasterGen->particleData.listAll();
+  }
+
+  if (pythiaPylistVerbosity > 10) {
+    if (pythiaPylistVerbosity == 11 || pythiaPylistVerbosity == 13)
+      fMasterGen->settings.listAll();
+    if (pythiaPylistVerbosity == 12 || pythiaPylistVerbosity == 13)
+      fMasterGen->particleData.listAll();
   }
 
   // init decayer
-  fDecayer->settings.flag("ProcessLevel:all", false ); // trick
-  fDecayer->settings.flag("ProcessLevel:resonanceDecays", true );
+  fDecayer->settings.flag("ProcessLevel:all", false);  // trick
+  fDecayer->settings.flag("ProcessLevel:resonanceDecays", true);
   edm::LogInfo("Pythia8Interface") << "Initializing Decayer";
   status1 = fDecayer->init();
 
   if (useEvtGen) {
     edm::LogInfo("Pythia8Hadronizer") << "Creating and initializing pythia8 EvtGen plugin";
     evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile, evtgenPdlFile));
-    for (unsigned int i=0; i<evtgenUserFiles.size(); i++) evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
+    for (unsigned int i = 0; i < evtgenUserFiles.size(); i++)
+      evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
   }
 
-  return (status&&status1);
+  return (status && status1);
 }
 
-
-void Pythia8Hadronizer::statistics()
-{
+void Pythia8Hadronizer::statistics() {
   fMasterGen->stat();
 
-  if(fEmissionVetoHook.get()) {
+  if (fEmissionVetoHook.get()) {
     edm::LogPrint("Pythia8Interface") << "\n"
-      << "Number of ISR vetoed = " << nISRveto;
-    edm::LogPrint("Pythia8Interface")
-      << "Number of FSR vetoed = " << nFSRveto;
+                                      << "Number of ISR vetoed = " << nISRveto;
+    edm::LogPrint("Pythia8Interface") << "Number of FSR vetoed = " << nFSRveto;
   }
 
-  double xsec = fMasterGen->info.sigmaGen(); // cross section in mb
-  xsec *= 1.0e9; // translate to pb (CMS/Gen "convention" as of May 2009)
-  double err  = fMasterGen->info.sigmaErr(); // cross section err in mb
-  err  *= 1.0e9; // translate to pb (CMS/Gen "convention" as of May 2009)
-  runInfo().setInternalXSec(GenRunInfoProduct::XSec(xsec,err));
+  double xsec = fMasterGen->info.sigmaGen();  // cross section in mb
+  xsec *= 1.0e9;                              // translate to pb (CMS/Gen "convention" as of May 2009)
+  double err = fMasterGen->info.sigmaErr();   // cross section err in mb
+  err *= 1.0e9;                               // translate to pb (CMS/Gen "convention" as of May 2009)
+  runInfo().setInternalXSec(GenRunInfoProduct::XSec(xsec, err));
 }
 
-
-bool Pythia8Hadronizer::generatePartonsAndHadronize()
-{
-
+bool Pythia8Hadronizer::generatePartonsAndHadronize() {
   DJR.resize(0);
   nME = -1;
   nMEFiltered = -1;
-  
-  if ( fJetMatchingHook.get() ) 
-  {
-    fJetMatchingHook->resetMatchingStatus(); 
-    fJetMatchingHook->beforeHadronization( lheEvent() );
+
+  if (fJetMatchingHook.get()) {
+    fJetMatchingHook->resetMatchingStatus();
+    fJetMatchingHook->beforeHadronization(lheEvent());
   }
-  
-  if (!fMasterGen->next()) return false;
+
+  if (!fMasterGen->next())
+    return false;
 
   double mergeweight = fMasterGen.get()->info.mergingWeightNLO();
   if (fMergingHook.get()) {
     mergeweight *= fMergingHook->getNormFactor();
   }
-  
+
   //protect against 0-weight from ckkw or similar
-  if (std::abs(mergeweight)==0.)
-  {
+  if (std::abs(mergeweight) == 0.) {
     event().reset();
     return false;
   }
-  
+
   if (fJetMatchingPy8InternalHook.get()) {
     const std::vector<double> djrmatch = fJetMatchingPy8InternalHook->getDJR();
     //cap size of djr vector to save storage space (keep only up to first 6 elements)
     unsigned int ndjr = std::min(djrmatch.size(), std::vector<double>::size_type(6));
-    for (unsigned int idjr=0; idjr<ndjr; ++idjr) {
+    for (unsigned int idjr = 0; idjr < ndjr; ++idjr) {
       DJR.push_back(djrmatch[idjr]);
     }
-    
-    nME=fJetMatchingPy8InternalHook->nMEpartons().first;
-    nMEFiltered=fJetMatchingPy8InternalHook->nMEpartons().second;
+
+    nME = fJetMatchingPy8InternalHook->nMEpartons().first;
+    nMEFiltered = fJetMatchingPy8InternalHook->nMEpartons().second;
   }
-  
-  if (evtgenDecays.get()) evtgenDecays->decay();
+
+  if (evtgenDecays.get())
+    evtgenDecays->decay();
 
   event().reset(new HepMC::GenEvent);
-  bool py8hepmc =  toHepMC.fill_next_event( *(fMasterGen.get()), event().get());
+  bool py8hepmc = toHepMC.fill_next_event(*(fMasterGen.get()), event().get());
 
   if (!py8hepmc) {
     return false;
   }
-  
+
   //add ckkw/umeps/unlops merging weight
-  if (mergeweight!=1.) {
+  if (mergeweight != 1.) {
     event()->weights()[0] *= mergeweight;
   }
-  
+
   if (fEmissionVetoHook.get()) {
     nISRveto += fEmissionVetoHook->getNISRveto();
-    nFSRveto += fEmissionVetoHook->getNFSRveto();  
+    nFSRveto += fEmissionVetoHook->getNFSRveto();
   }
-  
+
   //fill additional weights for systematic uncertainties
   if (fMasterGen->info.getWeightsDetailedSize() > 0) {
     for (const string &key : fMasterGen->info.initrwgt->weightsKeys) {
       double wgt = (*fMasterGen->info.weights_detailed)[key];
       event()->weights().push_back(wgt);
     }
-  }
-  else if (fMasterGen->info.getWeightsCompressedSize() > 0) {
+  } else if (fMasterGen->info.getWeightsCompressedSize() > 0) {
     for (unsigned int i = 0; i < fMasterGen->info.getWeightsCompressedSize(); i++) {
       double wgt = fMasterGen->info.getWeightsCompressedValue(i);
       event()->weights().push_back(wgt);
     }
   }
 
-  // fill shower weights 
+  // fill shower weights
   // http://home.thep.lu.se/~torbjorn/pythia82html/Variations.html
-  if( fMasterGen->info.nWeights() > 1 ){
-    for(int i = 0; i < fMasterGen->info.nWeights(); ++i) {
+  if (fMasterGen->info.nWeights() > 1) {
+    for (int i = 0; i < fMasterGen->info.nWeights(); ++i) {
       double wgt = fMasterGen->info.weight(i);
       event()->weights().push_back(wgt);
     }
   }
-  
+
   // VINCIA shower weights
   // http://vincia.hepforge.org/current/share/Vincia/htmldoc/VinciaUncertainties.html
-  if( fvincia.get() ) {
+  if (fvincia.get()) {
     event()->weights()[0] *= fvincia->weight(0);
-    for (int iVar=1; iVar < fvincia->nWeights(); iVar++) {
+    for (int iVar = 1; iVar < fvincia->nWeights(); iVar++) {
       event()->weights().push_back(fvincia->weight(iVar));
     }
   }
-  
+
   // Retrieve Dire shower weights
-  if( fDire.get() ) {
+  if (fDire.get()) {
     fDire->weightsPtr->calcWeight(0.);
     fDire->weightsPtr->reset();
-    
+
     //Make sure the base weight comes first
     event()->weights()[0] *= fDire->weightsPtr->getShowerWeight("base");
-    
+
     map<string, double>::iterator it;
-    for ( it = fDire->weightsPtr->getShowerWeights()->begin(); it != fDire->weightsPtr->getShowerWeights()->end(); it++ ) {
-      if (it->first == "base") continue;
+    for (it = fDire->weightsPtr->getShowerWeights()->begin(); it != fDire->weightsPtr->getShowerWeights()->end();
+         it++) {
+      if (it->first == "base")
+        continue;
       event()->weights().push_back(it->second);
     }
   }
 
   return true;
-  
 }
 
-
-bool Pythia8Hadronizer::hadronize()
-{
+bool Pythia8Hadronizer::hadronize() {
   DJR.resize(0);
   nME = -1;
   nMEFiltered = -1;
-  if(LHEInputFileName.empty()) lhaUP->loadEvent(lheEvent());
+  if (LHEInputFileName.empty())
+    lhaUP->loadEvent(lheEvent());
 
-  if ( fJetMatchingHook.get() ) 
-  {
-    fJetMatchingHook->resetMatchingStatus(); 
-    fJetMatchingHook->beforeHadronization( lheEvent() );
+  if (fJetMatchingHook.get()) {
+    fJetMatchingHook->resetMatchingStatus();
+    fJetMatchingHook->beforeHadronization(lheEvent());
   }
 
   bool py8next = fMasterGen->next();
@@ -816,120 +783,117 @@ bool Pythia8Hadronizer::hadronize()
   if (fMergingHook.get()) {
     mergeweight *= fMergingHook->getNormFactor();
   }
-  
-  
+
   //protect against 0-weight from ckkw or similar
-  if (!py8next || std::abs(mergeweight)==0.)
-  {
-    lheEvent()->count( lhef::LHERunInfo::kSelected, 1.0, mergeweight );
+  if (!py8next || std::abs(mergeweight) == 0.) {
+    lheEvent()->count(lhef::LHERunInfo::kSelected, 1.0, mergeweight);
     event().reset();
     return false;
   }
-  
+
   if (fJetMatchingPy8InternalHook.get()) {
     const std::vector<double> djrmatch = fJetMatchingPy8InternalHook->getDJR();
     //cap size of djr vector to save storage space (keep only up to first 6 elements)
     unsigned int ndjr = std::min(djrmatch.size(), std::vector<double>::size_type(6));
-    for (unsigned int idjr=0; idjr<ndjr; ++idjr) {
+    for (unsigned int idjr = 0; idjr < ndjr; ++idjr) {
       DJR.push_back(djrmatch[idjr]);
     }
-    
-    nME=fJetMatchingPy8InternalHook->nMEpartons().first;
-    nMEFiltered=fJetMatchingPy8InternalHook->nMEpartons().second;
+
+    nME = fJetMatchingPy8InternalHook->nMEpartons().first;
+    nMEFiltered = fJetMatchingPy8InternalHook->nMEpartons().second;
   }
-  
+
   // update LHE matching statistics
   //
-  lheEvent()->count( lhef::LHERunInfo::kAccepted, 1.0, mergeweight );
+  lheEvent()->count(lhef::LHERunInfo::kAccepted, 1.0, mergeweight);
 
-  if (evtgenDecays.get()) evtgenDecays->decay();
+  if (evtgenDecays.get())
+    evtgenDecays->decay();
 
   event().reset(new HepMC::GenEvent);
-  bool py8hepmc =  toHepMC.fill_next_event( *(fMasterGen.get()), event().get());
+  bool py8hepmc = toHepMC.fill_next_event(*(fMasterGen.get()), event().get());
   if (!py8hepmc) {
     return false;
   }
-  
+
   //add ckkw/umeps/unlops merging weight
-  if (mergeweight!=1.) {
+  if (mergeweight != 1.) {
     event()->weights()[0] *= mergeweight;
   }
 
   if (fEmissionVetoHook.get()) {
     nISRveto += fEmissionVetoHook->getNISRveto();
-    nFSRveto += fEmissionVetoHook->getNFSRveto();  
+    nFSRveto += fEmissionVetoHook->getNFSRveto();
   }
 
   // fill shower weights
   // http://home.thep.lu.se/~torbjorn/pythia82html/Variations.html
-  if( fMasterGen->info.nWeights() > 1 ){
-    for(int i = 0; i < fMasterGen->info.nWeights(); ++i) {
+  if (fMasterGen->info.nWeights() > 1) {
+    for (int i = 0; i < fMasterGen->info.nWeights(); ++i) {
       double wgt = fMasterGen->info.weight(i);
       event()->weights().push_back(wgt);
     }
   }
 
   return true;
-
 }
 
-
-bool Pythia8Hadronizer::residualDecay()
-{
-
-  Event* pythiaEvent = &(fMasterGen->event);
+bool Pythia8Hadronizer::residualDecay() {
+  Event *pythiaEvent = &(fMasterGen->event);
 
   int NPartsBeforeDecays = pythiaEvent->size();
   int NPartsAfterDecays = event().get()->particles_size();
 
-  if(NPartsAfterDecays == NPartsBeforeDecays) return true;
+  if (NPartsAfterDecays == NPartsBeforeDecays)
+    return true;
 
   bool result = true;
 
-  for ( int ipart=NPartsAfterDecays; ipart>NPartsBeforeDecays; ipart-- )
-  {
+  for (int ipart = NPartsAfterDecays; ipart > NPartsBeforeDecays; ipart--) {
+    HepMC::GenParticle *part = event().get()->barcode_to_particle(ipart);
 
-    HepMC::GenParticle* part = event().get()->barcode_to_particle( ipart );
-
-    if ( part->status() == 1 && (fDecayer->particleData).canDecay(part->pdg_id()) )
-    {
+    if (part->status() == 1 && (fDecayer->particleData).canDecay(part->pdg_id())) {
       fDecayer->event.reset();
-      Particle py8part(  part->pdg_id(), 93, 0, 0, 0, 0, 0, 0,
-                         part->momentum().x(),
-                         part->momentum().y(),
-                         part->momentum().z(),
-                         part->momentum().t(),
-                         part->generated_mass() );
-      HepMC::GenVertex* ProdVtx = part->production_vertex();
-      py8part.vProd( ProdVtx->position().x(), ProdVtx->position().y(),
-                     ProdVtx->position().z(), ProdVtx->position().t() );
-      py8part.tau( (fDecayer->particleData).tau0( part->pdg_id() ) );
-      fDecayer->event.append( py8part );
+      Particle py8part(part->pdg_id(),
+                       93,
+                       0,
+                       0,
+                       0,
+                       0,
+                       0,
+                       0,
+                       part->momentum().x(),
+                       part->momentum().y(),
+                       part->momentum().z(),
+                       part->momentum().t(),
+                       part->generated_mass());
+      HepMC::GenVertex *ProdVtx = part->production_vertex();
+      py8part.vProd(ProdVtx->position().x(), ProdVtx->position().y(), ProdVtx->position().z(), ProdVtx->position().t());
+      py8part.tau((fDecayer->particleData).tau0(part->pdg_id()));
+      fDecayer->event.append(py8part);
       int nentries = fDecayer->event.size();
-      if ( !fDecayer->event[nentries-1].mayDecay() ) continue;
+      if (!fDecayer->event[nentries - 1].mayDecay())
+        continue;
       fDecayer->next();
       int nentries1 = fDecayer->event.size();
-      if ( nentries1 <= nentries ) continue; //same number of particles, no decays...
+      if (nentries1 <= nentries)
+        continue;  //same number of particles, no decays...
 
       part->set_status(2);
 
-      result = toHepMC.fill_next_event( *(fDecayer.get()), event().get(), -1, true, part);
-
+      result = toHepMC.fill_next_event(*(fDecayer.get()), event().get(), -1, true, part);
     }
   }
 
   return result;
-
 }
 
-
-void Pythia8Hadronizer::finalizeEvent()
-{
+void Pythia8Hadronizer::finalizeEvent() {
   bool lhe = lheEvent() != nullptr;
 
   // now create the GenEventInfo product from the GenEvent and fill
   // the missing pieces
-  eventInfo().reset( new GenEventInfoProduct( event().get() ) );
+  eventInfo().reset(new GenEventInfoProduct(event().get()));
 
   // in pythia pthat is used to subdivide samples into different bins
   // in LHE mode the binning is done by the external ME generator
@@ -937,31 +901,27 @@ void Pythia8Hadronizer::finalizeEvent()
   if (!lhe) {
     eventInfo()->setBinningValues(std::vector<double>(1, fMasterGen->info.pTHat()));
   }
-  
+
   eventInfo()->setDJR(DJR);
   eventInfo()->setNMEPartons(nME);
   eventInfo()->setNMEPartonsFiltered(nMEFiltered);
 
   //******** Verbosity ********
 
-  if (maxEventsToPrint > 0 &&
-      (pythiaPylistVerbosity || pythiaHepMCVerbosity ||
-                                pythiaHepMCVerbosityParticles) ) {
+  if (maxEventsToPrint > 0 && (pythiaPylistVerbosity || pythiaHepMCVerbosity || pythiaHepMCVerbosityParticles)) {
     maxEventsToPrint--;
     if (pythiaPylistVerbosity) {
-      fMasterGen->info.list(); 
+      fMasterGen->info.list();
       fMasterGen->event.list();
-    } 
+    }
 
     if (pythiaHepMCVerbosity) {
-      std::cout << "Event process = "
-                << fMasterGen->info.code() << "\n"
+      std::cout << "Event process = " << fMasterGen->info.code() << "\n"
                 << "----------------------" << std::endl;
       event()->print();
     }
     if (pythiaHepMCVerbosityParticles) {
-      std::cout << "Event process = "
-                << fMasterGen->info.code() << "\n"
+      std::cout << "Event process = " << fMasterGen->info.code() << "\n"
                 << "----------------------" << std::endl;
       ascii_io->write_event(event().get());
     }
@@ -970,17 +930,18 @@ void Pythia8Hadronizer::finalizeEvent()
 
 std::unique_ptr<GenLumiInfoHeader> Pythia8Hadronizer::getGenLumiInfoHeader() const {
   auto genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
-  
+
   //fill lhe headers
   //*FIXME* initrwgt header is corrupt due to pythia bug
   for (const std::string &key : fMasterGen->info.headerKeys()) {
-    genLumiInfoHeader->lheHeaders().emplace_back(key,fMasterGen->info.header(key));
+    genLumiInfoHeader->lheHeaders().emplace_back(key, fMasterGen->info.header(key));
   }
 
   //check, if it is not only nominal weight
   int weights_number = fMasterGen->info.nWeights();
-  if (fMasterGen->info.initrwgt) weights_number += fMasterGen->info.initrwgt->weightsKeys.size();
-  if(weights_number > 1){
+  if (fMasterGen->info.initrwgt)
+    weights_number += fMasterGen->info.initrwgt->weightsKeys.size();
+  if (weights_number > 1) {
     genLumiInfoHeader->weightNames().reserve(weights_number + 1);
     genLumiInfoHeader->weightNames().push_back("nominal");
   }
@@ -995,41 +956,43 @@ std::unique_ptr<GenLumiInfoHeader> Pythia8Hadronizer::getGenLumiInfoHeader() con
           weightgroupname = wgtgrp.first;
         }
       }
-      
+
       std::ostringstream weightname;
       weightname << "LHE, id = " << key << ", ";
       if (!weightgroupname.empty()) {
         weightname << "group = " << weightgroupname << ", ";
       }
-      weightname<< fMasterGen->info.initrwgt->weights[key].contents;
-      genLumiInfoHeader->weightNames().push_back(weightname.str());    
+      weightname << fMasterGen->info.initrwgt->weights[key].contents;
+      genLumiInfoHeader->weightNames().push_back(weightname.str());
     }
   }
 
   //fill shower labels
   // http://home.thep.lu.se/~torbjorn/pythia82html/Variations.html
   // http://home.thep.lu.se/~torbjorn/doxygen/classPythia8_1_1Info.html
-  if( fMasterGen->info.nWeights() > 1 ){
-    for(int i = 0; i < fMasterGen->info.nWeights(); ++i) {
-      genLumiInfoHeader->weightNames().push_back( fMasterGen->info.weightLabel(i) );
+  if (fMasterGen->info.nWeights() > 1) {
+    for (int i = 0; i < fMasterGen->info.nWeights(); ++i) {
+      genLumiInfoHeader->weightNames().push_back(fMasterGen->info.weightLabel(i));
     }
   }
-  
+
   // VINCIA shower weights
   // http://vincia.hepforge.org/current/share/Vincia/htmldoc/VinciaUncertainties.html
-  if( fvincia.get() ) {
-    for (int iVar=0; iVar < fvincia->nWeights(); iVar++) {
-      genLumiInfoHeader->weightNames().push_back( fvincia->weightLabel(iVar) );
+  if (fvincia.get()) {
+    for (int iVar = 0; iVar < fvincia->nWeights(); iVar++) {
+      genLumiInfoHeader->weightNames().push_back(fvincia->weightLabel(iVar));
     }
   }
-  
-  if( fDire.get() ) {
+
+  if (fDire.get()) {
     //Make sure the base weight comes first
     genLumiInfoHeader->weightNames().push_back("base");
-    
+
     map<string, double>::iterator it;
-    for ( it = fDire->weightsPtr->getShowerWeights()->begin(); it != fDire->weightsPtr->getShowerWeights()->end(); it++ ) {
-      if (it->first == "base") continue;
+    for (it = fDire->weightsPtr->getShowerWeights()->begin(); it != fDire->weightsPtr->getShowerWeights()->end();
+         it++) {
+      if (it->first == "base")
+        continue;
       genLumiInfoHeader->weightNames().push_back(it->first);
     }
   }
@@ -1039,7 +1002,6 @@ std::unique_ptr<GenLumiInfoHeader> Pythia8Hadronizer::getGenLumiInfoHeader() con
 
 typedef edm::GeneratorFilter<Pythia8Hadronizer, ExternalDecayDriver> Pythia8GeneratorFilter;
 DEFINE_FWK_MODULE(Pythia8GeneratorFilter);
-
 
 typedef edm::HadronizerFilter<Pythia8Hadronizer, ExternalDecayDriver> Pythia8HadronizerFilter;
 DEFINE_FWK_MODULE(Pythia8HadronizerFilter);

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -37,6 +37,9 @@ using namespace Pythia8;
 #include "GeneratorInterface/Pythia8Interface/plugins/PowhegResHook.h"
 #include "GeneratorInterface/Pythia8Interface/plugins/PowhegHooksBB4L.h"
 
+//biased tau decayer
+#include "GeneratorInterface/Pythia8Interface/interface/BiasedTauDecayer.h"
+
 //decay filter hook
 #include "GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h"
 
@@ -139,6 +142,9 @@ class Pythia8Hadronizer : public Py8InterfaceBase {
     // Resonance scale hook
     std::unique_ptr<PowhegResHook> fPowhegResHook;
     std::unique_ptr<PowhegHooksBB4L> fPowhegHooksBB4L;
+    
+    // biased tau decayer
+    std::unique_ptr<BiasedTauDecayer> fBiasedTauDecayer;
     
     //resonance decay filter hook
     std::unique_ptr<ResonanceDecayFilterHook> fResonanceDecayFilterHook;
@@ -440,6 +446,15 @@ bool Pythia8Hadronizer::initializeForInternalPartons()
     fMultiUserHook->addHook(fMergingHook.get());
   }
   
+  bool biasedTauDecayer = fMasterGen->settings.flag("BiasedTauDecayer:filter");
+  if (biasedTauDecayer) {
+    fBiasedTauDecayer.reset(new BiasedTauDecayer(&(fMasterGen->info), &(fMasterGen->settings),
+	&(fMasterGen->particleData), &(fMasterGen->rndm), &(fMasterGen->couplings) ) );
+    std::vector<int> handledParticles;
+    handledParticles.push_back(15);
+    fMasterGen->setDecayPtr(fBiasedTauDecayer.get(),handledParticles);
+  }
+  
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
   if (resonanceDecayFilter) {
     fResonanceDecayFilterHook.reset(new ResonanceDecayFilterHook);
@@ -571,6 +586,15 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
                 0 );
     fMergingHook.reset(new Pythia8::amcnlo_unitarised_interface(scheme));
     fMultiUserHook->addHook(fMergingHook.get());
+  }
+  
+  bool biasedTauDecayer = fMasterGen->settings.flag("BiasedTauDecayer:filter");
+  if (biasedTauDecayer) {
+    fBiasedTauDecayer.reset(new BiasedTauDecayer(&(fMasterGen->info), &(fMasterGen->settings),
+	&(fMasterGen->particleData), &(fMasterGen->rndm), &(fMasterGen->couplings) ) );
+    std::vector<int> handledParticles;
+    handledParticles.push_back(15);
+    fMasterGen->setDecayPtr(fBiasedTauDecayer.get(),handledParticles);
   }
   
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");

--- a/GeneratorInterface/Pythia8Interface/src/BiasedTauDecayer.cc
+++ b/GeneratorInterface/Pythia8Interface/src/BiasedTauDecayer.cc
@@ -1,0 +1,97 @@
+#include "Pythia8/Pythia.h"
+#include "GeneratorInterface/Pythia8Interface/interface/BiasedTauDecayer.h"
+using namespace Pythia8;
+
+//==========================================================================
+
+// Specialized decayer for resonance decays to taus to allowing biasing to
+// leptonic decays
+//
+
+BiasedTauDecayer::BiasedTauDecayer(
+    Info* infoPtr, Settings* settingsPtr, ParticleData* particleDataPtr, Rndm* rndmPtr, Couplings* couplingsPtr) {
+  decayer = TauDecays();
+  decayer.init(infoPtr, settingsPtr, particleDataPtr, rndmPtr, couplingsPtr);
+  filter_ = settingsPtr->flag("BiasedTauDecayer:filter");
+  eMuDecays_ = settingsPtr->flag("BiasedTauDecayer:eMuDecays");
+}
+
+bool BiasedTauDecayer::decay(
+    std::vector<int>& idProd, std::vector<double>& mProd, std::vector<Vec4>& pProd, int iDec, const Event& event) {
+  if (!filter_)
+    return false;
+  if (idProd[0] != 15 && idProd[0] != -15)
+    return false;
+  int iStart = event[iDec].iTopCopyId();
+  int iMom = event[iStart].mother1();
+  int idMom = event[iMom].idAbs();
+  if (idMom != 23 && idMom != 24 && idMom != 25)
+    return false;
+  int iDau1 = event[iMom].daughter1();
+  int iDau2 = event[iMom].daughter2();
+  int iBot1 = event[iDau1].iBotCopyId();
+  int iBot2 = event[iDau2].iBotCopyId();
+  int iDecSis = (iDec == iBot1) ? iBot2 : iBot1;
+  // Check if sister has been decayed
+  // Since taus decays are correlated, use one decay, store the other
+  bool notDecayed = event[iDecSis].status() > 0 ? true : false;
+  if (notDecayed) {
+    // bias for leptonic decays
+    bool hasLepton = (eMuDecays_) ? false : true;
+    Event decay;
+    int i1 = -1;
+    int i2 = -1;
+    while (!hasLepton) {
+      decay = event;
+      decayer.decay(iDec, decay);
+      // check for lepton in first decay
+      i1 = decay[iDec].daughter1();
+      i2 = decay[iDec].daughter2();
+      for (int i = i1; i < i2 + 1; ++i) {
+        if (decay[i].isLepton() && decay[i].isCharged()) {
+          hasLepton = true;
+          break;
+        }
+      }
+      if (hasLepton)
+        break;
+      // check for lepton in second decay
+      i1 = decay[iDecSis].daughter1();
+      i2 = decay[iDecSis].daughter2();
+      for (int i = i1; i < i2 + 1; ++i) {
+        if (decay[i].isLepton() && decay[i].isCharged()) {
+          hasLepton = true;
+          break;
+        }
+      }
+    }
+    // Return decay products
+    i1 = decay[iDec].daughter1();
+    i2 = decay[iDec].daughter2();
+    for (int i = i1; i < i2 + 1; ++i) {
+      idProd.push_back(decay[i].id());
+      mProd.push_back(decay[i].m());
+      pProd.push_back(decay[i].p());
+    }
+    // Store correlated decay products
+    i1 = decay[iDecSis].daughter1();
+    i2 = decay[iDecSis].daughter2();
+    idProdSave.clear();
+    mProdSave.clear();
+    pProdSave.clear();
+    for (int i = i1; i < i2 + 1; ++i) {
+      idProdSave.push_back(decay[i].id());
+      mProdSave.push_back(decay[i].m());
+      pProdSave.push_back(decay[i].p());
+    }
+  } else {
+    // Return stored decay products
+    for (size_t i = 0; i < idProdSave.size(); ++i) {
+      idProd.push_back(idProdSave[i]);
+      mProd.push_back(mProdSave[i]);
+      pProd.push_back(pProdSave[i]);
+    }
+  }
+
+  return true;
+}

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -14,235 +14,214 @@ using namespace Pythia8;
 
 namespace gen {
 
-Py8InterfaceBase::Py8InterfaceBase( edm::ParameterSet const& ps ) :
-BaseHadronizer(ps),
-useEvtGen(false), evtgenDecays(nullptr)
-{  
-  fParameters = ps;
-  
-  pythiaPylistVerbosity = ps.getUntrackedParameter<int>("pythiaPylistVerbosity", 0);
-  pythiaHepMCVerbosity  = ps.getUntrackedParameter<bool>("pythiaHepMCVerbosity", false);
-  pythiaHepMCVerbosityParticles = ps.getUntrackedParameter<bool>("pythiaHepMCVerbosityParticles", false);
-  maxEventsToPrint      = ps.getUntrackedParameter<int>("maxEventsToPrint", 0);
+  Py8InterfaceBase::Py8InterfaceBase(edm::ParameterSet const& ps)
+      : BaseHadronizer(ps), useEvtGen(false), evtgenDecays(nullptr) {
+    fParameters = ps;
 
-  if(pythiaHepMCVerbosityParticles)
-    ascii_io = new HepMC::IO_AsciiParticles("cout", std::ios::out);
+    pythiaPylistVerbosity = ps.getUntrackedParameter<int>("pythiaPylistVerbosity", 0);
+    pythiaHepMCVerbosity = ps.getUntrackedParameter<bool>("pythiaHepMCVerbosity", false);
+    pythiaHepMCVerbosityParticles = ps.getUntrackedParameter<bool>("pythiaHepMCVerbosityParticles", false);
+    maxEventsToPrint = ps.getUntrackedParameter<int>("maxEventsToPrint", 0);
 
-  if ( ps.exists("useEvtGenPlugin") ) {
+    if (pythiaHepMCVerbosityParticles)
+      ascii_io = new HepMC::IO_AsciiParticles("cout", std::ios::out);
 
-    useEvtGen = true;
-    string evtgenpath(getenv("EVTGENDATA"));
-    evtgenDecFile = evtgenpath + string("/DECAY_2010.DEC");
-    evtgenPdlFile = evtgenpath + string("/evt.pdl");
+    if (ps.exists("useEvtGenPlugin")) {
+      useEvtGen = true;
+      string evtgenpath(getenv("EVTGENDATA"));
+      evtgenDecFile = evtgenpath + string("/DECAY_2010.DEC");
+      evtgenPdlFile = evtgenpath + string("/evt.pdl");
 
-    if (ps.exists("evtgenDecFile")) {
-       edm::FileInPath decay_table(ps.getParameter<std::string>("evtgenDecFile"));
-       evtgenDecFile = decay_table.fullPath();
-    }
-
-    if (ps.exists("evtgenPdlFile")) {      
-       edm::FileInPath pdt(ps.getParameter<std::string>("evtgenPdlFile"));
-       evtgenPdlFile = pdt.fullPath();
-    }
-
-    if (ps.exists("evtgenUserFile")) {
-       std::vector<std::string> user_decays = ps.getParameter<std::vector<std::string> >("evtgenUserFile");
-       for (unsigned int i=0;i<user_decays.size();i++) {
-          edm::FileInPath user_decay(user_decays.at(i)); 
-          evtgenUserFiles.push_back(user_decay.fullPath());
-       }
-	    //evtgenUserFiles = ps.getParameter< std::vector<std::string> >("evtgenUserFile");
-    }
-
-    if (ps.exists("evtgenUserFileEmbedded")) {
-       std::vector<std::string> user_decay_lines = ps.getParameter<std::vector<std::string> >("evtgenUserFileEmbedded");
-       auto tmp_dir = boost::filesystem::temp_directory_path();
-       tmp_dir += "/%%%%-%%%%-%%%%-%%%%";
-       auto tmp_path = boost::filesystem::unique_path(tmp_dir);
-       std::string user_decay_tmp = std::string(tmp_path.c_str());
-       FILE* tmpf = std::fopen(user_decay_tmp.c_str(), "w");
-       if (!tmpf) {
-          edm::LogError("Py8InterfaceBase::~Py8InterfaceBase") << "Py8InterfaceBase::Py8InterfaceBase fails when trying to open a temporary file for embedded user.dec for EvtGenPlugin. Terminating program ";
-          exit(0);
-       }
-       for (unsigned int i=0; i<user_decay_lines.size(); i++) {
-          user_decay_lines.at(i) += "\n";
-          std::fputs(user_decay_lines.at(i).c_str(), tmpf);
-       }
-       std::fclose(tmpf);
-       evtgenUserFiles.push_back(user_decay_tmp);
-    }
-
-  }
-
-}
-
-bool Py8InterfaceBase::readSettings( int ) 
-{
-
-   if(!fMasterGen.get()) fMasterGen.reset(new Pythia);
-   fDecayer.reset(new Pythia);
-
-   //add settings for resonance decay filter
-   fMasterGen->settings.addFlag("BiasedTauDecayer:filter", false);
-   fMasterGen->settings.addFlag("BiasedTauDecayer:eMuDecays", true);
-
-   //add settings for resonance decay filter
-   fMasterGen->settings.addFlag("ResonanceDecayFilter:filter",false);
-   fMasterGen->settings.addFlag("ResonanceDecayFilter:exclusive",false);
-   fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent",false);
-   fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuTauAsEquivalent",false);
-   fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent",false);
-   fMasterGen->settings.addFlag("ResonanceDecayFilter:udscAsEquivalent",false);
-   fMasterGen->settings.addFlag("ResonanceDecayFilter:udscbAsEquivalent",false);
-   fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent",false);
-   fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers",std::vector<int>(),false,false,0,0);
-   fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters",std::vector<int>(),false,false,0,0);   
-
-   //add settings for PT filter
-   fMasterGen->settings.addFlag("PTFilter:filter",false);
-   fMasterGen->settings.addMode("PTFilter:quarkToFilter", 5  ,true,true,3,    6);
-   fMasterGen->settings.addParm("PTFilter:scaleToFilter", 0.4,true,true,0.0, 10.);
-   fMasterGen->settings.addParm("PTFilter:quarkRapidity",10.0,true,true,0.0, 10.);
-   fMasterGen->settings.addParm("PTFilter:quarkPt",       -.1,true,true,-.1,100.);
-   
-   //add settings for powheg resonance scale calculation
-   fMasterGen->settings.addFlag("POWHEGres:calcScales",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:onlyDistance1",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:veto",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:dryRun",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoAtPL",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoQED",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:PartonLevel:veto",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:PartonLevel:excludeFSRConflicting",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:DEBUG",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:ScaleResonance:veto",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoDipoleFrame",false);
-   fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:pTpythiaVeto",false);
-   fMasterGen->settings.addParm("POWHEG:bb4l:pTminVeto",10.0,true,true,0.0, 10.);
-   
-   fMasterGen->setRndmEnginePtr( &p8RndmEngine_ );
-   fDecayer->setRndmEnginePtr( &p8RndmEngine_ );
-  
-   fMasterGen->readString("Next:numberShowEvent = 0");
-   fDecayer->readString("Next:numberShowEvent = 0");  
-  
-   edm::ParameterSet currentParameters;
-   if (randomIndex()>=0) {
-     std::vector<edm::ParameterSet> randomizedParameters = fParameters.getParameter<std::vector<edm::ParameterSet> >("RandomizedParameters");
-     currentParameters = randomizedParameters[randomIndex()];
-   }
-   else {
-     currentParameters = fParameters;
-   }
-      
-   ParameterCollector pCollector = currentParameters.getParameter<edm::ParameterSet>("PythiaParameters");
-   
-   for ( ParameterCollector::const_iterator line = pCollector.begin();
-         line != pCollector.end(); ++line ) 
-   {
-      if (line->find("Random:") != std::string::npos)
-         throw cms::Exception("PythiaError") << "Attempted to set random number "
-         "using Pythia commands. Please use " "the RandomNumberGeneratorService."
-         << std::endl;
-
-      if (!fMasterGen->readString(*line)) throw cms::Exception("PythiaError")
-			              << "Pythia 8 did not accept \""
-				      << *line << "\"." << std::endl;
-
-      if (line->find("ParticleDecays:") != std::string::npos) {
-
-        if (!fDecayer->readString(*line)) throw cms::Exception("PythiaError")
-                                      << "Pythia 8 Decayer did not accept \""
-                                      << *line << "\"." << std::endl;
+      if (ps.exists("evtgenDecFile")) {
+        edm::FileInPath decay_table(ps.getParameter<std::string>("evtgenDecFile"));
+        evtgenDecFile = decay_table.fullPath();
       }
 
-   }
+      if (ps.exists("evtgenPdlFile")) {
+        edm::FileInPath pdt(ps.getParameter<std::string>("evtgenPdlFile"));
+        evtgenPdlFile = pdt.fullPath();
+      }
 
-   slhafile_.clear();
-   
-   if( currentParameters.exists( "SLHAFileForPythia8" ) ) {
-     std::string slhafilenameshort = currentParameters.getParameter<std::string>("SLHAFileForPythia8");
-     edm::FileInPath f1( slhafilenameshort );
-    
-     fMasterGen->settings.mode("SLHA:readFrom", 2);
-     fMasterGen->settings.word("SLHA:file", f1.fullPath());    
-   }
-   else if( currentParameters.exists( "SLHATableForPythia8" ) ) {
-     std::string slhatable = currentParameters.getParameter<std::string>("SLHATableForPythia8");
-        
-     char tempslhaname[] = "pythia8SLHAtableXXXXXX";
-     int fd = mkstemp(tempslhaname);
-     write(fd,slhatable.c_str(),slhatable.size());
-     close(fd);
-    
-     slhafile_ = tempslhaname;
-    
-     fMasterGen->settings.mode("SLHA:readFrom", 2);
-     fMasterGen->settings.word("SLHA:file", slhafile_);
-   }   
-   
-   return true;
+      if (ps.exists("evtgenUserFile")) {
+        std::vector<std::string> user_decays = ps.getParameter<std::vector<std::string> >("evtgenUserFile");
+        for (unsigned int i = 0; i < user_decays.size(); i++) {
+          edm::FileInPath user_decay(user_decays.at(i));
+          evtgenUserFiles.push_back(user_decay.fullPath());
+        }
+        //evtgenUserFiles = ps.getParameter< std::vector<std::string> >("evtgenUserFile");
+      }
 
-}
-
-bool Py8InterfaceBase::declareStableParticles( const std::vector<int>& pdgIds )
-{
-  
-  for ( size_t i=0; i<pdgIds.size(); i++ )
-  {
-    // FIXME: need to double check if PID's are the same in Py6 & Py8,
-    //        because the HepPDT translation tool is actually for **Py6** 
-    // 
-    // well, actually it looks like Py8 operates in PDT id's rather than Py6's
-    //
-//    int PyID = HepPID::translatePDTtoPythia( pdgIds[i] ); 
-    int PyID = pdgIds[i]; 
-    std::ostringstream pyCard ;
-    pyCard << PyID <<":mayDecay=false";
-
-    if ( fMasterGen->particleData.isParticle( PyID ) ) {
-       fMasterGen->readString( pyCard.str() );
-    } else {
-
-       edm::LogWarning("DataNotUnderstood") << "Pythia8 does not "
-                                            << "recognize particle id = " 
-                                            << PyID << std::endl;
-    } 
-    // alternative:
-    // set the 2nd input argument warn=false 
-    // - this way Py8 will NOT print warnings about unknown particle code(s)
-    // fMasterPtr->readString( pyCard.str(), false )
+      if (ps.exists("evtgenUserFileEmbedded")) {
+        std::vector<std::string> user_decay_lines =
+            ps.getParameter<std::vector<std::string> >("evtgenUserFileEmbedded");
+        auto tmp_dir = boost::filesystem::temp_directory_path();
+        tmp_dir += "/%%%%-%%%%-%%%%-%%%%";
+        auto tmp_path = boost::filesystem::unique_path(tmp_dir);
+        std::string user_decay_tmp = std::string(tmp_path.c_str());
+        FILE* tmpf = std::fopen(user_decay_tmp.c_str(), "w");
+        if (!tmpf) {
+          edm::LogError("Py8InterfaceBase::~Py8InterfaceBase")
+              << "Py8InterfaceBase::Py8InterfaceBase fails when trying to open a temporary file for embedded user.dec "
+                 "for EvtGenPlugin. Terminating program ";
+          exit(0);
+        }
+        for (unsigned int i = 0; i < user_decay_lines.size(); i++) {
+          user_decay_lines.at(i) += "\n";
+          std::fputs(user_decay_lines.at(i).c_str(), tmpf);
+        }
+        std::fclose(tmpf);
+        evtgenUserFiles.push_back(user_decay_tmp);
+      }
+    }
   }
-        
-   return true;
 
-}
+  bool Py8InterfaceBase::readSettings(int) {
+    if (!fMasterGen.get())
+      fMasterGen.reset(new Pythia);
+    fDecayer.reset(new Pythia);
 
-bool Py8InterfaceBase:: declareSpecialSettings( const std::vector<std::string>& settings ){
-   for ( unsigned int iss=0; iss<settings.size(); iss++ ){
-     if ( settings[iss].find("QED-brem-off") != std::string::npos ){
-       fMasterGen->readString( "TimeShower:QEDshowerByL=off" );
-     }
-     else{
-       size_t fnd1 = settings[iss].find("Pythia8:");
-       if ( fnd1 != std::string::npos ){
-	 std::string value = settings[iss].substr (fnd1+8);
-	 fDecayer->readString(value);
-       }
-     }
-   }
-   return true;
-}
+    //add settings for resonance decay filter
+    fMasterGen->settings.addFlag("BiasedTauDecayer:filter", false);
+    fMasterGen->settings.addFlag("BiasedTauDecayer:eMuDecays", true);
 
+    //add settings for resonance decay filter
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:filter", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:exclusive", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuTauAsEquivalent", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:udscAsEquivalent", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:udscbAsEquivalent", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent", false);
+    fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers", std::vector<int>(), false, false, 0, 0);
+    fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters", std::vector<int>(), false, false, 0, 0);
 
-void Py8InterfaceBase::statistics()
-{
-  
-   fMasterGen->stat();
-   return;
-   
-}
+    //add settings for PT filter
+    fMasterGen->settings.addFlag("PTFilter:filter", false);
+    fMasterGen->settings.addMode("PTFilter:quarkToFilter", 5, true, true, 3, 6);
+    fMasterGen->settings.addParm("PTFilter:scaleToFilter", 0.4, true, true, 0.0, 10.);
+    fMasterGen->settings.addParm("PTFilter:quarkRapidity", 10.0, true, true, 0.0, 10.);
+    fMasterGen->settings.addParm("PTFilter:quarkPt", -.1, true, true, -.1, 100.);
 
-}
+    //add settings for powheg resonance scale calculation
+    fMasterGen->settings.addFlag("POWHEGres:calcScales", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:onlyDistance1", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:veto", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:dryRun", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoAtPL", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoQED", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:PartonLevel:veto", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:PartonLevel:excludeFSRConflicting", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:DEBUG", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:ScaleResonance:veto", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoDipoleFrame", false);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:pTpythiaVeto", false);
+    fMasterGen->settings.addParm("POWHEG:bb4l:pTminVeto", 10.0, true, true, 0.0, 10.);
+
+    fMasterGen->setRndmEnginePtr(&p8RndmEngine_);
+    fDecayer->setRndmEnginePtr(&p8RndmEngine_);
+
+    fMasterGen->readString("Next:numberShowEvent = 0");
+    fDecayer->readString("Next:numberShowEvent = 0");
+
+    edm::ParameterSet currentParameters;
+    if (randomIndex() >= 0) {
+      std::vector<edm::ParameterSet> randomizedParameters =
+          fParameters.getParameter<std::vector<edm::ParameterSet> >("RandomizedParameters");
+      currentParameters = randomizedParameters[randomIndex()];
+    } else {
+      currentParameters = fParameters;
+    }
+
+    ParameterCollector pCollector = currentParameters.getParameter<edm::ParameterSet>("PythiaParameters");
+
+    for (ParameterCollector::const_iterator line = pCollector.begin(); line != pCollector.end(); ++line) {
+      if (line->find("Random:") != std::string::npos)
+        throw cms::Exception("PythiaError") << "Attempted to set random number "
+                                               "using Pythia commands. Please use "
+                                               "the RandomNumberGeneratorService."
+                                            << std::endl;
+
+      if (!fMasterGen->readString(*line))
+        throw cms::Exception("PythiaError") << "Pythia 8 did not accept \"" << *line << "\"." << std::endl;
+
+      if (line->find("ParticleDecays:") != std::string::npos) {
+        if (!fDecayer->readString(*line))
+          throw cms::Exception("PythiaError") << "Pythia 8 Decayer did not accept \"" << *line << "\"." << std::endl;
+      }
+    }
+
+    slhafile_.clear();
+
+    if (currentParameters.exists("SLHAFileForPythia8")) {
+      std::string slhafilenameshort = currentParameters.getParameter<std::string>("SLHAFileForPythia8");
+      edm::FileInPath f1(slhafilenameshort);
+
+      fMasterGen->settings.mode("SLHA:readFrom", 2);
+      fMasterGen->settings.word("SLHA:file", f1.fullPath());
+    } else if (currentParameters.exists("SLHATableForPythia8")) {
+      std::string slhatable = currentParameters.getParameter<std::string>("SLHATableForPythia8");
+
+      char tempslhaname[] = "pythia8SLHAtableXXXXXX";
+      int fd = mkstemp(tempslhaname);
+      write(fd, slhatable.c_str(), slhatable.size());
+      close(fd);
+
+      slhafile_ = tempslhaname;
+
+      fMasterGen->settings.mode("SLHA:readFrom", 2);
+      fMasterGen->settings.word("SLHA:file", slhafile_);
+    }
+
+    return true;
+  }
+
+  bool Py8InterfaceBase::declareStableParticles(const std::vector<int>& pdgIds) {
+    for (size_t i = 0; i < pdgIds.size(); i++) {
+      // FIXME: need to double check if PID's are the same in Py6 & Py8,
+      //        because the HepPDT translation tool is actually for **Py6**
+      //
+      // well, actually it looks like Py8 operates in PDT id's rather than Py6's
+      //
+      //    int PyID = HepPID::translatePDTtoPythia( pdgIds[i] );
+      int PyID = pdgIds[i];
+      std::ostringstream pyCard;
+      pyCard << PyID << ":mayDecay=false";
+
+      if (fMasterGen->particleData.isParticle(PyID)) {
+        fMasterGen->readString(pyCard.str());
+      } else {
+        edm::LogWarning("DataNotUnderstood") << "Pythia8 does not "
+                                             << "recognize particle id = " << PyID << std::endl;
+      }
+      // alternative:
+      // set the 2nd input argument warn=false
+      // - this way Py8 will NOT print warnings about unknown particle code(s)
+      // fMasterPtr->readString( pyCard.str(), false )
+    }
+
+    return true;
+  }
+
+  bool Py8InterfaceBase::declareSpecialSettings(const std::vector<std::string>& settings) {
+    for (unsigned int iss = 0; iss < settings.size(); iss++) {
+      if (settings[iss].find("QED-brem-off") != std::string::npos) {
+        fMasterGen->readString("TimeShower:QEDshowerByL=off");
+      } else {
+        size_t fnd1 = settings[iss].find("Pythia8:");
+        if (fnd1 != std::string::npos) {
+          std::string value = settings[iss].substr(fnd1 + 8);
+          fDecayer->readString(value);
+        }
+      }
+    }
+    return true;
+  }
+
+  void Py8InterfaceBase::statistics() {
+    fMasterGen->stat();
+    return;
+  }
+
+}  // namespace gen

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -84,6 +84,10 @@ bool Py8InterfaceBase::readSettings( int )
    fDecayer.reset(new Pythia);
 
    //add settings for resonance decay filter
+   fMasterGen->settings.addFlag("BiasedTauDecayer:filter", false);
+   fMasterGen->settings.addFlag("BiasedTauDecayer:eMuDecays", true);
+
+   //add settings for resonance decay filter
    fMasterGen->settings.addFlag("ResonanceDecayFilter:filter",false);
    fMasterGen->settings.addFlag("ResonanceDecayFilter:exclusive",false);
    fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent",false);


### PR DESCRIPTION
#### PR description:

Backport of #29567 by @smrenna to require at least one tau decaying only to leptons after heavy resonance decays:

> Pythia8 has the capability to define a decay handler for specific particles through DecayHandler.
This request is a special tau decayer that can be used to bias tau pair decays to contain at least one lepton. It is meant to be used with Powheg samples containing taus so that no Powheg events are lost.
Since DecayHandler is meant to decay one particle at a time, while the standard Pythia tau decayer decays the correlated pair, part of the decay history is saved and then used to fill the products of the second (correlated) tau.

Note that code-format makes this PR look bigger than it is.

#### PR validation:

Validation plots for W and Z, things look as expected: https://mseidel.web.cern.ch/mseidel/cms/PDG_TAUS/

In particular, here is the number of tau->charged lepton decays in Z events:
![image](https://user-images.githubusercontent.com/1311783/81648578-37dfa980-942f-11ea-87d3-7255cd1eeee7.png)
As expected, 0 lepton is depleted completely, and the ratio betwen 1 and 2 leptons stays the same.

To check spin correlations, here is a plot of the dPhi between the two charged leptons, in case of both taus decaying to charged leptons:
![image](https://user-images.githubusercontent.com/1311783/81648708-6a89a200-942f-11ea-9ae7-1e2d2228ea32.png)


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #29567, needed for UL MC
