### PR TITLE
Introduce DeepDoubleX V2 

### DIFF
--- a/DataFormats/BTauReco/interface/ChargedCandidateFeatures.h
+++ b/DataFormats/BTauReco/interface/ChargedCandidateFeatures.h
@@ -6,6 +6,9 @@ namespace btagbtvdeep {
   class ChargedCandidateFeatures {
   public:
     float ptrel;
+    float ptrel_noclip;
+    float erel;
+    float etarel;
     float puppiw;
     float vtx_ass;
 
@@ -21,6 +24,14 @@ namespace btagbtvdeep {
     float btagPf_trackSip2dSig;
 
     float btagPf_trackJetDistVal;
+
+    float drsubjet1;
+    float drsubjet2;
+    float dxy;
+    float dxysig;
+    float dz;
+    float dzsig;
+    float deltaR;
 
     float chi2;
     float quality;

--- a/DataFormats/BTauReco/interface/DeepDoubleXFeatures.h
+++ b/DataFormats/BTauReco/interface/DeepDoubleXFeatures.h
@@ -7,6 +7,7 @@
 #include "DataFormats/BTauReco/interface/SecondaryVertexFeatures.h"
 #include "DataFormats/BTauReco/interface/BoostedDoubleSVTagInfoFeatures.h"
 #include "DataFormats/BTauReco/interface/ChargedCandidateFeatures.h"
+#include "DataFormats/BTauReco/interface/NeutralCandidateFeatures.h"
 
 namespace btagbtvdeep {
 
@@ -19,9 +20,11 @@ namespace btagbtvdeep {
     JetFeatures jet_features;
     BoostedDoubleSVTagInfoFeatures tag_info_features;
 
-    std::vector<SecondaryVertexFeatures> sv_features;
-
     std::vector<ChargedCandidateFeatures> c_pf_features;
+
+    std::vector<NeutralCandidateFeatures> n_pf_features;
+
+    std::vector<SecondaryVertexFeatures> sv_features;
 
     std::size_t npv;  // used by deep flavour
 

--- a/DataFormats/BTauReco/interface/NeutralCandidateFeatures.h
+++ b/DataFormats/BTauReco/interface/NeutralCandidateFeatures.h
@@ -6,9 +6,15 @@ namespace btagbtvdeep {
   class NeutralCandidateFeatures {
   public:
     float ptrel;
+    float ptrel_noclip;
+    float erel;
+
+    float drsubjet1;
+    float drsubjet2;
 
     float puppiw;
     float deltaR;
+    float deltaR_noclip;
     float isGamma;
 
     float hadFrac;

--- a/DataFormats/BTauReco/interface/SecondaryVertexFeatures.h
+++ b/DataFormats/BTauReco/interface/SecondaryVertexFeatures.h
@@ -6,6 +6,7 @@ namespace btagbtvdeep {
   class SecondaryVertexFeatures {
   public:
     float pt;
+    float ptrel;
     float mass;
 
     float deltaR;

--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -409,16 +409,19 @@
     <version ClassVersion="3" checksum="386672900"/>
     <version ClassVersion="4" checksum="113477759"/>
   </class>
-  <class name="btagbtvdeep::SecondaryVertexFeatures" ClassVersion="3">
+  <class name="btagbtvdeep::SecondaryVertexFeatures" ClassVersion="4">
+   <version ClassVersion="4" checksum="3987593676"/>
     <version ClassVersion="3" checksum="3610780843"/>
   </class>
   <class name="btagbtvdeep::ShallowTagInfoFeatures" ClassVersion="3">
     <version ClassVersion="3" checksum="273372007"/>
   </class>
-  <class name="btagbtvdeep::NeutralCandidateFeatures" ClassVersion="3">
+  <class name="btagbtvdeep::NeutralCandidateFeatures" ClassVersion="4">
+   <version ClassVersion="4" checksum="3657612864"/>
     <version ClassVersion="3" checksum="938442516"/>
   </class>
-  <class name="btagbtvdeep::ChargedCandidateFeatures" ClassVersion="4">
+  <class name="btagbtvdeep::ChargedCandidateFeatures" ClassVersion="5">
+   <version ClassVersion="5" checksum="3385708923"/>
     <version ClassVersion="4" checksum="2173116472"/>
     <version ClassVersion="3" checksum="1302021141"/>
   </class>
@@ -432,7 +435,8 @@
     <version ClassVersion="3" checksum="2487956635"/>
     <version ClassVersion="4" checksum="3827695028"/>
   </class>
-    <class name="btagbtvdeep::DeepDoubleXFeatures" ClassVersion="3">
+    <class name="btagbtvdeep::DeepDoubleXFeatures" ClassVersion="4">
+     <version ClassVersion="4" checksum="3057931654"/>
     <version ClassVersion="3" checksum="1764960743"/>
   </class>
   <class name="btagbtvdeep::BoostedDoubleSVTagInfoFeatures" ClassVersion="3">

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -206,6 +206,12 @@ supportedBtagDiscr = {
   , 'pfMassIndependentDeepDoubleCvLJetTags:probHcc'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
   , 'pfMassIndependentDeepDoubleCvBJetTags:probHbb'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
   , 'pfMassIndependentDeepDoubleCvBJetTags:probHcc'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
+  , 'pfMassIndependentDeepDoubleBvLV2JetTags:probQCD'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
+  , 'pfMassIndependentDeepDoubleBvLV2JetTags:probHbb'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
+  , 'pfMassIndependentDeepDoubleCvLV2JetTags:probQCD'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
+  , 'pfMassIndependentDeepDoubleCvLV2JetTags:probHcc'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
+  , 'pfMassIndependentDeepDoubleCvBV2JetTags:probHbb'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
+  , 'pfMassIndependentDeepDoubleCvBV2JetTags:probHcc'                     : [["pfDeepDoubleXTagInfos"], ['pfBoostedDoubleSVAK8TagInfos', "pfImpactParameterAK8TagInfos", 'pfInclusiveSecondaryVertexFinderAK8TagInfos']]
 }
 
 # meta-taggers are simple arithmetic on top of other taggers, they are stored here

--- a/RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h
+++ b/RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h
@@ -30,7 +30,12 @@ namespace btagbtvdeep {
       trackSip3dVal = -trackSip3dVal;
     }
 
+    c_pf_features.deltaR = reco::deltaR(*c_pf, jet);
     c_pf_features.ptrel = catch_infs_and_bound(c_pf->pt() / jet.pt(), 0, -1, 0, -1);
+    c_pf_features.ptrel_noclip = c_pf->pt() / jet.pt();
+    c_pf_features.erel = c_pf->energy() / jet.energy();
+    const float etasign = jet.eta() > 0 ? 1 : -1;
+    c_pf_features.etarel = etasign * (c_pf->eta() - jet.eta());
 
     c_pf_features.btagPf_trackEtaRel = catch_infs_and_bound(track_info.getTrackEtaRel(), 0, -5, 15);
     c_pf_features.btagPf_trackPtRel = catch_infs_and_bound(track_info.getTrackPtRel(), 0, -1, 4);
@@ -45,6 +50,26 @@ namespace btagbtvdeep {
     c_pf_features.btagPf_trackJetDistVal = catch_infs_and_bound(track_info.getTrackJetDistVal(), 0, -20, 1);
 
     c_pf_features.drminsv = catch_infs_and_bound(drminpfcandsv, 0, -1. * jetR, 0, -1. * jetR);
+
+    // subjet related
+    const auto* patJet = dynamic_cast<const pat::Jet*>(&jet);
+    if (!patJet) {
+      throw edm::Exception(edm::errors::InvalidReference) << "Input is not a pat::Jet.";
+    }
+
+    if (patJet->nSubjetCollections() > 0) {
+      auto subjets = patJet->subjets();
+      // sort by pt
+      std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet>& p1, const edm::Ptr<pat::Jet>& p2) {
+        return p1->pt() > p2->pt();
+      });
+      c_pf_features.drsubjet1 = !subjets.empty() ? reco::deltaR(*c_pf, *subjets.at(0)) : -1;
+      c_pf_features.drsubjet2 = subjets.size() > 1 ? reco::deltaR(*c_pf, *subjets.at(1)) : -1;
+    } else {
+      // AK4 jets don't have subjets
+      c_pf_features.drsubjet1 = -1;
+      c_pf_features.drsubjet2 = -1;
+    }
   }
 
   void packedCandidateToFeatures(const pat::PackedCandidate* c_pf,

--- a/RecoBTag/FeatureTools/plugins/DeepDoubleXTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepDoubleXTagInfoProducer.cc
@@ -22,6 +22,7 @@
 #include "DataFormats/BTauReco/interface/DeepDoubleXTagInfo.h"
 
 #include "RecoBTag/FeatureTools/interface/BoostedDoubleSVTagInfoConverter.h"
+#include "RecoBTag/FeatureTools/interface/NeutralCandidateConverter.h"
 #include "RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h"
 #include "RecoBTag/FeatureTools/interface/JetConverter.h"
 #include "RecoBTag/FeatureTools/interface/SecondaryVertexConverter.h"
@@ -119,6 +120,8 @@ void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
 
     // reco jet reference (use as much as possible)
     const auto& jet = jets->at(jet_n);
+    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&jet);
+    const auto* pat_jet = dynamic_cast<const pat::Jet*>(&jet);
 
     edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
     if (jet.pt() > min_jet_pt_) {
@@ -175,7 +178,8 @@ void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
       math::XYZVector jet_dir = jet.momentum().Unit();
       GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
 
-      std::vector<btagbtvdeep::SortingClass<size_t>> c_sorted;
+      std::vector<btagbtvdeep::SortingClass<size_t>> c_sorted, n_sorted;
+      std::vector<int> n_indexes;
 
       // to cache the TrackInfo
       std::map<unsigned int, btagbtvdeep::TrackInfoBuilder> trackinfos;
@@ -205,9 +209,9 @@ void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
         }
       }
 
+      std::sort(daughters.begin(), daughters.end(), [](const auto& a, const auto& b) { return a->pt() > b->pt(); });
       for (unsigned int i = 0; i < daughters.size(); i++) {
         auto const* cand = daughters.at(i);
-
         if (cand) {
           // candidates under 950MeV (configurable) are not considered
           // might change if we use also white-listing
@@ -220,35 +224,51 @@ void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
                                   trackinfo.getTrackSip2dSig(),
                                   -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand, jet_radius_),
                                   cand->pt() / jet.pt());
+          } else {
+            n_sorted.emplace_back(
+                i, -1, -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand, jet_radius_), cand->pt() / jet.pt());
+            n_indexes.push_back(i);
           }
         }
       }
 
-      // sort collections (open the black-box if you please)
+      // sort collections in added order of priority
       std::sort(c_sorted.begin(), c_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
+      std::sort(n_sorted.begin(), n_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
 
-      std::vector<size_t> c_sortedindices;
+      std::vector<size_t> c_sortedindices, n_sortedindices;
 
       // this puts 0 everywhere and the right position in ind
       c_sortedindices = btagbtvdeep::invertSortingVector(c_sorted);
+      n_sortedindices = btagbtvdeep::invertSortingVector(n_sorted);
 
       // set right size to vectors
       features.c_pf_features.clear();
       features.c_pf_features.resize(c_sorted.size());
+      features.n_pf_features.clear();
+      features.n_pf_features.resize(n_sorted.size());
 
       for (unsigned int i = 0; i < daughters.size(); i++) {
         auto const* cand = daughters.at(i);
         if (cand) {
           // candidates under 950MeV are not considered
           // might change if we use also white-listing
-          if (cand->pt() < 0.95)
+          if (cand->pt() < min_candidate_pt_)
             continue;
+          auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
+          auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
 
-          // get PUPPI weight from value map
+          // need some edm::Ptr or edm::Ref if reco candidates
+          reco::PFCandidatePtr reco_ptr;
+          if (pf_jet) {
+            reco_ptr = pf_jet->getPFConstituent(i);
+          } else if (pat_jet && reco_cand) {
+            reco_ptr = pat_jet->getPFConstituent(i);
+          }
+
           float puppiw = 1.0;  // fallback value
 
           float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, cand, jet_radius_);
-
           if (cand->charge() != 0) {
             // is charged candidate
             auto entry = c_sortedindices.at(i);
@@ -256,12 +276,9 @@ void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
             auto& trackinfo = trackinfos.at(i);
             // get_ref to vector element
             auto& c_pf_features = features.c_pf_features.at(entry);
-            // fill feature structure
-            auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
-            auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
             if (packed_cand) {
               btagbtvdeep::packedCandidateToFeatures(
-                  packed_cand, jet, trackinfo, drminpfcandsv, static_cast<float>(jet_radius_), c_pf_features);
+                  packed_cand, *pat_jet, trackinfo, drminpfcandsv, static_cast<float>(jet_radius_), c_pf_features);
             } else if (reco_cand) {
               // get vertex association quality
               int pv_ass_quality = 0;  // fallback value
@@ -287,6 +304,19 @@ void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
                                                    pv_ass_quality,
                                                    pv,
                                                    c_pf_features);
+            }
+          } else {
+            // is neutral candidate
+            auto entry = n_sortedindices.at(i);
+            // get_ref to vector element
+            auto& n_pf_features = features.n_pf_features.at(entry);
+            // // fill feature structure
+            if (packed_cand) {
+              btagbtvdeep::packedCandidateToFeatures(
+                  packed_cand, *pat_jet, drminpfcandsv, static_cast<float>(jet_radius_), n_pf_features);
+            } else if (reco_cand) {
+              btagbtvdeep::recoCandidateToFeatures(
+                  reco_cand, jet, drminpfcandsv, static_cast<float>(jet_radius_), puppiw, n_pf_features);
             }
           }
         }

--- a/RecoBTag/FeatureTools/src/ChargedCandidateConverter.cc
+++ b/RecoBTag/FeatureTools/src/ChargedCandidateConverter.cc
@@ -27,6 +27,11 @@ namespace btagbtvdeep {
       c_pf_features.chi2 = catch_infs_and_bound(-1, 300, -1, 300);
       c_pf_features.quality = (1 << reco::TrackBase::loose);
     }
+
+    c_pf_features.dxy = catch_infs(c_pf->dxy());
+    c_pf_features.dz = catch_infs(c_pf->dz());
+    c_pf_features.dxysig = c_pf->bestTrack() ? catch_infs(c_pf->dxy() / c_pf->dxyError()) : 0;
+    c_pf_features.dzsig = c_pf->bestTrack() ? catch_infs(c_pf->dz() / c_pf->dzError()) : 0;
   }
 
   void recoCandidateToFeatures(const reco::PFCandidate* c_pf,
@@ -47,6 +52,16 @@ namespace btagbtvdeep {
     const auto& pseudo_track = (c_pf->bestTrack()) ? *c_pf->bestTrack() : reco::Track();
     c_pf_features.chi2 = catch_infs_and_bound(std::floor(pseudo_track.normalizedChi2()), 300, -1, 300);
     c_pf_features.quality = quality_from_pfcand(*c_pf);
+
+    // To be implemented if FatJet tag becomes RECO compatible
+    // const auto *trk =
+    // float dz =
+    // float dxy =
+
+    // c_pf_features.dxy =
+    // c_pf_features.dz =
+    // c_pf_features.dxysig =
+    // c_pf_features.dzsig =
   }
 
 }  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/SecondaryVertexConverter.cc
+++ b/RecoBTag/FeatureTools/src/SecondaryVertexConverter.cc
@@ -16,6 +16,7 @@ namespace btagbtvdeep {
                     const bool flip) {
     math::XYZVector jet_dir = jet.momentum().Unit();
     sv_features.pt = sv.pt();
+    sv_features.ptrel = sv.pt() / jet.pt();
     sv_features.deltaR = catch_infs_and_bound(std::fabs(reco::deltaR(sv, jet_dir)) - 0.5, 0, -2, 0);
     sv_features.mass = sv.mass();
     sv_features.ntracks = sv.numberOfDaughters();

--- a/RecoBTag/ONNXRuntime/python/pfDeepDoubleX_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfDeepDoubleX_cff.py
@@ -4,3 +4,5 @@ from RecoBTag.ONNXRuntime.pfDeepDoubleCvLJetTags_cfi import pfDeepDoubleCvLJetTa
 
 from RecoBTag.ONNXRuntime.pfMassIndependentDeepDoubleXJetTags_cff import *
 
+from RecoBTag.ONNXRuntime.pfMassIndependentDeepDoubleXV2JetTags_cff import *
+

--- a/RecoBTag/ONNXRuntime/python/pfMassIndependentDeepDoubleXJetTags_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfMassIndependentDeepDoubleXJetTags_cff.py
@@ -5,8 +5,8 @@ from .pfDeepDoubleCvLJetTags_cfi import pfDeepDoubleCvLJetTags
 from .pfDeepDoubleCvBJetTags_cfi import pfDeepDoubleCvBJetTags
 
 pfMassIndependentDeepDoubleBvLJetTags = pfDeepDoubleBvLJetTags.clone(
-    model_path = 'RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDB_mass_independent.onnx')
+    model_path = "RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDB_mass_independent.onnx")
 pfMassIndependentDeepDoubleCvLJetTags = pfDeepDoubleCvLJetTags.clone(
-    model_path = 'RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDC_mass_independent.onnx')
+    model_path = "RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDC_mass_independent.onnx")
 pfMassIndependentDeepDoubleCvBJetTags = pfDeepDoubleCvBJetTags.clone(
-    model_path = 'RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB_mass_independent.onnx')
+    model_path = "RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB_mass_independent.onnx")

