### PR TITLE
Changed boost::tuple for std::tuple in SoftLepton

### DIFF
--- a/RecoBTag/SoftLepton/test/testLeptonAssociator.cc
+++ b/RecoBTag/SoftLepton/test/testLeptonAssociator.cc
@@ -1,10 +1,9 @@
-#include <memory>
 #include <iostream>
-#include <string>
 #include <map>
+#include <memory>
+#include <string>
 #include <set>
-
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -104,7 +103,7 @@ void printAssociations(const char* label,
   if (bychi2.find(tp) != bychi2.end())
     found_bychi2 = bychi2[tp];
 
-  typedef boost::tuple<double, double> Quality;
+  typedef std::tuple<double, double> Quality;
   Quality quality;
   std::map<edm::RefToBase<reco::Track>, Quality> found;
   for (std::vector<std::pair<edm::RefToBase<reco::Track>, double> >::const_iterator it = found_byhits.begin();
@@ -112,24 +111,24 @@ void printAssociations(const char* label,
        ++it) {
     const edm::RefToBase<reco::Track> ref = it->first;
     found.insert(std::make_pair(ref, Quality()));
-    found[ref].get<0>() = it->second;
+    std::get<0>(found[ref]) = it->second;
   }
   for (std::vector<std::pair<edm::RefToBase<reco::Track>, double> >::const_iterator it = found_bychi2.begin();
        it != found_bychi2.end();
        ++it) {
     const edm::RefToBase<reco::Track> ref = it->first;
     found.insert(std::make_pair(ref, Quality()));
-    found[ref].get<1>() = -it->second;  // why is chi2 negative ?
+    std::get<1>(found[ref]) = -it->second;  // why is chi2 negative ?
   }
 
   for (std::map<edm::RefToBase<reco::Track>, Quality>::const_iterator it = found.begin(); it != found.end(); ++it) {
     std::cout << "    " << std::setw(7) << std::left << label << std::right << it->first;
-    if (it->second.get<0>())
-      std::cout << " [" << std::setw(6) << std::setprecision(3) << it->second.get<0>() << "]";
+    if (std::get<0>(it->second))
+      std::cout << " [" << std::setw(6) << std::setprecision(3) << std::get<0>(it->second) << "]";
     else
       std::cout << "         ";
-    if (it->second.get<1>())
-      std::cout << " [" << std::setw(6) << std::setprecision(3) << it->second.get<1>() << "]";
+    if (std::get<1>(it->second))
+      std::cout << " [" << std::setw(6) << std::setprecision(3) << std::get<1>(it->second) << "]";
     else
       std::cout << "         ";
     std::cout << std::endl;
@@ -147,7 +146,7 @@ void printAssociations(const char* label,
   if (bychi2.find(tp) != bychi2.end())
     found_bychi2 = bychi2[tp];
 
-  typedef boost::tuple<double, double> Quality;
+  typedef std::tuple<double, double> Quality;
   Quality quality;
   std::map<TrackingParticleRef, Quality> found;
   for (std::vector<std::pair<TrackingParticleRef, double> >::const_iterator it = found_byhits.begin();
@@ -155,24 +154,24 @@ void printAssociations(const char* label,
        ++it) {
     const TrackingParticleRef ref = it->first;
     found.insert(std::make_pair(ref, Quality()));
-    found[ref].get<0>() = it->second;
+    std::get<0>(found[ref]) = it->second;
   }
   for (std::vector<std::pair<TrackingParticleRef, double> >::const_iterator it = found_bychi2.begin();
        it != found_bychi2.end();
        ++it) {
     const TrackingParticleRef ref = it->first;
     found.insert(std::make_pair(ref, Quality()));
-    found[ref].get<1>() = -it->second;  // why is chi2 negative ?
+    std::get<1>(found[ref]) = -it->second;  // why is chi2 negative ?
   }
 
   for (std::map<TrackingParticleRef, Quality>::const_iterator it = found.begin(); it != found.end(); ++it) {
     std::cout << "    " << std::setw(7) << std::left << label << std::right << it->first;
-    if (it->second.get<0>())
-      std::cout << " [" << std::setw(6) << std::setprecision(3) << it->second.get<0>() << "]";
+    if (std::get<0>(it->second))
+      std::cout << " [" << std::setw(6) << std::setprecision(3) << std::get<0>(it->second) << "]";
     else
       std::cout << "         ";
-    if (it->second.get<1>())
-      std::cout << " [" << std::setw(6) << std::setprecision(3) << it->second.get<1>() << "]";
+    if (std::get<1>(it->second))
+      std::cout << " [" << std::setw(6) << std::setprecision(3) << std::get<1>(it->second) << "]";
     else
       std::cout << "         ";
     std::cout << std::endl;

--- a/RecoBTag/SoftLepton/test/testLeptonAssociator.cc
+++ b/RecoBTag/SoftLepton/test/testLeptonAssociator.cc
@@ -104,7 +104,6 @@ void printAssociations(const char* label,
     found_bychi2 = bychi2[tp];
 
   typedef std::tuple<double, double> Quality;
-  Quality quality;
   std::map<edm::RefToBase<reco::Track>, Quality> found;
   for (std::vector<std::pair<edm::RefToBase<reco::Track>, double> >::const_iterator it = found_byhits.begin();
        it != found_byhits.end();
@@ -147,7 +146,6 @@ void printAssociations(const char* label,
     found_bychi2 = bychi2[tp];
 
   typedef std::tuple<double, double> Quality;
-  Quality quality;
   std::map<TrackingParticleRef, Quality> found;
   for (std::vector<std::pair<TrackingParticleRef, double> >::const_iterator it = found_byhits.begin();
        it != found_byhits.end();


### PR DESCRIPTION
#### PR description:
Replaced boost::tuple for std::tuple. They have similar functionality and std::tuple should reduce boost dependencies.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 
