### PR TITLE
SiPixelClusterProducer: apply gain calibration scheme update at HLT as well

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -170,10 +170,25 @@ def customiseFor2017DtUnpacking(process):
 
     return process
 
+
+# Update Pixel Gain calibration scheme for Run3 (PR #29333)
+def customiseFor29333(process):
+    for producer in producers_by_type(process, "SiPixelClusterProducer"):
+        # For Run3, change in the gain calibration scheme,
+        # to include the VCal conversion factors directly in the SiPixelGainCalibration DB object
+        # full details at: https://indico.cern.ch/event/879470/contributions/3796405/attachments/2009273/3356603/pix_off_25_3_gain_calibration_mc.pdf
+        producer.VCaltoElectronGain      = cms.int32(1) # all gains=1, pedestals=0
+        producer.VCaltoElectronGain_L1   = cms.int32(1)
+        producer.VCaltoElectronOffset    = cms.int32(0)
+        producer.VCaltoElectronOffset_L1 = cms.int32(0)
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseFor29333(process)
 
     return process


### PR DESCRIPTION
#### PR description:

Unfortunately the Pixel gain calibration scheme update introduced at https://github.com/cms-sw/cmssw/pull/29333 missed the HLT configuration. 
This PR provides the appropriate customization function to deal with the update of conditions also for the HLT.

#### PR validation:
Dumped the step3 configuration of https://cmsweb.cern.ch/couchdb/reqmgr_config_cache/95d680704ae17507a77b0e3350c8c1d5/configFile with and without this branch and obtained as expected:

```diff
$ colordiff dump.py dump2.py 
65455,65458c65455,65458
<     VCaltoElectronGain = cms.int32(47),
<     VCaltoElectronGain_L1 = cms.int32(50),
<     VCaltoElectronOffset = cms.int32(-60),
<     VCaltoElectronOffset_L1 = cms.int32(-670),
---
>     VCaltoElectronGain = cms.int32(1),
>     VCaltoElectronGain_L1 = cms.int32(1),
>     VCaltoElectronOffset = cms.int32(0),
>     VCaltoElectronOffset_L1 = cms.int32(0),
65484,65487c65484,65487
<     VCaltoElectronGain = cms.int32(47),
<     VCaltoElectronGain_L1 = cms.int32(50),
<     VCaltoElectronOffset = cms.int32(-60),
<     VCaltoElectronOffset_L1 = cms.int32(-670),
---
>     VCaltoElectronGain = cms.int32(1),
>     VCaltoElectronGain_L1 = cms.int32(1),
>     VCaltoElectronOffset = cms.int32(0),
>     VCaltoElectronOffset_L1 = cms.int32(0),
65513,65516c65513,65516
<     VCaltoElectronGain = cms.int32(47),
<     VCaltoElectronGain_L1 = cms.int32(50),
<     VCaltoElectronOffset = cms.int32(-60),
<     VCaltoElectronOffset_L1 = cms.int32(-670),
---
>     VCaltoElectronGain = cms.int32(1),
>     VCaltoElectronGain_L1 = cms.int32(1),
>     VCaltoElectronOffset = cms.int32(0),
>     VCaltoElectronOffset_L1 = cms.int32(0),
65542,65545c65542,65545
<     VCaltoElectronGain = cms.int32(47),
<     VCaltoElectronGain_L1 = cms.int32(50),
<     VCaltoElectronOffset = cms.int32(-60),
<     VCaltoElectronOffset_L1 = cms.int32(-670),
---
>     VCaltoElectronGain = cms.int32(1),
>     VCaltoElectronGain_L1 = cms.int32(1),
>     VCaltoElectronOffset = cms.int32(0),
>     VCaltoElectronOffset_L1 = cms.int32(0),
```
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.

cc: @tsusa @dkotlins @tvami 
