### PR TITLE
Fix bug affecting boosted tau isolation (10_6_X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -332,10 +332,6 @@ def miniAOD_customizeCommon(process):
     addBoostedTaus(process)
     process.load("RecoTauTag.Configuration.RecoPFTauTag_cff")
     process.load("RecoTauTag.Configuration.HPSPFTaus_cff")
-    #enable correct behaviour of overlap removal in boosted tau seeding
-    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-    run2_miniAOD_devel.toModify(process.boostedTauSeeds,
-                                correctlyExcludeOverlap = True)
     #-- Adding customization for 94X 2017 legacy reMniAOD
     from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
     _makePatTausTaskWithRetrainedMVATauID = process.makePatTausTask.copy()
@@ -377,6 +373,7 @@ def miniAOD_customizeCommon(process):
     process.deepTau2017v2p1.taus = _noUpdatedTauName
     deepTauIDTaskNew_ = cms.Task(process.deepTau2017v2p1,process.slimmedTaus)
 
+    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
     from Configuration.Eras.Modifier_run2_tau_ul_2016_cff import run2_tau_ul_2016
     from Configuration.Eras.Modifier_run2_tau_ul_2018_cff import run2_tau_ul_2018
     for era in [run2_miniAOD_devel,run2_tau_ul_2016,run2_tau_ul_2018]:

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -332,6 +332,10 @@ def miniAOD_customizeCommon(process):
     addBoostedTaus(process)
     process.load("RecoTauTag.Configuration.RecoPFTauTag_cff")
     process.load("RecoTauTag.Configuration.HPSPFTaus_cff")
+    #enable correct behaviour of overlap removal in boosted tau seeding
+    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+    run2_miniAOD_devel.toModify(process.boostedTauSeeds,
+                                correctlyExcludeOverlap = True)
     #-- Adding customization for 94X 2017 legacy reMniAOD
     from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
     _makePatTausTaskWithRetrainedMVATauID = process.makePatTausTask.copy()
@@ -373,7 +377,6 @@ def miniAOD_customizeCommon(process):
     process.deepTau2017v2p1.taus = _noUpdatedTauName
     deepTauIDTaskNew_ = cms.Task(process.deepTau2017v2p1,process.slimmedTaus)
 
-    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
     from Configuration.Eras.Modifier_run2_tau_ul_2016_cff import run2_tau_ul_2016
     from Configuration.Eras.Modifier_run2_tau_ul_2018_cff import run2_tau_ul_2018
     for era in [run2_miniAOD_devel,run2_tau_ul_2016,run2_tau_ul_2018]:

--- a/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
+++ b/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
@@ -40,15 +40,15 @@
 #include <iostream>
 #include <iomanip>
 
-class BoostedTauSeedsProducer : public edm::stream::EDProducer<>
-{
- public:
+class BoostedTauSeedsProducer : public edm::stream::EDProducer<> {
+public:
   explicit BoostedTauSeedsProducer(const edm::ParameterSet&);
   ~BoostedTauSeedsProducer() override {}
   void produce(edm::Event&, const edm::EventSetup&) override;
 
- private:
-  typedef edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>, std::vector<reco::PFCandidate>, unsigned int> > JetToPFCandidateAssociation;
+private:
+  typedef edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>, std::vector<reco::PFCandidate>, unsigned int> >
+      JetToPFCandidateAssociation;
 
   std::string moduleLabel_;
 
@@ -60,84 +60,80 @@ class BoostedTauSeedsProducer : public edm::stream::EDProducer<>
 };
 
 BoostedTauSeedsProducer::BoostedTauSeedsProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
   srcSubjets_ = consumes<JetView>(cfg.getParameter<edm::InputTag>("subjetSrc"));
   srcPFCandidates_ = consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("pfCandidateSrc"));
 
-  verbosity_ = ( cfg.exists("verbosity") ) ?
-    cfg.getParameter<int>("verbosity") : 0;
+  verbosity_ = (cfg.exists("verbosity")) ? cfg.getParameter<int>("verbosity") : 0;
 
   produces<reco::PFJetCollection>();
   produces<JetToPFCandidateAssociation>("pfCandAssocMapForIsolation");
   //produces<JetToPFCandidateAssociation>("pfCandAssocMapForIsoDepositVetos");
 }
 
