### PR TITLE
Do not apply the "const" modifier to the return type (11.1.x)

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalXtalGroupId.h
+++ b/CondFormats/EcalObjects/interface/EcalXtalGroupId.h
@@ -19,7 +19,7 @@ public:
   bool operator<(const EcalXtalGroupId& rhs) const { return (id_ < rhs.id()); }
   bool operator<=(const EcalXtalGroupId& rhs) const { return (id_ <= rhs.id()); }
 
-  const unsigned int id() const { return id_; }
+  unsigned int id() const { return id_; }
 
 private:
   unsigned int id_;


### PR DESCRIPTION
#### PR description:

Fixes the warning
```
CondFormats/EcalObjects/interface/EcalXtalGroupId.h(22): warning: type qualifier on return type is meaningless
```

No changes expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Backport https://github.com/cms-sw/cmssw/pull/29913 to avoid conflicts when squashing or rebasing the Patatrack developments.