--- a/RecoBTag/ONNXRuntime/python/pfMassIndependentDeepDoubleXV2JetTags_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfMassIndependentDeepDoubleXV2JetTags_cff.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+import FWCore.ParameterSet.Config as cms
+from .pfDeepDoubleBvLJetTags_cfi import pfDeepDoubleBvLJetTags
+from .pfDeepDoubleCvLJetTags_cfi import pfDeepDoubleCvLJetTags
+from .pfDeepDoubleCvBJetTags_cfi import pfDeepDoubleCvBJetTags
+
+pfMassIndependentDeepDoubleBvLV2JetTags = pfDeepDoubleBvLJetTags.clone(
+    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/BvL.onnx",
+    input_names={"input_1", "input_2", "input_3", "input_4"},
+    version="V2",
+)
+
+pfMassIndependentDeepDoubleCvLV2JetTags = pfDeepDoubleCvLJetTags.clone(
+    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/CvL.onnx",
+    input_names={"input_1", "input_2", "input_3", "input_4"},
+    version="V2",
+)
+
+pfMassIndependentDeepDoubleCvBV2JetTags = pfDeepDoubleCvBJetTags.clone(
+    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/CvB.onnx",
+    input_names={"input_1", "input_2", "input_3", "input_4"},
+    version="V2",
+)

