### PR TITLE
Improve friendly class names of unordered_set and unordered_map

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -57,10 +57,14 @@ namespace edm {
     static std::regex const reVector("std::vector");
     static std::regex const reUnorderedSetHashKeyEqual(
         "std::unordered_set< *(.*), *std::hash<\\1> *, *std::equal_to<\\1> *>");
+    static std::regex const reUnorderedSetCustomHashKeyEqual(
+        "std::unordered_set< *(.*), *(.*) *, *std::equal_to<\\1> *>");
     static std::regex const reUnorderedSetHash("std::unordered_set< *(.*), *std::hash<\\1> *>");
     static std::regex const reUnorderedSet("std::unordered_set");
     static std::regex const reUnorderedMapHashKeyEqual(
         "std::unordered_map< *(.*), *(.*), *std::hash<\\1> *, *std::equal_to<\\1> *>");
+    static std::regex const reUnorderedMapCustomHashKeyEqual(
+        "std::unordered_map< *(.*), *(.*), *(.*) *, *std::equal_to<\\1> *>");
     static std::regex const reUnorderedMapHash("std::unordered_map< *(.*), *(.*), *std::hash<\\1> *>");
     static std::regex const reUnorderedMap("std::unordered_map");
     static std::regex const reSharedPtr("std::shared_ptr");
@@ -152,6 +156,10 @@ namespace edm {
         auto result2 =
             regex_replace(result, reUnorderedSetHashKeyEqual, "stduset<$1>", std::regex_constants::format_first_only);
         if (result2 == result) {
+          result2 = regex_replace(
+              result, reUnorderedSetCustomHashKeyEqual, "stduset<$1, $2>", std::regex_constants::format_first_only);
+        }
+        if (result2 == result) {
           result2 = regex_replace(result, reUnorderedSetHash, "stduset<$1>", std::regex_constants::format_first_only);
         }
         if (result2 == result) {
@@ -163,6 +171,10 @@ namespace edm {
       {
         auto result2 = regex_replace(
             result, reUnorderedMapHashKeyEqual, "stdumap<$1, $2>", std::regex_constants::format_first_only);
+        if (result2 == result) {
+          result2 = regex_replace(
+              result, reUnorderedMapCustomHashKeyEqual, "stdumap<$1, $2, $3>", std::regex_constants::format_first_only);
+        }
         if (result2 == result) {
           result2 =
               regex_replace(result, reUnorderedMapHash, "stdumap<$1, $2>", std::regex_constants::format_first_only);

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -43,10 +43,16 @@ void testfriendlyName::test() {
   classToFriendly.insert(Values("std::unordered_set<bar::Foo, std::hash<bar::Foo>>", "barFoostduset"));
   classToFriendly.insert(
       Values("std::unordered_set<bar::Foo, std::hash<bar::Foo>, std::equal_to<bar::Foo>>", "barFoostduset"));
+  classToFriendly.insert(
+      Values("std::unordered_set<bar::Foo, CustomHash, std::equal_to<bar::Foo>>", "barFooCustomHashstduset"));
+  classToFriendly.insert(Values("std::unordered_set<bar::Foo, CustomHash>", "barFooCustomHashstduset"));
   classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar>", "FoobarBarstdumap"));
   classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar, std::hash<Foo>>", "FoobarBarstdumap"));
   classToFriendly.insert(
       Values("std::unordered_map<Foo, bar::Bar, std::hash<Foo>, std::equal_to<Foo>>", "FoobarBarstdumap"));
+  classToFriendly.insert(
+      Values("std::unordered_map<Foo, bar::Bar, CustomHash, std::equal_to<Foo>>", "FoobarBarCustomHashstdumap"));
+  classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar, CustomHash>", "FoobarBarCustomHashstdumap"));
   classToFriendly.insert(Values("std::shared_ptr<Foo>", "FooSharedPtr"));
   classToFriendly.insert(Values("std::shared_ptr<bar::Foo>", "barFooSharedPtr"));
   classToFriendly.insert(Values("std::basic_string<char>", "String"));

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -40,19 +40,52 @@ void testfriendlyName::test() {
   classToFriendly.insert(Values("std::set<bar::Foo>", "barFoostdset"));
   classToFriendly.insert(Values("std::map<Foo, bar::Bar>", "FoobarBarstdmap"));
   classToFriendly.insert(Values("std::unordered_set<bar::Foo>", "barFoostduset"));
+  classToFriendly.insert(Values("std::unordered_set<std::basic_string<char>>", "Stringstduset"));
   classToFriendly.insert(Values("std::unordered_set<bar::Foo, std::hash<bar::Foo>>", "barFoostduset"));
+  classToFriendly.insert(
+      Values("std::unordered_set<std::basic_string<char>, std::hash<std::basic_string<char>>>", "Stringstduset"));
   classToFriendly.insert(
       Values("std::unordered_set<bar::Foo, std::hash<bar::Foo>, std::equal_to<bar::Foo>>", "barFoostduset"));
   classToFriendly.insert(
+      Values("std::unordered_set<std::basic_string<char>, std::hash<std::basic_string<char>>, "
+             "std::equal_to<std::basic_string<char>>>",
+             "Stringstduset"));
+  classToFriendly.insert(
       Values("std::unordered_set<bar::Foo, CustomHash, std::equal_to<bar::Foo>>", "barFooCustomHashstduset"));
+  classToFriendly.insert(
+      Values("std::unordered_set<std::basic_string<char>, CustomHash, std::equal_to<std::basic_string<char>>>",
+             "StringCustomHashstduset"));
   classToFriendly.insert(Values("std::unordered_set<bar::Foo, CustomHash>", "barFooCustomHashstduset"));
+  classToFriendly.insert(Values("std::unordered_set<std::basic_string<char>, CustomHash>", "StringCustomHashstduset"));
   classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar>", "FoobarBarstdumap"));
+  classToFriendly.insert(Values("std::unordered_map<std::basic_string<char>, bar::Bar>", "StringbarBarstdumap"));
+  classToFriendly.insert(Values("std::unordered_map<Foo, std::basic_string<char>>", "FooStringstdumap"));
   classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar, std::hash<Foo>>", "FoobarBarstdumap"));
+  classToFriendly.insert(
+      Values("std::unordered_map<std::basic_string<char> , bar::Bar, std::hash<std::basic_string<char> > >",
+             "StringbarBarstdumap"));
+  classToFriendly.insert(
+      Values("std::unordered_map<Foo, std::basic_string<char> , std::hash<Foo>>", "FooStringstdumap"));
   classToFriendly.insert(
       Values("std::unordered_map<Foo, bar::Bar, std::hash<Foo>, std::equal_to<Foo>>", "FoobarBarstdumap"));
   classToFriendly.insert(
+      Values("std::unordered_map<std::basic_string<char>, bar::Bar, std::hash<std::basic_string<char>>, "
+             "std::equal_to<std::basic_string<char>>>",
+             "StringbarBarstdumap"));
+  classToFriendly.insert(Values("std::unordered_map<Foo, std::basic_string<char>, std::hash<Foo>, std::equal_to<Foo>>",
+                                "FooStringstdumap"));
+  classToFriendly.insert(
       Values("std::unordered_map<Foo, bar::Bar, CustomHash, std::equal_to<Foo>>", "FoobarBarCustomHashstdumap"));
+  classToFriendly.insert(Values(
+      "std::unordered_map<std::basic_string<char>, bar::Bar, CustomHash, std::equal_to<std::basic_string<char>>>",
+      "StringbarBarCustomHashstdumap"));
+  classToFriendly.insert(Values("std::unordered_map<Foo, std::basic_string<char>, CustomHash, std::equal_to<Foo>>",
+                                "FooStringCustomHashstdumap"));
   classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar, CustomHash>", "FoobarBarCustomHashstdumap"));
+  classToFriendly.insert(
+      Values("std::unordered_map<std::basic_string<char>, bar::Bar, CustomHash>", "StringbarBarCustomHashstdumap"));
+  classToFriendly.insert(
+      Values("std::unordered_map<Foo, std::basic_string<char>, CustomHash>", "FooStringCustomHashstdumap"));
   classToFriendly.insert(Values("std::shared_ptr<Foo>", "FooSharedPtr"));
   classToFriendly.insert(Values("std::shared_ptr<bar::Foo>", "barFooSharedPtr"));
   classToFriendly.insert(Values("std::basic_string<char>", "String"));

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -40,7 +40,13 @@ void testfriendlyName::test() {
   classToFriendly.insert(Values("std::set<bar::Foo>", "barFoostdset"));
   classToFriendly.insert(Values("std::map<Foo, bar::Bar>", "FoobarBarstdmap"));
   classToFriendly.insert(Values("std::unordered_set<bar::Foo>", "barFoostduset"));
+  classToFriendly.insert(Values("std::unordered_set<bar::Foo, std::hash<bar::Foo>>", "barFoostduset"));
+  classToFriendly.insert(
+      Values("std::unordered_set<bar::Foo, std::hash<bar::Foo>, std::equal_to<bar::Foo>>", "barFoostduset"));
   classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar>", "FoobarBarstdumap"));
+  classToFriendly.insert(Values("std::unordered_map<Foo, bar::Bar, std::hash<Foo>>", "FoobarBarstdumap"));
+  classToFriendly.insert(
+      Values("std::unordered_map<Foo, bar::Bar, std::hash<Foo>, std::equal_to<Foo>>", "FoobarBarstdumap"));
   classToFriendly.insert(Values("std::shared_ptr<Foo>", "FooSharedPtr"));
   classToFriendly.insert(Values("std::shared_ptr<bar::Foo>", "barFooSharedPtr"));
   classToFriendly.insert(Values("std::basic_string<char>", "String"));


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/29987 to handle the default `Hash` and `KeyEqual` template arguments (they get ignored for the friendly class name), and also custom `Hash` template argument. Resolves #29967.

#### PR validation:

Unit test runs.

