### PR TITLE
Move SiStrip calibration DQM modules back to Sequence

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBiasHI_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBiasHI_cff.py
@@ -59,7 +59,4 @@ qualityStatistics = DQMEDAnalyzer("SiStripQualityStatistics",
                                   )
 
 # Sequence #
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-seqALCARECOSiStripCalZeroBiasTask = cms.Task(calZeroBiasClusters,APVPhases,consecutiveHEs)
-seqALCARECOSiStripCalZeroBias = cms.Sequence(ALCARECOSiStripCalZeroBiasHLT*HLTPixelActivityFilterForSiStripCalZeroBias*DCSStatusForSiStripCalZeroBias, seqALCARECOSiStripCalZeroBiasTask)
+seqALCARECOSiStripCalZeroBias = cms.Sequence(ALCARECOSiStripCalZeroBiasHLT*HLTPixelActivityFilterForSiStripCalZeroBias*DCSStatusForSiStripCalZeroBias*calZeroBiasClusters*APVPhases*consecutiveHEs)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBias_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBias_cff.py
@@ -53,10 +53,7 @@ qualityStatistics = DQMEDAnalyzer("SiStripQualityStatistics",
                                   )
 
 # Sequence #
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-seqALCARECOSiStripCalZeroBiasTask = cms.Task(calZeroBiasClusters,APVPhases,consecutiveHEs)
-seqALCARECOSiStripCalZeroBias = cms.Sequence(ALCARECOSiStripCalZeroBiasHLT*DCSStatusForSiStripCalZeroBias, seqALCARECOSiStripCalZeroBiasTask)
+seqALCARECOSiStripCalZeroBias = cms.Sequence(ALCARECOSiStripCalZeroBiasHLT*DCSStatusForSiStripCalZeroBias*calZeroBiasClusters*APVPhases*consecutiveHEs)
 
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBias_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBias_cff.py
@@ -71,10 +71,7 @@ HLTPixelActivityFilterForSiStripCalZeroBias = HLTrigger.special.hltPixelActivity
 HLTPixelActivityFilterForSiStripCalZeroBias.maxClusters = 500
 HLTPixelActivityFilterForSiStripCalZeroBias.inputTag    = 'siPixelClusters'
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-seqALCARECOSiStripCalZeroBiasHITask = cms.Task(calZeroBiasClusters, APVPhases,consecutiveHEs)
-seqALCARECOSiStripCalZeroBiasHI = cms.Sequence(ALCARECOSiStripCalZeroBiasHLT*HLTPixelActivityFilterForSiStripCalZeroBias*DCSStatusForSiStripCalZeroBias, seqALCARECOSiStripCalZeroBiasHITask)
+seqALCARECOSiStripCalZeroBiasHI = cms.Sequence(ALCARECOSiStripCalZeroBiasHLT*HLTPixelActivityFilterForSiStripCalZeroBias*DCSStatusForSiStripCalZeroBias*calZeroBiasClusters*APVPhases*consecutiveHEs)
 
 #Specify we want to use our other sequence 
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(seqALCARECOSiStripCalZeroBias,

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_HeavyIons_cff.py
@@ -45,11 +45,8 @@ MonitorTrackResiduals_hi.Mod_On              = False
 
 
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-SiStripDQMTier0_hiTask = cms.Task(APVPhases, consecutiveHEs)
-SiStripDQMTier0_hi = cms.Sequence(siStripFEDCheck * siStripFEDMonitor *
+SiStripDQMTier0_hi = cms.Sequence(APVPhases * consecutiveHEs *
+                                  siStripFEDCheck * siStripFEDMonitor *
                                   SiStripMonitorDigi * SiStripMonitorCluster *
                                   SiStripMonitorTrack_hi *
-                                  MonitorTrackResiduals_hi,
-                                  SiStripDQMTier0_hiTask)
+                                  MonitorTrackResiduals_hi)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -152,30 +152,21 @@ from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 #    *SiStripMonitorTrackMB*MonitorTrackResiduals
 #    *dqmInfoSiStrip)
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-SiStripDQMTier0Task = cms.Task(APVPhases,consecutiveHEs)
 SiStripDQMTier0 = cms.Sequence(
-    siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
+    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackCommon*SiStripMonitorTrackIB*refittedForPixelDQM*MonitorTrackResiduals
-    *dqmInfoSiStrip, SiStripDQMTier0Task)
+    *dqmInfoSiStrip)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-SiStripDQMTier0CommonTask = cms.Task(APVPhases,consecutiveHEs)
 SiStripDQMTier0Common = cms.Sequence(
-    siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
+    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
     *SiStripMonitorTrackCommon*SiStripMonitorTrackIB
-    *dqmInfoSiStrip, SiStripDQMTier0CommonTask)
+    *dqmInfoSiStrip)
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-SiStripDQMTier0MinBiasTask = cms.Task(APVPhases,consecutiveHEs)
 SiStripDQMTier0MinBias = cms.Sequence(
-    siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
+    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackMB*SiStripMonitorTrackIB*refittedForPixelDQM*MonitorTrackResiduals
-    *dqmInfoSiStrip, SiStripDQMTier0MinBiasTask)
+    *dqmInfoSiStrip)
 
 
 

