### PR TITLE
Suppress warnings from ONNXRuntime

### DIFF
--- a/PhysicsTools/ONNXRuntime/src/ONNXRuntime.cc
+++ b/PhysicsTools/ONNXRuntime/src/ONNXRuntime.cc
@@ -19,7 +19,7 @@ namespace cms::Ort {
 
   using namespace ::Ort;
 
-  const Env ONNXRuntime::env_(ORT_LOGGING_LEVEL_WARNING, "");
+  const Env ONNXRuntime::env_(ORT_LOGGING_LEVEL_ERROR, "");
 
   ONNXRuntime::ONNXRuntime(const std::string& model_path, const SessionOptions* session_options) {
     // create session


### PR DESCRIPTION
Change ONNXRuntime logging level to `ORT_LOGGING_LEVEL_ERROR`.
This should fix https://github.com/cms-sw/cmsdist/pull/5857#issuecomment-634030814.