### PR TITLE
Changed boost::unordered_set to std::unordered_set in HcalCommon

### DIFF
--- a/DQM/HcalCommon/interface/HashFilter.h
+++ b/DQM/HcalCommon/interface/HashFilter.h
@@ -11,7 +11,7 @@
 
 #include "DQM/HcalCommon/interface/HashMapper.h"
 
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 #include <vector>
 
 namespace hcaldqm {
@@ -42,7 +42,7 @@ namespace hcaldqm {
 
     protected:
       FilterType _ftype;
-      typedef boost::unordered_set<uint32_t> FilterMap;
+      typedef std::unordered_set<uint32_t> FilterMap;
       FilterMap _ids;
 
       virtual bool preserve(uint32_t) const;


### PR DESCRIPTION
#### PR description:
std::unordered_set and boost::unordered_set have very similar performance. So, we can reduce boost dependency by replacing them.

#### PR validation:
Passed on basic runTheMatrix test.

<!-- Please replace this text with any link to  -->
@vgvassilev @davidlange6 