--- a/DQMOffline/CalibTracker/python/ALCARECOSiStripCalMinBiasDQMHI_cff.py
+++ b/DQMOffline/CalibTracker/python/ALCARECOSiStripCalMinBiasDQMHI_cff.py
@@ -43,7 +43,4 @@ ALCARECOSiStripCalMinBiasTrackerDQM = DQMOffline.Alignment.TkAlCaRecoMonitor_cfi
 # Sequence #
 #------------
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-ALCARECOSiStripCalMinBiasDQMTask = cms.Task(ALCARECOSiStripCalMinBiasTrackingDQM , ALCARECOSiStripCalMinBiasTrackerDQM)
-ALCARECOSiStripCalMinBiasDQM = cms.Sequence(ALCARECOSiStripCalMinBiasDQMTask)
+ALCARECOSiStripCalMinBiasDQM = cms.Sequence( ALCARECOSiStripCalMinBiasTrackingDQM + ALCARECOSiStripCalMinBiasTrackerDQM)

--- a/DQMOffline/CalibTracker/python/ALCARECOSiStripCalMinBiasDQM_cff.py
+++ b/DQMOffline/CalibTracker/python/ALCARECOSiStripCalMinBiasDQM_cff.py
@@ -39,5 +39,4 @@ ALCARECOSiStripCalMinBiasTrackerDQM = DQMOffline.Alignment.TkAlCaRecoMonitor_cfi
 # Sequence #
 #------------
 
-ALCARECOSiStripCalMinBiasDQMTask = cms.Task(ALCARECOSiStripCalMinBiasTrackingDQM , ALCARECOSiStripCalMinBiasTrackerDQM)
-ALCARECOSiStripCalMinBiasDQM = cms.Sequence(ALCARECOSiStripCalMinBiasDQMTask)
+ALCARECOSiStripCalMinBiasDQM = cms.Sequence( ALCARECOSiStripCalMinBiasTrackingDQM + ALCARECOSiStripCalMinBiasTrackerDQM)

--- a/DQMOffline/CalibTracker/python/ALCARECOSiStripCalZeroBiasDQMHI_cff.py
+++ b/DQMOffline/CalibTracker/python/ALCARECOSiStripCalZeroBiasDQMHI_cff.py
@@ -17,8 +17,5 @@ from DPGAnalysis.SiStripTools.FilterSequenceForAlCaRecoDQM_cfi import *
 # Sequence #
 #------------
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-ALCARECOSiStripCalZeroBiasDQMTask = cms.Task(SiStripCalZeroBiasMonitorCluster)
-ALCARECOSiStripCalZeroBiasDQM = cms.Sequence(seqAPVCycleFilter,
-                                             ALCARECOSiStripCalZeroBiasDQMTask)
+ALCARECOSiStripCalZeroBiasDQM = cms.Sequence(seqAPVCycleFilter*
+                                             SiStripCalZeroBiasMonitorCluster)

--- a/DQMOffline/CalibTracker/python/ALCARECOSiStripCalZeroBiasDQM_cff.py
+++ b/DQMOffline/CalibTracker/python/ALCARECOSiStripCalZeroBiasDQM_cff.py
@@ -17,8 +17,5 @@ from DPGAnalysis.SiStripTools.FilterSequenceForAlCaRecoDQM_cfi import *
 # Sequence #
 #------------
 
-# Short-term workaround to preserve the "run for every event" while removing the use of convertToUnscheduled()
-# To be reverted in a subsequent PR
-ALCARECOSiStripCalZeroBiasDQMTask = cms.Task(SiStripCalZeroBiasMonitorCluster)
-ALCARECOSiStripCalZeroBiasDQM = cms.Sequence(seqFilters,
-                                             ALCARECOSiStripCalZeroBiasDQMTask)
+ALCARECOSiStripCalZeroBiasDQM = cms.Sequence(seqFilters*
+                                             SiStripCalZeroBiasMonitorCluster)


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to #29630 and reverts the changes made to SiStrip calibration DQM modules by moving them back to Sequences, i.e. to be run only if the preceding filters keep processing the event.

#### PR validation:

Limited matrix runs, expecting changes in SiStrip AlcaReco DQM plots.

