### PR TITLE
Hcal calibration cache

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -17,6 +17,11 @@ from HLTrigger.Configuration.common import *
 #                     pset.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
 #     return process
 
+# Hcal calibration lookup using linear indexing
+def customiseForXXXXX(process):
+    process.hcalChannelPropertiesESProd = cms.ESProducer('HcalChannelPropertiesEP')
+    return process
+
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHCAL_cfi import _thresholdsHB
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHE_cfi import _seedingThresholdsHB, _thresholdsHB
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import _thresholdsHB as _thresholdsHBRec
@@ -175,5 +180,5 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-
+    process = customiseForXXXXX(process)
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -18,7 +18,7 @@ from HLTrigger.Configuration.common import *
 #     return process
 
 # Hcal calibration lookup using linear indexing
-def customiseForXXXXX(process):
+def customiseFor30060(process):
     process.hcalChannelPropertiesESProd = cms.ESProducer('HcalChannelPropertiesEP')
     return process
 
@@ -180,5 +180,5 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-    process = customiseForXXXXX(process)
+    process = customiseFor30060(process)
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -18,8 +18,10 @@ from HLTrigger.Configuration.common import *
 #     return process
 
 # Hcal calibration lookup using linear indexing
-def customiseFor30060(process):
-    process.hcalChannelPropertiesESProd = cms.ESProducer('HcalChannelPropertiesEP')
+def customiseFor30060(process, menuType):
+    menusToSkip = ("Fake", "Fake1", "Fake2")
+    if menuType not in menusToSkip:
+        process.hcalChannelPropertiesESProd = cms.ESProducer('HcalChannelPropertiesEP')
     return process
 
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHCAL_cfi import _thresholdsHB
@@ -180,5 +182,5 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-    process = customiseFor30060(process)
+    process = customiseFor30060(process, menuType)
     return process

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -14,6 +14,7 @@ from RecoLocalCalo.EcalRecAlgos.EcalSeverityLevelESProducer_cfi import *
 #HCAL reconstruction
 import RecoLocalCalo.Configuration.hcalLocalReco_cff as _hcalLocalReco_cff
 from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
+from RecoLocalCalo.HcalRecAlgos.hcalChannelPropertiesESProd_cfi import *
 #
 # sequence CaloLocalReco
 #

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
+from RecoLocalCalo.HcalRecAlgos.hcalChannelPropertiesESProd_cfi import *
 hcalOOTPileupESProducer = cms.ESProducer('OOTPileupDBCompatibilityESProducer')
 
 from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco as _phase1_hbheprereco

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFPreRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFPreRecAlgo.h
@@ -5,7 +5,7 @@
 
 class QIE10DataFrame;
 class HcalCoder;
-class HcalCalibrations;
+class HcalChannelProperties;
 
 class HFPreRecAlgo {
 public:
@@ -16,7 +16,7 @@ public:
   HFQIE10Info reconstruct(const QIE10DataFrame& digi,
                           int tsToUse,
                           const HcalCoder& coder,
-                          const HcalCalibrations& calibs) const;
+                          const HcalChannelProperties& prop) const;
 
 private:
   bool sumAllTS_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFPreRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFPreRecAlgo.h
@@ -5,7 +5,7 @@
 
 class QIE10DataFrame;
 class HcalCoder;
