### PR TITLE
optimize: rely on Candidate pt,eta,phi without casting in MuonPFIsolationWithConeVeto

### DIFF
--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -139,12 +139,13 @@ namespace citk {
       }
       for (size_t ic = 0; ic < isolate_with->size(); ++ic) {
         auto isocand = isolate_with->ptrAt(ic);
-        edm::Ptr<pat::PackedCandidate> aspackedCandidate(isocand);
+        edm::Ptr<pat::PackedCandidate> aspackedCandidate; 
         auto isotype = helper.translatePdgIdToType(isocand->pdgId());
         const auto& isolations = _isolation_types[isotype];
         for (unsigned i = 0; i < isolations.size(); ++i) {
           if (isolations[i]->isInIsolationCone(cand_to_isolate, isocand)) {
             double puppiWeight = 0.;
+            if (!useValueMapForPUPPI && aspackedCandidate.isNull()) aspackedCandidate = isocand;
             if (!useValueMapForPUPPI && !usePUPPINoLepton)
               puppiWeight = aspackedCandidate->puppiWeight();  // if miniAOD, take puppiWeight directly from the object
             else if (!useValueMapForPUPPI && usePUPPINoLepton)

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -139,13 +139,14 @@ namespace citk {
       }
       for (size_t ic = 0; ic < isolate_with->size(); ++ic) {
         auto isocand = isolate_with->ptrAt(ic);
-        edm::Ptr<pat::PackedCandidate> aspackedCandidate; 
+        edm::Ptr<pat::PackedCandidate> aspackedCandidate;
         auto isotype = helper.translatePdgIdToType(isocand->pdgId());
         const auto& isolations = _isolation_types[isotype];
         for (unsigned i = 0; i < isolations.size(); ++i) {
           if (isolations[i]->isInIsolationCone(cand_to_isolate, isocand)) {
             double puppiWeight = 0.;
-            if (!useValueMapForPUPPI && aspackedCandidate.isNull()) aspackedCandidate = edm::Ptr<pat::PackedCandidate>(isocand);
+            if (!useValueMapForPUPPI && aspackedCandidate.isNull()) 
+              aspackedCandidate = edm::Ptr<pat::PackedCandidate>(isocand);
             if (!useValueMapForPUPPI && !usePUPPINoLepton)
               puppiWeight = aspackedCandidate->puppiWeight();  // if miniAOD, take puppiWeight directly from the object
             else if (!useValueMapForPUPPI && usePUPPINoLepton)

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -145,7 +145,7 @@ namespace citk {
         for (unsigned i = 0; i < isolations.size(); ++i) {
           if (isolations[i]->isInIsolationCone(cand_to_isolate, isocand)) {
             double puppiWeight = 0.;
-            if (!useValueMapForPUPPI && aspackedCandidate.isNull()) 
+            if (!useValueMapForPUPPI && aspackedCandidate.isNull())
               aspackedCandidate = edm::Ptr<pat::PackedCandidate>(isocand);
             if (!useValueMapForPUPPI && !usePUPPINoLepton)
               puppiWeight = aspackedCandidate->puppiWeight();  // if miniAOD, take puppiWeight directly from the object

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -145,7 +145,7 @@ namespace citk {
         for (unsigned i = 0; i < isolations.size(); ++i) {
           if (isolations[i]->isInIsolationCone(cand_to_isolate, isocand)) {
             double puppiWeight = 0.;
-            if (!useValueMapForPUPPI && aspackedCandidate.isNull()) aspackedCandidate = isocand;
+            if (!useValueMapForPUPPI && aspackedCandidate.isNull()) aspackedCandidate = edm::Ptr<pat::PackedCandidate>(isocand);
             if (!useValueMapForPUPPI && !usePUPPINoLepton)
               puppiWeight = aspackedCandidate->puppiWeight();  // if miniAOD, take puppiWeight directly from the object
             else if (!useValueMapForPUPPI && usePUPPINoLepton)

--- a/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
@@ -41,12 +41,12 @@ DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory, MuonPFIsolationWithConeVet
 
 bool MuonPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& physob,
                                                     const reco::CandidatePtr& iso_obj) const {
-  if (iso_obj->pt() <= _vetoThreshold )
+  if (iso_obj->pt() <= _vetoThreshold)
     return false;
   const double deltar2 = reco::deltaR2(*physob, *iso_obj);
   if (deltar2 <= _vetoConeSize2 || deltar2 >= _coneSize2)
     return false;
-  
+
   //the rest will check the vertex selection
   const pat::PackedCandidatePtr aspacked(iso_obj);
   const reco::PFCandidatePtr aspf(iso_obj);

--- a/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
@@ -61,9 +61,7 @@ bool MuonPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& ph
       }
       result = result && (is_vertex_allowed);
     }
-    result = result;
   } else if (aspf.isNonnull() && aspf.get()) {
-    result = result;
   } else {
     throw cms::Exception("InvalidIsolationInput") << "The supplied candidate to be used as isolation "
                                                   << "was neither a reco::PFCandidate nor a pat::PackedCandidate!";

--- a/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
@@ -41,9 +41,13 @@ DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory, MuonPFIsolationWithConeVet
 
 bool MuonPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& physob,
                                                     const reco::CandidatePtr& iso_obj) const {
+  if (iso_obj->pt() <= _vetoThreshold ) return false;
+  const double deltar2 = reco::deltaR2(*physob, *iso_obj);
+  if (deltar2 <= _vetoConeSize2 || deltar2 >= _coneSize2) return false;
+  
+  //the rest will check the vertex selection
   const pat::PackedCandidatePtr aspacked(iso_obj);
   const reco::PFCandidatePtr aspf(iso_obj);
-  const double deltar2 = reco::deltaR2(*physob, *iso_obj);
 
   bool result = true;
   if (aspacked.isNonnull() && aspacked.get()) {
@@ -57,9 +61,9 @@ bool MuonPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& ph
       }
       result = result && (is_vertex_allowed);
     }
-    result = result && (aspacked->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2);
+    result = result;
   } else if (aspf.isNonnull() && aspf.get()) {
-    result = result && (aspf->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2);
+    result = result;
   } else {
     throw cms::Exception("InvalidIsolationInput") << "The supplied candidate to be used as isolation "
                                                   << "was neither a reco::PFCandidate nor a pat::PackedCandidate!";

--- a/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
@@ -41,9 +41,11 @@ DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory, MuonPFIsolationWithConeVet
 
 bool MuonPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& physob,
                                                     const reco::CandidatePtr& iso_obj) const {
-  if (iso_obj->pt() <= _vetoThreshold ) return false;
+  if (iso_obj->pt() <= _vetoThreshold )
+    return false;
   const double deltar2 = reco::deltaR2(*physob, *iso_obj);
-  if (deltar2 <= _vetoConeSize2 || deltar2 >= _coneSize2) return false;
+  if (deltar2 <= _vetoConeSize2 || deltar2 >= _coneSize2)
+    return false;
   
   //the rest will check the vertex selection
   const pat::PackedCandidatePtr aspacked(iso_obj);


### PR DESCRIPTION
visual optimization based on https://jiwoong.web.cern.ch/jiwoong/cgi-bin/igprof-navigator/igprofCPU_CMSSW_11_1_0_pre8PAT/28

