### PR TITLE
Fixing missing pointer between lumi boundaries [Backport]

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
@@ -98,6 +98,7 @@ bool LHAupLesHouches::setEvent(int inProcId)
     fEvAttributes->clear();
     infoPtr->eventAttributes = fEvAttributes;
   } else {
+    infoPtr->eventAttributes = fEvAttributes;  // make sure still there
     infoPtr->eventAttributes->clear();
   }
 


### PR DESCRIPTION
#### PR description:
This PR is to fix missing pointer between lumi boundaries reported in
https://github.com/cms-sw/cmssw/issues/30070
https://github.com/cms-sw/cmssw/issues/25708

Note that this is a workaround to make the production work as discussed in
https://github.com/cms-sw/cmssw/pull/25850

#### PR validation:
With this PR, GEN-SIM step runs fine using following cmsDriver on CMSSW_10_3_2
`cmsDriver.py Configuration/GenProduction/python/PPD-HINPbPbAutumn18GS-00005-fragment.py --filein "dbs:/Ups1SMMCoh_5p02TeV_STARlight_PPDTest/HINPbPbAutumn18pLHE-pilot_103X_upgrade2018_realistic_HI_v11-v1/LHE" --fileout file:PPD-HINPbPbAutumn18GS-00005.root --mc --eventcontent RAWSIM --no_exec --datatier GEN-SIM --conditions 103X_upgrade2018_realistic_HI_v11 --beamspot RealisticPbPbCollision2018 --step GEN,SIM --nThreads 1 --scenario HeavyIons --geometry DB:Extended --era Run2_2018_pp_on_AA --python_filename PPD-HINPbPbAutumn18GS-00005_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 500 --customise_commands "process.source.skipEvents=cms.untracked.uint32(90)"`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of https://github.com/cms-sw/cmssw/pull/25850