### PR TITLE
Continue work on electron seeding convergence

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -103,8 +103,7 @@ private:
   const float phiMax2B_;
   const float phiMax2F_;
 
-  PixelHitMatcher electronMatcher_;
-  PixelHitMatcher positronMatcher_;
+  PixelHitMatcher matcher_;
 };
 
 #endif  // ElectronSeedGenerator_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
@@ -49,11 +49,8 @@ public:
                   float phi2maxB,
                   float phi2minF,
                   float phi2maxF,
-                  float z2minB,
                   float z2maxB,
-                  float r2minF,
                   float r2maxF,
-                  float rMinI,
                   float rMaxI,
                   bool useRecoVertex);
 
@@ -71,7 +68,7 @@ public:
 
 private:
   struct BarrelMeasurementEstimator {
-    bool operator()(const GlobalPoint& vprim, const TrajectoryStateOnSurface& ts, const GlobalPoint& gp) const;
+    bool operator()(const GlobalPoint& vprim, const TrajectoryStateOnSurface&, const GlobalPoint&, int charge) const;
 
     float thePhiMin;
     float thePhiMax;
@@ -80,7 +77,7 @@ private:
   };
 
   struct ForwardMeasurementEstimator {
-    bool operator()(const GlobalPoint& vprim, const TrajectoryStateOnSurface& ts, const GlobalPoint& gp) const;
+    bool operator()(const GlobalPoint& vprim, const TrajectoryStateOnSurface&, const GlobalPoint&, int charge) const;
 
     float thePhiMin;
     float thePhiMax;
@@ -94,8 +91,8 @@ private:
   BarrelMeasurementEstimator meas2ndBLayer;
   ForwardMeasurementEstimator meas1stFLayer;
   ForwardMeasurementEstimator meas2ndFLayer;
-  std::unique_ptr<PropagatorWithMaterial> prop1stLayer;
-  std::unique_ptr<PropagatorWithMaterial> prop2ndLayer;
+  std::unique_ptr<PropagatorWithMaterial> prop1stLayer = nullptr;
+  std::unique_ptr<PropagatorWithMaterial> prop2ndLayer = nullptr;
   const MagneticField* theMagField;
   const TrackerGeometry* theTrackerGeometry;
   const bool useRecoVertex_;

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -152,32 +152,16 @@ ElectronSeedGenerator::ElectronSeedGenerator(const edm::ParameterSet &pset, cons
       phiMin2F_(-pset.getParameter<double>("PhiMax2F")),
       phiMax2B_(pset.getParameter<double>("PhiMax2B")),
       phiMax2F_(pset.getParameter<double>("PhiMax2F")),
-      electronMatcher_(pset.getParameter<double>("ePhiMin1"),
-                       pset.getParameter<double>("ePhiMax1"),
-                       phiMin2B_,
-                       phiMax2B_,
-                       phiMin2F_,
-                       phiMax2F_,
-                       -pset.getParameter<double>("z2MaxB"),
-                       pset.getParameter<double>("z2MaxB"),
-                       -pset.getParameter<double>("r2MaxF"),
-                       pset.getParameter<double>("r2MaxF"),
-                       -pset.getParameter<double>("rMaxI"),
-                       pset.getParameter<double>("rMaxI"),
-                       useRecoVertex_),
-      positronMatcher_(pset.getParameter<double>("pPhiMin1"),
-                       pset.getParameter<double>("pPhiMax1"),
-                       phiMin2B_,
-                       phiMax2B_,
-                       phiMin2F_,
-                       phiMax2F_,
-                       -pset.getParameter<double>("z2MaxB"),
-                       pset.getParameter<double>("z2MaxB"),
-                       -pset.getParameter<double>("r2MaxF"),
-                       pset.getParameter<double>("r2MaxF"),
-                       -pset.getParameter<double>("rMaxI"),
-                       pset.getParameter<double>("rMaxI"),
-                       useRecoVertex_) {}
+      matcher_(pset.getParameter<double>("ePhiMin1"),
+               pset.getParameter<double>("ePhiMax1"),
+               phiMin2B_,
+               phiMax2B_,
+               phiMin2F_,
+               phiMax2F_,
+               pset.getParameter<double>("z2MaxB"),
+               pset.getParameter<double>("r2MaxF"),
+               pset.getParameter<double>("rMaxI"),
+               useRecoVertex_) {}
 
 void ElectronSeedGenerator::setupES(const edm::EventSetup &setup) {
   // get records if necessary (called once per event)
@@ -197,8 +181,7 @@ void ElectronSeedGenerator::setupES(const edm::EventSetup &setup) {
   }
 
   if (tochange) {
-    electronMatcher_.setES(magField_.product(), trackerGeometry_.product());
-    positronMatcher_.setES(magField_.product(), trackerGeometry_.product());
+    matcher_.setES(magField_.product(), trackerGeometry_.product());
   }
 }
 
@@ -248,20 +231,8 @@ void ElectronSeedGenerator::seedsFromThisCluster(edm::Ref<reco::SuperClusterColl
       deltaPhi1 = dPhi1Coef1_ + dPhi1Coef2_ / clusterEnergyT;
     }
 
-    float ephimin1 = -deltaPhi1 * sizeWindowENeg_;
-    float ephimax1 = deltaPhi1 * (1. - sizeWindowENeg_);
-    float pphimin1 = -deltaPhi1 * (1. - sizeWindowENeg_);
-    float pphimax1 = deltaPhi1 * sizeWindowENeg_;
-
-    float phimin2B = -deltaPhi2B_ / 2.;
-    float phimax2B = deltaPhi2B_ / 2.;
-    float phimin2F = -deltaPhi2F_ / 2.;
-    float phimax2F = deltaPhi2F_ / 2.;
-
-    electronMatcher_.set1stLayer(ephimin1, ephimax1);
-    positronMatcher_.set1stLayer(pphimin1, pphimax1);
-    electronMatcher_.set2ndLayer(phimin2B, phimax2B, phimin2F, phimax2F);
-    positronMatcher_.set2ndLayer(phimin2B, phimax2B, phimin2F, phimax2F);
+    matcher_.set1stLayer(-deltaPhi1 * sizeWindowENeg_, deltaPhi1 * (1. - sizeWindowENeg_));
+    matcher_.set2ndLayer(-deltaPhi2B_ / 2., deltaPhi2B_ / 2., -deltaPhi2F_ / 2., deltaPhi2F_ / 2.);
   }
 
   if (!useRecoVertex_)  // here use the beam spot position
@@ -275,14 +246,13 @@ void ElectronSeedGenerator::seedsFromThisCluster(edm::Ref<reco::SuperClusterColl
     GlobalPoint vertexPos;
     ele_convert(beamSpot.position(), vertexPos);
 
-    electronMatcher_.set1stLayerZRange(myZmin1, myZmax1);
-    positronMatcher_.set1stLayerZRange(myZmin1, myZmax1);
+    matcher_.set1stLayerZRange(myZmin1, myZmax1);
 
     // try electron
-    auto elePixelSeeds = electronMatcher_(*initialSeedCollectionVector_, clusterPos, vertexPos, clusterEnergy, -1.);
+    auto elePixelSeeds = matcher_(*initialSeedCollectionVector_, clusterPos, vertexPos, clusterEnergy, -1.);
     seedsFromTrajectorySeeds(elePixelSeeds, caloCluster, out, false);
     // try positron
-    auto posPixelSeeds = positronMatcher_(*initialSeedCollectionVector_, clusterPos, vertexPos, clusterEnergy, 1.);
+    auto posPixelSeeds = matcher_(*initialSeedCollectionVector_, clusterPos, vertexPos, clusterEnergy, 1.);
     seedsFromTrajectorySeeds(posPixelSeeds, caloCluster, out, true);
 
   } else if (vertices)  // here we use the reco vertices
@@ -301,14 +271,13 @@ void ElectronSeedGenerator::seedsFromThisCluster(edm::Ref<reco::SuperClusterColl
         myZmax1 = vertex.position().z() + deltaZ1WithVertex_;
       }
 
-      electronMatcher_.set1stLayerZRange(myZmin1, myZmax1);
-      positronMatcher_.set1stLayerZRange(myZmin1, myZmax1);
+      matcher_.set1stLayerZRange(myZmin1, myZmax1);
 
       // try electron
-      auto elePixelSeeds = electronMatcher_(*initialSeedCollectionVector_, clusterPos, vertexPos, clusterEnergy, -1.);
+      auto elePixelSeeds = matcher_(*initialSeedCollectionVector_, clusterPos, vertexPos, clusterEnergy, -1.);
       seedsFromTrajectorySeeds(elePixelSeeds, caloCluster, out, false);
       // try positron
-      auto posPixelSeeds = positronMatcher_(*initialSeedCollectionVector_, clusterPos, vertexPos, clusterEnergy, 1.);
+      auto posPixelSeeds = matcher_(*initialSeedCollectionVector_, clusterPos, vertexPos, clusterEnergy, 1.);
       seedsFromTrajectorySeeds(posPixelSeeds, caloCluster, out, true);
     }
   }

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -53,6 +53,31 @@ namespace {
     float dRZ = hit.geographicalId().subdetId() == PixelSubdetector::PixelBarrel ? pointPair.dZ() : pointPair.dPerp();
     return {hit.geographicalId(), hit.globalPosition(), dRZ, pointPair.dPhi(), hit, et, eta, phi, charge, nrClus};
   }
