### PR TITLE
Apply code checks to the CondTools packages

### DIFF
--- a/CondTools/Hcal/interface/CmdLine.h
+++ b/CondTools/Hcal/interface/CmdLine.h
@@ -121,7 +121,7 @@ namespace cmdline {
   // Subsequent classes will throw exceptions of the following class
   class CmdLineError {
   public:
-    inline CmdLineError(const char* msg = 0) : os_(new std::ostringstream()) {
+    inline CmdLineError(const char* msg = nullptr) : os_(new std::ostringstream()) {
       if (msg)
         *os_ << msg;
     }
@@ -155,7 +155,7 @@ namespace cmdline {
 
     inline OneShotIStream(const std::string& s) : str_(s), valid_(true), readout_(false) {}
 
-    inline operator void*() const { return valid_ && !readout_ ? (void*)this : (void*)0; }
+    inline operator void*() const { return valid_ && !readout_ ? (void*)this : (void*)nullptr; }
 
     template <typename T>
     inline bool operator>>(T& obj) {
@@ -193,7 +193,7 @@ namespace cmdline {
     inline std::string demangle(T& obj) const {
       int status;
       const std::type_info& ti = typeid(obj);
-      char* realname = abi::__cxa_demangle(ti.name(), 0, 0, &status);
+      char* realname = abi::__cxa_demangle(ti.name(), nullptr, nullptr, &status);
       std::string s(realname);
       free(realname);
       return s;
@@ -275,7 +275,7 @@ namespace cmdline {
 
     inline const char* progname() const { return progname_.c_str(); }
 
-    inline bool has(const char* shortOpt, const char* longOpt = 0) {
+    inline bool has(const char* shortOpt, const char* longOpt = nullptr) {
       bool found = false;
       for (Optlist::iterator it = find(shortOpt, longOpt); it != args_.end(); it = find(shortOpt, longOpt)) {
         found = true;
@@ -288,7 +288,7 @@ namespace cmdline {
       return found;
     }
 
-    inline OneShotIStream option(const char* shortOpt, const char* longOpt = 0) {
+    inline OneShotIStream option(const char* shortOpt, const char* longOpt = nullptr) {
       OneShotIStream result;
       for (Optlist::iterator it = find(shortOpt, longOpt); it != args_.end(); it = find(shortOpt, longOpt)) {
         Optlist::iterator it0(it);
@@ -304,7 +304,7 @@ namespace cmdline {
       return result;
     }
 
-    inline OneShotIStream require(const char* shortOpt, const char* longOpt = 0) {
+    inline OneShotIStream require(const char* shortOpt, const char* longOpt = nullptr) {
       const OneShotIStream& is(option(shortOpt, longOpt));
       if (!is.isValid()) {
         const char empty[] = "";
@@ -340,7 +340,7 @@ namespace cmdline {
     }
 
   private:
-    CmdLine();
+    CmdLine() = delete;
 
     std::string progname_;
     Optlist args_;

--- a/CondTools/Hcal/interface/visualizeHFPhase1PMTParams.h
+++ b/CondTools/Hcal/interface/visualizeHFPhase1PMTParams.h
@@ -20,13 +20,13 @@ struct VisualizationOptions {
   bool verbose{false};
 
   void load(cmdline::CmdLine& cmdline) {
-    cmdline.option(0, "--minAsymm") >> minAsymm;
-    cmdline.option(0, "--maxAsymm") >> maxAsymm;
-    cmdline.option(0, "--minCharge") >> minCharge;
-    cmdline.option(0, "--maxCharge") >> maxCharge;
-    cmdline.option(0, "--minTDC") >> minTDC;
-    cmdline.option(0, "--maxTDC") >> maxTDC;
-    cmdline.option(0, "--plotPoints") >> plotPoints;
+    cmdline.option(nullptr, "--minAsymm") >> minAsymm;
+    cmdline.option(nullptr, "--maxAsymm") >> maxAsymm;
+    cmdline.option(nullptr, "--minCharge") >> minCharge;
+    cmdline.option(nullptr, "--maxCharge") >> maxCharge;
+    cmdline.option(nullptr, "--minTDC") >> minTDC;
+    cmdline.option(nullptr, "--maxTDC") >> maxTDC;
+    cmdline.option(nullptr, "--plotPoints") >> plotPoints;
     verbose = cmdline.has("-v");
   }
 


### PR DESCRIPTION
Apply `clang-tidy` automated code changes.
Apply `clang-format` automated code formatting.