### PR TITLE
Move EDProducers from Sequences to Tasks in L1T DQM and Validation configurations

### DIFF
--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -85,17 +85,23 @@ l1ExpertDataVsEmulator = cms.Sequence(
                                 )
 
 
+l1EmulatorMonitorTask = cms.Task(
+    l1GtUnpack
+)
 l1EmulatorMonitor = cms.Sequence(
-                            l1GtUnpack* 
                             l1demon+
-                            l1ExpertDataVsEmulator             
+                            l1ExpertDataVsEmulator,
+                            l1EmulatorMonitorTask
                             )
 
 # for use in processes where hardware validation is not run
+l1HwValEmulatorMonitorTask = cms.Task(
+    l1GtUnpack
+)
 l1HwValEmulatorMonitor = cms.Sequence(
-                                l1GtUnpack* 
                                 L1HardwareValidation*
-                                l1EmulatorMonitor
+                                l1EmulatorMonitor,
+                                l1HwValEmulatorMonitorTask
                                 )
 
 # for stage1
@@ -115,11 +121,14 @@ l1EmulatorMonitorStage1 = cms.Sequence(
     l1ExpertDataVsEmulatorStage1
     )
 
+l1Stage1HwValEmulatorMonitorTask = cms.Task(
+    rctDigis,
+    #caloStage1Digis,
+    #caloStage1LegacyFormatDigis,
+    l1GtUnpack
+)
 l1Stage1HwValEmulatorMonitor = cms.Sequence(
-    rctDigis*
-    #caloStage1Digis*
-    #caloStage1LegacyFormatDigis*
-    l1GtUnpack*
     L1HardwareValidationforStage1 +
-    l1EmulatorMonitorStage1                            
+    l1EmulatorMonitorStage1,
+    l1Stage1HwValEmulatorMonitorTask
     )

