### PR TITLE
MillePede: force user to specify cosmics-related settings

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
@@ -282,8 +282,7 @@ class SetupAlignment(object):
             tmpFile = re.sub(collection_regex,
                              'setupCollection = \"'+dataset["collection"]+'\"',
                              tmpFile)
-            if dataset["collection"] in ("ALCARECOTkAlCosmicsCTF0T",
-                                         "ALCARECOTkAlCosmicsInCollisions"):
+            if "ALCARECOTkAlCosmics" in dataset["collection"]:
                 if dataset['cosmicsZeroTesla']:
                     tmpFile = re.sub(czt_regex,
                                      'setupCosmicsZeroTesla = True',
@@ -351,8 +350,7 @@ class SetupAlignment(object):
             print("-"*75)
             print("Baseconfig:        ", dataset["configTemplate"])
             print("Collection:        ", dataset["collection"])
-            if dataset["collection"] in ("ALCARECOTkAlCosmicsCTF0T",
-                                         "ALCARECOTkAlCosmicsInCollisions"):
+            if "ALCARECOTkAlCosmics" in dataset["collection"]:
                 print("cosmicsDecoMode:   ", dataset["cosmicsDecoMode"])
                 print("cosmicsZeroTesla:  ", dataset["cosmicsZeroTesla"])
             print("Globaltag:         ", dataset["globaltag"])
@@ -789,8 +787,7 @@ class SetupAlignment(object):
                                     sys.exit(1)
 
                     # extract non-essential options
-                    if self._datasets[name]["collection"] in ("ALCARECOTkAlCosmicsCTF0T",
-                                         "ALCARECOTkAlCosmicsInCollisions"):
+                    if "ALCARECOTkAlCosmics" in self._datasets[name]["collection"]:
                         try:
                             self._datasets[name]["cosmicsZeroTesla"] \
                                 = config["config"].getboolean(section,"cosmicsZeroTesla")

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
@@ -282,14 +282,26 @@ class SetupAlignment(object):
             tmpFile = re.sub(collection_regex,
                              'setupCollection = \"'+dataset["collection"]+'\"',
                              tmpFile)
-            if dataset['cosmicsZeroTesla']:
-                tmpFile = re.sub(czt_regex,
-                                 'setupCosmicsZeroTesla = True',
-                                 tmpFile)
-            if dataset['cosmicsDecoMode']:
-                tmpFile = re.sub(cdm_regex,
-                                 'setupCosmicsDecoMode = True',
-                                 tmpFile)
+            if dataset["collection"] in ("ALCARECOTkAlCosmicsCTF0T",
+                                         "ALCARECOTkAlCosmicsInCollisions"):
+                if dataset['cosmicsZeroTesla']:
+                    tmpFile = re.sub(czt_regex,
+                                     'setupCosmicsZeroTesla = True',
+                                     tmpFile)
+                else :
+                    tmpFile = re.sub(czt_regex,
+                                    'setupCosmicsZeroTesla = False',
+                                     tmpFile)
+
+                if dataset['cosmicsDecoMode']:
+                     tmpFile = re.sub(cdm_regex,
+                                     'setupCosmicsDecoMode = True',
+                                     tmpFile)
+                else:
+                    tmpFile = re.sub(cdm_regex,
+                                     'setupCosmicsDecoMode = False',
+                                     tmpFile)
+
             if dataset['primaryWidth'] > 0.0:
                 tmpFile = re.sub(pw_regex,
                                  'setupPrimaryWidth = '+str(dataset["primaryWidth"]),
@@ -777,15 +789,20 @@ class SetupAlignment(object):
                                     sys.exit(1)
 
                     # extract non-essential options
-                    self._datasets[name]["cosmicsZeroTesla"] = False
-                    if config["config"].has_option(section,"cosmicsZeroTesla"):
-                        self._datasets[name]["cosmicsZeroTesla"] \
-                            = config["config"].getboolean(section,"cosmicsZeroTesla")
-
-                    self._datasets[name]["cosmicsDecoMode"] = False
-                    if config["config"].has_option(section,"cosmicsDecoMode"):
-                        self._datasets[name]["cosmicsDecoMode"] \
-                            = config["config"].getboolean(section,"cosmicsDecoMode")
+                    if self._datasets[name]["collection"] in ("ALCARECOTkAlCosmicsCTF0T",
+                                         "ALCARECOTkAlCosmicsInCollisions"):
+                        try:
+                            self._datasets[name]["cosmicsZeroTesla"] \
+                                = config["config"].getboolean(section,"cosmicsZeroTesla")
+                        except ConfigParser.NoOptionError:
+                            print("No option cosmicsZeroTesla found in", section,"even though it is required for dataset type", self._datasets[name]["collection"], ". Please check ini-file.")
+                            sys.exit(1)
+                        try:
+                            self._datasets[name]["cosmicsDecoMode"] \
+                                = config["config"].getboolean(section,"cosmicsDecoMode")
+                        except ConfigParser.NoOptionError:
+                            print("No option cosmicsDecoMode found in", section,"even though it is required for dataset type", self._datasets[name]["collection"], ".Please check ini-file.")
+                            sys.exit(1)
 
                     self._datasets[name]["primaryWidth"] = -1.0
                     if config["config"].has_option(section,"primaryWidth"):

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
@@ -89,18 +89,17 @@ FirstRunForStartGeometry = 0
 ;# inputFileList: Path to the list of datafiles. You can use the string ${datasetdir} which
 ;# is later replaced by the value of the datasetdir-variable in the general section.
 ;#
+;# REQUIRED FOR COSMICS ONLY:
+;# cosmicsDecoMode: Toggle deconvolution mode for cosmics. Was called apvmode before.
+;#
+;# cosmicsZeroTesla: Set to "true" for cosmics at 0T. Set to "false" for cosmics at 3.8T.
+;#
 ;###############################################################################
 ;# OPTIONAL VARIABLES:
 ;#
 ;# njobs: Overwrite the number of jobs. Per default mps_alisetup.py counts the number of
 ;# files listed in the Inputfilelist and submits this number as njobs. You can overwrite this
 ;# with any lower number. If the number of jobs here exceeds the default, the default is used.
-;#
-;# cosmicsDecoMode: Toggle deconvolution mode for cosmics. Was called apvmode before.
-;# Default is "false".
-;#
-;# cosmicsZeroTesla: Set to "true" for cosmics at 0T. Set to "false" for cosmics at 3.8T.
-;# Default is "false".
 ;#
 ;# primarywidth: Set a different primaryWidth for the AlignmentProducer.
 ;# Usage: primaryWidth = <somefloat>


### PR DESCRIPTION
#### PR description:

Changes the MillePede alignment setup scripts to force the user to specify certain options which were previously set by default (needed to ensure the settings don't accidentally get copied from elsewhere without the users' knowledge). Should not change any output of CMSSW unit tests. 

cc @connorpa @vbotta 

#### PR validation:

Verified (locally) the correct output for setting up the alignment is produced with the proposed changes

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport