### PR TITLE
DQM: Make DQMProvInfo not use lumi transitions.

### DIFF
--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -367,7 +367,16 @@ void DQMProvInfo::fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatus
                                                      bool* dcsBits) {
   // Loop over the DCSStatus entries in the DcsStatusCollection
   // (Typically there is only one)
+  bool first = true;
   for (auto const& dcsStatusItr : *dcsStatusCollection) {
+    // By default all the bits are false. We put all the bits on true only
+    // for the first DCSStatus that we encounter:
+    if (first) {
+      for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
+        dcsBits[vbin] = true;
+      }
+      first = false;
+    }
     dcsBits[VBIN_CSC_P] &= dcsStatusItr.ready(DcsStatus::CSCp);
     dcsBits[VBIN_CSC_M] &= dcsStatusItr.ready(DcsStatus::CSCm);
     dcsBits[VBIN_DT_0] &= dcsStatusItr.ready(DcsStatus::DT0);

--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -42,9 +42,6 @@ DQMProvInfo::DQMProvInfo(const edm::ParameterSet& ps) {
   // Initialization of the global tag
   globalTag_ = "MODULE::DEFAULT";  // default
   globalTagRetrieved_ = false;     // set as soon as retrieved from first event
-
-  // Initialization of run scope variables
-  previousLSNumber_ = 0;  // Previous LS compared to current, initializing at 0
 }
 
 // Destructor
@@ -93,7 +90,6 @@ void DQMProvInfo::bookHistogramsLhcInfo(DQMStore::IBooker& iBooker) {
   hBeamMode_ = iBooker.book1D("beamMode", "beamMode", MAX_LUMIS, 1., MAX_LUMIS + 1);
   hBeamMode_->getTH1F()->GetYaxis()->Set(21, 0.5, 21.5);
   hBeamMode_->getTH1F()->SetMaximum(21.5);
-  hBeamMode_->getTH1F()->SetCanExtend(TH1::kAllAxes);
   hBeamMode_->setBinContent(0., 22.);  // Not clear, remove when testable
 
   hBeamMode_->setAxisTitle("Luminosity Section", 1);
@@ -123,23 +119,19 @@ void DQMProvInfo::bookHistogramsLhcInfo(DQMStore::IBooker& iBooker) {
   hIntensity1_ = iBooker.book1D("intensity1", "Intensity Beam 1", MAX_LUMIS, 1., MAX_LUMIS + 1);
   hIntensity1_->setAxisTitle("Luminosity Section", 1);
   hIntensity1_->setAxisTitle("N [E10]", 2);
-  hIntensity1_->getTH1F()->SetCanExtend(TH1::kAllAxes);
 
   // Element: intensity2
   hIntensity2_ = iBooker.book1D("intensity2", "Intensity Beam 2", MAX_LUMIS, 1., MAX_LUMIS + 1);
   hIntensity2_->setAxisTitle("Luminosity Section", 1);
   hIntensity2_->setAxisTitle("N [E10]", 2);
-  hIntensity2_->getTH1F()->SetCanExtend(TH1::kAllAxes);
 
   // Element: lhcFill
   hLhcFill_ = iBooker.book1D("lhcFill", "LHC Fill Number", MAX_LUMIS, 1., MAX_LUMIS + 1);
   hLhcFill_->setAxisTitle("Luminosity Section", 1);
-  hLhcFill_->getTH1F()->SetCanExtend(TH1::kAllAxes);
 
   // Element: momentum
   hMomentum_ = iBooker.book1D("momentum", "Beam Energy [GeV]", MAX_LUMIS, 1., MAX_LUMIS + 1);
   hMomentum_->setAxisTitle("Luminosity Section", 1);
-  hMomentum_->getTH1F()->SetCanExtend(TH1::kAllAxes);
 }
 
 void DQMProvInfo::bookHistogramsEventInfo(DQMStore::IBooker& iBooker) {
@@ -147,16 +139,18 @@ void DQMProvInfo::bookHistogramsEventInfo(DQMStore::IBooker& iBooker) {
   reportSummary_ = iBooker.bookFloat("reportSummary");
 
   // Element: reportSummaryMap   (this is the famous HV plot)
-  reportSummaryMap_ = iBooker.book2D("reportSummaryMap",
-                                     "DCS HV Status and Beam Status per Lumisection",
-                                     MAX_LUMIS,
-                                     0,
-                                     MAX_LUMIS,
-                                     MAX_VBINS,
-                                     0.,
-                                     MAX_VBINS);
+  reportSummaryMap_ = iBooker.bookProfile2D("reportSummaryMap",
+                                            "DCS HV Status and Beam Status per Lumisection",
+                                            MAX_LUMIS,
+                                            0,
+                                            MAX_LUMIS,
+                                            MAX_VBINS,
+                                            0.,
+                                            MAX_VBINS,
+                                            1.,  // Z range -- does not really matter
+                                            0.,
+                                            1.);
   reportSummaryMap_->setAxisTitle("Luminosity Section");
-  reportSummaryMap_->getTH2F()->SetCanExtend(TH1::kAllAxes);
 
   reportSummaryMap_->setBinLabel(VBIN_CSC_P, "CSC+", 2);
   reportSummaryMap_->setBinLabel(VBIN_CSC_M, "CSC-", 2);
@@ -222,22 +216,6 @@ void DQMProvInfo::bookHistogramsProvInfo(DQMStore::IBooker& iBooker) {
   workingDir_ = iBooker.bookString("workingDir", gSystem->pwd());
 }
 
-void DQMProvInfo::beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) {
-  // By default we set the Physics Declared bit to false at the beginning of
-  // every LS
-  physicsDeclared_ = false;
-  // Boolean that tells the analyse method that we encountered the first real
-  // dcs info
-  foundFirstPhysicsDeclared_ = false;
-  // By default we set all the DCS bits to false at the beginning of every LS
-  for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
-    dcsBits_[vbin] = false;
-  }
-  // Boolean that tells the analyse method that we encountered the first real
-  // dcs info
-  foundFirstDcsBits_ = false;
-}
-
 void DQMProvInfo::analyze(const edm::Event& event, const edm::EventSetup& c) {
   // This happens on an event by event base
   // We extract information from events, placing them in local variables
@@ -245,46 +223,101 @@ void DQMProvInfo::analyze(const edm::Event& event, const edm::EventSetup& c) {
   // (Except for the global tag, which we only extract from the first event we
   //  ever encounter and put in the MonitorElement right away)
 
+  // We set the top value to "Valid" to 1 for each LS we encounter
+  setupLumiSection(event.id().luminosityBlock());
+
   analyzeLhcInfo(event);
   analyzeEventInfo(event);
   analyzeProvInfo(event);
 }
 
 void DQMProvInfo::analyzeLhcInfo(const edm::Event& event) {
+  unsigned int currentLSNumber = event.id().luminosityBlock();
   edm::Handle<TCDSRecord> tcdsData;
   event.getByToken(tcdsrecord_, tcdsData);
   // We unpack the TCDS record from TCDS
   if (tcdsData.isValid()) {
     //and we look at the BST information
-    lhcFill_ = static_cast<int>(tcdsData->getBST().getLhcFill());
+    auto lhcFill = static_cast<int>(tcdsData->getBST().getLhcFill());
     beamMode_ = static_cast<int>(tcdsData->getBST().getBeamMode());
-    momentum_ = static_cast<int>(tcdsData->getBST().getBeamMomentum());
-    intensity1_ = static_cast<int>(tcdsData->getBST().getIntensityBeam1());
-    intensity2_ = static_cast<int>(tcdsData->getBST().getIntensityBeam2());
+    auto momentum = static_cast<int>(tcdsData->getBST().getBeamMomentum());
+    auto intensity1 = static_cast<int>(tcdsData->getBST().getIntensityBeam1());
+    auto intensity2 = static_cast<int>(tcdsData->getBST().getIntensityBeam2());
+
+    // Quite straightforward: Fill in the value for the LS in each plot:
+    hLhcFill_->setBinContent(currentLSNumber, lhcFill);
+    hBeamMode_->setBinContent(currentLSNumber, beamMode_);
+    hMomentum_->setBinContent(currentLSNumber, momentum);
+    hIntensity1_->setBinContent(currentLSNumber, intensity1);
+    hIntensity2_->setBinContent(currentLSNumber, intensity2);
+
+    // Part3: Using LHC status info, fill in VBIN_MOMENTUM and VBIN_STABLE_BEAM
+    // Fill 13 TeV bit in y bin VBIN_MOMENTUM
+    if (momentum >= MAX_MOMENTUM - MOMENTUM_OFFSET) {
+      reportSummaryMap_->Fill(currentLSNumber, VBIN_MOMENTUM, 1.);
+    } else {
+      reportSummaryMap_->Fill(currentLSNumber, VBIN_MOMENTUM, 0.);
+    }
+
+    // Fill stable beams bit in y bin VBIN_STABLE_BEAM
+    if (beamMode_ == 11) {
+      hIsCollisionsRun_->Fill(1);
+      reportSummary_->Fill(1.);
+      reportSummaryMap_->Fill(currentLSNumber, VBIN_STABLE_BEAM, 1.);
+    } else {
+      reportSummary_->Fill(0.);
+      reportSummaryMap_->Fill(currentLSNumber, VBIN_STABLE_BEAM, 0.);
+    }
   } else {
     edm::LogWarning("DQMProvInfo") << "TCDS Data inaccessible.";
   }
 }
 
 void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
+  unsigned int currentLSNumber = event.id().luminosityBlock();
   // Part 1:
   // If FED#735 is available use it to extract DcsStatusCollection.
   // If not, use softFED#1022 to extract DCSRecord.
-  // Populate dcsBits_ array with received information.
 
   edm::Handle<DcsStatusCollection> dcsStatusCollection;
   event.getByToken(dcsStatusCollection_, dcsStatusCollection);
   edm::Handle<DCSRecord> dcsRecord;
   event.getByToken(dcsRecordToken_, dcsRecord);
 
+  // Populate dcsBits array with received information.
+  bool dcsBits[MAX_DCS_VBINS + 1] = {};
+
   if (dcsStatusCollection.isValid() && !dcsStatusCollection->empty()) {
     edm::LogInfo("DQMProvInfo") << "Using FED#735 for reading DCS bits" << std::endl;
-    fillDcsBitsFromDcsStatusCollection(dcsStatusCollection);
+    fillDcsBitsFromDcsStatusCollection(dcsStatusCollection, dcsBits);
   } else if (dcsRecord.isValid()) {
     edm::LogInfo("DQMProvInfo") << "Using softFED#1022 for reading DCS bits" << std::endl;
-    fillDcsBitsFromDCSRecord(*dcsRecord);
+    fillDcsBitsFromDCSRecord(*dcsRecord, dcsBits);
   } else {
     edm::LogError("DQMProvInfo") << "No DCS information found!" << std::endl;
+  }
+
+  // Part 2: Compute the PhysicsDeclared bit from the event
+  auto physicsDeclared = isPhysicsDeclared(dcsBits);
+
+  // Some info-level logging
+  edm::LogInfo("DQMProvInfo") << "Physics declared bit: " << physicsDeclared << std::endl;
+
+  // Part 1: Physics declared bit in y bin VBIN_PHYSICS_DECLARED
+  // This also is used as the global value of the summary.
+  if (physicsDeclared) {
+    reportSummaryMap_->Fill(currentLSNumber, VBIN_PHYSICS_DECLARED, 1.);
+  } else {
+    reportSummaryMap_->Fill(currentLSNumber, VBIN_PHYSICS_DECLARED, 0.);
+  }
+
+  // Part2: DCS bits in y bins 1 to MAX_DCS_VBINS
+  for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
+    if (dcsBits[vbin]) {
+      reportSummaryMap_->Fill(currentLSNumber, vbin, 1.);
+    } else {
+      reportSummaryMap_->Fill(currentLSNumber, vbin, 0.);
+    }
   }
 }
 
@@ -305,98 +338,71 @@ void DQMProvInfo::analyzeProvInfo(const edm::Event& event) {
   }
 }
 
