### PR TITLE
[11.1.X]  Fix several bugs introduced in the Pixel PI

### DIFF
--- a/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
+++ b/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
@@ -28,7 +28,7 @@ public:
   ~Phase1PixelMaps() {}
 
   //============================================================================
-  void bookBarrelHistograms(const std::string& currentHistoName, const char* what) {
+  void bookBarrelHistograms(const std::string& currentHistoName, const char* what, const char* zaxis) {
     std::string histName;
     std::shared_ptr<TH2Poly> th2p;
 
@@ -46,8 +46,8 @@ public:
 
       th2p->GetXaxis()->SetTitle("z [cm]");
       th2p->GetYaxis()->SetTitle("ladder");
-      //th2p->GetXaxis()->SetTitleOffset(0.09);
-      //th2p->GetYaxis()->SetTitleOffset(0.09);
+      th2p->GetZaxis()->SetTitle(zaxis);
+      th2p->GetZaxis()->CenterTitle();
       th2p->SetStats(false);
       th2p->SetOption(m_option);
       pxbTh2PolyBarrel[currentHistoName].push_back(th2p);
@@ -64,7 +64,7 @@ public:
   }
 
   //============================================================================
-  void bookForwardHistograms(const std::string& currentHistoName, const char* what) {
+  void bookForwardHistograms(const std::string& currentHistoName, const char* what,const char* zaxis) {
     std::string histName;
     std::shared_ptr<TH2Poly> th2p;
 
@@ -81,8 +81,8 @@ public:
         th2p->SetFloat();
         th2p->GetXaxis()->SetTitle("x [cm]");
         th2p->GetYaxis()->SetTitle("y [cm]");
-        //th2p->GetXaxis()->SetTitleOffset(0.09);
-        //th2p->GetYaxis()->SetTitleOffset(0.09);
+        th2p->GetZaxis()->SetTitle(zaxis);
+        th2p->GetZaxis()->CenterTitle();
         th2p->SetStats(false);
         th2p->SetOption(m_option);
         pxfTh2PolyForward[currentHistoName].push_back(th2p);
@@ -208,6 +208,8 @@ public:
         SiPixelPI::makeNicePlotStyle(plot.get());
         plot->GetXaxis()->SetTitleOffset(0.9);
         plot->GetYaxis()->SetTitleOffset(0.9);
+        plot->GetZaxis()->SetTitleOffset(1.2);
+        plot->GetZaxis()->SetTitleSize(0.05);
       }
     }
 
@@ -216,7 +218,53 @@ public:
         SiPixelPI::makeNicePlotStyle(plot.get());
         plot->GetXaxis()->SetTitleOffset(0.9);
         plot->GetYaxis()->SetTitleOffset(0.9);
+        plot->GetZaxis()->SetTitleOffset(1.2);
+        plot->GetZaxis()->SetTitleSize(0.05);
       }
+    }
+  }
+
+  //============================================================================
+  void rescaleAllBarrel(const std::string& currentHistoName){
+
+    std::vector<float> maxima;
+    std::transform( pxbTh2PolyBarrel[currentHistoName].begin(), 
+		    pxbTh2PolyBarrel[currentHistoName].end(),
+		    std::back_inserter(maxima),
+		    [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMaximum(); });
+    std::vector<float> minima;
+    std::transform( pxbTh2PolyBarrel[currentHistoName].begin(), 
+		    pxbTh2PolyBarrel[currentHistoName].end(),
+		    std::back_inserter(minima),
+		    [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMinimum(); });    
+
+    auto globalMax = *std::max_element(maxima.begin(), maxima.end());
+    auto globalMin = *std::min_element(minima.begin(), minima.end()) ;
+
+    for(auto& histo : pxbTh2PolyBarrel[currentHistoName]){
+      histo->GetZaxis()->SetRangeUser(globalMin,globalMax);
+    }
+  }
+
+  //============================================================================
+  void rescaleAllForward(const std::string& currentHistoName){
+
+    std::vector<float> maxima;
+    std::transform( pxfTh2PolyForward[currentHistoName].begin(), 
+		    pxfTh2PolyForward[currentHistoName].end(),
+		    std::back_inserter(maxima),
+		    [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMaximum(); });
+    std::vector<float> minima;
+    std::transform( pxfTh2PolyForward[currentHistoName].begin(), 
+		    pxfTh2PolyForward[currentHistoName].end(),
+		    std::back_inserter(minima),
+		    [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMinimum(); });    
+
+    auto globalMax = *std::max_element(maxima.begin(), maxima.end());
+    auto globalMin = *std::min_element(minima.begin(), minima.end()) ;
+
+    for(auto& histo : pxfTh2PolyForward[currentHistoName]){
+      histo->GetZaxis()->SetRangeUser(globalMin,globalMax);
     }
   }
 
@@ -229,7 +277,8 @@ public:
         canvas.cd(i)->SetRightMargin(0.02);
         pxbTh2PolyBarrel[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
       } else {
-        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.14);
+	rescaleAllBarrel(currentHistoName);
+        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.18);
       }
       pxbTh2PolyBarrel[currentHistoName].at(i - 1)->Draw();
     }
