### PR TITLE
Enable additional code checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,9 +4,21 @@ Checks: -*,
   ,misc-string-compare,
   ,misc-uniqueptr-reset-release,
   ,modernize-deprecated-headers,
+  ,performance-faster-string-find,
+  ,performance-for-range-copy,
+  ,performance-implicit-conversion-in-loop,
+  ,performance-inefficient-algorithm,
+  ,performance-inefficient-vector-operation,
+  ,performance-move-const-arg,
+  ,performance-unnecessary-copy-initialization,
+  ,performance-unnecessary-value-param,
   ,modernize-make-shared,
+  ,modernize-make-unique,
+  ,modernize-loop-convert,
+  ,modernize-use-auto,
   ,modernize-use-bool-literals,
   ,modernize-use-equals-delete,
+  ,modernize-use-emplace,
   ,modernize-use-nullptr,
   ,modernize-use-override,
   ,performance-unnecessary-copy-initialization,
@@ -36,6 +48,8 @@ CheckOptions:
     value:           llvm
   - key:             modernize-replace-auto-ptr.IncludeStyle
     value:           llvm
+  - key:             modernize-use-auto.MinTypeNameLength
+    value:           16
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks: -*,
   ,readability-redundant-string-cstr,
   ,readability-static-definition-in-anonymous-namespace,
   ,readability-uniqueptr-delete-release
+FormatStyle: 'file'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
### `performance-faster-string-find`:
Optimize calls to std::string::find() and friends when the needle passed is a single character string literal.

### `performance-for-range-copy`:
Finds C++11 for ranges where the loop variable is copied in each iteration but it would suffice to obtain it by const reference.

### `performance-implicit-conversion-in-loop`:
This warning appears in a range-based loop with a loop variable of const ref type where the type of the variable does not match the one returned by the iterator. This means that an implicit conversion happens, which can for example result in expensive deep copies.

### `performance-inefficient-algorithm`:
Warns on inefficient use of STL algorithms on associative containers.

### `performance-inefficient-vector-operation`:
Finds possible inefficient std::vector operations (e.g. push_back, emplace_back) that may cause unnecessary memory reallocations.

### `performance-move-const-arg`:
Warn about inefficient use of std::move, and suggest a fix that removes it.

### `performance-unnecessary-copy-initialization`:
Finds local variable declarations that are initialized using the copy constructor of a non-trivially-copyable type, where it would suffice to obtain a const reference.

### `performance-unnecessary-value-param`:
Flags value parameter declarations of expensive to copy types that are copied for each invocation, where it would suffice to pass them by const reference.

### `modernize-make-unique`:
Finds the creation of std::unique_ptr objects explicitly calling a new expression, and replaces it with a call to std::make_unique.

### `modernize-loop-convert`:
This check converts for(...; ...; ...) loops to use the new range-based loops in C++11.
The `MinConfidence` option was already set to "reasonable".

### `modernize-use-auto`:
Use the auto type specifier for variable declarations to improve code readability and maintainability.
The `MinTypeNameLength` option is set to 16 characters.

### `modernize-use-emplace`:
The check flags insertions to an STL-style container done by calling the push_back method with an explicitly-constructed temporary of the container element type. In this case, the corresponding emplace_back method results in less verbose and potentially more efficient code.