### PR TITLE
11.1.X  [Tracker Alignment] All-in-one tool support of multiple tags in user-inputed sqlite file

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
@@ -202,9 +202,12 @@ def getTagsMap(db):
     con = conddblib.connect(url = conddblib.make_url(db))
     session = con.session()
     TAG = session.get_dbtype(conddblib.Tag)
-    q1 = session.query(TAG.object_type).order_by(TAG.name).all()[0]
-    q2 = session.query(TAG.name).order_by(TAG.name).all()[0]
-    dictionary = dict(zip(q1, q2))
+    dictionary = {}
+    for i in range(0,len(session.query(TAG.object_type).order_by(TAG.name).all())):
+        q1 = session.query(TAG.object_type).order_by(TAG.name).all()[i][0]
+        q2 = session.query(TAG.name).order_by(TAG.name).all()[i][0]
+        dictionary[q1]=q2
+
     return dictionary
 
 def clean_name(s):

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -12,6 +12,7 @@ fi
 ## copy into local sqlite file the ideal alignment
 echo "COPYING locally Ideal Alignment ..."
 conddb --yes --db pro copy TrackerAlignment_Upgrade2017_design_v4 --destdb myfile.db
+conddb --yes --db pro copy TrackerAlignmentErrorsExtended_Upgrade2017_design_v0 --destdb myfile.db
 
 echo "GENERATING all-in-one tool configuration ..."
 cat <<EOF >> validation_config.ini
@@ -29,6 +30,7 @@ style = 2001
 title = express
 globaltag = 92X_dataRun2_Express_v2
 condition TrackerAlignmentRcd =  sqlite_file:myfile.db,TrackerAlignment_Upgrade2017_design_v4
+condition TrackerAlignmentErrorExtendedRcd = sqlite_file:myfile.db,TrackerAlignmentErrorsExtended_Upgrade2017_design_v0
 color = 2
 style = 2402
 


### PR DESCRIPTION
backport of  #30077

#### PR description:

In this commit: https://github.com/cms-sw/cmssw/commit/ca150f34c8908b194219de64eb4b2fa16ac06491 we introduced a new method in order to read local sqlite files in the tracker alignment all-in-one tool, by using `conddblib` to check contents of sqlite files.
In the original implementation in PR #29339 I did not foresee to put more than one tag into a local sqlite file, but this appears to be a required use case.
The issue and the fix have been provided by @adewit.
I profit of this PR also to update the unit test to cover this use-case. 

#### PR validation:

Relies on the existing unit test in the subsystem. I have tested this in `CMSSW_11_1_X_2020-06-02-1100`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a *verbatim* backport of #30077
