### PR TITLE
bug fix to runTauIdMVA.py tool

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -146,7 +146,7 @@ for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoA
 import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
 def nanoAOD_addTauIds(process):
     updatedTauName = "slimmedTausUpdated"
-    tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False, updatedTauName = updatedTauName,
+    tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug = False, updatedTauName = updatedTauName,
             toKeep = [ "deepTau2017v2p1" ])
     tauIdEmbedder.runTauID()
     process.patTauMVAIDsSeq.insert(process.patTauMVAIDsSeq.index(getattr(process, updatedTauName)),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -335,7 +335,7 @@ def miniAOD_customizeCommon(process):
     _noUpdatedTauName = 'slimmedTausNoDeepIDs'
     import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
     tauIdEmbedder = tauIdConfig.TauIDEmbedder(
-        process, cms, debug = False,
+        process, debug = False,
         updatedTauName = _updatedTauName,
         toKeep = ['deepTau2017v2p1']
     )

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -90,8 +90,8 @@ class TauIDEmbedder(object):
             if debug: print ("is_above_cmssw_version:", True)
             return True
 
-    def tauIDMVAinputs(module, wp):
-        return cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
+    def tauIDMVAinputs(self, module, wp):
+        return self.cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
 
     def loadMVA_WPs_run2_2017(self):
         if self.debug: print ("loadMVA_WPs_run2_2017: performed")
@@ -172,7 +172,7 @@ class TauIDEmbedder(object):
                         variable = self.cms.string("pt"),
                     )
                 ),
-                workingPoints = cms.vstring(
+                workingPoints = self.cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -190,14 +190,14 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2017v1Task)
             self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2017v1Task)
 
-            tauIDSources.byIsolationMVArun2017v1DBoldDMwLTraw2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "raw")
-            tauIDSources.byVVLooseIsolationMVArun2017v1DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff95")
-            tauIDSources.byVLooseIsolationMVArun2017v1DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff90")
-            tauIDSources.byLooseIsolationMVArun2017v1DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff80")
-            tauIDSources.byMediumIsolationMVArun2017v1DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff70")
-            tauIDSources.byTightIsolationMVArun2017v1DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff60")
-            tauIDSources.byVTightIsolationMVArun2017v1DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff50")
-            tauIDSources.byVVTightIsolationMVArun2017v1DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff40")
+            tauIDSources.byIsolationMVArun2017v1DBoldDMwLTraw2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "raw")
+            tauIDSources.byVVLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff95")
+            tauIDSources.byVLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff90")
+            tauIDSources.byLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff80")
+            tauIDSources.byMediumIsolationMVArun2017v1DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff70")
+            tauIDSources.byTightIsolationMVArun2017v1DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff60")
+            tauIDSources.byVTightIsolationMVArun2017v1DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff50")
+            tauIDSources.byVVTightIsolationMVArun2017v1DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff40")
 
 
         if "2017v2" in self.toKeep:
@@ -243,7 +243,7 @@ class TauIDEmbedder(object):
                         variable = self.cms.string("pt"),
                     )
                 ),
-                workingPoints = cms.vstring(
+                workingPoints = self.cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -262,14 +262,14 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2017v2Task)
             self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2017v2Task)
 
-            tauIDSources.byIsolationMVArun2017v2DBoldDMwLTraw2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "raw")
-            tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff95")
-            tauIDSources.byVLooseIsolationMVArun2017v2DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff90")
-            tauIDSources.byLooseIsolationMVArun2017v2DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff80")
-            tauIDSources.byMediumIsolationMVArun2017v2DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff70")
-            tauIDSources.byTightIsolationMVArun2017v2DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff60")
-            tauIDSources.byVTightIsolationMVArun2017v2DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff50")
-            tauIDSources.byVVTightIsolationMVArun2017v2DBoldDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff40")
+            tauIDSources.byIsolationMVArun2017v2DBoldDMwLTraw2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "raw")
+            tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff95")
+            tauIDSources.byVLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff90")
+            tauIDSources.byLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff80")
+            tauIDSources.byMediumIsolationMVArun2017v2DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff70")
+            tauIDSources.byTightIsolationMVArun2017v2DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff60")
+            tauIDSources.byVTightIsolationMVArun2017v2DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff50")
+            tauIDSources.byVVTightIsolationMVArun2017v2DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff40")
 
         if "newDM2017v2" in self.toKeep:
             self.tauIdDiscrMVA_2017_version = "v2"
@@ -314,7 +314,7 @@ class TauIDEmbedder(object):
                         variable = self.cms.string("pt"),
                     )
                 ),
-                workingPoints = cms.vstring(
+                workingPoints = self.cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -333,14 +333,14 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationNewDMMVArun2017v2Task)
             self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationNewDMMVArun2017v2Task)
 
-            tauIDSources.byIsolationMVArun2017v2DBnewDMwLTraw2017 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "raw")
-            tauIDSources.byVVLooseIsolationMVArun2017v2DBnewDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff95")
-            tauIDSources.byVLooseIsolationMVArun2017v2DBnewDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff90")
-            tauIDSources.byLooseIsolationMVArun2017v2DBnewDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff80")
-            tauIDSources.byMediumIsolationMVArun2017v2DBnewDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff70")
-            tauIDSources.byTightIsolationMVArun2017v2DBnewDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff60")
-            tauIDSources.byVTightIsolationMVArun2017v2DBnewDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff50")
-            tauIDSources.byVVTightIsolationMVArun2017v2DBnewDMwLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff40")
+            tauIDSources.byIsolationMVArun2017v2DBnewDMwLTraw2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "raw")
+            tauIDSources.byVVLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff95")
+            tauIDSources.byVLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff90")
+            tauIDSources.byLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff80")
+            tauIDSources.byMediumIsolationMVArun2017v2DBnewDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff70")
+            tauIDSources.byTightIsolationMVArun2017v2DBnewDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff60")
+            tauIDSources.byVTightIsolationMVArun2017v2DBnewDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff50")
+            tauIDSources.byVVTightIsolationMVArun2017v2DBnewDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff40")
 
         if "dR0p32017v2" in self.toKeep:
             self.tauIdDiscrMVA_2017_version = "v2"