-void DQMProvInfo::fillDcsBitsFromDCSRecord(const DCSRecord& dcsRecord) {
-  dcsBits_[VBIN_CSC_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::CSCp);
-  dcsBits_[VBIN_CSC_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::CSCm);
-  dcsBits_[VBIN_DT_0] = dcsRecord.highVoltageReady(DCSRecord::Partition::DT0);
-  dcsBits_[VBIN_DT_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::DTp);
-  dcsBits_[VBIN_DT_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::DTm);
-  dcsBits_[VBIN_EB_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::EBp);
-  dcsBits_[VBIN_EB_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::EBm);
-  dcsBits_[VBIN_EE_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::EEp);
-  dcsBits_[VBIN_EE_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::EEm);
-  dcsBits_[VBIN_ES_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::ESp);
-  dcsBits_[VBIN_ES_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::ESm);
-  dcsBits_[VBIN_HBHE_A] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEa);
-  dcsBits_[VBIN_HBHE_B] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEb);
-  dcsBits_[VBIN_HBHE_C] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEc);
-  dcsBits_[VBIN_HF] = dcsRecord.highVoltageReady(DCSRecord::Partition::HF);
-  dcsBits_[VBIN_HO] = dcsRecord.highVoltageReady(DCSRecord::Partition::HO);
-  dcsBits_[VBIN_BPIX] = dcsRecord.highVoltageReady(DCSRecord::Partition::BPIX);
-  dcsBits_[VBIN_FPIX] = dcsRecord.highVoltageReady(DCSRecord::Partition::FPIX);
-  dcsBits_[VBIN_RPC] = dcsRecord.highVoltageReady(DCSRecord::Partition::RPC);
-  dcsBits_[VBIN_TIBTID] = dcsRecord.highVoltageReady(DCSRecord::Partition::TIBTID);
-  dcsBits_[VBIN_TOB] = dcsRecord.highVoltageReady(DCSRecord::Partition::TOB);
-  dcsBits_[VBIN_TEC_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::TECp);
-  dcsBits_[VBIN_TE_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::TECm);
-  dcsBits_[VBIN_CASTOR] = dcsRecord.highVoltageReady(DCSRecord::Partition::CASTOR);
-  dcsBits_[VBIN_ZDC] = dcsRecord.highVoltageReady(DCSRecord::Partition::ZDC);
-
-  // Part 2: Compute the PhysicsDeclared bit from the event
-  physicsDeclared_ &= isPhysicsDeclared();
-
-  // Some info-level logging
-  edm::LogInfo("DQMProvInfo") << "Physics declared bit: " << physicsDeclared_ << std::endl;
+void DQMProvInfo::fillDcsBitsFromDCSRecord(const DCSRecord& dcsRecord, bool* dcsBits) {
+  dcsBits[VBIN_CSC_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::CSCp);
+  dcsBits[VBIN_CSC_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::CSCm);
+  dcsBits[VBIN_DT_0] = dcsRecord.highVoltageReady(DCSRecord::Partition::DT0);
+  dcsBits[VBIN_DT_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::DTp);
+  dcsBits[VBIN_DT_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::DTm);
+  dcsBits[VBIN_EB_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::EBp);
+  dcsBits[VBIN_EB_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::EBm);
+  dcsBits[VBIN_EE_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::EEp);
+  dcsBits[VBIN_EE_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::EEm);
+  dcsBits[VBIN_ES_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::ESp);
+  dcsBits[VBIN_ES_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::ESm);
+  dcsBits[VBIN_HBHE_A] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEa);
+  dcsBits[VBIN_HBHE_B] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEb);
+  dcsBits[VBIN_HBHE_C] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEc);
+  dcsBits[VBIN_HF] = dcsRecord.highVoltageReady(DCSRecord::Partition::HF);
+  dcsBits[VBIN_HO] = dcsRecord.highVoltageReady(DCSRecord::Partition::HO);
+  dcsBits[VBIN_BPIX] = dcsRecord.highVoltageReady(DCSRecord::Partition::BPIX);
+  dcsBits[VBIN_FPIX] = dcsRecord.highVoltageReady(DCSRecord::Partition::FPIX);
+  dcsBits[VBIN_RPC] = dcsRecord.highVoltageReady(DCSRecord::Partition::RPC);
+  dcsBits[VBIN_TIBTID] = dcsRecord.highVoltageReady(DCSRecord::Partition::TIBTID);
+  dcsBits[VBIN_TOB] = dcsRecord.highVoltageReady(DCSRecord::Partition::TOB);
+  dcsBits[VBIN_TEC_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::TECp);
+  dcsBits[VBIN_TE_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::TECm);
+  dcsBits[VBIN_CASTOR] = dcsRecord.highVoltageReady(DCSRecord::Partition::CASTOR);
+  dcsBits[VBIN_ZDC] = dcsRecord.highVoltageReady(DCSRecord::Partition::ZDC);
 }
 