-namespace
-{
+namespace {
   typedef std::vector<std::unordered_set<uint32_t> > JetToConstitMap;
-  
-  reco::PFJet convertToPFJet(const reco::Jet& jet, const reco::Jet::Constituents& jetConstituents)
-  {    
+
+  reco::PFJet convertToPFJet(const reco::Jet& jet, const reco::Jet::Constituents& jetConstituents) {
     // CV: code for filling pfJetSpecific objects taken from
     //        RecoParticleFlow/PFRootEvent/src/JetMaker.cc
     double chargedHadronEnergy = 0.;
     double neutralHadronEnergy = 0.;
-    double chargedEmEnergy     = 0.;
-    double neutralEmEnergy     = 0.;
-    double chargedMuEnergy     = 0.;
-    int    chargedMultiplicity = 0;
-    int    neutralMultiplicity = 0;
-    int    muonMultiplicity    = 0;
-    for ( reco::Jet::Constituents::const_iterator jetConstituent = jetConstituents.begin();
-	  jetConstituent != jetConstituents.end(); ++jetConstituent ) {
-      const reco::PFCandidate* pfCandidate = dynamic_cast<const reco::PFCandidate*>(jetConstituent->get());
-      if ( pfCandidate ) {
-	switch ( pfCandidate->particleId() ) {
-	case reco::PFCandidate::h :          // charged hadron
-	  chargedHadronEnergy += pfCandidate->energy();
-	  ++chargedMultiplicity;
-	  break;           
-	case reco::PFCandidate::e :          // electron 
-	  chargedEmEnergy += pfCandidate->energy(); 
-	  ++chargedMultiplicity;
-	  break;
-	case reco::PFCandidate::mu :         // muon
-	  chargedMuEnergy += pfCandidate->energy();
-	  ++chargedMultiplicity;
-	  ++muonMultiplicity;
-	  break;
-	case reco::PFCandidate::gamma :     // photon
-	case reco::PFCandidate::egamma_HF : // electromagnetic in HF
-	  neutralEmEnergy += pfCandidate->energy();
-	  ++neutralMultiplicity;
-	  break;
-	case reco::PFCandidate::h0 :        // neutral hadron
-	case reco::PFCandidate::h_HF :      // hadron in HF
-	  neutralHadronEnergy += pfCandidate->energy();
-	  ++neutralMultiplicity;
-	  break;
-	default:
-	  edm::LogWarning("convertToPFJet") 
-	    << "PFCandidate: Pt = " << pfCandidate->pt() << ", eta = " << pfCandidate->eta() << ", phi = " << pfCandidate->phi() 
-	    << " has invalid particleID = " << pfCandidate->particleId() << " !!" << std::endl;
-	  break;
-	}
+    double chargedEmEnergy = 0.;
+    double neutralEmEnergy = 0.;
+    double chargedMuEnergy = 0.;
+    int chargedMultiplicity = 0;
+    int neutralMultiplicity = 0;
+    int muonMultiplicity = 0;
+    for (auto const& jetConstituent : jetConstituents) {
+      const reco::PFCandidate* pfCandidate = dynamic_cast<const reco::PFCandidate*>(jetConstituent.get());
+      if (pfCandidate) {
+        switch (pfCandidate->particleId()) {
+          case reco::PFCandidate::h:  // charged hadron
+            chargedHadronEnergy += pfCandidate->energy();
+            ++chargedMultiplicity;
+            break;
+          case reco::PFCandidate::e:  // electron
+            chargedEmEnergy += pfCandidate->energy();
+            ++chargedMultiplicity;
+            break;
+          case reco::PFCandidate::mu:  // muon
+            chargedMuEnergy += pfCandidate->energy();
+            ++chargedMultiplicity;
+            ++muonMultiplicity;
+            break;
+          case reco::PFCandidate::gamma:      // photon
+          case reco::PFCandidate::egamma_HF:  // electromagnetic in HF
+            neutralEmEnergy += pfCandidate->energy();
+            ++neutralMultiplicity;
+            break;
+          case reco::PFCandidate::h0:    // neutral hadron
+          case reco::PFCandidate::h_HF:  // hadron in HF
+            neutralHadronEnergy += pfCandidate->energy();
+            ++neutralMultiplicity;
+            break;
+          default:
+            edm::LogWarning("convertToPFJet")
+                << "PFCandidate: Pt = " << pfCandidate->pt() << ", eta = " << pfCandidate->eta()
+                << ", phi = " << pfCandidate->phi() << " has invalid particleID = " << pfCandidate->particleId()
+                << " !!" << std::endl;
+            break;
+        }
       } else {
-	edm::LogWarning("convertToPFJet") 
-	  << "Jet constituent: Pt = " << pfCandidate->pt() << ", eta = " << pfCandidate->eta() << ", phi = " << pfCandidate->phi() 
-	  << " is not of type PFCandidate !!" << std::endl;
+        edm::LogWarning("convertToPFJet")
+            << "Jet constituent: Pt = " << jetConstituent->pt() << ", eta = " << jetConstituent->eta()
+            << ", phi = " << jetConstituent->phi() << " is not of type PFCandidate !!" << std::endl;
       }
     }
     reco::PFJet::Specific pfJetSpecific;
     pfJetSpecific.mChargedHadronEnergy = chargedHadronEnergy;
     pfJetSpecific.mNeutralHadronEnergy = neutralHadronEnergy;
-    pfJetSpecific.mChargedEmEnergy     = chargedEmEnergy;
-    pfJetSpecific.mChargedMuEnergy     = chargedMuEnergy;
-    pfJetSpecific.mNeutralEmEnergy     = neutralEmEnergy;
+    pfJetSpecific.mChargedEmEnergy = chargedEmEnergy;
+    pfJetSpecific.mChargedMuEnergy = chargedMuEnergy;
+    pfJetSpecific.mNeutralEmEnergy = neutralEmEnergy;
     pfJetSpecific.mChargedMultiplicity = chargedMultiplicity;
     pfJetSpecific.mNeutralMultiplicity = neutralMultiplicity;
-    pfJetSpecific.mMuonMultiplicity    = muonMultiplicity;
+    pfJetSpecific.mMuonMultiplicity = muonMultiplicity;
 
     reco::PFJet pfJet(jet.p4(), jet.vertex(), pfJetSpecific, jetConstituents);
     pfJet.setJetArea(jet.jetArea());
@@ -145,72 +141,72 @@ namespace
     return pfJet;
   }
 
-  void getJetConstituents(const reco::Jet& jet, reco::Jet::Constituents& jet_and_subjetConstituents)
-  {
+  void getJetConstituents(const reco::Jet& jet, reco::Jet::Constituents& jet_and_subjetConstituents) {
     reco::Jet::Constituents jetConstituents = jet.getJetConstituents();
-    for ( reco::Jet::Constituents::const_iterator jetConstituent = jetConstituents.begin();
-	  jetConstituent != jetConstituents.end(); ++jetConstituent ) {
-      const reco::Jet* subjet = dynamic_cast<const reco::Jet*>(jetConstituent->get());
-      if ( subjet ) {
-	getJetConstituents(*subjet, jet_and_subjetConstituents);
-      } else { 
-	jet_and_subjetConstituents.push_back(*jetConstituent);
+    for (auto const& jetConstituent : jetConstituents) {
+      const reco::Jet* subjet = dynamic_cast<const reco::Jet*>(jetConstituent.get());
+      if (subjet) {
+        getJetConstituents(*subjet, jet_and_subjetConstituents);
+      } else {
+        jet_and_subjetConstituents.push_back(jetConstituent);
       }
     }
   }
 
-  std::vector<reco::PFCandidateRef> getPFCandidates_exclJetConstituents(const reco::Jet& jet, const edm::Handle<reco::PFCandidateCollection>& pfCandidates, const JetToConstitMap::value_type& constitmap, const reco::Jet::Constituents& jetConstituents, double /*dRmatch*/, bool invert)
-  { 
-    //const double dRmatch2 = dRmatch*dRmatch; // comment out for now in case someone needs a dR-based search again
-    auto const & collection_cand = (*pfCandidates);
+  std::vector<reco::PFCandidateRef> getPFCandidates_exclJetConstituents(
+      const reco::Jet& jet,
+      const edm::Handle<reco::PFCandidateCollection>& pfCandidates,
+      const JetToConstitMap::value_type& constitmap,
+      bool invert) {
+    auto const& collection_cand = (*pfCandidates);
     std::vector<reco::PFCandidateRef> pfCandidates_exclJetConstituents;
     size_t numPFCandidates = pfCandidates->size();
-    for ( size_t pfCandidateIdx = 0; pfCandidateIdx < numPFCandidates; ++pfCandidateIdx ) {
-      if(!(deltaR2(collection_cand[pfCandidateIdx], jet)<1.0)) continue;
-      bool isJetConstituent = constitmap.count(pfCandidateIdx);      
-      if ( !(isJetConstituent^invert) ) {
-	reco::PFCandidateRef pfCandidate(pfCandidates, pfCandidateIdx);
-	pfCandidates_exclJetConstituents.push_back(pfCandidate);
+    for (size_t pfCandidateIdx = 0; pfCandidateIdx < numPFCandidates; ++pfCandidateIdx) {
+      if (!(deltaR2(collection_cand[pfCandidateIdx], jet) < 1.0))
+        continue;
+      bool isJetConstituent = constitmap.count(pfCandidateIdx);
+      if (!(isJetConstituent ^ invert)) {
+        reco::PFCandidateRef pfCandidate(pfCandidates, pfCandidateIdx);
+        pfCandidates_exclJetConstituents.push_back(pfCandidate);
       }
     }
     return pfCandidates_exclJetConstituents;
   }
 
-  void printJetConstituents(const std::string& label, const reco::Jet::Constituents& jetConstituents)
-  {
+  void printJetConstituents(const std::string& label, const reco::Jet::Constituents& jetConstituents) {
     std::cout << "#" << label << " = " << jetConstituents.size() << ":" << std::endl;
-    int idx = 0;
-    for ( reco::Jet::Constituents::const_iterator jetConstituent = jetConstituents.begin();
-	  jetConstituent != jetConstituents.end(); ++jetConstituent ) {
-      std::cout << " jetConstituent #" << idx << ": Pt = " << (*jetConstituent)->pt() << ", eta = " << (*jetConstituent)->eta() << ", phi = " << (*jetConstituent)->phi() << std::endl;
+    unsigned idx = 0;
+    for (auto const& jetConstituent : jetConstituents) {
+      std::cout << " jetConstituent #" << idx << ": Pt = " << (*jetConstituent).pt()
+                << ", eta = " << (*jetConstituent).eta() << ", phi = " << (*jetConstituent).phi() << std::endl;
       ++idx;
     }
   }
-}
+}  // namespace
 
-void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  if ( verbosity_ >= 1 ) {
+void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  if (verbosity_ >= 1) {
     std::cout << "<BoostedTauSeedsProducer::produce (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
   }
 
   edm::Handle<JetView> subjets;
   evt.getByToken(srcSubjets_, subjets);
-  if ( verbosity_ >= 1 ) {
+  if (verbosity_ >= 1) {
     std::cout << "#subjets = " << subjets->size() << std::endl;
   }
-  assert((subjets->size() % 2) == 0); // CV: ensure that subjets come in pairs
-  
+  assert((subjets->size() % 2) == 0);  // CV: ensure that subjets come in pairs
+
   edm::Handle<reco::PFCandidateCollection> pfCandidates;
   evt.getByToken(srcPFCandidates_, pfCandidates);
-  if ( verbosity_ >= 1 ) {
+  if (verbosity_ >= 1) {
     std::cout << "#pfCandidates = " << pfCandidates->size() << std::endl;
   }
-  
+
   auto selectedSubjets = std::make_unique<reco::PFJetCollection>();
   edm::RefProd<reco::PFJetCollection> selectedSubjetRefProd = evt.getRefBeforePut<reco::PFJetCollection>();
 
-  auto selectedSubjetPFCandidateAssociationForIsolation = std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
+  auto selectedSubjetPFCandidateAssociationForIsolation =
+      std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
   //auto selectedSubjetPFCandidateAssociationForIsoDepositVetos = std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
 
   // cache for jet->pfcandidate
@@ -218,33 +214,35 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
 
   // fill constituents map
   const auto& thesubjets = *subjets;
-  for( unsigned i = 0; i < thesubjets.size(); ++i ) {
-    for ( unsigned j = 0; j < thesubjets[i].numberOfDaughters(); ++j ) {
+  for (unsigned i = 0; i < thesubjets.size(); ++i) {
+    for (unsigned j = 0; j < thesubjets[i].numberOfDaughters(); ++j) {
       constitmap[i].emplace(thesubjets[i].daughterPtr(j).key());
     }
   }
 
-  for ( size_t idx = 0; idx < (subjets->size() / 2); ++idx ) {
-    const reco::Jet* subjet1 = &subjets->at(2*idx);
-    const reco::Jet* subjet2 = &subjets->at(2*idx + 1);
+  for (size_t idx = 0; idx < (subjets->size() / 2); ++idx) {
+    const reco::Jet* subjet1 = &subjets->at(2 * idx);
+    const reco::Jet* subjet2 = &subjets->at(2 * idx + 1);
     assert(subjet1 && subjet2);
-    if ( verbosity_ >= 1 ) {
+    if (verbosity_ >= 1) {
       std::cout << "processing jet #" << idx << ":" << std::endl;
-      std::cout << " subjet1: Pt = " << subjet1->pt() << ", eta = " << subjet1->eta() << ", phi = " << subjet1->phi() << ", mass = " << subjet1->mass() 
-		<< " (#constituents = " << subjet1->nConstituents() << ", area = " << subjet1->jetArea() << ")" << std::endl;
-      std::cout << " subjet2: Pt = " << subjet2->pt() << ", eta = " << subjet2->eta() << ", phi = " << subjet2->phi() << ", mass = " << subjet2->mass() 
-		<< " (#constituents = " << subjet2->nConstituents() << ", area = " << subjet2->jetArea() << ")" << std::endl;
+      std::cout << " subjet1: Pt = " << subjet1->pt() << ", eta = " << subjet1->eta() << ", phi = " << subjet1->phi()
+                << ", mass = " << subjet1->mass() << " (#constituents = " << subjet1->nConstituents()
+                << ", area = " << subjet1->jetArea() << ")" << std::endl;
+      std::cout << " subjet2: Pt = " << subjet2->pt() << ", eta = " << subjet2->eta() << ", phi = " << subjet2->phi()
+                << ", mass = " << subjet2->mass() << " (#constituents = " << subjet2->nConstituents()
+                << ", area = " << subjet2->jetArea() << ")" << std::endl;
     }
 
-    if ( !(subjet1->nConstituents() >= 1 && subjet1->pt() > 1. &&
-	   subjet2->nConstituents() >= 1 && subjet2->pt() > 1.) ) continue; // CV: skip pathological cases
+    if (!(subjet1->nConstituents() >= 1 && subjet1->pt() > 1. && subjet2->nConstituents() >= 1 && subjet2->pt() > 1.))
+      continue;  // CV: skip pathological cases
 
     // find PFCandidate constituents of each subjet
     reco::Jet::Constituents subjetConstituents1;
-    getJetConstituents(*subjet1, subjetConstituents1);    
+    getJetConstituents(*subjet1, subjetConstituents1);
     reco::Jet::Constituents subjetConstituents2;
     getJetConstituents(*subjet2, subjetConstituents2);
-    if ( verbosity_ >= 1 ) {
+    if (verbosity_ >= 1) {
       printJetConstituents("subjetConstituents1", subjetConstituents1);
       printJetConstituents("subjetConstituents2", subjetConstituents2);
     }
@@ -253,21 +251,23 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
     edm::Ref<reco::PFJetCollection> subjetRef1(selectedSubjetRefProd, selectedSubjets->size() - 1);
     selectedSubjets->push_back(convertToPFJet(*subjet2, subjetConstituents2));
     edm::Ref<reco::PFJetCollection> subjetRef2(selectedSubjetRefProd, selectedSubjets->size() - 1);
-        
+
     // find all PFCandidates that are not constituents of the **other** subjet
-    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 = getPFCandidates_exclJetConstituents(*subjet1, pfCandidates, constitmap[2*idx], subjetConstituents2, 1.e-4, false);
-    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 = getPFCandidates_exclJetConstituents(*subjet2, pfCandidates, constitmap[2*idx+1], subjetConstituents1, 1.e-4, false);
-    if ( verbosity_ >= 1 ) {
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 =
+        getPFCandidates_exclJetConstituents(*subjet1, pfCandidates, constitmap[2 * idx + 1], false);
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 =
+        getPFCandidates_exclJetConstituents(*subjet2, pfCandidates, constitmap[2 * idx], false);
+    if (verbosity_ >= 1) {
       std::cout << "#pfCandidatesNotInSubjet1 = " << pfCandidatesNotInSubjet1.size() << std::endl;
       std::cout << "#pfCandidatesNotInSubjet2 = " << pfCandidatesNotInSubjet2.size() << std::endl;
     }
 
-    // build JetToPFCandidateAssociation 
+    // build JetToPFCandidateAssociation
     // (key = subjet, value = collection of PFCandidates that are not constituents of subjet)
-    for(auto const& pfCandidate : pfCandidatesNotInSubjet1 ) {
+    for (auto const& pfCandidate : pfCandidatesNotInSubjet1) {
       selectedSubjetPFCandidateAssociationForIsolation->insert(subjetRef1, pfCandidate);
     }
-    for(auto const& pfCandidate : pfCandidatesNotInSubjet2 ) {
+    for (auto const& pfCandidate : pfCandidatesNotInSubjet2) {
       selectedSubjetPFCandidateAssociationForIsolation->insert(subjetRef2, pfCandidate);
     }
   }

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
@@ -43,6 +43,9 @@ boostedTauSeeds = cms.EDProducer("BoostedTauSeedsProducer",
     correctlyExcludeOverlap = cms.bool(False), #Set to False to keep buggy behaviour to fulfill non-changing policy; set to True for correct overlap removal
     verbosity = cms.int32(0)
 )
+#enable correct behaviour of overlap removal in boosted tau seeding
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+run2_miniAOD_devel.toModify(boostedTauSeeds, correctlyExcludeOverlap = True)
 
 boostedHPSPFTausTask = cms.Task(
     pfPileUpForBoostedTaus,

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
@@ -40,6 +40,7 @@ for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
 boostedTauSeeds = cms.EDProducer("BoostedTauSeedsProducer",
     subjetSrc = cms.InputTag('ca8PFJetsCHSprunedForBoostedTaus', 'subJetsForSeedingBoostedTaus'),
     pfCandidateSrc = cms.InputTag('particleFlow'),
+    correctlyExcludeOverlap = cms.bool(False), #Set to False to keep buggy behaviour to fulfill non-changing policy; set to True for correct overlap removal
     verbosity = cms.int32(0)
 )
 


### PR DESCRIPTION
#### PR description:

This PR fixes a bug affecting indexing jet-constituent-maps. In the result of the bug constituents of a subjet nearby a considered tau - a seed of a nearby tau candidate - are not excluded from particles used to compute isolation of the tau, which breaks the boosted tau algorithm. The bug has been introduced in #17087 (for 90X) speeding up boosted tau seed producer code. Unfortunately the bug was discovered only recently by users (*).
In addition to the bug fix, in this PR we remove remnants of previous implementation changed by #17087 and improve code formatting. 

Expected changes: boosted taus (in MiniAOD), especially those with other tau candidate within R<0.5, are more isolated. This will recover state from before #17087 as shown in the figure attached to #30064.

Backport of #30064 to 10_6_X. Some additional details therein.

#### PR validation:

Tested with the standard miniAOD workflow.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of  #30064
