### PR TITLE
Remove redundant product validity check from ConversionTrackProducer and modernize it

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackProducer.h
@@ -54,9 +54,6 @@ public:
   void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
-  edm::ParameterSet conf_;
-
-  std::string trackProducer;
   edm::EDGetTokenT<edm::View<reco::Track> > genericTracks;
   edm::EDGetTokenT<TrajTrackAssociationCollection> kfTrajectories;
   edm::EDGetTokenT<TrajGsfTrackAssociationCollection> gsfTrajectories;
@@ -77,8 +74,5 @@ private:
   bool filterOnConvTrackHyp;
   double minConvRadius;
   IdealHelixParameters ConvTrackPreSelector;
-  //--------------------------------------------------
-
-  std::unique_ptr<reco::ConversionTrackCollection> outputTrks;
 };
 #endif

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackProducer.h
@@ -14,7 +14,6 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/EgammaTrackReco/interface/ConversionTrack.h"
@@ -25,6 +24,9 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "TrackingTools/GsfTracking/interface/TrajGsfTrackAssociation.h"
@@ -71,6 +73,7 @@ private:
   // Reduction of the track sample based on geometric hypothesis for conversion tracks
 
   edm::EDGetTokenT<reco::BeamSpot> beamSpotInputTag;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken;
   bool filterOnConvTrackHyp;
   double minConvRadius;
   IdealHelixParameters ConvTrackPreSelector;

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
@@ -46,8 +46,10 @@ ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf)
       minConvRadius(conf.getParameter<double>("minConvRadius")) {
   edm::InputTag thetp(trackProducer);
   genericTracks = consumes<edm::View<reco::Track> >(thetp);
-  kfTrajectories = consumes<TrajTrackAssociationCollection>(thetp);
-  gsfTrajectories = consumes<TrajGsfTrackAssociationCollection>(thetp);
+  if (useTrajectory) {
+    kfTrajectories = consumes<TrajTrackAssociationCollection>(thetp);
+    gsfTrajectories = consumes<TrajGsfTrackAssociationCollection>(thetp);
+  }
   produces<reco::ConversionTrackCollection>();
 }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
@@ -101,11 +101,6 @@ void ConversionTrackProducer::produce(edm::Event& e, const edm::EventSetup& es) 
   edm::ESHandle<MagneticField> magFieldHandle;
   es.get<IdealMagneticFieldRecord>().get(magFieldHandle);
 
-  if (filterOnConvTrackHyp && !beamSpotHandle.isValid()) {
-    edm::LogError("Invalid Collection") << "invalid collection for the BeamSpot";
-    throw;
-  }
-
   ConvTrackPreSelector.setMagnField(magFieldHandle.product());
 
   //----------------------------------------------------------

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
@@ -29,9 +29,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf)
     : conf_(conf),
       trackProducer(conf.getParameter<std::string>("TrackProducer")),
@@ -50,6 +47,7 @@ ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf)
     kfTrajectories = consumes<TrajTrackAssociationCollection>(thetp);
     gsfTrajectories = consumes<TrajGsfTrackAssociationCollection>(thetp);
   }
+  magFieldToken = esConsumes<MagneticField, IdealMagneticFieldRecord>();
   produces<reco::ConversionTrackCollection>();
 }
 
@@ -91,10 +89,7 @@ void ConversionTrackProducer::produce(edm::Event& e, const edm::EventSetup& es) 
 
   math::XYZVector beamSpot{e.get(beamSpotInputTag).position()};
 
-  edm::ESHandle<MagneticField> magFieldHandle;
-  es.get<IdealMagneticFieldRecord>().get(magFieldHandle);
-
-  ConvTrackPreSelector.setMagnField(magFieldHandle.product());
+  ConvTrackPreSelector.setMagnField(&es.getData(magFieldToken));
 
   //----------------------------------------------------------
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
@@ -95,8 +95,7 @@ void ConversionTrackProducer::produce(edm::Event& e, const edm::EventSetup& es) 
   // 2011/08/05
   // Reduction of the track sample based on geometric hypothesis for conversion tracks
 