--- a/RecoBTag/ONNXRuntime/test/README.md
+++ b/RecoBTag/ONNXRuntime/test/README.md
@@ -1,0 +1,11 @@
+### Editing will most likely require
+
+```
+git cms-addpkg RecoBTag/ONNXRuntime
+git cms-addpkg RecoBTag/FeatureTools
+git cms-addpkg RecoBTag/Combined
+git cms-addpkg DataFormats/BTauReco
+
+# And to check out the models
+git clone https://github.com/cms-data/RecoBTag-Combined.git RecoBTag/Combined/data
+```

--- a/RecoBTag/ONNXRuntime/test/plotDDX.py
+++ b/RecoBTag/ONNXRuntime/test/plotDDX.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 import ROOT
 from DataFormats.FWLite import Handle, Events
+import numpy as np
+import pickle
 
 events_c = Events('output_test_DDX.root')
 
-handleJ  = Handle ("std::vector<pat::Jet>")
+handleJ  = Handle("std::vector<pat::Jet>")
 labelJ = ("selectedUpdatedPatJets","","PATtest")
 
 h_probQ_ddb = ROOT.TH1F('h_probQ_ddb', ';prob Q;', 40, 0., 1.)
@@ -13,24 +15,44 @@ h_probH_ddb = ROOT.TH1F('h_probH_ddb', ';prob H;', 40, 0., 1.)
 h_probQ_ddc = ROOT.TH1F('h_probQ_ddc', ';prob Q;', 40, 0., 1.)
 h_probH_ddc = ROOT.TH1F('h_probH_ddc', ';prob H;', 40, 0., 1.)
 
