### PR TITLE
skip complicated checks for PFCandidate-on-PFCandidate TopProjector

### DIFF
--- a/CommonTools/ParticleFlow/plugins/TopProjector.h
+++ b/CommonTools/ParticleFlow/plugins/TopProjector.h
@@ -1,5 +1,5 @@
-#ifndef PhysicsTools_PFCandProducer_TopProjector_
-#define PhysicsTools_PFCandProducer_TopProjector_
+#ifndef CommonTools_ParticleFlow_TopProjector_
+#define CommonTools_ParticleFlow_TopProjector_
 
 // system include files
 #include <iostream>
@@ -206,52 +206,10 @@ void TopProjector<Top, Bottom, Matcher>::produce(edm::Event& iEvent, const edm::
     topsList.push_back(*i);
   }
 
-  /*   if( !tops.isValid() ) { */
-  /*     std::ostringstream  err; */
-  /*     err<<"The top collection must be supplied."<<std::endl */
-  /*        <<"It is now set to : "<<inputTagTop_<<std::endl; */
-  /*     edm::LogError("PFPAT")<<err.str(); */
-  /*     throw cms::Exception( "MissingProduct", err.str()); */
-  /*   } */
-
   // Access the collection to
   // be masked by the other ones
   BottomFwdPtrHandle bottoms;
   iEvent.getByToken(tokenBottom_, bottoms);
-
-  /*   if( !bottoms.isValid() ) { */
-  /*     std::ostringstream  err; */
-  /*     err<<"The bottom collection must be supplied."<<std::endl */
-  /*        <<"It is now set to : "<<inputTagBottom_<<std::endl; */
-  /*     edm::LogError("PFPAT")<<err.str(); */
-  /*     throw cms::Exception( "MissingProduct", err.str()); */
-  /*   } */
-
-  /* if(verbose_) { */
-  /*   const edm::Provenance& topProv = iEvent.getProvenance(tops.id()); */
-  /*   const edm::Provenance& bottomProv = iEvent.getProvenance(bottoms.id()); */
-
-  /*   edm::LogDebug("TopProjection")<<"Top projector: event "<<iEvent.id().event()<<std::endl; */
-  /*   edm::LogDebug("TopProjection")<<"Inputs --------------------"<<std::endl; */
-  /*   edm::LogDebug("TopProjection")<<"Top      :  " */
-  /* 	     <<tops.id()<<"\t"<<tops->size()<<std::endl */
-  /* 	     <<topProv.branchDescription()<<std::endl; */
-
-  /*   for(unsigned i=0; i<tops->size(); i++) { */
-  /*     TopFwdPtr top = (*tops)[i]; */
-  /*     edm::LogDebug("TopProjection") << "< " << i << " " << top.key() << " : " << *top << std::endl; */
-  /*   } */
-
-  /*   edm::LogDebug("TopProjection")<<"Bottom   :  " */
-  /* 	     <<bottoms.id()<<"\t"<<bottoms->size()<<std::endl */
-  /* 	     <<bottomProv.branchDescription()<<std::endl; */
-
-  /*   for(unsigned i=0; i<bottoms->size(); i++) { */
-  /*     BottomFwdPtr bottom = (*bottoms)[i]; */
-  /*     edm::LogDebug("TopProjection") << "> " << i << " " << bottom.key() << " : " << *bottom << std::endl; */
-  /*   } */
-
-  /* } */
 
   // output collection of FwdPtrs to objects,
   // selected from the Bottom collection

