### PR TITLE
Allow DDNames to be created concurrently

### DIFF
--- a/DetectorDescription/Core/BuildFile.xml
+++ b/DetectorDescription/Core/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="boost"/>
 <use name="clhep"/>
 <use name="rootmath"/>
+<use name="tbb"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DetectorDescription/Core/interface/DDName.h
+++ b/DetectorDescription/Core/interface/DDName.h
@@ -2,10 +2,10 @@
 #define DETECTOR_DESCRIPTION_CORE_DDNAME_H
 
 #include <iosfwd>
-#include <map>
 #include <string>
 #include <utility>
-#include <vector>
+#include <tbb/concurrent_vector.h>
+#include <tbb/concurrent_unordered_map.h>
 
 class DDCurrentNamespace;
 
@@ -15,8 +15,8 @@ class DDCurrentNamespace;
 class DDName {
 public:
   using id_type = int;
-  using Registry = std::map<std::pair<std::string, std::string>, id_type>;
-  using IdToName = std::vector<Registry::const_iterator>;
+  using Registry = tbb::concurrent_unordered_map<std::pair<std::string, std::string>, id_type>;
+  using IdToName = tbb::concurrent_vector<Registry::const_iterator>;
 
   //! Constructs a DDName with name \a name and assigns \a name to the namespace \a ns.
   DDName(const std::string& name, const std::string& ns);
@@ -47,7 +47,7 @@ public:
 private:
   id_type id_;
 
-  static Registry::iterator registerName(const std::pair<std::string, std::string>& s);
+  static Registry::const_iterator registerName(const std::pair<std::string, std::string>& s);
 };
 
 std::ostream& operator<<(std::ostream& os, const DDName& n);

--- a/DetectorDescription/Core/src/StoresInstantiation.cc
+++ b/DetectorDescription/Core/src/StoresInstantiation.cc
@@ -17,6 +17,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <tbb/concurrent_vector.h>
+#include <tbb/concurrent_unordered_map.h>
 
 template class DDI::Singleton<AxesNames>;
 template class DDI::Singleton<DDRoot>;
@@ -31,6 +33,8 @@ template class DDI::Singleton<DDI::Store<DDName, std::unique_ptr<DDI::Solid> > >
 template class DDI::Singleton<DDI::Store<DDName, std::unique_ptr<double> > >;
 template class DDI::Singleton<DDI::Store<DDName, std::unique_ptr<DDRotationMatrix> > >;
 template class DDI::Singleton<DDI::Store<DDName, std::unique_ptr<DDI::Division>, std::unique_ptr<DDI::Division> > >;
-template class DDI::Singleton<std::map<std::pair<std::string, std::string>, int> >;
-template class DDI::Singleton<std::map<std::string, std::vector<DDName> > >;
-template class DDI::Singleton<std::vector<std::map<std::pair<std::string, std::string>, int>::const_iterator> >;
+template class DDI::Singleton<std::map<std::string, std::vector<DDName> > >;  //Used internally by DDLogicalPart
+//The following are used by DDName
+template class DDI::Singleton<tbb::concurrent_unordered_map<std::pair<std::string, std::string>, int> >;
+template class DDI::Singleton<
+    tbb::concurrent_vector<tbb::concurrent_unordered_map<std::pair<std::string, std::string>, int>::const_iterator> >;


### PR DESCRIPTION
#### PR description:

In order to support concurrent running of ES modules we need to be able to concurrently create DDNames. This change replaces the global containers being used with tbb concurrent containers.

#### PR validation:
The code compiles and all unit tests in DetectorDescription/Core pass.