### PR TITLE
Update CUDAUtilities from the Patatrack development

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/BuildFile.xml
@@ -1,5 +1,4 @@
 <iftool name="cuda-gcc-support">
-  <use name="cub"/>
   <use name="cuda"/>
   <use name="eigen"/>
   <use name="FWCore/Utilities"/>

--- a/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h
@@ -9,10 +9,6 @@
 #include <cstdint>
 #include <type_traits>
 
-#ifdef __CUDACC__
-#include <cub/cub.cuh>
-#endif
-
 #include "HeterogeneousCore/CUDAUtilities/interface/AtomicPairCounter.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h"
@@ -55,54 +51,52 @@ namespace cms {
     }
 
     template <typename Histo>
-    inline void launchZero(Histo *__restrict__ h,
-                           cudaStream_t stream
+    inline __attribute__((always_inline)) void launchZero(Histo *__restrict__ h,
+                                                          cudaStream_t stream
 #ifndef __CUDACC__
-                           = cudaStreamDefault
+                                                          = cudaStreamDefault
 #endif
     ) {
-      uint32_t *off = (uint32_t *)((char *)(h) + offsetof(Histo, off));
+      uint32_t *poff = (uint32_t *)((char *)(h) + offsetof(Histo, off));
+      int32_t size = offsetof(Histo, bins) - offsetof(Histo, off);
+      assert(size >= int(sizeof(uint32_t) * Histo::totbins()));
 #ifdef __CUDACC__
-      cudaCheck(cudaMemsetAsync(off, 0, 4 * Histo::totbins(), stream));
+      cudaCheck(cudaMemsetAsync(poff, 0, size, stream));
 #else
-      ::memset(off, 0, 4 * Histo::totbins());
+      ::memset(poff, 0, size);
 #endif
     }
 
     template <typename Histo>
-    inline void launchFinalize(Histo *__restrict__ h,
-                               uint8_t *__restrict__ ws
+    inline __attribute__((always_inline)) void launchFinalize(Histo *__restrict__ h,
+                                                              cudaStream_t stream
 #ifndef __CUDACC__
-                               = cudaStreamDefault
-#endif
-                               ,
-                               cudaStream_t stream
-#ifndef __CUDACC__
-                               = cudaStreamDefault
+                                                              = cudaStreamDefault
 #endif
     ) {
 #ifdef __CUDACC__
-      assert(ws);
-      uint32_t *off = (uint32_t *)((char *)(h) + offsetof(Histo, off));
-      size_t wss = Histo::wsSize();
-      assert(wss > 0);
-      CubDebugExit(cub::DeviceScan::InclusiveSum(ws, wss, off, off, Histo::totbins(), stream));
+      uint32_t *poff = (uint32_t *)((char *)(h) + offsetof(Histo, off));
+      int32_t *ppsws = (int32_t *)((char *)(h) + offsetof(Histo, psws));
+      auto nthreads = 1024;
+      auto nblocks = (Histo::totbins() + nthreads - 1) / nthreads;
+      multiBlockPrefixScan<<<nblocks, nthreads, sizeof(int32_t) * nblocks, stream>>>(
+          poff, poff, Histo::totbins(), ppsws);
+      cudaCheck(cudaGetLastError());
 #else
       h->finalize();
 #endif
     }
 
     template <typename Histo, typename T>
-    inline void fillManyFromVector(Histo *__restrict__ h,
-                                   uint8_t *__restrict__ ws,
-                                   uint32_t nh,
-                                   T const *__restrict__ v,
-                                   uint32_t const *__restrict__ offsets,
-                                   uint32_t totSize,
-                                   int nthreads,
-                                   cudaStream_t stream
+    inline __attribute__((always_inline)) void fillManyFromVector(Histo *__restrict__ h,
+                                                                  uint32_t nh,
+                                                                  T const *__restrict__ v,
+                                                                  uint32_t const *__restrict__ offsets,
+                                                                  uint32_t totSize,
+                                                                  int nthreads,
+                                                                  cudaStream_t stream
 #ifndef __CUDACC__
-                                   = cudaStreamDefault
+                                                                  = cudaStreamDefault
 #endif
     ) {
       launchZero(h, stream);
@@ -110,7 +104,7 @@ namespace cms {
       auto nblocks = (totSize + nthreads - 1) / nthreads;
       countFromVector<<<nblocks, nthreads, 0, stream>>>(h, nh, v, offsets);
       cudaCheck(cudaGetLastError());
-      launchFinalize(h, ws, stream);
+      launchFinalize(h, stream);
       fillFromVector<<<nblocks, nthreads, 0, stream>>>(h, nh, v, offsets);
       cudaCheck(cudaGetLastError());
 #else
@@ -186,18 +180,6 @@ namespace cms {
 
       static constexpr auto histOff(uint32_t nh) { return NBINS * nh; }
 
-      __host__ static size_t wsSize() {
-#ifdef __CUDACC__
-        uint32_t *v = nullptr;
-        void *d_temp_storage = nullptr;
-        size_t temp_storage_bytes = 0;
-        cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytes, v, v, totbins());
-        return temp_storage_bytes;
-#else
-        return 0;
-#endif
-      }
-
       static constexpr UT bin(T t) {
         constexpr uint32_t shift = sizeT() - nbits();
         constexpr uint32_t mask = (1 << nbits()) - 1;
@@ -209,7 +191,7 @@ namespace cms {
           i = 0;
       }
 
-      __host__ __device__ void add(CountersOnly const &co) {
+      __host__ __device__ __forceinline__ void add(CountersOnly const &co) {
         for (uint32_t i = 0; i < totbins(); ++i) {
 #ifdef __CUDA_ARCH__
           atomicAdd(off + i, co.off[i]);
@@ -325,6 +307,7 @@ namespace cms {
       constexpr index_type const *end(uint32_t b) const { return bins + off[b + 1]; }
 
       Counter off[totbins()];
+      int32_t psws;  // prefix-scan working space
       index_type bins[capacity()];
     };
 

--- a/HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h
@@ -1,0 +1,55 @@
+#ifndef HeterogeneousCore_CUDAUtilities_HostAllocator_h
+#define HeterogeneousCore_CUDAUtilities_HostAllocator_h
+
+#include <memory>
+#include <new>
+#include <cuda_runtime.h>
+
+namespace cms {
+  namespace cuda {
+
+    class bad_alloc : public std::bad_alloc {
+    public:
+      bad_alloc(cudaError_t error) noexcept : error_(error) {}
+
+      const char* what() const noexcept override { return cudaGetErrorString(error_); }
+
+    private:
+      cudaError_t error_;
+    };
+
+    template <typename T, unsigned int FLAGS = cudaHostAllocDefault>
+    class HostAllocator {
+    public:
+      using value_type = T;
+
+      template <typename U>
+      struct rebind {
+        using other = HostAllocator<U, FLAGS>;
+      };
+
+      T* allocate(std::size_t n) const __attribute__((warn_unused_result)) __attribute__((malloc))
+      __attribute__((returns_nonnull)) {
+        void* ptr = nullptr;
+        cudaError_t status = cudaMallocHost(&ptr, n * sizeof(T), FLAGS);
+        if (status != cudaSuccess) {
+          throw bad_alloc(status);
+        }
+        if (ptr == nullptr) {
+          throw std::bad_alloc();
+        }
+        return static_cast<T*>(ptr);
+      }
+
+      void deallocate(T* p, std::size_t n) const {
+        cudaError_t status = cudaFreeHost(p);
+        if (status != cudaSuccess) {
+          throw bad_alloc(status);
+        }
+      }
+    };
+
+  }  // namespace cuda
+}  // namespace cms
+
+#endif  // HeterogeneousCore_CUDAUtilities_HostAllocator_h

--- a/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h
@@ -127,15 +127,27 @@ namespace cms {
 #endif
     }
 
-    // limited to 1024*1024 elements....
+#ifdef __CUDA_ARCH__
+    // see https://stackoverflow.com/questions/40021086/can-i-obtain-the-amount-of-allocated-dynamic-shared-memory-from-within-a-kernel/40021087#40021087
+    __device__ __forceinline__ unsigned dynamic_smem_size() {
+      unsigned ret;
+      asm volatile("mov.u32 %0, %dynamic_smem_size;" : "=r"(ret));
+      return ret;
+    }
+#endif
+
+    // in principle not limited....
     template <typename T>
-    __global__ void multiBlockPrefixScan(T const* __restrict__ ci, T* __restrict__ co, int32_t size, int32_t* pc) {
+    __global__ void multiBlockPrefixScan(T const* ci, T* co, int32_t size, int32_t* pc) {
       __shared__ T ws[32];
-      // first each block does a scan of size 1024; (better be enough blocks....)
-      assert(1024 * gridDim.x >= size);
-      int off = 1024 * blockIdx.x;
+#ifdef __CUDA_ARCH__
+      assert(sizeof(T) * gridDim.x <= dynamic_smem_size());  // size of psum below
+#endif
+      assert(blockDim.x * gridDim.x >= size);
+      // first each block does a scan
+      int off = blockDim.x * blockIdx.x;
       if (size - off > 0)
-        blockPrefixScan(ci + off, co + off, std::min(1024, size - off), ws);
+        blockPrefixScan(ci + off, co + off, std::min(int(blockDim.x), size - off), ws);
 
       // count blocks that finished
       __shared__ bool isLastBlockDone;
@@ -149,25 +161,24 @@ namespace cms {
       if (!isLastBlockDone)
         return;
 
+      assert(int(gridDim.x) == *pc);
+
       // good each block has done its work and now we are left in last block
 
       // let's get the partial sums from each block
-      __shared__ T psum[1024];
+      extern __shared__ T psum[];
       for (int i = threadIdx.x, ni = gridDim.x; i < ni; i += blockDim.x) {
-        auto j = 1024 * i + 1023;
+        auto j = blockDim.x * i + blockDim.x - 1;
         psum[i] = (j < size) ? co[j] : T(0);
       }
       __syncthreads();
       blockPrefixScan(psum, psum, gridDim.x, ws);
 
       // now it would have been handy to have the other blocks around...
-      int first = threadIdx.x;                                 // + blockDim.x * blockIdx.x
-      for (int i = first + 1024; i < size; i += blockDim.x) {  //  *gridDim.x) {
-        auto k = i / 1024;                                     // block
-        co[i] += psum[k - 1];
+      for (int i = threadIdx.x + blockDim.x, k = 0; i < size; i += blockDim.x, ++k) {
+        co[i] += psum[k];
       }
     }
-
   }  // namespace cuda
 }  // namespace cms
 

--- a/HeterogeneousCore/CUDAUtilities/src/CachingHostAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/src/CachingHostAllocator.h
@@ -41,9 +41,9 @@
 #include <cmath>
 #include <map>
 #include <set>
+#include <mutex>
 
-#include <cub/util_debug.cuh>
-#include <cub/host/mutex.cuh>
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 /// CUB namespace
 namespace notcub {
@@ -212,7 +212,7 @@ namespace notcub {
     // Fields
     //---------------------------------------------------------------------
 
-    cub::Mutex mutex;  /// Mutex for thread-safety
+    std::mutex mutex;  /// Mutex for thread-safety
 
     unsigned int bin_growth;  /// Geometric growth factor for bin-sizes
     unsigned int min_bin;     /// Minimum bin enumeration
@@ -291,17 +291,17 @@ namespace notcub {
      */
     void SetMaxCachedBytes(size_t max_cached_bytes) {
       // Lock
-      mutex.Lock();
+      mutex.lock();
 
       if (debug)
-        _CubLog("Changing max_cached_bytes (%lld -> %lld)\n",
-                (long long)this->max_cached_bytes,
-                (long long)max_cached_bytes);
+        printf("Changing max_cached_bytes (%lld -> %lld)\n",
+               (long long)this->max_cached_bytes,
+               (long long)max_cached_bytes);
 
       this->max_cached_bytes = max_cached_bytes;
 
       // Unlock
-      mutex.Unlock();
+      mutex.unlock();
     }
 
     /**
@@ -318,8 +318,7 @@ namespace notcub {
       int device = INVALID_DEVICE_ORDINAL;
       cudaError_t error = cudaSuccess;
 
-      if (CubDebug(error = cudaGetDevice(&device)))
-        return error;
+      cudaCheck(error = cudaGetDevice(&device));
 
       // Create a block descriptor for the requested allocation
       bool found = false;
@@ -336,7 +335,7 @@ namespace notcub {
         search_key.bytes = bytes;
       } else {
         // Search for a suitable cached allocation: lock
-        mutex.Lock();
+        mutex.lock();
 
         if (search_key.bin < min_bin) {
           // Bin is less than minimum bin: round up
@@ -356,14 +355,10 @@ namespace notcub {
             search_key.associated_stream = active_stream;
             if (search_key.device != device) {
               // If "associated" device changes, need to re-create the event on the right device
-              if (CubDebug(error = cudaSetDevice(search_key.device)))
-                return error;
-              if (CubDebug(error = cudaEventDestroy(search_key.ready_event)))
-                return error;
-              if (CubDebug(error = cudaSetDevice(device)))
-                return error;
-              if (CubDebug(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming)))
-                return error;
+              cudaCheck(error = cudaSetDevice(search_key.device));
+              cudaCheck(error = cudaEventDestroy(search_key.ready_event));
+              cudaCheck(error = cudaSetDevice(device));
+              cudaCheck(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming));
               search_key.device = device;
             }
 
@@ -374,7 +369,7 @@ namespace notcub {
             cached_bytes.live += search_key.bytes;
 
             if (debug)
-              _CubLog(
+              printf(
                   "\tHost reused cached block at %p (%lld bytes) for stream %lld, event %lld on device %lld "
                   "(previously associated with stream %lld, event %lld).\n",
                   search_key.d_ptr,
@@ -393,18 +388,18 @@ namespace notcub {
         }
 
         // Done searching: unlock
-        mutex.Unlock();
+        mutex.unlock();
       }
 
       // Allocate the block if necessary
       if (!found) {
         // Attempt to allocate
         // TODO: eventually support allocation flags
-        if (CubDebug(error = cudaHostAlloc(&search_key.d_ptr, search_key.bytes, cudaHostAllocDefault)) ==
+        if ((error = cudaHostAlloc(&search_key.d_ptr, search_key.bytes, cudaHostAllocDefault)) ==
             cudaErrorMemoryAllocation) {
           // The allocation attempt failed: free all cached blocks on device and retry
           if (debug)
-            _CubLog(
+            printf(
                 "\tHost failed to allocate %lld bytes for stream %lld on device %lld, retrying after freeing cached "
                 "allocations",
                 (long long)search_key.bytes,
@@ -415,7 +410,7 @@ namespace notcub {
           cudaGetLastError();   // Reset CUDART's error
 
           // Lock
-          mutex.Lock();
+          mutex.lock();
 
           // Iterate the range of free blocks
           CachedBlocks::iterator block_itr = cached_blocks.begin();
@@ -426,16 +421,16 @@ namespace notcub {
             // on the current device
 
             // Free pinned host memory.
-            if (CubDebug(error = cudaFreeHost(block_itr->d_ptr)))
+            if ((error = cudaFreeHost(block_itr->d_ptr)))
               break;
-            if (CubDebug(error = cudaEventDestroy(block_itr->ready_event)))
+            if ((error = cudaEventDestroy(block_itr->ready_event)))
               break;
 
             // Reduce balance and erase entry
             cached_bytes.free -= block_itr->bytes;
 
             if (debug)
-              _CubLog(
+              printf(
                   "\tHost freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld "
                   "bytes) outstanding.\n",
                   (long long)block_itr->bytes,
@@ -450,29 +445,27 @@ namespace notcub {
           }
 
           // Unlock
-          mutex.Unlock();
+          mutex.unlock();
 
           // Return under error
           if (error)
             return error;
 
           // Try to allocate again
-          if (CubDebug(error = cudaHostAlloc(&search_key.d_ptr, search_key.bytes, cudaHostAllocDefault)))
-            return error;
+          cudaCheck(error = cudaHostAlloc(&search_key.d_ptr, search_key.bytes, cudaHostAllocDefault));
         }
 
         // Create ready event
-        if (CubDebug(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming)))
-          return error;
+        cudaCheck(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming));
 
         // Insert into live blocks
-        mutex.Lock();
+        mutex.lock();
         live_blocks.insert(search_key);
         cached_bytes.live += search_key.bytes;
-        mutex.Unlock();
+        mutex.unlock();
 
         if (debug)
-          _CubLog(
+          printf(
               "\tHost allocated new host block at %p (%lld bytes associated with stream %lld, event %lld on device "
               "%lld).\n",
               search_key.d_ptr,
@@ -486,11 +479,11 @@ namespace notcub {
       *d_ptr = search_key.d_ptr;
 
       if (debug)
-        _CubLog("\t\t%lld available blocks cached (%lld bytes), %lld live blocks outstanding(%lld bytes).\n",
-                (long long)cached_blocks.size(),
-                (long long)cached_bytes.free,
-                (long long)live_blocks.size(),
-                (long long)cached_bytes.live);
+        printf("\t\t%lld available blocks cached (%lld bytes), %lld live blocks outstanding(%lld bytes).\n",
+               (long long)cached_blocks.size(),
+               (long long)cached_bytes.free,
+               (long long)live_blocks.size(),
+               (long long)cached_bytes.live);
 
       return error;
     }
@@ -505,7 +498,7 @@ namespace notcub {
       cudaError_t error = cudaSuccess;
 
       // Lock
-      mutex.Lock();
+      mutex.lock();
 
       // Find corresponding block descriptor
       bool recached = false;
@@ -525,7 +518,7 @@ namespace notcub {
           cached_bytes.free += search_key.bytes;
 
           if (debug)
-            _CubLog(
+            printf(
                 "\tHost returned %lld bytes from associated stream %lld, event %lld on device %lld.\n\t\t %lld "
                 "available blocks cached (%lld bytes), %lld live blocks outstanding. (%lld bytes)\n",
                 (long long)search_key.bytes,
@@ -539,31 +532,26 @@ namespace notcub {
         }
       }
 
-      if (CubDebug(error = cudaGetDevice(&entrypoint_device)))
-        return error;
+      cudaCheck(error = cudaGetDevice(&entrypoint_device));
       if (entrypoint_device != search_key.device) {
-        if (CubDebug(error = cudaSetDevice(search_key.device)))
-          return error;
+        cudaCheck(error = cudaSetDevice(search_key.device));
       }
 
       if (recached) {
         // Insert the ready event in the associated stream (must have current device set properly)
-        if (CubDebug(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream)))
-          return error;
+        cudaCheck(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream));
       }
 
       // Unlock
-      mutex.Unlock();
+      mutex.unlock();
 
       if (!recached) {
         // Free the allocation from the runtime and cleanup the event.
-        if (CubDebug(error = cudaFreeHost(d_ptr)))
-          return error;
-        if (CubDebug(error = cudaEventDestroy(search_key.ready_event)))
-          return error;
+        cudaCheck(error = cudaFreeHost(d_ptr));
+        cudaCheck(error = cudaEventDestroy(search_key.ready_event));
 
         if (debug)
-          _CubLog(
+          printf(
               "\tHost freed %lld bytes from associated stream %lld, event %lld on device %lld.\n\t\t  %lld available "
               "blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
               (long long)search_key.bytes,
@@ -578,8 +566,7 @@ namespace notcub {
 
       // Reset device
       if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != search_key.device)) {
-        if (CubDebug(error = cudaSetDevice(entrypoint_device)))
-          return error;
+        cudaCheck(error = cudaSetDevice(entrypoint_device));
       }
 
       return error;
@@ -593,7 +580,7 @@ namespace notcub {
       int entrypoint_device = INVALID_DEVICE_ORDINAL;
       int current_device = INVALID_DEVICE_ORDINAL;
 
-      mutex.Lock();
+      mutex.lock();
 
       while (!cached_blocks.empty()) {
         // Get first block
@@ -601,28 +588,28 @@ namespace notcub {
 
         // Get entry-point device ordinal if necessary
         if (entrypoint_device == INVALID_DEVICE_ORDINAL) {
-          if (CubDebug(error = cudaGetDevice(&entrypoint_device)))
+          if ((error = cudaGetDevice(&entrypoint_device)))
             break;
         }
 
         // Set current device ordinal if necessary
         if (begin->device != current_device) {
-          if (CubDebug(error = cudaSetDevice(begin->device)))
+          if ((error = cudaSetDevice(begin->device)))
             break;
           current_device = begin->device;
         }
 
         // Free host memory
-        if (CubDebug(error = cudaFreeHost(begin->d_ptr)))
+        if ((error = cudaFreeHost(begin->d_ptr)))
           break;
-        if (CubDebug(error = cudaEventDestroy(begin->ready_event)))
+        if ((error = cudaEventDestroy(begin->ready_event)))
           break;
 
         // Reduce balance and erase entry
         cached_bytes.free -= begin->bytes;
 
         if (debug)
-          _CubLog(
+          printf(
               "\tHost freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld "
               "bytes) outstanding.\n",
               (long long)begin->bytes,
@@ -634,12 +621,11 @@ namespace notcub {
         cached_blocks.erase(begin);
       }
 
-      mutex.Unlock();
+      mutex.unlock();
 
       // Attempt to revert back to entry-point device if necessary
       if (entrypoint_device != INVALID_DEVICE_ORDINAL) {
-        if (CubDebug(error = cudaSetDevice(entrypoint_device)))
-          return error;
+        cudaCheck(error = cudaSetDevice(entrypoint_device));
       }
 
       return error;

--- a/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
@@ -1,30 +1,39 @@
 <use name="HeterogeneousCore/CUDAUtilities"/>
 <iftool name="cuda-gcc-support">
   <bin file="assert_t.cu" name="cudaAssert_t">
-</bin>
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
 
   <bin file="assert_t.cu" name="cudaAssert_debug">
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
-  <bin file="test_SimpleVector.cu" name="test_SimpleVector">
+  <bin file="test_SimpleVector.cu" name="gpuSimpleVector_t">
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
+
+  <bin file="test_SimpleVector.cu" name="gpuSimpleVector_debug">
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
   <bin file="cudastdAlgorithm_t.cpp">
-</bin>
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
 
   <bin file="cudastdAlgorithm_t.cu" name="gpuCudastdAlgorithm_t">
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
+
+  <bin file="cudastdAlgorithm_t.cu" name="gpuCudastdAlgorithm_debug">
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
   <bin file="radixSort_t.cu" name="gpuRadixSort_t">
-    <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
+    <flags CUDA_FLAGS="-g"/>
   </bin>
 
   <bin file="radixSort_t.cu" name="gpuRadixSort_debug">
-    <flags CUDA_FLAGS="-g -G -DGPU_DEBUG"/>
-    <flags REM_CUDA_FLAGS="--generate-line-info -lineinfo"/>
+    <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
   <bin file="HistoContainer_t.cpp">
@@ -32,36 +41,46 @@
   </bin>
 
   <bin file="HistoContainer_t.cu" name="gpuHistoContainer_t">
-    <use name="cub"/>
-    <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
+    <flags CUDA_FLAGS="-g"/>
   </bin>
 
   <bin file="HistoContainer_t.cu" name="gpuHistoContainer_debug">
-    <use name="cub"/>
-    <flags CUDA_FLAGS="-g -G -DGPU_DEBUG"/>
-    <flags REM_CUDA_FLAGS="--generate-line-info -lineinfo"/>
+    <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
   <bin file="OneHistoContainer_t.cu" name="gpuOneHistoContainer_t">
-    <use name="cub"/>
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
+
+  <bin file="OneHistoContainer_t.cu" name="gpuOneHistoContainer_debug">
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
   <bin file="AtomicPairCounter_t.cu" name="gpuAtomicPairCounter_t">
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
+
+  <bin file="AtomicPairCounter_t.cu" name="gpuAtomicPairCounter_debug">
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
   <bin file="OneToManyAssoc_t.cu" name="gpuOneToManyAssoc_t">
-    <use name="cub"/>
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
+
+  <bin file="OneToManyAssoc_t.cu" name="gpuOneToManyAssoc_debug">
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
   <bin file="OneToManyAssoc_t.cpp" name="cpuOneToManyAssoc_t">
-    <flags CXXFLAGS="-g -DGPU_DEBUG"/>
+    <flags CXXFLAGS="-g"/>
   </bin>
 
   <bin file="prefixScan_t.cu" name="gpuPrefixScan_t">
-    <use name="cub"/>
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
+
+  <bin file="prefixScan_t.cu" name="gpuPrefixScan_debug">
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
@@ -71,13 +90,18 @@
 
   <bin file="eigenSoA_t.cpp" name="cpuEigenSoA_t">
     <use name="eigen"/>
-    <flags CXXFLAGS="-g -DGPU_DEBUG"/>
+    <flags CXXFLAGS="-g"/>
   </bin>
 
   <bin file="eigenSoA_t.cu" name="gpuEigenSoA_t">
     <use name="eigen"/>
+    <flags CUDA_FLAGS="-g"/>
+    <flags CXXFLAGS="-g"/>
+  </bin>
+
+  <bin file="eigenSoA_t.cu" name="gpuEigenSoA_debug">
+    <use name="eigen"/>
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
     <flags CXXFLAGS="-g -DGPU_DEBUG"/>
   </bin>
-
 </iftool>

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
@@ -28,12 +28,11 @@ void go() {
 
   using Hist = HistoContainer<T, 128, N, 8 * sizeof(T), uint32_t, nParts>;
   std::cout << "HistoContainer " << (int)(offsetof(Hist, off)) << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
-            << Hist::capacity() << ' ' << Hist::wsSize() << ' '
+            << Hist::capacity() << ' ' << offsetof(Hist, bins) - offsetof(Hist, off) << ' '
             << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
 
   Hist h;
   auto h_d = make_device_unique<Hist[]>(1, nullptr);
-  auto ws_d = make_device_unique<uint8_t[]>(Hist::wsSize(), nullptr);
 
   auto off_d = make_device_unique<uint32_t[]>(nParts + 1, nullptr);
 
@@ -70,7 +69,7 @@ void go() {
 
     cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
 
-    fillManyFromVector(h_d.get(), ws_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, 0);
+    fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, 0);
     cudaCheck(cudaMemcpy(&h, h_d.get(), sizeof(Hist), cudaMemcpyDeviceToHost));
     assert(0 == h.off[0]);
     assert(offsets[10] == h.size());

--- a/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
+++ b/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
@@ -118,9 +118,9 @@ int main() {
   assert(gridDim.z == 1);
 #endif
 
-  std::cout << "OneToManyAssoc " << Assoc::nbins() << ' ' << Assoc::capacity() << ' ' << Assoc::wsSize() << std::endl;
-  std::cout << "OneToManyAssoc (small) " << SmallAssoc::nbins() << ' ' << SmallAssoc::capacity() << ' '
-            << SmallAssoc::wsSize() << std::endl;
+  std::cout << "OneToManyAssoc " << sizeof(Assoc) << ' ' << Assoc::nbins() << ' ' << Assoc::capacity() << std::endl;
+  std::cout << "OneToManyAssoc (small) " << sizeof(SmallAssoc) << ' ' << SmallAssoc::nbins() << ' '
+            << SmallAssoc::capacity() << std::endl;
 
   std::mt19937 eng;
 
@@ -169,8 +169,6 @@ int main() {
   assert(v_d.get());
   auto a_d = cms::cuda::make_device_unique<Assoc[]>(1, nullptr);
   auto sa_d = cms::cuda::make_device_unique<SmallAssoc[]>(1, nullptr);
-  auto ws_d = cms::cuda::make_device_unique<uint8_t[]>(Assoc::wsSize(), nullptr);
-
   cudaCheck(cudaMemcpy(v_d.get(), tr.data(), N * sizeof(std::array<uint16_t, 4>), cudaMemcpyHostToDevice));
 #else
   auto a_d = std::make_unique<Assoc>();
@@ -186,7 +184,7 @@ int main() {
 
   count<<<nBlocks, nThreads>>>(v_d.get(), a_d.get(), N);
 
-  launchFinalize(a_d.get(), ws_d.get(), 0);
+  launchFinalize(a_d.get(), 0);
   verify<<<1, 1>>>(a_d.get());
   fill<<<nBlocks, nThreads>>>(v_d.get(), a_d.get(), N);
 #else
@@ -287,8 +285,8 @@ int main() {
   countMultiLocal<<<nBlocks, nThreads>>>(v_d.get(), m2_d.get(), N);
   verifyMulti<<<1, Multiplicity::totbins()>>>(m1_d.get(), m2_d.get());
 
-  launchFinalize(m1_d.get(), ws_d.get(), 0);
-  launchFinalize(m2_d.get(), ws_d.get(), 0);
+  launchFinalize(m1_d.get(), 0);
+  launchFinalize(m2_d.get(), 0);
   verifyMulti<<<1, Multiplicity::totbins()>>>(m1_d.get(), m2_d.get());
 
   cudaCheck(cudaGetLastError());

--- a/HeterogeneousCore/CUDAUtilities/test/prefixScan_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/prefixScan_t.cu
@@ -1,7 +1,5 @@
 #include <iostream>
 
-#include <cub/cub.cuh>
-
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/prefixScan.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
@@ -134,34 +132,17 @@ int main() {
     // the block counter
     int32_t *d_pc;
     cudaCheck(cudaMalloc(&d_pc, sizeof(int32_t)));
-    cudaCheck(cudaMemset(d_pc, 0, 4));
+    cudaCheck(cudaMemset(d_pc, 0, sizeof(int32_t)));
 
     nthreads = 1024;
     nblocks = (num_items + nthreads - 1) / nthreads;
-    multiBlockPrefixScan<<<nblocks, nthreads, 0>>>(d_in, d_out1, num_items, d_pc);
+    std::cout << "launch multiBlockPrefixScan " << num_items << ' ' << nblocks << std::endl;
+    multiBlockPrefixScan<<<nblocks, nthreads, 4 * nblocks>>>(d_in, d_out1, num_items, d_pc);
+    cudaCheck(cudaGetLastError());
     verify<<<nblocks, nthreads, 0>>>(d_out1, num_items);
+    cudaCheck(cudaGetLastError());
     cudaDeviceSynchronize();
 
-    // test cub
-    std::cout << "cub" << std::endl;
-    // Determine temporary device storage requirements for inclusive prefix sum
-    void *d_temp_storage = nullptr;
-    size_t temp_storage_bytes = 0;
-    cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out2, num_items);
-
-    std::cout << "temp storage " << temp_storage_bytes << std::endl;
-
-    // Allocate temporary storage for inclusive prefix sum
-    // fake larger ws already available
-    temp_storage_bytes *= 8;
-    cudaCheck(cudaMalloc(&d_temp_storage, temp_storage_bytes));
-    std::cout << "temp storage " << temp_storage_bytes << std::endl;
-    // Run inclusive prefix sum
-    CubDebugExit(cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out2, num_items));
-    std::cout << "temp storage " << temp_storage_bytes << std::endl;
-
-    verify<<<nblocks, nthreads, 0>>>(d_out2, num_items);
-    cudaDeviceSynchronize();
   }  // ksize
   return 0;
 }


### PR DESCRIPTION
#### PR description:

Introduce an STL-compatible allocator for CUDA host memory.

Remove dependency on NVIDIA cub.

Replace the use of the prefix scan from cub with a home-brewed implementation, using dynamic instead of static shared memory.

Annotate all CMS-specific changes to CachingDeviceAllocator.

No changes to physics or timing performance.

#### PR validation:

See https://github.com/cms-patatrack/cmssw/pull/447 and https://github.com/cms-patatrack/cmssw/pull/449.