@@ -389,7 +389,7 @@ class TauIDEmbedder(object):
                         variable = self.cms.string("pt"),
                     )
                 ),
-                workingPoints = cms.vstring(
+                workingPoints = self.cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -408,14 +408,14 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMdR0p3MVArun2017v2Task)
             self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMdR0p3MVArun2017v2Task)
 
-            tauIDSources.byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "raw")
-            tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff95")
-            tauIDSources.byVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff90")
-            tauIDSources.byLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff80")
-            tauIDSources.byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff70")
-            tauIDSources.byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff60")
-            tauIDSources.byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff50")
-            tauIDSources.byVVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff40")
+            tauIDSources.byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "raw")
+            tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff95")
+            tauIDSources.byVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff90")
+            tauIDSources.byLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff80")
+            tauIDSources.byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff70")
+            tauIDSources.byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff60")
+            tauIDSources.byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff50")
+            tauIDSources.byVVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff40")
 
         # 2016 training strategy(v2) - essentially the same as 2017 training strategy (v1), trained on 2016MC, old DM - currently not implemented in the tau sequence of any release
         # self.process.rerunDiscriminationByIsolationOldDMMVArun2v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
@@ -467,7 +467,7 @@ class TauIDEmbedder(object):
                             variable = self.cms.string("pt"),
                         )
                     ),
-                    workingPoints = cms.vstring(
+                    workingPoints = self.cms.vstring(
                         "_WPEff90",
                         "_WPEff80",
                         "_WPEff70",
@@ -484,13 +484,13 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2016v1Task)
             self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2016v1Task)
 
-            tauIDSources.byIsolationMVArun2v1DBoldDMwLTraw2016 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "raw")
-            tauIDSources.byVLooseIsolationMVArun2v1DBoldDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff90")
-            tauIDSources.byLooseIsolationMVArun2v1DBoldDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff80")
-            tauIDSources.byMediumIsolationMVArun2v1DBoldDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff70")
-            tauIDSources.byTightIsolationMVArun2v1DBoldDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff60")
-            tauIDSources.byVTightIsolationMVArun2v1DBoldDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff50")
-            tauIDSources.byVVTightIsolationMVArun2v1DBoldDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff40")
+            tauIDSources.byIsolationMVArun2v1DBoldDMwLTraw2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "raw")
+            tauIDSources.byVLooseIsolationMVArun2v1DBoldDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff90")
+            tauIDSources.byLooseIsolationMVArun2v1DBoldDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff80")
+            tauIDSources.byMediumIsolationMVArun2v1DBoldDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff70")
+            tauIDSources.byTightIsolationMVArun2v1DBoldDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff60")
+            tauIDSources.byVTightIsolationMVArun2v1DBoldDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff50")
+            tauIDSources.byVVTightIsolationMVArun2v1DBoldDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff40")
 
         # 2016 training strategy(v1), trained on 2016MC, new DM
         if "newDM2016v1" in self.toKeep:
@@ -516,7 +516,7 @@ class TauIDEmbedder(object):
                         variable = self.cms.string("pt"),
                     )
                 ),
-                workingPoints = cms.vstring(
+                workingPoints = self.cms.vstring(
                     "_WPEff90",
                     "_WPEff80",
                     "_WPEff70",
@@ -533,13 +533,13 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationNewDMMVArun2016v1Task)
             self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationNewDMMVArun2016v1Task)
 
-            tauIDSources.byIsolationMVArun2v1DBnewDMwLTraw2016 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "raw")
-            tauIDSources.byVLooseIsolationMVArun2v1DBnewDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff90")
-            tauIDSources.byLooseIsolationMVArun2v1DBnewDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff80")
-            tauIDSources.byMediumIsolationMVArun2v1DBnewDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff70")
-            tauIDSources.byTightIsolationMVArun2v1DBnewDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff60")
-            tauIDSources.byVTightIsolationMVArun2v1DBnewDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff50")
-            tauIDSources.byVVTightIsolationMVArun2v1DBnewDMwLT2016 = tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff40")
+            tauIDSources.byIsolationMVArun2v1DBnewDMwLTraw2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "raw")
+            tauIDSources.byVLooseIsolationMVArun2v1DBnewDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff90")
+            tauIDSources.byLooseIsolationMVArun2v1DBnewDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff80")
+            tauIDSources.byMediumIsolationMVArun2v1DBnewDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff70")
+            tauIDSources.byTightIsolationMVArun2v1DBnewDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff60")
+            tauIDSources.byVTightIsolationMVArun2v1DBnewDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff50")
+            tauIDSources.byVVTightIsolationMVArun2v1DBnewDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff40")
 
         if "deepTau2017v1" in self.toKeep:
             if self.debug: print ("Adding DeepTau IDs")
@@ -785,7 +785,7 @@ class TauIDEmbedder(object):
             )
             ## WPs
             from RecoTauTag.RecoTau.PATTauDiscriminantCutMultiplexer_cfi import patTauDiscriminantCutMultiplexer
-            self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018 = patTauDiscriminantCutMultiplexer.clone(
+            self.process.patTauDiscriminationByElectronRejectionMVA62018 = patTauDiscriminantCutMultiplexer.clone(
                 PATTauProducer = self.process.patTauDiscriminationByElectronRejectionMVA62018Raw.PATTauProducer,
                 Prediscriminants = self.process.patTauDiscriminationByElectronRejectionMVA62018Raw.Prediscriminants,
                 toMultiplex = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"),
@@ -831,7 +831,7 @@ class TauIDEmbedder(object):
                         variable = self.cms.string('pt')
                     )
                 ),
