### PR TITLE
Better TrajectorySeed interface to recHits

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/SeedMultiplicityAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SeedMultiplicityAnalyzer.cc
@@ -372,7 +372,7 @@ void SeedMultiplicityAnalyzer::analyze(const edm::Event& iEvent, const edm::Even
       if (filter->isSelected(iseed)) {
         ++nseeds;
 
-        TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder->build(&*(seed->recHits().second - 1));
+        TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder->build(&*(seed->recHits().end() - 1));
         TrajectoryStateOnSurface state =
             trajectoryStateTransform::transientState(seed->startingState(), recHit->surface(), theMF.product());
         //      TrajectoryStateClosestToBeamLine tsAtClosestApproachSeed = tscblBuilder(*state.freeState(),bs); // here I need them BS
@@ -388,17 +388,13 @@ void SeedMultiplicityAnalyzer::analyze(const edm::Event& iEvent, const edm::Even
             (*histoeta2D)[i]->Fill(tmpmult[i], eta);
         }
 
-        // loop on rec hits
-
-        TrajectorySeed::range rechits = seed->recHits();
-
         int npixelrh = 0;
-        for (TrajectorySeed::const_iterator hit = rechits.first; hit != rechits.second; ++hit) {
-          const SiPixelRecHit* sphit = dynamic_cast<const SiPixelRecHit*>(&(*hit));
+        for (auto const& hit : seed->recHits()) {
+          const SiPixelRecHit* sphit = dynamic_cast<const SiPixelRecHit*>(&hit);
           if (sphit) {
             ++npixelrh;
             // compute state on recHit surface
-            TransientTrackingRecHit::RecHitPointer ttrhit = theTTRHBuilder->build(&*hit);
+            TransientTrackingRecHit::RecHitPointer ttrhit = theTTRHBuilder->build(&hit);
             TrajectoryStateOnSurface tsos =
                 trajectoryStateTransform::transientState(seed->startingState(), ttrhit->surface(), theMF.product());
 

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -525,7 +525,7 @@ void TrackBuildingAnalyzer::analyze(const edm::Event& iEvent,
   //double qoverp       = tsAtClosestApproachSeed.trackStateAtPCA().charge()/p.mag();
   //double theta        = p.theta();
   //double lambda       = M_PI/2-p.theta();
-  double numberOfHits = candidate.recHits().second - candidate.recHits().first;
+  double numberOfHits = candidate.nHits();
   double dxy = (-v.x() * sin(p.phi()) + v.y() * cos(p.phi()));
   double dz = v.z() - (v.x() * p.x() + v.y() * p.y()) / p.perp() * p.z() / p.perp();
 

--- a/DataFormats/EgammaReco/interface/ElectronSeed.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeed.h
@@ -65,7 +65,6 @@ namespace reco {
       void setDet(int iDetId, int iLayerOrDiskNr);
     };
 
-    typedef edm::OwnVector<TrackingRecHit> RecHitContainer;
     typedef edm::RefToBase<CaloCluster> CaloClusterRef;
     typedef edm::Ref<TrackCollection> CtfTrackRef;
 
@@ -135,7 +134,7 @@ namespace reco {
                                              const float dRZ2Pos,
                                              const float dRZ2Neg,
                                              const char hitMask,
-                                             const TrajectorySeed::range recHits);
+                                             RecHitContainer const& recHits);
 
   private:
     static float bestVal(float val1, float val2) { return std::abs(val1) < std::abs(val2) ? val1 : val2; }

--- a/DataFormats/EgammaReco/interface/ElectronSeed.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeed.h
@@ -134,7 +134,7 @@ namespace reco {
                                              const float dRZ2Pos,
                                              const float dRZ2Neg,
                                              const char hitMask,
-                                             RecHitContainer const& recHits);
+                                             TrajectorySeed::RecHitRange const& recHits);
 
   private:
     static float bestVal(float val1, float val2) { return std::abs(val1) < std::abs(val2) ? val1 : val2; }

--- a/DataFormats/EgammaReco/src/ElectronSeed.cc
+++ b/DataFormats/EgammaReco/src/ElectronSeed.cc
@@ -48,7 +48,7 @@ unsigned int ElectronSeed::hitsMask() const {
   int mask = 0;
   for (size_t hitNr = 0; hitNr < nHits(); hitNr++) {
     int bitNr = 0x1 << hitNr;
-    int hitDetId = recHits()[hitNr].geographicalId().rawId();
+    int hitDetId = (recHits().begin() + hitNr)->geographicalId().rawId();
     auto detIdMatcher = [hitDetId](const ElectronSeed::PMVars& var) { return hitDetId == var.detId; };
     if (std::find_if(hitInfo_.begin(), hitInfo_.end(), detIdMatcher) != hitInfo_.end()) {
       mask |= bitNr;
@@ -79,7 +79,7 @@ void ElectronSeed::initTwoHitSeed(const unsigned char hitMask) {
     auto& info = hitInfo_[hitNr];
     info.setDPhi(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
     info.setDRZ(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
-    info.setDet(recHits()[hitNrs[hitNr]].geographicalId(), -1);
+    info.setDet((recHits().begin() + hitNrs[hitNr])->geographicalId(), -1);
   }
 }
 
@@ -128,11 +128,11 @@ std::vector<ElectronSeed::PMVars> ElectronSeed::createHitInfo(const float dPhi1P
                                                               const float dRZ2Pos,
                                                               const float dRZ2Neg,
                                                               const char hitMask,
-                                                              RecHitContainer const& recHits) {
+                                                              TrajectorySeed::RecHitRange const& recHits) {
   if (hitMask == 0)
     return std::vector<ElectronSeed::PMVars>();  //was trackerDriven so no matched hits
 
-  size_t nrRecHits = recHits.size();
+  size_t nrRecHits = std::distance(recHits.begin(), recHits.end());
   std::vector<unsigned int> hitNrs = hitNrsFromMask(hitMask);
 
   if (hitNrs.size() != 2) {
@@ -153,12 +153,12 @@ std::vector<ElectronSeed::PMVars> ElectronSeed::createHitInfo(const float dPhi1P
   hitInfo[0].setDPhi(dPhi1Pos, dPhi1Neg);
   hitInfo[0].setDRZ(dRZ1Pos, dRZ1Neg);
   hitInfo[0].setDet(
-      recHits[hitNrs[0]].geographicalId(),
+      (recHits.begin() + hitNrs[0])->geographicalId(),
       -1);  //getting the layer information needs tracker topo, hence why its stored in the first as its a pain to access
   hitInfo[1].setDPhi(dPhi2Pos, dPhi2Neg);
   hitInfo[1].setDRZ(dRZ2Pos, dRZ2Neg);
   hitInfo[1].setDet(
-      recHits[hitNrs[1]].geographicalId(),
+      (recHits.begin() + hitNrs[1])->geographicalId(),
       -1);  //getting the layer information needs tracker topo, hence why its stored in the first as its a pain to access
   return hitInfo;
 }

--- a/DataFormats/EgammaReco/src/ElectronSeed.cc
+++ b/DataFormats/EgammaReco/src/ElectronSeed.cc
@@ -25,7 +25,7 @@ ElectronSeed::ElectronSeed(const TrajectorySeed& seed)
       isEcalDriven_(false),
       isTrackerDriven_(false) {}
 
-ElectronSeed::ElectronSeed(PTrajectoryStateOnDet& pts, recHitContainer& rh, PropagationDirection& dir)
+ElectronSeed::ElectronSeed(PTrajectoryStateOnDet& pts, RecHitContainer& rh, PropagationDirection& dir)
     : TrajectorySeed(pts, rh, dir),
       ctfTrack_(),
       caloCluster_(),
@@ -48,7 +48,7 @@ unsigned int ElectronSeed::hitsMask() const {
   int mask = 0;
   for (size_t hitNr = 0; hitNr < nHits(); hitNr++) {
     int bitNr = 0x1 << hitNr;
-    int hitDetId = (recHits().first + hitNr)->geographicalId().rawId();
+    int hitDetId = recHits()[hitNr].geographicalId().rawId();
     auto detIdMatcher = [hitDetId](const ElectronSeed::PMVars& var) { return hitDetId == var.detId; };
     if (std::find_if(hitInfo_.begin(), hitInfo_.end(), detIdMatcher) != hitInfo_.end()) {
       mask |= bitNr;
@@ -79,7 +79,7 @@ void ElectronSeed::initTwoHitSeed(const unsigned char hitMask) {
     auto& info = hitInfo_[hitNr];
     info.setDPhi(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
     info.setDRZ(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
-    info.setDet((recHits().first + hitNrs[hitNr])->geographicalId(), -1);
+    info.setDet(recHits()[hitNrs[hitNr]].geographicalId(), -1);
   }
 }
 
@@ -128,11 +128,11 @@ std::vector<ElectronSeed::PMVars> ElectronSeed::createHitInfo(const float dPhi1P
                                                               const float dRZ2Pos,
                                                               const float dRZ2Neg,
                                                               const char hitMask,
-                                                              const TrajectorySeed::range recHits) {
+                                                              RecHitContainer const& recHits) {
   if (hitMask == 0)
     return std::vector<ElectronSeed::PMVars>();  //was trackerDriven so no matched hits
 
-  size_t nrRecHits = std::distance(recHits.first, recHits.second);
+  size_t nrRecHits = recHits.size();
   std::vector<unsigned int> hitNrs = hitNrsFromMask(hitMask);
 
   if (hitNrs.size() != 2) {
@@ -153,12 +153,12 @@ std::vector<ElectronSeed::PMVars> ElectronSeed::createHitInfo(const float dPhi1P
   hitInfo[0].setDPhi(dPhi1Pos, dPhi1Neg);
   hitInfo[0].setDRZ(dRZ1Pos, dRZ1Neg);
   hitInfo[0].setDet(
-      (recHits.first + hitNrs[0])->geographicalId(),
+      recHits[hitNrs[0]].geographicalId(),
       -1);  //getting the layer information needs tracker topo, hence why its stored in the first as its a pain to access
   hitInfo[1].setDPhi(dPhi2Pos, dPhi2Neg);
   hitInfo[1].setDRZ(dRZ2Pos, dRZ2Neg);
   hitInfo[1].setDet(
-      (recHits.first + hitNrs[1])->geographicalId(),
+      recHits[hitNrs[1]].geographicalId(),
       -1);  //getting the layer information needs tracker topo, hence why its stored in the first as its a pain to access
   return hitInfo;
 }

--- a/DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h
+++ b/DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h
@@ -16,8 +16,6 @@
 
 class L2MuonTrajectorySeed : public TrajectorySeed {
 public:
-  typedef edm::OwnVector<TrackingRecHit> RecHitContainer;
-
   /// Default constructor
   L2MuonTrajectorySeed();
 

--- a/DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h
+++ b/DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h
@@ -15,8 +15,6 @@
 
 class L3MuonTrajectorySeed : public TrajectorySeed {
 public:
-  typedef edm::OwnVector<TrackingRecHit> RecHitContainer;
-
   /// Default constructor
   L3MuonTrajectorySeed() {}
 

--- a/DataFormats/MuonSeed/src/L2MuonTrajectorySeed.cc
+++ b/DataFormats/MuonSeed/src/L2MuonTrajectorySeed.cc
@@ -12,7 +12,7 @@ L2MuonTrajectorySeed::L2MuonTrajectorySeed() : TrajectorySeed() {}
 
 // Constructor
 L2MuonTrajectorySeed::L2MuonTrajectorySeed(PTrajectoryStateOnDet const& ptsos,
-                                           recHitContainer const& rh,
+                                           RecHitContainer const& rh,
                                            PropagationDirection dir,
                                            l1extra::L1MuonParticleRef l1Ref)
     : TrajectorySeed(ptsos, rh, dir) {
@@ -20,7 +20,7 @@ L2MuonTrajectorySeed::L2MuonTrajectorySeed(PTrajectoryStateOnDet const& ptsos,
 }
 
 L2MuonTrajectorySeed::L2MuonTrajectorySeed(PTrajectoryStateOnDet const& ptsos,
-                                           recHitContainer const& rh,
+                                           RecHitContainer const& rh,
                                            PropagationDirection dir,
                                            l1t::MuonRef l1Ref)
     : TrajectorySeed(ptsos, rh, dir) {

--- a/DataFormats/ParticleFlowReco/interface/ConvBremSeed.h
+++ b/DataFormats/ParticleFlowReco/interface/ConvBremSeed.h
@@ -23,8 +23,6 @@ namespace reco {
 
   class ConvBremSeed : public TrajectorySeed {
   public:
-    typedef edm::OwnVector<TrackingRecHit> recHitContainer;
-
     ConvBremSeed() {}
     ~ConvBremSeed() override {}
 

--- a/DataFormats/TrajectorySeed/interface/TrajectorySeed.h
+++ b/DataFormats/TrajectorySeed/interface/TrajectorySeed.h
@@ -16,20 +16,18 @@
 **/
 class TrajectorySeed {
 public:
-  typedef edm::OwnVector<TrackingRecHit> recHitContainer;
-  typedef recHitContainer::const_iterator const_iterator;
-  typedef std::pair<const_iterator, const_iterator> range;
+  typedef edm::OwnVector<TrackingRecHit> RecHitContainer;
 
   TrajectorySeed() {}
   virtual ~TrajectorySeed() {}
 
-  TrajectorySeed(PTrajectoryStateOnDet const& ptsos, recHitContainer const& rh, PropagationDirection dir)
+  TrajectorySeed(PTrajectoryStateOnDet const& ptsos, RecHitContainer const& rh, PropagationDirection dir)
       : hits_(rh), tsos_(ptsos), dir_(dir) {}
 
-  TrajectorySeed(PTrajectoryStateOnDet const& ptsos, recHitContainer&& rh, PropagationDirection dir) noexcept
+  TrajectorySeed(PTrajectoryStateOnDet const& ptsos, RecHitContainer&& rh, PropagationDirection dir) noexcept
       : hits_(std::move(rh)), tsos_(ptsos), dir_(dir) {}
 
-  void swap(PTrajectoryStateOnDet& ptsos, recHitContainer& rh, PropagationDirection& dir) noexcept {
+  void swap(PTrajectoryStateOnDet& ptsos, RecHitContainer& rh, PropagationDirection& dir) noexcept {
     hits_.swap(rh);
     std::swap(tsos_, ptsos);
     std::swap(dir_, dir);
@@ -49,7 +47,7 @@ public:
 
   TrajectorySeed& operator=(TrajectorySeed&& o) noexcept = default;
 
-  range recHits() const { return std::make_pair(hits_.begin(), hits_.end()); }
+  auto const& recHits() const { return hits_; }
   unsigned int nHits() const { return hits_.size(); }
   PropagationDirection direction() const { return dir_; }
   PTrajectoryStateOnDet const& startingState() const { return tsos_; }
@@ -57,7 +55,7 @@ public:
   virtual TrajectorySeed* clone() const { return new TrajectorySeed(*this); }
 
 private:
-  edm::OwnVector<TrackingRecHit> hits_;
+  RecHitContainer hits_;
   PTrajectoryStateOnDet tsos_;
   PropagationDirection dir_;
 };

--- a/DataFormats/TrajectorySeed/interface/TrajectorySeed.h
+++ b/DataFormats/TrajectorySeed/interface/TrajectorySeed.h
@@ -5,6 +5,7 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
+#include "FWCore/Utilities/interface/Range.h"
 #include <utility>
 #include <algorithm>
 
@@ -17,6 +18,7 @@
 class TrajectorySeed {
 public:
   typedef edm::OwnVector<TrackingRecHit> RecHitContainer;
+  typedef edm::Range<RecHitContainer::const_iterator> RecHitRange;
 
   TrajectorySeed() {}
   virtual ~TrajectorySeed() {}
@@ -47,7 +49,7 @@ public:
 
   TrajectorySeed& operator=(TrajectorySeed&& o) noexcept = default;
 
-  auto const& recHits() const { return hits_; }
+  RecHitRange recHits() const { return {hits_.begin(), hits_.end()}; }
   unsigned int nHits() const { return hits_.size(); }
   PropagationDirection direction() const { return dir_; }
   PTrajectoryStateOnDet const& startingState() const { return tsos_; }

--- a/DataFormats/TrajectorySeed/test/TrajectorySeed_t.cpp
+++ b/DataFormats/TrajectorySeed/test/TrajectorySeed_t.cpp
@@ -7,7 +7,7 @@ int main() {
   typedef std::vector<TrajectorySeed> TV;
 
   // absurd: just for test
-  TrajectorySeed::recHitContainer c;
+  TrajectorySeed::RecHitContainer c;
   c.reserve(1000);
   for (int i = 0; i != 100; ++i)
     c.push_back(new SiStripMatchedRecHit2D);

--- a/FastSimulation/Muons/plugins/FastTSGFromIOHit.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromIOHit.cc
@@ -60,7 +60,7 @@ void FastTSGFromIOHit::trackerSeeds(const TrackCand& staMuon,
   for (const auto& seeds : seedCollections) {
     for (const auto& seed : *seeds) {
       // Find the simtrack corresponding to the seed
-      int simTrackId = static_cast<FastTrackerRecHit const&>(seed.recHits()[0]).simTrackId(0);
+      int simTrackId = static_cast<FastTrackerRecHit const&>(*seed.recHits().begin()).simTrackId(0);
       const SimTrack& simTrack = (*simTracks)[simTrackId];
 
       // skip if simTrack already associated to a seed

--- a/FastSimulation/Muons/plugins/FastTSGFromIOHit.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromIOHit.cc
@@ -60,9 +60,7 @@ void FastTSGFromIOHit::trackerSeeds(const TrackCand& staMuon,
   for (const auto& seeds : seedCollections) {
     for (const auto& seed : *seeds) {
       // Find the simtrack corresponding to the seed
-      TrajectorySeed::range recHitRange = seed.recHits();
-      const FastTrackerRecHit* firstRecHit = (const FastTrackerRecHit*)(&(*(recHitRange.first)));
-      int simTrackId = firstRecHit->simTrackId(0);
+      int simTrackId = static_cast<FastTrackerRecHit const&>(seed.recHits()[0]).simTrackId(0);
       const SimTrack& simTrack = (*simTracks)[simTrackId];
 
       // skip if simTrack already associated to a seed

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -104,7 +104,7 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
         const BasicTrajectorySeed* aSeed = &((*aSeedCollection)[seednr]);
 
         // The SimTrack id associated to the first hit of the Seed
-        int simTrackId = static_cast<FastTrackerRecHit const&>(aSeed->recHits()[0]).simTrackId(0);
+        int simTrackId = static_cast<FastTrackerRecHit const&>(*aSeed->recHits().begin()).simTrackId(0);
 
         // Track already associated to a seed
         std::set<unsigned>::iterator tkId = tkIds.find(simTrackId);

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -103,12 +103,8 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
         // The seed
         const BasicTrajectorySeed* aSeed = &((*aSeedCollection)[seednr]);
 
-        // Find the first hit of the Seed
-        TrajectorySeed::range theSeedingRecHitRange = aSeed->recHits();
-        const FastTrackerRecHit* theFirstSeedingRecHit = (const FastTrackerRecHit*)(&(*(theSeedingRecHitRange.first)));
-
-        // The SimTrack id associated to that recHit
-        int simTrackId = theFirstSeedingRecHit->simTrackId(0);
+        // The SimTrack id associated to the first hit of the Seed
+        int simTrackId = static_cast<FastTrackerRecHit const&>(aSeed->recHits()[0]).simTrackId(0);
 
         // Track already associated to a seed
         std::set<unsigned>::iterator tkId = tkIds.find(simTrackId);

--- a/FastSimulation/Tracking/interface/FastTrackingUtilities.h
+++ b/FastSimulation/Tracking/interface/FastTrackingUtilities.h
@@ -21,12 +21,12 @@ namespace fastTrackingUtilities {
   template <class T>
   int32_t getRecHitCombinationIndex(const T &object) {
     // seed must have at least one hit
-    if (object.recHits().first == object.recHits().second) {
+    if (object.recHits().empty()) {
       throw cms::Exception("fastTrackingHelpers::getRecHitCombinationIndex")
           << "  given object has 0 hits" << std::endl;
     }
 
-    const TrackingRecHit &recHit = *object.recHits().first;
+    const TrackingRecHit &recHit = object.recHits()[0];
     if (!trackerHitRTTI::isFast(recHit)) {
       throw cms::Exception("fastTrackingHelpers::setRecHitCombinationIndex")
           << "  one of hits in OwnVector is non-fastsim" << std::endl;

--- a/FastSimulation/Tracking/interface/FastTrackingUtilities.h
+++ b/FastSimulation/Tracking/interface/FastTrackingUtilities.h
@@ -26,7 +26,7 @@ namespace fastTrackingUtilities {
           << "  given object has 0 hits" << std::endl;
     }
 
-    const TrackingRecHit &recHit = object.recHits()[0];
+    const TrackingRecHit &recHit = *object.recHits().begin();
     if (!trackerHitRTTI::isFast(recHit)) {
       throw cms::Exception("fastTrackingHelpers::setRecHitCombinationIndex")
           << "  one of hits in OwnVector is non-fastsim" << std::endl;

--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -98,15 +98,13 @@ void PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     TrajectorySeedCollection::const_iterator aSeed = theSeeds->begin();
     TrajectorySeedCollection::const_iterator lastSeed = theSeeds->end();
     for (; aSeed != lastSeed; ++aSeed) {
-      // Find the first hit and last hit of the Seed
-      TrajectorySeed::range theSeedingRecHitRange = aSeed->recHits();
-      edm::OwnVector<TrackingRecHit>::const_iterator aSeedingRecHit = theSeedingRecHitRange.first;
-      edm::OwnVector<TrackingRecHit>::const_iterator theLastSeedingRecHit = theSeedingRecHitRange.second;
-
       // Loop over the rechits
       std::vector<const TrackingRecHit*> TripletHits(3, static_cast<const TrackingRecHit*>(nullptr));
-      for (unsigned i = 0; aSeedingRecHit != theLastSeedingRecHit; ++i, ++aSeedingRecHit)
-        TripletHits[i] = &(*aSeedingRecHit);
+      unsigned int iRecHit = 0;
+      for (auto const& recHit : aSeed->recHits()) {
+        TripletHits[iRecHit] = &recHit;
+        ++iRecHit;
+      }
 
       // fitting the triplet
       std::unique_ptr<reco::Track> track = fitter.run(TripletHits, region, es);

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -140,9 +140,8 @@ void TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       std::vector<const FastTrackerRecHit*> selectedRecHits;
 
       // add the seed hits
-      TrajectorySeed::range seedHitRange = seed.recHits();  //Hits in a seed
-      for (TrajectorySeed::const_iterator ihit = seedHitRange.first; ihit != seedHitRange.second; ++ihit) {
-        selectedRecHits.push_back(static_cast<const FastTrackerRecHit*>(&*ihit));
+      for (auto const& recHit : seed.recHits()) {
+        selectedRecHits.push_back(static_cast<const FastTrackerRecHit*>(&recHit));
       }
 
       // prepare to skip seed hits

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -174,7 +174,6 @@ void testGeneralTracks::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
   std::vector<bool> firstSeed(2, static_cast<bool>(false));
   std::vector<bool> secondSeed(2, static_cast<bool>(false));
-  std::vector<TrajectorySeed::range> theRecHitRange(2);
 
   for (unsigned ievt = 0; ievt < 2; ++ievt) {
     edm::Handle<reco::TrackCollection> tkRef0;

--- a/Fireworks/Tracks/plugins/FWTrajectorySeedProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTrajectorySeedProxyBuilder.cc
@@ -60,13 +60,12 @@ void FWTrajectorySeedProxyBuilder::build(const TrajectorySeed& iData,
   TEvePointSet* pointSet = new TEvePointSet;
   TEveLine* line = new TEveLine;
   TEveStraightLineSet* lineSet = new TEveStraightLineSet;
-  TrajectorySeed::const_iterator hit = iData.recHits().first;
 
-  for (; hit != iData.recHits().second; hit++) {
-    unsigned int id = hit->geographicalId();
+  for (auto const& hit : iData.recHits()) {
+    unsigned int id = hit.geographicalId();
     const FWGeometry* geom = item()->getGeom();
     const float* pars = geom->getParameters(id);
-    const SiPixelRecHit* rh = dynamic_cast<const SiPixelRecHit*>(&*hit);
+    const SiPixelRecHit* rh = dynamic_cast<const SiPixelRecHit*>(&hit);
     // std::cout << id << "id "<< 	std::endl;
     if (rh) {
       const SiPixelCluster* itc = rh->cluster().get();
@@ -87,7 +86,7 @@ void FWTrajectorySeedProxyBuilder::build(const TrajectorySeed& iData,
     }
 
     else {
-      const SiStripCluster* cluster = fireworks::extractClusterFromTrackingRecHit(&*hit);
+      const SiStripCluster* cluster = fireworks::extractClusterFromTrackingRecHit(&hit);
 
       if (cluster) {
         short firststrip = cluster->firstStrip();

--- a/HLTrigger/Muon/plugins/HLTMuonTrackMassFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrackMassFilter.cc
@@ -350,10 +350,9 @@ bool HLTMuonTrackMassFilter::pairMatched(std::vector<reco::RecoChargedCandidateR
   // comparison by hits of TrajectorySeed of the new track
   // with the previous candidate
   //
-  TrajectorySeed::range seedHits = seedRef->recHits();
+  auto const& seedHits = seedRef->recHits();
   trackingRecHit_iterator prevTrackHitEnd;
   trackingRecHit_iterator iprev;
-  TrajectorySeed::const_iterator iseed;
   for (size_t i = 0; i < prevMuonRefs.size(); ++i) {
     // identity of muon
     if (prevMuonRefs[i] != muonRef)
@@ -369,11 +368,11 @@ bool HLTMuonTrackMassFilter::pairMatched(std::vector<reco::RecoChargedCandidateR
     if (seedRef->nHits() != prevTrackRef->recHitsSize())
       continue;
     // hit-by-hit comparison based on the sharesInput method
-    iseed = seedHits.first;
+    auto iseed = seedHits.begin();
     iprev = prevTrackRef->recHitsBegin();
     prevTrackHitEnd = prevTrackRef->recHitsEnd();
     bool identical(true);
-    for (; iseed != seedHits.second && iprev != prevTrackHitEnd; ++iseed, ++iprev) {
+    for (; iseed != seedHits.end() && iprev != prevTrackHitEnd; ++iseed, ++iprev) {
       if ((*iseed).isValid() != (**iprev).isValid() || !(*iseed).sharesInput(&**iprev, TrackingRecHit::all)) {
         // terminate loop over hits on first mismatch
         identical = false;

--- a/HLTrigger/Muon/plugins/HLTMuonTrackMassFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrackMassFilter.cc
@@ -350,7 +350,7 @@ bool HLTMuonTrackMassFilter::pairMatched(std::vector<reco::RecoChargedCandidateR
   // comparison by hits of TrajectorySeed of the new track
   // with the previous candidate
   //
-  auto const& seedHits = seedRef->recHits();
+  const TrajectorySeed::RecHitRange seedHits = seedRef->recHits();
   trackingRecHit_iterator prevTrackHitEnd;
   trackingRecHit_iterator iprev;
   for (size_t i = 0; i < prevMuonRefs.size(); ++i) {

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -37,8 +37,8 @@ namespace {
     if (s1.nHits() != s2.nHits())
       return false;
 
-    TrajectorySeed::RecHitRange r1 = s1.recHits();
-    TrajectorySeed::RecHitRange r2 = s2.recHits();
+    const TrajectorySeed::RecHitRange r1 = s1.recHits();
+    const TrajectorySeed::RecHitRange r2 = s2.recHits();
     for (auto i1 = r1.begin(), i2 = r2.begin(); i1 != r1.end(); ++i1, ++i2) {
       if (!i1->isValid() || !i2->isValid())
         return false;

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -37,7 +37,8 @@ namespace {
     if (s1.nHits() != s2.nHits())
       return false;
 
-    auto const &r1 = s1.recHits(), r2 = s2.recHits();
+    TrajectorySeed::RecHitRange r1 = s1.recHits();
+    TrajectorySeed::RecHitRange r2 = s2.recHits();
     for (auto i1 = r1.begin(), i2 = r2.begin(); i1 != r1.end(); ++i1, ++i2) {
       if (!i1->isValid() || !i2->isValid())
         return false;

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -37,10 +37,8 @@ namespace {
     if (s1.nHits() != s2.nHits())
       return false;
 
-    unsigned int nHits;
-    TrajectorySeed::range r1 = s1.recHits(), r2 = s2.recHits();
-    TrajectorySeed::const_iterator i1, i2;
-    for (i1 = r1.first, i2 = r2.first, nHits = 0; i1 != r1.second; ++i1, ++i2, ++nHits) {
+    auto const &r1 = s1.recHits(), r2 = s2.recHits();
+    for (auto i1 = r1.begin(), i2 = r2.begin(); i1 != r1.end(); ++i1, ++i2) {
       if (!i1->isValid() || !i2->isValid())
         return false;
       if (i1->geographicalId() != i2->geographicalId())

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -142,19 +142,19 @@ std::vector<SeedWithInfo> PixelHitMatcher::operator()(const std::vector<const Tr
         continue;
       }
 
-      const TrajectorySeed::range &hits = seed.recHits();
+      auto const &hits = seed.recHits();
       // cache the global points
 
-      for (auto it = hits.first; it != hits.second; ++it) {
-        hitGpMap.emplace_back(it->globalPosition());
+      for (auto const &hit : hits) {
+        hitGpMap.emplace_back(hit.globalPosition());
       }
 
       //iterate on the hits
-      auto he = hits.second - 1;
-      for (auto it1 = hits.first; it1 < he; ++it1) {
+      auto he = hits.end() - 1;
+      for (auto it1 = hits.begin(); it1 < he; ++it1) {
         if (!it1->isValid())
           continue;
-        auto idx1 = std::distance(hits.first, it1);
+        auto idx1 = std::distance(hits.begin(), it1);
         const DetId id1 = it1->geographicalId();
         const GeomDet *geomdet1 = it1->det();
 
@@ -209,10 +209,10 @@ std::vector<SeedWithInfo> PixelHitMatcher::operator()(const std::vector<const Tr
         GlobalPoint vertex(vprim.x(), vprim.y(), zVertex);
         auto fts2 = trackingTools::ftsFromVertexToPoint(*theMagField, hit1Pos, vertex, energy, charge);
         // now find the matching hit
-        for (auto it2 = it1 + 1; it2 != hits.second; ++it2) {
+        for (auto it2 = it1 + 1; it2 != hits.end(); ++it2) {
           if (!it2->isValid())
             continue;
-          auto idx2 = std::distance(hits.first, it2);
+          auto idx2 = std::distance(hits.begin(), it2);
           const DetId id2 = it2->geographicalId();
           const GeomDet *geomdet2 = it2->det();
           const auto det_key = std::make_pair(geomdet2->gdetIndex(), hit1Pos);

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -212,7 +212,7 @@ std::vector<TrajSeedMatcher::SCHitMatch> TrajSeedMatcher::processSeed(const Traj
   for (size_t iHit = 0;
        matches.size() < nCuts && iHit < seed.nHits() && (cfg_.enableHitSkipping || iHit == matches.size());
        iHit++) {
-    auto const& recHit = *(seed.recHits().first + iHit);
+    auto const& recHit = *(seed.recHits().begin() + iHit);
 
     if (!recHit.isValid()) {
       continue;

--- a/RecoEgamma/Examples/plugins/ElectronSeedAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/ElectronSeedAnalyzer.cc
@@ -210,7 +210,7 @@ void ElectronSeedAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &i
 
   for (ElectronSeedCollection::const_iterator MyS = (*elSeeds).begin(); MyS != (*elSeeds).end(); ++MyS) {
     LogDebug("") << "\nSeed nr " << is << ": ";
-    auto const &r = (*MyS).recHits();
+    const TrajectorySeed::RecHitRange r = MyS->recHits();
     LogDebug("") << " Number of RecHits= " << (*MyS).nHits();
     const GeomDet *det1 = nullptr;
     const GeomDet *det2 = nullptr;

--- a/RecoEgamma/Examples/plugins/ElectronSeedAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/ElectronSeedAnalyzer.cc
@@ -189,11 +189,6 @@ void ElectronSeedAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &i
   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
   iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
-  // rereads the seeds for test purposes
-  typedef edm::OwnVector<TrackingRecHit> recHitContainer;
-  typedef recHitContainer::const_iterator const_iterator;
-  typedef std::pair<const_iterator, const_iterator> range;
-
   // get beam spot
   edm::Handle<reco::BeamSpot> theBeamSpot;
   e.getByLabel(beamSpot_, theBeamSpot);
@@ -215,12 +210,12 @@ void ElectronSeedAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &i
 
   for (ElectronSeedCollection::const_iterator MyS = (*elSeeds).begin(); MyS != (*elSeeds).end(); ++MyS) {
     LogDebug("") << "\nSeed nr " << is << ": ";
-    range r = (*MyS).recHits();
+    auto const &r = (*MyS).recHits();
     LogDebug("") << " Number of RecHits= " << (*MyS).nHits();
     const GeomDet *det1 = nullptr;
     const GeomDet *det2 = nullptr;
 
-    TrajectorySeed::const_iterator it = r.first;
+    auto it = r.begin();
     DetId id1 = (*it).geographicalId();
     det1 = pDD->idToDet(id1);
     LogDebug("") << " First hit local x,y,z " << (*it).localPosition() << " det " << id1.det() << " subdet "
@@ -239,8 +234,9 @@ void ElectronSeedAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &i
 
     // state on last det
     const GeomDet *det = nullptr;
-    for (TrackingRecHitCollection::const_iterator rhits = r.first; rhits != r.second; rhits++)
-      det = pDD->idToDet(((*rhits)).geographicalId());
+    for (auto const &recHit : r) {
+      det = pDD->idToDet(recHit.geographicalId());
+    }
     TrajectoryStateOnSurface t =
         trajectoryStateTransform::transientState((*MyS).startingState(), &(det->surface()), &(*theMagField));
 
@@ -281,7 +277,7 @@ void ElectronSeedAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &i
     // TrajectorySeed::range r=(*seeds)[i].recHits();
 
     // first Hit
-    it = r.first;
+    it = r.begin();
     DetId id = (*it).geographicalId();
     const GeomDet *geomdet = pDD->idToDet((*it).geographicalId());
     LocalPoint lp = (*it).localPosition();
@@ -452,10 +448,10 @@ void ElectronSeedAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &i
           reco::ElectronSeed bestElectronSeed;
           for (ElectronSeedCollection::const_iterator gsfIter = (*elSeeds).begin(); gsfIter != (*elSeeds).end();
                ++gsfIter) {
-            range r = gsfIter->recHits();
             const GeomDet *det = nullptr;
-            for (TrackingRecHitCollection::const_iterator rhits = r.first; rhits != r.second; rhits++)
-              det = pDD->idToDet(((*rhits)).geographicalId());
+            for (auto const &recHit : gsfIter->recHits()) {
+              det = pDD->idToDet(recHit.geographicalId());
+            }
             TrajectoryStateOnSurface t =
                 trajectoryStateTransform::transientState(gsfIter->startingState(), &(det->surface()), &(*theMagField));
 
@@ -501,10 +497,10 @@ void ElectronSeedAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &i
           // find best matched seed
           for (ElectronSeedCollection::const_iterator gsfIter = (*elSeeds).begin(); gsfIter != (*elSeeds).end();
                ++gsfIter) {
-            range r = gsfIter->recHits();
             const GeomDet *det = nullptr;
-            for (TrackingRecHitCollection::const_iterator rhits = r.first; rhits != r.second; rhits++)
-              det = pDD->idToDet(((*rhits)).geographicalId());
+            for (auto const &recHit : gsfIter->recHits()) {
+              det = pDD->idToDet(recHit.geographicalId());
+            }
             TrajectoryStateOnSurface t =
                 trajectoryStateTransform::transientState(gsfIter->startingState(), &(det->surface()), &(*theMagField));
 
@@ -545,10 +541,10 @@ void ElectronSeedAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &i
           // find best matched seed
           for (ElectronSeedCollection::const_iterator gsfIter = (*elSeeds).begin(); gsfIter != (*elSeeds).end();
                ++gsfIter) {
-            range r = gsfIter->recHits();
             const GeomDet *det = nullptr;
-            for (TrackingRecHitCollection::const_iterator rhits = r.first; rhits != r.second; rhits++)
-              det = pDD->idToDet(((*rhits)).geographicalId());
+            for (auto const &recHit : gsfIter->recHits()) {
+              det = pDD->idToDet(recHit.geographicalId());
+            }
             TrajectoryStateOnSurface t =
                 trajectoryStateTransform::transientState(gsfIter->startingState(), &(det->surface()), &(*theMagField));
 

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
@@ -280,12 +280,10 @@ void SeedClusterRemover::produce(Event &iEvent, const EventSetup &iSetup) {
   iEvent.getByToken(trajectories_, seeds);
 
   for (auto const &seed : (*seeds)) {
-    auto hits = seed.recHits();
-    auto hit = hits.first;
-    for (; hit != hits.second; ++hit) {
-      if (!hit->isValid())
+    for (auto const &hit : seed.recHits()) {
+      if (!hit.isValid())
         continue;
-      process(&(*hit), 0., tgh.product());
+      process(&hit, 0., tgh.product());
     }
   }
 

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemoverPhase2.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemoverPhase2.cc
@@ -179,12 +179,10 @@ void SeedClusterRemoverPhase2::produce(Event &iEvent, const EventSetup &iSetup) 
   iEvent.getByToken(trajectories_, seeds);
 
   for (auto const &seed : (*seeds)) {
-    auto hits = seed.recHits();
-    auto hit = hits.first;
-    for (; hit != hits.second; ++hit) {
-      if (!hit->isValid())
+    for (auto const &hit : seed.recHits()) {
+      if (!hit.isValid())
         continue;
-      process(&(*hit), 0., tgh.product());
+      process(&hit, 0., tgh.product());
     }
   }
 

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
@@ -292,9 +292,8 @@ void L2MuonSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
             if (assoOffseed != nullptr) {
               PTrajectoryStateOnDet const& seedTSOS = assoOffseed->startingState();
-              TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first, tscie = assoOffseed->recHits().second;
-              for (; tsci != tscie; ++tsci) {
-                container.push_back(*tsci);
+              for (auto const& tsci : assoOffseed->recHits()) {
+                container.push_back(tsci);
               }
               output->push_back(
                   L2MuonTrajectorySeed(seedTSOS, container, alongMomentum, L1MuonParticleRef(muColl, l1ParticleIndex)));

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
@@ -301,9 +301,8 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event &iEvent, const edm::EventSet
 
             if (assoOffseed != nullptr) {
               PTrajectoryStateOnDet const &seedTSOS = assoOffseed->startingState();
-              TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first, tscie = assoOffseed->recHits().second;
-              for (; tsci != tscie; ++tsci) {
-                container.push_back(*tsci);
+              for (auto const &recHit : assoOffseed->recHits()) {
+                container.push_back(recHit);
               }
               output->push_back(
                   L2MuonTrajectorySeed(seedTSOS,
@@ -357,10 +356,8 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event &iEvent, const edm::EventSet
 
                 if (assoOffseed != nullptr) {
                   PTrajectoryStateOnDet const &seedTSOS = assoOffseed->startingState();
-                  TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first,
-                                                 tscie = assoOffseed->recHits().second;
-                  for (; tsci != tscie; ++tsci) {
-                    container.push_back(*tsci);
+                  for (auto const &recHit : assoOffseed->recHits()) {
+                    container.push_back(recHit);
                   }
                   output->push_back(
                       L2MuonTrajectorySeed(seedTSOS,
@@ -678,10 +675,8 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event &iEvent, const edm::EventSet
             edm::OwnVector<TrackingRecHit> newContainer;
 
             PTrajectoryStateOnDet const &seedTSOS = selOffseeds[nL1][theOffs]->startingState();
-            TrajectorySeed::const_iterator tsci = selOffseeds[nL1][theOffs]->recHits().first,
-                                           tscie = selOffseeds[nL1][theOffs]->recHits().second;
-            for (; tsci != tscie; ++tsci) {
-              newContainer.push_back(*tsci);
+            for (auto const &recHit : selOffseeds[nL1][theOffs]->recHits()) {
+              newContainer.push_back(recHit);
             }
             output->push_back(L2MuonTrajectorySeed(seedTSOS,
                                                    newContainer,
@@ -734,10 +729,8 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event &iEvent, const edm::EventSet
             edm::OwnVector<TrackingRecHit> newContainer;
 
             PTrajectoryStateOnDet const &seedTSOS = selOffseeds[theL1][theOffs]->startingState();
-            TrajectorySeed::const_iterator tsci = selOffseeds[theL1][theOffs]->recHits().first,
-                                           tscie = selOffseeds[theL1][theOffs]->recHits().second;
-            for (; tsci != tscie; ++tsci) {
-              newContainer.push_back(*tsci);
+            for (auto const &recHit : selOffseeds[theL1][theOffs]->recHits()) {
+              newContainer.push_back(recHit);
             }
             output->push_back(L2MuonTrajectorySeed(seedTSOS,
                                                    newContainer,
@@ -835,10 +828,8 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event &iEvent, const edm::EventSet
             edm::OwnVector<TrackingRecHit> newContainer;
 
             PTrajectoryStateOnDet const &seedTSOS = selOffseeds[theL1][theOffs]->startingState();
-            TrajectorySeed::const_iterator tsci = selOffseeds[theL1][theOffs]->recHits().first,
-                                           tscie = selOffseeds[theL1][theOffs]->recHits().second;
-            for (; tsci != tscie; ++tsci) {
-              newContainer.push_back(*tsci);
+            for (auto const &recHit : selOffseeds[theL1][theOffs]->recHits()) {
+              newContainer.push_back(recHit);
             }
             output->push_back(L2MuonTrajectorySeed(seedTSOS,
                                                    newContainer,
@@ -876,10 +867,8 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event &iEvent, const edm::EventSet
             edm::OwnVector<TrackingRecHit> newContainer;
 
             PTrajectoryStateOnDet const &seedTSOS = selOffseeds[i][theOffs]->startingState();
-            TrajectorySeed::const_iterator tsci = selOffseeds[i][theOffs]->recHits().first,
-                                           tscie = selOffseeds[i][theOffs]->recHits().second;
-            for (; tsci != tscie; ++tsci) {
-              newContainer.push_back(*tsci);
+            for (auto const &recHit : selOffseeds[i][theOffs]->recHits()) {
+              newContainer.push_back(recHit);
             }
             output->push_back(L2MuonTrajectorySeed(seedTSOS,
                                                    newContainer,

--- a/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
@@ -54,16 +54,13 @@ bool L3TkMuonProducer::sharedSeed(const L3MuonTrajectorySeed& s1, const L3MuonTr
   //quit right away if not the same number of hits
   if (s1.nHits() != s2.nHits())
     return false;
-  TrajectorySeed::range r1 = s1.recHits();
-  TrajectorySeed::range r2 = s2.recHits();
-  TrajectorySeed::const_iterator i1, i2;
-  TrajectorySeed::const_iterator &i1_e = r1.second, &i2_e = r2.second;
-  TrajectorySeed::const_iterator &i1_b = r1.first, &i2_b = r2.first;
+  auto const& r1 = s1.recHits();
+  auto const& r2 = s2.recHits();
   //quit right away if first detId does not match. front exist because of ==0 ->quit test
-  if (i1_b->geographicalId() != i2_b->geographicalId())
+  if (r1.begin()->geographicalId() != r2.begin()->geographicalId())
     return false;
   //then check hit by hit if they are the same
-  for (i1 = i1_b, i2 = i2_b; i1 != i1_e && i2 != i2_e; ++i1, ++i2) {
+  for (auto i1 = r1.begin(), i2 = r2.begin(); i1 != r1.end() && i2 != r2.end(); ++i1, ++i2) {
     if (!i1->sharesInput(&(*i2), TrackingRecHit::all))
       return false;
   }
@@ -100,11 +97,10 @@ string printvector(const vector<L3TkMuonProducer::SeedRef>& v) {
 string printseed(const L3TkMuonProducer::SeedRef& s) {
   std::stringstream ss;
   ss << " seed ref: " << s.id().id() << ":" << s.key() << " has " << s->nHits() << "rechits";
-  TrajectorySeed::range r = s->recHits();
-  TrajectorySeed::const_iterator it = r.first;
-  for (; it != r.second; ++it)
-    ss << "\n detId: " << std::hex << it->geographicalId().rawId() << std::dec << " position: " << it->localPosition()
-       << " and error: " << it->localPositionError();
+  for (auto const& hit : s->recHits()) {
+    ss << "\n detId: " << std::hex << hit.geographicalId().rawId() << std::dec << " position: " << hit.localPosition()
+       << " and error: " << hit.localPositionError();
+  }
   return ss.str();
 }
 

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.cc
@@ -69,12 +69,12 @@ void RPCSeedOverlapper::CheckOverlap(const edm::EventSetup &iSetup,
     for (vector<weightedTrajectorySeed>::iterator itweightedseed = weightedSeedsRef->begin();
          itweightedseed != weightedSeedsRef->end();
          N++) {
-      TrajectorySeed::range RecHitsRange = itweightedseed->first.recHits();
+      auto const &recHitsRange = itweightedseed->first.recHits();
       if (N == 0) {
         cout << "Always take the 1st weighted seed to be the referrence." << endl;
-        for (TrajectorySeed::const_iterator it = RecHitsRange.first; it != RecHitsRange.second; it++) {
+        for (auto const &hit : recHitsRange) {
           cout << "Put its recHits to tempRecHits" << endl;
-          tempRecHits.push_back(it->clone());
+          tempRecHits.push_back(hit.clone());
         }
         cout << "Put it to tempweightedSeeds" << endl;
         tempweightedSeeds.push_back(*itweightedseed);
@@ -84,16 +84,16 @@ void RPCSeedOverlapper::CheckOverlap(const edm::EventSetup &iSetup,
         cout << "Come to other weighted seed for checking " << itweightedseed->first.nHits() << " recHits from "
              << tempRecHits.size() << " temp recHits" << endl;
         unsigned int ShareRecHitsNumber = 0;
-        for (TrajectorySeed::const_iterator it = RecHitsRange.first; it != RecHitsRange.second; it++) {
-          if (isShareHit(tempRecHits, *it, rpcGeometry))
+        for (auto const &hit : recHitsRange) {
+          if (isShareHit(tempRecHits, hit, rpcGeometry))
             ShareRecHitsNumber++;
         }
         if (ShareRecHitsNumber >= ShareRecHitsNumberThreshold) {
           cout << "This seed is found to belong to current share group" << endl;
-          for (TrajectorySeed::const_iterator it = RecHitsRange.first; it != RecHitsRange.second; it++) {
-            if (!isShareHit(tempRecHits, *it, rpcGeometry)) {
+          for (auto const &hit : recHitsRange) {
+            if (!isShareHit(tempRecHits, hit, rpcGeometry)) {
               cout << "Put its extra recHits to tempRecHits" << endl;
-              tempRecHits.push_back(it->clone());
+              tempRecHits.push_back(hit.clone());
             }
           }
           cout << "Put it to tempSeeds" << endl;
@@ -132,20 +132,19 @@ void RPCSeedOverlapper::CheckOverlap(const edm::EventSetup &iSetup,
     tempweightedSeeds.erase(bestweightediter);
     tempRecHits.clear();
 
-    for (TrajectorySeed::const_iterator it = bestweightedSeed.first.recHits().first;
-         it != bestweightedSeed.first.recHits().second;
-         it++)
-      tempRecHits.push_back(it->clone());
+    for (auto const &hit : bestweightedSeed.first.recHits()) {
+      tempRecHits.push_back(hit.clone());
+    }
 
     for (vector<weightedTrajectorySeed>::iterator itweightedseed = tempweightedSeeds.begin();
          itweightedseed != tempweightedSeeds.end();) {
       cout << "Checking the temp weighted seed's " << itweightedseed->first.nHits() << " hits to " << tempRecHits.size()
            << " temp recHits" << endl;
-      TrajectorySeed::range RecHitsRange = itweightedseed->first.recHits();
       bool isShare = false;
-      for (TrajectorySeed::const_iterator it = RecHitsRange.first; it != RecHitsRange.second; it++)
-        if (isShareHit(tempRecHits, *it, rpcGeometry))
+      for (auto const &hit : itweightedseed->first.recHits()) {
+        if (isShareHit(tempRecHits, hit, rpcGeometry))
           isShare = true;
+      }
 
       if (isShare == true) {
         cout << "Find one temp seed share some recHits with best weighted seed" << endl;

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.h
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.h
@@ -32,7 +32,7 @@ public:
 
 private:
   void CheckOverlap(const edm::EventSetup &iSetup, std::vector<weightedTrajectorySeed> *SeedsRef);
-  bool isShareHit(const edm::OwnVector<TrackingRecHit> &RecHits,
+  bool isShareHit(const std::vector<TrackingRecHit const *> &RecHits,
                   const TrackingRecHit &hit,
                   edm::ESHandle<RPCGeometry> rpcGeometry);
   // Signal for call run()

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.cc
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.cc
@@ -912,14 +912,12 @@ void MuonSeedValidator::SegOfRecSeed(Handle<TrajectorySeedCollection> rec_seeds,
         trajectoryStateTransform::transientState(pTSOD, &(seedDet->surface()), &*theService->magneticField());
     GlobalPoint seedgp = seedTSOS.globalPosition();
 
-    for (edm::OwnVector<TrackingRecHit>::const_iterator rh_it = seed_it->recHits().first;
-         rh_it != seed_it->recHits().second;
-         rh_it++) {
-      const GeomDet* gdet = theService->trackingGeometry()->idToDet((*rh_it).geographicalId());
-      LocalPoint lp = (*rh_it).localPosition();
+    for (auto const& recHit : seed_it->recHits()) {
+      const GeomDet* gdet = theService->trackingGeometry()->idToDet(recHit.geographicalId());
+      LocalPoint lp = recHit.localPosition();
       GlobalPoint gp = gdet->toGlobal(lp);
       LocalPoint slp = gdet->toLocal(gp);
-      DetId pdid = (*rh_it).geographicalId();
+      DetId pdid = recHit.geographicalId();
 
       geoID.push_back(pdid);
       d_h.push_back(gp.eta() - seedgp.eta());
@@ -951,17 +949,15 @@ void MuonSeedValidator::SegOfRecSeed(Handle<TrajectorySeedCollection> rec_seeds,
       cout << " " << endl;
     }
 
-    for (edm::OwnVector<TrackingRecHit>::const_iterator rh_it = seed_it->recHits().first;
-         rh_it != seed_it->recHits().second;
-         rh_it++) {
-      const GeomDet* gdet = theService->trackingGeometry()->idToDet((*rh_it).geographicalId());
-      GlobalPoint gp = gdet->toGlobal((*rh_it).localPosition());
-      LocalPoint lp = (*rh_it).localPosition();
-      DetId pdid = (*rh_it).geographicalId();
+    for (auto const& recHit : seed_it->recHits()) {
+      const GeomDet* gdet = theService->trackingGeometry()->idToDet(recHit.geographicalId());
+      GlobalPoint gp = gdet->toGlobal(recHit.localPosition());
+      LocalPoint lp = recHit.localPosition();
+      DetId pdid = recHit.geographicalId();
 
       // for parameters [1]:dx/dz, [2]:dy/dz, [3]:x, [4]:y
-      double dxz = (*rh_it).parameters()[0];
-      double dyz = (*rh_it).parameters()[1];
+      double dxz = recHit.parameters()[0];
+      double dyz = recHit.parameters()[1];
       double dz = 1.0 / sqrt((dxz * dxz) + (dyz * dyz) + 1.0);
       if (pdid.subdetId() == MuonSubdetId::DT) {
         dz = -1.0 * dz;

--- a/RecoMuon/StandAloneTrackFinder/src/ExhaustiveMuonTrajectoryBuilder.cc
+++ b/RecoMuon/StandAloneTrackFinder/src/ExhaustiveMuonTrajectoryBuilder.cc
@@ -23,13 +23,11 @@ MuonTrajectoryBuilder::TrajectoryContainer ExhaustiveMuonTrajectoryBuilder::traj
   //   float p_err = sqr(sptmean/(ptmean*ptmean));
   //  mat[0][0]= p_err;
   float sigmapt = sqrt(err00) * pt * pt;
-  TrajectorySeed::range range = seed.recHits();
   TrajectoryContainer result;
   // Make a new seed based on each segment, using the original pt and sigmapt
-  for (TrajectorySeed::const_iterator recHitItr = range.first; recHitItr != range.second; ++recHitItr) {
-    const GeomDet* geomDet = theService->trackingGeometry()->idToDet((*recHitItr).geographicalId());
-    MuonTransientTrackingRecHit::MuonRecHitPointer muonRecHit =
-        MuonTransientTrackingRecHit::specificBuild(geomDet, &*recHitItr);
+  for (auto const& recHit : seed.recHits()) {
+    const GeomDet* geomDet = theService->trackingGeometry()->idToDet(recHit.geographicalId());
+    auto muonRecHit = MuonTransientTrackingRecHit::specificBuild(geomDet, &recHit);
     TrajectorySeed tmpSeed(theSeeder.createSeed(pt, sigmapt, muonRecHit));
     TrajectoryContainer trajectories(theTrajBuilder.trajectories(tmpSeed));
     result.insert(

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -328,7 +328,7 @@ void TSGForOI::findSeedsOnLayer(const TrackerTopology* tTopo,
         dets.front().second.rescaleError(errorSFHitless);
         PTrajectoryStateOnDet const& ptsod =
             trajectoryStateTransform::persistentState(tsosOnLayer, detOnLayer->geographicalId().rawId());
-        TrajectorySeed::recHitContainer rHC;
+        TrajectorySeed::RecHitContainer rHC;
         out->push_back(TrajectorySeed(ptsod, rHC, oppositeToMomentum));
         LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: TSOD (Hitless) done " << endl;
         numSeedsMade++;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.cc
@@ -347,7 +347,7 @@ void TSGForOIFromL2::makeSeedsWithoutHits(const GeometricSearchDet& layer,
       dets.front().second.rescaleError(errorSF);
       PTrajectoryStateOnDet const& ptsod =
           trajectoryStateTransform::persistentState(tsosOnLayer, detOnLayer->geographicalId().rawId());
-      TrajectorySeed::recHitContainer rHC;
+      TrajectorySeed::RecHitContainer rHC;
       out.push_back(TrajectorySeed(ptsod, rHC, oppositeToMomentum));
       LogTrace("TSGForOIFromL2") << "TSGForOIFromL2::makeSeedsWithoutHits: TSOS (Hitless) done " << std::endl;
       hitlessSeedsMade++;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
@@ -488,7 +488,7 @@ void TSGForRoadSearch::pushTrajectorySeed(const reco::Track &muon,
       for (std::vector<TrajectoryMeasurement>::iterator Mit = tmp.begin(); Mit != tmp.end(); ++Mit) {
         TrajectoryStateOnSurface predState(Mit->predictedState());
         TrajectoryMeasurement::ConstRecHitPointer hit = Mit->recHit();
-        TrajectorySeed::recHitContainer rhContainer;
+        TrajectorySeed::RecHitContainer rhContainer;
         if (theCopyMuonRecHit) {
           LogDebug(theCategory) << "copying (" << muon.recHitsSize() << ") muon recHits";
           //copy the muon rechit into the seed
@@ -536,7 +536,7 @@ void TSGForRoadSearch::pushTrajectorySeed(const reco::Track &muon,
                           << compatible.front().second
                           << "on detector: " << compatible.front().first->geographicalId().rawId();
 
-    TrajectorySeed::recHitContainer rhContainer;
+    TrajectorySeed::RecHitContainer rhContainer;
     if (theCopyMuonRecHit) {
       LogDebug(theCategory) << "copying (" << muon.recHitsSize() << ") muon recHits";
       //copy the muon rechit into the seed

--- a/RecoMuon/TrackerSeedGenerator/src/RedundantSeedCleaner.cc
+++ b/RecoMuon/TrackerSeedGenerator/src/RedundantSeedCleaner.cc
@@ -55,22 +55,17 @@ void RedundantSeedCleaner::clean(const std::vector<TrajectorySeed>& seedTr, std:
   for (TrajectorySeedCollection::iterator s1 = seed.begin(); s1 != seed.end(); ++s1) {
     //rechits from seed
 
-    TrajectorySeed::range r1 = s1->recHits();
-
     for (TrajectorySeedCollection::const_iterator s2 = seedTr.begin(); s2 != seedTr.end(); ++s2) {
       //empty
       if (s2->nHits() == 0)
         continue;
 
-      TrajectorySeed::range r2 = s2->recHits();
-      TrajectorySeed::const_iterator h2 = r2.first;
-
       //number of shared hits;
       int shared = 0;
 
-      for (; h2 < r2.second; h2++) {
-        for (TrajectorySeed::const_iterator h1 = r1.first; h1 < r1.second; h1++) {
-          if (h2->sharesInput(&(*h1), TrackingRecHit::all))
+      for (auto const& h2 : s2->recHits()) {
+        for (auto const& h1 : s1->recHits()) {
+          if (h2.sharesInput(&h1, TrackingRecHit::all))
             shared++;
           if (s1->nHits() != 3)
             LogDebug(theCategory) << shared << " shared hits counter if 2 erease the seed.";

--- a/RecoMuon/TrackerSeedGenerator/src/TrackerSeedCleaner.cc
+++ b/RecoMuon/TrackerSeedGenerator/src/TrackerSeedCleaner.cc
@@ -78,7 +78,7 @@ void TrackerSeedCleaner::clean(const reco::TrackRef& muR,
     if (seed->nHits() < 2)
       continue;
     //get parameters and errors from the seed state
-    TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder->build(&*(seed->recHits().second - 1));
+    TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder->build(&*(seed->recHits().end() - 1));
     TrajectoryStateOnSurface state = trajectoryStateTransform::transientState(
         seed->startingState(), recHit->surface(), theProxyService->magneticField().product());
 

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -498,15 +498,10 @@ vector<bool> ConvBremSeedProducer::sharedHits(const vector<pair<TrajectorySeed, 
           continue;
         //    if (unclean[iu].second.second *unclean[iu2].second.second >0)continue;
 
-        TrajectorySeed::const_iterator sh = unclean[iu].first.recHits().first;
-        TrajectorySeed::const_iterator sh_end = unclean[iu].first.recHits().second;
-
         unsigned int shar = 0;
-        for (; sh != sh_end; ++sh) {
-          TrajectorySeed::const_iterator sh2 = unclean[iu2].first.recHits().first;
-          TrajectorySeed::const_iterator sh2_end = unclean[iu2].first.recHits().second;
-          for (; sh2 != sh2_end; ++sh2) {
-            if ((*sh).sharesInput(&(*sh2), TrackingRecHit::all))
+        for (auto const& sh : unclean[iu].first.recHits()) {
+          for (auto const& sh2 : unclean[iu2].first.recHits()) {
+            if (sh.sharesInput(&sh2, TrackingRecHit::all))
 
               shar++;
           }

--- a/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
+++ b/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
@@ -73,26 +73,20 @@ void ElectronSeedMerger::produce(edm::StreamID, Event& iEvent, const EventSetup&
       if (AlreadyMatched)
         continue;
 
-      //HITS FOR ECAL SEED
-      TrajectorySeed::const_iterator eh = e_beg->recHits().first;
-      TrajectorySeed::const_iterator eh_end = e_beg->recHits().second;
-
       //HITS FOR TK SEED
       unsigned int hitShared = 0;
       unsigned int hitSeed = 0;
-      for (; eh != eh_end; ++eh) {
-        if (!eh->isValid())
+      for (auto const& eh : e_beg->recHits()) {
+        if (!eh.isValid())
           continue;
         hitSeed++;
         bool Shared = false;
-        TrajectorySeed::const_iterator th = TSeed[it].recHits().first;
-        TrajectorySeed::const_iterator th_end = TSeed[it].recHits().second;
-        for (; th != th_end; ++th) {
-          if (!th->isValid())
+        for (auto const& th : TSeed[it].recHits()) {
+          if (!th.isValid())
             continue;
           //CHECK THE HIT COMPATIBILITY: put back sharesInput
           // as soon Egamma solves the bug on the seed collection
-          if (eh->sharesInput(&(*th), TrackingRecHit::all))
+          if (eh.sharesInput(&th, TrackingRecHit::all))
             Shared = true;
           //   if(eh->geographicalId() == th->geographicalId() &&
           // 	     (eh->localPosition() - th->localPosition()).mag() < 0.001) Shared=true;

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -484,12 +484,10 @@ int PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection& PfRTkColl,
       for (auto const& hhit : pft->trackRef()->recHits()) {
         if (!hhit->isValid())
           continue;
-        TrajectorySeed::const_iterator hit = gsftk.seedRef()->recHits().first;
-        TrajectorySeed::const_iterator hit_end = gsftk.seedRef()->recHits().second;
-        for (; hit != hit_end; ++hit) {
-          if (!(hit->isValid()))
+        for (auto const& hit : gsftk.seedRef()->recHits()) {
+          if (!(hit.isValid()))
             continue;
-          if (hhit->sharesInput(&*(hit), TrackingRecHit::all))
+          if (hhit->sharesInput(&hit, TrackingRecHit::all))
             ish++;
           // if((hit->geographicalId()==hhit->geographicalId())&&
           //     ((hhit->localPosition()-hit->localPosition()).mag()<0.01)) ish++;

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -836,10 +836,6 @@ void GroupedCkfTrajectoryBuilder::rebuildSeedingRegion(const TrajectorySeed& see
   KFTrajectoryFitter fitter(backwardPropagator(seed), &updator(), &estimator(), 3, nullptr, &hitCloner);
   //
   std::vector<const TrackingRecHit*> seedHits;
-  //seedHits.insert(seedHits.end(), rseedHits.first, rseedHits.second);
-  //for (TrajectorySeed::recHitContainer::const_iterator iter = rseedHits.first; iter != rseedHits.second; iter++){
-  //	seedHits.push_back(&*iter);
-  //}
 
   unsigned int nSeed = seed.nHits();
   //seedHits.reserve(nSeed);

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -836,15 +836,13 @@ void GroupedCkfTrajectoryBuilder::rebuildSeedingRegion(const TrajectorySeed& see
   auto hitCloner = static_cast<TkTransientTrackingRecHitBuilder const*>(hitBuilder())->cloner();
   KFTrajectoryFitter fitter(backwardPropagator(seed), &updator(), &estimator(), 3, nullptr, &hitCloner);
   //
-  TrajectorySeed::range rseedHits = seed.recHits();
   std::vector<const TrackingRecHit*> seedHits;
   //seedHits.insert(seedHits.end(), rseedHits.first, rseedHits.second);
   //for (TrajectorySeed::recHitContainer::const_iterator iter = rseedHits.first; iter != rseedHits.second; iter++){
   //	seedHits.push_back(&*iter);
   //}
 
-  //unsigned int nSeed(seedHits.size());
-  unsigned int nSeed(rseedHits.second - rseedHits.first);
+  unsigned int nSeed = seed.nHits();
   //seedHits.reserve(nSeed);
   TempTrajectoryContainer rebuiltTrajectories;
 
@@ -1077,11 +1075,8 @@ TempTrajectory GroupedCkfTrajectoryBuilder::backwardFit(TempTrajectory& candidat
   //cout << "firstTsos "<< firstTsos << endl;
   firstTsos.rescaleError(10.);
   //TrajectoryContainer bwdFitted(fitter.fit(fwdTraj.seed(),fwdTraj.recHits(),firstTsos));
-  Trajectory&& bwdFitted = fitter.fitOne(
-      TrajectorySeed(
-          PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), oppositeDirection(candidate.direction())),
-      fwdTraj.recHits(),
-      firstTsos);
+  Trajectory&& bwdFitted =
+      fitter.fitOne(TrajectorySeed({}, {}, oppositeDirection(candidate.direction())), fwdTraj.recHits(), firstTsos);
   if
     UNLIKELY(!bwdFitted.isValid()) return TempTrajectory();
 

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -486,31 +486,30 @@ bool GroupedCkfTrajectoryBuilder::advanceOneLayer(const TrajectorySeed& seed,
     TSOS stateToUse = stateAndLayers.first;
 
     double dPhiCacheForLoopersReconstruction(0);
-    if
-      UNLIKELY(!traj.empty() && (*il) == traj.lastLayer()) {
-        if (maxPt2ForLooperReconstruction > 0) {
-          // ------ For loopers reconstruction
-          //cout<<" self propagating in advanceOneLayer (for loopers) \n";
-          const BarrelDetLayer* sbdl = dynamic_cast<const BarrelDetLayer*>(traj.lastLayer());
-          if (sbdl) {
-            HelixBarrelCylinderCrossing cylinderCrossing(stateToUse.globalPosition(),
-                                                         stateToUse.globalMomentum(),
-                                                         stateToUse.transverseCurvature(),
-                                                         propagator->propagationDirection(),
-                                                         sbdl->specificSurface());
-            if (!cylinderCrossing.hasSolution())
-              continue;
-            GlobalPoint starting = stateToUse.globalPosition();
-            GlobalPoint target1 = cylinderCrossing.position1();
-            GlobalPoint target2 = cylinderCrossing.position2();
+    if UNLIKELY (!traj.empty() && (*il) == traj.lastLayer()) {
+      if (maxPt2ForLooperReconstruction > 0) {
+        // ------ For loopers reconstruction
+        //cout<<" self propagating in advanceOneLayer (for loopers) \n";
+        const BarrelDetLayer* sbdl = dynamic_cast<const BarrelDetLayer*>(traj.lastLayer());
+        if (sbdl) {
+          HelixBarrelCylinderCrossing cylinderCrossing(stateToUse.globalPosition(),
+                                                       stateToUse.globalMomentum(),
+                                                       stateToUse.transverseCurvature(),
+                                                       propagator->propagationDirection(),
+                                                       sbdl->specificSurface());
+          if (!cylinderCrossing.hasSolution())
+            continue;
+          GlobalPoint starting = stateToUse.globalPosition();
+          GlobalPoint target1 = cylinderCrossing.position1();
+          GlobalPoint target2 = cylinderCrossing.position2();
 
-            GlobalPoint farther =
-                fabs(starting.phi() - target1.phi()) > fabs(starting.phi() - target2.phi()) ? target1 : target2;
+          GlobalPoint farther =
+              fabs(starting.phi() - target1.phi()) > fabs(starting.phi() - target2.phi()) ? target1 : target2;
 
-            const Bounds& bounds(sbdl->specificSurface().bounds());
-            float length = 0.5f * bounds.length();
+          const Bounds& bounds(sbdl->specificSurface().bounds());
+          float length = 0.5f * bounds.length();
 
-            /*
+          /*
 	      cout << "starting: " << starting << endl;
 	      cout << "target1: " << target1 << endl;
 	      cout << "target2: " << target2 << endl;
@@ -518,46 +517,46 @@ bool GroupedCkfTrajectoryBuilder::advanceOneLayer(const TrajectorySeed& seed,
 	    cout << "length: " << length << endl;
 	    */
 
-            /*
+          /*
 	      float deltaZ = bounds.thickness()/2.f/fabs(tan(stateToUse.globalDirection().theta()) ) ;
 	      if(stateToUse.hasError())
 	      deltaZ += 3*sqrt(stateToUse.cartesianError().position().czz());
 	      if( fabs(farther.z()) > length + deltaZ ) continue;
 	    */
-            if (fabs(farther.z()) * 0.95f > length)
-              continue;
-
-            Geom::Phi<float> tmpDphi = target1.phi() - target2.phi();
-            if (std::abs(tmpDphi) > maxDPhiForLooperReconstruction)
-              continue;
-            GlobalPoint target(0.5f * (target1.basicVector() + target2.basicVector()));
-            //cout << "target: " << target << endl;
-
-            TransverseImpactPointExtrapolator extrapolator;
-            stateToUse = extrapolator.extrapolate(stateToUse, target, *propagator);
-            if (!stateToUse.isValid())
-              continue;  //SK: consider trying the original? probably not
-
-            //dPhiCacheForLoopersReconstruction = fabs(target1.phi()-target2.phi())*2.;
-            dPhiCacheForLoopersReconstruction = std::abs(tmpDphi);
-            traj.incrementLoops();
-          } else {  // not barrel
+          if (fabs(farther.z()) * 0.95f > length)
             continue;
-          }
-        } else {  // loopers not requested (why else???)
-                  // ------ For cosmics reconstruction
-          LogDebug("CkfPattern") << " self propagating in advanceOneLayer.\n from: \n" << stateToUse;
-          //self navigation case
-          // go to a middle point first
-          TransverseImpactPointExtrapolator middle;
-          GlobalPoint center(0, 0, 0);
-          stateToUse = middle.extrapolate(stateToUse, center, *(forwardPropagator(seed)));
 
+          Geom::Phi<float> tmpDphi = target1.phi() - target2.phi();
+          if (std::abs(tmpDphi) > maxDPhiForLooperReconstruction)
+            continue;
+          GlobalPoint target(0.5f * (target1.basicVector() + target2.basicVector()));
+          //cout << "target: " << target << endl;
+
+          TransverseImpactPointExtrapolator extrapolator;
+          stateToUse = extrapolator.extrapolate(stateToUse, target, *propagator);
           if (!stateToUse.isValid())
-            continue;
-          LogDebug("CkfPattern") << "to: " << stateToUse;
+            continue;  //SK: consider trying the original? probably not
+
+          //dPhiCacheForLoopersReconstruction = fabs(target1.phi()-target2.phi())*2.;
+          dPhiCacheForLoopersReconstruction = std::abs(tmpDphi);
+          traj.incrementLoops();
+        } else {  // not barrel
+          continue;
         }
-      }  // last layer...
+      } else {  // loopers not requested (why else???)
+                // ------ For cosmics reconstruction
+        LogDebug("CkfPattern") << " self propagating in advanceOneLayer.\n from: \n" << stateToUse;
+        //self navigation case
+        // go to a middle point first
+        TransverseImpactPointExtrapolator middle;
+        GlobalPoint center(0, 0, 0);
+        stateToUse = middle.extrapolate(stateToUse, center, *(forwardPropagator(seed)));
+
+        if (!stateToUse.isValid())
+          continue;
+        LogDebug("CkfPattern") << "to: " << stateToUse;
+      }
+    }  // last layer...
 
     //unsigned int maxCandidates = theMaxCand > 21 ? theMaxCand*2 : 42; //limit the number of returned segments
     LayerMeasurements layerMeasurements(theMeasurementTracker->measurementTracker(), *theMeasurementTracker);
@@ -852,13 +851,12 @@ void GroupedCkfTrajectoryBuilder::rebuildSeedingRegion(const TrajectorySeed& see
     //
 
     auto&& reFitted = backwardFit(*it, nSeed, fitter, seedHits);
-    if
-      UNLIKELY(!reFitted.isValid()) {
-        rebuiltTrajectories.push_back(std::move(*it));
-        LogDebug("CkfPattern") << "RebuildSeedingRegion skipped as backward fit failed";
-        //			    << "after reFitted.size() " << reFitted.size();
-        continue;
-      }
+    if UNLIKELY (!reFitted.isValid()) {
+      rebuiltTrajectories.push_back(std::move(*it));
+      LogDebug("CkfPattern") << "RebuildSeedingRegion skipped as backward fit failed";
+      //			    << "after reFitted.size() " << reFitted.size();
+      continue;
+    }
     //LogDebug("CkfPattern")<<"after reFitted.size() " << reFitted.size();
     //
     // Rebuild seeding part. In case it fails: keep initial trajectory
@@ -1020,8 +1018,8 @@ TempTrajectory GroupedCkfTrajectoryBuilder::backwardFit(TempTrajectory& candidat
   unsigned int nHitMin = std::max(candidate.foundHits() - nSeed, theMinNrOfHitsForRebuild);
   //  unsigned int nHitMin = oldMeasurements.size()-nSeed;
   // we want to rebuild only if the number of VALID measurements excluding the seed measurements is higher than the cut
-  if
-    UNLIKELY(nHitMin < theMinNrOfHitsForRebuild) return TempTrajectory();
+  if UNLIKELY (nHitMin < theMinNrOfHitsForRebuild)
+    return TempTrajectory();
 
   LogDebug("CkfPattern") /* << "nHitMin " << nHitMin*/ << "Sizes: " << candidate.measurements().size() << " / ";
   //
@@ -1045,13 +1043,12 @@ TempTrajectory GroupedCkfTrajectoryBuilder::backwardFit(TempTrajectory& candidat
       //
       // count valid / 2D hits
       //
-      if
-        LIKELY(hit->isValid()) {
-          nHit++;
-          //if ( hit.isMatched() ||
-          //     hit.det().detUnits().front()->type().module()==pixel )
-          //nHit2d++;
-        }
+      if LIKELY (hit->isValid()) {
+        nHit++;
+        //if ( hit.isMatched() ||
+        //     hit.det().detUnits().front()->type().module()==pixel )
+        //nHit2d++;
+      }
     }
     //if (nHit==nHitMin) lastBwdDetLayer=im->layer();
     //
@@ -1065,8 +1062,8 @@ TempTrajectory GroupedCkfTrajectoryBuilder::backwardFit(TempTrajectory& candidat
   //
   // Fit only if required number of valid hits can be used
   //
-  if
-    UNLIKELY(nHit < nHitMin) return TempTrajectory();
+  if UNLIKELY (nHit < nHitMin)
+    return TempTrajectory();
 
   //
   // Do the backward fit (important: start from scaled, not random cov. matrix!)
@@ -1077,8 +1074,8 @@ TempTrajectory GroupedCkfTrajectoryBuilder::backwardFit(TempTrajectory& candidat
   //TrajectoryContainer bwdFitted(fitter.fit(fwdTraj.seed(),fwdTraj.recHits(),firstTsos));
   Trajectory&& bwdFitted =
       fitter.fitOne(TrajectorySeed({}, {}, oppositeDirection(candidate.direction())), fwdTraj.recHits(), firstTsos);
-  if
-    UNLIKELY(!bwdFitted.isValid()) return TempTrajectory();
+  if UNLIKELY (!bwdFitted.isValid())
+    return TempTrajectory();
 
   LogDebug("CkfPattern") << "Obtained bwdFitted trajectory with measurement size " << bwdFitted.measurements().size();
   TempTrajectory fitted(fwdTraj.direction(), nSeed);

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -83,10 +83,9 @@ void BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed, Temp
       TSOS innerState = backwardPropagator(seed)->propagate(outerState, hitGeomDet->surface());
 
       // try to recover if propagation failed
-      if
-        UNLIKELY(!innerState.isValid())
-      innerState = trajectoryStateTransform::transientState(
-          pState, &(hitGeomDet->surface()), forwardPropagator(seed)->magneticField());
+      if UNLIKELY (!innerState.isValid())
+        innerState = trajectoryStateTransform::transientState(
+            pState, &(hitGeomDet->surface()), forwardPropagator(seed)->magneticField());
 
       if (innerState.isValid()) {
         TSOS innerUpdated = theUpdator->update(innerState, *recHit);
@@ -110,16 +109,15 @@ TempTrajectory BaseCkfTrajectoryBuilder::createStartingTrajectory(const Trajecto
 }
 
 bool BaseCkfTrajectoryBuilder::toBeContinued(TempTrajectory& traj, bool inOut) const {
-  if
-    UNLIKELY(traj.measurements().size() > 400) {
-      edm::LogError("BaseCkfTrajectoryBuilder_InfiniteLoop");
-      LogTrace("BaseCkfTrajectoryBuilder_InfiniteLoop")
-          << "Cropping Track After 400 Measurements:\n"
-          << "   Last predicted state: " << traj.lastMeasurement().predictedState() << "\n"
-          << "   Last layer subdetector: " << (traj.lastLayer() ? traj.lastLayer()->subDetector() : -1) << "\n"
-          << "   Found hits: " << traj.foundHits() << ", lost hits: " << traj.lostHits() << "\n\n";
-      return false;
-    }
+  if UNLIKELY (traj.measurements().size() > 400) {
+    edm::LogError("BaseCkfTrajectoryBuilder_InfiniteLoop");
+    LogTrace("BaseCkfTrajectoryBuilder_InfiniteLoop")
+        << "Cropping Track After 400 Measurements:\n"
+        << "   Last predicted state: " << traj.lastMeasurement().predictedState() << "\n"
+        << "   Last layer subdetector: " << (traj.lastLayer() ? traj.lastLayer()->subDetector() : -1) << "\n"
+        << "   Found hits: " << traj.foundHits() << ", lost hits: " << traj.lostHits() << "\n\n";
+    return false;
+  }
   // Called after each new hit is added to the trajectory, to see if it is
   // worth continuing to build this track candidate.
   if (inOut) {

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -49,8 +49,6 @@ std::unique_ptr<TrajectoryFilter> BaseCkfTrajectoryBuilder::createTrajectoryFilt
 
 #include "RecoTracker/TransientTrackingRecHit/interface/TRecHit5DParamConstraint.h"
 void BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed, TempTrajectory& result, bool as5D) const {
-  TrajectorySeed::range hitRange = seed.recHits();
-
   PTrajectoryStateOnDet pState(seed.startingState());
   const GeomDet* gdet = theMeasurementTracker->geomTracker()->idToDet(pState.detId());
   TSOS outerState =
@@ -64,14 +62,14 @@ void BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed, Temp
     return;
   }
 
-  for (TrajectorySeed::const_iterator ihit = hitRange.first; ihit != hitRange.second; ihit++) {
+  for (auto ihit = seed.recHits().begin(); ihit != seed.recHits().end(); ihit++) {
     TrackingRecHit::RecHitPointer recHit = ihit->cloneSH();
     const GeomDet* hitGeomDet = recHit->det();
 
     const DetLayer* hitLayer = theMeasurementTracker->geometricSearchTracker()->detLayer(ihit->geographicalId());
 
     TSOS invalidState(hitGeomDet->surface());
-    if (ihit == hitRange.second - 1) {
+    if (ihit == seed.recHits().end() - 1) {
       // the seed trajectory state should correspond to this hit
       if (&gdet->surface() != &hitGeomDet->surface()) {
         edm::LogError("CkfPattern")

--- a/RecoTracker/CkfPattern/src/CachingSeedCleanerBySharedInput.cc
+++ b/RecoTracker/CkfPattern/src/CachingSeedCleanerBySharedInput.cc
@@ -45,10 +45,10 @@ bool CachingSeedCleanerBySharedInput::good(const TrajectorySeed *seed) {
     return true;
   }
 
-  auto range = seed->recHits();
+  auto const &range = seed->recHits();
 
-  auto first = range.first;
-  auto last = range.second;
+  auto first = range.begin();
+  auto last = range.end();
   auto detid = first->geographicalId().rawId();
 
   //calls_++;

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -436,9 +436,8 @@ namespace cms {
             PTrajectoryStateOnDet&& state = trajectoryStateTransform::persistentState(initState, initId);
             TrajectorySeed::RecHitContainer hits;
             hits.push_back(it->lastMeasurement().recHit()->hit()->clone());
-            std::shared_ptr<const TrajectorySeed> seed(new TrajectorySeed(state, std::move(hits), direction));
             // 3) make a trajectory
-            Trajectory trajectory(seed, direction);
+            Trajectory trajectory{std::make_shared<TrajectorySeed>(state, std::move(hits), direction), direction};
             trajectory.setNLoops(it->nLoops());
             trajectory.setSeedRef(it->seedRef());
             trajectory.setStopReason(it->stopReason());

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -434,7 +434,7 @@ namespace cms {
             TrajectoryStateOnSurface const& initState = it->lastMeasurement().updatedState();
             auto initId = it->lastMeasurement().recHitR().rawId();
             PTrajectoryStateOnDet&& state = trajectoryStateTransform::persistentState(initState, initId);
-            TrajectorySeed::recHitContainer hits;
+            TrajectorySeed::RecHitContainer hits;
             hits.push_back(it->lastMeasurement().recHit()->hit()->clone());
             std::shared_ptr<const TrajectorySeed> seed(new TrajectorySeed(state, std::move(hits), direction));
             // 3) make a trajectory

--- a/RecoTracker/ConversionSeedGenerators/plugins/PrintRecoObjects.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PrintRecoObjects.cc
@@ -22,8 +22,10 @@ void PrintRecoObjects::print(std::stringstream& ss, const TrajectorySeed& tjS) {
      << " charge " << tjS.startingState().parameters().charge() << "\n\t error ";
   for (size_t ie = 0; ie < 15; ++ie)
     ss << "\t " << tjS.startingState().error(ie);
-  for (TrajectorySeed::const_iterator iter = tjS.recHits().first; iter != tjS.recHits().second; ++iter)
-    ss << "\n\t TrackingRecHit on detid " << iter->geographicalId().rawId() << " \t localPos " << iter->localPosition();
+  for (auto const& recHit : tjS.recHits()) {
+    ss << "\n\t TrackingRecHit on detid " << recHit.geographicalId().rawId() << " \t localPos "
+       << recHit.localPosition();
+  }
 }
 
 void PrintRecoObjects::print(std::stringstream& ss, const uint32_t& detid, const TrackerTopology* tTopo) const {

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -461,182 +461,180 @@ void TrackListMerger::produce(edm::Event& e, const edm::EventSetup& es) {
       unsigned int id = hit->rawId();
       if (hit->geographicalId().subdetId() > 2)
         id &= (~3);  // mask mono/stereo in strips...
-      if
-        LIKELY(hit->isValid()) {
-          rh1[i].emplace_back(id, hit);
-          std::push_heap(rh1[i].begin(), rh1[i].end(), compById);
-        }
+      if LIKELY (hit->isValid()) {
+        rh1[i].emplace_back(id, hit);
+        std::push_heap(rh1[i].begin(), rh1[i].end(), compById);
+      }
     }
     std::sort_heap(rh1[i].begin(), rh1[i].end(), compById);
   }
 
   //DL here
-  if
-    LIKELY(ngood > 1 && collsSize > 1)
-  for (unsigned int ltm = 0; ltm < listsToMerge_.size(); ltm++) {
-    int saveSelected[rSize];
-    bool notActive[collsSize];
-    for (unsigned int cn = 0; cn != collsSize; ++cn)
-      notActive[cn] = find(listsToMerge_[ltm].begin(), listsToMerge_[ltm].end(), cn) == listsToMerge_[ltm].end();
+  if LIKELY (ngood > 1 && collsSize > 1)
+    for (unsigned int ltm = 0; ltm < listsToMerge_.size(); ltm++) {
+      int saveSelected[rSize];
+      bool notActive[collsSize];
+      for (unsigned int cn = 0; cn != collsSize; ++cn)
+        notActive[cn] = find(listsToMerge_[ltm].begin(), listsToMerge_[ltm].end(), cn) == listsToMerge_[ltm].end();
 
-    for (unsigned int i = 0; i < rSize; i++)
-      saveSelected[i] = selected[i];
+      for (unsigned int i = 0; i < rSize; i++)
+        saveSelected[i] = selected[i];
 
-    //DL protect against 0 tracks?
-    for (unsigned int i = 0; i < rSize - 1; i++) {
-      if (selected[i] == 0)
-        continue;
-      unsigned int collNum = trackCollNum[i];
-
-      //check that this track is in one of the lists for this iteration
-      if (notActive[collNum])
-        continue;
-
-      int k1 = indexG[i];
-      unsigned int nh1 = rh1[k1].size();
-      int qualityMaskT1 = trackQuals[i];
-
-      int nhit1 = nh1;  // validHits[k1];
-      float score1 = score[k1];
-
-      // start at next collection
-      for (unsigned int j = i + 1; j < rSize; j++) {
-        if (selected[j] == 0)
+      //DL protect against 0 tracks?
+      for (unsigned int i = 0; i < rSize - 1; i++) {
+        if (selected[i] == 0)
           continue;
-        unsigned int collNum2 = trackCollNum[j];
-        if ((collNum == collNum2) && indivShareFrac_[collNum] > 0.99)
-          continue;
+        unsigned int collNum = trackCollNum[i];
+
         //check that this track is in one of the lists for this iteration
-        if (notActive[collNum2])
+        if (notActive[collNum])
           continue;
 
-        int k2 = indexG[j];
+        int k1 = indexG[i];
+        unsigned int nh1 = rh1[k1].size();
+        int qualityMaskT1 = trackQuals[i];
 
-        int newQualityMask = -9;  //avoid resetting quality mask if not desired 10+ -9 =1
-        if (promoteQuality_[ltm]) {
-          int maskT1 = saveSelected[i] > 1 ? saveSelected[i] - 10 : qualityMaskT1;
-          int maskT2 = saveSelected[j] > 1 ? saveSelected[j] - 10 : trackQuals[j];
-          newQualityMask = (maskT1 | maskT2);  // take OR of trackQuality
-        }
-        unsigned int nh2 = rh1[k2].size();
-        int nhit2 = nh2;
+        int nhit1 = nh1;  // validHits[k1];
+        float score1 = score[k1];
 
-        auto share = use_sharesInput_ ? [](const TrackingRecHit* it, const TrackingRecHit* jt, float) -> bool {
-          return it->sharesInput(jt, TrackingRecHit::some);
-        }
-        : [](const TrackingRecHit* it, const TrackingRecHit* jt, float eps) -> bool {
-            float delta = std::abs(it->localPosition().x() - jt->localPosition().x());
-            return (it->geographicalId() == jt->geographicalId()) && (delta < eps);
-          };
+        // start at next collection
+        for (unsigned int j = i + 1; j < rSize; j++) {
+          if (selected[j] == 0)
+            continue;
+          unsigned int collNum2 = trackCollNum[j];
+          if ((collNum == collNum2) && indivShareFrac_[collNum] > 0.99)
+            continue;
+          //check that this track is in one of the lists for this iteration
+          if (notActive[collNum2])
+            continue;
 
-        statCount.start();
+          int k2 = indexG[j];
 
-        //loop over rechits
-        int noverlap = 0;
-        int firstoverlap = 0;
-        // check first hit  (should use REAL first hit?)
-        if
-          UNLIKELY(allowFirstHitShare_ && rh1[k1][0].first == rh1[k2][0].first) {
+          int newQualityMask = -9;  //avoid resetting quality mask if not desired 10+ -9 =1
+          if (promoteQuality_[ltm]) {
+            int maskT1 = saveSelected[i] > 1 ? saveSelected[i] - 10 : qualityMaskT1;
+            int maskT2 = saveSelected[j] > 1 ? saveSelected[j] - 10 : trackQuals[j];
+            newQualityMask = (maskT1 | maskT2);  // take OR of trackQuality
+          }
+          unsigned int nh2 = rh1[k2].size();
+          int nhit2 = nh2;
+
+          auto share = use_sharesInput_ ? [](const TrackingRecHit* it, const TrackingRecHit* jt, float) -> bool {
+            return it->sharesInput(jt, TrackingRecHit::some);
+          }
+          : [](const TrackingRecHit* it, const TrackingRecHit* jt, float eps) -> bool {
+              float delta = std::abs(it->localPosition().x() - jt->localPosition().x());
+              return (it->geographicalId() == jt->geographicalId()) && (delta < eps);
+            };
+
+          statCount.start();
+
+          //loop over rechits
+          int noverlap = 0;
+          int firstoverlap = 0;
+          // check first hit  (should use REAL first hit?)
+          if UNLIKELY (allowFirstHitShare_ && rh1[k1][0].first == rh1[k2][0].first) {
             const TrackingRecHit* it = rh1[k1][0].second;
             const TrackingRecHit* jt = rh1[k2][0].second;
             if (share(it, jt, epsilon_))
               firstoverlap = 1;
           }
 
-        // exploit sorting
-        unsigned int jh = 0;
-        unsigned int ih = 0;
-        while (ih != nh1 && jh != nh2) {
-          // break if not enough to go...
-          // if ( nprecut-noverlap+firstoverlap > int(nh1-ih)) break;
-          // if ( nprecut-noverlap+firstoverlap > int(nh2-jh)) break;
-          auto const id1 = rh1[k1][ih].first;
-          auto const id2 = rh1[k2][jh].first;
-          if (id1 < id2)
-            ++ih;
-          else if (id2 < id1)
-            ++jh;
-          else {
-            // in case of split-hit do full conbinatorics
-            auto li = ih;
-            while ((++li) != nh1 && id1 == rh1[k1][li].first) {
-            }
-            auto lj = jh;
-            while ((++lj) != nh2 && id2 == rh1[k2][lj].first) {
-            }
-            for (auto ii = ih; ii != li; ++ii)
-              for (auto jj = jh; jj != lj; ++jj) {
-                const TrackingRecHit* it = rh1[k1][ii].second;
-                const TrackingRecHit* jt = rh1[k2][jj].second;
-                if (share(it, jt, epsilon_))
-                  noverlap++;
+          // exploit sorting
+          unsigned int jh = 0;
+          unsigned int ih = 0;
+          while (ih != nh1 && jh != nh2) {
+            // break if not enough to go...
+            // if ( nprecut-noverlap+firstoverlap > int(nh1-ih)) break;
+            // if ( nprecut-noverlap+firstoverlap > int(nh2-jh)) break;
+            auto const id1 = rh1[k1][ih].first;
+            auto const id2 = rh1[k2][jh].first;
+            if (id1 < id2)
+              ++ih;
+            else if (id2 < id1)
+              ++jh;
+            else {
+              // in case of split-hit do full conbinatorics
+              auto li = ih;
+              while ((++li) != nh1 && id1 == rh1[k1][li].first) {
               }
-            jh = lj;
-            ih = li;
-          }  // equal ids
+              auto lj = jh;
+              while ((++lj) != nh2 && id2 == rh1[k2][lj].first) {
+              }
+              for (auto ii = ih; ii != li; ++ii)
+                for (auto jj = jh; jj != lj; ++jj) {
+                  const TrackingRecHit* it = rh1[k1][ii].second;
+                  const TrackingRecHit* jt = rh1[k2][jj].second;
+                  if (share(it, jt, epsilon_))
+                    noverlap++;
+                }
+              jh = lj;
+              ih = li;
+            }  // equal ids
 
-        }  //loop over ih & jh
+          }  //loop over ih & jh
 
-        bool dupfound =
-            (collNum != collNum2)
-                ? (noverlap - firstoverlap) > (std::min(nhit1, nhit2) - firstoverlap) * shareFrac_
-                : (noverlap - firstoverlap) > (std::min(nhit1, nhit2) - firstoverlap) * indivShareFrac_[collNum];
+          bool dupfound =
+              (collNum != collNum2)
+                  ? (noverlap - firstoverlap) > (std::min(nhit1, nhit2) - firstoverlap) * shareFrac_
+                  : (noverlap - firstoverlap) > (std::min(nhit1, nhit2) - firstoverlap) * indivShareFrac_[collNum];
 
-        auto seti = [&](unsigned int ii, unsigned int jj) {
-          selected[jj] = 0;
-          selected[ii] = 10 + newQualityMask;  // add 10 to avoid the case where mask = 1
-          trkUpdated[ii] = true;
-          if (trackAlgoPriorityOrder.priority(oriAlgo[jj]) < trackAlgoPriorityOrder.priority(oriAlgo[ii]))
-            oriAlgo[ii] = oriAlgo[jj];
-          algoMask[ii] |= algoMask[jj];
-          algoMask[jj] = algoMask[ii];  // in case we keep discarded
-        };
+          auto seti = [&](unsigned int ii, unsigned int jj) {
+            selected[jj] = 0;
+            selected[ii] = 10 + newQualityMask;  // add 10 to avoid the case where mask = 1
+            trkUpdated[ii] = true;
+            if (trackAlgoPriorityOrder.priority(oriAlgo[jj]) < trackAlgoPriorityOrder.priority(oriAlgo[ii]))
+              oriAlgo[ii] = oriAlgo[jj];
+            algoMask[ii] |= algoMask[jj];
+            algoMask[jj] = algoMask[ii];  // in case we keep discarded
+          };
 
-        if (dupfound) {
-          float score2 = score[k2];
-          constexpr float almostSame = 0.01f;  // difference rather than ratio due to possible negative values for score
-          if (score1 - score2 > almostSame) {
-            seti(i, j);
-          } else if (score2 - score1 > almostSame) {
-            seti(j, i);
-          } else {
-            // If tracks from both iterations are virtually identical, choose the one with the best quality or with lower algo
-            if ((trackQuals[j] &
-                 (1 << reco::TrackBase::loose | 1 << reco::TrackBase::tight | 1 << reco::TrackBase::highPurity)) ==
-                (trackQuals[i] &
-                 (1 << reco::TrackBase::loose | 1 << reco::TrackBase::tight | 1 << reco::TrackBase::highPurity))) {
-              //same quality, pick earlier algo
-              if (trackAlgoPriorityOrder.priority(algo[k1]) <= trackAlgoPriorityOrder.priority(algo[k2])) {
+          if (dupfound) {
+            float score2 = score[k2];
+            constexpr float almostSame =
+                0.01f;  // difference rather than ratio due to possible negative values for score
+            if (score1 - score2 > almostSame) {
+              seti(i, j);
+            } else if (score2 - score1 > almostSame) {
+              seti(j, i);
+            } else {
+              // If tracks from both iterations are virtually identical, choose the one with the best quality or with lower algo
+              if ((trackQuals[j] &
+                   (1 << reco::TrackBase::loose | 1 << reco::TrackBase::tight | 1 << reco::TrackBase::highPurity)) ==
+                  (trackQuals[i] &
+                   (1 << reco::TrackBase::loose | 1 << reco::TrackBase::tight | 1 << reco::TrackBase::highPurity))) {
+                //same quality, pick earlier algo
+                if (trackAlgoPriorityOrder.priority(algo[k1]) <= trackAlgoPriorityOrder.priority(algo[k2])) {
+                  seti(i, j);
+                } else {
+                  seti(j, i);
+                }
+              } else if ((trackQuals[j] & (1 << reco::TrackBase::loose | 1 << reco::TrackBase::tight |
+                                           1 << reco::TrackBase::highPurity)) <
+                         (trackQuals[i] & (1 << reco::TrackBase::loose | 1 << reco::TrackBase::tight |
+                                           1 << reco::TrackBase::highPurity))) {
                 seti(i, j);
               } else {
                 seti(j, i);
               }
-            } else if ((trackQuals[j] & (1 << reco::TrackBase::loose | 1 << reco::TrackBase::tight |
-                                         1 << reco::TrackBase::highPurity)) <
-                       (trackQuals[i] & (1 << reco::TrackBase::loose | 1 << reco::TrackBase::tight |
-                                         1 << reco::TrackBase::highPurity))) {
-              seti(i, j);
-            } else {
-              seti(j, i);
-            }
-          }  //end fi < fj
-          statCount.overlap();
-          /*
+            }  //end fi < fj
+            statCount.overlap();
+            /*
 	    if (at0[k1]&&at0[k2]) {
 	      statCount.dp(dphi);
 	      if (dz<1.f) statCount.de(deta);
 	    }
 	    */
-        }  //end got a duplicate
-        else {
-          statCount.noOverlap();
-        }
-        //stop if the ith track is now unselected
-        if (selected[i] == 0)
-          break;
-      }  //end track2 loop
-    }    //end track loop
-  }      //end loop over track list sets
+          }  //end got a duplicate
+          else {
+            statCount.noOverlap();
+          }
+          //stop if the ith track is now unselected
+          if (selected[i] == 0)
+            break;
+        }  //end track2 loop
+      }    //end track loop
+    }      //end loop over track list sets
 
   auto vmMVA = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler fillerMVA(*vmMVA);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -755,10 +755,9 @@ void TrackListMerger::produce(edm::Event& e, const edm::EventSetup& es) {
         edm::InputTag clusterRemovalInfos("");
         //grab on of the hits of the seed
         if (origSeedRef->nHits() != 0) {
-          TrajectorySeed::const_iterator firstHit = origSeedRef->recHits().first;
-          const TrackingRecHit* hit = &*firstHit;
-          if (firstHit->isValid()) {
-            edm::ProductID pID = clusterProductB(hit);
+          TrackingRecHit const& hit = origSeedRef->recHits()[0];
+          if (hit.isValid()) {
+            edm::ProductID pID = clusterProductB(&hit);
             // the cluster collection either produced a removalInfo or mot
             //get the clusterremoval info from the provenance: will rekey if this is found
             edm::Handle<reco::ClusterRemovalInfo> CRIh;
@@ -770,12 +769,10 @@ void TrackListMerger::produce(edm::Event& e, const edm::EventSetup& es) {
 
         if (doRekeyOnThisSeed && !(clusterRemovalInfos == edm::InputTag(""))) {
           ClusterRemovalRefSetter refSetter(e, clusterRemovalInfos);
-          TrajectorySeed::recHitContainer newRecHitContainer;
+          TrajectorySeed::RecHitContainer newRecHitContainer;
           newRecHitContainer.reserve(origSeedRef->nHits());
-          TrajectorySeed::const_iterator iH = origSeedRef->recHits().first;
-          TrajectorySeed::const_iterator iH_end = origSeedRef->recHits().second;
-          for (; iH != iH_end; ++iH) {
-            newRecHitContainer.push_back(*iH);
+          for (auto const& recHit : origSeedRef->recHits()) {
+            newRecHitContainer.push_back(recHit);
             refSetter.reKey(&newRecHitContainer.back());
           }
           outputSeeds->push_back(

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -755,7 +755,7 @@ void TrackListMerger::produce(edm::Event& e, const edm::EventSetup& es) {
         edm::InputTag clusterRemovalInfos("");
         //grab on of the hits of the seed
         if (origSeedRef->nHits() != 0) {
-          TrackingRecHit const& hit = origSeedRef->recHits()[0];
+          TrackingRecHit const& hit = *origSeedRef->recHits().begin();
           if (hit.isValid()) {
             edm::ProductID pID = clusterProductB(&hit);
             // the cluster collection either produced a removalInfo or mot

--- a/RecoTracker/MeasurementDet/src/StartingLayerFinder.cc
+++ b/RecoTracker/MeasurementDet/src/StartingLayerFinder.cc
@@ -72,11 +72,11 @@ vector<const DetLayer*> StartingLayerFinder::startingLayers(const TrajectorySeed
   if (aSeed.nHits() != 2)
     return vector<const DetLayer*>();
 
-  TrackingRecHitCollection::const_iterator firstHit = aSeed.recHits().first;
+  TrackingRecHitCollection::const_iterator firstHit = aSeed.recHits().begin();
   const TrackingRecHit* recHit1 = &(*firstHit);
   const DetLayer* hit1Layer = theMeasurementTracker->geometricSearchTracker()->detLayer(recHit1->geographicalId());
 
-  TrackingRecHitCollection::const_iterator secondHit = aSeed.recHits().second;
+  TrackingRecHitCollection::const_iterator secondHit = aSeed.recHits().end();
   const TrackingRecHit* recHit2 = &(*secondHit);
   const DetLayer* hit2Layer = theMeasurementTracker->geometricSearchTracker()->detLayer(recHit2->geographicalId());
 

--- a/RecoTracker/MeasurementDet/src/StartingLayerFinder.cc
+++ b/RecoTracker/MeasurementDet/src/StartingLayerFinder.cc
@@ -72,11 +72,11 @@ vector<const DetLayer*> StartingLayerFinder::startingLayers(const TrajectorySeed
   if (aSeed.nHits() != 2)
     return vector<const DetLayer*>();
 
-  TrackingRecHitCollection::const_iterator firstHit = aSeed.recHits().begin();
+  auto firstHit = aSeed.recHits().begin();
   const TrackingRecHit* recHit1 = &(*firstHit);
   const DetLayer* hit1Layer = theMeasurementTracker->geometricSearchTracker()->detLayer(recHit1->geographicalId());
 
-  TrackingRecHitCollection::const_iterator secondHit = aSeed.recHits().end();
+  auto secondHit = aSeed.recHits().end();
   const TrackingRecHit* recHit2 = &(*secondHit);
   const DetLayer* hit2Layer = theMeasurementTracker->geometricSearchTracker()->detLayer(recHit2->geographicalId());
 

--- a/RecoTracker/MkFit/plugins/MkFitInputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitInputConverter.cc
@@ -201,8 +201,8 @@ mkfit::TrackVec MkFitInputConverter::convertSeeds(const edm::View<TrajectorySeed
   ret.reserve(seeds.size());
   int index = 0;
   for (const auto& seed : seeds) {
-    const auto hitRange = seed.recHits();
-    const auto lastRecHit = ttrhBuilder.build(&*(hitRange.second - 1));
+    auto const& hitRange = seed.recHits();
+    const auto lastRecHit = ttrhBuilder.build(&*(hitRange.end() - 1));
     const auto tsos = trajectoryStateTransform::transientState(seed.startingState(), lastRecHit->surface(), &mf);
     const auto& stateGlobal = tsos.globalParameters();
     const auto& gpos = stateGlobal.position();
@@ -224,11 +224,11 @@ mkfit::TrackVec MkFitInputConverter::convertSeeds(const edm::View<TrajectorySeed
     ret.emplace_back(state, 0, index, 0, nullptr);
 
     // Add hits
-    for (auto iHit = hitRange.first; iHit != hitRange.second; ++iHit) {
-      if (not trackerHitRTTI::isFromDet(*iHit)) {
+    for (auto const& recHit : hitRange) {
+      if (not trackerHitRTTI::isFromDet(recHit)) {
         throw cms::Exception("Assert") << "Encountered a seed with a hit which is not trackerHitRTTI::isFromDet()";
       }
-      const auto& clusterRef = static_cast<const BaseTrackerRecHit&>(*iHit).firstClusterRef();
+      const auto& clusterRef = static_cast<const BaseTrackerRecHit&>(recHit).firstClusterRef();
       const auto& mkFitHit = hitIndexMap.mkFitHit(clusterRef.id(), clusterRef.index());
       ret.back().addHitIdx(mkFitHit.index(), mkFitHit.layer(), 0);  // per-hit chi2 is not known
     }

--- a/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
@@ -221,14 +221,14 @@ Trajectory CRackTrajectoryBuilder::createStartingTrajectory(const TrajectorySeed
 
 std::vector<TrajectoryMeasurement> CRackTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed) const {
   std::vector<TrajectoryMeasurement> result;
-  TrajectorySeed::range hitRange = seed.recHits();
-  for (TrajectorySeed::const_iterator ihit = hitRange.first; ihit != hitRange.second; ihit++) {
+  auto const& hitRange = seed.recHits();
+  for (auto ihit = hitRange.begin(); ihit != hitRange.end(); ihit++) {
     //RC TransientTrackingRecHit* recHit = RHBuilder->build(&(*ihit));
     TransientTrackingRecHit::RecHitPointer recHit = RHBuilder->build(&(*ihit));
     const GeomDet* hitGeomDet = (&(*tracker))->idToDet(ihit->geographicalId());
     TSOS invalidState(new BasicSingleTrajectoryState(hitGeomDet->surface()));
 
-    if (ihit == hitRange.second - 1) {
+    if (ihit == hitRange.end() - 1) {
       TSOS updatedState = startingTSOS(seed);
       result.emplace_back(invalidState, updatedState, recHit);
 
@@ -252,8 +252,6 @@ vector<const TrackingRecHit*> CRackTrajectoryBuilder::SortHits(const SiStripRecH
   vector<const TrackingRecHit*> allHits;
 
   SiStripRecHit2DCollection::DataContainer::const_iterator istrip;
-  TrajectorySeed::range hRange = seed.recHits();
-  TrajectorySeed::const_iterator ihit;
   float yref = 0.;
 
   if (debug_info)
@@ -275,19 +273,20 @@ vector<const TrackingRecHit*> CRackTrajectoryBuilder::SortHits(const SiStripRecH
   float_t yMin = 0.;
   float_t yMax = 0.;
 
-  int seedHitSize = hRange.second - hRange.first;
+  int seedHitSize = seed.nHits();
 
   vector<int> detIDSeedMatched(seedHitSize);
   vector<int> detIDSeedRphi(seedHitSize);
   vector<int> detIDSeedStereo(seedHitSize);
 
-  for (ihit = hRange.first; ihit != hRange.second; ihit++) {
+  auto const& hRange = seed.recHits();
+  for (auto ihit = hRange.begin(); ihit != hRange.end(); ihit++) {
     // need to find track with lowest (seed_plus)/ highest y (seed_minus)
     // split matched hits ...
     const SiStripMatchedRecHit2D* matchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>(&(*ihit));
 
     yref = RHBuilder->build(&(*ihit))->globalPosition().y();
-    if (ihit == hRange.first) {
+    if (ihit == hRange.begin()) {
       yMin = yref;
       yMax = yref;
     }

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrajectoryBuilder.cc
@@ -119,14 +119,14 @@ Trajectory CosmicTrajectoryBuilder::createStartingTrajectory(const TrajectorySee
 
 std::vector<TrajectoryMeasurement> CosmicTrajectoryBuilder::seedMeasurements(const TrajectorySeed &seed) const {
   std::vector<TrajectoryMeasurement> result;
-  TrajectorySeed::range hitRange = seed.recHits();
-  for (TrajectorySeed::const_iterator ihit = hitRange.first; ihit != hitRange.second; ihit++) {
+  auto const &hitRange = seed.recHits();
+  for (auto ihit = hitRange.begin(); ihit != hitRange.end(); ihit++) {
     //RC TransientTrackingRecHit* recHit = RHBuilder->build(&(*ihit));
     TransientTrackingRecHit::RecHitPointer recHit = RHBuilder->build(&(*ihit));
     const GeomDet *hitGeomDet = (&(*tracker))->idToDet(ihit->geographicalId());
     TSOS invalidState(new BasicSingleTrajectoryState(hitGeomDet->surface()));
 
-    if (ihit == hitRange.second - 1) {
+    if (ihit == hitRange.end() - 1) {
       TSOS updatedState = startingTSOS(seed);
       result.emplace_back(invalidState, updatedState, recHit);
     } else {
@@ -148,13 +148,11 @@ vector<const TrackingRecHit *> CosmicTrajectoryBuilder::SortHits(const SiStripRe
   vector<const TrackingRecHit *> allHits;
 
   SiStripRecHit2DCollection::DataContainer::const_iterator istrip;
-  TrajectorySeed::range hRange = seed.recHits();
-  TrajectorySeed::const_iterator ihit;
   float yref = 0.;
-  for (ihit = hRange.first; ihit != hRange.second; ihit++) {
-    yref = RHBuilder->build(&(*ihit))->globalPosition().y();
-    hits.push_back((RHBuilder->build(&(*ihit))));
-    LogDebug("CosmicTrackFinder") << "SEED HITS" << RHBuilder->build(&(*ihit))->globalPosition();
+  for (auto const &recHit : seed.recHits()) {
+    yref = RHBuilder->build(&recHit)->globalPosition().y();
+    hits.push_back((RHBuilder->build(&recHit)));
+    LogDebug("CosmicTrackFinder") << "SEED HITS" << RHBuilder->build(&recHit)->globalPosition();
   }
 
   SiPixelRecHitCollection::DataContainer::const_iterator ipix;

--- a/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
@@ -67,13 +67,11 @@ void SeedCombiner::produce(edm::Event& ev, const edm::EventSetup& es) {
       ClusterRemovalRefSetter refSetter(ev, clusterRemovalTokens_[iSC]);
 
       for (TrajectorySeedCollection::const_iterator iS = collection->begin(); iS != collection->end(); ++iS) {
-        TrajectorySeed::recHitContainer newRecHitContainer;
+        TrajectorySeed::RecHitContainer newRecHitContainer;
         newRecHitContainer.reserve(iS->nHits());
-        TrajectorySeed::const_iterator iH = iS->recHits().first;
-        TrajectorySeed::const_iterator iH_end = iS->recHits().second;
         //loop seed rechits, copy over and rekey.
-        for (; iH != iH_end; ++iH) {
-          newRecHitContainer.push_back(*iH);
+        for (auto const& recHit : iS->recHits()) {
+          newRecHitContainer.push_back(recHit);
           refSetter.reKey(&newRecHitContainer.back());
         }
         result->push_back(TrajectorySeed(iS->startingState(), std::move(newRecHitContainer), iS->direction()));

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
@@ -162,7 +162,7 @@ void TrackProducerAlgorithm<T>::runWithTrack(const TrackingGeometry* theG,
             << std::endl;
       }
 
-      const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), seedDir);
+      const TrajectorySeed seed({}, {}, seedDir);
       // =========================
       //LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
 
@@ -245,7 +245,7 @@ void TrackProducerAlgorithm<T>::runWithMomentum(
       hits.swap(tmpHits);
 
       // the seed has dummy state and hits.What matters for the fitting is the seedDirection;
-      const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), seedDir);
+      const TrajectorySeed seed({}, {}, seedDir);
       // =========================
       //LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
 
@@ -312,7 +312,7 @@ void TrackProducerAlgorithm<T>::runWithTrackParameters(
       TrajectoryStateOnSurface theInitialStateForRefitting = *(i->val);
 
       // the seed has dummy state and hits.What matters for the fitting is the seedDirection;
-      const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), seedDir);
+      const TrajectorySeed seed({}, {}, seedDir);
 
       //=====  the hits are in the same order as they were in the track::extra.
       FitterCloner fc(theFitter, builder);
@@ -418,7 +418,7 @@ void TrackProducerAlgorithm<T>::runWithVertex(const TrackingGeometry* theG,
       theInitialStateForRefitting = myPropagator.propagate(theInitialStateForRefitting, *(hits[0]->surface()));
 
       // the seed has dummy state and hits.What matters for the fitting is the seedDirection;
-      const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), seedDir);
+      const TrajectorySeed seed({}, {}, seedDir);
       // =========================
       //LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
 

--- a/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.cc
+++ b/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.cc
@@ -60,12 +60,9 @@ void ExtraFromSeeds::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
     if (!track.quality(reco::TrackBase::highPurity))
       continue;
 
-    TrajectorySeed::range seedRange = extra.seedRef()->recHits();
-    TrajectorySeed::const_iterator seedHit;
     (*exxtralOut)[ie] = extra.seedRef()->nHits();
-    for (seedHit = seedRange.first; seedHit != seedRange.second; ++seedHit) {
-      TrackingRecHit* hit = seedHit->clone();
-      hitOut->push_back(hit);
+    for (auto const& seedHit : extra.seedRef()->recHits()) {
+      hitOut->push_back(seedHit.clone());
     }
   }
 

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/Range.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
@@ -33,6 +34,15 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+
+namespace {
+  auto getHits(const TrajectorySeed &seed) { return seed.recHits(); }
+  auto getHits(const TrackCandidate &seed) {
+    auto range = seed.recHits();
+    return edm::Range{range.first, range.second};
+  }
+}  // namespace
 
 template <class T>
 class FakeTrackProducer : public edm::stream::EDProducer<> {
@@ -51,8 +61,6 @@ private:
 
   const PTrajectoryStateOnDet &getState(const TrajectorySeed &seed) const { return seed.startingState(); }
   const PTrajectoryStateOnDet &getState(const TrackCandidate &seed) const { return seed.trajectoryStateOnDet(); }
-  TrajectorySeed::range getHits(const TrajectorySeed &seed) const { return seed.recHits(); }
-  TrajectorySeed::range getHits(const TrackCandidate &seed) const { return seed.recHits(); }
 };
 
 template <typename T>
@@ -105,11 +113,11 @@ void FakeTrackProducer<T>::produce(edm::Event &iEvent, const edm::EventSetup &iS
     reco::Track::Vector p(gp.x(), gp.y(), gp.z());
     int charge = state.localParameters().charge();
     out->push_back(reco::Track(1.0, 1.0, x, p, charge, reco::Track::CovarianceMatrix()));
-    TrajectorySeed::range hits = getHits(mu);
-    out->back().appendHits(hits.first, hits.second, ttopo);
+    auto hits = getHits(mu);
+    out->back().appendHits(hits.begin(), hits.end(), ttopo);
     // Now Track Extra
-    const TrackingRecHit *hit0 = &*hits.first;
-    const TrackingRecHit *hit1 = &*(hits.second - 1);
+    const TrackingRecHit *hit0 = &*hits.begin();
+    const TrackingRecHit *hit1 = &*(hits.end() - 1);
     const GeomDet *det0 = theGeometry->idToDet(hit0->geographicalId());
     const GeomDet *det1 = theGeometry->idToDet(hit1->geographicalId());
     if (det0 == nullptr || det1 == nullptr) {
@@ -136,8 +144,8 @@ void FakeTrackProducer<T>::produce(edm::Event &iEvent, const edm::EventSetup &iS
     out->back().setExtra(reco::TrackExtraRef(rTrackExtras, outEx->size() - 1));
     reco::TrackExtra &ex = outEx->back();
     auto const firstHitIndex = outHits->size();
-    for (OwnVector<TrackingRecHit>::const_iterator it2 = hits.first; it2 != hits.second; ++it2) {
-      outHits->push_back(*it2);
+    for (auto const &it2 : hits) {
+      outHits->push_back(it2);
     }
     ex.setHits(rHits, firstHitIndex, outHits->size() - firstHitIndex);
   }

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -37,8 +37,10 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
 namespace {
-  auto getHits(const TrajectorySeed &seed) { return seed.recHits(); }
-  auto getHits(const TrackCandidate &seed) {
+  edm::Range<edm::OwnVector<TrackingRecHit>::const_iterator> getHits(const TrajectorySeed &seed) {
+    return seed.recHits();
+  }
+  edm::Range<edm::OwnVector<TrackingRecHit>::const_iterator> getHits(const TrackCandidate &seed) {
     auto range = seed.recHits();
     return edm::Range{range.first, range.second};
   }

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -37,10 +37,8 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
 namespace {
-  edm::Range<edm::OwnVector<TrackingRecHit>::const_iterator> getHits(const TrajectorySeed &seed) {
-    return seed.recHits();
-  }
-  edm::Range<edm::OwnVector<TrackingRecHit>::const_iterator> getHits(const TrackCandidate &seed) {
+  TrajectorySeed::RecHitRange getHits(const TrajectorySeed &seed) { return seed.recHits(); }
+  TrajectorySeed::RecHitRange getHits(const TrackCandidate &seed) {
     auto range = seed.recHits();
     return edm::Range{range.first, range.second};
   }

--- a/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
@@ -216,10 +216,7 @@ Trajectory DAFTrackProducerAlgorithm::fit(
     const TrajectoryFitter* theFitter,
     Trajectory vtraj) const {
   //creating a new trajectory starting from the direction of the seed of the input one and the hits
-  Trajectory newVec = theFitter->fitOne(
-      TrajectorySeed(PTrajectoryStateOnDet(), BasicTrajectorySeed::recHitContainer(), vtraj.seed().direction()),
-      hits.first,
-      hits.second);
+  Trajectory newVec = theFitter->fitOne(TrajectorySeed({}, {}, vtraj.seed().direction()), hits.first, hits.second);
 
   if (newVec.isValid())
     return newVec;
@@ -369,10 +366,9 @@ void DAFTrackProducerAlgorithm::filter(const TrajectoryFitter* fitter,
   LogDebug("DAFTrackProducerAlgorithm") << "starting tsos for final refitting " << curstartingTSOS;
   //curstartingTSOS.rescaleError(100);
 
-  output = fitter->fit(
-      TrajectorySeed(PTrajectoryStateOnDet(), BasicTrajectorySeed::recHitContainer(), input.front().seed().direction()),
-      hits,
-      TrajectoryStateWithArbitraryError()(curstartingTSOS));
+  output = fitter->fit(TrajectorySeed({}, {}, input.front().seed().direction()),
+                       hits,
+                       TrajectoryStateWithArbitraryError()(curstartingTSOS));
 
   LogDebug("DAFTrackProducerAlgorithm") << "After filtering " << output.size() << " trajectories";
 }

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
@@ -77,8 +77,6 @@ void SeedToTrackProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
   edm::Handle<edm::View<TrajectorySeed>> seedHandle;
   iEvent.getByToken(L2seedsTagS_, seedHandle);
 
-  int countRH = 0;
-
   // now  loop on the seeds :
   for (unsigned int i = 0; i < L2seeds->size(); i++) {
     // get the kinematic extrapolation from the seed
@@ -134,10 +132,8 @@ void SeedToTrackProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
 
     // fill the seed segments in the track
     unsigned int nHitsAdded = 0;
-    for (TrajectorySeed::recHitContainer::const_iterator itRecHits = (L2seeds->at(i)).recHits().first;
-         itRecHits != (L2seeds->at(i)).recHits().second;
-         ++itRecHits, ++countRH) {
-      TrackingRecHit *hit = (itRecHits)->clone();
+    for (auto const &recHit : L2seeds->at(i).recHits()) {
+      TrackingRecHit *hit = recHit.clone();
       theTrack.appendHitPattern(*hit, ttopo);
       selectedTrackHits->push_back(hit);
       nHitsAdded++;

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -607,13 +607,13 @@ reco::RecoToSimCollectionSeed QuickTrackAssociatorByHitsImpl::associateRecoToSim
         (clusterToTPMap_) ? associateTrack(*clusterToTPMap_,
                                            trackingParticleCollectionHandle,
                                            nullptr,
-                                           pSeed->recHits().first,
-                                           pSeed->recHits().second)
+                                           pSeed->recHits().begin(),
+                                           pSeed->recHits().end())
                           : associateTrack(*hitAssociator_,
                                            trackingParticleCollectionHandle,
                                            nullptr,
-                                           pSeed->recHits().first,
-                                           pSeed->recHits().second);
+                                           pSeed->recHits().begin(),
+                                           pSeed->recHits().end());
     for (auto iTrackingParticleQualityPair = trackingParticleQualityPairs.begin();
          iTrackingParticleQualityPair != trackingParticleQualityPairs.end();
          ++iTrackingParticleQualityPair) {
@@ -630,10 +630,10 @@ reco::RecoToSimCollectionSeed QuickTrackAssociatorByHitsImpl::associateRecoToSim
           (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1) {
         if (clusterToTPMap_)
           numberOfSharedClusters -=
-              getDoubleCount(*clusterToTPMap_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef);
+              getDoubleCount(*clusterToTPMap_, pSeed->recHits().begin(), pSeed->recHits().end(), trackingParticleRef);
         else
           numberOfSharedClusters -=
-              getDoubleCount(*hitAssociator_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef);
+              getDoubleCount(*hitAssociator_, pSeed->recHits().begin(), pSeed->recHits().end(), trackingParticleRef);
       }
 
       double quality;
@@ -683,13 +683,13 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
         (clusterToTPMap_) ? associateTrack(*clusterToTPMap_,
                                            trackingParticleCollectionHandle,
                                            nullptr,
-                                           pSeed->recHits().first,
-                                           pSeed->recHits().second)
+                                           pSeed->recHits().begin(),
+                                           pSeed->recHits().end())
                           : associateTrack(*hitAssociator_,
                                            trackingParticleCollectionHandle,
                                            nullptr,
-                                           pSeed->recHits().first,
-                                           pSeed->recHits().second);
+                                           pSeed->recHits().begin(),
+                                           pSeed->recHits().end());
     for (auto iTrackingParticleQualityPair = trackingParticleQualityPairs.begin();
          iTrackingParticleQualityPair != trackingParticleQualityPairs.end();
          ++iTrackingParticleQualityPair) {
@@ -707,10 +707,10 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
           (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1) {
         if (clusterToTPMap_)
           numberOfSharedClusters -=
-              getDoubleCount(*clusterToTPMap_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef);
+              getDoubleCount(*clusterToTPMap_, pSeed->recHits().begin(), pSeed->recHits().end(), trackingParticleRef);
         else
           numberOfSharedClusters -=
-              getDoubleCount(*hitAssociator_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef);
+              getDoubleCount(*hitAssociator_, pSeed->recHits().begin(), pSeed->recHits().end(), trackingParticleRef);
       }
 
       if (simToRecoDenominator_ == denomsim ||
@@ -762,7 +762,7 @@ double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const reco:
 double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const TrajectorySeed& seed,
                                                                      const TrackerHitAssociator&) const {
   double sum = 0.0;
-  for (auto iHit = seed.recHits().first; iHit != seed.recHits().second; ++iHit) {
+  for (auto iHit = seed.recHits().begin(); iHit != seed.recHits().end(); ++iHit) {
     const auto subdetId = track_associator::getHitFromIter(iHit)->geographicalId().subdetId();
     const double weight = (subdetId == PixelSubdetector::PixelBarrel || subdetId == PixelSubdetector::PixelEndcap)
                               ? pixelHitWeight_
@@ -780,7 +780,7 @@ double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const reco:
 double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const TrajectorySeed& seed,
                                                                      const ClusterTPAssociation&) const {
   const auto& hitRange = seed.recHits();
-  return weightedNumberOfTrackClusters(hitRange.first, hitRange.second);
+  return weightedNumberOfTrackClusters(hitRange.begin(), hitRange.end());
 }
 
 template <typename iter>

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.cc
@@ -342,10 +342,10 @@ RecoToSimCollectionSeed TrackAssociatorByHitsImpl::associateRecoToSim(
   for (edm::View<TrajectorySeed>::const_iterator seed = sC.begin(); seed != sC.end(); seed++, tindex++) {
     matchedIds.clear();
     int ri = 0;  //valid rechits
-    int nsimhit = seed->recHits().second - seed->recHits().first;
+    int nsimhit = seed->nHits();
     LogTrace("TrackAssociator") << "\nNEW SEED - seed number " << tindex << " # valid=" << nsimhit;
     getMatchedIds<edm::OwnVector<TrackingRecHit>::const_iterator>(
-        matchedIds, SimTrackIds, ri, seed->recHits().first, seed->recHits().second, associate.get());
+        matchedIds, SimTrackIds, ri, seed->recHits().begin(), seed->recHits().end(), associate.get());
 
     //save id for the track
     std::vector<SimHitIdpr> idcachev;
@@ -360,7 +360,7 @@ RecoToSimCollectionSeed TrackAssociatorByHitsImpl::associateRecoToSim(
         //if electron subtract double counting
         if (abs(t->pdgId()) == 11 && (t->g4Track_end() - t->g4Track_begin()) > 1) {
           nshared -= getDoubleCount<edm::OwnVector<TrackingRecHit>::const_iterator>(
-              seed->recHits().first, seed->recHits().second, associate.get(), *t);
+              seed->recHits().begin(), seed->recHits().end(), associate.get(), *t);
         }
 
         if (AbsoluteNumberOfHits)
@@ -412,10 +412,9 @@ SimToRecoCollectionSeed TrackAssociatorByHitsImpl::associateSimToReco(
   int tindex = 0;
   for (edm::View<TrajectorySeed>::const_iterator seed = sC.begin(); seed != sC.end(); seed++, tindex++) {
     int ri = 0;  //valid rechits
-    LogTrace("TrackAssociator") << "\nNEW SEED - seed number " << tindex
-                                << " # valid=" << seed->recHits().second - seed->recHits().first;
+    LogTrace("TrackAssociator") << "\nNEW SEED - seed number " << tindex << " # valid=" << seed->nHits();
     getMatchedIds<edm::OwnVector<TrackingRecHit>::const_iterator>(
-        matchedIds, SimTrackIds, ri, seed->recHits().first, seed->recHits().second, associate.get());
+        matchedIds, SimTrackIds, ri, seed->recHits().begin(), seed->recHits().end(), associate.get());
 
     //save id for the track
     std::vector<SimHitIdpr> idcachev;

--- a/TrackingTools/TrackRefitter/src/SeedTransformer.cc
+++ b/TrackingTools/TrackRefitter/src/SeedTransformer.cc
@@ -83,13 +83,10 @@ vector<Trajectory> SeedTransformer::seedTransform(const TrajectorySeed& aSeed) c
   aTSOS.rescaleError(errorRescale);
 
   vector<TransientTrackingRecHit::ConstRecHitPointer> recHits;
-  unsigned int countRH = 0;
 
-  for (TrajectorySeed::recHitContainer::const_iterator itRecHits = aSeed.recHits().first;
-       itRecHits != aSeed.recHits().second;
-       ++itRecHits, ++countRH) {
-    if ((*itRecHits).isValid()) {
-      TransientTrackingRecHit::ConstRecHitPointer ttrh(theMuonRecHitBuilder->build(&(*itRecHits)));
+  for (auto const& recHit : aSeed.recHits()) {
+    if (recHit.isValid()) {
+      TransientTrackingRecHit::ConstRecHitPointer ttrh(theMuonRecHitBuilder->build(&recHit));
 
       if (useSubRecHits) {
         TransientTrackingRecHit::ConstRecHitContainer subHits =
@@ -99,7 +96,7 @@ vector<Trajectory> SeedTransformer::seedTransform(const TrajectorySeed& aSeed) c
         recHits.push_back(ttrh);
       }
     }
-  }  // end for(TrajectorySeed::recHitContainer::const_iterator itRecHits=aSeed.recHits().first; itRecHits!=aSeed.recHits().second; ++itRecHits, ++countRH)
+  }
 
   TrajectoryStateOnSurface aInitTSOS = thePropagator->propagate(aTSOS, recHits.front()->det()->surface());
 

--- a/TrackingTools/TrackRefitter/src/TrackTransformer.cc
+++ b/TrackingTools/TrackRefitter/src/TrackTransformer.cc
@@ -267,7 +267,7 @@ vector<Trajectory> TrackTransformer::transform(const reco::TransientTrack& track
     return vector<Trajectory>();
   }
 
-  TrajectorySeed seed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), propagationDirection);
+  TrajectorySeed seed({}, {}, propagationDirection);
 
   if (recHitsForReFit.front()->geographicalId() != DetId(innerId)) {
     LogTrace(metname) << "Propagation occured" << endl;

--- a/TrackingTools/TrackRefitter/src/TrackTransformerForCosmicMuons.cc
+++ b/TrackingTools/TrackRefitter/src/TrackTransformerForCosmicMuons.cc
@@ -382,7 +382,7 @@ vector<Trajectory> TrackTransformerForCosmicMuons::transform(const reco::Track& 
 
   LogTrace(metname) << "Prop Dir: " << propagationDirection << " FirstId " << innerId << " firstTSOS " << firstTSOS;
 
-  TrajectorySeed seed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), propagationDirection);
+  TrajectorySeed seed({}, {}, propagationDirection);
 
   if (recHitsForReFit.front()->geographicalId() != DetId(innerId)) {
     LogTrace(metname) << "Propagation occurring" << endl;

--- a/TrackingTools/TrackRefitter/src/TrackTransformerForGlobalCosmicMuons.cc
+++ b/TrackingTools/TrackRefitter/src/TrackTransformerForGlobalCosmicMuons.cc
@@ -211,7 +211,7 @@ vector<Trajectory> TrackTransformerForGlobalCosmicMuons::transform(const reco::T
 
   LogTrace(metname) << "Prop Dir: " << propagationDirection << " FirstId " << innerId << " firstTSOS " << firstTSOS;
 
-  TrajectorySeed seed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), propagationDirection);
+  TrajectorySeed seed({}, {}, propagationDirection);
 
   if (recHitsForReFit.front()->geographicalId() != DetId(innerId)) {
     LogTrace(metname) << "Propagation occurring" << endl;

--- a/Validation/RecoMuon/src/MuonSeedTrack.cc
+++ b/Validation/RecoMuon/src/MuonSeedTrack.cc
@@ -204,8 +204,8 @@ pair<bool, reco::Track> MuonSeedTrack::buildTrackAtPCA(const TrajectorySeed& see
 double MuonSeedTrack::computeNDOF(const TrajectorySeed& trajectory) const {
   const string metname = "MuonSeedTrack";
 
-  BasicTrajectorySeed::const_iterator recHits1 = (trajectory.recHits().first);
-  BasicTrajectorySeed::const_iterator recHits2 = (trajectory.recHits().second);
+  auto recHits1 = (trajectory.recHits().begin());
+  auto recHits2 = (trajectory.recHits().end());
 
   double ndof = 0.;
 

--- a/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc
+++ b/Validation/RecoTrack/plugins/TrackFromSeedProducer.cc
@@ -132,7 +132,7 @@ void TrackFromSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm
   for (size_t iSeed = 0; iSeed < seeds.size(); ++iSeed) {
     auto const& seed = seeds[iSeed];
     // try to create a track
-    TransientTrackingRecHit::RecHitPointer lastRecHit = tTRHBuilder->build(&*(seed.recHits().second - 1));
+    TransientTrackingRecHit::RecHitPointer lastRecHit = tTRHBuilder->build(&*(seed.recHits().end() - 1));
     TrajectoryStateOnSurface state =
         trajectoryStateTransform::transientState(seed.startingState(), lastRecHit->surface(), theMF.product());
     TrajectoryStateClosestToBeamLine tsAtClosestApproachSeed =
@@ -157,11 +157,11 @@ void TrackFromSeedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm
       nfailed++;
     }
 
-    tracks->back().appendHits(seed.recHits().first, seed.recHits().second, ttopo);
+    tracks->back().appendHits(seed.recHits().begin(), seed.recHits().end(), ttopo);
     // store the hits
     size_t firsthitindex = rechits->size();
-    for (auto hitit = seed.recHits().first; hitit != seed.recHits().second; ++hitit) {
-      rechits->push_back(*hitit);
+    for (auto const& recHit : seed.recHits()) {
+      rechits->push_back(recHit);
     }
 
     // create a trackextra, just to store the hit range

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -2930,8 +2930,8 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       std::vector<int> hitIdx;
       std::vector<int> hitType;
 
-      for (auto hit = seed.recHits().begin(); hit != seed.recHits().end(); ++hit) {
-        TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder.build(&*hit);
+      for (auto const& hit : seed.recHits()) {
+        TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder.build(&hit);
         int subid = recHit->geographicalId().subdetId();
         if (subid == (int)PixelSubdetector::PixelBarrel || subid == (int)PixelSubdetector::PixelEndcap) {
           const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
@@ -3011,8 +3011,8 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       //the part below is not strictly needed
       float chi2 = -1;
       if (nHits == 2) {
-        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&seed.recHits()[0]);
-        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&seed.recHits()[1]);
+        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&*(seed.recHits().begin()));
+        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&*(seed.recHits().begin() + 1));
         std::vector<GlobalPoint> gp(2);
         std::vector<GlobalError> ge(2);
         gp[0] = recHit0->globalPosition();
@@ -3036,9 +3036,9 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
                                                     : GlobalPoint(0, 0, 0))
             << " eta,phi: " << gp[0].eta() << "," << gp[0].phi();
       } else if (nHits == 3) {
-        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&seed.recHits()[0]);
-        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&seed.recHits()[1]);
-        TransientTrackingRecHit::RecHitPointer recHit2 = theTTRHBuilder.build(&seed.recHits()[2]);
+        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&*(seed.recHits().begin()));
+        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&*(seed.recHits().begin() + 1));
+        TransientTrackingRecHit::RecHitPointer recHit2 = theTTRHBuilder.build(&*(seed.recHits().begin() + 2));
         declareDynArray(GlobalPoint, 4, gp);
         declareDynArray(GlobalError, 4, ge);
         declareDynArray(bool, 4, bl);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -2930,7 +2930,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       std::vector<int> hitIdx;
       std::vector<int> hitType;
 
-      for (auto hit = seed.recHits().first; hit != seed.recHits().second; ++hit) {
+      for (auto hit = seed.recHits().begin(); hit != seed.recHits().end(); ++hit) {
         TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder.build(&*hit);
         int subid = recHit->geographicalId().subdetId();
         if (subid == (int)PixelSubdetector::PixelBarrel || subid == (int)PixelSubdetector::PixelEndcap) {
@@ -3011,8 +3011,8 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       //the part below is not strictly needed
       float chi2 = -1;
       if (nHits == 2) {
-        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&*(seed.recHits().first));
-        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&*(seed.recHits().first + 1));
+        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&seed.recHits()[0]);
+        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&seed.recHits()[1]);
         std::vector<GlobalPoint> gp(2);
         std::vector<GlobalError> ge(2);
         gp[0] = recHit0->globalPosition();
@@ -3036,9 +3036,9 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
                                                     : GlobalPoint(0, 0, 0))
             << " eta,phi: " << gp[0].eta() << "," << gp[0].phi();
       } else if (nHits == 3) {
-        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&*(seed.recHits().first));
-        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&*(seed.recHits().first + 1));
-        TransientTrackingRecHit::RecHitPointer recHit2 = theTTRHBuilder.build(&*(seed.recHits().first + 2));
+        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&seed.recHits()[0]);
+        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&seed.recHits()[1]);
+        TransientTrackingRecHit::RecHitPointer recHit2 = theTTRHBuilder.build(&seed.recHits()[2]);
         declareDynArray(GlobalPoint, 4, gp);
         declareDynArray(GlobalError, 4, ge);
         declareDynArray(bool, 4, bl);

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -2529,9 +2529,8 @@ unsigned int MTVHistoProducerAlgoForTracker::getSeedingLayerSetBin(const reco::T
     return seedingLayerSetNames.size() - 1;
 
   const TrajectorySeed& seed = *(track.seedRef());
-  const auto hitRange = seed.recHits();
   SeedingLayerSetId searchId;
-  const int nhits = std::distance(hitRange.first, hitRange.second);
+  const int nhits = seed.nHits();
   if (nhits > static_cast<int>(std::tuple_size<SeedingLayerSetId>::value)) {
     LogDebug("TrackValidator") << "Got seed with " << nhits << " hits, but I have a hard-coded maximum of "
                                << std::tuple_size<SeedingLayerSetId>::value
@@ -2540,8 +2539,8 @@ unsigned int MTVHistoProducerAlgoForTracker::getSeedingLayerSetBin(const reco::T
     return seedingLayerSetNames.size() - 1;
   }
   int i = 0;
-  for (auto iHit = hitRange.first; iHit != hitRange.second; ++iHit, ++i) {
-    DetId detId = iHit->geographicalId();
+  for (auto const& recHit : seed.recHits()) {
+    DetId detId = recHit.geographicalId();
 
     if (detId.det() != DetId::Tracker) {
       throw cms::Exception("LogicError") << "Encountered seed hit detId " << detId.rawId() << " not from Tracker, but "
@@ -2582,7 +2581,7 @@ unsigned int MTVHistoProducerAlgoForTracker::getSeedingLayerSetBin(const reco::T
     // Even with the recent addition of
     // SeedingLayerSetsBuilder::fillDescription() this assumption is a
     // bit ugly.
-    const bool isStripMono = subdetStrip && trackerHitRTTI::isSingle(*iHit);
+    const bool isStripMono = subdetStrip && trackerHitRTTI::isSingle(recHit);
     searchId[i] =
         SeedingLayerId(SeedingLayerSetsBuilder::SeedingLayerId(subdet, side, ttopo.layer(detId)), isStripMono);
   }

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -2584,6 +2584,7 @@ unsigned int MTVHistoProducerAlgoForTracker::getSeedingLayerSetBin(const reco::T
     const bool isStripMono = subdetStrip && trackerHitRTTI::isSingle(recHit);
     searchId[i] =
         SeedingLayerId(SeedingLayerSetsBuilder::SeedingLayerId(subdet, side, ttopo.layer(detId)), isStripMono);
+    ++i;
   }
   auto found = seedingLayerSetToBin.find(searchId);
   if (found == seedingLayerSetToBin.end()) {


### PR DESCRIPTION
#### PR description:

The current interface of the TrajectorySeed class to its recHits bothered me for quite some time, especially since the ElectronSeed inherits it. I'm speaking about this member function [1]:

```C++
std::pair<const_iterator, const_iterator> recHits() const { return std::make_pair(hits_.begin(), hits_.end()); }
```
~~which I think should better just return a const reference to the `edm::OwnVector<TrackingRecHit>` of seeds (proposed in this PR):~~ *original idea that got discarded in review*
which should better return a `edm::Range<RecHitContainer::const_iterator>` that implements `begin()` and `end()` such that `recHits()` can be used in range-based loops:
```C++
edm::Range<RecHitContainer::const_iterator> recHits() const { return {hits_.begin(), hits_.end()}; }
```
this also avoids the very misleading expression `recHits().second`: one might think that it points to the second rechit, but actually it is the `hits_.end()` iterator. This caused possible bugs here [2] and here [3], I think. No attempt is made in this PR to fix these potential bugs, it only adapts the code to the newly proposed range-loop friendly interface without changing any functionality (hopefully).

[1] https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrajectorySeed/interface/TrajectorySeed.h#L52
[2] https://github.com/cms-sw/cmssw/blob/master/RecoTracker/MeasurementDet/src/StartingLayerFinder.cc#L79
[3] https://github.com/cms-sw/cmssw/blob/master/Validation/RecoMuon/src/MuonSeedTrack.cc#L208

#### PR validation:

CMSSW compiles and local matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.