### PR TITLE
add xml file and python customizer for D49 reco tracker material

### DIFF
--- a/Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/v2_ITonly/trackerRecoMaterial.xml
+++ b/Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/v2_ITonly/trackerRecoMaterial.xml
@@ -1,0 +1,618 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <SpecParSection label="spec-pars2.xml">
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelBarrelLayer1">
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule1Layer1/pixel:BModule1Layer1InnerPixelwafer/pixel:BModule1Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule2Layer1/pixel:BModule2Layer1InnerPixelwafer/pixel:BModule2Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule3Layer1/pixel:BModule3Layer1InnerPixelwafer/pixel:BModule3Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule4Layer1/pixel:BModule4Layer1InnerPixelwafer/pixel:BModule4Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule5Layer1/pixel:BModule5Layer1InnerPixelwafer/pixel:BModule5Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodFlipped1/pixel:BModule1Layer1/pixel:BModule1Layer1InnerPixelwafer/pixel:BModule1Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodFlipped1/pixel:BModule2Layer1/pixel:BModule2Layer1InnerPixelwafer/pixel:BModule2Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodFlipped1/pixel:BModule3Layer1/pixel:BModule3Layer1InnerPixelwafer/pixel:BModule3Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodFlipped1/pixel:BModule4Layer1/pixel:BModule4Layer1InnerPixelwafer/pixel:BModule4Layer1InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodFlipped1/pixel:BModule5Layer1/pixel:BModule5Layer1InnerPixelwafer/pixel:BModule5Layer1InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0233038" />
+<Parameter name="TrackerXi" value="4.68834e-05" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelBarrelLayer2">
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule1Layer2/pixel:BModule1Layer2InnerPixelwafer/pixel:BModule1Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule2Layer2/pixel:BModule2Layer2InnerPixelwafer/pixel:BModule2Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule3Layer2/pixel:BModule3Layer2InnerPixelwafer/pixel:BModule3Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule4Layer2/pixel:BModule4Layer2InnerPixelwafer/pixel:BModule4Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule5Layer2/pixel:BModule5Layer2InnerPixelwafer/pixel:BModule5Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodFlipped2/pixel:BModule1Layer2/pixel:BModule1Layer2InnerPixelwafer/pixel:BModule1Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodFlipped2/pixel:BModule2Layer2/pixel:BModule2Layer2InnerPixelwafer/pixel:BModule2Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodFlipped2/pixel:BModule3Layer2/pixel:BModule3Layer2InnerPixelwafer/pixel:BModule3Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodFlipped2/pixel:BModule4Layer2/pixel:BModule4Layer2InnerPixelwafer/pixel:BModule4Layer2InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodFlipped2/pixel:BModule5Layer2/pixel:BModule5Layer2InnerPixelwafer/pixel:BModule5Layer2InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0216167" />
+<Parameter name="TrackerXi" value="3.90594e-05" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelBarrelLayer3">
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule1Layer3/pixel:BModule1Layer3InnerPixelwafer/pixel:BModule1Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule2Layer3/pixel:BModule2Layer3InnerPixelwafer/pixel:BModule2Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule3Layer3/pixel:BModule3Layer3InnerPixelwafer/pixel:BModule3Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule4Layer3/pixel:BModule4Layer3InnerPixelwafer/pixel:BModule4Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule5Layer3/pixel:BModule5Layer3InnerPixelwafer/pixel:BModule5Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodFlipped3/pixel:BModule1Layer3/pixel:BModule1Layer3InnerPixelwafer/pixel:BModule1Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodFlipped3/pixel:BModule2Layer3/pixel:BModule2Layer3InnerPixelwafer/pixel:BModule2Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodFlipped3/pixel:BModule3Layer3/pixel:BModule3Layer3InnerPixelwafer/pixel:BModule3Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodFlipped3/pixel:BModule4Layer3/pixel:BModule4Layer3InnerPixelwafer/pixel:BModule4Layer3InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodFlipped3/pixel:BModule5Layer3/pixel:BModule5Layer3InnerPixelwafer/pixel:BModule5Layer3InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0183078" />
+<Parameter name="TrackerXi" value="3.37651e-05" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelBarrelLayer4">
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule1Layer4/pixel:BModule1Layer4InnerPixelwafer/pixel:BModule1Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule2Layer4/pixel:BModule2Layer4InnerPixelwafer/pixel:BModule2Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule3Layer4/pixel:BModule3Layer4InnerPixelwafer/pixel:BModule3Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule4Layer4/pixel:BModule4Layer4InnerPixelwafer/pixel:BModule4Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule5Layer4/pixel:BModule5Layer4InnerPixelwafer/pixel:BModule5Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodFlipped4/pixel:BModule1Layer4/pixel:BModule1Layer4InnerPixelwafer/pixel:BModule1Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodFlipped4/pixel:BModule2Layer4/pixel:BModule2Layer4InnerPixelwafer/pixel:BModule2Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodFlipped4/pixel:BModule3Layer4/pixel:BModule3Layer4InnerPixelwafer/pixel:BModule3Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodFlipped4/pixel:BModule4Layer4/pixel:BModule4Layer4InnerPixelwafer/pixel:BModule4Layer4InnerPixelActive" />
+<PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodFlipped4/pixel:BModule5Layer4/pixel:BModule5Layer4InnerPixelwafer/pixel:BModule5Layer4InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0292516" />
+<Parameter name="TrackerXi" value="6.87946e-05" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk1">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring1Disc1/pixel:EModule1Disc1/pixel:EModule1Disc1InnerPixelwafer/pixel:EModule1Disc1InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring2Disc1/pixel:EModule2Disc1/pixel:EModule2Disc1InnerPixelwafer/pixel:EModule2Disc1InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring3Disc1/pixel:EModule3Disc1/pixel:EModule3Disc1InnerPixelwafer/pixel:EModule3Disc1InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring4Disc1/pixel:EModule4Disc1/pixel:EModule4Disc1InnerPixelwafer/pixel:EModule4Disc1InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0519159" />
+<Parameter name="TrackerXi" value="0.000109782" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk2">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring1Disc2/pixel:EModule1Disc2/pixel:EModule1Disc2InnerPixelwafer/pixel:EModule1Disc2InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring2Disc2/pixel:EModule2Disc2/pixel:EModule2Disc2InnerPixelwafer/pixel:EModule2Disc2InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring3Disc2/pixel:EModule3Disc2/pixel:EModule3Disc2InnerPixelwafer/pixel:EModule3Disc2InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring4Disc2/pixel:EModule4Disc2/pixel:EModule4Disc2InnerPixelwafer/pixel:EModule4Disc2InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0500891" />
+<Parameter name="TrackerXi" value="0.000109366" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk3">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring1Disc3/pixel:EModule1Disc3/pixel:EModule1Disc3InnerPixelwafer/pixel:EModule1Disc3InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring2Disc3/pixel:EModule2Disc3/pixel:EModule2Disc3InnerPixelwafer/pixel:EModule2Disc3InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring3Disc3/pixel:EModule3Disc3/pixel:EModule3Disc3InnerPixelwafer/pixel:EModule3Disc3InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring4Disc3/pixel:EModule4Disc3/pixel:EModule4Disc3InnerPixelwafer/pixel:EModule4Disc3InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0577642" />
+<Parameter name="TrackerXi" value="0.000127312" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk4">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring1Disc4/pixel:EModule1Disc4/pixel:EModule1Disc4InnerPixelwafer/pixel:EModule1Disc4InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring2Disc4/pixel:EModule2Disc4/pixel:EModule2Disc4InnerPixelwafer/pixel:EModule2Disc4InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring3Disc4/pixel:EModule3Disc4/pixel:EModule3Disc4InnerPixelwafer/pixel:EModule3Disc4InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring4Disc4/pixel:EModule4Disc4/pixel:EModule4Disc4InnerPixelwafer/pixel:EModule4Disc4InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0657356" />
+<Parameter name="TrackerXi" value="0.000147819" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk5">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring1Disc5/pixel:EModule1Disc5/pixel:EModule1Disc5InnerPixelwafer/pixel:EModule1Disc5InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring2Disc5/pixel:EModule2Disc5/pixel:EModule2Disc5InnerPixelwafer/pixel:EModule2Disc5InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring3Disc5/pixel:EModule3Disc5/pixel:EModule3Disc5InnerPixelwafer/pixel:EModule3Disc5InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring4Disc5/pixel:EModule4Disc5/pixel:EModule4Disc5InnerPixelwafer/pixel:EModule4Disc5InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0634196" />
+<Parameter name="TrackerXi" value="0.000148421" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk6">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring1Disc6/pixel:EModule1Disc6/pixel:EModule1Disc6InnerPixelwafer/pixel:EModule1Disc6InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring2Disc6/pixel:EModule2Disc6/pixel:EModule2Disc6InnerPixelwafer/pixel:EModule2Disc6InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring3Disc6/pixel:EModule3Disc6/pixel:EModule3Disc6InnerPixelwafer/pixel:EModule3Disc6InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring4Disc6/pixel:EModule4Disc6/pixel:EModule4Disc6InnerPixelwafer/pixel:EModule4Disc6InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0739528" />
+<Parameter name="TrackerXi" value="0.000180459" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk7">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring1Disc7/pixel:EModule1Disc7/pixel:EModule1Disc7InnerPixelwafer/pixel:EModule1Disc7InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring2Disc7/pixel:EModule2Disc7/pixel:EModule2Disc7InnerPixelwafer/pixel:EModule2Disc7InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring3Disc7/pixel:EModule3Disc7/pixel:EModule3Disc7InnerPixelwafer/pixel:EModule3Disc7InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring4Disc7/pixel:EModule4Disc7/pixel:EModule4Disc7InnerPixelwafer/pixel:EModule4Disc7InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0634872" />
+<Parameter name="TrackerXi" value="0.000135391" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk8">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring1Disc8/pixel:EModule1Disc8/pixel:EModule1Disc8InnerPixelwafer/pixel:EModule1Disc8InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring2Disc8/pixel:EModule2Disc8/pixel:EModule2Disc8InnerPixelwafer/pixel:EModule2Disc8InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring3Disc8/pixel:EModule3Disc8/pixel:EModule3Disc8InnerPixelwafer/pixel:EModule3Disc8InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring4Disc8/pixel:EModule4Disc8/pixel:EModule4Disc8InnerPixelwafer/pixel:EModule4Disc8InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0433525" />
+<Parameter name="TrackerXi" value="8.79861e-05" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk9">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring1Disc9/pixel:EModule1Disc9/pixel:EModule1Disc9InnerPixelwafer/pixel:EModule1Disc9InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring2Disc9/pixel:EModule2Disc9/pixel:EModule2Disc9InnerPixelwafer/pixel:EModule2Disc9InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring3Disc9/pixel:EModule3Disc9/pixel:EModule3Disc9InnerPixelwafer/pixel:EModule3Disc9InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring4Disc9/pixel:EModule4Disc9/pixel:EModule4Disc9InnerPixelwafer/pixel:EModule4Disc9InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring5Disc9/pixel:EModule5Disc9/pixel:EModule5Disc9InnerPixelwafer/pixel:EModule5Disc9InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0934577" />
+<Parameter name="TrackerXi" value="0.000210661" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk10">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring1Disc10/pixel:EModule1Disc10/pixel:EModule1Disc10InnerPixelwafer/pixel:EModule1Disc10InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring2Disc10/pixel:EModule2Disc10/pixel:EModule2Disc10InnerPixelwafer/pixel:EModule2Disc10InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring3Disc10/pixel:EModule3Disc10/pixel:EModule3Disc10InnerPixelwafer/pixel:EModule3Disc10InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring4Disc10/pixel:EModule4Disc10/pixel:EModule4Disc10InnerPixelwafer/pixel:EModule4Disc10InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring5Disc10/pixel:EModule5Disc10/pixel:EModule5Disc10InnerPixelwafer/pixel:EModule5Disc10InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0474711" />
+<Parameter name="TrackerXi" value="9.59777e-05" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk11">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring1Disc11/pixel:EModule1Disc11/pixel:EModule1Disc11InnerPixelwafer/pixel:EModule1Disc11InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring2Disc11/pixel:EModule2Disc11/pixel:EModule2Disc11InnerPixelwafer/pixel:EModule2Disc11InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring3Disc11/pixel:EModule3Disc11/pixel:EModule3Disc11InnerPixelwafer/pixel:EModule3Disc11InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring4Disc11/pixel:EModule4Disc11/pixel:EModule4Disc11InnerPixelwafer/pixel:EModule4Disc11InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring5Disc11/pixel:EModule5Disc11/pixel:EModule5Disc11InnerPixelwafer/pixel:EModule5Disc11InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.044586" />
+<Parameter name="TrackerXi" value="8.96631e-05" />
+</SpecPar>
+
+<SpecPar eval="true" name="TrackerRecMaterialPhase2PixelForwardDisk12">
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring1Disc12/pixel:EModule1Disc12/pixel:EModule1Disc12InnerPixelwafer/pixel:EModule1Disc12InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring2Disc12/pixel:EModule2Disc12/pixel:EModule2Disc12InnerPixelwafer/pixel:EModule2Disc12InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring3Disc12/pixel:EModule3Disc12/pixel:EModule3Disc12InnerPixelwafer/pixel:EModule3Disc12InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring4Disc12/pixel:EModule4Disc12/pixel:EModule4Disc12InnerPixelwafer/pixel:EModule4Disc12InnerPixelActive" />
+<PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring5Disc12/pixel:EModule5Disc12/pixel:EModule5Disc12InnerPixelwafer/pixel:EModule5Disc12InnerPixelActive" />
+<Parameter name="TrackerRadLength" value="0.0202046" />
+<Parameter name="TrackerXi" value="4.26613e-05" />
+</SpecPar>
+
+
+<SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer1" eval="true">
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule1Layer1/BModule1Layer1Lowerwafer/BModule1Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule1Layer1/BModule1Layer1Upperwafer/BModule1Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule2Layer1/BModule2Layer1Lowerwafer/BModule2Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule2Layer1/BModule2Layer1Upperwafer/BModule2Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule3Layer1/BModule3Layer1Lowerwafer/BModule3Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule3Layer1/BModule3Layer1Upperwafer/BModule3Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule4Layer1/BModule4Layer1Lowerwafer/BModule4Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule4Layer1/BModule4Layer1Upperwafer/BModule4Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring5Layer1Minus/tracker:BModule5Layer1/BModule5Layer1Lowerwafer/BModule5Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring5Layer1Minus/tracker:BModule5Layer1/BModule5Layer1Upperwafer/BModule5Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring6Layer1Minus/tracker:BModule6Layer1/BModule6Layer1Lowerwafer/BModule6Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring6Layer1Minus/tracker:BModule6Layer1/BModule6Layer1Upperwafer/BModule6Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring7Layer1Minus/tracker:BModule7Layer1/BModule7Layer1Lowerwafer/BModule7Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring7Layer1Minus/tracker:BModule7Layer1/BModule7Layer1Upperwafer/BModule7Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring8Layer1Minus/tracker:BModule8Layer1/BModule8Layer1Lowerwafer/BModule8Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring8Layer1Minus/tracker:BModule8Layer1/BModule8Layer1Upperwafer/BModule8Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring9Layer1Minus/tracker:BModule9Layer1/BModule9Layer1Lowerwafer/BModule9Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring9Layer1Minus/tracker:BModule9Layer1/BModule9Layer1Upperwafer/BModule9Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring10Layer1Minus/tracker:BModule10Layer1/BModule10Layer1Lowerwafer/BModule10Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring10Layer1Minus/tracker:BModule10Layer1/BModule10Layer1Upperwafer/BModule10Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring11Layer1Minus/tracker:BModule11Layer1/BModule11Layer1Lowerwafer/BModule11Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring11Layer1Minus/tracker:BModule11Layer1/BModule11Layer1Upperwafer/BModule11Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring12Layer1Minus/tracker:BModule12Layer1/BModule12Layer1Lowerwafer/BModule12Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring12Layer1Minus/tracker:BModule12Layer1/BModule12Layer1Upperwafer/BModule12Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring13Layer1Minus/tracker:BModule13Layer1/BModule13Layer1Lowerwafer/BModule13Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring13Layer1Minus/tracker:BModule13Layer1/BModule13Layer1Upperwafer/BModule13Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring14Layer1Minus/tracker:BModule14Layer1/BModule14Layer1Lowerwafer/BModule14Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring14Layer1Minus/tracker:BModule14Layer1/BModule14Layer1Upperwafer/BModule14Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring15Layer1Minus/tracker:BModule15Layer1/BModule15Layer1Lowerwafer/BModule15Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring15Layer1Minus/tracker:BModule15Layer1/BModule15Layer1Upperwafer/BModule15Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring16Layer1Minus/tracker:BModule16Layer1/BModule16Layer1Lowerwafer/BModule16Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring16Layer1Minus/tracker:BModule16Layer1/BModule16Layer1Upperwafer/BModule16Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring5Layer1Plus/tracker:BModule5Layer1/BModule5Layer1Lowerwafer/BModule5Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring5Layer1Plus/tracker:BModule5Layer1/BModule5Layer1Upperwafer/BModule5Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring6Layer1Plus/tracker:BModule6Layer1/BModule6Layer1Lowerwafer/BModule6Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring6Layer1Plus/tracker:BModule6Layer1/BModule6Layer1Upperwafer/BModule6Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring7Layer1Plus/tracker:BModule7Layer1/BModule7Layer1Lowerwafer/BModule7Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring7Layer1Plus/tracker:BModule7Layer1/BModule7Layer1Upperwafer/BModule7Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring8Layer1Plus/tracker:BModule8Layer1/BModule8Layer1Lowerwafer/BModule8Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring8Layer1Plus/tracker:BModule8Layer1/BModule8Layer1Upperwafer/BModule8Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring9Layer1Plus/tracker:BModule9Layer1/BModule9Layer1Lowerwafer/BModule9Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring9Layer1Plus/tracker:BModule9Layer1/BModule9Layer1Upperwafer/BModule9Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring10Layer1Plus/tracker:BModule10Layer1/BModule10Layer1Lowerwafer/BModule10Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring10Layer1Plus/tracker:BModule10Layer1/BModule10Layer1Upperwafer/BModule10Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring11Layer1Plus/tracker:BModule11Layer1/BModule11Layer1Lowerwafer/BModule11Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring11Layer1Plus/tracker:BModule11Layer1/BModule11Layer1Upperwafer/BModule11Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring12Layer1Plus/tracker:BModule12Layer1/BModule12Layer1Lowerwafer/BModule12Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring12Layer1Plus/tracker:BModule12Layer1/BModule12Layer1Upperwafer/BModule12Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring13Layer1Plus/tracker:BModule13Layer1/BModule13Layer1Lowerwafer/BModule13Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring13Layer1Plus/tracker:BModule13Layer1/BModule13Layer1Upperwafer/BModule13Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring14Layer1Plus/tracker:BModule14Layer1/BModule14Layer1Lowerwafer/BModule14Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring14Layer1Plus/tracker:BModule14Layer1/BModule14Layer1Upperwafer/BModule14Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring15Layer1Plus/tracker:BModule15Layer1/BModule15Layer1Lowerwafer/BModule15Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring15Layer1Plus/tracker:BModule15Layer1/BModule15Layer1Upperwafer/BModule15Layer1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring16Layer1Plus/tracker:BModule16Layer1/BModule16Layer1Lowerwafer/BModule16Layer1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Ring16Layer1Plus/tracker:BModule16Layer1/BModule16Layer1Upperwafer/BModule16Layer1UpperPSStripactive"/>
+<Parameter name="TrackerRadLength" value="0.0412022"/>
+<Parameter name="TrackerXi" value="8.24044e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer2" eval="true">
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule1Layer2/BModule1Layer2Lowerwafer/BModule1Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule1Layer2/BModule1Layer2Upperwafer/BModule1Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule2Layer2/BModule2Layer2Lowerwafer/BModule2Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule2Layer2/BModule2Layer2Upperwafer/BModule2Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule3Layer2/BModule3Layer2Lowerwafer/BModule3Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule3Layer2/BModule3Layer2Upperwafer/BModule3Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule4Layer2/BModule4Layer2Lowerwafer/BModule4Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule4Layer2/BModule4Layer2Upperwafer/BModule4Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule5Layer2/BModule5Layer2Lowerwafer/BModule5Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule5Layer2/BModule5Layer2Upperwafer/BModule5Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule6Layer2/BModule6Layer2Lowerwafer/BModule6Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule6Layer2/BModule6Layer2Upperwafer/BModule6Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring7Layer2Minus/tracker:BModule7Layer2/BModule7Layer2Lowerwafer/BModule7Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring7Layer2Minus/tracker:BModule7Layer2/BModule7Layer2Upperwafer/BModule7Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring8Layer2Minus/tracker:BModule8Layer2/BModule8Layer2Lowerwafer/BModule8Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring8Layer2Minus/tracker:BModule8Layer2/BModule8Layer2Upperwafer/BModule8Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring9Layer2Minus/tracker:BModule9Layer2/BModule9Layer2Lowerwafer/BModule9Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring9Layer2Minus/tracker:BModule9Layer2/BModule9Layer2Upperwafer/BModule9Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring10Layer2Minus/tracker:BModule10Layer2/BModule10Layer2Lowerwafer/BModule10Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring10Layer2Minus/tracker:BModule10Layer2/BModule10Layer2Upperwafer/BModule10Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring11Layer2Minus/tracker:BModule11Layer2/BModule11Layer2Lowerwafer/BModule11Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring11Layer2Minus/tracker:BModule11Layer2/BModule11Layer2Upperwafer/BModule11Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring12Layer2Minus/tracker:BModule12Layer2/BModule12Layer2Lowerwafer/BModule12Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring12Layer2Minus/tracker:BModule12Layer2/BModule12Layer2Upperwafer/BModule12Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring13Layer2Minus/tracker:BModule13Layer2/BModule13Layer2Lowerwafer/BModule13Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring13Layer2Minus/tracker:BModule13Layer2/BModule13Layer2Upperwafer/BModule13Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring14Layer2Minus/tracker:BModule14Layer2/BModule14Layer2Lowerwafer/BModule14Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring14Layer2Minus/tracker:BModule14Layer2/BModule14Layer2Upperwafer/BModule14Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring15Layer2Minus/tracker:BModule15Layer2/BModule15Layer2Lowerwafer/BModule15Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring15Layer2Minus/tracker:BModule15Layer2/BModule15Layer2Upperwafer/BModule15Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring16Layer2Minus/tracker:BModule16Layer2/BModule16Layer2Lowerwafer/BModule16Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring16Layer2Minus/tracker:BModule16Layer2/BModule16Layer2Upperwafer/BModule16Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring17Layer2Minus/tracker:BModule17Layer2/BModule17Layer2Lowerwafer/BModule17Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring17Layer2Minus/tracker:BModule17Layer2/BModule17Layer2Upperwafer/BModule17Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring18Layer2Minus/tracker:BModule18Layer2/BModule18Layer2Lowerwafer/BModule18Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring18Layer2Minus/tracker:BModule18Layer2/BModule18Layer2Upperwafer/BModule18Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring7Layer2Plus/tracker:BModule7Layer2/BModule7Layer2Lowerwafer/BModule7Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring7Layer2Plus/tracker:BModule7Layer2/BModule7Layer2Upperwafer/BModule7Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring8Layer2Plus/tracker:BModule8Layer2/BModule8Layer2Lowerwafer/BModule8Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring8Layer2Plus/tracker:BModule8Layer2/BModule8Layer2Upperwafer/BModule8Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring9Layer2Plus/tracker:BModule9Layer2/BModule9Layer2Lowerwafer/BModule9Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring9Layer2Plus/tracker:BModule9Layer2/BModule9Layer2Upperwafer/BModule9Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring10Layer2Plus/tracker:BModule10Layer2/BModule10Layer2Lowerwafer/BModule10Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring10Layer2Plus/tracker:BModule10Layer2/BModule10Layer2Upperwafer/BModule10Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring11Layer2Plus/tracker:BModule11Layer2/BModule11Layer2Lowerwafer/BModule11Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring11Layer2Plus/tracker:BModule11Layer2/BModule11Layer2Upperwafer/BModule11Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring12Layer2Plus/tracker:BModule12Layer2/BModule12Layer2Lowerwafer/BModule12Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring12Layer2Plus/tracker:BModule12Layer2/BModule12Layer2Upperwafer/BModule12Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring13Layer2Plus/tracker:BModule13Layer2/BModule13Layer2Lowerwafer/BModule13Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring13Layer2Plus/tracker:BModule13Layer2/BModule13Layer2Upperwafer/BModule13Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring14Layer2Plus/tracker:BModule14Layer2/BModule14Layer2Lowerwafer/BModule14Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring14Layer2Plus/tracker:BModule14Layer2/BModule14Layer2Upperwafer/BModule14Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring15Layer2Plus/tracker:BModule15Layer2/BModule15Layer2Lowerwafer/BModule15Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring15Layer2Plus/tracker:BModule15Layer2/BModule15Layer2Upperwafer/BModule15Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring16Layer2Plus/tracker:BModule16Layer2/BModule16Layer2Lowerwafer/BModule16Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring16Layer2Plus/tracker:BModule16Layer2/BModule16Layer2Upperwafer/BModule16Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring17Layer2Plus/tracker:BModule17Layer2/BModule17Layer2Lowerwafer/BModule17Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring17Layer2Plus/tracker:BModule17Layer2/BModule17Layer2Upperwafer/BModule17Layer2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring18Layer2Plus/tracker:BModule18Layer2/BModule18Layer2Lowerwafer/BModule18Layer2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Ring18Layer2Plus/tracker:BModule18Layer2/BModule18Layer2Upperwafer/BModule18Layer2UpperPSStripactive"/>
+<Parameter name="TrackerRadLength" value="0.0392285"/>
+<Parameter name="TrackerXi" value="7.84571e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer3" eval="true">
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule1Layer3/BModule1Layer3Lowerwafer/BModule1Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule1Layer3/BModule1Layer3Upperwafer/BModule1Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule2Layer3/BModule2Layer3Lowerwafer/BModule2Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule2Layer3/BModule2Layer3Upperwafer/BModule2Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule3Layer3/BModule3Layer3Lowerwafer/BModule3Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule3Layer3/BModule3Layer3Upperwafer/BModule3Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule4Layer3/BModule4Layer3Lowerwafer/BModule4Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule4Layer3/BModule4Layer3Upperwafer/BModule4Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule5Layer3/BModule5Layer3Lowerwafer/BModule5Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule5Layer3/BModule5Layer3Upperwafer/BModule5Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule6Layer3/BModule6Layer3Lowerwafer/BModule6Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule6Layer3/BModule6Layer3Upperwafer/BModule6Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule7Layer3/BModule7Layer3Lowerwafer/BModule7Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule7Layer3/BModule7Layer3Upperwafer/BModule7Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule8Layer3/BModule8Layer3Lowerwafer/BModule8Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule8Layer3/BModule8Layer3Upperwafer/BModule8Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring9Layer3Minus/tracker:BModule9Layer3/BModule9Layer3Lowerwafer/BModule9Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring9Layer3Minus/tracker:BModule9Layer3/BModule9Layer3Upperwafer/BModule9Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring10Layer3Minus/tracker:BModule10Layer3/BModule10Layer3Lowerwafer/BModule10Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring10Layer3Minus/tracker:BModule10Layer3/BModule10Layer3Upperwafer/BModule10Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring11Layer3Minus/tracker:BModule11Layer3/BModule11Layer3Lowerwafer/BModule11Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring11Layer3Minus/tracker:BModule11Layer3/BModule11Layer3Upperwafer/BModule11Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring12Layer3Minus/tracker:BModule12Layer3/BModule12Layer3Lowerwafer/BModule12Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring12Layer3Minus/tracker:BModule12Layer3/BModule12Layer3Upperwafer/BModule12Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring13Layer3Minus/tracker:BModule13Layer3/BModule13Layer3Lowerwafer/BModule13Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring13Layer3Minus/tracker:BModule13Layer3/BModule13Layer3Upperwafer/BModule13Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring14Layer3Minus/tracker:BModule14Layer3/BModule14Layer3Lowerwafer/BModule14Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring14Layer3Minus/tracker:BModule14Layer3/BModule14Layer3Upperwafer/BModule14Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring15Layer3Minus/tracker:BModule15Layer3/BModule15Layer3Lowerwafer/BModule15Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring15Layer3Minus/tracker:BModule15Layer3/BModule15Layer3Upperwafer/BModule15Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring16Layer3Minus/tracker:BModule16Layer3/BModule16Layer3Lowerwafer/BModule16Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring16Layer3Minus/tracker:BModule16Layer3/BModule16Layer3Upperwafer/BModule16Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring17Layer3Minus/tracker:BModule17Layer3/BModule17Layer3Lowerwafer/BModule17Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring17Layer3Minus/tracker:BModule17Layer3/BModule17Layer3Upperwafer/BModule17Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring18Layer3Minus/tracker:BModule18Layer3/BModule18Layer3Lowerwafer/BModule18Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring18Layer3Minus/tracker:BModule18Layer3/BModule18Layer3Upperwafer/BModule18Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring19Layer3Minus/tracker:BModule19Layer3/BModule19Layer3Lowerwafer/BModule19Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring19Layer3Minus/tracker:BModule19Layer3/BModule19Layer3Upperwafer/BModule19Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring20Layer3Minus/tracker:BModule20Layer3/BModule20Layer3Lowerwafer/BModule20Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring20Layer3Minus/tracker:BModule20Layer3/BModule20Layer3Upperwafer/BModule20Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring9Layer3Plus/tracker:BModule9Layer3/BModule9Layer3Lowerwafer/BModule9Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring9Layer3Plus/tracker:BModule9Layer3/BModule9Layer3Upperwafer/BModule9Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring10Layer3Plus/tracker:BModule10Layer3/BModule10Layer3Lowerwafer/BModule10Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring10Layer3Plus/tracker:BModule10Layer3/BModule10Layer3Upperwafer/BModule10Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring11Layer3Plus/tracker:BModule11Layer3/BModule11Layer3Lowerwafer/BModule11Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring11Layer3Plus/tracker:BModule11Layer3/BModule11Layer3Upperwafer/BModule11Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring12Layer3Plus/tracker:BModule12Layer3/BModule12Layer3Lowerwafer/BModule12Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring12Layer3Plus/tracker:BModule12Layer3/BModule12Layer3Upperwafer/BModule12Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring13Layer3Plus/tracker:BModule13Layer3/BModule13Layer3Lowerwafer/BModule13Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring13Layer3Plus/tracker:BModule13Layer3/BModule13Layer3Upperwafer/BModule13Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring14Layer3Plus/tracker:BModule14Layer3/BModule14Layer3Lowerwafer/BModule14Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring14Layer3Plus/tracker:BModule14Layer3/BModule14Layer3Upperwafer/BModule14Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring15Layer3Plus/tracker:BModule15Layer3/BModule15Layer3Lowerwafer/BModule15Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring15Layer3Plus/tracker:BModule15Layer3/BModule15Layer3Upperwafer/BModule15Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring16Layer3Plus/tracker:BModule16Layer3/BModule16Layer3Lowerwafer/BModule16Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring16Layer3Plus/tracker:BModule16Layer3/BModule16Layer3Upperwafer/BModule16Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring17Layer3Plus/tracker:BModule17Layer3/BModule17Layer3Lowerwafer/BModule17Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring17Layer3Plus/tracker:BModule17Layer3/BModule17Layer3Upperwafer/BModule17Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring18Layer3Plus/tracker:BModule18Layer3/BModule18Layer3Lowerwafer/BModule18Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring18Layer3Plus/tracker:BModule18Layer3/BModule18Layer3Upperwafer/BModule18Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring19Layer3Plus/tracker:BModule19Layer3/BModule19Layer3Lowerwafer/BModule19Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring19Layer3Plus/tracker:BModule19Layer3/BModule19Layer3Upperwafer/BModule19Layer3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring20Layer3Plus/tracker:BModule20Layer3/BModule20Layer3Lowerwafer/BModule20Layer3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Ring20Layer3Plus/tracker:BModule20Layer3/BModule20Layer3Upperwafer/BModule20Layer3UpperPSStripactive"/>
+<Parameter name="TrackerRadLength" value="0.0384327"/>
+<Parameter name="TrackerXi" value="7.68654e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer4" eval="true">
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule1Layer4/BModule1Layer4Lowerwafer/BModule1Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule1Layer4/BModule1Layer4Upperwafer/BModule1Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule2Layer4/BModule2Layer4Lowerwafer/BModule2Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule2Layer4/BModule2Layer4Upperwafer/BModule2Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule3Layer4/BModule3Layer4Lowerwafer/BModule3Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule3Layer4/BModule3Layer4Upperwafer/BModule3Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule4Layer4/BModule4Layer4Lowerwafer/BModule4Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule4Layer4/BModule4Layer4Upperwafer/BModule4Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule5Layer4/BModule5Layer4Lowerwafer/BModule5Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule5Layer4/BModule5Layer4Upperwafer/BModule5Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule6Layer4/BModule6Layer4Lowerwafer/BModule6Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule6Layer4/BModule6Layer4Upperwafer/BModule6Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule7Layer4/BModule7Layer4Lowerwafer/BModule7Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule7Layer4/BModule7Layer4Upperwafer/BModule7Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule8Layer4/BModule8Layer4Lowerwafer/BModule8Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule8Layer4/BModule8Layer4Upperwafer/BModule8Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule9Layer4/BModule9Layer4Lowerwafer/BModule9Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule9Layer4/BModule9Layer4Upperwafer/BModule9Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule10Layer4/BModule10Layer4Lowerwafer/BModule10Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule10Layer4/BModule10Layer4Upperwafer/BModule10Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule11Layer4/BModule11Layer4Lowerwafer/BModule11Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule11Layer4/BModule11Layer4Upperwafer/BModule11Layer4Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule12Layer4/BModule12Layer4Lowerwafer/BModule12Layer4Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule12Layer4/BModule12Layer4Upperwafer/BModule12Layer4Upper2Sactive"/>
+<Parameter name="TrackerRadLength" value="0.0162202"/>
+<Parameter name="TrackerXi" value="3.24403e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer5" eval="true">
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule1Layer5/BModule1Layer5Lowerwafer/BModule1Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule1Layer5/BModule1Layer5Upperwafer/BModule1Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule2Layer5/BModule2Layer5Lowerwafer/BModule2Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule2Layer5/BModule2Layer5Upperwafer/BModule2Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule3Layer5/BModule3Layer5Lowerwafer/BModule3Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule3Layer5/BModule3Layer5Upperwafer/BModule3Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule4Layer5/BModule4Layer5Lowerwafer/BModule4Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule4Layer5/BModule4Layer5Upperwafer/BModule4Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule5Layer5/BModule5Layer5Lowerwafer/BModule5Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule5Layer5/BModule5Layer5Upperwafer/BModule5Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule6Layer5/BModule6Layer5Lowerwafer/BModule6Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule6Layer5/BModule6Layer5Upperwafer/BModule6Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule7Layer5/BModule7Layer5Lowerwafer/BModule7Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule7Layer5/BModule7Layer5Upperwafer/BModule7Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule8Layer5/BModule8Layer5Lowerwafer/BModule8Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule8Layer5/BModule8Layer5Upperwafer/BModule8Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule9Layer5/BModule9Layer5Lowerwafer/BModule9Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule9Layer5/BModule9Layer5Upperwafer/BModule9Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule10Layer5/BModule10Layer5Lowerwafer/BModule10Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule10Layer5/BModule10Layer5Upperwafer/BModule10Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule11Layer5/BModule11Layer5Lowerwafer/BModule11Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule11Layer5/BModule11Layer5Upperwafer/BModule11Layer5Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule12Layer5/BModule12Layer5Lowerwafer/BModule12Layer5Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule12Layer5/BModule12Layer5Upperwafer/BModule12Layer5Upper2Sactive"/>
+<Parameter name="TrackerRadLength" value="0.0162202"/>
+<Parameter name="TrackerXi" value="3.24403e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer6" eval="true">
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule1Layer6/BModule1Layer6Lowerwafer/BModule1Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule1Layer6/BModule1Layer6Upperwafer/BModule1Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule2Layer6/BModule2Layer6Lowerwafer/BModule2Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule2Layer6/BModule2Layer6Upperwafer/BModule2Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule3Layer6/BModule3Layer6Lowerwafer/BModule3Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule3Layer6/BModule3Layer6Upperwafer/BModule3Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule4Layer6/BModule4Layer6Lowerwafer/BModule4Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule4Layer6/BModule4Layer6Upperwafer/BModule4Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule5Layer6/BModule5Layer6Lowerwafer/BModule5Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule5Layer6/BModule5Layer6Upperwafer/BModule5Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule6Layer6/BModule6Layer6Lowerwafer/BModule6Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule6Layer6/BModule6Layer6Upperwafer/BModule6Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule7Layer6/BModule7Layer6Lowerwafer/BModule7Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule7Layer6/BModule7Layer6Upperwafer/BModule7Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule8Layer6/BModule8Layer6Lowerwafer/BModule8Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule8Layer6/BModule8Layer6Upperwafer/BModule8Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule9Layer6/BModule9Layer6Lowerwafer/BModule9Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule9Layer6/BModule9Layer6Upperwafer/BModule9Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule10Layer6/BModule10Layer6Lowerwafer/BModule10Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule10Layer6/BModule10Layer6Upperwafer/BModule10Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule11Layer6/BModule11Layer6Lowerwafer/BModule11Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule11Layer6/BModule11Layer6Upperwafer/BModule11Layer6Upper2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule12Layer6/BModule12Layer6Lowerwafer/BModule12Layer6Lower2Sactive"/>
+<PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule12Layer6/BModule12Layer6Upperwafer/BModule12Layer6Upper2Sactive"/>
+<Parameter name="TrackerRadLength" value="0.0162202"/>
+<Parameter name="TrackerXi" value="3.24403e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTForwardDisk1" eval="true">
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring1Disc1/tracker:EModule1Disc1/EModule1Disc1Lowerwafer/EModule1Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring1Disc1/tracker:EModule1Disc1/EModule1Disc1Upperwafer/EModule1Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring2Disc1/tracker:EModule2Disc1/EModule2Disc1Lowerwafer/EModule2Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring2Disc1/tracker:EModule2Disc1/EModule2Disc1Upperwafer/EModule2Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring3Disc1/tracker:EModule3Disc1/EModule3Disc1Lowerwafer/EModule3Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring3Disc1/tracker:EModule3Disc1/EModule3Disc1Upperwafer/EModule3Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring4Disc1/tracker:EModule4Disc1/EModule4Disc1Lowerwafer/EModule4Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring4Disc1/tracker:EModule4Disc1/EModule4Disc1Upperwafer/EModule4Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring5Disc1/tracker:EModule5Disc1/EModule5Disc1Lowerwafer/EModule5Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring5Disc1/tracker:EModule5Disc1/EModule5Disc1Upperwafer/EModule5Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring6Disc1/tracker:EModule6Disc1/EModule6Disc1Lowerwafer/EModule6Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring6Disc1/tracker:EModule6Disc1/EModule6Disc1Upperwafer/EModule6Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring7Disc1/tracker:EModule7Disc1/EModule7Disc1Lowerwafer/EModule7Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring7Disc1/tracker:EModule7Disc1/EModule7Disc1Upperwafer/EModule7Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring8Disc1/tracker:EModule8Disc1/EModule8Disc1Lowerwafer/EModule8Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring8Disc1/tracker:EModule8Disc1/EModule8Disc1Upperwafer/EModule8Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring9Disc1/tracker:EModule9Disc1/EModule9Disc1Lowerwafer/EModule9Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring9Disc1/tracker:EModule9Disc1/EModule9Disc1Upperwafer/EModule9Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring10Disc1/tracker:EModule10Disc1/EModule10Disc1Lowerwafer/EModule10Disc1LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring10Disc1/tracker:EModule10Disc1/EModule10Disc1Upperwafer/EModule10Disc1UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring11Disc1/tracker:EModule11Disc1/EModule11Disc1Lowerwafer/EModule11Disc1Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring11Disc1/tracker:EModule11Disc1/EModule11Disc1Upperwafer/EModule11Disc1Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring12Disc1/tracker:EModule12Disc1/EModule12Disc1Lowerwafer/EModule12Disc1Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring12Disc1/tracker:EModule12Disc1/EModule12Disc1Upperwafer/EModule12Disc1Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring13Disc1/tracker:EModule13Disc1/EModule13Disc1Lowerwafer/EModule13Disc1Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring13Disc1/tracker:EModule13Disc1/EModule13Disc1Upperwafer/EModule13Disc1Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring14Disc1/tracker:EModule14Disc1/EModule14Disc1Lowerwafer/EModule14Disc1Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring14Disc1/tracker:EModule14Disc1/EModule14Disc1Upperwafer/EModule14Disc1Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring15Disc1/tracker:EModule15Disc1/EModule15Disc1Lowerwafer/EModule15Disc1Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring15Disc1/tracker:EModule15Disc1/EModule15Disc1Upperwafer/EModule15Disc1Upper2Sactive"/>
+<Parameter name="TrackerRadLength" value="0.0255039"/>
+<Parameter name="TrackerXi" value="5.10078e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTForwardDisk2" eval="true">
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring1Disc2/tracker:EModule1Disc2/EModule1Disc2Lowerwafer/EModule1Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring1Disc2/tracker:EModule1Disc2/EModule1Disc2Upperwafer/EModule1Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring2Disc2/tracker:EModule2Disc2/EModule2Disc2Lowerwafer/EModule2Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring2Disc2/tracker:EModule2Disc2/EModule2Disc2Upperwafer/EModule2Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring3Disc2/tracker:EModule3Disc2/EModule3Disc2Lowerwafer/EModule3Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring3Disc2/tracker:EModule3Disc2/EModule3Disc2Upperwafer/EModule3Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring4Disc2/tracker:EModule4Disc2/EModule4Disc2Lowerwafer/EModule4Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring4Disc2/tracker:EModule4Disc2/EModule4Disc2Upperwafer/EModule4Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring5Disc2/tracker:EModule5Disc2/EModule5Disc2Lowerwafer/EModule5Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring5Disc2/tracker:EModule5Disc2/EModule5Disc2Upperwafer/EModule5Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring6Disc2/tracker:EModule6Disc2/EModule6Disc2Lowerwafer/EModule6Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring6Disc2/tracker:EModule6Disc2/EModule6Disc2Upperwafer/EModule6Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring7Disc2/tracker:EModule7Disc2/EModule7Disc2Lowerwafer/EModule7Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring7Disc2/tracker:EModule7Disc2/EModule7Disc2Upperwafer/EModule7Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring8Disc2/tracker:EModule8Disc2/EModule8Disc2Lowerwafer/EModule8Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring8Disc2/tracker:EModule8Disc2/EModule8Disc2Upperwafer/EModule8Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring9Disc2/tracker:EModule9Disc2/EModule9Disc2Lowerwafer/EModule9Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring9Disc2/tracker:EModule9Disc2/EModule9Disc2Upperwafer/EModule9Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring10Disc2/tracker:EModule10Disc2/EModule10Disc2Lowerwafer/EModule10Disc2LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring10Disc2/tracker:EModule10Disc2/EModule10Disc2Upperwafer/EModule10Disc2UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring11Disc2/tracker:EModule11Disc2/EModule11Disc2Lowerwafer/EModule11Disc2Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring11Disc2/tracker:EModule11Disc2/EModule11Disc2Upperwafer/EModule11Disc2Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring12Disc2/tracker:EModule12Disc2/EModule12Disc2Lowerwafer/EModule12Disc2Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring12Disc2/tracker:EModule12Disc2/EModule12Disc2Upperwafer/EModule12Disc2Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring13Disc2/tracker:EModule13Disc2/EModule13Disc2Lowerwafer/EModule13Disc2Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring13Disc2/tracker:EModule13Disc2/EModule13Disc2Upperwafer/EModule13Disc2Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring14Disc2/tracker:EModule14Disc2/EModule14Disc2Lowerwafer/EModule14Disc2Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring14Disc2/tracker:EModule14Disc2/EModule14Disc2Upperwafer/EModule14Disc2Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring15Disc2/tracker:EModule15Disc2/EModule15Disc2Lowerwafer/EModule15Disc2Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring15Disc2/tracker:EModule15Disc2/EModule15Disc2Upperwafer/EModule15Disc2Upper2Sactive"/>
+<Parameter name="TrackerRadLength" value="0.0255039"/>
+<Parameter name="TrackerXi" value="5.10078e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTForwardDisk3" eval="true">
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring4Disc3/tracker:EModule4Disc3/EModule4Disc3Lowerwafer/EModule4Disc3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring4Disc3/tracker:EModule4Disc3/EModule4Disc3Upperwafer/EModule4Disc3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring5Disc3/tracker:EModule5Disc3/EModule5Disc3Lowerwafer/EModule5Disc3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring5Disc3/tracker:EModule5Disc3/EModule5Disc3Upperwafer/EModule5Disc3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring6Disc3/tracker:EModule6Disc3/EModule6Disc3Lowerwafer/EModule6Disc3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring6Disc3/tracker:EModule6Disc3/EModule6Disc3Upperwafer/EModule6Disc3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring7Disc3/tracker:EModule7Disc3/EModule7Disc3Lowerwafer/EModule7Disc3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring7Disc3/tracker:EModule7Disc3/EModule7Disc3Upperwafer/EModule7Disc3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring8Disc3/tracker:EModule8Disc3/EModule8Disc3Lowerwafer/EModule8Disc3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring8Disc3/tracker:EModule8Disc3/EModule8Disc3Upperwafer/EModule8Disc3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring9Disc3/tracker:EModule9Disc3/EModule9Disc3Lowerwafer/EModule9Disc3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring9Disc3/tracker:EModule9Disc3/EModule9Disc3Upperwafer/EModule9Disc3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring10Disc3/tracker:EModule10Disc3/EModule10Disc3Lowerwafer/EModule10Disc3LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring10Disc3/tracker:EModule10Disc3/EModule10Disc3Upperwafer/EModule10Disc3UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring11Disc3/tracker:EModule11Disc3/EModule11Disc3Lowerwafer/EModule11Disc3Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring11Disc3/tracker:EModule11Disc3/EModule11Disc3Upperwafer/EModule11Disc3Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring12Disc3/tracker:EModule12Disc3/EModule12Disc3Lowerwafer/EModule12Disc3Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring12Disc3/tracker:EModule12Disc3/EModule12Disc3Upperwafer/EModule12Disc3Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring13Disc3/tracker:EModule13Disc3/EModule13Disc3Lowerwafer/EModule13Disc3Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring13Disc3/tracker:EModule13Disc3/EModule13Disc3Upperwafer/EModule13Disc3Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring14Disc3/tracker:EModule14Disc3/EModule14Disc3Lowerwafer/EModule14Disc3Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring14Disc3/tracker:EModule14Disc3/EModule14Disc3Upperwafer/EModule14Disc3Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring15Disc3/tracker:EModule15Disc3/EModule15Disc3Lowerwafer/EModule15Disc3Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring15Disc3/tracker:EModule15Disc3/EModule15Disc3Upperwafer/EModule15Disc3Upper2Sactive"/>
+<Parameter name="TrackerRadLength" value="0.0244127"/>
+<Parameter name="TrackerXi" value="4.88253e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTForwardDisk4" eval="true">
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring4Disc4/tracker:EModule4Disc4/EModule4Disc4Lowerwafer/EModule4Disc4LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring4Disc4/tracker:EModule4Disc4/EModule4Disc4Upperwafer/EModule4Disc4UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring5Disc4/tracker:EModule5Disc4/EModule5Disc4Lowerwafer/EModule5Disc4LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring5Disc4/tracker:EModule5Disc4/EModule5Disc4Upperwafer/EModule5Disc4UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring6Disc4/tracker:EModule6Disc4/EModule6Disc4Lowerwafer/EModule6Disc4LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring6Disc4/tracker:EModule6Disc4/EModule6Disc4Upperwafer/EModule6Disc4UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring7Disc4/tracker:EModule7Disc4/EModule7Disc4Lowerwafer/EModule7Disc4LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring7Disc4/tracker:EModule7Disc4/EModule7Disc4Upperwafer/EModule7Disc4UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring8Disc4/tracker:EModule8Disc4/EModule8Disc4Lowerwafer/EModule8Disc4LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring8Disc4/tracker:EModule8Disc4/EModule8Disc4Upperwafer/EModule8Disc4UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring9Disc4/tracker:EModule9Disc4/EModule9Disc4Lowerwafer/EModule9Disc4LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring9Disc4/tracker:EModule9Disc4/EModule9Disc4Upperwafer/EModule9Disc4UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring10Disc4/tracker:EModule10Disc4/EModule10Disc4Lowerwafer/EModule10Disc4LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring10Disc4/tracker:EModule10Disc4/EModule10Disc4Upperwafer/EModule10Disc4UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring11Disc4/tracker:EModule11Disc4/EModule11Disc4Lowerwafer/EModule11Disc4Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring11Disc4/tracker:EModule11Disc4/EModule11Disc4Upperwafer/EModule11Disc4Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring12Disc4/tracker:EModule12Disc4/EModule12Disc4Lowerwafer/EModule12Disc4Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring12Disc4/tracker:EModule12Disc4/EModule12Disc4Upperwafer/EModule12Disc4Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring13Disc4/tracker:EModule13Disc4/EModule13Disc4Lowerwafer/EModule13Disc4Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring13Disc4/tracker:EModule13Disc4/EModule13Disc4Upperwafer/EModule13Disc4Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring14Disc4/tracker:EModule14Disc4/EModule14Disc4Lowerwafer/EModule14Disc4Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring14Disc4/tracker:EModule14Disc4/EModule14Disc4Upperwafer/EModule14Disc4Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring15Disc4/tracker:EModule15Disc4/EModule15Disc4Lowerwafer/EModule15Disc4Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring15Disc4/tracker:EModule15Disc4/EModule15Disc4Upperwafer/EModule15Disc4Upper2Sactive"/>
+<Parameter name="TrackerRadLength" value="0.0244127"/>
+<Parameter name="TrackerXi" value="4.88253e-05"/>
+</SpecPar>
+
+<SpecPar name="TrackerRecMaterialPhase2OTForwardDisk5" eval="true">
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring4Disc5/tracker:EModule4Disc5/EModule4Disc5Lowerwafer/EModule4Disc5LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring4Disc5/tracker:EModule4Disc5/EModule4Disc5Upperwafer/EModule4Disc5UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring5Disc5/tracker:EModule5Disc5/EModule5Disc5Lowerwafer/EModule5Disc5LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring5Disc5/tracker:EModule5Disc5/EModule5Disc5Upperwafer/EModule5Disc5UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring6Disc5/tracker:EModule6Disc5/EModule6Disc5Lowerwafer/EModule6Disc5LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring6Disc5/tracker:EModule6Disc5/EModule6Disc5Upperwafer/EModule6Disc5UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring7Disc5/tracker:EModule7Disc5/EModule7Disc5Lowerwafer/EModule7Disc5LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring7Disc5/tracker:EModule7Disc5/EModule7Disc5Upperwafer/EModule7Disc5UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring8Disc5/tracker:EModule8Disc5/EModule8Disc5Lowerwafer/EModule8Disc5LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring8Disc5/tracker:EModule8Disc5/EModule8Disc5Upperwafer/EModule8Disc5UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring9Disc5/tracker:EModule9Disc5/EModule9Disc5Lowerwafer/EModule9Disc5LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring9Disc5/tracker:EModule9Disc5/EModule9Disc5Upperwafer/EModule9Disc5UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring10Disc5/tracker:EModule10Disc5/EModule10Disc5Lowerwafer/EModule10Disc5LowerPSMacroPixelactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring10Disc5/tracker:EModule10Disc5/EModule10Disc5Upperwafer/EModule10Disc5UpperPSStripactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring11Disc5/tracker:EModule11Disc5/EModule11Disc5Lowerwafer/EModule11Disc5Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring11Disc5/tracker:EModule11Disc5/EModule11Disc5Upperwafer/EModule11Disc5Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring12Disc5/tracker:EModule12Disc5/EModule12Disc5Lowerwafer/EModule12Disc5Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring12Disc5/tracker:EModule12Disc5/EModule12Disc5Upperwafer/EModule12Disc5Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring13Disc5/tracker:EModule13Disc5/EModule13Disc5Lowerwafer/EModule13Disc5Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring13Disc5/tracker:EModule13Disc5/EModule13Disc5Upperwafer/EModule13Disc5Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring14Disc5/tracker:EModule14Disc5/EModule14Disc5Lowerwafer/EModule14Disc5Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring14Disc5/tracker:EModule14Disc5/EModule14Disc5Upperwafer/EModule14Disc5Upper2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring15Disc5/tracker:EModule15Disc5/EModule15Disc5Lowerwafer/EModule15Disc5Lower2Sactive"/>
+<PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring15Disc5/tracker:EModule15Disc5/EModule15Disc5Upperwafer/EModule15Disc5Upper2Sactive"/>
+<Parameter name="TrackerRadLength" value="0.0244819"/>
+<Parameter name="TrackerXi" value="4.89637e-05"/>
+</SpecPar>
+
+  </SpecParSection>
+</DDDefinition>