-                workingPoints = cms.vstring(
+                workingPoints = self.cms.vstring(
                     "_WPeff98",
                     "_WPeff90",
                     "_WPeff80",
@@ -849,13 +849,13 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationSequence += self.process.patTauDiscriminationByElectronRejectionMVA62018Seq
 
             _againstElectronTauIDSources = self.cms.PSet(
-                againstElectronMVA6Raw2018 = tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "raw"),
-                againstElectronMVA6category2018 = tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "category"),
-                againstElectronVLooseMVA62018 = tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff98"),
-                againstElectronLooseMVA62018 = tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff90"),
-                againstElectronMediumMVA62018 = tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff80"),
-                againstElectronTightMVA62018 = tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff70"),
-                againstElectronVTightMVA62018 = tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff60")
+                againstElectronMVA6Raw2018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "raw"),
+                againstElectronMVA6category2018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "category"),
+                againstElectronVLooseMVA62018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff98"),
+                againstElectronLooseMVA62018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff90"),
+                againstElectronMediumMVA62018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff80"),
+                againstElectronTightMVA62018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff70"),
+                againstElectronVTightMVA62018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff60")
             )
             _tauIDSourcesWithAgainistEle = self.cms.PSet(
                 tauIDSources.clone(),

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -39,8 +39,8 @@ class TauIDEmbedder(object):
         self.updatedTauName = updatedTauName
         self.process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
         if len(conditionDB) != 0:
-            self.process.CondDBTauConnection.connect = cms.string(conditionDB)
-            self.process.loadRecoTauTagMVAsFromPrepDB.connect = cms.string(conditionDB)
+            self.process.CondDBTauConnection.connect = self.cms.string(conditionDB)
+            self.process.loadRecoTauTagMVAsFromPrepDB.connect = self.cms.string(conditionDB)
             # if debug:
             # 	print self.process.CondDBTauConnection.connect
             # 	print dir(self.process.loadRecoTauTagMVAsFromPrepDB)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import patDiscriminationByIsolationMVArun2v1raw, patDiscriminationByIsolationMVArun2v1
 import os
@@ -14,7 +15,7 @@ class TauIDEmbedder(object):
         "againstEle2018"
     ]
 
-    def __init__(self, process, cms, debug = False,
+    def __init__(self, process, debug = False,
                  updatedTauName = "slimmedTausNewID",
                  toKeep =  ["deepTau2017v2p1"],
                  tauIdDiscrMVA_trainings_run2_2017 = { 'tauIdMVAIsoDBoldDMwLT2017' : "tauIdMVAIsoDBoldDMwLT2017", },
@@ -34,13 +35,12 @@ class TauIDEmbedder(object):
                  ):
         super(TauIDEmbedder, self).__init__()
         self.process = process
-        self.cms = cms
         self.debug = debug
         self.updatedTauName = updatedTauName
         self.process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
         if len(conditionDB) != 0:
-            self.process.CondDBTauConnection.connect = self.cms.string(conditionDB)
-            self.process.loadRecoTauTagMVAsFromPrepDB.connect = self.cms.string(conditionDB)
+            self.process.CondDBTauConnection.connect = cms.string(conditionDB)
+            self.process.loadRecoTauTagMVAsFromPrepDB.connect = cms.string(conditionDB)
             # if debug:
             # 	print self.process.CondDBTauConnection.connect
             # 	print dir(self.process.loadRecoTauTagMVAsFromPrepDB)
@@ -91,7 +91,7 @@ class TauIDEmbedder(object):
             return True
 
     def tauIDMVAinputs(self, module, wp):
-        return self.cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
+        return cms.PSet(inputTag = cms.InputTag(module), workingPointIndex = cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
 
     def loadMVA_WPs_run2_2017(self):
         if self.debug: print ("loadMVA_WPs_run2_2017: performed")
@@ -99,34 +99,34 @@ class TauIDEmbedder(object):
         for training, gbrForestName in self.tauIdDiscrMVA_trainings_run2_2017.items():
 
             self.process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
-                self.cms.PSet(
-                    record = self.cms.string('GBRWrapperRcd'),
-                    tag = self.cms.string("RecoTauTag_%s%s" % (gbrForestName, self.tauIdDiscrMVA_2017_version)),
-                    label = self.cms.untracked.string("RecoTauTag_%s%s" % (gbrForestName, self.tauIdDiscrMVA_2017_version))
+                cms.PSet(
+                    record = cms.string('GBRWrapperRcd'),
+                    tag = cms.string("RecoTauTag_%s%s" % (gbrForestName, self.tauIdDiscrMVA_2017_version)),
+                    label = cms.untracked.string("RecoTauTag_%s%s" % (gbrForestName, self.tauIdDiscrMVA_2017_version))
                 )
             )
 
             for WP in self.tauIdDiscrMVA_WPs_run2_2017[training].keys():
                 self.process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
-                    self.cms.PSet(
-                        record = self.cms.string('PhysicsTGraphPayloadRcd'),
-                        tag = self.cms.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, self.tauIdDiscrMVA_2017_version, WP)),
-                        label = self.cms.untracked.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, self.tauIdDiscrMVA_2017_version, WP))
+                    cms.PSet(
+                        record = cms.string('PhysicsTGraphPayloadRcd'),
+                        tag = cms.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, self.tauIdDiscrMVA_2017_version, WP)),
+                        label = cms.untracked.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, self.tauIdDiscrMVA_2017_version, WP))
                     )
                 )
 
             self.process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
-                self.cms.PSet(
-                    record = self.cms.string('PhysicsTFormulaPayloadRcd'),
-                    tag = self.cms.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, self.tauIdDiscrMVA_2017_version)),
-                    label = self.cms.untracked.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, self.tauIdDiscrMVA_2017_version))
+                cms.PSet(
+                    record = cms.string('PhysicsTFormulaPayloadRcd'),
+                    tag = cms.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, self.tauIdDiscrMVA_2017_version)),
+                    label = cms.untracked.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, self.tauIdDiscrMVA_2017_version))
                 )
             )
 
     def runTauID(self):
-        self.process.rerunMvaIsolationTask = self.cms.Task()
-        self.process.rerunMvaIsolationSequence = self.cms.Sequence()
-        tauIDSources = self.cms.PSet()
+        self.process.rerunMvaIsolationTask = cms.Task()
+        self.process.rerunMvaIsolationSequence = cms.Sequence()
+        tauIDSources = cms.PSet()
 
         # rerun the seq to obtain the 2017 nom training with 0.5 iso cone, old DM, ptph>1, trained on 2017MCv1
         if "2017v1" in self.toKeep:
@@ -151,28 +151,28 @@ class TauIDEmbedder(object):
                 self.loadMVA_WPs_run2_2017()
 
             self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = self.cms.bool(True),
-                mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
-                mvaOpt = self.cms.string("DBoldDMwLTwGJ"),
-                verbosity = self.cms.int32(0)
+                loadMVAfromDB = cms.bool(True),
+                mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
+                mvaOpt = cms.string("DBoldDMwLTwGJ"),
+                verbosity = cms.int32(0)
             )
 
             self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1 = patDiscriminationByIsolationMVArun2v1.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1raw'),
