### PR TITLE
New O2O for BeamSpot online run start

### DIFF
--- a/CondCore/PopCon/src/PopCon.cc
+++ b/CondCore/PopCon/src/PopCon.cc
@@ -51,15 +51,15 @@ namespace popcon {
     }
     if (m_targetSession.existsDatabase() && m_targetSession.existsIov(m_tag)) {
       cond::persistency::IOVProxy iov = m_targetSession.readIov(m_tag);
-      size_t tagSize = iov.sequenceSize();
-      if (tagSize > 0) {
+      m_tagInfo.size = iov.sequenceSize();
+      if (m_tagInfo.size > 0) {
         m_tagInfo.lastInterval = iov.getLast();
       }
 
       edm::LogInfo("PopCon") << "destination DB: " << connectionStr << ", target DB: "
                              << (m_targetConnectionString.empty() ? connectionStr : m_targetConnectionString) << "\n"
                              << "TAG: " << m_tag << ", last since/till: " << m_tagInfo.lastInterval.since << "/"
-                             << m_tagInfo.lastInterval.till << ", size: " << tagSize << "\n"
+                             << m_tagInfo.lastInterval.till << ", size: " << m_tagInfo.size << "\n"
                              << std::endl;
     } else {
       edm::LogInfo("PopCon") << "destination DB: " << connectionStr << ", target DB: "

--- a/CondTools/BeamSpot/BuildFile.xml
+++ b/CondTools/BeamSpot/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="CondCore/CondDB"/>
+<use name="CondCore/DBOutputService"/>
+<use name="CondCore/PopCon"/>
+<use name="CondFormats/Common"/>
+<use name="CondFormats/BeamSpotObjects"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/CondTools/BeamSpot/interface/BeamSpotOnlinePopConSourceHandler.h
+++ b/CondTools/BeamSpot/interface/BeamSpotOnlinePopConSourceHandler.h
@@ -1,0 +1,26 @@
+#ifndef BEAMSPOTONLINESOURCEHANDLER_H
+#define BEAMSPOTONLINESOURCEHANDLER_H
+
+#include <string>
+
+#include "CondCore/PopCon/interface/PopConSourceHandler.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+class BeamSpotOnlinePopConSourceHandler : public popcon::PopConSourceHandler<BeamSpotOnlineObjects> {
+public:
+  BeamSpotOnlinePopConSourceHandler(const edm::ParameterSet& pset);
+  ~BeamSpotOnlinePopConSourceHandler() override;
+  void getNewObjects() override;
+  std::string id() const override;
+
+private:
+  bool m_debug;
+  std::string m_name;
+  unsigned int m_maxAge;
+  unsigned int m_runNumber;
+  std::string m_sourcePayloadTag;
+  std::unique_ptr<BeamSpotOnlineObjects> m_payload;
+};
+
+#endif

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlinePopConAnalyzer.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlinePopConAnalyzer.cc
@@ -1,0 +1,7 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondTools/BeamSpot/interface/BeamSpotOnlinePopConSourceHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef popcon::PopConAnalyzer<BeamSpotOnlinePopConSourceHandler> BeamSpotOnlinePopConAnalyzer;
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamSpotOnlinePopConAnalyzer);

--- a/CondTools/BeamSpot/plugins/BuildFile.xml
+++ b/CondTools/BeamSpot/plugins/BuildFile.xml
@@ -1,3 +1,5 @@
+<use name="CondTools/BeamSpot"/>
+<use name="CondCore/PopCon"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
@@ -5,5 +7,7 @@
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="CondCore/CondDB"/>
-<use name="CondCore/DBOutputService"/>
 <flags EDM_PLUGIN="1"/>
