### PR TITLE
Update event content structure for cosmic and BHM in RecoTracker

### DIFF
--- a/RecoTracker/Configuration/python/RecoTrackerBHM_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerBHM_EventContent_cff.py
@@ -1,27 +1,22 @@
-# The following comments couldn't be translated into the new config version:
-
-#Tracks
-
-#Tracks
-
+import FWCore.ParameterSet.Config as cms
 #Tracks without extra and hits
 
-import FWCore.ParameterSet.Config as cms
+#AOD content
+RecoTrackerAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep recoTracks_ctfWithMaterialTracksBeamHaloMuon_*_*')
+)
+
+#RECO content
+RecoTrackerRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep recoTrackExtras_ctfWithMaterialTracksBeamHaloMuon_*_*', 
+        'keep TrackingRecHitsOwned_ctfWithMaterialTracksBeamHaloMuon_*_*')
+)
+RecoTrackerRECO.outputCommands.extend(RecoTrackerAOD.outputCommands)
 
 #Full Event content 
 RecoTrackerFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_ctfWithMaterialTracksBeamHaloMuon_*_*', 
-        'keep recoTrackExtras_ctfWithMaterialTracksBeamHaloMuon_*_*', 
-        'keep TrackingRecHitsOwned_ctfWithMaterialTracksBeamHaloMuon_*_*')
+    outputCommands = cms.untracked.vstring()
 )
-#RECO content
-RecoTrackerRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_ctfWithMaterialTracksBeamHaloMuon_*_*', 
-        'keep recoTrackExtras_ctfWithMaterialTracksBeamHaloMuon_*_*', 
-        'keep TrackingRecHitsOwned_ctfWithMaterialTracksBeamHaloMuon_*_*')
-)
-#AOD content
-RecoTrackerAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_ctfWithMaterialTracksBeamHaloMuon_*_*')
-)
-
+RecoTrackerFEVT.outputCommands.extend(RecoTrackerRECO.outputCommands)

--- a/RecoTracker/Configuration/python/RecoTrackerP5_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_EventContent_cff.py
@@ -1,144 +1,70 @@
-# The following comments couldn't be translated into the new config version:
-
-#Tracks
-
-#Tracks
-
+import FWCore.ParameterSet.Config as cms
 #Tracks without extra and hits
 
-import FWCore.ParameterSet.Config as cms
-
-#Full Event content 
-RecoTrackerFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_ctfWithMaterialTracksP5_*_*', 
-        'keep recoTrackExtras_ctfWithMaterialTracksP5_*_*', 
-        'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5_*_*', 
+#AOD content
+RecoTrackerAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep recoTracks_ctfWithMaterialTracksP5_*_*',
         'keep recoTracks_ctfWithMaterialTracksP5LHCNavigation_*_*',
-        'keep recoTrackExtras_ctfWithMaterialTracksP5LHCNavigation_*_*',
-        'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5LHCNavigation_*_*',
-        'keep recoTracks_rsWithMaterialTracksP5_*_*', 
-        'keep recoTrackExtras_rsWithMaterialTracksP5_*_*', 
-        'keep TrackingRecHitsOwned_rsWithMaterialTracksP5_*_*', 
-        'keep recoTracks_cosmictrackfinderP5_*_*', 
-        'keep recoTrackExtras_cosmictrackfinderP5_*_*', 
-        'keep TrackingRecHitsOwned_cosmictrackfinderP5_*_*',
-        'keep recoTracks_beamhaloTracks_*_*', 
-        'keep recoTrackExtras_beamhaloTracks_*_*', 
-        'keep TrackingRecHitsOwned_beamhaloTracks_*_*',
+        'keep recoTracks_rsWithMaterialTracksP5_*_*',
+        'keep recoTracks_cosmictrackfinderP5_*_*',
+        'keep recoTracks_beamhaloTracks_*_*',
         'keep recoTracks_splittedTracksP5_*_*',
-        'keep recoTrackExtras_splittedTracksP5_*_*',
-        'keep TrackingRecHitsOwned_splittedTracksP5_*_*',                                           
         'keep recoTracks_ctfWithMaterialTracksP5Top_*_*',
-        'keep recoTrackExtras_ctfWithMaterialTracksP5Top_*_*',
-        'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5Top_*_*',
         'keep recoTracks_rsWithMaterialTracksP5Top_*_*',
