### PR TITLE
Move EDProducers in HLT tracking validation sequences to Tasks

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -74,11 +74,11 @@ prevalidation_preprod = cms.Sequence( preprodPrevalidation )
 validation_preprodNoHLT = cms.Sequence(
                             genvalid_all
                             +trackingTruthValid
+                            +tracksValidation
                             +METRelValSequence
                             +recoMuonValidation
                             +muIsoVal_seq
                             +muonIdValDQMSeq
-                            ,tracksValidation
                           )
 
 validation_preprod = cms.Sequence(

--- a/FastSimulation/Validation/test/TrackRecoAndValidation_FullSim_cfg.py
+++ b/FastSimulation/Validation/test/TrackRecoAndValidation_FullSim_cfg.py
@@ -118,6 +118,6 @@ process.reconstruction = cms.Sequence(
 
 # redefine validation paths
 process.prevalidation = cms.Sequence(process.tracksPreValidation)
-process.validation = cms.Sequence(process.trackingTruthValid , process.tracksValidation)
+process.validation = cms.Sequence(process.trackingTruthValid + process.tracksValidation)
 
 # END MODIFICATIONS

--- a/FastSimulation/Validation/test/TrackRecoAndValidation_cfg.py
+++ b/FastSimulation/Validation/test/TrackRecoAndValidation_cfg.py
@@ -116,5 +116,5 @@ process = customisePostLS1(process)
 # BEGIN MODIFICATIONS
 # redefine validation paths
 process.prevalidation = cms.Sequence(process.tracksPreValidation)
-process.validation = cms.Sequence(process.trackingTruthValid , process.tracksValidationFS)
+process.validation = cms.Sequence(process.trackingTruthValid + process.tracksValidationFS)
 # END MODIFICATIONS

--- a/HLTriggerOffline/Egamma/python/HLTmultiTrackValidatorGsfTracks_cff.py
+++ b/HLTriggerOffline/Egamma/python/HLTmultiTrackValidatorGsfTracks_cff.py
@@ -23,9 +23,12 @@ hltGsfTrackValidator = hltMultiTrackValidator.clone(
 )
 
 from Validation.RecoTrack.TrackValidation_cff import trackingParticlesElectron
+hltMultiTrackValidationGsfTracksTask = cms.Task(
+   hltTPClusterProducer
+   , hltTrackAssociatorByHits
+   , trackingParticlesElectron
+ )
 hltMultiTrackValidationGsfTracks = cms.Sequence(
-    hltTPClusterProducer
-    + hltTrackAssociatorByHits
-    + cms.ignore(trackingParticlesElectron)    
-    + hltGsfTrackValidator
+    hltGsfTrackValidator,
+    hltMultiTrackValidationGsfTracksTask
 )    

--- a/HLTriggerOffline/Muon/python/HLTmultiTrackValidatorMuonTracks_cff.py
+++ b/HLTriggerOffline/Muon/python/HLTmultiTrackValidatorMuonTracks_cff.py
@@ -23,9 +23,12 @@ hltMuonTrackValidator = hltMultiTrackValidator.clone(
 
 from Validation.RecoTrack.TrackValidation_cff import trackingParticlesElectron
 trackingParticlesMuon = trackingParticlesElectron.clone(pdgId = [-13, 13])
-hltMultiTrackValidationMuonTracks = cms.Sequence(
+hltMultiTrackValidationMuonTracksTask = cms.Task(
     hltTPClusterProducer
-    + hltTrackAssociatorByHits
-    + cms.ignore(trackingParticlesMuon)
-    + hltMuonTrackValidator
+    , hltTrackAssociatorByHits
+    , trackingParticlesMuon
+)
+hltMultiTrackValidationMuonTracks = cms.Sequence(
+    hltMuonTrackValidator,
+    hltMultiTrackValidationMuonTracksTask
 )

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -50,8 +50,8 @@ from Validation.SiTrackerPhase2V.Phase2TrackerValidationFirstStep_cff import *
 # filter/producer "pre-" sequence for globalValidation
 globalPrevalidationTracking = cms.Sequence(
     simHitTPAssocProducer
+  * tracksValidation
   * vertexValidation
-  , tracksValidation
 )
 globalPrevalidation = cms.Sequence(
     globalPrevalidationTracking
@@ -128,16 +128,16 @@ baseCommonValidation = cms.Sequence()
 # Tracking-only validation
 globalPrevalidationTrackingOnly = cms.Sequence(
       simHitTPAssocProducer
+    + tracksValidationTrackingOnly
     + vertexValidationTrackingOnly
-    , tracksValidationTrackingOnly
 )
 globalValidationTrackingOnly = cms.Sequence()
 
 # Pixel tracking only validation
 globalPrevalidationPixelTrackingOnly = cms.Sequence(
       simHitTPAssocProducer
+    + tracksValidationPixelTrackingOnly
     + vertexValidationPixelTrackingOnly
-    , tracksValidationPixelTrackingOnly
 )
 globalValidationPixelTrackingOnly = cms.Sequence()
 

--- a/Validation/RecoMuon/python/RelValCustoms.py
+++ b/Validation/RecoMuon/python/RelValCustoms.py
@@ -9,9 +9,9 @@ def validation_only(process):
     process.trackMCMatchSequence.remove(process.assoc2GsfTracks)
     process.only_validation_and_TP = cms.Sequence(process.mix
                                                   *process.trackingParticles
+                                                  *process.tracksValidation
                                                   *process.recoMuonValidation
                                                   *process.HLTMuonVal
-                                                  ,process.tracksValidation
                                                   )
     process.validation_step.replace(process.validation,process.only_validation_and_TP)
     

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -19,9 +19,12 @@ hltTrackValidator = hltMultiTrackValidator.clone(
     ]
 )
 
-hltMultiTrackValidation = cms.Sequence(
+hltMultiTrackValidationTask = cms.Task(
     hltTPClusterProducer
-    + trackingParticleNumberOfLayersProducer
-    + hltTrackAssociatorByHits
-    + hltTrackValidator
+    , trackingParticleNumberOfLayersProducer
+    , hltTrackAssociatorByHits
+)
+hltMultiTrackValidation = cms.Sequence(
+    hltTrackValidator,
+    hltMultiTrackValidationTask
 )

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -674,27 +674,27 @@ fastSim.toReplaceWith(tracksPreValidation, tracksPreValidation.copyAndExclude([
 
 
 
-tracksValidation = cms.Task(
-    trackValidator,
-    trackValidatorTPPtLess09,
-    trackValidatorFromPV,
-    trackValidatorFromPVAllTP,
-    trackValidatorAllTPEffic,
-    trackValidatorBuilding,
-    trackValidatorBuildingPreSplitting,
-    trackValidatorConversion,
+tracksValidation = cms.Sequence(
+    trackValidator +
+    trackValidatorTPPtLess09 +
+    trackValidatorFromPV +
+    trackValidatorFromPVAllTP +
+    trackValidatorAllTPEffic +
+    trackValidatorBuilding +
+    trackValidatorBuildingPreSplitting +
+    trackValidatorConversion +
     trackValidatorGsfTracks,
     tracksPreValidation
 )
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-#tracksValidationPhase2 = cms.Task(tracksValidation,trackValidatorTPEtaGreater2p7) # it does not work
+#tracksValidationPhase2 = cms.Sequence(tracksValidation+trackValidatorTPEtaGreater2p7) # it does not work
 tracksPreValidationPhase2 = tracksPreValidation.copy()
 tracksPreValidationPhase2.add(trackingParticlesEtaGreater2p7)
 phase2_tracker.toReplaceWith(tracksPreValidation, tracksPreValidationPhase2)
 
 tracksValidationPhase2 = tracksValidation.copy()
-tracksValidationPhase2.add(trackValidatorTPEtaGreater2p7)
+tracksValidationPhase2+=trackValidatorTPEtaGreater2p7
 phase2_tracker.toReplaceWith(tracksValidation, tracksValidationPhase2)
 
 
@@ -771,7 +771,7 @@ trackValidatorGsfTracksStandalone = trackValidatorGsfTracks.clone(
     cores = "highPtJets"
 )
 
-# tasks
+# sequences
 tracksPreValidationStandalone = tracksPreValidation.copy()
 tracksPreValidationStandalone.add(trackingParticlesBHadron)
 tracksPreValidationStandalone.replace(highPtJetsForTrk,highPtJets)
@@ -786,32 +786,29 @@ tracksValidationSelectorsStandalone = cms.Task(
 
 # we copy this for both Standalone and TrackingOnly
 #  and later make modifications from it which change based on era
-_trackValidatorsBase = cms.Task(
-    trackValidatorStandalone,
-    trackValidatorTPPtLess09Standalone,
-    trackValidatorFromPVStandalone,
-    trackValidatorFromPVAllTPStandalone,
-    trackValidatorAllTPEfficStandalone,
-    trackValidatorConversionStandalone,
-    trackValidatorGsfTracksStandalone,
+_trackValidatorsBase = cms.Sequence(
+    trackValidatorStandalone +
+    trackValidatorTPPtLess09Standalone +
+    trackValidatorFromPVStandalone +
+    trackValidatorFromPVAllTPStandalone +
+    trackValidatorAllTPEfficStandalone +
+    trackValidatorConversionStandalone +
+    trackValidatorGsfTracksStandalone +
     trackValidatorBHadronStandalone
 )
 
 _trackValidatorsBasePhase2 = _trackValidatorsBase.copy()
-_trackValidatorsBasePhase2.add(trackValidatorTPEtaGreater2p7)
+_trackValidatorsBasePhase2+=trackValidatorTPEtaGreater2p7
 phase2_tracker.toReplaceWith(_trackValidatorsBase, _trackValidatorsBasePhase2)
 
 trackValidatorsStandalone = _trackValidatorsBase.copy()
 fastSim.toModify(trackValidatorsStandalone, lambda x: x.remove(trackValidatorConversionStandalone) )
 
-tracksValidationStandaloneTask = cms.Task(
+tracksValidationStandalone = cms.Sequence(
+    ak4PFL1FastL2L3CorrectorChain +
     trackValidatorsStandalone,
     tracksPreValidationStandalone,
     tracksValidationSelectorsStandalone
-)
-tracksValidationStandalone = cms.Sequence(
-    ak4PFL1FastL2L3CorrectorChain,
-    tracksValidationStandaloneTask
 )
 
 ### TrackingOnly mode (i.e. MTV with DIGI input + tracking-only reconstruction)
@@ -853,7 +850,7 @@ trackValidatorTPPtLess09TrackingOnly = trackValidatorTPPtLess09Standalone.clone(
 trackValidatorFromPVTrackingOnly = trackValidatorFromPVStandalone.clone(cores = "highPtJetsForTrk")
 trackValidatorFromPVAllTPTrackingOnly = trackValidatorFromPVAllTPStandalone.clone(cores = "highPtJetsForTrk")
 trackValidatorAllTPEfficTrackingOnly = trackValidatorAllTPEfficStandalone.clone(cores = "highPtJetsForTrk")
-# tasks
+# sequences
 tracksPreValidationTrackingOnly = tracksPreValidationStandalone.copy()
 tracksPreValidationTrackingOnly.replace(tracksValidationSelectors, tracksValidationSelectorsTrackingOnly)
 tracksPreValidationTrackingOnly.replace(highPtJets,highPtJetsForTrk)
@@ -864,10 +861,10 @@ trackValidatorsTrackingOnly.replace(trackValidatorTPPtLess09Standalone,trackVali
 trackValidatorsTrackingOnly.replace(trackValidatorFromPVStandalone,trackValidatorFromPVTrackingOnly)
 trackValidatorsTrackingOnly.replace(trackValidatorFromPVAllTPStandalone,trackValidatorFromPVAllTPTrackingOnly)
 trackValidatorsTrackingOnly.replace(trackValidatorAllTPEfficStandalone,trackValidatorAllTPEfficTrackingOnly)
-trackValidatorsTrackingOnly.add(trackValidatorSeedingTrackingOnly,
-                                trackValidatorSeedingPreSplittingTrackingOnly,
-                                trackValidatorBuilding,
-                                trackValidatorBuildingPreSplitting)
+trackValidatorsTrackingOnly += trackValidatorSeedingTrackingOnly
+trackValidatorsTrackingOnly += trackValidatorSeedingPreSplittingTrackingOnly
+trackValidatorsTrackingOnly += trackValidatorBuilding
+trackValidatorsTrackingOnly += trackValidatorBuildingPreSplitting
 trackValidatorsTrackingOnly.replace(trackValidatorConversionStandalone, trackValidatorConversionTrackingOnly)
 trackValidatorsTrackingOnly.remove(trackValidatorGsfTracksStandalone)
 trackValidatorsTrackingOnly.replace(trackValidatorBHadronStandalone, trackValidatorBHadronTrackingOnly)
@@ -878,7 +875,7 @@ fastSim.toReplaceWith(trackValidatorsTrackingOnly, trackValidatorsTrackingOnly.c
     trackValidatorBHadronTrackingOnly
 ]))
 
-tracksValidationTrackingOnly = cms.Task(
+tracksValidationTrackingOnly = cms.Sequence(
     trackValidatorsTrackingOnly,
     tracksPreValidationTrackingOnly,
     tracksValidationSelectorsStandalone,
@@ -910,7 +907,7 @@ trackValidatorPixelTrackingOnly = trackValidator.clone(
 tracksValidationTruthPixelTrackingOnly = tracksValidationTruth.copy()
 tracksValidationTruthPixelTrackingOnly.replace(trackingParticleRecoTrackAsssociation, trackingParticlePixelTrackAsssociation)
 tracksValidationTruthPixelTrackingOnly.replace(VertexAssociatorByPositionAndTracks, PixelVertexAssociatorByPositionAndTracks)
-tracksValidationPixelTrackingOnly = cms.Task(
+tracksValidationPixelTrackingOnly = cms.Sequence(
     trackValidatorPixelTrackingOnly,
     tracksValidationTruthPixelTrackingOnly
 )
@@ -920,8 +917,8 @@ tracksValidationPixelTrackingOnly = cms.Task(
 trackValidatorLite = trackValidator.clone(
     label = ["generalTracks", "cutsRecoTracksHp"]
 )
-tracksValidationLite = cms.Task(
-    cutsRecoTracksHp,
+tracksValidationLite = cms.Sequence(
+    cutsRecoTracksHp +
     trackValidatorLite,
     tracksValidationTruth
 )

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -42,16 +42,16 @@ hltPVanalysis.vertexRecoCollections   = cms.VInputTag(
 #    "hltFastPVPixelVertices"
 )
 
-hltMultiPVAssociations = cms.Sequence(
-    hltTrackAssociatorByHits +
-    tpToHLTpixelTrackAssociation +
-    vertexAssociatorByPositionAndTracks4pixelTracks +
-    tpToHLTpfMuonMergingTrackAssociation +
+hltMultiPVAssociations = cms.Task(
+    hltTrackAssociatorByHits,
+    tpToHLTpixelTrackAssociation,
+    vertexAssociatorByPositionAndTracks4pixelTracks,
+    tpToHLTpfMuonMergingTrackAssociation,
     vertexAssociatorByPositionAndTracks4pfMuonMergingTracks
 )
 
 hltMultiPVValidation = cms.Sequence( 
-    hltMultiPVAssociations +
     hltPixelPVanalysis
-    + hltPVanalysis
+    + hltPVanalysis,
+    hltMultiPVAssociations
 )

--- a/Validation/TrackerConfiguration/test/ValidationChainOnly_cfg.py
+++ b/Validation/TrackerConfiguration/test/ValidationChainOnly_cfg.py
@@ -74,6 +74,6 @@ process.StripTrackingRecHitsValid.outputFile='striptrackingrechitshisto.root'
 process.simhits = cms.Sequence(process.trackerHitsValidation)
 process.digis = cms.Sequence(process.trackerDigisValidation)
 process.rechits = cms.Sequence(process.siPixelRecHits*process.siStripMatchedRecHits*process.trackerRecHitsValidation)
-process.tracks = cms.Sequence(process.trackingTruthValid,process.tracksValidation)
+process.tracks = cms.Sequence(process.trackingTruthValid*process.tracksValidation)
 process.trackinghits = cms.Sequence(process.TrackRefitter*process.trackingRecHitsValid)
 process.p1 = cms.Path(process.mix*process.simhits*process.digis*process.rechits*process.tracks*process.trackinghits)


### PR DESCRIPTION
#### PR description:

It appears I was too aggressive in https://github.com/cms-sw/cmssw/pull/29630 when moving all EDProducers and DQM modules from Sequences to Tasks in tracking validation configuration (https://github.com/cms-sw/cmssw/pull/29630/commits/d054368b008751c6fd5dff134e0259ae27d9a1ae). Moving also DQM modules (that are EDProducers using the Accumulator extension) to Tasks caused these modules to be run on each event even though the intention is to run them only if some EDFilter(s) keep the event. Therefore these DQM modules need to be kept in a Sequence (or in general, if a Sequence with Accumulators is (potentially) used also in conjunction with EDFilters that may reject events, the Accumulators should be kept in the Sequence).

The first commit in this PR reverts https://github.com/cms-sw/cmssw/pull/29630/commits/d054368b008751c6fd5dff134e0259ae27d9a1ae. The second commit is a more proper fix to the "unrunnable schedule" error I tried to fix with https://github.com/cms-sw/cmssw/pull/29630/commits/d054368b008751c6fd5dff134e0259ae27d9a1ae. The proposed fix is to move all non-Accumulator EDProducers from HLT tracking validation Sequences to Task (in offline tracking validation they pretty much all are already in Tasks).

Part of https://github.com/cms-sw/cmssw/issues/30074. Should fix all the workflows that failed with `SIBABRT` in https://github.com/cms-sw/cmssw/issues/30074 (the `abort()` itself is changed to an exception in #30082).

#### PR validation:

Limited matrix and workflows `135.9,2017.9,2018.9,25406.0,25406.17,25406.0,25406.17,25406.18` run.