### PR TITLE
[Payload Inspector] Add more SiPixel inspection classes

### DIFF
--- a/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
+++ b/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
@@ -9,144 +9,142 @@
 / Ancillary class to build pixel phase-1 tracker maps
 /--------------------------------------------------------------------*/
 class Phase1PixelMaps {
-public: 
-  Phase1PixelMaps(const char* option) :
-    m_option{option},
-    m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())}
-  {
+public:
+  Phase1PixelMaps(const char* option)
+      : m_option{option},
+        m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
+            edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
     // store the file in path for the corners (BPIX)
     for (unsigned int i = 1; i <= 4; i++) {
       m_cornersBPIX.push_back(edm::FileInPath(Form("DQM/SiStripMonitorClient/data/Geometry/vertices_barrel_%i", i)));
     }
-    
+
     // store the file in path for the corners (BPIX)
     for (int j : {-3, -2, -1, 1, 2, 3}) {
       m_cornersFPIX.push_back(edm::FileInPath(Form("DQM/SiStripMonitorClient/data/Geometry/vertices_forward_%i", j)));
     }
   }
-  
-  ~Phase1PixelMaps(){}
-  
+
+  ~Phase1PixelMaps() {}
+
   //============================================================================
   void bookBarrelHistograms(const std::string& currentHistoName) {
     std::string histName;
     TH2Poly* th2p;
-    
+
     for (unsigned i = 0; i < 4; ++i) {
       histName = "barrel_layer_";
-      
+
       th2p = new TH2Poly(
-			 (histName + std::to_string(i + 1)).c_str(), Form("PXBMap - Layer %i", i + 1), -15.0, 15.0, 0.0, 5.0);
-      
+          (histName + std::to_string(i + 1)).c_str(), Form("PXBMap - Layer %i", i + 1), -15.0, 15.0, 0.0, 5.0);
+
       th2p->SetFloat();
-      
+
       th2p->GetXaxis()->SetTitle("z [cm]");
       th2p->GetYaxis()->SetTitle("ladder");
       th2p->SetStats(false);
       th2p->SetOption(m_option);
-      th2PolyBarrel[currentHistoName].push_back(th2p);
+      pxbTh2PolyBarrel[currentHistoName].push_back(th2p);
     }
-    
+
     th2p = new TH2Poly("barrel_summary", "PXBMap", -5.0, 5.0, 0.0, 5.0);
     th2p->SetFloat();
-    
+
     th2p->GetXaxis()->SetTitle("");
     th2p->GetYaxis()->SetTitle("~ladder");
     th2p->SetStats(false);
     th2p->SetOption(m_option);
-    th2PolyBarrelSummary[currentHistoName] = th2p;
+    pxbTh2PolyBarrelSummary[currentHistoName] = th2p;
   }
-  
+
   //============================================================================
   void bookForwardHistograms(const std::string& currentHistoName) {
     std::string histName;
     TH2Poly* th2p;
-    
+
     for (unsigned side = 1; side <= 2; ++side) {
       for (unsigned disk = 1; disk <= 3; ++disk) {
-	histName = "forward_disk_";
-	
-	th2p = new TH2Poly((histName + std::to_string((side == 1 ? -(int(disk)) : (int)disk))).c_str(),
-			   Form("PXFMap - Side %i Disk %i", side, disk),
-			   -15.0,
-			   15.0,
-			   -15.0,
-			   15.0);
-	th2p->SetFloat();
-	th2p->GetXaxis()->SetTitle("x [cm]");
-	th2p->GetYaxis()->SetTitle("y [cm]");
-	th2p->SetStats(false);
-	th2p->SetOption(m_option);
-	pxfTh2PolyForward[currentHistoName].push_back(th2p);
+        histName = "forward_disk_";
+
+        th2p = new TH2Poly((histName + std::to_string((side == 1 ? -(int(disk)) : (int)disk))).c_str(),
+                           Form("PXFMap - Side %i Disk %i", side, disk),
+                           -15.0,
+                           15.0,
+                           -15.0,
+                           15.0);
+        th2p->SetFloat();
+        th2p->GetXaxis()->SetTitle("x [cm]");
+        th2p->GetYaxis()->SetTitle("y [cm]");
+        th2p->SetStats(false);
+        th2p->SetOption(m_option);
+        pxfTh2PolyForward[currentHistoName].push_back(th2p);
       }
     }
 
     th2p = new TH2Poly("forward_summary", "PXFMap", -40.0, 50.0, -20.0, 90.0);
     th2p->SetFloat();
-    
+
     th2p->GetXaxis()->SetTitle("");
     th2p->GetYaxis()->SetTitle("");
     th2p->SetStats(false);
     th2p->SetOption(m_option);
     pxfTh2PolyForwardSummary[currentHistoName] = th2p;
   }
-  
+
   //============================================================================
   void bookBarrelBins(const std::string& currentHistoName) {
-    
     auto theIndexedCorners = SiPixelPI::retrieveCorners(m_cornersBPIX, 4);
-    
+
     for (const auto& entry : theIndexedCorners) {
       auto id = entry.first;
       auto detid = DetId(id);
       if (detid.subdetId() != PixelSubdetector::PixelBarrel)
-	continue;
-      
+        continue;
+
       int layer = m_trackerTopo.pxbLayer(detid);
       int ladder = m_trackerTopo.pxbLadder(detid);
-      
+
       auto theVectX = entry.second.first;
       auto theVectY = entry.second.second;
-      
+
       float vertX[] = {theVectX[0], theVectX[1], theVectX[2], theVectX[3], theVectX[4]};
       float vertY[] = {(ladder - 1.0f), (ladder - 1.0f), (float)ladder, (float)ladder, (ladder - 1.0f)};
-      
+
       bins[id] = new TGraph(5, vertX, vertY);
       bins[id]->SetName(TString::Format("%u", id));
 
       // Summary plot
       for (unsigned k = 0; k < 5; ++k) {
-	vertX[k] += ((layer == 2 || layer == 3) ? 0.0f : -60.0f);
-	vertY[k] += ((layer > 2) ? 30.0f : 0.0f);
+        vertX[k] += ((layer == 2 || layer == 3) ? 0.0f : -60.0f);
+        vertY[k] += ((layer > 2) ? 30.0f : 0.0f);
       }
-      
+
       binsSummary[id] = new TGraph(5, vertX, vertY);
       binsSummary[id]->SetName(TString::Format("%u", id));
-      
-      th2PolyBarrel[currentHistoName][layer - 1]->AddBin(bins[id]->Clone());
-      th2PolyBarrelSummary[currentHistoName]->AddBin(binsSummary[id]->Clone());
+
+      pxbTh2PolyBarrel[currentHistoName][layer - 1]->AddBin(bins[id]->Clone());
+      pxbTh2PolyBarrelSummary[currentHistoName]->AddBin(binsSummary[id]->Clone());
     }
   }
-  
+
   //============================================================================
   void bookForwardBins(const std::string& currentHistoName) {
-    
     auto theIndexedCorners = SiPixelPI::retrieveCorners(m_cornersFPIX, 3);
-    
+
     for (const auto& entry : theIndexedCorners) {
       auto id = entry.first;
       auto detid = DetId(id);
       if (detid.subdetId() != PixelSubdetector::PixelEndcap)
-	continue;
-      
+        continue;
+
       int disk = m_trackerTopo.pxfDisk(detid);
       int side = m_trackerTopo.pxfSide(detid);
-      
+
       unsigned mapIdx = disk + (side - 1) * 3 - 1;
-      
+
       auto theVectX = entry.second.first;
       auto theVectY = entry.second.second;
-      
+
       float vertX[] = {theVectX[0], theVectX[1], theVectX[2], theVectX[3]};
       float vertY[] = {theVectY[0], theVectY[1], theVectY[2], theVectY[3]};
 
@@ -155,77 +153,82 @@ public:
 
       // Summary plot
       for (unsigned k = 0; k < 4; ++k) {
-	vertX[k] += (float(side) - 1.5f) * 40.0f;
-	vertY[k] += (disk - 1) * 35.0f;
+        vertX[k] += (float(side) - 1.5f) * 40.0f;
+        vertY[k] += (disk - 1) * 35.0f;
       }
-      
+
       binsSummary[id] = new TGraph(4, vertX, vertY);
       binsSummary[id]->SetName(TString::Format("%u", id));
-      
+
       pxfTh2PolyForward[currentHistoName][mapIdx]->AddBin(bins[id]->Clone());
       pxfTh2PolyForwardSummary[currentHistoName]->AddBin(binsSummary[id]->Clone());
     }
   }
-  
+
   //============================================================================
   template <typename type>