-void DQMProvInfo::fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatusCollection>& dcsStatusCollection) {
+void DQMProvInfo::fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatusCollection>& dcsStatusCollection,
+                                                     bool* dcsBits) {
   // Loop over the DCSStatus entries in the DcsStatusCollection
   // (Typically there is only one)
   for (auto const& dcsStatusItr : *dcsStatusCollection) {
-    // By default all the bits are false. We put all the bits on true only
-    // for the first DCSStatus that we encounter:
-    if (!foundFirstDcsBits_) {
-      for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
-        dcsBits_[vbin] = true;
-      }
-      foundFirstDcsBits_ = true;
-    }
-    // By default Physics Declared is false. We put it on true only for the
-    // first DCSStatus that we encounter:
-    if (!foundFirstPhysicsDeclared_) {
-      physicsDeclared_ = true;
-      foundFirstPhysicsDeclared_ = true;
-    }
-
-    // The DCS on lumi level is considered ON if the bit is set in EVERY event
-    dcsBits_[VBIN_CSC_P] &= dcsStatusItr.ready(DcsStatus::CSCp);
-    dcsBits_[VBIN_CSC_M] &= dcsStatusItr.ready(DcsStatus::CSCm);
-    dcsBits_[VBIN_DT_0] &= dcsStatusItr.ready(DcsStatus::DT0);
-    dcsBits_[VBIN_DT_P] &= dcsStatusItr.ready(DcsStatus::DTp);
-    dcsBits_[VBIN_DT_M] &= dcsStatusItr.ready(DcsStatus::DTm);
-    dcsBits_[VBIN_EB_P] &= dcsStatusItr.ready(DcsStatus::EBp);
-    dcsBits_[VBIN_EB_M] &= dcsStatusItr.ready(DcsStatus::EBm);
-    dcsBits_[VBIN_EE_P] &= dcsStatusItr.ready(DcsStatus::EEp);
-    dcsBits_[VBIN_EE_M] &= dcsStatusItr.ready(DcsStatus::EEm);
-    dcsBits_[VBIN_ES_P] &= dcsStatusItr.ready(DcsStatus::ESp);
-    dcsBits_[VBIN_ES_M] &= dcsStatusItr.ready(DcsStatus::ESm);
-    dcsBits_[VBIN_HBHE_A] &= dcsStatusItr.ready(DcsStatus::HBHEa);
-    dcsBits_[VBIN_HBHE_B] &= dcsStatusItr.ready(DcsStatus::HBHEb);
-    dcsBits_[VBIN_HBHE_C] &= dcsStatusItr.ready(DcsStatus::HBHEc);
-    dcsBits_[VBIN_HF] &= dcsStatusItr.ready(DcsStatus::HF);
-    dcsBits_[VBIN_HO] &= dcsStatusItr.ready(DcsStatus::HO);
-    dcsBits_[VBIN_BPIX] &= dcsStatusItr.ready(DcsStatus::BPIX);
-    dcsBits_[VBIN_FPIX] &= dcsStatusItr.ready(DcsStatus::FPIX);
-    dcsBits_[VBIN_RPC] &= dcsStatusItr.ready(DcsStatus::RPC);
-    dcsBits_[VBIN_TIBTID] &= dcsStatusItr.ready(DcsStatus::TIBTID);
-    dcsBits_[VBIN_TOB] &= dcsStatusItr.ready(DcsStatus::TOB);
-    dcsBits_[VBIN_TEC_P] &= dcsStatusItr.ready(DcsStatus::TECp);
-    dcsBits_[VBIN_TE_M] &= dcsStatusItr.ready(DcsStatus::TECm);
-    dcsBits_[VBIN_CASTOR] &= dcsStatusItr.ready(DcsStatus::CASTOR);
-    dcsBits_[VBIN_ZDC] &= dcsStatusItr.ready(DcsStatus::ZDC);
+    dcsBits[VBIN_CSC_P] &= dcsStatusItr.ready(DcsStatus::CSCp);
+    dcsBits[VBIN_CSC_M] &= dcsStatusItr.ready(DcsStatus::CSCm);
+    dcsBits[VBIN_DT_0] &= dcsStatusItr.ready(DcsStatus::DT0);
+    dcsBits[VBIN_DT_P] &= dcsStatusItr.ready(DcsStatus::DTp);
+    dcsBits[VBIN_DT_M] &= dcsStatusItr.ready(DcsStatus::DTm);
+    dcsBits[VBIN_EB_P] &= dcsStatusItr.ready(DcsStatus::EBp);
+    dcsBits[VBIN_EB_M] &= dcsStatusItr.ready(DcsStatus::EBm);
+    dcsBits[VBIN_EE_P] &= dcsStatusItr.ready(DcsStatus::EEp);
+    dcsBits[VBIN_EE_M] &= dcsStatusItr.ready(DcsStatus::EEm);
+    dcsBits[VBIN_ES_P] &= dcsStatusItr.ready(DcsStatus::ESp);
+    dcsBits[VBIN_ES_M] &= dcsStatusItr.ready(DcsStatus::ESm);
+    dcsBits[VBIN_HBHE_A] &= dcsStatusItr.ready(DcsStatus::HBHEa);
+    dcsBits[VBIN_HBHE_B] &= dcsStatusItr.ready(DcsStatus::HBHEb);
+    dcsBits[VBIN_HBHE_C] &= dcsStatusItr.ready(DcsStatus::HBHEc);
+    dcsBits[VBIN_HF] &= dcsStatusItr.ready(DcsStatus::HF);
+    dcsBits[VBIN_HO] &= dcsStatusItr.ready(DcsStatus::HO);
+    dcsBits[VBIN_BPIX] &= dcsStatusItr.ready(DcsStatus::BPIX);
+    dcsBits[VBIN_FPIX] &= dcsStatusItr.ready(DcsStatus::FPIX);
+    dcsBits[VBIN_RPC] &= dcsStatusItr.ready(DcsStatus::RPC);
+    dcsBits[VBIN_TIBTID] &= dcsStatusItr.ready(DcsStatus::TIBTID);
+    dcsBits[VBIN_TOB] &= dcsStatusItr.ready(DcsStatus::TOB);
+    dcsBits[VBIN_TEC_P] &= dcsStatusItr.ready(DcsStatus::TECp);
+    dcsBits[VBIN_TE_M] &= dcsStatusItr.ready(DcsStatus::TECm);
+    dcsBits[VBIN_CASTOR] &= dcsStatusItr.ready(DcsStatus::CASTOR);
+    dcsBits[VBIN_ZDC] &= dcsStatusItr.ready(DcsStatus::ZDC);
 
     // Some info-level logging
     edm::LogInfo("DQMProvInfo") << "DCS status: 0x" << std::hex << dcsStatusItr.ready() << std::dec << std::endl;
   }