--- a/DQM/L1TMonitor/python/L1TMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TMonitor_cff.py
@@ -129,25 +129,34 @@ l1tStage1Layer2Seq = cms.Sequence(
 # for L1ExtraDQM, one must run GGT and GMT/GT unpacker and L1Extra producer 
 # with special configurations
 
+l1ExtraDqmTask = cms.Task(
+    dqmGctDigis,
+    dqmGtDigis,
+    dqmL1ExtraParticles
+)
 l1ExtraDqmSeq = cms.Sequence(
-                        dqmGctDigis *
-                        dqmGtDigis *
-                        dqmL1ExtraParticles * 
-                        l1ExtraDQM
+                        l1ExtraDQM,
+                        l1ExtraDqmTask
                         )
 
+l1ExtraStage1DqmTask = cms.Task(
+    dqmGtDigis,
+    dqmL1ExtraParticlesStage1
+)
 l1ExtraStage1DqmSeq = cms.Sequence(
-    dqmGtDigis *
-    dqmL1ExtraParticlesStage1 *
-    l1ExtraDQMStage1
+    l1ExtraDQMStage1,
+    l1ExtraStage1DqmTask
     )
 
 
 # L1T monitor sequence 
 #     modules are independent, so the order is irrelevant 
 
+l1tMonitorOnlineTask = cms.Task(
+    l1GtUnpack
+
+)
 l1tMonitorOnline = cms.Sequence(
-                          l1GtUnpack*
                           bxTiming +
                           l1tDttf +
                           l1tCsctf + 
@@ -158,26 +167,30 @@ l1tMonitorOnline = cms.Sequence(
                           l1tBPTX +
                           l1tRate +
                           l1tRctRun1 +
-                          l1tGctSeq
+                          l1tGctSeq,
+                          l1tMonitorOnlineTask
                           )
 
+l1tMonitorStage1OnlineTask = cms.Task(
+    l1GtUnpack,
+    rctDigis,
+    caloStage1Digis,
+    caloStage1LegacyFormatDigis
+)
 l1tMonitorStage1Online = cms.Sequence(
-                          l1GtUnpack*
                           bxTiming +
                           l1tDttf +
                           l1tCsctf + 
                           l1tRpctf +
                           l1tGmt +
                           l1tGt +
-                          rctDigis *
-                          caloStage1Digis *
-                          caloStage1LegacyFormatDigis*
                           l1ExtraStage1DqmSeq +
                           #l1tBPTX +
                           #l1tRate +
                           l1tStage1Layer2Seq +
                           #l1tRctRun1 +
-                          l1tRctSeq 
+                          l1tRctSeq,
+                          l1tMonitorStage1OnlineTask
                           )
 
 

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -343,11 +343,12 @@ Stage2l1tMuonOffline = cms.Sequence(
 
 ##############################################################################
 # Emulator sequences
+Stage2l1TriggerEmulatorOnlineTask = cms.Task(valHcalTriggerPrimitiveDigis)
 Stage2l1TriggerEmulatorOnline = cms.Sequence(
-                                 valHcalTriggerPrimitiveDigis +
                                  Stage2L1HardwareValidation +
                                  l1tStage2EmulatorOnlineDQM +
-                                 dqmEnvL1TEMU
+                                 dqmEnvL1TEMU,
+                                 Stage2l1TriggerEmulatorOnlineTask
                                 )
 # Do not include the uGT emulation online DQM module in the offline
 # sequence since the large 2D histograms cause crashes at the T0.

--- a/L1Trigger/Configuration/python/ValL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/ValL1Emulator_cff.py
@@ -173,21 +173,22 @@ valStage1GtDigis.TechnicalTriggersInputTags = cms.VInputTag(
                                                     cms.InputTag('valRpcTechTrigDigis'),
                                                     cms.InputTag('valHcalTechTrigDigis')                                         )
 
-# L1 Trigger sequences
-ValL1MuTriggerPrimitives = cms.Sequence(valCscTriggerPrimitiveDigis+valDtTriggerPrimitiveDigis)
-ValL1MuTrackFinders = cms.Sequence(valCsctfTrackDigis*valCsctfDigis*valDttfDigis)
+# L1 Trigger tasks
+ValL1MuTriggerPrimitives = cms.Task(valCscTriggerPrimitiveDigis,valDtTriggerPrimitiveDigis)
+ValL1MuTrackFinders = cms.Task(valCsctfTrackDigis,valCsctfDigis,valDttfDigis)
 
-ValL1TechnicalTriggers = cms.Sequence(valRpcTechTrigDigis+valHcalTechTrigDigis)
+ValL1TechnicalTriggers = cms.Task(valRpcTechTrigDigis,valHcalTechTrigDigis)
 
-ValL1Emulator = cms.Sequence(
+ValL1Emulator = cms.Task(
     valEcalTriggerPrimitiveDigis
-    *valHcalTriggerPrimitiveDigis
-    *valHcalTTPDigis
-    *valRctDigis
-    *valGctDigis
-    *ValL1MuTriggerPrimitives*ValL1MuTrackFinders*valRpcTriggerDigis*valGmtDigis
-    *ValL1TechnicalTriggers
-    *valGtDigis)
+    ,valHcalTriggerPrimitiveDigis
+    ,valHcalTTPDigis
+    ,valRctDigis
+    ,valGctDigis
+    ,ValL1MuTriggerPrimitives,ValL1MuTrackFinders,valRpcTriggerDigis,valGmtDigis
+    ,ValL1TechnicalTriggers
+    ,valGtDigis
+)
 
 
 

--- a/L1Trigger/HardwareValidation/python/L1HardwareValidation_cff.py
+++ b/L1Trigger/HardwareValidation/python/L1HardwareValidation_cff.py
@@ -15,57 +15,57 @@ from L1Trigger.HardwareValidation.L1Comparator_cfi import *
 from L1Trigger.HardwareValidation.L1ComparatorforStage1_cfi import *
 
 # subsystem sequences
-deEcal = cms.Sequence(valEcalTriggerPrimitiveDigis)
-deHcal = cms.Sequence(valHcalTriggerPrimitiveDigis)
-deRct = cms.Sequence(valRctDigis)
-deGct = cms.Sequence(valGctDigis)
-deStage1Layer2 = cms.Sequence(
+deEcal = cms.Task(valEcalTriggerPrimitiveDigis)
+deHcal = cms.Task(valHcalTriggerPrimitiveDigis)
+deRct = cms.Task(valRctDigis)
+deGct = cms.Task(valGctDigis)
+deStage1Layer2 = cms.Task(
     valRctUpgradeFormatDigis
-    *valCaloStage1Digis
-    #*simCaloStage1FinalDigis
-    *valCaloStage1LegacyFormatDigis
+    ,valCaloStage1Digis
+    #,simCaloStage1FinalDigis
+    ,valCaloStage1LegacyFormatDigis
     )
-deDt = cms.Sequence(valDtTriggerPrimitiveDigis)
-deCsc = cms.Sequence(valCscTriggerPrimitiveDigis)
-deCsctfTracks = cms.Sequence(valCsctfTrackDigis)
-deDttf = cms.Sequence(valDttfDigis)
-deCsctf = cms.Sequence(valCsctfDigis)
-deRpc = cms.Sequence(valRpcTriggerDigis)
-deGmt = cms.Sequence(valGmtDigis)
-deGt = cms.Sequence(valGtDigis)
-deStage1Gt = cms.Sequence(valStage1GtDigis)
+deDt = cms.Task(valDtTriggerPrimitiveDigis)
+deCsc = cms.Task(valCscTriggerPrimitiveDigis)
+deCsctfTracks = cms.Task(valCsctfTrackDigis)
+deDttf = cms.Task(valDttfDigis)
+deCsctf = cms.Task(valCsctfDigis)
+deRpc = cms.Task(valRpcTriggerDigis)
+deGmt = cms.Task(valGmtDigis)
+deGt = cms.Task(valGtDigis)
+deStage1Gt = cms.Task(valStage1GtDigis)
 
 # the sequence
-L1HardwareValidation = cms.Sequence(
-                                deEcal+
-                                deHcal+
-                                deRct+
-                                deGct+
-                                deDt+
-                                deCsc+
-                                deCsctfTracks +
-                                deDttf+
-                                deCsctf+
-                                deRpc+
-                                deGmt+
-                                deGt*
+L1HardwareValidationTask = cms.Task(
+                                deEcal,
+                                deHcal,
+                                deRct,
+                                deGct,
+                                deDt,
+                                deCsc,
+                                deCsctfTracks ,
+                                deDttf,
+                                deCsctf,
+                                deRpc,
+                                deGmt,
+                                deGt,
                                 l1compare)
+L1HardwareValidation = cms.Sequence(L1HardwareValidationTask)
 
-L1HardwareValidationforStage1 = cms.Sequence(
-                                deEcal+
-                                deHcal+
-                                deRct+
-                                deStage1Layer2+
-                                deGct+
-                                deDt+
-                                deCsc+
-                                deCsctfTracks +
-                                deDttf+
-                                deCsctf+
-                                deRpc+
-                                deGmt+
-                                deStage1Gt*
+L1HardwareValidationforStage1Task = cms.Task(
+                                deEcal,
+                                deHcal,
+                                deRct,
+                                deStage1Layer2,
+                                deGct,
+                                deDt,
+                                deCsc,
+                                deCsctfTracks ,
+                                deDttf,
+                                deCsctf,
+                                deRpc,
+                                deGmt,
+                                deStage1Gt,
                                 l1compareforstage1)
-
-
+L1HardwareValidationforStage1 = cms.Sequence(L1HardwareValidationforStage1Task)
 


### PR DESCRIPTION
#### PR description:

This PR fixes an "unrunnable schedule" error in many workflows in CMSSW_11_2_X_2020-06-01-2300
```
Unrunnable schedule
Module run order problem found: 
L1Reco_step after l1extraParticles [path L1Reco_step], l1extraParticles consumes caloStage1LegacyFormatDigis, caloStage1LegacyFormatDigis after caloStage1Digis [path dqmoffline_step], caloStage1Digis after rctDigis [path dqmoffline_step], rctDigis after l1tGt [path dqmoffline_step], l1tGt after l1tGmt [path dqmoffline_step], l1tGmt after l1tRpctf [path dqmoffline_step], l1tRpctf after l1tCsctf [path dqmoffline_step], l1tCsctf after l1tDttf [path dqmoffline_step], l1tDttf after l1GtUnpack [path dqmoffline_step], l1GtUnpack after dqmProvInfo [path dqmoffline_step], dqmProvInfo after @EndPathStart [path dqmoffline_step], @EndPathStart consumes TriggerResults, TriggerResults consumes L1Reco_step
 Running in the threaded framework would lead to indeterminate results.
 Please change order of modules in mentioned Path(s) to avoid inconsistent module ordering.
```

The problem was that some EDProducer(s) were in a Task in `L1Reco` step, and put in a Sequence in `DQM` step. Before the aforementioned IB these EDProducers were moved from Sequence to Task by `convertToUnscheduled()`, which was removed in https://github.com/cms-sw/cmssw/pull/29630, leading to modules associated to a Path to depend on event products produced by producers in EndPath. The proposed fix is to move bunch of non-DQM EDProducers from Seqences to Tasks in L1T DQM and Validation configuration files.

Part of  #30074, a second attempt of #30081.

#### PR validation:

Limited matrix and workflows ` 134.801,134.802,134.803,134.804,134.805,134.806,134.807,134.808,134.809,134.81,134.811,134.812,134.901,134.902,134.903,134.904,134.905,134.906,134.907,134.908,134.909,134.91,134.911,134.912,134.99601,134.99602,134.99603,134.99901,140.55,145.0` run.