### PR TITLE
Fixes in PSetBlobProducer functionality for use in HLT (11_1_X)

### DIFF
--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -111,7 +111,7 @@ namespace evf {
         streamLabel_(ps.getParameter<std::string>("@module_label")),
         trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
         psetToken_(consumes<edm::SendJobHeader::ParameterSetMap, edm::InRun>(
-            ps.getUntrackedParameter<edm::InputTag>("hltPSetMap"))) {
+            ps.getUntrackedParameter<edm::InputTag>("psetMap"))) {
     //replace hltOutoputA with stream if the HLT menu uses this convention
     std::string testPrefix = "hltOutput";
     if (streamLabel_.find(testPrefix) == 0)
@@ -140,7 +140,7 @@ namespace evf {
     edm::ParameterSetDescription desc;
     edm::StreamerOutputModuleCommon::fillDescription(desc);
     EvFOutputModuleType::fillDescription(desc);
-    desc.addUntracked<edm::InputTag>("psetMap", {"psetMap"})
+    desc.addUntracked<edm::InputTag>("psetMap", {"hltPSetMap"})
         ->setComment("Optionally allow the map of ParameterSets to be calculated externally.");
     descriptions.addDefault(desc);
   }

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -111,7 +111,7 @@ namespace evf {
         streamLabel_(ps.getParameter<std::string>("@module_label")),
         trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
         psetToken_(consumes<edm::SendJobHeader::ParameterSetMap, edm::InRun>(
-            ps.getUntrackedParameter<edm::InputTag>("psetMap"))) {
+            ps.getUntrackedParameter<edm::InputTag>("hltPSetMap"))) {
     //replace hltOutoputA with stream if the HLT menu uses this convention
     std::string testPrefix = "hltOutput";
     if (streamLabel_.find(testPrefix) == 0)

--- a/IOPool/Streamer/plugins/ParameterSetBlobProducer.cc
+++ b/IOPool/Streamer/plugins/ParameterSetBlobProducer.cc
@@ -15,7 +15,10 @@ public:
 
   void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const final;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions&) {}
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.addWithDefaultLabel(desc);
+  }
 
 private:
   edm::EDPutTokenT<std::map<edm::ParameterSetID, edm::ParameterSetBlob>> const token_;

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -68,7 +68,7 @@ namespace edm {
   void StreamerOutputModuleBase::fillDescription(ParameterSetDescription& desc) {
     StreamerOutputModuleCommon::fillDescription(desc);
     OutputModule::fillDescription(desc);
-    desc.addUntracked<edm::InputTag>("psetMap", {"psetMap"})
+    desc.addUntracked<edm::InputTag>("psetMap", {"hltPSetMap"})
         ->setComment("Optionally allow the map of ParameterSets to be calculated externally.");
   }
 }  // namespace edm


### PR DESCRIPTION
#### PR description:

Fixes in PSetBlobProducer functionality for use in HLT (11_1_X)

#### PR validation:

TSG tests

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

#29998
Needed for use in 11_1.