-        'keep recoTrackExtras_rsWithMaterialTracksP5Top_*_*',
-        'keep TrackingRecHitsOwned_rsWithMaterialTracksP5Top_*_*',
         'keep recoTracks_cosmictrackfinderP5Top_*_*',
-        'keep recoTrackExtras_cosmictrackfinderP5Top_*_*',
-        'keep TrackingRecHitsOwned_cosmictrackfinderP5Top_*_*',
         'keep recoTracks_ctfWithMaterialTracksP5Bottom_*_*',
-        'keep recoTrackExtras_ctfWithMaterialTracksP5Bottom_*_*',
-        'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5Bottom_*_*',
         'keep recoTracks_rsWithMaterialTracksP5Bottom_*_*',
-        'keep recoTrackExtras_rsWithMaterialTracksP5Bottom_*_*',
-        'keep TrackingRecHitsOwned_rsWithMaterialTracksP5Bottom_*_*',
         'keep recoTracks_cosmictrackfinderP5Bottom_*_*',
-        'keep recoTrackExtras_cosmictrackfinderP5Bottom_*_*',
-        'keep TrackingRecHitsOwned_cosmictrackfinderP5Bottom_*_*',                                           
         'keep recoTracks_regionalCosmicTracks_*_*',
-        'keep recoTrackExtras_regionalCosmicTracks_*_*',
-        'keep TrackingRecHitsOwned_regionalCosmicTracks_*_*',  
-        'keep *_dedxTruncated40_*_*',
         'keep *_dedxHitInfo_*_*',
         'keep *_dedxHarmonic2_*_*',
-        'keep *_dedxTruncated40CTF_*_*',
         'keep *_dedxHitInfoCTF_*_*',
         'keep *_dedxHarmonic2CTF_*_*',
-        'keep *_dedxTruncated40CosmicTF_*_*',
         'keep *_dedxHitInfoCosmicTF_*_*',
-        'keep *_dedxHarmonic2CosmicTF_*_*',
-        'keep recoTracks_cosmicDCTracks_*_*',
-        'keep recoTrackExtras_cosmicDCTracks_*_*',
-        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*',
-    )
+        'keep *_dedxHarmonic2CosmicTF_*_*')
 )
+
 #RECO content
 RecoTrackerRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_ctfWithMaterialTracksP5_*_*', 
