### PR TITLE
Changed boost::tuple for std::tuple in CSCLaibration

### DIFF
--- a/CalibMuon/CSCCalibration/interface/CSCIndexerBase.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerBase.h
@@ -62,7 +62,7 @@
  */
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 #include <utility>  // for pair
 #include <vector>
 
@@ -70,10 +70,10 @@ class CSCIndexerBase {
 public:
   typedef uint16_t IndexType;
   typedef uint32_t LongIndexType;
-  typedef boost::tuple<CSCDetId,   // id
-                       IndexType,  // HV segment
-                       IndexType   // chip
-                       >
+  typedef std::tuple<CSCDetId,   // id
+                     IndexType,  // HV segment
+                     IndexType   // chip
+                     >
       GasGainIndexType;
 
   CSCIndexerBase();

--- a/CalibMuon/CSCCalibration/src/CSCIndexerPostls1.cc
+++ b/CalibMuon/CSCCalibration/src/CSCIndexerPostls1.cc
@@ -1,4 +1,5 @@
 #include <CalibMuon/CSCCalibration/interface/CSCIndexerPostls1.h>
+#include <algorithm>
 
 CSCIndexerPostls1::~CSCIndexerPostls1() {}
 
@@ -195,5 +196,5 @@ CSCIndexerBase::GasGainIndexType CSCIndexerPostls1::detIdFromGasGainIndex(IndexT
   IndexType chip = (igg_hvseg_etc - 1) % chips_per_layer + 1;
 
   CSCDetId id(endcaps[type], stations[type], rings[type], chamber, layer);
-  return boost::make_tuple(id, hvsegment, chip);
+  return std::make_tuple(id, hvsegment, chip);
 }

--- a/CalibMuon/CSCCalibration/src/CSCIndexerStartup.cc
+++ b/CalibMuon/CSCCalibration/src/CSCIndexerStartup.cc
@@ -1,4 +1,5 @@
 #include <CalibMuon/CSCCalibration/interface/CSCIndexerStartup.h>
+#include <algorithm>
 
 CSCIndexerStartup::~CSCIndexerStartup() {}
 
@@ -176,5 +177,5 @@ CSCIndexerBase::GasGainIndexType CSCIndexerStartup::detIdFromGasGainIndex(IndexT
   IndexType chip = (igg_hvseg_etc - 1) % chips_per_layer + 1;
 
   CSCDetId id(endcaps[type], stations[type], rings[type], chamber, layer);
-  return boost::make_tuple(id, hvsegment, chip);
+  return std::make_tuple(id, hvsegment, chip);
 }

--- a/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldPostls1.cc
+++ b/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldPostls1.cc
@@ -1,4 +1,5 @@
 #include "CSCIndexerOldPostls1.h"
+#include <algorithm>
 #include <iostream>
 
 void CSCIndexerOldPostls1::fillChamberLabel() const {
@@ -347,7 +348,7 @@ CSCIndexerOldPostls1::GasGainTuple CSCIndexerOldPostls1::detIdFromGasGainIndex(I
   IndexType chip = (igg_hvseg_etc - 1) % chips_per_layer + 1;
 
   CSCDetId id(endcaps[type], stations[type], rings[type], chamber, layer);
-  return boost::make_tuple(id, hvsegment, chip);
+  return std::make_tuple(id, hvsegment, chip);
 }
 
 int CSCIndexerOldPostls1::dbIndex(const CSCDetId &id, int &channel) {

--- a/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldPostls1.h
+++ b/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldPostls1.h
@@ -50,8 +50,8 @@
  */
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <boost/tuple/tuple.hpp>
 #include <iosfwd>
+#include <tuple>
 #include <utility>  // for pair
 #include <vector>
 
@@ -60,10 +60,10 @@ public:
   typedef uint16_t IndexType;
   typedef uint32_t LongIndexType;
 
-  typedef boost::tuple<CSCDetId,   // id
-                       IndexType,  // HV segment
-                       IndexType   // chip
-                       >
+  typedef std::tuple<CSCDetId,   // id
+                     IndexType,  // HV segment
+                     IndexType   // chip
+                     >
       GasGainTuple;
 
   static const IndexType MAX_CHAMBER_INDEX = 540;

--- a/CalibMuon/CSCCalibration/test/testCSCIndexer.cc
+++ b/CalibMuon/CSCCalibration/test/testCSCIndexer.cc
@@ -308,14 +308,14 @@ void testCSCIndexer::testGasGain() {
 
   for (IndexType i = 1; i <= indexer_->maxGasGainIndex(); ++i) {
     CSCIndexerBase::GasGainIndexType t = indexer_->detIdFromGasGainIndex(i);
-    CSCDetId id = t.get<0>();
+    CSCDetId id = std::get<0>(t);
     int ie = id.endcap();
     int is = id.station();
     int ir = id.ring();
     int ic = id.chamber();
     int il = id.layer();
-    int hv = t.get<1>();
-    int ch = t.get<2>();
+    int hv = std::get<1>(t);
+    int ch = std::get<2>(t);
     IndexType ii = indexer_->gasGainIndex(hv, ch, id);
 
     if (i != ii)


### PR DESCRIPTION
#### PR description:
Replaced boost::tuple for std::tuple. They have similar functionality and std::tuple should reduce boost dependencies.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 
