### PR TITLE
Cleaning Cosmic and HI event content structures

### DIFF
--- a/Configuration/EventContent/python/EventContentCosmics_cff.py
+++ b/Configuration/EventContent/python/EventContentCosmics_cff.py
@@ -1,4 +1,3 @@
-
 import FWCore.ParameterSet.Config as cms
 
 #
@@ -52,6 +51,7 @@ from EventFilter.ScalersRawToDigi.Scalers_EventContent_cff import *
 from EventFilter.OnlineMetaDataRawToDigi.OnlineMetaData_EventContent_cff import *
 from EventFilter.Utilities.Tcds_EventContent_cff import *
 from Configuration.EventContent.EventContent_cff import REGENEventContent,RESIMEventContent,REDIGIEventContent
+from Configuration.EventContent.EventContent_cff import DQMEventContent
 
 #not in Cosmics 
 #include "TrackingTools/Configuration/data/TrackingTools_EventContent.cff"
@@ -62,22 +62,17 @@ from Configuration.EventContent.EventContent_cff import REGENEventContent,RESIME
 #include "RecoPixelVertexing/Configuration/data/RecoPixelVertexing_EventContent.cff"
 #include "RecoEgamma/Configuration/data/RecoEgamma_EventContent.cff"
 #include "RecoParticleFlow/Configuration/data/RecoParticleFlow_EventContent.cff"
-#
-# FEVT Data Tier definition
-#
-#
-FEVTEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *',
-        'keep *_logErrorHarvester_*_*'),
+
+# RAW only data tier
+RAWEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep  FEDRawDataCollection_rawDataCollector_*_*', 
+        'keep  FEDRawDataCollection_source_*_*'),
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
-FEVTHLTALLEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *'),
-    splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
-)
-#replace FEVTEventContent.outputCommands += HLTriggerFEVT.outputCommands 
+RAWEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
+RAWEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 #
 #
 # RECO Data Tier definition
@@ -89,115 +84,6 @@ RECOEventContent = cms.PSet(
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
-#
-#
-# AOD Data Tier definition
-#
-#
-AODEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *',
-        'keep *_logErrorHarvester_*_*'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024)
-)
-# RAW only data tier
-RAWEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *', 
-        'keep  FEDRawDataCollection_rawDataCollector_*_*', 
-        'keep  FEDRawDataCollection_source_*_*'),
-    splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
-)
-
-#
-#
-# RAWSIM Data Tier definition
-#
-#
-RAWSIMEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *'),
-    splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
-)
-#
-#
-# RECOSIM Data Tier definition
-#
-#
-RECOSIMEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *',
-        'keep *_logErrorHarvester_*_*'),
-    splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
-)
-#
-#
-# AODSIM Data Tier definition
-#
-#
-AODSIMEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *',
-        'keep *_logErrorHarvester_*_*'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
-)
-
-#
-# FEVTSIM Data Tier definition
-#
-#
-FEVTSIMEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *',
-        'keep *_logErrorHarvester_*_*'),
-    splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
-)
-
-#
-#
-# FEVTDEBUG Data Tier definition
-#
-#
-FEVTDEBUGEventContent = cms.PSet(
-   outputCommands = cms.untracked.vstring('drop *',
-       'keep *_logErrorHarvester_*_*'),
-   splitLevel = cms.untracked.int32(0),
-   eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
-)
-
-#
-#
-# ALCARECO Data Tier definition
-#
-#
-
-from Configuration.EventContent.EventContent_cff import DQMEventContent
-
-
-RAWEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
-RAWEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
-
-#FEVT is by definition RECO + RAW
-FEVTEventContent.outputCommands.extend(RAWEventContent.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoLocalTrackerRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoLocalMuonRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoLocalCaloRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoEcalRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoEgammaRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoTrackerRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoJetsRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoMETRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoMuonRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(BeamSpotRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoVertexRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(L1TriggerRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(HLTriggerRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(MEtoEDMConverterRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(EvtScalersRECO.outputCommands)
-FEVTEventContent.outputCommands.extend(OnlineMetaDataContent.outputCommands)
-FEVTEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
-
-FEVTHLTALLEventContent.outputCommands.extend(FEVTEventContent.outputCommands)
-FEVTHLTALLEventContent.outputCommands.append('keep *_*_*_HLT')
-
 RECOEventContent.outputCommands.extend(RecoLocalTrackerRECO.outputCommands)
 RECOEventContent.outputCommands.extend(RecoLocalMuonRECO.outputCommands)
 RECOEventContent.outputCommands.extend(RecoLocalCaloRECO.outputCommands)
@@ -215,7 +101,16 @@ RECOEventContent.outputCommands.extend(MEtoEDMConverterRECO.outputCommands)
 RECOEventContent.outputCommands.extend(EvtScalersRECO.outputCommands)
 RECOEventContent.outputCommands.extend(OnlineMetaDataContent.outputCommands)
 RECOEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
-
+#
+#
+# AOD Data Tier definition
+#
+#
+AODEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *',
+        'keep *_logErrorHarvester_*_*'),
+    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024)
+)
 AODEventContent.outputCommands.extend(RecoLocalTrackerAOD.outputCommands)
 AODEventContent.outputCommands.extend(RecoLocalMuonAOD.outputCommands)
 AODEventContent.outputCommands.extend(RecoLocalCaloAOD.outputCommands)
@@ -231,7 +126,38 @@ AODEventContent.outputCommands.extend(MEtoEDMConverterAOD.outputCommands)
 AODEventContent.outputCommands.extend(EvtScalersAOD.outputCommands)
 AODEventContent.outputCommands.extend(OnlineMetaDataContent.outputCommands)
 AODEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
+#
+# FEVT Data Tier definition
+#
+#
+#FEVT is by definition RECO + RAW
+FEVTEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *',
+        'keep *_logErrorHarvester_*_*'),
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+)
+FEVTEventContent.outputCommands.extend(RAWEventContent.outputCommands)
+FEVTEventContent.outputCommands.extend(RECOEventContent.outputCommands)
 
