### PR TITLE
Initialize FileBlob data members

### DIFF
--- a/CondFormats/Common/interface/FileBlob.h
+++ b/CondFormats/Common/interface/FileBlob.h
@@ -9,7 +9,10 @@
 
 class FileBlob {
 public:
-  FileBlob(){};
+  FileBlob() {
+    compressed = false;
+    isize = 0;
+  };
   /// constructor from file to read
   FileBlob(const std::string &fname, bool zip);
   /// constructor from  stream to read


### PR DESCRIPTION
testSerializationCommon iunit tests fails for AARCH64 and CLANG IBs [a]. This change initialize the data member of FileBlob class which should fix this unit test.

This fixes cms-sw/cmsdist#5685
This fixes cms-sw/cmssw#21002

[a]
```
===== Test "testSerializationCommon" ====
Serializing 10ConfObject ...
Deserializing 10ConfObject ...
Serializing 15DropBoxMetadata ...
Deserializing 15DropBoxMetadata ...
Serializing N15DropBoxMetadata10ParametersE ...
Deserializing N15DropBoxMetadata10ParametersE ...
Serializing 8FileBlob ...
Deserializing 8FileBlob ...
terminate called after throwing an instance of 'eos::portable_archive_exception'
  what():  requested integer size exceeds type size: -64
/bin/sh: line 1:  7584 Aborted                 testSerializationCommon
```