### PR TITLE
Remove mcdb and libhepml dependencies

### DIFF
--- a/GeneratorInterface/LHEInterface/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/BuildFile.xml
@@ -10,14 +10,8 @@
 <use name="sigcpp"/>
 <use name="xerces-c"/>
 <use name="rootmath"/>
-<use name="libhepml"/>
 <use name="fastjet"/>
 <use name="xz"/>
 <export>
-  <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/PluginManager"/>
-  <use name="boost"/>
-  <use name="sigcpp"/>
-  <use name="hepmc"/>
-  <lib name="GeneratorInterfaceLHEInterface"/>
+  <lib name="1"/>
 </export>

--- a/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
@@ -16,7 +16,6 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/Sources"/>
   <use name="SimDataFormats/GeneratorProducts"/>
-  <use name="mcdb"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/GeneratorInterface/MCatNLOInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/MCatNLOInterface/plugins/BuildFile.xml
@@ -8,6 +8,5 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/Sources"/>
   <use name="SimDataFormats/GeneratorProducts"/>
-  <use name="mcdb"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
As proposed here https://github.com/cms-sw/cmssw/issues/14728 , we think there is nothing in cmssw which is using mcdb libhepml.