### PR TITLE
Update event content structure for cosmic in RecoEcal

### DIFF
--- a/RecoEcal/Configuration/python/RecoEcal_EventContentCosmics_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_EventContentCosmics_cff.py
@@ -1,46 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-RecoEcalFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_ecalRecHit_*_*', 
-        'keep *_ecalWeightUncalibRecHit_*_*', 
-        'keep *_ecalPreshowerRecHit_*_*', 
-        'keep *_islandBasicClusters_*_*', 
-        'keep *_islandSuperClusters_*_*', 
-        'keep *_hybridSuperClusters_*_*', 
-        'keep *_uncleanedHybridSuperClusters_*_*',
-        'keep *_correctedFixedMatrix*_*_*', 
-        'keep *_cosmicBasicClusters_*_*', 
-        'keep *_cosmicSuperClusters_*_*', 
-        'keep *_fixedMatrix*_*_*', 
-        'keep *_correctedIslandBarrelSuperClusters_*_*', 
-        'keep *_correctedIslandEndcapSuperClusters_*_*', 
-        'keep *_correctedHybridSuperClusters_*_*', 
-        'keep *_correctedEndcapSuperClustersWithPreshower_*_*', 
-        'keep *_preshowerClusterShape_*_*')
-)
-RecoEcalRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_islandBasicClusters_*_*', 
-        'keep *_fixedMatrixBasicClusters_*_*', 
-        'keep *_hybridSuperClusters_*_*',
-        'keep *_uncleanedHybridSuperClusters_*_*',                                           
-        'keep *_cosmicBasicClusters_*_*', 
-        'keep *_cosmicSuperClusters_*_*', 
-        'drop recoSuperClusters_hybridSuperClusters_*_*', 
-        'keep recoSuperClusters_islandSuperClusters_islandBarrelSuperClusters_*', 
-        'keep recoSuperClusters_correctedHybridSuperClusters_*_*', 
-        'keep *_correctedFixedMatrixSuperClustersWithPreshower_*_*', 
-        'keep recoPreshowerClusters_fixedMatrixSuperClustersWithPreshower_*_*', 
-        'keep *_correctedEndcapSuperClustersWithPreshower_*_*', 
-        'keep recoPreshowerClusterShapes_preshowerClusterShape_*_*', 
-        'keep recoPreshowerClusterShapes_fixedMatrixPreshowerClusterShape_*_*')
-)
+# AOD content
 RecoEcalAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_islandBasicClusters_*_*', 
+    outputCommands = cms.untracked.vstring(
+	'keep *_islandBasicClusters_*_*', 
         'keep *_fixedMatrixBasicClusters_*_*', 
-        'keep *_hybridSuperClusters_*_*', 
         'keep *_cosmicBasicClusters_*_*', 
         'keep *_cosmicSuperClusters_*_*', 
-        'drop recoSuperClusters_hybridSuperClusters_*_*', 
+        'keep recoCaloClusters_hybridSuperClusters_*_*', 
         'keep recoSuperClusters_islandSuperClusters_islandBarrelSuperClusters_*', 
         'keep recoSuperClusters_correctedHybridSuperClusters_*_*', 
         'keep recoSuperClusters_correctedEndcapSuperClustersWithPreshower_*_*', 
@@ -50,3 +17,27 @@ RecoEcalAOD = cms.PSet(
         'keep recoPreshowerClusterShapes_fixedMatrixPreshowerClusterShape_*_*')
 )
 
+# RECO content
+RecoEcalRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_uncleanedHybridSuperClusters_*_*',                         
+        'keep *_correctedFixedMatrixSuperClustersWithPreshower_*_*',
+        'keep *_correctedEndcapSuperClustersWithPreshower_*_*')
+)
+RecoEcalRECO.outputCommands.extend(RecoEcalAOD.outputCommands)
+
+RecoEcalFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep *_ecalRecHit_*_*', 
+        'keep *_ecalWeightUncalibRecHit_*_*', 
+        'keep *_ecalPreshowerRecHit_*_*', 
+        'keep *_islandSuperClusters_*_*', 
+        'keep *_hybridSuperClusters_*_*', 
+        'keep *_correctedFixedMatrix*_*_*', 
+        'keep *_fixedMatrix*_*_*', 
+        'keep *_correctedIslandBarrelSuperClusters_*_*', 
+        'keep *_correctedIslandEndcapSuperClusters_*_*', 
+        'keep *_correctedHybridSuperClusters_*_*', 
+        'keep *_preshowerClusterShape_*_*')
+)
+RecoEcalFEVT.outputCommands.extend(RecoEcalRECO.outputCommands)


### PR DESCRIPTION
#### PR description:  
Update cosmic event content definitions to explicitly have RECO to be a superset of AOD and for FEVT to be a superset of RECO. 
1 file changed :  `RecoEcal/Configuration/python/RecoEcal_EventContentCosmics_cff.py`
(The reference RecoEcal event content task was [PR#29299](https://github.com/cms-sw/cmssw/pull/29299))

In AOD and RECO contents,
```
 'keep *_hybridSuperClusters_*_*', 
 'drop recoSuperClusters_hybridSuperClusters_*_*', 
```
were replaced with*

```
 'keep recoCaloClusters_hybridSuperClusters_*_*', 
```
and used ` 'keep *_hybridSuperClusters_*_*', ` in FEVT content.

*(`hybridSuperClusters` has only 2 types : `vector<reco::CaloCluster>` & `vector<reco::SuperCluster>`.)

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).