### PR TITLE
Skip CUDA-related tests if no GPU is present

### DIFF
--- a/DataFormats/HcalDetId/test/BuildFile.xml
+++ b/DataFormats/HcalDetId/test/BuildFile.xml
@@ -2,6 +2,6 @@
   <bin name="test_hcal_detid" file="test_hcal_detid.cu">
     <use name="DataFormats/DetId"/>
     <use name="DataFormats/HcalDetId"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
   </bin>
-
 </iftool>

--- a/DataFormats/HcalDetId/test/test_hcal_detid.cu
+++ b/DataFormats/HcalDetId/test/test_hcal_detid.cu
@@ -1,10 +1,12 @@
-#include <cuda_runtime.h>
-#include <cuda.h>
-
+#include <cassert>
 #include <iostream>
-#include <assert.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 
 __global__ void test_gen_detid(DetId *id) {
   DetId did;
@@ -63,17 +65,13 @@ void test_hcal_detid() {
 }
 
 int main(int argc, char **argv) {
-  int nDevices;
-  cudaGetDeviceCount(&nDevices);
-  std::cout << "nDevices = " << nDevices << std::endl;
+  cms::cudatest::requireDevices();
 
   // test det id functionality
-  if (nDevices > 0)
-    test_detid();
+  test_detid();
 
   // test hcal det ids
-  if (nDevices > 0)
-    test_hcal_detid();
+  test_hcal_detid();
 
   return 0;
 }

--- a/DataFormats/HcalDigi/test/BuildFile.xml
+++ b/DataFormats/HcalDigi/test/BuildFile.xml
@@ -11,6 +11,6 @@
     <use name="DataFormats/HcalDetId"/>
     <use name="DataFormats/HcalDigi"/>
     <use name="DataFormats/Common"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
   </bin>
-
 </iftool>

--- a/DataFormats/HcalDigi/test/test_hcal_digi.cu
+++ b/DataFormats/HcalDigi/test/test_hcal_digi.cu
@@ -1,15 +1,17 @@
-#include <cuda_runtime.h>
-#include <cuda.h>
-
+#include <cassert>
 #include <iostream>
-#include <assert.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include "DataFormats/Common/interface/DataFrame.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 #include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
-#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
-#include "DataFormats/Common/interface/DataFrame.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 
 __global__ void kernel_test_hcal_qiesample(HcalQIESample *sample, uint16_t value) {
   printf("kernel: testing hcal qie sampel\n");
@@ -69,7 +71,6 @@ void test_hcal_qie1011_digis() {
   constexpr int samples = 10;
   constexpr int detid = 2;
   HcalDataFrameContainer<TDF> coll{samples, detid};
-  TDF *d_dfs;
   uint16_t *d_data;
   uint32_t *d_out;
   uint32_t h_out[size], h_test_out[size];
@@ -162,22 +163,18 @@ void test_hcal_qie8_hbhedf() {
 }
 
 int main(int argc, char **argv) {
-  int nDevices;
-  cudaGetDeviceCount(&nDevices);
-  std::cout << "nDevices = " << nDevices << std::endl;
+  cms::cudatest::requireDevices();
 
-  if (nDevices > 0) {
-    // qie8
-    test_hcal_qiesample();
-    test_hcal_qie8_hbhedf();
-    test_hcal_qie8_digis<HBHEDataFrame>();
-    test_hcal_qie8_digis<HFDataFrame>();
-    test_hcal_qie8_digis<HODataFrame>();
+  // qie8
+  test_hcal_qiesample();
+  test_hcal_qie8_hbhedf();
+  test_hcal_qie8_digis<HBHEDataFrame>();
+  test_hcal_qie8_digis<HFDataFrame>();
+  test_hcal_qie8_digis<HODataFrame>();
 
-    // qie1011
-    test_hcal_qie1011_digis<QIE10DataFrame>();
-    test_hcal_qie1011_digis<QIE11DataFrame>();
-  }
+  // qie1011
+  test_hcal_qie1011_digis<QIE10DataFrame>();
+  test_hcal_qie1011_digis<QIE11DataFrame>();
 
   return 0;
 }

--- a/DataFormats/HcalRecHit/test/BuildFile.xml
+++ b/DataFormats/HcalRecHit/test/BuildFile.xml
@@ -7,11 +7,11 @@
 
 <iftool name="cuda-gcc-support">
   <bin name="test_hcal_reco" file="test_hcal_reco.cu">
+    <use name="cuda"/>
     <use name="DataFormats/CaloRecHit"/>
     <use name="DataFormats/HcalRecHit"/>
     <use name="DataFormats/HcalDetId"/>
     <use name="DataFormats/HcalDigi"/>
-    <use name="cuda"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
   </bin>
-
 </iftool>

--- a/DataFormats/HcalRecHit/test/test_hcal_reco.cu
+++ b/DataFormats/HcalRecHit/test/test_hcal_reco.cu
@@ -10,6 +10,7 @@
 #include "DataFormats/HcalRecHit/interface/HORecHit.h"
 #include "DataFormats/HcalRecHit/interface/HFQIE10Info.h"
 #include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 
 template <typename T>
 __global__ void kernel_test_hcal_rechits(T *other) {
@@ -109,18 +110,13 @@ void test_hcal_hbhechinfo() {
 }
 
 int main(int argc, char **argv) {
-  int nDevices;
-  cudaGetDeviceCount(&nDevices);
-  std::cout << "nDevices = " << nDevices << std::endl;
+  cms::cudatest::requireDevices();
 
-  if (nDevices > 0) {
-    test_hcal_rechits<HBHERecHit>();
-    test_hcal_rechits<HFRecHit>();
-    test_hcal_rechits<HORecHit>();
-    test_hcal_hbhechinfo();
+  test_hcal_rechits<HBHERecHit>();
+  test_hcal_rechits<HFRecHit>();
+  test_hcal_rechits<HORecHit>();
+  test_hcal_hbhechinfo();
 
-    std::cout << "all good" << std::endl;
-  }
-
+  std::cout << "all good" << std::endl;
   return 0;
 }


### PR DESCRIPTION
#### PR description:

Make unit tests that require a CUDA device skip the test and exit
succesfully if the CUDA runtime is not available, or no CUDA devices
are available.

Rename the cudautils namespace to cms::cuda or cms::cudatest, and
drop the CUDA prefix from the symbols defined there.