### PR TITLE
Allow InputTag and ESInputTag in a PSet to be assigned from a sequence of strings

### DIFF
--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -587,14 +587,21 @@ class _ValidatingListBase(list):
             if not self._itemIsValid(item):
                 return False
         return True
+    def _itemFromArgument(self, x):
+        return x
+    def _convertArguments(self, seq):
+        if isinstance(seq, str):
+            yield seq
+        for x in seq:
+            yield self._itemFromArgument(x)
     def append(self,x):
         if not self._itemIsValid(x):
             raise TypeError("wrong type being appended to container "+self._labelIfAny())
-        super(_ValidatingListBase,self).append(x)
+        super(_ValidatingListBase,self).append(self._itemFromArgument(x))
     def extend(self,x):
         if not self._isValid(x):
             raise TypeError("wrong type being extended to container "+self._labelIfAny())
-        super(_ValidatingListBase,self).extend(x)
+        super(_ValidatingListBase,self).extend(self._convertArguments(x))
     def __add__(self,rhs):
         if not self._isValid(rhs):
             raise TypeError("wrong type being added to container "+self._labelIfAny())
@@ -605,7 +612,7 @@ class _ValidatingListBase(list):
     def insert(self,i,x):
         if not self._itemIsValid(x):
             raise TypeError("wrong type being inserted to container "+self._labelIfAny())
-        super(_ValidatingListBase,self).insert(i,x)
+        super(_ValidatingListBase,self).insert(i,self._itemFromArgument(x))
     def _labelIfAny(self):
         result = type(self).__name__
         if hasattr(self, '__label'):

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1532,6 +1532,25 @@ if __name__ == "__main__":
             self.assertEqual(it.getModuleLabel(), "label")
             self.assertEqual(it.getProductInstanceLabel(), "in")
             self.assertEqual(it.getProcessName(), "@skipCurrentProcess")
+
+            pset = PSet(it = InputTag("something"))
+            # "assignment" from string
+            pset.it = "label"
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "")
+            self.assertEqual(pset.it.getProcessName(), "")
+            pset.it = "label:in"
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "in")
+            self.assertEqual(pset.it.getProcessName(), "")
+            pset.it = "label:in:proc"
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "in")
+            self.assertEqual(pset.it.getProcessName(), "proc")
+            pset.it = "label::proc"
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "")
+            self.assertEqual(pset.it.getProcessName(), "proc")
         def testInputTagModified(self):
             a=InputTag("a")
             self.assertEqual(a.isModified(),False)

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -657,10 +657,12 @@ class InputTag(_ParameterTypeBase):
         if isinstance(arg, InputTag):
             return arg
         elif isinstance(arg, str):
+            if arg.count(":") > 2:
+                raise RuntimeError("InputTag may have at most 3 elements")
             return arg
         else:
             if len(arg) > 3:
-                raise RuntimeError("Sequence argument may have at most 3 elements")
+                raise RuntimeError("InputTag may have at most 3 elements")
             return ":".join(arg)
     def setValue(self,v):
         self._setValues(v)
@@ -671,6 +673,8 @@ class InputTag(_ParameterTypeBase):
         self.__processName=processName
         if -1 != self.__moduleLabel.find(":"):
             toks = self.__moduleLabel.split(":")
+            if len(toks) > 3:
+                raise RuntimeError("InputTag may have at most 3 elements")
             self.__moduleLabel = toks[0]
             if len(toks) > 1:
                 self.__productInstance = toks[1]
@@ -1553,6 +1557,10 @@ if __name__ == "__main__":
             self.assertEqual(it.getModuleLabel(), "label")
             self.assertEqual(it.getProductInstanceLabel(), "in")
             self.assertEqual(it.getProcessName(), "@skipCurrentProcess")
+            with self.assertRaises(RuntimeError):
+                it = InputTag("label:too:many:elements")
+            with self.assertRaises(RuntimeError):
+                vit = VInputTag("label:too:many:elements")
 
             pset = PSet(it = InputTag("something"))
             # "assignment" from string