+
+  const std::vector<TrajSeedMatcher::MatchInfo> makeMatchInfoVector(
+      std::vector<TrajSeedMatcher::SCHitMatch> const& posCharge,
+      std::vector<TrajSeedMatcher::SCHitMatch> const& negCharge) {
+    std::vector<TrajSeedMatcher::MatchInfo> matchInfos;
+    size_t nrHitsMax = std::max(posCharge.size(), negCharge.size());
+    for (size_t hitNr = 0; hitNr < nrHitsMax; hitNr++) {
+      DetId detIdPos = hitNr < posCharge.size() ? posCharge[hitNr].detId : DetId(0);
+      float dRZPos = hitNr < posCharge.size() ? posCharge[hitNr].dRZ : std::numeric_limits<float>::max();
+      float dPhiPos = hitNr < posCharge.size() ? posCharge[hitNr].dPhi : std::numeric_limits<float>::max();
+
+      DetId detIdNeg = hitNr < negCharge.size() ? negCharge[hitNr].detId : DetId(0);
+      float dRZNeg = hitNr < negCharge.size() ? negCharge[hitNr].dRZ : std::numeric_limits<float>::max();
+      float dPhiNeg = hitNr < negCharge.size() ? negCharge[hitNr].dPhi : std::numeric_limits<float>::max();
+
+      if (detIdPos != detIdNeg && (detIdPos.rawId() != 0 && detIdNeg.rawId() != 0)) {
+        cms::Exception("LogicError") << " error in " << __FILE__ << ", " << __LINE__
+                                     << " hits to be combined have different detIDs, this should not be possible and "
+                                        "nothing good will come of it";
+      }
+      DetId detId = detIdPos.rawId() != 0 ? detIdPos : detIdNeg;
+      matchInfos.push_back({detId, dRZPos, dRZNeg, dPhiPos, dPhiNeg});
+    }
+    return matchInfos;
+  }
 };  // namespace
 
 TrajSeedMatcher::Configuration::Configuration(const edm::ParameterSet& pset, edm::ConsumesCollector&& cc)
