### PR TITLE
[LLVM 10] Adjust Utilities/StaticAnalyzers for new clang

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -90,7 +90,6 @@
 <test name="import-notebook" command="python -c 'import notebook'"/>
 <test name="import-numexpr" command="python -c 'import numexpr'"/>
 <test name="import-numpy" command="python -c 'import numpy'"/>
-<test name="import-oamap" command="python -c 'import oamap'"/>
 <test name="import-ordereddict" command="python2 -c 'import ordereddict'"/>
 <test name="import-packaging" command="python -c 'import packaging'"/>
 <test name="import-pandas" command="python -c 'import pandas'"/>

--- a/PhysicsTools/PythonAnalysis/test/testNumba.py
+++ b/PhysicsTools/PythonAnalysis/test/testNumba.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 A moving average function using @guvectorize.
 """

--- a/RecoMET/METFilters/interface/EcalBoundaryInfoCalculator.h
+++ b/RecoMET/METFilters/interface/EcalBoundaryInfoCalculator.h
@@ -226,7 +226,7 @@ private:
   }
 
   CdOrientation goBackOneCell(CdOrientation currDirection, EcalDetId prev, CaloNavigator<EcalDetId>* theEcalNav) const {
-    std::map<CdOrientation, CdOrientation>::iterator oIt = oppositeDirs.find(currDirection);
+    auto oIt = oppositeDirs.find(currDirection);
     CdOrientation oppDirection = none;
     if (oIt != oppositeDirs.end()) {
       oppDirection = oIt->second;

--- a/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
@@ -101,7 +101,8 @@ namespace clangcms {
               clang::ento::PathDiagnosticLocation::createBegin(PVD, ctx.getSourceManager());
 
           BugType *BT = new BugType(this, "Function parameter copied by value with size > max", "ArgSize");
-          std::unique_ptr<BugReport> report = llvm::make_unique<BugReport>(*BT, os.str(), DLoc);
+          std::unique_ptr<BasicBugReport> report =
+              std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
           report->addRange(PVD->getSourceRange());
           ctx.emitReport(std::move(report));
         }
@@ -165,7 +166,7 @@ namespace clangcms {
       //             if ( fname.substr(0,oname.length()) == oname ) continue;
 
       BugType *BT = new BugType(this, "Function parameter with size > max", "ArgSize");
-      std::unique_ptr<BugReport> report = llvm::make_unique<BugReport>(*BT, os.str(), DLoc);
+      std::unique_ptr<BasicBugReport> report = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
       BR.emitReport(std::move(report));
     }
   }

--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -313,7 +313,7 @@ namespace clangcms {
     std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str() + ".";
     writeLog(tolog);
     BugType *BT = new BugType(Checker, "const_cast used in const function ", "Data Class Const Correctness");
-    std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, tolog, CELoc);
+    std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(tolog), CELoc);
     BR.emitReport(std::move(R));
     return;
   }
@@ -359,7 +359,7 @@ namespace clangcms {
         writeLog(tolog);
         BugType *BT = new BugType(
             Checker, "ClassChecker : non-const static local variable accessed", "Data Class Const Correctness");
-        std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+        std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
         return;
       }
@@ -379,7 +379,7 @@ namespace clangcms {
         std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str();
         writeLog(tolog);
         BugType *BT = new BugType(Checker, "Non-const static member variable accessed", "Data Class Const Correctness");
-        std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+        std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
         return;
       }
@@ -399,7 +399,7 @@ namespace clangcms {
         std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str();
         writeLog(tolog);
         BugType *BT = new BugType(Checker, "Non-const global static variable accessed", "Data Class Const Correctness");
-        std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+        std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
         return;
       }
@@ -539,7 +539,7 @@ namespace clangcms {
     writeLog(tolog);
     BugType *BT = new BugType(
         Checker, "Non-const member function could modify member data object", "Data Class Const Correctness");
-    std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+    std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
     BR.emitReport(std::move(R));
   }
 
@@ -564,7 +564,7 @@ namespace clangcms {
     writeLog(tolog);
     BugType *BT =
         new BugType(Checker, "Const cast away from member data in const function", "Data Class Const Correctness");
-    std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+    std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
     BR.emitReport(std::move(R));
   }
 
@@ -632,7 +632,7 @@ namespace clangcms {
         BugType *BT = new BugType(Checker,
                                   "Const function returns pointer or reference to non-const member data object",
                                   "Data Class Const Correctness");
-        std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+        std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
       }
     }
@@ -644,7 +644,7 @@ namespace clangcms {
           new BugType(Checker,
                       "Const function returns member data object of type const std::vector<*> or const std::vector<*>&",
                       "Data Class Const Correctness");
-      std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+      std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       BR.emitReport(std::move(R));
     }
   }

--- a/Utilities/StaticAnalyzers/src/CmsException.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsException.cpp
@@ -20,14 +20,14 @@ namespace clangcms {
   bool CmsException::reportConstCast(const clang::ento::BugReport& R, clang::ento::CheckerContext& C) const {
     clang::ento::BugReporter& BR = C.getBugReporter();
     const clang::SourceManager& SM = BR.getSourceManager();
-    clang::ento::PathDiagnosticLocation const& path = R.getLocation(SM);
+    clang::ento::PathDiagnosticLocation const& path = R.getLocation();
     return reportGeneral(path, BR);
   }
 
   bool CmsException::reportConstCastAway(const clang::ento::BugReport& R, clang::ento::CheckerContext& C) const {
     clang::ento::BugReporter& BR = C.getBugReporter();
     const clang::SourceManager& SM = BR.getSourceManager();
-    clang::ento::PathDiagnosticLocation const& path = R.getLocation(SM);
+    clang::ento::PathDiagnosticLocation const& path = R.getLocation();
     return reportGeneral(path, BR);
   }
 

--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -41,7 +41,10 @@ namespace clangcms {
         std::string buf;
         llvm::raw_string_ostream os(buf);
         os << "const qualifier was removed via a cast, this may result in thread-unsafe code.";
-        std::unique_ptr<clang::ento::BugReport> R = llvm::make_unique<clang::ento::BugReport>(*BT, os.str(), errorNode);
+        std::unique_ptr<clang::ento::PathSensitiveBugReport> PSBR =
+            std::make_unique<clang::ento::PathSensitiveBugReport>(*BT, llvm::StringRef(os.str()), errorNode);
+        std::unique_ptr<clang::ento::BasicBugReport> R =
+            std::make_unique<clang::ento::BasicBugReport>(*BT, llvm::StringRef(os.str()), PSBR->getLocation());
         R->addRange(CE->getSourceRange());
         if (!m_exception.reportConstCastAway(*R, C))
           return;

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -31,7 +31,10 @@ namespace clangcms {
       std::string buf;
       llvm::raw_string_ostream os(buf);
       os << "const_cast was used, this may result in thread-unsafe code.";
-      std::unique_ptr<clang::ento::BugReport> R = llvm::make_unique<clang::ento::BugReport>(*BT, os.str(), errorNode);
+      std::unique_ptr<clang::ento::PathSensitiveBugReport> PSBR =
+          std::make_unique<clang::ento::PathSensitiveBugReport>(*BT, llvm::StringRef(os.str()), errorNode);
+      std::unique_ptr<clang::ento::BasicBugReport> R =
+          std::make_unique<clang::ento::BasicBugReport>(*BT, llvm::StringRef(os.str()), PSBR->getLocation());
       R->addRange(CE->getSourceRange());
       if (!m_exception.reportConstCast(*R, C))
         return;

--- a/Utilities/StaticAnalyzers/src/EDMPluginDumper.cc
+++ b/Utilities/StaticAnalyzers/src/EDMPluginDumper.cc
@@ -21,7 +21,7 @@ namespace clangcms {
           llvm::SmallString<100> buf;
           llvm::raw_svector_ostream os(buf);
           I->getTemplateArgs().get(J).print(mgr.getASTContext().getPrintingPolicy(), os);
-          std::string rname = os.str();
+          std::string rname = os.str().str();
           std::string fname("plugins.txt.unsorted");
           std::string ostring = rname + "\n";
           support::writeLog(ostring, fname);

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
@@ -37,8 +37,10 @@ namespace clangcms {
                                         "std::isnan / std::isinf does not work when fast-math is used. Please use "
                                         "edm::isNotFinite from 'FWCore/Utilities/interface/isFinite.h'",
                                         "fastmath plugin"));
-
-    std::unique_ptr<clang::ento::BugReport> report = llvm::make_unique<clang::ento::BugReport>(*BT, BT->getName(), N);
+    std::unique_ptr<clang::ento::PathSensitiveBugReport> PSBR =
+        std::make_unique<clang::ento::PathSensitiveBugReport>(*BT, BT->getCheckerName(), N);
+    std::unique_ptr<clang::ento::BasicBugReport> report =
+        std::make_unique<clang::ento::BasicBugReport>(*BT, BT->getCheckerName(), PSBR->getLocation());
     report->addRange(Callee->getSourceRange());
     ctx.emitReport(std::move(report));
   }

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -46,7 +46,7 @@ namespace clangcms {
       os << "Known thread unsafe function " << mname << " is called in function " << pname;
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
       BugType *BT = new BugType(Checker, "known thread unsafe function called", "ThreadSafety");
-      std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+      std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
       R->setDeclWithIssue(AC->getDecl());
       R->addRange(CE->getSourceRange());
       BR.emitReport(std::move(R));

--- a/Utilities/StaticAnalyzers/src/TrunCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/TrunCastChecker.cpp
@@ -93,7 +93,7 @@ namespace clangcms {
       clang::ento::PathDiagnosticLocation CELoc =
           clang::ento::PathDiagnosticLocation::createBegin(BO, BR.getSourceManager(), AC);
       BR.EmitBasicReport(ACD,
-                         CheckName(),
+                         CheckerNameRef(),
                          "implicit cast of int type to float type",
                          "CMS code rules",
                          os.str(),
@@ -108,7 +108,7 @@ namespace clangcms {
       clang::ento::PathDiagnosticLocation CELoc =
           clang::ento::PathDiagnosticLocation::createBegin(BO, BR.getSourceManager(), AC);
       BR.EmitBasicReport(ACD,
-                         CheckName(),
+                         CheckerNameRef(),
                          "implicit cast of int type to smaller int type could truncate",
                          "CMS code rules",
                          os.str(),
@@ -125,7 +125,7 @@ namespace clangcms {
       clang::ento::PathDiagnosticLocation CELoc =
           clang::ento::PathDiagnosticLocation::createBegin(BO, BR.getSourceManager(), AC);
       BR.EmitBasicReport(
-          ACD, CheckName(), "implicit cast ins sign type", "CMS code rules", os.str(), CELoc, BO->getSourceRange());
+          ACD, CheckerNameRef(), "implicit cast ins sign type", "CMS code rules", os.str(), CELoc, BO->getSourceRange());
     }
     return;
     return;
@@ -158,7 +158,7 @@ namespace clangcms {
       clang::ento::PathDiagnosticLocation CELoc =
           clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
       BR.EmitBasicReport(ACD,
-                         CheckName(),
+                         CheckerNameRef(),
                          "implicit cast of int type to float type",
                          "CMS code rules",
                          os.str(),
@@ -173,7 +173,7 @@ namespace clangcms {
       clang::ento::PathDiagnosticLocation CELoc =
           clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
       BR.EmitBasicReport(ACD,
-                         CheckName(),
+                         CheckerNameRef(),
                          "implicit cast of int type to smaller int type could truncate",
                          "CMS code rules",
                          os.str(),
@@ -189,7 +189,7 @@ namespace clangcms {
       clang::ento::PathDiagnosticLocation CELoc =
           clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
       BR.EmitBasicReport(ACD,
-                         CheckName(),
+                         CheckerNameRef(),
                          "implicit cast changes int sign type",
                          "CMS code rules",
                          os.str(),

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -102,7 +102,7 @@ namespace clangcms {
       //			llvm::errs()<<os.str()<<"\n";
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
       BugType *BT = new BugType(Checker, "edm::getByLabel or edm::getManyByType called", "optional");
-      std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+      std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       R->addRange(CE->getSourceRange());
       BR.emitReport(std::move(R));
     } else {
@@ -125,7 +125,7 @@ namespace clangcms {
           //				llvm::errs()<<" "<<qtname<<"\n";
           PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
           BugType *BT = new BugType(Checker, "function call with argument of type edm::Event", "optional");
-          std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT, os.str(), CELoc);
+          std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
           R->addRange(CE->getSourceRange());
           BR.emitReport(std::move(R));
         }


### PR DESCRIPTION
Backport of #29391
Changes needed to go with LLVM 10 . 