### PR TITLE
Changed boost::array for std::array

### DIFF
--- a/RecoMET/METAlgorithms/interface/HcalHPDRBXMap.h
+++ b/RecoMET/METAlgorithms/interface/HcalHPDRBXMap.h
@@ -15,9 +15,9 @@
 //   author: J.P. Chou, Brown
 //
 
-#include "boost/array.hpp"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include <vector>
+#include <array>
 
 class HcalHPDRBXMap {
 public:
@@ -66,7 +66,7 @@ public:
   // returns a list of HPD indices found in a given RBX
   // exception is thrown if rbxindex is invalid
   // HPD indices are ordered in phi-space
-  void static indicesHPDfromRBX(int rbxindex, boost::array<int, NUM_HPDS_PER_RBX>& hpdindices);
+  void static indicesHPDfromRBX(int rbxindex, std::array<int, NUM_HPDS_PER_RBX>& hpdindices);
 
   // returns the RBX index given an HPD index
   // exception is thrown if hpdindex is invalid

--- a/RecoMET/METAlgorithms/interface/HcalNoiseRBXArray.h
+++ b/RecoMET/METAlgorithms/interface/HcalNoiseRBXArray.h
@@ -12,7 +12,7 @@
 //
 //
 
-#include "boost/array.hpp"
+#include <array>
 
 #include "DataFormats/METReco/interface/HcalNoiseHPD.h"
 #include "DataFormats/METReco/interface/HcalNoiseRBX.h"
@@ -24,7 +24,7 @@
 
 namespace reco {
 
-  class HcalNoiseRBXArray : public boost::array<HcalNoiseRBX, HcalHPDRBXMap::NUM_RBXS> {
+  class HcalNoiseRBXArray : public std::array<HcalNoiseRBX, HcalHPDRBXMap::NUM_RBXS> {
   public:
     // constructor/destructor
     HcalNoiseRBXArray();

--- a/RecoMET/METAlgorithms/src/HcalHPDRBXMap.cc
+++ b/RecoMET/METAlgorithms/src/HcalHPDRBXMap.cc
@@ -116,7 +116,7 @@ int HcalHPDRBXMap::iphiloRBX(int index) {
         << " RBX index " << index << " is invalid in HcalHPDRBXMap::iphiloRBX().\n";
 
   // get the list of HPD indices in the RBX
-  boost::array<int, NUM_HPDS_PER_RBX> arr;
+  std::array<int, NUM_HPDS_PER_RBX> arr;
   indicesHPDfromRBX(index, arr);
 
   // return the lowest iphi of the first HPD
@@ -154,7 +154,7 @@ int HcalHPDRBXMap::iphihiRBX(int index) {
         << " RBX index " << index << " is invalid in HcalHPDRBXMap::iphihiRBX().\n";
 
   // get the list of HPD indices in the RBX
-  boost::array<int, NUM_HPDS_PER_RBX> arr;
+  std::array<int, NUM_HPDS_PER_RBX> arr;
   indicesHPDfromRBX(index, arr);
 
   // return the highest iphi of the last HPD
@@ -162,7 +162,7 @@ int HcalHPDRBXMap::iphihiRBX(int index) {
 }
 
 // returns the list of HPD indices found in a given RBX
-void HcalHPDRBXMap::indicesHPDfromRBX(int rbxindex, boost::array<int, NUM_HPDS_PER_RBX>& hpdindices) {
+void HcalHPDRBXMap::indicesHPDfromRBX(int rbxindex, std::array<int, NUM_HPDS_PER_RBX>& hpdindices) {
   if (!isValidRBX(rbxindex))
     throw edm::Exception(edm::errors::LogicError)
         << " RBX index " << rbxindex << " is invalid in HcalHPDRBXMap::indicesHPD().\n";

--- a/RecoMET/METAlgorithms/src/HcalNoiseRBXArray.cc
+++ b/RecoMET/METAlgorithms/src/HcalNoiseRBXArray.cc
@@ -20,7 +20,7 @@ HcalNoiseRBXArray::HcalNoiseRBXArray() {
     rbx.idnumber_ = i;
 
     // set the hpdnumber here
-    boost::array<int, HcalHPDRBXMap::NUM_HPDS_PER_RBX> hpdindices;
+    std::array<int, HcalHPDRBXMap::NUM_HPDS_PER_RBX> hpdindices;
     HcalHPDRBXMap::indicesHPDfromRBX(i, hpdindices);
     for (int j = 0; j < HcalHPDRBXMap::NUM_HPDS_PER_RBX; j++) {
       rbx.hpds_[j].idnumber_ = hpdindices[j];


### PR DESCRIPTION
#### PR description:
Updated boost::array to std::array. They should behave identically in this situation.

#### PR validation:
Passed on the basic runTheMatrix test.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
@vgvassilev @davidlange6 

<!-- Please replace this text with any link to  -->

