### PR TITLE
Apply missed clang-tidy checks

### DIFF
--- a/CondFormats/HcalObjects/src/HBHEDarkening.cc
+++ b/CondFormats/HcalObjects/src/HBHEDarkening.cc
@@ -105,7 +105,7 @@ float HBHEDarkening::degradation(float intlumi, int ieta, int lay) const {
   //accumulate degradation over years
   float response = 1.0;
   std::string yearForLumi = getYearForLumi(intlumi);
-  assert(yearForLumi.size());
+  assert(!yearForLumi.empty());
 
   for (const auto& year : years_) {
     response *= degradationYear(year, intlumi, ieta, lay);

--- a/Fireworks/Core/src/FWDialogBuilder.cc
+++ b/Fireworks/Core/src/FWDialogBuilder.cc
@@ -51,7 +51,7 @@ FWLayoutBuilder &FWLayoutBuilder::indent(int left /*= 2*/, int right /* = -1*/) 
 
 /** Return the last vertical frame, for more control on the layout. */
 TGVerticalFrame *FWLayoutBuilder::verticalFrame(void) {
-  assert(m_framesStack.size());
+  assert(!m_framesStack.empty());
   return m_framesStack.back();
 }
 


### PR DESCRIPTION
Apply missed `clang-tidy --checks readability-container-size-empty` checks.