### PR TITLE
Add missing std library includes in FWCore

### DIFF
--- a/FWCore/PrescaleService/BuildFile.xml
+++ b/FWCore/PrescaleService/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/Provenance"/>
-<use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -52,6 +52,7 @@ to this file that go beyond the obvious cut and paste type of edits.
 
 // system include files
 #include <functional>
+#include <string>
 
 // user include files
 #include "FWCore/ServiceRegistry/interface/TerminationOrigin.h"

--- a/FWCore/Services/BuildFile.xml
+++ b/FWCore/Services/BuildFile.xml
@@ -1,14 +1,8 @@
-<use name="DataFormats/Provenance"/>
-<use name="DataFormats/Common"/>
-<use name="DataFormats/Streamer"/>
 <use name="SimDataFormats/RandomEngine"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
-<use name="FWCore/Concurrency"/>
-<use name="FWCore/Framework"/>
 <use name="boost"/>
 <use name="tinyxml2"/>
 <use name="rootcore"/>

--- a/FWCore/Services/plugins/BuildFile.xml
+++ b/FWCore/Services/plugins/BuildFile.xml
@@ -1,3 +1,8 @@
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Provenance"/>
+<use name="FWCore/Concurrency"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
 <use name="FWCore/Services"/>
 <use name="FWCore/Reflection"/>
 <use name="Utilities/StorageFactory"/>

--- a/FWCore/Sources/BuildFile.xml
+++ b/FWCore/Sources/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="DataFormats/Provenance"/>
 <use name="FWCore/Catalog"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Reflection"/>

--- a/FWCore/Utilities/interface/ESIndices.h
+++ b/FWCore/Utilities/interface/ESIndices.h
@@ -21,6 +21,7 @@
 //
 
 // system include files
+#include <limits>
 #include <ostream>
 
 // user include files


### PR DESCRIPTION
#### PR description:

I just noticed that FWCore does not build anymore on my machine with gcc 10.1.0. This can be fixed by including some headers from the standard library:

1. `#include <limits>` in FWCore/Utilities/interface/ESIndices.h to get `std::numeric_limits`
2. `#include <string>` in FWCore/ServiceRegistry/interface/ActivityRegistry.h to get `std::string`

I don't know how it compiled before in older gcc. Maybe it got these missing headers indirectly from other standard library headers like `functional`, but they are not in there anymore?

This opportunity was taken to also clean the BuildFiles in FWCore: dependencies which are not actually included in the library were removed or moved to the `plugins` BuildFile if appropriate.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.