@@ -1572,6 +1580,8 @@ if __name__ == "__main__":
             self.assertEqual(pset.it.getModuleLabel(), "label")
             self.assertEqual(pset.it.getProductInstanceLabel(), "")
             self.assertEqual(pset.it.getProcessName(), "proc")
+            with self.assertRaises(RuntimeError):
+                pset.it = "label:too:many:elements"
             # "assignment" from tuple of strings
             pset.it = ()
             self.assertEqual(pset.it.getModuleLabel(), "")

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -744,22 +744,36 @@ class ESInputTag(_ParameterTypeBase):
     def _valueFromString(string):
         parts = string.split(":")
         return ESInputTag(*parts)
+    @staticmethod
+    def _stringFromArgument(arg, dataLabel=None):
+        if isinstance(arg, ESInputTag):
+            return arg
+        elif isinstance(arg, str):
+            if arg:
+                cnt = arg.count(":")
+                if dataLabel is None and cnt == 0:
+                    raise RuntimeError("ESInputTag passed one string '"+str(arg)+"' which does not contain a ':'. Please add ':' to explicitly separate the module (1st) and data (2nd) label or use two strings.")
+                elif arg.count(":") >= 2:
+                    raise RuntimeError("an ESInputTag was passed the value'"+arg+"' which contains more than one ':'")
+            return arg
+        else:
+            if len(arg) > 2 or len(arg) == 1:
+                raise RuntimeError("ESInputTag must have either 2 or 0 elements")
+            if len(arg) == 2:
+                return ":".join(arg)
+            return ":"
     def setValue(self,v):
         self._setValues(v)
         self._isModified=True
     def _setValues(self,moduleLabel='',dataLabel=None):
-        self.__moduleLabel = moduleLabel
+        self.__moduleLabel = ESInputTag._stringFromArgument(moduleLabel, dataLabel)
         self.__data = dataLabel
         if dataLabel is None:
-            if moduleLabel:
-                if  -1 == moduleLabel.find(":"):
-                    raise RuntimeError("ESInputTag passed one string '"+str(moduleLabel)+"' which does not contain a ':'. Please add ':' to explicitly separate the module (1st) and data (2nd) label or use two strings.")
-                toks = moduleLabel.split(":")
+            if self.__moduleLabel:
+                toks = self.__moduleLabel.split(":")
                 self.__moduleLabel = toks[0]
                 if len(toks) > 1:
                     self.__data = toks[1]
-                if len(toks) > 2:
-                    raise RuntimeError("an ESInputTag was passed the value'"+moduleLabel+"' which contains more than one ':'")
             else:
                 self.__data = ''
             
@@ -1035,7 +1049,12 @@ class VInputTag(_ValidatingParameterListBase):
 
 class VESInputTag(_ValidatingParameterListBase):
     def __init__(self,*arg,**args):
-        super(VESInputTag,self).__init__(*arg,**args)
+        if len(arg) == 1 and not isinstance(arg[0], str):
+            try:
+                arg = iter(arg[0])
+            except TypeError:
+                pass
+        super(VESInputTag,self).__init__((ESInputTag._stringFromArgument(x) for x in arg),**args)
     @staticmethod
     def _itemIsValid(item):
         return ESInputTag._isValid(item)
@@ -1054,6 +1073,8 @@ class VESInputTag(_ValidatingParameterListBase):
     @staticmethod
     def _valueFromString(value):
         return VESInputTag(*_ValidatingParameterListBase._itemsFromStrings(value,ESInputTag._valueFromString))
+    def _itemFromArgument(self, x):
+        return ESInputTag._stringFromArgument(x)
     def insertInto(self, parameterSet, myname):
         cppTags = list()
         for i in self:
@@ -1671,6 +1692,83 @@ if __name__ == "__main__":
             self.assertEqual(repr(vit), 'cms.VESInputTag(cms.ESInputTag("label1",""), cms.ESInputTag("label2",""))')
             vit = VESInputTag("label1:", "label2:label3")
             self.assertEqual(repr(vit), "cms.VESInputTag(\"label1:\", \"label2:label3\")")
