### PR TITLE
Clean up of CondDB interface

### DIFF
--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -98,12 +98,6 @@ namespace cond {
       //
       bool existsIov(const std::string& tag);
 
-      // retrieves an IOV range. Peforms a query at every call.
-      bool getIovRange(const std::string& tag,
-                       cond::Time_t begin,
-                       cond::Time_t end,
-                       std::vector<std::tuple<cond::Time_t, cond::Hash> >& range);
-
       // create a non-existing iov sequence with the specified tag.
       // the type is required for consistency with the referenced payloads.
       // fixme: add creation time - required for the migration

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -23,7 +23,6 @@ namespace cond {
                           std::string& objectType,
                           cond::SynchronizationType& synchronizationType,
                           cond::Time_t& endOfValidity,
-                          std::string& description,
                           cond::Time_t& lastValidatedTime) = 0;
       virtual bool getMetadata(const std::string& name,
                                std::string& description,
@@ -40,9 +39,11 @@ namespace cond {
       virtual void update(const std::string& name,
                           cond::SynchronizationType synchronizationType,
                           cond::Time_t& endOfValidity,
-                          const std::string& description,
                           cond::Time_t lastValidatedTime,
                           const boost::posix_time::ptime& updateTime) = 0;
+      virtual void updateMetadata(const std::string& name,
+				  const std::string& description,
+				  const boost::posix_time::ptime& updateTime) = 0;
       virtual void updateValidity(const std::string& name,
                                   cond::Time_t lastValidatedTime,
                                   const boost::posix_time::ptime& updateTime) = 0;

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -42,8 +42,8 @@ namespace cond {
                           cond::Time_t lastValidatedTime,
                           const boost::posix_time::ptime& updateTime) = 0;
       virtual void updateMetadata(const std::string& name,
-				  const std::string& description,
-				  const boost::posix_time::ptime& updateTime) = 0;
+                                  const std::string& description,
+                                  const boost::posix_time::ptime& updateTime) = 0;
       virtual void updateValidity(const std::string& name,
                                   cond::Time_t lastValidatedTime,
                                   const boost::posix_time::ptime& updateTime) = 0;

--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -28,6 +28,7 @@ namespace cond {
       cond::Time_t lastValidatedTime = cond::time::MIN_VAL;
       boost::posix_time::ptime creationTime;
       bool change = false;
+      bool metadataChange = false;
       bool exists = false;
       // buffer for the iov sequence
       std::vector<std::tuple<cond::Time_t, cond::Hash, boost::posix_time::ptime> > iovBuffer;
@@ -53,6 +54,7 @@ namespace cond {
       m_data->synchronizationType = synchronizationType;
       m_data->creationTime = creationTime;
       m_data->change = true;
+      m_data->metadataChange = true;
     }
 
     IOVEditor::IOVEditor(const IOVEditor& rhs) : m_data(rhs.m_data), m_session(rhs.m_session) {}
@@ -71,7 +73,6 @@ namespace cond {
                                                     m_data->payloadType,
                                                     m_data->synchronizationType,
                                                     m_data->endOfValidity,
-                                                    m_data->description,
                                                     m_data->lastValidatedTime)) {
         cond::throwException("Tag \"" + tag + "\" has not been found in the database.", "IOVEditor::load");
       }
@@ -113,7 +114,7 @@ namespace cond {
     void IOVEditor::setDescription(const std::string& description) {
       if (m_data.get()) {
         m_data->description = description;
-        m_data->change = true;
+        m_data->metadataChange = true;
         m_data->changes.insert("Description");
       }
     }
@@ -169,8 +170,8 @@ namespace cond {
       std::string lt = logText;
       if (lt.empty())
         lt = "-";
-      if (m_data->change) {
-        if (m_data->description.empty())
+      if (m_data->change || m_data->metadataChange) {
+        if (m_data->metadataChange && m_data->description.empty())
           throwException("A non-empty description string is mandatory.", "IOVEditor::flush");
         if (m_data->validationMode)
           m_session->iovSchema().tagTable().setValidationMode();
@@ -197,12 +198,18 @@ namespace cond {
           m_data->exists = true;
           ret = true;
         } else {
-          m_session->iovSchema().tagTable().update(m_data->tag,
-                                                   m_data->synchronizationType,
-                                                   m_data->endOfValidity,
-                                                   m_data->description,
-                                                   m_data->lastValidatedTime,
-                                                   operationTime);
+          if(m_data->change){
+	    m_session->iovSchema().tagTable().update(m_data->tag,
+						     m_data->synchronizationType,
+						     m_data->endOfValidity,
+						     m_data->lastValidatedTime,
+						     operationTime);
+	  }
+	  if(m_data->metadataChange){
+	    m_session->iovSchema().tagTable().updateMetadata(m_data->tag,
+							     m_data->description,
+							     operationTime);
+	  }
           if (m_session->iovSchema().tagLogTable().exists()) {
             std::string action("Tag header updated. Changes involve: ");
             size_t i = 0;

--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -198,18 +198,16 @@ namespace cond {
           m_data->exists = true;
           ret = true;
         } else {
-          if(m_data->change){
-	    m_session->iovSchema().tagTable().update(m_data->tag,
-						     m_data->synchronizationType,
-						     m_data->endOfValidity,
-						     m_data->lastValidatedTime,
-						     operationTime);
-	  }
-	  if(m_data->metadataChange){
-	    m_session->iovSchema().tagTable().updateMetadata(m_data->tag,
-							     m_data->description,
-							     operationTime);
-	  }
+          if (m_data->change) {
+            m_session->iovSchema().tagTable().update(m_data->tag,
+                                                     m_data->synchronizationType,
+                                                     m_data->endOfValidity,
+                                                     m_data->lastValidatedTime,
+                                                     operationTime);
+          }
+          if (m_data->metadataChange) {
+            m_session->iovSchema().tagTable().updateMetadata(m_data->tag, m_data->description, operationTime);
+          }
           if (m_session->iovSchema().tagLogTable().exists()) {
             std::string action("Tag header updated. Changes involve: ");
             size_t i = 0;

--- a/CondCore/CondDB/src/IOVProxy.cc
+++ b/CondCore/CondDB/src/IOVProxy.cc
@@ -142,13 +142,11 @@ namespace cond {
 
       checkTransaction("IOVProxyNew::load");
 
-      std::string dummy;
       if (!m_session->iovSchema().tagTable().select(tagName,
                                                     m_data->tagInfo.timeType,
                                                     m_data->tagInfo.payloadType,
                                                     m_data->tagInfo.synchronizationType,
                                                     m_data->tagInfo.endOfValidity,
-                                                    dummy,
                                                     m_data->tagInfo.lastValidatedTime)) {
         throwException("Tag \"" + tagName + "\" has not been found in the database.", "IOVProxy::load");
       }

--- a/CondCore/CondDB/src/IOVSchema.cc
+++ b/CondCore/CondDB/src/IOVSchema.cc
@@ -68,12 +68,11 @@ namespace cond {
                             std::string& objectType,
                             cond::SynchronizationType& synchronizationType,
                             cond::Time_t& endOfValidity,
-                            std::string& description,
                             cond::Time_t& lastValidatedTime) {
-      Query<TIME_TYPE, OBJECT_TYPE, SYNCHRONIZATION, END_OF_VALIDITY, DESCRIPTION, LAST_VALIDATED_TIME> q(m_schema);
+      Query<TIME_TYPE, OBJECT_TYPE, SYNCHRONIZATION, END_OF_VALIDITY, LAST_VALIDATED_TIME> q(m_schema);
       q.addCondition<NAME>(name);
       for (auto row : q)
-        std::tie(timeType, objectType, synchronizationType, endOfValidity, description, lastValidatedTime) = row;
+        std::tie(timeType, objectType, synchronizationType, endOfValidity, lastValidatedTime) = row;
 
       return q.retrievedRows();
     }
@@ -121,12 +120,20 @@ namespace cond {
     void TAG::Table::update(const std::string& name,
                             cond::SynchronizationType synchronizationType,
                             cond::Time_t& endOfValidity,
-                            const std::string& description,
                             cond::Time_t lastValidatedTime,
                             const boost::posix_time::ptime& updateTime) {
       UpdateBuffer buffer;
-      buffer.setColumnData<SYNCHRONIZATION, END_OF_VALIDITY, DESCRIPTION, LAST_VALIDATED_TIME, MODIFICATION_TIME>(
-          std::tie(synchronizationType, endOfValidity, description, lastValidatedTime, updateTime));
+      buffer.setColumnData<SYNCHRONIZATION, END_OF_VALIDITY, LAST_VALIDATED_TIME, MODIFICATION_TIME>(
+          std::tie(synchronizationType, endOfValidity, lastValidatedTime, updateTime));
+      buffer.addWhereCondition<NAME>(name);
+      updateTable(m_schema, tname, buffer);
+    }
+
+    void TAG::Table::updateMetadata(const std::string& name,
+				    const std::string& description,
+				    const boost::posix_time::ptime& updateTime) {
+      UpdateBuffer buffer;
+      buffer.setColumnData<DESCRIPTION, MODIFICATION_TIME>(std::tie(description, updateTime));
       buffer.addWhereCondition<NAME>(name);
       updateTable(m_schema, tname, buffer);
     }

--- a/CondCore/CondDB/src/IOVSchema.cc
+++ b/CondCore/CondDB/src/IOVSchema.cc
@@ -130,8 +130,8 @@ namespace cond {
     }
 
     void TAG::Table::updateMetadata(const std::string& name,
-				    const std::string& description,
-				    const boost::posix_time::ptime& updateTime) {
+                                    const std::string& description,
+                                    const boost::posix_time::ptime& updateTime) {
       UpdateBuffer buffer;
       buffer.setColumnData<DESCRIPTION, MODIFICATION_TIME>(std::tie(description, updateTime));
       buffer.addWhereCondition<NAME>(name);

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -33,7 +33,6 @@ namespace cond {
                     std::string& objectType,
                     cond::SynchronizationType& synchronizationType,
                     cond::Time_t& endOfValidity,
-                    std::string& description,
                     cond::Time_t& lastValidatedTime) override;
         bool getMetadata(const std::string& name,
                          std::string& description,
@@ -50,9 +49,11 @@ namespace cond {
         void update(const std::string& name,
                     cond::SynchronizationType synchronizationType,
                     cond::Time_t& endOfValidity,
-                    const std::string& description,
                     cond::Time_t lastValidatedTime,
-                    const boost::posix_time::ptime& updateTime) override;
+		    const boost::posix_time::ptime& updateTime) override;
+	void updateMetadata(const std::string& name,
+			    const std::string& description,
+			    const boost::posix_time::ptime& updateTime) override;
         void updateValidity(const std::string& name,
                             cond::Time_t lastValidatedTime,
                             const boost::posix_time::ptime& updateTime) override;

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -50,10 +50,10 @@ namespace cond {
                     cond::SynchronizationType synchronizationType,
                     cond::Time_t& endOfValidity,
                     cond::Time_t lastValidatedTime,
-		    const boost::posix_time::ptime& updateTime) override;
-	void updateMetadata(const std::string& name,
-			    const std::string& description,
-			    const boost::posix_time::ptime& updateTime) override;
+                    const boost::posix_time::ptime& updateTime) override;
+        void updateMetadata(const std::string& name,
+                            const std::string& description,
+                            const boost::posix_time::ptime& updateTime) override;
         void updateValidity(const std::string& name,
                             cond::Time_t lastValidatedTime,
                             const boost::posix_time::ptime& updateTime) override;

--- a/CondCore/CondDB/src/Session.cc
+++ b/CondCore/CondDB/src/Session.cc
@@ -79,20 +79,14 @@ namespace cond {
       return m_session->iovSchema().tagTable().select(tag);
     }
 
-    //IOVProxy Session::iovProxy(){
+    //bool Session::getIovRange(const std::string& tag,
+    //                          cond::Time_t begin,
+    //                          cond::Time_t end,
+    //                          std::vector<std::tuple<cond::Time_t, cond::Hash> >& range) {
     //  m_session->openIovDb();
-    //  IOVProxy proxy( m_session );
-    //  return proxy;
+    //  boost::posix_time::ptime snapshotTime;
+    //  return m_session->iovSchema().iovTable().getRange(tag, begin, end, snapshotTime, range);
     //}
-
-    bool Session::getIovRange(const std::string& tag,
-                              cond::Time_t begin,
-                              cond::Time_t end,
-                              std::vector<std::tuple<cond::Time_t, cond::Hash> >& range) {
-      m_session->openIovDb();
-      boost::posix_time::ptime snapshotTime;
-      return m_session->iovSchema().iovTable().getRange(tag, begin, end, snapshotTime, range);
-    }
 
     IOVEditor Session::createIov(const std::string& payloadType,
                                  const std::string& tag,

--- a/CondCore/CondDB/test/testConditionDatabase_2.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_2.cpp
@@ -57,9 +57,10 @@ int run(const std::string& connectionString) {
     auto p0 = session.storePayload(pay0);
     auto p1 = session.storePayload(pay1);
     IOVEditor editor;
-    if (!session.existsIov("MyTag")) {
-      editor = session.createIov<std::string>("MyTag", cond::runnumber);
-      editor.setDescription("Test for timestamp selection");
+    std::string tag0("MyTag0");
+    if (!session.existsIov(tag0)) {
+      editor = session.createIov<std::string>(tag0, cond::runnumber);
+      editor.setDescription(tag0+" Test for timestamp selection");
       editor.insert(100, p0);
       editor.insert(200, p1);
       editor.insert(1001, p0);
@@ -71,9 +72,10 @@ int run(const std::string& connectionString) {
       editor.flush();
       std::cout << "> iov changes flushed..." << std::endl;
     }
-    if (!session.existsIov("MyTag2")) {
-      editor = session.createIov<std::string>("MyTag2", cond::runnumber);
-      editor.setDescription("Test for timestamp selection");
+    std::string tag1("MyTag1");
+    if (!session.existsIov(tag1)) {
+      editor = session.createIov<std::string>(tag1, cond::runnumber);
+      editor.setDescription(tag1+" Test for timestamp selection");
       editor.insert(100, p0);
       std::cout << "> inserted 1 iovs..." << std::endl;
       editor.flush();
@@ -83,7 +85,9 @@ int run(const std::string& connectionString) {
     std::cout << "> iov changes committed!..." << std::endl;
     ::sleep(2);
     session.transaction().start();
-    IOVProxy proxy = session.readIov("MyTag");
+    IOVProxy proxy = session.readIov(tag0);
+    auto md = proxy.getMetadata();
+    std::cout <<tag0<<" description is \""<<std::get<0>(md)<<"\""<<std::endl;
     readIov(proxy, 1, false);
     readIov(proxy, 100, true);
     readIov(proxy, 1499, true);
@@ -94,9 +98,22 @@ int run(const std::string& connectionString) {
     for (const auto i : iovs) {
       std::cout << "# iov since " << i.since << " - till " << i.till << std::endl;
     }
-    proxy = session.readIov("MyTag2");
+    proxy = session.readIov(tag1);
+    md = proxy.getMetadata();
+    std::cout <<tag1<<" description is \""<<std::get<0>(md)<<"\""<<std::endl;
     readIov(proxy, 1, false);
     readIov(proxy, 100, true);
+    session.transaction().commit();
+
+    session.transaction().start(false);
+    auto ed = session.editIov( tag1);
+    ed.setDescription("Changed description for tag "+tag1);
+    ed.flush();
+    session.transaction().commit();
+
+    session.transaction().start();
+    md = session.readIov(tag1).getMetadata();
+    std::cout <<tag1<<" description is \""<<std::get<0>(md)<<"\""<<std::endl;
     session.transaction().commit();
 
   } catch (const std::exception& e) {

--- a/CondCore/CondDB/test/testConditionDatabase_2.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_2.cpp
@@ -60,7 +60,7 @@ int run(const std::string& connectionString) {
     std::string tag0("MyTag0");
     if (!session.existsIov(tag0)) {
       editor = session.createIov<std::string>(tag0, cond::runnumber);
-      editor.setDescription(tag0+" Test for timestamp selection");
+      editor.setDescription(tag0 + " Test for timestamp selection");
       editor.insert(100, p0);
       editor.insert(200, p1);
       editor.insert(1001, p0);
@@ -75,7 +75,7 @@ int run(const std::string& connectionString) {
     std::string tag1("MyTag1");
     if (!session.existsIov(tag1)) {
       editor = session.createIov<std::string>(tag1, cond::runnumber);
-      editor.setDescription(tag1+" Test for timestamp selection");
+      editor.setDescription(tag1 + " Test for timestamp selection");
       editor.insert(100, p0);
       std::cout << "> inserted 1 iovs..." << std::endl;
       editor.flush();
@@ -87,7 +87,7 @@ int run(const std::string& connectionString) {
     session.transaction().start();
     IOVProxy proxy = session.readIov(tag0);
     auto md = proxy.getMetadata();
-    std::cout <<tag0<<" description is \""<<std::get<0>(md)<<"\""<<std::endl;
+    std::cout << tag0 << " description is \"" << std::get<0>(md) << "\"" << std::endl;
     readIov(proxy, 1, false);
     readIov(proxy, 100, true);
     readIov(proxy, 1499, true);
@@ -100,20 +100,20 @@ int run(const std::string& connectionString) {
     }
     proxy = session.readIov(tag1);
     md = proxy.getMetadata();
-    std::cout <<tag1<<" description is \""<<std::get<0>(md)<<"\""<<std::endl;
+    std::cout << tag1 << " description is \"" << std::get<0>(md) << "\"" << std::endl;
     readIov(proxy, 1, false);
     readIov(proxy, 100, true);
     session.transaction().commit();
 
     session.transaction().start(false);
-    auto ed = session.editIov( tag1);
-    ed.setDescription("Changed description for tag "+tag1);
+    auto ed = session.editIov(tag1);
+    ed.setDescription("Changed description for tag " + tag1);
     ed.flush();
     session.transaction().commit();
 
     session.transaction().start();
     md = session.readIov(tag1).getMetadata();
-    std::cout <<tag1<<" description is \""<<std::get<0>(md)<<"\""<<std::endl;
+    std::cout << tag1 << " description is \"" << std::get<0>(md) << "\"" << std::endl;
     session.transaction().commit();
 
   } catch (const std::exception& e) {

--- a/CondCore/CondDB/test/testConditionDatabase_3.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_3.cpp
@@ -47,7 +47,6 @@ int run(const std::string& connectionString) {
       editor.insert(cond::time::lumiTime(400, 11), p0);
       editor.insert(cond::time::lumiTime(400, 12), p1);
       editor.insert(cond::time::lumiTime(400, 13), p0);
-      //editor.insert( cond::time::lumiTime(9000, 11), p1 );
       std::cout << "> inserted iovs..." << std::endl;
       editor.flush();
       std::cout << "> iov changes flushed..." << std::endl;
@@ -59,11 +58,17 @@ int run(const std::string& connectionString) {
     ::sleep(2);
     session.transaction().start();
 
-    IOVProxy pxn = session.readIov("MyNewIOV");
-    IOVArray arr0 = pxn.selectAll();
+    auto arr0 = session.readIov("MyNewIOV").selectAll();
+    std::cout <<"# Selecting all iovs..."<<std::endl;
     for (auto iiov : arr0) {
       std::cout << "# since=" << iiov.since << " till:" << iiov.till << std::endl;
     }
+    auto arr1 = session.readIov("MyNewIOV").selectRange(cond::time::lumiTime(100, 15), cond::time::lumiTime(300, 15) );
+    std::cout <<"# Selecting range ("<<cond::time::lumiTime(100, 15)<<","<<cond::time::lumiTime(300, 15)<<")"<<std::endl;
+    for (auto iiov : arr1) {
+      std::cout << "# since=" << iiov.since << " till:" << iiov.till << std::endl;
+    }
+    auto pxn = session.readIov("MyNewIOV");
     std::vector<cond::Time_t> inputTimes{10,
                                          cond::time::lumiTime(100, 15),
                                          cond::time::lumiTime(100, 25),
@@ -77,13 +82,12 @@ int run(const std::string& connectionString) {
                                          cond::time::lumiTime(400, 11),
                                          cond::time::lumiTime(400, 12),
                                          cond::time::lumiTime(400, 13)};
-    //cond::time::lumiTime(10000, 15), cond::time::lumiTime(10000, 16), cond::time::lumiTime(10000, 17) };
     for (auto t : inputTimes) {
       cond::Iov_t iiov = pxn.getInterval(t);
-      std::cout << "#New: target=" << t << " since=" << iiov.since << " till:" << iiov.till << std::endl;
+      std::cout << "#Target=" << t << " since=" << iiov.since << " till:" << iiov.till << std::endl;
     }
 
-    std::cout << "#New: nqueries:" << pxn.numberOfQueries() << std::endl;
+    std::cout << "#Nqueries:" << pxn.numberOfQueries() << std::endl;
 
     session.transaction().commit();
 
@@ -96,11 +100,11 @@ int run(const std::string& connectionString) {
       iov = iovP.getInterval(t);
       ppn.initializeForNewIOV();
       ppn.make();
-      std::cout << "NewPP: target=" << t << " since=" << iov.since << " till:" << iov.till << std::endl;
+      std::cout << "PP: target=" << t << " since=" << iov.since << " till:" << iov.till << std::endl;
     }
     session.transaction().commit();
 
-    std::cout << "#NewPP: nqueries:" << iovP.numberOfQueries() << std::endl;
+    std::cout << "#PP: nqueries:" << iovP.numberOfQueries() << std::endl;
 
   } catch (const std::exception& e) {
     std::cout << "ERROR: " << e.what() << std::endl;

--- a/CondCore/CondDB/test/testConditionDatabase_3.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_3.cpp
@@ -59,12 +59,13 @@ int run(const std::string& connectionString) {
     session.transaction().start();
 
     auto arr0 = session.readIov("MyNewIOV").selectAll();
-    std::cout <<"# Selecting all iovs..."<<std::endl;
+    std::cout << "# Selecting all iovs..." << std::endl;
     for (auto iiov : arr0) {
       std::cout << "# since=" << iiov.since << " till:" << iiov.till << std::endl;
     }
-    auto arr1 = session.readIov("MyNewIOV").selectRange(cond::time::lumiTime(100, 15), cond::time::lumiTime(300, 15) );
-    std::cout <<"# Selecting range ("<<cond::time::lumiTime(100, 15)<<","<<cond::time::lumiTime(300, 15)<<")"<<std::endl;
+    auto arr1 = session.readIov("MyNewIOV").selectRange(cond::time::lumiTime(100, 15), cond::time::lumiTime(300, 15));
+    std::cout << "# Selecting range (" << cond::time::lumiTime(100, 15) << "," << cond::time::lumiTime(300, 15) << ")"
+              << std::endl;
     for (auto iiov : arr1) {
       std::cout << "# since=" << iiov.since << " till:" << iiov.till << std::endl;
     }

--- a/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
+++ b/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
@@ -161,14 +161,14 @@ void FastSiPixelFEDChannelContainerFromQuality::analyze(const edm::Event& evt, c
 
   // get the list of payloads for the SiPixelQuality tag
   std::vector<std::tuple<cond::Time_t, cond::Hash> > m_iovs;
-  condDbSession.getIovRange(m_QualityTagName, startIov, endIov, m_iovs);
+  condDbSession.readIov(m_QualityTagName).selectRange( startIov, endIov, m_iovs);
 
   const auto MIN_VAL = cond::timeTypeSpecs[cond::runnumber].beginValue;
   const auto MAX_VAL = cond::timeTypeSpecs[cond::runnumber].endValue;
 
   // get the list of payloads for the Cabling Map
   std::vector<std::tuple<cond::Time_t, cond::Hash> > m_cabling_iovs;
-  condDbSession2.getIovRange(m_CablingTagName, MIN_VAL, MAX_VAL, m_cabling_iovs);
+  condDbSession2.readIov(m_CablingTagName).selectRange( MIN_VAL, MAX_VAL, m_cabling_iovs);
 
   // create here the unpacked list of IOVs (run numbers)
   std::vector<unsigned int> listOfIOVs;

--- a/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
+++ b/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
@@ -161,14 +161,14 @@ void FastSiPixelFEDChannelContainerFromQuality::analyze(const edm::Event& evt, c
 
   // get the list of payloads for the SiPixelQuality tag
   std::vector<std::tuple<cond::Time_t, cond::Hash> > m_iovs;
-  condDbSession.readIov(m_QualityTagName).selectRange( startIov, endIov, m_iovs);
+  condDbSession.readIov(m_QualityTagName).selectRange(startIov, endIov, m_iovs);
 
   const auto MIN_VAL = cond::timeTypeSpecs[cond::runnumber].beginValue;
   const auto MAX_VAL = cond::timeTypeSpecs[cond::runnumber].endValue;
 
   // get the list of payloads for the Cabling Map
   std::vector<std::tuple<cond::Time_t, cond::Hash> > m_cabling_iovs;
-  condDbSession2.readIov(m_CablingTagName).selectRange( MIN_VAL, MAX_VAL, m_cabling_iovs);
+  condDbSession2.readIov(m_CablingTagName).selectRange(MIN_VAL, MAX_VAL, m_cabling_iovs);
 
   // create here the unpacked list of IOVs (run numbers)
   std::vector<unsigned int> listOfIOVs;


### PR DESCRIPTION
#### PR description:

This PR follows the changes introduced by https://github.com/cms-sw/cmssw/pull/29152

The IOV range selection is now accessible from the IOVProxy interface. Tag description is now loaded only on explicit request.  

#### PR validation:

A unit test has been modified to exercise the new behaviour concerning the Tag description.
The rest of unit tests run as expected.

