### PR TITLE
Apply existing clang-tidy checks

### DIFF
--- a/Alignment/Geners/interface/AbsReader.hh
+++ b/Alignment/Geners/interface/AbsReader.hh
@@ -42,9 +42,9 @@ namespace gs {
 
   template <class Base, class Derived>
   struct ConcreteReader : public AbsReader<Base> {
-    virtual ~ConcreteReader() {}
+    ~ConcreteReader() override {}
 
-    inline Derived *read(const ClassId &id, std::istream &in) const {
+    inline Derived *read(const ClassId &id, std::istream &in) const override {
       // Assume that Derived::read(id, in) returns a new object
       // of type "Derived" allocated on the heap
       return Derived::read(id, in);
@@ -74,8 +74,8 @@ namespace gs {
     }
 
   private:
-    DefaultReader(const DefaultReader &);
-    DefaultReader &operator=(const DefaultReader &);
+    DefaultReader(const DefaultReader &) = delete;
+    DefaultReader &operator=(const DefaultReader &) = delete;
   };
 
   // A trivial implementation of the Meyers singleton for use with reader
@@ -108,7 +108,7 @@ namespace gs {
 
   private:
     // Disable the constructor
-    StaticReader();
+    StaticReader() = delete;
   };
 }  // namespace gs
 

--- a/Alignment/Geners/interface/GenericIO.hh
+++ b/Alignment/Geners/interface/GenericIO.hh
@@ -151,7 +151,7 @@ namespace gs {
   struct GenericReader<Stream, State, T, Int2Type<IOTraits<int>::ISPOD>> {
     inline static bool readIntoPtr(T *&ptr, Stream &str, State *, const bool processClassId) {
       CPP11_auto_ptr<T> myptr;
-      if (ptr == 0)
+      if (ptr == nullptr)
         myptr = CPP11_auto_ptr<T>(new T());
       if (processClassId) {
         static const ClassId current(ClassId::makeId<T>());
@@ -161,7 +161,7 @@ namespace gs {
       read_pod(str, ptr ? ptr : myptr.get());
       if (str.fail())
         return false;
-      if (ptr == 0)
+      if (ptr == nullptr)
         ptr = myptr.release();
       return true;
     }

--- a/Alignment/Geners/interface/IOIsContainer.hh
+++ b/Alignment/Geners/interface/IOIsContainer.hh
@@ -19,7 +19,7 @@ namespace gs {
     static Two test(...);
 
   public:
-    enum { value = sizeof(IOIsContainer<T>::template test<T>(0)) == 1 };
+    enum { value = sizeof(IOIsContainer<T>::template test<T>(nullptr)) == 1 };
   };
 
   // Char strings get a special treatment

--- a/CalibMuon/CSCCalibration/interface/CSCDBL1TPParametersConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCDBL1TPParametersConditions.h
@@ -20,7 +20,7 @@
 class CSCDBL1TPParametersConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCDBL1TPParametersConditions(const edm::ParameterSet &);
-  ~CSCDBL1TPParametersConditions();
+  ~CSCDBL1TPParametersConditions() override;
 
   inline static CSCDBL1TPParameters *prefillCSCDBL1TPParameters();
 
@@ -30,7 +30,9 @@ public:
 
 private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &, edm::ValidityInterval &);
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
 };
 
 #include <fstream>

--- a/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
+++ b/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <boost/tokenizer.hpp>
 
-
 #include <TChain.h>
 #include <TFile.h>
 #include <TProfile2D.h>
@@ -12,391 +11,379 @@
 #include <TH2.h>
 #include <TH3.h>
 
-
-
-struct EcalTPGVariables
-{
+struct EcalTPGVariables {
   // event variables
-  unsigned int runNb ;
-  unsigned int evtNb ;
-  unsigned int bxNb ;
-  unsigned int orbitNb ;
-  unsigned int nbOfActiveTriggers ;
-  int activeTriggers[128] ;
-  
+  unsigned int runNb;
+  unsigned int evtNb;
+  unsigned int bxNb;
+  unsigned int orbitNb;
+  unsigned int nbOfActiveTriggers;
+  int activeTriggers[128];
+
   // tower variables
-  unsigned int nbOfTowers ; //max 4032 EB+EE
-  int ieta[4032] ;
-  int iphi[4032] ;
-  int nbOfXtals[4032] ;
-  int rawTPData[4032] ;
-  int rawTPEmul1[4032] ;
-  int rawTPEmul2[4032] ;
-  int rawTPEmul3[4032] ;
-  int rawTPEmul4[4032] ;
-  int rawTPEmul5[4032] ;
-  float eRec[4032] ;
-} ;
+  unsigned int nbOfTowers;  //max 4032 EB+EE
+  int ieta[4032];
+  int iphi[4032];
+  int nbOfXtals[4032];
+  int rawTPData[4032];
+  int rawTPEmul1[4032];
+  int rawTPEmul2[4032];
+  int rawTPEmul3[4032];
+  int rawTPEmul4[4032];
+  int rawTPEmul5[4032];
+  float eRec[4032];
+};
 
 //! branch addresses settings
-void setBranchAddresses (TChain * chain, EcalTPGVariables & treeVars) {
-   chain->SetBranchAddress ("runNb",&treeVars.runNb) ; 
-   chain->SetBranchAddress ("evtNb",&treeVars.evtNb) ; 
-   chain->SetBranchAddress ("bxNb",&treeVars.bxNb) ; 
-   chain->SetBranchAddress ("orbitNb",&treeVars.orbitNb) ; 
-   chain->SetBranchAddress ("nbOfActiveTriggers",&treeVars.nbOfActiveTriggers) ; 
-   chain->SetBranchAddress ("activeTriggers",treeVars.activeTriggers) ; 
+void setBranchAddresses(TChain* chain, EcalTPGVariables& treeVars) {
+  chain->SetBranchAddress("runNb", &treeVars.runNb);
+  chain->SetBranchAddress("evtNb", &treeVars.evtNb);
+  chain->SetBranchAddress("bxNb", &treeVars.bxNb);
+  chain->SetBranchAddress("orbitNb", &treeVars.orbitNb);
+  chain->SetBranchAddress("nbOfActiveTriggers", &treeVars.nbOfActiveTriggers);
+  chain->SetBranchAddress("activeTriggers", treeVars.activeTriggers);
 
-   chain->SetBranchAddress ("nbOfTowers",&treeVars.nbOfTowers) ; 
-   chain->SetBranchAddress ("ieta",treeVars.ieta) ; 
-   chain->SetBranchAddress ("iphi",treeVars.iphi) ; 
-   chain->SetBranchAddress ("nbOfXtals",treeVars.nbOfXtals) ; 
-   chain->SetBranchAddress ("rawTPData",treeVars.rawTPData) ; 
-   chain->SetBranchAddress ("rawTPEmul1",treeVars.rawTPEmul1) ; 
-   chain->SetBranchAddress ("rawTPEmul2",treeVars.rawTPEmul2) ; 
-   chain->SetBranchAddress ("rawTPEmul3",treeVars.rawTPEmul3) ; 
-   chain->SetBranchAddress ("rawTPEmul4",treeVars.rawTPEmul4) ; 
-   chain->SetBranchAddress ("rawTPEmul5",treeVars.rawTPEmul5) ; 
-   chain->SetBranchAddress ("eRec",treeVars.eRec) ; 
+  chain->SetBranchAddress("nbOfTowers", &treeVars.nbOfTowers);
+  chain->SetBranchAddress("ieta", treeVars.ieta);
+  chain->SetBranchAddress("iphi", treeVars.iphi);
+  chain->SetBranchAddress("nbOfXtals", treeVars.nbOfXtals);
+  chain->SetBranchAddress("rawTPData", treeVars.rawTPData);
+  chain->SetBranchAddress("rawTPEmul1", treeVars.rawTPEmul1);
+  chain->SetBranchAddress("rawTPEmul2", treeVars.rawTPEmul2);
+  chain->SetBranchAddress("rawTPEmul3", treeVars.rawTPEmul3);
+  chain->SetBranchAddress("rawTPEmul4", treeVars.rawTPEmul4);
+  chain->SetBranchAddress("rawTPEmul5", treeVars.rawTPEmul5);
+  chain->SetBranchAddress("eRec", treeVars.eRec);
 }
 
-void printHelp()
-{
-  std::cout << "\n Help" << std::endl ;
-  std::cout << " -h : display help" << std::endl ;
-  std::cout << " -i <input root files containing the TPG tree>" << std::endl ;     
-  std::cout << "    2 possible formats when more than 1 file:" << std::endl ;
-  std::cout << "    - files names separated by comma without blanks: file1.root,file2.root,file3.root" << std::endl ;
-  std::cout << "    - files names using the wildcard \":\" file:1:3:.root" << std::endl ;
-  std::cout << "      with this last format, the loop from file1.root to file3.root is performed (see examples below)" << std::endl ;
-  std::cout << " -d <directory containing the input root files, default=ignored>" << std::endl ;     
-  std::cout << " -o <output root file name, default=histoTPG.root>" << std::endl ;
-  std::cout << " -v <verbosity level(int), default=0 (minimal)>" << std::endl ;
-  std::cout << " -l1 <L1 algo bits required. If several, use a comma with no blank. Default=select all>" << std::endl ;
-  std::cout << " Additional long options are:" << std::endl ;
-  std::cout << " --cutTPOccup <minimal value of TP to fill the occupancy plot, default=0>" << std::endl ;
+void printHelp() {
+  std::cout << "\n Help" << std::endl;
+  std::cout << " -h : display help" << std::endl;
+  std::cout << " -i <input root files containing the TPG tree>" << std::endl;
+  std::cout << "    2 possible formats when more than 1 file:" << std::endl;
+  std::cout << "    - files names separated by comma without blanks: file1.root,file2.root,file3.root" << std::endl;
+  std::cout << "    - files names using the wildcard \":\" file:1:3:.root" << std::endl;
+  std::cout << "      with this last format, the loop from file1.root to file3.root is performed (see examples below)"
+            << std::endl;
+  std::cout << " -d <directory containing the input root files, default=ignored>" << std::endl;
+  std::cout << " -o <output root file name, default=histoTPG.root>" << std::endl;
+  std::cout << " -v <verbosity level(int), default=0 (minimal)>" << std::endl;
+  std::cout << " -l1 <L1 algo bits required. If several, use a comma with no blank. Default=select all>" << std::endl;
+  std::cout << " Additional long options are:" << std::endl;
+  std::cout << " --cutTPOccup <minimal value of TP to fill the occupancy plot, default=0>" << std::endl;
 
-  std::cout << "\n Example:" << std::endl ;
-  std::cout << "1) TPGTreeReder -o myfile -l1 16,46 -i file1,file2" << std::endl ;
-  std::cout << "will produce histo in file myfile, selecting only events triggered "<< std::endl ;
-  std::cout << "by algo bit 16 and 46 and using as inputs the file1 and file2" << std::endl ;
-  std::cout << "2) TPGTreeReder -d rfio:/castor/cern.ch/user/p/paganini/67977 -i run67977_:1:18:.root" << std::endl ;
-  std::cout << "will produce histo in the default file histoTPG.root, selecting all events"<< std::endl ;
-  std::cout << "and using as inputs the 18 files run67977_1.root to run67977_18.root" << std::endl ;
-  std::cout << "located in the castor directory /castor/cern.ch/user/p/paganini " << std::endl ;
-
+  std::cout << "\n Example:" << std::endl;
+  std::cout << "1) TPGTreeReder -o myfile -l1 16,46 -i file1,file2" << std::endl;
+  std::cout << "will produce histo in file myfile, selecting only events triggered " << std::endl;
+  std::cout << "by algo bit 16 and 46 and using as inputs the file1 and file2" << std::endl;
+  std::cout << "2) TPGTreeReder -d rfio:/castor/cern.ch/user/p/paganini/67977 -i run67977_:1:18:.root" << std::endl;
+  std::cout << "will produce histo in the default file histoTPG.root, selecting all events" << std::endl;
+  std::cout << "and using as inputs the 18 files run67977_1.root to run67977_18.root" << std::endl;
+  std::cout << "located in the castor directory /castor/cern.ch/user/p/paganini " << std::endl;
 }
 
-int getEt(int val) {return (val&0xff) ;}
+int getEt(int val) { return (val & 0xff); }
 
-unsigned int getFg(unsigned int val) {return ((val&0x100)!=0) ;}
+unsigned int getFg(unsigned int val) { return ((val & 0x100) != 0); }
 
-unsigned int getTtf(unsigned int val) {return ((val>>9)&0x7) ;}
+unsigned int getTtf(unsigned int val) { return ((val >> 9) & 0x7); }
 
-std::vector<std::string> split(std::string msg, std::string separator)
-{
+std::vector<std::string> split(std::string msg, std::string separator) {
   boost::char_separator<char> sep(separator.c_str());
-  boost::tokenizer<boost::char_separator<char> > tok(msg, sep );
-  std::vector<std::string> token ;
-  for ( boost::tokenizer<boost::char_separator<char> >::const_iterator i = tok.begin(); i != tok.end(); ++i ) {
-    token.push_back(std::string(*i)) ;
+  boost::tokenizer<boost::char_separator<char> > tok(msg, sep);
+  std::vector<std::string> token;
+  for (boost::tokenizer<boost::char_separator<char> >::const_iterator i = tok.begin(); i != tok.end(); ++i) {
+    token.push_back(std::string(*i));
   }
-  return token ;
+  return token;
 }
 
-double getEta(int ietaTower) 
-{
+double getEta(int ietaTower) {
   // Paga: to be confirmed, specially in EE:
-  return 0.0174*std::abs(ietaTower) ;
+  return 0.0174 * std::abs(ietaTower);
 }
-
-
 
 ///////  Main program /////////
 
-int main (int argc, char** argv)
-{
-
+int main(int argc, char** argv) {
   if (argc < 3) {
-    printHelp() ;
-    exit (1) ;
-  }
-
-  std::string inputfiles, inputdir ;
-  std::string outputRootName = "histoTPG.root" ;
-  int verbose = 0 ;
-  int occupancyCut = 0 ;
-  std::string l1algo ; 
-
-  bool ok(false) ;
-  for (int i=0 ; i<argc ; i++) {
-    if (argv[i] == std::string("-h") ) {
-      printHelp() ;
-      exit(1);
-    }
-    if (argv[i] == std::string("-i") && argc>i+1) {
-      ok = true ;
-      inputfiles = argv[i+1] ;
-    }
-    if (argv[i] == std::string("-d") && argc>i+1) inputdir = argv[i+1] ;
-    if (argv[i] == std::string("-o") && argc>i+1) outputRootName = argv[i+1] ;
-    if (argv[i] == std::string("-v") && argc>i+1) verbose = atoi(argv[i+1]) ;
-    if (argv[i] == std::string("-l1") && argc>i+1) l1algo =  std::string(argv[i+1]) ;
-    if (argv[i] == std::string("--cutTPOccup") && argc>i+1) occupancyCut = atoi(argv[i+1]) ;
-  }
-  if (!ok) {
-    std::cout<<"No input files have been given: nothing to do!"<<std::endl ;
-    printHelp() ;
+    printHelp();
     exit(1);
   }
-  
-  std::vector<int> algobits ;
-  std::vector<std::string> algos = split(l1algo,",") ;
-  for (unsigned int i=0 ; i<algos.size() ; i++) algobits.push_back(atoi(algos[i].c_str())) ;
 
+  std::string inputfiles, inputdir;
+  std::string outputRootName = "histoTPG.root";
+  int verbose = 0;
+  int occupancyCut = 0;
+  std::string l1algo;
 
-  unsigned int ref = 2 ;
+  bool ok(false);
+  for (int i = 0; i < argc; i++) {
+    if (argv[i] == std::string("-h")) {
+      printHelp();
+      exit(1);
+    }
+    if (argv[i] == std::string("-i") && argc > i + 1) {
+      ok = true;
+      inputfiles = argv[i + 1];
+    }
+    if (argv[i] == std::string("-d") && argc > i + 1)
+      inputdir = argv[i + 1];
+    if (argv[i] == std::string("-o") && argc > i + 1)
+      outputRootName = argv[i + 1];
+    if (argv[i] == std::string("-v") && argc > i + 1)
+      verbose = atoi(argv[i + 1]);
+    if (argv[i] == std::string("-l1") && argc > i + 1)
+      l1algo = std::string(argv[i + 1]);
+    if (argv[i] == std::string("--cutTPOccup") && argc > i + 1)
+      occupancyCut = atoi(argv[i + 1]);
+  }
+  if (!ok) {
+    std::cout << "No input files have been given: nothing to do!" << std::endl;
+    printHelp();
+    exit(1);
+  }
 
+  std::vector<int> algobits;
+  std::vector<std::string> algos = split(l1algo, ",");
+  for (unsigned int i = 0; i < algos.size(); i++)
+    algobits.push_back(atoi(algos[i].c_str()));
 
+  unsigned int ref = 2;
 
   ///////////////////////
   // book the histograms
   ///////////////////////
 
-  TH2F * occupancyTP = new TH2F("occupancyTP", "Occupancy TP data", 72, 1, 73, 38, -19, 19) ;
-  occupancyTP->GetYaxis()->SetTitle("eta index") ;
-  occupancyTP->GetXaxis()->SetTitle("phi index") ;
-  TH2F * occupancyTPEmul = new TH2F("occupancyTPEmul", "Occupancy TP emulator", 72, 1, 73, 38, -19, 19) ;
-  occupancyTPEmul->GetYaxis()->SetTitle("eta index") ;
-  occupancyTPEmul->GetXaxis()->SetTitle("phi index") ;
+  TH2F* occupancyTP = new TH2F("occupancyTP", "Occupancy TP data", 72, 1, 73, 38, -19, 19);
+  occupancyTP->GetYaxis()->SetTitle("eta index");
+  occupancyTP->GetXaxis()->SetTitle("phi index");
+  TH2F* occupancyTPEmul = new TH2F("occupancyTPEmul", "Occupancy TP emulator", 72, 1, 73, 38, -19, 19);
+  occupancyTPEmul->GetYaxis()->SetTitle("eta index");
+  occupancyTPEmul->GetXaxis()->SetTitle("phi index");
 
-  TH1F * TP = new TH1F("TP", "TP", 256, 0., 256.) ;
-  TP->GetXaxis()->SetTitle("TP (ADC)") ;
-  TH1F * TPEmul = new TH1F("TPEmul", "TP Emulator", 256, 0., 256.) ;
-  TPEmul->GetXaxis()->SetTitle("TP (ADC)") ;
-  TH1F * TPEmulMax = new TH1F("TPEmulMax", "TP Emulator max", 256, 0., 256.) ;
-  TPEmulMax->GetXaxis()->SetTitle("TP (ADC)") ;
-  TH3F * TPspectrumMap3D = new TH3F("TPspectrumMap3D", "TP data spectrum map", 72, 1, 73, 38, -19, 19, 256, 0., 256.) ;
-  TPspectrumMap3D->GetYaxis()->SetTitle("eta index") ;
-  TPspectrumMap3D->GetXaxis()->SetTitle("phi index") ;
+  TH1F* TP = new TH1F("TP", "TP", 256, 0., 256.);
+  TP->GetXaxis()->SetTitle("TP (ADC)");
+  TH1F* TPEmul = new TH1F("TPEmul", "TP Emulator", 256, 0., 256.);
+  TPEmul->GetXaxis()->SetTitle("TP (ADC)");
+  TH1F* TPEmulMax = new TH1F("TPEmulMax", "TP Emulator max", 256, 0., 256.);
+  TPEmulMax->GetXaxis()->SetTitle("TP (ADC)");
+  TH3F* TPspectrumMap3D = new TH3F("TPspectrumMap3D", "TP data spectrum map", 72, 1, 73, 38, -19, 19, 256, 0., 256.);
+  TPspectrumMap3D->GetYaxis()->SetTitle("eta index");
+  TPspectrumMap3D->GetXaxis()->SetTitle("phi index");
 
-  TH1F * TPMatchEmul = new TH1F("TPMatchEmul", "TP data matching Emulator", 7, -1., 6.) ;
-  TH1F * TPEmulMaxIndex = new TH1F("TPEmulMaxIndex", "Index of the max TP from Emulator", 7, -1., 6.) ;
-  TH3I * TPMatchEmul3D = new TH3I("TPMatchEmul3D", "TP data matching Emulator", 72, 1, 73, 38, -19, 19, 7, -1, 6) ;
-  TPMatchEmul3D->GetYaxis()->SetTitle("eta index") ;
-  TPMatchEmul3D->GetXaxis()->SetTitle("phi index") ;
+  TH1F* TPMatchEmul = new TH1F("TPMatchEmul", "TP data matching Emulator", 7, -1., 6.);
+  TH1F* TPEmulMaxIndex = new TH1F("TPEmulMaxIndex", "Index of the max TP from Emulator", 7, -1., 6.);
+  TH3I* TPMatchEmul3D = new TH3I("TPMatchEmul3D", "TP data matching Emulator", 72, 1, 73, 38, -19, 19, 7, -1, 6);
+  TPMatchEmul3D->GetYaxis()->SetTitle("eta index");
+  TPMatchEmul3D->GetXaxis()->SetTitle("phi index");
 
-  TH2I * ttfMismatch = new TH2I("ttfMismatch", "TTF mismatch map",  72, 1, 73, 38, -19, 19) ;
-  ttfMismatch->GetYaxis()->SetTitle("eta index") ;
-  ttfMismatch->GetXaxis()->SetTitle("phi index") ;
+  TH2I* ttfMismatch = new TH2I("ttfMismatch", "TTF mismatch map", 72, 1, 73, 38, -19, 19);
+  ttfMismatch->GetYaxis()->SetTitle("eta index");
+  ttfMismatch->GetXaxis()->SetTitle("phi index");
 
   ///////////////////////
   // Chain the trees:
   ///////////////////////
 
-  TChain * chain = new TChain ("EcalTPGAnalysis") ;
-  std::vector<std::string> files ;
-  if (inputfiles.find(std::string(",")) != std::string::npos) files = split(inputfiles,",") ;
+  TChain* chain = new TChain("EcalTPGAnalysis");
+  std::vector<std::string> files;
+  if (inputfiles.find(std::string(",")) != std::string::npos)
+    files = split(inputfiles, ",");
   if (inputfiles.find(std::string(":")) != std::string::npos) {
-    std::vector<std::string> filesbase = split(inputfiles,":") ;
+    std::vector<std::string> filesbase = split(inputfiles, ":");
     if (filesbase.size() == 4) {
-      int first = atoi(filesbase[1].c_str()) ;
-      int last = atoi(filesbase[2].c_str()) ;
-      for (int i=first ; i<=last ; i++) {
-	std::stringstream name ;
-	name<<filesbase[0]<<i<<filesbase[3] ;
-	files.push_back(name.str()) ;
+      int first = atoi(filesbase[1].c_str());
+      int last = atoi(filesbase[2].c_str());
+      for (int i = first; i <= last; i++) {
+        std::stringstream name;
+        name << filesbase[0] << i << filesbase[3];
+        files.push_back(name.str());
       }
     }
   }
-  for (unsigned int i=0 ; i<files.size() ; i++) {
-    files[i] = inputdir+"/"+files[i] ;
-    std::cout<<"Input file: "<<files[i]<<std::endl ;
-    chain->Add (files[i].c_str()) ;
+  for (unsigned int i = 0; i < files.size(); i++) {
+    files[i] = inputdir + "/" + files[i];
+    std::cout << "Input file: " << files[i] << std::endl;
+    chain->Add(files[i].c_str());
   }
 
-  EcalTPGVariables treeVars ;
-  setBranchAddresses (chain, treeVars) ;
+  EcalTPGVariables treeVars;
+  setBranchAddresses(chain, treeVars);
 
-  int nEntries = chain->GetEntries () ;
-  std::cout << "Number of entries: " << nEntries <<std::endl ;    
-
-
+  int nEntries = chain->GetEntries();
+  std::cout << "Number of entries: " << nEntries << std::endl;
 
   ///////////////////////
   // Main loop over entries
   ///////////////////////
 
-  for (int entry = 0 ; entry < nEntries ; ++entry) {
-    chain->GetEntry (entry) ;
-    if (entry%1000==0) std::cout <<"------> "<< entry+1 <<" entries processed" << " <------\n" ; 
-    if (verbose>0) std::cout<<"Run="<<treeVars.runNb<<" Evt="<<treeVars.runNb<<std::endl ;
+  for (int entry = 0; entry < nEntries; ++entry) {
+    chain->GetEntry(entry);
+    if (entry % 1000 == 0)
+      std::cout << "------> " << entry + 1 << " entries processed"
+                << " <------\n";
+    if (verbose > 0)
+      std::cout << "Run=" << treeVars.runNb << " Evt=" << treeVars.runNb << std::endl;
 
     // trigger selection if any
-    bool keep(false) ;
+    bool keep(false);
     if (algobits.empty())
       keep = true;  // keep all events when no trigger selection
-    for (unsigned int algo = 0 ; algo<algobits.size() ; algo++)
-      for (unsigned int ntrig = 0 ; ntrig < treeVars.nbOfActiveTriggers ; ntrig++)
-	if (algobits[algo] == treeVars.activeTriggers[ntrig]) keep = true ;
-    if (!keep) continue ;
-    
-             
+    for (unsigned int algo = 0; algo < algobits.size(); algo++)
+      for (unsigned int ntrig = 0; ntrig < treeVars.nbOfActiveTriggers; ntrig++)
+        if (algobits[algo] == treeVars.activeTriggers[ntrig])
+          keep = true;
+    if (!keep)
+      continue;
+
     // loop on towers
-    for (unsigned int tower = 0 ; tower < treeVars.nbOfTowers ; tower++) {
-
-      int tp = getEt(treeVars.rawTPData[tower]) ;
+    for (unsigned int tower = 0; tower < treeVars.nbOfTowers; tower++) {
+      int tp = getEt(treeVars.rawTPData[tower]);
       int emul[5] = {getEt(treeVars.rawTPEmul1[tower]),
-		     getEt(treeVars.rawTPEmul2[tower]),
-		     getEt(treeVars.rawTPEmul3[tower]),
-		     getEt(treeVars.rawTPEmul4[tower]),
-		     getEt(treeVars.rawTPEmul5[tower])} ;
-      int maxOfTPEmul = 0 ;
-      int indexOfTPEmulMax = -1 ;
-      for (int i=0 ; i<5 ; i++) if (emul[i]>maxOfTPEmul) {
-	maxOfTPEmul = emul[i] ; 
-	indexOfTPEmulMax = i ;
+                     getEt(treeVars.rawTPEmul2[tower]),
+                     getEt(treeVars.rawTPEmul3[tower]),
+                     getEt(treeVars.rawTPEmul4[tower]),
+                     getEt(treeVars.rawTPEmul5[tower])};
+      int maxOfTPEmul = 0;
+      int indexOfTPEmulMax = -1;
+      for (int i = 0; i < 5; i++)
+        if (emul[i] > maxOfTPEmul) {
+          maxOfTPEmul = emul[i];
+          indexOfTPEmulMax = i;
+        }
+      int ieta = treeVars.ieta[tower];
+      int iphi = treeVars.iphi[tower];
+      int nbXtals = treeVars.nbOfXtals[tower];
+      int ttf = getTtf(treeVars.rawTPData[tower]);
+
+      if (verbose > 9 && (tp > 0 || maxOfTPEmul > 0)) {
+        std::cout << "(phi,eta, Nbxtals)=" << std::dec << iphi << " " << ieta << " " << nbXtals << std::endl;
+        std::cout << "Data Et, TTF: " << tp << " " << ttf << std::endl;
+        std::cout << "Emulator: ";
+        for (int i = 0; i < 5; i++)
+          std::cout << emul[i] << " ";
+        std::cout << std::endl;
       }
-      int ieta = treeVars.ieta[tower] ;
-      int iphi = treeVars.iphi[tower] ;
-      int nbXtals = treeVars.nbOfXtals[tower] ;
-      int ttf = getTtf(treeVars.rawTPData[tower]) ;
-
-
-      if (verbose>9 && (tp>0 || maxOfTPEmul>0)) {
-	std::cout<<"(phi,eta, Nbxtals)="<<std::dec<<iphi<<" "<<ieta<<" "<<nbXtals<<std::endl ;
-	std::cout<<"Data Et, TTF: "<<tp<<" "<<ttf<<std::endl ;
-	std::cout<<"Emulator: " ;
-	for (int i=0 ; i<5 ; i++) std::cout<<emul[i]<<" " ;
-	std::cout<<std::endl ;
-      }
-
 
       // Fill TP spctrum
-      TP->Fill(tp) ;
-      TPEmul->Fill(emul[ref]) ;
-      TPEmulMax->Fill(maxOfTPEmul) ;
-      TPspectrumMap3D->Fill(iphi, ieta, tp) ;
-
+      TP->Fill(tp);
+      TPEmul->Fill(emul[ref]);
+      TPEmulMax->Fill(maxOfTPEmul);
+      TPspectrumMap3D->Fill(iphi, ieta, tp);
 
       // Fill TP occupancy
-      if (tp>occupancyCut) occupancyTP->Fill(iphi, ieta) ;
-      if (emul[ref]>occupancyCut) occupancyTPEmul->Fill(iphi, ieta) ;
-
+      if (tp > occupancyCut)
+        occupancyTP->Fill(iphi, ieta);
+      if (emul[ref] > occupancyCut)
+        occupancyTPEmul->Fill(iphi, ieta);
 
       // Fill TP-Emulator matching
       // comparison is meaningful when:
-      if (tp>0 && nbXtals == 25) {
-	bool match(false) ;
-	for (int i=0 ; i<5 ; i++) {
-	  if (tp == emul[i]) {
-	    TPMatchEmul->Fill(i+1) ;
-	    TPMatchEmul3D->Fill(iphi, ieta, i+1) ;
-	    match = true ;
-	  }
-	}
-	if (!match) {
-	  TPMatchEmul->Fill(-1) ;
-	  TPMatchEmul3D->Fill(iphi, ieta, -1) ;
-	  if (verbose>5) {
-	    std::cout<<"MISMATCH"<<std::endl ;
-	    std::cout<<"(phi,eta, Nbxtals)="<<std::dec<<iphi<<" "<<ieta<<" "<<nbXtals<<std::endl ;
-	    std::cout<<"Data Et, TTF: "<<tp<<" "<<ttf<<std::endl ;
-	    std::cout<<"Emulator: " ;
-	    for (int i=0 ; i<5 ; i++) std::cout<<emul[i]<<" " ;
-	    std::cout<<std::endl ;
-	  }
-	}
+      if (tp > 0 && nbXtals == 25) {
+        bool match(false);
+        for (int i = 0; i < 5; i++) {
+          if (tp == emul[i]) {
+            TPMatchEmul->Fill(i + 1);
+            TPMatchEmul3D->Fill(iphi, ieta, i + 1);
+            match = true;
+          }
+        }
+        if (!match) {
+          TPMatchEmul->Fill(-1);
+          TPMatchEmul3D->Fill(iphi, ieta, -1);
+          if (verbose > 5) {
+            std::cout << "MISMATCH" << std::endl;
+            std::cout << "(phi,eta, Nbxtals)=" << std::dec << iphi << " " << ieta << " " << nbXtals << std::endl;
+            std::cout << "Data Et, TTF: " << tp << " " << ttf << std::endl;
+            std::cout << "Emulator: ";
+            for (int i = 0; i < 5; i++)
+              std::cout << emul[i] << " ";
+            std::cout << std::endl;
+          }
+        }
       }
-      if (maxOfTPEmul>0) TPEmulMaxIndex->Fill(indexOfTPEmulMax+1) ;
-
+      if (maxOfTPEmul > 0)
+        TPEmulMaxIndex->Fill(indexOfTPEmulMax + 1);
 
       // Fill TTF mismatch
-      if ((ttf==1 || ttf==3) && nbXtals != 25) ttfMismatch->Fill(iphi, ieta) ;
+      if ((ttf == 1 || ttf == 3) && nbXtals != 25)
+        ttfMismatch->Fill(iphi, ieta);
 
+    }  // end loop towers
 
-    } // end loop towers
-
-
-  } // endloop entries
-
-  
+  }  // endloop entries
 
   ///////////////////////
   // Format & write histos
   ///////////////////////
 
-
-  // 1. TP Spectrum  
-  TProfile2D * TPspectrumMap = TPspectrumMap3D->Project3DProfile("yx") ;
-  TPspectrumMap->SetName("TPspectrumMap") ;
+  // 1. TP Spectrum
+  TProfile2D* TPspectrumMap = TPspectrumMap3D->Project3DProfile("yx");
+  TPspectrumMap->SetName("TPspectrumMap");
 
   // 2. TP Timing
-  TH2F * TPMatchEmul2D = new TH2F("TPMatchEmul2D", "TP data matching Emulator", 72, 1, 73, 38, -19, 19) ;
-  TH2F * TPMatchFraction2D = new TH2F("TPMatchFraction2D", "TP data: fraction of non-single timing", 72, 1, 73, 38, -19, 19) ;
-  TPMatchEmul2D->GetYaxis()->SetTitle("eta index") ; 
-  TPMatchEmul2D->GetXaxis()->SetTitle("phi index") ;
-  TPMatchEmul2D->GetZaxis()->SetRangeUser(-1,6) ;
-  TPMatchFraction2D->GetYaxis()->SetTitle("eta index") ; 
-  TPMatchFraction2D->GetXaxis()->SetTitle("phi index") ;
-  for (int binx=1 ; binx<=72 ; binx++)    
-    for (int biny=1 ; biny<=38 ; biny++) {
-      int maxBinz = 5 ;
-      double maxCell = TPMatchEmul3D->GetBinContent(binx, biny, maxBinz) ;
-      double totalCell(0) ;
-      for (int binz=1; binz<=7 ; binz++) {
-	double content = TPMatchEmul3D->GetBinContent(binx, biny, binz) ;
-	if (content>maxCell) {
-	  maxCell = content ;
-	  maxBinz = binz ;
-	}
-	totalCell += content ;
+  TH2F* TPMatchEmul2D = new TH2F("TPMatchEmul2D", "TP data matching Emulator", 72, 1, 73, 38, -19, 19);
+  TH2F* TPMatchFraction2D =
+      new TH2F("TPMatchFraction2D", "TP data: fraction of non-single timing", 72, 1, 73, 38, -19, 19);
+  TPMatchEmul2D->GetYaxis()->SetTitle("eta index");
+  TPMatchEmul2D->GetXaxis()->SetTitle("phi index");
+  TPMatchEmul2D->GetZaxis()->SetRangeUser(-1, 6);
+  TPMatchFraction2D->GetYaxis()->SetTitle("eta index");
+  TPMatchFraction2D->GetXaxis()->SetTitle("phi index");
+  for (int binx = 1; binx <= 72; binx++)
+    for (int biny = 1; biny <= 38; biny++) {
+      int maxBinz = 5;
+      double maxCell = TPMatchEmul3D->GetBinContent(binx, biny, maxBinz);
+      double totalCell(0);
+      for (int binz = 1; binz <= 7; binz++) {
+        double content = TPMatchEmul3D->GetBinContent(binx, biny, binz);
+        if (content > maxCell) {
+          maxCell = content;
+          maxBinz = binz;
+        }
+        totalCell += content;
       }
-      if (maxCell <=0) maxBinz = 2 ; // empty cell
-      TPMatchEmul2D->SetBinContent(binx, biny, float(maxBinz)-2.) ; //z must be in [-1,5] 
-      double fraction = 0 ;
-      if (totalCell>0) fraction = 1.- maxCell/totalCell ;
-      TPMatchFraction2D->SetBinContent(binx, biny, fraction) ;
-      if (totalCell > maxCell && verbose>9) {
-	std::cout<<"--->"<<std::endl ;	
-	for (int binz=1; binz<=7 ; binz++) {	  
-	  std::cout<< "(phi,eta, z): (" 
-		   << TPMatchEmul3D->GetXaxis()->GetBinLowEdge(binx) 
-		   << ", " << TPMatchEmul3D->GetYaxis()->GetBinLowEdge(biny) 
-		   << ", " << TPMatchEmul3D->GetZaxis()->GetBinLowEdge(binz)		   
-		   << ") Content="<<TPMatchEmul3D->GetBinContent(binx, biny, binz)		   
-		   << ", erro="<<TPMatchEmul3D->GetBinContent(binx, biny, binz)	   
-		   << std::endl ;	
-	}
+      if (maxCell <= 0)
+        maxBinz = 2;                                                  // empty cell
+      TPMatchEmul2D->SetBinContent(binx, biny, float(maxBinz) - 2.);  //z must be in [-1,5]
+      double fraction = 0;
+      if (totalCell > 0)
+        fraction = 1. - maxCell / totalCell;
+      TPMatchFraction2D->SetBinContent(binx, biny, fraction);
+      if (totalCell > maxCell && verbose > 9) {
+        std::cout << "--->" << std::endl;
+        for (int binz = 1; binz <= 7; binz++) {
+          std::cout << "(phi,eta, z): (" << TPMatchEmul3D->GetXaxis()->GetBinLowEdge(binx) << ", "
+                    << TPMatchEmul3D->GetYaxis()->GetBinLowEdge(biny) << ", "
+                    << TPMatchEmul3D->GetZaxis()->GetBinLowEdge(binz)
+                    << ") Content=" << TPMatchEmul3D->GetBinContent(binx, biny, binz)
+                    << ", erro=" << TPMatchEmul3D->GetBinContent(binx, biny, binz) << std::endl;
+        }
       }
     }
 
+  TFile saving(outputRootName.c_str(), "recreate");
+  saving.cd();
 
+  occupancyTP->Write();
+  occupancyTPEmul->Write();
 
-  TFile saving (outputRootName.c_str (),"recreate") ;
-  saving.cd () ;
-  
-  occupancyTP->Write() ;
-  occupancyTPEmul->Write() ;
-  
-  TP->Write() ;
-  TPEmul->Write() ;
-  TPEmulMax->Write() ;
-  TPspectrumMap->Write() ;
+  TP->Write();
+  TPEmul->Write();
+  TPEmulMax->Write();
+  TPspectrumMap->Write();
 
-  TPMatchEmul->Write() ; 
-  TPMatchEmul3D->Write() ; 
-  TPEmulMaxIndex->Write() ;
-  TPMatchEmul2D->Write() ; 
-  TPMatchFraction2D->Write() ; 
+  TPMatchEmul->Write();
+  TPMatchEmul3D->Write();
+  TPEmulMaxIndex->Write();
+  TPMatchEmul2D->Write();
+  TPMatchFraction2D->Write();
 
-  ttfMismatch->Write() ; 
+  ttfMismatch->Write();
 
-     
-  saving.Close () ;
-  delete chain ;
+  saving.Close();
+  delete chain;
 
-  return 0 ;
+  return 0;
 }
-
-

--- a/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
+++ b/CaloOnlineTools/EcalTools/bin/TPGTreeReader.cpp
@@ -234,7 +234,8 @@ int main (int argc, char** argv)
 
     // trigger selection if any
     bool keep(false) ;
-    if (!algobits.size()) keep = true ; // keep all events when no trigger selection
+    if (algobits.empty())
+      keep = true;  // keep all events when no trigger selection
     for (unsigned int algo = 0 ; algo<algobits.size() ; algo++)
       for (unsigned int ntrig = 0 ; ntrig < treeVars.nbOfActiveTriggers ; ntrig++)
 	if (algobits[algo] == treeVars.activeTriggers[ntrig]) keep = true ;

--- a/CommonTools/CandUtils/interface/CandMatcherNew.h
+++ b/CommonTools/CandUtils/interface/CandMatcherNew.h
@@ -58,7 +58,7 @@ namespace reco {
       using namespace reco;
       using namespace std;
       if (c.hasMasterClone()) {
-        CandidateBaseRef master = c.masterClone();
+        const CandidateBaseRef &master = c.masterClone();
         return master->numberOfDaughters() == 0 ? map_[master] : (*this)[*master];
       }
       size_t nDau = c.numberOfDaughters();
@@ -75,16 +75,16 @@ namespace reco {
           m = m->motherRef();
           momIdx.insert(m.key());
         }
-        if (momIdx.size() == 0)
+        if (momIdx.empty())
           return reference_type();
-        if (common.size() == 0)
+        if (common.empty())
           common = momIdx;
         else {
           tmp.clear();
           set_intersection(common.begin(), common.end(), momIdx.begin(), momIdx.end(), inserter(tmp, tmp.begin()));
           swap(common, tmp);
         }
-        if (common.size() == 0)
+        if (common.empty())
           return reference_type();
       }
       size_t idx = *max_element(common.begin(), common.end());

--- a/CommonTools/Utils/interface/PointerComparator.h
+++ b/CommonTools/Utils/interface/PointerComparator.h
@@ -18,7 +18,7 @@ struct PointerComparator {
   typedef typename C::first_argument_type first_argument_type;
   typedef typename C::second_argument_type second_argument_type;
   bool operator()(const first_argument_type* t1, const second_argument_type* t2) const {
-    if (t1 == 0 || t2 == 0)
+    if (t1 == nullptr || t2 == nullptr)
       throw edm::Exception(edm::errors::NullPointerError) << "PointerComparator: passed null pointer.";
     return cmp(*t1, *t2);
   }

--- a/CondFormats/Common/interface/IOVKeysDescription.h
+++ b/CondFormats/Common/interface/IOVKeysDescription.h
@@ -16,8 +16,8 @@ namespace cond {
     explicit IOVKeysDescription(std::vector<std::string> const& idict, std::string const& itag)
         : dict_m(idict), m_tag(itag) {}
 
-    virtual ~IOVKeysDescription() {}
-    virtual IOVKeysDescription* clone() const { return new IOVKeysDescription(*this); }
+    ~IOVKeysDescription() override {}
+    IOVKeysDescription* clone() const override { return new IOVKeysDescription(*this); }
 
     // the associated "tag"
     std::string const& tag() const { return m_tag; }

--- a/CondTools/Hcal/interface/CmdLine.h
+++ b/CondTools/Hcal/interface/CmdLine.h
@@ -121,7 +121,7 @@ namespace cmdline {
   // Subsequent classes will throw exceptions of the following class
   class CmdLineError {
   public:
-    inline CmdLineError(const char* msg = 0) : os_(new std::ostringstream()) {
+    inline CmdLineError(const char* msg = nullptr) : os_(new std::ostringstream()) {
       if (msg)
         *os_ << msg;
     }
@@ -155,7 +155,7 @@ namespace cmdline {
 
     inline OneShotIStream(const std::string& s) : str_(s), valid_(true), readout_(false) {}
 
-    inline operator void*() const { return valid_ && !readout_ ? (void*)this : (void*)0; }
+    inline operator void*() const { return valid_ && !readout_ ? (void*)this : (void*)nullptr; }
 
     template <typename T>
     inline bool operator>>(T& obj) {
@@ -193,7 +193,7 @@ namespace cmdline {
     inline std::string demangle(T& obj) const {
       int status;
       const std::type_info& ti = typeid(obj);
-      char* realname = abi::__cxa_demangle(ti.name(), 0, 0, &status);
+      char* realname = abi::__cxa_demangle(ti.name(), nullptr, nullptr, &status);
       std::string s(realname);
       free(realname);
       return s;
@@ -275,7 +275,7 @@ namespace cmdline {
 
     inline const char* progname() const { return progname_.c_str(); }
 
-    inline bool has(const char* shortOpt, const char* longOpt = 0) {
+    inline bool has(const char* shortOpt, const char* longOpt = nullptr) {
       bool found = false;
       for (Optlist::iterator it = find(shortOpt, longOpt); it != args_.end(); it = find(shortOpt, longOpt)) {
         found = true;
@@ -288,7 +288,7 @@ namespace cmdline {
       return found;
     }
 
-    inline OneShotIStream option(const char* shortOpt, const char* longOpt = 0) {
+    inline OneShotIStream option(const char* shortOpt, const char* longOpt = nullptr) {
       OneShotIStream result;
       for (Optlist::iterator it = find(shortOpt, longOpt); it != args_.end(); it = find(shortOpt, longOpt)) {
         Optlist::iterator it0(it);
@@ -304,7 +304,7 @@ namespace cmdline {
       return result;
     }
 
-    inline OneShotIStream require(const char* shortOpt, const char* longOpt = 0) {
+    inline OneShotIStream require(const char* shortOpt, const char* longOpt = nullptr) {
       const OneShotIStream& is(option(shortOpt, longOpt));
       if (!is.isValid()) {
         const char empty[] = "";
@@ -340,7 +340,7 @@ namespace cmdline {
     }
 
   private:
-    CmdLine();
+    CmdLine() = delete;
 
     std::string progname_;
     Optlist args_;

--- a/CondTools/Hcal/interface/visualizeHFPhase1PMTParams.h
+++ b/CondTools/Hcal/interface/visualizeHFPhase1PMTParams.h
@@ -20,13 +20,13 @@ struct VisualizationOptions {
   bool verbose{false};
 
   void load(cmdline::CmdLine& cmdline) {
-    cmdline.option(0, "--minAsymm") >> minAsymm;
-    cmdline.option(0, "--maxAsymm") >> maxAsymm;
-    cmdline.option(0, "--minCharge") >> minCharge;
-    cmdline.option(0, "--maxCharge") >> maxCharge;
-    cmdline.option(0, "--minTDC") >> minTDC;
-    cmdline.option(0, "--maxTDC") >> maxTDC;
-    cmdline.option(0, "--plotPoints") >> plotPoints;
+    cmdline.option(nullptr, "--minAsymm") >> minAsymm;
+    cmdline.option(nullptr, "--maxAsymm") >> maxAsymm;
+    cmdline.option(nullptr, "--minCharge") >> minCharge;
+    cmdline.option(nullptr, "--maxCharge") >> maxCharge;
+    cmdline.option(nullptr, "--minTDC") >> minTDC;
+    cmdline.option(nullptr, "--maxTDC") >> maxTDC;
+    cmdline.option(nullptr, "--plotPoints") >> plotPoints;
     verbose = cmdline.has("-v");
   }
 

--- a/DQM/SiStripMonitorSummary/bin/makeTKTrend.cc
+++ b/DQM/SiStripMonitorSummary/bin/makeTKTrend.cc
@@ -13,36 +13,41 @@
 #include "TH1F.h"
 #include "TFile.h"
 
-void makeTKTrend(const char* inFileName, const char* outFileName, std::string subDetName, std::string partName, const unsigned int partNumber);
+void makeTKTrend(const char* inFileName,
+                 const char* outFileName,
+                 std::string subDetName,
+                 std::string partName,
+                 const unsigned int partNumber);
 
-int main(int argc , char *argv[]) {
-
-  if(argc==6) {
+int main(int argc, char* argv[]) {
+  if (argc == 6) {
     char* inFileName = argv[1];
     char* outFileName = argv[2];
     char* subDetName = argv[3];
     char* partName = argv[4];
     int partNumber = atoi(argv[5]);
 
-    std::cout << "ready to make trend plots from " 
-	      << inFileName << " to " << outFileName << " for " 
-	      << subDetName << " " << partName << " " << partNumber << std::endl;
+    std::cout << "ready to make trend plots from " << inFileName << " to " << outFileName << " for " << subDetName
+              << " " << partName << " " << partNumber << std::endl;
 
-    
     int returncode = 0;
-    makeTKTrend(inFileName,outFileName,subDetName,partName,partNumber);
+    makeTKTrend(inFileName, outFileName, subDetName, partName, partNumber);
 
-    return  returncode;
+    return returncode;
 
+  } else {
+    std::cout << "Too few arguments: " << argc << std::endl;
+    return -1;
   }
-  else {std::cout << "Too few arguments: " << argc << std::endl; return -1; }
 
   return -9;
-
 }
 
-void makeTKTrend(const char* inFileName, const char* outFileName, std::string subDetName, std::string partName, const unsigned int partNumber)
-{
+void makeTKTrend(const char* inFileName,
+                 const char* outFileName,
+                 std::string subDetName,
+                 std::string partName,
+                 const unsigned int partNumber) {
   // Maps <Run number, nBad>
   std::map<unsigned int, unsigned int> badModulesTK;
   std::map<unsigned int, unsigned int> badFibersTK;
@@ -50,280 +55,278 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   std::map<unsigned int, unsigned int> badStripsTK;
   std::map<unsigned int, unsigned int> badStripsFromAPVsTK;
   std::map<unsigned int, unsigned int> allBadStripsTK;
-  
-  std::ostringstream oss;
-  
-  if(partName=="All") partName="";
 
-//   // Number of modules, fibers, APVs, strips for each tracker part
-//   std::vector< std::string > tkParts;
-//   tkParts.push_back("Tracker");
-//   tkParts.push_back("TIB");
-//   tkParts.push_back("TID");
-//   tkParts.push_back("TOB");
-//   tkParts.push_back("TEC");
-//   tkParts.push_back("TIB Layer 1");
-//   tkParts.push_back("TIB Layer 2");
-//   tkParts.push_back("TIB Layer 3");
-//   tkParts.push_back("TIB Layer 4");
-//   tkParts.push_back("TID+ Disk 1");
-//   tkParts.push_back("TID+ Disk 2");
-//   tkParts.push_back("TID+ Disk 3");
-//   tkParts.push_back("TID- Disk 1");
-//   tkParts.push_back("TID- Disk 2");
-//   tkParts.push_back("TID- Disk 3");
-//   tkParts.push_back("TOB Layer 1");
-//   tkParts.push_back("TOB Layer 2");
-//   tkParts.push_back("TOB Layer 3");
-//   tkParts.push_back("TOB Layer 4");
-//   tkParts.push_back("TOB Layer 5");
-//   tkParts.push_back("TOB Layer 6");
-//   tkParts.push_back("TEC+ Disk 1");
-//   tkParts.push_back("TEC+ Disk 2");
-//   tkParts.push_back("TEC+ Disk 3");
-//   tkParts.push_back("TEC+ Disk 4");
-//   tkParts.push_back("TEC+ Disk 5");
-//   tkParts.push_back("TEC+ Disk 6");
-//   tkParts.push_back("TEC+ Disk 7");
-//   tkParts.push_back("TEC+ Disk 8");
-//   tkParts.push_back("TEC+ Disk 9");
-//   tkParts.push_back("TEC- Disk 1");
-//   tkParts.push_back("TEC- Disk 2");
-//   tkParts.push_back("TEC- Disk 3");
-//   tkParts.push_back("TEC- Disk 4");
-//   tkParts.push_back("TEC- Disk 5");
-//   tkParts.push_back("TEC- Disk 6");
-//   tkParts.push_back("TEC- Disk 7");
-//   tkParts.push_back("TEC- Disk 8");
-//   tkParts.push_back("TEC- Disk 9");
-//   
-//   std::vector<unsigned int> nModules;
-//   nModules.push_back(15148);
-//   nModules.push_back(2724);
-//   nModules.push_back(816);
-//   nModules.push_back(5208);
-//   nModules.push_back(6400);
-//   nModules.push_back(672);
-//   nModules.push_back(864);
-//   nModules.push_back(540);
-//   nModules.push_back(648);
-//   nModules.push_back(136);
-//   nModules.push_back(136);
-//   nModules.push_back(136);
-//   nModules.push_back(136);
-//   nModules.push_back(136);
-//   nModules.push_back(136);
-//   nModules.push_back(1008);
-//   nModules.push_back(1152);
-//   nModules.push_back(648);
-//   nModules.push_back(720);
-//   nModules.push_back(792);
-//   nModules.push_back(888);
-//   nModules.push_back(408);
-//   nModules.push_back(408);
-//   nModules.push_back(408);
-//   nModules.push_back(360);
-//   nModules.push_back(360);
-//   nModules.push_back(360);
-//   nModules.push_back(312);
-//   nModules.push_back(312);
-//   nModules.push_back(272);
-//   nModules.push_back(408);
-//   nModules.push_back(408);
-//   nModules.push_back(408);
-//   nModules.push_back(360);
-//   nModules.push_back(360);
-//   nModules.push_back(360);
-//   nModules.push_back(312);
-//   nModules.push_back(312);
-//   nModules.push_back(272);
-//   
-//   std::vector<unsigned int> nFibers;
-//   nFibers.push_back(36392);
-//   nFibers.push_back(6984);
-//   nFibers.push_back(2208);
-//   nFibers.push_back(12096);
-//   nFibers.push_back(15104);
-//   nFibers.push_back(2016);
-//   nFibers.push_back(2592);
-//   nFibers.push_back(1080);
-//   nFibers.push_back(1296);
-//   nFibers.push_back(368);
-//   nFibers.push_back(368);
-//   nFibers.push_back(368);
-//   nFibers.push_back(368);
-//   nFibers.push_back(368);
-//   nFibers.push_back(368);
-//   nFibers.push_back(2016);
-//   nFibers.push_back(2304);
-//   nFibers.push_back(1296);
-//   nFibers.push_back(1440);
-//   nFibers.push_back(2376);
-//   nFibers.push_back(2664);
-//   nFibers.push_back(992);
-//   nFibers.push_back(992);
-//   nFibers.push_back(992);
-//   nFibers.push_back(848);
-//   nFibers.push_back(848);
-//   nFibers.push_back(848);
-//   nFibers.push_back(704);
-//   nFibers.push_back(704);
-//   nFibers.push_back(624);
-//   nFibers.push_back(992);
-//   nFibers.push_back(992);
-//   nFibers.push_back(992);
-//   nFibers.push_back(848);
-//   nFibers.push_back(848);
-//   nFibers.push_back(848);
-//   nFibers.push_back(704);
-//   nFibers.push_back(704);
-//   nFibers.push_back(624);
-//   
-//   std::vector<unsigned int> nAPVs;
-//   nAPVs.push_back(72784);
-//   nAPVs.push_back(13968);
-//   nAPVs.push_back(4416);
-//   nAPVs.push_back(24192);
-//   nAPVs.push_back(30208);
-//   nAPVs.push_back(4032);
-//   nAPVs.push_back(5184);
-//   nAPVs.push_back(2160);
-//   nAPVs.push_back(2592);
-//   nAPVs.push_back(736);
-//   nAPVs.push_back(736);
-//   nAPVs.push_back(736);
-//   nAPVs.push_back(736);
-//   nAPVs.push_back(736);
-//   nAPVs.push_back(736);
-//   nAPVs.push_back(4032);
-//   nAPVs.push_back(4608);
-//   nAPVs.push_back(2592);
-//   nAPVs.push_back(2880);
-//   nAPVs.push_back(4752);
-//   nAPVs.push_back(5328);
-//   nAPVs.push_back(1984);
-//   nAPVs.push_back(1984);
-//   nAPVs.push_back(1984);
-//   nAPVs.push_back(1696);
-//   nAPVs.push_back(1696);
-//   nAPVs.push_back(1696);
-//   nAPVs.push_back(1408);
-//   nAPVs.push_back(1408);
-//   nAPVs.push_back(1248);
-//   nAPVs.push_back(1984);
-//   nAPVs.push_back(1984);
-//   nAPVs.push_back(1984);
-//   nAPVs.push_back(1696);
-//   nAPVs.push_back(1696);
-//   nAPVs.push_back(1696);
-//   nAPVs.push_back(1408);
-//   nAPVs.push_back(1408);
-//   nAPVs.push_back(1248);
-//   
-//   std::vector<unsigned int> nStrips;
-//   nStrips.push_back(9316352);
-//   nStrips.push_back(1787904);
-//   nStrips.push_back(565248);
-//   nStrips.push_back(3096576);
-//   nStrips.push_back(3866624);
-//   nStrips.push_back(516096);
-//   nStrips.push_back(663552);
-//   nStrips.push_back(276480);
-//   nStrips.push_back(331776);
-//   nStrips.push_back(94208);
-//   nStrips.push_back(94208);
-//   nStrips.push_back(94208);
-//   nStrips.push_back(94208);
-//   nStrips.push_back(94208);
-//   nStrips.push_back(94208);
-//   nStrips.push_back(516096);
-//   nStrips.push_back(589824);
-//   nStrips.push_back(331776);
-//   nStrips.push_back(368640);
-//   nStrips.push_back(608256);
-//   nStrips.push_back(681984);
-//   nStrips.push_back(253952);
-//   nStrips.push_back(253952);
-//   nStrips.push_back(253952);
-//   nStrips.push_back(217088);
-//   nStrips.push_back(217088);
-//   nStrips.push_back(217088);
-//   nStrips.push_back(180224);
-//   nStrips.push_back(180224);
-//   nStrips.push_back(159744);
-//   nStrips.push_back(253952);
-//   nStrips.push_back(253952);
-//   nStrips.push_back(253952);
-//   nStrips.push_back(217088);
-//   nStrips.push_back(217088);
-//   nStrips.push_back(217088);
-//   nStrips.push_back(180224);
-//   nStrips.push_back(180224);
-//   nStrips.push_back(159744);
-//   
-//   // Map with <name of tracker part, count of channels in the part>
-//   std::map<std::string, unsigned int> allModulesTK;
-//   std::map<std::string, unsigned int> allFibersTK;
-//   std::map<std::string, unsigned int> allAPVsTK;
-//   std::map<std::string, unsigned int> allStripsTK;
-//   for(unsigned int i = 0; i < tkParts.size(); i++)
-//   {
-//     allModulesTK[tkParts[i].c_str()] = nModules[i];
-//     allFibersTK[tkParts[i].c_str()] = nFibers[i];
-//     allAPVsTK[tkParts[i].c_str()] = nAPVs[i];
-//     allStripsTK[tkParts[i].c_str()] = nStrips[i];
-//   }
-//   
-// //   for(std::map< std::string, unsigned int>::iterator it = allStripsTK.begin(); it != allStripsTK.end(); it++)
-// //   {
-// //     std::cout << it->first.c_str() << " " << it->second << std::endl;
-// //   }
-//   
-//   // Finds number of channels from above map
-//   std::string completePartName = subDetName;
-//   if(partName.compare("") != 0)
-//     completePartName += " " + partName;
-//   if(partNumber != 0)
-//   {
-//     oss.str("");
-//     oss << partNumber;
-//     completePartName += " " + oss.str();
-//   }
-  
-//   // Total number of channels in currently processed map
-//   const unsigned int nModulesInPart = allModulesTK[completePartName.c_str()];
-//   const unsigned int nFibersInPart = allFibersTK[completePartName.c_str()];
-//   const unsigned int nAPVsInPart = allAPVsTK[completePartName.c_str()];
-//   const unsigned int nStripsInPart = allStripsTK[completePartName.c_str()];
-  
+  std::ostringstream oss;
+
+  if (partName == "All")
+    partName = "";
+
+  //   // Number of modules, fibers, APVs, strips for each tracker part
+  //   std::vector< std::string > tkParts;
+  //   tkParts.push_back("Tracker");
+  //   tkParts.push_back("TIB");
+  //   tkParts.push_back("TID");
+  //   tkParts.push_back("TOB");
+  //   tkParts.push_back("TEC");
+  //   tkParts.push_back("TIB Layer 1");
+  //   tkParts.push_back("TIB Layer 2");
+  //   tkParts.push_back("TIB Layer 3");
+  //   tkParts.push_back("TIB Layer 4");
+  //   tkParts.push_back("TID+ Disk 1");
+  //   tkParts.push_back("TID+ Disk 2");
+  //   tkParts.push_back("TID+ Disk 3");
+  //   tkParts.push_back("TID- Disk 1");
+  //   tkParts.push_back("TID- Disk 2");
+  //   tkParts.push_back("TID- Disk 3");
+  //   tkParts.push_back("TOB Layer 1");
+  //   tkParts.push_back("TOB Layer 2");
+  //   tkParts.push_back("TOB Layer 3");
+  //   tkParts.push_back("TOB Layer 4");
+  //   tkParts.push_back("TOB Layer 5");
+  //   tkParts.push_back("TOB Layer 6");
+  //   tkParts.push_back("TEC+ Disk 1");
+  //   tkParts.push_back("TEC+ Disk 2");
+  //   tkParts.push_back("TEC+ Disk 3");
+  //   tkParts.push_back("TEC+ Disk 4");
+  //   tkParts.push_back("TEC+ Disk 5");
+  //   tkParts.push_back("TEC+ Disk 6");
+  //   tkParts.push_back("TEC+ Disk 7");
+  //   tkParts.push_back("TEC+ Disk 8");
+  //   tkParts.push_back("TEC+ Disk 9");
+  //   tkParts.push_back("TEC- Disk 1");
+  //   tkParts.push_back("TEC- Disk 2");
+  //   tkParts.push_back("TEC- Disk 3");
+  //   tkParts.push_back("TEC- Disk 4");
+  //   tkParts.push_back("TEC- Disk 5");
+  //   tkParts.push_back("TEC- Disk 6");
+  //   tkParts.push_back("TEC- Disk 7");
+  //   tkParts.push_back("TEC- Disk 8");
+  //   tkParts.push_back("TEC- Disk 9");
+  //
+  //   std::vector<unsigned int> nModules;
+  //   nModules.push_back(15148);
+  //   nModules.push_back(2724);
+  //   nModules.push_back(816);
+  //   nModules.push_back(5208);
+  //   nModules.push_back(6400);
+  //   nModules.push_back(672);
+  //   nModules.push_back(864);
+  //   nModules.push_back(540);
+  //   nModules.push_back(648);
+  //   nModules.push_back(136);
+  //   nModules.push_back(136);
+  //   nModules.push_back(136);
+  //   nModules.push_back(136);
+  //   nModules.push_back(136);
+  //   nModules.push_back(136);
+  //   nModules.push_back(1008);
+  //   nModules.push_back(1152);
+  //   nModules.push_back(648);
+  //   nModules.push_back(720);
+  //   nModules.push_back(792);
+  //   nModules.push_back(888);
+  //   nModules.push_back(408);
+  //   nModules.push_back(408);
+  //   nModules.push_back(408);
+  //   nModules.push_back(360);
+  //   nModules.push_back(360);
+  //   nModules.push_back(360);
+  //   nModules.push_back(312);
+  //   nModules.push_back(312);
+  //   nModules.push_back(272);
+  //   nModules.push_back(408);
+  //   nModules.push_back(408);
+  //   nModules.push_back(408);
+  //   nModules.push_back(360);
+  //   nModules.push_back(360);
+  //   nModules.push_back(360);
+  //   nModules.push_back(312);
+  //   nModules.push_back(312);
+  //   nModules.push_back(272);
+  //
+  //   std::vector<unsigned int> nFibers;
+  //   nFibers.push_back(36392);
+  //   nFibers.push_back(6984);
+  //   nFibers.push_back(2208);
+  //   nFibers.push_back(12096);
+  //   nFibers.push_back(15104);
+  //   nFibers.push_back(2016);
+  //   nFibers.push_back(2592);
+  //   nFibers.push_back(1080);
+  //   nFibers.push_back(1296);
+  //   nFibers.push_back(368);
+  //   nFibers.push_back(368);
+  //   nFibers.push_back(368);
+  //   nFibers.push_back(368);
+  //   nFibers.push_back(368);
+  //   nFibers.push_back(368);
+  //   nFibers.push_back(2016);
+  //   nFibers.push_back(2304);
+  //   nFibers.push_back(1296);
+  //   nFibers.push_back(1440);
+  //   nFibers.push_back(2376);
+  //   nFibers.push_back(2664);
+  //   nFibers.push_back(992);
+  //   nFibers.push_back(992);
+  //   nFibers.push_back(992);
+  //   nFibers.push_back(848);
+  //   nFibers.push_back(848);
+  //   nFibers.push_back(848);
+  //   nFibers.push_back(704);
+  //   nFibers.push_back(704);
+  //   nFibers.push_back(624);
+  //   nFibers.push_back(992);
+  //   nFibers.push_back(992);
+  //   nFibers.push_back(992);
+  //   nFibers.push_back(848);
+  //   nFibers.push_back(848);
+  //   nFibers.push_back(848);
+  //   nFibers.push_back(704);
+  //   nFibers.push_back(704);
+  //   nFibers.push_back(624);
+  //
+  //   std::vector<unsigned int> nAPVs;
+  //   nAPVs.push_back(72784);
+  //   nAPVs.push_back(13968);
+  //   nAPVs.push_back(4416);
+  //   nAPVs.push_back(24192);
+  //   nAPVs.push_back(30208);
+  //   nAPVs.push_back(4032);
+  //   nAPVs.push_back(5184);
+  //   nAPVs.push_back(2160);
+  //   nAPVs.push_back(2592);
+  //   nAPVs.push_back(736);
+  //   nAPVs.push_back(736);
+  //   nAPVs.push_back(736);
+  //   nAPVs.push_back(736);
+  //   nAPVs.push_back(736);
+  //   nAPVs.push_back(736);
+  //   nAPVs.push_back(4032);
+  //   nAPVs.push_back(4608);
+  //   nAPVs.push_back(2592);
+  //   nAPVs.push_back(2880);
+  //   nAPVs.push_back(4752);
+  //   nAPVs.push_back(5328);
+  //   nAPVs.push_back(1984);
+  //   nAPVs.push_back(1984);
+  //   nAPVs.push_back(1984);
+  //   nAPVs.push_back(1696);
+  //   nAPVs.push_back(1696);
+  //   nAPVs.push_back(1696);
+  //   nAPVs.push_back(1408);
+  //   nAPVs.push_back(1408);
+  //   nAPVs.push_back(1248);
+  //   nAPVs.push_back(1984);
+  //   nAPVs.push_back(1984);
+  //   nAPVs.push_back(1984);
+  //   nAPVs.push_back(1696);
+  //   nAPVs.push_back(1696);
+  //   nAPVs.push_back(1696);
+  //   nAPVs.push_back(1408);
+  //   nAPVs.push_back(1408);
+  //   nAPVs.push_back(1248);
+  //
+  //   std::vector<unsigned int> nStrips;
+  //   nStrips.push_back(9316352);
+  //   nStrips.push_back(1787904);
+  //   nStrips.push_back(565248);
+  //   nStrips.push_back(3096576);
+  //   nStrips.push_back(3866624);
+  //   nStrips.push_back(516096);
+  //   nStrips.push_back(663552);
+  //   nStrips.push_back(276480);
+  //   nStrips.push_back(331776);
+  //   nStrips.push_back(94208);
+  //   nStrips.push_back(94208);
+  //   nStrips.push_back(94208);
+  //   nStrips.push_back(94208);
+  //   nStrips.push_back(94208);
+  //   nStrips.push_back(94208);
+  //   nStrips.push_back(516096);
+  //   nStrips.push_back(589824);
+  //   nStrips.push_back(331776);
+  //   nStrips.push_back(368640);
+  //   nStrips.push_back(608256);
+  //   nStrips.push_back(681984);
+  //   nStrips.push_back(253952);
+  //   nStrips.push_back(253952);
+  //   nStrips.push_back(253952);
+  //   nStrips.push_back(217088);
+  //   nStrips.push_back(217088);
+  //   nStrips.push_back(217088);
+  //   nStrips.push_back(180224);
+  //   nStrips.push_back(180224);
+  //   nStrips.push_back(159744);
+  //   nStrips.push_back(253952);
+  //   nStrips.push_back(253952);
+  //   nStrips.push_back(253952);
+  //   nStrips.push_back(217088);
+  //   nStrips.push_back(217088);
+  //   nStrips.push_back(217088);
+  //   nStrips.push_back(180224);
+  //   nStrips.push_back(180224);
+  //   nStrips.push_back(159744);
+  //
+  //   // Map with <name of tracker part, count of channels in the part>
+  //   std::map<std::string, unsigned int> allModulesTK;
+  //   std::map<std::string, unsigned int> allFibersTK;
+  //   std::map<std::string, unsigned int> allAPVsTK;
+  //   std::map<std::string, unsigned int> allStripsTK;
+  //   for(unsigned int i = 0; i < tkParts.size(); i++)
+  //   {
+  //     allModulesTK[tkParts[i].c_str()] = nModules[i];
+  //     allFibersTK[tkParts[i].c_str()] = nFibers[i];
+  //     allAPVsTK[tkParts[i].c_str()] = nAPVs[i];
+  //     allStripsTK[tkParts[i].c_str()] = nStrips[i];
+  //   }
+  //
+  // //   for(std::map< std::string, unsigned int>::iterator it = allStripsTK.begin(); it != allStripsTK.end(); it++)
+  // //   {
+  // //     std::cout << it->first.c_str() << " " << it->second << std::endl;
+  // //   }
+  //
+  //   // Finds number of channels from above map
+  //   std::string completePartName = subDetName;
+  //   if(partName.compare("") != 0)
+  //     completePartName += " " + partName;
+  //   if(partNumber != 0)
+  //   {
+  //     oss.str("");
+  //     oss << partNumber;
+  //     completePartName += " " + oss.str();
+  //   }
+
+  //   // Total number of channels in currently processed map
+  //   const unsigned int nModulesInPart = allModulesTK[completePartName.c_str()];
+  //   const unsigned int nFibersInPart = allFibersTK[completePartName.c_str()];
+  //   const unsigned int nAPVsInPart = allAPVsTK[completePartName.c_str()];
+  //   const unsigned int nStripsInPart = allStripsTK[completePartName.c_str()];
+
   // Read input file
   std::ifstream resultsFile(inFileName);
   unsigned int runIOV;
   unsigned int values[6];
-  do
-  {
+  do {
     resultsFile >> runIOV;
     resultsFile >> values[0] >> values[1] >> values[2] >> values[3] >> values[4] >> values[5];
     //    std::cout << runIOV << " " << values[0] << " " << values[1] << " " << values[2] << " " << values[3] << " " << values[4] << " " << values[5] << std::endl;
-    badModulesTK[runIOV]=values[0];
-    badFibersTK[runIOV]=values[1];
-    badAPVsTK[runIOV]=values[2];
-    badStripsTK[runIOV]=values[3];
-    badStripsFromAPVsTK[runIOV]=values[4];
-    allBadStripsTK[runIOV]=values[5];
-  }
-  while(!resultsFile.eof());
-  
+    badModulesTK[runIOV] = values[0];
+    badFibersTK[runIOV] = values[1];
+    badAPVsTK[runIOV] = values[2];
+    badStripsTK[runIOV] = values[3];
+    badStripsFromAPVsTK[runIOV] = values[4];
+    allBadStripsTK[runIOV] = values[5];
+  } while (!resultsFile.eof());
+
   const unsigned int IOVSize = badStripsTK.size();
-  
+
   // Create histograms
   std::string histoName;
   std::string histoTitle;
-  
+
   oss.str("");
   histoName = "hBadModules" + subDetName + partName;
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoName += oss.str();
   }
@@ -332,17 +335,15 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   if (!partName.empty()) {
     histoTitle += " " + partName;
   }
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoTitle += " " + oss.str();
   }
-  TH1F* hBadModulesTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize+0.5);
+  TH1F* hBadModulesTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize + 0.5);
 
   oss.str("");
   histoName = "hBadFibers" + subDetName + partName;
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoName += oss.str();
   }
@@ -351,17 +352,15 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   if (!partName.empty()) {
     histoTitle += " " + partName;
   }
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoTitle += " " + oss.str();
   }
-  TH1F* hBadFibersTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize+0.5);
-  
+  TH1F* hBadFibersTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize + 0.5);
+
   oss.str("");
   histoName = "hBadAPVs" + subDetName + partName;
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoName += oss.str();
   }
@@ -370,17 +369,15 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   if (!partName.empty()) {
     histoTitle += " " + partName;
   }
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoTitle += " " + oss.str();
   }
-  TH1F* hBadAPVsTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize+0.5);
-  
+  TH1F* hBadAPVsTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize + 0.5);
+
   oss.str("");
   histoName = "hBadStrips" + subDetName + partName;
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoName += oss.str();
   }
@@ -389,17 +386,15 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   if (!partName.empty()) {
     histoTitle += " " + partName;
   }
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoTitle += " " + oss.str();
   }
-  TH1F* hBadStripsTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize+0.5);
-  
+  TH1F* hBadStripsTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize + 0.5);
+
   oss.str("");
   histoName = "hBadStripsFromAPVs" + subDetName + partName;
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoName += oss.str();
   }
@@ -408,17 +403,15 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   if (!partName.empty()) {
     histoTitle += " " + partName;
   }
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoTitle += " " + oss.str();
   }
-  TH1F* hBadStripsFromAPVsTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize+0.5);
-  
+  TH1F* hBadStripsFromAPVsTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize + 0.5);
+
   oss.str("");
   histoName = "hAllBadStrips" + subDetName + partName;
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoName += oss.str();
   }
@@ -427,46 +420,42 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   if (!partName.empty()) {
     histoTitle += " " + partName;
   }
-  if(partNumber!=0)
-  {
+  if (partNumber != 0) {
     oss << partNumber;
     histoTitle += " " + oss.str();
   }
-  TH1F* hAllBadStripsTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize+0.5);
-  
+  TH1F* hAllBadStripsTK = new TH1F(histoName.c_str(), histoTitle.c_str(), IOVSize, 0.5, IOVSize + 0.5);
+
   unsigned int j = 0;
-  for(std::map<unsigned int, unsigned int>::iterator iMap=badModulesTK.begin(); iMap!=badModulesTK.end(); iMap++ )
-  {
-    hBadModulesTK->SetBinContent(++j,/*(double)*/iMap->second/*/(double)nModulesInPart*/);
+  for (std::map<unsigned int, unsigned int>::iterator iMap = badModulesTK.begin(); iMap != badModulesTK.end(); iMap++) {
+    hBadModulesTK->SetBinContent(++j, /*(double)*/ iMap->second /*/(double)nModulesInPart*/);
     oss.str("");
     oss << iMap->first;
-    hBadModulesTK->GetXaxis()->SetBinLabel(j,oss.str().c_str());
+    hBadModulesTK->GetXaxis()->SetBinLabel(j, oss.str().c_str());
     //    std::cout << hBadModulesTK->GetBinContent(j) << std::endl;
   }
   TCanvas* cBadModulesTK = new TCanvas();
   hBadModulesTK->Draw();
   cBadModulesTK->Update();
-  
+
   j = 0;
-  for(std::map<unsigned int, unsigned int>::iterator iMap=badFibersTK.begin(); iMap!=badFibersTK.end(); iMap++ )
-  {
-    hBadFibersTK->SetBinContent(++j,/*(double)*/iMap->second/*/(double)nFibersInPart*/);
+  for (std::map<unsigned int, unsigned int>::iterator iMap = badFibersTK.begin(); iMap != badFibersTK.end(); iMap++) {
+    hBadFibersTK->SetBinContent(++j, /*(double)*/ iMap->second /*/(double)nFibersInPart*/);
     oss.str("");
     oss << iMap->first;
-    hBadFibersTK->GetXaxis()->SetBinLabel(j,oss.str().c_str());
+    hBadFibersTK->GetXaxis()->SetBinLabel(j, oss.str().c_str());
     //    std::cout << hBadFibersTK->GetBinContent(j) << std::endl;
   }
   TCanvas* cBadFibersTK = new TCanvas();
   hBadFibersTK->Draw();
   cBadFibersTK->Update();
-  
+
   j = 0;
-  for(std::map<unsigned int, unsigned int>::iterator iMap=badAPVsTK.begin(); iMap!=badAPVsTK.end(); iMap++ )
-  {
-    hBadAPVsTK->SetBinContent(++j,/*(double)*/iMap->second/*/(double)nAPVsInPart*/);
+  for (std::map<unsigned int, unsigned int>::iterator iMap = badAPVsTK.begin(); iMap != badAPVsTK.end(); iMap++) {
+    hBadAPVsTK->SetBinContent(++j, /*(double)*/ iMap->second /*/(double)nAPVsInPart*/);
     oss.str("");
     oss << iMap->first;
-    hBadAPVsTK->GetXaxis()->SetBinLabel(j,oss.str().c_str());
+    hBadAPVsTK->GetXaxis()->SetBinLabel(j, oss.str().c_str());
     //    std::cout << hBadAPVsTK->GetBinContent(j) << std::endl;
   }
   TCanvas* cBadAPVsTK = new TCanvas();
@@ -474,25 +463,25 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   cBadAPVsTK->Update();
 
   j = 0;
-  for(std::map<unsigned int, unsigned int>::iterator iMap=badStripsTK.begin(); iMap!=badStripsTK.end(); iMap++ )
-  {
-    hBadStripsTK->SetBinContent(++j,/*(double)*/iMap->second/*/(double)nStripsInPart*/);
+  for (std::map<unsigned int, unsigned int>::iterator iMap = badStripsTK.begin(); iMap != badStripsTK.end(); iMap++) {
+    hBadStripsTK->SetBinContent(++j, /*(double)*/ iMap->second /*/(double)nStripsInPart*/);
     oss.str("");
     oss << iMap->first;
-    hBadStripsTK->GetXaxis()->SetBinLabel(j,oss.str().c_str());
+    hBadStripsTK->GetXaxis()->SetBinLabel(j, oss.str().c_str());
     //    std::cout << hBadStripsTK->GetBinContent(j) << std::endl;
   }
   TCanvas* cBadStripsTK = new TCanvas();
   hBadStripsTK->Draw();
   cBadStripsTK->Update();
-  
+
   j = 0;
-  for(std::map<unsigned int, unsigned int>::iterator iMap=badStripsFromAPVsTK.begin(); iMap!=badStripsFromAPVsTK.end(); iMap++ )
-  {
-    hBadStripsFromAPVsTK->SetBinContent(++j,/*(double)*/iMap->second/*/(double)nStripsInPart*/);
+  for (std::map<unsigned int, unsigned int>::iterator iMap = badStripsFromAPVsTK.begin();
+       iMap != badStripsFromAPVsTK.end();
+       iMap++) {
+    hBadStripsFromAPVsTK->SetBinContent(++j, /*(double)*/ iMap->second /*/(double)nStripsInPart*/);
     oss.str("");
     oss << iMap->first;
-    hBadStripsFromAPVsTK->GetXaxis()->SetBinLabel(j,oss.str().c_str());
+    hBadStripsFromAPVsTK->GetXaxis()->SetBinLabel(j, oss.str().c_str());
     //    std::cout << hBadStripsTK->GetBinContent(j) << std::endl;
   }
   TCanvas* cBadStripsFromAPVsTK = new TCanvas();
@@ -500,20 +489,20 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   cBadStripsFromAPVsTK->Update();
 
   j = 0;
-  for(std::map<unsigned int, unsigned int>::iterator iMap=allBadStripsTK.begin(); iMap!=allBadStripsTK.end(); iMap++ )
-  {
-    hAllBadStripsTK->SetBinContent(++j,/*(double)*/iMap->second/*/(double)nStripsInPart*/);
+  for (std::map<unsigned int, unsigned int>::iterator iMap = allBadStripsTK.begin(); iMap != allBadStripsTK.end();
+       iMap++) {
+    hAllBadStripsTK->SetBinContent(++j, /*(double)*/ iMap->second /*/(double)nStripsInPart*/);
     oss.str("");
     oss << iMap->first;
-    hAllBadStripsTK->GetXaxis()->SetBinLabel(j,oss.str().c_str());
+    hAllBadStripsTK->GetXaxis()->SetBinLabel(j, oss.str().c_str());
     //    std::cout << hAllBadStripsTK->GetBinContent(j) << std::endl;
   }
   TCanvas* cAllBadStripsTK = new TCanvas();
   hAllBadStripsTK->Draw();
   cAllBadStripsTK->Update();
-  
+
   // Write histograms to output file
-  
+
   //  std::cout << "Ready to open the file " << outFileName << std::endl;
 
   TFile* outFile = new TFile(outFileName, "UPDATE");
@@ -543,5 +532,4 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   delete cBadStripsTK;
   delete cBadStripsFromAPVsTK;
   delete cAllBadStripsTK;
-
 }

--- a/DQM/SiStripMonitorSummary/bin/makeTKTrend.cc
+++ b/DQM/SiStripMonitorSummary/bin/makeTKTrend.cc
@@ -329,8 +329,7 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   }
   oss.str("");
   histoTitle = "Bad modules in " + subDetName;
-  if(partName!="")
-  {
+  if (!partName.empty()) {
     histoTitle += " " + partName;
   }
   if(partNumber!=0)
@@ -349,8 +348,7 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   }
   oss.str("");
   histoTitle = "Bad fibers in " + subDetName;
-  if(partName!="")
-  {
+  if (!partName.empty()) {
     histoTitle += " " + partName;
   }
   if(partNumber!=0)
@@ -369,8 +367,7 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   }
   oss.str("");
   histoTitle = "Bad APVs in " + subDetName;
-  if(partName!="")
-  {
+  if (!partName.empty()) {
     histoTitle += " " + partName;
   }
   if(partNumber!=0)
@@ -389,8 +386,7 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   }
   oss.str("");
   histoTitle = "Bad strips in " + subDetName;
-  if(partName!="")
-  {
+  if (!partName.empty()) {
     histoTitle += " " + partName;
   }
   if(partNumber!=0)
@@ -409,8 +405,7 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   }
   oss.str("");
   histoTitle = "Bad strips from APVs in " + subDetName;
-  if(partName!="")
-  {
+  if (!partName.empty()) {
     histoTitle += " " + partName;
   }
   if(partNumber!=0)
@@ -429,8 +424,7 @@ void makeTKTrend(const char* inFileName, const char* outFileName, std::string su
   }
   oss.str("");
   histoTitle = "All bad strips in " + subDetName;
-  if(partName!="")
-  {
+  if (!partName.empty()) {
     histoTitle += " " + partName;
   }
   if(partNumber!=0)

--- a/DQMServices/Core/interface/DQMOneEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMOneEDAnalyzer.h
@@ -49,7 +49,7 @@ public:
     edm::Service<DQMStore>()->enterLumi(run.run(), /* lumi */ 0, this->moduleDescription().id());
   }
 
-  void accumulate(edm::Event const& event, edm::EventSetup const& setup) {
+  void accumulate(edm::Event const& event, edm::EventSetup const& setup) override {
     auto& lumi = event.getLuminosityBlock();
     edm::Service<dqm::legacy::DQMStore>()->enterLumi(
         lumi.run(), lumi.luminosityBlock(), this->moduleDescription().id());

--- a/DQMServices/Core/src/ROOTFilePB.pb.h
+++ b/DQMServices/Core/src/ROOTFilePB.pb.h
@@ -75,7 +75,7 @@ namespace dqmstorepb {
                                Message /* @@protoc_insertion_point(class_definition:dqmstorepb.ROOTFilePB.Histo) */ {
   public:
     ROOTFilePB_Histo();
-    virtual ~ROOTFilePB_Histo();
+    ~ROOTFilePB_Histo() override;
 
     ROOTFilePB_Histo(const ROOTFilePB_Histo& from);
     ROOTFilePB_Histo(ROOTFilePB_Histo&& from) noexcept : ROOTFilePB_Histo() { *this = ::std::move(from); }
@@ -272,7 +272,7 @@ namespace dqmstorepb {
       : public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:dqmstorepb.ROOTFilePB) */ {
   public:
     ROOTFilePB();
-    virtual ~ROOTFilePB();
+    ~ROOTFilePB() override;
 
     ROOTFilePB(const ROOTFilePB& from);
     ROOTFilePB(ROOTFilePB&& from) noexcept : ROOTFilePB() { *this = ::std::move(from); }

--- a/DataFormats/Candidate/interface/CandidateWithRef.h
+++ b/DataFormats/Candidate/interface/CandidateWithRef.h
@@ -55,7 +55,7 @@ namespace reco {
   template <typename Ref>
   bool CandidateWithRef<Ref>::overlap(const Candidate &c) const {
     const CandidateWithRef *o = dynamic_cast<const CandidateWithRef *>(&c);
-    if (o == 0)
+    if (o == nullptr)
       return false;
     if (ref().isNull())
       return false;

--- a/DataFormats/Candidate/interface/component.h
+++ b/DataFormats/Candidate/interface/component.h
@@ -36,13 +36,13 @@ namespace reco {
     struct MultipleComponents {
       static size_t numberOf(const Candidate &c) {
         const C *dc = dynamic_cast<const C *>(&c);
-        if (dc == 0)
+        if (dc == nullptr)
           return 0;
         return (dc->*S)();
       }
       static T get(const Candidate &c, size_t i) {
         const C *dc = dynamic_cast<const C *>(&c);
-        if (dc == 0)
+        if (dc == nullptr)
           return T();
         if (i < (dc->*S)())
           return (dc->*F)(i);

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -360,7 +360,7 @@ namespace edm {
       return;
     delete data_[i];
     data_[i] = d;
-    d = 0;
+    d = nullptr;
   }
 
   template <typename T, typename P>
@@ -394,7 +394,7 @@ namespace edm {
   template <typename D>
   inline void OwnVector<T, P>::insert(const_iterator it, D*& d) {
     data_.insert(it.base_iter(), d);
-    d = 0;
+    d = nullptr;
   }
 
   template <typename T, typename P>

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -79,7 +79,7 @@ namespace edm {
     // any object containing this Ptr.
     template <typename C>
     Ptr(TestHandle<C> const& handle, key_type itemKey, bool /*setNow*/ = true)
-        : core_(handle.id(), getItem_(handle.product(), itemKey), 0, true), key_(itemKey) {}
+        : core_(handle.id(), getItem_(handle.product(), itemKey), nullptr, true), key_(itemKey) {}
 
     /** Constructor for those users who do not have a product handle,
      but have a pointer to a product getter (such as the EventPrincipal).

--- a/DataFormats/Common/interface/Ref.h
+++ b/DataFormats/Common/interface/Ref.h
@@ -349,7 +349,7 @@ namespace edm {
     //  the Event.
 
     Ref(ProductID const& iProductID, T const* item, key_type itemKey, product_type const* /* iProduct */)
-        : product_(iProductID, item, 0, false, itemKey) {}
+        : product_(iProductID, item, nullptr, false, itemKey) {}
 
     Ref(ProductID const& iProductID, T const* item, key_type itemKey)
         : product_(iProductID, item, nullptr, false, itemKey) {}
@@ -400,7 +400,7 @@ namespace edm {
     key_type index() const { return product_.index(); }
 
     /// Returns true if container referenced by the Ref has been cached
-    bool hasProductCache() const { return product_.productPtr() != 0; }
+    bool hasProductCache() const { return product_.productPtr() != nullptr; }
 
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.

--- a/DataFormats/Common/interface/RefProd.h
+++ b/DataFormats/Common/interface/RefProd.h
@@ -75,14 +75,14 @@ namespace edm {
     //  any object containing this RefProd.  Also, in the future work will
     //  be done to throw an exception if an attempt is made to put any object
     //  containing this RefProd into an event(or run or lumi).
-    RefProd(C const* iProduct) : product_(ProductID(), iProduct, 0, true) { checkTypeAtCompileTime(iProduct); }
+    RefProd(C const* iProduct) : product_(ProductID(), iProduct, nullptr, true) { checkTypeAtCompileTime(iProduct); }
 
     /// General purpose constructor from test handle.
     //  An exception will be thrown if an attempt is made to persistify
     //  any object containing this RefProd.  Also, in the future work will
     //  be done to throw an exception if an attempt is made to put any object
     //  containing this RefProd into an event(or run or lumi).
-    explicit RefProd(TestHandle<C> const& handle) : product_(handle.id(), handle.product(), 0, true) {
+    explicit RefProd(TestHandle<C> const& handle) : product_(handle.id(), handle.product(), nullptr, true) {
       checkTypeAtCompileTime(handle.product());
     }
 

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -54,7 +54,7 @@ namespace edm {
 
     /// Returns C++ pointer to the product
     /// Will attempt to retrieve product
-    product_type const* get() const { return isNull() ? 0 : this->operator->(); }
+    product_type const* get() const { return isNull() ? nullptr : this->operator->(); }
 
     /// Returns C++ pointer to the product
     /// Will attempt to retrieve product
@@ -76,7 +76,7 @@ namespace edm {
     EDProductGetter const* productGetter() const { return product_.productGetter(); }
 
     /// Checks if product is in memory.
-    bool hasCache() const { return product_.productPtr() != 0; }
+    bool hasCache() const { return product_.productPtr() != nullptr; }
 
     RefToBaseProd<T>& operator=(const RefToBaseProd<T>& other);
 
@@ -195,11 +195,11 @@ namespace edm {
   template <typename T>
   template <typename C>
   inline RefToBaseProd<T>::RefToBaseProd(OrphanHandle<C> const& handle)
-      : product_(handle.id(), handle.product(), 0, false) {
+      : product_(handle.id(), handle.product(), nullptr, false) {
     std::vector<void const*> pointers;
     FillViewHelperVector helpers;
     fillView(*handle, handle.id(), pointers, helpers);
-    product_.setProductPtr(new View<T>(pointers, helpers, 0));
+    product_.setProductPtr(new View<T>(pointers, helpers, nullptr));
   }
 
   template <typename T>

--- a/DataFormats/Common/interface/Trie.h
+++ b/DataFormats/Common/interface/Trie.h
@@ -229,9 +229,9 @@ namespace edm {
   public:
     typedef TrieNodeIter<T> self;
     typedef TrieNode<T> const node_base;
-    TrieNodeIter() : m_node(0), m_label(0) {}
+    TrieNodeIter() : m_node(nullptr), m_label(0) {}
 
-    explicit TrieNodeIter(node_base *p) : m_node(p ? p->subNode() : 0), m_label(p ? p->subNodeLabel() : 0) {}
+    explicit TrieNodeIter(node_base *p) : m_node(p ? p->subNode() : nullptr), m_label(p ? p->subNodeLabel() : 0) {}
 
     unsigned char label() const { return m_label; }
 
@@ -286,7 +286,7 @@ namespace edm {
 
 template <typename T>
 edm::TrieFactory<T>::TrieFactory(unsigned paquetSize)
-    : _paquetSize(paquetSize), _lastNodes(0x0), _nbUsedInLastNodes(0) {
+    : _paquetSize(paquetSize), _lastNodes(nullptr), _nbUsedInLastNodes(0) {
   _lastNodes = new TrieNode<T>[paquetSize];
 }
 
@@ -325,9 +325,9 @@ void edm::TrieFactory<T>::clear() {
 
 template <typename T>
 edm::TrieNode<T>::TrieNode()
-    : _brother(0),
+    : _brother(nullptr),
       _brotherLabel(0),
-      _firstSubNode(0),
+      _firstSubNode(nullptr),
       _firstSubNodeLabel(0),
       _value()
 /// we can not set _value here because type is unknown. assert that
@@ -346,7 +346,7 @@ edm::TrieNodeIter<T> edm::TrieNode<T>::begin() const {
 }
 template <typename T>
 edm::TrieNodeIter<T> edm::TrieNode<T>::end() const {
-  return const_iterator(0);
+  return const_iterator(nullptr);
 }
 
 template <typename T>
@@ -464,9 +464,9 @@ void edm::TrieNode<T>::display(std::ostream &os, unsigned offset, unsigned char 
 
 template <typename T>
 void edm::TrieNode<T>::clear() {
-  _brother = 0x0;
+  _brother = nullptr;
   _brotherLabel = 0;
-  _firstSubNode = 0x0;
+  _firstSubNode = nullptr;
   _firstSubNodeLabel = 0;
 }
 
@@ -489,7 +489,7 @@ namespace edm {
 }  // namespace edm
 
 template <typename T>
-edm::Trie<T>::Trie(const T &empty) : _empty(empty), _factory(0x0), _initialNode(0x0) {
+edm::Trie<T>::Trie(const T &empty) : _empty(empty), _factory(nullptr), _initialNode(nullptr) {
   // initialize nodes by paquets of 10000
   _factory = new TrieFactory<T>(10000);
   _initialNode = _factory->newNode(_empty);
@@ -514,7 +514,7 @@ template <typename T>
 edm::TrieNode<T> *edm::Trie<T>::_addEntry(const char *str, unsigned strLen) {
   unsigned pos = 0;
   bool found = true;
-  TrieNode<T> *node = _initialNode, *previous = 0x0;
+  TrieNode<T> *node = _initialNode, *previous = nullptr;
 
   // Look for the part of the word which is in Trie
   while (found && pos < strLen) {
@@ -537,7 +537,7 @@ edm::TrieNode<T> *edm::Trie<T>::_addEntry(const char *str, unsigned strLen) {
       ++pos;
     }
   }
-  assert(node != 0x0);
+  assert(node != nullptr);
   return node;
 }
 

--- a/DataFormats/Common/interface/ValueMap.h
+++ b/DataFormats/Common/interface/ValueMap.h
@@ -169,7 +169,7 @@ namespace edm {
 
     struct const_iterator {
       typedef ptrdiff_t difference_type;
-      const_iterator() : values_(0) {}
+      const_iterator() : values_(nullptr) {}
       ProductID id() const { return i_->first; }
       typename container::const_iterator begin() const { return values_->begin() + i_->second; }
       typename container::const_iterator end() const {

--- a/DataFormats/Math/interface/Graph.h
+++ b/DataFormats/Math/interface/Graph.h
@@ -62,7 +62,7 @@ namespace math {
           vt_.e_ = 0;
           ++vt_.a_;
           while (vt_.gr_.size() > vt_.a_) {
-            if (vt_.gr_.adjl_[vt_.a_].size()) {
+            if (!vt_.gr_.adjl_[vt_.a_].empty()) {
               return;
             }
             ++vt_.a_;

--- a/DataFormats/PatCandidates/interface/EventHypothesis.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesis.h
@@ -176,7 +176,7 @@ namespace pat {
   const T *EventHypothesis::getAs(const std::string &role, int index) const {
     CandRefType ref = get(role, index);
     const T *ret = dynamic_cast<const T *>(ref.get());
-    if ((ret == 0) && (ref.get() != nullptr))
+    if ((ret == nullptr) && (ref.get() != nullptr))
       throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
     return ret;
   }

--- a/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
@@ -32,7 +32,7 @@ namespace pat {
     template <typename T>
     const T *DynCastCandPtr<T>::get(const reco::Candidate *ptr) {
       doPtr(ptr);
-      if ((ptr != nullptr) && (cachePtr_ == 0))
+      if ((ptr != nullptr) && (cachePtr_ == nullptr))
         throw cms::Exception("Type Checking")
             << "You can't convert a " << typeid(*ptr).name() << " to a " << typeid(T).name() << "\n"
             << "note: you can use c++filt command to convert the above in human readable types.\n";

--- a/ElectroWeakAnalysis/WMuNu/bin/WMuNuValidatorMacro.cpp
+++ b/ElectroWeakAnalysis/WMuNu/bin/WMuNuValidatorMacro.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv){
 
   if (ntrueargs!=3) return printUsage();
 
-  TRint* app = new TRint("CMS Root Application", 0, 0);
+  TRint* app = new TRint("CMS Root Application", nullptr, nullptr);
 
   TString cmssw_version = gSystem->Getenv("CMSSW_VERSION");
   TString chsample = "WMuNu";

--- a/ElectroWeakAnalysis/WMuNu/bin/WMuNuValidatorMacro.cpp
+++ b/ElectroWeakAnalysis/WMuNu/bin/WMuNuValidatorMacro.cpp
@@ -9,52 +9,56 @@
 #include "TH1D.h"
 #include "TLegend.h"
 
-int printUsage(){
-    printf("Usage: WMuNuValidatorMacro [-lbh] 'root_file_to_validate' 'reference_root_file' 'directory_name'\n\n");
+int printUsage() {
+  printf("Usage: WMuNuValidatorMacro [-lbh] 'root_file_to_validate' 'reference_root_file' 'directory_name'\n\n");
 
-    printf("\tOptions:\t -l ==> linear scale for Y axes (default is log-scale)\n");
-    printf("\t        \t -b ==> run in batch (no graphics)\n");
-    printf("\t        \t -n ==> normalize reference to data (default = false)\n");
-    printf("\t        \t -h ==> print this message\n\n");
+  printf("\tOptions:\t -l ==> linear scale for Y axes (default is log-scale)\n");
+  printf("\t        \t -b ==> run in batch (no graphics)\n");
+  printf("\t        \t -n ==> normalize reference to data (default = false)\n");
+  printf("\t        \t -h ==> print this message\n\n");
 
+  printf("\tInput files:\t Created via '*Validator.py' configuration files in:\n");
+  printf("\t            \t   $CMSSW_BASE/src/ElectroWeakAnalysis/WMuNu/test/\n\n");
 
-    printf("\tInput files:\t Created via '*Validator.py' configuration files in:\n");
-    printf("\t            \t   $CMSSW_BASE/src/ElectroWeakAnalysis/WMuNu/test/\n\n");
+  printf("\tOutput: \t Canvases: './WMuNuValidation_$CMSSW_VERSION_*.root'\n");
+  printf("\t        \t Gifs:     './WMuNuValidation_$CMSSW_VERSION_*.gif'\n\n");
 
-    printf("\tOutput: \t Canvases: './WMuNuValidation_$CMSSW_VERSION_*.root'\n");
-    printf("\t        \t Gifs:     './WMuNuValidation_$CMSSW_VERSION_*.gif'\n\n");
-
-    return 1;
+  return 1;
 }
 
-int main(int argc, char** argv){
-
+int main(int argc, char** argv) {
   TString chfile;
   TString chfileref;
   TString DirectoryLast;
-
 
   int ntrueargs = 0;
   bool logyFlag = true;
   bool normalize = false;
 
-  for (int i=1; i<argc; ++i) {
-      if (argv[i][0] == '-') {
-            if (argv[i][1]=='l') logyFlag = false;
-            else if (argv[i][1]=='b') gROOT->SetBatch();
-            else if (argv[i][1]=='h') return printUsage();
-            else if (argv[i][1]=='n') normalize=true;
+  for (int i = 1; i < argc; ++i) {
+    if (argv[i][0] == '-') {
+      if (argv[i][1] == 'l')
+        logyFlag = false;
+      else if (argv[i][1] == 'b')
+        gROOT->SetBatch();
+      else if (argv[i][1] == 'h')
+        return printUsage();
+      else if (argv[i][1] == 'n')
+        normalize = true;
 
-      } else {
-            ntrueargs += 1;
-            if (ntrueargs==1) chfile = argv[i];
-            else if (ntrueargs==2) chfileref = argv[i];
-            else if (ntrueargs==3) DirectoryLast = argv[i];
-
-      }
+    } else {
+      ntrueargs += 1;
+      if (ntrueargs == 1)
+        chfile = argv[i];
+      else if (ntrueargs == 2)
+        chfileref = argv[i];
+      else if (ntrueargs == 3)
+        DirectoryLast = argv[i];
+    }
   }
 
-  if (ntrueargs!=3) return printUsage();
+  if (ntrueargs != 3)
+    return printUsage();
 
   TRint* app = new TRint("CMS Root Application", nullptr, nullptr);
 
@@ -63,9 +67,9 @@ int main(int argc, char** argv){
   TString chtitle = chsample + " validation for " + cmssw_version;
 
   //TCanvas* c1 = new TCanvas("c1",chtitle.Data());
-  TCanvas* c1 = new TCanvas("c1",chtitle.Data(),0,0,1024,768);
+  TCanvas* c1 = new TCanvas("c1", chtitle.Data(), 0, 0, 1024, 768);
 
-  TPaveLabel* paveTitle = new TPaveLabel(0.1,0.93,0.9,0.99, chtitle.Data());
+  TPaveLabel* paveTitle = new TPaveLabel(0.1, 0.93, 0.9, 0.99, chtitle.Data());
   paveTitle->Draw();
 
   gStyle->SetOptLogy(logyFlag);
@@ -75,16 +79,17 @@ int main(int argc, char** argv){
   gStyle->SetFillColor(0);
 
   TPad* pad[4];
-  pad[0] = new TPad("pad_tl","The top-left pad",0.01,0.48,0.49,0.92); 
-  pad[1] = new TPad("pad_tr","The top-right pad",0.51,0.48,0.99,0.92); 
-  pad[2] = new TPad("pad_bl","The bottom-left pad",0.01,0.01,0.49,0.46); 
-  pad[3] = new TPad("pad_br","The bottom-right pad",0.51,0.01,0.99,0.46); 
-  for (unsigned int i=0; i<4; ++i) pad[i]->Draw();
-                                                                                
-  TLegend* leg = new TLegend(0.5,0.9,0.7,1.0);
+  pad[0] = new TPad("pad_tl", "The top-left pad", 0.01, 0.48, 0.49, 0.92);
+  pad[1] = new TPad("pad_tr", "The top-right pad", 0.51, 0.48, 0.99, 0.92);
+  pad[2] = new TPad("pad_bl", "The bottom-left pad", 0.01, 0.01, 0.49, 0.46);
+  pad[3] = new TPad("pad_br", "The bottom-right pad", 0.51, 0.01, 0.99, 0.46);
+  for (unsigned int i = 0; i < 4; ++i)
+    pad[i]->Draw();
 
-  TFile* input_file = new TFile(chfile.Data(),"READONLY");
-  TFile* input_fileref = new TFile(chfileref.Data(),"READONLY");
+  TLegend* leg = new TLegend(0.5, 0.9, 0.7, 1.0);
+
+  TFile* input_file = new TFile(chfile.Data(), "READONLY");
+  TFile* input_fileref = new TFile(chfileref.Data(), "READONLY");
   bool first_plots_done = false;
 
   TString directory = DirectoryLast + "/BeforeCuts";
@@ -96,55 +101,60 @@ int main(int argc, char** argv){
 
   unsigned int list_before_size = list_before->GetSize();
   TString auxTitle = chtitle + ": BEFORE CUTS";
-  for (unsigned int i=0; i<list_before_size; i+=4) {
-      if (first_plots_done==true) c1->DrawClone();
-      paveTitle->SetLabel(auxTitle.Data());
-      for (unsigned int j=0; j<4; ++j) {
-            pad[j]->cd(); 
-            pad[j]->Clear(); 
-            if ((i+j)>=list_before_size) continue;
+  for (unsigned int i = 0; i < list_before_size; i += 4) {
+    if (first_plots_done == true)
+      c1->DrawClone();
+    paveTitle->SetLabel(auxTitle.Data());
+    for (unsigned int j = 0; j < 4; ++j) {
+      pad[j]->cd();
+      pad[j]->Clear();
+      if ((i + j) >= list_before_size)
+        continue;
 
-            TH1D* h1 = (TH1D*)dir_before->Get(list_before->At(i+j)->GetName()); 
-//            h1->SetLineColor(kBlue);
-//            h1->SetMarkerColor(kBlue);
-            h1->SetMarkerStyle(21);
-            h1->SetLineStyle(1);
-            h1->SetLineWidth(3);
-            h1->SetTitleSize(0.05,"X");
-            h1->SetTitleSize(0.05,"Y");
-            h1->SetXTitle(h1->GetTitle()); 
-            h1->SetYTitle("");
-            h1->SetTitle(""); 
-            h1->SetTitleOffset(0.85,"X");
+      TH1D* h1 = (TH1D*)dir_before->Get(list_before->At(i + j)->GetName());
+      //            h1->SetLineColor(kBlue);
+      //            h1->SetMarkerColor(kBlue);
+      h1->SetMarkerStyle(21);
+      h1->SetLineStyle(1);
+      h1->SetLineWidth(3);
+      h1->SetTitleSize(0.05, "X");
+      h1->SetTitleSize(0.05, "Y");
+      h1->SetXTitle(h1->GetTitle());
+      h1->SetYTitle("");
+      h1->SetTitle("");
+      h1->SetTitleOffset(0.85, "X");
 
-            TH1D* hr = (TH1D*)dirref_before->Get(list_before->At(i+j)->GetName()); 
-            hr->SetLineColor(kRed);
-//            hr->SetLineStyle(2);
-            hr->SetLineWidth(3);
-            hr->SetTitleSize(0.05,"X");
-            hr->SetTitleSize(0.05,"Y");
-            hr->SetXTitle(h1->GetTitle());
-            hr->SetYTitle("");
-            hr->SetTitle("");
-            hr->SetTitleOffset(0.85,"X");
+      TH1D* hr = (TH1D*)dirref_before->Get(list_before->At(i + j)->GetName());
+      hr->SetLineColor(kRed);
+      //            hr->SetLineStyle(2);
+      hr->SetLineWidth(3);
+      hr->SetTitleSize(0.05, "X");
+      hr->SetTitleSize(0.05, "Y");
+      hr->SetXTitle(h1->GetTitle());
+      hr->SetYTitle("");
+      hr->SetTitle("");
+      hr->SetTitleOffset(0.85, "X");
 
-            if(normalize) {hr->DrawNormalized("hist",h1->Integral());}
-            else{hr->Draw("hist");}
-            h1->Draw("same,p");
-
-            leg->Clear();
-            leg->AddEntry(h1,"Skim","L");
-            leg->AddEntry(hr,"Reference","L");
-            leg->Draw();
+      if (normalize) {
+        hr->DrawNormalized("hist", h1->Integral());
+      } else {
+        hr->Draw("hist");
       }
-      first_plots_done = true;
-      c1->Modified();
-      c1->Update();
-      char chplot[80];
-      sprintf(chplot,"%sValidation_%s_BEFORECUTS_%d.root",chsample.Data(),cmssw_version.Data(),i/4);
-      c1->SaveAs(chplot);
-      sprintf(chplot,"%sValidation_%s_BEFORECUTS_%d.gif",chsample.Data(),cmssw_version.Data(),i/4);
-      c1->SaveAs(chplot);
+      h1->Draw("same,p");
+
+      leg->Clear();
+      leg->AddEntry(h1, "Skim", "L");
+      leg->AddEntry(hr, "Reference", "L");
+      leg->Draw();
+    }
+    first_plots_done = true;
+    c1->Modified();
+    c1->Update();
+    char chplot[80];
+    sprintf(chplot, "%sValidation_%s_BEFORECUTS_%d.root", chsample.Data(), cmssw_version.Data(), i / 4);
+    c1->SaveAs(chplot);
+    sprintf(chplot, "%sValidation_%s_BEFORECUTS_%d.gif", chsample.Data(), cmssw_version.Data(), i / 4);
+    c1->SaveAs(chplot);
   }
 
   TString directory2 = DirectoryLast + "/LastCut";
@@ -156,59 +166,64 @@ int main(int argc, char** argv){
 
   unsigned int list_lastcut_size = list_lastcut->GetSize();
   auxTitle = chtitle + ": AFTER N-1 CUTS";
-  for (unsigned int i=0; i<list_lastcut_size; i+=4) {
-      if (first_plots_done==true) c1->DrawClone();
-      paveTitle->SetLabel(auxTitle.Data());
-      for (unsigned int j=0; j<4; ++j) {
-            pad[j]->cd(); 
-            pad[j]->Clear(); 
-            if ((i+j)>=list_lastcut_size) continue;
+  for (unsigned int i = 0; i < list_lastcut_size; i += 4) {
+    if (first_plots_done == true)
+      c1->DrawClone();
+    paveTitle->SetLabel(auxTitle.Data());
+    for (unsigned int j = 0; j < 4; ++j) {
+      pad[j]->cd();
+      pad[j]->Clear();
+      if ((i + j) >= list_lastcut_size)
+        continue;
 
-            TH1D* h1 = (TH1D*)dir_lastcut->Get(list_lastcut->At(i+j)->GetName()); 
-//            h1->SetLineColor(kBlue);
-//            h1->SetMarkerColor(kBlue);
-            h1->SetMarkerStyle(21);
-            h1->SetLineWidth(3);
-            h1->SetTitleSize(0.05,"X");
-            h1->SetTitleSize(0.05,"Y");
-            h1->SetXTitle(h1->GetTitle()); 
-            h1->SetYTitle("");
-            h1->SetTitle(""); 
-            h1->SetTitleOffset(0.85,"X");
+      TH1D* h1 = (TH1D*)dir_lastcut->Get(list_lastcut->At(i + j)->GetName());
+      //            h1->SetLineColor(kBlue);
+      //            h1->SetMarkerColor(kBlue);
+      h1->SetMarkerStyle(21);
+      h1->SetLineWidth(3);
+      h1->SetTitleSize(0.05, "X");
+      h1->SetTitleSize(0.05, "Y");
+      h1->SetXTitle(h1->GetTitle());
+      h1->SetYTitle("");
+      h1->SetTitle("");
+      h1->SetTitleOffset(0.85, "X");
 
-            TH1D* hr = (TH1D*)dirref_lastcut->Get(list_lastcut->At(i+j)->GetName()); 
-            hr->SetLineColor(kRed);
-//            hr->SetLineStyle(2);
-            hr->SetLineWidth(3);
-            hr->SetTitleSize(0.05,"X");
-            hr->SetTitleSize(0.05,"Y");
-            hr->SetXTitle(h1->GetTitle());
-            hr->SetYTitle("");
-            hr->SetTitle("");
-            hr->SetTitleOffset(0.85,"X");
+      TH1D* hr = (TH1D*)dirref_lastcut->Get(list_lastcut->At(i + j)->GetName());
+      hr->SetLineColor(kRed);
+      //            hr->SetLineStyle(2);
+      hr->SetLineWidth(3);
+      hr->SetTitleSize(0.05, "X");
+      hr->SetTitleSize(0.05, "Y");
+      hr->SetXTitle(h1->GetTitle());
+      hr->SetYTitle("");
+      hr->SetTitle("");
+      hr->SetTitleOffset(0.85, "X");
 
-//            h1->Draw();
-            if(normalize) {hr->DrawNormalized("hist",h1->Integral());}
-            else{hr->Draw("hist");}
-            h1->Draw("same,p");
-
-
-            leg->Clear();
-            leg->AddEntry(h1,"Skim" ,"L");
-            leg->AddEntry(hr,"Reference","L");
-            leg->Draw();
+      //            h1->Draw();
+      if (normalize) {
+        hr->DrawNormalized("hist", h1->Integral());
+      } else {
+        hr->Draw("hist");
       }
-      first_plots_done = true;
-      c1->Modified();
-      c1->Update();
-      char chplot[80];
-      sprintf(chplot,"%sValidation_%s_LASTCUT_%d.root",chsample.Data(),cmssw_version.Data(),i/4);
-      c1->SaveAs(chplot);
-      sprintf(chplot,"%sValidation_%s_LASTCUT_%d.gif",chsample.Data(),cmssw_version.Data(),i/4);
-      c1->SaveAs(chplot);
+      h1->Draw("same,p");
+
+      leg->Clear();
+      leg->AddEntry(h1, "Skim", "L");
+      leg->AddEntry(hr, "Reference", "L");
+      leg->Draw();
+    }
+    first_plots_done = true;
+    c1->Modified();
+    c1->Update();
+    char chplot[80];
+    sprintf(chplot, "%sValidation_%s_LASTCUT_%d.root", chsample.Data(), cmssw_version.Data(), i / 4);
+    c1->SaveAs(chplot);
+    sprintf(chplot, "%sValidation_%s_LASTCUT_%d.gif", chsample.Data(), cmssw_version.Data(), i / 4);
+    c1->SaveAs(chplot);
   }
 
-  if (!gROOT->IsBatch()) app->Run();
+  if (!gROOT->IsBatch())
+    app->Run();
 
   return 0;
 }

--- a/ElectroWeakAnalysis/ZMuMu/bin/toyMonteCarlo.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/toyMonteCarlo.cpp
@@ -12,7 +12,7 @@
 #include "TF1.h"
 #include "TFile.h"
 #include "TDirectory.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <vector>
 #include <string>
 #include <iostream>

--- a/ElectroWeakAnalysis/ZMuMu/bin/toyMonteCarlo.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/toyMonteCarlo.cpp
@@ -23,59 +23,57 @@
 
 using namespace std;
 
-void fillRandom(int N, TH1F *pdf, TH1F * histo, double min, double max, TRandom3 * rndm){
-  int i=0;
-  double m=0;
+void fillRandom(int N, TH1F *pdf, TH1F *histo, double min, double max, TRandom3 *rndm) {
+  int i = 0;
+  double m = 0;
   const double maxY = pdf->GetMaximum();
   const double nBins = pdf->GetNbinsX();
   const double xMin = pdf->GetXaxis()->GetXmin();
   const double xMax = pdf->GetXaxis()->GetXmax();
-  do{
+  do {
     m = rndm->Uniform(min, max);
-    int n = (int)((m - xMin)/(xMax - xMin)*nBins) + 1;
+    int n = (int)((m - xMin) / (xMax - xMin) * nBins) + 1;
     double y = pdf->GetBinContent(n);
-    if(rndm->Uniform() < y/maxY){
+    if (rndm->Uniform() < y / maxY) {
       histo->Fill(m);
       i++;
     }
-  }while(i<N);
-} 
-
+  } while (i < N);
+}
 
 enum MuTag { globalMu, trackerMu, standaloneMu, undefinedMu };
 
-MuTag mu(double effTrk, double effSa, TRandom3 * rndm) {
-  double _isTraker     = rndm->Rndm();
+MuTag mu(double effTrk, double effSa, TRandom3 *rndm) {
+  double _isTraker = rndm->Rndm();
   double _isStandAlone = rndm->Rndm();
-  if((_isTraker< effTrk)   && (_isStandAlone< effSa)) return globalMu;
-  if((_isStandAlone< effSa)&& (_isTraker >effTrk)) return standaloneMu;
-  if((_isTraker < effTrk)  && (_isStandAlone > effSa)) return trackerMu;
+  if ((_isTraker < effTrk) && (_isStandAlone < effSa))
+    return globalMu;
+  if ((_isStandAlone < effSa) && (_isTraker > effTrk))
+    return standaloneMu;
+  if ((_isTraker < effTrk) && (_isStandAlone > effSa))
+    return trackerMu;
   return undefinedMu;
 }
 
-
-bool efficiencyTag(double eff, TRandom3 * rndm ){
- return (rndm->Rndm()< eff);
-}
-
+bool efficiencyTag(double eff, TRandom3 *rndm) { return (rndm->Rndm() < eff); }
 
 class BkgShape {
 public:
-  BkgShape(double min, double max, double slope, double a0, double a1, double a2) :
-    norm_(1), min_(min), max_(max), fmax_(0),
-    slope_(slope), a0_(a0), a1_(a1), a2_(a2) { 
+  BkgShape(double min, double max, double slope, double a0, double a1, double a2)
+      : norm_(1), min_(min), max_(max), fmax_(0), slope_(slope), a0_(a0), a1_(a1), a2_(a2) {
     normalize();
   }
   double operator()(double x) const {
-    if(x < min_ || x > max_) return 0;
-    return exp(-slope_*x)*(a0_ + (a1_ + a2_*x)*x);
+    if (x < min_ || x > max_)
+      return 0;
+    return exp(-slope_ * x) * (a0_ + (a1_ + a2_ * x) * x);
   }
-  double rndm(TRandom3 * rndm) const {
+  double rndm(TRandom3 *rndm) const {
     double x, f;
     do {
       x = rndm->Uniform(min_, max_);
       f = operator()(x);
-    } while(rndm->Uniform(0, fmax_) > f);
+    } while (rndm->Uniform(0, fmax_) > f);
     return x;
   }
   double integral() const { return norm_; }
@@ -85,29 +83,30 @@ private:
     static const unsigned int steps = 1000;
     double s = 0, x, f;
     double base = max_ - min_;
-    double dx = base/steps;
-    for(unsigned int n = 0; n < steps; ++n) {
+    double dx = base / steps;
+    for (unsigned int n = 0; n < steps; ++n) {
       x = min_ + (n * dx);
-      s += (f = operator()(x))* dx;
-      if(f > fmax_) fmax_ = f;
+      s += (f = operator()(x)) * dx;
+      if (f > fmax_)
+        fmax_ = f;
     }
-    fmax_ *= 1.001;//max of f
+    fmax_ *= 1.001;  //max of f
     norm_ = s;
   }
   double norm_, min_, max_, fmax_;
   double slope_, a0_, a1_, a2_;
 };
 
-int main(int argc, char * argv[]){
+int main(int argc, char *argv[]) {
   TRandom3 *rndm = new TRandom3();
   int o;
-  char* endPtr;
-  const char* pdf("analysis_Z_133pb_trackIso_3.root");
-  double yield(3810.0), effTrk(.996), effSa(.987),effHlt(.913), effIso(.982),factor(1.0),MIN(60.),MAX(120.);
+  char *endPtr;
+  const char *pdf("analysis_Z_133pb_trackIso_3.root");
+  double yield(3810.0), effTrk(.996), effSa(.987), effHlt(.913), effIso(.982), factor(1.0), MIN(60.), MAX(120.);
   double slopeMuTk(0.02), a0MuTk(1.0), a1MuTk(0.0), a2MuTk(0.0);
-  double slopeMuMuNonIso(0.02),a0MuMuNonIso(1.0), a1MuMuNonIso(0.0), a2MuMuNonIso(0.0);
-  double slopeMuSa(0.02), a0MuSa(1.0), a1MuSa(0.0), a2MuSa(0.0);  
-// double yield(50550.0), effTrk(.998364), effSa(.989626),effHlt(.915496), effIso(.978575),factor(1.0);
+  double slopeMuMuNonIso(0.02), a0MuMuNonIso(1.0), a1MuMuNonIso(0.0), a2MuMuNonIso(0.0);
+  double slopeMuSa(0.02), a0MuSa(1.0), a1MuSa(0.0), a2MuSa(0.0);
+  // double yield(50550.0), effTrk(.998364), effSa(.989626),effHlt(.915496), effIso(.978575),factor(1.0);
   // double slopeMuTk(.015556), a0MuTk(.00035202), a1MuTk(2.99663), a2MuTk(-0.0211138);
   // double slopeMuMuNonIso(.0246876),a0MuMuNonIso(.884777), a1MuMuNonIso(6.67684), a2MuMuNonIso(-0.0523693);
   // BkgShape zMuTkBkgPdf(60., 120., slopeMuTk, a0MuTk, a1MuTk, a2MuTk);
@@ -115,63 +114,73 @@ int main(int argc, char * argv[]){
 
   int expt(1), seed(1);
 
-  while ((o = getopt(argc, argv,"p:n:s:y:m:M:f:T:S:H:I:h"))!=EOF) {
-    switch(o) {
-    case 'p':
-      pdf  = optarg;
-      break;
-    case 'n':
-      expt  = strtoul(optarg,&endPtr,0);
-      break;
-    case 's':
-      seed = strtoul(optarg,&endPtr,0);
-      break;
-    case 'y':
-      yield = strtoul(optarg,&endPtr,0);
-      break;
-    case 'm':
-      MIN = strtoul(optarg,&endPtr,0);
-      break;
-    case 'M':
-      MAX = strtoul(optarg,&endPtr,0);
-      break;
-    case 'f':
-      factor = strtoul(optarg,&endPtr,0);
-      break;
-    case 'T':
-      effTrk  = strtod(optarg,&endPtr);
-      break;
-    case 'S':
-      effSa = strtod(optarg,&endPtr);
-      break;
-    case 'H':
-      effHlt = strtod(optarg,&endPtr);
-      break;
-    case 'I':
-      effIso  = strtod(optarg,&endPtr);
-      break;
-    case 'h':
-      cout<< " -p : input root file for pdf"<<endl <<" -n : number of experiment (default 1)"<<endl <<" -s : seed for generator (default 1)"<<endl <<" -T : efficiency of track (default 0.9984)"<<endl <<" -S : efficiency of standAlone(default 0.9896)"<< endl <<" -I : efficiency of Isolation (default 0.9786)" << endl << " -H : efficiency of HLT (default 0.9155)" <<endl << " -y : yield (default 50550)"<<endl<<" -f : scaling_factor for bkg (default 1.0)"<<endl<< " -m : Min (60)"<< endl<< " -M : Max (120)"<<endl;
-      break;
-    default:
-      break;
+  while ((o = getopt(argc, argv, "p:n:s:y:m:M:f:T:S:H:I:h")) != EOF) {
+    switch (o) {
+      case 'p':
+        pdf = optarg;
+        break;
+      case 'n':
+        expt = strtoul(optarg, &endPtr, 0);
+        break;
+      case 's':
+        seed = strtoul(optarg, &endPtr, 0);
+        break;
+      case 'y':
+        yield = strtoul(optarg, &endPtr, 0);
+        break;
+      case 'm':
+        MIN = strtoul(optarg, &endPtr, 0);
+        break;
+      case 'M':
+        MAX = strtoul(optarg, &endPtr, 0);
+        break;
+      case 'f':
+        factor = strtoul(optarg, &endPtr, 0);
+        break;
+      case 'T':
+        effTrk = strtod(optarg, &endPtr);
+        break;
+      case 'S':
+        effSa = strtod(optarg, &endPtr);
+        break;
+      case 'H':
+        effHlt = strtod(optarg, &endPtr);
+        break;
+      case 'I':
+        effIso = strtod(optarg, &endPtr);
+        break;
+      case 'h':
+        cout << " -p : input root file for pdf" << endl
+             << " -n : number of experiment (default 1)" << endl
+             << " -s : seed for generator (default 1)" << endl
+             << " -T : efficiency of track (default 0.9984)" << endl
+             << " -S : efficiency of standAlone(default 0.9896)" << endl
+             << " -I : efficiency of Isolation (default 0.9786)" << endl
+             << " -H : efficiency of HLT (default 0.9155)" << endl
+             << " -y : yield (default 50550)" << endl
+             << " -f : scaling_factor for bkg (default 1.0)" << endl
+             << " -m : Min (60)" << endl
+             << " -M : Max (120)" << endl;
+        break;
+      default:
+        break;
     }
   }
   BkgShape zMuTkBkgPdf(MIN, MAX, slopeMuTk, a0MuTk, a1MuTk, a2MuTk);
   BkgShape zMuMuNonIsoBkgPdf(MIN, MAX, slopeMuMuNonIso, a0MuMuNonIso, a1MuMuNonIso, a2MuMuNonIso);
   BkgShape zMuSaBkgPdf(MIN, MAX, slopeMuSa, a0MuSa, a1MuSa, a2MuSa);
-  MuTag mu1,mu2;
+  MuTag mu1, mu2;
   rndm->SetSeed(seed);
-  int count = 0; 
+  int count = 0;
   //PDF
   TFile *inputfile = new TFile(pdf);
-  TH1F *pdfzmm = (TH1F*)inputfile->Get("goodZToMuMuPlots/zMass");//pdf signal Zmumu(1hlt,2hlt), ZMuMunotIso, ZmuTk
-  TH1F *pdfzmsa = (TH1F*)inputfile->Get("zmumuSaMassHistogram/zMass");//pdf signal ZmuSa
-  double IntegralzmumuNoIsobkg =factor * ( zMuMuNonIsoBkgPdf.integral());
-  double Integralzmutkbkg =factor * (zMuTkBkgPdf.integral());
-  double Integralzmusabkg =factor * (zMuSaBkgPdf.integral());
+  TH1F *pdfzmm = (TH1F *)inputfile->Get("goodZToMuMuPlots/zMass");  //pdf signal Zmumu(1hlt,2hlt), ZMuMunotIso, ZmuTk
+  TH1F *pdfzmsa = (TH1F *)inputfile->Get("zmumuSaMassHistogram/zMass");  //pdf signal ZmuSa
+  double IntegralzmumuNoIsobkg = factor * (zMuMuNonIsoBkgPdf.integral());
+  double Integralzmutkbkg = factor * (zMuTkBkgPdf.integral());
+  double Integralzmusabkg = factor * (zMuSaBkgPdf.integral());
 
-  for(int j = 1; j <=expt; ++j){//loop on number of experiments  
+  for (int j = 1; j <= expt; ++j) {  //loop on number of experiments
     int N0 = rndm->Poisson(yield);
     int nMuTkBkg = rndm->Poisson(Integralzmutkbkg);
     int nMuMuNonIsoBkg = rndm->Poisson(IntegralzmumuNoIsobkg);
@@ -182,156 +191,151 @@ int main(int argc, char * argv[]){
     int NISO = 0;
     int NSa = 0;
     int NTk = 0;
-    for(int i = 0; i < N0; ++i){//loop on Z Yield
-      mu1=mu(effTrk,effSa, rndm);
-      mu2=mu(effTrk,effSa, rndm);
-      bool iso1 =  efficiencyTag(effIso,rndm);
-      bool iso2 =  efficiencyTag(effIso,rndm);
-      bool trig1 = efficiencyTag(effHlt,rndm);
-      bool trig2 = efficiencyTag(effHlt,rndm);
-   
-      if(mu1 == globalMu && mu2 == globalMu){
-	 if(iso1 && iso2){//two global mu isolated
-	   if(trig1 && trig2) N2HLT++;//two trigger
-	   else if((trig1 && !trig2)||(!trig1 && trig2)) N1HLT++;//one trigger
-	 }
-	 else if(!iso1 || !iso2){//at least one not iso
-	   if( trig1 || trig2) NISO++;//at least one trigger
-	 }
-       }//end global
-       else if(((mu1 == globalMu && trig1) &&  mu2 == standaloneMu ) 
-	       ||((mu2 == globalMu && trig2) && mu1 == standaloneMu )){
-	 if(iso1 && iso2) NSa++;
-       }//end mu sa
-      else if(((mu1 == globalMu && trig1) && mu2 == trackerMu) 
-	       || ((mu2 == globalMu && trig2) && mu1 == trackerMu)){
-	 if(iso1 && iso2) NTk++;
-       }//end mu tk
-     
+    for (int i = 0; i < N0; ++i) {  //loop on Z Yield
+      mu1 = mu(effTrk, effSa, rndm);
+      mu2 = mu(effTrk, effSa, rndm);
+      bool iso1 = efficiencyTag(effIso, rndm);
+      bool iso2 = efficiencyTag(effIso, rndm);
+      bool trig1 = efficiencyTag(effHlt, rndm);
+      bool trig2 = efficiencyTag(effHlt, rndm);
 
-    }//end of generation given the yield
-       
+      if (mu1 == globalMu && mu2 == globalMu) {
+        if (iso1 && iso2) {  //two global mu isolated
+          if (trig1 && trig2)
+            N2HLT++;  //two trigger
+          else if ((trig1 && !trig2) || (!trig1 && trig2))
+            N1HLT++;                  //one trigger
+        } else if (!iso1 || !iso2) {  //at least one not iso
+          if (trig1 || trig2)
+            NISO++;  //at least one trigger
+        }
+      }  //end global
+      else if (((mu1 == globalMu && trig1) && mu2 == standaloneMu) ||
+               ((mu2 == globalMu && trig2) && mu1 == standaloneMu)) {
+        if (iso1 && iso2)
+          NSa++;
+      }  //end mu sa
+      else if (((mu1 == globalMu && trig1) && mu2 == trackerMu) || ((mu2 == globalMu && trig2) && mu1 == trackerMu)) {
+        if (iso1 && iso2)
+          NTk++;
+      }  //end mu tk
+
+    }  //end of generation given the yield
+
     Nmumu = N2HLT + N1HLT;
-    
+
     //Define signal Histo
-    TH1F *zMuMu = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuMu2HLT = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuMu1HLT = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuMuNotIso= new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuSa = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuTk = new TH1F("zMass","zMass",200,0,200);
+    TH1F *zMuMu = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuMu2HLT = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuMu1HLT = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuMuNotIso = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuSa = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuTk = new TH1F("zMass", "zMass", 200, 0, 200);
     pdfzmsa->SetName("zMass");
-  
+
     //Fill signal Histo
-   
-    fillRandom(Nmumu,pdfzmm,zMuMu,MIN,MAX, rndm);
-    fillRandom(N2HLT, pdfzmm,zMuMu2HLT,MIN,MAX, rndm);
-    fillRandom(N1HLT, pdfzmm,zMuMu1HLT,MIN,MAX, rndm);
-    fillRandom(NISO,pdfzmm,zMuMuNotIso,MIN,MAX, rndm);
-    fillRandom(NSa,pdfzmsa,zMuSa,MIN,MAX, rndm);
-    fillRandom(NTk, pdfzmm,zMuTk,MIN,MAX, rndm);
-        
-    //output	
+
+    fillRandom(Nmumu, pdfzmm, zMuMu, MIN, MAX, rndm);
+    fillRandom(N2HLT, pdfzmm, zMuMu2HLT, MIN, MAX, rndm);
+    fillRandom(N1HLT, pdfzmm, zMuMu1HLT, MIN, MAX, rndm);
+    fillRandom(NISO, pdfzmm, zMuMuNotIso, MIN, MAX, rndm);
+    fillRandom(NSa, pdfzmsa, zMuSa, MIN, MAX, rndm);
+    fillRandom(NTk, pdfzmm, zMuTk, MIN, MAX, rndm);
+
+    //output
     char head[30];
-    sprintf(head,"zmm_%d",j);
-    string tail =".root";
+    sprintf(head, "zmm_%d", j);
+    string tail = ".root";
     string title = head + tail;
-    
-    TFile *outputfile = new TFile(title.c_str(),"RECREATE");
-    
-    //Hierarchy directory  
-    
-    TDirectory * goodZToMuMu = outputfile->mkdir("goodZToMuMuPlots");
-    TDirectory * goodZToMuMu2HLT = outputfile->mkdir("goodZToMuMu2HLTPlots");
-    TDirectory * goodZToMuMu1HLT = outputfile->mkdir("goodZToMuMu1HLTPlots");
-    TDirectory * nonIsolatedZToMuMu = outputfile->mkdir("nonIsolatedZToMuMuPlots");
-    TDirectory * goodZToMuMuOneStandAloneMuon = outputfile->mkdir("goodZToMuMuOneStandAloneMuonPlots");
-    TDirectory * zmumuSaMassHistogram = outputfile->mkdir("zmumuSaMassHistogram");
-    TDirectory * goodZToMuMuOneTrack = outputfile->mkdir("goodZToMuMuOneTrackPlots");
-  
+
+    TFile *outputfile = new TFile(title.c_str(), "RECREATE");
+
+    //Hierarchy directory
+
+    TDirectory *goodZToMuMu = outputfile->mkdir("goodZToMuMuPlots");
+    TDirectory *goodZToMuMu2HLT = outputfile->mkdir("goodZToMuMu2HLTPlots");
+    TDirectory *goodZToMuMu1HLT = outputfile->mkdir("goodZToMuMu1HLTPlots");
+    TDirectory *nonIsolatedZToMuMu = outputfile->mkdir("nonIsolatedZToMuMuPlots");
+    TDirectory *goodZToMuMuOneStandAloneMuon = outputfile->mkdir("goodZToMuMuOneStandAloneMuonPlots");
+    TDirectory *zmumuSaMassHistogram = outputfile->mkdir("zmumuSaMassHistogram");
+    TDirectory *goodZToMuMuOneTrack = outputfile->mkdir("goodZToMuMuOneTrackPlots");
+
     goodZToMuMu->cd();
     zMuMu->Write();
-    
+
     goodZToMuMu2HLT->cd();
     zMuMu2HLT->Write();
-    
+
     goodZToMuMu1HLT->cd();
     zMuMu1HLT->Write();
-    
+
     nonIsolatedZToMuMu->cd();
     zMuMuNotIso->Write();
-    
+
     goodZToMuMuOneStandAloneMuon->cd();
     zMuSa->Write();
 
     zmumuSaMassHistogram->cd();
     pdfzmsa->Write();
 
-
     goodZToMuMuOneTrack->cd();
     zMuTk->Write();
-    
-    
+
     outputfile->Write();
     outputfile->Close();
-    
+
     delete zMuMu;
     delete zMuMu2HLT;
     delete zMuMu1HLT;
     delete zMuMuNotIso;
     delete zMuSa;
     delete zMuTk;
-    
-       
-    
+
     //Define Background Histo
-    TH1F *zMuMuBkg = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuMu2HLTBkg = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuMu1HLTBkg = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuSaBkg = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuSafromGoldenBkg = new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuMuNotIsoBkg= new TH1F("zMass","zMass",200,0,200);
-    TH1F *zMuTkBkg = new TH1F("zMass","zMass",200,0,200);
-    
-    
-    
-    //Fill >Bkg Histograms 
-    for(int i = 0; i < nMuTkBkg; ++i) {
+    TH1F *zMuMuBkg = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuMu2HLTBkg = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuMu1HLTBkg = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuSaBkg = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuSafromGoldenBkg = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuMuNotIsoBkg = new TH1F("zMass", "zMass", 200, 0, 200);
+    TH1F *zMuTkBkg = new TH1F("zMass", "zMass", 200, 0, 200);
+
+    //Fill >Bkg Histograms
+    for (int i = 0; i < nMuTkBkg; ++i) {
       zMuTkBkg->Fill(zMuTkBkgPdf.rndm(rndm));
     }
-    for(int i = 0; i < nMuMuNonIsoBkg; ++i) {
+    for (int i = 0; i < nMuMuNonIsoBkg; ++i) {
       zMuMuNotIsoBkg->Fill(zMuMuNonIsoBkgPdf.rndm(rndm));
     }
-    for(int i = 0; i < nMuSaBkg; ++i) {
+    for (int i = 0; i < nMuSaBkg; ++i) {
       zMuSaBkg->Fill(zMuSaBkgPdf.rndm(rndm));
     }
     char head2[30];
-    sprintf(head2,"bkg_%d",j);
+    sprintf(head2, "bkg_%d", j);
     string title2 = head2 + tail;
-    TFile *outputfile2 = new TFile(title2.c_str(),"RECREATE");
-    
-    //Hierarchy directory  
-    TDirectory * goodZToMuMu2 = outputfile2->mkdir("goodZToMuMuPlots");
-    TDirectory * goodZToMuMu2HLT2 = outputfile2->mkdir("goodZToMuMu2HLTPlots");
-    TDirectory * goodZToMuMu1HLT2 = outputfile2->mkdir("goodZToMuMu1HLTPlots");
-    TDirectory * nonIsolatedZToMuMu2 = outputfile2->mkdir("nonIsolatedZToMuMuPlots");
-    TDirectory * goodZToMuMuOneStandAloneMuon2 = outputfile2->mkdir("goodZToMuMuOneStandAloneMuonPlots");
-    TDirectory * zmumuSaMassHistogram2 = outputfile2->mkdir("zmumuSaMassHistogram");
-    TDirectory * goodZToMuMuOneTrack2 = outputfile2->mkdir("goodZToMuMuOneTrackPlots");
-    
+    TFile *outputfile2 = new TFile(title2.c_str(), "RECREATE");
+
+    //Hierarchy directory
+    TDirectory *goodZToMuMu2 = outputfile2->mkdir("goodZToMuMuPlots");
+    TDirectory *goodZToMuMu2HLT2 = outputfile2->mkdir("goodZToMuMu2HLTPlots");
+    TDirectory *goodZToMuMu1HLT2 = outputfile2->mkdir("goodZToMuMu1HLTPlots");
+    TDirectory *nonIsolatedZToMuMu2 = outputfile2->mkdir("nonIsolatedZToMuMuPlots");
+    TDirectory *goodZToMuMuOneStandAloneMuon2 = outputfile2->mkdir("goodZToMuMuOneStandAloneMuonPlots");
+    TDirectory *zmumuSaMassHistogram2 = outputfile2->mkdir("zmumuSaMassHistogram");
+    TDirectory *goodZToMuMuOneTrack2 = outputfile2->mkdir("goodZToMuMuOneTrackPlots");
 
     goodZToMuMu2->cd();
     zMuMuBkg->Write();
-    
+
     goodZToMuMu2HLT2->cd();
     zMuMu2HLTBkg->Write();
-    
+
     goodZToMuMu1HLT2->cd();
     zMuMu1HLTBkg->Write();
-    
+
     nonIsolatedZToMuMu2->cd();
     zMuMuNotIsoBkg->Write();
-    
+
     goodZToMuMuOneStandAloneMuon2->cd();
     zMuSaBkg->Write();
 
@@ -340,7 +344,7 @@ int main(int argc, char * argv[]){
 
     goodZToMuMuOneTrack2->cd();
     zMuTkBkg->Write();
-    
+
     outputfile2->Write();
     outputfile2->Close();
 
@@ -352,13 +356,11 @@ int main(int argc, char * argv[]){
     delete zMuSaBkg;
     delete zMuTkBkg;
 
-    
     // cout<<count<<"\n";
     count++;
-  }//end of experiments 
+  }  //end of experiments
 
   delete inputfile;
-    
+
   return 0;
-  
 }

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMuMuRooFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMuMuRooFit.cpp
@@ -11,7 +11,7 @@
 #include "RooExponential.h"
 #include "RooProdPdf.h"
 #include "RooChi2Var.h"
-#include "RooGlobalFunc.h" 
+#include "RooGlobalFunc.h"
 #include "RooPlot.h"
 #include "RooMinuit.h"
 #include "RooFitResult.h"
@@ -37,491 +37,508 @@ using namespace RooFit;
 
 // A function that get histogram, restricting it on fit range  and sets contents to 0.0 if entries are too small
 
-
-TH1F * getHisto(TFile * file, const char * name, double fMin, double fMax, unsigned int rebin) {
-  TObject * h = file->Get(name);
+TH1F *getHisto(TFile *file, const char *name, double fMin, double fMax, unsigned int rebin) {
+  TObject *h = file->Get(name);
   if (h == nullptr)
-    cout  << "Can't find object " << name << "\n";
-  TH1F * histo = dynamic_cast<TH1F*>(h);
+    cout << "Can't find object " << name << "\n";
+  TH1F *histo = dynamic_cast<TH1F *>(h);
   if (histo == nullptr)
     cout << "Object " << name << " is of type " << h->ClassName() << ", not TH1\n";
-  TH1F * new_histo = new TH1F(name, name, (int) (fMax-fMin), fMin, fMax);
-  int bin_num=0;
-  for (int i = (int)fMin; i <= (int)fMax; ++i ) {
-    bin_num= (i - (int)fMin + 1);  
-    new_histo->SetBinContent( bin_num, histo->GetBinContent(i) );				    
-  } 
+  TH1F *new_histo = new TH1F(name, name, (int)(fMax - fMin), fMin, fMax);
+  int bin_num = 0;
+  for (int i = (int)fMin; i <= (int)fMax; ++i) {
+    bin_num = (i - (int)fMin + 1);
+    new_histo->SetBinContent(bin_num, histo->GetBinContent(i));
+  }
   delete histo;
   new_histo->Sumw2();
   new_histo->Rebin(rebin);
-  for(int i = 1; i <= new_histo->GetNbinsX(); ++i) {
-    if(new_histo->GetBinContent(i) == 0.00) {
-      cout<< " WARNING: histo " << name << " has 0 enter in bin number " << i << endl;   
-        }
-    if(new_histo->GetBinContent(i) < 0.1) {
+  for (int i = 1; i <= new_histo->GetNbinsX(); ++i) {
+    if (new_histo->GetBinContent(i) == 0.00) {
+      cout << " WARNING: histo " << name << " has 0 enter in bin number " << i << endl;
+    }
+    if (new_histo->GetBinContent(i) < 0.1) {
       new_histo->SetBinContent(i, 0.0);
       new_histo->SetBinError(i, 0.0);
-       cout<< " WARNING: setting value 0.0 to histo " << name << " for bin number " << i << endl;   
-    }  
+      cout << " WARNING: setting value 0.0 to histo " << name << " for bin number " << i << endl;
+    }
   }
-  
+
   return new_histo;
 }
 
 // a function that create fromm a model pdf a toy RooDataHist
 
-RooDataHist * genHistFromModelPdf(const char * name, RooAbsPdf *model,  RooRealVar *var,    double ScaleLumi,  int range, int rebin, int seed ) {
-  double genEvents =  model->expectedEvents(*var);
+RooDataHist *genHistFromModelPdf(
+    const char *name, RooAbsPdf *model, RooRealVar *var, double ScaleLumi, int range, int rebin, int seed) {
+  double genEvents = model->expectedEvents(*var);
   TRandom3 *rndm = new TRandom3();
   rndm->SetSeed(seed);
-  double nEvt = rndm->PoissonD( genEvents) ;
-  int intEvt = ( (nEvt- (int)nEvt) >= 0.5) ? (int)nEvt +1 : int(nEvt);
-  RooDataSet * data = model->generate(*var ,   intEvt   );
-  cout<< " expected events for " << name << " = "<< genEvents << endl; 
-  cout<< " data->numEntries() for name " << name << " == " << data->numEntries()<< endl;
+  double nEvt = rndm->PoissonD(genEvents);
+  int intEvt = ((nEvt - (int)nEvt) >= 0.5) ? (int)nEvt + 1 : int(nEvt);
+  RooDataSet *data = model->generate(*var, intEvt);
+  cout << " expected events for " << name << " = " << genEvents << endl;
+  cout << " data->numEntries() for name " << name << " == " << data->numEntries() << endl;
   // cout<< " nEvt from PoissonD for" << name << " == " << nEvt<< endl;
-  //cout<< " cast of nEvt  for" << name << " == " << intEvt<< endl; 
+  //cout<< " cast of nEvt  for" << name << " == " << intEvt<< endl;
   RooAbsData *binned_data = data->binnedClone();
-  TH1 * toy_hist = binned_data->createHistogram( name, *var, Binning(range/rebin )  );
-  for(int i = 1; i <= toy_hist->GetNbinsX(); ++i) {
-    toy_hist->SetBinError( i,  sqrt( toy_hist->GetBinContent(i)) );
-    if(toy_hist->GetBinContent(i) == 0.00) {
-      cout<< " WARNING: histo " << name << " has 0 enter in bin number " << i << endl;   
+  TH1 *toy_hist = binned_data->createHistogram(name, *var, Binning(range / rebin));
+  for (int i = 1; i <= toy_hist->GetNbinsX(); ++i) {
+    toy_hist->SetBinError(i, sqrt(toy_hist->GetBinContent(i)));
+    if (toy_hist->GetBinContent(i) == 0.00) {
+      cout << " WARNING: histo " << name << " has 0 enter in bin number " << i << endl;
     }
-    if(toy_hist->GetBinContent(i) < 0.1) {
+    if (toy_hist->GetBinContent(i) < 0.1) {
       toy_hist->SetBinContent(i, 0.0);
       toy_hist->SetBinError(i, 0.0);
-      cout<< " WARNING: setting value 0.0 to histo " << name << " for bin number " << i << endl;   
-    }  
+      cout << " WARNING: setting value 0.0 to histo " << name << " for bin number " << i << endl;
+    }
   }
-  RooDataHist * toy_rooHist = new RooDataHist(name, name , RooArgList(*var), toy_hist );
-  return toy_rooHist; 
+  RooDataHist *toy_rooHist = new RooDataHist(name, name, RooArgList(*var), toy_hist);
+  return toy_rooHist;
 }
 
+// a function to create the pdf used for the fit, need the histo model, should be zmm except for zmusta case.....
 
-// a function to create the pdf used for the fit, need the histo model, should be zmm except for zmusta case..... 
-
-RooHistPdf * createHistPdf( const char * name, TH1F *model,  RooRealVar *var,  int rebin){
-  TH1F * model_clone = new TH1F(*model);
+RooHistPdf *createHistPdf(const char *name, TH1F *model, RooRealVar *var, int rebin) {
+  TH1F *model_clone = new TH1F(*model);
   model_clone->Sumw2();
-  model_clone-> Rebin( rebin ); 
-  RooDataHist * model_dataHist = new RooDataHist(name, name , RooArgList(*var), model_clone ); 
-  RooHistPdf * HistPdf = new RooHistPdf(name, name, *var, *model_dataHist,  0);
+  model_clone->Rebin(rebin);
+  RooDataHist *model_dataHist = new RooDataHist(name, name, RooArgList(*var), model_clone);
+  RooHistPdf *HistPdf = new RooHistPdf(name, name, *var, *model_dataHist, 0);
   delete model_clone;
   return HistPdf;
 }
 
-
-
-void fit( RooAbsReal & chi2, int numberOfBins, const char * outFileNameWithFitResult ){
-  TFile * out_root_file = new TFile(outFileNameWithFitResult , "recreate");
-  RooMinuit m_tot(chi2) ;
+void fit(RooAbsReal &chi2, int numberOfBins, const char *outFileNameWithFitResult) {
+  TFile *out_root_file = new TFile(outFileNameWithFitResult, "recreate");
+  RooMinuit m_tot(chi2);
   m_tot.migrad();
   // m_tot.hesse();
-  RooFitResult* r_chi2 = m_tot.save() ;
-  cout << "==> Chi2 Fit results " << endl ;
-  r_chi2->Print("v") ;
+  RooFitResult *r_chi2 = m_tot.save();
+  cout << "==> Chi2 Fit results " << endl;
+  r_chi2->Print("v");
   //  r_chi2->floatParsFinal().Print("v") ;
-  int NumberOfFreeParameters =  r_chi2->floatParsFinal().getSize() ;
-  for (int i =0; i< NumberOfFreeParameters; ++i){
+  int NumberOfFreeParameters = r_chi2->floatParsFinal().getSize();
+  for (int i = 0; i < NumberOfFreeParameters; ++i) {
     r_chi2->floatParsFinal()[i].Print();
   }
-  cout<<"chi2:" <<chi2.getVal() << ", numberOfBins: " << numberOfBins  << ", NumberOfFreeParameters: " << NumberOfFreeParameters << endl; 
-  cout<<"Normalized Chi2   = " << chi2.getVal()/ (numberOfBins - NumberOfFreeParameters)<<endl; 
-  r_chi2->Write( ) ;
+  cout << "chi2:" << chi2.getVal() << ", numberOfBins: " << numberOfBins
+       << ", NumberOfFreeParameters: " << NumberOfFreeParameters << endl;
+  cout << "Normalized Chi2   = " << chi2.getVal() / (numberOfBins - NumberOfFreeParameters) << endl;
+  r_chi2->Write();
   delete out_root_file;
 }
 
-
-int main(int argc, char** argv){
+int main(int argc, char **argv) {
   gROOT->SetStyle("Plain");
-  double fMin , fMax,  lumi, scaleLumi =1;
+  double fMin, fMax, lumi, scaleLumi = 1;
   int seed;
   Bool_t toy = kFALSE;
-  Bool_t  fitFromData = kFALSE;
-  string  infile, outfile;
-  int rebinZMuMu =1, rebinZMuSa = 1,   rebinZMuTk = 1,  rebinZMuMuNoIso=1,  rebinZMuMuHlt =  1; 
+  Bool_t fitFromData = kFALSE;
+  string infile, outfile;
+  int rebinZMuMu = 1, rebinZMuSa = 1, rebinZMuTk = 1, rebinZMuMuNoIso = 1, rebinZMuMuHlt = 1;
   po::options_description desc("Allowed options");
-  desc.add_options()
-    ("help,h", "produce help message")
-    ("toy,t", "toy enabled")
-    ("seed,s", po::value<int>(&seed)->default_value(34567), "seed value for toy")
-    ("luminosity,l", po::value<double>(&lumi)->default_value(45.), "luminosity value for toy ")
-    ("fit,f", "fit from data enabled")
-    ("rebin,r", po::value< vector<int> > (), "rebin value: r_mutrk r mumuNotIso r_musa r _muhlt")
-    ("input-file,i", po::value< string> (&infile), "input file")
-    ("output-file,o", po::value< string> (&outfile), "output file with fit results")
-    ("min,m", po::value<double>(&fMin)->default_value(60), "minimum value for fit range")
-    ("max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range");
+  desc.add_options()("help,h", "produce help message")("toy,t", "toy enabled")(
+      "seed,s", po::value<int>(&seed)->default_value(34567), "seed value for toy")(
+      "luminosity,l", po::value<double>(&lumi)->default_value(45.), "luminosity value for toy ")(
+      "fit,f", "fit from data enabled")(
+      "rebin,r", po::value<vector<int> >(), "rebin value: r_mutrk r mumuNotIso r_musa r _muhlt")(
+      "input-file,i", po::value<string>(&infile), "input file")(
+      "output-file,o", po::value<string>(&outfile), "output file with fit results")(
+      "min,m", po::value<double>(&fMin)->default_value(60), "minimum value for fit range")(
+      "max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range");
   po::positional_options_description p;
   p.add("rebin", -1);
   po::variables_map vm;
-  po::store(po::command_line_parser(argc, argv).
-	    options(desc).positional(p).run(), vm);
+  po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
   po::notify(vm);
   if (vm.count("help")) {
     cout << "Usage: options_description [options]\n";
     cout << desc;
     return 0;
-  }      
+  }
 
   if (vm.count("toy")) {
     cout << "toy enabled with seed " << seed << "\n";
     toy = kTRUE;
     //RooRandom::randomGenerator()->SetSeed(seed) ;
     // lumi should be intented as pb-1 and passed from outside
-    scaleLumi=  lumi / 45.0 ; // 45 is the current lumi correspondent to the histogram.....
-  }      
+    scaleLumi = lumi / 45.0;  // 45 is the current lumi correspondent to the histogram.....
+  }
   if (vm.count("fit")) {
     cout << "fit from data enabled \n";
     fitFromData = kTRUE;
-  }      
-  
+  }
+
   if (!vm.count("toy") && !vm.count("fit")) {
     cerr << "Choose one beetween  fitting form data or with a toy MC \n";
     return 1;
-  }      
-  
-  if ( toy == fitFromData ){
+  }
+
+  if (toy == fitFromData) {
     cerr << "Choose if fit from data or with a toy MC \n";
     return 1;
   }
-  
-  if (vm.count("rebin") ) {
-    vector<int> v_rebin = vm["rebin"].as< vector<int> >();
-    if (v_rebin.size()!=4){
+
+  if (vm.count("rebin")) {
+    vector<int> v_rebin = vm["rebin"].as<vector<int> >();
+    if (v_rebin.size() != 4) {
       cerr << " please provide 4 numbers in the given order:r_mutrk r mumuNotIso r_musa r _muhlt \n";
       return 1;
     }
-    rebinZMuTk = v_rebin[0];  rebinZMuMuNoIso=v_rebin[1];   rebinZMuSa = v_rebin[2];rebinZMuMuHlt = v_rebin[3]; 
+    rebinZMuTk = v_rebin[0];
+    rebinZMuMuNoIso = v_rebin[1];
+    rebinZMuSa = v_rebin[2];
+    rebinZMuMuHlt = v_rebin[3];
   }
 
-  RooRealVar * mass = new RooRealVar("mass", "mass (GeV/c^{2})", fMin, fMax );
-  TFile * root_file = new TFile(infile.c_str(), "read");
+  RooRealVar *mass = new RooRealVar("mass", "mass (GeV/c^{2})", fMin, fMax);
+  TFile *root_file = new TFile(infile.c_str(), "read");
   int range = (int)(fMax - fMin);
-  int numberOfBins = range/rebinZMuSa  + range/rebinZMuTk + range/rebinZMuMuNoIso + 2* range/rebinZMuMuHlt ;
-  // zmm histograms used for pdf 
-  TH1F * zmm = getHisto(root_file, "goodZToMuMuPlots/zMass",fMin, fMax, rebinZMuMu );  
+  int numberOfBins = range / rebinZMuSa + range / rebinZMuTk + range / rebinZMuMuNoIso + 2 * range / rebinZMuMuHlt;
+  // zmm histograms used for pdf
+  TH1F *zmm = getHisto(root_file, "goodZToMuMuPlots/zMass", fMin, fMax, rebinZMuMu);
   // zmsta used for pdf
-  TH1F *zmsta = getHisto(root_file, "zmumuSaMassHistogram/zMass",fMin, fMax, 1);  // histogramms to fit.....
-  TH1F *zmmsta = getHisto(root_file, "goodZToMuMuOneStandAloneMuonPlots/zMass",fMin, fMax,  rebinZMuSa/rebinZMuMu);  
-  TH1F *zmt = getHisto(root_file, "goodZToMuMuOneTrackPlots/zMass", fMin, fMax, rebinZMuTk / rebinZMuMu);  
-  TH1F *zmmNotIso = getHisto(root_file,"nonIsolatedZToMuMuPlots/zMass",  fMin, fMax, rebinZMuMuNoIso / rebinZMuMu); 
-  TH1F *zmm1hlt = getHisto(root_file, "goodZToMuMu1HLTPlots/zMass", fMin, fMax, rebinZMuMuHlt / rebinZMuMu);   
-  TH1F *zmm2hlt = getHisto(root_file, "goodZToMuMu2HLTPlots/zMass", fMin, fMax, rebinZMuMuHlt / rebinZMuMu);   
+  TH1F *zmsta = getHisto(root_file, "zmumuSaMassHistogram/zMass", fMin, fMax, 1);  // histogramms to fit.....
+  TH1F *zmmsta = getHisto(root_file, "goodZToMuMuOneStandAloneMuonPlots/zMass", fMin, fMax, rebinZMuSa / rebinZMuMu);
+  TH1F *zmt = getHisto(root_file, "goodZToMuMuOneTrackPlots/zMass", fMin, fMax, rebinZMuTk / rebinZMuMu);
+  TH1F *zmmNotIso = getHisto(root_file, "nonIsolatedZToMuMuPlots/zMass", fMin, fMax, rebinZMuMuNoIso / rebinZMuMu);
+  TH1F *zmm1hlt = getHisto(root_file, "goodZToMuMu1HLTPlots/zMass", fMin, fMax, rebinZMuMuHlt / rebinZMuMu);
+  TH1F *zmm2hlt = getHisto(root_file, "goodZToMuMu2HLTPlots/zMass", fMin, fMax, rebinZMuMuHlt / rebinZMuMu);
 
-  
-  
-  
   // creating a pdf for Zmt
-  
-  RooHistPdf * ZmtPdf = createHistPdf( "ZmtPdf", zmm, mass, rebinZMuTk/ rebinZMuMu  );
+
+  RooHistPdf *ZmtPdf = createHistPdf("ZmtPdf", zmm, mass, rebinZMuTk / rebinZMuMu);
   // creating a pdf for Zmm not iso
-  RooHistPdf * ZmmNoIsoPdf = createHistPdf( "ZmmNoIsoPdf", zmm, mass, rebinZMuMuNoIso/ rebinZMuMu   );
+  RooHistPdf *ZmmNoIsoPdf = createHistPdf("ZmmNoIsoPdf", zmm, mass, rebinZMuMuNoIso / rebinZMuMu);
   // creating a pdf for Zms from zmsta!!!
-  RooHistPdf * ZmsPdf = createHistPdf( "ZmsPdf", zmsta, mass, rebinZMuSa/ rebinZMuMu  );
+  RooHistPdf *ZmsPdf = createHistPdf("ZmsPdf", zmsta, mass, rebinZMuSa / rebinZMuMu);
   // creating a pdf for Zmmhlt
-  RooHistPdf * ZmmHltPdf = createHistPdf( "ZmmHltPdf", zmm, mass, rebinZMuMuHlt/ rebinZMuMu  );
-  
+  RooHistPdf *ZmmHltPdf = createHistPdf("ZmmHltPdf", zmm, mass, rebinZMuMuHlt / rebinZMuMu);
+
   // creating the variable with random init values
-  
-  RooRealVar Yield("Yield","Yield", 15000.,345.,3567890.)  ;
-  RooRealVar nbkg_mutrk("nbkg_mutrk","background _mutrk fraction",500,0.,100000.) ; 
-  RooRealVar nbkg_mumuNotIso("nbkg_mumuNotIso","background fraction",500,0.,100000.) ;
-  RooRealVar nbkg_musa("nbkg_musa","background fraction",50,0.,100000.) ;
-  RooRealVar eff_tk("eff_tk","signal _mutrk fraction",.99,0.8,1.0) ;
-  RooRealVar eff_sa("eff_sa","eff musta",0.99,0.8,1.0) ;
-  RooRealVar eff_iso("eff_iso","eff mumuNotIso",.99,0.8,1.0) ;
-  RooRealVar eff_hlt("eff_hlt","eff 1hlt",0.99, 0.8,1.0) ;
-  RooRealVar alpha  ("alpha","coefficient alpha", -0.01 , -1000, 1000.) ;
-  RooRealVar a0 ("a0","coefficient 0", 1,-1000.,1000.) ;
-  RooRealVar a1 ("a1","coefficient 1", -0.001,-1000,1000.) ;
-  RooRealVar a2 ("a2","coefficient 2", 0.0,-1000.,1000.) ;
-  RooRealVar beta ("beta","coefficient beta", -0.01,-1000 , 1000. ) ;
-  RooRealVar b0 ("b0","coefficient 0", 1,-1000.,1000.) ;
-  RooRealVar b1 ("b1","coefficient 1", -0.001,-1000,1000.) ;
-  RooRealVar b2("b2","coefficient 2", 0.0,-1000.,1000.) ;
-  RooRealVar gamma ("gamma","coefficient gamma", -0.01,-1000 , 1000. ) ;
-  RooRealVar c0 ("c0","coefficient 0", 1,-1000.,1000.) ;
-  RooRealVar c1 ("c1","coefficient 1", -0.001,-1000,1000.) ;
-  // fit parameters setted from datacard 
+
+  RooRealVar Yield("Yield", "Yield", 15000., 345., 3567890.);
+  RooRealVar nbkg_mutrk("nbkg_mutrk", "background _mutrk fraction", 500, 0., 100000.);
+  RooRealVar nbkg_mumuNotIso("nbkg_mumuNotIso", "background fraction", 500, 0., 100000.);
+  RooRealVar nbkg_musa("nbkg_musa", "background fraction", 50, 0., 100000.);
+  RooRealVar eff_tk("eff_tk", "signal _mutrk fraction", .99, 0.8, 1.0);
+  RooRealVar eff_sa("eff_sa", "eff musta", 0.99, 0.8, 1.0);
+  RooRealVar eff_iso("eff_iso", "eff mumuNotIso", .99, 0.8, 1.0);
+  RooRealVar eff_hlt("eff_hlt", "eff 1hlt", 0.99, 0.8, 1.0);
+  RooRealVar alpha("alpha", "coefficient alpha", -0.01, -1000, 1000.);
+  RooRealVar a0("a0", "coefficient 0", 1, -1000., 1000.);
+  RooRealVar a1("a1", "coefficient 1", -0.001, -1000, 1000.);
+  RooRealVar a2("a2", "coefficient 2", 0.0, -1000., 1000.);
+  RooRealVar beta("beta", "coefficient beta", -0.01, -1000, 1000.);
+  RooRealVar b0("b0", "coefficient 0", 1, -1000., 1000.);
+  RooRealVar b1("b1", "coefficient 1", -0.001, -1000, 1000.);
+  RooRealVar b2("b2", "coefficient 2", 0.0, -1000., 1000.);
+  RooRealVar gamma("gamma", "coefficient gamma", -0.01, -1000, 1000.);
+  RooRealVar c0("c0", "coefficient 0", 1, -1000., 1000.);
+  RooRealVar c1("c1", "coefficient 1", -0.001, -1000, 1000.);
+  // fit parameters setted from datacard
   filebuf fb;
-  fb.open ("zMuMuRooFit.txt",ios::in);
+  fb.open("zMuMuRooFit.txt", ios::in);
   istream is(&fb);
   char line[1000];
-  
-  Yield.readFromStream(is.getline(line, 1000), kFALSE);  
-  nbkg_mutrk.readFromStream(is.getline(line,1000), kFALSE);
-  nbkg_mumuNotIso.readFromStream(is.getline(line,1000),  kFALSE);
-  nbkg_musa.readFromStream(is.getline(line,1000),  kFALSE);
-  eff_tk.readFromStream(is.getline(line,1000),  kFALSE);
-  eff_sa.readFromStream(is.getline(line,1000),  kFALSE);
-  eff_iso.readFromStream(is.getline(line,1000),  kFALSE);
-  eff_hlt.readFromStream(is.getline(line,1000),  kFALSE);
-  alpha.readFromStream(is.getline(line,1000),  kFALSE);
-  a0.readFromStream(is.getline(line,1000),  kFALSE);  
-  a1.readFromStream(is.getline(line,1000), kFALSE );  
-  a2.readFromStream(is.getline(line,1000), kFALSE);  
-  beta.readFromStream(is.getline(line,1000), kFALSE);
-  b0.readFromStream(is.getline(line,1000), kFALSE);  
-  b1.readFromStream(is.getline(line,1000), kFALSE);  
-  b2.readFromStream(is.getline(line,1000), kFALSE);  
-  gamma.readFromStream(is.getline(line,1000), kFALSE);
-  c0.readFromStream(is.getline(line,1000), kFALSE);  
-  c1.readFromStream(is.getline(line,1000), kFALSE);  
+
+  Yield.readFromStream(is.getline(line, 1000), kFALSE);
+  nbkg_mutrk.readFromStream(is.getline(line, 1000), kFALSE);
+  nbkg_mumuNotIso.readFromStream(is.getline(line, 1000), kFALSE);
+  nbkg_musa.readFromStream(is.getline(line, 1000), kFALSE);
+  eff_tk.readFromStream(is.getline(line, 1000), kFALSE);
+  eff_sa.readFromStream(is.getline(line, 1000), kFALSE);
+  eff_iso.readFromStream(is.getline(line, 1000), kFALSE);
+  eff_hlt.readFromStream(is.getline(line, 1000), kFALSE);
+  alpha.readFromStream(is.getline(line, 1000), kFALSE);
+  a0.readFromStream(is.getline(line, 1000), kFALSE);
+  a1.readFromStream(is.getline(line, 1000), kFALSE);
+  a2.readFromStream(is.getline(line, 1000), kFALSE);
+  beta.readFromStream(is.getline(line, 1000), kFALSE);
+  b0.readFromStream(is.getline(line, 1000), kFALSE);
+  b1.readFromStream(is.getline(line, 1000), kFALSE);
+  b2.readFromStream(is.getline(line, 1000), kFALSE);
+  gamma.readFromStream(is.getline(line, 1000), kFALSE);
+  c0.readFromStream(is.getline(line, 1000), kFALSE);
+  c1.readFromStream(is.getline(line, 1000), kFALSE);
   fb.close();
-  
+
   // scaling to lumi if toy is enabled...
   if (vm.count("toy")) {
     Yield.setVal(scaleLumi * (Yield.getVal()));
     nbkg_mutrk.setVal(scaleLumi * (nbkg_mutrk.getVal()));
     nbkg_mumuNotIso.setVal(scaleLumi * (nbkg_mumuNotIso.getVal()));
-  }   
-  
-  
+  }
+
   //efficiency term
-  
-  //zMuMuEff1HLTTerm = _2 * (effTk ^ _2) *  (effSa ^ _2) * (effIso ^ _2) * effHLT * (_1 - effHLT); 
-  RooFormulaVar zMuMu1HLTEffTerm("zMuMu1HLTEffTerm", "Yield * (2.* (eff_tk)^2 * (eff_sa)^2 * (eff_iso)^2 * eff_hlt *(1.- eff_hlt))", 
-				 RooArgList(eff_tk, eff_sa,eff_iso, eff_hlt, Yield)); //zMuMuEff2HLTTerm = (effTk ^ _2) *  (effSa ^ _2) * (effIso ^ _2) * (effHLT ^ _2) ; 
-  RooFormulaVar zMuMu2HLTEffTerm("zMuMu2HLTEffTerm", "Yield * ((eff_tk)^2 * (eff_sa)^2 * (eff_iso)^2 * (eff_hlt)^2)", 
-				 RooArgList(eff_tk, eff_sa,eff_iso, eff_hlt, Yield));
+
+  //zMuMuEff1HLTTerm = _2 * (effTk ^ _2) *  (effSa ^ _2) * (effIso ^ _2) * effHLT * (_1 - effHLT);
+  RooFormulaVar zMuMu1HLTEffTerm(
+      "zMuMu1HLTEffTerm",
+      "Yield * (2.* (eff_tk)^2 * (eff_sa)^2 * (eff_iso)^2 * eff_hlt *(1.- eff_hlt))",
+      RooArgList(eff_tk,
+                 eff_sa,
+                 eff_iso,
+                 eff_hlt,
+                 Yield));  //zMuMuEff2HLTTerm = (effTk ^ _2) *  (effSa ^ _2) * (effIso ^ _2) * (effHLT ^ _2) ;
+  RooFormulaVar zMuMu2HLTEffTerm("zMuMu2HLTEffTerm",
+                                 "Yield * ((eff_tk)^2 * (eff_sa)^2 * (eff_iso)^2 * (eff_hlt)^2)",
+                                 RooArgList(eff_tk, eff_sa, eff_iso, eff_hlt, Yield));
   //zMuMuNoIsoEffTerm = (effTk ^ _2) * (effSa ^ _2) * (_1 - (effIso ^ _2)) * (_1 - ((_1 - effHLT)^_2));
-  RooFormulaVar zMuMuNoIsoEffTerm("zMuMuNoIsoEffTerm", "Yield * ((eff_tk)^2 * (eff_sa)^2 * (1.- (eff_iso)^2) * (1.- ((1.-eff_hlt)^2)))", 
-				  RooArgList(eff_tk, eff_sa,eff_iso, eff_hlt, Yield));
+  RooFormulaVar zMuMuNoIsoEffTerm("zMuMuNoIsoEffTerm",
+                                  "Yield * ((eff_tk)^2 * (eff_sa)^2 * (1.- (eff_iso)^2) * (1.- ((1.-eff_hlt)^2)))",
+                                  RooArgList(eff_tk, eff_sa, eff_iso, eff_hlt, Yield));
   //zMuTkEffTerm = _2 * (effTk ^ _2) * effSa * (_1 - effSa) * (effIso ^ _2) * effHLT;
-  RooFormulaVar  zMuTkEffTerm("zMuTkEffTerm", "Yield * (2. *(eff_tk)^2 * eff_sa * (1.-eff_sa)* (eff_iso)^2 * eff_hlt)", 
-			     RooArgList(eff_tk, eff_sa,eff_iso, eff_hlt, Yield));
+  RooFormulaVar zMuTkEffTerm("zMuTkEffTerm",
+                             "Yield * (2. *(eff_tk)^2 * eff_sa * (1.-eff_sa)* (eff_iso)^2 * eff_hlt)",
+                             RooArgList(eff_tk, eff_sa, eff_iso, eff_hlt, Yield));
   //zMuSaEffTerm = _2 * (effSa ^ _2) * effTk * (_1 - effTk) * (effIso ^ _2) * effHLT;
-  RooFormulaVar zMuSaEffTerm("zMuSaEffTerm", "Yield * (2. *(eff_sa)^2 * eff_tk * (1.-eff_tk)* (eff_iso)^2 * eff_hlt)", 
-			     RooArgList(eff_tk, eff_sa,eff_iso, eff_hlt, Yield));
-  
-    
-  // creating model for the  fit 
+  RooFormulaVar zMuSaEffTerm("zMuSaEffTerm",
+                             "Yield * (2. *(eff_sa)^2 * eff_tk * (1.-eff_tk)* (eff_iso)^2 * eff_hlt)",
+                             RooArgList(eff_tk, eff_sa, eff_iso, eff_hlt, Yield));
+
+  // creating model for the  fit
   // z mu track
-  
-  RooGenericPdf *bkg_mutrk = new RooGenericPdf("bkg_mutrk","zmt bkg_model", "exp(alpha*mass) * ( a0 + a1 * mass + a2 * mass^2 )", RooArgSet( *mass, alpha, a0, a1,a2) );
+
+  RooGenericPdf *bkg_mutrk = new RooGenericPdf("bkg_mutrk",
+                                               "zmt bkg_model",
+                                               "exp(alpha*mass) * ( a0 + a1 * mass + a2 * mass^2 )",
+                                               RooArgSet(*mass, alpha, a0, a1, a2));
   // RooFormulaVar fracSigMutrk("fracSigMutrk", "@0 / (@0 + @1)", RooArgList(zMuTkEffTerm, nbkg_mutrk ));
-  RooAddPdf * model_mutrk= new RooAddPdf("model_mutrk","model_mutrk",RooArgList(*ZmtPdf,*bkg_mutrk),RooArgList(zMuTkEffTerm , nbkg_mutrk)) ;
+  RooAddPdf *model_mutrk = new RooAddPdf(
+      "model_mutrk", "model_mutrk", RooArgList(*ZmtPdf, *bkg_mutrk), RooArgList(zMuTkEffTerm, nbkg_mutrk));
   // z mu mu not Iso
-  
+
   // creating background pdf for zmu mu not Iso
-  RooGenericPdf *bkg_mumuNotIso = new RooGenericPdf("bkg_mumuNotIso","zmumuNotIso bkg_model", "exp(beta * mass) * (b0 + b1 * mass + b2 * mass^2)", RooArgSet( *mass, beta, b0, b1,b2) );
+  RooGenericPdf *bkg_mumuNotIso = new RooGenericPdf("bkg_mumuNotIso",
+                                                    "zmumuNotIso bkg_model",
+                                                    "exp(beta * mass) * (b0 + b1 * mass + b2 * mass^2)",
+                                                    RooArgSet(*mass, beta, b0, b1, b2));
   // RooFormulaVar fracSigMuMuNoIso("fracSigMuMuNoIso", "@0 / (@0 + @1)", RooArgList(zMuMuNoIsoEffTerm, nbkg_mumuNotIso ));
-  RooAddPdf * model_mumuNotIso= new RooAddPdf("model_mumuNotIso","model_mumuNotIso",RooArgList(*ZmmNoIsoPdf,*bkg_mumuNotIso), RooArgList(zMuMuNoIsoEffTerm, nbkg_mumuNotIso)); 
+  RooAddPdf *model_mumuNotIso = new RooAddPdf("model_mumuNotIso",
+                                              "model_mumuNotIso",
+                                              RooArgList(*ZmmNoIsoPdf, *bkg_mumuNotIso),
+                                              RooArgList(zMuMuNoIsoEffTerm, nbkg_mumuNotIso));
   // z mu sta
-  
+
   // RooGenericPdf model_musta("model_musta",  " ZmsPdf * zMuSaEffTerm ", RooArgSet( *ZmsPdf, zMuSaEffTerm)) ;
-  RooGenericPdf *bkg_musa = new RooGenericPdf("bkg_musa","zmusa bkg_model", "exp(gamma * mass) * (c0 + c1 * mass )", RooArgSet( *mass, gamma, c0, c1) );
-  // RooAddPdf * eZmsSig= new RooAddPdf("eZmsSig","eZmsSig",RooArgList(*,*bkg_mumuNotIso), RooArgList(zMuMuNoIsoEffTerm, nbkg_mumuNotIso)); 
-  RooAddPdf *eZmsSig = new RooAddPdf("eZmsSig","eZmsSig",RooArgList(*ZmsPdf,*bkg_musa),RooArgList(zMuSaEffTerm , nbkg_musa)) ;
+  RooGenericPdf *bkg_musa = new RooGenericPdf(
+      "bkg_musa", "zmusa bkg_model", "exp(gamma * mass) * (c0 + c1 * mass )", RooArgSet(*mass, gamma, c0, c1));
+  // RooAddPdf * eZmsSig= new RooAddPdf("eZmsSig","eZmsSig",RooArgList(*,*bkg_mumuNotIso), RooArgList(zMuMuNoIsoEffTerm, nbkg_mumuNotIso));
+  RooAddPdf *eZmsSig =
+      new RooAddPdf("eZmsSig", "eZmsSig", RooArgList(*ZmsPdf, *bkg_musa), RooArgList(zMuSaEffTerm, nbkg_musa));
 
   //RooExtendPdf * eZmsSig= new RooExtendPdf("eZmsSig","extended signal p.d.f for zms ",*ZmsPdf,  zMuSaEffTerm ) ;
- 
 
- // z mu mu HLT
-  
+  // z mu mu HLT
+
   // count ZMuMu Yield
   double nZMuMu = 0.;
   double nZMuMu1HLT = 0.;
-  double  nZMuMu2HLT = 0.;
+  double nZMuMu2HLT = 0.;
   unsigned int nBins = zmm->GetNbinsX();
   double xMin = zmm->GetXaxis()->GetXmin();
   double xMax = zmm->GetXaxis()->GetXmax();
-  double deltaX =(xMax - xMin) / nBins;
-  for(unsigned int i = 0; i < nBins; ++i) { 
-    double x = xMin + (i +.5) * deltaX;
-    if(x > fMin && x < fMax){
-      nZMuMu += zmm->GetBinContent(i+1);
-      nZMuMu1HLT += zmm1hlt->GetBinContent(i+1);
-      nZMuMu2HLT += zmm2hlt->GetBinContent(i+1);
+  double deltaX = (xMax - xMin) / nBins;
+  for (unsigned int i = 0; i < nBins; ++i) {
+    double x = xMin + (i + .5) * deltaX;
+    if (x > fMin && x < fMax) {
+      nZMuMu += zmm->GetBinContent(i + 1);
+      nZMuMu1HLT += zmm1hlt->GetBinContent(i + 1);
+      nZMuMu2HLT += zmm2hlt->GetBinContent(i + 1);
     }
   }
-  
+
   cout << ">>> count of ZMuMu yield in the range [" << fMin << ", " << fMax << "]: " << nZMuMu << endl;
-  cout << ">>> count of ZMuMu (1HLT) yield in the range [" << fMin << ", " << fMax << "]: "  << nZMuMu1HLT << endl;
-  cout << ">>> count of ZMuMu (2HLT) yield in the range [" << fMin << ", " << fMax << "]: "  << nZMuMu2HLT << endl;
-  // we set eff_hlt 
+  cout << ">>> count of ZMuMu (1HLT) yield in the range [" << fMin << ", " << fMax << "]: " << nZMuMu1HLT << endl;
+  cout << ">>> count of ZMuMu (2HLT) yield in the range [" << fMin << ", " << fMax << "]: " << nZMuMu2HLT << endl;
+  // we set eff_hlt
   //eff_hlt.setVal( 1. / (1. + (nZMuMu1HLT/ (2 * nZMuMu2HLT))) ) ;
   // creating the pdf for z mu mu 1hlt
-  
-  RooExtendPdf * eZmm1hltSig= new RooExtendPdf("eZmm1hltSig","extended signal p.d.f for zmm 1hlt",*ZmmHltPdf,  zMuMu1HLTEffTerm ) ;
-  // creating the pdf for z mu mu 2hlt 
-  RooExtendPdf * eZmm2hltSig= new RooExtendPdf("eZmm2hltSig","extended signal p.d.f for zmm 2hlt",*ZmmHltPdf,  zMuMu2HLTEffTerm ) ;
-  
-  
+
+  RooExtendPdf *eZmm1hltSig =
+      new RooExtendPdf("eZmm1hltSig", "extended signal p.d.f for zmm 1hlt", *ZmmHltPdf, zMuMu1HLTEffTerm);
+  // creating the pdf for z mu mu 2hlt
+  RooExtendPdf *eZmm2hltSig =
+      new RooExtendPdf("eZmm2hltSig", "extended signal p.d.f for zmm 2hlt", *ZmmHltPdf, zMuMu2HLTEffTerm);
+
   // getting the data if fit otherwise constructed the data for model if toy....
-  
-  RooDataHist *zmtMass, * zmmNotIsoMass, *zmsMass, *zmm1hltMass,  *zmm2hltMass;
-  
-  if (toy){
-    zmtMass = genHistFromModelPdf("zmtMass", model_mutrk, mass,  scaleLumi, range,rebinZMuTk, seed);
-    zmmNotIsoMass = genHistFromModelPdf("zmmNotIsoMass", model_mumuNotIso, mass, scaleLumi,  range,rebinZMuMuNoIso, seed);
-    zmsMass = genHistFromModelPdf("zmsMass", eZmsSig, mass,  scaleLumi, range,rebinZMuSa , seed);
-    zmm1hltMass = genHistFromModelPdf("zmm1hltMass", eZmm1hltSig, mass, scaleLumi,  range,rebinZMuMuHlt, seed );
-    zmm2hltMass = genHistFromModelPdf("zmm2hltMass", eZmm2hltSig, mass,   scaleLumi, range,rebinZMuMuHlt, seed);
-  } else {// if  fit from data....
-    zmtMass = new RooDataHist("zmtMass", "good z mu track" , RooArgList(*mass), zmt );
-    zmmNotIsoMass = new RooDataHist("ZmmNotIso", "good z mu mu not isolated" , RooArgList(*mass), zmmNotIso );
-    zmsMass = new RooDataHist("zmsMass", "good z mu sta mass" , RooArgList(*mass), zmmsta );
-    zmm1hltMass = new RooDataHist("zmm1hltMass", "good Z mu mu 1hlt" , RooArgList(*mass),   zmm1hlt );
-    zmm2hltMass = new RooDataHist("zmm2hltMass", "good Z mu mu 2hlt" , RooArgList(*mass),   zmm2hlt );
+
+  RooDataHist *zmtMass, *zmmNotIsoMass, *zmsMass, *zmm1hltMass, *zmm2hltMass;
+
+  if (toy) {
+    zmtMass = genHistFromModelPdf("zmtMass", model_mutrk, mass, scaleLumi, range, rebinZMuTk, seed);
+    zmmNotIsoMass =
+        genHistFromModelPdf("zmmNotIsoMass", model_mumuNotIso, mass, scaleLumi, range, rebinZMuMuNoIso, seed);
+    zmsMass = genHistFromModelPdf("zmsMass", eZmsSig, mass, scaleLumi, range, rebinZMuSa, seed);
+    zmm1hltMass = genHistFromModelPdf("zmm1hltMass", eZmm1hltSig, mass, scaleLumi, range, rebinZMuMuHlt, seed);
+    zmm2hltMass = genHistFromModelPdf("zmm2hltMass", eZmm2hltSig, mass, scaleLumi, range, rebinZMuMuHlt, seed);
+  } else {  // if  fit from data....
+    zmtMass = new RooDataHist("zmtMass", "good z mu track", RooArgList(*mass), zmt);
+    zmmNotIsoMass = new RooDataHist("ZmmNotIso", "good z mu mu not isolated", RooArgList(*mass), zmmNotIso);
+    zmsMass = new RooDataHist("zmsMass", "good z mu sta mass", RooArgList(*mass), zmmsta);
+    zmm1hltMass = new RooDataHist("zmm1hltMass", "good Z mu mu 1hlt", RooArgList(*mass), zmm1hlt);
+    zmm2hltMass = new RooDataHist("zmm2hltMass", "good Z mu mu 2hlt", RooArgList(*mass), zmm2hlt);
   }
-  
-  // creting the chi2s 
-  RooChi2Var *chi2_mutrk = new RooChi2Var("chi2_mutrk","chi2_mutrk",*model_mutrk,*zmtMass, Extended(kTRUE),DataError(RooAbsData::SumW2) ) ;
-  RooChi2Var *chi2_mumuNotIso = new RooChi2Var("chi2_mumuNotIso","chi2_mumuNotIso",*model_mumuNotIso,*zmmNotIsoMass,Extended(kTRUE), DataError(RooAbsData::SumW2)) ;
-  
-  RooChi2Var *chi2_musta = new RooChi2Var("chi2_musta","chi2_musta",*eZmsSig, *zmsMass,  Extended(kTRUE) ,DataError(RooAbsData::SumW2) ) ;
-  // uncomment this line if you want to use logLik for mu sta 
+
+  // creting the chi2s
+  RooChi2Var *chi2_mutrk =
+      new RooChi2Var("chi2_mutrk", "chi2_mutrk", *model_mutrk, *zmtMass, Extended(kTRUE), DataError(RooAbsData::SumW2));
+  RooChi2Var *chi2_mumuNotIso = new RooChi2Var("chi2_mumuNotIso",
+                                               "chi2_mumuNotIso",
+                                               *model_mumuNotIso,
+                                               *zmmNotIsoMass,
+                                               Extended(kTRUE),
+                                               DataError(RooAbsData::SumW2));
+
+  RooChi2Var *chi2_musta =
+      new RooChi2Var("chi2_musta", "chi2_musta", *eZmsSig, *zmsMass, Extended(kTRUE), DataError(RooAbsData::SumW2));
+  // uncomment this line if you want to use logLik for mu sta
   // RooNLLVar *chi2_musta = new RooNLLVar("chi2_musta","chi2_musta",*eZmsSig, *zmsMass,  Extended(kTRUE), DataError(RooAbsData::SumW2) ) ;
-  RooChi2Var *chi2_mu1hlt = new RooChi2Var("chi2_mu1hlt","chi2_mu1hlt", *eZmm1hltSig, *zmm1hltMass,  Extended(kTRUE) , DataError(RooAbsData::SumW2)) ;
-  RooChi2Var *chi2_mu2hlt = new RooChi2Var("chi2_mu2hlt","chi2_mu2hlt", *eZmm2hltSig, *zmm2hltMass,  Extended(kTRUE), DataError(RooAbsData::SumW2) ) ;  
-  
+  RooChi2Var *chi2_mu1hlt = new RooChi2Var(
+      "chi2_mu1hlt", "chi2_mu1hlt", *eZmm1hltSig, *zmm1hltMass, Extended(kTRUE), DataError(RooAbsData::SumW2));
+  RooChi2Var *chi2_mu2hlt = new RooChi2Var(
+      "chi2_mu2hlt", "chi2_mu2hlt", *eZmm2hltSig, *zmm2hltMass, Extended(kTRUE), DataError(RooAbsData::SumW2));
+
   // adding the chi2
-  RooAddition totChi2("totChi2","chi2_mutrk + chi2_mumuNotIso  + chi2_musta   + chi2_mu1hlt  +  chi2_mu2hlt " , RooArgSet(*chi2_mutrk   ,*chi2_mumuNotIso  ,  *chi2_musta ,  *chi2_mu1hlt  ,  *chi2_mu2hlt  )) ;
-  
-  
+  RooAddition totChi2("totChi2",
+                      "chi2_mutrk + chi2_mumuNotIso  + chi2_musta   + chi2_mu1hlt  +  chi2_mu2hlt ",
+                      RooArgSet(*chi2_mutrk, *chi2_mumuNotIso, *chi2_musta, *chi2_mu1hlt, *chi2_mu2hlt));
+
   // printing out the model integral befor fitting
-  double  N_zMuMu1hlt = eZmm1hltSig->expectedEvents(*mass);
-  double  N_bkgTk = bkg_mutrk->expectedEvents(*mass);
-  double  N_bkgIso = bkg_mumuNotIso->expectedEvents(*mass);
-  
-  double  N_zMuTk = zMuTkEffTerm.getVal();
-  
-  double  e_hlt = eff_hlt.getVal();
-  double  e_tk = eff_tk.getVal();
-  double  e_sa = eff_sa.getVal();
-  double  e_iso = eff_iso.getVal();
-  double  Y_hlt = N_zMuMu1hlt / ((2.* (e_tk * e_tk) * (e_sa * e_sa)  * (e_iso* e_iso) * e_hlt *(1.- e_hlt))) ; 
-  double  Y_mutk = N_zMuTk / ((2.* (e_tk * e_tk) * e_sa *(1.- e_sa)  * (e_iso* e_iso) * e_hlt )) ; 
-  
-  cout << "Yield prediction from mumu1hlt integral befor fitting: " <<  Y_hlt << endl
-    ;
-  cout << "Yield prediction from mutk integral befor fitting: " <<  Y_mutk << endl; 
-  cout << "Bkg for mutk prediction from mutk integral after fitting: " <<  N_bkgTk << endl; 
-  cout << "Bkg for mumuNotIso prediction from mumuNotIso integral after fitting: " <<  N_bkgIso << endl; 
-  
-  
-  fit( totChi2,  numberOfBins, outfile.c_str());
+  double N_zMuMu1hlt = eZmm1hltSig->expectedEvents(*mass);
+  double N_bkgTk = bkg_mutrk->expectedEvents(*mass);
+  double N_bkgIso = bkg_mumuNotIso->expectedEvents(*mass);
+
+  double N_zMuTk = zMuTkEffTerm.getVal();
+
+  double e_hlt = eff_hlt.getVal();
+  double e_tk = eff_tk.getVal();
+  double e_sa = eff_sa.getVal();
+  double e_iso = eff_iso.getVal();
+  double Y_hlt = N_zMuMu1hlt / ((2. * (e_tk * e_tk) * (e_sa * e_sa) * (e_iso * e_iso) * e_hlt * (1. - e_hlt)));
+  double Y_mutk = N_zMuTk / ((2. * (e_tk * e_tk) * e_sa * (1. - e_sa) * (e_iso * e_iso) * e_hlt));
+
+  cout << "Yield prediction from mumu1hlt integral befor fitting: " << Y_hlt << endl;
+  cout << "Yield prediction from mutk integral befor fitting: " << Y_mutk << endl;
+  cout << "Bkg for mutk prediction from mutk integral after fitting: " << N_bkgTk << endl;
+  cout << "Bkg for mumuNotIso prediction from mumuNotIso integral after fitting: " << N_bkgIso << endl;
+
+  fit(totChi2, numberOfBins, outfile.c_str());
   N_zMuMu1hlt = eZmm1hltSig->expectedEvents(*mass);
   N_zMuTk = zMuTkEffTerm.getVal();
-  double  N_zMuMuNoIso = zMuMuNoIsoEffTerm.getVal(); 
+  double N_zMuMuNoIso = zMuMuNoIsoEffTerm.getVal();
   double N_Tk = model_mutrk->expectedEvents(*mass);
   double N_Iso = model_mumuNotIso->expectedEvents(*mass);
   e_hlt = eff_hlt.getVal();
   e_tk = eff_tk.getVal();
   e_sa = eff_sa.getVal();
   e_iso = eff_iso.getVal();
-  Y_hlt = N_zMuMu1hlt / ((2.* (e_tk * e_tk) * (e_sa * e_sa)  * (e_iso* e_iso) * e_hlt *(1.- e_hlt))) ; 
-  Y_mutk = N_zMuTk / ((2.* (e_tk * e_tk) * e_sa *(1.- e_sa)  * (e_iso* e_iso) * e_hlt )) ; 
-  
-  cout << "Yield prediction from mumu1hlt integral after fitting: " <<  Y_hlt << endl;
-  //cout << "Yield prediction from mutk integral after fitting: " <<  Y_mutk << endl; 
-  cout << "N + B  prediction from mutk integral after fitting: " <<  N_Tk << endl; 
-  cout << "zMuTkEffTerm " <<  N_zMuTk << endl; 
-  cout << "N + B  prediction from mumuNotIso integral after fitting: " <<  N_Iso << endl;   
-  cout << "zMuMuNoIsoEffTerm " <<  N_zMuMuNoIso << endl; 
-  
-  cout << "chi2_mutrk:" << chi2_mutrk->getVal()<< endl;
-  cout << "chi2_mumuNotIso:" <<    chi2_mumuNotIso->getVal() << endl;
-  cout << "chi2_musta:" <<   chi2_musta->getVal() << endl;
-  cout << "chi2_mumu1hlt:" <<   chi2_mu1hlt->getVal()<< endl;
-  cout << "chi2_mumu2hlt:" <<   chi2_mu2hlt->getVal()<< endl;
-  
-  
+  Y_hlt = N_zMuMu1hlt / ((2. * (e_tk * e_tk) * (e_sa * e_sa) * (e_iso * e_iso) * e_hlt * (1. - e_hlt)));
+  Y_mutk = N_zMuTk / ((2. * (e_tk * e_tk) * e_sa * (1. - e_sa) * (e_iso * e_iso) * e_hlt));
+
+  cout << "Yield prediction from mumu1hlt integral after fitting: " << Y_hlt << endl;
+  //cout << "Yield prediction from mutk integral after fitting: " <<  Y_mutk << endl;
+  cout << "N + B  prediction from mutk integral after fitting: " << N_Tk << endl;
+  cout << "zMuTkEffTerm " << N_zMuTk << endl;
+  cout << "N + B  prediction from mumuNotIso integral after fitting: " << N_Iso << endl;
+  cout << "zMuMuNoIsoEffTerm " << N_zMuMuNoIso << endl;
+
+  cout << "chi2_mutrk:" << chi2_mutrk->getVal() << endl;
+  cout << "chi2_mumuNotIso:" << chi2_mumuNotIso->getVal() << endl;
+  cout << "chi2_musta:" << chi2_musta->getVal() << endl;
+  cout << "chi2_mumu1hlt:" << chi2_mu1hlt->getVal() << endl;
+  cout << "chi2_mumu2hlt:" << chi2_mu2hlt->getVal() << endl;
+
   //plotting
-  RooPlot * massFrame_mutrk = mass->frame() ; 
-  RooPlot * massFrame_mumuNotIso = mass->frame() ;
-  RooPlot * massFrame_musta = mass->frame() ;
-  RooPlot * massFrame_mumu1hlt = mass->frame() ;
-  RooPlot * massFrame_mumu2hlt = mass->frame() ;
-  
-  TCanvas  * canv1 = new TCanvas("canvas");
-  TCanvas  * canv2 = new TCanvas("new_canvas");
-  canv1->Divide(2,3);
+  RooPlot *massFrame_mutrk = mass->frame();
+  RooPlot *massFrame_mumuNotIso = mass->frame();
+  RooPlot *massFrame_musta = mass->frame();
+  RooPlot *massFrame_mumu1hlt = mass->frame();
+  RooPlot *massFrame_mumu2hlt = mass->frame();
+
+  TCanvas *canv1 = new TCanvas("canvas");
+  TCanvas *canv2 = new TCanvas("new_canvas");
+  canv1->Divide(2, 3);
   canv1->cd(1);
   canv1->SetLogy(kTRUE);
-  zmtMass->plotOn(massFrame_mutrk, LineColor(kBlue)) ;
-  model_mutrk->plotOn(massFrame_mutrk,LineColor(kRed)) ;
-  model_mutrk->plotOn(massFrame_mutrk,Components(*bkg_mutrk),LineColor(kGreen)) ;
+  zmtMass->plotOn(massFrame_mutrk, LineColor(kBlue));
+  model_mutrk->plotOn(massFrame_mutrk, LineColor(kRed));
+  model_mutrk->plotOn(massFrame_mutrk, Components(*bkg_mutrk), LineColor(kGreen));
   massFrame_mutrk->SetTitle("Z -> #mu track");
- // massFrame_mutrk->GetYaxis()->SetLogScale();
-  massFrame_mutrk->Draw();  
-  gPad->SetLogy(1); 
-  
+  // massFrame_mutrk->GetYaxis()->SetLogScale();
+  massFrame_mutrk->Draw();
+  gPad->SetLogy(1);
+
   canv2->cd();
   canv2->SetLogy(kTRUE);
-  massFrame_mutrk->Draw();  
-  canv2->SaveAs("LogZMuTk.eps"); 
+  massFrame_mutrk->Draw();
+  canv2->SaveAs("LogZMuTk.eps");
   canv2->SetLogy(kFALSE);
-  canv2->SaveAs("LinZMuTk.eps"); 
-  
+  canv2->SaveAs("LinZMuTk.eps");
+
   canv1->cd(2);
-  zmmNotIsoMass->plotOn(massFrame_mumuNotIso, LineColor(kBlue)) ;
-  model_mumuNotIso->plotOn(massFrame_mumuNotIso,LineColor(kRed)) ;
-  model_mumuNotIso->plotOn(massFrame_mumuNotIso,Components(*bkg_mumuNotIso), LineColor(kGreen)) ;
+  zmmNotIsoMass->plotOn(massFrame_mumuNotIso, LineColor(kBlue));
+  model_mumuNotIso->plotOn(massFrame_mumuNotIso, LineColor(kRed));
+  model_mumuNotIso->plotOn(massFrame_mumuNotIso, Components(*bkg_mumuNotIso), LineColor(kGreen));
   massFrame_mumuNotIso->SetTitle("Z -> #mu #mu not isolated");
-  massFrame_mumuNotIso->Draw(); 
-  gPad->SetLogy(1); 
-  
+  massFrame_mumuNotIso->Draw();
+  gPad->SetLogy(1);
+
   canv2->cd();
   canv2->Clear();
   canv2->SetLogy(kTRUE);
-  massFrame_mumuNotIso->Draw(); 
+  massFrame_mumuNotIso->Draw();
   canv2->SaveAs("LogZMuMuNotIso.eps");
   canv2->SetLogy(kFALSE);
-  canv2->SaveAs("LinZMuMuNotIso.eps"); 
-  
-  canv1->cd(3);
-  zmsMass->plotOn(massFrame_musta, LineColor(kBlue)) ;
-  eZmsSig->plotOn(massFrame_musta,Components(*bkg_musa), LineColor(kGreen)) ;
-  eZmsSig->plotOn(massFrame_musta,LineColor(kRed)) ;
-  massFrame_musta->SetTitle("Z -> #mu sta");
-  massFrame_musta->Draw(); 
-  
-  canv2->cd();
-  canv2->Clear();
-  canv2->SetLogy(kTRUE);
-  massFrame_musta->Draw();  
-  canv2->SaveAs("LogZMuSa.eps"); 
-  canv2->SetLogy(kFALSE);
-  canv2->SaveAs("LinZMuSa.eps"); 
-  
-  
-  canv1->cd(4);  
-  zmm1hltMass->plotOn(massFrame_mumu1hlt, LineColor(kBlue)) ;
-  eZmm1hltSig->plotOn(massFrame_mumu1hlt,LineColor(kRed)) ;
-  massFrame_mumu1hlt->SetTitle("Z -> #mu #mu 1hlt");
-  massFrame_mumu1hlt->Draw(); 
-  canv2->cd();
-  canv2->Clear();
-  canv2->SetLogy(kTRUE);
-  massFrame_mumu1hlt->Draw();  
-  canv2->SaveAs("LogZMuMu1Hlt.eps"); 
-  canv2->SetLogy(kFALSE);
-  canv2->SaveAs("LinZMuMu1Hlt.eps"); 
-  
+  canv2->SaveAs("LinZMuMuNotIso.eps");
 
+  canv1->cd(3);
+  zmsMass->plotOn(massFrame_musta, LineColor(kBlue));
+  eZmsSig->plotOn(massFrame_musta, Components(*bkg_musa), LineColor(kGreen));
+  eZmsSig->plotOn(massFrame_musta, LineColor(kRed));
+  massFrame_musta->SetTitle("Z -> #mu sta");
+  massFrame_musta->Draw();
+
+  canv2->cd();
+  canv2->Clear();
+  canv2->SetLogy(kTRUE);
+  massFrame_musta->Draw();
+  canv2->SaveAs("LogZMuSa.eps");
+  canv2->SetLogy(kFALSE);
+  canv2->SaveAs("LinZMuSa.eps");
+
+  canv1->cd(4);
+  zmm1hltMass->plotOn(massFrame_mumu1hlt, LineColor(kBlue));
+  eZmm1hltSig->plotOn(massFrame_mumu1hlt, LineColor(kRed));
+  massFrame_mumu1hlt->SetTitle("Z -> #mu #mu 1hlt");
+  massFrame_mumu1hlt->Draw();
+  canv2->cd();
+  canv2->Clear();
+  canv2->SetLogy(kTRUE);
+  massFrame_mumu1hlt->Draw();
+  canv2->SaveAs("LogZMuMu1Hlt.eps");
+  canv2->SetLogy(kFALSE);
+  canv2->SaveAs("LinZMuMu1Hlt.eps");
 
   canv1->cd(5);
-  zmm2hltMass->plotOn(massFrame_mumu2hlt, LineColor(kBlue)) ;
-  eZmm2hltSig->plotOn(massFrame_mumu2hlt,LineColor(kRed)) ;
+  zmm2hltMass->plotOn(massFrame_mumu2hlt, LineColor(kBlue));
+  eZmm2hltSig->plotOn(massFrame_mumu2hlt, LineColor(kRed));
   massFrame_mumu2hlt->SetTitle("Z -> #mu #mu 2hlt");
-  massFrame_mumu2hlt->Draw(); 
-  
+  massFrame_mumu2hlt->Draw();
+
   canv1->SaveAs("mass.eps");
-  
+
   canv2->cd();
   canv2->Clear();
   canv2->SetLogy(kTRUE);
-  massFrame_mumu2hlt->Draw();  
-  canv2->SaveAs("LogZMuMu2Hlt.eps"); 
+  massFrame_mumu2hlt->Draw();
+  canv2->SaveAs("LogZMuMu2Hlt.eps");
   canv2->SetLogy(kFALSE);
-  canv2->SaveAs("LinZMuMu2Hlt.eps"); 
-  
+  canv2->SaveAs("LinZMuMu2Hlt.eps");
 
-  
   /* how to read the fit result in root 
      TH1D h_Yield("h_Yield", "h_Yield", 100, 10000, 30000)
      for (int i =0: i < 100; i++){ 
@@ -541,7 +558,7 @@ int main(int argc, char** argv){
      }
      
   */
-  
+
   delete root_file;
   //delete out_root_file;
   return 0;

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMuMuRooFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMuMuRooFit.cpp
@@ -40,10 +40,10 @@ using namespace RooFit;
 
 TH1F * getHisto(TFile * file, const char * name, double fMin, double fMax, unsigned int rebin) {
   TObject * h = file->Get(name);
-  if(h == 0)
+  if (h == nullptr)
     cout  << "Can't find object " << name << "\n";
   TH1F * histo = dynamic_cast<TH1F*>(h);
-  if(histo == 0)
+  if (histo == nullptr)
     cout << "Object " << name << " is of type " << h->ClassName() << ", not TH1\n";
   TH1F * new_histo = new TH1F(name, name, (int) (fMax-fMin), fMin, fMax);
   int bin_num=0;

--- a/FWCore/Framework/interface/ESOutlet.h
+++ b/FWCore/Framework/interface/ESOutlet.h
@@ -38,7 +38,7 @@ namespace edm {
       Getter(const edm::EventSetup& iES, const std::string& iLabel = std::string()) : es_(&iES), label_(iLabel) {}
 
     private:
-      virtual const T* getImpl() const {
+      const T* getImpl() const override {
         ESHandle<T> data;
         es_->template get<TRec>().get(label_, data);
         return &(*data);
@@ -59,9 +59,9 @@ namespace edm {
     //virtual ~ESOutlet();
 
   private:
-    ESOutlet(const ESOutlet&);  // stop default
+    ESOutlet(const ESOutlet&) = delete;  // stop default
 
-    const ESOutlet& operator=(const ESOutlet&);  // stop default
+    const ESOutlet& operator=(const ESOutlet&) = delete;  // stop default
 
     // ---------- member data --------------------------------
     Getter getter_;

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -405,7 +405,7 @@ namespace edm {
 
   template <typename PROD>
   OrphanHandle<PROD> Event::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -213,7 +213,7 @@ namespace edm {
 
   template <typename PROD>
   void LuminosityBlock::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct(
           "LuminosityBlock", typeID, provRecorder_.productInstanceLabel(token));
@@ -226,7 +226,7 @@ namespace edm {
 
   template <typename PROD>
   void LuminosityBlock::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct(
           "LuminosityBlock", typeID, provRecorder_.productInstanceLabel(token));

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -214,7 +214,7 @@ namespace edm {
 
   template <typename PROD>
   void Run::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Run", typeID, provRecorder_.productInstanceLabel(token));
     }

--- a/FWCore/Framework/interface/es_impl/MayConsumeChooser.h
+++ b/FWCore/Framework/interface/es_impl/MayConsumeChooser.h
@@ -43,8 +43,8 @@ namespace edm::eventsetup::impl {
       return func_(this->tagGetter(), iRecord.getTransientHandle(token_));
     }
 
-    virtual EventSetupRecordKey recordKey() const noexcept final { return EventSetupRecordKey::makeKey<RCD>(); }
-    virtual TypeTag productType() const noexcept final { return DataKey::makeTypeTag<PRODUCT>(); }
+    EventSetupRecordKey recordKey() const noexcept final { return EventSetupRecordKey::makeKey<RCD>(); }
+    TypeTag productType() const noexcept final { return DataKey::makeTypeTag<PRODUCT>(); }
 
     // ---------- static member functions --------------------
 

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -148,7 +148,7 @@ namespace edm {
         RunSummaryCacheHolder() = default;
         RunSummaryCacheHolder(RunSummaryCacheHolder<T, C> const&) = delete;
         RunSummaryCacheHolder<T, C>& operator=(RunSummaryCacheHolder<T, C> const&) = delete;
-        ~RunSummaryCacheHolder() noexcept(false){};
+        ~RunSummaryCacheHolder() noexcept(false) override{};
 
       private:
         friend class EndRunSummaryProducer<T, C>;
@@ -251,7 +251,7 @@ namespace edm {
         EndRunSummaryProducer() = default;
         EndRunSummaryProducer(EndRunSummaryProducer const&) = delete;
         EndRunSummaryProducer& operator=(EndRunSummaryProducer const&) = delete;
-        ~EndRunSummaryProducer() noexcept(false){};
+        ~EndRunSummaryProducer() noexcept(false) override{};
 
       private:
         void doEndRunProduce_(Run& rp, EventSetup const& c) final {
@@ -293,7 +293,7 @@ namespace edm {
         EndLuminosityBlockSummaryProducer() = default;
         EndLuminosityBlockSummaryProducer(EndLuminosityBlockSummaryProducer const&) = delete;
         EndLuminosityBlockSummaryProducer& operator=(EndLuminosityBlockSummaryProducer const&) = delete;
-        ~EndLuminosityBlockSummaryProducer() noexcept(false){};
+        ~EndLuminosityBlockSummaryProducer() noexcept(false) override{};
 
       private:
         void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final {

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -46,7 +46,7 @@ namespace edm {
         StreamCacheHolder(edm::ParameterSet const& iPSet) : T(iPSet) {}
         StreamCacheHolder(StreamCacheHolder<T, C> const&) = delete;
         StreamCacheHolder<T, C>& operator=(StreamCacheHolder<T, C> const&) = delete;
-        ~StreamCacheHolder() {
+        ~StreamCacheHolder() override {
           for (auto c : caches_) {
             delete c;
           }
@@ -93,7 +93,7 @@ namespace edm {
         RunCacheHolder(edm::ParameterSet const& iPSet) : T(iPSet) {}
         RunCacheHolder(RunCacheHolder<T, C> const&) = delete;
         RunCacheHolder<T, C>& operator=(RunCacheHolder<T, C> const&) = delete;
-        ~RunCacheHolder() noexcept(false){};
+        ~RunCacheHolder() noexcept(false) override{};
 
       protected:
         C const* runCache(edm::RunIndex iID) const { return cache_.get(); }
@@ -117,7 +117,7 @@ namespace edm {
         LuminosityBlockCacheHolder(edm::ParameterSet const& iPSet) : T(iPSet) {}
         LuminosityBlockCacheHolder(LuminosityBlockCacheHolder<T, C> const&) = delete;
         LuminosityBlockCacheHolder<T, C>& operator=(LuminosityBlockCacheHolder<T, C> const&) = delete;
-        ~LuminosityBlockCacheHolder() noexcept(false){};
+        ~LuminosityBlockCacheHolder() noexcept(false) override{};
 
       protected:
         C const* luminosityBlockCache(edm::LuminosityBlockIndex iID) const { return caches_[iID].get(); }
@@ -149,7 +149,7 @@ namespace edm {
         RunSummaryCacheHolder(edm::ParameterSet const& iPSet) : T(iPSet) {}
         RunSummaryCacheHolder(RunSummaryCacheHolder<T, C> const&) = delete;
         RunSummaryCacheHolder<T, C>& operator=(RunSummaryCacheHolder<T, C> const&) = delete;
-        ~RunSummaryCacheHolder() noexcept(false){};
+        ~RunSummaryCacheHolder() noexcept(false) override{};
 
       private:
         friend class EndRunSummaryProducer<T, C>;
@@ -182,7 +182,7 @@ namespace edm {
         LuminosityBlockSummaryCacheHolder(edm::ParameterSet const& iPSet) : T(iPSet) {}
         LuminosityBlockSummaryCacheHolder(LuminosityBlockSummaryCacheHolder<T, C> const&) = delete;
         LuminosityBlockSummaryCacheHolder<T, C>& operator=(LuminosityBlockSummaryCacheHolder<T, C> const&) = delete;
-        ~LuminosityBlockSummaryCacheHolder() noexcept(false){};
+        ~LuminosityBlockSummaryCacheHolder() noexcept(false) override{};
 
       private:
         void preallocLumisSummary(unsigned int iNLumis) final { caches_.reset(new std::shared_ptr<C>[iNLumis]); }
@@ -252,7 +252,7 @@ namespace edm {
         EndRunSummaryProducer(edm::ParameterSet const& iPSet) : T(iPSet), RunSummaryCacheHolder<T, C>(iPSet) {}
         EndRunSummaryProducer(EndRunSummaryProducer const&) = delete;
         EndRunSummaryProducer& operator=(EndRunSummaryProducer const&) = delete;
-        ~EndRunSummaryProducer() noexcept(false){};
+        ~EndRunSummaryProducer() noexcept(false) override{};
 
       private:
         void doEndRunProduce_(Run& rp, EventSetup const& c) final {
@@ -295,7 +295,7 @@ namespace edm {
             : T(iPSet), LuminosityBlockSummaryCacheHolder<T, S>(iPSet) {}
         EndLuminosityBlockSummaryProducer(EndLuminosityBlockSummaryProducer const&) = delete;
         EndLuminosityBlockSummaryProducer& operator=(EndLuminosityBlockSummaryProducer const&) = delete;
-        ~EndLuminosityBlockSummaryProducer() noexcept(false){};
+        ~EndLuminosityBlockSummaryProducer() noexcept(false) override{};
 
       private:
         void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final {

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -30,14 +30,14 @@ namespace edm {
   class ThinningProducer : public stream::EDProducer<> {
   public:
     explicit ThinningProducer(ParameterSet const& pset);
-    virtual ~ThinningProducer();
+    ~ThinningProducer() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
-    virtual void produce(Event& event, EventSetup const& eventSetup) override;
+    void produce(Event& event, EventSetup const& eventSetup) override;
 
-    virtual void registerThinnedAssociations(ProductRegistry const& productRegistry,
-                                             ThinnedAssociationsHelper& thinnedAssociationsHelper) override;
+    void registerThinnedAssociations(ProductRegistry const& productRegistry,
+                                     ThinnedAssociationsHelper& thinnedAssociationsHelper) override;
 
   private:
     edm::propagate_const<std::unique_ptr<Selector>> selector_;

--- a/FWCore/SOA/interface/TableExaminer.h
+++ b/FWCore/SOA/interface/TableExaminer.h
@@ -40,27 +40,27 @@ namespace edm {
 
       // ---------- const member functions ---------------------
 
-      size_t size() const override final { return m_table->size(); }
+      size_t size() const final { return m_table->size(); }
 
-      void const* columnAddress(unsigned int iColumnIndex) const override final {
+      void const* columnAddress(unsigned int iColumnIndex) const final {
         return m_table->columnAddressByIndex(iColumnIndex);
       }
 
-      std::vector<std::type_index> columnTypes() const override final {
+      std::vector<std::type_index> columnTypes() const final {
         std::vector<std::type_index> returnValue;
         returnValue.reserve(T::kNColumns);
         columnTypesImpl<0, T::kNColumns>(returnValue);
         return returnValue;
       }
 
-      std::vector<std::pair<char const*, std::type_index>> columnDescriptions() const override final {
+      std::vector<std::pair<char const*, std::type_index>> columnDescriptions() const final {
         std::vector<std::pair<char const*, std::type_index>> returnValue;
         returnValue.reserve(T::kNColumns);
         columnDescImpl<0, T::kNColumns>(returnValue);
         return returnValue;
       }
 
-      const std::type_info* typeID() const override final { return &typeid(T); }
+      const std::type_info* typeID() const final { return &typeid(T); }
 
     private:
       template <int I, int S>

--- a/FWCore/Utilities/interface/ECGetterBase.h
+++ b/FWCore/Utilities/interface/ECGetterBase.h
@@ -28,12 +28,12 @@ namespace edm {
     template <class T>
     class ECGetterBase {
     public:
-      ECGetterBase() : data_(0) {}
+      ECGetterBase() : data_(nullptr) {}
       virtual ~ECGetterBase() {}
 
       // ---------- const member functions ---------------------
       const T* get() const {
-        if (data_ == 0) {
+        if (data_ == nullptr) {
           data_ = this->getImpl();
         }
         return data_;
@@ -58,7 +58,7 @@ namespace edm {
     ValueHolderECGetter(const T& iValue) : value_(&iValue) {}
 
   private:
-    virtual const T* getImpl() const { return value_; }
+    const T* getImpl() const override { return value_; }
     const T* value_;
   };
 }  // namespace edm

--- a/FWCore/Utilities/interface/ExtensionCord.h
+++ b/FWCore/Utilities/interface/ExtensionCord.h
@@ -59,7 +59,7 @@ namespace edm {
     const T& operator*() const { return *(this->get()); }
 
     ///Returns true if the ExtensionCord is connected to an outlet and can therefore deliver data
-    bool connected() const { return 0 != holder_->getter_; }
+    bool connected() const { return nullptr != holder_->getter_; }
     // ---------- static member functions --------------------
 
     // ---------- member functions ---------------------------

--- a/FWCore/Utilities/interface/OutletBase.h
+++ b/FWCore/Utilities/interface/OutletBase.h
@@ -29,14 +29,14 @@ namespace edm {
   class OutletBase {
   protected:
     OutletBase(ExtensionCord<T>& iCord) : cord_(iCord) {}
-    virtual ~OutletBase() { this->setGetter(0); }
+    virtual ~OutletBase() { this->setGetter(nullptr); }
 
     void setGetter(extensioncord::ECGetterBase<T>* iGetter) { cord_.setGetter(iGetter); }
 
   private:
-    OutletBase(const OutletBase&);  // stop default
+    OutletBase(const OutletBase&) = delete;  // stop default
 
-    const OutletBase& operator=(const OutletBase&);  // stop default
+    const OutletBase& operator=(const OutletBase&) = delete;  // stop default
 
     // ---------- member data --------------------------------
     ExtensionCord<T>& cord_;

--- a/FWCore/Utilities/interface/SimpleOutlet.h
+++ b/FWCore/Utilities/interface/SimpleOutlet.h
@@ -34,9 +34,9 @@ namespace edm {
     }
 
   private:
-    SimpleOutlet(const SimpleOutlet&);  // stop default
+    SimpleOutlet(const SimpleOutlet&) = delete;  // stop default
 
-    const SimpleOutlet& operator=(const SimpleOutlet&);  // stop default
+    const SimpleOutlet& operator=(const SimpleOutlet&) = delete;  // stop default
   };
 
 }  // namespace edm

--- a/Fireworks/Core/src/FWDetailViewCanvas.icc
+++ b/Fireworks/Core/src/FWDetailViewCanvas.icc
@@ -4,7 +4,7 @@
 #include "TRootEmbeddedCanvas.h"
 
 template <typename T>
-FWDetailViewCanvas<T>::FWDetailViewCanvas() : m_infoCanvas(0), m_guiFrame(0), m_viewCanvas(0) {}
+FWDetailViewCanvas<T>::FWDetailViewCanvas() : m_infoCanvas(nullptr), m_guiFrame(nullptr), m_viewCanvas(nullptr) {}
 
 template <typename T>
 FWDetailViewCanvas<T>::~FWDetailViewCanvas() {}

--- a/GeneratorInterface/RivetInterface/src/CMS_2013_I1224539_DIJET.cc
+++ b/GeneratorInterface/RivetInterface/src/CMS_2013_I1224539_DIJET.cc
@@ -30,7 +30,7 @@ namespace Rivet {
     //@{
 
     /// Book histograms and initialise projections before the run
-    void init() {
+    void init() override {
       FinalState fs((Cuts::etaIn(-2.4, 2.4)));
       declare(fs, "FS");
 
@@ -60,7 +60,7 @@ namespace Rivet {
     }
 
     /// Perform the per-event analysis
-    void analyze(const Event& event) {
+    void analyze(const Event& event) override {
       const double weight = 1.0;
 
       // Look at events with >= 2 jets
@@ -94,7 +94,7 @@ namespace Rivet {
     }
 
     /// Normalise histograms etc., after the run
-    void finalize() {
+    void finalize() override {
       const double normalizationVal = 1000;
       for (size_t i = 0; i < N_PT_BINS_dj; ++i) {
         normalize(_h_ungroomedAvgJetMass_dj[i], normalizationVal);

--- a/HeterogeneousCore/SonicCore/interface/SonicClientAsync.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientAsync.h
@@ -10,7 +10,7 @@ template <typename InputT, typename OutputT = InputT>
 class SonicClientAsync : public SonicClientBase, public SonicClientTypes<InputT, OutputT> {
 public:
   //main operation
-  void dispatch(edm::WaitingTaskWithArenaHolder holder) override final {
+  void dispatch(edm::WaitingTaskWithArenaHolder holder) final {
     holder_ = std::move(holder);
     setStartTime();
     evaluate();

--- a/HeterogeneousCore/SonicCore/interface/SonicClientPseudoAsync.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientPseudoAsync.h
@@ -33,7 +33,7 @@ public:
     }
   }
   //accessor
-  void dispatch(edm::WaitingTaskWithArenaHolder holder) override final {
+  void dispatch(edm::WaitingTaskWithArenaHolder holder) final {
     //do all read/writes inside lock to ensure cache synchronization
     {
       std::lock_guard<std::mutex> guard(mutex_);

--- a/HeterogeneousCore/SonicCore/interface/SonicClientSync.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientSync.h
@@ -12,7 +12,7 @@ template <typename InputT, typename OutputT = InputT>
 class SonicClientSync : public SonicClientBase, public SonicClientTypes<InputT, OutputT> {
 public:
   //main operation
-  void dispatch(edm::WaitingTaskWithArenaHolder holder) override final {
+  void dispatch(edm::WaitingTaskWithArenaHolder holder) final {
     holder_ = std::move(holder);
     setStartTime();
 

--- a/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
@@ -22,13 +22,11 @@ public:
   //constructor
   SonicEDProducer(edm::ParameterSet const& cfg) : client_(cfg.getParameter<edm::ParameterSet>("Client")) {}
   //destructor
-  virtual ~SonicEDProducer() = default;
+  ~SonicEDProducer() override = default;
 
   //derived classes use a dedicated acquire() interface that incorporates client_.input()
   //(no need to interact with callback holder)
-  void acquire(edm::Event const& iEvent,
-               edm::EventSetup const& iSetup,
-               edm::WaitingTaskWithArenaHolder holder) override final {
+  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, edm::WaitingTaskWithArenaHolder holder) final {
     auto t0 = std::chrono::high_resolution_clock::now();
     acquire(iEvent, iSetup, client_.input());
     auto t1 = std::chrono::high_resolution_clock::now();
@@ -39,7 +37,7 @@ public:
   }
   virtual void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) = 0;
   //derived classes use a dedicated produce() interface that incorporates client_.output()
-  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override final {
+  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) final {
     //todo: measure time between acquire and produce
     produce(iEvent, iSetup, client_.output());
   }

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceLoader.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceLoader.h
@@ -7,7 +7,7 @@
 class FFTBasicJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTBasicJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTBasicJetCorrectorSequence> Base;
   friend class StaticFFTJetRcdMapper<FFTBasicJetCorrectorSequenceLoader>;
-  FFTBasicJetCorrectorSequenceLoader();
+  FFTBasicJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
 };
 
 typedef StaticFFTJetRcdMapper<FFTBasicJetCorrectorSequenceLoader> StaticFFTBasicJetCorrectorSequenceLoader;
@@ -15,7 +15,7 @@ typedef StaticFFTJetRcdMapper<FFTBasicJetCorrectorSequenceLoader> StaticFFTBasic
 class FFTCaloJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTCaloJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTCaloJetCorrectorSequence> Base;
   friend class StaticFFTJetRcdMapper<FFTCaloJetCorrectorSequenceLoader>;
-  FFTCaloJetCorrectorSequenceLoader();
+  FFTCaloJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
 };
 
 typedef StaticFFTJetRcdMapper<FFTCaloJetCorrectorSequenceLoader> StaticFFTCaloJetCorrectorSequenceLoader;
@@ -23,7 +23,7 @@ typedef StaticFFTJetRcdMapper<FFTCaloJetCorrectorSequenceLoader> StaticFFTCaloJe
 class FFTGenJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTGenJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTGenJetCorrectorSequence> Base;
   friend class StaticFFTJetRcdMapper<FFTGenJetCorrectorSequenceLoader>;
-  FFTGenJetCorrectorSequenceLoader();
+  FFTGenJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
 };
 
 typedef StaticFFTJetRcdMapper<FFTGenJetCorrectorSequenceLoader> StaticFFTGenJetCorrectorSequenceLoader;
@@ -31,7 +31,7 @@ typedef StaticFFTJetRcdMapper<FFTGenJetCorrectorSequenceLoader> StaticFFTGenJetC
 class FFTPFJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTPFJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTPFJetCorrectorSequence> Base;
   friend class StaticFFTJetRcdMapper<FFTPFJetCorrectorSequenceLoader>;
-  FFTPFJetCorrectorSequenceLoader();
+  FFTPFJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
 };
 
 typedef StaticFFTJetRcdMapper<FFTPFJetCorrectorSequenceLoader> StaticFFTPFJetCorrectorSequenceLoader;
@@ -39,7 +39,7 @@ typedef StaticFFTJetRcdMapper<FFTPFJetCorrectorSequenceLoader> StaticFFTPFJetCor
 class FFTTrackJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTTrackJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTTrackJetCorrectorSequence> Base;
   friend class StaticFFTJetRcdMapper<FFTTrackJetCorrectorSequenceLoader>;
-  FFTTrackJetCorrectorSequenceLoader();
+  FFTTrackJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
 };
 
 typedef StaticFFTJetRcdMapper<FFTTrackJetCorrectorSequenceLoader> StaticFFTTrackJetCorrectorSequenceLoader;
@@ -47,7 +47,7 @@ typedef StaticFFTJetRcdMapper<FFTTrackJetCorrectorSequenceLoader> StaticFFTTrack
 class FFTJPTJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTJPTJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTJPTJetCorrectorSequence> Base;
   friend class StaticFFTJetRcdMapper<FFTJPTJetCorrectorSequenceLoader>;
-  FFTJPTJetCorrectorSequenceLoader();
+  FFTJPTJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
 };
 
 typedef StaticFFTJetRcdMapper<FFTJPTJetCorrectorSequenceLoader> StaticFFTJPTJetCorrectorSequenceLoader;

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequenceLoader.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequenceLoader.h
@@ -11,7 +11,7 @@
 class FFTJetLookupTableSequenceLoader : public DefaultFFTJetRcdMapper<FFTJetLookupTableSequence> {
   typedef DefaultFFTJetRcdMapper<FFTJetLookupTableSequence> Base;
   friend class StaticFFTJetRcdMapper<FFTJetLookupTableSequenceLoader>;
-  FFTJetLookupTableSequenceLoader();
+  FFTJetLookupTableSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
 };
 
 typedef StaticFFTJetRcdMapper<FFTJetLookupTableSequenceLoader> StaticFFTJetLookupTableSequenceLoader;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -527,7 +527,7 @@ void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
                                              CSCCorrelatedLCTDigi& lct2) const {
   CSCALCTDigi bestALCT = bALCT;
   CSCALCTDigi secondALCT = sALCT;
-  CSCCLCTDigi bestCLCT = bCLCT;
+  const CSCCLCTDigi& bestCLCT = bCLCT;
   CSCCLCTDigi secondCLCT = sCLCT;
 
   // assume that always anodeBestValid and cathodeBestValid

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -449,7 +449,7 @@ void CSCGEMMotherboardME21::correlateLCTsGEM(const CSCALCTDigi& bALCT,
                                              CSCCorrelatedLCTDigi& lct2) const {
   CSCALCTDigi bestALCT = bALCT;
   CSCALCTDigi secondALCT = sALCT;
-  CSCCLCTDigi bestCLCT = bCLCT;
+  const CSCCLCTDigi& bestCLCT = bCLCT;
   CSCCLCTDigi secondCLCT = sCLCT;
 
   // assume that always anodeBestValid and cathodeBestValid

--- a/OnlineDB/EcalCondDB/bin/cmsecal_rootplot.cpp
+++ b/OnlineDB/EcalCondDB/bin/cmsecal_rootplot.cpp
@@ -26,7 +26,7 @@ public:
 
   RootPlot(string type, string format, string file, float hmin=0., float hmax=0.) 
   {
-    m_isInit = 0;
+    m_isInit = false;
     m_type = type;
     m_outputFormat = format;
     m_outputFile = file+"."+format;
@@ -57,7 +57,7 @@ public:
     gROOT->SetStyle("Plain");
     gStyle->SetOptStat(111111);
     gStyle->SetOptFit();
-    gStyle->SetPalette(1,0);
+    gStyle->SetPalette(1, nullptr);
 
     int pCol[2] = { 2, 3 };
     if((m_type == "Map" || m_type == "EBEEMap") && (TString(m_title).Contains("status")) ) {
@@ -105,7 +105,7 @@ public:
   {
     if (!m_isInit) {
       this->init();
-      m_isInit = 1;
+      m_isInit = true;
     }
 
     if (str[0] == '#') {
@@ -191,7 +191,7 @@ public:
       this->drawEBEEMap();
     }
 
-    m_isInit = 0;
+    m_isInit = false;
   };
 
   void drawTH1F()

--- a/OnlineDB/EcalCondDB/bin/cmsecal_rootplot.cpp
+++ b/OnlineDB/EcalCondDB/bin/cmsecal_rootplot.cpp
@@ -24,27 +24,25 @@ public:
   static const int DEFAULT_AXIS = 111;
   static const int TIME_AXIS = 222;
 
-  RootPlot(string type, string format, string file, float hmin=0., float hmax=0.) 
-  {
+  RootPlot(string type, string format, string file, float hmin = 0., float hmax = 0.) {
     m_isInit = false;
     m_type = type;
     m_outputFormat = format;
-    m_outputFile = file+"."+format;
-    m_outputRoot = file+".root";
+    m_outputFile = file + "." + format;
+    m_outputRoot = file + ".root";
     m_title = "rootplot Plot";
     m_xtitle = "X";
     m_ytitle = "Y";
     m_xAxisType = DEFAULT_AXIS;
     m_debug = 1;
-    m_T0 = TDatime(2005,01,01,00,00,00);
+    m_T0 = TDatime(2005, 01, 01, 00, 00, 00);
     m_hmin = hmin;
     m_hmax = hmax;
   };
 
-  ~RootPlot() {};
+  ~RootPlot(){};
 
-  void init()
-  {
+  void init() {
     m_nbins[0] = m_nbins[1] = 100;
     m_mins[0] = m_mins[1] = FLT_MAX;
     m_maxs[0] = m_maxs[1] = FLT_MIN;
@@ -59,9 +57,9 @@ public:
     gStyle->SetOptFit();
     gStyle->SetPalette(1, nullptr);
 
-    int pCol[2] = { 2, 3 };
-    if((m_type == "Map" || m_type == "EBEEMap") && (TString(m_title).Contains("status")) ) {
-      gStyle->SetPalette(2,pCol);
+    int pCol[2] = {2, 3};
+    if ((m_type == "Map" || m_type == "EBEEMap") && (TString(m_title).Contains("status"))) {
+      gStyle->SetPalette(2, pCol);
     }
 
     m_rootfile = new TFile(m_outputRoot.c_str(), "RECREATE");
@@ -70,7 +68,7 @@ public:
     if (m_type == "TH1F") {
       m_nfields = 1;
       m_tree->Branch("x", &m_data[0], "x/F");
-    } else if(m_type == "TH2F") {
+    } else if (m_type == "TH2F") {
       m_nfields = 2;
       m_tree->Branch("x", &m_data[0], "x/F");
       m_tree->Branch("y", &m_data[1], "y/F");
@@ -80,20 +78,17 @@ public:
       m_tree->Branch("y", &m_data[1], "y/F");
     } else if (m_type == "Map") {
       m_nfields = 2;
-      m_tree->Branch("x", &m_data[0], "x/F"); // channel number
-      m_tree->Branch("y", &m_data[1], "y/F"); // variable var
+      m_tree->Branch("x", &m_data[0], "x/F");  // channel number
+      m_tree->Branch("y", &m_data[1], "y/F");  // variable var
     } else if (m_type == "EBEEMap") {
       m_nfields = 5;
-      m_tree->Branch("ism_z", &m_data[0], "ism_z/F"); // SM number (EB), z (EE)
-      m_tree->Branch("chnum_x", &m_data[1], "chnum_x/F"); // channel number (EB) , x (EE)
-      m_tree->Branch("var", &m_data[2], "var/F"); // variable var
-      m_tree->Branch("null_y", &m_data[3], "z/F"); // null value (EB), y (EE)
-      m_tree->Branch("isEB", &m_data[4], "isEB/F"); // 1 (EB), 0 (EE)
-
-    } 
-
+      m_tree->Branch("ism_z", &m_data[0], "ism_z/F");      // SM number (EB), z (EE)
+      m_tree->Branch("chnum_x", &m_data[1], "chnum_x/F");  // channel number (EB) , x (EE)
+      m_tree->Branch("var", &m_data[2], "var/F");          // variable var
+      m_tree->Branch("null_y", &m_data[3], "z/F");         // null value (EB), y (EE)
+      m_tree->Branch("isEB", &m_data[4], "isEB/F");        // 1 (EB), 0 (EE)
+    }
   };
-
 
   void setTitle(string title) { m_title = title; }
   void setXTitle(string xtitle) { m_xtitle = xtitle; }
@@ -101,8 +96,7 @@ public:
   void setDebug(int debug) { m_debug = debug; }
   void setXAxisType(int code) { m_xAxisType = code; }
 
-  void parseAndFill(std::string str)
-  {
+  void parseAndFill(std::string str) {
     if (!m_isInit) {
       this->init();
       m_isInit = true;
@@ -113,32 +107,39 @@ public:
       return;
     }
 
-    if (m_debug) { cout << "[data] " << flush; }
-    
+    if (m_debug) {
+      cout << "[data] " << flush;
+    }
+
     typedef boost::tokenizer<boost::escaped_list_separator<char> > tokenizer;
     escaped_list_separator<char> sep('\\', ' ', '\"');
     tokenizer tokens(str, sep);
     float datum;
     int cnt = 0;
 
-    for (tokenizer::iterator tok_iter = tokens.begin();
-	 tok_iter != tokens.end(); ++tok_iter) {
-      if (cnt > m_nfields) { continue; }
+    for (tokenizer::iterator tok_iter = tokens.begin(); tok_iter != tokens.end(); ++tok_iter) {
+      if (cnt > m_nfields) {
+        continue;
+      }
 
       if (m_debug) {
-	cout << "<" << *tok_iter << ">" << flush;
-      }
-      
-      if (m_xAxisType == TIME_AXIS && cnt == 0) {
-	TDatime d((*tok_iter).c_str());
-	datum = (Float_t)(d.Convert() - m_T0.Convert());
-      } else {
-	datum = atof((*tok_iter).c_str());
+        cout << "<" << *tok_iter << ">" << flush;
       }
 
-      if(m_type != "EBEEMap") {
-	if (datum < m_mins[cnt]) { m_mins[cnt] = datum; }
-	if (datum > m_maxs[cnt]) { m_maxs[cnt] = datum; }
+      if (m_xAxisType == TIME_AXIS && cnt == 0) {
+        TDatime d((*tok_iter).c_str());
+        datum = (Float_t)(d.Convert() - m_T0.Convert());
+      } else {
+        datum = atof((*tok_iter).c_str());
+      }
+
+      if (m_type != "EBEEMap") {
+        if (datum < m_mins[cnt]) {
+          m_mins[cnt] = datum;
+        }
+        if (datum > m_maxs[cnt]) {
+          m_maxs[cnt] = datum;
+        }
       }
 
       m_data[cnt] = datum;
@@ -146,31 +147,32 @@ public:
       cnt++;
     }
 
-    if (m_debug) { cout << endl; }
+    if (m_debug) {
+      cout << endl;
+    }
     m_tree->Fill();
   };
-  
-  void draw()
-  {
-    for (int i=0; i<m_nfields; i++) {
+
+  void draw() {
+    for (int i = 0; i < m_nfields; i++) {
       if (m_mins[i] == m_maxs[i]) {
-	m_mins[i] -= m_mins[i]*(0.05);
-	m_maxs[i] += m_mins[i]*(0.05);
+        m_mins[i] -= m_mins[i] * (0.05);
+        m_maxs[i] += m_mins[i] * (0.05);
       }
     }
 
     if (m_debug) {
       cout << "[draw()]:" << endl;
       cout << "  m_type:          " << m_type << endl;
-      cout << "  m_outputFormat:  " <<  m_outputFormat << endl;
-      cout << "  m_outputFile:    " <<  m_outputFile << endl;
-      cout << "  m_outputRoot:    " <<  m_outputRoot << endl;
-      cout << "  m_title:         " <<  m_title << endl;
-      cout << "  m_xtitle:        " <<  m_xtitle << endl;
+      cout << "  m_outputFormat:  " << m_outputFormat << endl;
+      cout << "  m_outputFile:    " << m_outputFile << endl;
+      cout << "  m_outputRoot:    " << m_outputRoot << endl;
+      cout << "  m_title:         " << m_title << endl;
+      cout << "  m_xtitle:        " << m_xtitle << endl;
       cout << "  m_ytitle:        " << m_ytitle << endl;
-      cout << "  m_xAxisType:     " <<  m_xAxisType << endl;
-      cout << "  m_nfields:       " <<  m_nfields << endl;
-      cout << "  m_nbins[]:       " <<  m_nbins[0] << " " << m_nbins[1] << endl;
+      cout << "  m_xAxisType:     " << m_xAxisType << endl;
+      cout << "  m_nfields:       " << m_nfields << endl;
+      cout << "  m_nbins[]:       " << m_nbins[0] << " " << m_nbins[1] << endl;
       cout << "  m_mins[]:        " << m_mins[0] << " " << m_mins[1] << endl;
       cout << "  m_maxs[]:        " << m_maxs[0] << " " << m_maxs[1] << endl;
     }
@@ -194,48 +196,46 @@ public:
     m_isInit = false;
   };
 
-  void drawTH1F()
-  {
-    TCanvas c1("c1","rootplot",200,10,450,300);
+  void drawTH1F() {
+    TCanvas c1("c1", "rootplot", 200, 10, 450, 300);
     c1.SetGrid();
 
-    if((TString(m_title).Contains("status"))) {
-      m_mins[0]=-0.001;
-      m_maxs[0]=1.001;
+    if ((TString(m_title).Contains("status"))) {
+      m_mins[0] = -0.001;
+      m_maxs[0] = 1.001;
     }
-    
+
     TH1F* plot = new TH1F("rootplot", m_title.c_str(), m_nbins[0], m_mins[0], m_maxs[0]);
     plot->GetXaxis()->SetTitle(m_xtitle.c_str());
     plot->GetYaxis()->SetTitle(m_ytitle.c_str());
-    
+
     if (m_xAxisType == TIME_AXIS) {
       TAxis* axis = plot->GetXaxis();
       setTimeAxis(axis);
     }
-    
+
     m_tree->Draw("x >> rootplot");
 
     plot->Draw();
     c1.Print(m_outputFile.c_str(), m_outputFormat.c_str());
 
     plot->Write();
-
   };
 
-  void drawTH2F()
-  {
-    TCanvas c1("c1","rootplot",200,10,600,400);
+  void drawTH2F() {
+    TCanvas c1("c1", "rootplot", 200, 10, 600, 400);
     c1.SetGrid();
 
-    TH2F* plot = new TH2F("rootplot", m_title.c_str(), m_nbins[0], m_mins[0], m_maxs[0], m_nbins[1], m_mins[1], m_maxs[1]);
+    TH2F* plot =
+        new TH2F("rootplot", m_title.c_str(), m_nbins[0], m_mins[0], m_maxs[0], m_nbins[1], m_mins[1], m_maxs[1]);
     plot->GetXaxis()->SetTitle(m_xtitle.c_str());
     plot->GetYaxis()->SetTitle(m_ytitle.c_str());
-    
+
     if (m_xAxisType == TIME_AXIS) {
       TAxis* axis = plot->GetXaxis();
       setTimeAxis(axis);
     }
-    
+
     m_tree->Draw("x:y >> rootplot");
 
     plot->Draw();
@@ -244,9 +244,8 @@ public:
     plot->Write();
   }
 
-  void drawTGraph()
-  {
-    TCanvas c1("c1","rootplot",200,10,600,400);
+  void drawTGraph() {
+    TCanvas c1("c1", "rootplot", 200, 10, 600, 400);
     c1.SetGrid();
 
     Int_t n = (Int_t)m_tree->GetEntries();
@@ -264,7 +263,7 @@ public:
       TAxis* axis = plot->GetXaxis();
       setTimeAxis(axis);
     }
-    
+
     plot->SetTitle(m_title.c_str());
     plot->GetXaxis()->SetTitle(m_xtitle.c_str());
     plot->GetYaxis()->SetTitle(m_ytitle.c_str());
@@ -275,13 +274,12 @@ public:
     plot->Write();
   };
 
-  void drawMap()
-  {
+  void drawMap() {
     gStyle->SetOptStat(0);
 
     const Int_t csize = 250;
-    TCanvas c1("c1","rootplot",Int_t(85./20.*csize),csize);
-    TH2F* plot = new TH2F("rootplot",m_title.c_str(),85,0.0001,85.0001,20,0.0001,20.0001);
+    TCanvas c1("c1", "rootplot", Int_t(85. / 20. * csize), csize);
+    TH2F* plot = new TH2F("rootplot", m_title.c_str(), 85, 0.0001, 85.0001, 20, 0.0001, 20.0001);
     plot->GetXaxis()->SetTitle(m_xtitle.c_str());
     plot->GetYaxis()->SetTitle(m_ytitle.c_str());
 
@@ -291,21 +289,20 @@ public:
 
     // now fill the map...
     Int_t n = (Int_t)m_tree->GetEntries();
-    for(Int_t i=0; i<n; i++) {
+    for (Int_t i = 0; i < n; i++) {
       m_tree->GetEntry(i);
       //      while(x>1700) x-=1700;
-      Float_t xmap = Float_t(Int_t(x-1)/20)+1;
-      Float_t ymap = Float_t(Int_t(x-1)%20)+1;
-      plot->Fill(xmap,ymap,y);
+      Float_t xmap = Float_t(Int_t(x - 1) / 20) + 1;
+      Float_t ymap = Float_t(Int_t(x - 1) % 20) + 1;
+      plot->Fill(xmap, ymap, y);
     }
 
     // draw the map
     plot->SetTitle(m_title.c_str());
-    if((TString(m_title).Contains("status"))) {
+    if ((TString(m_title).Contains("status"))) {
       plot->SetMinimum(-0.001);
       plot->SetMaximum(1.001);
-    }
-    else if(!(m_hmin==0 && m_hmax==0)) {
+    } else if (!(m_hmin == 0 && m_hmax == 0)) {
       plot->SetMinimum(m_hmin);
       plot->SetMaximum(m_hmax);
     }
@@ -321,10 +318,10 @@ public:
 
     // and draw the grid upon the map...
     TH2C* labelGrid = new TH2C("labelGrid", "label grid for SM", 85, 0., 85., 20, 0., 20.);
-    for(Int_t i=0; i<68; i++){
-      Float_t X = (i/4)*5+2;
-      Float_t Y = (i%4)*5+2;
-      labelGrid->Fill(X,Y,i+1);
+    for (Int_t i = 0; i < 68; i++) {
+      Float_t X = (i / 4) * 5 + 2;
+      Float_t Y = (i % 4) * 5 + 2;
+      labelGrid->Fill(X, Y, i + 1);
     }
     labelGrid->SetMinimum(0.1);
     labelGrid->SetMarkerSize(4);
@@ -332,25 +329,21 @@ public:
 
     c1.Print(m_outputFile.c_str(), m_outputFormat.c_str());
     plot->Write();
-
   };
 
-  void drawEBEEMap()
-  {
-
+  void drawEBEEMap() {
     const Int_t csize = 900;
-        
-    TCanvas c1("c1","rootplot",csize,csize);
-    TPad p1("EBPad","EBPad",0.,0.5,1.,1.);
+
+    TCanvas c1("c1", "rootplot", csize, csize);
+    TPad p1("EBPad", "EBPad", 0., 0.5, 1., 1.);
     p1.Draw();
-    TPad p2("EEPlusPad","EEPlusPad",0.,0.,0.48,0.5);
+    TPad p2("EEPlusPad", "EEPlusPad", 0., 0., 0.48, 0.5);
     p2.Draw();
-    TPad p3("EEPlusPad","EEPlusPad",0.50,0.,0.98,0.5);
+    TPad p3("EEPlusPad", "EEPlusPad", 0.50, 0., 0.98, 0.5);
     p3.Draw();
 
-  
     //EB
-    TH2F* EBPlot = new TH2F("rootplotEB",m_title.c_str(), 360, 0., 360., 170, -85., 85.);
+    TH2F* EBPlot = new TH2F("rootplotEB", m_title.c_str(), 360, 0., 360., 170, -85., 85.);
     EBPlot->GetXaxis()->SetTitle("i#phi");
     EBPlot->GetYaxis()->SetTitle("i#eta");
     EBPlot->GetZaxis()->SetTitle(m_ytitle.c_str());
@@ -358,7 +351,7 @@ public:
     EBPlot->GetYaxis()->SetNdivisions(2);
 
     //EE+
-    TH2F* EEPlot_plus = new TH2F("rootplotEE+",m_title.c_str(), 100, 0., 100., 100, 0., 100.);
+    TH2F* EEPlot_plus = new TH2F("rootplotEE+", m_title.c_str(), 100, 0., 100., 100, 0., 100.);
     EEPlot_plus->GetXaxis()->SetTitle("ix");
     EEPlot_plus->GetYaxis()->SetTitleOffset(1.3);
     EEPlot_plus->GetYaxis()->SetTitle("iy");
@@ -367,14 +360,14 @@ public:
     EEPlot_plus->GetYaxis()->SetNdivisions(10);
 
     //EE-
-    TH2F* EEPlot_minus = new TH2F("rootplotEE-",m_title.c_str(), 100, 0., 100., 100, 0., 100.);
+    TH2F* EEPlot_minus = new TH2F("rootplotEE-", m_title.c_str(), 100, 0., 100., 100, 0., 100.);
     EEPlot_minus->GetXaxis()->SetTitle("ix");
     EEPlot_minus->GetYaxis()->SetTitle("iy");
     EEPlot_minus->GetYaxis()->SetTitleOffset(1.3);
     EEPlot_minus->GetZaxis()->SetTitle(m_ytitle.c_str());
     EEPlot_minus->GetXaxis()->SetNdivisions(10, kTRUE);
     EEPlot_minus->GetYaxis()->SetNdivisions(10);
-    
+
     Float_t chnum_x, var, ism_z, isEB, null_y;
     m_tree->SetBranchAddress("ism_z", &ism_z);
     m_tree->SetBranchAddress("chnum_x", &chnum_x);
@@ -384,64 +377,60 @@ public:
 
     // now fill the maps...
     Int_t n = (Int_t)m_tree->GetEntries();
-    for(Int_t i=0; i<n; i++) {
+    for (Int_t i = 0; i < n; i++) {
       m_tree->GetEntry(i);
 
       if (isEB) {
-	Float_t iex = -1;
-	Float_t ipx = -1;
-	for ( unsigned int i=1; i<=36; i++ ) {
-		
-		if(i == ism_z) {
-	
-		Float_t ie = Float_t(Int_t(chnum_x-1)/20)+1;       
-		Float_t ip = Float_t(Int_t(chnum_x-1)%20)+1;       
-	
-		if ( ism_z <= 18 ) {
-		iex = ie - 1;
-		ipx = (20-ip)+20*(ism_z-1);
-		} else {
-		iex = -1*ie;
-		ipx = ip+20*(ism_z-19)-1;
-		}
-	
-		EBPlot->Fill(ipx,iex,var);  
-	
-		}
-	
-	}
-      }//end loop on EB
-      
+        Float_t iex = -1;
+        Float_t ipx = -1;
+        for (unsigned int i = 1; i <= 36; i++) {
+          if (i == ism_z) {
+            Float_t ie = Float_t(Int_t(chnum_x - 1) / 20) + 1;
+            Float_t ip = Float_t(Int_t(chnum_x - 1) % 20) + 1;
+
+            if (ism_z <= 18) {
+              iex = ie - 1;
+              ipx = (20 - ip) + 20 * (ism_z - 1);
+            } else {
+              iex = -1 * ie;
+              ipx = ip + 20 * (ism_z - 19) - 1;
+            }
+
+            EBPlot->Fill(ipx, iex, var);
+          }
+        }
+      }  //end loop on EB
+
       //assuming: if not EB, it's EE (TODO: check strings)...
       else {
-	      //EE+
-	      if (ism_z==1) EEPlot_plus->Fill(chnum_x-0.5,null_y-0.5,var);
-	      //EE-
-	      if (ism_z==-1) EEPlot_minus->Fill(chnum_x-0.5,null_y-0.5,var);
-      }//end loop on EE
-      
-    }//end loop on entries
+        //EE+
+        if (ism_z == 1)
+          EEPlot_plus->Fill(chnum_x - 0.5, null_y - 0.5, var);
+        //EE-
+        if (ism_z == -1)
+          EEPlot_minus->Fill(chnum_x - 0.5, null_y - 0.5, var);
+      }  //end loop on EE
+
+    }  //end loop on entries
 
     // draw the map
     //setting
     gStyle->SetOptStat("e");
     gStyle->SetPaintTextFormat("+g");
-    
-    
+
     EBPlot->SetTitle(m_title.c_str());
     EEPlot_plus->SetTitle(m_title.c_str());
     EEPlot_minus->SetTitle(m_title.c_str());
 
-    if((TString(m_title).Contains("status"))) {
+    if ((TString(m_title).Contains("status"))) {
       EBPlot->SetMinimum(-0.001);
       EBPlot->SetMaximum(1.001);
       EEPlot_plus->SetMinimum(-0.001);
       EEPlot_plus->SetMaximum(1.001);
       EEPlot_minus->SetMinimum(-0.001);
       EEPlot_minus->SetMaximum(1.001);
-      
-    }
-    else if(!(m_hmin==0 && m_hmax==0)) {
+
+    } else if (!(m_hmin == 0 && m_hmax == 0)) {
       EBPlot->SetMinimum(m_hmin);
       EBPlot->SetMaximum(m_hmax);
       EEPlot_plus->SetMinimum(m_hmin);
@@ -449,7 +438,7 @@ public:
       EEPlot_minus->SetMinimum(m_hmin);
       EEPlot_minus->SetMaximum(m_hmax);
     }
-    
+
     p1.cd();
     gPad->SetGridx();
     gPad->SetGridy();
@@ -457,86 +446,100 @@ public:
 
     // and draw the grid upon the map...
     TH2C* labelGrid = new TH2C("labelGrid", "label grid for SM", 18, 0., 360., 2, -85., 85.);
-    for(Int_t sm=1; sm<=36; sm++) {
-      int X = (sm<=18) ? sm : sm-18;
-      int Y = (sm<=18) ? 2 : 1;
-      double posSM = (sm<=18) ? sm : -1*(sm-18);
-      labelGrid->SetBinContent(X,Y,posSM);
+    for (Int_t sm = 1; sm <= 36; sm++) {
+      int X = (sm <= 18) ? sm : sm - 18;
+      int Y = (sm <= 18) ? 2 : 1;
+      double posSM = (sm <= 18) ? sm : -1 * (sm - 18);
+      labelGrid->SetBinContent(X, Y, posSM);
     }
     labelGrid->SetMarkerSize(2);
     labelGrid->Draw("text,same");
 
     c1.Print(m_outputFile.c_str(), m_outputFormat.c_str());
     EBPlot->Write();
-    
+
     //END OF EBPLOT
-    
-    int ixSectorsEE[202] = {61, 61, 60, 60, 59, 59, 58, 58, 57, 57, 55, 55, 45, 45, 43, 43, 42, 42, 41, 41, 40, 40, 39, 39, 40, 40, 41, 41, 42, 42, 43, 43, 45, 45, 55, 55, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 0,100,100, 97, 97, 95, 95, 92, 92, 87, 87, 85, 85, 80, 80, 75, 75, 65, 65, 60, 60, 40, 40, 35, 35, 25, 25, 20, 20, 15, 15, 13, 13,  8,  8,  5,  5,  3,  3,  0,  0,  3,  3,  5,  5,  8,  8, 13, 13, 15, 15, 20, 20, 25, 25, 35, 35, 40, 40, 60, 60, 65, 65, 75, 75, 80, 80, 85, 85, 87, 87, 92, 92, 95, 95, 97, 97,100,100,  0, 61, 65, 65, 70, 70, 80, 80, 90, 90, 92,  0, 61, 65, 65, 90, 90, 97,  0, 57, 60, 60, 65, 65, 70, 70, 75, 75, 80, 80,  0, 50, 50,  0, 43, 40, 40, 35, 35, 30, 30, 25, 25, 20, 20,  0, 39, 35, 35, 10, 10,  3,  0, 39, 35, 35, 30, 30, 20, 20, 10, 10,  8,  0, 45, 45, 40, 40, 35, 35,  0, 55, 55, 60, 60, 65, 65};
-    
-    int iySectorsEE[202] = {50, 55, 55, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 60, 60, 59, 59, 58, 58, 57, 57, 55, 55, 45, 45, 43, 43, 42, 42, 41, 41, 40, 40, 39, 39, 40, 40, 41, 41, 42, 42, 43, 43, 45, 45, 50,  0, 50, 60, 60, 65, 65, 75, 75, 80, 80, 85, 85, 87, 87, 92, 92, 95, 95, 97, 97,100,100, 97, 97, 95, 95, 92, 92, 87, 87, 85, 85, 80, 80, 75, 75, 65, 65, 60, 60, 40, 40, 35, 35, 25, 25, 20, 20, 15, 15, 13, 13,  8,  8,  5,  5,  3,  3,  0,  0,  3,  3,  5,  5,  8,  8, 13, 13, 15, 15, 20, 20, 25, 25, 35, 35, 40, 40, 50,  0, 45, 45, 40, 40, 35, 35, 30, 30, 25, 25,  0, 50, 50, 55, 55, 60, 60,  0, 60, 60, 65, 65, 70, 70, 75, 75, 85, 85, 87,  0, 61,100,  0, 60, 60, 65, 65, 70, 70, 75, 75, 85, 85, 87,  0, 50, 50, 55, 55, 60, 60,  0, 45, 45, 40, 40, 35, 35, 30, 30, 25, 25,  0, 39, 30, 30, 15, 15,  5,  0, 39, 30, 30, 15, 15,  5};
+
+    int ixSectorsEE[202] = {
+        61, 61, 60, 60, 59, 59, 58, 58, 57, 57, 55, 55, 45, 45, 43, 43, 42, 42, 41, 41,  40,  40,  39,  39, 40, 40,
+        41, 41, 42, 42, 43, 43, 45, 45, 55, 55, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61,  0,   100, 100, 97, 97, 95,
+        95, 92, 92, 87, 87, 85, 85, 80, 80, 75, 75, 65, 65, 60, 60, 40, 40, 35, 35, 25,  25,  20,  20,  15, 15, 13,
+        13, 8,  8,  5,  5,  3,  3,  0,  0,  3,  3,  5,  5,  8,  8,  13, 13, 15, 15, 20,  20,  25,  25,  35, 35, 40,
+        40, 60, 60, 65, 65, 75, 75, 80, 80, 85, 85, 87, 87, 92, 92, 95, 95, 97, 97, 100, 100, 0,   61,  65, 65, 70,
+        70, 80, 80, 90, 90, 92, 0,  61, 65, 65, 90, 90, 97, 0,  57, 60, 60, 65, 65, 70,  70,  75,  75,  80, 80, 0,
+        50, 50, 0,  43, 40, 40, 35, 35, 30, 30, 25, 25, 20, 20, 0,  39, 35, 35, 10, 10,  3,   0,   39,  35, 35, 30,
+        30, 20, 20, 10, 10, 8,  0,  45, 45, 40, 40, 35, 35, 0,  55, 55, 60, 60, 65, 65};
+
+    int iySectorsEE[202] = {
+        50, 55,  55, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 60, 60,  59,  59, 58, 58, 57, 57, 55, 55, 45, 45, 43,
+        43, 42,  42, 41, 41, 40, 40, 39, 39, 40, 40, 41, 41, 42, 42,  43,  43, 45, 45, 50, 0,  50, 60, 60, 65, 65,
+        75, 75,  80, 80, 85, 85, 87, 87, 92, 92, 95, 95, 97, 97, 100, 100, 97, 97, 95, 95, 92, 92, 87, 87, 85, 85,
+        80, 80,  75, 75, 65, 65, 60, 60, 40, 40, 35, 35, 25, 25, 20,  20,  15, 15, 13, 13, 8,  8,  5,  5,  3,  3,
+        0,  0,   3,  3,  5,  5,  8,  8,  13, 13, 15, 15, 20, 20, 25,  25,  35, 35, 40, 40, 50, 0,  45, 45, 40, 40,
+        35, 35,  30, 30, 25, 25, 0,  50, 50, 55, 55, 60, 60, 0,  60,  60,  65, 65, 70, 70, 75, 75, 85, 85, 87, 0,
+        61, 100, 0,  60, 60, 65, 65, 70, 70, 75, 75, 85, 85, 87, 0,   50,  50, 55, 55, 60, 60, 0,  45, 45, 40, 40,
+        35, 35,  30, 30, 25, 25, 0,  39, 30, 30, 15, 15, 5,  0,  39,  30,  30, 15, 15, 5};
 
     //grid
-	TH2C labelGrid1("labelGrid1","label grid for EE -", 10, 0., 100., 10, 0., 100.);
-	for ( int i=1; i<=10; i++) {
-		for ( int j=1; j<=10; j++) {
-			labelGrid1.SetBinContent(i, j, -10);
-		}
-	}
+    TH2C labelGrid1("labelGrid1", "label grid for EE -", 10, 0., 100., 10, 0., 100.);
+    for (int i = 1; i <= 10; i++) {
+      for (int j = 1; j <= 10; j++) {
+        labelGrid1.SetBinContent(i, j, -10);
+      }
+    }
 
-	labelGrid1.SetBinContent(2, 5, -3);
-	labelGrid1.SetBinContent(2, 7, -2);
-	labelGrid1.SetBinContent(4, 9, -1);
-	labelGrid1.SetBinContent(7, 9, -9);
-	labelGrid1.SetBinContent(9, 7, -8);
-	labelGrid1.SetBinContent(9, 5, -7);
-	labelGrid1.SetBinContent(8, 3, -6);
-	labelGrid1.SetBinContent(6, 2, -5);
-	labelGrid1.SetBinContent(3, 3, -4);
-	labelGrid1.SetMarkerSize(2);
-	labelGrid1.SetMinimum(-9.01);
-	labelGrid1.SetMaximum(-0.01);
+    labelGrid1.SetBinContent(2, 5, -3);
+    labelGrid1.SetBinContent(2, 7, -2);
+    labelGrid1.SetBinContent(4, 9, -1);
+    labelGrid1.SetBinContent(7, 9, -9);
+    labelGrid1.SetBinContent(9, 7, -8);
+    labelGrid1.SetBinContent(9, 5, -7);
+    labelGrid1.SetBinContent(8, 3, -6);
+    labelGrid1.SetBinContent(6, 2, -5);
+    labelGrid1.SetBinContent(3, 3, -4);
+    labelGrid1.SetMarkerSize(2);
+    labelGrid1.SetMinimum(-9.01);
+    labelGrid1.SetMaximum(-0.01);
 
-	TH2C labelGrid2("labelGrid2","label grid for EE +", 10, 0., 100., 10, 0., 100.);
+    TH2C labelGrid2("labelGrid2", "label grid for EE +", 10, 0., 100., 10, 0., 100.);
 
-	for ( int i=1; i<=10; i++) {
-		for ( int j=1; j<=10; j++) {
-			labelGrid2.SetBinContent(i, j, -10);
-		}
-	}
+    for (int i = 1; i <= 10; i++) {
+      for (int j = 1; j <= 10; j++) {
+        labelGrid2.SetBinContent(i, j, -10);
+      }
+    }
 
-	labelGrid2.SetBinContent(2, 5, +3);
-	labelGrid2.SetBinContent(2, 7, +2);
-	labelGrid2.SetBinContent(4, 9, +1);
-	labelGrid2.SetBinContent(7, 9, +9);
-	labelGrid2.SetBinContent(9, 7, +8);
-	labelGrid2.SetBinContent(9, 5, +7);
-	labelGrid2.SetBinContent(8, 3, +6);
-	labelGrid2.SetBinContent(5, 2, +5);
-	labelGrid2.SetBinContent(3, 3, +4);
+    labelGrid2.SetBinContent(2, 5, +3);
+    labelGrid2.SetBinContent(2, 7, +2);
+    labelGrid2.SetBinContent(4, 9, +1);
+    labelGrid2.SetBinContent(7, 9, +9);
+    labelGrid2.SetBinContent(9, 7, +8);
+    labelGrid2.SetBinContent(9, 5, +7);
+    labelGrid2.SetBinContent(8, 3, +6);
+    labelGrid2.SetBinContent(5, 2, +5);
+    labelGrid2.SetBinContent(3, 3, +4);
 
-	labelGrid2.SetMarkerSize(2);
-	labelGrid2.SetMinimum(+0.01);
-	labelGrid2.SetMaximum(+9.01);
+    labelGrid2.SetMarkerSize(2);
+    labelGrid2.SetMinimum(+0.01);
+    labelGrid2.SetMaximum(+9.01);
 
-	
     //EE+
     p2.cd();
     gPad->SetGridx();
     gPad->SetGridy();
     EEPlot_plus->Draw("colz");
     labelGrid2.Draw("text,same");
-    
-    //drawing sector grid	
+
+    //drawing sector grid
 
     TLine l;
     l.SetLineWidth(1);
-    for ( int i=0; i<201; i=i+1) {
-	    if ( (ixSectorsEE[i]!=0 || iySectorsEE[i]!=0) && (ixSectorsEE[i+1]!=0 || iySectorsEE[i+1]!=0) ) {
-		    l.DrawLine(ixSectorsEE[i], iySectorsEE[i], ixSectorsEE[i+1], iySectorsEE[i+1]);
-	    }
+    for (int i = 0; i < 201; i = i + 1) {
+      if ((ixSectorsEE[i] != 0 || iySectorsEE[i] != 0) && (ixSectorsEE[i + 1] != 0 || iySectorsEE[i + 1] != 0)) {
+        l.DrawLine(ixSectorsEE[i], iySectorsEE[i], ixSectorsEE[i + 1], iySectorsEE[i + 1]);
+      }
     }
 
-    
     //EE-
     p3.cd();
     gPad->SetGridx();
@@ -545,16 +548,14 @@ public:
     labelGrid1.Draw("text,same");
 
     //drawing sector grid
-    for ( int i=0; i<201; i=i+1) {
-	    if ( (ixSectorsEE[i]!=0 || iySectorsEE[i]!=0) && (ixSectorsEE[i+1]!=0 || iySectorsEE[i+1]!=0) ) {
-		    l.DrawLine(ixSectorsEE[i], iySectorsEE[i], ixSectorsEE[i+1], iySectorsEE[i+1]);
-	    }
+    for (int i = 0; i < 201; i = i + 1) {
+      if ((ixSectorsEE[i] != 0 || iySectorsEE[i] != 0) && (ixSectorsEE[i + 1] != 0 || iySectorsEE[i + 1] != 0)) {
+        l.DrawLine(ixSectorsEE[i], iySectorsEE[i], ixSectorsEE[i + 1], iySectorsEE[i + 1]);
+      }
     }
-    
-    
-    //drawing everything & printing 
-    c1.Print(m_outputFile.c_str(), m_outputFormat.c_str());
 
+    //drawing everything & printing
+    c1.Print(m_outputFile.c_str(), m_outputFormat.c_str());
   };
 
   void setTimeAxis(TAxis* axis) {
@@ -564,9 +565,9 @@ public:
     axis->SetLabelOffset(0.02);
     axis->SetLabelSize(0.03);
   }
-  
+
 private:
-  RootPlot() {};  // hidden default constructor
+  RootPlot(){};  // hidden default constructor
 
   bool m_isInit;
   TFile* m_rootfile;
@@ -591,35 +592,28 @@ private:
   TDatime m_T0;
 };
 
-void arg_error(string msg)
-{
+void arg_error(string msg) {
   cerr << "ERROR:  " << msg << endl;
   cerr << "Use 'ECALrootPlotter -h' for help" << endl;
   exit(1);
 }
 
-int main (int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   // Parse command line
   program_options::options_description desc("options");
-  program_options::options_description visible("Usage:  ECALrootPlotter [options] [Plot Type] [Output Format] [Output File] \noptions");
-  visible.add_options()
-    ("time,t", "X axis takes time values")
-    ("file,f", program_options::value<string>(), "input file name")
-    ("title,T", program_options::value<string>(), "Set plot title")
-    ("xtitle,X", program_options::value<string>(), "X axis title")
-    ("ytitle,Y", program_options::value<string>(), "Y axis title")
-    ("debug","Print debug information")
-    ("help,h", "help message")
-    ;
+  program_options::options_description visible(
+      "Usage:  ECALrootPlotter [options] [Plot Type] [Output Format] [Output File] \noptions");
+  visible.add_options()("time,t", "X axis takes time values")(
+      "file,f", program_options::value<string>(), "input file name")(
+      "title,T", program_options::value<string>(), "Set plot title")(
+      "xtitle,X", program_options::value<string>(), "X axis title")(
+      "ytitle,Y", program_options::value<string>(), "Y axis title")("debug", "Print debug information")("help,h",
+                                                                                                        "help message");
   program_options::options_description hidden("argument");
-  hidden.add_options()
-    ("type", program_options::value<string>(),"Type of ROOT plot")
-    ("format", program_options::value<string>(), "Output format")
-    ("output", program_options::value<string>(), "Output file")
-    ("hmin", program_options::value<float>(), "histo_min")
-    ("hmax", program_options::value<float>(), "histo_max")
-    ;
+  hidden.add_options()("type", program_options::value<string>(), "Type of ROOT plot")(
+      "format", program_options::value<string>(), "Output format")(
+      "output", program_options::value<string>(), "Output file")("hmin", program_options::value<float>(), "histo_min")(
+      "hmax", program_options::value<float>(), "histo_max");
   desc.add(visible).add(hidden);
   program_options::positional_options_description pd;
   pd.add("type", 1);
@@ -651,37 +645,51 @@ int main (int argc, char* argv[])
   int axisCode = RootPlot::DEFAULT_AXIS;
   int debug = 0;
 
-  if (vm.count("type")) { 
-    type = vm["type"].as<string>(); 
-    if (type != "TH1F" && type != "TH2F" && type != "TGraph" && type != "Map" && type != "EBEEMap" ) {
+  if (vm.count("type")) {
+    type = vm["type"].as<string>();
+    if (type != "TH1F" && type != "TH2F" && type != "TGraph" && type != "Map" && type != "EBEEMap") {
       cerr << "ERROR:  Plot type " << type << " is not valid." << endl;
-      arg_error("Valid types are:\n"
-		"  'TH1F'   (1 col data)\n"
-		"  'TH2F'   (2 col data)\n"
-		"  'TGraph' (2 col data)\n"
-		"  'Map'    (2 col data)\n"
-		"  'EBEEMap'  (5 col data)\n"
-		); 
+      arg_error(
+          "Valid types are:\n"
+          "  'TH1F'   (1 col data)\n"
+          "  'TH2F'   (2 col data)\n"
+          "  'TGraph' (2 col data)\n"
+          "  'Map'    (2 col data)\n"
+          "  'EBEEMap'  (5 col data)\n");
     }
-  } else {  
-   arg_error("type is required.\n"
-	      "Valid types are:\n"
-	      "  'TH1F'   (1 col data)\n"
-	      "  'TH2F'   (2 col data)\n"
-	      "  'TGraph' (2 col data)\n"
-              "  'Map'    (2 col data)\n"
-              "  'EBEEMap'  (5 col data)"
-	      ); 
+  } else {
+    arg_error(
+        "type is required.\n"
+        "Valid types are:\n"
+        "  'TH1F'   (1 col data)\n"
+        "  'TH2F'   (2 col data)\n"
+        "  'TGraph' (2 col data)\n"
+        "  'Map'    (2 col data)\n"
+        "  'EBEEMap'  (5 col data)");
   }
-  if (vm.count("format")) { outputFormat = vm["format"].as<string>(); }
-  else { arg_error("format is required"); }
-  if (vm.count("output")) { outputFile = vm["output"].as<string>(); }
-  else { arg_error("output is required"); }
-  if (vm.count("hmin")) {histo_min = vm["hmin"].as<float>(); }
-  if (vm.count("hmax")) {histo_max = vm["hmax"].as<float>(); }
-  if (vm.count("file")) {file = vm["file"].as<string>(); }
+  if (vm.count("format")) {
+    outputFormat = vm["format"].as<string>();
+  } else {
+    arg_error("format is required");
+  }
+  if (vm.count("output")) {
+    outputFile = vm["output"].as<string>();
+  } else {
+    arg_error("output is required");
+  }
+  if (vm.count("hmin")) {
+    histo_min = vm["hmin"].as<float>();
+  }
+  if (vm.count("hmax")) {
+    histo_max = vm["hmax"].as<float>();
+  }
+  if (vm.count("file")) {
+    file = vm["file"].as<string>();
+  }
 
-  if (vm.count("time")) { axisCode = RootPlot::TIME_AXIS; }
+  if (vm.count("time")) {
+    axisCode = RootPlot::TIME_AXIS;
+  }
   if (vm.count("title")) {
     title = vm["title"].as<string>();
   }
@@ -691,8 +699,10 @@ int main (int argc, char* argv[])
   if (vm.count("ytitle")) {
     ytitle = vm["ytitle"].as<string>();
   }
-  if (vm.count("debug")) { debug = 1; }
-  
+  if (vm.count("debug")) {
+    debug = 1;
+  }
+
   string path = "";
   if ((int)file.find("/") >= 0) {
     path = file.substr(0, file.rfind("/"));
@@ -701,9 +711,12 @@ int main (int argc, char* argv[])
 
   // substitute _ with spaces
   size_t t;
-  while ((t = title.find('_'))!=string::npos) title[t] = ' ';
-  while ((t = xtitle.find('_'))!=string::npos) xtitle[t] = ' ';
-  while ((t = ytitle.find('_'))!=string::npos) ytitle[t] = ' ';
+  while ((t = title.find('_')) != string::npos)
+    title[t] = ' ';
+  while ((t = xtitle.find('_')) != string::npos)
+    xtitle[t] = ' ';
+  while ((t = ytitle.find('_')) != string::npos)
+    ytitle[t] = ' ';
 
   if (debug) {
     cout << "Debug info:    " << endl;
@@ -729,8 +742,8 @@ int main (int argc, char* argv[])
     rootplot.setDebug(debug);
 
     string line;
-    
-    ifstream *finput = (ifstream *)&cin;
+
+    ifstream* finput = (ifstream*)&cin;
     if (file.length() > 0) {
       finput = new ifstream(file.c_str());
     }
@@ -738,7 +751,7 @@ int main (int argc, char* argv[])
       rootplot.parseAndFill(line);
     }
 
-    if ( finput->bad() || !finput->eof() ) {
+    if (finput->bad() || !finput->eof()) {
       cerr << "Input error." << endl;
     }
 
@@ -749,7 +762,7 @@ int main (int argc, char* argv[])
     }
     rootplot.draw();
 
-  } catch (std::exception &e) {
+  } catch (std::exception& e) {
     cerr << "ERROR:  " << e.what() << endl;
   }
 }

--- a/PhysicsTools/FWLite/interface/EventSelectors.h
+++ b/PhysicsTools/FWLite/interface/EventSelectors.h
@@ -15,7 +15,7 @@ namespace fwlite {
   class EventSelector : public TNamed {
   public:
     EventSelector(const char *name = "", const char *title = "") : TNamed(name, title) {}
-    virtual ~EventSelector() {}
+    ~EventSelector() override {}
     virtual bool accept(const fwlite::EventBase &ev) const = 0;
   };
 
@@ -28,8 +28,8 @@ namespace fwlite {
       add(run, firstLumi, lastLumi);
     }
 
-    virtual ~RunLumiSelector() {}
-    virtual bool accept(const fwlite::EventBase &ev) const { return accept(ev.id().run(), ev.luminosityBlock()); }
+    ~RunLumiSelector() override {}
+    bool accept(const fwlite::EventBase &ev) const override { return accept(ev.id().run(), ev.luminosityBlock()); }
     void add(int run, int firstLumi = 0, int lastLumi = 9999999) {
       runs.push_back(run);
       firstLumis.push_back(firstLumi);
@@ -74,8 +74,8 @@ namespace fwlite {
       scanner->setCut(cut);
       scanner->setIgnoreExceptions(true);
     }
-    ~ObjectCountSelector() { delete scanner; }
-    virtual bool accept(const fwlite::EventBase &ev) const {
+    ~ObjectCountSelector() override { delete scanner; }
+    bool accept(const fwlite::EventBase &ev) const override {
       int nfound = 0;
       HandleT handle;  // here, not as a datamember, otherwise CINT segfaults (!?)
       handle.getByLabel(ev, label_.c_str(), instance_.c_str(), process_.c_str());

--- a/PhysicsTools/FWLite/interface/Scanner.h
+++ b/PhysicsTools/FWLite/interface/Scanner.h
@@ -201,16 +201,16 @@ namespace fwlite {
       helper::ScannerBase scanner(objType);
       scanner.setIgnoreExceptions(ignoreExceptions_);
       if (!scanner.addExpression(expr))
-        return 0;
+        return nullptr;
       if (strlen(cut))
         scanner.setCut(cut);
 
       // check histo
-      if (hist == 0) {
+      if (hist == nullptr) {
         std::cerr << "Method draw(expr, cut, drawopt, hist) cannot be called with null 'hist'. Use the other draw "
                      "methods instead."
                   << std::endl;
-        return 0;
+        return nullptr;
       }
 
       // fill histogram
@@ -249,9 +249,9 @@ namespace fwlite {
               const char *cut = "",
               TString drawopt = "",
               const char *hname = "htemp",
-              const TH1 *htemplate = 0) {
-      TH1 *hist = 0;
-      if (htemplate != 0) {
+              const TH1 *htemplate = nullptr) {
+      TH1 *hist = nullptr;
+      if (htemplate != nullptr) {
         if ((strcmp(hname, "htemp") == 0) && (strcmp(hname, htemplate->GetName()) != 0))
           htempDelete();
         hist = (TH1 *)hist->Clone(hname);
@@ -260,7 +260,7 @@ namespace fwlite {
       }
 
       // if in the end we found no way to make "hist"
-      if (hist == 0) {
+      if (hist == nullptr) {
         if (strcmp(hname, "htemp") == 0)
           htempDelete();
         hist = new TH1F(hname, "", gEnv->GetValue("Hist.Binning.1D.x", 100), 0, 0);
@@ -322,18 +322,18 @@ namespace fwlite {
       helper::ScannerBase scanner(objType);
       scanner.setIgnoreExceptions(ignoreExceptions_);
       if (!scanner.addExpression(xexpr.Data()))
-        return 0;
+        return nullptr;
       if (!scanner.addExpression(yexpr.Data()))
-        return 0;
+        return nullptr;
       if (strlen(cut))
         scanner.setCut(cut);
 
       // check histo
-      if (hist == 0) {
+      if (hist == nullptr) {
         std::cerr << "Method drawProf(xexpr, yexpr, cut, drawopt, hist) cannot be called with null 'hist'. Use the "
                      "other draw methods instead."
                   << std::endl;
-        return 0;
+        return nullptr;
       }
 
       // fill histogram
@@ -366,9 +366,9 @@ namespace fwlite {
                        const char *cut = "",
                        TString drawopt = "",
                        const char *hname = "htemp",
-                       TProfile *htemplate = 0) {
-      TProfile *hist = 0;
-      if (htemplate != 0) {
+                       TProfile *htemplate = nullptr) {
+      TProfile *hist = nullptr;
+      if (htemplate != nullptr) {
         if ((strcmp(hname, "htemp") == 0) && (strcmp(hname, htemplate->GetName()) != 0))
           htempDelete();
         hist = (TProfile *)hist->Clone(hname);
@@ -377,7 +377,7 @@ namespace fwlite {
       }
 
       // if in the end we found no way to make "hist"
-      if (hist == 0) {
+      if (hist == nullptr) {
         if (strcmp(hname, "htemp") == 0)
           htempDelete();
         hist = new TProfile(hname, "", gEnv->GetValue("Hist.Binning.1D.x", 100), 0., 0.);
@@ -413,18 +413,18 @@ namespace fwlite {
       helper::ScannerBase scanner(objType);
       scanner.setIgnoreExceptions(ignoreExceptions_);
       if (!scanner.addExpression((const char *)xexpr))
-        return 0;
+        return nullptr;
       if (!scanner.addExpression((const char *)yexpr))
-        return 0;
+        return nullptr;
       if (strlen(cut))
         scanner.setCut(cut);
 
       // check histo
-      if (hist == 0) {
+      if (hist == nullptr) {
         std::cerr << "Method draw2D(xexpr, yexpr, cut, drawopt, hist) cannot be called with null 'hist'. Use the other "
                      "draw methods instead."
                   << std::endl;
-        return 0;
+        return nullptr;
       }
 
       // fill histogram
@@ -458,9 +458,9 @@ namespace fwlite {
                 const char *cut = "",
                 TString drawopt = "",
                 const char *hname = "htemp",
-                TH2 *htemplate = 0) {
-      TH2 *hist = 0;
-      if (htemplate != 0) {
+                TH2 *htemplate = nullptr) {
+      TH2 *hist = nullptr;
+      if (htemplate != nullptr) {
         if ((strcmp(hname, "htemp") == 0) && (strcmp(hname, htemplate->GetName()) != 0))
           htempDelete();
         hist = (TH2 *)hist->Clone(hname);
@@ -469,14 +469,14 @@ namespace fwlite {
       }
 
       // if in the end we found no way to make "hist"
-      if (hist == 0) {
+      if (hist == nullptr) {
         // prep the machinery
         helper::ScannerBase scanner(objType);
         scanner.setIgnoreExceptions(ignoreExceptions_);
         if (!scanner.addExpression((const char *)xexpr))
-          return 0;
+          return nullptr;
         if (!scanner.addExpression((const char *)yexpr))
-          return 0;
+          return nullptr;
         if (strlen(cut))
           scanner.setCut(cut);
 
@@ -548,14 +548,14 @@ namespace fwlite {
       helper::ScannerBase scanner(objType);
       scanner.setIgnoreExceptions(ignoreExceptions_);
       if (!scanner.addExpression((const char *)xexpr))
-        return 0;
+        return nullptr;
       if (!scanner.addExpression((const char *)yexpr))
-        return 0;
+        return nullptr;
       if (strlen(cut))
         scanner.setCut(cut);
 
       // make graph, if needed
-      if (graph == 0) {
+      if (graph == nullptr) {
         graph = new TGraph();
         graph->SetNameTitle("htemp", (strlen(cut) ? yexpr + ":" + xexpr + "{" + cut + "}" : yexpr + ":" + xexpr));
       }
@@ -624,7 +624,7 @@ namespace fwlite {
         }
         if (!scanner.addExpression(ex.c_str())) {
           std::cerr << "Filed to define real variable '" << lb << "', expr = '" << ex << "'" << std::endl;
-          return 0;
+          return nullptr;
         }
         // FIXME: I have to leave it dangling on the HEAP otherwise ROOT segfaults...
         RooRealVar *var = new RooRealVar(lb.c_str(), lb.c_str(), 0.0);
@@ -640,7 +640,7 @@ namespace fwlite {
         }
         if (!scanner.addExtraCut(ex.c_str())) {
           std::cerr << "Filed to define bool variable '" << lb << "', cut = '" << ex << "'" << std::endl;
-          return 0;
+          return nullptr;
         }
         RooCategory *cat = new RooCategory(lb.c_str(), lb.c_str());
         cat->defineType("fail", 0);
@@ -740,7 +740,8 @@ namespace fwlite {
     /// Get whatever histogram makes sense for a plot passing "SAME" in drawOpt, and call it hname
     /// Currently it won't work if the histogram of which we want to be "SAME" is not called "htemp"
     TH1 *getSameH1(const char *hname) {
-      if (gDirectory && gDirectory->Get("htemp") != 0 && gDirectory->Get("htemp")->IsA()->InheritsFrom(TH1::Class())) {
+      if (gDirectory && gDirectory->Get("htemp") != nullptr &&
+          gDirectory->Get("htemp")->IsA()->InheritsFrom(TH1::Class())) {
         TH1 *hist = (TH1 *)((TH1 *)gDirectory->Get("htemp"))->Clone(hname);
         hist->Reset();
         hist->SetLineColor(kBlack);
@@ -748,14 +749,15 @@ namespace fwlite {
         return hist;
       } else {
         std::cerr << "There is no 'htemp' histogram from which to 'SAME'." << std::endl;
-        return 0;
+        return nullptr;
       }
     }
 
     /// Get whatever histogram makes sense for a plot passing "SAME" in drawOpt, and call it hname
     /// Currently it won't work if the histogram of which we want to be "SAME" is not called "htemp"
     TH2 *getSameH2(const char *hname) {
-      if (gDirectory && gDirectory->Get("htemp") != 0 && gDirectory->Get("htemp")->IsA()->InheritsFrom(TH2::Class())) {
+      if (gDirectory && gDirectory->Get("htemp") != nullptr &&
+          gDirectory->Get("htemp")->IsA()->InheritsFrom(TH2::Class())) {
         TH2 *hist = (TH2 *)((TH2 *)gDirectory->Get("htemp"))->Clone(hname);
         hist->Reset();
         hist->SetLineColor(kBlack);
@@ -763,14 +765,14 @@ namespace fwlite {
         return hist;
       } else {
         std::cerr << "There is no 'htemp' histogram from which to 'SAME'." << std::endl;
-        return 0;
+        return nullptr;
       }
     }
 
     /// Get whatever histogram makes sense for a plot passing "SAME" in drawOpt, and call it hname
     /// Currently it won't work if the histogram of which we want to be "SAME" is not called "htemp"
     TProfile *getSameProf(const char *hname) {
-      if (gDirectory && gDirectory->Get("htemp") != 0 &&
+      if (gDirectory && gDirectory->Get("htemp") != nullptr &&
           gDirectory->Get("htemp")->IsA()->InheritsFrom(TProfile::Class())) {
         TProfile *hist = (TProfile *)((TProfile *)gDirectory->Get("htemp"))->Clone(hname);
         hist->Reset();
@@ -779,7 +781,7 @@ namespace fwlite {
         return hist;
       } else {
         std::cerr << "There is no 'htemp' histogram from which to 'SAME'." << std::endl;
-        return 0;
+        return nullptr;
       }
     }
   };

--- a/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
+++ b/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
@@ -70,7 +70,7 @@ int main(int argc, char * argv[]) {
     return -1;
   }
 
-  if(fileNames.size()==0) {
+  if (fileNames.empty()) {
     cerr << "at least one file name must be specified with option -i" <<endl;
     return -1;
   }
@@ -129,8 +129,8 @@ int main(int argc, char * argv[]) {
       string className(key->GetClassName());
       string name(key->GetName());
       TObject * obj = file.Get(name.c_str());
-      if(obj == 0) {
-	cerr <<"error: key " << name << " not found in file " << fileName << endl;
+      if (obj == nullptr) {
+        cerr <<"error: key " << name << " not found in file " << fileName << endl;
 	return -1;
       }
       if(empty) make(out, obj);
@@ -153,7 +153,7 @@ void make(TDirectory & out, TObject * o) {
   TH2F * th2f;
   TH2D * th2d;
   out.cd();
-  if((dir = dynamic_cast<TDirectory*>(o)) != 0) {
+  if ((dir = dynamic_cast<TDirectory *>(o)) != nullptr) {
     TDirectory * outDir = out.mkdir(dir->GetName(), dir->GetTitle());
     TIter next(dir->GetListOfKeys());
     TKey *key;
@@ -161,28 +161,28 @@ void make(TDirectory & out, TObject * o) {
       string className(key->GetClassName());
       string name(key->GetName());
       TObject * obj = dir->Get(name.c_str());
-      if(obj == 0) {
-	cerr <<"error: key " << name << " not found in directory " << dir->GetName() << endl;
+      if (obj == nullptr) {
+        cerr <<"error: key " << name << " not found in directory " << dir->GetName() << endl;
 	exit(-1);
       }
       make(*outDir, obj);
     }
-  } else if((th1f = dynamic_cast<TH1F*>(o)) != 0) {
+  } else if ((th1f = dynamic_cast<TH1F *>(o)) != nullptr) {
     TH1F *h = (TH1F*) th1f->Clone();
     h->Reset();
     h->Sumw2();
     h->SetDirectory(&out);
-  } else if((th1d = dynamic_cast<TH1D*>(o)) != 0) {
+  } else if ((th1d = dynamic_cast<TH1D *>(o)) != nullptr) {
     TH1D *h = (TH1D*) th1d->Clone();
     h->Reset();
     h->Sumw2();
     h->SetDirectory(&out);
-  } else if((th2f = dynamic_cast<TH2F*>(o)) != 0) {
+  } else if ((th2f = dynamic_cast<TH2F *>(o)) != nullptr) {
     TH2F *h = (TH2F*) th2f->Clone();
     h->Reset();   
     h->Sumw2();
     h->SetDirectory(&out);
-  } else if((th2d = dynamic_cast<TH2D*>(o)) != 0) {
+  } else if ((th2d = dynamic_cast<TH2D *>(o)) != nullptr) {
     TH2D *h = (TH2D*) th2d->Clone();
     h->Reset();   
     h->Sumw2();
@@ -196,10 +196,10 @@ void fill(TDirectory & out, TObject * o, double w) {
   TH1D * th1d;
   TH2F * th2f;
   TH2D * th2d;
-  if((dir  = dynamic_cast<TDirectory*>(o)) != 0) {
+  if ((dir = dynamic_cast<TDirectory *>(o)) != nullptr) {
     const char * name = dir->GetName();
     TDirectory * outDir = dynamic_cast<TDirectory*>(out.Get(name));
-    if(outDir == 0) {
+    if (outDir == nullptr) {
       cerr << "can't find directory " << name << " in output file" << endl;
       exit(-1);
     }
@@ -209,42 +209,42 @@ void fill(TDirectory & out, TObject * o, double w) {
       string className(key->GetClassName());
       string name(key->GetName());
       TObject * obj = dir->Get(name.c_str());
-      if(obj == 0) {
-	cerr <<"error: key " << name << " not found in directory " << dir->GetName() << endl;
+      if (obj == nullptr) {
+        cerr <<"error: key " << name << " not found in directory " << dir->GetName() << endl;
 	exit(-1);
       }
       fill(*outDir, obj, w);
     }
-  } else if((th1f = dynamic_cast<TH1F*>(o)) != 0) {
+  } else if ((th1f = dynamic_cast<TH1F *>(o)) != nullptr) {
     const char * name = th1f->GetName();
     TH1F * outTh1f = dynamic_cast<TH1F*>(out.Get(name));
-    if(outTh1f == 0) {
+    if (outTh1f == nullptr) {
       cerr <<"error: histogram TH1F" << name << " not found in directory " << out.GetName() << endl;
-      exit(-1);	
+      exit(-1);
     }
     outTh1f->Add(th1f, w);
-  } else if((th1d = dynamic_cast<TH1D*>(o)) != 0) {
+  } else if ((th1d = dynamic_cast<TH1D *>(o)) != nullptr) {
     const char * name = th1d->GetName();
     TH1D * outTh1d = dynamic_cast<TH1D*>(out.Get(name));
-    if(outTh1d == 0) {
+    if (outTh1d == nullptr) {
       cerr <<"error: histogram TH1D" << name << " not found in directory " << out.GetName() << endl;
-      exit(-1);	
-    } 
+      exit(-1);
+    }
     outTh1d->Add(th1d, w);
-  } else if((th2f = dynamic_cast<TH2F*>(o)) != 0) {
+  } else if ((th2f = dynamic_cast<TH2F *>(o)) != nullptr) {
     const char * name = th2f->GetName();
     TH2F * outTh2f = dynamic_cast<TH2F*>(out.Get(name));
-    if(outTh2f == 0) {
+    if (outTh2f == nullptr) {
       cerr <<"error: histogram TH2F" << name << " not found in directory " << out.GetName() << endl;
-      exit(-1);	
+      exit(-1);
     }
     outTh2f->Add(th2f, w);
-  } else if((th2d = dynamic_cast<TH2D*>(o)) != 0) {
+  } else if ((th2d = dynamic_cast<TH2D *>(o)) != nullptr) {
     const char * name = th2d->GetName();
     TH2D * outTh2d = dynamic_cast<TH2D*>(out.Get(name));
-    if(outTh2d == 0) {
+    if (outTh2d == nullptr) {
       cerr <<"error: histogram TH2D" << name << " not found in directory " << out.GetName() << endl;
-      exit(-1);	
+      exit(-1);
     }
     outTh2d->Add(th2d, w);
   }

--- a/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
+++ b/PhysicsTools/UtilAlgos/bin/mergeTFileServiceHistograms.cpp
@@ -18,52 +18,51 @@ using namespace boost::program_options;
 using namespace boost;
 using namespace std;
 
-void make(TDirectory & out, TObject * o);
-void fill(TDirectory & out, TObject * o, double);
+void make(TDirectory &out, TObject *o);
+void fill(TDirectory &out, TObject *o, double);
 
-static const char * const kHelpOpt = "help";
-static const char * const kHelpCommandOpt = "help,h";
-static const char * const kOutputFileOpt = "output-file";
-static const char * const kOutputFileCommandOpt = "output-file,o";
-static const char * const kInputFilesOpt = "input-files";
-static const char * const kInputFilesCommandOpt = "input-files,i";
-static const char * const kWeightsOpt = "weights";
-static const char * const kWeightsCommandOpt = "weights,w";
+static const char *const kHelpOpt = "help";
+static const char *const kHelpCommandOpt = "help,h";
+static const char *const kOutputFileOpt = "output-file";
+static const char *const kOutputFileCommandOpt = "output-file,o";
+static const char *const kInputFilesOpt = "input-files";
+static const char *const kInputFilesCommandOpt = "input-files,i";
+static const char *const kWeightsOpt = "weights";
+static const char *const kWeightsCommandOpt = "weights,w";
 
 vector<double> weights;
 
-int main(int argc, char * argv[]) {
+int main(int argc, char *argv[]) {
   string programName(argv[0]);
   string descString(programName);
   descString += " [options] ";
   descString += "data_file \nAllowed options";
   options_description desc(descString);
 
-  desc.add_options()
-    (kHelpCommandOpt, "produce help message")
-    (kOutputFileCommandOpt, value<string>()->default_value("out.root"), "output root file")
-    (kWeightsCommandOpt, value<string>(), "list of weights (comma separates).\ndefault: weights are assumed to be 1")
-    (kInputFilesCommandOpt, value<vector<string> >()->multitoken(), "input root files");
+  desc.add_options()(kHelpCommandOpt, "produce help message")(
+      kOutputFileCommandOpt, value<string>()->default_value("out.root"), "output root file")(
+      kWeightsCommandOpt, value<string>(), "list of weights (comma separates).\ndefault: weights are assumed to be 1")(
+      kInputFilesCommandOpt, value<vector<string> >()->multitoken(), "input root files");
 
   positional_options_description p;
 
   variables_map vm;
   try {
-    store(command_line_parser(argc,argv).options(desc).positional(p).run(), vm);
+    store(command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
     notify(vm);
-  } catch(const error&) {
+  } catch (const error &) {
     cerr << "invalid arguments. usage:" << endl;
-    cerr << desc <<std::endl;
+    cerr << desc << std::endl;
     return -1;
   }
 
-  if(vm.count(kHelpOpt)) {
-    cout << desc <<std::endl;
+  if (vm.count(kHelpOpt)) {
+    cout << desc << std::endl;
     return 0;
   }
 
   vector<string> fileNames;
-  if(vm.count(kInputFilesOpt)) {
+  if (vm.count(kInputFilesOpt)) {
     fileNames = vm[kInputFilesOpt].as<vector<string> >();
   } else {
     cerr << "option -i must be specifyed" << endl;
@@ -71,37 +70,37 @@ int main(int argc, char * argv[]) {
   }
 
   if (fileNames.empty()) {
-    cerr << "at least one file name must be specified with option -i" <<endl;
+    cerr << "at least one file name must be specified with option -i" << endl;
     return -1;
   }
 
   string outputFile;
-  if(vm.count(kOutputFileOpt)) {
+  if (vm.count(kOutputFileOpt)) {
     outputFile = vm[kOutputFileOpt].as<string>();
   } else {
     cerr << "option -o must be specifyed" << endl;
     return -1;
   }
 
-  if(vm.count(kWeightsOpt)) {
+  if (vm.count(kWeightsOpt)) {
     string w = vm[kWeightsOpt].as<string>();
     char_separator<char> sep(",");
     tokenizer<char_separator<char> > tokens(w, sep);
-    for(tokenizer<char_separator<char> >::iterator t = tokens.begin(); t != tokens.end();++t) {
-      const char * begin = t->c_str();
-      char * end;
+    for (tokenizer<char_separator<char> >::iterator t = tokens.begin(); t != tokens.end(); ++t) {
+      const char *begin = t->c_str();
+      char *end;
       double w = strtod(begin, &end);
       size_t s = end - begin;
-      if(s < t->size()) {
-	cerr << "invalid weight: " << begin << endl;
-	exit(1);
+      if (s < t->size()) {
+        cerr << "invalid weight: " << begin << endl;
+        exit(1);
       }
       weights.push_back(w);
     }
   } else {
     weights = vector<double>(fileNames.size(), 1.0);
   }
-  if(weights.size() != fileNames.size()) {
+  if (weights.size() != fileNames.size()) {
     cerr << "the number of weights and the number of files must be the same" << endl;
     exit(-1);
   }
@@ -109,31 +108,32 @@ int main(int argc, char * argv[]) {
   gROOT->SetBatch();
 
   TFile out(outputFile.c_str(), "RECREATE");
-  if(!out.IsOpen()) { 
-    cerr << "can't open output file: " << outputFile <<endl;
-    return -1;  
+  if (!out.IsOpen()) {
+    cerr << "can't open output file: " << outputFile << endl;
+    return -1;
   }
-  
+
   bool empty = true;
-  for(size_t i = 0; i < fileNames.size(); ++i) {
+  for (size_t i = 0; i < fileNames.size(); ++i) {
     string fileName = fileNames[i];
     TFile file(fileName.c_str(), "read");
-    if(!file.IsOpen()) {
-      cerr << "can't open input file: " << fileName <<endl;
+    if (!file.IsOpen()) {
+      cerr << "can't open input file: " << fileName << endl;
       return -1;
     }
 
     TIter next(file.GetListOfKeys());
     TKey *key;
-    while ((key = dynamic_cast<TKey*>(next()))) {
+    while ((key = dynamic_cast<TKey *>(next()))) {
       string className(key->GetClassName());
       string name(key->GetName());
-      TObject * obj = file.Get(name.c_str());
+      TObject *obj = file.Get(name.c_str());
       if (obj == nullptr) {
-        cerr <<"error: key " << name << " not found in file " << fileName << endl;
-	return -1;
+        cerr << "error: key " << name << " not found in file " << fileName << endl;
+        return -1;
       }
-      if(empty) make(out, obj);
+      if (empty)
+        make(out, obj);
       fill(out, obj, weights[i]);
     }
     file.Close();
@@ -146,107 +146,106 @@ int main(int argc, char * argv[]) {
   return 0;
 }
 
-void make(TDirectory & out, TObject * o) {
-  TDirectory * dir;
-  TH1F * th1f;
-  TH1D * th1d;
-  TH2F * th2f;
-  TH2D * th2d;
+void make(TDirectory &out, TObject *o) {
+  TDirectory *dir;
+  TH1F *th1f;
+  TH1D *th1d;
+  TH2F *th2f;
+  TH2D *th2d;
   out.cd();
   if ((dir = dynamic_cast<TDirectory *>(o)) != nullptr) {
-    TDirectory * outDir = out.mkdir(dir->GetName(), dir->GetTitle());
+    TDirectory *outDir = out.mkdir(dir->GetName(), dir->GetTitle());
     TIter next(dir->GetListOfKeys());
     TKey *key;
-    while( (key = dynamic_cast<TKey*>(next())) ) {
+    while ((key = dynamic_cast<TKey *>(next()))) {
       string className(key->GetClassName());
       string name(key->GetName());
-      TObject * obj = dir->Get(name.c_str());
+      TObject *obj = dir->Get(name.c_str());
       if (obj == nullptr) {
-        cerr <<"error: key " << name << " not found in directory " << dir->GetName() << endl;
-	exit(-1);
+        cerr << "error: key " << name << " not found in directory " << dir->GetName() << endl;
+        exit(-1);
       }
       make(*outDir, obj);
     }
   } else if ((th1f = dynamic_cast<TH1F *>(o)) != nullptr) {
-    TH1F *h = (TH1F*) th1f->Clone();
+    TH1F *h = (TH1F *)th1f->Clone();
     h->Reset();
     h->Sumw2();
     h->SetDirectory(&out);
   } else if ((th1d = dynamic_cast<TH1D *>(o)) != nullptr) {
-    TH1D *h = (TH1D*) th1d->Clone();
+    TH1D *h = (TH1D *)th1d->Clone();
     h->Reset();
     h->Sumw2();
     h->SetDirectory(&out);
   } else if ((th2f = dynamic_cast<TH2F *>(o)) != nullptr) {
-    TH2F *h = (TH2F*) th2f->Clone();
-    h->Reset();   
+    TH2F *h = (TH2F *)th2f->Clone();
+    h->Reset();
     h->Sumw2();
     h->SetDirectory(&out);
   } else if ((th2d = dynamic_cast<TH2D *>(o)) != nullptr) {
-    TH2D *h = (TH2D*) th2d->Clone();
-    h->Reset();   
+    TH2D *h = (TH2D *)th2d->Clone();
+    h->Reset();
     h->Sumw2();
     h->SetDirectory(&out);
   }
 }
 
-void fill(TDirectory & out, TObject * o, double w) {
-  TDirectory * dir;
-  TH1F * th1f;
-  TH1D * th1d;
-  TH2F * th2f;
-  TH2D * th2d;
+void fill(TDirectory &out, TObject *o, double w) {
+  TDirectory *dir;
+  TH1F *th1f;
+  TH1D *th1d;
+  TH2F *th2f;
+  TH2D *th2d;
   if ((dir = dynamic_cast<TDirectory *>(o)) != nullptr) {
-    const char * name = dir->GetName();
-    TDirectory * outDir = dynamic_cast<TDirectory*>(out.Get(name));
+    const char *name = dir->GetName();
+    TDirectory *outDir = dynamic_cast<TDirectory *>(out.Get(name));
     if (outDir == nullptr) {
       cerr << "can't find directory " << name << " in output file" << endl;
       exit(-1);
     }
     TIter next(dir->GetListOfKeys());
     TKey *key;
-    while( (key = dynamic_cast<TKey*>(next())) ) {
+    while ((key = dynamic_cast<TKey *>(next()))) {
       string className(key->GetClassName());
       string name(key->GetName());
-      TObject * obj = dir->Get(name.c_str());
+      TObject *obj = dir->Get(name.c_str());
       if (obj == nullptr) {
-        cerr <<"error: key " << name << " not found in directory " << dir->GetName() << endl;
-	exit(-1);
+        cerr << "error: key " << name << " not found in directory " << dir->GetName() << endl;
+        exit(-1);
       }
       fill(*outDir, obj, w);
     }
   } else if ((th1f = dynamic_cast<TH1F *>(o)) != nullptr) {
-    const char * name = th1f->GetName();
-    TH1F * outTh1f = dynamic_cast<TH1F*>(out.Get(name));
+    const char *name = th1f->GetName();
+    TH1F *outTh1f = dynamic_cast<TH1F *>(out.Get(name));
     if (outTh1f == nullptr) {
-      cerr <<"error: histogram TH1F" << name << " not found in directory " << out.GetName() << endl;
+      cerr << "error: histogram TH1F" << name << " not found in directory " << out.GetName() << endl;
       exit(-1);
     }
     outTh1f->Add(th1f, w);
   } else if ((th1d = dynamic_cast<TH1D *>(o)) != nullptr) {
-    const char * name = th1d->GetName();
-    TH1D * outTh1d = dynamic_cast<TH1D*>(out.Get(name));
+    const char *name = th1d->GetName();
+    TH1D *outTh1d = dynamic_cast<TH1D *>(out.Get(name));
     if (outTh1d == nullptr) {
-      cerr <<"error: histogram TH1D" << name << " not found in directory " << out.GetName() << endl;
+      cerr << "error: histogram TH1D" << name << " not found in directory " << out.GetName() << endl;
       exit(-1);
     }
     outTh1d->Add(th1d, w);
   } else if ((th2f = dynamic_cast<TH2F *>(o)) != nullptr) {
-    const char * name = th2f->GetName();
-    TH2F * outTh2f = dynamic_cast<TH2F*>(out.Get(name));
+    const char *name = th2f->GetName();
+    TH2F *outTh2f = dynamic_cast<TH2F *>(out.Get(name));
     if (outTh2f == nullptr) {
-      cerr <<"error: histogram TH2F" << name << " not found in directory " << out.GetName() << endl;
+      cerr << "error: histogram TH2F" << name << " not found in directory " << out.GetName() << endl;
       exit(-1);
     }
     outTh2f->Add(th2f, w);
   } else if ((th2d = dynamic_cast<TH2D *>(o)) != nullptr) {
-    const char * name = th2d->GetName();
-    TH2D * outTh2d = dynamic_cast<TH2D*>(out.Get(name));
+    const char *name = th2d->GetName();
+    TH2D *outTh2d = dynamic_cast<TH2D *>(out.Get(name));
     if (outTh2d == nullptr) {
-      cerr <<"error: histogram TH2D" << name << " not found in directory " << out.GetName() << endl;
+      cerr << "error: histogram TH2D" << name << " not found in directory " << out.GetName() << endl;
       exit(-1);
     }
     outTh2d->Add(th2d, w);
   }
 }
-

--- a/PhysicsTools/Utilities/interface/Expression.h
+++ b/PhysicsTools/Utilities/interface/Expression.h
@@ -16,10 +16,10 @@ namespace funct {
   template <typename F>
   struct ExpressionT : public AbsExpression {
     inline ExpressionT(const F& f) : _f(f) {}
-    virtual ~ExpressionT() {}
-    virtual double operator()() const { return _f(); }
-    virtual AbsExpression* clone() const { return new ExpressionT<F>(_f); }
-    virtual std::ostream& print(std::ostream& cout) const { return cout << _f; }
+    ~ExpressionT() override {}
+    double operator()() const override { return _f(); }
+    AbsExpression* clone() const override { return new ExpressionT<F>(_f); }
+    std::ostream& print(std::ostream& cout) const override { return cout << _f; }
 
   private:
     F _f;
@@ -55,9 +55,9 @@ namespace funct {
   template <typename F>
   struct FunctExpressionT : public AbsFunctExpression {
     inline FunctExpressionT(const F& f) : _f(f) {}
-    virtual ~FunctExpressionT() {}
-    virtual double operator()(double x) const { return _f(x); }
-    virtual AbsFunctExpression* clone() const { return new FunctExpressionT<F>(_f); }
+    ~FunctExpressionT() override {}
+    double operator()(double x) const override { return _f(x); }
+    AbsFunctExpression* clone() const override { return new FunctExpressionT<F>(_f); }
 
   private:
     F _f;

--- a/PhysicsTools/Utilities/interface/LumiReweightingStandAlone.h
+++ b/PhysicsTools/Utilities/interface/LumiReweightingStandAlone.h
@@ -540,7 +540,7 @@ namespace reweight {
 
       //WeightOOTPU_ = {0};
 
-      const double* WeightPtr = 0;
+      const double* WeightPtr = nullptr;
 
       for (int iint = 0; iint < 25; ++iint) {
         if (iint == 0)

--- a/PhysicsTools/Utilities/interface/RooFitFunction.h
+++ b/PhysicsTools/Utilities/interface/RooFitFunction.h
@@ -13,7 +13,7 @@ namespace root {
   template <typename X, typename Expr>
   class RooFitFunction : public RooAbsReal {
   public:
-    RooFitFunction(const RooFitFunction<X, Expr>& other, const char* name = 0)
+    RooFitFunction(const RooFitFunction<X, Expr>& other, const char* name = nullptr)
         : RooAbsReal(other, name), e_(other.e_), x_(X::name(), this, other.x_) {
       std::cout << ">>> making new RooFitFunction" << std::endl;
       std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> >::const_iterator i = other.pars_.begin(),
@@ -57,17 +57,17 @@ namespace root {
       pars_.push_back(std::make_pair(b.ptr(), RooRealProxy(b.name().c_str(), b.name().c_str(), this, rB)));
       pars_.push_back(std::make_pair(c.ptr(), RooRealProxy(c.name().c_str(), c.name().c_str(), this, rC)));
     }
-    virtual ~RooFitFunction() {}
+    ~RooFitFunction() override {}
     void add(RooAbsReal& rA, funct::Parameter& a) {
       pars_.push_back(std::make_pair(a.ptr(), RooRealProxy(a.name().c_str(), a.name().c_str(), this, rA)));
     }
-    virtual TObject* clone(const char* newName) const { return new RooFitFunction<X, Expr>(*this, newName); }
+    TObject* clone(const char* newName) const override { return new RooFitFunction<X, Expr>(*this, newName); }
 
   private:
     Expr e_;
     RooRealProxy x_;
     std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> > pars_;
-    Double_t evaluate() const {
+    Double_t evaluate() const override {
       X::set(x_);
       std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> >::const_iterator i = pars_.begin(),
                                                                                      end = pars_.end();

--- a/PhysicsTools/Utilities/interface/RootFunctionAdapter.h
+++ b/PhysicsTools/Utilities/interface/RootFunctionAdapter.h
@@ -10,7 +10,7 @@ namespace root {
 
     template <typename F, unsigned int args>
     struct RootFunctionAdapter {
-      RootFunctionAdapter() : f_(0) {}
+      RootFunctionAdapter() : f_(nullptr) {}
       RootFunctionAdapter(F& f) : f_(&f) {}
       void addParameter(const std::shared_ptr<double>& par) { pars_.push_back(par); }
       void setParameters(const double* pars) {

--- a/PhysicsTools/Utilities/interface/RootMinuit.h
+++ b/PhysicsTools/Utilities/interface/RootMinuit.h
@@ -242,7 +242,7 @@ namespace fit {
   Function RootMinuit<Function>::f_;
 
   template <class Function>
-  std::vector<std::shared_ptr<double> > *RootMinuit<Function>::fPars_ = 0;
+  std::vector<std::shared_ptr<double> > *RootMinuit<Function>::fPars_ = nullptr;
 }  // namespace fit
 
 #endif

--- a/PhysicsTools/Utilities/interface/RootMinuitCommands.h
+++ b/PhysicsTools/Utilities/interface/RootMinuitCommands.h
@@ -29,14 +29,14 @@ namespace fit {
     std::vector<double> doubleArgs;
     void print(std::ostream& cout) const {
       cout << name;
-      if (stringArgs.size() > 0) {
+      if (!stringArgs.empty()) {
         for (size_t i = 0; i != stringArgs.size(); ++i) {
           if (i != 0)
             cout << ",";
           cout << " \"" << stringArgs[i] << "\"";
         }
       }
-      if (doubleArgs.size() > 0) {
+      if (!doubleArgs.empty()) {
         for (size_t i = 0; i != doubleArgs.size(); ++i) {
           if (i != 0)
             cout << ",";
@@ -138,7 +138,7 @@ namespace fit {
     bool commands = false;
     while (getline(file, line)) {
       ++lineNumber_;
-      if (line.size() == 0)
+      if (line.empty())
         continue;
       char last = *line.rbegin();
       if (!(last >= '0' && last <= 'z'))

--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -131,7 +131,7 @@ BoostedDoubleSVProducer::BoostedDoubleSVProducer(const edm::ParameterSet& iConfi
       trackPairV0Filter(iConfig.getParameter<edm::ParameterSet>("trackPairV0Filter")),
       trackSelector(iConfig.getParameter<edm::ParameterSet>("trackSelection")) {
   edm::InputTag srcWeights = iConfig.getParameter<edm::InputTag>("weights");
-  if (srcWeights.label() != "")
+  if (!srcWeights.label().empty())
     weightsToken_ = consumes<edm::ValueMap<float>>(srcWeights);
   produces<std::vector<reco::BoostedDoubleSVTagInfo>>();
 }

--- a/RecoBTag/XMLCalibration/interface/AlgorithmCalibration.h
+++ b/RecoBTag/XMLCalibration/interface/AlgorithmCalibration.h
@@ -72,7 +72,7 @@ protected:
 
 protected:
   DOMElement *dom() {
-    if (m_xml == 0) {
+    if (m_xml == nullptr) {
       m_xml = new CalibrationXML();
       m_xml->openFile(m_filename);
     }
@@ -85,7 +85,7 @@ private:
 };
 
 template <class T, class CO>
-AlgorithmCalibration<T, CO>::AlgorithmCalibration(const std::string &filename) : m_filename(filename), m_xml(0) {
+AlgorithmCalibration<T, CO>::AlgorithmCalibration(const std::string &filename) : m_filename(filename), m_xml(nullptr) {
   readCategories();
   if (m_xml) {
     m_xml->closeFile();
@@ -100,7 +100,7 @@ AlgorithmCalibration<T, CO>::~AlgorithmCalibration() {
 
 template <class T, class CO>
 bool AlgorithmCalibration<T, CO>::readCategories() {
-  if (dom() == 0)
+  if (dom() == nullptr)
     return false;
 
   DOMNode *n1 = dom()->getFirstChild();
@@ -129,8 +129,8 @@ CO *AlgorithmCalibration<T, CO>::readObject(DOMNode *dom) {
     n1 = n1->getNextSibling();
   }
 
-  if (n1 == 0)
-    return 0;  //Cannot find any calibrated objects
+  if (n1 == nullptr)
+    return nullptr;  //Cannot find any calibrated objects
 
   CO *co = new CO();
   co->read((DOMElement *)n1);

--- a/RecoBTag/XMLCalibration/interface/CalibrationCategory.h
+++ b/RecoBTag/XMLCalibration/interface/CalibrationCategory.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/util/XMLString.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 #include "CalibrationXML.h"
 
 class CalibratedObject;

--- a/RecoBTag/XMLCalibration/interface/CalibrationInterface.h
+++ b/RecoBTag/XMLCalibration/interface/CalibrationInterface.h
@@ -80,7 +80,7 @@ CalibDataT* CalibrationInterface<CategoryT, CalibDataT>::getCalibData(int i) {
   if (i >= 0 && ii < m_categoriesWithData.size())
     return &m_categoriesWithData[i].second;
   else
-    return 0;
+    return nullptr;
 }
 
 template <class CategoryT, class CalibDataT>

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/PixelFakeCPE.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/PixelFakeCPE.h
@@ -18,7 +18,7 @@
 class PixelFakeCPE final : public PixelClusterParameterEstimator {
 public:
   PixelFakeCPE() = default;
-  ~PixelFakeCPE() = default;
+  ~PixelFakeCPE() override = default;
 
   typedef std::pair<LocalPoint, LocalError> LocalValues;
   typedef std::vector<LocalValues> VLocalValues;

--- a/RecoPixelVertexing/PixelLowPtUtilities/bin/ClusterShapeAnalyzer.cpp
+++ b/RecoPixelVertexing/PixelLowPtUtilities/bin/ClusterShapeAnalyzer.cpp
@@ -107,12 +107,12 @@ public:
         outFile.exceptions(std::ofstream::failbit | std::ofstream::badbit);
         outFile.open(args.output);
         std::shared_ptr<std::ofstream> mapFile;
-        if(args.map_output.size()) {
-            mapFile = std::make_shared<std::ofstream>();
-            mapFile->exceptions(std::ofstream::failbit | std::ofstream::badbit);
-            mapFile->open(args.map_output);
+        if (!args.map_output.empty()) {
+          mapFile = std::make_shared<std::ofstream>();
+          mapFile->exceptions(std::ofstream::failbit | std::ofstream::badbit);
+          mapFile->open(args.map_output);
         }
-        
+
         for(size_t is = 0; is < subName.size(); ++is) {
             for(int ix =  0; ix <= args.exMax; ++ix) {
                 std::cout << " " << subName.at(is) << " dx= " << ix << " ";

--- a/RecoPixelVertexing/PixelLowPtUtilities/bin/ClusterShapeAnalyzer.cpp
+++ b/RecoPixelVertexing/PixelLowPtUtilities/bin/ClusterShapeAnalyzer.cpp
@@ -13,354 +13,343 @@
 
 namespace cluster_shape_filter {
 
-static constexpr size_t n_dim = 2;
+  static constexpr size_t n_dim = 2;
 
-using Position = std::array<double, n_dim>;
+  using Position = std::array<double, n_dim>;
 
-struct Limits {
+  struct Limits {
     double down, up;
     Limits() : down(-std::numeric_limits<double>::infinity()), up(std::numeric_limits<double>::infinity()) {}
     Limits(double _down, double _up) : down(_down), up(_up) {}
     double size() const { return std::abs(down - up); }
-};
+  };
 
-using BoxLimits = std::array<Limits, n_dim>;
+  using BoxLimits = std::array<Limits, n_dim>;
 
-struct Point {
+  struct Point {
     Position x;
     int weight;
     int cluster_index;
-};
+  };
 
-struct Center {
+  struct Center {
     Position x;
     int n_clusters;
     BoxLimits limits;
 
-    double distance2(const Point& p) const
-    {
-        double d = 0;
-        for(size_t n = 0; n < x.size(); ++n)
-            d += std::pow(x[n] - p.x[n], 2);
-        return d;
+    double distance2(const Point& p) const {
+      double d = 0;
+      for (size_t n = 0; n < x.size(); ++n)
+        d += std::pow(x[n] - p.x[n], 2);
+      return d;
     }
 
     double area() const {
-        double s = 1;
-        for(size_t n = 0; n < limits.size(); ++n)
-            s *= limits[n].size();
-        return s;
+      double s = 1;
+      for (size_t n = 0; n < limits.size(); ++n)
+        s *= limits[n].size();
+      return s;
     }
-};
+  };
 
-using AsymmetricCut = std::array<Center, 2>;
+  using AsymmetricCut = std::array<Center, 2>;
 
-std::ostream& operator<<(std::ostream& os, const AsymmetricCut& c)
-{
-    for(size_t b = 0; b < c.size(); ++b) {
-        for(size_t d = 0; d < c[b].limits.size(); ++d) {
-            os << " " << c[b].limits[d].down << " " << c[b].limits[d].up;
-        }
+  std::ostream& operator<<(std::ostream& os, const AsymmetricCut& c) {
+    for (size_t b = 0; b < c.size(); ++b) {
+      for (size_t d = 0; d < c[b].limits.size(); ++d) {
+        os << " " << c[b].limits[d].down << " " << c[b].limits[d].up;
+      }
     }
 
-    for(size_t b = 0; b < c.size(); ++b) {
-        const double v = c[b].area() > 0 ? c[b].n_clusters / c[b].area() : 0.;
-        os << " " << v << " " << c[b].n_clusters;
+    for (size_t b = 0; b < c.size(); ++b) {
+      const double v = c[b].area() > 0 ? c[b].n_clusters / c[b].area() : 0.;
+      os << " " << v << " " << c[b].n_clusters;
     }
     return os;
-}
+  }
 
-template<typename Object>
-Object* ReadObject(TFile& file, const std::string& name)
-{
+  template <typename Object>
+  Object* ReadObject(TFile& file, const std::string& name) {
     auto object = dynamic_cast<Object*>(file.Get(name.c_str()));
-    if(!object) {
-        std::ostringstream ss;
-        ss << "Object '" << name << "' with type '" << typeid(Object).name() << "' not found in '"
-           << file.GetName() << "'.";
-        throw std::runtime_error(ss.str());
+    if (!object) {
+      std::ostringstream ss;
+      ss << "Object '" << name << "' with type '" << typeid(Object).name() << "' not found in '" << file.GetName()
+         << "'.";
+      throw std::runtime_error(ss.str());
     }
     return object;
-}
+  }
 
-struct Arguments {
+  struct Arguments {
     std::string input, output, map_output;
     double loss{0.005};
     size_t minEntries{100};
     int exMax{10}, eyMax{15};
     bool verbose{false};
-};
+  };
 
-class ClusterAnalyzer {
-public:
+  class ClusterAnalyzer {
+  public:
     ClusterAnalyzer(const Arguments& _args) : args(_args) {}
-    
-    void analyze()
-    {
-        static const std::vector<std::string> subName = { "barrel", "endcap" };
-        
-        TFile resFile(args.input.c_str(), "READ");
-        if(resFile.IsZombie())
-            throw std::runtime_error("Input file not opened.");
 
-        std::ofstream outFile;
-        outFile.exceptions(std::ofstream::failbit | std::ofstream::badbit);
-        outFile.open(args.output);
-        std::shared_ptr<std::ofstream> mapFile;
-        if (!args.map_output.empty()) {
-          mapFile = std::make_shared<std::ofstream>();
-          mapFile->exceptions(std::ofstream::failbit | std::ofstream::badbit);
-          mapFile->open(args.map_output);
-        }
+    void analyze() {
+      static const std::vector<std::string> subName = {"barrel", "endcap"};
 
-        for(size_t is = 0; is < subName.size(); ++is) {
-            for(int ix =  0; ix <= args.exMax; ++ix) {
-                std::cout << " " << subName.at(is) << " dx= " << ix << " ";
-                for(int iy = 0; iy <= args.eyMax; ++iy) {
-                    std::ostringstream histName;
-//                    histName << "hrpc_" << is << "_" << ix << "_" << iy;
-                    histName << "hspc_" << is << "_" << ix << "_" << iy;
-                    auto histo = ReadObject<TH2F>(resFile, histName.str());
-                    
-                    std::cout << ".";
-                    
-                    // Initial guess
-                    AsymmetricCut c;
-                    c[0].n_clusters = 0;
-                    c[0].x[0] = ix+1;
-                    c[0].x[1] = iy+1;
-                    
-                    c[1].n_clusters = 0;
-                    c[1].x[0] =-ix-1;
-                    c[1].x[1] =-iy-1;
-                    
-                    std::ostringstream flag;
-                    flag << subName.at(is) << "_" << ix << "_" << iy;
-                    process(*histo, c, flag.str());
-                    
-                    if(histo->Integral() >= args.minEntries) {
-                        // Fix barrel_0_0
-                        if(is == 0 && ix == 0 && iy == 0) {
-                            c[0].limits[1].down = 0.;
-                            c[1].limits[1].up = 0.;
-                        }
-                        
-                        outFile << is << " " << ix << " " << iy << c << std::endl;
-                    }
+      TFile resFile(args.input.c_str(), "READ");
+      if (resFile.IsZombie())
+        throw std::runtime_error("Input file not opened.");
 
-                    if(mapFile)
-                        *mapFile << ix << " " << iy << " " << histo->Integral() << std::endl;
-                }
-                outFile << std::endl;
-                std::cout << std::endl;
-                if(mapFile)
-                    *mapFile << ix << " " << args.eyMax+1 << " " << 0 << "\n" << std::endl;
+      std::ofstream outFile;
+      outFile.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+      outFile.open(args.output);
+      std::shared_ptr<std::ofstream> mapFile;
+      if (!args.map_output.empty()) {
+        mapFile = std::make_shared<std::ofstream>();
+        mapFile->exceptions(std::ofstream::failbit | std::ofstream::badbit);
+        mapFile->open(args.map_output);
+      }
+
+      for (size_t is = 0; is < subName.size(); ++is) {
+        for (int ix = 0; ix <= args.exMax; ++ix) {
+          std::cout << " " << subName.at(is) << " dx= " << ix << " ";
+          for (int iy = 0; iy <= args.eyMax; ++iy) {
+            std::ostringstream histName;
+            //                    histName << "hrpc_" << is << "_" << ix << "_" << iy;
+            histName << "hspc_" << is << "_" << ix << "_" << iy;
+            auto histo = ReadObject<TH2F>(resFile, histName.str());
+
+            std::cout << ".";
+
+            // Initial guess
+            AsymmetricCut c;
+            c[0].n_clusters = 0;
+            c[0].x[0] = ix + 1;
+            c[0].x[1] = iy + 1;
+
+            c[1].n_clusters = 0;
+            c[1].x[0] = -ix - 1;
+            c[1].x[1] = -iy - 1;
+
+            std::ostringstream flag;
+            flag << subName.at(is) << "_" << ix << "_" << iy;
+            process(*histo, c, flag.str());
+
+            if (histo->Integral() >= args.minEntries) {
+              // Fix barrel_0_0
+              if (is == 0 && ix == 0 && iy == 0) {
+                c[0].limits[1].down = 0.;
+                c[1].limits[1].up = 0.;
+              }
+
+              outFile << is << " " << ix << " " << iy << c << std::endl;
             }
 
-            if(mapFile) {
-                for(int iy = 0; iy <= args.eyMax + 1; ++iy)
-                    *mapFile << args.exMax + 1 << " " << iy << " " << 0 << std::endl;
-                *mapFile << std::endl << std::endl;
-            }
-            
-            outFile << std::endl;
+            if (mapFile)
+              *mapFile << ix << " " << iy << " " << histo->Integral() << std::endl;
+          }
+          outFile << std::endl;
+          std::cout << std::endl;
+          if (mapFile)
+            *mapFile << ix << " " << args.eyMax + 1 << " " << 0 << "\n" << std::endl;
         }
+
+        if (mapFile) {
+          for (int iy = 0; iy <= args.eyMax + 1; ++iy)
+            *mapFile << args.exMax + 1 << " " << iy << " " << 0 << std::endl;
+          *mapFile << std::endl << std::endl;
+        }
+
+        outFile << std::endl;
+      }
     }
-    
-private:
+
+  private:
     using HistArray = std::array<std::array<TH1D*, 2>, 2>;
 
-    HistArray CreateHistArray(const std::vector<Point>& points, const TH1D& line) const
-    {
-        HistArray x;
-        for(size_t n = 0; n < x.size(); ++n) {
-            for(size_t d = 0; d < x[n].size(); ++d) {
-                std::ostringstream name;
-                name << n << "_" << d;
-                x[n][d] = dynamic_cast<TH1D*>(line.Clone(name.str().c_str()));
-            }
+    HistArray CreateHistArray(const std::vector<Point>& points, const TH1D& line) const {
+      HistArray x;
+      for (size_t n = 0; n < x.size(); ++n) {
+        for (size_t d = 0; d < x[n].size(); ++d) {
+          std::ostringstream name;
+          name << n << "_" << d;
+          x[n][d] = dynamic_cast<TH1D*>(line.Clone(name.str().c_str()));
         }
-        
-        for(const auto& point : points) {
-            for(size_t d = 0; d < x[point.cluster_index].size(); ++d) {
-                x[point.cluster_index][d]->Fill(point.x[d], point.weight);
-            }
+      }
+
+      for (const auto& point : points) {
+        for (size_t d = 0; d < x[point.cluster_index].size(); ++d) {
+          x[point.cluster_index][d]->Fill(point.x[d], point.weight);
         }
-        return x;
-    }
-    
-    static double getFraction(const TH1D& line, double fraction)
-    {
-        double n = line.Integral();
-        double s = 0;
-        
-        for(int i = 0 ; i <= line.GetNbinsX() + 1; ++i) {
-            s += line.GetBinContent(i);
-            if(s > n * fraction) {
-                return line.GetXaxis()->GetBinUpEdge(i)
-                        - (s - n * fraction) / line.GetBinContent(i) * line.GetXaxis()->GetBinWidth(i);
-            }
-        }
-        
-        throw std::runtime_error("Unable to determine a point for the given fraction.");
-    }
-    
-    void kMeans(std::vector<Point>& points, AsymmetricCut& c, const TH1D& line) const
-    {
-        int changes;
-        do {
-            changes = 0;
-            
-            // Sort point into clusters
-            for(auto& point : points) {
-                const int n = c[0].distance2(point) < c[1].distance2(point) ? 0 : 1;
-                if(n != point.cluster_index) {
-                    point.cluster_index = n;
-                    ++changes;
-                }
-            }
-            
-            if(changes != 0) {
-                // Re-compute centers
-                auto x = CreateHistArray(points, line);
-                
-                for(size_t n = 0; n < c.size(); ++n) {
-                    for(size_t d = 0; d < c[n].x.size(); ++d) {
-                        c[n].n_clusters = std::ceil(x[n][d]->Integral());
-                        if(x[n][d]->Integral() > 0)
-                            c[n].x[d] = getFraction(*x[n][d], 0.5);
-                    }
-                }
-            }
-        } while(changes != 0);
+      }
+      return x;
     }
 
-    void findLimits(const std::vector<Point>& points, AsymmetricCut& c, const TH1D& line) const
-    {
-        auto x = CreateHistArray(points, line);
-        
-        for(size_t b = 0; b < x.size(); ++b) {
-            for(size_t d = 0; d < x[b].size(); ++d) {
-                if(x[b][d]->Integral() <= 0) continue;
-                Limits best_limits;
-                for(double f = (args.loss/2) / 100; f < args.loss/2 - (args.loss/2)/200; f+=(args.loss/2)/100) {
-                    const Limits limits(getFraction(*x[b][d], f), getFraction(*x[b][d], 1 - (args.loss/2 - f)));
-                    if(limits.size() < best_limits.size())
-                        best_limits = limits;
-                }
-                c[b].limits[d] = best_limits;
-            }
-        }
-    }
-    
-    static void printOut(const TH2F& histo, const AsymmetricCut& c, const std::string& flag)
-    {
-        printToFile(histo, "points_" + flag + ".dat");
-        
-        std::ofstream limitsFile("limits_" + flag + ".par");
-        for(size_t b = 0; b < c.size(); ++b) {
-            for(size_t d = 0; d < c[b].limits.size(); ++d) {
-                limitsFile << " l" << b << d << "=" << c[b].limits[d].down << std::endl;
-                limitsFile << " h" << b << d << "=" << c[b].limits[d].up << std::endl;
-            }
-        }
-        
-        std::ofstream centersFile("centers_" + flag + ".dat");
-        for(size_t b = 0; b < c.size(); ++b)
-            centersFile << " " << c[b].x[0] << " " << c[b].x[1] << std::endl;
-    }
-    
-    void process(const TH2F& histo, AsymmetricCut& c, const std::string& flag)
-    {
-        std::vector<Point> points;
-        points.reserve(histo.GetNbinsX() * histo.GetNbinsY());
-        
-        for(int i = 1 ; i <= histo.GetNbinsX(); ++i) {
-            for(int j = 1 ; j <= histo.GetNbinsY(); ++j) {
-                if(histo.GetBinContent(i,j) <= 0) continue;
-                Point p;
-                p.x[0] = histo.GetXaxis()->GetBinCenter(i);
-                p.x[1] = histo.GetYaxis()->GetBinCenter(j);
-                p.weight = std::ceil(histo.GetBinContent(i, j));
-                points.push_back(p);
-            }
-        }
-        
-        auto line = histo.ProjectionY("_py", 0, 0);
-        line->Reset();
+    static double getFraction(const TH1D& line, double fraction) {
+      double n = line.Integral();
+      double s = 0;
 
-        kMeans(points, c, *line);
-        findLimits(points, c, *line);
-        if(args.verbose)
-            printOut(histo, c, flag);
-    }
-    
-    static void printToFile(const TH2F& h2, const std::string& fileName)
-    {
-        std::ofstream file;
-        file.exceptions(std::ofstream::failbit | std::ofstream::badbit);
-        file.open(fileName);
-        
-        for(int i = 1; i <= h2.GetNbinsX(); i++) {
-            for(int j = 1; j <= h2.GetNbinsY(); j++)
-                file << " " << h2.GetXaxis()->GetBinLowEdge(i) << " " << h2.GetYaxis()->GetBinLowEdge(j)
-                     << " " << h2.GetBinContent(i,j) << "\n";
-            
-            file << " " << h2.GetXaxis()->GetBinLowEdge(i) << " " << h2.GetYaxis()->GetXmax() << " 0\n\n";
+      for (int i = 0; i <= line.GetNbinsX() + 1; ++i) {
+        s += line.GetBinContent(i);
+        if (s > n * fraction) {
+          return line.GetXaxis()->GetBinUpEdge(i) -
+                 (s - n * fraction) / line.GetBinContent(i) * line.GetXaxis()->GetBinWidth(i);
         }
-        
-        for(int j = 1; j <= h2.GetNbinsY(); j++) {
-            file << " " << h2.GetXaxis()->GetXmax() << " " << h2.GetYaxis()->GetBinLowEdge(j) << " 0\n";
-        }
-        
-        file << " " << h2.GetXaxis()->GetXmax() << " " << h2.GetYaxis()->GetXmax() << " 0" << std::endl;
+      }
+
+      throw std::runtime_error("Unable to determine a point for the given fraction.");
     }
 
-private:
+    void kMeans(std::vector<Point>& points, AsymmetricCut& c, const TH1D& line) const {
+      int changes;
+      do {
+        changes = 0;
+
+        // Sort point into clusters
+        for (auto& point : points) {
+          const int n = c[0].distance2(point) < c[1].distance2(point) ? 0 : 1;
+          if (n != point.cluster_index) {
+            point.cluster_index = n;
+            ++changes;
+          }
+        }
+
+        if (changes != 0) {
+          // Re-compute centers
+          auto x = CreateHistArray(points, line);
+
+          for (size_t n = 0; n < c.size(); ++n) {
+            for (size_t d = 0; d < c[n].x.size(); ++d) {
+              c[n].n_clusters = std::ceil(x[n][d]->Integral());
+              if (x[n][d]->Integral() > 0)
+                c[n].x[d] = getFraction(*x[n][d], 0.5);
+            }
+          }
+        }
+      } while (changes != 0);
+    }
+
+    void findLimits(const std::vector<Point>& points, AsymmetricCut& c, const TH1D& line) const {
+      auto x = CreateHistArray(points, line);
+
+      for (size_t b = 0; b < x.size(); ++b) {
+        for (size_t d = 0; d < x[b].size(); ++d) {
+          if (x[b][d]->Integral() <= 0)
+            continue;
+          Limits best_limits;
+          for (double f = (args.loss / 2) / 100; f < args.loss / 2 - (args.loss / 2) / 200;
+               f += (args.loss / 2) / 100) {
+            const Limits limits(getFraction(*x[b][d], f), getFraction(*x[b][d], 1 - (args.loss / 2 - f)));
+            if (limits.size() < best_limits.size())
+              best_limits = limits;
+          }
+          c[b].limits[d] = best_limits;
+        }
+      }
+    }
+
+    static void printOut(const TH2F& histo, const AsymmetricCut& c, const std::string& flag) {
+      printToFile(histo, "points_" + flag + ".dat");
+
+      std::ofstream limitsFile("limits_" + flag + ".par");
+      for (size_t b = 0; b < c.size(); ++b) {
+        for (size_t d = 0; d < c[b].limits.size(); ++d) {
+          limitsFile << " l" << b << d << "=" << c[b].limits[d].down << std::endl;
+          limitsFile << " h" << b << d << "=" << c[b].limits[d].up << std::endl;
+        }
+      }
+
+      std::ofstream centersFile("centers_" + flag + ".dat");
+      for (size_t b = 0; b < c.size(); ++b)
+        centersFile << " " << c[b].x[0] << " " << c[b].x[1] << std::endl;
+    }
+
+    void process(const TH2F& histo, AsymmetricCut& c, const std::string& flag) {
+      std::vector<Point> points;
+      points.reserve(histo.GetNbinsX() * histo.GetNbinsY());
+
+      for (int i = 1; i <= histo.GetNbinsX(); ++i) {
+        for (int j = 1; j <= histo.GetNbinsY(); ++j) {
+          if (histo.GetBinContent(i, j) <= 0)
+            continue;
+          Point p;
+          p.x[0] = histo.GetXaxis()->GetBinCenter(i);
+          p.x[1] = histo.GetYaxis()->GetBinCenter(j);
+          p.weight = std::ceil(histo.GetBinContent(i, j));
+          points.push_back(p);
+        }
+      }
+
+      auto line = histo.ProjectionY("_py", 0, 0);
+      line->Reset();
+
+      kMeans(points, c, *line);
+      findLimits(points, c, *line);
+      if (args.verbose)
+        printOut(histo, c, flag);
+    }
+
+    static void printToFile(const TH2F& h2, const std::string& fileName) {
+      std::ofstream file;
+      file.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+      file.open(fileName);
+
+      for (int i = 1; i <= h2.GetNbinsX(); i++) {
+        for (int j = 1; j <= h2.GetNbinsY(); j++)
+          file << " " << h2.GetXaxis()->GetBinLowEdge(i) << " " << h2.GetYaxis()->GetBinLowEdge(j) << " "
+               << h2.GetBinContent(i, j) << "\n";
+
+        file << " " << h2.GetXaxis()->GetBinLowEdge(i) << " " << h2.GetYaxis()->GetXmax() << " 0\n\n";
+      }
+
+      for (int j = 1; j <= h2.GetNbinsY(); j++) {
+        file << " " << h2.GetXaxis()->GetXmax() << " " << h2.GetYaxis()->GetBinLowEdge(j) << " 0\n";
+      }
+
+      file << " " << h2.GetXaxis()->GetXmax() << " " << h2.GetYaxis()->GetXmax() << " 0" << std::endl;
+    }
+
+  private:
     const Arguments args;
-};
+  };
 
-} // namespace cluster_shape_filter
+}  // namespace cluster_shape_filter
 
-int main(int argc, char* argv[])
-{
-    namespace po = boost::program_options;
-    using namespace cluster_shape_filter;
+int main(int argc, char* argv[]) {
+  namespace po = boost::program_options;
+  using namespace cluster_shape_filter;
 
-    Arguments args;
-    po::options_description desc("Cluster shape filter analyzer");
-    std::ostringstream ss_loss;
-    ss_loss << std::setprecision(4) << args.loss;
-    desc.add_options()
-            ("help", "print help message")
-            ("input", po::value<std::string>(&args.input)->required(), "input file with extracted cluster shapes")
-            ("output", po::value<std::string>(&args.output)->required(), "output calibration file")
-            ("map-output",  po::value<std::string>(&args.map_output)->default_value(""), "output calibration file")
-            ("loss", po::value<double>(&args.loss)->default_value(args.loss, ss_loss.str()),
-             "(1 - efficiency) threshold for the WP definition")
-            ("min-entries", po::value<size_t>(&args.minEntries)->default_value(args.minEntries), "")
-            ("ex-max", po::value<int>(&args.exMax)->default_value(args.exMax), "")
-            ("ey-max", po::value<int>(&args.eyMax)->default_value(args.eyMax), "")
-            ("verbose", po::bool_switch(&args.verbose));
+  Arguments args;
+  po::options_description desc("Cluster shape filter analyzer");
+  std::ostringstream ss_loss;
+  ss_loss << std::setprecision(4) << args.loss;
+  desc.add_options()("help", "print help message")(
+      "input", po::value<std::string>(&args.input)->required(), "input file with extracted cluster shapes")(
+      "output", po::value<std::string>(&args.output)->required(), "output calibration file")(
+      "map-output", po::value<std::string>(&args.map_output)->default_value(""), "output calibration file")(
+      "loss",
+      po::value<double>(&args.loss)->default_value(args.loss, ss_loss.str()),
+      "(1 - efficiency) threshold for the WP definition")(
+      "min-entries", po::value<size_t>(&args.minEntries)->default_value(args.minEntries), "")(
+      "ex-max", po::value<int>(&args.exMax)->default_value(args.exMax), "")(
+      "ey-max", po::value<int>(&args.eyMax)->default_value(args.eyMax), "")("verbose", po::bool_switch(&args.verbose));
 
-    try {
-        po::variables_map variables;
-        po::store(po::command_line_parser(argc, argv).options(desc).run(), variables);
-        if(variables.count("help")) {
-            std::cout << desc << std::endl;
-            return 0;
-        }
-        po::notify(variables);
-
-        cluster_shape_filter::ClusterAnalyzer analyzer(args);
-        analyzer.analyze();
-
-    } catch(po::error& e) {
-        std::cerr << "ERROR: " << e.what() << ".\n\n" << desc << std::endl;
-    } catch(std::exception& e) {
-        std::cerr << "\nERROR: " << e.what() << std::endl;
+  try {
+    po::variables_map variables;
+    po::store(po::command_line_parser(argc, argv).options(desc).run(), variables);
+    if (variables.count("help")) {
+      std::cout << desc << std::endl;
+      return 0;
     }
+    po::notify(variables);
 
-    return 0;
+    cluster_shape_filter::ClusterAnalyzer analyzer(args);
+    analyzer.analyze();
+
+  } catch (po::error& e) {
+    std::cerr << "ERROR: " << e.what() << ".\n\n" << desc << std::endl;
+  } catch (std::exception& e) {
+    std::cerr << "\nERROR: " << e.what() << std::endl;
+  }
+
+  return 0;
 }
-

--- a/Utilities/General/test/google-benchmark-basic.cpp
+++ b/Utilities/General/test/google-benchmark-basic.cpp
@@ -11,7 +11,7 @@ BENCHMARK(BM_StringCreation);
 static void BM_StringCopy(benchmark::State& state) {
   std::string x = "hello";
   for (auto _ : state)
-    std::string copy(x);
+    std::string copy(x);  // NOLINT - prevent clang-tidy from changing to a `const &`
 }
 BENCHMARK(BM_StringCopy);
 


### PR DESCRIPTION
#### PR description:

As a prerequisite for enabling additional `clang-tidy` checks, apply the *existing* checks to the whole code base.

Technical changes only, no changes expected.