### PR TITLE
[HGCal] Validation scripts and code for RelVal campaigns

### DIFF
--- a/Validation/HGCalValidation/macros/validationplots.C
+++ b/Validation/HGCalValidation/macros/validationplots.C
@@ -1,0 +1,86 @@
+//Author: Andreas Psallidas
+//A very helpful small macro to easily make plots of the final root file
+void plotkeys(TDirectory *curdir, TFile *newfi, TString dir, string input, string objecttoplot, string sample){
+
+  curdir = gDirectory;
+  TIter next(curdir->GetListOfKeys());
+  TKey *key;
+  TCanvas c1;
+
+  newfi->mkdir( dir );
+  newfi->cd( dir );
+
+  while ((key = (TKey*)next())) {
+    key->ls();
+    TClass *cl = gROOT->GetClass(key->GetClassName());
+    TH1 *h = (TH1*)key->ReadObj();
+    h->Draw();
+    // std::cout<< key->GetName() << std::endl;
+    
+    TString plotname; TString keyname = key->GetName();
+    plotname = (keyname + ".png");
+    if (sample == ""){
+      c1.SaveAs(dir+'/'+plotname);
+    } else {
+      if (objecttoplot == "Calibrations"){ c1.SaveAs(sample+'/'+plotname);}
+      if (objecttoplot == "CaloParticles"){ 
+	//unsigned last = dir.find_last_of("/");
+	unsigned last = dir.Last('/');
+	c1.SaveAs(sample+'/'+ dir(last+1,dir.Length())+'/'+plotname);
+      }
+    } 
+    h->Write();
+  }
+
+}
+
+
+void validationplots(string input, string objecttoplot, string sample = ""){
+
+  gROOT->ForceStyle(); 
+  gStyle->SetOptStat("ksiourmen");
+ 
+  TFile *file = TFile::Open(input.c_str());
+  TDirectory *currentdir;
+  //Folder to be examined and plot objects
+  std::vector<TString> folders;
+  if (objecttoplot == "SimHits"){
+    folders.push_back("hgcalSimHitStudy");
+  } else if (objecttoplot == "Digis"){
+    folders.push_back("hgcalDigiStudyEE");
+    folders.push_back("hgcalDigiStudyHEF");
+    folders.push_back("hgcalDigiStudyHEB");
+  } else if (objecttoplot == "RecHits"){
+    folders.push_back("hgcalRecHitStudyEE");
+    folders.push_back("hgcalRecHitStudyHEF");
+    folders.push_back("hgcalRecHitStudyHEB");
+  } else if (objecttoplot == "CaloParticles"){
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/-11");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/-13");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/-211");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/-321");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/11");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/111");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/13");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/211");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/22");
+    folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/321");
+  } else if (objecttoplot == "Calibrations"){
+    folders.push_back("DQMData/Run 1/HGCalHitCalibration/Run summary");
+  }
+
+
+
+  TFile* newfi=new TFile("newfi.root","recreate");
+
+  for (std::vector<TString>::iterator fol=folders.begin(); fol!=folders.end(); ++fol) {
+    file->cd( (*fol) );
+    plotkeys(currentdir, newfi , (*fol) , input, objecttoplot, sample);
+  }
+
+  newfi->Close();
+  
+    
+
+}
+   

--- a/Validation/HGCalValidation/macros/validationplots.C
+++ b/Validation/HGCalValidation/macros/validationplots.C
@@ -1,60 +1,59 @@
 //Author: Andreas Psallidas
 //A very helpful small macro to easily make plots of the final root file
