### PR TITLE
Release memory in HGCGraph

### DIFF
--- a/RecoHGCal/TICL/plugins/HGCGraph.h
+++ b/RecoHGCal/TICL/plugins/HGCGraph.h
@@ -43,8 +43,10 @@ public:
   void clear() {
     allDoublets_.clear();
     theRootDoublets_.clear();
-    theNtuplets_.clear();
     isOuterClusterOfDoublets_.clear();
+    allDoublets_.shrink_to_fit();
+    theRootDoublets_.shrink_to_fit();
+    isOuterClusterOfDoublets_.shrink_to_fit();
   }
   void setVerbosity(int level) { verbosity_ = level; }
   enum VerbosityLevel { None = 0, Basic, Advanced, Expert, Guru };
@@ -52,7 +54,6 @@ public:
 private:
   std::vector<HGCDoublet> allDoublets_;
   std::vector<unsigned int> theRootDoublets_;
-  std::vector<std::vector<HGCDoublet *>> theNtuplets_;
   std::vector<std::vector<int>> isOuterClusterOfDoublets_;
   int verbosity_;
 };

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -187,6 +187,7 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
       }
     }
   }
+  theGraph_->clear();
 }
 
 void PatternRecognitionbyCA::mergeTrackstersTRK(


### PR DESCRIPTION
#### PR description:

Recent memory profiles done using igprof revealed an important usage of
memory by TICL, in particular during the pattern-recognition stage by
the HGCGraph. After inspection, it has been noticed that the dynamic data
structured internally used, mainly vectors, were cleared at every event
but that a request to free the underlying memory was never
triggered. A call to `shrink_to_fit` has been added to the clearing
step. This solved the issue. The memory profile while processing
events is far less demanding. The swap with an empty vector has also
been tested: since the results were identical, the former solution has
been implemented.

This PR does not reduce the overall memory footprint of TICL. Memory
allocations will still be present while processing data. The possible
absolute improvement of the memory footprint can be addressed at a later
stage. Moreover, the underlying memory re-allocations could be reduced, to a
partial extent, by implementing some smart pre-allocation. In all cases
in which the dimension of the dynamic data structures is known upfront,
the memory allocation is done in one single step calling `reserve`.  In
all other cases, the memory is increased and re-allocated following the
usual exponential growth.


#### PR validation:

`runTheMatrix.py -l limited`