### PR TITLE
Rivet3 fallback for old samples without GenLumiInfoHeader

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -107,8 +107,7 @@ void RivetAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& iLumi, cons
   // need to reset the default weight name (or plotting will fail)
   if (!_weightNames.empty()) {
     _weightNames[0] = "";
-  }
-  else { // Summer16 samples have 1 weight stored in HepMC but no weightNames
+  } else {  // Summer16 samples have 1 weight stored in HepMC but no weightNames
     _weightNames.push_back("");
   }
 }

--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -100,13 +100,16 @@ void RivetAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup
 
 void RivetAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) {
   edm::Handle<GenLumiInfoHeader> genLumiInfoHandle;
-  iLumi.getByToken(_genLumiInfoToken, genLumiInfoHandle);
-
-  _weightNames = genLumiInfoHandle->weightNames();
+  if (iLumi.getByToken(_genLumiInfoToken, genLumiInfoHandle)) {
+    _weightNames = genLumiInfoHandle->weightNames();
+  }
 
   // need to reset the default weight name (or plotting will fail)
   if (!_weightNames.empty()) {
     _weightNames[0] = "";
+  }
+  else { // Summer16 samples have 1 weight stored in HepMC but no weightNames
+    _weightNames.push_back("");
   }
 }
 


### PR DESCRIPTION
#### PR description:

Updated Rivet3 interface expected GenLumiInfoHeader with weight names. This is not present in older samples (<=Summer16), so the run aborted. This PR fixes the issue.

#### PR validation:

Summer16 DY MINIAODSIM sample processes as expected now.
