### PR TITLE
EMTF: Drop rpcRecHits input

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/TrackFinder.h
+++ b/L1Trigger/L1TMuonEndCap/interface/TrackFinder.h
@@ -37,7 +37,6 @@ private:
   const edm::EDGetToken tokenCSC_;
   const edm::EDGetToken tokenCSCComparator_;
   const edm::EDGetToken tokenRPC_;
-  const edm::EDGetToken tokenRPCRecHit_;
   const edm::EDGetToken tokenCPPF_;
   const edm::EDGetToken tokenGEM_;
   const edm::EDGetToken tokenME0_;

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -29,7 +29,6 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
     CSCInput = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
     CSCComparatorInput = cms.InputTag('simMuonCSCDigis','MuonCSCComparatorDigi'),
     RPCInput = cms.InputTag('simMuonRPCDigis'),
-    RPCRecHitInput = cms.InputTag('rpcRecHits'),
     CPPFInput = cms.InputTag('simCPPFDigis'),  ## Cannot use in MC workflow, does not exist yet.  CPPFEnable set to False - AWB 01.06.18
     GEMInput = cms.InputTag('simMuonGEMPadDigiClusters'),
     ME0Input = cms.InputTag('me0TriggerConvertedPseudoDigis'),

--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -13,8 +13,6 @@ TrackFinder::TrackFinder(const edm::ParameterSet& iConfig, edm::ConsumesCollecto
       tokenCSCComparator_(iConsumes.consumes<emtf::CSCTag::comparator_digi_collection>(
           iConfig.getParameter<edm::InputTag>("CSCComparatorInput"))),
       tokenRPC_(iConsumes.consumes<emtf::RPCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("RPCInput"))),
-      tokenRPCRecHit_(
-          iConsumes.consumes<emtf::RPCTag::rechit_collection>(iConfig.getParameter<edm::InputTag>("RPCRecHitInput"))),
       tokenCPPF_(iConsumes.consumes<emtf::CPPFTag::digi_collection>(iConfig.getParameter<edm::InputTag>("CPPFInput"))),
       tokenGEM_(iConsumes.consumes<emtf::GEMTag::digi_collection>(iConfig.getParameter<edm::InputTag>("GEMInput"))),
       tokenME0_(iConsumes.consumes<emtf::ME0Tag::digi_collection>(iConfig.getParameter<edm::InputTag>("ME0Input"))),
@@ -71,11 +69,9 @@ void TrackFinder::process(const edm::Event& iEvent,
     collector.extractPrimitives(emtf::CPPFTag(), tp_geom_, iEvent, tokenCPPF_, muon_primitives);
   } else if (useRPC) {
     collector.extractPrimitives(emtf::RPCTag(), tp_geom_, iEvent, tokenRPC_, muon_primitives);
-    //collector.extractPrimitives(emtf::RPCTag(), tp_geom_, iEvent, tokenRPC_, tokenRPCRecHit_, muon_primitives);
   }
   if (useIRPC) {
     collector.extractPrimitives(emtf::IRPCTag(), tp_geom_, iEvent, tokenRPC_, muon_primitives);
-    //collector.extractPrimitives(emtf::IRPCTag(), tp_geom_, iEvent, tokenRPC_, tokenRPCRecHit_, muon_primitives);
   }
   if (useGEM) {
     collector.extractPrimitives(emtf::GEMTag(), tp_geom_, iEvent, tokenGEM_, muon_primitives);


### PR DESCRIPTION
#### PR description:

As requested by @makortel , this PR removes the `rpcRecHits` input from being used by the EMTF emulator (`simEmtfDigis`), as it causes the conflict found in #29897 . It doesn't change the behavior of the EMTF emulator, because `rpcRecHits` is not used at the moment. (It was going to be used to receive Phase-2 iRPC hits, but the use has not yet been implemented.)

#### PR validation:

N/A