-  void fillBarrelBin(const std::string& currentHistoName,
-		     unsigned int id,
-		     type value){
+  void fillBarrelBin(const std::string& currentHistoName, unsigned int id, type value) {
+    auto detid = DetId(id);
+    if (detid.subdetId() != PixelSubdetector::PixelBarrel) {
+      edm::LogError("Phase1PixelMaps") << "fillBarrelBin() The following detid " << id << " is not Pixel Barrel!"
+                                       << std::endl;
+      return;
+    }
     int layer = m_trackerTopo.pxbLayer(id);
-    th2PolyBarrel[currentHistoName][layer - 1]->Fill(TString::Format("%u", id), value);
+    pxbTh2PolyBarrel[currentHistoName][layer - 1]->Fill(TString::Format("%u", id), value);
   }
-  
+
   //============================================================================
   template <typename type>
-  void fillEndcapBin(const std::string& currentHistoName,
-		     unsigned int id,
-		     type value){
+  void fillForwardBin(const std::string& currentHistoName, unsigned int id, type value) {
+    auto detid = DetId(id);
+    if (detid.subdetId() != PixelSubdetector::PixelEndcap) {
+      edm::LogError("Phase1PixelMaps") << "fillForwardBin() The following detid " << id << " is not Pixel Forward!"
+                                       << std::endl;
+      return;
+    }
     int disk = m_trackerTopo.pxfDisk(id);
     int side = m_trackerTopo.pxfSide(id);
     unsigned mapIdx = disk + (side - 1) * 3 - 1;
     pxfTh2PolyForward[currentHistoName][mapIdx]->Fill(TString::Format("%u", id), value);
   }
-  
+
   //============================================================================
-  void DrawBarrelMaps(const std::string& currentHistoName,
-		      TCanvas &canvas){
+  void DrawBarrelMaps(const std::string& currentHistoName, TCanvas& canvas) {
     canvas.Divide(2, 2);
     for (int i = 1; i <= 4; i++) {
       canvas.cd(i);
-      if( strcmp(m_option, "text") == 0){
-	th2PolyBarrel[currentHistoName].at(i-1)->SetMarkerColor(kRed);
+      if (strcmp(m_option, "text") == 0) {
+        pxbTh2PolyBarrel[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
       }
-      th2PolyBarrel[currentHistoName].at(i-1)->Draw();
+      pxbTh2PolyBarrel[currentHistoName].at(i - 1)->Draw();
     }
   }
-  
+
   //============================================================================
-  void DrawEndcapMaps(const std::string& currentHistoName,
-		      TCanvas &canvas){
+  void DrawForwardMaps(const std::string& currentHistoName, TCanvas& canvas) {
     canvas.Divide(3, 2);
     for (int i = 1; i <= 6; i++) {
       canvas.cd(i);
-      if( strcmp(m_option, "text") == 0){
-	pxfTh2PolyForward[currentHistoName].at(i-1)->SetMarkerColor(kRed);
+      if (strcmp(m_option, "text") == 0) {
+        pxfTh2PolyForward[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
       }
-      pxfTh2PolyForward[currentHistoName].at(i-1)->Draw();
+      pxfTh2PolyForward[currentHistoName].at(i - 1)->Draw();
     }
   }
 
 private:
   Option_t* m_option;
   TrackerTopology m_trackerTopo;
-  
+
   std::map<uint32_t, TGraph*> bins, binsSummary;
-  std::map<std::string, std::vector<TH2Poly*>> th2PolyBarrel;
-  std::map<std::string, TH2Poly*> th2PolyBarrelSummary;
+  std::map<std::string, std::vector<TH2Poly*>> pxbTh2PolyBarrel;
+  std::map<std::string, TH2Poly*> pxbTh2PolyBarrelSummary;
   std::map<std::string, std::vector<TH2Poly*>> pxfTh2PolyForward;
   std::map<std::string, TH2Poly*> pxfTh2PolyForwardSummary;
-  
+
   std::vector<edm::FileInPath> m_cornersBPIX;
   std::vector<edm::FileInPath> m_cornersFPIX;
 };
-
 
 #endif

--- a/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
+++ b/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
@@ -28,20 +28,26 @@ public:
   ~Phase1PixelMaps() {}
 
   //============================================================================
-  void bookBarrelHistograms(const std::string& currentHistoName) {
+  void bookBarrelHistograms(const std::string& currentHistoName, const char* what) {
     std::string histName;
     TH2Poly* th2p;
 
     for (unsigned i = 0; i < 4; ++i) {
       histName = "barrel_layer_";
 
-      th2p = new TH2Poly(
-          (histName + std::to_string(i + 1)).c_str(), Form("PXBMap - Layer %i", i + 1), -15.0, 15.0, 0.0, 5.0);
+      th2p = new TH2Poly((histName + std::to_string(i + 1)).c_str(),
+                         Form("PXBMap of %s - Layer %i", what, i + 1),
+                         -15.0,
+                         15.0,
+                         0.0,
+                         5.0);
 
       th2p->SetFloat();
 
       th2p->GetXaxis()->SetTitle("z [cm]");
       th2p->GetYaxis()->SetTitle("ladder");
+      //th2p->GetXaxis()->SetTitleOffset(0.09);
+      //th2p->GetYaxis()->SetTitleOffset(0.09);
       th2p->SetStats(false);
       th2p->SetOption(m_option);
       pxbTh2PolyBarrel[currentHistoName].push_back(th2p);
@@ -58,7 +64,7 @@ public:
   }
 
   //============================================================================
-  void bookForwardHistograms(const std::string& currentHistoName) {
+  void bookForwardHistograms(const std::string& currentHistoName, const char* what) {
     std::string histName;
     TH2Poly* th2p;
 
@@ -67,7 +73,7 @@ public:
         histName = "forward_disk_";
 
         th2p = new TH2Poly((histName + std::to_string((side == 1 ? -(int(disk)) : (int)disk))).c_str(),
-                           Form("PXFMap - Side %i Disk %i", side, disk),
+                           Form("PXFMap of %s - Side %i Disk %i", what, side, disk),
                            -15.0,
                            15.0,
                            -15.0,
@@ -75,6 +81,8 @@ public:
         th2p->SetFloat();
         th2p->GetXaxis()->SetTitle("x [cm]");
         th2p->GetYaxis()->SetTitle("y [cm]");
+        //th2p->GetXaxis()->SetTitleOffset(0.09);
+        //th2p->GetYaxis()->SetTitleOffset(0.09);
         th2p->SetStats(false);
         th2p->SetOption(m_option);
         pxfTh2PolyForward[currentHistoName].push_back(th2p);
@@ -198,12 +206,16 @@ public:
     for (const auto& vec : pxbTh2PolyBarrel) {
       for (const auto& plot : vec.second) {
         SiPixelPI::makeNicePlotStyle(plot);
+        plot->GetXaxis()->SetTitleOffset(0.9);
+        plot->GetYaxis()->SetTitleOffset(0.9);
       }
     }
 
     for (const auto& vec : pxfTh2PolyForward) {
       for (const auto& plot : vec.second) {
         SiPixelPI::makeNicePlotStyle(plot);
+        plot->GetXaxis()->SetTitleOffset(0.9);
+        plot->GetYaxis()->SetTitleOffset(0.9);
       }
     }
   }
@@ -214,7 +226,10 @@ public:
     for (int i = 1; i <= 4; i++) {
       canvas.cd(i);
       if (strcmp(m_option, "text") == 0) {
+        canvas.cd(i)->SetRightMargin(0.02);
         pxbTh2PolyBarrel[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
+      } else {
+        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.14);
       }
       pxbTh2PolyBarrel[currentHistoName].at(i - 1)->Draw();
     }
@@ -226,7 +241,10 @@ public:
     for (int i = 1; i <= 6; i++) {
       canvas.cd(i);
       if (strcmp(m_option, "text") == 0) {
+        canvas.cd(i)->SetRightMargin(0.02);
         pxfTh2PolyForward[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
+      } else {
+        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.16);
       }
       pxfTh2PolyForward[currentHistoName].at(i - 1)->Draw();
     }

--- a/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
+++ b/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
@@ -194,6 +194,21 @@ public:
   }
 
   //============================================================================
+  void beautifyAllHistograms() {
+    for (const auto& vec : pxbTh2PolyBarrel) {
+      for (const auto& plot : vec.second) {
+        SiPixelPI::makeNicePlotStyle(plot);
+      }
+    }
+
+    for (const auto& vec : pxfTh2PolyForward) {
+      for (const auto& plot : vec.second) {
+        SiPixelPI::makeNicePlotStyle(plot);
+      }
+    }
+  }
+
+  //============================================================================
   void DrawBarrelMaps(const std::string& currentHistoName, TCanvas& canvas) {
     canvas.Divide(2, 2);
     for (int i = 1; i <= 4; i++) {

--- a/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
+++ b/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
@@ -1,0 +1,231 @@
+#ifndef CONDCORE_SIPIXELPLUGINS_PHASE1PIXELMAPS_H
+#define CONDCORE_SIPIXELPLUGINS_PHASE1PIXELMAPS_H
+
+#include "TH2Poly.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+
+/*--------------------------------------------------------------------
+/ Ancillary class to build pixel phase-1 tracker maps
+/--------------------------------------------------------------------*/
+class Phase1PixelMaps {
+public: 
+  Phase1PixelMaps(const char* option) :
+    m_option{option},
+    m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())}
+  {
+    // store the file in path for the corners (BPIX)
+    for (unsigned int i = 1; i <= 4; i++) {
+      m_cornersBPIX.push_back(edm::FileInPath(Form("DQM/SiStripMonitorClient/data/Geometry/vertices_barrel_%i", i)));
+    }
+    
+    // store the file in path for the corners (BPIX)
+    for (int j : {-3, -2, -1, 1, 2, 3}) {
+      m_cornersFPIX.push_back(edm::FileInPath(Form("DQM/SiStripMonitorClient/data/Geometry/vertices_forward_%i", j)));
+    }
+  }
+  
+  ~Phase1PixelMaps(){}
+  
+  //============================================================================
+  void bookBarrelHistograms(const std::string& currentHistoName) {
+    std::string histName;
+    TH2Poly* th2p;
+    
+    for (unsigned i = 0; i < 4; ++i) {
+      histName = "barrel_layer_";
+      
+      th2p = new TH2Poly(
+			 (histName + std::to_string(i + 1)).c_str(), Form("PXBMap - Layer %i", i + 1), -15.0, 15.0, 0.0, 5.0);
+      
+      th2p->SetFloat();
+      
+      th2p->GetXaxis()->SetTitle("z [cm]");
+      th2p->GetYaxis()->SetTitle("ladder");
+      th2p->SetStats(false);
+      th2p->SetOption(m_option);
+      th2PolyBarrel[currentHistoName].push_back(th2p);
+    }
+    
+    th2p = new TH2Poly("barrel_summary", "PXBMap", -5.0, 5.0, 0.0, 5.0);
+    th2p->SetFloat();
+    
+    th2p->GetXaxis()->SetTitle("");
+    th2p->GetYaxis()->SetTitle("~ladder");
+    th2p->SetStats(false);
+    th2p->SetOption(m_option);
+    th2PolyBarrelSummary[currentHistoName] = th2p;
+  }
+  
+  //============================================================================
+  void bookForwardHistograms(const std::string& currentHistoName) {
+    std::string histName;
+    TH2Poly* th2p;
+    
+    for (unsigned side = 1; side <= 2; ++side) {
+      for (unsigned disk = 1; disk <= 3; ++disk) {
+	histName = "forward_disk_";
+	
+	th2p = new TH2Poly((histName + std::to_string((side == 1 ? -(int(disk)) : (int)disk))).c_str(),
+			   Form("PXFMap - Side %i Disk %i", side, disk),
+			   -15.0,
+			   15.0,
+			   -15.0,
+			   15.0);
+	th2p->SetFloat();
+	th2p->GetXaxis()->SetTitle("x [cm]");
+	th2p->GetYaxis()->SetTitle("y [cm]");
+	th2p->SetStats(false);
+	th2p->SetOption(m_option);
+	pxfTh2PolyForward[currentHistoName].push_back(th2p);
+      }
+    }
+
+    th2p = new TH2Poly("forward_summary", "PXFMap", -40.0, 50.0, -20.0, 90.0);
+    th2p->SetFloat();
+    
+    th2p->GetXaxis()->SetTitle("");
+    th2p->GetYaxis()->SetTitle("");
+    th2p->SetStats(false);
+    th2p->SetOption(m_option);
+    pxfTh2PolyForwardSummary[currentHistoName] = th2p;
+  }
+  
+  //============================================================================
+  void bookBarrelBins(const std::string& currentHistoName) {
+    
+    auto theIndexedCorners = SiPixelPI::retrieveCorners(m_cornersBPIX, 4);
+    
+    for (const auto& entry : theIndexedCorners) {
+      auto id = entry.first;
+      auto detid = DetId(id);
+      if (detid.subdetId() != PixelSubdetector::PixelBarrel)
+	continue;
+      
+      int layer = m_trackerTopo.pxbLayer(detid);
+      int ladder = m_trackerTopo.pxbLadder(detid);
+      
+      auto theVectX = entry.second.first;
+      auto theVectY = entry.second.second;
+      
+      float vertX[] = {theVectX[0], theVectX[1], theVectX[2], theVectX[3], theVectX[4]};
+      float vertY[] = {(ladder - 1.0f), (ladder - 1.0f), (float)ladder, (float)ladder, (ladder - 1.0f)};
+      
+      bins[id] = new TGraph(5, vertX, vertY);
+      bins[id]->SetName(TString::Format("%u", id));
+
+      // Summary plot
+      for (unsigned k = 0; k < 5; ++k) {
+	vertX[k] += ((layer == 2 || layer == 3) ? 0.0f : -60.0f);
+	vertY[k] += ((layer > 2) ? 30.0f : 0.0f);
+      }
+      
+      binsSummary[id] = new TGraph(5, vertX, vertY);
+      binsSummary[id]->SetName(TString::Format("%u", id));
+      
+      th2PolyBarrel[currentHistoName][layer - 1]->AddBin(bins[id]->Clone());
+      th2PolyBarrelSummary[currentHistoName]->AddBin(binsSummary[id]->Clone());
+    }
+  }
+  
+  //============================================================================
+  void bookForwardBins(const std::string& currentHistoName) {
+    
+    auto theIndexedCorners = SiPixelPI::retrieveCorners(m_cornersFPIX, 3);
+    
+    for (const auto& entry : theIndexedCorners) {
+      auto id = entry.first;
+      auto detid = DetId(id);
+      if (detid.subdetId() != PixelSubdetector::PixelEndcap)
+	continue;
+      
+      int disk = m_trackerTopo.pxfDisk(detid);
+      int side = m_trackerTopo.pxfSide(detid);
+      
+      unsigned mapIdx = disk + (side - 1) * 3 - 1;
+      
+      auto theVectX = entry.second.first;
+      auto theVectY = entry.second.second;
+      
+      float vertX[] = {theVectX[0], theVectX[1], theVectX[2], theVectX[3]};
+      float vertY[] = {theVectY[0], theVectY[1], theVectY[2], theVectY[3]};
+
+      bins[id] = new TGraph(4, vertX, vertY);
+      bins[id]->SetName(TString::Format("%u", id));
+
+      // Summary plot
+      for (unsigned k = 0; k < 4; ++k) {
+	vertX[k] += (float(side) - 1.5f) * 40.0f;
+	vertY[k] += (disk - 1) * 35.0f;
+      }
+      
+      binsSummary[id] = new TGraph(4, vertX, vertY);
+      binsSummary[id]->SetName(TString::Format("%u", id));
+      
+      pxfTh2PolyForward[currentHistoName][mapIdx]->AddBin(bins[id]->Clone());
+      pxfTh2PolyForwardSummary[currentHistoName]->AddBin(binsSummary[id]->Clone());
+    }
+  }
+  
+  //============================================================================
+  template <typename type>
+  void fillBarrelBin(const std::string& currentHistoName,
+		     unsigned int id,
+		     type value){
+    int layer = m_trackerTopo.pxbLayer(id);
+    th2PolyBarrel[currentHistoName][layer - 1]->Fill(TString::Format("%u", id), value);
+  }
+  
+  //============================================================================
+  template <typename type>
+  void fillEndcapBin(const std::string& currentHistoName,
+		     unsigned int id,
+		     type value){
+    int disk = m_trackerTopo.pxfDisk(id);
+    int side = m_trackerTopo.pxfSide(id);
+    unsigned mapIdx = disk + (side - 1) * 3 - 1;
+    pxfTh2PolyForward[currentHistoName][mapIdx]->Fill(TString::Format("%u", id), value);
+  }
+  
+  //============================================================================
+  void DrawBarrelMaps(const std::string& currentHistoName,
+		      TCanvas &canvas){
+    canvas.Divide(2, 2);
+    for (int i = 1; i <= 4; i++) {
+      canvas.cd(i);
+      if( strcmp(m_option, "text") == 0){
+	th2PolyBarrel[currentHistoName].at(i-1)->SetMarkerColor(kRed);
+      }
+      th2PolyBarrel[currentHistoName].at(i-1)->Draw();
+    }
+  }
+  
+  //============================================================================
+  void DrawEndcapMaps(const std::string& currentHistoName,
+		      TCanvas &canvas){
+    canvas.Divide(3, 2);
+    for (int i = 1; i <= 6; i++) {
+      canvas.cd(i);
+      if( strcmp(m_option, "text") == 0){
+	pxfTh2PolyForward[currentHistoName].at(i-1)->SetMarkerColor(kRed);
+      }
+      pxfTh2PolyForward[currentHistoName].at(i-1)->Draw();
+    }
+  }
+
+private:
+  Option_t* m_option;
+  TrackerTopology m_trackerTopo;
+  
+  std::map<uint32_t, TGraph*> bins, binsSummary;
+  std::map<std::string, std::vector<TH2Poly*>> th2PolyBarrel;
+  std::map<std::string, TH2Poly*> th2PolyBarrelSummary;
+  std::map<std::string, std::vector<TH2Poly*>> pxfTh2PolyForward;
+  std::map<std::string, TH2Poly*> pxfTh2PolyForwardSummary;
+  
+  std::vector<edm::FileInPath> m_cornersBPIX;
+  std::vector<edm::FileInPath> m_cornersFPIX;
+};
+
+
+#endif

--- a/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
+++ b/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
@@ -30,17 +30,17 @@ public:
   //============================================================================
   void bookBarrelHistograms(const std::string& currentHistoName, const char* what) {
     std::string histName;
-    TH2Poly* th2p;
+    std::shared_ptr<TH2Poly> th2p;
 
     for (unsigned i = 0; i < 4; ++i) {
       histName = "barrel_layer_";
 
-      th2p = new TH2Poly((histName + std::to_string(i + 1)).c_str(),
-                         Form("PXBMap of %s - Layer %i", what, i + 1),
-                         -15.0,
-                         15.0,
-                         0.0,
-                         5.0);
+      th2p = std::make_shared<TH2Poly>((histName + std::to_string(i + 1)).c_str(),
+                                       Form("PXBMap of %s - Layer %i", what, i + 1),
+                                       -15.0,
+                                       15.0,
+                                       0.0,
+                                       5.0);
 
       th2p->SetFloat();
 
@@ -53,7 +53,7 @@ public:
       pxbTh2PolyBarrel[currentHistoName].push_back(th2p);
     }
 
-    th2p = new TH2Poly("barrel_summary", "PXBMap", -5.0, 5.0, 0.0, 5.0);
+    th2p = std::make_shared<TH2Poly>("barrel_summary", "PXBMap", -5.0, 5.0, 0.0, 5.0);
     th2p->SetFloat();
 
     th2p->GetXaxis()->SetTitle("");
@@ -66,18 +66,18 @@ public:
   //============================================================================
   void bookForwardHistograms(const std::string& currentHistoName, const char* what) {
     std::string histName;
-    TH2Poly* th2p;
+    std::shared_ptr<TH2Poly> th2p;
 
     for (unsigned side = 1; side <= 2; ++side) {
       for (unsigned disk = 1; disk <= 3; ++disk) {
         histName = "forward_disk_";
 
-        th2p = new TH2Poly((histName + std::to_string((side == 1 ? -(int(disk)) : (int)disk))).c_str(),
-                           Form("PXFMap of %s - Side %i Disk %i", what, side, disk),
-                           -15.0,
-                           15.0,
-                           -15.0,
-                           15.0);
+        th2p = std::make_shared<TH2Poly>((histName + std::to_string((side == 1 ? -(int(disk)) : (int)disk))).c_str(),
+                                         Form("PXFMap of %s - Side %i Disk %i", what, side, disk),
+                                         -15.0,
+                                         15.0,
+                                         -15.0,
+                                         15.0);
         th2p->SetFloat();
         th2p->GetXaxis()->SetTitle("x [cm]");
         th2p->GetYaxis()->SetTitle("y [cm]");
@@ -89,7 +89,7 @@ public:
       }
     }
 
-    th2p = new TH2Poly("forward_summary", "PXFMap", -40.0, 50.0, -20.0, 90.0);
+    th2p = std::make_shared<TH2Poly>("forward_summary", "PXFMap", -40.0, 50.0, -20.0, 90.0);
     th2p->SetFloat();
 
     th2p->GetXaxis()->SetTitle("");
@@ -118,7 +118,7 @@ public:
       float vertX[] = {theVectX[0], theVectX[1], theVectX[2], theVectX[3], theVectX[4]};
       float vertY[] = {(ladder - 1.0f), (ladder - 1.0f), (float)ladder, (float)ladder, (ladder - 1.0f)};
 
-      bins[id] = new TGraph(5, vertX, vertY);
+      bins[id] = std::make_shared<TGraph>(5, vertX, vertY);
       bins[id]->SetName(TString::Format("%u", id));
 
       // Summary plot
@@ -127,7 +127,7 @@ public:
         vertY[k] += ((layer > 2) ? 30.0f : 0.0f);
       }
 
-      binsSummary[id] = new TGraph(5, vertX, vertY);
+      binsSummary[id] = std::make_shared<TGraph>(5, vertX, vertY);
       binsSummary[id]->SetName(TString::Format("%u", id));
 
       pxbTh2PolyBarrel[currentHistoName][layer - 1]->AddBin(bins[id]->Clone());
@@ -156,7 +156,7 @@ public:
       float vertX[] = {theVectX[0], theVectX[1], theVectX[2], theVectX[3]};
       float vertY[] = {theVectY[0], theVectY[1], theVectY[2], theVectY[3]};
 
-      bins[id] = new TGraph(4, vertX, vertY);
+      bins[id] = std::make_shared<TGraph>(4, vertX, vertY);
       bins[id]->SetName(TString::Format("%u", id));
 
       // Summary plot
@@ -165,7 +165,7 @@ public:
         vertY[k] += (disk - 1) * 35.0f;
       }
 
-      binsSummary[id] = new TGraph(4, vertX, vertY);
+      binsSummary[id] = std::make_shared<TGraph>(4, vertX, vertY);
       binsSummary[id]->SetName(TString::Format("%u", id));
 
       pxfTh2PolyForward[currentHistoName][mapIdx]->AddBin(bins[id]->Clone());
@@ -205,7 +205,7 @@ public:
   void beautifyAllHistograms() {
     for (const auto& vec : pxbTh2PolyBarrel) {
       for (const auto& plot : vec.second) {
-        SiPixelPI::makeNicePlotStyle(plot);
+        SiPixelPI::makeNicePlotStyle(plot.get());
         plot->GetXaxis()->SetTitleOffset(0.9);
         plot->GetYaxis()->SetTitleOffset(0.9);
       }
@@ -213,7 +213,7 @@ public:
 
     for (const auto& vec : pxfTh2PolyForward) {
       for (const auto& plot : vec.second) {
-        SiPixelPI::makeNicePlotStyle(plot);
+        SiPixelPI::makeNicePlotStyle(plot.get());
         plot->GetXaxis()->SetTitleOffset(0.9);
         plot->GetYaxis()->SetTitleOffset(0.9);
       }
@@ -254,11 +254,11 @@ private:
   Option_t* m_option;
   TrackerTopology m_trackerTopo;
 
-  std::map<uint32_t, TGraph*> bins, binsSummary;
-  std::map<std::string, std::vector<TH2Poly*>> pxbTh2PolyBarrel;
-  std::map<std::string, TH2Poly*> pxbTh2PolyBarrelSummary;
-  std::map<std::string, std::vector<TH2Poly*>> pxfTh2PolyForward;
-  std::map<std::string, TH2Poly*> pxfTh2PolyForwardSummary;
+  std::map<uint32_t, std::shared_ptr<TGraph>> bins, binsSummary;
+  std::map<std::string, std::vector<std::shared_ptr<TH2Poly>>> pxbTh2PolyBarrel;
+  std::map<std::string, std::shared_ptr<TH2Poly>> pxbTh2PolyBarrelSummary;
+  std::map<std::string, std::vector<std::shared_ptr<TH2Poly>>> pxfTh2PolyForward;
+  std::map<std::string, std::shared_ptr<TH2Poly>> pxfTh2PolyForwardSummary;
 
   std::vector<edm::FileInPath> m_cornersBPIX;
   std::vector<edm::FileInPath> m_cornersFPIX;

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -125,11 +125,13 @@ namespace PixelRegions {
   static const std::vector<uint32_t> attachedDets(const PixelRegions::PixelId theId,
                                                   const TrackerTopology* trackTopo,
                                                   const bool phase1) {
-    std::vector<uint32_t> out;
+    std::vector<uint32_t> out = {};
     edm::FileInPath m_fp;
     if (phase1) {
+      // phase-1 skimmed geometry from release
       m_fp = edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt");
     } else {
+      // phase-0 skimmed geometry from release
       m_fp = edm::FileInPath("CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt");
     }
 
@@ -141,6 +143,20 @@ namespace PixelRegions {
         out.push_back(d);
       }
     }
+
+    // in case no DetIds are assigned, fill with UINT32_MAX
+    // in order to be able to tell a part the default case
+    // in SiPixelGainCalibHelper::fillTheHitsto
+    if (out.empty()) {
+      out.push_back(0xFFFFFFFF);
+    }
+
+    COUT << "ID:" << theId << " ";
+    for (const auto& entry : out) {
+      COUT << entry << ",";
+    }
+    COUT << std::endl;
+
     return out;
   }
 
@@ -198,7 +214,18 @@ namespace PixelRegions {
           } else {
             canv.cd(j)->SetLogy();
           }
-          m_theMap.at(PixelIDs[j - 1])->Draw(option);
+          if ((j == 4) && !m_isPhase1) {
+            m_theMap.at(PixelIDs[j - 1])->Draw("AXIS");
+            TLatex t2;
+            t2.SetTextAlign(22);
+            t2.SetTextSize(0.1);
+            t2.SetTextAngle(45);
+            t2.SetTextFont(61);
+            t2.SetTextColor(kBlack);
+            t2.DrawLatexNDC(0.5, 0.5, "Not in Phase-0!");
+          } else {
+            m_theMap.at(PixelIDs[j - 1])->Draw(option);
+          }
         }
       } else {  // forward
         for (int j = 1; j <= 12; j++) {
@@ -207,7 +234,18 @@ namespace PixelRegions {
           } else {
             canv.cd(j)->SetLogy();
           }
-          m_theMap.at(PixelIDs[j + 3])->Draw(option);
+          if ((j % 6 == 5 || j % 6 == 0) && !m_isPhase1) {
+            m_theMap.at(PixelIDs[j + 3])->Draw("AXIS");
+            TLatex t2;
+            t2.SetTextAlign(22);
+            t2.SetTextSize(0.1);
+            t2.SetTextAngle(45);
+            t2.SetTextFont(61);
+            t2.SetTextColor(kBlack);
+            t2.DrawLatexNDC(0.5, 0.5, "Not in Phase-0!");
+          } else {
+            m_theMap.at(PixelIDs[j + 3])->Draw(option);
+          }
         }
       }
     }

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -295,12 +295,12 @@ namespace PixelRegions {
     }
 
     //============================================================================
-    void rescaleMax(PixelRegionContainers& the2Container) {
+    void rescaleMax(PixelRegionContainers& the2ndContainer) {
       for (const auto& plot : m_theMap) {
         auto thePixId = plot.first;
-        auto extrema = SiPixelPI::getExtrema((plot.second).get(), the2Container.getHistoFromMap(thePixId).get());
+        auto extrema = SiPixelPI::getExtrema((plot.second).get(), the2ndContainer.getHistoFromMap(thePixId).get());
         plot.second->GetYaxis()->SetRangeUser(extrema.first, extrema.second);
-        the2Container.getHistoFromMap(thePixId)->GetYaxis()->SetRangeUser(extrema.first, extrema.second);
+        the2ndContainer.getHistoFromMap(thePixId)->GetYaxis()->SetRangeUser(extrema.first, extrema.second);
       }
     }
 

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -94,12 +94,6 @@ namespace PixelRegions {
   }
 
   //============================================================================
-  static const int getPixelSubDetector(const unsigned int pixid) {
-    // subdetId: BPix=1, FPix=2
-    return (pixid / 1000) % 10;
-  }
-
-  //============================================================================
   static const PixelId detIdToPixelId(const unsigned int detid, const TrackerTopology* trackTopo, const bool phase1) {
     DetId detId = DetId(detid);
     unsigned int subid = detId.subdetId();
@@ -122,9 +116,9 @@ namespace PixelRegions {
   }
 
   //============================================================================
-  static const std::vector<uint32_t> attachedDets(const PixelRegions::PixelId theId,
-                                                  const TrackerTopology* trackTopo,
-                                                  const bool phase1) {
+  const std::vector<uint32_t> attachedDets(const PixelRegions::PixelId theId,
+                                           const TrackerTopology* trackTopo,
+                                           const bool phase1) {
     std::vector<uint32_t> out = {};
     edm::FileInPath m_fp;
     if (phase1) {

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -7,56 +7,105 @@
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 
 #include "TH1.h"
+#include <cstdlib>
 
-namespace PixelRegions{
+namespace PixelRegions {
+
+  std::string itoa(int i) {
+    char temp[20];
+    sprintf(temp, "%d", i);
+    return ((std::string)temp);
+  }
 
   // "PixelId"
   // BPix: 1000*(subdetId=1) + 100*(layer=1,2,3,4)
   // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
   enum PixelId {
-    L1=1100, L2=1200, L3=1300, L4=1400, // BPix
-    Rm1l=2111, Rm1u=2112, Rm2l=2121, Rm2u=2122, Rm3l=2131, Rm3u=2132, // FPix minus
-    Rp1l=2211, Rp1u=2212, Rp2l=2221, Rp2u=2222, Rp3l=2231, Rp3u=2232, // FPix plus
-    End=99999
+    L1 = 1100,
+    L2 = 1200,
+    L3 = 1300,
+    L4 = 1400,  // BPix
+    Rm1l = 2111,
+    Rm1u = 2112,
+    Rm2l = 2121,
+    Rm2u = 2122,
+    Rm3l = 2131,
+    Rm3u = 2132,  // FPix minus
+    Rp1l = 2211,
+    Rp1u = 2212,
+    Rp2l = 2221,
+    Rp2u = 2222,
+    Rp3l = 2231,
+    Rp3u = 2232,  // FPix plus
+    End = 99999
   };
-  
-  const std::vector<PixelId> PixelIDs = {PixelId::L1,PixelId::L2,PixelId::L3,PixelId::L4,                                     // BPix
-					 PixelId::Rm1l,PixelId::Rm1u,PixelId::Rm2l,PixelId::Rm2u,PixelId::Rm3l,PixelId::Rm3u, // FPix minus
-					 PixelId::Rp1l,PixelId::Rp1u,PixelId::Rp2l,PixelId::Rp2u,PixelId::Rp3l,PixelId::Rp3u, // FPix plus
-					 PixelId::End};
- 
-  static const PixelId calculateBPixID(const unsigned int layer){
+
+  const std::vector<PixelId> PixelIDs = {PixelId::L1,
+                                         PixelId::L2,
+                                         PixelId::L3,
+                                         PixelId::L4,  // BPix
+                                         PixelId::Rm1l,
+                                         PixelId::Rm1u,
+                                         PixelId::Rm2l,
+                                         PixelId::Rm2u,
+                                         PixelId::Rm3l,
+                                         PixelId::Rm3u,  // FPix minus
+                                         PixelId::Rp1l,
+                                         PixelId::Rp1u,
+                                         PixelId::Rp2l,
+                                         PixelId::Rp2u,
+                                         PixelId::Rp3l,
+                                         PixelId::Rp3u,  // FPix plus
+                                         PixelId::End};
+
+  const std::vector<std::string> IDlabels = {"Barrel Pixel L1",
+                                             "Barrel Pixel L2",
+                                             "Barrel Pixel L3",
+                                             "Barrel Pixel L4",
+                                             "FPIX(-) Disk 1 inner ring",
+                                             "FPIX(-) Disk 1 outer ring",
+                                             "FPIX(-) Disk 2 inner ring",
+                                             "FPIX(-) Disk 2 outer ring",
+                                             "FPIX(-) Disk 3 inner ring",
+                                             "FPIX(-) Disk 3 outer ring",
+                                             "FPIX(+) Disk 1 inner ring",
+                                             "FPIX(+) Disk 1 outer ring",
+                                             "FPIX(+) Disk 2 inner ring",
+                                             "FPIX(+) Disk 2 outer ring",
+                                             "FPIX(+) Disk 3 inner ring",
+                                             "FPIX(+) Disk 3 outer ring"};
+
+  static const PixelId calculateBPixID(const unsigned int layer) {
     // BPix: 1000*(subdetId=1) + 100*(layer=1,2,3,4)
-    PixelId bpixLayer = static_cast<PixelId>(1000+100*layer);
+    PixelId bpixLayer = static_cast<PixelId>(1000 + 100 * layer);
     return bpixLayer;
   }
-  
-  static const PixelId calculateFPixID(const unsigned int side, const unsigned int disk, const unsigned int ring){
+
+  static const PixelId calculateFPixID(const unsigned int side, const unsigned int disk, const unsigned int ring) {
     // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
-    PixelId fpixRing = static_cast<PixelId>(2000+100*side+10*disk+ring);
+    PixelId fpixRing = static_cast<PixelId>(2000 + 100 * side + 10 * disk + ring);
     return fpixRing;
   }
-  
-  static const int getPixelSubDetector(const unsigned int pixid){ //SiPixelVCalDB::PixelId
+
+  static const int getPixelSubDetector(const unsigned int pixid) {
     // subdetId: BPix=1, FPix=2
-    return (pixid/1000)%10;
+    return (pixid / 1000) % 10;
   }
-  
-  static const PixelId detIdToPixelId(const unsigned int detid, const TrackerTopology* trackTopo, const bool phase1){
+
+  static const PixelId detIdToPixelId(const unsigned int detid, const TrackerTopology* trackTopo, const bool phase1) {
     DetId detId = DetId(detid);
     unsigned int subid = detId.subdetId();
     unsigned int pixid = 0;
-    if (subid==PixelSubdetector::PixelBarrel){
-      PixelBarrelName bpix(detId,trackTopo,phase1);
+    if (subid == PixelSubdetector::PixelBarrel) {
+      PixelBarrelName bpix(detId, trackTopo, phase1);
       int layer = bpix.layerName();
       pixid = calculateBPixID(layer);
-    }
-    else if (subid==PixelSubdetector::PixelEndcap){
-      PixelEndcapName fpix(detId,trackTopo,phase1);
-      int side = trackTopo->pxfSide(detId); // 1 (-z), 2 for (+z)
-      int disk = fpix.diskName(); //trackTopo->pxfDisk(detId); // 1, 2, 3
-      int ring = fpix.ringName(); // 1 (lower), 2 (upper)
-      pixid = calculateFPixID(side,disk,ring);
+    } else if (subid == PixelSubdetector::PixelEndcap) {
+      PixelEndcapName fpix(detId, trackTopo, phase1);
+      int side = trackTopo->pxfSide(detId);  // 1 (-z), 2 for (+z)
+      int disk = fpix.diskName();            //trackTopo->pxfDisk(detId); // 1, 2, 3
+      int ring = fpix.ringName();            // 1 (lower), 2 (upper)
+      pixid = calculateFPixID(side, disk, ring);
     }
     PixelId pixID = static_cast<PixelId>(pixid);
     return pixID;
@@ -64,103 +113,192 @@ namespace PixelRegions{
 
   class PixelRegionContainers {
   public:
-    PixelRegionContainers(const TrackerTopology*& t_topo, const bool isPhase1):
-      m_trackerTopo(t_topo),
-      m_isPhase1(isPhase1) {}
+    PixelRegionContainers(const TrackerTopology* t_topo, const bool isPhase1)
+        : m_trackerTopo(t_topo), m_isPhase1(isPhase1) {}
 
-    ~PixelRegionContainers(){}
+    ~PixelRegionContainers() {}
 
-    void bookAll(std::string x_label,std::string y_label,const int nbins, const float xmin, const float xmax){
-      
-      for (int i = PixelId::L1; i < PixelId::End; i++ ){ 
-	switch(i)
-	  {
-	  case PixelId::L1:
-	    m_theMap.at(PixelId::L1) = std::make_shared<TH1F>(Form("Barrel Pixel L1 %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::L2:
-	    m_theMap.at(PixelId::L2) = std::make_shared<TH1F>(Form("Barrel Pixel L2 %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::L3:
-	    m_theMap.at(PixelId::L3) = std::make_shared<TH1F>(Form("Barrel Pixel L3 %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::L4:
-	    m_theMap.at(PixelId::L4) = std::make_shared<TH1F>(Form("Barrel Pixel L4 %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rm1l:
-	    m_theMap.at(PixelId::Rm1l) = std::make_shared<TH1F>(Form("FPIX(-) Disk 1 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rm1u:
-	    m_theMap.at(PixelId::Rm1u) = std::make_shared<TH1F>(Form("FPIX(-) Disk 1 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rm2l:
-	    m_theMap.at(PixelId::Rm2l) = std::make_shared<TH1F>(Form("FPIX(-) Disk 2 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rm2u:
-	    m_theMap.at(PixelId::Rm2u) = std::make_shared<TH1F>(Form("FPIX(-) Disk 2 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rm3l:
-	    m_theMap.at(PixelId::Rm3l) = std::make_shared<TH1F>(Form("FPIX(-) Disk 3 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rm3u:
-	    m_theMap.at(PixelId::Rm3u) = std::make_shared<TH1F>(Form("FPIX(-) Disk 3 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rp1l:
-	    m_theMap.at(PixelId::Rp1l) = std::make_shared<TH1F>(Form("FPIX(+) Disk 1 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rp1u:
-	    m_theMap.at(PixelId::Rp1u) = std::make_shared<TH1F>(Form("FPIX(+) Disk 1 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rp2l:
-	    m_theMap.at(PixelId::Rp2l) = std::make_shared<TH1F>(Form("FPIX(+) Disk 2 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rp2u:
-	    m_theMap.at(PixelId::Rp2u) = std::make_shared<TH1F>(Form("FPIX(+) Disk 2 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rp3l:
-	    m_theMap.at(PixelId::Rp3l) = std::make_shared<TH1F>(Form("FPIX(+) Disk 3 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;
-	  case PixelId::Rp3u:
-	    m_theMap.at(PixelId::Rp3u) = std::make_shared<TH1F>(Form("FPIX(+) Disk 3 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
-	    break;	   
-	  default:
+    void bookAll(std::string title_label,
+                 std::string x_label,
+                 std::string y_label,
+                 const int nbins,
+                 const float xmin,
+                 const float xmax) {
+      for (int i = PixelId::L1; i < PixelId::End; i++) {
+        switch (i) {
+          case PixelId::L1:
+            m_theMap[PixelId::L1] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("Barrel Pixel L1 %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::L2:
+            m_theMap[PixelId::L2] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("Barrel Pixel L2 %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::L3:
+            m_theMap[PixelId::L3] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("Barrel Pixel L3 %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::L4:
+            m_theMap[PixelId::L4] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("Barrel Pixel L4 %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rm1l:
+            m_theMap[PixelId::Rm1l] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(-) Disk 1 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rm1u:
+            m_theMap[PixelId::Rm1u] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(-) Disk 1 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rm2l:
+            m_theMap[PixelId::Rm2l] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(-) Disk 2 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rm2u:
+            m_theMap[PixelId::Rm2u] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(-) Disk 2 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rm3l:
+            m_theMap[PixelId::Rm3l] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(-) Disk 3 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rm3u:
+            m_theMap[PixelId::Rm3u] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(-) Disk 3 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rp1l:
+            m_theMap[PixelId::Rp1l] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(+) Disk 1 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rp1u:
+            m_theMap[PixelId::Rp1u] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(+) Disk 1 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rp2l:
+            m_theMap[PixelId::Rp2l] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(+) Disk 2 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rp2u:
+            m_theMap[PixelId::Rp2u] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(+) Disk 2 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rp3l:
+            m_theMap[PixelId::Rp3l] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(+) Disk 3 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          case PixelId::Rp3u:
+            m_theMap[PixelId::Rp3u] = std::make_shared<TH1F>(
+                itoa(i).c_str(),
+                Form("FPIX(+) Disk 3 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
+                nbins,
+                xmin,
+                xmax);
+            break;
+          default:
             /* Found an invalid enum entry; ignore it */
-	    break;
-	  }
+            break;
+        }
       }
     }
 
-    void fill(const unsigned int detid,const float value){
+    void fill(const unsigned int detid, const float value) {
       // convert from detid to pixelid
-      PixelRegions::PixelId myId = PixelRegions::detIdToPixelId(detid,m_trackerTopo,m_isPhase1);
-      m_theMap.at(myId)->Fill(value);
+      PixelRegions::PixelId myId = PixelRegions::detIdToPixelId(detid, m_trackerTopo, m_isPhase1);
+      m_theMap[myId]->Fill(value);
     }
 
-    void draw(TCanvas &canv,bool isBarrel){
-      
-      if(isBarrel){
-	for(int j = 1; j<=4;j++){
-	  canv.cd(j);
-	  m_theMap.at(PixelIDs[j-1])->Draw();
-	}
-      } else { // forward
-	for(int j = 1; j<=12;j++){
-	  canv.cd(j);
-	  m_theMap.at(PixelIDs[j+3])->Draw();
-	}
+    void draw(TCanvas& canv, bool isBarrel) {
+      if (isBarrel) {
+        for (int j = 1; j <= 4; j++) {
+          canv.cd(j);
+          m_theMap.at(PixelIDs[j - 1])->Draw("bar2");
+        }
+      } else {  // forward
+        for (int j = 1; j <= 12; j++) {
+          canv.cd(j);
+          m_theMap.at(PixelIDs[j + 3])->Draw("bar2");
+        }
       }
+    }
 
+    void beautify() {
+      for (const auto& plot : m_theMap) {
+        plot.second->GetYaxis()->SetRangeUser(0., plot.second->GetMaximum() * 1.30);
+        plot.second->SetFillColor(kRed);
+        plot.second->SetMarkerStyle(20);
+        plot.second->SetMarkerSize(1);
+        SiPixelPI::makeNicePlotStyle(plot.second.get());
+      }
     }
 
   private:
     const TrackerTopology* m_trackerTopo;
     bool m_isPhase1;
 
-    std::map<PixelId,std::shared_ptr<TH1F>> m_theMap;
+    std::map<PixelId, std::shared_ptr<TH1F>> m_theMap;
     int m_nbins;
     float m_xim, m_xmax;
     bool m_isLog;
-
   };
-}
+}  // namespace PixelRegions
 #endif

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -1,0 +1,166 @@
+#ifndef CONDCORE_SIPIXELPLUGINS_PIXELREGIONCONTAINERS_H
+#define CONDCORE_SIPIXELPLUGINS_PIXELREGIONCONTAINERS_H
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+
+#include "TH1.h"
+
+namespace PixelRegions{
+
+  // "PixelId"
+  // BPix: 1000*(subdetId=1) + 100*(layer=1,2,3,4)
+  // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
+  enum PixelId {
+    L1=1100, L2=1200, L3=1300, L4=1400, // BPix
+    Rm1l=2111, Rm1u=2112, Rm2l=2121, Rm2u=2122, Rm3l=2131, Rm3u=2132, // FPix minus
+    Rp1l=2211, Rp1u=2212, Rp2l=2221, Rp2u=2222, Rp3l=2231, Rp3u=2232, // FPix plus
+    End=99999
+  };
+  
+  const std::vector<PixelId> PixelIDs = {PixelId::L1,PixelId::L2,PixelId::L3,PixelId::L4,                                     // BPix
+					 PixelId::Rm1l,PixelId::Rm1u,PixelId::Rm2l,PixelId::Rm2u,PixelId::Rm3l,PixelId::Rm3u, // FPix minus
+					 PixelId::Rp1l,PixelId::Rp1u,PixelId::Rp2l,PixelId::Rp2u,PixelId::Rp3l,PixelId::Rp3u, // FPix plus
+					 PixelId::End};
+ 
+  static const PixelId calculateBPixID(const unsigned int layer){
+    // BPix: 1000*(subdetId=1) + 100*(layer=1,2,3,4)
+    PixelId bpixLayer = static_cast<PixelId>(1000+100*layer);
+    return bpixLayer;
+  }
+  
+  static const PixelId calculateFPixID(const unsigned int side, const unsigned int disk, const unsigned int ring){
+    // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
+    PixelId fpixRing = static_cast<PixelId>(2000+100*side+10*disk+ring);
+    return fpixRing;
+  }
+  
+  static const int getPixelSubDetector(const unsigned int pixid){ //SiPixelVCalDB::PixelId
+    // subdetId: BPix=1, FPix=2
+    return (pixid/1000)%10;
+  }
+  
+  static const PixelId detIdToPixelId(const unsigned int detid, const TrackerTopology* trackTopo, const bool phase1){
+    DetId detId = DetId(detid);
+    unsigned int subid = detId.subdetId();
+    unsigned int pixid = 0;
+    if (subid==PixelSubdetector::PixelBarrel){
+      PixelBarrelName bpix(detId,trackTopo,phase1);
+      int layer = bpix.layerName();
+      pixid = calculateBPixID(layer);
+    }
+    else if (subid==PixelSubdetector::PixelEndcap){
+      PixelEndcapName fpix(detId,trackTopo,phase1);
+      int side = trackTopo->pxfSide(detId); // 1 (-z), 2 for (+z)
+      int disk = fpix.diskName(); //trackTopo->pxfDisk(detId); // 1, 2, 3
+      int ring = fpix.ringName(); // 1 (lower), 2 (upper)
+      pixid = calculateFPixID(side,disk,ring);
+    }
+    PixelId pixID = static_cast<PixelId>(pixid);
+    return pixID;
+  }
+
+  class PixelRegionContainers {
+  public:
+    PixelRegionContainers(const TrackerTopology*& t_topo, const bool isPhase1):
+      m_trackerTopo(t_topo),
+      m_isPhase1(isPhase1) {}
+
+    ~PixelRegionContainers(){}
+
+    void bookAll(std::string x_label,std::string y_label,const int nbins, const float xmin, const float xmax){
+      
+      for (int i = PixelId::L1; i < PixelId::End; i++ ){ 
+	switch(i)
+	  {
+	  case PixelId::L1:
+	    m_theMap.at(PixelId::L1) = std::make_shared<TH1F>(Form("Barrel Pixel L1 %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::L2:
+	    m_theMap.at(PixelId::L2) = std::make_shared<TH1F>(Form("Barrel Pixel L2 %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::L3:
+	    m_theMap.at(PixelId::L3) = std::make_shared<TH1F>(Form("Barrel Pixel L3 %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::L4:
+	    m_theMap.at(PixelId::L4) = std::make_shared<TH1F>(Form("Barrel Pixel L4 %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rm1l:
+	    m_theMap.at(PixelId::Rm1l) = std::make_shared<TH1F>(Form("FPIX(-) Disk 1 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rm1u:
+	    m_theMap.at(PixelId::Rm1u) = std::make_shared<TH1F>(Form("FPIX(-) Disk 1 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rm2l:
+	    m_theMap.at(PixelId::Rm2l) = std::make_shared<TH1F>(Form("FPIX(-) Disk 2 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rm2u:
+	    m_theMap.at(PixelId::Rm2u) = std::make_shared<TH1F>(Form("FPIX(-) Disk 2 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rm3l:
+	    m_theMap.at(PixelId::Rm3l) = std::make_shared<TH1F>(Form("FPIX(-) Disk 3 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rm3u:
+	    m_theMap.at(PixelId::Rm3u) = std::make_shared<TH1F>(Form("FPIX(-) Disk 3 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rp1l:
+	    m_theMap.at(PixelId::Rp1l) = std::make_shared<TH1F>(Form("FPIX(+) Disk 1 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rp1u:
+	    m_theMap.at(PixelId::Rp1u) = std::make_shared<TH1F>(Form("FPIX(+) Disk 1 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rp2l:
+	    m_theMap.at(PixelId::Rp2l) = std::make_shared<TH1F>(Form("FPIX(+) Disk 2 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rp2u:
+	    m_theMap.at(PixelId::Rp2u) = std::make_shared<TH1F>(Form("FPIX(+) Disk 2 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rp3l:
+	    m_theMap.at(PixelId::Rp3l) = std::make_shared<TH1F>(Form("FPIX(+) Disk 3 inner ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;
+	  case PixelId::Rp3u:
+	    m_theMap.at(PixelId::Rp3u) = std::make_shared<TH1F>(Form("FPIX(+) Disk 3 outer ring %s",x_label.c_str()),Form("%s;%s",x_label.c_str(),y_label.c_str()),nbins,xmin,xmax);
+	    break;	   
+	  default:
+            /* Found an invalid enum entry; ignore it */
+	    break;
+	  }
+      }
+    }
+
+    void fill(const unsigned int detid,const float value){
+      // convert from detid to pixelid
+      PixelRegions::PixelId myId = PixelRegions::detIdToPixelId(detid,m_trackerTopo,m_isPhase1);
+      m_theMap.at(myId)->Fill(value);
+    }
+
+    void draw(TCanvas &canv,bool isBarrel){
+      
+      if(isBarrel){
+	for(int j = 1; j<=4;j++){
+	  canv.cd(j);
+	  m_theMap.at(PixelIDs[j-1])->Draw();
+	}
+      } else { // forward
+	for(int j = 1; j<=12;j++){
+	  canv.cd(j);
+	  m_theMap.at(PixelIDs[j+3])->Draw();
+	}
+      }
+
+    }
+
+  private:
+    const TrackerTopology* m_trackerTopo;
+    bool m_isPhase1;
+
+    std::map<PixelId,std::shared_ptr<TH1F>> m_theMap;
+    int m_nbins;
+    float m_xim, m_xmax;
+    bool m_isLog;
+
+  };
+}
+#endif

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -150,7 +150,10 @@ namespace PixelRegions {
   class PixelRegionContainers {
   public:
     PixelRegionContainers(const TrackerTopology* t_topo, const bool isPhase1)
-        : m_trackerTopo(t_topo), m_isPhase1(isPhase1) {}
+        : m_trackerTopo(t_topo), m_isPhase1(isPhase1) {
+      // set log scale by default to false
+      m_isLog = false;
+    }
 
     ~PixelRegionContainers() {}
 
@@ -187,26 +190,39 @@ namespace PixelRegions {
     }
 
     //============================================================================
-    void draw(TCanvas& canv, bool isBarrel) {
+    void draw(TCanvas& canv, bool isBarrel, const char* option = "bar2") {
       if (isBarrel) {
         for (int j = 1; j <= 4; j++) {
-          canv.cd(j);
-          m_theMap.at(PixelIDs[j - 1])->Draw("bar2");
+          if (!m_isLog) {
+            canv.cd(j);
+          } else {
+            canv.cd(j)->SetLogy();
+          }
+          m_theMap.at(PixelIDs[j - 1])->Draw(option);
         }
       } else {  // forward
         for (int j = 1; j <= 12; j++) {
-          canv.cd(j);
-          m_theMap.at(PixelIDs[j + 3])->Draw("bar2");
+          if (!m_isLog) {
+            canv.cd(j);
+          } else {
+            canv.cd(j)->SetLogy();
+          }
+          m_theMap.at(PixelIDs[j + 3])->Draw(option);
         }
       }
     }
 
     //============================================================================
-    void beautify() {
+    void beautify(const int linecolor = kBlack, const int fillcolor = kRed) {
       for (const auto& plot : m_theMap) {
         plot.second->SetTitle("");
-        plot.second->GetYaxis()->SetRangeUser(0., plot.second->GetMaximum() * 1.30);
-        plot.second->SetFillColor(kRed);
+        if (!m_isLog) {
+          plot.second->GetYaxis()->SetRangeUser(0., plot.second->GetMaximum() * 1.30);
+        } else {
+          plot.second->GetYaxis()->SetRangeUser(0.1, plot.second->GetMaximum() * 10.);
+        }
+        plot.second->SetLineColor(linecolor);
+        plot.second->SetFillColor(fillcolor);
         plot.second->SetMarkerStyle(20);
         plot.second->SetMarkerSize(1);
         SiPixelPI::makeNicePlotStyle(plot.second.get());
@@ -215,12 +231,15 @@ namespace PixelRegions {
     }
 
     //============================================================================
+    void setLogScale() { m_isLog = true; }
+
+    //============================================================================
     void stats() {
       for (const auto& plot : m_theMap) {
         TPaveStats* st = (TPaveStats*)plot.second->FindObject("stats");
         if (st) {
           st->SetTextSize(0.03);
-          SiPixelPI::adjustStats(st, 0.15, 0.83, 0.39, 0.93);
+          SiPixelPI::adjustStats(st, 0.15, 0.85, 0.39, 0.93);
         }
       }
     }

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -5,7 +5,9 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
-
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include <boost/range/adaptor/indexed.hpp>
 #include "TH1.h"
 #include <cstdlib>
 
@@ -20,42 +22,43 @@ namespace PixelRegions {
   // "PixelId"
   // BPix: 1000*(subdetId=1) + 100*(layer=1,2,3,4)
   // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
+
   enum PixelId {
-    L1 = 1100,
+    L1 = 1100,  // BPix
     L2 = 1200,
     L3 = 1300,
-    L4 = 1400,  // BPix
-    Rm1l = 2111,
+    L4 = 1400,
+    Rm1l = 2111,  // FPix minus
     Rm1u = 2112,
     Rm2l = 2121,
     Rm2u = 2122,
     Rm3l = 2131,
-    Rm3u = 2132,  // FPix minus
-    Rp1l = 2211,
+    Rm3u = 2132,
+    Rp1l = 2211,  // FPix plus
     Rp1u = 2212,
     Rp2l = 2221,
     Rp2u = 2222,
     Rp3l = 2231,
-    Rp3u = 2232,  // FPix plus
+    Rp3u = 2232,
     End = 99999
   };
 
-  const std::vector<PixelId> PixelIDs = {PixelId::L1,
+  const std::vector<PixelId> PixelIDs = {PixelId::L1,  // BPix
                                          PixelId::L2,
                                          PixelId::L3,
-                                         PixelId::L4,  // BPix
-                                         PixelId::Rm1l,
+                                         PixelId::L4,
+                                         PixelId::Rm1l,  // FPix minus
                                          PixelId::Rm1u,
                                          PixelId::Rm2l,
                                          PixelId::Rm2u,
                                          PixelId::Rm3l,
-                                         PixelId::Rm3u,  // FPix minus
-                                         PixelId::Rp1l,
+                                         PixelId::Rm3u,
+                                         PixelId::Rp1l,  // FPix plus
                                          PixelId::Rp1u,
                                          PixelId::Rp2l,
                                          PixelId::Rp2u,
                                          PixelId::Rp3l,
-                                         PixelId::Rp3u,  // FPix plus
+                                         PixelId::Rp3u,
                                          PixelId::End};
 
   const std::vector<std::string> IDlabels = {"Barrel Pixel L1",
@@ -73,25 +76,30 @@ namespace PixelRegions {
                                              "FPIX(+) Disk 2 inner ring",
                                              "FPIX(+) Disk 2 outer ring",
                                              "FPIX(+) Disk 3 inner ring",
-                                             "FPIX(+) Disk 3 outer ring"};
+                                             "FPIX(+) Disk 3 outer ring",
+                                             "END"};
 
+  //============================================================================
   static const PixelId calculateBPixID(const unsigned int layer) {
     // BPix: 1000*(subdetId=1) + 100*(layer=1,2,3,4)
     PixelId bpixLayer = static_cast<PixelId>(1000 + 100 * layer);
     return bpixLayer;
   }
 
+  //============================================================================
   static const PixelId calculateFPixID(const unsigned int side, const unsigned int disk, const unsigned int ring) {
     // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
     PixelId fpixRing = static_cast<PixelId>(2000 + 100 * side + 10 * disk + ring);
     return fpixRing;
   }
 
+  //============================================================================
   static const int getPixelSubDetector(const unsigned int pixid) {
     // subdetId: BPix=1, FPix=2
     return (pixid / 1000) % 10;
   }
 
+  //============================================================================
   static const PixelId detIdToPixelId(const unsigned int detid, const TrackerTopology* trackTopo, const bool phase1) {
     DetId detId = DetId(detid);
     unsigned int subid = detId.subdetId();
@@ -104,15 +112,41 @@ namespace PixelRegions {
       PixelEndcapName fpix(detId, trackTopo, phase1);
       int side = trackTopo->pxfSide(detId);  // 1 (-z), 2 for (+z)
       int disk = fpix.diskName();            //trackTopo->pxfDisk(detId); // 1, 2, 3
-      int ring = fpix.ringName();            // 1 (lower), 2 (upper)
-      // ### FIXME ###
-      // ring numbering for phase-0 needs to be adjusted
+      // This works only in case of the Phase-1 detector
+      //int ring = fpix.ringName();          // 1 (lower), 2 (upper)
+      int ring = SiPixelPI::ring(detid, *trackTopo, phase1);  // 1 (lower), 2 (upper)
       pixid = calculateFPixID(side, disk, ring);
     }
     PixelId pixID = static_cast<PixelId>(pixid);
     return pixID;
   }
 
+  //============================================================================
+  static const std::vector<uint32_t> attachedDets(const PixelRegions::PixelId theId,
+                                                  const TrackerTopology* trackTopo,
+                                                  const bool phase1) {
+    std::vector<uint32_t> out;
+    edm::FileInPath m_fp;
+    if (phase1) {
+      m_fp = edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt");
+    } else {
+      m_fp = edm::FileInPath("CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt");
+    }
+
+    SiPixelDetInfoFileReader pxlreader(m_fp.fullPath());
+    const std::vector<uint32_t>& pxldetids = pxlreader.getAllDetIds();
+    for (const auto& d : pxldetids) {
+      auto ID = detIdToPixelId(d, trackTopo, phase1);
+      if (ID == theId) {
+        out.push_back(d);
+      }
+    }
+    return out;
+  }
+
+  /*--------------------------------------------------------------------
+  / Ancillary class to build pixel phase0/phase1 plots per region
+  /--------------------------------------------------------------------*/
   class PixelRegionContainers {
   public:
     PixelRegionContainers(const TrackerTopology* t_topo, const bool isPhase1)
@@ -120,149 +154,27 @@ namespace PixelRegions {
 
     ~PixelRegionContainers() {}
 
+    //============================================================================
     void bookAll(std::string title_label,
                  std::string x_label,
                  std::string y_label,
                  const int nbins,
                  const float xmin,
                  const float xmax) {
-      for (int i = PixelId::L1; i < PixelId::End; i++) {
-        switch (i) {
-          case PixelId::L1:
-            m_theMap[PixelId::L1] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("Barrel Pixel L1 %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::L2:
-            m_theMap[PixelId::L2] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("Barrel Pixel L2 %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::L3:
-            m_theMap[PixelId::L3] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("Barrel Pixel L3 %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::L4:
-            m_theMap[PixelId::L4] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("Barrel Pixel L4 %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rm1l:
-            m_theMap[PixelId::Rm1l] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(-) Disk 1 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rm1u:
-            m_theMap[PixelId::Rm1u] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(-) Disk 1 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rm2l:
-            m_theMap[PixelId::Rm2l] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(-) Disk 2 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rm2u:
-            m_theMap[PixelId::Rm2u] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(-) Disk 2 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rm3l:
-            m_theMap[PixelId::Rm3l] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(-) Disk 3 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rm3u:
-            m_theMap[PixelId::Rm3u] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(-) Disk 3 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rp1l:
-            m_theMap[PixelId::Rp1l] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(+) Disk 1 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rp1u:
-            m_theMap[PixelId::Rp1u] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(+) Disk 1 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rp2l:
-            m_theMap[PixelId::Rp2l] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(+) Disk 2 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rp2u:
-            m_theMap[PixelId::Rp2u] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(+) Disk 2 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rp3l:
-            m_theMap[PixelId::Rp3l] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(+) Disk 3 inner ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          case PixelId::Rp3u:
-            m_theMap[PixelId::Rp3u] = std::make_shared<TH1F>(
-                itoa(i).c_str(),
-                Form("FPIX(+) Disk 3 outer ring %s;%s;%s", title_label.c_str(), x_label.c_str(), y_label.c_str()),
-                nbins,
-                xmin,
-                xmax);
-            break;
-          default:
-            /* Found an invalid enum entry; ignore it */
-            break;
-        }
+      for (const auto& pixelId : PixelIDs | boost::adaptors::indexed(0)) {
+        m_theMap[pixelId.value()] = std::make_shared<TH1F>(itoa(pixelId.value()).c_str(),
+                                                           Form("%s %s;%s;%s",
+                                                                (IDlabels.at(pixelId.index())).c_str(),
+                                                                title_label.c_str(),
+                                                                x_label.c_str(),
+                                                                y_label.c_str()),
+                                                           nbins,
+                                                           xmin,
+                                                           xmax);
       }
     }
 
+    //============================================================================
     void fill(const unsigned int detid, const float value) {
       // convert from detid to pixelid
       PixelRegions::PixelId myId = PixelRegions::detIdToPixelId(detid, m_trackerTopo, m_isPhase1);
@@ -274,6 +186,7 @@ namespace PixelRegions {
       }
     }
 
+    //============================================================================
     void draw(TCanvas& canv, bool isBarrel) {
       if (isBarrel) {
         for (int j = 1; j <= 4; j++) {
@@ -288,6 +201,7 @@ namespace PixelRegions {
       }
     }
 
+    //============================================================================
     void beautify() {
       for (const auto& plot : m_theMap) {
         plot.second->SetTitle("");
@@ -300,6 +214,7 @@ namespace PixelRegions {
       }
     }
 
+    //============================================================================
     void stats() {
       for (const auto& plot : m_theMap) {
         TPaveStats* st = (TPaveStats*)plot.second->FindObject("stats");
@@ -307,6 +222,16 @@ namespace PixelRegions {
           st->SetTextSize(0.03);
           SiPixelPI::adjustStats(st, 0.15, 0.83, 0.39, 0.93);
         }
+      }
+    }
+
+    //============================================================================
+    std::shared_ptr<TH1F>& getHistoFromMap(const PixelRegions::PixelId& theId) {
+      auto it = m_theMap.find(theId);
+      if (it != m_theMap.end()) {
+        return it->second;
+      } else {
+        throw cms::Exception("PixelRegionContainer") << "No histogram is available for PixelId" << theId << "\n";
       }
     }
 

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -251,10 +251,12 @@ namespace PixelRegions {
         if (!m_isLog) {
           plot.second->GetYaxis()->SetRangeUser(0., plot.second->GetMaximum() * 1.30);
         } else {
-          plot.second->GetYaxis()->SetRangeUser(0.1, plot.second->GetMaximum() * 10.);
+          plot.second->GetYaxis()->SetRangeUser(0.1, plot.second->GetMaximum() * 100.);
         }
         plot.second->SetLineColor(linecolor);
-        plot.second->SetFillColor(fillcolor);
+        if (fillcolor > 0) {
+          plot.second->SetFillColor(fillcolor);
+        }
         plot.second->SetMarkerStyle(20);
         plot.second->SetMarkerSize(1);
         SiPixelPI::makeNicePlotStyle(plot.second.get());
@@ -272,7 +274,11 @@ namespace PixelRegions {
         if (st) {
           st->SetTextSize(0.03);
           st->SetLineColor(10);
-          st->SetTextColor(plot.second->GetFillColor());
+          if (plot.second->GetFillColor() != 0) {
+            st->SetTextColor(plot.second->GetFillColor());
+          } else {
+            st->SetTextColor(plot.second->GetLineColor());
+          }
           SiPixelPI::adjustStats(st, 0.13, 0.85 - index * 0.08, 0.36, 0.93 - index * 0.08);
         }
       }

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -203,11 +203,12 @@ namespace gainCalibHelper {
     1d histogram of SiPixelGainCalibration for Gains of 1 IOV 
   ********************************************************************/
   template <gainCalibPI::type myType, class PayloadType>
-  class SiPixelGainCalibrationValues : public cond::payloadInspector::PlotImage<PayloadType> {
+  class SiPixelGainCalibrationValues
+      : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelGainCalibrationValues()
-        : cond::payloadInspector::PlotImage<PayloadType>(Form("SiPixelGainCalibration %s Values", TypeName[myType])) {
-      this->setSingleIov(true);
+        : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
+              Form("SiPixelGainCalibration %s Values", TypeName[myType])) {
       if constexpr (std::is_same_v<PayloadType, SiPixelGainCalibrationOffline>) {
         isForHLT_ = false;
         label_ = "SiPixelGainCalibrationOffline_PayloadInspector";
@@ -217,11 +218,13 @@ namespace gainCalibHelper {
       }
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      gStyle->SetOptStat("emr");
+    bool fill() override {
+      auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
 
-      auto iov = iovs.front();
       std::shared_ptr<PayloadType> payload = this->fetchPayload(std::get<1>(iov));
+
+      gStyle->SetOptStat("emr");
 
       float minimum(9999.);
       float maximum(-9999.);
@@ -307,12 +310,12 @@ namespace gainCalibHelper {
     1d histograms per region of SiPixelGainCalibration for Gains of 1 IOV
   ********************************************************************/
   template <bool isBarrel, gainCalibPI::type myType, class PayloadType>
-  class SiPixelGainCalibrationValuesPerRegion : public cond::payloadInspector::PlotImage<PayloadType> {
+  class SiPixelGainCalibrationValuesPerRegion
+      : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelGainCalibrationValuesPerRegion()
-        : cond::payloadInspector::PlotImage<PayloadType>(
+        : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
               Form("SiPixelGainCalibration %s Values Per Region", TypeName[myType])) {
-      this->setSingleIov(true);
       cond::payloadInspector::PlotBase::addInputParam("SetLog");
 
       if constexpr (std::is_same_v<PayloadType, SiPixelGainCalibrationOffline>) {
@@ -324,7 +327,12 @@ namespace gainCalibHelper {
       }
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
+      gStyle->SetOptStat("mr");
+
+      auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+
       // parse first if log
       bool setLog(false);
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
@@ -333,9 +341,6 @@ namespace gainCalibHelper {
         setLog = boost::lexical_cast<bool>(ip->second);
       }
 
-      gStyle->SetOptStat("mr");
-
-      auto iov = iovs.front();
       std::shared_ptr<PayloadType> payload = this->fetchPayload(std::get<1>(iov));
 
       std::vector<uint32_t> detids;
@@ -445,11 +450,12 @@ namespace gainCalibHelper {
     correlation of 1 IOV
   ********************************************************************/
   template <class PayloadType>
-  class SiPixelGainCalibrationCorrelations : public cond::payloadInspector::PlotImage<PayloadType> {
+  class SiPixelGainCalibrationCorrelations
+      : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelGainCalibrationCorrelations()
-        : cond::payloadInspector::PlotImage<PayloadType>("SiPixelGainCalibration gain/pedestal correlations") {
-      this->setSingleIov(true);
+        : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelGainCalibration gain/pedestal correlations") {
       if constexpr (std::is_same_v<PayloadType, SiPixelGainCalibrationOffline>) {
         isForHLT_ = false;
         label_ = "SiPixelGainCalibrationOffline_PayloadInspector";
@@ -459,11 +465,13 @@ namespace gainCalibHelper {
       }
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
+      auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+
       gStyle->SetOptStat("emr");
       gStyle->SetPalette(1);
 
-      auto iov = iovs.front();
       std::shared_ptr<PayloadType> payload = this->fetchPayload(std::get<1>(iov));
 
       TCanvas canvas("Canv", "Canv", 1400, 800);
@@ -563,12 +571,12 @@ namespace gainCalibHelper {
     1d histogram of SiPixelGainCalibration for Pedestals of 1 IOV
   ********************************************************************/
   template <gainCalibPI::type myType, class PayloadType>
-  class SiPixelGainCalibrationValuesByPart : public cond::payloadInspector::PlotImage<PayloadType> {
+  class SiPixelGainCalibrationValuesByPart
+      : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelGainCalibrationValuesByPart()
-        : cond::payloadInspector::PlotImage<PayloadType>(
+        : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
               Form("SiPixelGainCalibrationOffline %s Values By Partition", TypeName[myType])) {
-      this->setSingleIov(true);
       if constexpr (std::is_same_v<PayloadType, SiPixelGainCalibrationOffline>) {
         isForHLT_ = false;
         label_ = "SiPixelGainCalibrationOffline_PayloadInspector";
@@ -578,10 +586,12 @@ namespace gainCalibHelper {
       }
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
+      auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+
       gStyle->SetOptStat("emr");
 
-      auto iov = iovs.front();
       std::shared_ptr<PayloadType> payload = this->fetchPayload(std::get<1>(iov));
 
       TCanvas canvas("Canv", "Canv", 1400, 800);
@@ -886,10 +896,11 @@ namespace gainCalibHelper {
    occupancy style map BPix
   *************************************************/
   template <gainCalibPI::type myType, class PayloadType>
-  class SiPixelGainCalibrationBPIXMap : public cond::payloadInspector::PlotImage<PayloadType> {
+  class SiPixelGainCalibrationBPIXMap
+      : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelGainCalibrationBPIXMap()
-        : cond::payloadInspector::PlotImage<PayloadType>(
+        : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
               Form("SiPixelGainCalibration %s Barrel Pixel Map", TypeName[myType])),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
@@ -900,11 +911,12 @@ namespace gainCalibHelper {
         isForHLT_ = true;
         label_ = "SiPixelGainCalibrationForHLT_PayloadInspector";
       }
-      this->setSingleIov(true);
     };
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+
       std::shared_ptr<PayloadType> payload = this->fetchPayload(std::get<1>(iov));
 
       static const int n_layers = 4;
@@ -1016,14 +1028,14 @@ namespace gainCalibHelper {
   *************************************************/
 
   template <gainCalibPI::type myType, class PayloadType>
-  class SiPixelGainCalibrationFPIXMap : public cond::payloadInspector::PlotImage<PayloadType> {
+  class SiPixelGainCalibrationFPIXMap
+      : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelGainCalibrationFPIXMap()
-        : cond::payloadInspector::PlotImage<PayloadType>(
+        : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
               Form("SiPixelGainCalibration %s Forward Pixel Map", TypeName[myType])),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
-      this->setSingleIov(true);
       if constexpr (std::is_same_v<PayloadType, SiPixelGainCalibrationOffline>) {
         isForHLT_ = false;
         label_ = "SiPixelGainCalibrationOffline_PayloadInspector";
@@ -1033,8 +1045,9 @@ namespace gainCalibHelper {
       }
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<PayloadType> payload = this->fetchPayload(std::get<1>(iov));
 
       static const int n_rings = 2;

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -359,11 +359,11 @@ namespace gainCalibHelper {
       }
 
       TCanvas canvas("Canv", "Canv", isBarrel ? 1400 : 1800, 1200);
-      if(detids.size() > SiPixelPI::phase1size){
-	SiPixelPI::displayNotSupported(canvas, detids.size());
+      if (detids.size() > SiPixelPI::phase1size) {
+        SiPixelPI::displayNotSupported(canvas, detids.size());
         std::string fileName(this->m_imageFileName);
         canvas.SaveAs(fileName.c_str());
-	return false;
+        return false;
       }
 
       canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -784,6 +784,21 @@ namespace gainCalibHelper {
 
       std::map<uint32_t, float> GainCalibMap_;
       gainCalibPI::fillThePerModuleMap(payload, GainCalibMap_, myType);
+      if (GainCalibMap_.size() != SiPixelPI::phase1size) {
+        edm::LogError(label_) << "SiPixelGainCalibration maps are not supported for non-Phase1 Pixel geometries !";
+        std::string phase = (GainCalibMap_.size() < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
+        TCanvas canvas("Canv", "Canv", 1200, 1000);
+        canvas.cd();
+        TLatex t2;
+        t2.SetTextAlign(21);
+        t2.SetTextSize(0.1);
+        t2.SetTextAngle(45);
+        t2.SetTextColor(kRed);
+        t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+        return false;
+      }
 
       // hard-coded phase-I
       std::array<double, 4> minima = {{999., 999., 999., 999.}};
@@ -899,6 +914,21 @@ namespace gainCalibHelper {
 
       std::map<uint32_t, float> GainCalibMap_;
       gainCalibPI::fillThePerModuleMap(payload, GainCalibMap_, myType);
+      if (GainCalibMap_.size() != SiPixelPI::phase1size) {
+        edm::LogError(label_) << "SiPixelGainCalibration maps are not supported for non-Phase1 Pixel geometries !";
+        std::string phase = (GainCalibMap_.size() < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
+        TCanvas canvas("Canv", "Canv", 1200, 1000);
+        canvas.cd();
+        TLatex t2;
+        t2.SetTextAlign(21);
+        t2.SetTextSize(0.1);
+        t2.SetTextAngle(45);
+        t2.SetTextColor(kRed);
+        t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+        return false;
+      }
 
       // hardcoded phase-I
       std::array<double, 2> minima = {{999., 999.}};

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -359,6 +359,13 @@ namespace gainCalibHelper {
       }
 
       TCanvas canvas("Canv", "Canv", isBarrel ? 1400 : 1800, 1200);
+      if(detids.size() > SiPixelPI::phase1size){
+	SiPixelPI::displayNotSupported(canvas, detids.size());
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+	return false;
+      }
+
       canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -786,15 +786,8 @@ namespace gainCalibHelper {
       gainCalibPI::fillThePerModuleMap(payload, GainCalibMap_, myType);
       if (GainCalibMap_.size() != SiPixelPI::phase1size) {
         edm::LogError(label_) << "SiPixelGainCalibration maps are not supported for non-Phase1 Pixel geometries !";
-        std::string phase = (GainCalibMap_.size() < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
         TCanvas canvas("Canv", "Canv", 1200, 1000);
-        canvas.cd();
-        TLatex t2;
-        t2.SetTextAlign(21);
-        t2.SetTextSize(0.1);
-        t2.SetTextAngle(45);
-        t2.SetTextColor(kRed);
-        t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+        SiPixelPI::displayNotSupported(canvas, GainCalibMap_.size());
         std::string fileName(this->m_imageFileName);
         canvas.SaveAs(fileName.c_str());
         return false;
@@ -916,15 +909,8 @@ namespace gainCalibHelper {
       gainCalibPI::fillThePerModuleMap(payload, GainCalibMap_, myType);
       if (GainCalibMap_.size() != SiPixelPI::phase1size) {
         edm::LogError(label_) << "SiPixelGainCalibration maps are not supported for non-Phase1 Pixel geometries !";
-        std::string phase = (GainCalibMap_.size() < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
         TCanvas canvas("Canv", "Canv", 1200, 1000);
-        canvas.cd();
-        TLatex t2;
-        t2.SetTextAlign(21);
-        t2.SetTextSize(0.1);
-        t2.SetTextAngle(45);
-        t2.SetTextColor(kRed);
-        t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+        SiPixelPI::displayNotSupported(canvas, GainCalibMap_.size());
         std::string fileName(this->m_imageFileName);
         canvas.SaveAs(fileName.c_str());
         return false;

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -338,7 +338,12 @@ namespace gainCalibHelper {
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
       auto ip = paramValues.find("SetLog");
       if (ip != paramValues.end()) {
-        setLog = boost::lexical_cast<bool>(ip->second);
+        auto answer = boost::lexical_cast<std::string>(ip->second);
+        if (!SiPixelPI::checkAnswerOK(answer, setLog)) {
+          throw cms::Exception(label_)
+              << "\nERROR: " << answer
+              << " is not a valid setting for this parameter, please use True,False,1,0,Yes,No \n\n";
+        }
       }
 
       std::shared_ptr<PayloadType> payload = this->fetchPayload(std::get<1>(iov));

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -51,6 +51,10 @@ namespace gainCalibHelper {
       }
 
       for (const auto& d : detids) {
+        // skip the special case used to signal there are no attached dets
+        if (d == 0xFFFFFFFF)
+          continue;
+
         auto range = payload->getRange(d);
         int numberOfRowsToAverageOver = payload->getNumberOfRowsToAverageOver();
         int ncols = payload->getNCols(d);

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -4,6 +4,9 @@
 #include <vector>
 #include <numeric>
 #include <string>
+#include <boost/tokenizer.hpp>
+#include <boost/range/adaptor/indexed.hpp>
+
 #include "TGraph.h"
 #include "TH1.h"
 #include "TH2.h"
@@ -14,8 +17,10 @@
 #include "TPaveText.h"
 #include "TStyle.h"
 #include "TCanvas.h"
+
 #include "CondCore/CondDB/interface/Time.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
@@ -186,7 +191,7 @@ namespace SiPixelPI {
 
     // Draw Lines around modules
     if (lay > 0) {
-      std::vector<std::vector<int> > nladder = {{10, 16, 22}, {6, 14, 22, 32}};
+      std::vector<std::vector<int>> nladder = {{10, 16, 22}, {6, 14, 22, 32}};
       int nlad = nladder[phase][lay - 1];
       for (int xsign = -1; xsign <= 1; xsign += 2)
         for (int ysign = -1; ysign <= 1; ysign += 2) {
@@ -688,10 +693,10 @@ namespace SiPixelPI {
 
   // overloaded method: mask entire module
   /*--------------------------------------------------------------------*/
-  std::vector<std::pair<int, int> > maskedBarrelRocsToBins(int layer, int ladder, int module)
+  std::vector<std::pair<int, int>> maskedBarrelRocsToBins(int layer, int ladder, int module)
   /*--------------------------------------------------------------------*/
   {
-    std::vector<std::pair<int, int> > rocsToMask;
+    std::vector<std::pair<int, int>> rocsToMask;
 
     int nlad_list[4] = {6, 14, 22, 32};
     int nlad = nlad_list[layer - 1];
@@ -718,11 +723,11 @@ namespace SiPixelPI {
 
   // overloaded method: mask single ROCs
   /*--------------------------------------------------------------------*/
-  std::vector<std::tuple<int, int, int> > maskedBarrelRocsToBins(
+  std::vector<std::tuple<int, int, int>> maskedBarrelRocsToBins(
       int layer, int ladder, int module, std::bitset<16> bad_rocs, bool isFlipped)
   /*--------------------------------------------------------------------*/
   {
-    std::vector<std::tuple<int, int, int> > rocsToMask;
+    std::vector<std::tuple<int, int, int>> rocsToMask;
 
     int nlad_list[4] = {6, 14, 22, 32};
     int nlad = nlad_list[layer - 1];
@@ -794,10 +799,10 @@ namespace SiPixelPI {
 
   // overloaded method: mask entire module
   /*--------------------------------------------------------------------*/
-  std::vector<std::pair<int, int> > maskedForwardRocsToBins(int ring, int blade, int panel, int disk)
+  std::vector<std::pair<int, int>> maskedForwardRocsToBins(int ring, int blade, int panel, int disk)
   /*--------------------------------------------------------------------*/
   {
-    std::vector<std::pair<int, int> > rocsToMask;
+    std::vector<std::pair<int, int>> rocsToMask;
 
     //int nblade_list[2] = {11, 17};
     int nybins_list[2] = {92, 140};
@@ -828,11 +833,11 @@ namespace SiPixelPI {
 
   // overloaded method: mask single ROCs
   /*--------------------------------------------------------------------*/
-  std::vector<std::tuple<int, int, int> > maskedForwardRocsToBins(
+  std::vector<std::tuple<int, int, int>> maskedForwardRocsToBins(
       int ring, int blade, int panel, int disk, std::bitset<16> bad_rocs, bool isFlipped)
   /*--------------------------------------------------------------------*/
   {
-    std::vector<std::tuple<int, int, int> > rocsToMask;
+    std::vector<std::tuple<int, int, int>> rocsToMask;
 
     //int nblade_list[2] = {11, 17};
     int nybins_list[2] = {92, 140};
@@ -906,5 +911,67 @@ namespace SiPixelPI {
     return rocsToMask;
   }
 
+  using indexedCorners = std::map<unsigned int, std::pair<std::vector<float>, std::vector<float>>>;
+
+  /*--------------------------------------------------------------------*/
+  const indexedCorners retrieveCorners(const std::vector<edm::FileInPath>& cornerFiles, const unsigned int reads)
+  /*--------------------------------------------------------------------*/
+  {
+    indexedCorners theOutMap;
+
+    for (const auto& file : cornerFiles) {
+      auto cornerFileName = file.fullPath();
+      std::ifstream cornerFile(cornerFileName.c_str());
+      if (!cornerFile.good()) {
+        throw cms::Exception("FileError") << "Problem opening corner file: " << cornerFileName;
+      }
+      std::string line;
+      while (std::getline(cornerFile, line)) {
+        if (!line.empty()) {
+          std::istringstream iss(line);
+          unsigned int id;
+          std::string name;
+          std::vector<std::string> corners(reads, "");
+          std::vector<float> xP, yP;
+
+          iss >> id >> name;
+          for (unsigned int i = 0; i < reads; ++i) {
+            iss >> corners.at(i);
+          }
+
+          COUT << id << " : ";
+          for (unsigned int i = 0; i < reads; i++) {
+            // remove the leading and trailing " signs in the corners list
+            (corners[i]).erase(std::remove(corners[i].begin(), corners[i].end(), '"'), corners[i].end());
+            COUT << corners.at(i) << " ";
+            typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+            boost::char_separator<char> sep{","};
+            tokenizer tok{corners.at(i), sep};
+            for (const auto& t : tok | boost::adaptors::indexed(0)) {
+              if (t.index() == 0) {
+                xP.push_back(atof((t.value()).c_str()));
+              } else if (t.index() == 1) {
+                yP.push_back(atof((t.value()).c_str()));
+              } else {
+		edm::LogError("LogicError") << "There should not be any token with index " << t.index() << std::endl;
+              }
+            }
+          }
+          COUT << std::endl;
+
+          xP.push_back(xP.front());
+          yP.push_back(yP.front());
+
+          for (unsigned int i = 0; i < xP.size(); i++) {
+            COUT << "x[" << i << "]=" << xP[i] << " y[" << i << "]" << yP[i] << std::endl;
+          }
+
+          theOutMap[id] = std::make_pair(xP, yP);
+
+        }  // if line is empty
+      }    // loop on lines
+    }      // loop on files
+    return theOutMap;
+  }
 };  // namespace SiPixelPI
 #endif

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -953,7 +953,7 @@ namespace SiPixelPI {
               } else if (t.index() == 1) {
                 yP.push_back(atof((t.value()).c_str()));
               } else {
-		edm::LogError("LogicError") << "There should not be any token with index " << t.index() << std::endl;
+                edm::LogError("LogicError") << "There should not be any token with index " << t.index() << std::endl;
               }
             }
           }

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -974,5 +974,33 @@ namespace SiPixelPI {
     }      // loop on files
     return theOutMap;
   }
+
+  /*--------------------------------------------------------------------*/
+  void displayNotSupported(TCanvas& canv, const unsigned int size)
+  /*--------------------------------------------------------------------*/
+  {
+    std::string phase = (size < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
+    canv.cd();
+    TLatex t2;
+    t2.SetTextAlign(21);
+    t2.SetTextSize(0.1);
+    t2.SetTextAngle(45);
+    t2.SetTextColor(kRed);
+    t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+  }
+
+  /*--------------------------------------------------------------------*/
+  template <typename T>
+  std::pair<T, T> findMinMaxInMap(const std::map<unsigned int, T>& theMap)
+  /*--------------------------------------------------------------------*/
+  {
+    using pairtype = std::pair<unsigned int, T>;
+    auto max = *std::max_element(
+        theMap.begin(), theMap.end(), [](const pairtype& p1, const pairtype& p2) { return p1.second < p2.second; });
+    auto min = *std::min_element(
+        theMap.begin(), theMap.end(), [](const pairtype& p1, const pairtype& p2) { return p1.second < p2.second; });
+    return std::make_pair(min.second, max.second);
+  }
+
 };  // namespace SiPixelPI
 #endif

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -1002,5 +1002,17 @@ namespace SiPixelPI {
     return std::make_pair(min.second, max.second);
   }
 
+  /*--------------------------------------------------------------------*/
+  bool checkAnswerOK(std::string& answer, bool& result)
+  /*--------------------------------------------------------------------*/
+  {
+    std::transform(answer.begin(), answer.end(), answer.begin(), [](unsigned char x) { return ::tolower(x); });
+
+    bool answer_valid = (answer == "y") || (answer == "n") || (answer == "yes") || (answer == "no") ||
+                        (answer == "true") || (answer == "false") || (answer == "1") || (answer == "0");
+
+    result = answer_valid && (answer[0] == 'y' || answer[0] == 't' || answer[0] == '1');
+    return answer_valid;
+  }
 };  // namespace SiPixelPI
 #endif

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -38,6 +38,7 @@ namespace SiPixelPI {
 
   // size of the phase-0 pixel detID list
   static const unsigned int phase0size = 1440;
+  static const unsigned int phase1size = 1856;
 
   //============================================================================
   std::pair<unsigned int, unsigned int> unpack(cond::Time_t since) {

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/Common"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
   <use name="boost_python"/>
 </library>
 
@@ -11,6 +12,7 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/Common"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
   <use name="boost_python"/>
 </library>
 
@@ -19,6 +21,7 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/Common"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
   <use name="boost_python"/>
 </library>
 
@@ -27,14 +30,16 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/Common"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
   <use name="boost_python"/>
 </library>
 
 <library file="SiPixelTemplateDBObject_PayloadInspector.cc" name="SiPixelTemplateDBObject_PayloadInspector">
-  <use   name="CondCore/Utilities"/>
-  <use   name="CondCore/CondDB"/>
-  <use   name="CondFormats/Common"/>
-  <use   name="CondFormats/SiPixelTransient"/>
-  <use   name="CalibTracker/StandaloneTrackerTopology"/>
-  <use   name="boost_python"/>
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/Common"/>
+  <use name="CondFormats/SiPixelTransient"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
+  <use name="boost_python"/>
 </library>

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -29,3 +29,12 @@
   <use name="CalibTracker/StandaloneTrackerTopology"/>
   <use name="boost_python"/>
 </library>
+
+<library file="SiPixelTemplateDBObject_PayloadInspector.cc" name="SiPixelTemplateDBObject_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="CondFormats/SiPixelTransient"/>
+  <use   name="CalibTracker/StandaloneTrackerTopology"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
@@ -16,6 +16,20 @@ namespace {
       gainCalibHelper::SiPixelGainCalibrationValues<gainCalibHelper::gainCalibPI::t_pedestal,
                                                     SiPixelGainCalibrationForHLT>;
 
+  using SiPixelGainCalibrationForHLTGainsValuesBarrel = gainCalibHelper::
+      SiPixelGainCalibrationValuesPerRegion<true, gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
+  using SiPixelGainCalibrationForHLTGainsValuesEndcap = gainCalibHelper::
+      SiPixelGainCalibrationValuesPerRegion<false, gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibrationForHLTPedestalsValuesBarrel =
+      gainCalibHelper::SiPixelGainCalibrationValuesPerRegion<true,
+                                                             gainCalibHelper::gainCalibPI::t_pedestal,
+                                                             SiPixelGainCalibrationForHLT>;
+  using SiPixelGainCalibrationForHLTPedestalsValuesEndcap =
+      gainCalibHelper::SiPixelGainCalibrationValuesPerRegion<false,
+                                                             gainCalibHelper::gainCalibPI::t_pedestal,
+                                                             SiPixelGainCalibrationForHLT>;
+
   using SiPixelGainCalibrationForHLTCorrelations =
       gainCalibHelper::SiPixelGainCalibrationCorrelations<SiPixelGainCalibrationForHLT>;
 
@@ -71,6 +85,10 @@ namespace {
 PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationForHLT) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTGainsValues);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTPedestalsValues);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTGainsValuesBarrel);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTGainsValuesEndcap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTPedestalsValuesBarrel);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTPedestalsValuesEndcap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTCorrelations);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTGainsByPart);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTPedestalsByPart);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
@@ -54,6 +54,54 @@ namespace {
       gainCalibHelper::SiPixelGainCalibrationValueComparisonTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
                                                                     SiPixelGainCalibrationForHLT>;
 
+  using SiPixelGainCalibForHLTGainComparisonBarrelSingleTag =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       1,
+                                                                       SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibForHLTPedestalComparisonBarrelSingleTag =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                       1,
+                                                                       SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibForHLTGainComparisonBarrelTwoTags =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       2,
+                                                                       SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibForHLTPedestalComparisonBarrelTwoTags =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                       2,
+                                                                       SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibForHLTGainComparisonEndcapSingleTag =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       1,
+                                                                       SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibForHLTPedestalComparisonEndcapSingleTag =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                       1,
+                                                                       SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibForHLTGainComparisonEndcapTwoTags =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       2,
+                                                                       SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibForHLTPedestalComparisonEndcapTwoTags =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                       2,
+                                                                       SiPixelGainCalibrationForHLT>;
+
   using SiPixelGainCalibForHLTGainsBPIXMap =
       gainCalibHelper::SiPixelGainCalibrationBPIXMap<gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
   using SiPixelGainCalibForHLTPedestalsBPIXMap =
@@ -92,6 +140,14 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationForHLT) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTCorrelations);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTGainsByPart);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationForHLTPedestalsByPart);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTGainComparisonBarrelSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTGainComparisonBarrelTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTPedestalComparisonBarrelSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTPedestalComparisonBarrelTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTGainComparisonEndcapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTGainComparisonEndcapTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTPedestalComparisonEndcapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTPedestalComparisonEndcapTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTGainComparisonSingleTag)
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTPedestalComparisonSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTGainComparisonTwoTags);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -55,6 +55,54 @@ namespace {
       gainCalibHelper::SiPixelGainCalibrationValueComparisonTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
                                                                     SiPixelGainCalibrationOffline>;
 
+  using SiPixelGainCalibOfflineGainComparisonBarrelSingleTag =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       1,
+                                                                       SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibOfflinePedestalComparisonBarrelSingleTag =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                       1,
+                                                                       SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibOfflineGainComparisonBarrelTwoTags =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       2,
+                                                                       SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibOfflinePedestalComparisonBarrelTwoTags =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                       2,
+                                                                       SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibOfflineGainComparisonEndcapSingleTag =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       1,
+                                                                       SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibOfflinePedestalComparisonEndcapSingleTag =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                       1,
+                                                                       SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibOfflineGainComparisonEndcapTwoTags =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       2,
+                                                                       SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibOfflinePedestalComparisonEndcapTwoTags =
+      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                       2,
+                                                                       SiPixelGainCalibrationOffline>;
+
   using SiPixelGainCalibOfflineGainsBPIXMap =
       gainCalibHelper::SiPixelGainCalibrationBPIXMap<gainCalibHelper::gainCalibPI::t_gain,
                                                      SiPixelGainCalibrationOffline>;
@@ -95,6 +143,19 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationOffline) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineCorrelations);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineGainsByPart);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflinePedestalsByPart);
+
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonBarrelSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonBarrelTwoTags);
+
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonBarrelSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonBarrelTwoTags);
+
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonEndcapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonEndcapTwoTags);
+
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonEndcapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonEndcapTwoTags);
+
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonSingleTag)
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonTwoTags);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -17,6 +17,20 @@ namespace {
       gainCalibHelper::SiPixelGainCalibrationValues<gainCalibHelper::gainCalibPI::t_pedestal,
                                                     SiPixelGainCalibrationOffline>;
 
+  using SiPixelGainCalibrationOfflineGainsValuesBarrel = gainCalibHelper::
+      SiPixelGainCalibrationValuesPerRegion<true, gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
+  using SiPixelGainCalibrationOfflineGainsValuesEndcap = gainCalibHelper::
+      SiPixelGainCalibrationValuesPerRegion<false, gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibrationOfflinePedestalsValuesBarrel =
+      gainCalibHelper::SiPixelGainCalibrationValuesPerRegion<true,
+                                                             gainCalibHelper::gainCalibPI::t_pedestal,
+                                                             SiPixelGainCalibrationOffline>;
+  using SiPixelGainCalibrationOfflinePedestalsValuesEndcap =
+      gainCalibHelper::SiPixelGainCalibrationValuesPerRegion<false,
+                                                             gainCalibHelper::gainCalibPI::t_pedestal,
+                                                             SiPixelGainCalibrationOffline>;
+
   using SiPixelGainCalibrationOfflineCorrelations =
       gainCalibHelper::SiPixelGainCalibrationCorrelations<SiPixelGainCalibrationOffline>;
 
@@ -74,6 +88,10 @@ namespace {
 PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationOffline) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineGainsValues);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflinePedestalsValues);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineGainsValuesBarrel);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineGainsValuesEndcap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflinePedestalsValuesBarrel);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflinePedestalsValuesEndcap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineCorrelations);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineGainsByPart);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflinePedestalsByPart);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -7,7 +7,6 @@
 */
 
 #include "CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h"
-//#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h"
 
 namespace {
 
@@ -143,19 +142,14 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationOffline) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineCorrelations);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflineGainsByPart);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibrationOfflinePedestalsByPart);
-
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonBarrelSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonBarrelTwoTags);
-
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonBarrelSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonBarrelTwoTags);
-
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonEndcapSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonEndcapTwoTags);
-
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonEndcapSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonEndcapTwoTags);
-
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonSingleTag)
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalComparisonSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainComparisonTwoTags);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -153,6 +153,13 @@ namespace {
       auto extrema = SiPixelPI::findMinMaxInMap(LAMap_);
 
       TCanvas canvas("Canv", "Canv", isBarrel ? 1400 : 1800, 1200);
+      if(LAMap_.size() > SiPixelPI::phase1size){
+	SiPixelPI::displayNotSupported(canvas, LAMap_.size());
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+	return false;
+      }
+
       canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 
@@ -374,6 +381,12 @@ namespace {
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
 
       TCanvas canvas("Comparison", "Comparison", 1600, 800);
+      if(f_LAMap_.size() > SiPixelPI::phase1size || l_LAMap_.size() > SiPixelPI::phase1size){
+	SiPixelPI::displayNotSupported(canvas, std::max(f_LAMap_.size(),l_LAMap_.size()));
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+	return false;
+      }
 
       std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> FirstLA_spectraByRegion;
       std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> LastLA_spectraByRegion;

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -153,11 +153,11 @@ namespace {
       auto extrema = SiPixelPI::findMinMaxInMap(LAMap_);
 
       TCanvas canvas("Canv", "Canv", isBarrel ? 1400 : 1800, 1200);
-      if(LAMap_.size() > SiPixelPI::phase1size){
-	SiPixelPI::displayNotSupported(canvas, LAMap_.size());
+      if (LAMap_.size() > SiPixelPI::phase1size) {
+        SiPixelPI::displayNotSupported(canvas, LAMap_.size());
         std::string fileName(this->m_imageFileName);
         canvas.SaveAs(fileName.c_str());
-	return false;
+        return false;
       }
 
       canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
@@ -381,11 +381,11 @@ namespace {
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
 
       TCanvas canvas("Comparison", "Comparison", 1600, 800);
-      if(f_LAMap_.size() > SiPixelPI::phase1size || l_LAMap_.size() > SiPixelPI::phase1size){
-	SiPixelPI::displayNotSupported(canvas, std::max(f_LAMap_.size(),l_LAMap_.size()));
+      if (f_LAMap_.size() > SiPixelPI::phase1size || l_LAMap_.size() > SiPixelPI::phase1size) {
+        SiPixelPI::displayNotSupported(canvas, std::max(f_LAMap_.size(), l_LAMap_.size()));
         std::string fileName(this->m_imageFileName);
         canvas.SaveAs(fileName.c_str());
-	return false;
+        return false;
       }
 
       std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> FirstLA_spectraByRegion;

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -162,7 +162,7 @@ namespace {
       TrackerTopology tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
-      auto myPlots = PixelRegions::PixelRegionContainers(&tTopo, true);
+      auto myPlots = PixelRegions::PixelRegionContainers(&tTopo, (LAMap_.size() == SiPixelPI::phase1size));
       myPlots.bookAll("SiPixel LA",
                       "SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T]",
                       "#modules",
@@ -176,13 +176,11 @@ namespace {
         myPlots.fill(element.first, element.second);
       }
 
-      //h1->SetStats(true);
-
       myPlots.beautify();
       myPlots.draw(canvas, isBarrel);
 
-      TLegend legend = TLegend(0.30, 0.88, 0.85, 0.90);
-      legend.SetHeader(("Payload hash: #bf{" + (std::get<1>(iov)) + "}").c_str(),
+      TLegend legend = TLegend(0.40, 0.88, 0.93, 0.90);
+      legend.SetHeader(("Hash: #bf{" + (std::get<1>(iov)) + "}").c_str(),
                        "C");  // option "C" allows to center the header
       //legend.AddEntry(h1.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
       legend.SetTextSize(0.025);
@@ -191,28 +189,26 @@ namespace {
       unsigned int maxPads = isBarrel ? 4 : 12;
       for (unsigned int c = 1; c <= maxPads; c++) {
         canvas.cd(c);
-        SiPixelPI::adjustCanvasMargins(canvas.cd(c), 0.07, 0.11, 0.12, 0.03);
+        SiPixelPI::adjustCanvasMargins(canvas.cd(c), 0.07, 0.12, 0.12, 0.05);
         legend.Draw("same");
+        canvas.cd(c)->Update();
       }
 
-      /*
-      TPaveStats *st = (TPaveStats *)h1->FindObject("stats");
-      st->SetTextSize(0.03);
-      SiPixelPI::adjustStats(st, 0.15, 0.83, 0.39, 0.93);
-      */
-
-      /*
-      canvas.cd(1);
+      myPlots.stats();
 
       auto ltx = TLatex();
       ltx.SetTextFont(62);
-      //ltx.SetTextColor(kBlue);
       ltx.SetTextSize(0.05);
       ltx.SetTextAlign(11);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-                       1 - gPad->GetTopMargin() + 0.01,
-                       ("SiPixel Lorentz Angle IOV:" + std::to_string(std::get<0>(iov))).c_str());
-      */
+
+      for (unsigned int c = 1; c <= maxPads; c++) {
+        auto index = isBarrel ? c - 1 : c + 3;
+
+        canvas.cd(c);
+        ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                         1 - gPad->GetTopMargin() + 0.01,
+                         (PixelRegions::IDlabels.at(index) + ", IOV:" + std::to_string(std::get<0>(iov))).c_str());
+      }
 
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -239,7 +239,7 @@ namespace {
   public:
     SiPixelLorentzAngleValuesComparisonPerRegion()
         : cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::MULTI_IOV, ntags>(
-              "SiPixelLorentzAngle Values Comparisons per region") {}
+              Form("SiPixelLorentzAngle Values Comparisons per region %i tags(s)", ntags)) {}
 
     bool fill() override {
       gStyle->SetOptStat("emr");
@@ -388,9 +388,9 @@ namespace {
       std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
-      //#ifdef MMDEBUG
+#ifdef MMDEBUG
       canvas.SaveAs("DEBUG.root");
-      //#endif
+#endif
 
       return true;
     }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -37,16 +37,16 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiPixelLorentzAngleValue : public cond::payloadInspector::Histogram1D<SiPixelLorentzAngle> {
+  class SiPixelLorentzAngleValue
+      : public cond::payloadInspector::Histogram1D<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelLorentzAngleValue()
-        : cond::payloadInspector::Histogram1D<SiPixelLorentzAngle>(
-              "SiPixel LorentzAngle values", "SiPixel LorentzAngle values", 100, 0.0, 0.1) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixel LorentzAngle values", "SiPixel LorentzAngle values", 100, 0.0, 0.1) {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
-      for (auto const &iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const &iov : tag.iovs) {
         std::shared_ptr<SiPixelLorentzAngle> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();
@@ -63,16 +63,18 @@ namespace {
   /************************************************
     1d histogram of SiPixelLorentzAngle of 1 IOV 
   *************************************************/
-  class SiPixelLorentzAngleValues : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
+  class SiPixelLorentzAngleValues
+      : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
   public:
-    SiPixelLorentzAngleValues() : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Values") {
-      setSingleIov(true);
-    }
+    SiPixelLorentzAngleValues()
+        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelLorentzAngle Values") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
+    bool fill() override {
       gStyle->SetOptStat("emr");
 
-      auto iov = iovs.front();
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiPixelLorentzAngle> payload = fetchPayload(std::get<1>(iov));
       std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();
       auto extrema = SiPixelPI::findMinMaxInMap(LAMap_);
@@ -137,17 +139,18 @@ namespace {
     1d histogram of SiPixelLorentzAngle of 1 IOV per region
   *************************************************/
   template <bool isBarrel>
-  class SiPixelLorentzAngleValuesPerRegion : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
+  class SiPixelLorentzAngleValuesPerRegion
+      : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelLorentzAngleValuesPerRegion()
-        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Values per region") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelLorentzAngle Values per region") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
+    bool fill() override {
       gStyle->SetOptStat("emr");
 
-      auto iov = iovs.front();
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiPixelLorentzAngle> payload = fetchPayload(std::get<1>(iov));
       std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();
       auto extrema = SiPixelPI::findMinMaxInMap(LAMap_);
@@ -576,17 +579,18 @@ namespace {
    occupancy style map BPix
   *************************************************/
 
-  class SiPixelBPixLorentzAngleMap : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
+  class SiPixelBPixLorentzAngleMap
+      : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelBPixLorentzAngleMap()
-        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Barrel Pixel Map"),
+        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelLorentzAngle Barrel Pixel Map"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiPixelLorentzAngle> payload = fetchPayload(std::get<1>(iov));
 
       static const int n_layers = 4;
@@ -698,17 +702,18 @@ namespace {
    occupancy style map FPix
   *************************************************/
 
-  class SiPixelFPixLorentzAngleMap : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
+  class SiPixelFPixLorentzAngleMap
+      : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelFPixLorentzAngleMap()
-        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Forward Pixel Map"),
+        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelLorentzAngle Forward Pixel Map"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiPixelLorentzAngle> payload = fetchPayload(std::get<1>(iov));
 
       static const int n_rings = 2;

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -13,6 +13,7 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 #include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+#include "CondCore/SiPixelPlugins/interface/PixelRegionContainers.h"
 
 #include <memory>
 #include <sstream>

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -42,16 +42,16 @@ namespace {
     test class
   *************************************************/
 
-  class SiPixelQualityTest : public cond::payloadInspector::Histogram1D<SiPixelQuality> {
+  class SiPixelQualityTest
+      : public cond::payloadInspector::Histogram1D<SiPixelQuality, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelQualityTest()
-        : cond::payloadInspector::Histogram1D<SiPixelQuality>(
-              "SiPixelQuality test", "SiPixelQuality test", 10, 0.0, 10.0) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiPixelQuality, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelQuality test", "SiPixelQuality test", 10, 0.0, 10.0) {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiPixelQuality> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           fillWithValue(1.);
@@ -76,16 +76,16 @@ namespace {
     summary class
   *************************************************/
 
-  class SiPixelQualityBadRocsSummary : public cond::payloadInspector::PlotImage<SiPixelQuality> {
+  class SiPixelQualityBadRocsSummary
+      : public cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::MULTI_IOV, 1> {
   public:
-    SiPixelQualityBadRocsSummary() : cond::payloadInspector::PlotImage<SiPixelQuality>("SiPixel Quality Summary") {
-      setSingleIov(false);
-    }
+    SiPixelQualityBadRocsSummary()
+        : cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::MULTI_IOV, 1>(
+              "SiPixel Quality Summary") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
-
-      for (const auto& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (const auto& iov : tag.iovs) {
         std::shared_ptr<SiPixelQuality> payload = fetchPayload(std::get<1>(iov));
         auto unpacked = SiPixelPI::unpack(std::get<0>(iov));
 
@@ -145,17 +145,18 @@ namespace {
    occupancy style map BPix
   *************************************************/
 
-  class SiPixelBPixQualityMap : public cond::payloadInspector::PlotImage<SiPixelQuality> {
+  class SiPixelBPixQualityMap
+      : public cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelBPixQualityMap()
-        : cond::payloadInspector::PlotImage<SiPixelQuality>("SiPixelQuality Barrel Pixel Map"),
+        : cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelQuality Barrel Pixel Map"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiPixelQuality> payload = fetchPayload(std::get<1>(iov));
 
       static const int n_layers = 4;
@@ -259,17 +260,18 @@ namespace {
    occupancy style map FPix
   *************************************************/
 
-  class SiPixelFPixQualityMap : public cond::payloadInspector::PlotImage<SiPixelQuality> {
+  class SiPixelFPixQualityMap
+      : public cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelFPixQualityMap()
-        : cond::payloadInspector::PlotImage<SiPixelQuality>("SiPixelQuality Forward Pixel Map"),
+        : cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelQuality Forward Pixel Map"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiPixelQuality> payload = fetchPayload(std::get<1>(iov));
 
       static const int n_rings = 2;

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -1,5 +1,5 @@
 /*!
-  \file SiPixelQulity_PayloadInspector
+  \file SiPixelQuality_PayloadInspector
   \Payload Inspector Plugin for SiPixelQuality
   \author M. Musich
   \version $Revision: 1.0 $

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -188,15 +188,8 @@ namespace {
         if (templMap.size() != SiPixelPI::phase1size) {
           edm::LogError("SiPixelTemplateDBObject_PayloadInspector")
               << "SiPixelTempateLA maps are not supported for non-Phase1 Pixel geometries !";
-          std::string phase = (templMap.size() < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
           TCanvas canvas("Canv", "Canv", 1200, 1000);
-          canvas.cd();
-          TLatex t2;
-          t2.SetTextAlign(21);
-          t2.SetTextSize(0.1);
-          t2.SetTextAngle(45);
-          t2.SetTextColor(kRed);
-          t2.DrawLatexNDC(0.6, 0.50, Form("%s NOT SUPPORTED!", phase.c_str()));
+          SiPixelPI::displayNotSupported(canvas, templMap.size());
           std::string fileName(m_imageFileName);
           canvas.SaveAs(fileName.c_str());
           return false;
@@ -270,15 +263,8 @@ namespace {
         if (templMap.size() != SiPixelPI::phase1size) {
           edm::LogError("SiPixelTemplateDBObject_PayloadInspector")
               << "SiPixelTempateIDs maps are not supported for non-Phase1 Pixel geometries !";
-          std::string phase = (templMap.size() < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
           TCanvas canvas("Canv", "Canv", 1200, 1000);
-          canvas.cd();
-          TLatex t2;
-          t2.SetTextAlign(21);
-          t2.SetTextSize(0.1);
-          t2.SetTextAngle(45);
-          t2.SetTextColor(kRed);
-          t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+          SiPixelPI::displayNotSupported(canvas, templMap.size());
           std::string fileName(m_imageFileName);
           canvas.SaveAs(fileName.c_str());
           return false;

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -43,6 +43,7 @@
 #include "TLatex.h"
 #include "TPave.h"
 #include "TPaveStats.h"
+#include "TGaxis.h"
 
 namespace {
 
@@ -136,7 +137,9 @@ namespace {
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      //gStyle->SetPalette(kRainBow);
+      gStyle->SetPalette(kBlackBody);
+      TGaxis::SetMaxDigits(2);
+
       auto iov = iovs.front();
 
       std::vector<SiPixelTemplateStore> thePixelTemp_;
@@ -174,10 +177,10 @@ namespace {
         Phase1PixelMaps theMaps("COLZ L");
 
         if (myType == t_barrel) {
-          theMaps.bookBarrelHistograms("templateLABarrel");
+          theMaps.bookBarrelHistograms("templateLABarrel", "#muH");
           theMaps.bookBarrelBins("templateLABarrel");
         } else if (myType == t_forward) {
-          theMaps.bookForwardHistograms("templateLAForward");
+          theMaps.bookForwardHistograms("templateLAForward", "#muH");
           theMaps.bookForwardBins("templateLAForward");
         }
 
@@ -217,7 +220,7 @@ namespace {
 
         theMaps.beautifyAllHistograms();
 
-        TCanvas canvas("Canv", "Canv", (myType == t_barrel) ? 1200 : 1500, 1000);
+        TCanvas canvas("Canv", "Canv", (myType == t_barrel) ? 1200 : 1600, 1000);
         if (myType == t_barrel) {
           theMaps.DrawBarrelMaps("templateLABarrel", canvas);
         } else if (myType == t_forward) {
@@ -254,11 +257,11 @@ namespace {
         // Book the TH2Poly
         Phase1PixelMaps theMaps("text");
         if (myType == t_barrel) {
-          theMaps.bookBarrelHistograms("templateIDsBarrel");
+          theMaps.bookBarrelHistograms("templateIDsBarrel", "IDs");
           // book the barrel bins of the TH2Poly
           theMaps.bookBarrelBins("templateIDsBarrel");
         } else if (myType == t_forward) {
-          theMaps.bookForwardHistograms("templateIDsForward");
+          theMaps.bookForwardHistograms("templateIDsForward", "IDs");
           // book the forward bins of the TH2Poly
           theMaps.bookForwardBins("templateIDsForward");
         }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -1,0 +1,88 @@
+/*!
+  \file SiPixelTemplateDBObject_PayloadInspector
+  \Payload Inspector Plugin for SiPixelTemplateDBObject
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2020/04/16 18:00:00 $
+*/
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h"
+#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+
+// include ROOT
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TGraph.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+
+namespace {
+
+  /************************************************
+    test class
+  *************************************************/
+
+  class SiPixelTemplateDBObjectTest : public cond::payloadInspector::Histogram1D<SiPixelTemplateDBObject> {
+  public:
+    SiPixelTemplateDBObjectTest()
+        : cond::payloadInspector::Histogram1D<SiPixelTemplateDBObject>(
+              "SiPixelTemplateDBObject test", "SiPixelTemplateDBObject test", 10, 0.0, 100.) {
+      Base::setSingleIov(true);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+      for (auto const& iov : iovs) {
+        std::vector<SiPixelTemplateStore> thePixelTemp_;
+
+        std::shared_ptr<SiPixelTemplateDBObject> payload = Base::fetchPayload(std::get<1>(iov));
+        if (payload.get()) {
+          if (!SiPixelTemplate::pushfile(*payload, thePixelTemp_)) {
+            throw cms::Exception("") << "\nERROR: Templates not filled correctly. Check the sqlite file. Using "
+                                        "SiPixelTemplateDBObject version "
+                                     << payload->version() << "\n\n";
+          }
+
+          SiPixelTemplate templ(thePixelTemp_);
+
+          std::map<unsigned int, short> templMap = payload->getTemplateIDs();
+          for (auto const& entry : templMap) {
+            std::cout << "DetID: " << entry.first << " template ID: " << entry.second << std::endl;
+            templ.interpolate(entry.second, 0.f, 0.f, 1.f, 1.f);
+
+            std::cout << "\t lorywidth  " << templ.lorywidth() << " lorxwidth: " << templ.lorxwidth() << " lorybias "
+                      << templ.lorybias() << " lorxbias: " << templ.lorxbias() << "\n"
+                      << std::endl;
+          }
+
+          fillWithValue(1.);
+
+        }  // payload
+      }    // iovs
+      return true;
+    }  // fill
+  };
+}  // namespace
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(SiPixelTemplateDBObject) { PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateDBObjectTest); }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -61,10 +61,10 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      for (auto const& iov : iovs) {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto iov : tag.iovs) {
         std::vector<SiPixelTemplateStore> thePixelTemp_;
-
         std::shared_ptr<SiPixelTemplateDBObject> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           if (!SiPixelTemplate::pushfile(*payload, thePixelTemp_)) {

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -186,7 +186,7 @@ namespace {
         ltx.SetTextAlign(11);
         ltx.DrawLatexNDC(gPad->GetLeftMargin(),
                          1 - gPad->GetTopMargin() + 0.01,
-                         (tagname + ",IOV:" + std::to_string(std::get<0>(iov))).c_str());
+                         (tagname + ", IOV:" + std::to_string(std::get<0>(iov))).c_str());
 
         std::string fileName(m_imageFileName);
         canvas.SaveAs(fileName.c_str());

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -53,17 +53,16 @@ namespace {
   /************************************************
     test class
   *************************************************/
-  class SiPixelTemplateDBObjectTest : public cond::payloadInspector::Histogram1D<SiPixelTemplateDBObject> {
+  class SiPixelTemplateDBObjectTest
+      : public cond::payloadInspector::Histogram1D<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelTemplateDBObjectTest()
-        : cond::payloadInspector::Histogram1D<SiPixelTemplateDBObject>(
-              "SiPixelTemplateDBObject test", "SiPixelTemplateDBObject test", 10, 0.0, 100.) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelTemplateDBObject test", "SiPixelTemplateDBObject test", 10, 0.0, 100.) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
-      for (auto iov : tag.iovs) {
+      for (auto const& iov : tag.iovs) {
         std::vector<SiPixelTemplateStore> thePixelTemp_;
         std::shared_ptr<SiPixelTemplateDBObject> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
@@ -114,16 +113,17 @@ namespace {
   /************************************************
   // header plotting
   *************************************************/
-  class SiPixelTemplateHeaderTable : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject> {
+  class SiPixelTemplateHeaderTable
+      : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiPixelTemplateHeaderTable()
-        : cond::payloadInspector::PlotImage<SiPixelTemplateDBObject>("SiPixelTemplateDBObject Header summary") {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelTemplateDBObject Header summary") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
-
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      auto tagname = tag.name;
       std::vector<SiPixelTemplateStore> thePixelTemp_;
       std::shared_ptr<SiPixelTemplateDBObject> payload = fetchPayload(std::get<1>(iov));
 
@@ -182,11 +182,11 @@ namespace {
         auto ltx = TLatex();
         ltx.SetTextFont(62);
         ltx.SetTextColor(kBlue);
-        ltx.SetTextSize(0.05);
+        ltx.SetTextSize(0.045);
         ltx.SetTextAlign(11);
         ltx.DrawLatexNDC(gPad->GetLeftMargin(),
                          1 - gPad->GetTopMargin() + 0.01,
-                         ("SiPixelTemplate IOV:" + std::to_string(std::get<0>(iov))).c_str());
+                         (tagname + ",IOV:" + std::to_string(std::get<0>(iov))).c_str());
 
         std::string fileName(m_imageFileName);
         canvas.SaveAs(fileName.c_str());
@@ -204,7 +204,8 @@ namespace {
   // testing TH2Poly classes for plotting
   *************************************************/
   template <MapType myType>
-  class SiPixelTemplateLA : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject> {
+  class SiPixelTemplateLA
+      : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV> {
     struct header_info {
       int ID;             //!< template ID number
       float lorywidth;    //!< estimate of y-lorentz width for optimal resolution
@@ -222,16 +223,15 @@ namespace {
 
   public:
     SiPixelTemplateLA()
-        : cond::payloadInspector::PlotImage<SiPixelTemplateDBObject>("SiPixelTemplate assumed value of uH") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelTemplate assumed value of uH") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
       gStyle->SetPalette(kBlackBody);
       TGaxis::SetMaxDigits(2);
 
-      auto iov = iovs.front();
-
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::vector<SiPixelTemplateStore> thePixelTemp_;
       std::shared_ptr<SiPixelTemplateDBObject> payload = fetchPayload(std::get<1>(iov));
 
@@ -326,15 +326,18 @@ namespace {
   // testing TH2Poly classes for plotting
   *************************************************/
   template <MapType myType>
-  class SiPixelTemplateIDs : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject> {
+  class SiPixelTemplateIDs
+      : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV> {
   public:
-    SiPixelTemplateIDs() : cond::payloadInspector::PlotImage<SiPixelTemplateDBObject>("SiPixelTemplate ID Values") {
-      setSingleIov(true);
-    }
+    SiPixelTemplateIDs()
+        : cond::payloadInspector::PlotImage<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelTemplate ID Values") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
       gStyle->SetPalette(kRainBow);
-      auto iov = iovs.front();
+
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiPixelTemplateDBObject> payload = fetchPayload(std::get<1>(iov));
 
       if (payload.get()) {

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -182,6 +182,23 @@ namespace {
         }
 
         std::map<unsigned int, short> templMap = payload->getTemplateIDs();
+        if (templMap.size() != SiPixelPI::phase1size) {
+          edm::LogError("SiPixelTemplateDBObject_PayloadInspector")
+              << "SiPixelTempateLA maps are not supported for non-Phase1 Pixel geometries !";
+          std::string phase = (templMap.size() < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
+          TCanvas canvas("Canv", "Canv", 1200, 1000);
+          canvas.cd();
+          TLatex t2;
+          t2.SetTextAlign(21);
+          t2.SetTextSize(0.1);
+          t2.SetTextAngle(45);
+          t2.SetTextColor(kRed);
+          t2.DrawLatexNDC(0.6, 0.50, Form("%s NOT SUPPORTED!", phase.c_str()));
+          std::string fileName(m_imageFileName);
+          canvas.SaveAs(fileName.c_str());
+          return false;
+        }
+
         for (auto const& entry : templMap) {
           templ.interpolate(entry.second, 0.f, 0.f, 1.f, 1.f);
 
@@ -197,6 +214,8 @@ namespace {
             theMaps.fillForwardBin("templateLAForward", entry.first, uH);
           }
         }
+
+        theMaps.beautifyAllHistograms();
 
         TCanvas canvas("Canv", "Canv", (myType == t_barrel) ? 1200 : 1500, 1000);
         if (myType == t_barrel) {
@@ -245,6 +264,22 @@ namespace {
         }
 
         std::map<unsigned int, short> templMap = payload->getTemplateIDs();
+        if (templMap.size() != SiPixelPI::phase1size) {
+          edm::LogError("SiPixelTemplateDBObject_PayloadInspector")
+              << "SiPixelTempateIDs maps are not supported for non-Phase1 Pixel geometries !";
+          std::string phase = (templMap.size() < SiPixelPI::phase1size) ? "Phase-0" : "Phase-2";
+          TCanvas canvas("Canv", "Canv", 1200, 1000);
+          canvas.cd();
+          TLatex t2;
+          t2.SetTextAlign(21);
+          t2.SetTextSize(0.1);
+          t2.SetTextAngle(45);
+          t2.SetTextColor(kRed);
+          t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+          std::string fileName(m_imageFileName);
+          canvas.SaveAs(fileName.c_str());
+          return false;
+        }
 
         /*
         std::vector<unsigned int> detids;
@@ -263,6 +298,8 @@ namespace {
             theMaps.fillForwardBin("templateIDsForward", entry.first, entry.second);
           }
         }
+
+        theMaps.beautifyAllHistograms();
 
         TCanvas canvas("Canv", "Canv", (myType == t_barrel) ? 1200 : 1500, 1000);
         if (myType == t_barrel) {

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -12,7 +12,8 @@
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/Time.h"
 #include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h"
+
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 
 // the data format of the condition to be inspected
@@ -23,10 +24,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <memory>
+#include <map>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
 
 // include ROOT
+#include "TH2.h"
+#include "TProfile2D.h"
+#include "TH2Poly.h"
+#include "TGraph.h"
 #include "TH2F.h"
 #include "TLegend.h"
 #include "TCanvas.h"
@@ -51,7 +58,7 @@ namespace {
       Base::setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       for (auto const& iov : iovs) {
         std::vector<SiPixelTemplateStore> thePixelTemp_;
 
@@ -64,6 +71,23 @@ namespace {
           }
 
           SiPixelTemplate templ(thePixelTemp_);
+
+          for (const auto& theTemp : thePixelTemp_) {
+            std::cout << "\n\n"
+                      << "Template ID = " << theTemp.head.ID << ", Template Version " << theTemp.head.templ_version
+                      << ", Bfield = " << theTemp.head.Bfield << ", NTy = " << theTemp.head.NTy
+                      << ", NTyx = " << theTemp.head.NTyx << ", NTxx = " << theTemp.head.NTxx
+                      << ", Dtype = " << theTemp.head.Dtype << ", Bias voltage " << theTemp.head.Vbias
+                      << ", temperature " << theTemp.head.temperature << ", fluence " << theTemp.head.fluence
+                      << ", Q-scaling factor " << theTemp.head.qscale << ", 1/2 multi dcol threshold "
+                      << theTemp.head.s50 << ", 1/2 single dcol threshold " << theTemp.head.ss50 << ", y Lorentz Width "
+                      << theTemp.head.lorywidth << ", y Lorentz Bias " << theTemp.head.lorybias << ", x Lorentz width "
+                      << theTemp.head.lorxwidth << ", x Lorentz Bias " << theTemp.head.lorxbias
+                      << ", Q/Q_avg fractions for Qbin defs " << theTemp.head.fbin[0] << ", " << theTemp.head.fbin[1]
+                      << ", " << theTemp.head.fbin[2] << ", pixel x-size " << theTemp.head.xsize << ", y-size "
+                      << theTemp.head.ysize << ", zsize " << theTemp.head.zsize << "\n"
+                      << std::endl;
+          }
 
           std::map<unsigned int, short> templMap = payload->getTemplateIDs();
           for (auto const& entry : templMap) {
@@ -82,7 +106,181 @@ namespace {
       return true;
     }  // fill
   };
+
+  /************************************************
+  // testing TH2Poly classes for plotting
+  *************************************************/
+  class SiPixelTemplateLA : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject> {
+
+    struct header_info{
+      int ID;                       //!< template ID number
+      float lorywidth;              //!< estimate of y-lorentz width for optimal resolution
+      float lorxwidth;              //!< estimate of x-lorentz width for optimal resolution
+      float lorybias;               //!< estimate of y-lorentz bias
+      float lorxbias;               //!< estimate of x-lorentz bias
+      float Vbias;                  //!< detector bias potential in Volts
+      float temperature;            //!< detector temperature in deg K
+      int   templ_version;          //!< Version number of the template to ensure code compatibility
+      float Bfield;                 //!< Bfield in Tesla
+      float xsize;                  //!< pixel size (for future use in upgraded geometry)
+      float ysize;                  //!< pixel size (for future use in upgraded geometry)
+      float zsize;                  //!< pixel size (for future use in upgraded geometry)
+    };
+
+  public:
+    SiPixelTemplateLA()
+      : cond::payloadInspector::PlotImage<SiPixelTemplateDBObject>("SiPixelTemplate assumed value of uH"){
+      setSingleIov(true);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto iov = iovs.front();
+
+      std::vector<SiPixelTemplateStore> thePixelTemp_;
+      std::shared_ptr<SiPixelTemplateDBObject> payload = fetchPayload(std::get<1>(iov));
+
+      if (payload.get()) {
+	if (!SiPixelTemplate::pushfile(*payload, thePixelTemp_)) {
+	  throw cms::Exception("") << "\nERROR: Templates not filled correctly. Check the sqlite file. Using "
+	    "SiPixelTemplateDBObject version "
+				   << payload->version() << "\n\n";
+	}
+
+	// store the map of ID / interesting quantities
+	SiPixelTemplate templ(thePixelTemp_);
+	std::map<int, header_info> theInfos;
+	for (const auto& theTemp : thePixelTemp_) {
+	  header_info info;
+	  info.ID            = theTemp.head.ID;
+	  info.lorywidth     = theTemp.head.lorywidth;     
+	  info.lorxwidth     = theTemp.head.lorxwidth;     
+	  info.lorybias      = theTemp.head.lorybias;      
+	  info.lorxbias      = theTemp.head.lorxbias;      
+	  info.Vbias         = theTemp.head.Vbias;         
+	  info.temperature   = theTemp.head.temperature;   
+	  info.templ_version = theTemp.head.templ_version; 
+	  info.Bfield        = theTemp.head.Bfield;      
+	  info.xsize         = theTemp.head.xsize;
+	  info.ysize         = theTemp.head.ysize;
+	  info.zsize         = theTemp.head.zsize;
+
+	  theInfos[theTemp.head.ID]=info;
+	}
+
+        // Book the TH2Poly
+	Phase1PixelMaps theMaps("COLZ L");
+        theMaps.bookBarrelHistograms("templateLABarrel");
+	theMaps.bookBarrelBins("templateLABarrel");
+        theMaps.bookForwardHistograms("templateLAForward");
+        theMaps.bookForwardBins("templateLAForward");
+
+        std::map<unsigned int, short> templMap = payload->getTemplateIDs();
+	for (auto const& entry : templMap) {
+
+	  templ.interpolate(entry.second, 0.f, 0.f, 1.f, 1.f);
+	  
+	  //mu_H = lorentz width / sensor thickness / B field
+	  float uH =  templ.lorxwidth() / theInfos[entry.second].zsize / theInfos[entry.second].Bfield;
+	  COUT << "uH: " << uH 
+	       << " lor x width:"  << templ.lorxwidth() 
+	       << " z size: " << theInfos[entry.second].zsize 
+	       << " B-field: " << theInfos[entry.second].Bfield
+	       << std::endl;
+
+	  auto detid = DetId(entry.first);
+          if (detid.subdetId() == PixelSubdetector::PixelBarrel) {
+	    theMaps.fillBarrelBin("templateLABarrel",entry.first,uH);
+	  } else if (detid.subdetId() == PixelSubdetector::PixelEndcap) {
+	    theMaps.fillEndcapBin("templateLAForward",entry.first,uH);
+	  }
+	}
+
+	/*
+	TCanvas canvas("Canv", "Canv", 1200, 1000);
+	std::cout << "draw canvas" << std::endl;
+	theMaps.DrawBarrelMaps("templateLABarrel",canvas);
+	*/	
+	
+	TCanvas canvas("Canv", "Canv", 1500, 1000);
+	std::cout << "draw canvas" << std::endl;
+	theMaps.DrawEndcapMaps("templateLAForward",canvas);
+
+	canvas.cd();
+	std::string fileName(m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+
+      }
+      return true;
+    } // fill
+  };
+
+  /************************************************
+  // testing TH2Poly classes for plotting
+  *************************************************/
+  class SiPixelTemplateIDs : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject> {
+  public:
+    SiPixelTemplateIDs()
+      : cond::payloadInspector::PlotImage<SiPixelTemplateDBObject>("SiPixelTemplate ID Values"){
+      setSingleIov(true);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto iov = iovs.front();
+      std::shared_ptr<SiPixelTemplateDBObject> payload = fetchPayload(std::get<1>(iov));
+
+      if (payload.get()) {
+        // Book the TH2Poly
+	Phase1PixelMaps theMaps("COLZ L");
+        theMaps.bookBarrelHistograms("templateIDsBarrel");
+        theMaps.bookForwardHistograms("templateIDsForward");
+
+        std::map<unsigned int, short> templMap = payload->getTemplateIDs();
+
+	/*
+        std::vector<unsigned int> detids;
+        std::transform(templMap.begin(),
+                       templMap.end(),
+                       std::back_inserter(detids),
+                       [](const std::map<unsigned int, short>::value_type& pair) { return pair.first; });
+	*/
+
+        // book the barrel bins of the TH2Poly
+        theMaps.bookBarrelBins("templateIDsBarrel");
+
+        // book the forward bins of the TH2Poly
+        theMaps.bookForwardBins("templateIDsForward");
+
+        for (auto const& entry : templMap) {
+          COUT << "DetID: " << entry.first << " template ID: " << entry.second << std::endl;
+          auto detid = DetId(entry.first);
+          if (detid.subdetId() == PixelSubdetector::PixelBarrel) {
+	    theMaps.fillBarrelBin("templateIDsBarrel",entry.first,entry.second);
+          } else if (detid.subdetId() == PixelSubdetector::PixelEndcap) {
+	    theMaps.fillBarrelBin("templateIDsBarrel",entry.first,entry.second);
+          }
+        }
+
+        TCanvas canvas("Canv", "Canv", 1200, 1000);
+	theMaps.DrawBarrelMaps("templateIDsBarrel",canvas);
+
+	/*
+        TCanvas canvas("Canv", "Canv", 1500, 1000);
+	theMaps.DrawEndcapMaps("templateIDsForward",canvas);
+	*/
+
+        canvas.cd();
+
+        std::string fileName(m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+      }
+      return true;
+    }
+  };
 }  // namespace
 
 // Register the classes as boost python plugin
-PAYLOAD_INSPECTOR_MODULE(SiPixelTemplateDBObject) { PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateDBObjectTest); }
+PAYLOAD_INSPECTOR_MODULE(SiPixelTemplateDBObject) {
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateDBObjectTest);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateIDs);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateLA);
+}

--- a/CondCore/SiPixelPlugins/test/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/test/BuildFile.xml
@@ -5,5 +5,6 @@
 <use name="FWCore/Utilities"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <use name="CondFormats/SiPixelTransient"/>
+<use name="CalibTracker/SiPixelESProducers"/>
 <bin file="testSiPixelPayloadInspector.cpp" name="testPixelPayloadInspector">
 </bin>

--- a/CondCore/SiPixelPlugins/test/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/test/BuildFile.xml
@@ -4,5 +4,6 @@
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
+<use name="CondFormats/SiPixelTransient"/>
 <bin file="testSiPixelPayloadInspector.cpp" name="testPixelPayloadInspector">
 </bin>

--- a/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
@@ -75,3 +75,25 @@ getPayloadData.py \
      --test ;
 
 mv *.png  $W_DIR/plots_LA/SiPixelBPixLorentzAngleMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+    --plot plot_SiPixelLorentzAngleValuesEndcap \
+    --tag SiPixelLorentzAngle_forWidth_phase1_mc_v1 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+mv *.png  $W_DIR/plots_LA/SiPixelBPixLorentzAngleEndcapPlots.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+    --plot plot_SiPixelLorentzAngleValuesBarrel \
+    --tag SiPixelLorentzAngle_forWidth_phase1_mc_v1 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+mv *.png  $W_DIR/plots_LA/SiPixelBPixLorentzAngleBarrel.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
@@ -17,6 +17,30 @@ mkdir $W_DIR/plots_LA
 
 getPayloadData.py \
      --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+     --plot plot_SiPixelLorentzAngleValuesBarrelCompareTwoTags \
+     --tag SiPixelLorentzAngleSim_phase1_BoR3_HV350_Tr2000 \
+     --tagtwo SiPixelLorentzAngle_phase1_EEoR3_HV800_Tr2000  \
+     --time_type Run \
+     --iovs '{"start_iov": "1", "end_iov": "1"}' \
+     --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+     --db Prod \
+     --test ;
+
+mv *.png  $W_DIR/plots_LA/comparisonByRegionTwoTagsPhase1.png
+
+getPayloadData.py \
+     --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+     --plot plot_SiPixelLorentzAngleValuesEndcapCompareSingleTag \
+     --tag SiPixelLorentzAngle_2009_v1_express  \
+     --time_type Run \
+     --iovs '{"start_iov": "197571", "end_iov": "326083"}' \
+     --db Prod \
+     --test ;
+
+mv *.png  $W_DIR/plots_LA/comparisonByRegionSingleTagsPhase0-Phase1.png
+
+getPayloadData.py \
+     --plugin pluginSiPixelLorentzAngle_PayloadInspector \
      --plot plot_SiPixelLorentzAngleValueComparisonTwoTags \
      --tag SiPixelLorentzAngleSim_phase1_BoR3_HV350_Tr1300 \
      --tagtwo SiPixelLorentzAngle_phase1_BoR3_HV350_Tr1300 \

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -4,6 +4,7 @@
 #include "CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc"
+#include "CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
@@ -118,6 +119,22 @@ int main(int argc, char** argv) {
   SiPixelGainCalibrationOfflineCorrelations histo16;
   histo16.process(connectionString, PI::mk_input(tag, end, end));
   std::cout << histo16.data() << std::endl;
+
+  // SiPixelTemplates
+
+  tag = "SiPixelTemplateDBObject38Tv3_express";
+  start = boost::lexical_cast<unsigned long long>(326083);
+  end = boost::lexical_cast<unsigned long long>(326083);
+
+  std::cout << "## Exercising SiPixelTemplates plots " << std::endl;
+
+  SiPixelTemplateIDsBPixMap histo17;
+  histo17.process(connectionString, PI::mk_input(tag, end, end));
+  std::cout << histo17.data() << std::endl;
+
+  SiPixelTemplateLAFPixMap histo18;
+  histo18.process(connectionString, PI::mk_input(tag, end, end));
+  std::cout << histo18.data() << std::endl;
 
   Py_Finalize();
 }

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -120,6 +120,14 @@ int main(int argc, char** argv) {
   histo16.process(connectionString, PI::mk_input(tag, end, end));
   std::cout << histo16.data() << std::endl;
 
+  boost::python::dict inputs;
+  inputs["SetLog"] = "True";  // sets to true, 1,True,Yes will work
+
+  SiPixelGainCalibrationOfflineGainsValuesBarrel histo17;
+  histo17.setInputParamValues(inputs);
+  histo17.process(connectionString, PI::mk_input(tag, end, end));
+  std::cout << histo17.data() << std::endl;
+
   // SiPixelTemplates
 
   tag = "SiPixelTemplateDBObject38Tv3_express";
@@ -128,13 +136,13 @@ int main(int argc, char** argv) {
 
   std::cout << "## Exercising SiPixelTemplates plots " << std::endl;
 
-  SiPixelTemplateIDsBPixMap histo17;
-  histo17.process(connectionString, PI::mk_input(tag, end, end));
+  SiPixelTemplateIDsBPixMap histo18;
+  histo18.process(connectionString, PI::mk_input(tag, end, end));
   std::cout << histo17.data() << std::endl;
 
-  SiPixelTemplateLAFPixMap histo18;
+  SiPixelTemplateLAFPixMap histo19;
   histo18.process(connectionString, PI::mk_input(tag, end, end));
-  std::cout << histo18.data() << std::endl;
+  std::cout << histo19.data() << std::endl;
 
   Py_Finalize();
 }

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -138,10 +138,10 @@ int main(int argc, char** argv) {
 
   SiPixelTemplateIDsBPixMap histo18;
   histo18.process(connectionString, PI::mk_input(tag, end, end));
-  std::cout << histo17.data() << std::endl;
+  std::cout << histo18.data() << std::endl;
 
   SiPixelTemplateLAFPixMap histo19;
-  histo18.process(connectionString, PI::mk_input(tag, end, end));
+  histo19.process(connectionString, PI::mk_input(tag, end, end));
   std::cout << histo19.data() << std::endl;
 
   Py_Finalize();

--- a/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+if [ -d $W_DIR/plots_Template ]; then
+    rm -fr $W_DIR/plots_Template
+fi
+
+mkdir $W_DIR/plots_Template
+
+getPayloadData.py \
+    --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixelTemplateDBObjectTest \
+    --tag SiPixelTemplateDBObject38Tv3_express \
+    --time_type Run \
+    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/plots_Template/Test.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixelTemplateIDs \
+    --tag SiPixelTemplateDBObject38Tv3_express \
+    --time_type Run \
+    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/plots_Template/Test.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
@@ -28,11 +28,44 @@ mv *.png $W_DIR/plots_Template/Test.png
 
 getPayloadData.py \
     --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
-    --plot plot_SiPixelTemplateIDs \
+    --plot plot_SiPixelTemplateIDsBPixMap \
     --tag SiPixelTemplateDBObject38Tv3_express \
     --time_type Run \
     --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
     --db Prod \
     --test ;
 
-mv *.png $W_DIR/plots_Template/Test.png
+mv *.png $W_DIR/plots_Template/IDsBPixMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixelTemplateIDsFPixMap \
+    --tag SiPixelTemplateDBObject38Tv3_express \
+    --time_type Run \
+    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/plots_Template/IDsFPixMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixelTemplateLABPixMap \
+    --tag SiPixelTemplateDBObject38Tv3_express \
+    --time_type Run \
+    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/plots_Template/LABPixMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixelTemplateLAFPixMap \
+    --tag SiPixelTemplateDBObject38Tv3_express \
+    --time_type Run \
+    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/plots_Template/LAFPixMap.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
@@ -24,8 +24,6 @@ getPayloadData.py \
     --db Prod \
     --test ;
 
-mv *.png $W_DIR/plots_Template/Test.png
-
 getPayloadData.py \
     --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
     --plot plot_SiPixelTemplateIDsBPixMap \

--- a/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
@@ -67,3 +67,14 @@ getPayloadData.py \
     --test ;
 
 mv *.png $W_DIR/plots_Template/LAFPixMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixelTemplateHeaderTable \
+    --tag SiPixelTemplateDBObject38Tv3_express \
+    --time_type Run \
+    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/plots_Template/HeaderTable.png


### PR DESCRIPTION
#### PR description:

This PR introduces several improvement of the SiPixel Payload Inspector suite:
   * introduces inspection of the `SiPixelTemplate` Condition Format;
   * introduces new plot format types, `Phase1PixelMaps` and `PixelRegionContainers` in order to display cleaner Pixel Tracker Maps and values / comparison plots split by Layer (Barrel) / Ring (Endcap);
   * deploy the new plots for the `SiStripLorentzAngle` and `SiPixelGainCalibrationOffline(ForHLT)`;
   * migrate several classes to use the new template recommended after integration of https://github.com/cms-sw/cmssw/pull/29622;
   * deploy new unit tests and test scripts;

#### PR validation:

Relies on the existing and newly introduced unit tests. 
All the new plots have been tested also by hand; few examples are reproduced here: 

   *  `PixelRegionContainers` comparing two `SiPixelGainCalibrationOffline` payloads from two different tags
![image](https://user-images.githubusercontent.com/5082376/82095949-634ce780-9700-11ea-97fb-c562979cc60e.png)

   * `Phase1PixelMaps` of the assume value of μH for one payload of `SiPixelTemplate`
![image](https://user-images.githubusercontent.com/5082376/82096305-f8e87700-9700-11ea-871e-30917220c082.png)


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is intended.