-                loadMVAfromDB = self.cms.bool(True),
-                mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1"), #writeTauIdDiscrWPs
-                        variable = self.cms.string("pt"),
+                toMultiplex = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1raw'),
+                loadMVAfromDB = cms.bool(True),
+                mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
+                mapping = cms.VPSet(
+                    cms.PSet(
+                        category = cms.uint32(0),
+                        cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1"), #writeTauIdDiscrWPs
+                        variable = cms.string("pt"),
                     )
                 ),
-                workingPoints = self.cms.vstring(
+                workingPoints = cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -183,12 +183,12 @@ class TauIDEmbedder(object):
                 )
             )
 
-            self.rerunIsolationOldDMMVArun2017v1Task =  self.cms.Task(
+            self.rerunIsolationOldDMMVArun2017v1Task =  cms.Task(
                 self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1raw,
                 self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1
             )
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2017v1Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2017v1Task)
+            self.process.rerunMvaIsolationSequence += cms.Sequence(self.rerunIsolationOldDMMVArun2017v1Task)
 
             tauIDSources.byIsolationMVArun2017v1DBoldDMwLTraw2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "raw")
             tauIDSources.byVVLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v1", "_WPEff95")
@@ -222,28 +222,28 @@ class TauIDEmbedder(object):
                 self.loadMVA_WPs_run2_2017()
 
             self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = self.cms.bool(True),
-                mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
-                mvaOpt = self.cms.string("DBoldDMwLTwGJ"),
-                verbosity = self.cms.int32(0)
+                loadMVAfromDB = cms.bool(True),
+                mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
+                mvaOpt = cms.string("DBoldDMwLTwGJ"),
+                verbosity = cms.int32(0)
             )
 
             self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2 = patDiscriminationByIsolationMVArun2v1.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2raw'),
-                loadMVAfromDB = self.cms.bool(True),
-                mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2"), #writeTauIdDiscrWPs
-                        variable = self.cms.string("pt"),
+                toMultiplex = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2raw'),
+                loadMVAfromDB = cms.bool(True),
+                mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
+                mapping = cms.VPSet(
+                    cms.PSet(
+                        category = cms.uint32(0),
+                        cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2"), #writeTauIdDiscrWPs
+                        variable = cms.string("pt"),
                     )
                 ),
-                workingPoints = self.cms.vstring(
+                workingPoints = cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -252,15 +252,15 @@ class TauIDEmbedder(object):
                     "_WPEff50",
                     "_WPEff40"
                 ),
-                verbosity = self.cms.int32(0)
+                verbosity = cms.int32(0)
             )
 
-            self.rerunIsolationOldDMMVArun2017v2Task = self.cms.Task(
+            self.rerunIsolationOldDMMVArun2017v2Task = cms.Task(
                 self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2raw,
                 self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2
             )
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2017v2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2017v2Task)
+            self.process.rerunMvaIsolationSequence += cms.Sequence(self.rerunIsolationOldDMMVArun2017v2Task)
 
             tauIDSources.byIsolationMVArun2017v2DBoldDMwLTraw2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "raw")
             tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2017v2", "_WPEff95")
@@ -293,28 +293,28 @@ class TauIDEmbedder(object):
                 self.loadMVA_WPs_run2_2017()
 
             self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = self.cms.bool(True),
-                mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
-                mvaOpt = self.cms.string("DBnewDMwLTwGJ"),
-                verbosity = self.cms.int32(0)
+                loadMVAfromDB = cms.bool(True),
+                mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
+                mvaOpt = cms.string("DBnewDMwLTwGJ"),
+                verbosity = cms.int32(0)
             )
 
             self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2 = patDiscriminationByIsolationMVArun2v1.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2raw'),
-                loadMVAfromDB = self.cms.bool(True),
-                mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2"), #writeTauIdDiscrWPs
-                        variable = self.cms.string("pt"),
+                toMultiplex = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2raw'),
+                loadMVAfromDB = cms.bool(True),
+                mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
+                mapping = cms.VPSet(
+                    cms.PSet(
+                        category = cms.uint32(0),
+                        cut = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2"), #writeTauIdDiscrWPs
+                        variable = cms.string("pt"),
                     )
                 ),
-                workingPoints = self.cms.vstring(
+                workingPoints = cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -323,15 +323,15 @@ class TauIDEmbedder(object):
                     "_WPEff50",
                     "_WPEff40"
                 ),
-                verbosity = self.cms.int32(0)
+                verbosity = cms.int32(0)
             )
 
-            self.rerunIsolationNewDMMVArun2017v2Task = self.cms.Task(
+            self.rerunIsolationNewDMMVArun2017v2Task = cms.Task(
                 self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2raw,
                 self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2
             )
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationNewDMMVArun2017v2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationNewDMMVArun2017v2Task)
+            self.process.rerunMvaIsolationSequence += cms.Sequence(self.rerunIsolationNewDMMVArun2017v2Task)
 
             tauIDSources.byIsolationMVArun2017v2DBnewDMwLTraw2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "raw")
             tauIDSources.byVVLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2017v2", "_WPEff95")
@@ -364,32 +364,32 @@ class TauIDEmbedder(object):
                 self.loadMVA_WPs_run2_2017()
 
             self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = self.cms.bool(True),
-                mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2"),
-                mvaOpt = self.cms.string("DBoldDMwLTwGJ"),
-                srcChargedIsoPtSum = self.cms.string('chargedIsoPtSumdR03'),
-                srcFootprintCorrection = self.cms.string('footprintCorrectiondR03'),
-                srcNeutralIsoPtSum = self.cms.string('neutralIsoPtSumdR03'),
-                srcPhotonPtSumOutsideSignalCone = self.cms.string('photonPtSumOutsideSignalConedR03'),
-                verbosity = self.cms.int32(0)
+                loadMVAfromDB = cms.bool(True),
+                mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2"),
+                mvaOpt = cms.string("DBoldDMwLTwGJ"),
+                srcChargedIsoPtSum = cms.string('chargedIsoPtSumdR03'),
+                srcFootprintCorrection = cms.string('footprintCorrectiondR03'),
+                srcNeutralIsoPtSum = cms.string('neutralIsoPtSumdR03'),
+                srcPhotonPtSumOutsideSignalCone = cms.string('photonPtSumOutsideSignalConedR03'),
+                verbosity = cms.int32(0)
             )
 
             self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2= patDiscriminationByIsolationMVArun2v1.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw'),
