### PR TITLE
[HLT]Replaced boost::tuple for std::tuple

### DIFF
--- a/HLTriggerOffline/Muon/interface/HLTMuonPlotter.h
+++ b/HLTriggerOffline/Muon/interface/HLTMuonPlotter.h
@@ -37,12 +37,12 @@
 
 #include "DQMServices/Core/interface/DQMStore.h"
 
-#include "boost/tuple/tuple.hpp"
 #include <algorithm>
 #include <cctype>
 #include <iostream>
 #include <map>
 #include <set>
+#include <tuple>
 #include <vector>
 
 #include "TPRegexp.h"
@@ -58,9 +58,9 @@ public:
                  std::string,
                  const std::vector<std::string> &,
                  const std::vector<std::string> &,
-                 const boost::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
-                                    edm::EDGetTokenT<reco::GenParticleCollection>,
-                                    edm::EDGetTokenT<reco::MuonCollection>> &);
+                 const std::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
+                                  edm::EDGetTokenT<reco::GenParticleCollection>,
+                                  edm::EDGetTokenT<reco::MuonCollection>> &);
 
   ~HLTMuonPlotter() {
     delete genMuonSelector_;
@@ -71,9 +71,9 @@ public:
   void beginRun(DQMStore::IBooker &, const edm::Run &, const edm::EventSetup &);
   void analyze(const edm::Event &, const edm::EventSetup &);
 
-  static boost::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
-                      edm::EDGetTokenT<reco::GenParticleCollection>,
-                      edm::EDGetTokenT<reco::MuonCollection>>
+  static std::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
+                    edm::EDGetTokenT<reco::GenParticleCollection>,
+                    edm::EDGetTokenT<reco::MuonCollection>>
   getTokens(const edm::ParameterSet &, edm::ConsumesCollector &&);
 
 private:

--- a/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
@@ -28,9 +28,9 @@ HLTMuonPlotter::HLTMuonPlotter(const ParameterSet &pset,
                                string hltPath,
                                const std::vector<string> &moduleLabels,
                                const std::vector<string> &stepLabels,
-                               const boost::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
-                                                  edm::EDGetTokenT<reco::GenParticleCollection>,
-                                                  edm::EDGetTokenT<reco::MuonCollection>> &tokens)
+                               const std::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
+                                                edm::EDGetTokenT<reco::GenParticleCollection>,
+                                                edm::EDGetTokenT<reco::MuonCollection>> &tokens)
     :
 
       l1Matcher_(pset) {
@@ -52,9 +52,9 @@ HLTMuonPlotter::HLTMuonPlotter(const ParameterSet &pset,
   recMuonSelector_ = nullptr;
 
   // set tokens
-  hltTriggerSummaryRAW_ = tokens.get<0>();
-  genParticleLabel_ = tokens.get<1>();
-  recMuonLabel_ = tokens.get<2>();
+  hltTriggerSummaryRAW_ = std::get<0>(tokens);
+  genParticleLabel_ = std::get<1>(tokens);
+  recMuonLabel_ = std::get<2>(tokens);
 }
 
 void HLTMuonPlotter::beginJob() {}
@@ -258,9 +258,9 @@ void HLTMuonPlotter::analyze(const Event &iEvent, const EventSetup &iSetup) {
   }  // End loop over sources
 }
 
-boost::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
-             edm::EDGetTokenT<reco::GenParticleCollection>,
-             edm::EDGetTokenT<reco::MuonCollection>>
+std::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
+           edm::EDGetTokenT<reco::GenParticleCollection>,
+           edm::EDGetTokenT<reco::MuonCollection>>
 HLTMuonPlotter::getTokens(const edm::ParameterSet &pset, edm::ConsumesCollector &&iC) {
   edm::EDGetTokenT<trigger::TriggerEventWithRefs> _hltTriggerSummaryRAW =
       iC.consumes<TriggerEventWithRefs>(edm::InputTag("hltTriggerSummaryRAW"));
@@ -269,9 +269,9 @@ HLTMuonPlotter::getTokens(const edm::ParameterSet &pset, edm::ConsumesCollector 
   edm::EDGetTokenT<reco::MuonCollection> _recMuonLabel =
       iC.consumes<MuonCollection>(pset.getParameter<string>("recMuonLabel"));
 
-  boost::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
-               edm::EDGetTokenT<reco::GenParticleCollection>,
-               edm::EDGetTokenT<reco::MuonCollection>>
+  std::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
+             edm::EDGetTokenT<reco::GenParticleCollection>,
+             edm::EDGetTokenT<reco::MuonCollection>>
       myTuple(_hltTriggerSummaryRAW, _genParticleLabel, _recMuonLabel);
 
   return (myTuple);

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -12,6 +12,7 @@
 // system include files
 #include <iostream>
 #include <memory>
+#include <tuple>
 
 // user include files
 #include "HLTriggerOffline/Muon/interface/HLTMuonPlotter.h"
@@ -28,7 +29,6 @@
 #include "TDirectory.h"
 #include "TFile.h"
 #include "TPRegexp.h"
-#include "boost/tuple/tuple.hpp"
 
 //////////////////////////////////////////////////////////////////////////////
 //////// Define the interface ////////////////////////////////////////////////
@@ -55,9 +55,9 @@ private:
   // Member Variables
   std::vector<HLTMuonPlotter> analyzers_;
   HLTConfigProvider hltConfig_;
-  boost::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
-               edm::EDGetTokenT<reco::GenParticleCollection>,
-               edm::EDGetTokenT<reco::MuonCollection>>
+  std::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
+             edm::EDGetTokenT<reco::GenParticleCollection>,
+             edm::EDGetTokenT<reco::MuonCollection>>
       myTokens_;
 };
 


### PR DESCRIPTION
#### PR description:
Replaced boost::tuple for std::tuple. They have similar functionality and std::tuple should reduce boost dependencies.


#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 

