### PR TITLE
[LLVM10] fix llvm warning to prevent copying

### DIFF
--- a/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
+++ b/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
@@ -374,7 +374,7 @@ namespace tmtt {
         }
       }
       PrintL1trk() << "Number of tracks after HT = " << numHTtracks;
-      for (const auto p : mapFinalTracks) {
+      for (const auto& p : mapFinalTracks) {
         const string& fitName = p.first;
         const list<const L1fittedTrack*> fittedTracks = p.second;
         PrintL1trk() << "Number of tracks after " << fitName << " track helix fit = " << fittedTracks.size();


### PR DESCRIPTION
#### PR description:

Fixed clang warning to avoid copying of loop variable.

#### PR validation:

Local build in normal and CLANG IBs build successfully.