--- a/SLHCUpgradeSimulations/Configuration/python/customise_TkRecoMaterial.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_TkRecoMaterial.py
@@ -1,21 +1,21 @@
 '''Customization functions for cmsDriver to change the phase-2 tracker reco material for geometry D49'''
 import FWCore.ParameterSet.Config as cms
-def customizeRecoMaterial(process):
+def customizeRecoMaterialD49(process):
     
     ''' will replace one tracker reco material file with another one for geometry D49
-    syntax: --customise SLHCUpgradeSimulations/Configuration/customise_TkRecoMaterial.customizeRecoMaterial
+    syntax: --customise SLHCUpgradeSimulations/Configuration/customise_TkRecoMaterial.customizeRecoMaterialD49
     '''
     
     if hasattr(process,'XMLIdealGeometryESSource') and hasattr(process.XMLIdealGeometryESSource,'geomXMLFiles'):
         
-
-        if 'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/trackerRecoMaterial.xml' in process.XMLIdealGeometryESSource.geomXMLFiles :
+        try:
             process.XMLIdealGeometryESSource.geomXMLFiles.remove(
                 'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/trackerRecoMaterial.xml'
             )
-        
             process.XMLIdealGeometryESSource.geomXMLFiles.append(
                 'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/v2_ITonly/trackerRecoMaterial.xml'
             )