-
-  // Part 2: Compute the PhysicsDeclared bit from the event
-  physicsDeclared_ &= isPhysicsDeclared();
-
-  // Some info-level logging
-  edm::LogInfo("DQMProvInfo") << "Physics declared bit: " << physicsDeclared_ << std::endl;
 }
 
-bool DQMProvInfo::isPhysicsDeclared() {
+bool DQMProvInfo::isPhysicsDeclared(bool* dcsBits) {
   // Compute the PhysicsDeclared bit from the event
   // The bit is set to to true if:
   // - the LHC is in stable beams
@@ -405,95 +411,10 @@ bool DQMProvInfo::isPhysicsDeclared() {
   // Basically: we do an AND of the physicsDeclared of ALL events.
   // As soon as one value is not "1", physicsDeclared_ becomes false.
   return (beamMode_ == 11) &&
-         (dcsBits_[VBIN_BPIX] && dcsBits_[VBIN_FPIX] && dcsBits_[VBIN_TIBTID] && dcsBits_[VBIN_TOB] &&
-          dcsBits_[VBIN_TEC_P] && dcsBits_[VBIN_TE_M]) &&
-         (dcsBits_[VBIN_CSC_P] || dcsBits_[VBIN_CSC_M] || dcsBits_[VBIN_DT_0] || dcsBits_[VBIN_DT_P] ||
-          dcsBits_[VBIN_DT_M] || dcsBits_[VBIN_RPC]);
-}
-
-void DQMProvInfo::endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& c) {
-  int currentLSNumber = iLumi.id().luminosityBlock();
-
-  // We assume that we encounter the LumiSections in chronological order
-  // We only process a LS if it's greater than the previous one:
-  if (currentLSNumber > previousLSNumber_) {
-    endLuminosityBlockLhcInfo(currentLSNumber);
-    endLuminosityBlockEventInfo(currentLSNumber);
-  }
-
-  // Set current LS number as previous number for the next cycle:
-  previousLSNumber_ = currentLSNumber;
-}
-
-void DQMProvInfo::endLuminosityBlockLhcInfo(const int currentLSNumber) {
-  // Quite straightforward: Fill in the value for the LS in each plot:
-  hBeamMode_->setBinContent(currentLSNumber, beamMode_);
-  hIntensity1_->setBinContent(currentLSNumber, intensity1_);
-  hIntensity2_->setBinContent(currentLSNumber, intensity2_);
-  hLhcFill_->setBinContent(currentLSNumber, lhcFill_);
-  hMomentum_->setBinContent(currentLSNumber, momentum_);
-}
-
-void DQMProvInfo::endLuminosityBlockEventInfo(const int currentLSNumber) {
-  // If we skipped LumiSections, we make them "white"
-  blankPreviousLumiSections(currentLSNumber);
-
-  // We set the top value to "Valid" to 1 for each LS we end
-  reportSummaryMap_->setBinContent(currentLSNumber, VBIN_VALID, 1.);
-
-  // Part 1: Physics declared bit in y bin VBIN_PHYSICS_DECLARED
-  // This also is used as the global value of the summary.
-  if (physicsDeclared_) {
-    reportSummary_->Fill(1.);
-    reportSummaryMap_->setBinContent(currentLSNumber, VBIN_PHYSICS_DECLARED, 1.);
-  } else {
-    reportSummary_->Fill(0.);
-    reportSummaryMap_->setBinContent(currentLSNumber, VBIN_PHYSICS_DECLARED, 0.);
-  }
-
-  // Part2: DCS bits in y bins 1 to MAX_DCS_VBINS
-  for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
-    if (dcsBits_[vbin]) {
-      reportSummaryMap_->setBinContent(currentLSNumber, vbin, 1.);
-    } else {
-      reportSummaryMap_->setBinContent(currentLSNumber, vbin, 0.);
-    }
-  }
-
-  // Part3: Using LHC status info, fill in VBIN_MOMENTUM and VBIN_STABLE_BEAM
-  // Fill 13 TeV bit in y bin VBIN_MOMENTUM
-  if (momentum_ >= MAX_MOMENTUM - MOMENTUM_OFFSET) {
-    reportSummary_->Fill(1.);
-    reportSummaryMap_->setBinContent(currentLSNumber, VBIN_MOMENTUM, 1.);
-  } else {
-    reportSummary_->Fill(0.);
-    reportSummaryMap_->setBinContent(currentLSNumber, VBIN_MOMENTUM, 0.);
-  }
-
-  // Fill stable beams bit in y bin VBIN_STABLE_BEAM
-  if (beamMode_ == 11) {
-    hIsCollisionsRun_->Fill(1);
-    reportSummary_->Fill(1.);
-    reportSummaryMap_->setBinContent(currentLSNumber, VBIN_STABLE_BEAM, 1.);
-  } else {
-    reportSummary_->Fill(0.);
-    reportSummaryMap_->setBinContent(currentLSNumber, VBIN_STABLE_BEAM, 0.);
-  }
-}
-
-void DQMProvInfo::blankPreviousLumiSections(const int currentLSNumber) {
-  // In case we skipped lumisections, the current lumisection number will be
-  // more than the previous lumisection number + 1.
-  // We paint all the skipped lumisections completely white (-1), except for
-  // the top flag (the "valid" flag), which we paint red (0).
-  for (int ls = previousLSNumber_ + 1; ls < currentLSNumber; ls++) {
-    // Color the "Valid" bin red (0)
-    reportSummaryMap_->setBinContent(ls, VBIN_VALID, 0.);
-    // Color all the other bins white (-1)
-    for (int vBin = 1; vBin < VBIN_VALID; vBin++) {
-      reportSummaryMap_->setBinContent(ls, vBin, -1.);
-    }
-  }
+         (dcsBits[VBIN_BPIX] && dcsBits[VBIN_FPIX] && dcsBits[VBIN_TIBTID] && dcsBits[VBIN_TOB] &&
+          dcsBits[VBIN_TEC_P] && dcsBits[VBIN_TE_M]) &&
+         (dcsBits[VBIN_CSC_P] || dcsBits[VBIN_CSC_M] || dcsBits[VBIN_DT_0] || dcsBits[VBIN_DT_P] ||
+          dcsBits[VBIN_DT_M] || dcsBits[VBIN_RPC]);
 }
 
 void DQMProvInfo::blankAllLumiSections() {
@@ -503,6 +424,27 @@ void DQMProvInfo::blankAllLumiSections() {
     // Color all the bins white (-1)
     for (int vBin = 1; vBin <= MAX_VBINS; vBin++) {
       reportSummaryMap_->setBinContent(ls, vBin, -1.);
+    }
+  }
+}
+
+void DQMProvInfo::setupLumiSection(int currentLSNumber) {
+  // All lumis are initialized as -1 (white). Before we can start filling,
+  // we need to make them 0 (or 1, for the "valid" bit).
+  // Color all the bins red (0)
+  // This need to be atomic, DQMOneEDAnalyzer for this reason.
+  if (reportSummaryMap_->getBinContent(currentLSNumber, VBIN_VALID) < 1.) {
+    for (int vBin = 1; vBin <= MAX_VBINS; vBin++) {
+      reportSummaryMap_->setBinContent(currentLSNumber, vBin, 0.);
+    }
+    reportSummaryMap_->setBinContent(currentLSNumber, VBIN_VALID, 1.);
+
+    // Mark all lower LS as invalid, if they are not set valid yet.
+    // This is a hint for the render plugin to show the correct range.
+    for (int ls = 1; ls < currentLSNumber; ls++) {
+      if (reportSummaryMap_->getBinContent(ls, VBIN_VALID) == -1.) {
+        reportSummaryMap_->setBinContent(ls, VBIN_VALID, 0.);
+      }
     }
   }
 }

