### PR TITLE
Fix DetectorDescription Parser TE unit test so it runs

### DIFF
--- a/DetectorDescription/Parser/test/run_testDoc.sh
+++ b/DetectorDescription/Parser/test/run_testDoc.sh
@@ -7,6 +7,7 @@ pushd ${LOCAL_TMP_DIR}
   cd ${LOCAL_TEST_DIR}
 #  cp ${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/testDoc .
   echo ${test}testDoc ------------------------------------------------------------
+  env
   testDoc testConfiguration.xml || die "testDoc" $?
   export PATH=${mecpath}
   popd

--- a/DetectorDescription/Parser/test/run_testDoc.sh
+++ b/DetectorDescription/Parser/test/run_testDoc.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
+
 test=testtestDoc
 function die { echo Failure $1: status $2 ; exit $2 ; }
 pushd ${LOCAL_TMP_DIR}
-  export mecpath=${PATH}
-  test -z "${CMSSW_RELEASE_BASE}" && echo CMSSW_RELEASE_BASE is not set.
-  export PATH=${CMSSW_RELEASE_BASE}/test/${SCRAM_ARCH}/:${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/:${PATH}
+  export PATH=${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/:${PATH}
   cd ${LOCAL_TEST_DIR}
   echo ${test} testDoc ------------------------------------------------------------
-  testDoc testConfiguration.xml || die "testDoc" $?
-  export PATH=${mecpath}
+  testDocProg=testDoc
+  for scriptDir in $CMSSW_BASE $CMSSW_RELEASE_BASE $CMSSW_FULL_RELEASE_BASE ; do
+    if [ -x $scriptDir/test/${SCRAM_ARCH}/testDoc ] ; then 
+      testDocProg=$scriptDir/test/${SCRAM_ARCH}/testDoc
+      echo Found $testDocProg
+      break
+    fi
+  done
+  $testDocProg testConfiguration.xml || die "testDoc" $?
   popd
 exit 0

--- a/DetectorDescription/Parser/test/run_testDoc.sh
+++ b/DetectorDescription/Parser/test/run_testDoc.sh
@@ -3,11 +3,10 @@ test=testtestDoc
 function die { echo Failure $1: status $2 ; exit $2 ; }
 pushd ${LOCAL_TMP_DIR}
   export mecpath=${PATH}
-  export PATH=${RELEASETOP}/test/${SCRAM_ARCH}/:${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/:${PATH}
+  test -z "${CMSSW_RELEASE_BASE}" && echo CMSSW_RELEASE_BASE is not set.
+  export PATH=${CMSSW_RELEASE_BASE}/test/${SCRAM_ARCH}/:${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/:${PATH}
   cd ${LOCAL_TEST_DIR}
-#  cp ${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/testDoc .
-  echo ${test}testDoc ------------------------------------------------------------
-  env
+  echo ${test} testDoc ------------------------------------------------------------
   testDoc testConfiguration.xml || die "testDoc" $?
   export PATH=${mecpath}
   popd

--- a/DetectorDescription/Parser/test/run_testDoc.sh
+++ b/DetectorDescription/Parser/test/run_testDoc.sh
@@ -3,11 +3,11 @@ test=testtestDoc
 function die { echo Failure $1: status $2 ; exit $2 ; }
 pushd ${LOCAL_TMP_DIR}
   export mecpath=${PATH}
-  export PATH=${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/:${PATH}
+  export PATH=${CMSSW_RELEASE_BASE}/test/${SCRAM_ARCH}/:${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/:${PATH}
   cd ${LOCAL_TEST_DIR}
 #  cp ${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/testDoc .
   echo ${test}testDoc ------------------------------------------------------------
-  testDoc testConfiguration.xml|| die "testDoc" $?
+  testDoc testConfiguration.xml || die "testDoc" $?
   export PATH=${mecpath}
   popd
 exit 0

--- a/DetectorDescription/Parser/test/run_testDoc.sh
+++ b/DetectorDescription/Parser/test/run_testDoc.sh
@@ -3,7 +3,7 @@ test=testtestDoc
 function die { echo Failure $1: status $2 ; exit $2 ; }
 pushd ${LOCAL_TMP_DIR}
   export mecpath=${PATH}
-  export PATH=${CMSSW_RELEASE_BASE}/test/${SCRAM_ARCH}/:${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/:${PATH}
+  export PATH=${RELEASETOP}/test/${SCRAM_ARCH}/:${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/:${PATH}
   cd ${LOCAL_TEST_DIR}
 #  cp ${LOCAL_TOP_DIR}/test/${SCRAM_ARCH}/testDoc .
   echo ${test}testDoc ------------------------------------------------------------


### PR DESCRIPTION
In PR #29926, the DetectorDescription Parser TE unit test fails because a test program cannot be found in the PATH. The test program may be located in any of three locations, depending on how the unit tests are being run. I added a search of those directories to find the program.

#### PR validation:

The unit test for the DetectorDescription/Parser package that was failing can now run successfully.

Backport to 11_1 will be done after this PR is merged.