--- a/CommonTools/ParticleFlow/plugins/TopProjector.h
+++ b/CommonTools/ParticleFlow/plugins/TopProjector.h
@@ -192,6 +192,8 @@ template <class Top, class Bottom, class Matcher>
 void TopProjector<Top, Bottom, Matcher>::fillDescriptions(edm::ConfigurationDescriptions& desc) {
   edm::ParameterSetDescription psD;
   psD.add<bool>("enable");
+  if (std::is_same<Matcher, TopProjectorDeltaROverlap<Top, Bottom>>::value)
+    psD.add<double>("deltaR");
   psD.addUntracked<std::string>("name", "No Name");
   psD.add<edm::InputTag>("topCollection");
   psD.add<edm::InputTag>("bottomCollection");

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoElectron_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoElectron_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi import tppfCandidatesOnPFCandidates
+import CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi as _mod
 
-pfNoElectron = tppfCandidatesOnPFCandidates.clone(
+pfNoElectron = _mod.tppfCandidatesOnPFCandidates.clone(
     enable = True,
     name = "noElectron",
     topCollection = "pfIsolatedElectrons",

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoElectron_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoElectron_cfi.py
@@ -1,22 +1,15 @@
 import FWCore.ParameterSet.Config as cms
+from CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi import tppfCandidatesOnPFCandidates
 
-pfNoElectron = cms.EDProducer(
-    "TPPFCandidatesOnPFCandidates",
-    enable =  cms.bool( True ),
-    verbose = cms.untracked.bool( False ),
-    name = cms.untracked.string("noElectron"),
-    topCollection = cms.InputTag("pfIsolatedElectrons"),
-    bottomCollection = cms.InputTag("pfNoMuon"),
+pfNoElectron = tppfCandidatesOnPFCandidates.clone(
+    enable = True,
+    name = "noElectron",
+    topCollection = "pfIsolatedElectrons",
+    bottomCollection = "pfNoMuon",
 )
 
-
-pfNoElectronJME = cms.EDProducer(
-    "TPPFCandidatesOnPFCandidates",
-    enable =  cms.bool( True ),
-    verbose = cms.untracked.bool( False ),
-    name = cms.untracked.string("noElectron"),
-    topCollection = cms.InputTag("pfIsolatedElectrons"),
-    bottomCollection = cms.InputTag("pfNoMuonJME"),
+pfNoElectronJME = pfNoElectron.clone(
+    bottomCollection = "pfNoMuonJME",
 )
 
 pfNoElectronJMEClones = cms.EDProducer("PFCandidateFromFwdPtrProducer",

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoJet_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoJet_cfi.py
@@ -1,10 +1,9 @@
 import FWCore.ParameterSet.Config as cms
+from CommonTools.ParticleFlow.tppfJetsOnPFCandidates_cfi import tppfJetsOnPFCandidates
 
-pfNoJet = cms.EDProducer(
-    "TPPFJetsOnPFCandidates",
-    enable =  cms.bool( True ),
-    verbose = cms.untracked.bool( False ),
-    name = cms.untracked.string("noJet"),
-    topCollection = cms.InputTag("pfJetsPtrs"),
-    bottomCollection = cms.InputTag("pfNoElectronJME"),
+pfNoJet = tppfJetsOnPFCandidates.clone(
+    enable = True,
+    name = "noJet",
+    topCollection = "pfJetsPtrs",
+    bottomCollection = "pfNoElectronJME",
 )

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoJet_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoJet_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from CommonTools.ParticleFlow.tppfJetsOnPFCandidates_cfi import tppfJetsOnPFCandidates
+import CommonTools.ParticleFlow.tppfJetsOnPFCandidates_cfi as _mod
 
-pfNoJet = tppfJetsOnPFCandidates.clone(
+pfNoJet = _mod.tppfJetsOnPFCandidates.clone(
     enable = True,
     name = "noJet",
     topCollection = "pfJetsPtrs",

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoMuon_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoMuon_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi import tppfCandidatesOnPFCandidates
+import CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi as _mod
 
-pfNoMuon = tppfCandidatesOnPFCandidates.clone(
+pfNoMuon = _mod.tppfCandidatesOnPFCandidates.clone(
     enable = True,
     name = "noMuon",
     topCollection = "pfIsolatedMuons",

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoMuon_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoMuon_cfi.py
@@ -1,19 +1,13 @@
 import FWCore.ParameterSet.Config as cms
+from CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi import tppfCandidatesOnPFCandidates
 
-pfNoMuon = cms.EDProducer(
-    "TPPFCandidatesOnPFCandidates",
-    enable =  cms.bool( True ),
-    verbose = cms.untracked.bool( False ),
-    name = cms.untracked.string("noMuon"),
-    topCollection = cms.InputTag("pfIsolatedMuons"),
-    bottomCollection = cms.InputTag("pfNoPileUp"),
+pfNoMuon = tppfCandidatesOnPFCandidates.clone(
+    enable = True,
+    name = "noMuon",
+    topCollection = "pfIsolatedMuons",
+    bottomCollection = "pfNoPileUp",
 )
 
-pfNoMuonJME = cms.EDProducer(
-    "TPPFCandidatesOnPFCandidates",
-    enable =  cms.bool( True ),
-    verbose = cms.untracked.bool( False ),
-    name = cms.untracked.string("noMuon"),
-    topCollection = cms.InputTag("pfIsolatedMuons"),
-    bottomCollection = cms.InputTag("pfNoPileUpJME")
+pfNoMuonJME = pfNoMuon.clone(
+    bottomCollection = "pfNoPileUpJME"
 )

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoPileUp_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoPileUp_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
+from CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi import tppfCandidatesOnPFCandidates
 
-pfNoPileUp = cms.EDProducer(
-    "TPPFCandidatesOnPFCandidates",
-    enable =  cms.bool( True ),
-    verbose = cms.untracked.bool( False ),
-    name = cms.untracked.string("pileUpOnPFCandidates"),
-    topCollection = cms.InputTag("pfPileUp"),
-    bottomCollection = cms.InputTag("particleFlowTmpPtrs"),
+pfNoPileUp = tppfCandidatesOnPFCandidates.clone(
+    enable =  True,
+    name = "pileUpOnPFCandidates",
+    topCollection = "pfPileUp",
+    bottomCollection = "particleFlowTmpPtrs",
+    matchByPtrDirect = True
 )

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoPileUp_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoPileUp_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi import tppfCandidatesOnPFCandidates
+import CommonTools.ParticleFlow.tppfCandidatesOnPFCandidates_cfi as _mod
 
-pfNoPileUp = tppfCandidatesOnPFCandidates.clone(
+pfNoPileUp = _mod.tppfCandidatesOnPFCandidates.clone(
     enable =  True,
     name = "pileUpOnPFCandidates",
     topCollection = "pfPileUp",

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoTau_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoTau_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from CommonTools.ParticleFlow.tppfTausOnPFJetsDeltaR_cfi import tppfTausOnPFJetsDeltaR
+import CommonTools.ParticleFlow.tppfTausOnPFJetsDeltaR_cfi as _mod
 
-pfNoTau = tppfTausOnPFJetsDeltaR.clone(
+pfNoTau = _mod.tppfTausOnPFJetsDeltaR.clone(
     enable = True,
     deltaR = 0.5,
     name = "noTau",

--- a/CommonTools/ParticleFlow/python/TopProjectors/pfNoTau_cfi.py
+++ b/CommonTools/ParticleFlow/python/TopProjectors/pfNoTau_cfi.py
@@ -1,11 +1,10 @@
 import FWCore.ParameterSet.Config as cms
+from CommonTools.ParticleFlow.tppfTausOnPFJetsDeltaR_cfi import tppfTausOnPFJetsDeltaR
 
-pfNoTau = cms.EDProducer(
-    "TPPFTausOnPFJetsDeltaR",
-    enable =  cms.bool( True ),
-    verbose = cms.untracked.bool( False ),
-    deltaR = cms.double( 0.5 ),
-    name = cms.untracked.string("noTau"),
-    topCollection = cms.InputTag("pfTausPtrs"),
-    bottomCollection = cms.InputTag("pfJetsPtrs"),
+pfNoTau = tppfTausOnPFJetsDeltaR.clone(
+    enable = True,
+    deltaR = 0.5,
+    name = "noTau",
+    topCollection = "pfTausPtrs",
+    bottomCollection = "pfJetsPtrs",
 )

--- a/PhysicsTools/PatAlgos/python/tools/helpers.py
+++ b/PhysicsTools/PatAlgos/python/tools/helpers.py
@@ -156,12 +156,13 @@ class GatherAllModulesVisitor(object):
 class CloneSequenceVisitor(object):
     """Visitor that travels within a cms.Sequence, and returns a cloned version of the Sequence.
     All modules and sequences are cloned and a postfix is added"""
-    def __init__(self, process, label, postfix, removePostfix="", noClones = [], addToTask = False):
+    def __init__(self, process, label, postfix, removePostfix="", noClones = [], addToTask = False, verbose = False):
         self._process = process
         self._postfix = postfix
         self._removePostfix = removePostfix
         self._noClones = noClones
         self._addToTask = addToTask
+        self._verbose = verbose
         self._moduleLabels = []
         self._clonedSequence = cms.Sequence()
         setattr(process, self._newLabel(label), self._clonedSequence)
@@ -189,7 +190,7 @@ class CloneSequenceVisitor(object):
 
     def clonedSequence(self):
         for label in self._moduleLabels:
-            massSearchReplaceAnyInputTag(self._clonedSequence, label, self._newLabel(label), moduleLabelOnly=True, verbose=False)
+            massSearchReplaceAnyInputTag(self._clonedSequence, label, self._newLabel(label), moduleLabelOnly=True, verbose=self._verbose)
         self._moduleLabels = [] # prevent the InputTag replacement next time the 'clonedSequence' function is called.
         return self._clonedSequence
 
@@ -254,7 +255,7 @@ def contains(sequence, moduleName):
 
 
 
-def cloneProcessingSnippet(process, sequence, postfix, removePostfix="", noClones = [], addToTask = False):
+def cloneProcessingSnippet(process, sequence, postfix, removePostfix="", noClones = [], addToTask = False, verbose = False):
     """
     ------------------------------------------------------------------
     copy a sequence plus the modules and sequences therein
@@ -264,7 +265,7 @@ def cloneProcessingSnippet(process, sequence, postfix, removePostfix="", noClone
     """
     result = sequence
     if not postfix == "":
-        visitor = CloneSequenceVisitor(process, sequence.label(), postfix, removePostfix, noClones, addToTask)
+        visitor = CloneSequenceVisitor(process, sequence.label(), postfix, removePostfix, noClones, addToTask, verbose)
         sequence.visit(visitor)
         result = visitor.clonedSequence()
     return result

--- a/PhysicsTools/PatAlgos/test/patTuple_PF2PAT_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_PF2PAT_cfg.py
@@ -49,8 +49,7 @@ getattr(process,"pfNoJet"+postfix).enable = True
 # to use tau-cleaned jet collection uncomment the following:
 #getattr(process,"pfNoTau"+postfix).enable = True
 
-# verbose flags for the PF2PAT modules
-getattr(process,"pfNoMuonJME"+postfix).verbose = False
+# verbose flags for the PF2PAT modules, if any:
 
 # enable delta beta correction for muon selection in PF2PAT?
 getattr(process,"pfIsolatedMuons"+postfix).doDeltaBetaCorrection = cms.bool(False)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1606,12 +1606,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 process.load("CommonTools.ParticleFlow.pfNoPileUpJME_cff")
                 task.add(process.pfNoPileUpJMETask)
                 configtools.cloneProcessingSnippet(process, getattr(process,"pfNoPileUpJMESequence"), postfix, addToTask = True )
-                getattr(process, "pfPileUpJME"+postfix).PFCandidates = cms.InputTag("tmpPFCandCollPtr"+postfix)
-                addToProcessAndTask("pfNoPileUpJME"+postfix,
-                        getattr(process, "pfNoPileUpJME"+postfix).clone( 
-                        bottomCollection = cms.InputTag("tmpPFCandCollPtr"+postfix) ),
-                        process, task )
-                pfCandColl = cms.InputTag("pfNoPileUpJME"+postfix)
+                getattr(process, "pfPileUpJME"+postfix).PFCandidates = "tmpPFCandCollPtr"+postfix
+                getattr(process, "pfNoPileUpJME"+postfix).bottomCollection = "tmpPFCandCollPtr"+postfix
+                pfCandColl = "pfNoPileUpJME"+postfix
                 patMetModuleSequence += getattr(process, "tmpPFCandCollPtr"+postfix)
                 patMetModuleSequence += getattr(process, "pfNoPileUpJME"+postfix)
 

--- a/RecoMET/METFilters/test/filters_cfg.py
+++ b/RecoMET/METFilters/test/filters_cfg.py
@@ -97,8 +97,7 @@ getattr(process,"pfNoElectron"+postfix).enable = True
 getattr(process,"pfNoTau"+postfix).enable = False
 getattr(process,"pfNoJet"+postfix).enable = True
 
-# verbose flags for the PF2PAT modules
-getattr(process,"pfNoMuon"+postfix).verbose = False
+# verbose flags for the PF2PAT modules, if any:
 
 # Add the PV selector and KT6 producer to the sequence
 getattr(process,"patPF2PATSequence"+postfix).replace(

--- a/Validation/RecoParticleFlow/Benchmarks/ElectronBenchmarkGeneric/benchmark_cfg.py
+++ b/Validation/RecoParticleFlow/Benchmarks/ElectronBenchmarkGeneric/benchmark_cfg.py
@@ -39,7 +39,6 @@ process.pfNoPileUp = cms.EDProducer("TPPileUpPFCandidatesOnPFCandidates",
     bottomCollection = cms.InputTag("particleFlow"),
     topCollection = cms.InputTag("pfPileUp"),
     name = cms.untracked.string('pileUpOnPFCandidates'),
-    verbose = cms.untracked.bool(False)
 )
 
 

--- a/Validation/RecoParticleFlow/test/pflowValidationStep1_Template_cfg.py
+++ b/Validation/RecoParticleFlow/test/pflowValidationStep1_Template_cfg.py
@@ -132,7 +132,6 @@ process.pfPileUp = cms.EDProducer("PFPileUp",
 #                                    enable = cms.bool(True),
 #                                    topCollection = cms.InputTag("pfPileUp"),
 #                                    name = cms.untracked.string('pileUpOnPFCandidates'),
-#                                    verbose = cms.untracked.bool(False)
 #                                    )
 
 process.pfElectronBenchmarkGeneric = cms.EDAnalyzer("GenericBenchmarkAnalyzer",

--- a/Validation/RecoParticleFlow/test/pflowValidationStep1_cfg.py
+++ b/Validation/RecoParticleFlow/test/pflowValidationStep1_cfg.py
@@ -53,7 +53,6 @@ process.pfNoPileUp = cms.EDProducer("TPPileUpPFCandidatesOnPFCandidates",
                                         enable = cms.bool(True),
                                         topCollection = cms.InputTag("pfPileUp"),
                                         name = cms.untracked.string('pileUpOnPFCandidates'),
-                                        verbose = cms.untracked.bool(False)
 )
 process.pfPileUp = cms.EDProducer("PFPileUp",
                                       Enable = cms.bool(True),

--- a/Validation/RecoParticleFlow/test/pflowValidationStep1_test_cfg.py
+++ b/Validation/RecoParticleFlow/test/pflowValidationStep1_test_cfg.py
@@ -152,7 +152,6 @@ process.pfPileUp = cms.EDProducer("PFPileUp",
 #                                    enable = cms.bool(True),
 #                                    topCollection = cms.InputTag("pfPileUp"),
 #                                    name = cms.untracked.string('pileUpOnPFCandidates'),
-#                                    verbose = cms.untracked.bool(False)
 #                                    )
 
 process.pfElectronBenchmarkGeneric = cms.EDAnalyzer("GenericBenchmarkAnalyzer",


### PR DESCRIPTION
another case of CPU optimization/minimization from PU200 hotspots
https://jiwoong.web.cern.ch/jiwoong/cgi-bin/igprof-navigator/igprofCPU_CMSSW_11_1_0_pre8PAT/16

TopProjector matching collections of PFCandidate-on-PFCandidate by Ptr can now check for just the available pointer value, without navigating deep to the parent pointers. This is enabled for pfNoPileUp\*. Other cases can possibly be made from different collections where the deeper matching may be useful.

Time spent in pfNoPileUpJMENoHF and pfNoPileUpIsoPFBRECO goes down by about a factor of 10, or 19% of the miniAOD step in wf 23434.21 (PU200 ttbar) relative to a separate improvement in #30054 . 
The impact is small for Run2/3 (perhaps up to 4% for "nominal" pileup cases).

tests were limited to the miniAOD wf with PU.