-for iev,event in enumerate(events_c):
+info = {}
+info['pt'] = []
+info['eta'] = []
+info['mass'] = []
+info['BvL'] = []
+info['CvL'] = []
+info['CvB'] = []
+
+
+for iev, event in enumerate(events_c):
     event.getByLabel (labelJ, handleJ)
     jets = handleJ.product()
-    for jet in jets  :
-        if jet.pt() < 300 or jet.pt() > 2000: continue
-        if jet.mass() < 40 or jet.mass() > 200: continue
+    print(iev)
+    for jet in jets:
+        #if jet.pt() < 300 or jet.pt() > 2000: continue
+        #if jet.mass() < 40 or jet.mass() > 200: continue
 
-        print(jet.pt(), jet.mass())
+        print(jet.pt(), jet.mass(), jet.eta())
         print("DDB", jet.bDiscriminator("pfDeepDoubleBvLJetTags:probQCD"), jet.bDiscriminator("pfDeepDoubleBvLJetTags:probHbb"))
-        print("DDB", jet.bDiscriminator("pfMassIndependentDeepDoubleBvLJetTags:probQCD"), jet.bDiscriminator("pfMassIndependentDeepDoubleBvLJetTags:probHbb"))
+        # print("DDB", jet.bDiscriminator("pfMassIndependentDeepDoubleBvLJetTags:probQCD"), jet.bDiscriminator("pfMassIndependentDeepDoubleBvLJetTags:probHbb"))
         print("DDCvL", jet.bDiscriminator("pfDeepDoubleCvLJetTags:probQCD"), jet.bDiscriminator("pfDeepDoubleCvLJetTags:probHcc"))
