### PR TITLE
Dumping HBHEChannelInfo contents

### DIFF
--- a/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
+++ b/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
@@ -2,6 +2,7 @@
 #define DataFormats_HcalRecHit_HBHEChannelInfo_h_
 
 #include <cfloat>
+#include <iostream>
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalRecHit/interface/HcalSpecialTimes.h"
@@ -290,5 +291,7 @@ private:
   bool hasLinkError_;
   bool hasCapidError_;
 };
+
+std::ostream& operator<<(std::ostream& s, const HBHEChannelInfo& inf);
 
 #endif  // DataFormats_HcalRecHit_HBHEChannelInfo_h_

--- a/DataFormats/HcalRecHit/src/HBHEChannelInfo.cc
+++ b/DataFormats/HcalRecHit/src/HBHEChannelInfo.cc
@@ -4,32 +4,28 @@ namespace {
   template <typename T>
   void dumpArray(std::ostream& s, const char* p, const T* arr, const unsigned len) {
     s << ' ' << p;
-    for (unsigned i=0; i<len; ++i) {s << ' ' << *arr++;}
+    for (unsigned i = 0; i < len; ++i) {
+      s << ' ' << *arr++;
+    }
   }
 
   template <typename T>
   void dumpArrayAsUnsigned(std::ostream& s, const char* p, const T* arr, const unsigned len) {
     s << ' ' << p;
-    for (unsigned i=0; i<len; ++i) {s << ' ' << static_cast<unsigned>(*arr++);}
+    for (unsigned i = 0; i < len; ++i) {
+      s << ' ' << static_cast<unsigned>(*arr++);
+    }
   }
-}
+}  // namespace
 
 std::ostream& operator<<(std::ostream& s, const HBHEChannelInfo& inf) {
   const unsigned nSamples = inf.nSamples();
 
   s << inf.id() << " :"
-    << " recoShape " << inf.recoShape()
-    << " nSamples " << nSamples
-    << " soi " << inf.soi()
-    << " capid " << inf.capid()
-    << " hasTDC " << inf.hasTimeInfo()
-    << " hasEffPeds " << inf.hasEffectivePedestals()
-    << " dropped " << inf.isDropped()
-    << " linkErr " << inf.hasLinkError()
-    << " capidErr " << inf.hasCapidError()
-    << " darkI " << inf.darkCurrent()
-    << " fcByPE " << inf.fcByPE()
-    << " lambda " << inf.lambda();
+    << " recoShape " << inf.recoShape() << " nSamples " << nSamples << " soi " << inf.soi() << " capid " << inf.capid()
+    << " hasTDC " << inf.hasTimeInfo() << " hasEffPeds " << inf.hasEffectivePedestals() << " dropped "
+    << inf.isDropped() << " linkErr " << inf.hasLinkError() << " capidErr " << inf.hasCapidError() << " darkI "
+    << inf.darkCurrent() << " fcByPE " << inf.fcByPE() << " lambda " << inf.lambda();
   dumpArray(s, "rawCharge", inf.rawCharge(), nSamples);
   dumpArray(s, "peds", inf.pedestal(), nSamples);
   dumpArray(s, "noise", inf.pedestalWidth(), nSamples);
@@ -37,7 +33,9 @@ std::ostream& operator<<(std::ostream& s, const HBHEChannelInfo& inf) {
   dumpArray(s, "gainWidth", inf.gainWidth(), nSamples);
   dumpArray(s, "dFcPerADC", inf.dFcPerADC(), nSamples);
   dumpArrayAsUnsigned(s, "adc", inf.adc(), nSamples);
-  if (inf.hasTimeInfo()) {dumpArray(s, "tdc", inf.riseTime(), nSamples);}
+  if (inf.hasTimeInfo()) {
+    dumpArray(s, "tdc", inf.riseTime(), nSamples);
+  }
 
   return s;
 }

--- a/DataFormats/HcalRecHit/src/HBHEChannelInfo.cc
+++ b/DataFormats/HcalRecHit/src/HBHEChannelInfo.cc
@@ -1,0 +1,43 @@
+#include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
+
+namespace {
+  template <typename T>
+  void dumpArray(std::ostream& s, const char* p, const T* arr, const unsigned len) {
+    s << ' ' << p;
+    for (unsigned i=0; i<len; ++i) {s << ' ' << *arr++;}
+  }
+
+  template <typename T>
+  void dumpArrayAsUnsigned(std::ostream& s, const char* p, const T* arr, const unsigned len) {
+    s << ' ' << p;
+    for (unsigned i=0; i<len; ++i) {s << ' ' << static_cast<unsigned>(*arr++);}
+  }
+}
+
+std::ostream& operator<<(std::ostream& s, const HBHEChannelInfo& inf) {
+  const unsigned nSamples = inf.nSamples();
+
+  s << inf.id() << " :"
+    << " recoShape " << inf.recoShape()
+    << " nSamples " << nSamples
+    << " soi " << inf.soi()
+    << " capid " << inf.capid()
+    << " hasTDC " << inf.hasTimeInfo()
+    << " hasEffPeds " << inf.hasEffectivePedestals()
+    << " dropped " << inf.isDropped()
+    << " linkErr " << inf.hasLinkError()
+    << " capidErr " << inf.hasCapidError()
+    << " darkI " << inf.darkCurrent()
+    << " fcByPE " << inf.fcByPE()
+    << " lambda " << inf.lambda();
+  dumpArray(s, "rawCharge", inf.rawCharge(), nSamples);
+  dumpArray(s, "peds", inf.pedestal(), nSamples);
+  dumpArray(s, "noise", inf.pedestalWidth(), nSamples);
+  dumpArray(s, "gain", inf.gain(), nSamples);
+  dumpArray(s, "gainWidth", inf.gainWidth(), nSamples);
+  dumpArray(s, "dFcPerADC", inf.dFcPerADC(), nSamples);
+  dumpArrayAsUnsigned(s, "adc", inf.adc(), nSamples);
+  if (inf.hasTimeInfo()) {dumpArray(s, "tdc", inf.riseTime(), nSamples);}
+
+  return s;
+}


### PR DESCRIPTION
#### PR description:

Added operator<< to the HBHEChannelInfo class. The ability to print HBHEChannelInfo contents is useful in certain debugging scenarios (in particular, it was used to validate PR #29852).

There is no hurry to get this PR in.

#### PR validation:

Private tests were run (the standard relvals would not use this code)