+#replace FEVTEventContent.outputCommands += HLTriggerFEVT.outputCommands 
+FEVTHLTALLEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *'),
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+)
+FEVTHLTALLEventContent.outputCommands.extend(FEVTEventContent.outputCommands)
+FEVTHLTALLEventContent.outputCommands.append('keep *_*_*_HLT')
+#
+#
+# RAWSIM Data Tier definition
+#
+#
+RAWSIMEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *'),
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+)
 RAWSIMEventContent.outputCommands.extend(RAWEventContent.outputCommands)
 RAWSIMEventContent.outputCommands.extend(SimG4CoreRAW.outputCommands)
 RAWSIMEventContent.outputCommands.extend(SimTrackerRAW.outputCommands)
@@ -244,7 +170,17 @@ RAWSIMEventContent.outputCommands.extend(RecoGenMETFEVT.outputCommands)
 RAWSIMEventContent.outputCommands.extend(DigiToRawFEVT.outputCommands)
 RAWSIMEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputCommands)
 RAWSIMEventContent.outputCommands.extend(IOMCRAW.outputCommands)
-
+#
+#
+# RECOSIM Data Tier definition
+#
+#
+RECOSIMEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *',
+        'keep *_logErrorHarvester_*_*'),
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+)
 RECOSIMEventContent.outputCommands.extend(RECOEventContent.outputCommands)
 RECOSIMEventContent.outputCommands.extend(GeneratorInterfaceRECO.outputCommands)
 RECOSIMEventContent.outputCommands.extend(SimG4CoreRECO.outputCommands)
@@ -254,62 +190,37 @@ RECOSIMEventContent.outputCommands.extend(SimCalorimetryRECO.outputCommands)
 RECOSIMEventContent.outputCommands.extend(RecoGenMETRECO.outputCommands)
 RECOSIMEventContent.outputCommands.extend(RecoGenJetsRECO.outputCommands)
 RECOSIMEventContent.outputCommands.extend(SimGeneralRECO.outputCommands)