+            vit = VESInputTag(["label1:", "label2:label3"])
+            self.assertEqual(repr(vit), "cms.VESInputTag(\"label1:\", \"label2:label3\")")
+
+            with self.assertRaises(RuntimeError):
+                it = ESInputTag("label:too:many:elements")
+            with self.assertRaises(RuntimeError):
+                vit = VESInputTag("label:too:many:elements")
+
+            pset = PSet(it = ESInputTag("something:"))
+            # "assignment" from string
+            pset.it = ""
+            self.assertEqual(pset.it.getModuleLabel(), "")
+            self.assertEqual(pset.it.getDataLabel(), "")
+            pset.it = "label:"
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getDataLabel(), "")
+            pset.it = "label:data"
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getDataLabel(), "data")
+            pset.it = ":data"
+            self.assertEqual(pset.it.getModuleLabel(), "")
+            self.assertEqual(pset.it.getDataLabel(), "data")
+            with self.assertRaises(RuntimeError):
+                pset.it = "label:too:many:elements"
+            with self.assertRaises(RuntimeError):
+                pset.it = "too_few_elements"
+            # "assignment" from tuple of strings
+            pset.it = ()
+            self.assertEqual(pset.it.getModuleLabel(), "")
+            self.assertEqual(pset.it.getDataLabel(), "")
+            pset.it = ("label", "")
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getDataLabel(), "")
+            pset.it = ("label", "data")
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getDataLabel(), "data")
+            pset.it = ("", "data")
+            self.assertEqual(pset.it.getModuleLabel(), "")
+            self.assertEqual(pset.it.getDataLabel(), "data")
+            with self.assertRaises(RuntimeError):
+                pset.it = ("label", "too", "many", "elements")
+            with self.assertRaises(RuntimeError):
+                pset.it = ("too_few_elements",)
+            # "assignment" from list of strings
+            pset.it = []
+            self.assertEqual(pset.it.getModuleLabel(), "")
+            self.assertEqual(pset.it.getDataLabel(), "")
+            pset.it = ["label", ""]
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getDataLabel(), "")
+            pset.it = ["label", "data"]
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getDataLabel(), "data")
+            pset.it = ["", "data"]
+            self.assertEqual(pset.it.getModuleLabel(), "")
+            self.assertEqual(pset.it.getDataLabel(), "data")
+            with self.assertRaises(RuntimeError):
+                pset.it = ["label", "too", "many", "elements"]
+            with self.assertRaises(RuntimeError):
+                pset.it = ["too_few_elements"]
+
+            vit = VESInputTag(("a2", ""), ("b2", "d"), ("", "c"))
+            self.assertEqual(repr(vit), "cms.VESInputTag(\"a2:\", \"b2:d\", \":c\")")
+
+            pset = PSet(vit = VESInputTag())
+            pset.vit = ["a:", "b:d", ":c"]
+            self.assertEqual(repr(pset.vit), "cms.VESInputTag(\"a:\", \"b:d\", \":c\")")
+            pset.vit = [("a2", ""), ("b2", "d2"), ("", "c2")]
+            self.assertEqual(repr(pset.vit), "cms.VESInputTag(\"a2:\", \"b2:d2\", \":c2\")")
+            pset.vit = [["a3", ""], ["b3", "d3"], ["", "c3"]]
+            self.assertEqual(repr(pset.vit), "cms.VESInputTag(\"a3:\", \"b3:d3\", \":c3\")")
+            with self.assertRaises(RuntimeError):
+                pset.vit = [("label", "too", "many", "elements")]
+            with self.assertRaises(RuntimeError):
+                pset.vit = ["too_few_elements"]
+            with self.assertRaises(RuntimeError):
+                pset.vit = [("too_few_elements")]
 
         def testPSet(self):
             p1 = PSet(anInt = int32(1), a = PSet(b = int32(1)))

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -656,10 +656,18 @@ class InputTag(_ParameterTypeBase):
         self._setValues(v)
         self._isModified=True
     def _setValues(self,moduleLabel,productInstanceLabel='',processName=''):
-        self.__moduleLabel = moduleLabel
         self.__productInstance = productInstanceLabel
         self.__processName=processName
