### PR TITLE
[backport] Disble illegal parameters when LHESource is used with steps

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -451,13 +451,13 @@ class ConfigBuilder(object):
                 self.process.source.processingMode = cms.untracked.string("RunsAndLumis")
 
         ##drop LHEXMLStringProduct on input to save memory if appropriate
-        if 'GEN' in self.stepMap.keys():
+        if 'GEN' in self.stepMap.keys() and not self._options.filetype == "LHE":
             if self._options.inputCommands:
                 self._options.inputCommands+=',drop LHEXMLStringProduct_*_*_*,'
             else:
                 self._options.inputCommands='keep *, drop LHEXMLStringProduct_*_*_*,'
 
-        if self.process.source and self._options.inputCommands:
+        if self.process.source and self._options.inputCommands and not self._options.filetype == "LHE":
             if not hasattr(self.process.source,'inputCommands'): self.process.source.inputCommands=cms.untracked.vstring()
             for command in self._options.inputCommands.split(','):
                 # remove whitespace around the keep/drop statements
@@ -786,7 +786,6 @@ class ConfigBuilder(object):
                         if count!=0:
                             iec.remove(item)
                         count+=1
-
 
             ## allow comma separated input eventcontent
             if not hasattr(self.process.source,'inputCommands'): self.process.source.inputCommands=cms.untracked.vstring()
@@ -1425,7 +1424,7 @@ class ConfigBuilder(object):
         if sequence == 'pdigi_valid' or sequence == 'pdigi_hi':
             self.executeAndRemember("process.mix.digitizers = cms.PSet(process.theDigitizersValid)")
 
-        if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and sequence != 'pdigi_hi_nogen' and not self.process.source.type_()=='EmptySource':
+        if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and sequence != 'pdigi_hi_nogen' and not self.process.source.type_()=='EmptySource' and not self._options.filetype == "LHE":
             if self._options.inputEventContent=='':
                 self._options.inputEventContent='REGEN'
             else:


### PR DESCRIPTION
#### PR description:
When cmsDriver.py with multiple steps is used with LHESource, it currently dumps with illegal parameters in process.source. This is an issue when LHE is used as a source for steps in private MC (not convert LHE to EDM first).

Reported in
https://hypernews.cern.ch/HyperNews/CMS/get/physics-validation/3516/1/1/1/1/1/1.html

#### PR validation:
Test with
`cmsDriver.py Configuration/GenProduction/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_generic_LHE_pythia8_cff.py --filein file:1000GeV_SpinHalf_100.lhe --fileout file:RAW.root --mc --eventcontent PREMIXRAW --datatier GEN-SIM-RAW --conditions 106X_mc2017_realistic_v6 --step GEN,SIM,DIGI,DATAMIX,L1,DIGI2RAW,HLT:@relval2017 --beamspot Realistic25ns13TeVEarly2017Collision --procModifiers premix_stage2 --datamix PreMix --era Run2_2017 --nThreads 8 --geometry DB:Extended --pileup_input "dbs:/RelValPREMIXUP17_PU25/CMSSW_10_6_1-PU25ns_106X_mc2017_realistic_v6_UL17-v1/PREMIX" --python_filename GENToHLT_LHE_cfg.py -n -1 --no_exec`

process.source comes with proper parameter:
```
process.source = cms.Source("LHESource",
    fileNames = cms.untracked.vstring('file:1000GeV_SpinHalf_100.lhe')
)
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of https://github.com/cms-sw/cmssw/pull/29855 to use for Legacy analysis

