### PR TITLE
[Payload Inspector] Update derived classes to use fill() method for Histrogram1D after PR  #29622

### DIFF
--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
@@ -67,8 +67,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<AlignmentErrorsExtended> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<AlignTransformErrorExtended> alignErrors = payload->m_alignError;

--- a/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
@@ -52,8 +52,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      for (auto const &iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const &iov : tag.iovs) {
         std::shared_ptr<AlignmentSurfaceDeformations> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           int i = 0;

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
@@ -57,8 +57,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalIntercalibConstantsMC> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -115,8 +116,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalIntercalibConstantsMC> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
@@ -57,8 +57,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalIntercalibConstants> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -105,8 +106,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalIntercalibConstants> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
@@ -58,8 +58,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalIntercalibErrors> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -114,8 +115,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalIntercalibErrors> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
@@ -57,8 +57,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalLaserAPDPNRatiosRef> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -113,8 +114,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalLaserAPDPNRatiosRef> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatios_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatios_PayloadInspector.cc
@@ -57,8 +57,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalLaserAPDPNRatios> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // set to -1 for ieta 0 (no crystal)
@@ -96,8 +97,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalLaserAPDPNRatios> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // set to -1 everywhwere

--- a/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
@@ -57,8 +57,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalLaserAlphas> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -113,8 +114,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalLaserAlphas> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
@@ -57,8 +57,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPFRecHitThresholds> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -113,8 +114,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPFRecHitThresholds> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -705,8 +705,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -753,8 +754,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -797,8 +799,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -842,8 +845,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())
@@ -893,8 +897,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())
@@ -943,8 +948,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())
@@ -994,8 +1000,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -1041,8 +1048,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -1084,8 +1092,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -1128,8 +1137,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())
@@ -1178,8 +1188,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())
@@ -1227,8 +1238,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
@@ -58,8 +58,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalTimeCalibConstants> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -114,8 +115,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalTimeCalibConstants> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
@@ -58,8 +58,9 @@ namespace {
     }
 
     // Histogram2D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalTimeCalibErrors> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
@@ -114,8 +115,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalTimeCalibErrors> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (payload->endcapItems().empty())

--- a/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
@@ -45,12 +45,14 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<RunInfo> payload = Base::fetchPayload(std::get<1>(iov));
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
+        std::shared_ptr<RunInfo> payload = Base::fetchPayload(std::get<1>(iov));
 
-      if (payload.get()) {
-        payload->printAllValues();
+        if (payload.get()) {
+          payload->printAllValues();
+        }
       }
       return true;
     }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -44,8 +44,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
-      for (auto const &iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const &iov : tag.iovs) {
         std::shared_ptr<SiPixelLorentzAngle> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -50,8 +50,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiPixelQuality> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           fillWithValue(1.);

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -53,8 +53,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<uint32_t> detid;
@@ -92,8 +93,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           TrackerTopology tTopo = StandaloneTrackerTopology::fromTrackerParametersXMLFile(
@@ -155,8 +157,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           TrackerTopology tTopo = StandaloneTrackerTopology::fromTrackerParametersXMLFile(
@@ -200,8 +203,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           TrackerTopology tTopo = StandaloneTrackerTopology::fromTrackerParametersXMLFile(
@@ -269,8 +273,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           TrackerTopology tTopo = StandaloneTrackerTopology::fromTrackerParametersXMLFile(
@@ -340,8 +345,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           TrackerTopology tTopo = StandaloneTrackerTopology::fromTrackerParametersXMLFile(
@@ -399,8 +405,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           TrackerTopology tTopo = StandaloneTrackerTopology::fromTrackerParametersXMLFile(
@@ -1162,8 +1169,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<uint32_t> detid;

--- a/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
@@ -46,8 +46,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      for (auto const &iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const &iov : tag.iovs) {
         std::shared_ptr<SiStripBackPlaneCorrection> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::map<uint32_t, float> BPMap_ = payload->getBackPlaneCorrections();

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -58,8 +58,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripBadStrip> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           fillWithValue(1.);

--- a/CondCore/SiStripPlugins/plugins/SiStripConfObject_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripConfObject_PayloadInspector.cc
@@ -45,8 +45,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripConfObject> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           fillWithValue(1.);

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -160,8 +160,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripDetVOff> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<uint32_t> detid;

--- a/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
@@ -52,8 +52,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripLatency> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<SiStripLatency::Latency> lat = payload->allLatencyAndModes();
@@ -75,8 +76,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripLatency> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<uint16_t> modes;

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -46,8 +46,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      for (auto const &iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const &iov : tag.iovs) {
         std::shared_ptr<SiStripLorentzAngle> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -59,8 +59,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripNoises> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           fillWithValue(1.);
@@ -196,8 +197,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripNoises> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<uint32_t> detid;
@@ -231,8 +233,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripNoises> payload = Base::fetchPayload(std::get<1>(iov));
         unsigned int the_detid(0xFFFFFFFF);
         auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -59,8 +59,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           fillWithValue(1.);
@@ -197,8 +198,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<uint32_t> detid;
@@ -232,8 +234,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         unsigned int the_detid(0xFFFFFFFF);
         auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
@@ -592,7 +595,7 @@ namespace {
     1d histogram of fraction of Zero SiStripPedestals of 1 IOV 
   *************************************************/
 
-  // inherit from one of the predefined plot class: Histogram1D
+  // inherit from one of the predefined plot class PlotImage
   class SiStripZeroPedestalsFraction_TrackerMap : public cond::payloadInspector::PlotImage<SiStripPedestals> {
   public:
     SiStripZeroPedestalsFraction_TrackerMap()

--- a/CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc
@@ -58,8 +58,9 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripThreshold> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           fillWithValue(1.);
@@ -96,11 +97,12 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
-      for (auto const& iov : iovs) {
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripThreshold> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<uint32_t> detid;
@@ -141,11 +143,12 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
-      for (auto const& iov : iovs) {
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripThreshold> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::vector<uint32_t> detid;


### PR DESCRIPTION
#### PR description:

Integration of PR #29622 introduced new warnings in CLANG IBs. This has been discussed in PR https://github.com/cms-sw/cmssw/pull/29789. 
It turns out, as highlighted in comments at https://github.com/cms-sw/cmssw/pull/29789#discussion_r422876676 that the method 
```
virtual bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) { ... }
```
has totally disappeared from `cond::payloadInspector::Histogram*`. 
So the proper fix consists in migrating all the derived classes to use instead 
https://github.com/cms-sw/cmssw/blob/29634922c859dc7a7cec988de55ee4ff48becb6c/CondCore/Utilities/interface/PayloadInspector.h#L724

as at the moment all of these plots are not functional.
#### PR validation:

Compilation and unit tests run in standard IB. Compilation has been checked in `CMSSW_11_1_CLANG_X_2020-05-10-2300` and errors reported at https://github.com/cms-sw/cmssw/pull/29789#issue-415552443 are not observed anymore.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.