-        print("DDCvL", jet.bDiscriminator("pfMassIndependentDeepDoubleCvLJetTags:probQCD"), jet.bDiscriminator("pfMassIndependentDeepDoubleCvLJetTags:probHcc"))
+        # print("DDCvL", jet.bDiscriminator("pfMassIndependentDeepDoubleCvLJetTags:probQCD"), jet.bDiscriminator("pfMassIndependentDeepDoubleCvLJetTags:probHcc"))
         print("DDCvB", jet.bDiscriminator("pfDeepDoubleCvBJetTags:probHbb"), jet.bDiscriminator("pfDeepDoubleCvBJetTags:probHcc") )
-        print("DDCvB", jet.bDiscriminator("pfMassIndependentDeepDoubleCvBJetTags:probHbb"), jet.bDiscriminator("pfMassIndependentDeepDoubleCvBJetTags:probHcc"))
+        # print("DDCvB", jet.bDiscriminator("pfMassIndependentDeepDoubleCvBJetTags:probHbb"), jet.bDiscriminator("pfMassIndependentDeepDoubleCvBJetTags:probHcc"))
         h_probQ_ddb.Fill(jet.bDiscriminator("pfDeepDoubleBvLJetTags:probQCD"))
         h_probH_ddb.Fill(jet.bDiscriminator("pfDeepDoubleBvLJetTags:probHbb"))
         h_probQ_ddc.Fill(jet.bDiscriminator("pfDeepDoubleCvLJetTags:probQCD"))
         h_probH_ddc.Fill(jet.bDiscriminator("pfDeepDoubleCvLJetTags:probHcc"))