@@ -77,10 +102,14 @@ TrajSeedMatcher::Configuration::Configuration(const edm::ParameterSet& pset, edm
   }
 }
 
-TrajSeedMatcher::TrajSeedMatcher(TrajSeedMatcher::Configuration const& cfg,
+TrajSeedMatcher::TrajSeedMatcher(TrajectorySeedCollection const& seeds,
+                                 math::XYZPoint const& vprim,
+                                 TrajSeedMatcher::Configuration const& cfg,
                                  edm::EventSetup const& iSetup,
                                  MeasurementTrackerEvent const& measTkEvt)
-    : cfg_{cfg},
+    : seeds_{seeds},
+      vprim_(vprim.x(), vprim.y(), vprim.z()),
+      cfg_{cfg},
       magField_{iSetup.getData(cfg_.magFieldToken)},
       magFieldParam_{iSetup.getData(cfg_.paramMagFieldToken)},
       measTkEvt_{measTkEvt},
@@ -127,29 +156,26 @@ edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription() {
   return desc;
 }
 
-std::vector<TrajSeedMatcher::SeedWithInfo> TrajSeedMatcher::operator()(const TrajectorySeedCollection& seeds,
-                                                                       const GlobalPoint& candPos,
-                                                                       const GlobalPoint& vprim,
-                                                                       const float energy) {
+std::vector<TrajSeedMatcher::SeedWithInfo> TrajSeedMatcher::operator()(const GlobalPoint& candPos, const float energy) {
   clearCache();
 
   std::vector<SeedWithInfo> matchedSeeds;
 
   //these are super expensive functions
-  TrajectoryStateOnSurface scTrajStateOnSurfNeg = makeTrajStateOnSurface(candPos, vprim, energy, -1);
-  TrajectoryStateOnSurface scTrajStateOnSurfPos = makeTrajStateOnSurface(candPos, vprim, energy, 1);
+  TrajectoryStateOnSurface scTrajStateOnSurfNeg = makeTrajStateOnSurface(candPos, energy, -1);
+  TrajectoryStateOnSurface scTrajStateOnSurfPos = makeTrajStateOnSurface(candPos, energy, 1);
 
-  for (const auto& seed : seeds) {
-    std::vector<SCHitMatch> matchedHitsNeg = processSeed(seed, candPos, vprim, energy, scTrajStateOnSurfNeg);
-    std::vector<SCHitMatch> matchedHitsPos = processSeed(seed, candPos, vprim, energy, scTrajStateOnSurfPos);
+  for (const auto& seed : seeds_) {
+    std::vector<SCHitMatch> matchedHitsNeg = processSeed(seed, candPos, energy, scTrajStateOnSurfNeg);
+    std::vector<SCHitMatch> matchedHitsPos = processSeed(seed, candPos, energy, scTrajStateOnSurfPos);
 
     int nrValidLayersPos = 0;
     int nrValidLayersNeg = 0;
     if (matchedHitsNeg.size() >= 2) {
-      nrValidLayersNeg = getNrValidLayersAlongTraj(matchedHitsNeg[0], matchedHitsNeg[1], candPos, vprim, energy, -1);
+      nrValidLayersNeg = getNrValidLayersAlongTraj(matchedHitsNeg[0], matchedHitsNeg[1], candPos, energy, -1);
     }
     if (matchedHitsPos.size() >= 2) {
-      nrValidLayersPos = getNrValidLayersAlongTraj(matchedHitsPos[0], matchedHitsPos[1], candPos, vprim, energy, +1);
+      nrValidLayersPos = getNrValidLayersAlongTraj(matchedHitsPos[0], matchedHitsPos[1], candPos, energy, +1);
     }
 
     int nrValidLayers = std::max(nrValidLayersNeg, nrValidLayersPos);
@@ -163,7 +189,7 @@ std::vector<TrajSeedMatcher::SeedWithInfo> TrajSeedMatcher::operator()(const Tra
       matchCountPasses = matchedHitsNeg.size() >= nrHitsRequired || matchedHitsPos.size() >= nrHitsRequired;
     }
     if (matchCountPasses) {
-      matchedSeeds.push_back({seed, matchedHitsPos, matchedHitsNeg, nrValidLayers});
+      matchedSeeds.push_back({seed, makeMatchInfoVector(matchedHitsPos, matchedHitsNeg), nrValidLayers});
     }
   }
   return matchedSeeds;
@@ -171,7 +197,6 @@ std::vector<TrajSeedMatcher::SeedWithInfo> TrajSeedMatcher::operator()(const Tra
 
 std::vector<TrajSeedMatcher::SCHitMatch> TrajSeedMatcher::processSeed(const TrajectorySeed& seed,
                                                                       const GlobalPoint& candPos,
-                                                                      const GlobalPoint& vprim,
                                                                       const float energy,
                                                                       const TrajectoryStateOnSurface& initialTrajState) {
   //next try passing these variables in once...
@@ -179,22 +204,21 @@ std::vector<TrajSeedMatcher::SCHitMatch> TrajSeedMatcher::processSeed(const Traj
   const float candEt = energy * std::sin(candPos.theta());
   const int charge = initialTrajState.charge();
 
-  std::vector<SCHitMatch> matchedHits;
+  std::vector<SCHitMatch> matches;
   FreeTrajectoryState firstMatchFreeTraj;
   GlobalPoint prevHitPos;
   GlobalPoint vertex;
-  for (size_t hitNr = 0; hitNr < cfg_.matchingCuts.size() && hitNr < seed.nHits(); hitNr++) {
-    if (!cfg_.enableHitSkipping && hitNr > 0 && matchedHits.empty()) {
-      break;
-    }
-
-    auto const& recHit = *(seed.recHits().first + hitNr);
+  const auto nCuts = cfg_.matchingCuts.size();
+  for (size_t iHit = 0;
+       matches.size() < nCuts && iHit < seed.nHits() && (cfg_.enableHitSkipping || iHit == matches.size());
+       iHit++) {
+    auto const& recHit = *(seed.recHits().first + iHit);
 
     if (!recHit.isValid()) {
       continue;
     }
 
-    const bool doFirstMatch = matchedHits.empty();
+    const bool doFirstMatch = matches.empty();
 
     auto const& trajState = doFirstMatch
                                 ? getTrajStateFromVtx(recHit, initialTrajState, backwardPropagator_)
@@ -203,22 +227,21 @@ std::vector<TrajSeedMatcher::SCHitMatch> TrajSeedMatcher::processSeed(const Traj
       continue;
     }
 
-    auto const& vtxForMatchObject = doFirstMatch ? vprim : vertex;
+    auto const& vtxForMatchObject = doFirstMatch ? vprim_ : vertex;
     auto match = makeSCHitMatch(vtxForMatchObject, trajState, recHit, candEt, candEta, candPos.phi(), charge, 1);
 
-    if (passesMatchSel(match, matchedHits.size())) {
-      matchedHits.push_back(match);
+    if ((*cfg_.matchingCuts[matches.size()])(match)) {
+      matches.push_back(match);
       if (doFirstMatch) {
         //now we can figure out the z vertex
-        double zVertex = cfg_.useRecoVertex ? vprim.z() : getZVtxFromExtrapolation(vprim, match.hitPos, candPos);
-        vertex = GlobalPoint(vprim.x(), vprim.y(), zVertex);
-        firstMatchFreeTraj =
-            trackingTools::ftsFromVertexToPoint(getMagField(match.hitPos), match.hitPos, vertex, energy, charge);
+        double zVertex = cfg_.useRecoVertex ? vprim_.z() : getZVtxFromExtrapolation(vprim_, match.hitPos, candPos);
+        vertex = GlobalPoint(vprim_.x(), vprim_.y(), zVertex);
+        firstMatchFreeTraj = ftsFromVertexToPoint(match.hitPos, vertex, energy, charge);
       }
       prevHitPos = match.hitPos;
     }
   }
-  return matchedHits;
+  return matches;
 }
 
 // compute the z vertex from the candidate position and the found pixel hit
@@ -270,12 +293,10 @@ const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromPoint(const Tra
 }
 
 TrajectoryStateOnSurface TrajSeedMatcher::makeTrajStateOnSurface(const GlobalPoint& pos,
-                                                                 const GlobalPoint& vtx,
                                                                  const float energy,
                                                                  const int charge) const {
-  auto freeTS = trackingTools::ftsFromVertexToPoint(getMagField(pos), pos, vtx, energy, charge);
-  PerpendicularBoundPlaneBuilder bpb;
-  return TrajectoryStateOnSurface(freeTS, *bpb(freeTS.position(), freeTS.momentum()));
+  auto freeTS = ftsFromVertexToPoint(pos, vprim_, energy, charge);
+  return TrajectoryStateOnSurface(freeTS, *PerpendicularBoundPlaneBuilder{}(freeTS.position(), freeTS.momentum()));
 }
 
 void TrajSeedMatcher::clearCache() {
@@ -285,26 +306,12 @@ void TrajSeedMatcher::clearCache() {
   trajStateFromPointNegChargeCache_.clear();
 }
 
-bool TrajSeedMatcher::passesMatchSel(const TrajSeedMatcher::SCHitMatch& hit, const size_t hitNr) const {
-  if (hitNr < cfg_.matchingCuts.size()) {
-    return (*cfg_.matchingCuts[hitNr])(hit);
-  } else {
-    throw cms::Exception("LogicError") << " Error, attempting to apply selection to hit " << hitNr
-                                       << " but only cuts for " << cfg_.matchingCuts.size() << " defined";
-  }
-}
+int TrajSeedMatcher::getNrValidLayersAlongTraj(
+    const SCHitMatch& hit1, const SCHitMatch& hit2, const GlobalPoint& candPos, const float energy, const int charge) {
+  double zVertex = cfg_.useRecoVertex ? vprim_.z() : getZVtxFromExtrapolation(vprim_, hit1.hitPos, candPos);
+  GlobalPoint vertex(vprim_.x(), vprim_.y(), zVertex);
 
-int TrajSeedMatcher::getNrValidLayersAlongTraj(const SCHitMatch& hit1,
-                                               const SCHitMatch& hit2,
-                                               const GlobalPoint& candPos,
-                                               const GlobalPoint& vprim,
-                                               const float energy,
-                                               const int charge) {
-  double zVertex = cfg_.useRecoVertex ? vprim.z() : getZVtxFromExtrapolation(vprim, hit1.hitPos, candPos);
-  GlobalPoint vertex(vprim.x(), vprim.y(), zVertex);
-
-  auto firstMatchFreeTraj =
-      trackingTools::ftsFromVertexToPoint(getMagField(hit1.hitPos), hit1.hitPos, vertex, energy, charge);
+  auto firstMatchFreeTraj = ftsFromVertexToPoint(hit1.hitPos, vertex, energy, charge);
   auto const& secondHitTraj = getTrajStateFromPoint(hit2.hit, firstMatchFreeTraj, hit1.hitPos, forwardPropagator_);
   return getNrValidLayersAlongTraj(hit2.hit.geographicalId(), secondHitTraj);
 }
@@ -366,31 +373,6 @@ size_t TrajSeedMatcher::getNrHitsRequired(const int nrValidLayers) const {
       return cfg_.minNrHits[binNr];
   }
   return cfg_.minNrHits.back();
-}
-
-TrajSeedMatcher::SeedWithInfo::SeedWithInfo(const TrajectorySeed& seed,
-                                            const std::vector<SCHitMatch>& posCharge,
-                                            const std::vector<SCHitMatch>& negCharge,
-                                            int nrValidLayers)
-    : seed_(seed), nrValidLayers_(nrValidLayers) {
-  size_t nrHitsMax = std::max(posCharge.size(), negCharge.size());
-  for (size_t hitNr = 0; hitNr < nrHitsMax; hitNr++) {
-    DetId detIdPos = hitNr < posCharge.size() ? posCharge[hitNr].detId : DetId(0);
-    float dRZPos = hitNr < posCharge.size() ? posCharge[hitNr].dRZ : std::numeric_limits<float>::max();
-    float dPhiPos = hitNr < posCharge.size() ? posCharge[hitNr].dPhi : std::numeric_limits<float>::max();
-
-    DetId detIdNeg = hitNr < negCharge.size() ? negCharge[hitNr].detId : DetId(0);
-    float dRZNeg = hitNr < negCharge.size() ? negCharge[hitNr].dRZ : std::numeric_limits<float>::max();
-    float dPhiNeg = hitNr < negCharge.size() ? negCharge[hitNr].dPhi : std::numeric_limits<float>::max();
-
-    if (detIdPos != detIdNeg && (detIdPos.rawId() != 0 && detIdNeg.rawId() != 0)) {
-      cms::Exception("LogicError")
-          << " error in " << __FILE__ << ", " << __LINE__
-          << " hits to be combined have different detIDs, this should not be possible and nothing good will come of it";
-    }
-    DetId detId = detIdPos.rawId() != 0 ? detIdPos : detIdNeg;
-    matchInfo_.push_back(MatchInfo(detId, dRZPos, dRZNeg, dPhiPos, dPhiNeg));
-  }
 }
 
 TrajSeedMatcher::MatchingCutsV1::MatchingCutsV1(const edm::ParameterSet& pset)

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
@@ -56,11 +56,6 @@ private:
 };
 
 namespace {
-  template <typename T>
-  inline auto convertToGP(const T& orgPoint) {
-    return GlobalPoint(orgPoint.x(), orgPoint.y(), orgPoint.z());
-  }
-
   int getLayerOrDiskNr(DetId detId, const TrackerTopology& trackerTopo) {
     if (detId.subdetId() == PixelSubdetector::PixelBarrel) {
       return trackerTopo.pxbLayer(detId);
@@ -111,12 +106,13 @@ void ElectronNHitSeedProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 void ElectronNHitSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   auto const& trackerTopology = iSetup.getData(trackerTopologyToken_);
 
-  TrajSeedMatcher matcher{matcherConfiguration_, iSetup, iEvent.get(measTkEvtToken_)};
-
   reco::ElectronSeedCollection eleSeeds{};
-  auto const& initialSeeds = iEvent.get(initialSeedsToken_);
 
-  auto primVtxPos = convertToGP(iEvent.get(beamSpotToken_).position());
+  TrajSeedMatcher matcher{iEvent.get(initialSeedsToken_),
+                          iEvent.get(beamSpotToken_).position(),
+                          matcherConfiguration_,
+                          iSetup,
+                          iEvent.get(measTkEvtToken_)};
 
   // Loop over all super-cluster collections (typically barrel and forward are supplied separately)
   for (const auto& superClustersToken : superClustersTokens_) {
@@ -127,14 +123,12 @@ void ElectronNHitSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const 
                                                   superClusRef->position().phi(),            //supercluster phi
                                                   superClusRef->position().r()));            //supercluster r
 
-      const auto matchedSeeds = matcher(initialSeeds, caloPosition, primVtxPos, superClusRef->energy());
-
-      for (auto& matchedSeed : matchedSeeds) {
-        reco::ElectronSeed eleSeed(matchedSeed.seed());
+      for (auto const& matchedSeed : matcher(caloPosition, superClusRef->energy())) {
+        reco::ElectronSeed eleSeed(matchedSeed.seed);
         reco::ElectronSeed::CaloClusterRef caloClusRef(superClusRef);
         eleSeed.setCaloCluster(caloClusRef);
-        eleSeed.setNrLayersAlongTraj(matchedSeed.nrValidLayers());
-        for (auto& matchInfo : matchedSeed.matches()) {
+        eleSeed.setNrLayersAlongTraj(matchedSeed.nrValidLayers);
+        for (auto const& matchInfo : matchedSeed.matchInfos) {
           eleSeed.addHitInfo(makeSeedPixelVar(matchInfo, trackerTopology));
         }
         eleSeeds.emplace_back(eleSeed);

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -245,8 +245,6 @@ void ElectronSeedProducer::fillDescriptions(edm::ConfigurationDescriptions& desc
   // phi windows (non dynamic, overwritten in case dynamic is selected)
   desc.add<double>("ePhiMin1", -0.125);
   desc.add<double>("ePhiMax1", 0.075);
-  desc.add<double>("pPhiMin1", -0.075);
-  desc.add<double>("pPhiMax1", 0.125);
   desc.add<double>("PhiMax2B", 0.002);
   desc.add<double>("PhiMax2F", 0.003);
 


### PR DESCRIPTION
#### PR description:

After https://github.com/cms-sw/cmssw/pull/29512, this is the next PR that takes little steps towards the convergence of the HLT and offline electron pixel matching code:

1. Simplify helper structs of `TrajSeedMatcher`
2. Be more consistent in treating electrons and positrons symmetrically in the offline `ElectronSeedProucer`, as already started with https://github.com/cms-sw/cmssw/pull/29304
3. Again fix the hit skipping logic in `TrajSeedMatcher`. One fix was already done in the previous PR, but I noticed there was still a problem that would end the matching loop prematurely if hits were skipped. After this PR, the logic for hit skipping should be correct (at least in the matching loop).
4. Some minor simplifications in the `TrajSeedMatcher`

#### PR validation:

CMSSW compiles and local matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.