-                loadMVAfromDB = self.cms.bool(True),
-                mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2"), #writeTauIdDiscrWPs
-                        variable = self.cms.string("pt"),
+                toMultiplex = cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw'),
+                loadMVAfromDB = cms.bool(True),
+                mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
+                mapping = cms.VPSet(
+                    cms.PSet(
+                        category = cms.uint32(0),
+                        cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2"), #writeTauIdDiscrWPs
+                        variable = cms.string("pt"),
                     )
                 ),
-                workingPoints = self.cms.vstring(
+                workingPoints = cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -398,15 +398,15 @@ class TauIDEmbedder(object):
                     "_WPEff50",
                     "_WPEff40"
                 ),
-                verbosity = self.cms.int32(0)
+                verbosity = cms.int32(0)
             )
 
-            self.rerunIsolationOldDMdR0p3MVArun2017v2Task = self.cms.Task(
+            self.rerunIsolationOldDMdR0p3MVArun2017v2Task = cms.Task(
                 self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw,
                 self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2
             )
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMdR0p3MVArun2017v2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMdR0p3MVArun2017v2Task)
+            self.process.rerunMvaIsolationSequence += cms.Sequence(self.rerunIsolationOldDMdR0p3MVArun2017v2Task)
 
             tauIDSources.byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "raw")
             tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2", "_WPEff95")
@@ -419,26 +419,26 @@ class TauIDEmbedder(object):
 
         # 2016 training strategy(v2) - essentially the same as 2017 training strategy (v1), trained on 2016MC, old DM - currently not implemented in the tau sequence of any release
         # self.process.rerunDiscriminationByIsolationOldDMMVArun2v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-        #     PATTauProducer = self.cms.InputTag('slimmedTaus'),
+        #     PATTauProducer = cms.InputTag('slimmedTaus'),
         #     Prediscriminants = noPrediscriminants,
-        #     loadMVAfromDB = self.cms.bool(True),
-        #     mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
-        #     mvaOpt = self.cms.string("DBoldDMwLTwGJ"),
-        #     verbosity = self.cms.int32(0)
+        #     loadMVAfromDB = cms.bool(True),
+        #     mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
+        #     mvaOpt = cms.string("DBoldDMwLTwGJ"),
+        #     verbosity = cms.int32(0)
         # )
         # #
         # self.process.rerunDiscriminationByIsolationOldDMMVArun2v2VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
-        #     PATTauProducer = self.cms.InputTag('slimmedTaus'),
+        #     PATTauProducer = cms.InputTag('slimmedTaus'),
         #     Prediscriminants = noPrediscriminants,
-        #     toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v2raw'),
-        #     key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v2raw:category'),#?
-        #     loadMVAfromDB = self.cms.bool(True),
-        #     mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
-        #     mapping = self.cms.VPSet(
-        #         self.cms.PSet(
-        #             category = self.cms.uint32(0),
-        #             cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v2_WPEff90"), #writeTauIdDiscrWPs
-        #             variable = self.cms.string("pt"),
+        #     toMultiplex = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v2raw'),
+        #     key = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v2raw:category'),#?
+        #     loadMVAfromDB = cms.bool(True),
+        #     mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
+        #     mapping = cms.VPSet(
+        #         cms.PSet(
+        #             category = cms.uint32(0),
+        #             cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v2_WPEff90"), #writeTauIdDiscrWPs
+        #             variable = cms.string("pt"),
         #         )
         #     )
         # )
@@ -446,28 +446,28 @@ class TauIDEmbedder(object):
         # 2016 training strategy(v1), trained on 2016MC, old DM
         if "2016v1" in self.toKeep:
             self.process.rerunDiscriminationByIsolationOldDMMVArun2v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = self.cms.bool(True),