--- a/DQMServices/Components/plugins/DQMProvInfo.h
+++ b/DQMServices/Components/plugins/DQMProvInfo.h
@@ -45,7 +45,8 @@ private:
   bool isPhysicsDeclared(bool* dcsBits);
 
   void blankAllLumiSections();
-  void setupLumiSection(const int ls);
+  void fillSummaryMapBin(int ls, int bin, double value);
+  void setupLumiSection(int ls);
 
   // To max amount of lumisections we foresee for the plots
   // DQM GUI renderplugins provide scaling to actual amount

--- a/DQMServices/Components/plugins/DQMProvInfo.h
+++ b/DQMServices/Components/plugins/DQMProvInfo.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-class DQMProvInfo : public DQMOneEDAnalyzer<edm::one::WatchLuminosityBlocks> {
+class DQMProvInfo : public DQMOneEDAnalyzer<> {
 public:
   // Constructor
   DQMProvInfo(const edm::ParameterSet& ps);
@@ -29,9 +29,7 @@ public:
 protected:
   void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
 
 private:
   void bookHistogramsLhcInfo(DQMStore::IBooker&);
@@ -42,14 +40,12 @@ private:
   void analyzeEventInfo(const edm::Event& e);
   void analyzeProvInfo(const edm::Event& e);
 
-  void fillDcsBitsFromDCSRecord(const DCSRecord&);
-  void fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatusCollection>&);
-  bool isPhysicsDeclared();
+  void fillDcsBitsFromDCSRecord(const DCSRecord&, bool* dcsBits);
+  void fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatusCollection>&, bool* dcsBits);
+  bool isPhysicsDeclared(bool* dcsBits);
 
