### PR TITLE
Add specific friendly names for unordered_set and unordered_map

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -55,6 +55,8 @@ namespace edm {
     static std::regex const reUnsigned("unsigned ");
     static std::regex const reLong("long ");
     static std::regex const reVector("std::vector");
+    static std::regex const reUnorderedSet("std::unordered_set");
+    static std::regex const reUnorderedMap("std::unordered_map");
     static std::regex const reSharedPtr("std::shared_ptr");
     static std::regex const reAIKR(
         ", *edm::helper::AssociationIdenticalKeyReference");  //this is a default so can replaced with empty
@@ -98,6 +100,8 @@ namespace edm {
       name = regex_replace(name, reUnsigned, "u");
       name = regex_replace(name, reLong, "l");
       name = regex_replace(name, reVector, "s");
+      name = regex_replace(name, reUnorderedSet, "stduset");
+      name = regex_replace(name, reUnorderedMap, "stdumap");
       name = regex_replace(name, reSharedPtr, "SharedPtr");
       name = regex_replace(name, reOwnVector, "sOwned<$1>");
       name = regex_replace(name, reToVector, "AssociationVector<$1,To,$2>");

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -37,6 +37,10 @@ void testfriendlyName::test() {
   classToFriendly.insert(Values("bar::Foo", "barFoo"));
   classToFriendly.insert(Values("std::vector<Foo>", "Foos"));
   classToFriendly.insert(Values("std::vector<bar::Foo>", "barFoos"));
+  classToFriendly.insert(Values("std::set<bar::Foo>", "barFoostdset"));
+  classToFriendly.insert(Values("std::map<Foo, bar::Bar>", "FoobarBarstdmap"));
+  classToFriendly.insert(Values("std::unordered_set<bar::Foo>", "barFoostduset"));
+  classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar>", "FoobarBarstdumap"));
   classToFriendly.insert(Values("std::shared_ptr<Foo>", "FooSharedPtr"));
   classToFriendly.insert(Values("std::shared_ptr<bar::Foo>", "barFooSharedPtr"));
   classToFriendly.insert(Values("std::basic_string<char>", "String"));


### PR DESCRIPTION
#### PR description:

This PR adds specific friendly class names for `std::unordered_set` and `std::unordered_map` to avoid underscores in their friendly class names. Resolves https://github.com/cms-sw/cmssw/issues/29967.

#### PR validation:

Unit test passes.