@@ -244,7 +293,8 @@ public:
         canvas.cd(i)->SetRightMargin(0.02);
         pxfTh2PolyForward[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
       } else {
-        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.16);
+	rescaleAllForward(currentHistoName);
+        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.18);
       }
       pxfTh2PolyForward[currentHistoName].at(i - 1)->Draw();
     }

--- a/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
+++ b/CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h
@@ -64,7 +64,7 @@ public:
   }
 
   //============================================================================
-  void bookForwardHistograms(const std::string& currentHistoName, const char* what,const char* zaxis) {
+  void bookForwardHistograms(const std::string& currentHistoName, const char* what, const char* zaxis) {
     std::string histName;
     std::shared_ptr<TH2Poly> th2p;
 
@@ -225,46 +225,44 @@ public:
   }
 
   //============================================================================
-  void rescaleAllBarrel(const std::string& currentHistoName){
-
+  void rescaleAllBarrel(const std::string& currentHistoName) {
     std::vector<float> maxima;
-    std::transform( pxbTh2PolyBarrel[currentHistoName].begin(), 
-		    pxbTh2PolyBarrel[currentHistoName].end(),
-		    std::back_inserter(maxima),
-		    [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMaximum(); });
+    std::transform(pxbTh2PolyBarrel[currentHistoName].begin(),
+                   pxbTh2PolyBarrel[currentHistoName].end(),
+                   std::back_inserter(maxima),
+                   [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMaximum(); });
     std::vector<float> minima;
-    std::transform( pxbTh2PolyBarrel[currentHistoName].begin(), 
-		    pxbTh2PolyBarrel[currentHistoName].end(),
-		    std::back_inserter(minima),
-		    [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMinimum(); });    
+    std::transform(pxbTh2PolyBarrel[currentHistoName].begin(),
+                   pxbTh2PolyBarrel[currentHistoName].end(),
+                   std::back_inserter(minima),
+                   [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMinimum(); });
 
     auto globalMax = *std::max_element(maxima.begin(), maxima.end());
-    auto globalMin = *std::min_element(minima.begin(), minima.end()) ;
+    auto globalMin = *std::min_element(minima.begin(), minima.end());
 
-    for(auto& histo : pxbTh2PolyBarrel[currentHistoName]){
-      histo->GetZaxis()->SetRangeUser(globalMin,globalMax);
+    for (auto& histo : pxbTh2PolyBarrel[currentHistoName]) {
+      histo->GetZaxis()->SetRangeUser(globalMin, globalMax);
     }
   }
 
   //============================================================================
-  void rescaleAllForward(const std::string& currentHistoName){
-
+  void rescaleAllForward(const std::string& currentHistoName) {
     std::vector<float> maxima;
-    std::transform( pxfTh2PolyForward[currentHistoName].begin(), 
-		    pxfTh2PolyForward[currentHistoName].end(),
-		    std::back_inserter(maxima),
-		    [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMaximum(); });
+    std::transform(pxfTh2PolyForward[currentHistoName].begin(),
+                   pxfTh2PolyForward[currentHistoName].end(),
+                   std::back_inserter(maxima),
+                   [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMaximum(); });
     std::vector<float> minima;
-    std::transform( pxfTh2PolyForward[currentHistoName].begin(), 
-		    pxfTh2PolyForward[currentHistoName].end(),
-		    std::back_inserter(minima),
-		    [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMinimum(); });    
+    std::transform(pxfTh2PolyForward[currentHistoName].begin(),
+                   pxfTh2PolyForward[currentHistoName].end(),
+                   std::back_inserter(minima),
+                   [](std::shared_ptr<TH2Poly> thp) -> float { return thp->GetMinimum(); });
 
     auto globalMax = *std::max_element(maxima.begin(), maxima.end());
-    auto globalMin = *std::min_element(minima.begin(), minima.end()) ;
+    auto globalMin = *std::min_element(minima.begin(), minima.end());
 
-    for(auto& histo : pxfTh2PolyForward[currentHistoName]){
-      histo->GetZaxis()->SetRangeUser(globalMin,globalMax);
+    for (auto& histo : pxfTh2PolyForward[currentHistoName]) {
+      histo->GetZaxis()->SetRangeUser(globalMin, globalMax);
     }
   }
 
@@ -277,7 +275,7 @@ public:
         canvas.cd(i)->SetRightMargin(0.02);
         pxbTh2PolyBarrel[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
       } else {
-	rescaleAllBarrel(currentHistoName);
+        rescaleAllBarrel(currentHistoName);
         SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.18);
       }
       pxbTh2PolyBarrel[currentHistoName].at(i - 1)->Draw();
@@ -293,7 +291,7 @@ public:
         canvas.cd(i)->SetRightMargin(0.02);
         pxfTh2PolyForward[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
       } else {
-	rescaleAllForward(currentHistoName);
+        rescaleAllForward(currentHistoName);
         SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.18);
       }
       pxfTh2PolyForward[currentHistoName].at(i - 1)->Draw();

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -200,7 +200,7 @@ namespace PixelRegions {
     }
 
     //============================================================================
-    void draw(TCanvas& canv, bool isBarrel, const char* option = "bar2", bool isComparison = false) {
+    void draw(TCanvas& canv, bool isBarrel, const char* option = "bar2", bool isPhase1Comparison = false) {
       if (isBarrel) {
         for (int j = 1; j <= 4; j++) {
           if (!m_isLog) {
@@ -208,7 +208,7 @@ namespace PixelRegions {
           } else {
             canv.cd(j)->SetLogy();
           }
-          if ((j == 4) && !m_isPhase1 && !isComparison) {
+          if ((j == 4) && !m_isPhase1 && !isPhase1Comparison) {
             m_theMap.at(PixelIDs[j - 1])->Draw("AXIS");
             TLatex t2;
             t2.SetTextAlign(22);
@@ -228,7 +228,7 @@ namespace PixelRegions {
           } else {
             canv.cd(j)->SetLogy();
           }
-          if ((j % 6 == 5 || j % 6 == 0) && !m_isPhase1 && !isComparison) {
+          if ((j % 6 == 5 || j % 6 == 0) && !m_isPhase1 && !isPhase1Comparison) {
             m_theMap.at(PixelIDs[j + 3])->Draw("AXIS");
             TLatex t2;
             t2.SetTextAlign(22);

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -404,7 +404,7 @@ namespace gainCalibHelper {
       if (setLog) {
         myPlots.setLogScale();
       }
-      myPlots.beautify(kBlue,-1);
+      myPlots.beautify(kBlue, -1);
       myPlots.draw(canvas, isBarrel, "HIST");
 
       TLegend legend = TLegend(0.45, 0.88, 0.91, 0.92);
@@ -453,7 +453,11 @@ namespace gainCalibHelper {
   /*******************************************************************
     1d histograms comparison per region of SiPixelGainCalibration for Gains of 2 IOV
   ********************************************************************/
-  template <bool isBarrel, gainCalibPI::type myType, cond::payloadInspector::IOVMultiplicity nIOVs, int ntags, class PayloadType>
+  template <bool isBarrel,
+            gainCalibPI::type myType,
+            cond::payloadInspector::IOVMultiplicity nIOVs,
+            int ntags,
+            class PayloadType>
   class SiPixelGainCalibrationValuesComparisonPerRegion
       : public cond::payloadInspector::PlotImage<PayloadType, nIOVs, ntags> {
   public:
@@ -548,9 +552,8 @@ namespace gainCalibHelper {
       bool is_l_phase0 = (l_detids.size() == SiPixelPI::phase0size);
       bool is_f_phase0 = (f_detids.size() == SiPixelPI::phase0size);
 
-      const char* path_toTopologyXML = is_l_phase0
-                                           ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                                           : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      const char* path_toTopologyXML = is_l_phase0 ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
+                                                   : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
       auto l_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
@@ -563,9 +566,8 @@ namespace gainCalibHelper {
           minimum,
           maximum);
 
-      path_toTopologyXML = is_f_phase0
-                               ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                               : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      path_toTopologyXML = is_f_phase0 ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
+                                       : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
       auto f_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
@@ -594,8 +596,8 @@ namespace gainCalibHelper {
       l_myPlots.beautify(kRed, -1);
       f_myPlots.beautify(kAzure, -1);
 
-      l_myPlots.draw(canvas, isBarrel, "HIST", (!is_f_phase0 || !is_l_phase0) );
-      f_myPlots.draw(canvas, isBarrel, "HISTsames", (!is_f_phase0 || ! is_l_phase0) );
+      l_myPlots.draw(canvas, isBarrel, "HIST", (!is_f_phase0 || !is_l_phase0));
+      f_myPlots.draw(canvas, isBarrel, "HISTsames", (!is_f_phase0 || !is_l_phase0));
 
       // rescale the y-axis ranges in order to fit the canvas
       l_myPlots.rescaleMax(f_myPlots);
@@ -860,7 +862,6 @@ namespace gainCalibHelper {
       hBPix->SetFillColor(kBlue);
       hBPix->SetMarkerStyle(20);
       hBPix->SetMarkerSize(1);
-      //hBPix->Draw("bar2");
       hBPix->Draw("hist");
 
       SiPixelPI::makeNicePlotStyle(hBPix.get());
@@ -872,7 +873,6 @@ namespace gainCalibHelper {
       hFPix->SetFillColor(kBlue);
       hFPix->SetMarkerStyle(20);
       hFPix->SetMarkerSize(1);
-      //hFPix->Draw("bar2");
       hFPix->Draw("hist");
 
       SiPixelPI::makeNicePlotStyle(hFPix.get());
@@ -1014,16 +1014,13 @@ namespace gainCalibHelper {
       hfirst->GetYaxis()->SetRangeUser(1., extrema.second * 10);
 
       hfirst->SetTitle("");
-      //hfirst->SetFillColor(kRed);
       hfirst->SetLineColor(kRed);
       hfirst->SetBarWidth(0.95);
-      //hfirst->Draw("histbar");
       hfirst->Draw("hist");
 
       hlast->SetTitle("");
       hlast->SetFillColorAlpha(kBlue, 0.20);
       hlast->SetBarWidth(0.95);
-      //hlast->Draw("histbarsame");
       hlast->Draw("histsames");
 
       SiPixelPI::makeNicePlotStyle(hfirst.get());

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -334,7 +334,7 @@ namespace gainCalibHelper {
       auto iov = tag.iovs.front();
 
       // parse first if log
-      bool setLog(false);
+      bool setLog(true);
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
       auto ip = paramValues.find("SetLog");
       if (ip != paramValues.end()) {
@@ -404,7 +404,7 @@ namespace gainCalibHelper {
       if (setLog) {
         myPlots.setLogScale();
       }
-      myPlots.beautify(kBlue, 10);
+      myPlots.beautify(kBlue,-1);
       myPlots.draw(canvas, isBarrel, "HIST");
 
       TLegend legend = TLegend(0.45, 0.88, 0.91, 0.92);
@@ -418,7 +418,7 @@ namespace gainCalibHelper {
       unsigned int maxPads = isBarrel ? 4 : 12;
       for (unsigned int c = 1; c <= maxPads; c++) {
         canvas.cd(c);
-        SiPixelPI::adjustCanvasMargins(canvas.cd(c), 0.07, 0.12, 0.12, 0.05);
+        SiPixelPI::adjustCanvasMargins(canvas.cd(c), 0.06, 0.12, 0.12, 0.05);
         legend.Draw("same");
         canvas.cd(c)->Update();
       }
@@ -453,12 +453,12 @@ namespace gainCalibHelper {
   /*******************************************************************
     1d histograms comparison per region of SiPixelGainCalibration for Gains of 2 IOV
   ********************************************************************/
-  template <bool isBarrel, gainCalibPI::type myType, int ntags, class PayloadType>
+  template <bool isBarrel, gainCalibPI::type myType, cond::payloadInspector::IOVMultiplicity nIOVs, int ntags, class PayloadType>
   class SiPixelGainCalibrationValuesComparisonPerRegion
-      : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::MULTI_IOV, ntags> {
+      : public cond::payloadInspector::PlotImage<PayloadType, nIOVs, ntags> {
   public:
     SiPixelGainCalibrationValuesComparisonPerRegion()
-        : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::MULTI_IOV, ntags>(
+        : cond::payloadInspector::PlotImage<PayloadType, nIOVs, ntags>(
               Form("SiPixelGainCalibration %s Values Per Region %i tag(s)", TypeName[myType], ntags)) {
       cond::payloadInspector::PlotBase::addInputParam("SetLog");
 
@@ -495,7 +495,7 @@ namespace gainCalibHelper {
       }
 
       // parse first if log
-      bool setLog(false);
+      bool setLog(true);
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
       auto ip = paramValues.find("SetLog");
       if (ip != paramValues.end()) {
@@ -545,13 +545,16 @@ namespace gainCalibHelper {
       canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 
-      const char* path_toTopologyXML = (l_detids.size() == SiPixelPI::phase0size)
+      bool is_l_phase0 = (l_detids.size() == SiPixelPI::phase0size);
+      bool is_f_phase0 = (f_detids.size() == SiPixelPI::phase0size);
+
+      const char* path_toTopologyXML = is_l_phase0
                                            ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
                                            : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
       auto l_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
-      auto l_myPlots = PixelRegions::PixelRegionContainers(&l_tTopo, (l_detids.size() == SiPixelPI::phase1size));
+      auto l_myPlots = PixelRegions::PixelRegionContainers(&l_tTopo, !is_l_phase0);
       l_myPlots.bookAll(
           Form("Last SiPixel Gain Calibration %s - %s", (isForHLT_ ? "ForHLT" : "Offline"), TypeName[myType]),
           Form("per %s %s", (isForHLT_ ? "Column" : "Pixel"), TypeName[myType]),
@@ -560,13 +563,13 @@ namespace gainCalibHelper {
           minimum,
           maximum);
 
-      path_toTopologyXML = (f_detids.size() == SiPixelPI::phase0size)
+      path_toTopologyXML = is_f_phase0
                                ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
                                : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
       auto f_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
-      auto f_myPlots = PixelRegions::PixelRegionContainers(&f_tTopo, (f_detids.size() == SiPixelPI::phase1size));
+      auto f_myPlots = PixelRegions::PixelRegionContainers(&f_tTopo, !is_f_phase0);
       f_myPlots.bookAll(
           Form("First SiPixel Gain Calibration %s - %s", (isForHLT_ ? "ForHLT" : "Offline"), TypeName[myType]),
           Form("per %s %s", (isForHLT_ ? "Column" : "Pixel"), TypeName[myType]),
@@ -577,8 +580,8 @@ namespace gainCalibHelper {
 
       // fill the histograms
       for (const auto& pixelId : PixelRegions::PixelIDs) {
-        auto f_wantedDets = PixelRegions::attachedDets(pixelId, &f_tTopo, (f_detids.size() == SiPixelPI::phase1size));
-        auto l_wantedDets = PixelRegions::attachedDets(pixelId, &l_tTopo, (l_detids.size() == SiPixelPI::phase1size));
+        auto f_wantedDets = PixelRegions::attachedDets(pixelId, &f_tTopo, !is_f_phase0);
+        auto l_wantedDets = PixelRegions::attachedDets(pixelId, &l_tTopo, !is_l_phase0);
         gainCalibPI::fillTheHisto(first_payload, f_myPlots.getHistoFromMap(pixelId), myType, f_wantedDets);
         gainCalibPI::fillTheHisto(last_payload, l_myPlots.getHistoFromMap(pixelId), myType, l_wantedDets);
       }
@@ -591,8 +594,8 @@ namespace gainCalibHelper {
       l_myPlots.beautify(kRed, -1);
       f_myPlots.beautify(kAzure, -1);
 
-      l_myPlots.draw(canvas, isBarrel, "HIST", true);
-      f_myPlots.draw(canvas, isBarrel, "HISTsames", true);
+      l_myPlots.draw(canvas, isBarrel, "HIST", (!is_f_phase0 || !is_l_phase0) );
+      f_myPlots.draw(canvas, isBarrel, "HISTsames", (!is_f_phase0 || ! is_l_phase0) );
 
       // rescale the y-axis ranges in order to fit the canvas
       l_myPlots.rescaleMax(f_myPlots);

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -804,14 +804,10 @@ namespace SiPixelPI {
   /*--------------------------------------------------------------------*/
   {
     std::vector<std::pair<int, int>> rocsToMask;
-
-    //int nblade_list[2] = {11, 17};
     int nybins_list[2] = {92, 140};
-    //int nblade = nblade_list[ring - 1];
     int nybins = nybins_list[ring - 1];
 
     int start_x = disk > 0 ? ((disk + 3) * 8) + 1 : ((3 - (std::abs(disk))) * 8) + 1;
-    //int start_y = blade > 0 ? ((blade+nblade)*4)-panel*2  : ((nblade-(std::abs(blade)))*4)-panel*2;
     int start_y = blade > 0 ? (nybins / 2) + (blade * 4) - (panel * 2) + 3
                             : ((nybins / 2) - (std::abs(blade) * 4) - panel * 2) + 3;
 
@@ -839,14 +835,10 @@ namespace SiPixelPI {
   /*--------------------------------------------------------------------*/
   {
     std::vector<std::tuple<int, int, int>> rocsToMask;
-
-    //int nblade_list[2] = {11, 17};
     int nybins_list[2] = {92, 140};
-    //int nblade = nblade_list[ring - 1];
     int nybins = nybins_list[ring - 1];
 
     int start_x = disk > 0 ? ((disk + 3) * 8) + 1 : ((3 - (std::abs(disk))) * 8) + 1;
-    //int start_y = blade > 0 ? ((blade+nblade)*4)-panel*2  : ((nblade-(std::abs(blade)))*4)-panel*2;
     int start_y = blade > 0 ? (nybins / 2) + (blade * 4) - (panel * 2) + 3
                             : ((nybins / 2) - (std::abs(blade) * 4) - panel * 2) + 3;
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
@@ -57,48 +57,56 @@ namespace {
   using SiPixelGainCalibForHLTGainComparisonBarrelSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
+								       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonBarrelSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
+								       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonBarrelTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       gainCalibHelper::gainCalibPI::t_gain, 
+								       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonBarrelTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
+								       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonEndcapSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
+								       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonEndcapSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
+								       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonEndcapTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
+								       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonEndcapTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
+								       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationForHLT>;
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
@@ -57,56 +57,56 @@ namespace {
   using SiPixelGainCalibForHLTGainComparisonBarrelSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
-								       cond::payloadInspector::MULTI_IOV,
+                                                                       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonBarrelSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
-								       cond::payloadInspector::MULTI_IOV,
+                                                                       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonBarrelTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_gain, 
-								       cond::payloadInspector::SINGLE_IOV,
+                                                                       gainCalibHelper::gainCalibPI::t_gain,
+                                                                       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonBarrelTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
-								       cond::payloadInspector::SINGLE_IOV,
+                                                                       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonEndcapSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
-								       cond::payloadInspector::MULTI_IOV,
+                                                                       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonEndcapSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
-								       cond::payloadInspector::MULTI_IOV,
+                                                                       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonEndcapTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
-								       cond::payloadInspector::SINGLE_IOV,
+                                                                       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonEndcapTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
-								       cond::payloadInspector::SINGLE_IOV,
+                                                                       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationForHLT>;
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -57,48 +57,56 @@ namespace {
   using SiPixelGainCalibOfflineGainComparisonBarrelSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
+								       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonBarrelSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
+								       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonBarrelTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
+								       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonBarrelTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
+								       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonEndcapSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
+								       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonEndcapSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
+								       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonEndcapTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
+								       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonEndcapTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
+								       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationOffline>;
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -57,56 +57,56 @@ namespace {
   using SiPixelGainCalibOfflineGainComparisonBarrelSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
-								       cond::payloadInspector::MULTI_IOV,
+                                                                       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonBarrelSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
-								       cond::payloadInspector::MULTI_IOV,
+                                                                       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonBarrelTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
-								       cond::payloadInspector::SINGLE_IOV,
+                                                                       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonBarrelTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
-								       cond::payloadInspector::SINGLE_IOV,
+                                                                       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonEndcapSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
-								       cond::payloadInspector::MULTI_IOV,
+                                                                       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonEndcapSingleTag =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
-								       cond::payloadInspector::MULTI_IOV,
+                                                                       cond::payloadInspector::MULTI_IOV,
                                                                        1,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonEndcapTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_gain,
-								       cond::payloadInspector::SINGLE_IOV,
+                                                                       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonEndcapTwoTags =
       gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
                                                                        gainCalibHelper::gainCalibPI::t_pedestal,
-								       cond::payloadInspector::SINGLE_IOV,
+                                                                       cond::payloadInspector::SINGLE_IOV,
                                                                        2,
                                                                        SiPixelGainCalibrationOffline>;
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -292,9 +292,8 @@ namespace {
 
       // deal with last IOV
 
-      const char *path_toTopologyXML = is_l_phase0
-                                           ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                                           : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      const char *path_toTopologyXML = is_l_phase0 ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
+                                                   : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
 
       auto l_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
@@ -307,20 +306,17 @@ namespace {
                         min * 0.9,
                         max * 1.1);
 
-      //canvas.Modified();
-
       for (const auto &element : l_LAMap_) {
         l_myPlots.fill(element.first, element.second);
       }
 
       l_myPlots.beautify();
-      l_myPlots.draw(canvas, isBarrel, "bar2", (!is_f_phase0 || !is_l_phase0) );
+      l_myPlots.draw(canvas, isBarrel, "bar2", (!is_f_phase0 || !is_l_phase0));
 
       // deal with first IOV
 
-      path_toTopologyXML = is_f_phase0
-                               ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                               : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      path_toTopologyXML = is_f_phase0 ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
+                                       : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
 
       auto f_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
@@ -333,14 +329,12 @@ namespace {
                         min * 0.9,
                         max * 1.1);
 
-      //canvas.Modified();
-
       for (const auto &element : f_LAMap_) {
         f_myPlots.fill(element.first, element.second);
       }
 
       f_myPlots.beautify(kAzure, kBlue);
-      f_myPlots.draw(canvas, isBarrel, "HISTsames", (!is_f_phase0 || !is_l_phase0) );
+      f_myPlots.draw(canvas, isBarrel, "HISTsames", (!is_f_phase0 || !is_l_phase0));
 
       // rescale the y-axis ranges in order to fit the canvas
       l_myPlots.rescaleMax(f_myPlots);
@@ -399,11 +393,15 @@ namespace {
     }
   };
 
-  using SiPixelLorentzAngleValuesBarrelCompareSingleTag = SiPixelLorentzAngleValuesComparisonPerRegion<true, cond::payloadInspector::MULTI_IOV, 1>;
-  using SiPixelLorentzAngleValuesEndcapCompareSingleTag = SiPixelLorentzAngleValuesComparisonPerRegion<false, cond::payloadInspector::MULTI_IOV, 1>;
+  using SiPixelLorentzAngleValuesBarrelCompareSingleTag =
+      SiPixelLorentzAngleValuesComparisonPerRegion<true, cond::payloadInspector::MULTI_IOV, 1>;
+  using SiPixelLorentzAngleValuesEndcapCompareSingleTag =
+      SiPixelLorentzAngleValuesComparisonPerRegion<false, cond::payloadInspector::MULTI_IOV, 1>;
 
-  using SiPixelLorentzAngleValuesBarrelCompareTwoTags = SiPixelLorentzAngleValuesComparisonPerRegion<true, cond::payloadInspector::SINGLE_IOV, 2>;
-  using SiPixelLorentzAngleValuesEndcapCompareTwoTags = SiPixelLorentzAngleValuesComparisonPerRegion<false, cond::payloadInspector::SINGLE_IOV, 2>;
+  using SiPixelLorentzAngleValuesBarrelCompareTwoTags =
+      SiPixelLorentzAngleValuesComparisonPerRegion<true, cond::payloadInspector::SINGLE_IOV, 2>;
+  using SiPixelLorentzAngleValuesEndcapCompareTwoTags =
+      SiPixelLorentzAngleValuesComparisonPerRegion<false, cond::payloadInspector::SINGLE_IOV, 2>;
 
   /************************************************
     1d histogram of SiPixelLorentzAngle of 1 IOV 
@@ -473,20 +471,10 @@ namespace {
       hfirst->SetBarWidth(0.95);
       hfirst->Draw("histbar");
 
-      //hfirst->SetMarkerStyle(kFullCircle);
-      //hfirst->SetMarkerSize(1.5);
-      //hfirst->SetMarkerColor(kRed);
-      //hfirst->Draw("Psame");
-
       hlast->SetTitle("");
       hlast->SetFillColorAlpha(kBlue, 0.20);
       hlast->SetBarWidth(0.95);
       hlast->Draw("histbarsame");
-
-      //hlast->SetMarkerStyle(kOpenCircle);
-      //hlast->SetMarkerSize(1.5);
-      //hlast->SetMarkerColor(kBlue);
-      //hlast->Draw("Psame");
 
       SiPixelPI::makeNicePlotStyle(hfirst.get());
       SiPixelPI::makeNicePlotStyle(hlast.get());

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -227,7 +227,7 @@ namespace {
               "SiPixelTemplate assumed value of uH") {}
 
     bool fill() override {
-      gStyle->SetPalette(kBlackBody);
+      gStyle->SetPalette(kRainBow);
       TGaxis::SetMaxDigits(2);
 
       auto tag = PlotBase::getTag<0>();
@@ -268,10 +268,10 @@ namespace {
         Phase1PixelMaps theMaps("COLZ L");
 
         if (myType == t_barrel) {
-          theMaps.bookBarrelHistograms("templateLABarrel", "#muH");
+          theMaps.bookBarrelHistograms("templateLABarrel","#muH","#mu_{H} [1/T]");
           theMaps.bookBarrelBins("templateLABarrel");
         } else if (myType == t_forward) {
-          theMaps.bookForwardHistograms("templateLAForward", "#muH");
+          theMaps.bookForwardHistograms("templateLAForward","#muH","#mu_{H} [1/T]");
           theMaps.bookForwardBins("templateLAForward");
         }
 
@@ -344,11 +344,11 @@ namespace {
         // Book the TH2Poly
         Phase1PixelMaps theMaps("text");
         if (myType == t_barrel) {
-          theMaps.bookBarrelHistograms("templateIDsBarrel", "IDs");
+          theMaps.bookBarrelHistograms("templateIDsBarrel", "IDs","template IDs");
           // book the barrel bins of the TH2Poly
           theMaps.bookBarrelBins("templateIDsBarrel");
         } else if (myType == t_forward) {
-          theMaps.bookForwardHistograms("templateIDsForward", "IDs");
+          theMaps.bookForwardHistograms("templateIDsForward", "IDs","template IDs");
           // book the forward bins of the TH2Poly
           theMaps.bookForwardBins("templateIDsForward");
         }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -268,10 +268,10 @@ namespace {
         Phase1PixelMaps theMaps("COLZ L");
 
         if (myType == t_barrel) {
-          theMaps.bookBarrelHistograms("templateLABarrel","#muH","#mu_{H} [1/T]");
+          theMaps.bookBarrelHistograms("templateLABarrel", "#muH", "#mu_{H} [1/T]");
           theMaps.bookBarrelBins("templateLABarrel");
         } else if (myType == t_forward) {
-          theMaps.bookForwardHistograms("templateLAForward","#muH","#mu_{H} [1/T]");
+          theMaps.bookForwardHistograms("templateLAForward", "#muH", "#mu_{H} [1/T]");
           theMaps.bookForwardBins("templateLAForward");
         }
 
@@ -344,11 +344,11 @@ namespace {
         // Book the TH2Poly
         Phase1PixelMaps theMaps("text");
         if (myType == t_barrel) {
-          theMaps.bookBarrelHistograms("templateIDsBarrel", "IDs","template IDs");
+          theMaps.bookBarrelHistograms("templateIDsBarrel", "IDs", "template IDs");
           // book the barrel bins of the TH2Poly
           theMaps.bookBarrelBins("templateIDsBarrel");
         } else if (myType == t_forward) {
-          theMaps.bookForwardHistograms("templateIDsForward", "IDs","template IDs");
+          theMaps.bookForwardHistograms("templateIDsForward", "IDs", "template IDs");
           // book the forward bins of the TH2Poly
           theMaps.bookForwardBins("templateIDsForward");
         }

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -5,6 +5,7 @@
 #include "CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
@@ -31,27 +32,27 @@ int main(int argc, char** argv) {
   cond::Time_t start = boost::lexical_cast<unsigned long long>(303790);
   cond::Time_t end = boost::lexical_cast<unsigned long long>(324245);
 
-  std::cout << "## Exercising Lorentz Angle plots " << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising Lorentz Angle plots " << std::endl;
 
   SiPixelLorentzAngleValues histo1;
   histo1.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo1.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo1.data() << std::endl;
 
   SiPixelLorentzAngleValueComparisonSingleTag histo2;
   histo2.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo2.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo2.data() << std::endl;
 
   SiPixelLorentzAngleByRegionComparisonSingleTag histo3;
   histo3.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo3.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo3.data() << std::endl;
 
   SiPixelBPixLorentzAngleMap histo4;
   histo4.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo4.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo4.data() << std::endl;
 
   SiPixelFPixLorentzAngleMap histo5;
   histo5.process(connectionString, PI::mk_input(tag, end, end));
-  std::cout << histo5.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo5.data() << std::endl;
 
   // 2 tags comparisons
 
@@ -60,11 +61,11 @@ int main(int argc, char** argv) {
 
   SiPixelLorentzAngleValueComparisonTwoTags histo6;
   histo6.process(connectionString, PI::mk_input(tag, start, start, tag2, start2, start2));
-  std::cout << histo6.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo6.data() << std::endl;
 
   SiPixelLorentzAngleByRegionComparisonTwoTags histo7;
   histo7.process(connectionString, PI::mk_input(tag, start, start, tag2, start2, start2));
-  std::cout << histo7.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo7.data() << std::endl;
 
   // SiPixelQuality
 
@@ -72,15 +73,15 @@ int main(int argc, char** argv) {
   start = boost::lexical_cast<unsigned long long>(1);
   end = boost::lexical_cast<unsigned long long>(1);
 
-  std::cout << "## Exercising SiPixelQuality plots " << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising SiPixelQuality plots " << std::endl;
 
   SiPixelBPixQualityMap histo8;
   histo8.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo8.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo8.data() << std::endl;
 
   SiPixelFPixQualityMap histo9;
   histo9.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo9.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo9.data() << std::endl;
 
   // SiPixelGainCalibrationOffline
 
@@ -88,37 +89,37 @@ int main(int argc, char** argv) {
   start = boost::lexical_cast<unsigned long long>(312203);
   end = boost::lexical_cast<unsigned long long>(312203);
 
-  std::cout << "## Exercising SiPixelGainCalibrationOffline plots " << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising SiPixelGainCalibrationOffline plots " << std::endl;
 
   SiPixelGainCalibrationOfflineGainsValues histo10;
   histo10.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo10.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo10.data() << std::endl;
 
   SiPixelGainCalibrationOfflinePedestalsValues histo11;
   histo11.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo11.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo11.data() << std::endl;
 
   SiPixelGainCalibrationOfflineGainsByPart histo12;
   histo12.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo12.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo12.data() << std::endl;
 
   SiPixelGainCalibrationOfflinePedestalsByPart histo13;
   histo13.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo13.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo13.data() << std::endl;
 
   end = boost::lexical_cast<unsigned long long>(326851);
 
   SiPixelGainCalibOfflinePedestalComparisonSingleTag histo14;
   histo14.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo14.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo14.data() << std::endl;
 
   SiPixelGainCalibOfflineGainByRegionComparisonSingleTag histo15;
   histo15.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo15.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo15.data() << std::endl;
 
   SiPixelGainCalibrationOfflineCorrelations histo16;
   histo16.process(connectionString, PI::mk_input(tag, end, end));
-  std::cout << histo16.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo16.data() << std::endl;
 
   boost::python::dict inputs;
   inputs["SetLog"] = "True";  // sets to true, 1,True,Yes will work
@@ -126,7 +127,7 @@ int main(int argc, char** argv) {
   SiPixelGainCalibrationOfflineGainsValuesBarrel histo17;
   histo17.setInputParamValues(inputs);
   histo17.process(connectionString, PI::mk_input(tag, end, end));
-  std::cout << histo17.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo17.data() << std::endl;
 
   // SiPixelTemplates
 
@@ -134,15 +135,15 @@ int main(int argc, char** argv) {
   start = boost::lexical_cast<unsigned long long>(326083);
   end = boost::lexical_cast<unsigned long long>(326083);
 
-  std::cout << "## Exercising SiPixelTemplates plots " << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising SiPixelTemplates plots " << std::endl;
 
   SiPixelTemplateIDsBPixMap histo18;
   histo18.process(connectionString, PI::mk_input(tag, end, end));
-  std::cout << histo18.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo18.data() << std::endl;
 
   SiPixelTemplateLAFPixMap histo19;
   histo19.process(connectionString, PI::mk_input(tag, end, end));
-  std::cout << histo19.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo19.data() << std::endl;
 
   Py_Finalize();
 }


### PR DESCRIPTION
backport of #29938

#### PR description:

After PR #29864 has been merged, it has been possible to visually inspect the rendering of all the newly added plots at [ConDBBrowser](http://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod/CMSSW_11_1_X_2020-05-20-2300).
This has revealed that several of the plots introduced in PR #29864 had some problems in the rendering in the browser. This PR aims to fix this, as well as addressing some of the comments received at https://github.com/cms-sw/cmssw/pull/29864#pullrequestreview-414457447

#### PR validation:

Individual plots have been tested by hand, (see results at [link1](http://musich.web.cern.ch/musich/display/plots_PerRegion/), [link2](http://musich.web.cern.ch/musich/display/plots_PerRegion/comparisons/) and [link3](http://musich.web.cern.ch/musich/display/plots_Templates/) ) . Moreover this branch is passing standard unit tests provided in the package.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #29938