### PR TITLE
add phase-2 test using 11_0_X input to monitor bw compatibility

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -88,6 +88,7 @@ if __name__ == '__main__':
                      20434.0, #2026D41 ttbar (L1T TDR baseline)
                      21234.0, #2026D44 (exercise HF nose)
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
+                     23234.1001, #as 23234.0 but reading 11_0_X digi inputs
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix
                      ],


### PR DESCRIPTION
this is somewhat temporary, until we give up on bw compatibility for 11_0_X DIGIs in phase-2