-        
+        except ValueError:
+            raise SystemExit("\n\n ERROR! Could not replace trackerRecoMaterial.xml file, please check if D49 geometry is being used \n\n")
+            
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/customise_TkRecoMaterial.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_TkRecoMaterial.py
@@ -8,13 +8,14 @@ def customizeRecoMaterial(process):
     
     if hasattr(process,'XMLIdealGeometryESSource') and hasattr(process.XMLIdealGeometryESSource,'geomXMLFiles'):
         
-        print("customizing Tracker Reco Material")
-        process.XMLIdealGeometryESSource.geomXMLFiles.remove(
-            'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/trackerRecoMaterial.xml'
-        )
+
+        if 'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/trackerRecoMaterial.xml' in process.XMLIdealGeometryESSource.geomXMLFiles :
+            process.XMLIdealGeometryESSource.geomXMLFiles.remove(
+                'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/trackerRecoMaterial.xml'
+            )
         
-        process.XMLIdealGeometryESSource.geomXMLFiles.append(
-            'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/v2_ITonly/trackerRecoMaterial.xml'
-        )
+            process.XMLIdealGeometryESSource.geomXMLFiles.append(
+                'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/v2_ITonly/trackerRecoMaterial.xml'
+            )
         
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/customise_TkRecoMaterial.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_TkRecoMaterial.py
@@ -1,0 +1,20 @@
+'''Customization functions for cmsDriver to change the phase-2 tracker reco material for geometry D49'''
+import FWCore.ParameterSet.Config as cms
+def customizeRecoMaterial(process):
+    
+    ''' will replace one tracker reco material file with another one for geometry D49
+    syntax: --customise SLHCUpgradeSimulations/Configuration/customise_TkRecoMaterial.customizeRecoMaterial
+    '''
+    
+    if hasattr(process,'XMLIdealGeometryESSource') and hasattr(process.XMLIdealGeometryESSource,'geomXMLFiles'):
+        
+        print("customizing Tracker Reco Material")
+        process.XMLIdealGeometryESSource.geomXMLFiles.remove(
+            'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/trackerRecoMaterial.xml'
+        )
+        
+        process.XMLIdealGeometryESSource.geomXMLFiles.append(
+            'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker613_MB_2019_04/v2_ITonly/trackerRecoMaterial.xml'
+        )
+        
+    return process


### PR DESCRIPTION
#### PR description:
during the studies of the tracking performance in phase2 targeting the 111X
it turned out that the current material budget used in the track reconstruction is sub-optimal,
in particular in describing the IT material

preliminary results have been presented and shown during the TK DPG meeting last week [1]

a new --very preliminary-- version of the reco tracker material budget has been derived 
thanks to the Rovere's workflow using NeutrinoGun events for the D49 geometry

this PR provides the corresponding `recoTrackerMaterial.xml` file,
as well as the customization function for making use of it instead of the default file (thanks @mmusich)

no changes are expected in the standard workflows,
but this customization function is needed in order to make relval samples

[1]
https://indico.cern.ch/event/879450/contributions/3857982/attachments/2036336/3410814/200512_TRKPOGPH2.pdf