### PR TITLE
Adding new R9 plots to ECAL

### DIFF
--- a/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
@@ -184,6 +184,42 @@ ecalClusterTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Distribution of E_seed / E_3x3 of the super clusters.')
         ),
+        SCR9Raw = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC R9 Raw'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1.2),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0)
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Distribution of E_seed / E_3x3 of the super clusters. Uses raw energy definition')
+        ),
+        SCR9Full = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC R9 Full'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1.2),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0)
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Distribution of E_seed / E_3x3 of the super clusters. Uses full E_3x3 definition')
+        ),
+        SCR9FullRaw = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC R9 Full Raw'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1.2),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0)
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Distribution of E_seed / E_3x3 of the super clusters. Uses full E_3x3 and raw energy definition')
+        ),
         SCNum = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC number'),
             kind = cms.untracked.string('TH1F'),
@@ -236,6 +272,19 @@ ecalClusterTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Super cluster energy distribution.')
         ),
+        SCRawE = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC raw energy'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(150.0),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Super cluster raw energy distribution.')
+        ),
         SCNcrystals = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC size (crystal)'),
             kind = cms.untracked.string('TH1F'),
@@ -276,6 +325,19 @@ ecalClusterTask = cms.untracked.PSet(
         ),
         SCELow = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC energy (low scale)'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(10.0),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Energy distribution (raw energy) of the super clusters (low scale).')
+        ),
+        SCRawELow = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC raw energy (low scale)'),
             kind = cms.untracked.string('TH1F'),
             otype = cms.untracked.string('Ecal2P'),
             xaxis = cms.untracked.PSet(

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -366,6 +366,8 @@ namespace ecaldqm {
 
     MESet& meSCE(MEs_.at("SCE"));
     MESet& meSCELow(MEs_.at("SCELow"));
+    MESet& meSCRawE(MEs_.at("SCRawE"));
+    MESet& meSCRawELow(MEs_.at("SCRawELow"));
     MESet& meSCNBCs(MEs_.at("SCNBCs"));
     MESet& meSCNcrystals(MEs_.at("SCNcrystals"));
     MESet& meTrendSCSize(MEs_.at("TrendSCSize"));
@@ -374,6 +376,9 @@ namespace ecaldqm {
     MESet& meSCSeedOccupancy(MEs_.at("SCSeedOccupancy"));
     MESet& meSingleCrystalCluster(MEs_.at("SingleCrystalCluster"));
     MESet& meSCR9(MEs_.at("SCR9"));
+    MESet& meSCR9Raw(MEs_.at("SCR9Raw"));
+    MESet& meSCR9Full(MEs_.at("SCR9Full"));
+    MESet& meSCR9FullRaw(MEs_.at("SCR9FullRaw"));
 
     MESet* meSCSizeVsEnergy(doExtra_ ? &MEs_.at("SCSizeVsEnergy") : nullptr);
     MESet* meSCSeedOccupancyHighE(doExtra_ ? &MEs_.at("SCSeedOccupancyHighE") : nullptr);
@@ -414,10 +419,14 @@ namespace ecaldqm {
       ++nSC;
 
       float energy(scItr->energy());
+      float rawEnergy(scItr->rawEnergy());
       float size(scItr->size());
 
       meSCE.fill(seedId, energy);
       meSCELow.fill(seedId, energy);
+
+      meSCRawE.fill(seedId, rawEnergy);
+      meSCRawELow.fill(seedId, rawEnergy);
 
       meSCNBCs.fill(seedId, scItr->clustersSize());
       meSCNcrystals.fill(seedId, size);
@@ -438,7 +447,12 @@ namespace ecaldqm {
         meSingleCrystalCluster.fill(seedId);
 
       float e3x3(EcalClusterTools::e3x3(*scItr->seed(), hits, getTopology()));
+      float e3x3Full(noZS::EcalClusterTools::e3x3(*scItr->seed(), hits, getTopology()));
+
       meSCR9.fill(seedId, e3x3 / energy);
+      meSCR9Raw.fill(seedId, e3x3 / rawEnergy);
+      meSCR9Full.fill(seedId, e3x3Full / energy);
+      meSCR9FullRaw.fill(seedId, e3x3Full / rawEnergy);
 
       if (doExtra_) {
         for (unsigned iT(0); iT != nTriggerTypes; ++iT) {


### PR DESCRIPTION
#### PR description:

Since some sections of the current ECAL DQM code were written originally, there have been some minor changes in how variables important to the monitoring are commonly understood by ECAL experts. Specifically, there are a few ways of defining R9, all of which might give slightly different values for the variable -- whether to use the zero-suppressed energy, whether to use the raw values for the energy, and so on. And so the current plots are sometimes a little difficult to interpret -- for example, there was an inconsistency noted in the R9 1D distributions between UL and EOY rereco for some samples, and we are investigating whether this has to do with the old definition.

#### PR validation:

Validation of added SC energy and R9 definitions have been done by processing some sample runs with ECAL DQM code and uploading them to a private DQM GUI. Plots appear to have no issues.