-class HcalChannelProperties;
+struct HcalChannelProperties;
 
 class HFPreRecAlgo {
 public:

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h
@@ -16,37 +16,44 @@ class HcalSiPMParameter;
 // Collection of HCAL channel information, for faster lookup of this
 // information in reco. This struct does not own any pointers.
 struct HcalChannelProperties {
-    inline HcalChannelProperties()
-        : calib(nullptr), paramTs(nullptr), channelCoder(nullptr),
-          shape(nullptr), siPMParameter(nullptr), taggedBadByDb(false) {}
+  inline HcalChannelProperties()
+      : calib(nullptr),
+        paramTs(nullptr),
+        channelCoder(nullptr),
+        shape(nullptr),
+        siPMParameter(nullptr),
+        taggedBadByDb(false) {}
 
-    inline HcalChannelProperties(
-        const HcalCalibrations* i_calib,
-        const HcalRecoParam* i_paramTs,
-        const HcalQIECoder* i_channelCoder,
-        const HcalQIEShape* i_shape,
-        const HcalSiPMParameter* i_siPMParameter,
-        const std::array<HcalPipelinePedestalAndGain, 4>& i_pedsAndGains,
-        const bool i_taggedBadByDb)
-        : calib(i_calib), paramTs(i_paramTs), channelCoder(i_channelCoder),
-          shape(i_shape), siPMParameter(i_siPMParameter),
-          pedsAndGains(i_pedsAndGains), taggedBadByDb(i_taggedBadByDb) {
-        assert(calib);
-        assert(paramTs);
-        assert(channelCoder);
-        assert(shape);
-        /* siPMParameter is allowed to be nullptr for QIE8 */
-    }
+  inline HcalChannelProperties(const HcalCalibrations* i_calib,
+                               const HcalRecoParam* i_paramTs,
+                               const HcalQIECoder* i_channelCoder,
+                               const HcalQIEShape* i_shape,
+                               const HcalSiPMParameter* i_siPMParameter,
+                               const std::array<HcalPipelinePedestalAndGain, 4>& i_pedsAndGains,
+                               const bool i_taggedBadByDb)
+      : calib(i_calib),
+        paramTs(i_paramTs),
+        channelCoder(i_channelCoder),
+        shape(i_shape),
+        siPMParameter(i_siPMParameter),
+        pedsAndGains(i_pedsAndGains),
+        taggedBadByDb(i_taggedBadByDb) {
+    assert(calib);
+    assert(paramTs);
+    assert(channelCoder);
+    assert(shape);
+    /* siPMParameter is allowed to be nullptr for QIE8 */
+  }
 
-    const HcalCalibrations* calib;
-    const HcalRecoParam* paramTs;
-    const HcalQIECoder* channelCoder;
-    const HcalQIEShape* shape;
-    const HcalSiPMParameter* siPMParameter;
-    std::array<HcalPipelinePedestalAndGain, 4> pedsAndGains;
-    bool taggedBadByDb;
+  const HcalCalibrations* calib;
+  const HcalRecoParam* paramTs;
+  const HcalQIECoder* channelCoder;
+  const HcalQIEShape* shape;
+  const HcalSiPMParameter* siPMParameter;
+  std::array<HcalPipelinePedestalAndGain, 4> pedsAndGains;
+  bool taggedBadByDb;
 };
 
 typedef std::vector<HcalChannelProperties> HcalChannelPropertiesVec;
 
-#endif // RecoLocalCalo_HcalRecAlgos_HcalChannelProperties_h_
+#endif  // RecoLocalCalo_HcalRecAlgos_HcalChannelProperties_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h
@@ -1,0 +1,52 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_HcalChannelProperties_h_
+#define RecoLocalCalo_HcalRecAlgos_HcalChannelProperties_h_
+
+#include <array>
+#include <vector>
+#include <cassert>
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalPipelinePedestalAndGain.h"
+
+class HcalCalibrations;
+class HcalRecoParam;
+class HcalQIECoder;
+class HcalQIEShape;
+class HcalSiPMParameter;
+
+// Collection of HCAL channel information, for faster lookup of this
+// information in reco. This struct does not own any pointers.
+struct HcalChannelProperties {
+    inline HcalChannelProperties()
+        : calib(nullptr), paramTs(nullptr), channelCoder(nullptr),
+          shape(nullptr), siPMParameter(nullptr), taggedBadByDb(false) {}
+
+    inline HcalChannelProperties(
+        const HcalCalibrations* i_calib,
+        const HcalRecoParam* i_paramTs,
+        const HcalQIECoder* i_channelCoder,
+        const HcalQIEShape* i_shape,
+        const HcalSiPMParameter* i_siPMParameter,
+        const std::array<HcalPipelinePedestalAndGain, 4>& i_pedsAndGains,
+        const bool i_taggedBadByDb)
+        : calib(i_calib), paramTs(i_paramTs), channelCoder(i_channelCoder),
+          shape(i_shape), siPMParameter(i_siPMParameter),
+          pedsAndGains(i_pedsAndGains), taggedBadByDb(i_taggedBadByDb) {
+        assert(calib);
+        assert(paramTs);
+        assert(channelCoder);
+        assert(shape);
+        /* siPMParameter is allowed to be nullptr for QIE8 */
+    }
+
+    const HcalCalibrations* calib;
+    const HcalRecoParam* paramTs;
+    const HcalQIECoder* channelCoder;
+    const HcalQIEShape* shape;
+    const HcalSiPMParameter* siPMParameter;
+    std::array<HcalPipelinePedestalAndGain, 4> pedsAndGains;
+    bool taggedBadByDb;
+};
+
+typedef std::vector<HcalChannelProperties> HcalChannelPropertiesVec;
+
+#endif // RecoLocalCalo_HcalRecAlgos_HcalChannelProperties_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h
@@ -7,9 +7,8 @@
 class HcalRecNumberingRecord;
 class HcalRecoParamsRcd;
 
-class HcalChannelPropertiesAuxRecord
-    : public edm::eventsetup::DependentRecordImplementation<
-          HcalChannelPropertiesAuxRecord,
-          boost::mpl::vector<HcalRecNumberingRecord, HcalRecoParamsRcd> > {};
+class HcalChannelPropertiesAuxRecord : public edm::eventsetup::DependentRecordImplementation<
+                                           HcalChannelPropertiesAuxRecord,
+                                           boost::mpl::vector<HcalRecNumberingRecord, HcalRecoParamsRcd> > {};
 
 #endif  // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesAuxRecord_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h
@@ -1,0 +1,15 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesAuxRecord_h_
+#define RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesAuxRecord_h_
+
+#include "boost/mpl/vector.hpp"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+
+class HcalRecNumberingRecord;
+class HcalRecoParamsRcd;
+
+class HcalChannelPropertiesAuxRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          HcalChannelPropertiesAuxRecord,
+          boost::mpl::vector<HcalRecNumberingRecord, HcalRecoParamsRcd> > {};
+
+#endif  // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesAuxRecord_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
@@ -1,6 +1,7 @@
 #ifndef RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_
 #define RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_
 
+#include "boost/mpl/vector.hpp"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 class HcalDbRecord;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
@@ -12,6 +12,8 @@ class HcalChannelPropertiesAuxRecord;
 class HcalChannelPropertiesRecord
     : public edm::eventsetup::DependentRecordImplementation<
           HcalChannelPropertiesRecord,
-          boost::mpl::vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd, HcalChannelPropertiesAuxRecord> > {};
+          boost::mpl::
+              vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd, HcalChannelPropertiesAuxRecord> > {
+};
 
 #endif  // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
@@ -7,6 +7,9 @@ class HcalDbRecord;
 class CaloGeometryRecord;
 class HcalSeverityLevelComputerRcd;
 
-class HcalChannelPropertiesRecord : public edm::eventsetup::DependentRecordImplementation<HcalChannelPropertiesRecord, boost::mpl::vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd> > {};
+class HcalChannelPropertiesRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          HcalChannelPropertiesRecord,
+          boost::mpl::vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd> > {};
 
-#endif // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_
+#endif  // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
@@ -7,10 +7,11 @@
 class HcalDbRecord;
 class CaloGeometryRecord;
 class HcalSeverityLevelComputerRcd;
+class HcalChannelPropertiesAuxRecord;
 
 class HcalChannelPropertiesRecord
     : public edm::eventsetup::DependentRecordImplementation<
           HcalChannelPropertiesRecord,
-          boost::mpl::vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd> > {};
+          boost::mpl::vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd, HcalChannelPropertiesAuxRecord> > {};
 
 #endif  // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
@@ -1,0 +1,12 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_
+#define RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_
+
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+
+class HcalDbRecord;
+class CaloGeometryRecord;
+class HcalSeverityLevelComputerRcd;
+
+class HcalChannelPropertiesRecord : public edm::eventsetup::DependentRecordImplementation<HcalChannelPropertiesRecord, boost::mpl::vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd> > {};
+
+#endif // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalPipelinePedestalAndGain.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalPipelinePedestalAndGain.h
@@ -20,9 +20,7 @@ public:
         gain_(i_gain),
         gainWidth_(i_gainWidth) {}
 
-  inline float pedestal(const bool useEffectivePeds) const {
-    return useEffectivePeds ? effPedestal_ : pedestal_;
-  }
+  inline float pedestal(const bool useEffectivePeds) const { return useEffectivePeds ? effPedestal_ : pedestal_; }
 
   inline float pedestalWidth(const bool useEffectivePeds) const {
     return useEffectivePeds ? effPedestalWidth_ : pedestalWidth_;
@@ -40,4 +38,4 @@ private:
   float gainWidth_;
 };
 
-#endif // RecoLocalCalo_HcalRecAlgos_HcalPipelinePedestalAndGain_h_
+#endif  // RecoLocalCalo_HcalRecAlgos_HcalPipelinePedestalAndGain_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalPipelinePedestalAndGain.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalPipelinePedestalAndGain.h
@@ -1,0 +1,43 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_HcalPipelinePedestalAndGain_h_
+#define RecoLocalCalo_HcalRecAlgos_HcalPipelinePedestalAndGain_h_
+
+// HB/HE channel information stored for each pipeline "capacitor id"
+class HcalPipelinePedestalAndGain {
+public:
+  inline HcalPipelinePedestalAndGain()
+      : pedestal_(0.f), pedestalWidth_(0.f), effPedestal_(0.f), effPedestalWidth_(0.f), gain_(0.f), gainWidth_(0.f) {}
+
+  inline HcalPipelinePedestalAndGain(const float i_pedestal,
+                                     const float i_pedestalWidth,
+                                     const float i_effPedestal,
+                                     const float i_effPedestalWidth,
+                                     const float i_gain,
+                                     const float i_gainWidth)
+      : pedestal_(i_pedestal),
+        pedestalWidth_(i_pedestalWidth),
+        effPedestal_(i_effPedestal),
+        effPedestalWidth_(i_effPedestalWidth),
+        gain_(i_gain),
+        gainWidth_(i_gainWidth) {}
+
+  inline float pedestal(const bool useEffectivePeds) const {
+    return useEffectivePeds ? effPedestal_ : pedestal_;
+  }
+
+  inline float pedestalWidth(const bool useEffectivePeds) const {
+    return useEffectivePeds ? effPedestalWidth_ : pedestalWidth_;
+  }
+
+  inline float gain() const { return gain_; }
+  inline float gainWidth() const { return gainWidth_; }
+
+private:
+  float pedestal_;
+  float pedestalWidth_;
+  float effPedestal_;
+  float effPedestalWidth_;
+  float gain_;
+  float gainWidth_;
+};
+
+#endif // RecoLocalCalo_HcalRecAlgos_HcalPipelinePedestalAndGain_h_

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
@@ -45,7 +45,7 @@ public:
     const HcalTopology& htopo = rcd.getRecord<HcalRecNumberingRecord>().get(topoToken_);
     const HcalRecoParams& params = rcd.getRecord<HcalRecoParamsRcd>().get(paramsToken_);
 
-    ReturnType1 prod(new HcalRecoParams(params));
+    ReturnType1 prod = std::make_unique<HcalRecoParams>(params);
     prod->setTopo(&htopo);
     return prod;
   }
