### PR TITLE
drop type specs in RecoLocalCalo/{CaloTowersCreator,Configuration,EcalRecProducers}

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -152,26 +152,26 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 run2_HE_2018.toModify(calotowermaker, 
-                      HcalPhase = cms.int32(1),
-                      HESThreshold1 = cms.double(0.1),
-                      HESThreshold  = cms.double(0.2),
-                      HEDThreshold1 = cms.double(0.1),
-                      HEDThreshold  = cms.double(0.2)
+                      HcalPhase = 1,
+                      HESThreshold1 = 0.1,
+                      HESThreshold  = 0.2,
+                      HEDThreshold1 = 0.1,
+                      HEDThreshold  = 0.2
 )
 
 # needed to handle inner/outer assignment
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
 run2_HECollapse_2018.toModify(calotowermaker,
-    HcalPhase = cms.int32(0),
-    HESThreshold1 = cms.double(0.8),
-    HESThreshold  = cms.double(0.8),
-    HEDThreshold1 = cms.double(0.8),
-    HEDThreshold  = cms.double(0.8)
+    HcalPhase = 0,
+    HESThreshold1 = 0.8,
+    HESThreshold  = 0.8,
+    HEDThreshold1 = 0.8,
+    HEDThreshold  = 0.8
 )
 
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify(calotowermaker,
-    HBThreshold1 = cms.double(0.1),
-    HBThreshold2 = cms.double(0.2),
-    HBThreshold = cms.double(0.3),
+    HBThreshold1 = 0.1,
+    HBThreshold2 = 0.2,
+    HBThreshold = 0.3,
 )

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -20,18 +20,18 @@ from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
 
 def hbheCosmic(module):
     return module.clone(
-        tsFromDB = cms.bool(False),
-        recoParamsFromDB = cms.bool(False),
+        tsFromDB = False,
+        recoParamsFromDB = False,
         algorithm = dict(
-            useMahi = cms.bool(False),
-            useM2 = cms.bool(False),
-            useM3 = cms.bool(False),
-            firstSampleShift = cms.int32(-1000),
-            samplesToAdd = cms.int32(10),
-            correctForPhaseContainment = cms.bool(False),
+            useMahi = False,
+            useM2 = False,
+            useM3 = False,
+            firstSampleShift = -1000,
+            samplesToAdd = 10,
+            correctForPhaseContainment = False,
         ),
-        sipmQTSShift = cms.int32(-100),
-        sipmQNTStoSum = cms.int32(200),
+        sipmQTSShift = -100,
+        sipmQNTStoSum = 200,
     )
 
 hbhereco = hbheCosmic(_hcalLocalReco_cff.hbheprereco)