-        'keep recoTrackExtras_ctfWithMaterialTracksP5_*_*', 
+    outputCommands = cms.untracked.vstring(
+        'keep recoTrackExtras_ctfWithMaterialTracksP5_*_*',
         'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5_*_*',
-        'keep recoTracks_ctfWithMaterialTracksP5LHCNavigation_*_*',
         'keep recoTrackExtras_ctfWithMaterialTracksP5LHCNavigation_*_*',
-        'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5LHCNavigation_*_*',                                           
-        'keep recoTracks_rsWithMaterialTracksP5_*_*', 
-        'keep recoTrackExtras_rsWithMaterialTracksP5_*_*', 
-        'keep TrackingRecHitsOwned_rsWithMaterialTracksP5_*_*', 
-        'keep recoTracks_cosmictrackfinderP5_*_*', 
-        'keep recoTrackExtras_cosmictrackfinderP5_*_*', 
+        'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5LHCNavigation_*_*',
+        'keep recoTrackExtras_rsWithMaterialTracksP5_*_*',
+        'keep TrackingRecHitsOwned_rsWithMaterialTracksP5_*_*',
+        'keep recoTrackExtras_cosmictrackfinderP5_*_*',
         'keep TrackingRecHitsOwned_cosmictrackfinderP5_*_*',
-        'keep recoTracks_beamhaloTracks_*_*', 
-        'keep recoTrackExtras_beamhaloTracks_*_*', 
+        'keep recoTrackExtras_beamhaloTracks_*_*',
         'keep TrackingRecHitsOwned_beamhaloTracks_*_*',
-        'keep recoTracks_splittedTracksP5_*_*',
         'keep recoTrackExtras_splittedTracksP5_*_*',
         'keep TrackingRecHitsOwned_splittedTracksP5_*_*',
-        'keep recoTracks_ctfWithMaterialTracksP5Top_*_*',
         'keep recoTrackExtras_ctfWithMaterialTracksP5Top_*_*',
         'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5Top_*_*',
-        'keep recoTracks_rsWithMaterialTracksP5Top_*_*',
         'keep recoTrackExtras_rsWithMaterialTracksP5Top_*_*',
         'keep TrackingRecHitsOwned_rsWithMaterialTracksP5Top_*_*',
-        'keep recoTracks_cosmictrackfinderP5Top_*_*',
         'keep recoTrackExtras_cosmictrackfinderP5Top_*_*',
         'keep TrackingRecHitsOwned_cosmictrackfinderP5Top_*_*',
-        'keep recoTracks_ctfWithMaterialTracksP5Bottom_*_*',
         'keep recoTrackExtras_ctfWithMaterialTracksP5Bottom_*_*',
         'keep TrackingRecHitsOwned_ctfWithMaterialTracksP5Bottom_*_*',
-        'keep recoTracks_rsWithMaterialTracksP5Bottom_*_*',
         'keep recoTrackExtras_rsWithMaterialTracksP5Bottom_*_*',
         'keep TrackingRecHitsOwned_rsWithMaterialTracksP5Bottom_*_*',
-        'keep recoTracks_cosmictrackfinderP5Bottom_*_*',
         'keep recoTrackExtras_cosmictrackfinderP5Bottom_*_*',
-        'keep TrackingRecHitsOwned_cosmictrackfinderP5Bottom_*_*',                                           
-        'keep recoTracks_regionalCosmicTracks_*_*',
+        'keep TrackingRecHitsOwned_cosmictrackfinderP5Bottom_*_*',
         'keep recoTrackExtras_regionalCosmicTracks_*_*',
         'keep TrackingRecHitsOwned_regionalCosmicTracks_*_*',
         'keep *_dedxTruncated40_*_*',
-        'keep *_dedxHitInfo_*_*',
-        'keep *_dedxHarmonic2_*_*',
         'keep *_dedxTruncated40CTF_*_*',
-        'keep *_dedxHitInfoCTF_*_*',
-        'keep *_dedxHarmonic2CTF_*_*',
         'keep *_dedxTruncated40CosmicTF_*_*',
-        'keep *_dedxHitInfoCosmicTF_*_*',
-        'keep *_dedxHarmonic2CosmicTF_*_*',
         'keep recoTracks_cosmicDCTracks_*_*',
         'keep recoTrackExtras_cosmicDCTracks_*_*',
-        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*',
-    )
+        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*')
 )
-#AOD content
-RecoTrackerAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoTracks_ctfWithMaterialTracksP5_*_*', 
-        'keep recoTracks_ctfWithMaterialTracksP5LHCNavigation_*_*',
-        'keep recoTracks_rsWithMaterialTracksP5_*_*', 
-        'keep recoTracks_cosmictrackfinderP5_*_*',
-        'keep recoTracks_beamhaloTracks_*_*', 
-        'keep recoTracks_splittedTracksP5_*_*',
-        'keep recoTracks_ctfWithMaterialTracksP5Top_*_*',
-        'keep recoTracks_rsWithMaterialTracksP5Top_*_*',
-        'keep recoTracks_cosmictrackfinderP5Top_*_*',
-        'keep recoTracks_ctfWithMaterialTracksP5Bottom_*_*',
-        'keep recoTracks_rsWithMaterialTracksP5Bottom_*_*',
-        'keep recoTracks_cosmictrackfinderP5Bottom_*_*',
-        'keep recoTracks_regionalCosmicTracks_*_*',
-        'keep *_dedxHitInfo_*_*',
-        'keep *_dedxHarmonic2_*_*',
-        'keep *_dedxHitInfoCTF_*_*',
-        'keep *_dedxHarmonic2CTF_*_*',
-        'keep *_dedxHitInfoCosmicTF_*_*',
-        'keep *_dedxHarmonic2CosmicTF_*_*',
-    )
-)
+RecoTrackerRECO.outputCommands.extend(RecoTrackerAOD.outputCommands)
 
+#Full Event content 
+RecoTrackerFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoTrackerFEVT.outputCommands.extend(RecoTrackerRECO.outputCommands)


### PR DESCRIPTION
#### PR description:  
Update cosmic & BHM (BeamHaloMuon) event content definitions in RecoTracker package 
to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. 
2 files changed: 
+ `RecoTracker/Configuration/python/RecoTrackerP5_EventContent_cff.py`
+ `RecoTracker/Configuration/python/RecoTrackerBHM_EventContent_cff.py`

(The reference RecoTracker event content task was [PR#29158](https://github.com/cms-sw/cmssw/pull/29158))
#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X_2020-05-12-1100, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).