### PR TITLE
Move DT calibration DQM modules back to Sequence

### DIFF
--- a/CalibMuon/DTCalibration/python/ALCARECODtCalib_cff.py
+++ b/CalibMuon/DTCalibration/python/ALCARECODtCalib_cff.py
@@ -20,10 +20,7 @@ dt4DSegmentsNoWire.Reco4DAlgoConfig.Reco2DAlgoConfig.recAlgoConfig.tTrigModeConf
 #this is to select collisions
 from RecoMET.METFilters.metFilters_cff import primaryVertexFilter, noscraping
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-seqALCARECODtCalibTask = cms.Task(dt4DSegmentsNoWire)
-seqALCARECODtCalib = cms.Sequence(primaryVertexFilter * noscraping * ALCARECODtCalibHLTFilter * DTCalibMuonSelection, seqALCARECODtCalibTask)
+seqALCARECODtCalib = cms.Sequence(primaryVertexFilter * noscraping * ALCARECODtCalibHLTFilter * DTCalibMuonSelection * dt4DSegmentsNoWire) 
 
 ## customizations for the pp_on_AA_2018 eras
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
@@ -31,7 +28,7 @@ pp_on_AA_2018.toModify(ALCARECODtCalibHLTFilter,
                        eventSetupPathsKey='DtCalibHI'
 )
 
-seqALCARECODtCalibHI = cms.Sequence(ALCARECODtCalibHLTFilter, seqALCARECODtCalibTask)
+seqALCARECODtCalibHI = cms.Sequence(ALCARECODtCalibHLTFilter * dt4DSegmentsNoWire)
 
 #Specify to use HI sequence for the pp_on_AA_2018 eras
 pp_on_AA_2018.toReplaceWith(seqALCARECODtCalib,seqALCARECODtCalibHI)

--- a/DQM/DTMonitorModule/python/ALCARECODTCalibSynchCosmicsDQM_cff.py
+++ b/DQM/DTMonitorModule/python/ALCARECODTCalibSynchCosmicsDQM_cff.py
@@ -31,8 +31,6 @@ from CalibMuon.DTCalibration.ALCARECODtCalibCosmics_cff import ALCARECODtCalibCo
 #                                               dtAlcaResolutionMonitorCosmics + 
 #                                               ALCARECODtCalibCosmicsHLTDQM )
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-ALCARECODTCalibSynchCosmicsDQMTask = cms.Task(dtPreCalibrationTaskAlcaCosmics, dtAlcaResolutionMonitorCosmics)
-ALCARECODTCalibSynchCosmicsDQM = cms.Sequence(ALCARECODTCalibSynchCosmicsDQMTask)
+ALCARECODTCalibSynchCosmicsDQM = cms.Sequence( dtPreCalibrationTaskAlcaCosmics +
+                                               dtAlcaResolutionMonitorCosmics )
 

--- a/DQM/DTMonitorModule/python/ALCARECODTCalibSynchDQM_cff.py
+++ b/DQM/DTMonitorModule/python/ALCARECODTCalibSynchDQM_cff.py
@@ -30,8 +30,6 @@ from CalibMuon.DTCalibration.ALCARECODtCalib_cff import ALCARECODtCalibHLTFilter
 #                                        dtAlcaResolutionMonitor + 
 #                                        dtTriggerSynchMonitor +
 #                                        ALCARECODtCalibHLTDQM )
-
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-ALCARECODTCalibSynchDQMTask = cms.Task(dtPreCalibrationTaskAlca, dtAlcaResolutionMonitor, dtTriggerSynchMonitor)
-ALCARECODTCalibSynchDQM = cms.Sequence(ALCARECODTCalibSynchDQMTask)
+ALCARECODTCalibSynchDQM = cms.Sequence( dtPreCalibrationTaskAlca +
+                                        dtAlcaResolutionMonitor +
+                                        dtTriggerSynchMonitor )

--- a/DQM/DTMonitorModule/python/ALCARECODTCalibSynchHIDQM_cff.py
+++ b/DQM/DTMonitorModule/python/ALCARECODTCalibSynchHIDQM_cff.py
@@ -30,8 +30,5 @@ from CalibMuon.DTCalibration.ALCARECODtCalibHI_cff import ALCARECODtCalibHIHLTFi
 #ALCARECODTCalibSynchHIDQM = cms.Sequence( dtPreCalibrationTaskAlcaHI +
 #                                          dtAlcaResolutionMonitorHI + 
 #                                          ALCARECODtCalibHIHLTDQM )
-
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-ALCARECODTCalibSynchHIDQMTask = cms.Task(dtPreCalibrationTaskAlcaHI, dtAlcaResolutionMonitorHI)
-ALCARECODTCalibSynchHIDQM = cms.Sequence(ALCARECODTCalibSynchHIDQMTask)
+ALCARECODTCalibSynchHIDQM = cms.Sequence( dtPreCalibrationTaskAlcaHI +
+                                          dtAlcaResolutionMonitorHI )


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to #29630 and reverts the changes made to DT calibration DQM modules by moving them back to Sequences, i.e. to be run only if the preceding filters keep processing the event.

#### PR validation:

Limited matrix runs, expecting changes in DT AlcaReco DQM plots.