-void plotkeys(TDirectory *curdir, TFile *newfi, TString dir, string input, string objecttoplot, string sample){
-
+void plotkeys(TDirectory *curdir, TFile *newfi, TString dir, string input, string objecttoplot, string sample) {
   curdir = gDirectory;
   TIter next(curdir->GetListOfKeys());
   TKey *key;
   TCanvas c1;
 
-  newfi->mkdir( dir );
-  newfi->cd( dir );
+  newfi->mkdir(dir);
+  newfi->cd(dir);
 
-  while ((key = (TKey*)next())) {
+  while ((key = (TKey *)next())) {
     key->ls();
     TClass *cl = gROOT->GetClass(key->GetClassName());
-    TH1 *h = (TH1*)key->ReadObj();
+    TH1 *h = (TH1 *)key->ReadObj();
     h->Draw();
     // std::cout<< key->GetName() << std::endl;
-    
-    TString plotname; TString keyname = key->GetName();
+
+    TString plotname;
+    TString keyname = key->GetName();
     plotname = (keyname + ".png");
-    if (sample == ""){
-      c1.SaveAs(dir+'/'+plotname);
+    if (sample == "") {
+      c1.SaveAs(dir + '/' + plotname);
     } else {
-      if (objecttoplot == "Calibrations"){ c1.SaveAs(sample+'/'+plotname);}
-      if (objecttoplot == "CaloParticles"){ 
-	//unsigned last = dir.find_last_of("/");
-	unsigned last = dir.Last('/');
-	c1.SaveAs(sample+'/'+ dir(last+1,dir.Length())+'/'+plotname);
+      if (objecttoplot == "Calibrations") {
+        c1.SaveAs(sample + '/' + plotname);
       }
-    } 
+      if (objecttoplot == "CaloParticles") {
+        //unsigned last = dir.find_last_of("/");
+        unsigned last = dir.Last('/');
+        c1.SaveAs(sample + '/' + dir(last + 1, dir.Length()) + '/' + plotname);
+      }
+    }
     h->Write();
   }
-
 }
 
-
-void validationplots(string input, string objecttoplot, string sample = ""){
-
-  gROOT->ForceStyle(); 
+void validationplots(string input, string objecttoplot, string sample = "") {
+  gROOT->ForceStyle();
   gStyle->SetOptStat("ksiourmen");
- 
+
   TFile *file = TFile::Open(input.c_str());
   TDirectory *currentdir;
   //Folder to be examined and plot objects
   std::vector<TString> folders;
-  if (objecttoplot == "SimHits"){
+  if (objecttoplot == "SimHits") {
     folders.push_back("hgcalSimHitStudy");
-  } else if (objecttoplot == "Digis"){
+  } else if (objecttoplot == "Digis") {
     folders.push_back("hgcalDigiStudyEE");
     folders.push_back("hgcalDigiStudyHEF");
     folders.push_back("hgcalDigiStudyHEB");
-  } else if (objecttoplot == "RecHits"){
+  } else if (objecttoplot == "RecHits") {
     folders.push_back("hgcalRecHitStudyEE");
     folders.push_back("hgcalRecHitStudyHEF");
     folders.push_back("hgcalRecHitStudyHEB");
-  } else if (objecttoplot == "CaloParticles"){
+  } else if (objecttoplot == "CaloParticles") {
     folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/-11");
     folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/-13");
     folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/-211");
@@ -65,22 +64,16 @@ void validationplots(string input, string objecttoplot, string sample = ""){
     folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/211");
     folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/22");
     folders.push_back("DQMData/Run 1/HGCAL/Run summary/CaloParticles/321");
-  } else if (objecttoplot == "Calibrations"){
+  } else if (objecttoplot == "Calibrations") {
     folders.push_back("DQMData/Run 1/HGCalHitCalibration/Run summary");
   }
 
+  TFile *newfi = new TFile("newfi.root", "recreate");
 
-
-  TFile* newfi=new TFile("newfi.root","recreate");
-
-  for (std::vector<TString>::iterator fol=folders.begin(); fol!=folders.end(); ++fol) {
-    file->cd( (*fol) );
-    plotkeys(currentdir, newfi , (*fol) , input, objecttoplot, sample);
+  for (std::vector<TString>::iterator fol = folders.begin(); fol != folders.end(); ++fol) {
+    file->cd((*fol));
+    plotkeys(currentdir, newfi, (*fol), input, objecttoplot, sample);
   }
 
   newfi->Close();
-  
-    
-
 }
-   

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1412,9 +1412,9 @@ _clusternum_in_multicluster_vs_layer = PlotGroup("clusternum_in_multicluster_vs_
 
 _common["scale"] = 100.
 #, ztitle = "% of clusters" normalizeToUnitArea=True
-_multiplicity_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA/multiplicity_numberOfEventsHistogram"
-_multiplicity_zminus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA/multiplicity_zminus_numberOfEventsHistogram"
-_multiplicity_zplus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA/multiplicity_zplus_numberOfEventsHistogram"
+_multiplicity_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_numberOfEventsHistogram"
+_multiplicity_zminus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_zminus_numberOfEventsHistogram"
+_multiplicity_zplus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_zplus_numberOfEventsHistogram"
 _multiplicityOfLCinMCL = PlotGroup("multiplicityOfLCinMCL",[
   Plot("multiplicityOfLCinMCL", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Cluster size (n_{hit})         ", drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)
 ],ncols=1)
@@ -2270,10 +2270,10 @@ for i,item in enumerate(_energyscore_lc2cp_zplus, start=1):
 hgcalMultiClustersPlotter = Plotter()
 # [A] Score of CaloParticles wrt Multi Clusters
 hgcalMultiClustersPlotter.append("ScoreCaloParticlesToMultiClusters", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
             ], PlotFolder(
             _score_caloparticle_to_multiclusters,
@@ -2282,10 +2282,10 @@ hgcalMultiClustersPlotter.append("ScoreCaloParticlesToMultiClusters", [
 
 # [B] Score of MultiClusters wrt CaloParticles
 hgcalMultiClustersPlotter.append("ScoreMultiClustersToCaloParticles", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             _score_multicluster_to_caloparticles,
@@ -2294,10 +2294,10 @@ hgcalMultiClustersPlotter.append("ScoreMultiClustersToCaloParticles", [
 
 # [C] Shared Energy between CaloParticle and MultiClusters
 hgcalMultiClustersPlotter.append("SharedEnergy_CP2MCL", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             _sharedEnergy_caloparticle_to_multicluster,
@@ -2306,10 +2306,10 @@ hgcalMultiClustersPlotter.append("SharedEnergy_CP2MCL", [
 
 # [C2] Shared Energy between MultiClusters and CaloParticle
 hgcalMultiClustersPlotter.append("SharedEnergy_MCL2CP", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             _sharedEnergy_multicluster_to_caloparticle,
@@ -2318,10 +2318,10 @@ hgcalMultiClustersPlotter.append("SharedEnergy_MCL2CP", [
 
 # [E] Efficiency Plots
 hgcalMultiClustersPlotter.append("Efficiencies", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             _efficiencies,
@@ -2330,10 +2330,10 @@ hgcalMultiClustersPlotter.append("Efficiencies", [
 
 # [F] Duplicate Plots
 hgcalMultiClustersPlotter.append("Duplicates", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             _duplicates,
@@ -2342,10 +2342,10 @@ hgcalMultiClustersPlotter.append("Duplicates", [
 
 # [G] Fake Rate Plots
 hgcalMultiClustersPlotter.append("FakeRate", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             _fakes,
@@ -2354,10 +2354,10 @@ hgcalMultiClustersPlotter.append("FakeRate", [
 
 # [H] Merge Rate Plots
 hgcalMultiClustersPlotter.append("MergeRate", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             _merges,
@@ -2366,10 +2366,10 @@ hgcalMultiClustersPlotter.append("MergeRate", [
 
 # [I] Energy vs Score 2D plots CP to MCL and MCL to CP
 hgcalMultiClustersPlotter.append("Energy_vs_Score_CP2MCL_MCL2CP", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             #_energyscore_cp2mcl_mcl2cp,
@@ -2379,10 +2379,10 @@ hgcalMultiClustersPlotter.append("Energy_vs_Score_CP2MCL_MCL2CP", [
 
 # [J] Energy vs Score 2D plots MCL to CP
 hgcalMultiClustersPlotter.append("Energy_vs_Score_MCL2CP", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
              ], PlotFolder(
             _energyscore_mcl2cp,
@@ -2391,10 +2391,10 @@ hgcalMultiClustersPlotter.append("Energy_vs_Score_MCL2CP", [
 
 #[K] Number of multiclusters per event.
 hgcalMultiClustersPlotter.append("NumberofMultiClusters", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
         "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
         ], PlotFolder(
         _totmulticlusternum,
@@ -2404,10 +2404,10 @@ hgcalMultiClustersPlotter.append("NumberofMultiClusters", [
 
 #[L] total number of layer clusters in multicluster per event and per layer
 hgcalMultiClustersPlotter.append("NumberofLayerClustersinMultiClusterPerEventAndPerLayer", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
         "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
         ], PlotFolder(
         _clusternum_in_multicluster,
@@ -2424,10 +2424,10 @@ hgcalMultiClustersPlotter.append("NumberofLayerClustersinMultiClusterPerEventAnd
 
 #[M] For each multicluster: pt, eta, phi, energy, x, y, z.
 hgcalMultiClustersPlotter.append("MultiClustersPtEtaPhiEneXYZ", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
         "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
         ], PlotFolder(
         _multicluster_pt,
@@ -2443,10 +2443,10 @@ hgcalMultiClustersPlotter.append("MultiClustersPtEtaPhiEneXYZ", [
 
 #[N] Multicluster first, last, total number of layers
 hgcalMultiClustersPlotter.append("NumberofMultiClusters_First_Last_NLayers", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
         "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
         ], PlotFolder(
         _multicluster_firstlayer,
@@ -2458,10 +2458,10 @@ hgcalMultiClustersPlotter.append("NumberofMultiClusters_First_Last_NLayers", [
 
 #[O] Multiplicity of layer clusters in multicluster
 hgcalMultiClustersPlotter.append("Multiplicity", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
         "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
        ], PlotFolder(
         _multiplicityOfLCinMCL,
@@ -2474,10 +2474,10 @@ hgcalMultiClustersPlotter.append("Multiplicity", [
 #We append here two PlotFolder because we want the text to be in percent
 #and the number of events are different in zplus and zminus
 hgcalMultiClustersPlotter.append("Multiplicity", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
         "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
         ], PlotFolder(
         _multiplicityOfLCinMCL_vs_layercluster_zminus,
@@ -2487,10 +2487,10 @@ hgcalMultiClustersPlotter.append("Multiplicity", [
         ))
 
 hgcalMultiClustersPlotter.append("Multiplicity", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA",
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/multiClustersFromTrackstersHAD_MultiClustersFromTracksterByCA",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersMerge",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersTrk",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM",
+        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersHAD",
         "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalMultiClusters",
         ], PlotFolder(
         _multiplicityOfLCinMCL_vs_layercluster_zplus,

--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -1,0 +1,182 @@
+import os
+import collections
+import six
+
+_sampleName = {
+    "RelValCloseByParticleGun_CE_H_Fine_300um" : "CloseByParticleGun in CE-H Fine section with 300 um",
+    "RelValCloseByParticleGun_CE_H_Fine_200um" : "CloseByParticleGun in CE-H Fine section with 200 um",
+    "RelValCloseByParticleGun_CE_H_Fine_120um" : "CloseByParticleGun in CE-H Fine section with 120 um",
+    "RelValCloseByParticleGun_CE_H_Coarse_Scint" : "CloseByParticleGun in CE-H Coarse section with scintillator",
+    "RelValCloseByParticleGun_CE_H_Coarse_300um" : "CloseByParticleGun in CE-H Coarse section with 300 um",
+    "RelValCloseByParticleGun_CE_E_Front_300um" : "CloseByParticleGun in CE-E Front section with 300 um",
+    "RelValCloseByParticleGun_CE_E_Front_200um" : "CloseByParticleGun in CE-E Front section with 200 um",
+    "RelValCloseByParticleGun_CE_E_Front_120um" : "CloseByParticleGun in CE-E Front section with 120 um",
+    "RelValTTbar" : "TTbar",
+    "RelValSingleGammaFlatPt8To150" : "Single Gamma Pt 8 GeV to 150 GeV ",
+    "RelValSingleMuPt10" : "Single Muon Pt 10 GeV",
+    "RelValSingleMuPt100" : "Single Muon Pt 100 GeV",
+    "RelValSingleMuPt1000" : "Single Muon Pt 1000 GeV",
+    "RelValSingleMuFlatPt2To100" : "Single Muon Pt 2 GeV to 100 GeV",
+    "RelValSingleMuFlatPt0p7To10" : "Single Muon Pt 0.7 GeV to 10 GeV",
+    "RelValSingleEFlatPt2To100" : "Single Electron Pt 2 GeV to 100 GeV",
+    "RelValSingleTauFlatPt2To150" : "Single Tau Pt 2 GeV to 150 GeV",
+    "RelValSinglePiFlatPt0p7To10" : "Single Pion Pt 0.7 GeV to 10 GeV",
+    "RelValQCD_Pt20toInfMuEnrichPt15" : "QCD Pt 20 GeV to Inf with Muon Pt 15 GeV",
+    "RelValQCD_Pt15To7000_Flat" : "QCD Pt 15 GeV to 7 TeV",
+    "RelValZTT" : "ZTauTau",
+    "RelValZMM" : "ZMuMu",
+    "RelValZEE" : "ZEleEle",
+    "RelValB0ToKstarMuMu" : "B0 To Kstar Muon Muon",
+    "RelValBsToEleEle" : "Bs To Electron Electron",
+    "RelValBsToMuMu" : "Bs To Muon Muon",
+    "RelValBsToJpsiGamma" : "Bs To Jpsi Gamma",
+    "RelValBsToJpsiPhi_mumuKK" : "Bs To JpsiPhi_mumuKK",
+    "RelValBsToPhiPhi_KKKK" : "Bs To PhiPhi_KKKK",
+    "RelValDisplacedMuPt30To100" : "Displaced Muon Pt 30 GeV to 100 GeV",
+    "RelValDisplacedMuPt2To10" : "Displaced Muon Pt 2 GeV to 10 GeV",
+    "RelValDisplacedMuPt10To30" : "Displaced Muon Pt 10 GeV to 30 GeV",
+    "RelValTauToMuMuMu" : "Tau To Muon Muon Muon",
+    "RelValMinBias" : "Min Bias",
+    "RelValH125GGgluonfusion" : "Higgs to gamma gamma",
+    "RelValNuGun" : "Neutrino gun",
+    "RelValZpTT_1500" : "Z prime with 1500 GeV nominal mass",
+    "RelValTenTau_15_500" : "Ten Taus with energy from 15 GeV to 500 GeV"
+}
+
+_sampleFileName = {
+    "RelValCloseByParticleGun_CE_H_Fine_300um" : "closebycehf300",
+    "RelValCloseByParticleGun_CE_H_Fine_200um" : "closebycehf200",
+    "RelValCloseByParticleGun_CE_H_Fine_120um" : "closebycehf120",
+    "RelValCloseByParticleGun_CE_H_Coarse_Scint" : "closebycehcscint",
+    "RelValCloseByParticleGun_CE_H_Coarse_300um" : "closebycehc300",
+    "RelValCloseByParticleGun_CE_E_Front_300um" : "closebyceef300",
+    "RelValCloseByParticleGun_CE_E_Front_200um" : "closebyceef200",
+    "RelValCloseByParticleGun_CE_E_Front_120um" : "closebyceef120",
+    "RelValTTbar" : "ttbar",
+    "RelValSingleGammaFlatPt8To150" : "gam8",
+    "RelValSingleMuPt10" : "m10",
+    "RelValSingleMuPt100" : "m100",
+    "RelValSingleMuPt1000" : "m1000",
+    "RelValSingleMuFlatPt2To100" : "mflat2t100",
+    "RelValSingleMuFlatPt0p7To10" : "mflat0p7t10",
+    "RelValSingleEFlatPt2To100" : "eflat2t100",
+    "RelValSingleTauFlatPt2To150" : "tauflat2t150",
+    "RelValSinglePiFlatPt0p7To10" : "piflat0p7t10",
+    "RelValQCD_Pt20toInfMuEnrichPt15" : "qcd20enmu15",
+    "RelValQCD_Pt15To7000_Flat" : "qcdflat15",
+    "RelValZTT" : "ztautau",
+    "RelValZMM" : "zmm",
+    "RelValZEE" : "zee",
+    "RelValB0ToKstarMuMu" : "b0kstmm",
+    "RelValBsToEleEle" : "bsee",
+    "RelValBsToMuMu" : "bsmm",
+    "RelValBsToJpsiGamma" : "bsjpsg",
+    "RelValBsToJpsiPhi_mumuKK" : "bsjpspmmkk",
+    "RelValBsToPhiPhi_KKKK" : "bsjpsppkkkk",
+    "RelValDisplacedMuPt30To100" : "dm30",
+    "RelValDisplacedMuPt2To10" : "dm2",
+    "RelValDisplacedMuPt10To30" : "dm10",
+    "RelValTauToMuMuMu" : "taummm",
+    "RelValMinBias" : "minbias",
+    "RelValH125GGgluonfusion" : "hgg",
+    "RelValNuGun" : "nug",
+    "RelValZpTT_1500" : "zp1500tautau",
+    "RelValTenTau_15_500" : "tentaus15to1500"
+
+}
+
+
+_pageNameMap = {
+    "summary": "Summary",
+    "hitCalibration": "Reconstructed hits calibration",
+    "hitValidation" : "Simulated hits, digis, reconstructed hits validation" , 
+    "hgcalLayerClusters": "Layer clusters",
+    "multiClustersFromTrackstersEM": "Electromagnetic multiclusters",
+    "multiClustersFromTrackstersHAD": "Hadronic multiclusters",
+    "hgcalMultiClusters" : "Old multiclusters",
+    "standalone" : "Standalone study on simulated hits, digis, reconstructed hits"   
+}
+
+_sectionNameMapOrder = collections.OrderedDict([
+    # These are for the summary page
+    # Will add later
+    # hgcalLayerClusters
+    ("hgcalLayerClusters", "Layer clusters"),
+    # multiClustersFromTrackstersEM
+    ("multiClustersFromTrackstersEM","Electromagnetic multiclusters"),
+    # multiClustersFromTrackstersHAD
+    ("multiClustersFromTrackstersHAD","Hadronic multiclusters"),
+    # hgcalMultiClusters
+    ("hgcalMultiClusters","Old multiclusters"),
+])
+
+#This is the summary section, where we define which plots will be shown in the summary page. 
+_summary = {}
+
+#Objects to keep in summary
+_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','multiClustersFromTrackstersEM','multiClustersFromTrackstersHAD']
+#_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters']
+
+#Plots to keep in summary from hitCalibration
+summhitcalib=[
+    'Layer_Occupancy/LayerOccupancy_LayerOccupancy.png',
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_300_calib_fraction.png',
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_200_calib_fraction.png',
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_100_calib_fraction.png'
+    ]
+
+#Plots to keep in summary from hitValidation
+summhitvalid = [
+    'SimHits_Validation/HitValidation_heeEnSim.png',
+    'SimHits_Validation/HitValidation_hebEnSim.png',
+    'SimHits_Validation/HitValidation_hefEnSim.png']
+                          
+#Plots to keep in summary from layer clusters
+summlc = [
+    'Efficiencies_zminus/Efficiencies_zminus_globalEfficiencies.png' ,
+    'Efficiencies_zplus/Efficiencies_zplus_globalEfficiencies.png' ,
+    'Duplicates_zminus/Duplicates_zminus_globalEfficiencies.png' ,
+    'Duplicates_zplus/Duplicates_zplus_globalEfficiencies.png' ,
+    'FakeRate_zminus/FakeRate_zminus_globalEfficiencies.png' ,
+    'FakeRate_zplus/FakeRate_zplus_globalEfficiencies.png' ,
+    'MergeRate_zminus/MergeRate_zminus_globalEfficiencies.png' ,
+    'MergeRate_zplus/MergeRate_zplus_globalEfficiencies.png',
+    'SelectedCaloParticles_Photons/SelectedCaloParticles_num_caloparticle_eta.png',
+    'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_pt.png',
+    'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_phi.png',
+    'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_energy.png',
+    'SelectedCaloParticles_Photons/SelectedCaloParticles_Eta vs Zorigin.png'
+    ]
+                          
+
+#Plots to keep in summary from multiClustersFromTrackstersEM
+summmcEM = [
+    'Efficiencies/Efficiencies_globalEfficiencies.png' ,
+    'Duplicates/Duplicates_globalDuplicates.png' ,
+    'FakeRate/FakeRate_globalFakeRate.png' ,
+    'MergeRate/MergeRate_globalMergeRate.png'
+]
+
+#Plots to keep in summary from multiClustersFromTrackstersHAD
+summmcHAD = summmcEM
+
+#Plots to keep in summary from standalone analysis
+summstandalone = [
+    'hgcalSimHitStudy/RZ_AllDetectors.png'                          
+]
+
+#Let's save the above for later
+for obj in _summobj: 
+    _summary[obj] = {}
+_summary['hitCalibration'] = summhitcalib
+_summary['hitValidation'] = summhitvalid
+_summary['hgcalLayerClusters'] = summlc
+_summary['multiClustersFromTrackstersEM'] = summmcEM
+_summary['multiClustersFromTrackstersHAD'] = summmcHAD                          
+
+
+
+
+
+
+

--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -10,7 +10,15 @@ _sampleName = {
     "RelValCloseByParticleGun_CE_H_Coarse_300um" : "CloseByParticleGun in CE-H Coarse section with 300 um",
     "RelValCloseByParticleGun_CE_E_Front_300um" : "CloseByParticleGun in CE-E Front section with 300 um",
     "RelValCloseByParticleGun_CE_E_Front_200um" : "CloseByParticleGun in CE-E Front section with 200 um",
-    "RelValCloseByParticleGun_CE_E_Front_120um" : "CloseByParticleGun in CE-E Front section with 120 um",
+    "RelValCloseByPGun_CE_E_Front_120um" : "CloseByParticleGun in CE-E Front section with 120 um",
+    "RelValCloseByPGun_CE_H_Fine_300um" : "CloseByParticleGun in CE-H Fine section with 300 um",
+    "RelValCloseByPGun_CE_H_Fine_200um" : "CloseByParticleGun in CE-H Fine section with 200 um",
+    "RelValCloseByPGun_CE_H_Fine_120um" : "CloseByParticleGun in CE-H Fine section with 120 um",
+    "RelValCloseByPGun_CE_H_Coarse_Scint" : "CloseByParticleGun in CE-H Coarse section with scintillator",
+    "RelValCloseByPGun_CE_H_Coarse_300um" : "CloseByParticleGun in CE-H Coarse section with 300 um",
+    "RelValCloseByPGun_CE_E_Front_300um" : "CloseByParticleGun in CE-E Front section with 300 um",
+    "RelValCloseByPGun_CE_E_Front_200um" : "CloseByParticleGun in CE-E Front section with 200 um",
+    "RelValCloseByPGun_CE_E_Front_120um" : "CloseByParticleGun in CE-E Front section with 120 um",
     "RelValTTbar" : "TTbar",
     "RelValSingleGammaFlatPt8To150" : "Single Gamma Pt 8 GeV to 150 GeV ",
     "RelValSingleMuPt10" : "Single Muon Pt 10 GeV",
@@ -122,7 +130,8 @@ summhitcalib=[
     'Layer_Occupancy/LayerOccupancy_LayerOccupancy.png',
     'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_300_calib_fraction.png',
     'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_200_calib_fraction.png',
-    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_100_calib_fraction.png'
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_100_calib_fraction.png',
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_scint_calib_fraction.png'
     ]
 
 #Plots to keep in summary from hitValidation
@@ -152,9 +161,9 @@ summlc = [
 #Plots to keep in summary from multiClustersFromTrackstersEM
 summmcEM = [
     'Efficiencies/Efficiencies_globalEfficiencies.png' ,
-    'Duplicates/Duplicates_globalDuplicates.png' ,
-    'FakeRate/FakeRate_globalFakeRate.png' ,
-    'MergeRate/MergeRate_globalMergeRate.png'
+    'Duplicates/Duplicates_globalEfficiencies.png' ,
+    'FakeRate/FakeRate_globalEfficiencies.png' ,
+    'MergeRate/MergeRate_globalEfficiencies.png'
 ]
 
 #Plots to keep in summary from multiClustersFromTrackstersHAD

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -79,6 +79,8 @@ def putype(t):
 #------------------------------------------------------------------------------------------
 #thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
 thereleases = { "CMSSW 11_1_X" : [
+    "CMSSW_11_1_0_pre6_raw1100_vs_CMSSW_11_1_0_pre6",
+    "CMSSW_11_1_0_pre6_raw1100_vs_CMSSW_11_1_0_pre5_raw1100",
     "CMSSW_11_1_0_pre6_vs_CMSSW_11_1_0_pre5",
     "CMSSW_11_1_0_pre5_vs_CMSSW_11_1_0_pre4",
     "CMSSW_11_1_0_pre5_raw1100_vs_CMSSW_11_1_0_pre5",
@@ -88,11 +90,11 @@ thereleases = { "CMSSW 11_1_X" : [
     "CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre4"
 ] }
 
-RefRelease='CMSSW_11_1_0_pre5'
+RefRelease='CMSSW_11_1_0_pre6'
 
 NewRelease='CMSSW_11_1_0_pre6'
 
-NotNormalRelease = "normal"
+NotNormalRelease = "raw"
 NotNormalRefRelease = "normal"
 
 if ( os.path.isdir('%s/%s' %(opt.WWWAREA, NewRelease))) : 
@@ -101,13 +103,13 @@ if ( os.path.isdir('%s/%s' %(opt.WWWAREA, NewRelease))) :
     exit()
 
 if "raw" in NotNormalRelease: 
-   appendglobaltag = "_raw1100"
+   appendglobaltag = "_2026D49noPU_raw1100_rsb"
 else: 
    appendglobaltag = "_2026D49noPU"
 
 #Until the final list of RelVals settles down the following sample list is under constant review
 '''
-phase2samples_noPU = [
+phase2samples_noPU_oldnaming = [
 #    Sample("RelValCloseByParticleGun_CE_H_Fine_300um", dqmVersion="0002", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValCloseByParticleGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValCloseByParticleGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
@@ -148,7 +150,6 @@ phase2samples_noPU = [
     Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValNuGun", scenario="2026D49", appendGlobalTag=appendglobaltag )
     ]
-
 '''
 
 #Main workflow RelVals
@@ -160,7 +161,7 @@ phase2samples_noPU = [
     Sample("RelValZEE", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValTenTau_15_500", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
     Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValQCD_Pt15To7000_Flat", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValQCD_Pt15To7000_Flat", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValNuGun", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     #Sample("RelValMinBias", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag )
@@ -207,6 +208,7 @@ phase2samples_noPU_extend_more = [
 '''
 phase2samples_noPU.extend(phase2samples_noPU_extend)
 #phase2samples_noPU.extend(phase2samples_noPU_extend_more)
+#phase2samples_noPU.extend(phase2samples_noPU_oldnaming)
 
 #For the PU samples 
 phase2samples_PU = [
@@ -271,9 +273,11 @@ if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ ==
         if RefRelease == None:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_raw1100-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_raw1100-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_2026D49noPU_raw1100_rsb","_raw1100") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
@@ -365,7 +369,8 @@ if (opt.OBJ == 'hitValidation'):
         elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_raw1100-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_2026D49noPU_raw1100_rsb","_raw1100") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -79,6 +79,9 @@ def putype(t):
 #------------------------------------------------------------------------------------------
 #thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
 thereleases = { "CMSSW 11_1_X" : [
+    "CMSSW_11_1_0_pre7_raw1100_vs_CMSSW_11_1_0_pre7",
+    "CMSSW_11_1_0_pre7_raw1100_vs_CMSSW_11_1_0_pre6_raw1100",
+    "CMSSW_11_1_0_pre7_vs_CMSSW_11_1_0_pre6",
     "CMSSW_11_1_0_pre6_raw1100_vs_CMSSW_11_1_0_pre6",
     "CMSSW_11_1_0_pre6_raw1100_vs_CMSSW_11_1_0_pre5_raw1100",
     "CMSSW_11_1_0_pre6_vs_CMSSW_11_1_0_pre5",
@@ -90,9 +93,9 @@ thereleases = { "CMSSW 11_1_X" : [
     "CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre4"
 ] }
 
-RefRelease='CMSSW_11_1_0_pre6'
+RefRelease='CMSSW_11_1_0_pre7'
 
-NewRelease='CMSSW_11_1_0_pre6'
+NewRelease='CMSSW_11_1_0_pre7'
 
 NotNormalRelease = "raw"
 NotNormalRefRelease = "normal"
@@ -167,7 +170,8 @@ phase2samples_noPU = [
     Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag )
 
 ]
-    
+
+
 #More workflows 
 phase2samples_noPU_extend = [
     Sample("RelValSingleMuPt10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
@@ -177,6 +181,7 @@ phase2samples_noPU_extend = [
 
 #These workflows were added in CMSSW_11_1_0_pre6 but there were missing from CMSSW_11_1_0_pre5.
 #So, I am only download them to be reary for pre7. Then, I comment them out
+#For the moment I cannot find these in pre7. 
 '''
 phase2samples_noPU_extend_more = [
     Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
@@ -276,8 +281,8 @@ if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ ==
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_raw1100-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_2026D49noPU_raw1100_rsb","_raw1100") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_2026D49noPU_raw1100_rsb","_raw1100") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
@@ -367,10 +372,10 @@ if (opt.OBJ == 'hitValidation'):
         if RefRelease == None:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_raw1100-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_2026D49noPU_raw1100_rsb","_raw1100") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_2026D49noPU_raw1100_rsb","_raw1100") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
@@ -673,6 +678,21 @@ if (opt.GATHER != None) :
     index_file.write('</html>\n')
     index_file.close()
 
-    processCmd('cp -r %s %s/.' %(localoutputdir,opt.WWWAREA) )
+    #We choose to zip in uncompressed form all the files for two reasons:
+    #1. Copying to eos so many files is really slow. It is faster to
+    #   create one uncompressed file, copy that and unzip there.
+    #2. Inevitably, we will have to do some cleanup of the older campaigns,
+    #   since we will reach the number of files limit quite easily. 
+    #   It will be easier to have already save the zip file and just delete
+    #   the directory content, leaving inside only the zip file.
+
+    # This will take some time. 
+    processCmd('zip -0 -r %s.zip %s' %(localoutputdir,localoutputdir) )
+    processCmd('cp %s.zip %s/.' %(localoutputdir,opt.WWWAREA) )
+    processCmd('cd %s' %(opt.WWWAREA) )
+    processCmd('unzip %s.zip' %(localoutputdir) )
+    processCmd('mv %s.zip %s/.' %(localoutputdir,localoutputdir) )
+    processCmd('cd -')
+
 
 

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -1,0 +1,639 @@
+#! /usr/bin/env python
+
+#------------------------------------------------------------------------------------------
+# Description: This script is used to produce the results of the regurarly announced RelVal campaings.
+#              Essentially, this is a wrapper around the basic HGCal Validation script:
+#              Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+# Documentation: Full documentation on this script and details on how to run it are in the section 
+#                "Campaign Validation" in the HGCal DPG website:
+#                http://hgcal.web.cern.ch/hgcal/Validation/RelVals/
+#                Information on the CMSSW HGCalValidation package and relevant objects can be 
+#                found in the "Validation" section.  
+#------------------------------------------------------------------------------------------
+
+import sys
+import os
+import commands
+import optparse
+import pandas as pd
+
+from Validation.RecoTrack.plotting.validation import Sample, Validation
+from Validation.HGCalValidation.html import _sampleName,_pageNameMap,_summary,_summobj
+
+#------------------------------------------------------------------------------------------
+#Parsing input options
+def parseOptions():
+
+    usage = ('usage: %prog [options]\n'
+             + '%prog -h for help')
+    parser = optparse.OptionParser(usage)
+
+    parser.add_option('', '--Obj', dest='OBJ',  type='string', default=None, help='Object to run. Options are: Geometry, SimHits, Digis, RecHits, Calibrations, CaloParticles, hgcalLayerClusters')
+    parser.add_option('', '--html-validation-name', dest='HTMLVALNAME', type='string', default='', help='Could be either be hgcalLayerClusters or hgcalMultiClusters')
+    parser.add_option('-d', '--download', action='store_true', dest='DOWNLOAD', default=False, help='Download DQM files from RelVals')
+    parser.add_option('-g', '--gather', dest='GATHER',  type='string', default=None, help='Objects to gather: hitValidation, hitCalibration, hgcalLayerClusters, hgcalMultiClusters, multiClustersFromTrackstersEM, multiClustersFromTrackstersHAD')
+    parser.add_option('-w', '--wwwarea', dest='WWWAREA',  type='string', default='/eos/project/h/hgcaldpg/www', help='Objects to gather: hitValidation, hitCalibration, hgcalLayerClusters, hgcalMultiClusters, multiClustersFromTrackstersEM, multiClustersFromTrackstersHAD')
+    parser.add_option('-y', '--dry-run', action='store_true', dest='DRYRUN', default=False, help='perform a dry run (nothing is lauched).')
+    parser.add_option('-i', '--inputeosarea', dest='INPUT',  type='string', default='/eos/cms/store/group/dpg_hgcal/comm_hgcal/apsallid/RelVals', help='Eos area where we will place all DQM files of the new and reference release campaign')
+
+    # store options and arguments as global variables
+    global opt, args
+    (opt, args) = parser.parse_args()
+
+parseOptions()
+
+#------------------------------------------------------------------------------------------
+#Some helpful functions
+#Processing the external os commands
+def processCmd(cmd, quite = 0):
+    print cmd
+    status, output = commands.getstatusoutput(cmd)
+    if (status !=0 and not quite):
+        print 'Error in processing command:\n   ['+cmd+']'
+        print 'Output:\n   ['+output+'] \n'
+    return output
+
+#PUtype
+def putype(t):
+    if "_pmx" in NewRelease:
+        if "_pmx" in RefRelease:
+            return {"default": "pmx"+t}
+        return {"default": t, NewRelease: "pmx"+t}
+    return t
+
+#------------------------------------------------------------------------------------------
+#Input section: Each time a new RelVal campaign is announced the following variables should 
+#               be updated:
+#               NewRelease: The new release being validated.
+#               RefRelease: The reference release we want to test the new one against.
+#               thereleases: All releases validated for which we have validation results 
+#                            including the NewRelease.
+#               NotNormalRelease , NotNormalRefRelease: If one of the releases to be validated has
+#                            used the DIGI on 11_0_0 put "raw". Otherwise put "normal". 
+#               phase2samples_noPU: These are the noPU phase 2 RelVal samples that are regurarly 
+#                                   produced.   
+#               phase2samples_PU: These are the PU phase 2 RelVal samples that are regurarly 
+#                                 produced.  
+#               RefRepository, NewRepository: The path where the DQM files of the campaign 
+#                                             will be placed.
+#------------------------------------------------------------------------------------------
+#thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
+thereleases = { "CMSSW 11_1_X" : [
+    "CMSSW_11_1_0_pre5_vs_CMSSW_11_1_0_pre4",
+    "CMSSW_11_1_0_pre5_raw1100_vs_CMSSW_11_1_0_pre5",
+    "CMSSW_11_1_0_pre5_raw1100_vs_CMSSW_11_1_0_pre4_raw1100",
+    "CMSSW_11_1_0_pre4_raw1100_vs_CMSSW_11_1_0_pre4",
+    "CMSSW_11_1_0_pre4_raw1100_vs_CMSSW_11_1_0_pre3_raw1100",
+    "CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre4"
+] }
+
+RefRelease='CMSSW_11_1_0_pre4'
+
+NewRelease='CMSSW_11_1_0_pre5'
+
+NotNormalRelease = "normal"
+NotNormalRefRelease = "normal"
+
+if ( os.path.isdir('%s/%s' %(opt.WWWAREA, NewRelease))) : 
+    print("The campaign you are trying to validate has already an existing validation folder in the official www area.")
+    print("Make sure you are not overwriting anything and try again.")
+    exit()
+
+if "raw" in NotNormalRelease: 
+   appendglobaltag = "_raw1100"
+else: 
+   appendglobaltag = "_2026D49noPU"
+
+#Until the final list of RelVals settles down the following sample list is under constant review
+'''
+phase2samples_noPU = [
+#    Sample("RelValCloseByParticleGun_CE_H_Fine_300um", dqmVersion="0002", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByParticleGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByParticleGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByParticleGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByParticleGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByParticleGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByParticleGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByParticleGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByParticleGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValCloseByParticleGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag , version="v2"),
+    Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValZMM", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleMuPt10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleMuPt100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleMuPt1000", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleMuFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleMuFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleTauFlatPt2To150", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValQCD_Pt20toInfMuEnrichPt15", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValQCD_Pt15To7000_Flat", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValZTT", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValZMM", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValZEE", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValB0ToKstarMuMu", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToEleEle", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToMuMu", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToJpsiGamma", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToJpsiPhi_mumuKK", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToPhiPhi_KKKK", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValDisplacedMuPt30To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValDisplacedMuPt2To10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValDisplacedMuPt10To30", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValTauToMuMuMu", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValMinBias", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValNuGun", scenario="2026D49", appendGlobalTag=appendglobaltag )
+    ]
+
+'''
+#Main workflow RelVals
+phase2samples_noPU = [
+
+    Sample("RelValZpTT_1500", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValZTT", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValZMM", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValZEE", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValTenTau_15_500", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
+    Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValQCD_Pt15To7000_Flat", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValNuGun", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValMinBias", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag )
+
+]
+    
+#More workflows 
+phase2samples_noPU_extend = [
+    Sample("RelValSingleMuPt10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleMuPt100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleMuPt1000", scenario="2026D49", appendGlobalTag=appendglobaltag )
+]
+
+phase2samples_noPU.extend(phase2samples_noPU_extend)
+ 
+#For the PU samples 
+phase2samples_PU = [
+    Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", putype=putype("25ns"), punum=200, appendGlobalTag="_2026D49PU200", version="v2"),
+]
+
+# Reference and new repository
+RefRepository = '%s' %(opt.INPUT)
+NewRepository = '%s' %(opt.INPUT)
+
+#------------------------------------------------------------------------------------------
+#Download section: The basic HGCal validation object is created and the DQM files of the 
+#                  DQM files of the RelVals are downloaded. 
+#------------------------------------------------------------------------------------------
+
+#Create basic object for the HGCal validation plots
+val = Validation(
+    fullsimSamples = phase2samples_noPU,
+    fastsimSamples = [],
+    refRelease=RefRelease, refRepository=RefRepository,
+    newRelease=NewRelease, newRepository=NewRepository
+)
+
+#------------------------------------------------------------------------------------------
+#Download the DQM files of the RelVals. 
+if(opt.DOWNLOAD): 
+    val.download()
+
+    #Keep them in eos, save afs space. 
+    if (not os.path.isdir(RefRepository+'/'+NewRelease)) :
+        processCmd('mkdir -p '+RefRepository+'/'+NewRelease)
+
+    for infi in phase2samples_noPU:
+        processCmd('mv ' + infi.filename(NewRelease) + ' ' + RefRepository+'/'+NewRelease)
+
+#------------------------------------------------------------------------------------------
+#Objects processing section: The objects defined in --Obj are analyzed here. 
+#------------------------------------------------------------------------------------------
+
+#This is the hgcalLayerClusters,  multiClustersFromTrackstersEM, multiClustersFromTrackstersHAD, and hitCalibration part
+if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'multiClustersFromTrackstersEM' or opt.OBJ == 'multiClustersFromTrackstersHAD'):
+    fragments = []
+    #Now  that we have them in eos lets produce plots
+    #Let's loop through RelVals
+    for infi in phase2samples_noPU:
+        samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").replace("__DQMIO.root","")
+        #samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").split("__CMSSW_10_6_0_pre4",1)[0]
+        #samplename = samplename + infi.pileup()
+        if infi.pileup() == "PU":
+            samplename = samplename + str(infi.pileupNumber())
+
+        #print( infi.name()  )
+        print(_sampleName[infi.name()])
+        print("="*40)
+        print(samplename)
+        print("="*40)
+
+        inputpathRef = ""
+        if RefRelease != None: inputpathRef = RefRepository +'/' + RefRelease +'/'
+        inputpathNew = NewRepository +'/' + NewRelease+ '/'
+
+        if RefRelease == None:
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
+        elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_raw1100-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+        elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+        elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+        else: 
+            #print inputpathRef, infi.filename(RefRelease).replace("D49","D41")
+            #YOU SHOULD INSPECT EACH TIME THIS COMMAND AND THE REPLACE
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) .replace("v2__", "v1__")
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
+            #print cmd
+
+        if(opt.DRYRUN):
+            print 'Dry-run: ['+cmd+']'
+        else:
+            output = processCmd(cmd)
+            if opt.OBJ == 'hgcalLayerClusters':
+                processCmd('awk \'NR>=6&&NR<=44\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+            if opt.OBJ == 'hitCalibration':
+                processCmd('awk \'NR>=6&&NR<=15\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+            if opt.OBJ == 'multiClustersFromTrackstersEM' or opt.OBJ == 'multiClustersFromTrackstersHAD':
+                processCmd('awk \'NR>=6&&NR<=25\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+
+    
+        fragments.append( 'HGCValid_%s_Plots/index_%s.html'% (opt.HTMLVALNAME, samplename) )
+            
+    
+    #Let's also create the final index xml file. 
+    processCmd('mv HGCValid_%s_Plots/index.html HGCValid_%s_Plots/test.html' %(opt.HTMLVALNAME,opt.HTMLVALNAME) )
+    index_file = open('HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME),'w')            
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <head>\n')
+    index_file.write('  <title>HGCal validation %s </title>\n' %(opt.HTMLVALNAME) )
+    index_file.write(' </head>\n')
+    index_file.write(' <body>\n')
+                   
+    for frag in fragments:   
+        with open(frag,'r') as f:
+            lines = f.read().splitlines()
+            for line in lines:
+                print line
+                index_file.write(line + '\n')
+                #processCmd( 'cat ' + frag + ' >> HGCalValidationPlots/index.html '   )
+                #index_file.write(frag)
+
+        
+    #Writing postamble"
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+    
+#------------------------------------------------------------------------------------------
+#This is the SimHits part
+if (opt.OBJ == 'SimHits'):
+    #This is where we will save the final output pngs: 
+    if (not os.path.isdir("hgcalSimHitStudy")) :
+        processCmd('mkdir -p hgcalSimHitStudy')
+    #Prepare for www
+    processCmd('cp %s/../public/index.php hgcalSimHitStudy/.'%(opt.WWWAREA) )
+
+    #The input to this is for the moment 100 GeV muon from runnin cmsRun runHGCalSimHitStudy_cfg.py 
+    #Input: hgcSimHits.root
+    cmd = 'root.exe -b -q Validation/HGCalValidation/macros/validationplots.C\(\\"hgcSimHit.root' +  '\\",\\"'+ opt.OBJ + '\\"\)'
+    if(opt.DRYRUN):
+        print 'Dry-run: ['+cmd+']'
+    else:
+        output = processCmd(cmd)
+
+#------------------------------------------------------------------------------------------
+if (opt.OBJ == 'hitValidation'):
+    fragments = []
+    #Now  that we have them in eos lets produce plots
+    #Let's loop through RelVals
+    for infi in phase2samples_noPU:
+        samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").replace("__DQMIO.root","")
+        #samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").split("__CMSSW_10_6_0_pre4",1)[0]
+        #samplename = samplename + infi.pileup()
+        if infi.pileup() == "PU":
+            samplename = samplename + str(infi.pileupNumber())
+
+        print("="*40)
+        print(samplename)
+        print("="*40)
+
+        inputpathRef = ""
+        if RefRelease != None: inputpathRef = RefRepository +'/' + RefRelease +'/'
+        inputpathNew = NewRepository +'/' + NewRelease+ '/'
+
+        if RefRelease == None:
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
+        elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_raw1100-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+        elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+        elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+        else: 
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+ 
+
+        if(opt.DRYRUN):
+            print 'Dry-run: ['+cmd+']'
+        else:
+            output = processCmd(cmd)
+            processCmd('awk \'NR>=6&&NR<=28\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+    
+        fragments.append( 'HGCValid_%s_Plots/index_%s.html'% (opt.HTMLVALNAME, samplename) )
+            
+    
+    #Let's also create the final index xml file. 
+    processCmd('mv HGCValid_%s_Plots/index.html HGCValid_%s_Plots/test.html' %(opt.HTMLVALNAME,opt.HTMLVALNAME) )
+    index_file = open('HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME),'w')            
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <head>\n')
+    index_file.write('  <title>HGCal validation %s </title>\n' %(opt.HTMLVALNAME) )
+    index_file.write(' </head>\n')
+    index_file.write(' <body>\n')
+                   
+    for frag in fragments:   
+        with open(frag,'r') as f:
+            lines = f.read().splitlines()
+            for line in lines:
+                print line
+                index_file.write(line + '\n')
+                #processCmd( 'cat ' + frag + ' >> HGCalValidationPlots/index.html '   )
+                #index_file.write(frag)
+
+        
+    #Writing postamble"
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+
+#-------------------------------------------------------------------------------------------
+#This is the Digis part
+if (opt.OBJ == 'Digis'):
+    #This is where we will save the final output pngs: 
+    if (not os.path.isdir("hgcalDigiStudy")) :
+        processCmd('mkdir -p hgcalDigiStudy')
+        processCmd('mkdir -p hgcalDigiStudyEE')
+        processCmd('mkdir -p hgcalDigiStudyHEF')
+        processCmd('mkdir -p hgcalDigiStudyHEB')
+    #Prepare for www
+    processCmd('cp %s/../public/index.php hgcalDigiStudy/.'%(opt.WWWAREA) )
+    processCmd('cp %s/../public/index.php hgcalDigiStudyEE/.'%(opt.WWWAREA) )
+    processCmd('cp %s/../public/index.php hgcalDigiStudyHEF/.'%(opt.WWWAREA) )
+    processCmd('cp %s/../public/index.php hgcalDigiStudyHEB/.'%(opt.WWWAREA) )
+    #The input here is from running cmsRun runHGCalDigiStudy_cfg.py, to which 
+    #we usually give ttbar noPU as input 
+    #Input: hgcDigi.root
+    cmd = 'root.exe -b -q Validation/HGCalValidation/macros/validationplots.C\(\\"hgcDigi.root' +  '\\",\\"'+ opt.OBJ + '\\"\)'
+    if(opt.DRYRUN):
+        print 'Dry-run: ['+cmd+']'
+    else:
+        output = processCmd(cmd)
+        #mv the output under the main directory
+        processCmd('mv hgcalDigiStudyEE hgcalDigiStudy/.')
+        processCmd('mv hgcalDigiStudyHEF hgcalDigiStudy/.')
+        processCmd('mv hgcalDigiStudyHEB hgcalDigiStudy/.')
+
+#-------------------------------------------------------------------------------------------
+#This is the RecHits part
+if (opt.OBJ == 'RecHits'):
+    #This is where we will save the final output pngs: 
+    if (not os.path.isdir("hgcalRecHitStudy")) :
+        processCmd('mkdir -p hgcalRecHitStudy')
+        processCmd('mkdir -p hgcalRecHitStudyEE')
+        processCmd('mkdir -p hgcalRecHitStudyHEF')
+        processCmd('mkdir -p hgcalRecHitStudyHEB')
+    #Prepare for www
+    processCmd('cp %s/../public/index.php hgcalRecHitStudy/.'%(opt.WWWAREA) )
+    processCmd('cp %s/../public/index.php hgcalRecHitStudyEE/.'%(opt.WWWAREA) )
+    processCmd('cp %s/../public/index.php hgcalRecHitStudyHEF/.'%(opt.WWWAREA) )
+    processCmd('cp %s/../public/index.php hgcalRecHitStudyHEB/.'%(opt.WWWAREA) )
+    #The input here is from running cmsRun runHGCalRecHitStudy_cfg.py, to which 
+    #we usually give ttbar noPU as input 
+    #Input: hgcRecHit.root
+    cmd = 'root.exe -b -q Validation/HGCalValidation/macros/validationplots.C\(\\"hgcRecHit.root' +  '\\",\\"'+ opt.OBJ + '\\"\)'
+    if(opt.DRYRUN):
+        print 'Dry-run: ['+cmd+']'
+    else:
+        output = processCmd(cmd)
+        #mv the output under the main directory
+        processCmd('mv hgcalRecHitStudyEE hgcalRecHitStudy/.')
+        processCmd('mv hgcalRecHitStudyHEF hgcalRecHitStudy/.')
+        processCmd('mv hgcalRecHitStudyHEB hgcalRecHitStudy/.')
+
+#-------------------------------------------------------------------------------------------
+## TODO #This is the CaloParticles part
+if (opt.OBJ == 'CaloParticles'):
+    particletypes = ["-11","-13","-211","-321","11","111","13","211","22","321"]
+    #This is where we will save the final output pngs: 
+    if (not os.path.isdir("CaloParticles")) :
+        processCmd('mkdir -p CaloParticles')
+    #Prepare for www
+    processCmd('cp %s/../public/index.php CaloParticles/.'%(opt.WWWAREA) )
+
+    #Let's loop through RelVals
+    for infi in phase2samples_noPU:
+        #samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").replace("__DQMIO.root","")
+        samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").split("__"+NewRelease,1)[0]
+        samplename = samplename + infi.pileup()
+        if infi.pileup() == "PU":
+            samplename = samplename + str(infi.pileupNumber())
+
+        print("="*40)
+        print(samplename)
+        print("="*40)
+        if (not os.path.isdir(samplename)) :
+            processCmd('mkdir -p ' + samplename )
+            processCmd('cp %s/RelVals/index.php '%(opt.WWWAREA) + samplename + '/.')
+            for part in particletypes: 
+                processCmd('mkdir -p ' + samplename + '/' +part )
+                #Prepare for www
+                processCmd('cp %s/RelVals/index.php '%(opt.WWWAREA) + samplename + '/' +part + '/.')
+
+        inputpathRef = ""
+        if RefRelease != None: inputpathRef = RefRepository +'/' + RefRelease +'/'
+        inputpathNew = NewRepository +'/' + NewRelease+ '/'
+        cmd = 'root.exe -b -q Validation/HGCalValidation/macros/validationplots.C\(\\"'+ inputpathNew + infi.filename(NewRelease) +  '\\",\\"'+ opt.OBJ + '\\",\\"'+ samplename + '\\"\\)'
+        if(opt.DRYRUN):
+            print 'Dry-run: ['+cmd+']'
+        else:
+            output = processCmd(cmd)
+            processCmd('mv ' +samplename+ ' CaloParticles/.' )
+
+#------------------------------------------------------------------------------------------
+#Summary section: After processing all the objects the results are gathered, webpages are 
+#                 created and a summary page is added. 
+#-------------------------------------------------------------------------------------------
+#Here we will gather all results. 
+if (opt.GATHER != None) :
+
+    #First we need the top folder to contain all validation releases. 
+    index_file = open('index.html','w')            
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <head>\n')
+    index_file.write('  <title>HGCAL validation results </title>\n'  )
+    index_file.write(' </head>\n')
+    index_file.write(' <body>\n')
+    index_file.write(' <h1>\n')
+    index_file.write(' HGCAL Validation Results \n'  )
+    index_file.write(' </h1>\n')
+    index_file.write('  <ul>\n' )
+
+    for trel in thereleases.keys():
+        index_file.write('   <li>\n' )
+        index_file.write('   %s\n' %(trel) )
+        for rel in thereleases[trel]: 
+            index_file.write('  <ul>\n' )
+            index_file.write('   <li><a href="%s/index.html">%s</a></li>\n' %(rel, rel ) )
+            index_file.write('  </ul>\n' )
+        index_file.write('   </li>\n' )
+        index_file.write('  <br>\n' )
+        index_file.write('  <br>\n' )
+        index_file.write('  <br>\n' )
+       
+    #Writing postamble"
+    index_file.write('  </ul>\n' )
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+
+    processCmd('cp index.html %s/.' %(opt.WWWAREA) )
+ 
+    #Let's make also the summary folder
+    if (not os.path.isdir("HGCValid_summary_Plots")):  
+        processCmd('mkdir -p HGCValid_summary_Plots')	
+
+    #To avoid the nans transpose later                          
+    df = pd.DataFrame.from_dict(_summary, orient = 'index').transpose()
+    #Make a specific order in columns
+    df = df[_summobj]
+
+    index_file = open('HGCValid_summary_Plots/index.html','w')
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <body>\n')
+
+    #Let's loop through RelVals
+    for infi in phase2samples_noPU:
+        samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").replace("__DQMIO.root","")
+        index_file.write( '<h2> %s </h2> \n' %(_sampleName[infi.name()]) )
+        #table here with summary objects
+        index_file.write('<table> \n')
+        index_file.write('  <tr>\n')
+        #This is the row with the headers. So, the objects for us.
+        for obj in _summobj:
+            index_file.write('    <th>%s</th>\n' %(_pageNameMap[obj]) )
+        index_file.write('  </tr>\n')
+
+        for i, row in df.iterrows():
+            index_file.write('  <tr>\n')
+            for j, column in row.iteritems():
+                print(column)  
+                index_file.write('    <td>\n')
+                index_file.write('    <ul>\n')
+
+#                if df[obj][ind] == None: 
+                if column == None:  
+                   index_file.write('    </ul>\n')
+                   index_file.write('    </td>\n')
+                   continue
+                   #index_file.write(' \n')
+                else:
+                   #print(df[obj][ind])          
+                   print(j)
+                   #index_file.write(' <li><a href="plots_%s_%s">%s</a></li>   \n' %(samplename, df[obj][ind], df[obj][ind].partition("/")[2] ))
+                   index_file.write(' <li><a href="../HGCValid_%s_Plots/plots_%s_%s">%s</a></li>   \n' %(j, samplename, column, column.partition("/")[2] ))
+
+                index_file.write('    </ul>\n')                        
+                index_file.write('    </td>\n')
+
+            index_file.write('  </tr>\n')
+
+        index_file.write(' </table>\n')
+        index_file.write('  <br/>\n' )
+        index_file.write('  <br/>\n' )
+        index_file.write('  <br/>\n' )
+                          
+        #Writing postamble"
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+
+    objects = opt.GATHER.split(",")
+   
+    localoutputdir = ""
+    if "raw" in NotNormalRelease and "raw" in NotNormalRefRelease: 
+       localoutputdir = NewRelease + "_raw1100" + "_vs_" + RefRelease + "_raw1100"
+    elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease: 
+       localoutputdir = NewRelease + "_raw1100" + "_vs_" + RefRelease
+    elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease: 
+       localoutputdir = NewRelease + "_vs_" + RefRelease
+    else: 
+       localoutputdir = NewRelease
+ 
+    #make the structure to hold the objects
+    for obj in objects:
+        #This is where we will save the final output per campaing: 
+        if (not os.path.isdir('%s/standalone' %(localoutputdir))) :
+            processCmd('mkdir -p %s/standalone' %(localoutputdir))
+        if (obj!="standalone"): processCmd('mv HGCValid_%s_Plots %s'%(obj, localoutputdir) )
+	else : 
+	    processCmd('mv hgcalSimHitStudy %s/standalone/.'%(localoutputdir) )
+	    processCmd('mv hgcalDigiStudy %s/standalone/.'%(localoutputdir) )
+            processCmd('mv hgcalRecHitStudy %s/standalone/.'%(localoutputdir) )
+            processCmd('cp %s/../public/index.php %s/standalone/.'%(opt.WWWAREA, localoutputdir) )
+
+    '''
+    #Let's also copy to the summary folder what we need. 
+    for infi in phase2samples_noPU:
+        samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").replace("__DQMIO.root","")
+        for obj in _summobj:
+            #print obj 
+            #if obj == "hitValidation" : samplename = samplename + infi.pileup()
+            #else : samplename = infi.filename(NewRelease).replace("DQM_V0001_R000000001__","").replace("__DQMIO.root","")
+            for ind in df.index:
+                if df[obj][ind] == None: continue
+                else: processCmd('cp -r %s/HGCValid_%s_Plots/plots_%s_%s %s/HGCValid_summary_Plots ' %(NewRelease, obj, samplename, df[obj][ind].partition("/")[0], NewRelease ) )
+    '''
+
+    index_file = open('%s/index.html'%(localoutputdir),'w')            
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <head>\n')
+    index_file.write('  <title> <h2> HGCal validation results for %s </h2> </title>\n' %(localoutputdir) )
+    index_file.write(' </head>\n')
+    index_file.write(' <body>\n')
+    index_file.write(' HGCal validation results for %s \n' %(localoutputdir) )
+
+    for obj in objects:
+        print(obj)
+        if (obj!="standalone"):
+             index_file.write('  <br/>\n' )
+             index_file.write('  <ul>\n' )
+             index_file.write('   <li><a href="HGCValid_%s_Plots/index.html">%s</a></li>\n' %(obj, _pageNameMap[obj] ) )
+             index_file.write('  </ul>\n' )
+             index_file.write('  <br/>\n' )
+        else : 
+             index_file.write('  <br/>\n' )
+             index_file.write('  <ul>\n' )
+             index_file.write('   <li><a href="%s/index.php">%s</a></li>\n' %(obj, _pageNameMap[obj] ) )
+             index_file.write('  </ul>\n' )
+             index_file.write('  <br/>\n' )
+
+
+    #Writing postamble
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+
+    processCmd('cp -r %s %s/.' %(localoutputdir,opt.WWWAREA) )
+
+

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -79,6 +79,7 @@ def putype(t):
 #------------------------------------------------------------------------------------------
 #thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
 thereleases = { "CMSSW 11_1_X" : [
+    "CMSSW_11_1_0_pre6_vs_CMSSW_11_1_0_pre5",
     "CMSSW_11_1_0_pre5_vs_CMSSW_11_1_0_pre4",
     "CMSSW_11_1_0_pre5_raw1100_vs_CMSSW_11_1_0_pre5",
     "CMSSW_11_1_0_pre5_raw1100_vs_CMSSW_11_1_0_pre4_raw1100",
@@ -87,9 +88,9 @@ thereleases = { "CMSSW 11_1_X" : [
     "CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre4"
 ] }
 
-RefRelease='CMSSW_11_1_0_pre4'
+RefRelease='CMSSW_11_1_0_pre5'
 
-NewRelease='CMSSW_11_1_0_pre5'
+NewRelease='CMSSW_11_1_0_pre6'
 
 NotNormalRelease = "normal"
 NotNormalRefRelease = "normal"
@@ -149,18 +150,19 @@ phase2samples_noPU = [
     ]
 
 '''
+
 #Main workflow RelVals
 phase2samples_noPU = [
 
-    Sample("RelValZpTT_1500", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValZpTT_1500", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValZTT", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValZMM", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValZEE", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValTenTau_15_500", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
     Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValQCD_Pt15To7000_Flat", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValQCD_Pt15To7000_Flat", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValNuGun", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValMinBias", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValMinBias", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag )
 
 ]
@@ -172,8 +174,40 @@ phase2samples_noPU_extend = [
     Sample("RelValSingleMuPt1000", scenario="2026D49", appendGlobalTag=appendglobaltag )
 ]
 
+#These workflows were added in CMSSW_11_1_0_pre6 but there were missing from CMSSW_11_1_0_pre5.
+#So, I am only download them to be reary for pre7. Then, I comment them out
+'''
+phase2samples_noPU_extend_more = [
+    Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValQCD_Pt20toInfMuEnrichPt15", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValDisplacedMuPt30To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValDisplacedMuPt2To10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValDisplacedMuPt10To30", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValB0ToKstarMuMu", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToEleEle", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToMuMu", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToJpsiGamma", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToJpsiPhi_mumuKK", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValBsToPhiPhi_KKKK", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValTauToMuMuMu", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleTauFlatPt2To150", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleMuFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag )
+
+]
+'''
 phase2samples_noPU.extend(phase2samples_noPU_extend)
- 
+#phase2samples_noPU.extend(phase2samples_noPU_extend_more)
+
 #For the PU samples 
 phase2samples_PU = [
     Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", putype=putype("25ns"), punum=200, appendGlobalTag="_2026D49PU200", version="v2"),


### PR DESCRIPTION
#### PR description:

This PR contains code we (@rovere, @felicepantaleo, @lecriste) developed and tested in order to create the validation reports for the regular RelVal campaigns. 

The workflow for a validation report is fully documented in [1], where the code is also described in more detail. 

You will spot some commented code in the RelVal sample list as well as in a few commands, which we would like to keep. The RelVal list is under constant review (e.g CloseByParticleGun samples are really helpful but not unfortunately in pre7 or after pre4 and only produced in pre6), while certain strings in the "raw" campaigns are slightly changing each time and some tweaks are necessary. 

This work is based on and inspired from the Tracker validation work. 

These scripts can also be used for a custom validation of certain new features and compared with the RelVal samples of the latest pre-release. 

Also, after the introduction of TICL, we update the `hgcalPlots.py` with the correct path where the plots of the relevant objects lives in the DQM files. 

#### PR validation:

The code in this PR has been used for the validation reports in campaigns from 11_1_0_pre4_phase2 until this week pre7 campaigns and all results are placed in a dedicated webpage [2].

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

[1] http://hgcal.web.cern.ch/hgcal/Validation/RelVals/

[2] http://cms-hgcal-validation.web.cern.ch/cms-hgcal-validation/
