### PR TITLE
EMTF: Prevent out-of-bounds access in BDT event data

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/bdt/Node.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Node.cc
@@ -277,7 +277,7 @@ void Node::filterEventsToDaughters() {
   // node depending on whether it is < or > the split point
   // for the given split variable.
 
-  int sv = splitVariable;
+  unsigned int sv = splitVariable;
   double sp = splitValue;
 
   Node* left = leftDaughter;
@@ -289,6 +289,9 @@ void Node::filterEventsToDaughters() {
   for (unsigned int i = 0; i < events.size(); i++) {
     for (unsigned int j = 0; j < events[i].size(); j++) {
       Event* e = events[i][j];
+      // Prevent out-of-bounds access
+      if (sv >= e->data.size())
+        continue;
       if (e->data[sv] < sp)
         l[i].push_back(e);
       if (e->data[sv] > sp)
@@ -314,14 +317,15 @@ Node* Node::filterEventToDaughter(Event* e) {
   // node depending on whether it is < or > the split point
   // for the given split variable.
 
-  int sv = splitVariable;
+  unsigned int sv = splitVariable;
   double sp = splitValue;
 
   Node* left = leftDaughter;
   Node* right = rightDaughter;
   Node* nextNode = nullptr;
 
-  if (left == nullptr || right == nullptr)
+  // Prevent out-of-bounds access
+  if (left == nullptr || right == nullptr || sv >= e->data.size())
     return nullptr;
 
   if (e->data[sv] < sp)


### PR DESCRIPTION
#### PR description:

This PR fixes the out-of-bounds access in BDT event data that was pointed out in #29332 . When a wrong BDT tree is loaded, the number of variables in the BDT tree may differ from what is carried by the event data. This can cause out-of-bounds accesses in the particular vector (`e->data`) that stores the event variables.

The suggestion from @smuzaffar has been implemented. For further details, please refer to #29332 .

#### PR validation:

This was checked with the ASAN release (`CMSSW_11_2_ASAN_X_2020-05-22-2300`) using:

```
runTheMatrix.py -i all --ibeos -t 4 -l 1330.0
```

Before the fix, there was an AddressSanitizer error:

```
1 0 0 0 0 tests passed, 0 1 0 0 0 failed
```

After the fix:

```
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```