### PR TITLE
[Phase2 Pixel3D digitizer] add new histos and fix entry angles for tracks to test beam validator 

### DIFF
--- a/SimTracker/SiPhase2Digitizer/python/PixelTestBeamValidation_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/PixelTestBeamValidation_cfi.py
@@ -18,6 +18,11 @@ Charge1D = cms.PSet(
     xmin = cms.double(-0.5),
     xmax = cms.double(199.5)
     )
+ChargeElec1D = cms.PSet(
+    Nxbins = cms.int32(300),
+    xmin = cms.double(0),
+    xmax = cms.double(120.0e3)
+    )
 DigiCharge1D = cms.PSet(
     Nxbins = cms.int32(17),
     xmin = cms.double(-0.5),
@@ -42,6 +47,14 @@ Dy1D = cms.PSet(
     Nxbins = cms.int32(300),
     xmin = cms.double(-150),
     xmax = cms.double(150)
+    )
+SimClusterCharge = cms.PSet(
+    Nxbins = cms.int32(300),
+    Nybins = cms.int32(201),
+    xmin   = cms.double(0.),
+    xmax   = cms.double(300.),
+    ymin   = cms.double(0),
+    ymax   = cms.double(120.5e3)
     )
 TrackXY = cms.PSet(
     Nxbins = cms.int32(1250),
@@ -95,6 +108,8 @@ Dy = cms.PSet(
     )
 
 dqmcell = DQMEDAnalyzer('PixelTestBeamValidation',
+    # WARNING: be sure it is the same value used with the Pixel3DDigitizer
+    ElectronsPerADC   = cms.double(1600.0),
     TracksEntryAngleX = cms.untracked.vdouble(-np.radians(2.0),np.radians(2.0)),
     TracksEntryAngleY = cms.untracked.vdouble(-np.radians(2.0),np.radians(2.0)),
     TopFolderName = cms.string("PixelCell"),
@@ -119,6 +134,7 @@ dqmcell = DQMEDAnalyzer('PixelTestBeamValidation',
     ClusterSize1Dx = ClusterSize1D.clone(),
     ClusterSize1Dy = ClusterSize1D.clone(),
     Charge1D = Charge1D.clone(),
+    ChargeElec1D = ChargeElec1D.clone(),
     TrackAngleDxdz = TrackAngleDxdz.clone(),
     TrackAngleDydz = TrackAngleDydz.clone(),
     TrackXY = TrackXY.clone(),
@@ -128,6 +144,7 @@ dqmcell = DQMEDAnalyzer('PixelTestBeamValidation',
     Dx1D = Dx1D.clone(),
     Dy1D = Dy1D.clone(),
     DigiCharge1D = DigiCharge1D.clone(),
+    SimClusterCharge = SimClusterCharge.clone(),
 
     Position_0 = Position.clone(),
     Position_1 = Position.clone(),
@@ -148,6 +165,10 @@ dqmcell = DQMEDAnalyzer('PixelTestBeamValidation',
     Charge_0 = Charge.clone(),
     Charge_1 = Charge.clone(),
     Charge_2 = Charge.clone(),
+    
+    Charge_elec_0 = Charge.clone(),
+    Charge_elec_1 = Charge.clone(),
+    Charge_elec_2 = Charge.clone(),
     
     Dx_0 = Dx.clone(),
     Dx_1 = Dx.clone(),

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
@@ -32,6 +32,8 @@
 using cms_units::operators::operator""_deg;
 // Analogously to CMSUnits (no um defined, using inverse)
 constexpr double operator""_inv_um(long double length) { return length * 1e4; }
+// Energy (keV) -- to be used with the PSimHit::energyLoss with energy in GeV
+constexpr double operator""_inv_keV(long double energy_in_GeV) { return energy_in_GeV * 1e6; }
 
 using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
 
@@ -39,6 +41,8 @@ PixelTestBeamValidation::PixelTestBeamValidation(const edm::ParameterSet& iConfi
     : config_(iConfig),
       geomType_(iConfig.getParameter<std::string>("GeometryType")),
       //phiValues(iConfig.getParameter<std::vector<double> >("PhiAngles")),
+      electronsPerADC_(
+          iConfig.getParameter<double>("ElectronsPerADC")),
       tracksEntryAngleX_(
           iConfig.getUntrackedParameter<std::vector<double>>("TracksEntryAngleX", std::vector<double>())),
       tracksEntryAngleY_(
@@ -87,6 +91,10 @@ PixelTestBeamValidation::PixelTestBeamValidation(const edm::ParameterSet& iConfi
                                             << "Invalid number of elements in 'TracksEntryAngle" << label_v.first
                                             << ".size()' = " << label_v.second->size() << ". Valid sizes are 1 or 2.";
     }
+    // convert the angles into its tangent (the check is going to be done 
+    // against the tangent dx/dz and dy/dz)
+    (*label_v.second)[0] = std::tan((*label_v.second)[0]);
+    (*label_v.second)[1] = std::tan((*label_v.second)[1]);
     active_entry_angles_[conversor[label_v.first]] =
         std::pair<double, double>({(*label_v.second)[0], (*label_v.second)[1]});
   }
@@ -94,12 +102,10 @@ PixelTestBeamValidation::PixelTestBeamValidation(const edm::ParameterSet& iConfi
   if (prov_ref_m.size() != 0) {
     // The algorithm is defined in the implementation of _check_input_angles_
     use_this_track_ = std::bind(&PixelTestBeamValidation::_check_input_angles_, this, std::placeholders::_1);
-    //edm::LogInfo("Configuration") << "Considering hits from tracks entering the detectors between\n "
-    std::cout << "Configuration "
+    edm::LogInfo("Configuration") << "Considering hits from tracks entering the detectors between\n "
               << "Considering hits from tracks entering the detectors between\n "
-              << "\tX-plane: (" << active_entry_angles_[0].first << "," << active_entry_angles_[0].second << ") rad. "
-              << "\tY-plane: (" << active_entry_angles_[1].first << "," << active_entry_angles_[1].second << ") rad. "
-              << std::endl;
+              << "\tX-plane: (" << std::atan(active_entry_angles_[0].first) << "," << std::atan(active_entry_angles_[0].second) << ") rad. "
+              << "\tY-plane: (" << std::atan(active_entry_angles_[1].first) << "," << std::atan(active_entry_angles_[1].second) << ") rad. ";
   } else {
     // There is no requiremnt, so always process it
     use_this_track_ = [](const PSimHit*) -> bool { return true; };
@@ -239,8 +245,8 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
         const GlobalPoint tk_ep_gbl(dunit->surface().toGlobal(ps->entryPoint()));
         vME_track_XYMap_->Fill(tk_ep_gbl.x(), tk_ep_gbl.y());
         vME_track_RZMap_->Fill(tk_ep_gbl.z(), std::hypot(tk_ep_gbl.x(), tk_ep_gbl.y()));
-        vME_track_dxdzAngle_[me_unit]->Fill(ps->thetaAtEntry());
-        vME_track_dydzAngle_[me_unit]->Fill(ps->phiAtEntry());
+        vME_track_dxdzAngle_[me_unit]->Fill(std::atan2(ps->momentumAtEntry().x(),ps->momentumAtEntry().z()));
+        vME_track_dydzAngle_[me_unit]->Fill(std::atan2(ps->momentumAtEntry().y(),ps->momentumAtEntry().z()));
 
         // Obtain the detected position of the sim particle:
         // the middle point between the entry and the exit
@@ -253,6 +259,7 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
         // Get the total charge for this cluster size
         // and obtain the center of the cluster using a charge-weighted mean
         int cluster_tot = 0;
+        double cluster_tot_elec = 0.0;
         int cluster_size = 0;
         std::pair<std::set<int>, std::set<int>> cluster_size_xy;
         std::pair<double, double> cluster_position({0.0, 0.0});
@@ -282,6 +289,7 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
           vME_digi_RZMap_->Fill(digi_global_pos.z(), std::hypot(digi_global_pos.x(), digi_global_pos.y()));
           // Create the MC-cluster
           cluster_tot += current_digi.adc();
+          cluster_tot_elec += current_digi.adc() * electronsPerADC_;
           // Use the center of the pixel
           cluster_position.first += current_digi.adc() * (current_digi.row() + 0.5);
           cluster_position.second += current_digi.adc() * (current_digi.column() + 0.5);
@@ -313,8 +321,11 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
         const double dy_um = (psh_pos.y() - cluster_position.second) * pitch.second * 1.0_inv_um;
         if (is_cluster_present) {
           vME_charge1D_[me_unit]->Fill(cluster_tot);
+          vME_charge_elec1D_[me_unit]->Fill(cluster_tot_elec);
           vME_dx1D_[me_unit]->Fill(dx_um);
           vME_dy1D_[me_unit]->Fill(dy_um);
+          // The track energy loss corresponding to that cluster
+          vME_sim_cluster_charge_[me_unit]->Fill(ps->energyLoss()*1.0_inv_keV,cluster_tot_elec);
         }
         // Histograms per cell
         for (unsigned int i = 0; i < vME_position_cell_[me_unit].size(); ++i) {
@@ -336,6 +347,8 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
             // Charge
             vME_charge_cell_[me_unit][i]->Fill(
                 icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot);
+            vME_charge_elec_cell_[me_unit][i]->Fill(
+                icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot*electronsPerADC_);
             // Cluster size
             vME_clsize_cell_[me_unit][i]->Fill(
                 icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_size);
@@ -429,6 +442,8 @@ void PixelTestBeamValidation::bookHistograms(DQMStore::IBooker& ibooker,
           setupH1D_(ibooker, "ClusterSize1Dy", "MC-truth DIGI cluster size in Y;Cluster size;N_{clusters}");
       vME_charge1D_[me_unit] =
           setupH1D_(ibooker, "Charge1D", "MC-truth DIGI cluster charge;Cluster charge [ToT];N_{clusters}");
+      vME_charge_elec1D_[me_unit] =
+          setupH1D_(ibooker, "ChargeElec1D", "MC-truth DIGI cluster charge;Cluster charge [Electrons];N_{clusters}");
       vME_track_dxdzAngle_[me_unit] = setupH1D_(
           ibooker,
           "TrackAngleDxdz",
@@ -442,6 +457,10 @@ void PixelTestBeamValidation::bookHistograms(DQMStore::IBooker& ibooker,
       vME_dy1D_[me_unit] = setupH1D_(
           ibooker, "Dy1D", "MC-truth DIGI cluster residual Ys;y_{PSimHit}-y^{cluster}_{digi} [#mum];N_{digi clusters}");
       vME_digi_charge1D_[me_unit] = setupH1D_(ibooker, "DigiCharge1D", "Digi charge;digi charge [ToT];N_{digi}");
+      vME_sim_cluster_charge_[me_unit] =
+          setupH2D_(ibooker,
+                  "SimClusterCharge",
+                  "PSimHit Energy deposit vs. Cluster Charge;deposited E_{sim} [keV];cluster_{charge} [Electrons];");
 
       // The histos per cell
       // Prepare the ranges: 0- whole sensor, 1- cell 1x1, 2-cell 2x2,
@@ -483,6 +502,11 @@ void PixelTestBeamValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                                          cell + "MC-truth charge;x [#mum];y [#mum];<ToT>",
                                                          xranges[i],
                                                          yranges[i]));
+        vME_charge_elec_cell_[me_unit].push_back(setupProf2D_(ibooker,
+                                                         "Charge_elec_" + std::to_string(i),
+                                                         cell + "MC-truth charge;x [#mum];y [#mum];<Electrons>",
+                                                         xranges[i],
+                                                         yranges[i]));
         vME_dx_cell_[me_unit].push_back(setupProf2D_(ibooker,
                                                      "Dx_" + std::to_string(i),
                                                      cell + "MC-truth residuals;x [#mum];y [#mum];<#Deltax [#mum]>",
@@ -495,9 +519,9 @@ void PixelTestBeamValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                                      yranges[i]));
       }
 
-      std::cout << "PixelTestBeamValidation"
-                << "Booking Histograms in: " << folder_name << " ME UNIT:" << me_unit << std::endl;
-      edm::LogInfo("PixelTestBeamValidation") << "Booking Histograms in: " << folder_name << std::endl;
+      edm::LogInfo("PixelTestBeamValidation")
+                << "Booking Histograms in: " << folder_name << " ME UNIT:" << me_unit;
+      edm::LogInfo("PixelTestBeamValidation") << "Booking Histograms in: " << folder_name;
     }
   }
 }
@@ -723,11 +747,12 @@ std::set<std::pair<int, int>> PixelTestBeamValidation::get_illuminated_pixels_(c
 bool PixelTestBeamValidation::_check_input_angles_(const PSimHit* psimhit) {
   // Create a vector to check against the range map where
   // X axis is in the key 0, Y axis in the key 1
-  const std::vector<double> theta_phi({psimhit->thetaAtEntry(), psimhit->phiAtEntry()});
+  const std::vector<double> entry_tan({psimhit->momentumAtEntry().x()/psimhit->momentumAtEntry().z(),
+          psimhit->momentumAtEntry().y()/psimhit->momentumAtEntry().z()});
 
   for (const auto& axis_ranges : active_entry_angles_) {
-    if (axis_ranges.second.first > theta_phi[axis_ranges.first] ||
-        axis_ranges.second.second < theta_phi[axis_ranges.first]) {
+    if (axis_ranges.second.first > entry_tan[axis_ranges.first] ||
+        axis_ranges.second.second < entry_tan[axis_ranges.first]) {
       return false;
     }
   }

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
@@ -41,8 +41,7 @@ PixelTestBeamValidation::PixelTestBeamValidation(const edm::ParameterSet& iConfi
     : config_(iConfig),
       geomType_(iConfig.getParameter<std::string>("GeometryType")),
       //phiValues(iConfig.getParameter<std::vector<double> >("PhiAngles")),
-      electronsPerADC_(
-          iConfig.getParameter<double>("ElectronsPerADC")),
+      electronsPerADC_(iConfig.getParameter<double>("ElectronsPerADC")),
       tracksEntryAngleX_(
           iConfig.getUntrackedParameter<std::vector<double>>("TracksEntryAngleX", std::vector<double>())),
       tracksEntryAngleY_(
@@ -91,7 +90,7 @@ PixelTestBeamValidation::PixelTestBeamValidation(const edm::ParameterSet& iConfi
                                             << "Invalid number of elements in 'TracksEntryAngle" << label_v.first
                                             << ".size()' = " << label_v.second->size() << ". Valid sizes are 1 or 2.";
     }
-    // convert the angles into its tangent (the check is going to be done 
+    // convert the angles into its tangent (the check is going to be done
     // against the tangent dx/dz and dy/dz)
     (*label_v.second)[0] = std::tan((*label_v.second)[0]);
     (*label_v.second)[1] = std::tan((*label_v.second)[1]);
@@ -103,9 +102,11 @@ PixelTestBeamValidation::PixelTestBeamValidation(const edm::ParameterSet& iConfi
     // The algorithm is defined in the implementation of _check_input_angles_
     use_this_track_ = std::bind(&PixelTestBeamValidation::_check_input_angles_, this, std::placeholders::_1);
     edm::LogInfo("Configuration") << "Considering hits from tracks entering the detectors between\n "
-              << "Considering hits from tracks entering the detectors between\n "
-              << "\tX-plane: (" << std::atan(active_entry_angles_[0].first) << "," << std::atan(active_entry_angles_[0].second) << ") rad. "
-              << "\tY-plane: (" << std::atan(active_entry_angles_[1].first) << "," << std::atan(active_entry_angles_[1].second) << ") rad. ";
+                                  << "Considering hits from tracks entering the detectors between\n "
+                                  << "\tX-plane: (" << std::atan(active_entry_angles_[0].first) << ","
+                                  << std::atan(active_entry_angles_[0].second) << ") rad. "
+                                  << "\tY-plane: (" << std::atan(active_entry_angles_[1].first) << ","
+                                  << std::atan(active_entry_angles_[1].second) << ") rad. ";
   } else {
     // There is no requiremnt, so always process it
     use_this_track_ = [](const PSimHit*) -> bool { return true; };
@@ -245,8 +246,8 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
         const GlobalPoint tk_ep_gbl(dunit->surface().toGlobal(ps->entryPoint()));
         vME_track_XYMap_->Fill(tk_ep_gbl.x(), tk_ep_gbl.y());
         vME_track_RZMap_->Fill(tk_ep_gbl.z(), std::hypot(tk_ep_gbl.x(), tk_ep_gbl.y()));
-        vME_track_dxdzAngle_[me_unit]->Fill(std::atan2(ps->momentumAtEntry().x(),ps->momentumAtEntry().z()));
-        vME_track_dydzAngle_[me_unit]->Fill(std::atan2(ps->momentumAtEntry().y(),ps->momentumAtEntry().z()));
+        vME_track_dxdzAngle_[me_unit]->Fill(std::atan2(ps->momentumAtEntry().x(), ps->momentumAtEntry().z()));
+        vME_track_dydzAngle_[me_unit]->Fill(std::atan2(ps->momentumAtEntry().y(), ps->momentumAtEntry().z()));
 
         // Obtain the detected position of the sim particle:
         // the middle point between the entry and the exit
@@ -325,7 +326,7 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
           vME_dx1D_[me_unit]->Fill(dx_um);
           vME_dy1D_[me_unit]->Fill(dy_um);
           // The track energy loss corresponding to that cluster
-          vME_sim_cluster_charge_[me_unit]->Fill(ps->energyLoss()*1.0_inv_keV,cluster_tot_elec);
+          vME_sim_cluster_charge_[me_unit]->Fill(ps->energyLoss() * 1.0_inv_keV, cluster_tot_elec);
         }
         // Histograms per cell
         for (unsigned int i = 0; i < vME_position_cell_[me_unit].size(); ++i) {
@@ -348,7 +349,7 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
             vME_charge_cell_[me_unit][i]->Fill(
                 icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot);
             vME_charge_elec_cell_[me_unit][i]->Fill(
-                icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot*electronsPerADC_);
+                icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot * electronsPerADC_);
             // Cluster size
             vME_clsize_cell_[me_unit][i]->Fill(
                 icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_size);
@@ -459,8 +460,8 @@ void PixelTestBeamValidation::bookHistograms(DQMStore::IBooker& ibooker,
       vME_digi_charge1D_[me_unit] = setupH1D_(ibooker, "DigiCharge1D", "Digi charge;digi charge [ToT];N_{digi}");
       vME_sim_cluster_charge_[me_unit] =
           setupH2D_(ibooker,
-                  "SimClusterCharge",
-                  "PSimHit Energy deposit vs. Cluster Charge;deposited E_{sim} [keV];cluster_{charge} [Electrons];");
+                    "SimClusterCharge",
+                    "PSimHit Energy deposit vs. Cluster Charge;deposited E_{sim} [keV];cluster_{charge} [Electrons];");
 
       // The histos per cell
       // Prepare the ranges: 0- whole sensor, 1- cell 1x1, 2-cell 2x2,
@@ -503,10 +504,10 @@ void PixelTestBeamValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                                          xranges[i],
                                                          yranges[i]));
         vME_charge_elec_cell_[me_unit].push_back(setupProf2D_(ibooker,
-                                                         "Charge_elec_" + std::to_string(i),
-                                                         cell + "MC-truth charge;x [#mum];y [#mum];<Electrons>",
-                                                         xranges[i],
-                                                         yranges[i]));
+                                                              "Charge_elec_" + std::to_string(i),
+                                                              cell + "MC-truth charge;x [#mum];y [#mum];<Electrons>",
+                                                              xranges[i],
+                                                              yranges[i]));
         vME_dx_cell_[me_unit].push_back(setupProf2D_(ibooker,
                                                      "Dx_" + std::to_string(i),
                                                      cell + "MC-truth residuals;x [#mum];y [#mum];<#Deltax [#mum]>",
@@ -519,8 +520,7 @@ void PixelTestBeamValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                                      yranges[i]));
       }
 
-      edm::LogInfo("PixelTestBeamValidation")
-                << "Booking Histograms in: " << folder_name << " ME UNIT:" << me_unit;
+      edm::LogInfo("PixelTestBeamValidation") << "Booking Histograms in: " << folder_name << " ME UNIT:" << me_unit;
       edm::LogInfo("PixelTestBeamValidation") << "Booking Histograms in: " << folder_name;
     }
   }
@@ -747,8 +747,8 @@ std::set<std::pair<int, int>> PixelTestBeamValidation::get_illuminated_pixels_(c
 bool PixelTestBeamValidation::_check_input_angles_(const PSimHit* psimhit) {
   // Create a vector to check against the range map where
   // X axis is in the key 0, Y axis in the key 1
-  const std::vector<double> entry_tan({psimhit->momentumAtEntry().x()/psimhit->momentumAtEntry().z(),
-          psimhit->momentumAtEntry().y()/psimhit->momentumAtEntry().z()});
+  const std::vector<double> entry_tan({psimhit->momentumAtEntry().x() / psimhit->momentumAtEntry().z(),
+                                       psimhit->momentumAtEntry().y() / psimhit->momentumAtEntry().z()});
 
   for (const auto& axis_ranges : active_entry_angles_) {
     if (axis_ranges.second.first > entry_tan[axis_ranges.first] ||

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
@@ -290,7 +290,8 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
           vME_digi_RZMap_->Fill(digi_global_pos.z(), std::hypot(digi_global_pos.x(), digi_global_pos.y()));
           // Create the MC-cluster
           cluster_tot += current_digi.adc();
-          cluster_tot_elec += current_digi.adc() * electronsPerADC_;
+          // Add 0.5 to allow ToT = 0 (valid value)
+          cluster_tot_elec += (current_digi.adc() + 0.5) * electronsPerADC_;
           // Use the center of the pixel
           cluster_position.first += current_digi.adc() * (current_digi.row() + 0.5);
           cluster_position.second += current_digi.adc() * (current_digi.column() + 0.5);
@@ -349,7 +350,7 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
             vME_charge_cell_[me_unit][i]->Fill(
                 icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot);
             vME_charge_elec_cell_[me_unit][i]->Fill(
-                icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot * electronsPerADC_);
+                icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot_elec);
             // Cluster size
             vME_clsize_cell_[me_unit][i]->Fill(
                 icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_size);

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
@@ -132,6 +132,7 @@ private:
   std::map<int, MonitorElement *> vME_clsize1Dx_;
   std::map<int, MonitorElement *> vME_clsize1Dy_;
   std::map<int, MonitorElement *> vME_charge1D_;
+  std::map<int, MonitorElement *> vME_charge_elec1D_;
   std::map<int, MonitorElement *> vME_track_dxdz_;
   std::map<int, MonitorElement *> vME_track_dydz_;
   std::map<int, MonitorElement *> vME_track_dxdzAngle_;
@@ -139,6 +140,8 @@ private:
   std::map<int, MonitorElement *> vME_dx1D_;
   std::map<int, MonitorElement *> vME_dy1D_;
   std::map<int, MonitorElement *> vME_digi_charge1D_;
+  std::map<int, MonitorElement *> vME_digi_chargeElec1D_;
+  std::map<int, MonitorElement *> vME_sim_cluster_charge_;
   // --- cell histograms per subdector , each element on the
   //     vector 0: total, 1: 1x1, 2: 2x2, (3: 3x3, 4: 4x4)?
   std::map<int, std::vector<MonitorElement *>> vME_pshpos_cell_;
@@ -146,6 +149,7 @@ private:
   std::map<int, std::vector<MonitorElement *>> vME_eff_cell_;
   std::map<int, std::vector<MonitorElement *>> vME_clsize_cell_;
   std::map<int, std::vector<MonitorElement *>> vME_charge_cell_;
+  std::map<int, std::vector<MonitorElement *>> vME_charge_elec_cell_;
   std::map<int, std::vector<MonitorElement *>> vME_dx_cell_;
   std::map<int, std::vector<MonitorElement *>> vME_dy_cell_;
 
@@ -157,6 +161,9 @@ private:
   // Geometry to use
   std::string geomType_;
 
+  // The conversion between ToT to electrons (Be carefull, this should
+  // be using the same value used in the digitization module)
+  double electronsPerADC_;
   // The tracks entry angle to accept (if any)
   std::vector<double> tracksEntryAngleX_;
   std::vector<double> tracksEntryAngleY_;

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidator_cfg.py
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidator_cfg.py
@@ -1,0 +1,84 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
+
+process = cms.Process('digiTest',Phase2C9,phase2_PixelCPEGeneric)
+
+import FWCore.ParameterSet.VarParsing as VarParsing 
+options = VarParsing.VarParsing ("analysis") 
+options.register("skipEvents",default=0)
+# Not needed in the config, but needed because used as input option by htcondor_jobs
+options.register("firstEvent",default=1)
+options.maxEvents = -1
+options.skipEvents = 0
+options.firstEvent = 1
+
+options.parseArguments() 
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D54Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 5000
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T19', '')
+# list of files
+
+process.source = cms.Source("PoolSource",
+    fileNames =  cms.untracked.vstring(options.inputFiles),
+    skipEvents = cms.untracked.uint32(options.skipEvents),
+    )
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('step1 nevts:1'),
+    name = cms.untracked.string('Applications')
+)
+# Output definition
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string(options.outputFile),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('')
+    )
+)
+process.load('DQM.SiTrackerPhase2.Phase2TrackerMonitorDigi_cff')
+process.load('Validation.SiTrackerPhase2V.Phase2TrackerValidateDigi_cff')
+process.load('SimTracker.SiPhase2Digitizer.PixelTestBeamValidation_cff')
+
+# Include the same value was used in the digitizer 
+process.pixelcells.ElectronsPerADC = cms.double(1700)
+# Tracks are processed only for entering angles to the sensor of -2.5,2.5 degrees.
+# Uncomment lines below to allow all angles (values in radians)
+#process.pixelcells.TracksEntryAngleX = cms.untracked.vdouble(-1.5,1.5)
+#process.pixelcells.TracksEntryAngleY = cms.untracked.vdouble(-1.5,1.5)
+
+#process.digiana_seq = cms.Sequence(process.pixDigiMon * process.otDigiMon * process.pixDigiValid * process.otDigiValid)
+process.digiana_seq = cms.Sequence(process.pixDigiMon*process.pixDigiValid*process.pixelcells)
+
+process.load('DQMServices.Components.DQMEventInfo_cfi')
+process.dqmEnv.subSystemFolder = cms.untracked.string('Ph2TkDigi')
+
+process.dqm_comm = cms.Sequence(process.dqmEnv)
+
+# Path and EndPath definitions
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+#process.digi_step = cms.Sequence(process.siPixelRawData*process.siPixelDigis)
+process.p = cms.Path(process.digiana_seq * process.dqm_comm )


### PR DESCRIPTION
#### PR description:
This PR is only related with the provisional validator placed at test folder, used to check and validate the 3d digitizer development. There is a fix on the entry angles of the tracks (before using wrong angles) and introduce extra histograms (charge related).

This PR does not affect any class used in the sim/digi chain, only the validator (used only by the developers of the Pixel3D digi)
   * there is no changes in the outputs

@emiglior and @skinnari, as the Phase2 upgrade simulation conveners are aware of this PR.
Adding @suchandradutta 

#### PR validation:
No need to validate anything as the changes only affect a validator not included in any workflow or processing.