### PR TITLE
Davix unit test fix: use google instead of cern.ch

### DIFF
--- a/Utilities/DavixAdaptor/test/http.cpp
+++ b/Utilities/DavixAdaptor/test/http.cpp
@@ -8,7 +8,7 @@ int main(int, char** /*argv*/) try {
 
   IOSize n;
   char buf[1024];
-  auto s = StorageFactory::get()->open("http://home.web.cern.ch", IOFlags::OpenRead);
+  auto s = StorageFactory::get()->open("http://google.com", IOFlags::OpenRead);
 
   assert(s);
   while ((n = s->read(buf, sizeof(buf))))


### PR DESCRIPTION
Davix htp unit test again start failing in IB with error [a]. I propse to change the URL to google.

[a]
```
An exception of category 'FileOpenError' occurred while
   [0] Calling StorageFactory::open()
   [1] Calling DavixFile::open()
Exception Message:
Failed to open the file 'http://home.web.cern.ch'
   Additional Info:
      [a] Davix::open(name='http://home.web.cern.ch') failed with error 'Failure (Neon): Server certificate verification failed: bad certificate chain after 3 attempts and error code 6
```