-        if isinstance(moduleLabel, tuple) or isinstance(moduleLabel, list):
+        if isinstance(moduleLabel, str):
+            self.__moduleLabel = moduleLabel
+            if -1 != moduleLabel.find(":"):
+                toks = moduleLabel.split(":")
+                self.__moduleLabel = toks[0]
+                if len(toks) > 1:
+                    self.__productInstance = toks[1]
+                if len(toks) > 2:
+                    self.__processName=toks[2]
+        else:
             self.__moduleLabel = moduleLabel[0] if len(moduleLabel) > 0 else ""
             if len(moduleLabel) > 1:
                 self.__productInstance = moduleLabel[1]
@@ -667,13 +675,6 @@ class InputTag(_ParameterTypeBase):
                 self.__processName = moduleLabel[2]
             if len(moduleLabel) > 3:
                 raise RuntimeError("Tuple argument may have at most 3 elements")
-        elif -1 != moduleLabel.find(":"):
-            toks = moduleLabel.split(":")
-            self.__moduleLabel = toks[0]
-            if len(toks) > 1:
-                self.__productInstance = toks[1]
-            if len(toks) > 2:
-                self.__processName=toks[2]
     # convert to the wrapper class for C++ InputTags
     def cppTag(self, parameterSet):
         return parameterSet.newInputTag(self.getModuleLabel(),

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1565,7 +1565,7 @@ if __name__ == "__main__":
             self.assertEqual(pset.it.getModuleLabel(), "")
             self.assertEqual(pset.it.getProductInstanceLabel(), "")
             self.assertEqual(pset.it.getProcessName(), "")
-            pset.it = ("label")
+            pset.it = ("label",)
             self.assertEqual(pset.it.getModuleLabel(), "label")
             self.assertEqual(pset.it.getProductInstanceLabel(), "")
             self.assertEqual(pset.it.getProcessName(), "")

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -659,7 +659,15 @@ class InputTag(_ParameterTypeBase):
         self.__moduleLabel = moduleLabel
         self.__productInstance = productInstanceLabel
         self.__processName=processName
-        if -1 != moduleLabel.find(":"):
+        if isinstance(moduleLabel, tuple):
+            self.__moduleLabel = moduleLabel[0] if len(moduleLabel) > 0 else ""
+            if len(moduleLabel) > 1:
+                self.__productInstance = moduleLabel[1]
+            if len(moduleLabel) > 2:
+                self.__processName = moduleLabel[2]
+            if len(moduleLabel) > 3:
+                raise RuntimeError("Tuple argument may have at most 3 elements")
+        elif -1 != moduleLabel.find(":"):
             toks = moduleLabel.split(":")
             self.__moduleLabel = toks[0]
             if len(toks) > 1:
@@ -1551,6 +1559,31 @@ if __name__ == "__main__":
             self.assertEqual(pset.it.getModuleLabel(), "label")
             self.assertEqual(pset.it.getProductInstanceLabel(), "")
             self.assertEqual(pset.it.getProcessName(), "proc")
+            # "assignment" from tuple of strings
+            pset.it = ()
+            self.assertEqual(pset.it.getModuleLabel(), "")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "")
+            self.assertEqual(pset.it.getProcessName(), "")
+            pset.it = ("label")
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "")
+            self.assertEqual(pset.it.getProcessName(), "")
+            pset.it = ("label", "in")
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "in")
+            self.assertEqual(pset.it.getProcessName(), "")
+            pset.it = ("label", "in", "proc")
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "in")
+            self.assertEqual(pset.it.getProcessName(), "proc")
+            pset.it = ("label", "", "proc")
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "")
+            self.assertEqual(pset.it.getProcessName(), "proc")
+            with self.assertRaises(RuntimeError):
+                pset.it = ("label", "too", "many", "elements")
+            with self.assertRaises(AttributeError):
+                pset.it = ["label"]
         def testInputTagModified(self):
             a=InputTag("a")
             self.assertEqual(a.isModified(),False)

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -659,7 +659,7 @@ class InputTag(_ParameterTypeBase):
         self.__moduleLabel = moduleLabel
         self.__productInstance = productInstanceLabel
         self.__processName=processName
-        if isinstance(moduleLabel, tuple):
+        if isinstance(moduleLabel, tuple) or isinstance(moduleLabel, list):
             self.__moduleLabel = moduleLabel[0] if len(moduleLabel) > 0 else ""
             if len(moduleLabel) > 1:
                 self.__productInstance = moduleLabel[1]
