### PR TITLE
Apply code checks to the CalibMuon packages

### DIFF
--- a/CalibMuon/CSCCalibration/interface/CSCDBL1TPParametersConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCDBL1TPParametersConditions.h
@@ -20,7 +20,7 @@
 class CSCDBL1TPParametersConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCDBL1TPParametersConditions(const edm::ParameterSet &);
-  ~CSCDBL1TPParametersConditions();
+  ~CSCDBL1TPParametersConditions() override;
 
   inline static CSCDBL1TPParameters *prefillCSCDBL1TPParameters();
 
@@ -30,7 +30,9 @@ public:
 
 private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &, edm::ValidityInterval &);
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
 };
 
 #include <fstream>


### PR DESCRIPTION
Apply `clang-tidy` automated code changes.
Apply `clang-format` automated code formatting.