### PR TITLE
reduced boost use in PhysicsTools/Utilities

### DIFF
--- a/PhysicsTools/Utilities/interface/Fraction.h
+++ b/PhysicsTools/Utilities/interface/Fraction.h
@@ -3,7 +3,7 @@
 
 #include "PhysicsTools/Utilities/interface/Numerical.h"
 #include "PhysicsTools/Utilities/interface/Operations.h"
-#include <boost/integer/common_factor.hpp>
+#include <numeric>
 
 namespace funct {
 
@@ -17,7 +17,7 @@ namespace funct {
     double operator()(double, double) const { return double(n) / double(m); }
   };
 
-  template <int n, int m, unsigned gcd = boost::integer::static_gcd<n, m>::value, int num = n / gcd, int den = m / gcd>
+  template <int n, int m, unsigned gcd = std::gcd(n, m), int num = n / gcd, int den = m / gcd>
   struct PositiveFraction {
     typedef FractionStruct<num, den> type;
   };


### PR DESCRIPTION
#### PR description:
Replaced boost library use for C++ STL alternatives. All the code should behave identically. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 