### PR TITLE
optimize some hotspot use cases of deltaR and polar in reco/miniAOD

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -50,7 +50,7 @@ void CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetu
       bool addcand = true;
       if (useDeltaRforFootprint_)
         for (const auto& it : vetoedPtrs)
-          if ((it.isNonnull()) && (it.isAvailable()) && (reco::deltaR2(it->p4(), c->p4()) < 0.00000025)) {
+          if (it.isNonnull() && it.isAvailable() && reco::deltaR2(*it, *c) < 0.00000025) {
             addcand = false;
             break;
           }

--- a/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
@@ -162,7 +162,7 @@ void pat::LeptonUpdater<T>::produce(edm::StreamID, edm::Event &iEvent, edm::Even
     if (computeMiniIso_) {
       const auto &params = miniIsoParams(lep);
       pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc.product(),
-                                                         lep.p4(),
+                                                         lep.polarP4(),
                                                          params[0],
                                                          params[1],
                                                          params[2],

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -991,7 +991,7 @@ void PATElectronProducer::setElectronMiniIso(Electron& anElectron, const PackedC
   pat::PFIsolation miniiso;
   if (anElectron.isEE())
     miniiso = pat::getMiniPFIsolation(pc,
-                                      anElectron.p4(),
+                                      anElectron.polarP4(),
                                       miniIsoParamsE_[0],
                                       miniIsoParamsE_[1],
                                       miniIsoParamsE_[2],
@@ -1003,7 +1003,7 @@ void PATElectronProducer::setElectronMiniIso(Electron& anElectron, const PackedC
                                       miniIsoParamsE_[8]);
   else
     miniiso = pat::getMiniPFIsolation(pc,
-                                      anElectron.p4(),
+                                      anElectron.polarP4(),
                                       miniIsoParamsB_[0],
                                       miniIsoParamsB_[1],
                                       miniIsoParamsB_[2],

--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
@@ -300,7 +300,8 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
 
     // isolation cut
     if (polarP4.pt() < pT_cut_noIso_ && prescaled <= 1 &&
-        !(isolationDR03.chargedHadronIso() < absIso_cut_ || isolationDR03.chargedHadronIso() / polarP4.pt() < relIso_cut_ ||
+        !(isolationDR03.chargedHadronIso() < absIso_cut_ ||
+          isolationDR03.chargedHadronIso() / polarP4.pt() < relIso_cut_ ||
           miniIso.chargedHadronIso() / polarP4.pt() < miniRelIso_cut_))
       continue;
 
@@ -459,9 +460,9 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     getIsolation(polarP4, pc, ipc, isolationDR03, miniIso);
 
     // isolation cut
-    if (polarP4.pt() < pT_cut_noIso_ &&
-        !(isolationDR03.chargedHadronIso() < absIso_cut_ || isolationDR03.chargedHadronIso() / polarP4.pt() < relIso_cut_ ||
-          miniIso.chargedHadronIso() / polarP4.pt() < miniRelIso_cut_))
+    if (polarP4.pt() < pT_cut_noIso_ && !(isolationDR03.chargedHadronIso() < absIso_cut_ ||
+                                          isolationDR03.chargedHadronIso() / polarP4.pt() < relIso_cut_ ||
+                                          miniIso.chargedHadronIso() / polarP4.pt() < miniRelIso_cut_))
       continue;
 
     pdgId = pfCand.pdgId();

--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
@@ -43,6 +43,7 @@ namespace pat {
 
   class PATIsolatedTrackProducer : public edm::stream::EDProducer<> {
   public:
+    typedef pat::IsolatedTrack::PolarLorentzVector PolarLorentzVector;
     typedef pat::IsolatedTrack::LorentzVector LorentzVector;
 
     explicit PATIsolatedTrackProducer(const edm::ParameterSet&);
@@ -51,17 +52,17 @@ namespace pat {
     void produce(edm::Event&, const edm::EventSetup&) override;
 
     // compute iso/miniiso
-    void getIsolation(const LorentzVector& p4,
+    void getIsolation(const PolarLorentzVector& p4,
                       const pat::PackedCandidateCollection* pc,
                       int pc_idx,
                       pat::PFIsolation& iso,
                       pat::PFIsolation& miniiso) const;
 
-    bool getPFLeptonOverlap(const LorentzVector& p4, const pat::PackedCandidateCollection* pc) const;
+    bool getPFLeptonOverlap(const PolarLorentzVector& p4, const pat::PackedCandidateCollection* pc) const;
 
-    float getPFNeutralSum(const LorentzVector& p4, const pat::PackedCandidateCollection* pc, int pc_idx) const;
+    float getPFNeutralSum(const PolarLorentzVector& p4, const pat::PackedCandidateCollection* pc, int pc_idx) const;
 
-    void getNearestPCRef(const LorentzVector& p4,
+    void getNearestPCRef(const PolarLorentzVector& p4,
                          const pat::PackedCandidateCollection* pc,
                          int pc_idx,
                          int& pc_ref_idx) const;
@@ -70,7 +71,7 @@ namespace pat {
 
     TrackDetMatchInfo getTrackDetMatchInfo(const edm::Event&, const edm::EventSetup&, const reco::Track&);
 
-    void getCaloJetEnergy(const LorentzVector&, const reco::CaloJetCollection*, float&, float&) const;
+    void getCaloJetEnergy(const PolarLorentzVector&, const reco::CaloJetCollection*, float&, float&) const;
 
   private:
     const edm::EDGetTokenT<pat::PackedCandidateCollection> pc_;
@@ -248,6 +249,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     bool isInPackedCands = (pcref.isNonnull() && pcref.id() == pc_h.id() && pfCand->charge() != 0);
     bool isInLostTracks = (ltref.isNonnull() && ltref.id() == lt_h.id());
 
+    PolarLorentzVector polarP4;
     LorentzVector p4;
     pat::PackedCandidateRef refToCand;
     int pdgId, charge, fromPV;
@@ -258,11 +260,13 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     // get the four-momentum and charge
     if (isInPackedCands) {
       p4 = pfCand->p4();
+      polarP4 = pfCand->p4();
       charge = pfCand->charge();
       pfCandInd = pcref.key();
       ltCandInd = -1;
     } else if (isInLostTracks) {
       p4 = lostTrack->p4();
+      polarP4 = lostTrack->p4();
       charge = lostTrack->charge();
       pfCandInd = -1;
       ltCandInd = ltref.key();
@@ -270,6 +274,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
       double m = 0.13957018;  //assume pion mass
       double E = sqrt(m * m + gentk.p() * gentk.p());
       p4.SetPxPyPzE(gentk.px(), gentk.py(), gentk.pz(), E);
+      polarP4.SetCoordinates(gentk.pt(), gentk.eta(), gentk.phi(), m);
       charge = gentk.charge();
       pfCandInd = -1;
       ltCandInd = -1;
@@ -283,7 +288,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
       }
     }
 
-    if (p4.pt() < pT_cut_ && prescaled <= 1)
+    if (polarP4.pt() < pT_cut_ && prescaled <= 1)
       continue;
     if (charge == 0)
       continue;
@@ -291,12 +296,12 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     // get the isolation of the track
     pat::PFIsolation isolationDR03;
     pat::PFIsolation miniIso;
-    getIsolation(p4, pc, pfCandInd, isolationDR03, miniIso);
+    getIsolation(polarP4, pc, pfCandInd, isolationDR03, miniIso);
 
     // isolation cut
-    if (p4.pt() < pT_cut_noIso_ && prescaled <= 1 &&
-        !(isolationDR03.chargedHadronIso() < absIso_cut_ || isolationDR03.chargedHadronIso() / p4.pt() < relIso_cut_ ||
-          miniIso.chargedHadronIso() / p4.pt() < miniRelIso_cut_))
+    if (polarP4.pt() < pT_cut_noIso_ && prescaled <= 1 &&
+        !(isolationDR03.chargedHadronIso() < absIso_cut_ || isolationDR03.chargedHadronIso() / polarP4.pt() < relIso_cut_ ||
+          miniIso.chargedHadronIso() / polarP4.pt() < miniRelIso_cut_))
       continue;
 
     // get the rest after the pt/iso cuts. Saves some runtime
@@ -327,20 +332,20 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     }
 
     float caloJetEm, caloJetHad;
-    getCaloJetEnergy(p4, caloJets.product(), caloJetEm, caloJetHad);
+    getCaloJetEnergy(polarP4, caloJets.product(), caloJetEm, caloJetHad);
 
-    bool pfLepOverlap = getPFLeptonOverlap(p4, pc);
-    float pfNeutralSum = getPFNeutralSum(p4, pc, pfCandInd);
+    bool pfLepOverlap = getPFLeptonOverlap(polarP4, pc);
+    float pfNeutralSum = getPFNeutralSum(polarP4, pc, pfCandInd);
 
     pat::PackedCandidateRef refToNearestPF = pat::PackedCandidateRef();
     int refToNearestPF_idx = -1;
-    getNearestPCRef(p4, pc, pfCandInd, refToNearestPF_idx);
+    getNearestPCRef(polarP4, pc, pfCandInd, refToNearestPF_idx);
     if (refToNearestPF_idx != -1)
       refToNearestPF = pat::PackedCandidateRef(pc_h, refToNearestPF_idx);
 
     pat::PackedCandidateRef refToNearestLostTrack = pat::PackedCandidateRef();
     int refToNearestLostTrack_idx = -1;
-    getNearestPCRef(p4, lt, ltCandInd, refToNearestLostTrack_idx);
+    getNearestPCRef(polarP4, lt, ltCandInd, refToNearestLostTrack_idx);
     if (refToNearestLostTrack_idx != -1)
       refToNearestLostTrack = pat::PackedCandidateRef(lt_h, refToNearestLostTrack_idx);
 
@@ -435,15 +440,15 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     if (pfref.get()->trackRef().isNonnull() && pfref.get()->trackRef().id() == gt_h.id())
       continue;
 
-    LorentzVector p4;
+    PolarLorentzVector polarP4;
     pat::PackedCandidateRef refToCand;
     int pdgId, charge, fromPV;
     float dz, dxy, dzError, dxyError;
 
-    p4 = pfCand.p4();
+    polarP4 = pfCand.polarP4();
     charge = pfCand.charge();
 
-    if (p4.pt() < pT_cut_)
+    if (polarP4.pt() < pT_cut_)
       continue;
     if (charge == 0)
       continue;
@@ -451,12 +456,12 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     // get the isolation of the track
     pat::PFIsolation isolationDR03;
     pat::PFIsolation miniIso;
-    getIsolation(p4, pc, ipc, isolationDR03, miniIso);
+    getIsolation(polarP4, pc, ipc, isolationDR03, miniIso);
 
     // isolation cut
-    if (p4.pt() < pT_cut_noIso_ &&
-        !(isolationDR03.chargedHadronIso() < absIso_cut_ || isolationDR03.chargedHadronIso() / p4.pt() < relIso_cut_ ||
-          miniIso.chargedHadronIso() / p4.pt() < miniRelIso_cut_))
+    if (polarP4.pt() < pT_cut_noIso_ &&
+        !(isolationDR03.chargedHadronIso() < absIso_cut_ || isolationDR03.chargedHadronIso() / polarP4.pt() < relIso_cut_ ||
+          miniIso.chargedHadronIso() / polarP4.pt() < miniRelIso_cut_))
       continue;
 
     pdgId = pfCand.pdgId();
@@ -473,20 +478,20 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     refToCand = pcref;
 
     float caloJetEm, caloJetHad;
-    getCaloJetEnergy(p4, caloJets.product(), caloJetEm, caloJetHad);
+    getCaloJetEnergy(polarP4, caloJets.product(), caloJetEm, caloJetHad);
 
-    bool pfLepOverlap = getPFLeptonOverlap(p4, pc);
-    float pfNeutralSum = getPFNeutralSum(p4, pc, ipc);
+    bool pfLepOverlap = getPFLeptonOverlap(polarP4, pc);
+    float pfNeutralSum = getPFNeutralSum(polarP4, pc, ipc);
 
     pat::PackedCandidateRef refToNearestPF = pat::PackedCandidateRef();
     int refToNearestPF_idx = -1;
-    getNearestPCRef(p4, pc, ipc, refToNearestPF_idx);
+    getNearestPCRef(polarP4, pc, ipc, refToNearestPF_idx);
     if (refToNearestPF_idx != -1)
       refToNearestPF = pat::PackedCandidateRef(pc_h, refToNearestPF_idx);
 
     pat::PackedCandidateRef refToNearestLostTrack = pat::PackedCandidateRef();
     int refToNearestLostTrack_idx = -1;
-    getNearestPCRef(p4, lt, -1, refToNearestLostTrack_idx);
+    getNearestPCRef(polarP4, lt, -1, refToNearestLostTrack_idx);
     if (refToNearestLostTrack_idx != -1)
       refToNearestLostTrack = pat::PackedCandidateRef(lt_h, refToNearestLostTrack_idx);
 
@@ -505,7 +510,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
                                           caloJetHad,
                                           pfLepOverlap,
                                           pfNeutralSum,
-                                          p4,
+                                          pfCand.p4(),
                                           charge,
                                           pdgId,
                                           dz,
@@ -539,7 +544,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
   }
 }
 
-void pat::PATIsolatedTrackProducer::getIsolation(const LorentzVector& p4,
+void pat::PATIsolatedTrackProducer::getIsolation(const PolarLorentzVector& p4,
                                                  const pat::PackedCandidateCollection* pc,
                                                  int pc_idx,
                                                  pat::PFIsolation& iso,
@@ -553,7 +558,7 @@ void pat::PATIsolatedTrackProducer::getIsolation(const LorentzVector& p4,
     int id = std::abs(pf_it->pdgId());
     bool fromPV = (pf_it->fromPV() > 1 || fabs(pf_it->dz()) < pfIsolation_DZ_);
     float pt = pf_it->p4().pt();
-    float dr = deltaR(p4, pf_it->p4());
+    float dr = deltaR(p4, *pf_it);
 
     if (dr < pfIsolation_DR_) {
       // charged cands from PV get added to trackIso
@@ -587,7 +592,7 @@ void pat::PATIsolatedTrackProducer::getIsolation(const LorentzVector& p4,
 }
 
 //get overlap of isolated track with a PF lepton
-bool pat::PATIsolatedTrackProducer::getPFLeptonOverlap(const LorentzVector& p4,
+bool pat::PATIsolatedTrackProducer::getPFLeptonOverlap(const PolarLorentzVector& p4,
                                                        const pat::PackedCandidateCollection* pc) const {
   bool isOverlap = false;
   float dr_min = pflepoverlap_DR_;
@@ -604,7 +609,7 @@ bool pat::PATIsolatedTrackProducer::getPFLeptonOverlap(const LorentzVector& p4,
     if (pt < pflepoverlap_pTmin_)  // exclude pf candidates w/ pT below threshold
       continue;
 
-    float dr = deltaR(p4, pf.p4());
+    float dr = deltaR(p4, pf);
     if (dr > pflepoverlap_DR_)  // exclude pf candidates far from isolated track
       continue;
 
@@ -621,7 +626,7 @@ bool pat::PATIsolatedTrackProducer::getPFLeptonOverlap(const LorentzVector& p4,
 }
 
 //get ref to nearest pf packed candidate
-void pat::PATIsolatedTrackProducer::getNearestPCRef(const LorentzVector& p4,
+void pat::PATIsolatedTrackProducer::getNearestPCRef(const PolarLorentzVector& p4,
                                                     const pat::PackedCandidateCollection* pc,
                                                     int pc_idx,
                                                     int& pc_ref_idx) const {
@@ -634,7 +639,7 @@ void pat::PATIsolatedTrackProducer::getNearestPCRef(const LorentzVector& p4,
     int charge = std::abs(pf_it->charge());
     bool fromPV = (pf_it->fromPV() > 1 || fabs(pf_it->dz()) < pfIsolation_DZ_);
     float pt = pf_it->p4().pt();
-    float dr = deltaR(p4, pf_it->p4());
+    float dr = deltaR(p4, *pf_it);
     if (charge == 0)  // exclude neutral candidates
       continue;
     if (pt < pcRefNearest_pTmin_)  // exclude candidates w/ pT below threshold
@@ -661,7 +666,7 @@ void pat::PATIsolatedTrackProducer::getNearestPCRef(const LorentzVector& p4,
 }
 
 // get PF neutral pT sum around isolated track
-float pat::PATIsolatedTrackProducer::getPFNeutralSum(const LorentzVector& p4,
+float pat::PATIsolatedTrackProducer::getPFNeutralSum(const PolarLorentzVector& p4,
                                                      const pat::PackedCandidateCollection* pc,
                                                      int pc_idx) const {
   float nsum = 0;
@@ -671,7 +676,7 @@ float pat::PATIsolatedTrackProducer::getPFNeutralSum(const LorentzVector& p4,
       continue;
     int id = std::abs(pf_it->pdgId());
     float pt = pf_it->p4().pt();
-    float dr = deltaR(p4, pf_it->p4());
+    float dr = deltaR(p4, *pf_it);
 
     if (dr < pfneutralsum_DR_) {
       // neutral hadron sum
@@ -747,14 +752,14 @@ TrackDetMatchInfo pat::PATIsolatedTrackProducer::getTrackDetMatchInfo(const edm:
   return trackAssociator_.associate(iEvent, iSetup, trackAssocParameters_, &initialState);
 }
 
-void pat::PATIsolatedTrackProducer::getCaloJetEnergy(const LorentzVector& p4,
+void pat::PATIsolatedTrackProducer::getCaloJetEnergy(const PolarLorentzVector& p4,
                                                      const reco::CaloJetCollection* cJets,
                                                      float& caloJetEm,
                                                      float& caloJetHad) const {
   float nearestDR = 999;
   int ind = -1;
   for (unsigned int i = 0; i < cJets->size(); i++) {
-    float dR = deltaR(cJets->at(i).p4(), p4);
+    float dR = deltaR(cJets->at(i), p4);
     if (dR < caloJet_DR_ && dR < nearestDR) {
       nearestDR = dR;
       ind = i;

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -876,7 +876,7 @@ void PATMuonProducer::fillMuon(Muon& aMuon,
 
 void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollection* pc) {
   pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc,
-                                                     aMuon.p4(),
+                                                     aMuon.polarP4(),
                                                      miniIsoParams_[0],
                                                      miniIsoParams_[1],
                                                      miniIsoParams_[2],
@@ -893,8 +893,8 @@ double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double r
   double mindr(miniIsoParams_[0]);
   double maxdr(miniIsoParams_[1]);
   double kt_scale(miniIsoParams_[2]);
-  double drcut = pat::miniIsoDr(muon.p4(), mindr, maxdr, kt_scale);
-  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho, area);
+  double drcut = pat::miniIsoDr(muon.polarP4(), mindr, maxdr, kt_scale);
+  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.polarP4(), drcut, rho, area);
 }
 
 double PATMuonProducer::puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection* pc) {

--- a/PhysicsTools/PatUtils/interface/MiniIsolation.h
+++ b/PhysicsTools/PatUtils/interface/MiniIsolation.h
@@ -15,11 +15,11 @@
 
 namespace pat {
 
-  float miniIsoDr(const math::XYZTLorentzVector& p4, float mindr, float maxdr, float kt_scale);
+  float miniIsoDr(const reco::Candidate::PolarLorentzVector& p4, float mindr, float maxdr, float kt_scale);
 
   // see src file for definitions of parameters
   PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection* pfcands,
-                                 const math::XYZTLorentzVector& p4,
+                                 const reco::Candidate::PolarLorentzVector& p4,
                                  float mindr = 0.05,
                                  float maxdr = 0.2,
                                  float kt_scale = 10.0,
@@ -31,7 +31,7 @@ namespace pat {
                                  float dZ_cut = 0.0);
 
   double muonRelMiniIsoPUCorrected(const PFIsolation& iso,
-                                   const math::XYZTLorentzVector& p4,
+                                   const reco::Candidate::PolarLorentzVector& p4,
                                    double dr,
                                    double rho,
                                    const std::vector<double>& area);

--- a/PhysicsTools/PatUtils/src/MiniIsolation.cc
+++ b/PhysicsTools/PatUtils/src/MiniIsolation.cc
@@ -31,25 +31,25 @@ namespace pat {
     float drcut = miniIsoDr(p4, mindr, maxdr, kt_scale);
     for (auto const &pc : *pfcands) {
       float dr2 = deltaR2(p4, pc);
-      if (dr2 > drcut*drcut)
+      if (dr2 > drcut * drcut)
         continue;
       float pt = pc.p4().pt();
       int id = pc.pdgId();
       if (std::abs(id) == 211) {
         bool fromPV = (pc.fromPV() > 1 || fabs(pc.dz()) < dZ_cut);
-        if (fromPV && dr2 > deadcone_ch*deadcone_ch) {
+        if (fromPV && dr2 > deadcone_ch * deadcone_ch) {
           // if charged hadron and from primary vertex, add to charged hadron isolation
           chiso += pt;
-        } else if (!fromPV && pt > ptthresh && dr2 > deadcone_pu*deadcone_pu) {
+        } else if (!fromPV && pt > ptthresh && dr2 > deadcone_pu * deadcone_pu) {
           // if charged hadron and NOT from primary vertex, add to pileup isolation
           puiso += pt;
         }
       }
       // if neutral hadron, add to neutral hadron isolation
-      if (std::abs(id) == 130 && pt > ptthresh && dr2 > deadcone_nh*deadcone_nh)
+      if (std::abs(id) == 130 && pt > ptthresh && dr2 > deadcone_nh * deadcone_nh)
         nhiso += pt;
       // if photon, add to photon isolation
-      if (std::abs(id) == 22 && pt > ptthresh && dr2 > deadcone_ph*deadcone_ph)
+      if (std::abs(id) == 22 && pt > ptthresh && dr2 > deadcone_ph * deadcone_ph)
         phiso += pt;
     }
 

--- a/PhysicsTools/PatUtils/src/MiniIsolation.cc
+++ b/PhysicsTools/PatUtils/src/MiniIsolation.cc
@@ -12,12 +12,12 @@ namespace pat {
   // For nh, ph, pu, only include particles with pT > ptthresh
   // Some documentation can be found here: https://hypernews.cern.ch/HyperNews/CMS/get/susy/1991.html
 
-  float miniIsoDr(const math::XYZTLorentzVector &p4, float mindr, float maxdr, float kt_scale) {
+  float miniIsoDr(const reco::Candidate::PolarLorentzVector &p4, float mindr, float maxdr, float kt_scale) {
     return std::max(mindr, std::min(maxdr, float(kt_scale / p4.pt())));
   }
 
   PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands,
-                                 const math::XYZTLorentzVector &p4,
+                                 const reco::Candidate::PolarLorentzVector &p4,
                                  float mindr,
                                  float maxdr,
                                  float kt_scale,
@@ -30,26 +30,26 @@ namespace pat {
     float chiso = 0, nhiso = 0, phiso = 0, puiso = 0;
     float drcut = miniIsoDr(p4, mindr, maxdr, kt_scale);
     for (auto const &pc : *pfcands) {
-      float dr = deltaR(p4, pc.p4());
-      if (dr > drcut)
+      float dr2 = deltaR2(p4, pc);
+      if (dr2 > drcut*drcut)
         continue;
       float pt = pc.p4().pt();
       int id = pc.pdgId();
       if (std::abs(id) == 211) {
         bool fromPV = (pc.fromPV() > 1 || fabs(pc.dz()) < dZ_cut);
-        if (fromPV && dr > deadcone_ch) {
+        if (fromPV && dr2 > deadcone_ch*deadcone_ch) {
           // if charged hadron and from primary vertex, add to charged hadron isolation
           chiso += pt;
-        } else if (!fromPV && pt > ptthresh && dr > deadcone_pu) {
+        } else if (!fromPV && pt > ptthresh && dr2 > deadcone_pu*deadcone_pu) {
           // if charged hadron and NOT from primary vertex, add to pileup isolation
           puiso += pt;
         }
       }
       // if neutral hadron, add to neutral hadron isolation
-      if (std::abs(id) == 130 && pt > ptthresh && dr > deadcone_nh)
+      if (std::abs(id) == 130 && pt > ptthresh && dr2 > deadcone_nh*deadcone_nh)
         nhiso += pt;
       // if photon, add to photon isolation
-      if (std::abs(id) == 22 && pt > ptthresh && dr > deadcone_ph)
+      if (std::abs(id) == 22 && pt > ptthresh && dr2 > deadcone_ph*deadcone_ph)
         phiso += pt;
     }
 
@@ -57,7 +57,7 @@ namespace pat {
   }
 
   double muonRelMiniIsoPUCorrected(const PFIsolation &iso,
-                                   const math::XYZTLorentzVector &p4,
+                                   const reco::Candidate::PolarLorentzVector &p4,
                                    double dr,
                                    double rho,
                                    const std::vector<double> &area) {


### PR DESCRIPTION
this was somewhat motivated by the report today in https://indico.cern.ch/event/921063/
More details followed from phase-2 PAT step CPU profiling https://jiwoong.web.cern.ch/jiwoong/cgi-bin/igprof-navigator/igprofCPU_CMSSW_11_1_0_pre6PAT/21

tested on data wf 136.88811 (re-miniAOD from UL) and rereco wf 136.888, showing no differences