-RECOSIMEventContent.outputCommands.extend(MEtoEDMConverterRECO.outputCommands)
-
-AODSIMEventContent.outputCommands.extend(AODEventContent.outputCommands)
-AODSIMEventContent.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(SimG4CoreAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(SimTrackerAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(SimMuonAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(SimCalorimetryAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(RecoGenJetsAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(RecoGenMETAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(SimGeneralAOD.outputCommands)
-AODSIMEventContent.outputCommands.extend(MEtoEDMConverterAOD.outputCommands)
-
-FEVTSIMEventContent.outputCommands.extend(RAWEventContent.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimG4CoreRAW.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimTrackerRAW.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimMuonRAW.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimCalorimetryRAW.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimGeneralRAW.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(GeneratorInterfaceRAW.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoGenJetsFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoGenMETFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(DigiToRawFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(IOMCRAW.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoLocalTrackerRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoLocalMuonRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoLocalCaloRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoEcalRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoTrackerRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoJetsRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoMETRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoMuonRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoEgammaRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(BeamSpotRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoVertexRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(L1TriggerRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(HLTriggerRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(MEtoEDMConverterRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(GeneratorInterfaceRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoGenMETRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoGenJetsRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimG4CoreRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimTrackerRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimMuonRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimCalorimetryRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(SimGeneralRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(MEtoEDMConverterRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(EvtScalersRECO.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(OnlineMetaDataContent.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
-
+#
+# FEVTSIM Data Tier definition
+#
+#
+FEVTSIMEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *',
+        'keep *_logErrorHarvester_*_*'),
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+)
+FEVTSIMEventContent.outputCommands.extend(RAWSIMEventContent.outputCommands)
+FEVTSIMEventContent.outputCommands.extend(RECOSIMEventContent.outputCommands)
+#
+#
+# FEVTDEBUG Data Tier definition
+#
+#
+FEVTDEBUGEventContent = cms.PSet(
+   outputCommands = cms.untracked.vstring('drop *',
+       'keep *_logErrorHarvester_*_*'),
+   splitLevel = cms.untracked.int32(0),
+   eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+)
 FEVTDEBUGEventContent.outputCommands.extend(FEVTSIMEventContent.outputCommands)
 FEVTDEBUGEventContent.outputCommands.extend(L1TriggerFEVTDEBUG.outputCommands)
 FEVTDEBUGEventContent.outputCommands.extend(SimGeneralFEVTDEBUG.outputCommands)
 FEVTDEBUGEventContent.outputCommands.extend(SimTrackerFEVTDEBUG.outputCommands)
 FEVTDEBUGEventContent.outputCommands.extend(SimMuonFEVTDEBUG.outputCommands)
 FEVTDEBUGEventContent.outputCommands.extend(SimCalorimetryFEVTDEBUG.outputCommands)
-
+#
+#
+# ALCARECO Data Tier definition
+#
+#

--- a/Configuration/EventContent/python/EventContentHeavyIons_cff.py
+++ b/Configuration/EventContent/python/EventContentHeavyIons_cff.py
@@ -12,14 +12,14 @@ from Configuration.EventContent.EventContent_cff import *
 from SimGeneral.Configuration.SimGeneral_HiMixing_EventContent_cff import * # heavy ion signal mixing
 from RecoHI.Configuration.RecoHI_EventContent_cff import *       # heavy ion reconstruction
 
-#################################################################
 
 #RAW
-RecoHIRAWOutput=cms.untracked.vstring('keep FEDRawDataCollection_rawDataRepacker_*_*',
-                                      'keep FEDRawDataCollection_hybridRawDataRepacker_*_*',
-                                      'keep FEDRawDataCollection_virginRawDataRepacker_*_*')
-
-RAWEventContent.outputCommands.extend(RecoHIRAWOutput)
+RAWEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+	'keep FEDRawDataCollection_rawDataRepacker_*_*',
+        'keep FEDRawDataCollection_hybridRawDataRepacker_*_*',
+        'keep FEDRawDataCollection_virginRawDataRepacker_*_*')
+)
 
 #RECO
 RECOEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
@@ -27,45 +27,45 @@ RECOEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
 #AOD
 AODEventContent.outputCommands.extend(RecoHIAOD.outputCommands)
 
-#RAWSIM, RAWSIMHLT, RECOSIM, AODSIM
+#RAWSIM
 RAWSIMEventContent.outputCommands.extend(HiMixRAW.outputCommands)
-RAWSIMEventContent.outputCommands.extend(RecoHIRAWOutput)
+RAWSIMEventContent.outputCommands.extend(RAWEventContent.outputCommands)
 
-RAWSIMHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)
-RAWSIMHLTEventContent.outputCommands.extend(RecoHIRAWOutput)
+#RAWSIMHLT
+RAWSIMHLTEventContent.outputCommands.extend(RAWSIMEventContent.outputCommands)
 
+#RECOSIM
 RECOSIMEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
 RECOSIMEventContent.outputCommands.extend(HiMixRECO.outputCommands)
 
+#AODSIM
 AODSIMEventContent.outputCommands.extend(RecoHIAOD.outputCommands)
 AODSIMEventContent.outputCommands.extend(HiMixAOD.outputCommands)
 
-#FEVT (RAW + RECO), FEVTHLTALL (FEVT + all HLT), FEVTSIM (RAWSIM + RECOSIM)
+#FEVT (RAW + RECO)
 FEVTEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoHIRAWOutput)
+FEVTEventContent.outputCommands.extend(RAWEventContent.outputCommands)
 
-FEVTHLTALLEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTHLTALLEventContent.outputCommands.extend(RecoHIRAWOutput)
+#FEVTHLTALL (FEVT + all HLT)
+FEVTHLTALLEventContent.outputCommands.extend(FEVTEventContent.outputCommands)
 
+#FEVTSIM (RAWSIM + RECOSIM)
 FEVTSIMEventContent.outputCommands.extend(HiMixRAW.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoHIRAWOutput)
+FEVTSIMEventContent.outputCommands.extend(FEVTEventContent.outputCommands)
 
-#add (HLT)DEBUG content to RAW, RECO, FEVT (e.g. mergedtruth from trackingParticles)
+#RAW DEBUG(e.g. mergedtruth from trackingParticles) 
 RAWDEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
-RAWDEBUGEventContent.outputCommands.extend(RecoHIRAWOutput)
+RAWDEBUGEventContent.outputCommands.extend(RAWEventContent.outputCommands)
 
-RAWDEBUGHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)
-RAWDEBUGHLTEventContent.outputCommands.extend(RecoHIRAWOutput)
+#RAW HLT DEBUG 
+RAWDEBUGHLTEventContent.outputCommands.extend(RAWDEBUGEventContent.outputCommands)
 
-FEVTDEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
-FEVTDEBUGEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTDEBUGEventContent.outputCommands.extend(RecoHIRAWOutput)
-
-FEVTDEBUGHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)
-FEVTDEBUGHLTEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTDEBUGHLTEventContent.outputCommands.extend(RecoHIRAWOutput)
-
+#RECO DEBUG  
 RECODEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 RECODEBUGEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
 
+#FEVT DEBUG 
+FEVTDEBUGEventContent.outputCommands.extend(FEVTSIMEventContent.outputCommands)
+
+#FEVT HLT DEBUG  
+FEVTDEBUGHLTEventContent.outputCommands.extend(FEVTSIMEventContent.outputCommands)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -170,10 +170,25 @@ def customiseFor2017DtUnpacking(process):
 
     return process
 
+
+# Update Pixel Gain calibration scheme for Run3 (PR #29333)
+def customiseFor29333(process):
+    for producer in producers_by_type(process, "SiPixelClusterProducer"):
+        # For Run3, change in the gain calibration scheme,
+        # to include the VCal conversion factors directly in the SiPixelGainCalibration DB object
+        # full details at: https://indico.cern.ch/event/879470/contributions/3796405/attachments/2009273/3356603/pix_off_25_3_gain_calibration_mc.pdf
+        producer.VCaltoElectronGain      = cms.int32(1) # all gains=1, pedestals=0
+        producer.VCaltoElectronGain_L1   = cms.int32(1)
+        producer.VCaltoElectronOffset    = cms.int32(0)
+        producer.VCaltoElectronOffset_L1 = cms.int32(0)
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseFor29333(process)
 
     return process

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_EventContent_cff.py
@@ -1,36 +1,26 @@
-# The following comments couldn't be translated into the new config version:
-
-# DT 
-
-# no Drift algo
-
-# CSC
-
-# RPC
-
-# DT
-
-# no Drift algo
-
-# CSC
-
-# RPC
-
 import FWCore.ParameterSet.Config as cms
 
-# Full Event content 
-RecoLocalMuonFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_muonDTDigis_*_*', 
-        'keep *_dttfDigis_*_*', 
-        'keep *_dt1DRecHits_*_*', 
-        'keep *_dt4DSegments_*_*', 
-        'keep *_dt4DSegmentsT0Seg_*_*', 
-        'keep *_csc2DRecHits_*_*', 
-        'keep *_cscSegments_*_*', 
-        'keep RPCDetIdRPCDigiMuonDigiCollection_*_*_*', 
-        'keep *_rpcRecHits_*_*')
+# AOD content
+RecoLocalMuonAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring()
 )
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+
+run2_GEM_2017.toModify( RecoLocalMuonAOD, 
+    outputCommands = RecoLocalMuonAOD.outputCommands + [
+	'keep *_gemRecHits_*_*', 
+	'keep *_gemSegments_*_*'])
+run3_GEM.toModify( RecoLocalMuonAOD, 
+    outputCommands = RecoLocalMuonAOD.outputCommands + [
+	'keep *_gemRecHits_*_*', 
+	'keep *_gemSegments_*_*'])
+phase2_muon.toModify( RecoLocalMuonAOD, 
+    outputCommands = RecoLocalMuonAOD.outputCommands + [
+	'keep *_me0RecHits_*_*', 
+	'keep *_me0Segments_*_*'])
+
 # RECO content
 RecoLocalMuonRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -41,23 +31,14 @@ RecoLocalMuonRECO = cms.PSet(
         'keep *_dt4DSegmentsT0Seg_*_*', 
         'keep *_csc2DRecHits_*_*', 
         'keep *_cscSegments_*_*',
-        #'keep RPCDetIdRPCDigiMuonDigiCollection_*_*_*', 
         'keep RPCDetIdRPCDigiMuonDigiCollection_muonRPCDigis_*_*', 
         'keep *_rpcRecHits_*_*')
 )
-# AOD content
-RecoLocalMuonAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring()
+RecoLocalMuonRECO.outputCommands.extend(RecoLocalMuonAOD.outputCommands)
+
+# Full Event content 
+RecoLocalMuonFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep RPCDetIdRPCDigiMuonDigiCollection_*_*_*') 
 )
-
-def _updateOutput( era, outputPSets, commands):
-   for o in outputPSets:
-      era.toModify( o, outputCommands = o.outputCommands + commands )
-
-from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-_outputs = [RecoLocalMuonFEVT, RecoLocalMuonRECO, RecoLocalMuonAOD]
-_updateOutput( run2_GEM_2017, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
-_updateOutput( run3_GEM, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
-_updateOutput(phase2_muon, _outputs, ['keep *_me0RecHits_*_*', 'keep *_me0Segments_*_*'])
+RecoLocalMuonFEVT.outputCommands.extend(RecoLocalMuonRECO.outputCommands)

--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_EventContent_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_EventContent_cff.py
@@ -1,16 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-RecoLocalTrackerFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep PixelDigiedmDetSetVector_siPixelDigis_*_*', 
-        'keep *_siStripDigis_*_*', 
-        'keep *_siStripZeroSuppression_*_*', 
-        'keep *_siPixelClusters_*_*', 
-        'keep *_siStripClusters_*_*', 
-        'keep *_siPixelRecHits_*_*', 
-        'keep *_siStripRecHits_*_*', 
-        'keep *_siStripMatchedRecHits_*_*')
+# AOD content
+RecoLocalTrackerAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring()
 )
+
+# RECO content
 RecoLocalTrackerRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep PixelDigiedmDetSetVector_siPixelDigis_*_*', 
@@ -22,7 +17,10 @@ RecoLocalTrackerRECO = cms.PSet(
         'keep *_siStripRecHits_*_*', 
         'keep *_siStripMatchedRecHits_*_*')
 )
-RecoLocalTrackerAOD = cms.PSet(
+RecoLocalTrackerRECO.outputCommands.extend(RecoLocalTrackerAOD.outputCommands)
+
+# FEVT content
+RecoLocalTrackerFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
-
+RecoLocalTrackerFEVT.outputCommands.extend(RecoLocalTrackerRECO.outputCommands)


### PR DESCRIPTION
#### PR description:  
Cleaning up the cosmic and heavy-ion event content structures.
- For improving clarity, moving extend commands to the right after the corresponding output commands (PSet). 
- Clean up unused parts and Remove duplicated import lines. 
- Unify the Modifier styles. 
2 central event content file (`Configuration/EventContent/python/EventContentCosmics_cff.py` and `Configuration/EventContent/python/EventContentHeavyIons_cff.py` ) +
2 additional cosmic files also changed (`RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_EventContent_cff.py` and `RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_EventContent_cff.py`).

(the previous PR was [#PR29920](https://github.com/cms-sw/cmssw/pull/29920))
#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_1_X_2020-05-26-1100, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).