### PR TITLE
add packages used by headers in CondFormats

### DIFF
--- a/CondFormats/BeamSpotObjects/BuildFile.xml
+++ b/CondFormats/BeamSpotObjects/BuildFile.xml
@@ -1,5 +1,7 @@
 <use name="CondFormats/Serialization"/>
 <use name="FWCore/Utilities"/>
+<use name="FWCore/ParameterSet"/>
+<use name="CondFormats/Common"/>
 <use name="CLHEP"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/RecoMuonObjects/BuildFile.xml
+++ b/CondFormats/RecoMuonObjects/BuildFile.xml
@@ -1,6 +1,8 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
+<use name="CondFormats/External"/>
+<use name="DataFormats/DetId"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
As noted in the modules IB, some package dependencies are missing from the BuildFile. This PR adds them. Changes are to CondFormats/BeamSpotObjects and CondFormats/RecoMuonObjects.