-  void endLuminosityBlockLhcInfo(const int currentLSNumber);
-  void endLuminosityBlockEventInfo(const int currentLSNumber);
-  void blankPreviousLumiSections(const int currentLSNumber);
   void blankAllLumiSections();
+  void setupLumiSection(const int ls);
 
   // To max amount of lumisections we foresee for the plots
   // DQM GUI renderplugins provide scaling to actual amount
@@ -118,22 +114,13 @@ private:
   MonitorElement* hBeamMode_;
   int beamMode_;
   MonitorElement* hIntensity1_;
-  int intensity1_;
   MonitorElement* hIntensity2_;
-  int intensity2_;
   MonitorElement* hLhcFill_;
-  int lhcFill_;
   MonitorElement* hMomentum_;
-  int momentum_;
 
   // MonitorElements for EventInfo and corresponding variables
   MonitorElement* reportSummary_;
   MonitorElement* reportSummaryMap_;
-  int previousLSNumber_;
-  bool physicsDeclared_;
-  bool foundFirstPhysicsDeclared_;
-  bool dcsBits_[MAX_DCS_VBINS + 1];
-  bool foundFirstDcsBits_;
 
   // MonitorElements for ProvInfo and corresponding variables
   MonitorElement* versCMSSW_;


### PR DESCRIPTION
#### PR description:
As pointed out in #25090 , `DQMProvInfo` is still a `DQMOneLumiEDAnalyzer`.

