### PR TITLE
moved hardcoded correction boundary values to configuration file in EcalLaserCondTools

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h
@@ -93,6 +93,7 @@ private:
   int nIovs_;
   int fromTime_;
   int toTime_;
+  double minP_, maxP_;
   FILE* ferr_;
 };
 

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -33,8 +33,7 @@ EcalLaserCondTools::EcalLaserCondTools(const edm::ParameterSet& ps)
       fromTime_(ps.getParameter<int>("fromTime")),
       toTime_(ps.getParameter<int>("toTime")),
       minP_(ps.getParameter<double>("transparencyMin")),
-      maxP_(ps.getParameter<double>("transparencyMax"))
-{
+      maxP_(ps.getParameter<double>("transparencyMax")) {
   ferr_ = fopen("corr_errors.txt", "w");
   fprintf(ferr_, "#t1\tdetid\tp1\tp2\tp3");
 
@@ -210,16 +209,10 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
       std::cout << "Duplicate det id, for IOV " << iIov << " t1 = " << t1 << " detid = " << int(detid) << endl;
     }
 
-
-    if(!isfinite(corr.p1)
-       || !isfinite(corr.p2)
-       || !isfinite(corr.p3)
-       || corr.p1 < minP_ || corr.p1 > maxP_
-       || corr.p2 < minP_ || corr.p2 > maxP_
-       || corr.p3 < minP_ || corr.p3 > maxP_ ){
-       fprintf(ferr_, "%d %d %f %f %f\n", t1, (int)detid, corr.p1,
-               corr.p2, corr.p3);
-      corr.p1=corr.p2=corr.p3 = 1;
+    if (!isfinite(corr.p1) || !isfinite(corr.p2) || !isfinite(corr.p3) || corr.p1 < minP_ || corr.p1 > maxP_ ||
+        corr.p2 < minP_ || corr.p2 > maxP_ || corr.p3 < minP_ || corr.p3 > maxP_) {
+      fprintf(ferr_, "%d %d %f %f %f\n", t1, (int)detid, corr.p1, corr.p2, corr.p3);
+      corr.p1 = corr.p2 = corr.p3 = 1;
     }
 
     if (verb_ > 2) {
@@ -236,7 +229,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
            << "p3 = " << corr.p3 << "\n";
     }
 
-    corrSet->setValue((int)detid, corr );
+    corrSet->setValue((int)detid, corr);
   }
 
   try {

--- a/CalibCalorimetry/EcalTrivialCondModules/src/SealModule.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/SealModule.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
+#include "CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h"
 #include "CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h"
 #include "CalibCalorimetry/EcalTrivialCondModules/interface/ESTrivialConditionRetriever.h"
 
@@ -8,3 +9,4 @@
 DEFINE_FWK_EVENTSETUP_SOURCE(EcalTrivialConditionRetriever);
 DEFINE_FWK_EVENTSETUP_SOURCE(ESTrivialConditionRetriever);
 DEFINE_FWK_MODULE(EcalTrivialObjectAnalyzer);
+DEFINE_FWK_MODULE(EcalLaserCondTools);


### PR DESCRIPTION
Two parameters (correction boudaries) were hardcoded in the module EcalLaserCondTools. This PR makes them configurable thanks to the work of @fcouderc . Application of correction boundaries has also been simplified.

The code is not used in the reco and simulation workflows.