+<library file="BeamSpotOnlinePopConAnalyzer.cc" name="CondToolsBeamSpotOnlinePopConAnalyzer">
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/CondTools/BeamSpot/python/BeamSpotOnlineAnalyzerStartRun.py
+++ b/CondTools/BeamSpot/python/BeamSpotOnlineAnalyzerStartRun.py
@@ -1,0 +1,87 @@
+import socket
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+process = cms.Process("BeamSpotOnlineStartRun")
+from CondCore.CondDB.CondDB_cfi import *
+
+options = VarParsing.VarParsing()
+options.register( 'destinationConnection'
+                , 'sqlite_file:beamspot_test.db' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Connection string to the DB where payloads will be possibly written."
+                  )
+options.register( 'targetConnection'
+                , '' #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , """Connection string to the target DB:
+                     if not empty (default), this provides the latest IOV and payloads to compare;
+                     it is the DB where payloads should be finally uploaded."""
+                  )
+options.register( 'tag'
+                , 'beamspot_test'
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag written in destinationConnection and finally appended in targetConnection."
+                  )
+options.register( 'sourceTag'
+                , ''
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.string
+                , "Tag used to retrieve the source payload from the targetConnection."
+                  )
+options.register( 'runNumber'
+                , 1 #default value                                                                                                                                                          
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Run number for the target since."
+                  )
+options.register( 'messageLevel'
+                , 0 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Message level; default to 0"
+                  )
+options.parseArguments()
+
+CondDBConnection = CondDB.clone( connect = cms.string( options.destinationConnection ) )
+CondDBConnection.DBParameters.messageLevel = cms.untracked.int32( options.messageLevel )
+
+process.MessageLogger = cms.Service("MessageLogger",
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
+                                    destinations = cms.untracked.vstring('cout')
+                                    )
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(1),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            interval = cms.uint64(1)
+                            )
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBConnection,
+                                          timetype = cms.untracked.string('lumiid'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('BeamSpotRcd'),
+                                                                     tag = cms.string( options.tag )
+                                                                     )
+                                                            )
+                                          )
+
+process.PopCon = cms.EDAnalyzer("BeamSpotOnlinePopConAnalyzer",
+                                SinceAppendMode = cms.bool(True),
+                                record = cms.string('BeamSpotRcd'),
+                                name = cms.untracked.string('BeamSpotOnline'),
+                                Source = cms.PSet(
+                                    runNumber = cms.untracked.uint32( options.runNumber ),
+                                    sourcePayloadTag = cms.untracked.string( options.sourceTag ),
+                                    # maxAge = one day in seconds
+                                    maxAge = cms.untracked.uint32( 86400 ),
+                                    debug=cms.untracked.bool(False)
+                                ),
+                               loggingOn = cms.untracked.bool(True),
+                               IsDestDbCheckedInQueryLog = cms.untracked.bool(False)
+                               )
+
+process.p = cms.Path(process.PopCon)

--- a/CondTools/BeamSpot/src/BeamSpotOnlinePopConSourceHandler.cc
+++ b/CondTools/BeamSpot/src/BeamSpotOnlinePopConSourceHandler.cc
@@ -10,12 +10,11 @@ BeamSpotOnlinePopConSourceHandler::BeamSpotOnlinePopConSourceHandler(edm::Parame
       m_name(pset.getUntrackedParameter<std::string>("name", "BeamSpotOnlineSourceHandler")),
       m_maxAge(pset.getUntrackedParameter<unsigned int>("maxAge", 86400)),
       m_runNumber(pset.getUntrackedParameter<unsigned int>("runNumber", 1)),
-      m_sourcePayloadTag( pset.getUntrackedParameter<std::string>("sourcePayloadTag","")) {
-}
+      m_sourcePayloadTag(pset.getUntrackedParameter<std::string>("sourcePayloadTag", "")) {}
 
 BeamSpotOnlinePopConSourceHandler::~BeamSpotOnlinePopConSourceHandler() {}
 
-bool checkPayloadAge( const BeamSpotOnlineObjects& payload, unsigned int maxAge ){
+bool checkPayloadAge(const BeamSpotOnlineObjects& payload, unsigned int maxAge) {
   long creationTimeInSeconds = payload.GetCreationTime() >> 32;
   auto timeNow = std::chrono::system_clock::now();
   auto nowSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
@@ -23,45 +22,43 @@ bool checkPayloadAge( const BeamSpotOnlineObjects& payload, unsigned int maxAge 
   return age < maxAge;
 }
 
-std::unique_ptr<BeamSpotOnlineObjects> makeDummyPayload(){
+std::unique_ptr<BeamSpotOnlineObjects> makeDummyPayload() {
   // implement here
   std::unique_ptr<BeamSpotOnlineObjects> ret;
-  ret.reset( new BeamSpotOnlineObjects() );
+  ret.reset(new BeamSpotOnlineObjects());
   auto timeNow = std::chrono::system_clock::now();
   auto nowSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
-  ret->SetCreationTime( nowSinceEpoch << 32 );
+  ret->SetCreationTime(nowSinceEpoch << 32);
   return ret;
 }
 
 void BeamSpotOnlinePopConSourceHandler::getNewObjects() {
-
   bool addNewPayload = false;
   if (!tagInfo().size) {
     edm::LogInfo(m_name) << "New tag " << tagInfo().name << "; from " << m_name << "::getNewObjects";
     addNewPayload = true;
   } else {
-    edm::LogInfo(m_name) << "got info for tag " << tagInfo().name
-                         << ", last object valid since " << tagInfo().lastInterval.since 
-                         << "; from " << m_name << "::getNewObjects";
-    if( !checkPayloadAge( *lastPayload(), m_maxAge ) ){
+    edm::LogInfo(m_name) << "got info for tag " << tagInfo().name << ", last object valid since "
+                         << tagInfo().lastInterval.since << "; from " << m_name << "::getNewObjects";
+    if (!checkPayloadAge(*lastPayload(), m_maxAge)) {
       addNewPayload = true;
     }
   }
 
-  if( addNewPayload ){
-    if( !m_sourcePayloadTag.empty() ){
+  if (addNewPayload) {
+    if (!m_sourcePayloadTag.empty()) {
       edm::LogInfo(m_name) << "Reading target payload from tag " << m_sourcePayloadTag;
       auto session = dbSession();
       session.transaction().start(true);
-      auto lastIov = session.readIov( m_sourcePayloadTag ).getLast();
-      m_payload = session.fetchPayload<BeamSpotOnlineObjects>( lastIov.payloadId );
+      auto lastIov = session.readIov(m_sourcePayloadTag).getLast();
+      m_payload = session.fetchPayload<BeamSpotOnlineObjects>(lastIov.payloadId);
       session.transaction().commit();
-    }  else {
+    } else {
       m_payload = makeDummyPayload();
     }
- 
-    cond::Time_t targetTime = cond::time::lumiTime( m_runNumber, 1 );
-    m_to_transfer.push_back( std::make_pair( m_payload.get(), targetTime ) );
+
+    cond::Time_t targetTime = cond::time::lumiTime(m_runNumber, 1);
+    m_to_transfer.push_back(std::make_pair(m_payload.get(), targetTime));
 
     edm::LogInfo(m_name) << "Payload added with IOV since " << targetTime;
   } else {

--- a/CondTools/BeamSpot/src/BeamSpotOnlinePopConSourceHandler.cc
+++ b/CondTools/BeamSpot/src/BeamSpotOnlinePopConSourceHandler.cc
@@ -1,0 +1,72 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/Common/interface/TimeConversions.h"
+#include "CondTools/BeamSpot/interface/BeamSpotOnlinePopConSourceHandler.h"
+
+#include <chrono>
+
+BeamSpotOnlinePopConSourceHandler::BeamSpotOnlinePopConSourceHandler(edm::ParameterSet const& pset)
+    : m_debug(pset.getUntrackedParameter<bool>("debug", false)),
+      m_name(pset.getUntrackedParameter<std::string>("name", "BeamSpotOnlineSourceHandler")),
+      m_maxAge(pset.getUntrackedParameter<unsigned int>("maxAge", 86400)),
+      m_runNumber(pset.getUntrackedParameter<unsigned int>("runNumber", 1)),
+      m_sourcePayloadTag( pset.getUntrackedParameter<std::string>("sourcePayloadTag","")) {
+}
+
+BeamSpotOnlinePopConSourceHandler::~BeamSpotOnlinePopConSourceHandler() {}
+
+bool checkPayloadAge( const BeamSpotOnlineObjects& payload, unsigned int maxAge ){
+  long creationTimeInSeconds = payload.GetCreationTime() >> 32;
+  auto timeNow = std::chrono::system_clock::now();
+  auto nowSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
+  long age = nowSinceEpoch - creationTimeInSeconds;
+  return age < maxAge;
+}
+
+std::unique_ptr<BeamSpotOnlineObjects> makeDummyPayload(){
+  // implement here
+  std::unique_ptr<BeamSpotOnlineObjects> ret;
+  ret.reset( new BeamSpotOnlineObjects() );
+  auto timeNow = std::chrono::system_clock::now();
+  auto nowSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
+  ret->SetCreationTime( nowSinceEpoch << 32 );
+  return ret;
+}
+
+void BeamSpotOnlinePopConSourceHandler::getNewObjects() {
+
+  bool addNewPayload = false;
+  if (!tagInfo().size) {
+    edm::LogInfo(m_name) << "New tag " << tagInfo().name << "; from " << m_name << "::getNewObjects";
+    addNewPayload = true;
+  } else {
+    edm::LogInfo(m_name) << "got info for tag " << tagInfo().name
+                         << ", last object valid since " << tagInfo().lastInterval.since 
+                         << "; from " << m_name << "::getNewObjects";
+    if( !checkPayloadAge( *lastPayload(), m_maxAge ) ){
+      addNewPayload = true;
+    }
+  }
+
+  if( addNewPayload ){
+    if( !m_sourcePayloadTag.empty() ){
+      edm::LogInfo(m_name) << "Reading target payload from tag " << m_sourcePayloadTag;
+      auto session = dbSession();
+      session.transaction().start(true);
+      auto lastIov = session.readIov( m_sourcePayloadTag ).getLast();
+      m_payload = session.fetchPayload<BeamSpotOnlineObjects>( lastIov.payloadId );
+      session.transaction().commit();
+    }  else {
+      m_payload = makeDummyPayload();
+    }
+ 
+    cond::Time_t targetTime = cond::time::lumiTime( m_runNumber, 1 );
+    m_to_transfer.push_back( std::make_pair( m_payload.get(), targetTime ) );
+
+    edm::LogInfo(m_name) << "Payload added with IOV since " << targetTime;
+  } else {
+    edm::LogInfo(m_name) << "Nothing to do, last payload satisfies maximum age requirement.";
+  }
+}
+
+std::string BeamSpotOnlinePopConSourceHandler::id() const { return m_name; }


### PR DESCRIPTION
#### PR description:

Implementation of a new O2O workflow, required to initialise the BeamSpot tags with some adapted values for the HLT consumption at every new run.

This PR also contain a fix to correctly load the tag size in the Tag Info, in the context of the PopCon based workflow. 

#### PR validation:

A dedicated python cfg file has been used to test the new workflow against a local sqlite file.
