### PR TITLE
 replace boost::hash for std::hash

### DIFF
--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -13,7 +13,7 @@
 //
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/functional/hash.hpp>
+#include <functional>
 //
 #include "CondCore/CondDB/interface/Time.h"
 
@@ -123,7 +123,7 @@ namespace cond {
     std::size_t hashvalue() const {
       // Derived from CondDB v1 TagMetadata implementation.
       // Unique Keys constructed with Record and Labels - allowing for multiple references of the same Tag in a GT
-      boost::hash<std::string> hasher;
+      std::hash<std::string> hasher;
       std::string key = recordName();
       if (!recordLabel().empty())
         key = key + "_" + recordLabel();


### PR DESCRIPTION
#### PR description:
 Replace boost::hash for std::hash , std::hash and boost::hash should have very similar behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 