### PR TITLE
Validate GsfElectron before running MVA to avoid reading wrong DataFormat

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducers.cc
+++ b/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducers.cc
@@ -1,11 +1,13 @@
 #include "ModifiedObjectProducer.h"
 
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
+typedef pat::ModifiedObjectProducer<reco::GsfElectron> ModifiedGsfElectronProducer;
 typedef pat::ModifiedObjectProducer<pat::Electron> ModifiedElectronProducer;
 typedef pat::ModifiedObjectProducer<pat::Photon> ModifiedPhotonProducer;
 typedef pat::ModifiedObjectProducer<pat::Muon> ModifiedMuonProducer;
@@ -13,6 +15,7 @@ typedef pat::ModifiedObjectProducer<pat::Tau> ModifiedTauProducer;
 typedef pat::ModifiedObjectProducer<pat::Jet> ModifiedJetProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(ModifiedGsfElectronProducer);
 DEFINE_FWK_MODULE(ModifiedElectronProducer);
 DEFINE_FWK_MODULE(ModifiedPhotonProducer);
 DEFINE_FWK_MODULE(ModifiedMuonProducer);

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -283,16 +283,21 @@ def miniAOD_customizeCommon(process):
                     'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff',
                     ]
     switchOnVIDElectronIdProducer(process,DataFormat.MiniAOD, task)
-    process.egmGsfElectronIDs.physicsObjectSrc = \
-        cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
-    process.electronMVAValueMapProducer.src = \
-        cms.InputTag('reducedEgamma','reducedGedGsfElectrons')
+    process.egmGsfElectronIDs.physicsObjectSrc = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.electronMVAValueMapProducer.src = cms.InputTag('reducedEgamma','reducedGedGsfElectrons')
 
     # To use older DataFormats, the electronMVAValueMapProducer MUST take a updated electron collection
     # such that the conversion variables are filled correctly.
+    process.load("RecoEgamma.EgammaTools.gedGsfElectronsTo106X_cff")
+    run2_miniAOD_80XLegacy.toModify(task, func=lambda t: t.add(process.gedGsfElectronsFrom80XTo106XTask))
     run2_miniAOD_80XLegacy.toModify(process.electronMVAValueMapProducer,
                                      keysForValueMaps = cms.InputTag('reducedEgamma','reducedGedGsfElectrons'),
-                                     src = cms.InputTag("gedGsfElectronsTo106X"))
+                                     src = cms.InputTag("gedGsfElectronsFrom80XTo106X"))
+
+    run2_miniAOD_94XFall17.toModify(task, func=lambda t: t.add(process.gedGsfElectronsFrom94XTo106XTask))
+    run2_miniAOD_94XFall17.toModify(process.electronMVAValueMapProducer,
+                                     keysForValueMaps = cms.InputTag('reducedEgamma','reducedGedGsfElectrons'),
+                                     src = cms.InputTag("gedGsfElectronsFrom94XTo106X"))
 
     for idmod in electron_ids:
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection,None,False,task)
@@ -306,10 +311,8 @@ def miniAOD_customizeCommon(process):
                   'RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring16_V2p2_cff',
                   'RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring16_nonTrig_V1_cff']
     switchOnVIDPhotonIdProducer(process,DataFormat.AOD, task) 
-    process.egmPhotonIDs.physicsObjectSrc = \
-        cms.InputTag("reducedEgamma","reducedGedPhotons")
-    process.photonMVAValueMapProducer.src = \
-        cms.InputTag('reducedEgamma','reducedGedPhotons')
+    process.egmPhotonIDs.physicsObjectSrc = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.photonMVAValueMapProducer.src = cms.InputTag('reducedEgamma','reducedGedPhotons')
     for idmod in photon_ids:
         setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection,None,False,task)
  

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -287,6 +287,13 @@ def miniAOD_customizeCommon(process):
         cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
     process.electronMVAValueMapProducer.src = \
         cms.InputTag('reducedEgamma','reducedGedGsfElectrons')
+
+    # To use older DataFormats, the electronMVAValueMapProducer MUST take a updated electron collection
+    # such that the conversion variables are filled correctly.
+    run2_miniAOD_80XLegacy.toModify(process.electronMVAValueMapProducer,
+                                     keysForValueMaps = cms.InputTag('reducedEgamma','reducedGedGsfElectrons'),
+                                     src = cms.InputTag("gedGsfElectronsTo106X"))
+
     for idmod in electron_ids:
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection,None,False,task)
 