@@ -41,7 +41,7 @@ hfreco = _hcalLocalReco_cff._default_hfreco.clone(
     correctForTimeslew = False,
     correctForPhaseContainment = False,
     tsFromDB = False,
-    recoParamsFromDB = cms.bool(False),
+    recoParamsFromDB = False,
     digiTimeFromDB = False,
 )
 horeco = _hcalLocalReco_cff.horeco.clone(
@@ -50,7 +50,7 @@ horeco = _hcalLocalReco_cff.horeco.clone(
     correctForTimeslew = False,
     correctForPhaseContainment = False,
     tsFromDB = False,
-    recoParamsFromDB = cms.bool(False),
+    recoParamsFromDB = False,
 )
 zdcreco = _hcalLocalReco_cff.zdcreco.clone(
 #    firstSample = 1,
@@ -65,8 +65,8 @@ from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 
 _phase1_hfreco = _hcalLocalReco_cff._phase1_hfreco.clone(
     algorithm = dict(
-        Class = cms.string("HFSimpleTimeCheck"),
-        rejectAllFailures = cms.bool(False),
+        Class = "HFSimpleTimeCheck",
+        rejectAllFailures = False,
     )
 )
 
@@ -74,7 +74,7 @@ _phase1_hfreco = _hcalLocalReco_cff._phase1_hfreco.clone(
 run2_HF_2017.toReplaceWith(hfreco, _phase1_hfreco )
 
 hfprereco = _hcalLocalReco_cff.hfprereco.clone(
-    sumAllTimeSlices = cms.bool(True)
+    sumAllTimeSlices = True
 )
 
 from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1

--- a/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
@@ -2,32 +2,34 @@ import FWCore.ParameterSet.Config as cms
 
 import RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi
 hbherecoMB = RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi.hbheprereco.clone(
-    dropZSmarkedPassed = cms.bool(False),
+    dropZSmarkedPassed = False,
     algorithm = dict(
-        useMahi = cms.bool(False),
-        useM2 = cms.bool(False),
-        useM3 = cms.bool(False)
+        useMahi = False,
+        useM2 = False,
+        useM3 = False
     ),
-    processQIE11 = cms.bool(False),
-    setNegativeFlagsQIE8 = cms.bool(False),
-    setNegativeFlagsQIE11 = cms.bool(False),
-    setNoiseFlagsQIE8 = cms.bool(True),
-    setNoiseFlagsQIE11 = cms.bool(False),
-    setPulseShapeFlagsQIE8 = cms.bool(False),
-    setPulseShapeFlagsQIE11 = cms.bool(False),
-    setLegacyFlagsQIE8 = cms.bool(False),
-    setLegacyFlagsQIE11 = cms.bool(False),
+    processQIE11 = False,
+    setNegativeFlagsQIE8 = False,
+    setNegativeFlagsQIE11 = False,
+    setNoiseFlagsQIE8 = True,
+    setNoiseFlagsQIE11 = False,
+    setPulseShapeFlagsQIE8 = False,
+    setPulseShapeFlagsQIE11 = False,
+    setLegacyFlagsQIE8 = False,
+    setLegacyFlagsQIE11 = False,
 )
 
 import RecoLocalCalo.HcalRecProducers.hfsimplereco_cfi
-hfrecoMB = RecoLocalCalo.HcalRecProducers.hfsimplereco_cfi.hfsimplereco.clone()
+hfrecoMB = RecoLocalCalo.HcalRecProducers.hfsimplereco_cfi.hfsimplereco.clone(
+    # switch off "Hcal ZS in reco":
+    dropZSmarkedPassed = False
+)
 
 import RecoLocalCalo.HcalRecProducers.hosimplereco_cfi
-horecoMB = RecoLocalCalo.HcalRecProducers.hosimplereco_cfi.hosimplereco.clone()
-
-# switch off "Hcal ZS in reco":
-hfrecoMB.dropZSmarkedPassed = cms.bool(False)
-horecoMB.dropZSmarkedPassed = cms.bool(False)
+horecoMB = RecoLocalCalo.HcalRecProducers.hosimplereco_cfi.hosimplereco.clone(
+    # switch off "Hcal ZS in reco":
+    dropZSmarkedPassed = False
+)
 
 hcalLocalRecoTaskNZS = cms.Task(hbherecoMB,hfrecoMB,horecoMB) 
 hcalLocalRecoSequenceNZS = cms.Sequence(hcalLocalRecoTaskNZS) 
@@ -36,19 +38,19 @@ import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 import RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi
 
 hfprerecoMB = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    dropZSmarkedPassed = cms.bool(False)
+    dropZSmarkedPassed = False
 )
 _phase1_hfrecoMB = RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi.hfreco.clone(
-    inputLabel = cms.InputTag("hfprerecoMB"),
-    setNoiseFlags = cms.bool(False),
+    inputLabel = "hfprerecoMB",
+    setNoiseFlags = False,
     algorithm = dict(
-        Class = cms.string("HFSimpleTimeCheck"),
-        rejectAllFailures = cms.bool(False)
+        Class = "HFSimpleTimeCheck",
+        rejectAllFailures = False
     ),
 )
 import RecoLocalCalo.HcalRecProducers.hbheplan1_cfi
 hbheplan1MB = RecoLocalCalo.HcalRecProducers.hbheplan1_cfi.hbheplan1.clone(
-    hbheInput = cms.InputTag("hbheprerecoMB")
+    hbheInput = "hbheprerecoMB"
 )
 
 _phase1_hcalLocalRecoTaskNZS = hcalLocalRecoTaskNZS.copy()
@@ -60,7 +62,7 @@ run2_HF_2017.toReplaceWith( hfrecoMB, _phase1_hfrecoMB )
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( hbherecoMB,
-    processQIE11 = cms.bool(True),
+    processQIE11 = True,
 # temporarily disabled until RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py:flagParametersQIE11 is filled
 #    setNoiseFlagsQIE11 = cms.bool(True),
 )

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -5,10 +5,10 @@ hcalOOTPileupESProducer = cms.ESProducer('OOTPileupDBCompatibilityESProducer')
 
 from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco as _phase1_hbheprereco
 hbheprereco = _phase1_hbheprereco.clone(
-    processQIE11 = cms.bool(False),
-    tsFromDB = cms.bool(True),
+    processQIE11 = False,
+    tsFromDB = True,
     pulseShapeParametersQIE8 = dict(
-        TrianglePeakTS = cms.uint32(4),
+        TrianglePeakTS = 4,
     )
 )
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalLocalCustom.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalLocalCustom.py
@@ -2,16 +2,16 @@
 import FWCore.ParameterSet.Config as cms
 
 def configureEcalLocal25ns(process):
-    process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4),
+    process.ecalMultiFitUncalibRecHit.activeBXs = [-5,-4,-3,-2,-1,0,1,2,3,4],
     process.ecalMultiFitUncalibRecHit.useLumiInfoRunHeader = False
     return process
 
 def configureEcalLocal50ns(process):
-    process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(-4,-2,0,2,4)
+    process.ecalMultiFitUncalibRecHit.activeBXs = [-4,-2,0,2,4]
     process.ecalMultiFitUncalibRecHit.useLumiInfoRunHeader = False
     return process
   
 def configureEcalLocalNoOOTPU(process):
-    process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(0)
+    process.ecalMultiFitUncalibRecHit.activeBXs = [0]
     process.ecalMultiFitUncalibRecHit.useLumiInfoRunHeader = False
     return process


### PR DESCRIPTION
Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter,
it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.

Additionally, in a few places this also moves parameter modifications in the ```clone``` method calls to the argument list instead of a separate line.

This PR is an example for the planned migration/update task.