-                mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1"),
-                mvaOpt = self.cms.string("DBoldDMwLT"),
-                verbosity = self.cms.int32(0)
+                loadMVAfromDB = cms.bool(True),
+                mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1"),
+                mvaOpt = cms.string("DBoldDMwLT"),
+                verbosity = cms.int32(0)
             )
 
             self.process.rerunDiscriminationByIsolationOldDMMVArun2v1 = patDiscriminationByIsolationMVArun2v1.clone(
-                    PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                    PATTauProducer = cms.InputTag('slimmedTaus'),
                     Prediscriminants = noPrediscriminants,
-                    toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw'),
-                    loadMVAfromDB = self.cms.bool(True),
-                    mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_mvaOutput_normalization"),
-                    mapping = self.cms.VPSet(
-                        self.cms.PSet(
-                            category = self.cms.uint32(0),
-                            cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1"),
-                            variable = self.cms.string("pt"),
+                    toMultiplex = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw'),
+                    loadMVAfromDB = cms.bool(True),
+                    mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_mvaOutput_normalization"),
+                    mapping = cms.VPSet(
+                        cms.PSet(
+                            category = cms.uint32(0),
+                            cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1"),
+                            variable = cms.string("pt"),
                         )
                     ),
-                    workingPoints = self.cms.vstring(
+                    workingPoints = cms.vstring(
                         "_WPEff90",
                         "_WPEff80",
                         "_WPEff70",
@@ -477,12 +477,12 @@ class TauIDEmbedder(object):
                     )
                 )
 
-            self.rerunIsolationOldDMMVArun2016v1Task = self.cms.Task(
+            self.rerunIsolationOldDMMVArun2016v1Task = cms.Task(
                 self.process.rerunDiscriminationByIsolationOldDMMVArun2v1raw,
                 self.process.rerunDiscriminationByIsolationOldDMMVArun2v1
             )
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2016v1Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2016v1Task)
+            self.process.rerunMvaIsolationSequence += cms.Sequence(self.rerunIsolationOldDMMVArun2016v1Task)
 
             tauIDSources.byIsolationMVArun2v1DBoldDMwLTraw2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "raw")
             tauIDSources.byVLooseIsolationMVArun2v1DBoldDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationOldDMMVArun2v1", "_WPEff90")
@@ -495,28 +495,28 @@ class TauIDEmbedder(object):
         # 2016 training strategy(v1), trained on 2016MC, new DM
         if "newDM2016v1" in self.toKeep:
             self.process.rerunDiscriminationByIsolationNewDMMVArun2v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = self.cms.bool(True),
-                mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1"),
-                mvaOpt = self.cms.string("DBnewDMwLT"),
-                verbosity = self.cms.int32(0)
+                loadMVAfromDB = cms.bool(True),
+                mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1"),
+                mvaOpt = cms.string("DBnewDMwLT"),
+                verbosity = cms.int32(0)
             )
 
             self.process.rerunDiscriminationByIsolationNewDMMVArun2v1 = patDiscriminationByIsolationMVArun2v1.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw'),
-                loadMVAfromDB = self.cms.bool(True),
-                mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_mvaOutput_normalization"),
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff90"),
-                        variable = self.cms.string("pt"),
+                toMultiplex = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw'),
+                loadMVAfromDB = cms.bool(True),
+                mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_mvaOutput_normalization"),
+                mapping = cms.VPSet(
+                    cms.PSet(
+                        category = cms.uint32(0),
+                        cut = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff90"),
+                        variable = cms.string("pt"),
                     )
                 ),
-                workingPoints = self.cms.vstring(
+                workingPoints = cms.vstring(
                     "_WPEff90",
                     "_WPEff80",
                     "_WPEff70",
@@ -526,12 +526,12 @@ class TauIDEmbedder(object):
                 )
             )
 
-            self.rerunIsolationNewDMMVArun2016v1Task = self.cms.Task(
+            self.rerunIsolationNewDMMVArun2016v1Task = cms.Task(
                 self.process.rerunDiscriminationByIsolationNewDMMVArun2v1raw,
                 self.process.rerunDiscriminationByIsolationNewDMMVArun2v1
             )
             self.process.rerunMvaIsolationTask.add(self.rerunIsolationNewDMMVArun2016v1Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationNewDMMVArun2016v1Task)
+            self.process.rerunMvaIsolationSequence += cms.Sequence(self.rerunIsolationNewDMMVArun2016v1Task)
 
             tauIDSources.byIsolationMVArun2v1DBnewDMwLTraw2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "raw")
             tauIDSources.byVLooseIsolationMVArun2v1DBnewDMwLT2016 = self.tauIDMVAinputs("rerunDiscriminationByIsolationNewDMMVArun2v1", "_WPEff90")
@@ -578,18 +578,18 @@ class TauIDEmbedder(object):
                 }
             }
             file_names = ['RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb']
-            self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
-                electrons              = self.cms.InputTag('slimmedElectrons'),
-                muons                  = self.cms.InputTag('slimmedMuons'),
-                taus                   = self.cms.InputTag('slimmedTaus'),
-                pfcands                = self.cms.InputTag('packedPFCandidates'),
-                vertices               = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                rho                    = self.cms.InputTag('fixedGridRhoAll'),
-                graph_file             = self.cms.vstring(file_names),
-                mem_mapped             = self.cms.bool(False),
-                version                = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
-                debug_level            = self.cms.int32(0),
-                disable_dxy_pca        = self.cms.bool(False)
+            self.process.deepTau2017v1 = cms.EDProducer("DeepTauId",
+                electrons              = cms.InputTag('slimmedElectrons'),
+                muons                  = cms.InputTag('slimmedMuons'),
+                taus                   = cms.InputTag('slimmedTaus'),
+                pfcands                = cms.InputTag('packedPFCandidates'),
+                vertices               = cms.InputTag('offlineSlimmedPrimaryVertices'),
+                rho                    = cms.InputTag('fixedGridRhoAll'),
+                graph_file             = cms.vstring(file_names),
+                mem_mapped             = cms.bool(False),
+                version                = cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
+                debug_level            = cms.int32(0),
+                disable_dxy_pca        = cms.bool(False)
             )
 
             self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
@@ -634,18 +634,18 @@ class TauIDEmbedder(object):
                 'inner:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_inner.pb',
                 'outer:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_outer.pb',
             ]
-            self.process.deepTau2017v2 = self.cms.EDProducer("DeepTauId",
-                electrons              = self.cms.InputTag('slimmedElectrons'),
-                muons                  = self.cms.InputTag('slimmedMuons'),
-                taus                   = self.cms.InputTag('slimmedTaus'),
-                pfcands                = self.cms.InputTag('packedPFCandidates'),
-                vertices               = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                rho                    = self.cms.InputTag('fixedGridRhoAll'),
-                graph_file             = self.cms.vstring(file_names),
-                mem_mapped             = self.cms.bool(False),
-                version                = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
-                debug_level            = self.cms.int32(0),
-                disable_dxy_pca        = self.cms.bool(False)
+            self.process.deepTau2017v2 = cms.EDProducer("DeepTauId",
+                electrons              = cms.InputTag('slimmedElectrons'),
+                muons                  = cms.InputTag('slimmedMuons'),
+                taus                   = cms.InputTag('slimmedTaus'),
+                pfcands                = cms.InputTag('packedPFCandidates'),
+                vertices               = cms.InputTag('offlineSlimmedPrimaryVertices'),
+                rho                    = cms.InputTag('fixedGridRhoAll'),
+                graph_file             = cms.vstring(file_names),
+                mem_mapped             = cms.bool(False),
+                version                = cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
+                debug_level            = cms.int32(0),
+                disable_dxy_pca        = cms.bool(False)
             )
 
             self.processDeepProducer('deepTau2017v2', tauIDSources, workingPoints_)
@@ -690,18 +690,18 @@ class TauIDEmbedder(object):
                 'inner:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_inner.pb',
                 'outer:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_outer.pb',
             ]
