### PR TITLE
ECAL : Tools to include EcalPFRecHitThresholds in Cond DB

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
@@ -27,10 +27,11 @@
 using namespace edm;
 
 EcalTrivialConditionRetriever::EcalTrivialConditionRetriever(const edm::ParameterSet& ps) {
-  //  std::string path = "CalibCalorimetry/EcalTrivialCondModules/data/";
-  std::string path = "CalibCalorimetry/EcalTrivialCondModules/data_test/";
+  std::string dataPath_ =
+      ps.getUntrackedParameter<std::string>("dataPath", "CalibCalorimetry/EcalTrivialCondModules/data/");
+  //  std::string dataPath_ = "CalibCalorimetry/EcalTrivialCondModules/data_test/";
 
-  /*since CMSSW_10_6_0, this path points to https://github.com/cms-data/CalibCalorimetry-EcalTrivialCondModules  (extra package). 
+  /*since CMSSW_10_6_0, this dataPath_ points to https://github.com/cms-data/CalibCalorimetry-EcalTrivialCondModules  (extra package). 
 To modify the default values :
 $ git clone https://github.com/cms-data/CalibCalorimetry-EcalTrivialCondModules.git
 $ cd CalibCalorimetry-EcalTrivialCondModules
@@ -39,9 +40,9 @@ $ git commit -a
 $ git remote add ModifyCalibCalorimetryExtraPackage  git@github.com:yourName/CalibCalorimetry-EcalTrivialCondModules
 $ git push ModifyCalibCalorimetryExtraPackage master:building-calibCalorimetry-extra-package
 
-other solution : change this path name to work directly in afs, ex. :
+other solution : change this dataPath name to work directly in afs, ex. :
 
-  std::string path="CalibCalorimetry/EcalTrivialCondModules/data_test/";
+  std::string dataPath_="CalibCalorimetry/EcalTrivialCondModules/data_test/";
 
  */
 
@@ -177,18 +178,18 @@ other solution : change this path name to work directly in afs, ex. :
 
   weightType = str.str();
 
-  amplWeightsFile_ = ps.getUntrackedParameter<std::string>("amplWeightsFile", path + "ampWeights" + weightType);
+  amplWeightsFile_ = ps.getUntrackedParameter<std::string>("amplWeightsFile", dataPath_ + "ampWeights" + weightType);
   amplWeightsAftFile_ =
-      ps.getUntrackedParameter<std::string>("amplWeightsAftFile", path + "ampWeightsAfterGainSwitch" + weightType);
-  pedWeightsFile_ = ps.getUntrackedParameter<std::string>("pedWeightsFile", path + "pedWeights" + weightType);
+      ps.getUntrackedParameter<std::string>("amplWeightsAftFile", dataPath_ + "ampWeightsAfterGainSwitch" + weightType);
+  pedWeightsFile_ = ps.getUntrackedParameter<std::string>("pedWeightsFile", dataPath_ + "pedWeights" + weightType);
   pedWeightsAftFile_ =
-      ps.getUntrackedParameter<std::string>("pedWeightsAftFile", path + "pedWeightsAfterGainSwitch" + weightType);
-  jittWeightsFile_ = ps.getUntrackedParameter<std::string>("jittWeightsFile", path + "timeWeights" + weightType);
-  jittWeightsAftFile_ =
-      ps.getUntrackedParameter<std::string>("jittWeightsAftFile", path + "timeWeightsAfterGainSwitch" + weightType);
-  chi2MatrixFile_ = ps.getUntrackedParameter<std::string>("chi2MatrixFile", path + "chi2Matrix" + weightType);
+      ps.getUntrackedParameter<std::string>("pedWeightsAftFile", dataPath_ + "pedWeightsAfterGainSwitch" + weightType);
+  jittWeightsFile_ = ps.getUntrackedParameter<std::string>("jittWeightsFile", dataPath_ + "timeWeights" + weightType);
+  jittWeightsAftFile_ = ps.getUntrackedParameter<std::string>("jittWeightsAftFile",
+                                                              dataPath_ + "timeWeightsAfterGainSwitch" + weightType);
+  chi2MatrixFile_ = ps.getUntrackedParameter<std::string>("chi2MatrixFile", dataPath_ + "chi2Matrix" + weightType);
   chi2MatrixAftFile_ =
-      ps.getUntrackedParameter<std::string>("chi2MatrixAftFile", path + "chi2MatrixAfterGainSwitch" + weightType);
+      ps.getUntrackedParameter<std::string>("chi2MatrixAftFile", dataPath_ + "chi2MatrixAfterGainSwitch" + weightType);
 
   amplWeights_.resize(nTDCbins_);
   amplWeightsAft_.resize(nTDCbins_);
@@ -222,17 +223,17 @@ other solution : change this path name to work directly in afs, ex. :
   // Alignment from file
   getEBAlignmentFromFile_ = ps.getUntrackedParameter<bool>("getEBAlignmentFromFile", false);
   if (getEBAlignmentFromFile_) {
-    EBAlignmentFile_ = ps.getUntrackedParameter<std::string>("EBAlignmentFile", path + "EBAlignment.txt");
+    EBAlignmentFile_ = ps.getUntrackedParameter<std::string>("EBAlignmentFile", dataPath_ + "EBAlignment.txt");
   }
 
   getEEAlignmentFromFile_ = ps.getUntrackedParameter<bool>("getEEAlignmentFromFile", false);
   if (getEEAlignmentFromFile_) {
-    EEAlignmentFile_ = ps.getUntrackedParameter<std::string>("EEAlignmentFile", path + "EEAlignment.txt");
+    EEAlignmentFile_ = ps.getUntrackedParameter<std::string>("EEAlignmentFile", dataPath_ + "EEAlignment.txt");
   }
 
   getESAlignmentFromFile_ = ps.getUntrackedParameter<bool>("getESAlignmentFromFile", false);
   if (getESAlignmentFromFile_)
-    ESAlignmentFile_ = ps.getUntrackedParameter<std::string>("ESAlignmentFile", path + "ESAlignment.txt");
+    ESAlignmentFile_ = ps.getUntrackedParameter<std::string>("ESAlignmentFile", dataPath_ + "ESAlignment.txt");
 
   verbose_ = ps.getUntrackedParameter<int>("verbose", 0);
 
@@ -353,8 +354,8 @@ other solution : change this path name to work directly in afs, ex. :
   producedEcalPFRecHitThresholds_ = ps.getUntrackedParameter<bool>("producedEcalPFRecHitThresholds", false);
 
   // new for PFRecHit Thresholds
-  pfRecHitFile_ = ps.getUntrackedParameter<std::string>("pFRecHitFile", path + "EB_product_TL235.txt");
-  pfRecHitFileEE_ = ps.getUntrackedParameter<std::string>("pFRecHitFileEE", path + "EE_product_TL235.txt");
+  pfRecHitFile_ = ps.getUntrackedParameter<std::string>("pFRecHitFile", dataPath_ + "EB_product_TL235.txt");
+  pfRecHitFileEE_ = ps.getUntrackedParameter<std::string>("pFRecHitFileEE", dataPath_ + "EE_product_TL235.txt");
 
   if (producedEcalPFRecHitThresholds_) {  // user asks to produce constants
     if (!pfRecHitFile_.empty()) {         // if file provided read constants
@@ -413,17 +414,17 @@ other solution : change this path name to work directly in afs, ex. :
     edm::LogInfo(" getLaserAlphaFromTypeEE_ ") << getLaserAlphaFromTypeEE_;
     if (getLaserAlphaFromFileEB_) {
       EBLaserAlphaFile_ = ps.getUntrackedParameter<std::string>(
-          "EBLaserAlphaFile", path + "EBLaserAlpha.txt");  // file is used to read the alphas
+          "EBLaserAlphaFile", dataPath_ + "EBLaserAlpha.txt");  // file is used to read the alphas
     }
     if (getLaserAlphaFromFileEE_) {
       EELaserAlphaFile_ = ps.getUntrackedParameter<std::string>(
-          "EELaserAlphaFile", path + "EELaserAlpha.txt");  // file is used to read the alphas
+          "EELaserAlphaFile", dataPath_ + "EELaserAlpha.txt");  // file is used to read the alphas
     }
     if (getLaserAlphaFromTypeEB_) {
       laserAlphaMeanEBR_ = ps.getUntrackedParameter<double>("laserAlphaMeanEBR", 1.55);  // alpha russian crystals in EB
       laserAlphaMeanEBC_ = ps.getUntrackedParameter<double>("laserAlphaMeanEBC", 1.00);  // alpha chinese crystals in EB
       EBLaserAlphaFile_ = ps.getUntrackedParameter<std::string>(
-          "EBLaserAlphaFile", path + "EBLaserAlpha.txt");  // file to find out which one is russian/chinese
+          "EBLaserAlphaFile", dataPath_ + "EBLaserAlpha.txt");  // file to find out which one is russian/chinese
     }
     if (getLaserAlphaFromTypeEE_) {
       laserAlphaMeanEEC_higheta_ = ps.getUntrackedParameter<double>("laserAlphaMeanEEC_higheta",
@@ -433,9 +434,10 @@ other solution : change this path name to work directly in afs, ex. :
       laserAlphaMeanEER_ = ps.getUntrackedParameter<double>("laserAlphaMeanEER", 1.16);  // alpha russian crystals in EE
       laserAlphaMeanEEC_ = ps.getUntrackedParameter<double>("laserAlphaMeanEEC", 1.00);  // alpha chinese crystals in EE
       EELaserAlphaFile_ = ps.getUntrackedParameter<std::string>(
-          "EELaserAlphaFile", path + "EELaserAlpha.txt");  // file is used to find out which one is russian or chinese
+          "EELaserAlphaFile",
+          dataPath_ + "EELaserAlpha.txt");  // file is used to find out which one is russian or chinese
       EELaserAlphaFile2_ = ps.getUntrackedParameter<std::string>(
-          "EELaserAlphaFile2", path + "EELaserAlpha2.txt");  // file is used to read the alphas
+          "EELaserAlphaFile2", dataPath_ + "EELaserAlpha2.txt");  // file is used to read the alphas
     }
     setWhatProduced(this, &EcalTrivialConditionRetriever::produceEcalLaserAPDPNRatiosRef);
     findingRecord<EcalLaserAPDPNRatiosRefRcd>();

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
@@ -27,7 +27,8 @@
 using namespace edm;
 
 EcalTrivialConditionRetriever::EcalTrivialConditionRetriever(const edm::ParameterSet& ps) {
-  std::string path = "CalibCalorimetry/EcalTrivialCondModules/data/";
+  //  std::string path = "CalibCalorimetry/EcalTrivialCondModules/data/";
+  std::string path = "CalibCalorimetry/EcalTrivialCondModules/data_test/";
 
   /*since CMSSW_10_6_0, this path points to https://github.com/cms-data/CalibCalorimetry-EcalTrivialCondModules  (extra package). 
 To modify the default values :
@@ -352,8 +353,8 @@ other solution : change this path name to work directly in afs, ex. :
   producedEcalPFRecHitThresholds_ = ps.getUntrackedParameter<bool>("producedEcalPFRecHitThresholds", false);
 
   // new for PFRecHit Thresholds
-  pfRecHitFile_ = ps.getUntrackedParameter<std::string>("pFRecHitFile", path + "EB_thresholds_-1.txt");
-  pfRecHitFileEE_ = ps.getUntrackedParameter<std::string>("pFRecHitFileEE", path + "EE_thresholds_-1.txt");
+  pfRecHitFile_ = ps.getUntrackedParameter<std::string>("pFRecHitFile", path + "EB_product_TL235.txt");
+  pfRecHitFileEE_ = ps.getUntrackedParameter<std::string>("pFRecHitFileEE", path + "EE_product_TL235.txt");
 
   if (producedEcalPFRecHitThresholds_) {  // user asks to produce constants
     if (!pfRecHitFile_.empty()) {         // if file provided read constants
@@ -2861,9 +2862,10 @@ std::unique_ptr<EcalPFRecHitThresholds> EcalTrivialConditionRetriever::getPFRecH
       edm::LogInfo("EB ") << std::dec << eta << "/" << std::dec << phi << "/" << std::dec << zeta
                           << " thresh: " << thresh;
     nxt = nxt + 1;
-
-    EBDetId ebid(eta, phi);
-    ical->setValue(ebid, thresh);
+    if (EBDetId::validDetId(eta, phi)) {
+      EBDetId ebid(eta, phi);
+      ical->setValue(ebid.rawId(), thresh);
+    }
   }
   PFRecHitsFile.close();
   // fclose(inpFile);
@@ -2901,14 +2903,13 @@ std::unique_ptr<EcalPFRecHitThresholds> EcalTrivialConditionRetriever::getPFRecH
     }
 
     if (ix == 50)
-      edm::LogInfo("EE ") << std::dec << ix << "/" << std::dec << iy << "/" << std::dec << iz << " thresh: " << thresh
-                          << " eta=" << eta;
-
-    EEDetId eeid(ix, iy, iz);
-    ical->setValue(eeid, thresh);
+      edm::LogInfo("EE ") << std::dec << ix << "/" << std::dec << iy << "/" << std::dec << iz << " thresh: " << thresh;
+    if (EEDetId::validDetId(ix, iy, iz)) {
+      EEDetId eeid(ix, iy, iz);
+      ical->setValue(eeid.rawId(), thresh);
+    }
     nxt = nxt + 1;
   }
-
   PFRecHitsFileEE.close();
   //  fclose(inpFileEE);
   edm::LogInfo("Read number of EE crystals: ") << nxt;

--- a/CondTools/Ecal/interface/EcalPFRecHitThresholdsHandler.h
+++ b/CondTools/Ecal/interface/EcalPFRecHitThresholdsHandler.h
@@ -11,7 +11,6 @@
 #include "CondCore/PopCon/interface/PopConSourceHandler.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
-
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -22,8 +21,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
-
-
 
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
@@ -36,38 +33,34 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 
-
-
 #include "CondTools/Ecal/interface/EcalCondHeader.h"
 #include <string>
-
 
 namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 namespace popcon {
   class EcalPFRecHitThresholdsHandler : public popcon::PopConSourceHandler<EcalPFRecHitThresholds> {
   public:
-    EcalPFRecHitThresholdsHandler(edm::ParameterSet const & );
-    ~EcalPFRecHitThresholdsHandler() override; 
-			
+    EcalPFRecHitThresholdsHandler(edm::ParameterSet const&);
+    ~EcalPFRecHitThresholdsHandler() override;
+
     void getNewObjects() override;
     void readXML(const std::string& filename, EcalFloatCondObjectContainer& record);
     void readTXT(const std::string& filename, EcalFloatCondObjectContainer& record);
 
-    std::string id() const override { return m_name;}
+    std::string id() const override { return m_name; }
     EcalCondDBInterface* econn;
 
   private:
-    const EcalPFRecHitThresholds * myPFRecHitThresholds;
+    const EcalPFRecHitThresholds* myPFRecHitThresholds;
     std::string m_name;
-    unsigned int m_firstRun ;		
+    unsigned int m_firstRun;
     std::string m_file_name;
     std::string m_file_type;
   };
-}
+}  // namespace popcon
 #endif
-

--- a/CondTools/Ecal/interface/EcalPFRecHitThresholdsHandler.h
+++ b/CondTools/Ecal/interface/EcalPFRecHitThresholdsHandler.h
@@ -1,0 +1,73 @@
+#ifndef ECAL_PFRECHITTHRESHOLDS_HANDLER_H
+#define ECAL_PFRECHITTHRESHOLDS_HANDLER_H
+
+#include <vector>
+#include <typeinfo>
+#include <string>
+#include <map>
+#include <iostream>
+#include <ctime>
+
+#include "CondCore/PopCon/interface/PopConSourceHandler.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+
+
+
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+
+#include "OnlineDB/EcalCondDB/interface/all_monitoring_types.h"
+#include "OnlineDB/EcalCondDB/interface/RunDCSMagnetDat.h"
+#include "OnlineDB/Oracle/interface/Oracle.h"
+#include "OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+
+
+
+#include "CondTools/Ecal/interface/EcalCondHeader.h"
+#include <string>
+
+
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}
+
+namespace popcon {
+  class EcalPFRecHitThresholdsHandler : public popcon::PopConSourceHandler<EcalPFRecHitThresholds> {
+  public:
+    EcalPFRecHitThresholdsHandler(edm::ParameterSet const & );
+    ~EcalPFRecHitThresholdsHandler() override; 
+			
+    void getNewObjects() override;
+    void readXML(const std::string& filename, EcalFloatCondObjectContainer& record);
+    void readTXT(const std::string& filename, EcalFloatCondObjectContainer& record);
+
+    std::string id() const override { return m_name;}
+    EcalCondDBInterface* econn;
+
+  private:
+    const EcalPFRecHitThresholds * myPFRecHitThresholds;
+    std::string m_name;
+    unsigned int m_firstRun ;		
+    std::string m_file_name;
+    std::string m_file_type;
+  };
+}
+#endif
+

--- a/CondTools/Ecal/plugins/TestEcalPFRecHitThresholdsAnalyzer.cc
+++ b/CondTools/Ecal/plugins/TestEcalPFRecHitThresholdsAnalyzer.cc
@@ -1,0 +1,13 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondTools/Ecal/interface/EcalPFRecHitThresholdsHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+
+
+typedef popcon::PopConAnalyzer<popcon::EcalPFRecHitThresholdsHandler> ExTestEcalPFRecHitThresholdsAnalyzer;
+
+
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ExTestEcalPFRecHitThresholdsAnalyzer);

--- a/CondTools/Ecal/plugins/TestEcalPFRecHitThresholdsAnalyzer.cc
+++ b/CondTools/Ecal/plugins/TestEcalPFRecHitThresholdsAnalyzer.cc
@@ -2,12 +2,7 @@
 #include "CondTools/Ecal/interface/EcalPFRecHitThresholdsHandler.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
-
 typedef popcon::PopConAnalyzer<popcon::EcalPFRecHitThresholdsHandler> ExTestEcalPFRecHitThresholdsAnalyzer;
-
-
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(ExTestEcalPFRecHitThresholdsAnalyzer);

--- a/CondTools/Ecal/python/updatePFRecHitThresholds.py
+++ b/CondTools/Ecal/python/updatePFRecHitThresholds.py
@@ -1,0 +1,50 @@
+#copied from git cmssw/CondTools/Ecal/python/updateIntercali.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ProcessOne")
+
+process.MessageLogger = cms.Service("MessageLogger",
+    debugModules = cms.untracked.vstring('*'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    destinations = cms.untracked.vstring('cout')
+)
+
+process.source = cms.Source("EmptyIOVSource",
+    lastValue = cms.uint64(100000000000),
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(100000000000),
+    interval = cms.uint64(1)
+)
+
+process.load("CondCore.CondDB.CondDB_cfi")
+
+process.CondDB.connect = 'sqlite_file:EcalPFRecHitThresholds_34sigma_TL235.db'
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+  process.CondDB, 
+  logconnect = cms.untracked.string('sqlite_file:log.db'),   
+  toPut = cms.VPSet(
+    cms.PSet(
+      record = cms.string('EcalPFRecHitThresholdsRcd'),
+      tag = cms.string('EcalPFRecHitThresholds_34sigma_TL235')
+    )
+  )
+)
+
+process.Test1 = cms.EDAnalyzer("ExTestEcalPFRecHitThresholdsAnalyzer",
+  record = cms.string('EcalPFRecHitThresholdsRcd'),
+  loggingOn= cms.untracked.bool(True),
+  IsDestDbCheckedInQueryLog=cms.untracked.bool(True),
+  SinceAppendMode=cms.bool(True),
+  Source=cms.PSet(
+    firstRun = cms.string('1'),
+    type = cms.string('txt'),
+    fileName = cms.string('product_TL235.txt'),
+#    type = cms.string('xml'),
+#    fileName = cms.string('Intercalib_Bon.xml'),
+  )                            
+)
+
+process.p = cms.Path(process.Test1)

--- a/CondTools/Ecal/src/EcalPFRecHitThresholdsHandler.cc
+++ b/CondTools/Ecal/src/EcalPFRecHitThresholdsHandler.cc
@@ -3,16 +3,15 @@
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondTools/Ecal/interface/EcalFloatCondObjectContainerXMLTranslator.h"
 
-#include<iostream>
+#include <iostream>
 
 const Int_t kEBChannels = 61200, kEEChannels = 14648;
 
-popcon::EcalPFRecHitThresholdsHandler::EcalPFRecHitThresholdsHandler(const edm::ParameterSet & ps)
-  :    m_name(ps.getUntrackedParameter<std::string>("name","EcalPFRecHitThresholdsHandler")) {
-
+popcon::EcalPFRecHitThresholdsHandler::EcalPFRecHitThresholdsHandler(const edm::ParameterSet& ps)
+    : m_name(ps.getUntrackedParameter<std::string>("name", "EcalPFRecHitThresholdsHandler")) {
   edm::LogInfo("EcalPFRecHitThresholds Source handler constructor\n");
-  m_firstRun = static_cast<unsigned int>(atoi( ps.getParameter<std::string>("firstRun").c_str()));
-  m_file_type = ps.getParameter<std::string>("type");           // xml/txt
+  m_firstRun = static_cast<unsigned int>(atoi(ps.getParameter<std::string>("firstRun").c_str()));
+  m_file_type = ps.getParameter<std::string>("type");  // xml/txt
   m_file_name = ps.getParameter<std::string>("fileName");
 }
 
@@ -20,49 +19,48 @@ popcon::EcalPFRecHitThresholdsHandler::~EcalPFRecHitThresholdsHandler() {}
 
 void popcon::EcalPFRecHitThresholdsHandler::getNewObjects() {
   //  std::cout << "------- Ecal - > getNewObjects\n";
-  std::ostringstream ss; 
-  ss<<"ECAL ";
-	
-  unsigned long long  irun;
-  std::string file_= m_file_name;
+  std::ostringstream ss;
+  ss << "ECAL ";
+
+  unsigned long long irun;
+  std::string file_ = m_file_name;
   edm::LogInfo("going to open file ") << file_;
-	    	    
+
   //      EcalCondHeader   header;
-  EcalPFRecHitThresholds * payload = new EcalPFRecHitThresholds;
-  if(m_file_type == "xml")
+  EcalPFRecHitThresholds* payload = new EcalPFRecHitThresholds;
+  if (m_file_type == "xml")
     readXML(file_, *payload);
   else
     readTXT(file_, *payload);
   irun = m_firstRun;
-  Time_t snc= (Time_t) irun ;
+  Time_t snc = (Time_t)irun;
 
   popcon::PopConSourceHandler<EcalPFRecHitThresholds>::m_to_transfer.push_back(std::make_pair(payload, snc));
 }
 
-void popcon::EcalPFRecHitThresholdsHandler::readXML(const std::string& file_,
-					    EcalFloatCondObjectContainer& record){
+void popcon::EcalPFRecHitThresholdsHandler::readXML(const std::string& file_, EcalFloatCondObjectContainer& record) {
   std::string dummyLine, bid;
   std::ifstream fxml;
   fxml.open(file_);
-  if(!fxml.is_open()) {
+  if (!fxml.is_open()) {
     edm::LogInfo("ERROR : cannot open file ") << file_;
-    exit (1);
+    exit(1);
   }
   // header
-  for( int i=0; i< 6; i++) {
-    getline(fxml, dummyLine);   // skip first lines
+  for (int i = 0; i < 6; i++) {
+    getline(fxml, dummyLine);  // skip first lines
     //	std::cout << dummyLine << std::endl;
   }
   fxml >> bid;
-  std::string stt = bid.substr(7,5);
+  std::string stt = bid.substr(7, 5);
   std::istringstream iEB(stt);
   int nEB;
   iEB >> nEB;
-  if(nEB != kEBChannels) {
+  if (nEB != kEBChannels) {
     edm::LogInfo("strange number of EB channels ") << nEB;
     exit(-1);
   }
-  fxml >> bid;   // <item_version>0</item_version>
+  fxml >> bid;  // <item_version>0</item_version>
   for (int iChannel = 0; iChannel < kEBChannels; iChannel++) {
     EBDetId myEBDetId = EBDetId::unhashIndex(iChannel);
     fxml >> bid;
@@ -71,20 +69,20 @@ void popcon::EcalPFRecHitThresholdsHandler::readXML(const std::string& file_,
     float val = std::stof(stt);
     record[myEBDetId] = val;
   }
-  for( int i=0; i< 5; i++) {
-    getline(fxml, dummyLine);   // skip first lines
+  for (int i = 0; i < 5; i++) {
+    getline(fxml, dummyLine);  // skip first lines
     //	std::cout << dummyLine << std::endl;
   }
   fxml >> bid;
-  stt = bid.substr(7,5);
+  stt = bid.substr(7, 5);
   std::istringstream iEE(stt);
   int nEE;
   iEE >> nEE;
-  if(nEE != kEEChannels) {
+  if (nEE != kEEChannels) {
     edm::LogInfo("strange number of EE channels ") << nEE;
     exit(-1);
   }
-  fxml >> bid;   // <item_version>0</item_version>
+  fxml >> bid;  // <item_version>0</item_version>
   // now endcaps
   for (int iChannel = 0; iChannel < kEEChannels; iChannel++) {
     EEDetId myEEDetId = EEDetId::unhashIndex(iChannel);
@@ -96,24 +94,22 @@ void popcon::EcalPFRecHitThresholdsHandler::readXML(const std::string& file_,
   }
 }
 
-void popcon::EcalPFRecHitThresholdsHandler::readTXT(const std::string& file_,
-					    EcalFloatCondObjectContainer& record){
+void popcon::EcalPFRecHitThresholdsHandler::readTXT(const std::string& file_, EcalFloatCondObjectContainer& record) {
   std::ifstream ftxt;
   ftxt.open(file_);
-  if(!ftxt.is_open()) {
+  if (!ftxt.is_open()) {
     edm::LogInfo("ERROR : cannot open file ") << file_;
-    exit (1);
+    exit(1);
   }
   int number_of_lines = 0, eta, phi, x, y, z;
   float val;
   std::string line;
   while (std::getline(ftxt, line)) {
-    if(number_of_lines < kEBChannels) {                                    // barrel
+    if (number_of_lines < kEBChannels) {  // barrel
       sscanf(line.c_str(), "%i %i %i %f", &eta, &phi, &z, &val);
       EBDetId ebdetid(eta, phi, EBDetId::ETAPHIMODE);
       record[ebdetid] = val;
-    }
-    else {                                                                 // endcaps
+    } else {  // endcaps
       sscanf(line.c_str(), "%i %i %i %f", &x, &y, &z, &val);
       EEDetId eedetid(x, y, z, EEDetId::XYMODE);
       record[eedetid] = val;
@@ -122,6 +118,6 @@ void popcon::EcalPFRecHitThresholdsHandler::readTXT(const std::string& file_,
   }
   edm::LogInfo("Number of lines in text file: ") << number_of_lines;
   int kChannels = kEBChannels + kEEChannels;
-  if(number_of_lines != kChannels)
-  edm::LogInfo("wrong number of channels!  Please check ");
+  if (number_of_lines != kChannels)
+    edm::LogInfo("wrong number of channels!  Please check ");
 }

--- a/CondTools/Ecal/src/EcalPFRecHitThresholdsHandler.cc
+++ b/CondTools/Ecal/src/EcalPFRecHitThresholdsHandler.cc
@@ -1,0 +1,127 @@
+#include "CondTools/Ecal/interface/EcalPFRecHitThresholdsHandler.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondTools/Ecal/interface/EcalFloatCondObjectContainerXMLTranslator.h"
+
+#include<iostream>
+
+const Int_t kEBChannels = 61200, kEEChannels = 14648;
+
+popcon::EcalPFRecHitThresholdsHandler::EcalPFRecHitThresholdsHandler(const edm::ParameterSet & ps)
+  :    m_name(ps.getUntrackedParameter<std::string>("name","EcalPFRecHitThresholdsHandler")) {
+
+  edm::LogInfo("EcalPFRecHitThresholds Source handler constructor\n");
+  m_firstRun = static_cast<unsigned int>(atoi( ps.getParameter<std::string>("firstRun").c_str()));
+  m_file_type = ps.getParameter<std::string>("type");           // xml/txt
+  m_file_name = ps.getParameter<std::string>("fileName");
+}
+
+popcon::EcalPFRecHitThresholdsHandler::~EcalPFRecHitThresholdsHandler() {}
+
+void popcon::EcalPFRecHitThresholdsHandler::getNewObjects() {
+  //  std::cout << "------- Ecal - > getNewObjects\n";
+  std::ostringstream ss; 
+  ss<<"ECAL ";
+	
+  unsigned long long  irun;
+  std::string file_= m_file_name;
+  edm::LogInfo("going to open file ") << file_;
+	    	    
+  //      EcalCondHeader   header;
+  EcalPFRecHitThresholds * payload = new EcalPFRecHitThresholds;
+  if(m_file_type == "xml")
+    readXML(file_, *payload);
+  else
+    readTXT(file_, *payload);
+  irun = m_firstRun;
+  Time_t snc= (Time_t) irun ;
+
+  popcon::PopConSourceHandler<EcalPFRecHitThresholds>::m_to_transfer.push_back(std::make_pair(payload, snc));
+}
+
+void popcon::EcalPFRecHitThresholdsHandler::readXML(const std::string& file_,
+					    EcalFloatCondObjectContainer& record){
+  std::string dummyLine, bid;
+  std::ifstream fxml;
+  fxml.open(file_);
+  if(!fxml.is_open()) {
+    edm::LogInfo("ERROR : cannot open file ") << file_;
+    exit (1);
+  }
+  // header
+  for( int i=0; i< 6; i++) {
+    getline(fxml, dummyLine);   // skip first lines
+    //	std::cout << dummyLine << std::endl;
+  }
+  fxml >> bid;
+  std::string stt = bid.substr(7,5);
+  std::istringstream iEB(stt);
+  int nEB;
+  iEB >> nEB;
+  if(nEB != kEBChannels) {
+    edm::LogInfo("strange number of EB channels ") << nEB;
+    exit(-1);
+  }
+  fxml >> bid;   // <item_version>0</item_version>
+  for (int iChannel = 0; iChannel < kEBChannels; iChannel++) {
+    EBDetId myEBDetId = EBDetId::unhashIndex(iChannel);
+    fxml >> bid;
+    std::size_t found = bid.find("</");
+    stt = bid.substr(6, found - 6);
+    float val = std::stof(stt);
+    record[myEBDetId] = val;
+  }
+  for( int i=0; i< 5; i++) {
+    getline(fxml, dummyLine);   // skip first lines
+    //	std::cout << dummyLine << std::endl;
+  }
+  fxml >> bid;
+  stt = bid.substr(7,5);
+  std::istringstream iEE(stt);
+  int nEE;
+  iEE >> nEE;
+  if(nEE != kEEChannels) {
+    edm::LogInfo("strange number of EE channels ") << nEE;
+    exit(-1);
+  }
+  fxml >> bid;   // <item_version>0</item_version>
+  // now endcaps
+  for (int iChannel = 0; iChannel < kEEChannels; iChannel++) {
+    EEDetId myEEDetId = EEDetId::unhashIndex(iChannel);
+    fxml >> bid;
+    std::size_t found = bid.find("</");
+    stt = bid.substr(6, found - 6);
+    float val = std::stof(stt);
+    record[myEEDetId] = val;
+  }
+}
+
+void popcon::EcalPFRecHitThresholdsHandler::readTXT(const std::string& file_,
+					    EcalFloatCondObjectContainer& record){
+  std::ifstream ftxt;
+  ftxt.open(file_);
+  if(!ftxt.is_open()) {
+    edm::LogInfo("ERROR : cannot open file ") << file_;
+    exit (1);
+  }
+  int number_of_lines = 0, eta, phi, x, y, z;
+  float val;
+  std::string line;
+  while (std::getline(ftxt, line)) {
+    if(number_of_lines < kEBChannels) {                                    // barrel
+      sscanf(line.c_str(), "%i %i %i %f", &eta, &phi, &z, &val);
+      EBDetId ebdetid(eta, phi, EBDetId::ETAPHIMODE);
+      record[ebdetid] = val;
+    }
+    else {                                                                 // endcaps
+      sscanf(line.c_str(), "%i %i %i %f", &x, &y, &z, &val);
+      EEDetId eedetid(x, y, z, EEDetId::XYMODE);
+      record[eedetid] = val;
+    }
+    number_of_lines++;
+  }
+  edm::LogInfo("Number of lines in text file: ") << number_of_lines;
+  int kChannels = kEBChannels + kEEChannels;
+  if(number_of_lines != kChannels)
+  edm::LogInfo("wrong number of channels!  Please check ");
+}


### PR DESCRIPTION
#### PR description:

To allow the test of multiple scenarii with Ecal Particle Flow RecHit Thresholds, some simple txt files are asked to be included in DataBase in tag form.  These pgms are the tools for this.  a bug was found in  CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc  to perform this operation.  It is corrected.

#### PR validation:

Creation of sqlite files with the pgms and dumping the payloads gives the same results as txt files.


Done : 
scram build code-checks
scram build code-format