@@ -1582,8 +1582,29 @@ if __name__ == "__main__":
             self.assertEqual(pset.it.getProcessName(), "proc")
             with self.assertRaises(RuntimeError):
                 pset.it = ("label", "too", "many", "elements")
-            with self.assertRaises(AttributeError):
-                pset.it = ["label"]
+            # "assignment" from list of strings
+            pset.it = []
+            self.assertEqual(pset.it.getModuleLabel(), "")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "")
+            self.assertEqual(pset.it.getProcessName(), "")
+            pset.it = ["label"]
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "")
+            self.assertEqual(pset.it.getProcessName(), "")
+            pset.it = ["label", "in"]
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "in")
+            self.assertEqual(pset.it.getProcessName(), "")
+            pset.it = ["label", "in", "proc"]
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "in")
+            self.assertEqual(pset.it.getProcessName(), "proc")
+            pset.it = ["label", "", "proc"]
+            self.assertEqual(pset.it.getModuleLabel(), "label")
+            self.assertEqual(pset.it.getProductInstanceLabel(), "")
+            self.assertEqual(pset.it.getProcessName(), "proc")
+            with self.assertRaises(RuntimeError):
+                pset.it = ["label", "too", "many", "elements"]
         def testInputTagModified(self):
             a=InputTag("a")
             self.assertEqual(a.isModified(),False)

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1715,7 +1715,7 @@ if __name__ == "__main__":
             self.assertEqual(pset.it.getModuleLabel(), "")
             self.assertEqual(pset.it.getDataLabel(), "data")
             with self.assertRaises(RuntimeError):
-                pset.it = "label:too:many:elements"
+                pset.it = "too:many:elements"
             with self.assertRaises(RuntimeError):
                 pset.it = "too_few_elements"
             # "assignment" from tuple of strings
@@ -1732,7 +1732,7 @@ if __name__ == "__main__":
             self.assertEqual(pset.it.getModuleLabel(), "")
             self.assertEqual(pset.it.getDataLabel(), "data")
             with self.assertRaises(RuntimeError):
-                pset.it = ("label", "too", "many", "elements")
+                pset.it = ("too", "many", "elements")
             with self.assertRaises(RuntimeError):
                 pset.it = ("too_few_elements",)
             # "assignment" from list of strings
@@ -1749,7 +1749,7 @@ if __name__ == "__main__":
             self.assertEqual(pset.it.getModuleLabel(), "")
             self.assertEqual(pset.it.getDataLabel(), "data")
             with self.assertRaises(RuntimeError):
-                pset.it = ["label", "too", "many", "elements"]
+                pset.it = ["too", "many", "elements"]
             with self.assertRaises(RuntimeError):
                 pset.it = ["too_few_elements"]
 
@@ -1764,7 +1764,7 @@ if __name__ == "__main__":
             pset.vit = [["a3", ""], ["b3", "d3"], ["", "c3"]]
             self.assertEqual(repr(pset.vit), "cms.VESInputTag(\"a3:\", \"b3:d3\", \":c3\")")
             with self.assertRaises(RuntimeError):
-                pset.vit = [("label", "too", "many", "elements")]
+                pset.vit = [("too", "many", "elements")]
             with self.assertRaises(RuntimeError):
                 pset.vit = ["too_few_elements"]
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
#### PR description:

This PR allows an existing `InputTag` in a `PSet` to be assigned from a sequence (e.g. tuple or list) of strings in addition of a string with a colon as the field separator, e.g.
```python
pset.tag = ("label", "instance", "process")
```
`VInputTag` can be constructed with a sequence of sequences of strings. A sequence of strings is still considered to mean one `InputTag` per string, e.g. `VInputTag(["one", "two", "three"])` has three elements.

`ESInputTag` can be assigned from a sequence of 0 or 2 strings (to be consistent with the colon-separated-string assignment constraints). `VESInputTag` can be constructed with a sequence of a sequence of 0 or 2 strings.

Resolves #29846

#### PR validation:

Unit test runs.