### PR TITLE
Fix bug affecting boosted tau isolation

### DIFF
--- a/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
+++ b/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
@@ -157,10 +157,7 @@ namespace {
       const reco::Jet& jet,
       const edm::Handle<reco::PFCandidateCollection>& pfCandidates,
       const JetToConstitMap::value_type& constitmap,
-      const reco::Jet::Constituents& jetConstituents,
-      double /*dRmatch*/,
       bool invert) {
-    //const double dRmatch2 = dRmatch*dRmatch; // comment out for now in case someone needs a dR-based search again
     auto const& collection_cand = (*pfCandidates);
     std::vector<reco::PFCandidateRef> pfCandidates_exclJetConstituents;
     size_t numPFCandidates = pfCandidates->size();
@@ -257,9 +254,9 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
 
     // find all PFCandidates that are not constituents of the **other** subjet
     std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 = getPFCandidates_exclJetConstituents(
-        *subjet1, pfCandidates, constitmap[2 * idx], subjetConstituents2, 1.e-4, false);
+        *subjet1, pfCandidates, constitmap[2 * idx + 1], false);
     std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 = getPFCandidates_exclJetConstituents(
-        *subjet2, pfCandidates, constitmap[2 * idx + 1], subjetConstituents1, 1.e-4, false);
+        *subjet2, pfCandidates, constitmap[2 * idx], false);
     if (verbosity_ >= 1) {
       std::cout << "#pfCandidatesNotInSubjet1 = " << pfCandidatesNotInSubjet1.size() << std::endl;
       std::cout << "#pfCandidatesNotInSubjet2 = " << pfCandidatesNotInSubjet2.size() << std::endl;

--- a/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
+++ b/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
@@ -253,10 +253,10 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
     edm::Ref<reco::PFJetCollection> subjetRef2(selectedSubjetRefProd, selectedSubjets->size() - 1);
 
     // find all PFCandidates that are not constituents of the **other** subjet
-    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 = getPFCandidates_exclJetConstituents(
-        *subjet1, pfCandidates, constitmap[2 * idx + 1], false);
-    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 = getPFCandidates_exclJetConstituents(
-        *subjet2, pfCandidates, constitmap[2 * idx], false);
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 =
+        getPFCandidates_exclJetConstituents(*subjet1, pfCandidates, constitmap[2 * idx + 1], false);
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 =
+        getPFCandidates_exclJetConstituents(*subjet2, pfCandidates, constitmap[2 * idx], false);
     if (verbosity_ >= 1) {
       std::cout << "#pfCandidatesNotInSubjet1 = " << pfCandidatesNotInSubjet1.size() << std::endl;
       std::cout << "#pfCandidatesNotInSubjet2 = " << pfCandidatesNotInSubjet2.size() << std::endl;


### PR DESCRIPTION
#### PR description:

This PR fixes a bug affecting indexing jet-constituent-maps. In the result of the bug constituents of a subjet nearby a considered tau - a seed of a nearby tau candidate - are not excluded from particles used to compute isolation of the tau, which breaks the boosted tau algorithm. The bug has been introduced in #17087 (for 90X) speeding up boosted tau seed producer code. Unfortunately the bug was discovered only recently by users (*).
In addition to the bug fix, in this PR we remove remnants of previous implementation changed by #17087.

Expected changes: boosted taus (in MiniAOD), especially those with other tau candidate within R<0.5, are more isolated. This will recover states from before #17087 as shown in the attached figure.

<img width="827" alt="BoostedH" src="https://user-images.githubusercontent.com/5220469/83402897-ee6bf400-a407-11ea-9389-0f43a050ac66.png">

We intend to backport the fix to 11_1_X (using current dev branch) and 10_6_X for analyses based on those releases, i.e. respectively preparation to Run3 and Run2 legacy analyses.

(*) Unfortunately, developers and users of boosted taus prepared their analyses with 80X samples and then changed interests or even left CMS. In addition the code resides beyond tau packages and the change has not been consulted with Tau POG... This suggest need of more focus on monitoring boosted Taus, but this requires DQM based on miniAOD objects not present for taus, yet.

#### PR validation:

Tested with the standard miniAOD workflow.