--- a/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
+++ b/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
@@ -14,6 +14,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "RecoEgamma/EgammaTools/interface/validateEgammaCandidate.h"
 
 #include <cmath>
 #include <memory>
@@ -121,6 +122,7 @@ void MVAValueMapProducer<ParticleType>::produce(edm::StreamID,
 
     // Loop over particles
     for (auto const& cand : src->ptrs()) {
+      egammaTools::validateEgammaCandidate(*cand);
       int cat = -1;  // Passed by reference to the mvaValue function to store the category
       const float response = mvaEstimators_[iEstimator]->mvaValue(cand.get(), auxVariables, cat);
       mvaRawValues.push_back(response);                             // The MVA score

--- a/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
+++ b/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
@@ -15,6 +15,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "RecoEgamma/EgammaTools/interface/validateEgammaCandidate.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <cmath>
 #include <memory>
@@ -31,8 +32,8 @@ public:
 private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-  // for AOD and MiniAOD case
-  const edm::EDGetTokenT<edm::View<ParticleType>> src_;
+  const edm::EDGetTokenT<edm::View<ParticleType>> srcToken_;
+  const edm::EDGetTokenT<edm::View<ParticleType>> keysForValueMapsToken_;
 
   // MVA estimators
   const std::vector<std::unique_ptr<AnyMVAEstimatorRun2Base>> mvaEstimators_;
@@ -88,11 +89,21 @@ namespace {
 
     return names;
   }
+
+  template <class ParticleType>
+  auto getKeysForValueMapsToken(edm::InputTag const& keysForValueMapsTag, edm::ConsumesCollector&& cc) {
+    const bool tagGiven = !keysForValueMapsTag.label().empty();
+    return tagGiven ? cc.consumes<edm::View<ParticleType>>(keysForValueMapsTag)
+                    : edm::EDGetTokenT<edm::View<ParticleType>>{};
+  }
+
 }  // namespace
 
 template <class ParticleType>
 MVAValueMapProducer<ParticleType>::MVAValueMapProducer(const edm::ParameterSet& iConfig)
-    : src_(consumes<edm::View<ParticleType>>(iConfig.getParameter<edm::InputTag>("src"))),
+    : srcToken_(consumes<edm::View<ParticleType>>(iConfig.getParameter<edm::InputTag>("src"))),
+      keysForValueMapsToken_(getKeysForValueMapsToken<ParticleType>(
+          iConfig.getParameter<edm::InputTag>("keysForValueMaps"), consumesCollector())),
       mvaEstimators_(getMVAEstimators(iConfig.getParameterSetVector("mvaConfigurations"))),
       mvaValueMapNames_(getValueMapNames(iConfig.getParameterSetVector("mvaConfigurations"), "Values")),
       mvaRawValueMapNames_(getValueMapNames(iConfig.getParameterSetVector("mvaConfigurations"), "RawValues")),
@@ -112,7 +123,9 @@ void MVAValueMapProducer<ParticleType>::produce(edm::StreamID,
                                                 const edm::EventSetup& iSetup) const {
   std::vector<float> auxVariables = variableHelper_.getAuxVariables(iEvent);
 
-  auto src = iEvent.getHandle(src_);
+  auto srcHandle = iEvent.getHandle(srcToken_);
+  auto keysForValueMapsHandle =
+      keysForValueMapsToken_.isUninitialized() ? srcHandle : iEvent.getHandle(keysForValueMapsToken_);
 
   // Loop over MVA estimators
   for (unsigned iEstimator = 0; iEstimator < mvaEstimators_.size(); iEstimator++) {
@@ -121,28 +134,34 @@ void MVAValueMapProducer<ParticleType>::produce(edm::StreamID,
     std::vector<int> mvaCategories;
 
     // Loop over particles
-    for (auto const& cand : src->ptrs()) {
-      egammaTools::validateEgammaCandidate(*cand);
+    for (auto const& cand : *srcHandle) {
+      egammaTools::validateEgammaCandidate(cand);
       int cat = -1;  // Passed by reference to the mvaValue function to store the category
-      const float response = mvaEstimators_[iEstimator]->mvaValue(cand.get(), auxVariables, cat);
+      const float response = mvaEstimators_[iEstimator]->mvaValue(&cand, auxVariables, cat);
       mvaRawValues.push_back(response);                             // The MVA score
       mvaValues.push_back(2.0 / (1.0 + exp(-2.0 * response)) - 1);  // MVA output between -1 and 1
       mvaCategories.push_back(cat);
     }  // end loop over particles
 
-    writeValueMap(iEvent, src, mvaValues, mvaValueMapNames_[iEstimator]);
-    writeValueMap(iEvent, src, mvaRawValues, mvaRawValueMapNames_[iEstimator]);
-    writeValueMap(iEvent, src, mvaCategories, mvaCategoriesMapNames_[iEstimator]);
+    writeValueMap(iEvent, keysForValueMapsHandle, mvaValues, mvaValueMapNames_[iEstimator]);
+    writeValueMap(iEvent, keysForValueMapsHandle, mvaRawValues, mvaRawValueMapNames_[iEstimator]);
+    writeValueMap(iEvent, keysForValueMapsHandle, mvaCategories, mvaCategoriesMapNames_[iEstimator]);
 
   }  // end loop over estimators
 }
 
 template <class ParticleType>
 void MVAValueMapProducer<ParticleType>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
+  desc.add<edm::InputTag>("src", {});
+  desc.add<edm::InputTag>("keysForValueMaps", {});
+  {
+    //The following says we do not know what parameters are allowed so do no validation
+    // Please change this to state exactly what you do use, even if it is no parameters
+    edm::ParameterSetDescription mvaConfigurations;
+    mvaConfigurations.setUnknown();
+    desc.addVPSet("mvaConfigurations", mvaConfigurations);
+  }
   descriptions.addDefault(desc);
 }
 

--- a/RecoEgamma/EgammaTools/interface/validateEgammaCandidate.h
+++ b/RecoEgamma/EgammaTools/interface/validateEgammaCandidate.h
@@ -1,0 +1,19 @@
+#ifndef __RecoEgamma_EgammaTools_EgammaCandidateValidation_H__
+#define __RecoEgamma_EgammaTools_EgammaCandidateValidation_H__
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+
+namespace egammaTools {
+
+  void validateGsfElectron(reco::GsfElectron const& electron);
+
+  template <class Candidate>
+  void validateEgammaCandidate(Candidate const& candidate) {
+    if constexpr (std::is_same<Candidate, reco::GsfElectron>()) {
+      validateGsfElectron(candidate);
+    }
+  }
+
+}  // namespace egammaTools
+
+#endif

--- a/RecoEgamma/EgammaTools/python/gedGsfElectronsTo106X_cff.py
+++ b/RecoEgamma/EgammaTools/python/gedGsfElectronsTo106X_cff.py
@@ -1,0 +1,60 @@
+#
+# While reducing the AOD data tier produced in 80X to miniAOD, the electron
+# MVAs are computed before slimming. However, the object updators in
+# egammaObjectModificationsInMiniAOD_cff are written for pat::Electrons.
+# Therefore, we must adapt the object modifiers to the AOD level such that the
+# MVA producer can run on electrons that are updated and correctly store the
+# conversion rejection variables.
+#
+# Little annoyance: updating the object also requires computing the HEEP value
+# maps for the gedGsfElectrons, even though they are recomputed later from the
+# reducedEgamma collections. Unfortunately we can't use these HEEP value maps
+# that already exists, because reducedEgamma in turn depends on the
+# electronMVAValueMap producer. Hence, this is a problem of circular
+# dependency.
+#
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+from RecoEgamma.EgammaTools.egammaObjectModificationsInMiniAOD_cff import (
+    egamma8XObjectUpdateModifier,
+    egamma9X105XUpdateModifier,
+)
+from RecoEgamma.ElectronIdentification.heepIdVarValueMapProducer_cfi import heepIDVarValueMaps
+
+heepIDVarValueMapsAOD = heepIDVarValueMaps.copy()
+heepIDVarValueMapsAOD.dataFormat = 1
+
+gsfElectron8XObjectUpdateModifier = egamma8XObjectUpdateModifier.clone(
+    ecalRecHitsEB="reducedEcalRecHitsEB", ecalRecHitsEE="reducedEcalRecHitsEE"
+)
+gsfElectron9X105XUpdateModifier = egamma9X105XUpdateModifier.clone(
+    eleCollVMsAreKeyedTo="gedGsfElectrons",
+    eleTrkIso="heepIDVarValueMapsAOD:eleTrkPtIso",
+    eleTrkIso04="heepIDVarValueMapsAOD:eleTrkPtIso04",
+    conversions="allConversions",
+    ecalRecHitsEB="reducedEcalRecHitsEB",
+    ecalRecHitsEE="reducedEcalRecHitsEE",
+)
+
+# we have dataformat changes to 106X so to read older releases we use egamma updators
+gedGsfElectronsFrom80XTo106X = cms.EDProducer(
+    "ModifiedGsfElectronProducer",
+    src=cms.InputTag("gedGsfElectrons"),
+    modifierConfig=cms.PSet(
+        modifications=cms.VPSet(gsfElectron8XObjectUpdateModifier, gsfElectron9X105XUpdateModifier)
+    ),
+)
+
+gedGsfElectronsFrom80XTo106XTask = cms.Task(heepIDVarValueMapsAOD, gedGsfElectronsFrom80XTo106X)
+
+gedGsfElectronsFrom94XTo106X = cms.EDProducer(
+    "ModifiedGsfElectronProducer",
+    src=cms.InputTag("gedGsfElectrons"),
+    modifierConfig=cms.PSet(
+        modifications=cms.VPSet(gsfElectron9X105XUpdateModifier)
+    ),
+)
+
+gedGsfElectronsFrom94XTo106XTask = cms.Task(heepIDVarValueMapsAOD, gedGsfElectronsFrom94XTo106X)

--- a/RecoEgamma/EgammaTools/src/validateEgammaCandidate.cc
+++ b/RecoEgamma/EgammaTools/src/validateEgammaCandidate.cc
@@ -1,0 +1,13 @@
+#include "RecoEgamma/EgammaTools/interface/validateEgammaCandidate.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+
+void egammaTools::validateGsfElectron(reco::GsfElectron const& electron) {
+  if (electron.convVtxFitProb() > 1.0f) {
+    throw cms::Exception("EgammaError")
+        << "invalid value " << electron.convVtxFitProb() << " for reco::GsfElectron.conversionRejection_.vtxFitProb\n"
+        << "It should be either beween 0.0f and 1.0f or negative in case no matching conversion was found.\n"
+        << "Probably you need to update the electron collection with the EG9X105XObjectUpdateModifier plugin:\n"
+        << "see PhysicsTools/NanoAOD/python/electrons_cff.py for an example.\n";
+  }
+}


### PR DESCRIPTION
#### PR description:

You might remember that the GsfElectron DataFormat was changed in the beginning of last year: https://github.com/cms-sw/cmssw/pull/26485. One good thing about the new format was that all ID variables are stored in it and the MVA producer got adapted accordingly.

This broke the possibility to run the MVA ID directly on the old format with the new CMSSW code. One variable (conversion rejection probability) will just assume a default value, and the MVA gets wrong input variables but will not complain. It is something that I noticed back then but didn't say anything, because EGM PostRecoTools convert the old format into the new one if you follow the instructions from the EGM Twiki. 

However, not all production workflows convert the GsffElectron format where needed. Workflows that produce miniAOD from pre-106X AOD get it wrong. Two of these workflows are also in the bot-tests: `136.8311` and `136.7611` (see first tests below). There is also some pedagogic EGammma code like my [ElectronMVATutorial](https://github.com/guitargeek/ElectronMVATutorial) (presented on the last Physics Object School and still getting many views and clones) which doesn't do any DataFormat conversion. Maybe there is also other code floating around that doesn't do it. After all, samples in the old DataFormat are still recommended for analysis until the ultra-legacy samples are out, If I get that correctly.

I suggest to add a simple check which makes sure that the affected variables in the GsfElectron are not their default  value, so it's sure that they are filled and we are dealing with the new format. If this not the case, an error will be thrown with a reference to NanoAOD as an example where the conversion is implemented correctly.

The workflows that don't do the data format updating before computing the MVA on the electrons from older AOD files are also fixed.

[1] https://github.com/cms-sw/cmssw/pull/26485/files#diff-857e86e09a96cefe6edac6eb206e1d22R611

#### PR validation:

CMSSW compiles, matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended (so far).
