### PR TITLE
Fixing online behaviour of DQMFileSaverPB

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -44,6 +44,13 @@ void DQMFileSaverPB::initRun() const {
     transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(streamLabel_);
     mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(streamLabel_, evf::MergeTypePB);
   }
+
+  if (!fakeFilterUnitMode_) {
+    evf::EvFDaqDirector* daqDirector = (evf::EvFDaqDirector*)(edm::Service<evf::EvFDaqDirector>().operator->());
+    const std::string initFileName = daqDirector->getInitFilePath(streamLabel_);
+    std::ofstream file(initFileName);
+    file.close();
+  }
 }
 
 void DQMFileSaverPB::saveLumi(const FileParameters& fp) const {


### PR DESCRIPTION
#### PR description:

This PR is a bug fix to the recent DQM revamp which solely effects the HLT when run by the DAQ.   For hltd to properly collect and merge the dqm histogram stream produced by the HLT, it needs a init file to be written.  Otherwise the stream is ignored and at best the histograms are lost. 

This PR adds that code.  It should have no effect on any offline test, this only effects P5 running.

#### PR validation:

The hilton tests successfully produced the DQM Histogram stream.

