### PR TITLE
Update event content structure for cosmic in RecoLocalCalo

### DIFF
--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContentCosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContentCosmics_cff.py
@@ -4,46 +4,40 @@ from RecoLocalCalo.Configuration.ecalLocalReco_EventContentCosmics_cff import *
 #
 # start with HCAL part
 #
-#FEVT
-RecoLocalCaloFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_hbhereco_*_*',
-                                           'keep *_hbheprereco_*_*', 
-                                           'keep *_hfprereco_*_*', 
-                                           'keep *_hfreco_*_*', 
-                                           'keep *_horeco_*_*',
-                                           'keep HBHERecHitsSorted_hbherecoMB_*_*',
-                                           'keep HBHERecHitsSorted_hbheprerecoMB_*_*',
-                                           'keep HORecHitsSorted_horecoMB_*_*',
-                                           'keep HFRecHitsSorted_hfrecoMB_*_*',
-                                           'keep ZDCDataFramesSorted_*Digis_*_*',
-                                           'keep ZDCRecHitsSorted_*_*_*',
-                                           'keep HcalUnpackerReport_*_*_*'
-        )
-)
-#RECO content
-RecoLocalCaloRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_hbhereco_*_*', 
-                                           'keep *_hfprereco_*_*', 
-                                           'keep *_hfreco_*_*', 
-                                           'keep *_horeco_*_*',
-                                           'keep HBHERecHitsSorted_hbherecoMB_*_*',
-                                           'keep HORecHitsSorted_horecoMB_*_*',
-                                           'keep HFRecHitsSorted_hfrecoMB_*_*',
-                                           #'keep ZDCDataFramesSorted_*Digis_*_*',
-                                           'keep ZDCDataFramesSorted_hcalDigis_*_*',
-                                           'keep ZDCDataFramesSorted_castorDigis_*_*',
-                                           'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
-                                           'keep ZDCRecHitsSorted_zdcreco_*_*',
-                                           #'keep HcalUnpackerReport_*_*_*'
-                                           'keep HcalUnpackerReport_castorDigis_*_*',
-                                           'keep HcalUnpackerReport_hcalDigis_*_*'
-        )
-)
 #AOD content
 RecoLocalCaloAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
-RecoLocalCaloFEVT.outputCommands.extend(ecalLocalRecoFEVT.outputCommands)
-RecoLocalCaloRECO.outputCommands.extend(ecalLocalRecoRECO.outputCommands)
 RecoLocalCaloAOD.outputCommands.extend(ecalLocalRecoAOD.outputCommands)
 
+#RECO content
+RecoLocalCaloRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep *_hbhereco_*_*', 
+	'keep *_hfprereco_*_*', 
+	'keep *_hfreco_*_*', 
+	'keep *_horeco_*_*',
+	'keep HBHERecHitsSorted_hbherecoMB_*_*',
+	'keep HORecHitsSorted_horecoMB_*_*',
+	'keep HFRecHitsSorted_hfrecoMB_*_*',
+	'keep ZDCDataFramesSorted_hcalDigis_*_*',
+	'keep ZDCDataFramesSorted_castorDigis_*_*',
+	'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
+	'keep ZDCRecHitsSorted_zdcreco_*_*',
+	'keep HcalUnpackerReport_castorDigis_*_*',
+	'keep HcalUnpackerReport_hcalDigis_*_*')
+)
+RecoLocalCaloRECO.outputCommands.extend(RecoLocalCaloAOD.outputCommands)
+RecoLocalCaloRECO.outputCommands.extend(ecalLocalRecoRECO.outputCommands)
+
+#FEVT content
+RecoLocalCaloFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep *_hbheprereco_*_*', 
+	'keep HBHERecHitsSorted_hbheprerecoMB_*_*',
+	'keep ZDCDataFramesSorted_*Digis_*_*',
+	'keep ZDCRecHitsSorted_*_*_*',
+	'keep HcalUnpackerReport_*_*_*')
+)
+RecoLocalCaloFEVT.outputCommands.extend(RecoLocalCaloRECO.outputCommands)
+RecoLocalCaloFEVT.outputCommands.extend(ecalLocalRecoFEVT.outputCommands)

--- a/RecoLocalCalo/Configuration/python/ecalLocalReco_EventContentCosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalReco_EventContentCosmics_cff.py
@@ -1,34 +1,28 @@
 import FWCore.ParameterSet.Config as cms
 
+# AOD content
+ecalLocalRecoAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+# RECO content
+# .. calibrated RecHits
+ecalLocalRecoRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_ecalPreshowerRecHit_*_*',
+        'keep *_ecalRecHit_*_*',
+        'keep *_ecalCompactTrigPrim_*_*',
+        'keep ESDataFramesSorted_ecalPreshowerDigis_*_*',
+        'keep EBSrFlagsSorted_ecalDigis__*',
+        'keep EESrFlagsSorted_ecalDigis__*')
+)
+ecalLocalRecoRECO.outputCommands.extend(ecalLocalRecoAOD.outputCommands)
+
 # Full Event content 
 # .. EB + EE uncalibrated recHits
 # .. calibrated RecHits
 ecalLocalRecoFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_ecalWeightUncalibRecHit_*_*', 
-        'keep *_ecalFixedAlphaBetaFitUncalibRecHit_*_*', 
-        'keep *_ecalPreshowerRecHit_*_*', 
-        'keep *_ecalRecHit_*_*',
-        'keep ESDataFramesSorted_ecalPreshowerDigis_*_*',
-        'keep EBSrFlagsSorted_ecalDigis__*',
-        'keep EESrFlagsSorted_ecalDigis__*'
-        )
+        'keep *_ecalFixedAlphaBetaFitUncalibRecHit_*_*')
 )
-# RECO content
-# .. calibrated RecHits
-ecalLocalRecoRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_ecalPreshowerRecHit_*_*', 
-        'keep *_ecalRecHit_*_*',
-        'keep *_ecalCompactTrigPrim_*_*',
-        'keep ESDataFramesSorted_ecalPreshowerDigis_*_*',
-        'keep EBSrFlagsSorted_ecalDigis__*',
-        'keep EESrFlagsSorted_ecalDigis__*'
-        )
-)
-# AOD content
-# .. nothing
-ecalLocalRecoAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring()
-)
-
+ecalLocalRecoFEVT.outputCommands.extend(ecalLocalRecoRECO.outputCommands)


### PR DESCRIPTION
#### PR description:  
Update cosmic event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. 
2 files changed: 
+ `RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContentCosmics_cff.py`
+ `RecoLocalCalo/Configuration/python/ecalLocalReco_EventContentCosmics_cff.py`

(The reference RecoLocalCalo event content task was [PR#29225](https://github.com/cms-sw/cmssw/pull/29225))
#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X_2020-05-12-1100, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).