Rather than giving it the 1:1 port to lumi caches, I restructured it in a way that it does not need lumi transitions at all: In part, to have a nice example for how to do this; in part, because I think this is easier to understand; and in part, because it gives more correct output.

This is done by using a `TProfile` (edit: not any more) to aggregate data within a lumisection, and keeping state in local variables rather than instance variables. The code could easily run as `DQMEDAnalyzer` or `DQMGlobalEDAnalyzer` apart from one logical race condition around `setupLumiSection`, which is needed to treat "never seen" different from "empty". There would be other ways to do this, but `DQMOneEDAnalyzer` should be ok for such a small/fast analyzer.

However, this means the semantics *have* slightly changed, and a more thorough validation is needed.

~Themain difference is that now `reportSummaryMap` is a `TProfile2D`, where each bin is the _percentage (0..1)  of events where this flag was set_. This matches the old definition in the corner cases, but provides more information on the transitions. It also handles merging more correctly (though we should never merge *inside* lumis, so this is not really relevant).~ (Edit: switched back to TH2F for compatibility with the render plugin).

A side effect of the design change is that _empty_ LS now show up as _not valid_, while they were _valid_ before. In case of missing information, bins will be white, instead of red. I think this is acceptable.

Finally, the _valid_ flag for each lumi is set as soon as _at least one_ event of it is processed, while before it was set when _the lumisection is completely processed_. The latter semantics are hard to achieve in modern CMSSW, since we never really know if we have seen the full lumi or not. (It also does not really mean much in online, since this plot is created in a different client compared to most others, and its indistinguishable in the offline output).

#### PR validation:

Not much so far. PR tests should provide a good check on whether things work correctly.