@@ -71,7 +71,7 @@ public:
     const HcalTopology& htopo(*params.topo());
 
     // Build the product
-    ReturnType2 prod(new HcalChannelPropertiesVec(htopo.ncells()));
+    ReturnType2 prod = std::make_unique<HcalChannelPropertiesVec>(htopo.ncells());
     std::array<HcalPipelinePedestalAndGain, 4> pedsAndGains;
     const HcalSubdetector subdetectors[3] = {HcalBarrel, HcalEndcap, HcalForward};
 

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
@@ -1,0 +1,119 @@
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+
+#include "CondFormats/HcalObjects/interface/HcalRecoParams.h"
+#include "CondFormats/DataRecord/interface/HcalRecoParamsRcd.h"
+
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h"
+
+class HcalChannelPropertiesEP : public edm::ESProducer {
+public:
+    typedef std::unique_ptr<HcalChannelPropertiesVec> ReturnType;
+
+    inline HcalChannelPropertiesEP(const edm::ParameterSet&) 
+    {
+        auto cc = setWhatProduced(this);
+        edm::ESInputTag qTag("", "withTopo");
+        cc.setConsumes(condToken_).setConsumes(topoToken_).setConsumes(paramsToken_);
+        cc.setConsumes(sevToken_).setConsumes(qualToken_, qTag).setConsumes(geomToken_);
+    }
+
+    inline virtual ~HcalChannelPropertiesEP() override {}
+
+    ReturnType produce(const HcalChannelPropertiesRecord& rcd)
+    {
+        // There appears to be no easy way to trace the internal
+        // dependencies of HcalDbService. So, rebuild the product
+        // every time anything changes in the parent records.
+        // This means that we are sometimes going to rebuild the
+        // whole table on the lumi block boundaries instead of
+        // just updating the list of bad channels.
+        using namespace edm;
+
+        // Retrieve various event setup records and data products
+        const HcalDbRecord& dbRecord = rcd.getRecord<HcalDbRecord>();
+        const HcalDbService& cond = dbRecord.get(condToken_);
+        const HcalTopology& htopo = dbRecord.getRecord<HcalRecNumberingRecord>().get(topoToken_);
+        const HcalRecoParams& params = dbRecord.getRecord<HcalRecoParamsRcd>().get(paramsToken_);
+        const HcalSeverityLevelComputer& severity = rcd.getRecord<HcalSeverityLevelComputerRcd>().get(sevToken_);
+        const HcalChannelQuality& qual = dbRecord.getRecord<HcalChannelQualityRcd>().get(qualToken_);
+        const CaloGeometry& geom = rcd.getRecord<CaloGeometryRecord>().get(geomToken_);
+
+        paramTS_ = std::make_unique<HcalRecoParams>(params);
+        paramTS_->setTopo(&htopo);
+
+        // Build the product
+        ReturnType prod(new HcalChannelPropertiesVec(htopo.ncells()));
+        std::array<HcalPipelinePedestalAndGain, 4> pedsAndGains;
+        const HcalSubdetector subdetectors[3] = {HcalBarrel, HcalEndcap, HcalForward};
+
+        for (HcalSubdetector subd : subdetectors) {
+            const HcalGeometry* hcalGeom = static_cast<const HcalGeometry*>(
+                geom.getSubdetectorGeometry(DetId::Hcal, subd));
+            const std::vector<DetId>& ids = hcalGeom->getValidDetIds(DetId::Hcal, subd);
+
+            for (const auto cell : ids) {
+                const auto rawId = cell.rawId();
+
+                // ADC decoding tools, etc
+                const HcalRecoParam* param_ts = paramTS_->getValues(rawId);
+                const HcalQIECoder* channelCoder = cond.getHcalCoder(cell);
+                const HcalQIEShape* shape = cond.getHcalShape(channelCoder);
+                const HcalSiPMParameter* siPMParameter = cond.getHcalSiPMParameter(cell);
+
+                // Pedestals and gains
+                const HcalCalibrations& calib = cond.getHcalCalibrations(cell);
+                const HcalCalibrationWidths& calibWidth = cond.getHcalCalibrationWidths(cell);
+                for (int capid=0; capid<4; ++capid) {
+                    pedsAndGains[capid] = HcalPipelinePedestalAndGain(
+                        calib.pedestal(capid), calibWidth.pedestal(capid),
+                        calib.effpedestal(capid), calibWidth.effpedestal(capid),
+                        calib.respcorrgain(capid), calibWidth.gain(capid));
+                }
+
+                // Channel quality
+                const HcalChannelStatus* digistatus = qual.getValues(rawId);
+                const bool taggedBadByDb = severity.dropChannel(digistatus->getValue());
+
+                // Fill the table entry
+                const unsigned linearId = htopo.detId2denseId(cell);
+                prod->at(linearId) = HcalChannelProperties(
+                    &calib, param_ts, channelCoder, shape,
+                    siPMParameter, pedsAndGains, taggedBadByDb);
+            }
+        }
+
+        return prod;
+    }
+
+private:
+    HcalChannelPropertiesEP() = delete;
+    HcalChannelPropertiesEP(const HcalChannelPropertiesEP&) = delete;
+    HcalChannelPropertiesEP& operator=(const HcalChannelPropertiesEP&) = delete;
+
+    edm::ESGetToken<HcalDbService, HcalDbRecord> condToken_;
+    edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topoToken_;
+    edm::ESGetToken<HcalRecoParams, HcalRecoParamsRcd> paramsToken_;
+    edm::ESGetToken<HcalSeverityLevelComputer, HcalSeverityLevelComputerRcd> sevToken_;
+    edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> qualToken_;
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
+
+    std::unique_ptr<HcalRecoParams> paramTS_;
+};
+
+DEFINE_FWK_EVENTSETUP_MODULE(HcalChannelPropertiesEP);

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
@@ -23,97 +23,95 @@
 
 class HcalChannelPropertiesEP : public edm::ESProducer {
 public:
-    typedef std::unique_ptr<HcalChannelPropertiesVec> ReturnType;
+  typedef std::unique_ptr<HcalChannelPropertiesVec> ReturnType;
 
-    inline HcalChannelPropertiesEP(const edm::ParameterSet&) 
-    {
-        auto cc = setWhatProduced(this);
-        edm::ESInputTag qTag("", "withTopo");
-        cc.setConsumes(condToken_).setConsumes(topoToken_).setConsumes(paramsToken_);
-        cc.setConsumes(sevToken_).setConsumes(qualToken_, qTag).setConsumes(geomToken_);
-    }
+  inline HcalChannelPropertiesEP(const edm::ParameterSet&) {
+    auto cc = setWhatProduced(this);
+    edm::ESInputTag qTag("", "withTopo");
+    cc.setConsumes(condToken_).setConsumes(topoToken_).setConsumes(paramsToken_);
+    cc.setConsumes(sevToken_).setConsumes(qualToken_, qTag).setConsumes(geomToken_);
+  }
 
-    inline virtual ~HcalChannelPropertiesEP() override {}
+  inline ~HcalChannelPropertiesEP() override {}
 
-    ReturnType produce(const HcalChannelPropertiesRecord& rcd)
-    {
-        // There appears to be no easy way to trace the internal
-        // dependencies of HcalDbService. So, rebuild the product
-        // every time anything changes in the parent records.
-        // This means that we are sometimes going to rebuild the
-        // whole table on the lumi block boundaries instead of
-        // just updating the list of bad channels.
-        using namespace edm;
+  ReturnType produce(const HcalChannelPropertiesRecord& rcd) {
+    // There appears to be no easy way to trace the internal
+    // dependencies of HcalDbService. So, rebuild the product
+    // every time anything changes in the parent records.
+    // This means that we are sometimes going to rebuild the
+    // whole table on the lumi block boundaries instead of
+    // just updating the list of bad channels.
+    using namespace edm;
 
-        // Retrieve various event setup records and data products
-        const HcalDbRecord& dbRecord = rcd.getRecord<HcalDbRecord>();
-        const HcalDbService& cond = dbRecord.get(condToken_);
-        const HcalTopology& htopo = dbRecord.getRecord<HcalRecNumberingRecord>().get(topoToken_);
-        const HcalRecoParams& params = dbRecord.getRecord<HcalRecoParamsRcd>().get(paramsToken_);
-        const HcalSeverityLevelComputer& severity = rcd.getRecord<HcalSeverityLevelComputerRcd>().get(sevToken_);
-        const HcalChannelQuality& qual = dbRecord.getRecord<HcalChannelQualityRcd>().get(qualToken_);
-        const CaloGeometry& geom = rcd.getRecord<CaloGeometryRecord>().get(geomToken_);
+    // Retrieve various event setup records and data products
+    const HcalDbRecord& dbRecord = rcd.getRecord<HcalDbRecord>();
+    const HcalDbService& cond = dbRecord.get(condToken_);
+    const HcalTopology& htopo = dbRecord.getRecord<HcalRecNumberingRecord>().get(topoToken_);
+    const HcalRecoParams& params = dbRecord.getRecord<HcalRecoParamsRcd>().get(paramsToken_);
+    const HcalSeverityLevelComputer& severity = rcd.getRecord<HcalSeverityLevelComputerRcd>().get(sevToken_);
+    const HcalChannelQuality& qual = dbRecord.getRecord<HcalChannelQualityRcd>().get(qualToken_);
+    const CaloGeometry& geom = rcd.getRecord<CaloGeometryRecord>().get(geomToken_);
 
-        paramTS_ = std::make_unique<HcalRecoParams>(params);
-        paramTS_->setTopo(&htopo);
+    paramTS_ = std::make_unique<HcalRecoParams>(params);
+    paramTS_->setTopo(&htopo);
 
-        // Build the product
-        ReturnType prod(new HcalChannelPropertiesVec(htopo.ncells()));
-        std::array<HcalPipelinePedestalAndGain, 4> pedsAndGains;
-        const HcalSubdetector subdetectors[3] = {HcalBarrel, HcalEndcap, HcalForward};
+    // Build the product
+    ReturnType prod(new HcalChannelPropertiesVec(htopo.ncells()));
+    std::array<HcalPipelinePedestalAndGain, 4> pedsAndGains;
+    const HcalSubdetector subdetectors[3] = {HcalBarrel, HcalEndcap, HcalForward};
 
-        for (HcalSubdetector subd : subdetectors) {
-            const HcalGeometry* hcalGeom = static_cast<const HcalGeometry*>(
-                geom.getSubdetectorGeometry(DetId::Hcal, subd));
-            const std::vector<DetId>& ids = hcalGeom->getValidDetIds(DetId::Hcal, subd);
+    for (HcalSubdetector subd : subdetectors) {
+      const HcalGeometry* hcalGeom = static_cast<const HcalGeometry*>(geom.getSubdetectorGeometry(DetId::Hcal, subd));
+      const std::vector<DetId>& ids = hcalGeom->getValidDetIds(DetId::Hcal, subd);
 
-            for (const auto cell : ids) {
-                const auto rawId = cell.rawId();
+      for (const auto cell : ids) {
+        const auto rawId = cell.rawId();
 
-                // ADC decoding tools, etc
-                const HcalRecoParam* param_ts = paramTS_->getValues(rawId);
-                const HcalQIECoder* channelCoder = cond.getHcalCoder(cell);
-                const HcalQIEShape* shape = cond.getHcalShape(channelCoder);
-                const HcalSiPMParameter* siPMParameter = cond.getHcalSiPMParameter(cell);
+        // ADC decoding tools, etc
+        const HcalRecoParam* param_ts = paramTS_->getValues(rawId);
+        const HcalQIECoder* channelCoder = cond.getHcalCoder(cell);
+        const HcalQIEShape* shape = cond.getHcalShape(channelCoder);
+        const HcalSiPMParameter* siPMParameter = cond.getHcalSiPMParameter(cell);
 
-                // Pedestals and gains
-                const HcalCalibrations& calib = cond.getHcalCalibrations(cell);
-                const HcalCalibrationWidths& calibWidth = cond.getHcalCalibrationWidths(cell);
-                for (int capid=0; capid<4; ++capid) {
-                    pedsAndGains[capid] = HcalPipelinePedestalAndGain(
-                        calib.pedestal(capid), calibWidth.pedestal(capid),
-                        calib.effpedestal(capid), calibWidth.effpedestal(capid),
-                        calib.respcorrgain(capid), calibWidth.gain(capid));
-                }
-
-                // Channel quality
-                const HcalChannelStatus* digistatus = qual.getValues(rawId);
-                const bool taggedBadByDb = severity.dropChannel(digistatus->getValue());
-
-                // Fill the table entry
-                const unsigned linearId = htopo.detId2denseId(cell);
-                prod->at(linearId) = HcalChannelProperties(
-                    &calib, param_ts, channelCoder, shape,
-                    siPMParameter, pedsAndGains, taggedBadByDb);
-            }
+        // Pedestals and gains
+        const HcalCalibrations& calib = cond.getHcalCalibrations(cell);
+        const HcalCalibrationWidths& calibWidth = cond.getHcalCalibrationWidths(cell);
+        for (int capid = 0; capid < 4; ++capid) {
+          pedsAndGains[capid] = HcalPipelinePedestalAndGain(calib.pedestal(capid),
+                                                            calibWidth.pedestal(capid),
+                                                            calib.effpedestal(capid),
+                                                            calibWidth.effpedestal(capid),
+                                                            calib.respcorrgain(capid),
+                                                            calibWidth.gain(capid));
         }
 
-        return prod;
+        // Channel quality
+        const HcalChannelStatus* digistatus = qual.getValues(rawId);
+        const bool taggedBadByDb = severity.dropChannel(digistatus->getValue());
+
+        // Fill the table entry
+        const unsigned linearId = htopo.detId2denseId(cell);
+        prod->at(linearId) =
+            HcalChannelProperties(&calib, param_ts, channelCoder, shape, siPMParameter, pedsAndGains, taggedBadByDb);
+      }
     }
 
+    return prod;
+  }
+
+  HcalChannelPropertiesEP() = delete;
+  HcalChannelPropertiesEP(const HcalChannelPropertiesEP&) = delete;
+  HcalChannelPropertiesEP& operator=(const HcalChannelPropertiesEP&) = delete;
+
 private:
-    HcalChannelPropertiesEP() = delete;
-    HcalChannelPropertiesEP(const HcalChannelPropertiesEP&) = delete;
-    HcalChannelPropertiesEP& operator=(const HcalChannelPropertiesEP&) = delete;
+  edm::ESGetToken<HcalDbService, HcalDbRecord> condToken_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topoToken_;
+  edm::ESGetToken<HcalRecoParams, HcalRecoParamsRcd> paramsToken_;
+  edm::ESGetToken<HcalSeverityLevelComputer, HcalSeverityLevelComputerRcd> sevToken_;
+  edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> qualToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 
-    edm::ESGetToken<HcalDbService, HcalDbRecord> condToken_;
-    edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topoToken_;
-    edm::ESGetToken<HcalRecoParams, HcalRecoParamsRcd> paramsToken_;
-    edm::ESGetToken<HcalSeverityLevelComputer, HcalSeverityLevelComputerRcd> sevToken_;
-    edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> qualToken_;
-    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
-
-    std::unique_ptr<HcalRecoParams> paramTS_;
+  std::unique_ptr<HcalRecoParams> paramTS_;
 };
 
 DEFINE_FWK_EVENTSETUP_MODULE(HcalChannelPropertiesEP);

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalChannelPropertiesESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalChannelPropertiesESProd_cfi.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+hcalChannelPropertiesESProd = cms.ESProducer('HcalChannelPropertiesEP')

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalChannelPropertiesAuxRecord.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalChannelPropertiesAuxRecord.cc
@@ -1,0 +1,7 @@
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "CondFormats/DataRecord/interface/HcalRecoParamsRcd.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h"
+
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(HcalChannelPropertiesAuxRecord);

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalChannelPropertiesRecord.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalChannelPropertiesRecord.cc
@@ -1,6 +1,7 @@
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h"
 
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalChannelPropertiesRecord.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalChannelPropertiesRecord.cc
@@ -1,0 +1,8 @@
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h"
+
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(HcalChannelPropertiesRecord);

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalChannelPropertiesVec.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalChannelPropertiesVec.cc
@@ -1,0 +1,4 @@
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(HcalChannelPropertiesVec);

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -18,6 +18,7 @@
 
 // system include files
 #include <cmath>
+#include <vector>
 #include <utility>
 #include <algorithm>
 
@@ -45,8 +46,8 @@
 
 #include "CalibCalorimetry/HcalAlgos/interface/HcalSiPMnonlinearity.h"
 
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HBHEStatusBitSetter.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h"
 
@@ -75,7 +76,7 @@ namespace {
     inline RawChargeFromSample(const int sipmQTSShift,
                                const int sipmQNTStoSum,
                                const HcalDbService& cond,
-                               const HcalDetId id,
+                               const HcalChannelProperties& properties,
                                const CaloSamples& cs,
                                const int soi,
                                const DFrame& frame,
@@ -90,24 +91,23 @@ namespace {
     inline RawChargeFromSample(const int sipmQTSShift,
                                const int sipmQNTStoSum,
                                const HcalDbService& cond,
-                               const HcalDetId id,
+                               const HcalChannelProperties& properties,
                                const CaloSamples& cs,
                                const int soi,
                                const QIE11DataFrame& frame,
                                const int maxTS)
-        : siPMParameter_(*cond.getHcalSiPMParameter(id)),
+        : siPMParameter_(*properties.siPMParameter),
           fcByPE_(siPMParameter_.getFCByPE()),
           corr_(cond.getHcalSiPMCharacteristics()->getNonLinearities(siPMParameter_.getType())) {
       if (fcByPE_ <= 0.0)
-        throw cms::Exception("HBHEPhase1BadDB") << "Invalid fC/PE conversion factor for SiPM " << id << std::endl;
+        throw cms::Exception("HBHEPhase1BadDB") << "Invalid fC/PE conversion factor" << std::endl;
 
-      const HcalCalibrations& calib = cond.getHcalCalibrations(id);
       const int firstTS = std::max(soi + sipmQTSShift, 0);
       const int lastTS = std::min(firstTS + sipmQNTStoSum, maxTS);
       double sipmQ = 0.0;
 
       for (int ts = firstTS; ts < lastTS; ++ts) {
-        const double pedestal = calib.pedestal(frame[ts].capid());
+        const float pedestal = properties.pedsAndGains[frame[ts].capid()].pedestal(false);
         sipmQ += (cs[ts] - pedestal);
       }
 
@@ -287,7 +287,6 @@ private:
   edm::EDGetTokenT<QIE11DigiCollection> tok_qie11_;
   std::unique_ptr<AbsHBHEPhase1Algo> reco_;
   std::unique_ptr<AbsHcalAlgoData> recoConfig_;
-  std::unique_ptr<HcalRecoParams> paramTS_;
 
   // Status bit setters
   const HBHENegativeEFilter* negEFilter_;  // We don't manage this pointer
@@ -300,14 +299,13 @@ private:
   // are allowed to be null.
   template <class DataFrame, class Collection>
   void processData(const Collection& coll,
+                   const HcalTopology& htopo,
                    const HcalDbService& cond,
-                   const HcalChannelQuality& qual,
-                   const HcalSeverityLevelComputer& severity,
+                   const HcalChannelPropertiesVec& prop,
                    const bool isRealData,
                    HBHEChannelInfo* info,
                    HBHEChannelInfoCollection* infoColl,
-                   HBHERecHitCollection* rechits,
-                   const bool use8ts);
+                   HBHERecHitCollection* rechits);
 
   // Methods for setting rechit status bits
   void setAsicSpecificBits(const HBHEDataFrame& frame,
@@ -395,14 +393,13 @@ HBHEPhase1Reconstructor::~HBHEPhase1Reconstructor() {
 //
 template <class DFrame, class Collection>
 void HBHEPhase1Reconstructor::processData(const Collection& coll,
+                                          const HcalTopology& htopo,
                                           const HcalDbService& cond,
-                                          const HcalChannelQuality& qual,
-                                          const HcalSeverityLevelComputer& severity,
+                                          const HcalChannelPropertiesVec& prop,
                                           const bool isRealData,
                                           HBHEChannelInfo* channelInfo,
                                           HBHEChannelInfoCollection* infos,
-                                          HBHERecHitCollection* rechits,
-                                          const bool use8ts_) {
+                                          HBHERecHitCollection* rechits) {
   // If "saveDroppedInfos_" flag is set, fill the info with something
   // meaningful even if the database tells us to drop this channel.
   // Note that this flag affects only "infos", the rechits are still
@@ -421,10 +418,11 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     if (!(subdet == HcalSubdetector::HcalBarrel || subdet == HcalSubdetector::HcalEndcap))
       continue;
 
+    // Look up the channel properties. This lookup is O(1).
+    const HcalChannelProperties& properties(prop.at(htopo.detId2denseId(cell)));
+
     // Check if the database tells us to drop this channel
-    const HcalChannelStatus* mydigistatus = qual.getValues(cell.rawId());
-    const bool taggedBadByDb = severity.dropChannel(mydigistatus->getValue());
-    if (taggedBadByDb && skipDroppedChannels)
+    if (properties.taggedBadByDb && skipDroppedChannels)
       continue;
 
     // Check if the channel is zero suppressed
@@ -435,23 +433,17 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     if (dropByZS && skipDroppedChannels)
       continue;
 
-    // Basic ADC decoding tools
-    const HcalRecoParam* param_ts = paramTS_->getValues(cell.rawId());
-    const HcalCalibrations& calib = cond.getHcalCalibrations(cell);
-    const HcalCalibrationWidths& calibWidth = cond.getHcalCalibrationWidths(cell);
-    const HcalQIECoder* channelCoder = cond.getHcalCoder(cell);
-    const HcalQIEShape* shape = cond.getHcalShape(channelCoder);
-    const HcalCoderDb coder(*channelCoder, *shape);
+    // ADC decoding tool
+    const HcalCoderDb coder(*properties.channelCoder, *properties.shape);
 
     const bool saveEffectivePeds = channelInfo->hasEffectivePedestals();
-    const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
-    const double fcByPE = siPMParameter.getFCByPE();
+    const double fcByPE = properties.siPMParameter->getFCByPE();
     double darkCurrent = 0.;
     double lambda = 0.;
     if (!saveEffectivePeds || saveInfos_) {
       // needed for the dark current in the M2 in alternative of the effectivePed
-      darkCurrent = siPMParameter.getDarkCurrent();
-      lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(siPMParameter.getType());
+      darkCurrent = properties.siPMParameter->getDarkCurrent();
+      lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(properties.siPMParameter->getType());
     }
 
     // ADC to fC conversion
@@ -461,8 +453,8 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     // Prepare to iterate over time slices
     const int nRead = cs.size();
     const int maxTS = std::min(nRead, static_cast<int>(HBHEChannelInfo::MAXSAMPLES));
-    const int soi = tsFromDB_ ? param_ts->firstSample() : frame.presamples();
-    const RawChargeFromSample<DFrame> rcfs(sipmQTSShift_, sipmQNTStoSum_, cond, cell, cs, soi, frame, maxTS);
+    const int soi = tsFromDB_ ? properties.paramTs->firstSample() : frame.presamples();
+    const RawChargeFromSample<DFrame> rcfs(sipmQTSShift_, sipmQNTStoSum_, cond, properties, cs, soi, frame, maxTS);
     int soiCapid = 4;
 
     // Typical expected cases:
@@ -505,24 +497,24 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
       auto s(frame[inputTS]);
       const uint8_t adc = s.adc();
       const int capid = s.capid();
-      //optionally store "effective" pedestal (measured with bias voltage on)
-      // = QIE contribution + SiPM contribution (from dark current + crosstalk)
-      const double pedestal = saveEffectivePeds ? calib.effpedestal(capid) : calib.pedestal(capid);
-      const double pedestalWidth = saveEffectivePeds ? calibWidth.effpedestal(capid) : calibWidth.pedestal(capid);
-      const double gain = calib.respcorrgain(capid);
-      const double gainWidth = calibWidth.gain(capid);
-      //always use QIE-only pedestal for this computation
-      const double rawCharge = rcfs.getRawCharge(cs[inputTS], calib.pedestal(capid));
+      const HcalPipelinePedestalAndGain& pAndGain(properties.pedsAndGains.at(capid));
+
+      // Always use QIE-only pedestal for this computation
+      const double rawCharge = rcfs.getRawCharge(cs[inputTS], pAndGain.pedestal(false));
       const float t = getTDCTimeFromSample(s);
-      const float dfc = getDifferentialChargeGain(*channelCoder, *shape, adc, capid, channelInfo->hasTimeInfo());
-      channelInfo->setSample(copyTS, adc, dfc, rawCharge, pedestal, pedestalWidth, gain, gainWidth, t);
+      const float dfc = getDifferentialChargeGain(*properties.channelCoder, *properties.shape,
+                                                  adc, capid, channelInfo->hasTimeInfo());
+      channelInfo->setSample(copyTS, adc, dfc, rawCharge,
+                             pAndGain.pedestal(saveEffectivePeds),
+                             pAndGain.pedestalWidth(saveEffectivePeds),
+                             pAndGain.gain(), pAndGain.gainWidth(), t);
       if (inputTS == soi)
         soiCapid = capid;
     }
 
     // Fill the overall channel info items
     const int fitSoi = soi - tsShift;
-    const int pulseShapeID = param_ts->pulseShapeID();
+    const int pulseShapeID = properties.paramTs->pulseShapeID();
     const std::pair<bool, bool> hwerr = findHWErrors(frame, maxTS);
     channelInfo->setChannelInfo(cell,
                                 pulseShapeID,
@@ -534,7 +526,7 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
                                 lambda,
                                 hwerr.first,
                                 hwerr.second,
-                                taggedBadByDb || dropByZS);
+                                properties.taggedBadByDb || dropByZS);
 
     // If needed, add the channel info to the output collection
     const bool makeThisRechit = !channelInfo->isDropped();
@@ -545,11 +537,11 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     if (rechits && makeThisRechit) {
       const HcalRecoParam* pptr = nullptr;
       if (recoParamsFromDB_)
-        pptr = param_ts;
-      HBHERecHit rh = reco_->reconstruct(*channelInfo, pptr, calib, isRealData);
+        pptr = properties.paramTs;
+      HBHERecHit rh = reco_->reconstruct(*channelInfo, pptr, *properties.calib, isRealData);
       if (rh.id().rawId()) {
-        setAsicSpecificBits(frame, coder, *channelInfo, calib, &rh);
-        setCommonStatusBits(*channelInfo, calib, &rh);
+        setAsicSpecificBits(frame, coder, *channelInfo, *properties.calib, &rh);
+        setCommonStatusBits(*channelInfo, *properties.calib, &rh);
         rechits->push_back(rh);
       }
     }
@@ -607,17 +599,13 @@ void HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& even
   // Get the Hcal topology
   ESHandle<HcalTopology> htopo;
   eventSetup.get<HcalRecNumberingRecord>().get(htopo);
-  paramTS_->setTopo(htopo.product());
 
   // Fetch the calibrations
   ESHandle<HcalDbService> conditions;
   eventSetup.get<HcalDbRecord>().get(conditions);
 
-  ESHandle<HcalChannelQuality> p;
-  eventSetup.get<HcalChannelQualityRcd>().get("withTopo", p);
-
-  ESHandle<HcalSeverityLevelComputer> mycomputer;
-  eventSetup.get<HcalSeverityLevelComputerRcd>().get(mycomputer);
+  ESHandle<HcalChannelPropertiesVec> prop;
+  eventSetup.get<HcalChannelPropertiesRecord>().get(prop);
 
   // Configure the negative energy filter
   ESHandle<HBHENegativeEFilter> negEHandle;
@@ -661,7 +649,7 @@ void HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& even
 
     HBHEChannelInfo channelInfo(false, false);
     processData<HBHEDataFrame>(
-        *hbDigis, *conditions, *p, *mycomputer, isData, &channelInfo, infos.get(), out.get(), use8ts_);
+        *hbDigis, *htopo, *conditions, *prop, isData, &channelInfo, infos.get(), out.get());
     if (setNoiseFlagsQIE8_)
       hbheFlagSetterQIE8_->SetFlagsFromRecHits(*out);
   }
@@ -672,7 +660,7 @@ void HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& even
 
     HBHEChannelInfo channelInfo(true, saveEffectivePedestal_);
     processData<QIE11DataFrame>(
-        *heDigis, *conditions, *p, *mycomputer, isData, &channelInfo, infos.get(), out.get(), use8ts_);
+        *heDigis, *htopo, *conditions, *prop, isData, &channelInfo, infos.get(), out.get());
     if (setNoiseFlagsQIE11_)
       hbheFlagSetterQIE11_->SetFlagsFromRecHits(*out);
   }
@@ -686,10 +674,6 @@ void HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& even
 
 // ------------ method called when starting to processes a run  ------------
 void HBHEPhase1Reconstructor::beginRun(edm::Run const& r, edm::EventSetup const& es) {
-  edm::ESHandle<HcalRecoParams> p;
-  es.get<HcalRecoParamsRcd>().get(p);
-  paramTS_ = std::make_unique<HcalRecoParams>(*p.product());
-
   if (reco_->isConfigurable()) {
     recoConfig_ = fetchHcalAlgoData(algoConfigClass_, es);
     if (!recoConfig_.get())

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -502,12 +502,17 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
       // Always use QIE-only pedestal for this computation
       const double rawCharge = rcfs.getRawCharge(cs[inputTS], pAndGain.pedestal(false));
       const float t = getTDCTimeFromSample(s);
-      const float dfc = getDifferentialChargeGain(*properties.channelCoder, *properties.shape,
-                                                  adc, capid, channelInfo->hasTimeInfo());
-      channelInfo->setSample(copyTS, adc, dfc, rawCharge,
+      const float dfc = getDifferentialChargeGain(
+          *properties.channelCoder, *properties.shape, adc, capid, channelInfo->hasTimeInfo());
+      channelInfo->setSample(copyTS,
+                             adc,
+                             dfc,
+                             rawCharge,
                              pAndGain.pedestal(saveEffectivePeds),
                              pAndGain.pedestalWidth(saveEffectivePeds),
-                             pAndGain.gain(), pAndGain.gainWidth(), t);
+                             pAndGain.gain(),
+                             pAndGain.gainWidth(),
+                             t);
       if (inputTS == soi)
         soiCapid = capid;
     }
@@ -648,8 +653,7 @@ void HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& even
       hbheFlagSetterQIE8_->Clear();
 
     HBHEChannelInfo channelInfo(false, false);
-    processData<HBHEDataFrame>(
-        *hbDigis, *htopo, *conditions, *prop, isData, &channelInfo, infos.get(), out.get());
+    processData<HBHEDataFrame>(*hbDigis, *htopo, *conditions, *prop, isData, &channelInfo, infos.get(), out.get());
     if (setNoiseFlagsQIE8_)
       hbheFlagSetterQIE8_->SetFlagsFromRecHits(*out);
   }
@@ -659,8 +663,7 @@ void HBHEPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& even
       hbheFlagSetterQIE11_->Clear();
 
     HBHEChannelInfo channelInfo(true, saveEffectivePedestal_);
-    processData<QIE11DataFrame>(
-        *heDigis, *htopo, *conditions, *prop, isData, &channelInfo, infos.get(), out.get());
+    processData<QIE11DataFrame>(*heDigis, *htopo, *conditions, *prop, isData, &channelInfo, infos.get(), out.get());
     if (setNoiseFlagsQIE11_)
       hbheFlagSetterQIE11_->SetFlagsFromRecHits(*out);
   }

--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -199,8 +199,7 @@ void HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& e
   }
 }
 