+
+        info['mass'].append(jet.mass())
+        info['pt'].append(jet.pt())
+        info['eta'].append(jet.eta())
+        info['BvL'].append(jet.bDiscriminator("pfDeepDoubleBvLJetTags:probHbb"))
+        info['CvL'].append(jet.bDiscriminator("pfDeepDoubleCvLJetTags:probHcc"))
+        info['CvB'].append(jet.bDiscriminator("pfDeepDoubleCvBJetTags:probHcc"))
+
+with open('outputs.pkl', 'wb') as handle:
+    pickle.dump(info, handle)
 
 c1a = ROOT.TCanvas()
 h_probH_ddb.Draw("HISTO")

--- a/RecoBTag/ONNXRuntime/test/test_deep_doublex_cfg.py
+++ b/RecoBTag/ONNXRuntime/test/test_deep_doublex_cfg.py
@@ -1,4 +1,3 @@
-
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
 
@@ -6,18 +5,24 @@ process = cms.Process("PATtest")
 
 ## MessageLogger
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 
 ## Options and Output Report
-process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True),
+SkipEvent = cms.untracked.vstring('ProductNotFound'))
 
 ## Source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring()
+    fileNames = cms.untracked.vstring(),
+    #skipEvents=cms.untracked.uint32(250)
 )
