### PR TITLE
Allow std::move to work with Core classes

### DIFF
--- a/DataFormats/Provenance/interface/Parentage.h
+++ b/DataFormats/Provenance/interface/Parentage.h
@@ -43,7 +43,7 @@ namespace edm {
 
     std::vector<BranchID> const& parents() const { return parents_; }
     std::vector<BranchID>& parentsForUpdate() { return parents_; }
-    void setParents(std::vector<BranchID> const& parents) { parents_ = parents; }
+    void setParents(std::vector<BranchID> parents) { parents_ = std::move(parents); }
     void swap(Parentage& other) { parents_.swap(other.parents_); }
     void initializeTransients() { transient_.reset(); }
     struct Transients {

--- a/FWCore/Concurrency/interface/WaitingTaskHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskHolder.h
@@ -48,6 +48,12 @@ namespace edm {
       return *this;
     }
 
+    WaitingTaskHolder& operator=(WaitingTaskHolder&& iRHS) {
+      WaitingTaskHolder tmp(std::move(iRHS));
+      std::swap(m_task, tmp.m_task);
+      return *this;
+    }
+
     // ---------- const member functions ---------------------
     bool taskHasFailed() const { return m_task->exceptionPtr() != nullptr; }
 

--- a/FWCore/Utilities/src/InputTag.cc
+++ b/FWCore/Utilities/src/InputTag.cc
@@ -83,9 +83,9 @@ namespace edm {
   }
 
   InputTag::InputTag(InputTag&& other)
-      : label_(std::move(other.label())),
-        instance_(std::move(other.instance())),
-        process_(std::move(other.process())),
+      : label_(std::move(other.label_)),
+        instance_(std::move(other.instance_)),
+        process_(std::move(other.process_)),
         typeID_(),
         productRegistry_(nullptr),
         index_(ProductResolverIndexInvalid),


### PR DESCRIPTION
#### PR description:

These instances were caught by a clang static analysis.

#### PR validation:

The code compiles.