-void HFPreReconstructor::beginRun(const edm::Run& r, const edm::EventSetup& es) {
-}
+void HFPreReconstructor::beginRun(const edm::Run& r, const edm::EventSetup& es) {}
 
 // ------------ method called to produce the data  ------------
 void HFPreReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup) {

--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -34,11 +34,16 @@
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
-#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
-#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 
+#include "CondFormats/HcalObjects/interface/HcalRecoParam.h"
+
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFPreRecAlgo.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h"
 
 //
 // class declaration
@@ -70,7 +75,6 @@ private:
   edm::EDGetTokenT<QIE10DigiCollection> tok_hfQIE10_;
   std::vector<HFQIE10Info> qie10Infos_;
   std::vector<QIE10InfoWithId> sortedQIE10Infos_;
-  std::unique_ptr<HcalRecoParams> paramTS_;
 
   // Fill qie10Infos_ from the event data
   void fillInfos(const edm::Event& e, const edm::EventSetup& eventSetup);
@@ -138,16 +142,14 @@ void HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& e
   // Clear the collection we want to fill in this method
   qie10Infos_.clear();
 
-  // Get the Hcal topology if needed
-  ESHandle<HcalTopology> htopo;
-  if (tsFromDB_) {
-    eventSetup.get<HcalRecNumberingRecord>().get(htopo);
-    paramTS_->setTopo(htopo.product());
-  }
-
   // Get the calibrations
-  ESHandle<HcalDbService> conditions;
-  eventSetup.get<HcalDbRecord>().get(conditions);
+  ESHandle<HcalTopology> htopoHandle;
+  eventSetup.get<HcalRecNumberingRecord>().get(htopoHandle);
+  const HcalTopology& htopo(*htopoHandle);
+
+  ESHandle<HcalChannelPropertiesVec> propHandle;
+  eventSetup.get<HcalChannelPropertiesRecord>().get(propHandle);
+  const HcalChannelPropertiesVec& prop(*propHandle);
 
   // Get the input collection
   Handle<QIE10DigiCollection> digi;
@@ -173,23 +175,24 @@ void HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& e
         if (frame.zsMarkAndPass())
           continue;
 
-      const HcalCalibrations& calibrations(conditions->getHcalCalibrations(cell));
-      const HcalQIECoder* channelCoder = conditions->getHcalCoder(cell);
-      const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);
-      const HcalCoderDb coder(*channelCoder, *shape);
+      // Look up the channel properties. This lookup is O(1).
+      const HcalChannelProperties& properties(prop.at(htopo.detId2denseId(cell)));
+
+      // ADC decoding tool
+      const HcalCoderDb coder(*properties.channelCoder, *properties.shape);
 
       int tsToUse = forceSOI_;
       if (tsToUse < 0) {
         if (tsFromDB_) {
-          const HcalRecoParam* param_ts = paramTS_->getValues(cell.rawId());
-          tsToUse = param_ts->firstSample();
-        } else
+          tsToUse = properties.paramTs->firstSample();
+        } else {
           // Get the "sample of interest" from the data frame itself
           tsToUse = frame.presamples();
+        }
       }
 
       // Reconstruct the charge, energy, etc
-      const HFQIE10Info& info = reco_.reconstruct(frame, tsToUse + soiShift_, coder, calibrations);
+      const HFQIE10Info& info = reco_.reconstruct(frame, tsToUse + soiShift_, coder, properties);
       if (info.id().rawId())
         qie10Infos_.push_back(info);
     }
@@ -197,11 +200,6 @@ void HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& e
 }
 
 void HFPreReconstructor::beginRun(const edm::Run& r, const edm::EventSetup& es) {
-  if (tsFromDB_) {
-    edm::ESHandle<HcalRecoParams> p;
-    es.get<HcalRecoParamsRcd>().get(p);
-    paramTS_ = std::make_unique<HcalRecoParams>(*p.product());
-  }
 }
 
 // ------------ method called to produce the data  ------------


### PR DESCRIPTION
#### PR description:

This pull request replaces PR #29852 with a similar calibration cache implementation based on an ESProducer. In addition to HBHEPhase1Reconstructor, HFPreReconstructor has been switched to this cache as well.

One additional push to follow, for the HLT customization.

#### PR validation:

The usual runTheMatrix tests were run. Some private modifications were also used to print calibration info and to make sure that it is the same as before.
