### PR TITLE
 optimize some hotspot use cases of deltaR and polar in reco/miniAOD (backport of #29918 )

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -54,8 +54,8 @@ CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup con
     if (vetoedPtrs.find(c)==vetoedPtrs.cend()) {
       bool addcand = true;
       if (useDeltaRforFootprint_)
-        for( const auto& it : vetoedPtrs)
-          if ((it.isNonnull()) && (it.isAvailable()) && (reco::deltaR2(it->p4(), c->p4()) < 0.00000025)) {
+        for (const auto& it : vetoedPtrs)
+          if (it.isNonnull() && it.isAvailable() && reco::deltaR2(*it, *c) < 0.00000025) {
             addcand = false;
             break;
           }

--- a/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
@@ -133,7 +133,7 @@ void pat::LeptonUpdater<T>::produce(edm::StreamID, edm::Event& iEvent, edm::Even
         setDZ(lep, pv);
         if (computeMiniIso_) {
             const auto & params = miniIsoParams(lep);
-            pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc.product(), lep.p4(),
+            pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc.product(), lep.polarP4(),
                                                                params[0], params[1], params[2],
                                                                params[3], params[4], params[5],
                                                                params[6], params[7], params[8]);

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -973,12 +973,12 @@ void PATElectronProducer::setElectronMiniIso(Electron& anElectron, const PackedC
 {
   pat::PFIsolation miniiso;
   if(anElectron.isEE())
-      miniiso = pat::getMiniPFIsolation(pc, anElectron.p4(),
+      miniiso = pat::getMiniPFIsolation(pc, anElectron.polarP4(),
                                         miniIsoParamsE_[0], miniIsoParamsE_[1], miniIsoParamsE_[2],
                                         miniIsoParamsE_[3], miniIsoParamsE_[4], miniIsoParamsE_[5],
                                         miniIsoParamsE_[6], miniIsoParamsE_[7], miniIsoParamsE_[8]);
   else
-      miniiso = pat::getMiniPFIsolation(pc, anElectron.p4(),
+      miniiso = pat::getMiniPFIsolation(pc, anElectron.polarP4(),
                                         miniIsoParamsB_[0], miniIsoParamsB_[1], miniIsoParamsB_[2],
                                         miniIsoParamsB_[3], miniIsoParamsB_[4], miniIsoParamsB_[5],
                                         miniIsoParamsB_[6], miniIsoParamsB_[7], miniIsoParamsB_[8]);

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -868,7 +868,7 @@ void PATMuonProducer::fillMuon(Muon& aMuon,
 
 void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollection* pc) {
   pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc,
-                                                     aMuon.p4(),
+                                                     aMuon.polarP4(),
                                                      miniIsoParams_[0],
                                                      miniIsoParams_[1],
                                                      miniIsoParams_[2],
@@ -885,8 +885,8 @@ double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double r
   double mindr(miniIsoParams_[0]);
   double maxdr(miniIsoParams_[1]);
   double kt_scale(miniIsoParams_[2]);
-  double drcut = pat::miniIsoDr(muon.p4(), mindr, maxdr, kt_scale);
-  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho, area);
+  double drcut = pat::miniIsoDr(muon.polarP4(), mindr, maxdr, kt_scale);
+  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.polarP4(), drcut, rho, area);
 }
 
 double PATMuonProducer::puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection* pc) {

--- a/PhysicsTools/PatUtils/interface/MiniIsolation.h
+++ b/PhysicsTools/PatUtils/interface/MiniIsolation.h
@@ -15,18 +15,18 @@
 
 namespace pat{
 
-  float miniIsoDr(const math::XYZTLorentzVector &p4, float mindr, float maxdr,
+  float miniIsoDr(const reco::Candidate::PolarLorentzVector &p4, float mindr, float maxdr,
 		  float kt_scale);
 
   // see src file for definitions of parameters
-  PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands, const math::XYZTLorentzVector& p4,
-                                   float mindr=0.05, float maxdr=0.2, float kt_scale=10.0,
-                                   float ptthresh=0.5, float deadcone_ch=0.0001,
-                                   float deadcone_pu=0.01, float deadcone_ph=0.01, float deadcone_nh=0.01,
-                                   float dZ_cut=0.0);
+  PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands, const reco::Candidate::PolarLorentzVector& p4,
+                                 float mindr=0.05, float maxdr=0.2, float kt_scale=10.0,
+                                 float ptthresh=0.5, float deadcone_ch=0.0001,
+                                 float deadcone_pu=0.01, float deadcone_ph=0.01, float deadcone_nh=0.01,
+                                 float dZ_cut=0.0);
 
   double muonRelMiniIsoPUCorrected(const PFIsolation& iso,
-				   const math::XYZTLorentzVector& p4,
+				   const reco::Candidate::PolarLorentzVector& p4,
 				   double dr,
 				   double rho,
                                    const std::vector<double> &area);

--- a/PhysicsTools/PatUtils/src/MiniIsolation.cc
+++ b/PhysicsTools/PatUtils/src/MiniIsolation.cc
@@ -12,55 +12,56 @@ namespace pat{
 // For nh, ph, pu, only include particles with pT > ptthresh
 // Some documentation can be found here: https://hypernews.cern.ch/HyperNews/CMS/get/susy/1991.html
 
-float miniIsoDr(const math::XYZTLorentzVector &p4, float mindr, float maxdr,
-		 float kt_scale){
-  return std::max(mindr, std::min(maxdr, float(kt_scale/p4.pt())));
-}
+  float miniIsoDr(const reco::Candidate::PolarLorentzVector &p4, float mindr, float maxdr, float kt_scale) {
+    return std::max(mindr, std::min(maxdr, float(kt_scale / p4.pt())));
+  }
 
-PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands,
-                                 const math::XYZTLorentzVector &p4, float mindr, float maxdr,
-                                 float kt_scale, float ptthresh, float deadcone_ch,
-                                 float deadcone_pu, float deadcone_ph, float deadcone_nh,
-                                 float dZ_cut)
-{
-    
-    float chiso=0, nhiso=0, phiso=0, puiso=0;
-    float drcut = miniIsoDr(p4,mindr,maxdr,kt_scale);
-    for(auto const & pc : *pfcands){
-        float dr = deltaR(p4, pc.p4());
-        if(dr>drcut)
-            continue;
-        float pt = pc.p4().pt();
-        int id = pc.pdgId();
-        if(std::abs(id)==211){
-            bool fromPV = (pc.fromPV()>1 || fabs(pc.dz()) < dZ_cut);
-            if(fromPV && dr > deadcone_ch){
-                // if charged hadron and from primary vertex, add to charged hadron isolation
-                chiso += pt;
-            }else if(!fromPV && pt > ptthresh && dr > deadcone_pu){
-                // if charged hadron and NOT from primary vertex, add to pileup isolation
-                puiso += pt;
-            }
+  PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands,
+                                 const reco::Candidate::PolarLorentzVector &p4,
+                                 float mindr,
+                                 float maxdr,
+                                 float kt_scale,
+                                 float ptthresh,
+                                 float deadcone_ch,
+                                 float deadcone_pu,
+                                 float deadcone_ph,
+                                 float deadcone_nh,
+                                 float dZ_cut) {
+    float chiso = 0, nhiso = 0, phiso = 0, puiso = 0;
+    float drcut = miniIsoDr(p4, mindr, maxdr, kt_scale);
+    for (auto const &pc : *pfcands) {
+      float dr2 = deltaR2(p4, pc);
+      if (dr2 > drcut*drcut)
+        continue;
+      float pt = pc.p4().pt();
+      int id = pc.pdgId();
+      if (std::abs(id) == 211) {
+        bool fromPV = (pc.fromPV() > 1 || fabs(pc.dz()) < dZ_cut);
+        if (fromPV && dr2 > deadcone_ch*deadcone_ch) {
+          // if charged hadron and from primary vertex, add to charged hadron isolation
+          chiso += pt;
+        } else if (!fromPV && pt > ptthresh && dr2 > deadcone_pu*deadcone_pu) {
+          // if charged hadron and NOT from primary vertex, add to pileup isolation
+          puiso += pt;
         }
-        // if neutral hadron, add to neutral hadron isolation
-        if(std::abs(id)==130 && pt>ptthresh && dr>deadcone_nh)
-            nhiso += pt;
-        // if photon, add to photon isolation
-        if(std::abs(id)==22 && pt>ptthresh && dr>deadcone_ph)
-            phiso += pt;
-                
+      }
+      // if neutral hadron, add to neutral hadron isolation
+      if (std::abs(id) == 130 && pt > ptthresh && dr2 > deadcone_nh*deadcone_nh)
+        nhiso += pt;
+      // if photon, add to photon isolation
+      if (std::abs(id) == 22 && pt > ptthresh && dr2 > deadcone_ph*deadcone_ph)
+        phiso += pt;
     }
                       
     return pat::PFIsolation(chiso, nhiso, phiso, puiso);
 
 }
 
-  double muonRelMiniIsoPUCorrected(const PFIsolation& iso,
-				   const math::XYZTLorentzVector& p4,
-				   double dr,
-				   double rho,
-                                   const std::vector<double> &area)
-  {
+  double muonRelMiniIsoPUCorrected(const PFIsolation &iso,
+                                   const reco::Candidate::PolarLorentzVector &p4,
+                                   double dr,
+                                   double rho,
+                                   const std::vector<double> &area) {
     double absEta = std::abs(p4.eta());
     double ea = 0;
     //Eta dependent effective area

--- a/PhysicsTools/PatUtils/src/MiniIsolation.cc
+++ b/PhysicsTools/PatUtils/src/MiniIsolation.cc
@@ -31,25 +31,25 @@ namespace pat{
     float drcut = miniIsoDr(p4, mindr, maxdr, kt_scale);
     for (auto const &pc : *pfcands) {
       float dr2 = deltaR2(p4, pc);
-      if (dr2 > drcut*drcut)
+      if (dr2 > drcut * drcut)
         continue;
       float pt = pc.p4().pt();
       int id = pc.pdgId();
       if (std::abs(id) == 211) {
         bool fromPV = (pc.fromPV() > 1 || fabs(pc.dz()) < dZ_cut);
-        if (fromPV && dr2 > deadcone_ch*deadcone_ch) {
+        if (fromPV && dr2 > deadcone_ch * deadcone_ch) {
           // if charged hadron and from primary vertex, add to charged hadron isolation
           chiso += pt;
-        } else if (!fromPV && pt > ptthresh && dr2 > deadcone_pu*deadcone_pu) {
+        } else if (!fromPV && pt > ptthresh && dr2 > deadcone_pu * deadcone_pu) {
           // if charged hadron and NOT from primary vertex, add to pileup isolation
           puiso += pt;
         }
       }
       // if neutral hadron, add to neutral hadron isolation
-      if (std::abs(id) == 130 && pt > ptthresh && dr2 > deadcone_nh*deadcone_nh)
+      if (std::abs(id) == 130 && pt > ptthresh && dr2 > deadcone_nh * deadcone_nh)
         nhiso += pt;
       // if photon, add to photon isolation
-      if (std::abs(id) == 22 && pt > ptthresh && dr2 > deadcone_ph*deadcone_ph)
+      if (std::abs(id) == 22 && pt > ptthresh && dr2 > deadcone_ph * deadcone_ph)
         phiso += pt;
     }
                       


### PR DESCRIPTION
backport of #29918

Technical improvements to reduce time in calls to deltaR where polar Lorentz vectors can be used or where (eta,phi) are available directly.
Here the expected gain is mainly limited to miniIsolation and isolatedTracks. 
In a 2016 re-miniAOD workflow  136.7611 times per event in relevant modules are reduced significantly for a total of about 4% of the re-miniAOD step:
```
2.32 ms/ev ->         0.81 ms/ev patElectrons
115.03 ms/ev ->        51.91 ms/ev isolatedTracks
21.10 ms/ev ->         9.67 ms/ev patMuons

```
no changes are expected based on #29918 
