### PR TITLE
Changed boost::tuple for std::tuple in RecoMuon/TrackingTools

### DIFF
--- a/RecoMuon/TrackingTools/src/MuonUpdatorAtVertex.cc
+++ b/RecoMuon/TrackingTools/src/MuonUpdatorAtVertex.cc
@@ -109,10 +109,10 @@ pair<bool, FreeTrajectoryState> MuonUpdatorAtVertex::update(const reco::Transien
     return result;
   }
 
-  if (constrainedTransientTrack.get<0>())
-    if (constrainedTransientTrack.get<2>() <= theChi2Cut) {
+  if (std::get<0>(constrainedTransientTrack))
+    if (std::get<2>(constrainedTransientTrack) <= theChi2Cut) {
       result.first = true;
-      result.second = *constrainedTransientTrack.get<1>().impactPointState().freeState();
+      result.second = *std::get<1>(constrainedTransientTrack).impactPointState().freeState();
     } else
       LogTrace(metname) << "Constraint at vertex failed: too large chi2";
   else

--- a/RecoVertex/KalmanVertexFit/interface/SingleTrackVertexConstraint.h
+++ b/RecoVertex/KalmanVertexFit/interface/SingleTrackVertexConstraint.h
@@ -8,7 +8,8 @@
 #include "RecoVertex/VertexTools/interface/LinearizedTrackStateFactory.h"
 #include "RecoVertex/VertexTools/interface/VertexTrackFactory.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackFromFTSFactory.h"
-#include "boost/tuple/tuple.hpp"
+
+#include <tuple>
 /**
  * Class to re-estimate the parameters of the track at the vertex,
  *  with the vertex constraint or a BeamSpot, using the Kalman filter algorithms.
@@ -19,7 +20,7 @@
 class SingleTrackVertexConstraint {
 public:
   typedef std::pair<reco::TransientTrack, float> TrackFloatPair;
-  typedef boost::tuple<bool, reco::TransientTrack, float> BTFtuple;
+  typedef std::tuple<bool, reco::TransientTrack, float> BTFtuple;
 
   SingleTrackVertexConstraint(bool doTrackerBoundCheck = true) : doTrackerBoundCheck_(doTrackerBoundCheck) {}
 

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.cc
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.cc
@@ -77,10 +77,10 @@ void KVFTrackUpdate::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     SingleTrackVertexConstraint stvc;
     for (unsigned int i = 0; i < t_tks.size(); i++) {
       SingleTrackVertexConstraint::BTFtuple a = stvc.constrain(t_tks[i], glbPos, glbErrPos);
-      std::cout << "Chi2: " << a.get<2>() << std::endl;
+      std::cout << "Chi2: " << std::get<2>(a) << std::endl;
       if (recoBeamSpotHandle.isValid()) {
         SingleTrackVertexConstraint::BTFtuple b = stvc.constrain(t_tks[i], *recoBeamSpotHandle);
-        std::cout << "Chi2: " << b.get<2>() << std::endl;
+        std::cout << "Chi2: " << std::get<2>(b) << std::endl;
       }
     }
   }


### PR DESCRIPTION
#### PR description:
Replaced boost::tuple for std::tuple. They have similar functionality and std::tuple should reduce boost dependencies.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 
