### PR TITLE
Replaced boost::unordered_map for std::unordered_map at HcalCommon

### DIFF
--- a/DQM/HcalCommon/interface/Container1D.h
+++ b/DQM/HcalCommon/interface/Container1D.h
@@ -17,8 +17,8 @@
 #include "DQM/HcalCommon/interface/Utilities.h"
 #include "DQM/HcalCommon/interface/ValueQuantity.h"
 
-#include "boost/unordered_map.hpp"
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace hcaldqm {
@@ -228,7 +228,7 @@ namespace hcaldqm {
   protected:
     virtual void customize(MonitorElement *);
 
-    typedef boost::unordered_map<uint32_t, MonitorElement *> MEMap;
+    typedef std::unordered_map<uint32_t, MonitorElement *> MEMap;
     MEMap _mes;
     mapper::HashMapper _hashmap;
     quantity::Quantity *_qx;

--- a/DQM/HcalCommon/interface/ContainerXXX.h
+++ b/DQM/HcalCommon/interface/ContainerXXX.h
@@ -12,9 +12,9 @@
 #include <cmath>
 
 namespace hcaldqm {
-  typedef boost::unordered_map<uint32_t, double> doubleCompactMap;
-  typedef boost::unordered_map<uint32_t, int> intCompactMap;
-  typedef boost::unordered_map<uint32_t, uint32_t> uintCompactMap;
+  typedef std::unordered_map<uint32_t, double> doubleCompactMap;
+  typedef std::unordered_map<uint32_t, int> intCompactMap;
+  typedef std::unordered_map<uint32_t, uint32_t> uintCompactMap;
 
   template <typename STDTYPE>
   class ContainerXXX {
@@ -60,7 +60,7 @@ namespace hcaldqm {
     virtual void print();
 
   protected:
-    typedef boost::unordered_map<uint32_t, STDTYPE> CompactMap;
+    typedef std::unordered_map<uint32_t, STDTYPE> CompactMap;
     CompactMap _cmap;
     mapper::HashMapper _hashmap;
     Logger _logger;

--- a/DQM/HcalCommon/interface/ElectronicsMap.h
+++ b/DQM/HcalCommon/interface/ElectronicsMap.h
@@ -15,8 +15,8 @@
 #include "DQM/HcalCommon/interface/HashMapper.h"
 #include "DQM/HcalCommon/interface/HcalCommonHeaders.h"
 
-#include "boost/unordered_map.hpp"
 #include "string"
+#include <unordered_map>
 
 namespace hcaldqm {
   namespace electronicsmap {
@@ -51,7 +51,7 @@ namespace hcaldqm {
       ElectronicsMapType _etype;
 
       //	2 choices either use as HcalElectronicsMap or as ur hash
-      typedef boost::unordered_map<uint32_t, uint32_t> EMapType;
+      typedef std::unordered_map<uint32_t, uint32_t> EMapType;
       EMapType _ids;
 
       //

--- a/DQM/HcalCommon/interface/ElectronicsQuantity.h
+++ b/DQM/HcalCommon/interface/ElectronicsQuantity.h
@@ -7,7 +7,7 @@
  */
 
 #include "DQM/HcalCommon/interface/Quantity.h"
-#include "boost/unordered_map.hpp"
+#include <unordered_map>
 
 namespace hcaldqm {
   namespace quantity {
@@ -369,7 +369,7 @@ namespace hcaldqm {
       std::vector<std::string> getLabels() override;
 
     protected:
-      typedef boost::unordered_map<int, uint32_t> FEDMap;
+      typedef std::unordered_map<int, uint32_t> FEDMap;
       FEDMap _feds;
 
     public:

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -3,7 +3,7 @@
 
 #include "DQM/HcalCommon/interface/Flag.h"
 #include "DQM/HcalCommon/interface/Quantity.h"
-#include "boost/unordered_map.hpp"
+#include <unordered_map>
 
 namespace hcaldqm {
   namespace quantity {
@@ -505,7 +505,7 @@ namespace hcaldqm {
       std::string name() override { return "Event Type"; }
 
     protected:
-      typedef boost::unordered_map<uint32_t, int> TypeMap;
+      typedef std::unordered_map<uint32_t, int> TypeMap;
       TypeMap _types;
 
     public:


### PR DESCRIPTION
#### PR description:
std::unordered_map and boost::unordered_map have very similar performance. So, we can reduce boost dependency by replacing boost::unordered_map for std::unordered_map.

#### PR validation:
Passed on basic runTheMatrix test.

I've run some benchmarks to compare boost vs std unordered_maps performance:

Map search benchmark.
https://gist.github.com/camolezi/f14800fd4c60af7d2ef501b6b92f9ddd

Adding and removing elements.
https://gist.github.com/camolezi/a5a39539a8c7252d74ec8e6f17f6aa37

<!-- Please replace this text with any link to  -->
@vgvassilev @davidlange6 

