### PR TITLE
Apply code checks to the DataFormats packages

### DIFF
--- a/DataFormats/Candidate/interface/CandidateWithRef.h
+++ b/DataFormats/Candidate/interface/CandidateWithRef.h
@@ -55,7 +55,7 @@ namespace reco {
   template <typename Ref>
   bool CandidateWithRef<Ref>::overlap(const Candidate &c) const {
     const CandidateWithRef *o = dynamic_cast<const CandidateWithRef *>(&c);
-    if (o == 0)
+    if (o == nullptr)
       return false;
     if (ref().isNull())
       return false;

--- a/DataFormats/Candidate/interface/component.h
+++ b/DataFormats/Candidate/interface/component.h
@@ -36,13 +36,13 @@ namespace reco {
     struct MultipleComponents {
       static size_t numberOf(const Candidate &c) {
         const C *dc = dynamic_cast<const C *>(&c);
-        if (dc == 0)
+        if (dc == nullptr)
           return 0;
         return (dc->*S)();
       }
       static T get(const Candidate &c, size_t i) {
         const C *dc = dynamic_cast<const C *>(&c);
-        if (dc == 0)
+        if (dc == nullptr)
           return T();
         if (i < (dc->*S)())
           return (dc->*F)(i);

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -360,7 +360,7 @@ namespace edm {
       return;
     delete data_[i];
     data_[i] = d;
-    d = 0;
+    d = nullptr;
   }
 
   template <typename T, typename P>
@@ -394,7 +394,7 @@ namespace edm {
   template <typename D>
   inline void OwnVector<T, P>::insert(const_iterator it, D*& d) {
     data_.insert(it.base_iter(), d);
-    d = 0;
+    d = nullptr;
   }
 
   template <typename T, typename P>

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -79,7 +79,7 @@ namespace edm {
     // any object containing this Ptr.
     template <typename C>
     Ptr(TestHandle<C> const& handle, key_type itemKey, bool /*setNow*/ = true)
-        : core_(handle.id(), getItem_(handle.product(), itemKey), 0, true), key_(itemKey) {}
+        : core_(handle.id(), getItem_(handle.product(), itemKey), nullptr, true), key_(itemKey) {}
 
     /** Constructor for those users who do not have a product handle,
      but have a pointer to a product getter (such as the EventPrincipal).

--- a/DataFormats/Common/interface/Ref.h
+++ b/DataFormats/Common/interface/Ref.h
@@ -349,7 +349,7 @@ namespace edm {
     //  the Event.
 
     Ref(ProductID const& iProductID, T const* item, key_type itemKey, product_type const* /* iProduct */)
-        : product_(iProductID, item, 0, false, itemKey) {}
+        : product_(iProductID, item, nullptr, false, itemKey) {}
 
     Ref(ProductID const& iProductID, T const* item, key_type itemKey)
         : product_(iProductID, item, nullptr, false, itemKey) {}
@@ -400,7 +400,7 @@ namespace edm {
     key_type index() const { return product_.index(); }
 
     /// Returns true if container referenced by the Ref has been cached
-    bool hasProductCache() const { return product_.productPtr() != 0; }
+    bool hasProductCache() const { return product_.productPtr() != nullptr; }
 
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.

--- a/DataFormats/Common/interface/RefProd.h
+++ b/DataFormats/Common/interface/RefProd.h
@@ -75,14 +75,14 @@ namespace edm {
     //  any object containing this RefProd.  Also, in the future work will
     //  be done to throw an exception if an attempt is made to put any object
     //  containing this RefProd into an event(or run or lumi).
-    RefProd(C const* iProduct) : product_(ProductID(), iProduct, 0, true) { checkTypeAtCompileTime(iProduct); }
+    RefProd(C const* iProduct) : product_(ProductID(), iProduct, nullptr, true) { checkTypeAtCompileTime(iProduct); }
 
     /// General purpose constructor from test handle.
     //  An exception will be thrown if an attempt is made to persistify
     //  any object containing this RefProd.  Also, in the future work will
     //  be done to throw an exception if an attempt is made to put any object
     //  containing this RefProd into an event(or run or lumi).
-    explicit RefProd(TestHandle<C> const& handle) : product_(handle.id(), handle.product(), 0, true) {
+    explicit RefProd(TestHandle<C> const& handle) : product_(handle.id(), handle.product(), nullptr, true) {
       checkTypeAtCompileTime(handle.product());
     }
 

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -54,7 +54,7 @@ namespace edm {
 
     /// Returns C++ pointer to the product
     /// Will attempt to retrieve product
-    product_type const* get() const { return isNull() ? 0 : this->operator->(); }
+    product_type const* get() const { return isNull() ? nullptr : this->operator->(); }
 
     /// Returns C++ pointer to the product
     /// Will attempt to retrieve product
@@ -76,7 +76,7 @@ namespace edm {
     EDProductGetter const* productGetter() const { return product_.productGetter(); }
 
     /// Checks if product is in memory.
-    bool hasCache() const { return product_.productPtr() != 0; }
+    bool hasCache() const { return product_.productPtr() != nullptr; }
 
     RefToBaseProd<T>& operator=(const RefToBaseProd<T>& other);
 
@@ -195,11 +195,11 @@ namespace edm {
   template <typename T>
   template <typename C>
   inline RefToBaseProd<T>::RefToBaseProd(OrphanHandle<C> const& handle)
-      : product_(handle.id(), handle.product(), 0, false) {
+      : product_(handle.id(), handle.product(), nullptr, false) {
     std::vector<void const*> pointers;
     FillViewHelperVector helpers;
     fillView(*handle, handle.id(), pointers, helpers);
-    product_.setProductPtr(new View<T>(pointers, helpers, 0));
+    product_.setProductPtr(new View<T>(pointers, helpers, nullptr));
   }
 
   template <typename T>

--- a/DataFormats/Common/interface/Trie.h
+++ b/DataFormats/Common/interface/Trie.h
@@ -229,9 +229,9 @@ namespace edm {
   public:
     typedef TrieNodeIter<T> self;
     typedef TrieNode<T> const node_base;
-    TrieNodeIter() : m_node(0), m_label(0) {}
+    TrieNodeIter() : m_node(nullptr), m_label(0) {}
 
-    explicit TrieNodeIter(node_base *p) : m_node(p ? p->subNode() : 0), m_label(p ? p->subNodeLabel() : 0) {}
+    explicit TrieNodeIter(node_base *p) : m_node(p ? p->subNode() : nullptr), m_label(p ? p->subNodeLabel() : 0) {}
 
     unsigned char label() const { return m_label; }
 
@@ -286,7 +286,7 @@ namespace edm {
 
 template <typename T>
 edm::TrieFactory<T>::TrieFactory(unsigned paquetSize)
-    : _paquetSize(paquetSize), _lastNodes(0x0), _nbUsedInLastNodes(0) {
+    : _paquetSize(paquetSize), _lastNodes(nullptr), _nbUsedInLastNodes(0) {
   _lastNodes = new TrieNode<T>[paquetSize];
 }
 
@@ -325,9 +325,9 @@ void edm::TrieFactory<T>::clear() {
 
 template <typename T>
 edm::TrieNode<T>::TrieNode()
-    : _brother(0),
+    : _brother(nullptr),
       _brotherLabel(0),
-      _firstSubNode(0),
+      _firstSubNode(nullptr),
       _firstSubNodeLabel(0),
       _value()
 /// we can not set _value here because type is unknown. assert that
@@ -346,7 +346,7 @@ edm::TrieNodeIter<T> edm::TrieNode<T>::begin() const {
 }
 template <typename T>
 edm::TrieNodeIter<T> edm::TrieNode<T>::end() const {
-  return const_iterator(0);
+  return const_iterator(nullptr);
 }
 
 template <typename T>
@@ -464,9 +464,9 @@ void edm::TrieNode<T>::display(std::ostream &os, unsigned offset, unsigned char 
 
 template <typename T>
 void edm::TrieNode<T>::clear() {
-  _brother = 0x0;
+  _brother = nullptr;
   _brotherLabel = 0;
-  _firstSubNode = 0x0;
+  _firstSubNode = nullptr;
   _firstSubNodeLabel = 0;
 }
 
@@ -489,7 +489,7 @@ namespace edm {
 }  // namespace edm
 
 template <typename T>
-edm::Trie<T>::Trie(const T &empty) : _empty(empty), _factory(0x0), _initialNode(0x0) {
+edm::Trie<T>::Trie(const T &empty) : _empty(empty), _factory(nullptr), _initialNode(nullptr) {
   // initialize nodes by paquets of 10000
   _factory = new TrieFactory<T>(10000);
   _initialNode = _factory->newNode(_empty);
@@ -514,7 +514,7 @@ template <typename T>
 edm::TrieNode<T> *edm::Trie<T>::_addEntry(const char *str, unsigned strLen) {
   unsigned pos = 0;
   bool found = true;
-  TrieNode<T> *node = _initialNode, *previous = 0x0;
+  TrieNode<T> *node = _initialNode, *previous = nullptr;
 
   // Look for the part of the word which is in Trie
   while (found && pos < strLen) {
@@ -537,7 +537,7 @@ edm::TrieNode<T> *edm::Trie<T>::_addEntry(const char *str, unsigned strLen) {
       ++pos;
     }
   }
-  assert(node != 0x0);
+  assert(node != nullptr);
   return node;
 }
 

--- a/DataFormats/Common/interface/ValueMap.h
+++ b/DataFormats/Common/interface/ValueMap.h
@@ -169,7 +169,7 @@ namespace edm {
 
     struct const_iterator {
       typedef ptrdiff_t difference_type;
-      const_iterator() : values_(0) {}
+      const_iterator() : values_(nullptr) {}
       ProductID id() const { return i_->first; }
       typename container::const_iterator begin() const { return values_->begin() + i_->second; }
       typename container::const_iterator end() const {

--- a/DataFormats/Math/interface/Graph.h
+++ b/DataFormats/Math/interface/Graph.h
@@ -62,7 +62,7 @@ namespace math {
           vt_.e_ = 0;
           ++vt_.a_;
           while (vt_.gr_.size() > vt_.a_) {
-            if (vt_.gr_.adjl_[vt_.a_].size()) {
+            if (!vt_.gr_.adjl_[vt_.a_].empty()) {
               return;
             }
             ++vt_.a_;

--- a/DataFormats/PatCandidates/interface/EventHypothesis.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesis.h
@@ -176,7 +176,7 @@ namespace pat {
   const T *EventHypothesis::getAs(const std::string &role, int index) const {
     CandRefType ref = get(role, index);
     const T *ret = dynamic_cast<const T *>(ref.get());
-    if ((ret == 0) && (ref.get() != nullptr))
+    if ((ret == nullptr) && (ref.get() != nullptr))
       throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
     return ret;
   }

--- a/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
@@ -32,7 +32,7 @@ namespace pat {
     template <typename T>
     const T *DynCastCandPtr<T>::get(const reco::Candidate *ptr) {
       doPtr(ptr);
-      if ((ptr != nullptr) && (cachePtr_ == 0))
+      if ((ptr != nullptr) && (cachePtr_ == nullptr))
         throw cms::Exception("Type Checking")
             << "You can't convert a " << typeid(*ptr).name() << " to a " << typeid(T).name() << "\n"
             << "note: you can use c++filt command to convert the above in human readable types.\n";


### PR DESCRIPTION
Apply `clang-tidy` automated code changes.
Apply `clang-format` automated code formatting.