-  edm::Handle<reco::BeamSpot> beamSpotHandle;
-  e.getByToken(beamSpotInputTag, beamSpotHandle);
+  math::XYZVector beamSpot{e.get(beamSpotInputTag).position()};
 
   edm::ESHandle<MagneticField> magFieldHandle;
   es.get<IdealMagneticFieldRecord>().get(magFieldHandle);
@@ -112,7 +111,6 @@ void ConversionTrackProducer::produce(edm::Event& e, const edm::EventSetup& es) 
     // 2011/08/05
     // Reduction of the track sample based on geometric hypothesis for conversion tracks
 
-    math::XYZVector beamSpot = math::XYZVector(beamSpotHandle->position());
     edm::RefToBase<reco::Track> trackBaseRef = hTrks->refAt(i);
     if (filterOnConvTrackHyp &&
         ConvTrackPreSelector.isTangentPointDistanceLessThan(minConvRadius, trackBaseRef.get(), beamSpot))

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
@@ -30,9 +30,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf)
-    : conf_(conf),
-      trackProducer(conf.getParameter<std::string>("TrackProducer")),
-      useTrajectory(conf.getParameter<bool>("useTrajectory")),
+    : useTrajectory(conf.getParameter<bool>("useTrajectory")),
       setTrackerOnly(conf.getParameter<bool>("setTrackerOnly")),
       setIsGsfTrackOpen(conf.getParameter<bool>("setIsGsfTrackOpen")),
       setArbitratedEcalSeeded(conf.getParameter<bool>("setArbitratedEcalSeeded")),
@@ -41,7 +39,7 @@ ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf)
       beamSpotInputTag(consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpotInputTag"))),
       filterOnConvTrackHyp(conf.getParameter<bool>("filterOnConvTrackHyp")),
       minConvRadius(conf.getParameter<double>("minConvRadius")) {
-  edm::InputTag thetp(trackProducer);
+  edm::InputTag thetp(conf.getParameter<std::string>("TrackProducer"));
   genericTracks = consumes<edm::View<reco::Track> >(thetp);
   if (useTrajectory) {
     kfTrajectories = consumes<TrajTrackAssociationCollection>(thetp);
@@ -80,7 +78,7 @@ void ConversionTrackProducer::produce(edm::Event& e, const edm::EventSetup& es) 
   }
 
   // Step B: create empty output collection
-  outputTrks = std::make_unique<reco::ConversionTrackCollection>();
+  auto outputTrks = std::make_unique<reco::ConversionTrackCollection>();
 
   //--------------------------------------------------
   //Added by D. Giordano


### PR DESCRIPTION
#### PR description:

This PR is part of https://github.com/cms-sw/cmssw/issues/30074 even though it itself does not fix any workflow. The bare "throw" will lead to abort (*) because there is no exception to be thrown. On the other hand, the `beamSpotHandle->position() `will throw an exception if the product is missing (with much clearer message), so this PR proposes just remove the check.

(*) https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/slc7_amd64_gcc820/CMSSW_11_2_X_2020-06-01-2300/pyRelValMatrixLogs/run/135.9_ZMM_13+ZMMFS_13+HARVESTUP15FS+MINIAODMCUP15FS/step1_ZMM_13+ZMMFS_13+HARVESTUP15FS+MINIAODMCUP15FS.log

In addition this PR modernizes `ConversionTrackProducer` by
* Constructing BeamSpot position as `math::XYZVector` once
* Using `edm::Event::get()` instead of going via `edm::Handle`
* Consuming trajectory maps only if `useTrajectory == True`
* Using `edm::ESGetToken`
* Removing unnecessary member variables

#### PR validation:

Workflow 135.9 does not abort anymore (but it won't succeed either, the real fix is different but independent of this PR). Limited matrix runs.