+
+#process.source.eventsToProcess = cms.untracked.VEventRange("1:3127296-1:3127297")
+
 ## Maximal Number of Events
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+#process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
 ## Geometry and Detector Conditions (needed for a few patTuple production steps)
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
@@ -52,31 +57,34 @@ updateJetCollection(
    jetCorrections = ('AK8PFchs', cms.vstring(['L2Relative', 'L3Absolute']), 'None'),
    btagDiscriminators = [
       'pfBoostedDoubleSecondaryVertexAK8BJetTags',
-      'pfDeepDoubleBvLJetTags:probQCD', 
-      'pfDeepDoubleBvLJetTags:probHbb',
-      'pfDeepDoubleCvLJetTags:probQCD',
-      'pfDeepDoubleCvLJetTags:probHcc',
-      'pfDeepDoubleCvBJetTags:probHbb',
-      'pfDeepDoubleCvBJetTags:probHcc',
       'pfMassIndependentDeepDoubleBvLJetTags:probQCD', 
       'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
       'pfMassIndependentDeepDoubleCvLJetTags:probQCD',
       'pfMassIndependentDeepDoubleCvLJetTags:probHcc',
       'pfMassIndependentDeepDoubleCvBJetTags:probHbb',
       'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
+      'pfMassIndependentDeepDoubleBvLV2JetTags:probQCD', 
+      'pfMassIndependentDeepDoubleBvLV2JetTags:probHbb',
+      'pfMassIndependentDeepDoubleCvLV2JetTags:probQCD',
+      'pfMassIndependentDeepDoubleCvLV2JetTags:probHcc',
+      'pfMassIndependentDeepDoubleCvBV2JetTags:probHbb',
+      'pfMassIndependentDeepDoubleCvBV2JetTags:probHcc',
+      
       ]
    )
+   
 
 from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
 
 process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 process.source.fileNames = cms.untracked.vstring(
-'/store/relval/CMSSW_10_3_0_pre2/RelValTTbar_13/MINIAODSIM/PU25ns_103X_upgrade2018_realistic_v2-v1/20000/85820ACA-657B-BC44-AC74-AACD6D54B348.root'
+#'/store/relval/CMSSW_10_3_0_pre2/RelValTTbar_13/MINIAODSIM/PU25ns_103X_upgrade2018_realistic_v2-v1/20000/85820ACA-657B-BC44-AC74-AACD6D54B348.root'
 #'/store/mc/RunIIFall17MiniAOD/GluGluHToBB_M125_13TeV_powheg_pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/20000/C8932584-5006-E811-9840-141877410512.root',
 #'/store/mc/RunIIFall17MiniAODv2/GluGluHToCC_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/30000/72164088-CB67-E811-9D0D-008CFA197AC4.root',
+'file:72164088-CB67-E811-9D0D-008CFA197AC4.root',
 #'/store/mc/RunIIFall17MiniAOD/QCD_HT700to1000_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/20000/C0F304A4-23FA-E711-942E-E0071B6CAD20.root'
 )
-process.maxEvents.input = 1000 
+#process.maxEvents.input = 1000
 
 from Configuration.EventContent.EventContent_cff import MINIAODSIMEventContent
 process.out.outputCommands.append('keep *_slimmedJetsAK8*_*_*')


### PR DESCRIPTION
This PR introduces V2 of DeepDoubleX. Required changes w.r.t. V1 of DeepDoubleX producer include adding a new group of variables, add more variables to existing groups and reordering some of them. 

Input x-check in training FW and CMSSW - :white_check_mark:.
![image](https://user-images.githubusercontent.com/13226500/84907345-5d597600-b0b3-11ea-8fe4-8d1a562bd2ad.png)

Evaluation x-check - :white_check_mark:

![image](https://user-images.githubusercontent.com/13226500/84908572-ea50ff00-b0b4-11ea-82bb-56108a857f47.png)

