### PR TITLE
changed boost::unordered_map for std::unordered_map in SiStripObjects

### DIFF
--- a/CalibFormats/SiStripObjects/interface/SiStripDelay.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripDelay.h
@@ -26,8 +26,8 @@
  */
 
 #include "CondFormats/SiStripObjects/interface/SiStripBaseDelay.h"
-#include <boost/unordered_map.hpp>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 class SiStripDelay {
@@ -82,7 +82,7 @@ private:
   std::vector<const SiStripBaseDelay *> baseDelayVector_;
   std::vector<int> sumSignVector_;
   std::vector<std::pair<std::string, std::string>> recordLabelPair_;
-  boost::unordered_map<uint32_t, double> delays_;
+  std::unordered_map<uint32_t, double> delays_;
 };
 
 #endif

--- a/CalibFormats/SiStripObjects/src/SiStripDelay.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripDelay.cc
@@ -24,7 +24,7 @@ void SiStripDelay::fillNewDelay(const SiStripBaseDelay &baseDelay,
 }
 
 float SiStripDelay::getDelay(const uint32_t detId) const {
-  boost::unordered_map<uint32_t, double>::const_iterator it = delays_.find(detId);
+  std::unordered_map<uint32_t, double>::const_iterator it = delays_.find(detId);
   if (it != delays_.end()) {
     return it->second;
   }
@@ -92,7 +92,7 @@ bool SiStripDelay::makeDelay() {
     for (; detIdIt != detIds.end(); ++detIdIt) {
       // The same detIds should be in both maps, if not don't rely on the
       // default initialization
-      boost::unordered_map<uint32_t, double>::iterator delayIt = delays_.find(*detIdIt);
+      std::unordered_map<uint32_t, double>::iterator delayIt = delays_.find(*detIdIt);
       if (delayIt != delays_.end()) {
         delays_[*detIdIt] += (*it)->delay(*detIdIt) * sumSign;
       } else {
@@ -116,7 +116,7 @@ void SiStripDelay::clear() {
 }
 
 void SiStripDelay::printDebug(std::stringstream &ss, const TrackerTopology * /*trackerTopo*/) const {
-  boost::unordered_map<uint32_t, double>::const_iterator it = delays_.begin();
+  std::unordered_map<uint32_t, double>::const_iterator it = delays_.begin();
   for (; it != delays_.end(); ++it) {
     ss << "detId = " << it->first << " delay = " << it->second << std::endl;
   }
@@ -124,7 +124,7 @@ void SiStripDelay::printDebug(std::stringstream &ss, const TrackerTopology * /*t
 
 void SiStripDelay::printSummary(std::stringstream &ss, const TrackerTopology *trackerTopo) const {
   SiStripDetSummary summaryDelays{trackerTopo};
-  boost::unordered_map<uint32_t, double>::const_iterator it = delays_.begin();
+  std::unordered_map<uint32_t, double>::const_iterator it = delays_.begin();
   for (; it != delays_.end(); ++it) {
     summaryDelays.add(it->first, it->second);
   }


### PR DESCRIPTION
#### PR description:
std::unordered_map and boost::unordered_map have very similar performance. So, we can reduce boost dependency by replacing boost::unordered_map for std::unordered_map.

#### PR validation:
Passed on basic runTheMatrix test.

I've run some benchmarks to compare boost vs std unordered_maps performance:

Map search benchmark.
https://gist.github.com/camolezi/f14800fd4c60af7d2ef501b6b92f9ddd

Adding and removing elements.
https://gist.github.com/camolezi/a5a39539a8c7252d74ec8e6f17f6aa37

<!-- Please replace this text with any link to  -->
@vgvassilev @davidlange6 