-            self.process.deepTau2017v2p1 = self.cms.EDProducer("DeepTauId",
-                electrons                = self.cms.InputTag('slimmedElectrons'),
-                muons                    = self.cms.InputTag('slimmedMuons'),
-                taus                     = self.cms.InputTag('slimmedTaus'),
-                pfcands                  = self.cms.InputTag('packedPFCandidates'),
-                vertices                 = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                rho                      = self.cms.InputTag('fixedGridRhoAll'),
-                graph_file               = self.cms.vstring(file_names),
-                mem_mapped               = self.cms.bool(False),
-                version                  = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
-                debug_level              = self.cms.int32(0),
-                disable_dxy_pca          = self.cms.bool(True)
+            self.process.deepTau2017v2p1 = cms.EDProducer("DeepTauId",
+                electrons                = cms.InputTag('slimmedElectrons'),
+                muons                    = cms.InputTag('slimmedMuons'),
+                taus                     = cms.InputTag('slimmedTaus'),
+                pfcands                  = cms.InputTag('packedPFCandidates'),
+                vertices                 = cms.InputTag('offlineSlimmedPrimaryVertices'),
+                rho                      = cms.InputTag('fixedGridRhoAll'),
+                graph_file               = cms.vstring(file_names),
+                mem_mapped               = cms.bool(False),
+                version                  = cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
+                debug_level              = cms.int32(0),
+                disable_dxy_pca          = cms.bool(True)
             )
 
             self.processDeepProducer('deepTau2017v2p1', tauIDSources, workingPoints_)
@@ -727,13 +727,13 @@ class TauIDEmbedder(object):
                 }
             }
             file_names = [ 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb' ]
-            self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
-                pfcands     = self.cms.InputTag('packedPFCandidates'),
-                taus        = self.cms.InputTag('slimmedTaus'),
-                vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                graph_file  = self.cms.vstring(file_names),
-                version     = self.cms.uint32(self.getDpfTauVersion(file_names[0])),
-                mem_mapped  = self.cms.bool(False)
+            self.process.dpfTau2016v0 = cms.EDProducer("DPFIsolation",
+                pfcands     = cms.InputTag('packedPFCandidates'),
+                taus        = cms.InputTag('slimmedTaus'),
+                vertices    = cms.InputTag('offlineSlimmedPrimaryVertices'),
+                graph_file  = cms.vstring(file_names),
+                version     = cms.uint32(self.getDpfTauVersion(file_names[0])),
+                mem_mapped  = cms.bool(False)
             )
 
             self.processDeepProducer('dpfTau2016v0', tauIDSources, workingPoints_)
@@ -752,13 +752,13 @@ class TauIDEmbedder(object):
             }
 
             file_names = [ 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb' ]
-            self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
-                pfcands     = self.cms.InputTag('packedPFCandidates'),
-                taus        = self.cms.InputTag('slimmedTaus'),
-                vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                graph_file  = self.cms.vstring(file_names),
-                version     = self.cms.uint32(self.getDpfTauVersion(file_names[0])),
-                mem_mapped  = self.cms.bool(False)
+            self.process.dpfTau2016v1 = cms.EDProducer("DPFIsolation",
+                pfcands     = cms.InputTag('packedPFCandidates'),
+                taus        = cms.InputTag('slimmedTaus'),
+                vertices    = cms.InputTag('offlineSlimmedPrimaryVertices'),
+                graph_file  = cms.vstring(file_names),
+                version     = cms.uint32(self.getDpfTauVersion(file_names[0])),
+                mem_mapped  = cms.bool(False)
             )
 
             self.processDeepProducer('dpfTau2016v1', tauIDSources, workingPoints_)
@@ -773,7 +773,7 @@ class TauIDEmbedder(object):
             from RecoTauTag.RecoTau.PATTauDiscriminationAgainstElectronMVA6_cfi import patTauDiscriminationAgainstElectronMVA6
             self.process.patTauDiscriminationByElectronRejectionMVA62018Raw = patTauDiscriminationAgainstElectronMVA6.clone(
                 Prediscriminants = noPrediscriminants, #already selected for MiniAOD
-                vetoEcalCracks = self.cms.bool(False), #keep taus in EB-EE cracks
+                vetoEcalCracks = cms.bool(False), #keep taus in EB-EE cracks
                 mvaName_NoEleMatch_wGwoGSF_BL = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL',
                 mvaName_NoEleMatch_wGwoGSF_EC = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC',
                 mvaName_NoEleMatch_woGwoGSF_BL = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL',
@@ -788,50 +788,50 @@ class TauIDEmbedder(object):
             self.process.patTauDiscriminationByElectronRejectionMVA62018 = patTauDiscriminantCutMultiplexer.clone(
                 PATTauProducer = self.process.patTauDiscriminationByElectronRejectionMVA62018Raw.PATTauProducer,
                 Prediscriminants = self.process.patTauDiscriminationByElectronRejectionMVA62018Raw.Prediscriminants,
-                toMultiplex = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"),
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL'),
-                        variable = self.cms.string('pt')
+                toMultiplex = cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"),
+                mapping = cms.VPSet(
+                    cms.PSet(
+                        category = cms.uint32(0),
+                        cut = cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL'),
+                        variable = cms.string('pt')
                     ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(2),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL'),
-                        variable = self.cms.string('pt')
+                    cms.PSet(
+                        category = cms.uint32(2),
+                        cut = cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL'),
+                        variable = cms.string('pt')
                     ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(5),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL'),
-                        variable = self.cms.string('pt')
+                    cms.PSet(
+                        category = cms.uint32(5),
+                        cut = cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL'),
+                        variable = cms.string('pt')
                     ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(7),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL'),
-                        variable = self.cms.string('pt')
+                    cms.PSet(
+                        category = cms.uint32(7),
+                        cut = cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL'),
+                        variable = cms.string('pt')
                     ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(8),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC'),
-                        variable = self.cms.string('pt')
+                    cms.PSet(
+                        category = cms.uint32(8),
+                        cut = cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC'),
+                        variable = cms.string('pt')
                     ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(10),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC'),
-                        variable = self.cms.string('pt')
+                    cms.PSet(
+                        category = cms.uint32(10),
+                        cut = cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC'),
+                        variable = cms.string('pt')
                     ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(13),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC'),
-                        variable = self.cms.string('pt')
+                    cms.PSet(
+                        category = cms.uint32(13),
+                        cut = cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC'),
+                        variable = cms.string('pt')
                     ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(15),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC'),
-                        variable = self.cms.string('pt')
+                    cms.PSet(
+                        category = cms.uint32(15),
+                        cut = cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC'),
+                        variable = cms.string('pt')
                     )
                 ),
-                workingPoints = self.cms.vstring(
+                workingPoints = cms.vstring(
                     "_WPeff98",
                     "_WPeff90",
                     "_WPeff80",
@@ -840,15 +840,15 @@ class TauIDEmbedder(object):
                 )
             )
             ### Put all new anti-e discrminats to a sequence
-            self.process.patTauDiscriminationByElectronRejectionMVA62018Task = self.cms.Task(
+            self.process.patTauDiscriminationByElectronRejectionMVA62018Task = cms.Task(
                 self.process.patTauDiscriminationByElectronRejectionMVA62018Raw,
                 self.process.patTauDiscriminationByElectronRejectionMVA62018
             )
-            self.process.patTauDiscriminationByElectronRejectionMVA62018Seq = self.cms.Sequence(self.process.patTauDiscriminationByElectronRejectionMVA62018Task)
+            self.process.patTauDiscriminationByElectronRejectionMVA62018Seq = cms.Sequence(self.process.patTauDiscriminationByElectronRejectionMVA62018Task)
             self.process.rerunMvaIsolationTask.add(self.process.patTauDiscriminationByElectronRejectionMVA62018Task)
             self.process.rerunMvaIsolationSequence += self.process.patTauDiscriminationByElectronRejectionMVA62018Seq
 
-            _againstElectronTauIDSources = self.cms.PSet(
+            _againstElectronTauIDSources = cms.PSet(
                 againstElectronMVA6Raw2018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "raw"),
                 againstElectronMVA6category2018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "category"),
                 againstElectronVLooseMVA62018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff98"),
@@ -857,7 +857,7 @@ class TauIDEmbedder(object):
                 againstElectronTightMVA62018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff70"),
                 againstElectronVTightMVA62018 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA62018", "_WPeff60")
             )
-            _tauIDSourcesWithAgainistEle = self.cms.PSet(
+            _tauIDSourcesWithAgainistEle = cms.PSet(
                 tauIDSources.clone(),
                 _againstElectronTauIDSources
             )
@@ -866,13 +866,13 @@ class TauIDEmbedder(object):
         ##
         if self.debug: print('Embedding new TauIDs into \"'+self.updatedTauName+'\"')
         if not hasattr(self.process, self.updatedTauName):
-            embedID = self.cms.EDProducer("PATTauIDEmbedder",
-               src = self.cms.InputTag('slimmedTaus'),
+            embedID = cms.EDProducer("PATTauIDEmbedder",
+               src = cms.InputTag('slimmedTaus'),
                tauIDSources = tauIDSources
             )
             setattr(self.process, self.updatedTauName, embedID)
         else: #assume same type
-            tauIDSources = self.cms.PSet(
+            tauIDSources = cms.PSet(
                 getattr(self.process, self.updatedTauName).tauIDSources,
                 tauIDSources)
             getattr(self.process, self.updatedTauName).tauIDSources = tauIDSources
@@ -881,16 +881,16 @@ class TauIDEmbedder(object):
     def processDeepProducer(self, producer_name, tauIDSources, workingPoints_):
         for target,points in six.iteritems(workingPoints_):
             setattr(tauIDSources, 'by{}VS{}raw'.format(producer_name[0].upper()+producer_name[1:], target),
-                        self.cms.PSet(inputTag = self.cms.InputTag(producer_name, 'VS{}'.format(target)), workingPointIndex = self.cms.int32(-1)))
+                        cms.PSet(inputTag = cms.InputTag(producer_name, 'VS{}'.format(target)), workingPointIndex = cms.int32(-1)))
             
             cut_expressions = []
             for index, (point,cut) in enumerate(six.iteritems(points)):
                 cut_expressions.append(str(cut))
 
                 setattr(tauIDSources, 'by{}{}VS{}'.format(point, producer_name[0].upper()+producer_name[1:], target),
-                        self.cms.PSet(inputTag = self.cms.InputTag(producer_name, 'VS{}'.format(target)), workingPointIndex = self.cms.int32(index)))
+                        cms.PSet(inputTag = cms.InputTag(producer_name, 'VS{}'.format(target)), workingPointIndex = cms.int32(index)))
 
-            setattr(getattr(self.process, producer_name), 'VS{}WP'.format(target), self.cms.vstring(*cut_expressions))
+            setattr(getattr(self.process, producer_name), 'VS{}WP'.format(target), cms.vstring(*cut_expressions))
 
 
     def getDpfTauVersion(self, file_name):

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -30,7 +30,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProc
 
 # Add new TauIDs
 import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
-tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
+tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug = False,
                     updatedTauName = updatedTauName,
                     toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2",
                                # "deepTau2017v1",

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -8,7 +8,7 @@ import FWCore.ParameterSet.Config as cms
 # options.parseArguments()
 updatedTauName = "slimmedTausNewID"
 minimalOutput = True
-eventsToProcess = 1
+eventsToProcess = 100
 nThreads = 1
 
 process = cms.Process('TauID')
@@ -23,7 +23,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic', '
 # Input source
 process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
     # File from dataset DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
-    ' /store/mc/RunIIFall17MiniAODv2/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/A256C80D-0943-E811-998E-7CD30AB0522C.root'
+    '/store/relval/CMSSW_10_5_0_pre1/RelValZTT_13/MINIAODSIM/PU25ns_103X_upgrade2018_realistic_v8-v1/20000/EA29017F-9967-3F41-BB8A-22C44A454235.root'
 ))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProcess) )

--- a/RecoTauTag/RecoTau/test/runtests.sh
+++ b/RecoTauTag/RecoTau/test/runtests.sh
@@ -3,4 +3,4 @@
 function die { echo $1: status $2 ;  exit $2; }
 
 cmsRun ${LOCAL_TEST_DIR}/rerunTauRecoOnMiniAOD.py || die 'Failure using rerunTauRecoOnMiniAOD.py' $?
-
+cmsRun ${LOCAL_TEST_DIR}/runDeepTauIDsOnMiniAOD.py || die 'Failure using runDeepTauIDsOnMiniAOD.py' $?


### PR DESCRIPTION
#### PR description:

This PR fixes bugs introduced to `runTauIdMVA.py` tool during implementation of the new tauID dataformat #28417.

#### PR validation:

This tool is not used in standard workflows except miniAOD (to include deepTauID) which uses its non-affected part. Therefore, the fix was tested with [RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py](https://github.com/cms-sw/cmssw/blob/master/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py) test configuration. (Actaully, the bugs have been discovered when running this configuration). 
=> This test configuration is added to units tests in this PR.

Q: It will be good to have this fix already in 11_1_X series - does it require a backport, i.e. if master is already switched to 11_2_X?
