### PR TITLE
[Tracker Alignment] Split vertex resolution validation submitter

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolutionTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolutionTemplates.py
@@ -39,7 +39,10 @@ process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel                       
 process.offlinePrimaryVerticesFromRefittedTrks.vertexCollections.maxDistanceToBeam              = 1
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxNormalizedChi2             = 20
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minSiliconLayersWithHits      = 5
-process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Significance             = 5.0 
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Significance             = 5.0
+# as it was prior to https://github.com/cms-sw/cmssw/commit/c8462ae4313b6be3bbce36e45373aa6e87253c59
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Error                    = 1.0
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxDzError                    = 1.0
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minPixelLayersWithHits        = 2   
 
 ###################################################################

--- a/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
+++ b/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python
+'''
+Submits per run Primary Vertex Resoltion Alignment validation using the split vertex method,
+usage:
+
+python submitPVResolutionJobs.py -i PVResolutionExample.ini -D /JetHT/Run2018C-TkAlMinBias-12Nov2019_UL2018-v2/ALCARECO
+'''
+
+from __future__ import print_function
+import os,sys
+import getopt
+import commands
+import time
+import json
+import ROOT
+import urllib
+import string
+import subprocess
+import pprint
+from subprocess import Popen, PIPE
+import multiprocessing
+from optparse import OptionParser
+import os, shlex, shutil, getpass
+import ConfigParser
+
+##############################################
+def check_proxy():
+##############################################
+    """Check if GRID proxy has been initialized."""
+
+    try:
+        with open(os.devnull, "w") as dump:
+            subprocess.check_call(["voms-proxy-info", "--exists"],
+                                  stdout = dump, stderr = dump)
+    except subprocess.CalledProcessError:
+        return False
+    return True
+
+##############################################
+def forward_proxy(rundir):
+##############################################
+    """Forward proxy to location visible from the batch system.
+    Arguments:
+    - `rundir`: directory for storing the forwarded proxy
+    """
+
+    if not check_proxy():
+        print("Please create proxy via 'voms-proxy-init -voms cms -rfc'.")
+        sys.exit(1)
+
+    local_proxy = subprocess.check_output(["voms-proxy-info", "--path"]).strip()
+    shutil.copyfile(local_proxy, os.path.join(rundir,".user_proxy"))
+
+##############################################
+def getFilesForRun(blob):
+##############################################
+    """
+    returns the list of list files associated with a given dataset for a certain run
+    """
+
+    cmd2 = ' dasgoclient -limit=0 -query \'file run='+blob[0]+' dataset='+blob[1]+'\''
+    q = Popen(cmd2 , shell=True, stdout=PIPE, stderr=PIPE)
+    out, err = q.communicate()
+    outputList = out.decode().split('\n')
+    outputList.pop()
+    return outputList 
+
+##############################################
+def write_HTCondor_submit_file(path, name, nruns, proxy_path=None):
+##############################################
+    """Writes 'job.submit' file in `path`.
+    Arguments:
+    - `path`: job directory
+    - `script`: script to be executed
+    - `proxy_path`: path to proxy (only used in case of requested proxy forward)
+    """
+        
+    job_submit_template="""\
+universe              = vanilla
+executable            = {script:s}
+output                = {jobm:s}/{out:s}.out
+error                 = {jobm:s}/{out:s}.err
+log                   = {jobm:s}/{out:s}.log
+transfer_output_files = ""
++JobFlavour           = "{flavour:s}"
+queue {njobs:s}
+"""
+    if proxy_path is not None:
+        job_submit_template += """\
++x509userproxy        = "{proxy:s}"
+"""
+        
+    job_submit_file = os.path.join(path, "job_"+name+".submit")
+    with open(job_submit_file, "w") as f:
+        f.write(job_submit_template.format(script = os.path.join(path,name+"_$(ProcId).sh"),
+                                           out  = name+"_$(ProcId)",
+                                           jobm = os.path.abspath(path),
+                                           flavour = "tomorrow",
+                                           njobs = str(nruns),
+                                           proxy = proxy_path))
+
+    return job_submit_file
+
+##############################################
+def getLuminosity(minRun,maxRun,isRunBased,verbose):
+##############################################
+    """Expects something like
+    +-------+------+--------+--------+-------------------+------------------+
+    | nfill | nrun | nls    | ncms   | totdelivered(/fb) | totrecorded(/fb) |
+    +-------+------+--------+--------+-------------------+------------------+
+    | 73    | 327  | 142418 | 138935 | 19.562            | 18.036           |
+    +-------+------+--------+--------+-------------------+------------------+
+    And extracts the total recorded luminosity (/b).
+    """
+    myCachedLumi={}
+    if(not isRunBased):
+        return myCachedLumi
+    
+    ## using normtag
+    #output = subprocess.check_output(["/afs/cern.ch/user/m/musich/.local/bin/brilcalc", "lumi", "-b", "STABLE BEAMS", "--normtag","/cvmfs/cms-bril.cern.ch/cms-lumi-pog/Normtags/normtag_PHYSICS.json", "-u", "/pb", "--begin", str(minRun),"--end",str(maxRun),"--output-style","csv"])
+
+    ## no normtag
+    output = subprocess.check_output(["/afs/cern.ch/user/m/musich/.local/bin/brilcalc", "lumi", "-b", "STABLE BEAMS","-u", "/pb", "--begin", str(minRun),"--end",str(maxRun),"--output-style","csv"])
+
+    if(verbose):
+        print("INSIDE GET LUMINOSITY")
+        print(output)
+
+    for line in output.split("\n"):
+        if ("#" not in line):
+            runToCache  = line.split(",")[0].split(":")[0] 
+            lumiToCache = line.split(",")[-1].replace("\r", "")
+            #print("run",runToCache)
+            #print("lumi",lumiToCache)
+            myCachedLumi[runToCache] = lumiToCache
+
+    #print(myCachedLumi)
+    return myCachedLumi
+
+##############################################
+def isInJSON(run,jsonfile):
+##############################################
+    with open(jsonfile, 'rb') as myJSON:
+        jsonDATA = json.load(myJSON)
+        return (run in jsonDATA)
+
+#######################################################
+def as_dict(config):
+#######################################################
+    dictionary = {}
+    for section in config.sections():
+        dictionary[section] = {}
+        for option in config.options(section):
+            dictionary[section][option] = config.get(section, option)
+
+    return dictionary
+
+#######################################################
+def batchScriptCERN(runindex,lumiToRun,key,config):
+#######################################################
+    '''prepare the batch script, to run on HTCondor'''
+    script = """
+#!/bin/bash 
+CMSSW_DIR=$CMSSW_BASE/src/Alignment/OfflineValidation/test
+OUT_DIR=$CMSSW_DIR/harvest 
+LOG_DIR=$CMSSW_DIR/out
+LXBATCH_DIR=`pwd`  
+cd $CMSSW_DIR
+eval `scram runtime -sh`
+cd $LXBATCH_DIR 
+cp -pr $CMSSW_DIR/cfg/PrimaryVertexResolution_{KEY}_{runindex}_cfg.py .
+cmsRun PrimaryVertexResolution_{KEY}_{runindex}_cfg.py GlobalTag={GT} lumi={LUMITORUN} {REC} {EXT} >& log_{KEY}_run{runindex}.out
+ls -lh . 
+#for payloadOutput in $(ls *root ); do cp $payloadOutput $OUT_DIR/pvresolution_{KEY}_{runindex}.root ; done 
+for payloadOutput in $(ls *root ); do xrdcp -f $payloadOutput root://eoscms//eos/cms/store/group/alca_trackeralign/musich/test_out/PVResolutions2018WrongTemplates/pvresolution_{KEY}_{runindex}.root ; done
+tar czf log_{KEY}_run{runindex}.tgz log_{KEY}_run{runindex}.out  
+for logOutput in $(ls *tgz ); do cp $logOutput $LOG_DIR/ ; done 
+""".format(runindex=runindex,
+           KEY=key,
+           LUMITORUN=lumiToRun,
+           GT=config['globaltag'],
+           EXT="external="+config['external'] if 'external' in config.keys() else "",
+           REC="records="+config['records'] if 'records' in config.keys() else "")
+   
+    return script
+
+##############################################
+def main():
+##############################################
+
+    desc="""This is a description of %prog."""
+    parser = OptionParser(description=desc,version='%prog version 0.1')
+    parser.add_option('-s','--submit',  help='job submitted',       dest='submit',      action='store_true', default=False)
+    parser.add_option('-i','--init',    help='ini file',            dest='iniPathName', action='store',      default="default.ini")
+    parser.add_option('-b','--begin',   help='starting point',      dest='start',       action='store',      default='1')
+    parser.add_option('-e','--end',     help='ending point',        dest='end',         action='store',      default='999999')
+    parser.add_option('-D','--Dataset', help='dataset to run upon', dest='DATASET',     action='store',      default='/StreamExpressAlignment/Run2017F-TkAlMinBias-Express-v1/ALCARECO')
+    parser.add_option('-v','--verbose', help='verbose output',      dest='verbose',     action='store_true', default=False)
+    
+    (opts, args) = parser.parse_args()
+
+    try:
+        config = ConfigParser.ConfigParser()
+        config.read(opts.iniPathName)
+    except ConfigParser.MissingSectionHeaderError, e:
+        raise WrongIniFormatError(`e`)
+
+    print("Parsed the following configuration \n\n")
+    inputDict = as_dict(config)
+    pprint.pprint(inputDict)
+
+    ## check first there is a valid grid proxy
+    forward_proxy(".")
+
+    runs = commands.getstatusoutput("dasgoclient -query='run dataset="+opts.DATASET+"'")[1].split("\n")
+    print("\n\n Will run on the following runs: \n",runs)
+
+    if(not os.path.exists("cfg")):
+        os.system("mkdir cfg")
+        os.system("mkdir bash")
+        os.system("mkdir harvest")
+        os.system("mkdir out")
+
+    cwd = os.getcwd()
+    bashdir = os.path.join(cwd,"bash")
+
+    runs.sort()
+    # get from the DB the int luminosities
+    myLumiDB = getLuminosity(runs[0],runs[-1],True,opts.verbose)    
+    if(opts.verbose):
+        pprint.pprint(myLumiDB)
+
+    lumimask = inputDict["Input"]["lumimask"]
+    print("\n\n Using JSON file:",lumimask)
+
+    mytuple=[]
+    print("\n\n First run:",opts.start,"last run:",opts.end)
+
+    for run in runs:
+        if (int(run)<int(opts.start) or int(run)>int(opts.end)):
+            print("excluding run",run)
+            continue
+
+        if not isInJSON(run,lumimask):
+            continue
+
+        else:
+            print("'======> taking run",run)
+            mytuple.append((run,opts.DATASET))
+
+        #print mytuple
+
+    pool = multiprocessing.Pool(processes=20)  # start 20 worker processes
+    count = pool.map(getFilesForRun,mytuple)
+    file_info = dict(zip(runs, count))
+
+    if(opts.verbose):
+        print(file_info)
+
+    count=0
+    for run in runs:
+        count=count+1
+        #if(count>10): 
+        #    continue
+        #run = run.strip("[").strip("]")
+
+        if (int(run)<int(opts.start) or int(run)>int(opts.end)):
+            print("excluding",run)
+            continue
+
+        if not isInJSON(run,lumimask):
+            print("=====> excluding run:",run)
+            continue
+
+        files = file_info[run]
+        if(opts.verbose):
+            print(run, files)
+        listOfFiles='['
+        for ffile in files:
+            listOfFiles=listOfFiles+"\""+str(ffile)+"\","
+        listOfFiles+="]"
+        
+        #print(listOfFiles)
+
+        theLumi='1'
+        if (run) in myLumiDB:
+            theLumi = myLumiDB[run]
+            print("run",run," int. lumi:",theLumi,"/pb")
+        else:
+            print("=====> COULD NOT FIND LUMI, setting default = 1/pb")
+            theLumi='1'
+            print("run",run," int. lumi:",theLumi,"/pb")
+
+        # loop on the dictionary
+        for key, value in inputDict.items():            
+            #print(key,value)
+            if "Input" in key:
+                continue
+            else: 
+                key = key.split(":", 1)[1]
+                print("dealing with",key)
+
+            os.system("cp PrimaryVertexResolution_templ_cfg.py ./cfg/PrimaryVertexResolution_"+key+"_"+run+"_cfg.py")
+            os.system("sed -i 's|XXX_FILES_XXX|"+listOfFiles+"|g' "+cwd+"/cfg/PrimaryVertexResolution_"+key+"_"+run+"_cfg.py")
+            os.system("sed -i 's|XXX_RUN_XXX|"+run+"|g' "+cwd+"/cfg/PrimaryVertexResolution_"+key+"_"+run+"_cfg.py")
+            os.system("sed -i 's|YYY_KEY_YYY|"+key+"|g' "+cwd+"/cfg/PrimaryVertexResolution_"+key+"_"+run+"_cfg.py")
+
+            scriptFileName = os.path.join(bashdir,"batchHarvester_"+key+"_"+str(count)+".sh")
+            scriptFile = open(scriptFileName,'w')
+            scriptFile.write(batchScriptCERN(run,theLumi,key,value)) 
+            scriptFile.close()
+            #os.system('chmod +x %s' % scriptFileName)
+
+    for key, value in inputDict.items():
+        job_submit_file = write_HTCondor_submit_file(bashdir,"batchHarvester_"+key,count,None)
+
+        if opts.submit:
+            os.system("chmod u+x "+bashdir+"/*.sh")
+            submissionCommand = "condor_submit "+job_submit_file
+            submissionOutput = getCommandOutput(submissionCommand)
+            print(submissionOutput)
+
+if __name__ == "__main__":        
+    main()

--- a/Alignment/OfflineValidation/test/PVResolutionExample.ini
+++ b/Alignment/OfflineValidation/test/PVResolutionExample.ini
@@ -1,0 +1,8 @@
+[Input]
+lumimask=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/DCSOnly/json_DCSONLY.txt
+[Validation:Prompt]
+globaltag=111X_dataRun2_v3
+records=TrackerAlignmentRcd:TrackerAlignment_PCL_byRun_v2_express,TrackerAlignmentErrorExtendedRcd:TrackerAlignmentExtendedErr_2009_v2_express_IOVs,TrackerSurfaceDeformationRcd:TrackerSurafceDeformations_v1_express
+[Validation:Ultra-Legacy]
+globaltag=111X_dataRun2_v3
+

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
@@ -137,6 +137,9 @@ process.offlinePrimaryVerticesFromRefittedTrks.vertexCollections.maxDistanceToBe
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxNormalizedChi2             = 20
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minSiliconLayersWithHits      = 5
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Significance             = 5.0 
+# as it was prior to https://github.com/cms-sw/cmssw/commit/c8462ae4313b6be3bbce36e45373aa6e87253c59
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Error                    = 1.0
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxDzError                    = 1.0
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minPixelLayersWithHits        = 2   
 
 ###################################################################

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
@@ -133,7 +133,10 @@ process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel                       
 process.offlinePrimaryVerticesFromRefittedTrks.vertexCollections.maxDistanceToBeam              = 1
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxNormalizedChi2             = 20
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minSiliconLayersWithHits      = 5
-process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Significance             = 5.0 
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Significance             = 5.0
+# as it was prior to https://github.com/cms-sw/cmssw/commit/c8462ae4313b6be3bbce36e45373aa6e87253c59
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Error                    = 1.0
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxDzError                    = 1.0
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minPixelLayersWithHits        = 2   
 
 process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
@@ -1,0 +1,160 @@
+#! /bin/env cmsRun
+
+'''
+cfg to produce pv resolution plots
+here doing refit of tracks and vertices using latest alignment 
+'''
+
+import FWCore.ParameterSet.Config as cms
+from fnmatch import fnmatch
+import FWCore.ParameterSet.VarParsing as VarParsing
+from pdb import set_trace
+
+process = cms.Process("PrimaryVertexResolution")
+
+###################################################################
+def best_match(rcd):
+###################################################################
+    '''
+    find out where to best match the input conditions
+    '''
+    print rcd
+    for pattern, string in connection_map:
+        print pattern, fnmatch(rcd, pattern)
+        if fnmatch(rcd, pattern):
+            return string
+
+options = VarParsing.VarParsing("analysis")
+
+options.register('lumi',
+                 1.,
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.float,          # string, int, or float
+                 "luminosity used")
+
+options.register ('outputRootFile',
+                  "pvresolution_YYY_KEY_YYY_XXX_RUN_XXX.root",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "output root file")
+
+options.register ('records',
+                  [],
+                  VarParsing.VarParsing.multiplicity.list, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "record:tag names to be used/changed from GT")
+
+options.register ('external',
+                  [],
+                  VarParsing.VarParsing.multiplicity.list, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "record:fle.db picks the following record from this external file")
+
+options.register ('GlobalTag',
+                  '110X_dataRun3_Prompt_v3',
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "Global Tag to be used")
+
+options.parseArguments()
+
+print "conditionGT       : ", options.GlobalTag
+print "conditionOverwrite: ", options.records
+print "external conditions:", options.external
+print "outputFile        : ", options.outputRootFile
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr = cms.untracked.PSet(placeholder = cms.untracked.bool(True))
+process.MessageLogger.cout = cms.untracked.PSet(INFO = cms.untracked.PSet(
+        reportEvery = cms.untracked.int32(1000) # every 100th only
+        #    limit = cms.untracked.int32(10)       # or limit to 10 printouts...
+    ))
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(150000) )
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
+process.load('Configuration.Geometry.GeometryRecoDB_cff')
+
+process.load('Configuration/StandardSequences/Services_cff')
+process.load('TrackingTools.TransientTrack.TransientTrackBuilder_cfi')
+
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(XXX_FILES_XXX)
+                            )
+
+###################################################################
+# Tell the program where to find the conditons
+connection_map = [
+    ('Tracker*', 'frontier://PromptProd/CMS_CONDITIONS'),
+    ('SiPixel*', 'frontier://PromptProd/CMS_CONDITIONS'),
+    ('SiStrip*', 'frontier://PromptProd/CMS_CONDITIONS'),
+    ('Beam*', 'frontier://PromptProd/CMS_CONDITIONS'),
+    ]
+
+if options.external:
+    connection_map.extend(
+        (i.split(':')[0], 'sqlite_file:%s' % i.split(':')[1]) for i in options.external
+        )
+
+connection_map.sort(key=lambda x: -1*len(x[0]))
+
+###################################################################
+# creat the map for the GT toGet
+records = []
+if options.records:
+    for record in options.records:
+        rcd, tag = tuple(record.split(':'))
+        records.append(
+            cms.PSet(
+                record = cms.string(rcd),
+                tag    = cms.string(tag),
+                connect = cms.string(best_match(rcd))
+                )
+            )
+
+process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
+process.GlobalTag.globaltag  = options.GlobalTag
+#process.GlobalTag.DumpStat = cms.untracked.bool(True)
+process.GlobalTag.toGet = cms.VPSet(*records)
+
+process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
+# remove the following lines if you run on RECO files
+process.TrackRefitter.src = 'ALCARECOTkAlMinBias'
+process.TrackRefitter.NavigationSchool = ''
+
+## PV refit
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices 
+process.offlinePrimaryVerticesFromRefittedTrks  = offlinePrimaryVertices.clone()
+process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel                                       = cms.InputTag("TrackRefitter") 
+process.offlinePrimaryVerticesFromRefittedTrks.vertexCollections.maxDistanceToBeam              = 1
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxNormalizedChi2             = 20
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minSiliconLayersWithHits      = 5
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Significance             = 5.0 
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minPixelLayersWithHits        = 2   
+
+process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
+                                                 storeNtuple         = cms.bool(False),
+                                                 intLumi             = cms.untracked.double(options.lumi),
+                                                 vtxCollection       = cms.InputTag("offlinePrimaryVerticesFromRefittedTrks"),
+                                                 trackCollection     = cms.InputTag("TrackRefitter"),		
+                                                 minVertexNdf        = cms.untracked.double(10.),
+                                                 minVertexMeanWeight = cms.untracked.double(0.5),
+                                                 runControl = cms.untracked.bool(True),
+                                                 runControlNumber = cms.untracked.vuint32(int(XXX_RUN_XXX))
+                                                 )
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string(options.outputRootFile),	
+                                   closeFileFast = cms.untracked.bool(False)
+                                   )
+
+process.p = cms.Path(process.offlineBeamSpot                        + 
+                     process.TrackRefitter                          + 
+                     process.offlinePrimaryVerticesFromRefittedTrks +
+                     process.PrimaryVertexResolution)
+
+

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -260,9 +260,9 @@ if isDA:
                                                                          maxNormalizedChi2 = cms.double(5.0),                        # chi2ndof < 5                  
                                                                          minPixelLayersWithHits = cms.int32(2),                      # PX hits > 2                       
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5  
-                                                                         maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)     
-                                                                         maxD0Error = cms.double(100.0),                        # fake cut (requiring 1 PXB hit)     
-                                                                         maxDzError = cms.double(100.0),                        # fake cut (requiring 1 PXB hit)     
+                                                                         maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)
+                                                                         maxD0Error = cms.double(100.0),                             # fake cut (requiring 1 PXB hit)
+                                                                         maxDzError = cms.double(100.0),                             # fake cut (requiring 1 PXB hit)
                                                                          minPt = cms.double(0.0),                                    # better for softish events
                                                                          maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330
                                                                          trackQuality = cms.string("any")
@@ -308,13 +308,13 @@ else:
                                            runControlNumber = cms.untracked.vuint32(int(runboundary)),
                                            
                                            TkFilterParameters = cms.PSet(algorithm=cms.string('filter'),                             
-                                                                         maxNormalizedChi2 = cms.double(5.0),                        # chi2ndof < 20                  
-                                                                         minPixelLayersWithHits=cms.int32(2),                        # PX hits > 2                   
-                                                                         minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5                   
+                                                                         maxNormalizedChi2 = cms.double(5.0),                        # chi2ndof < 20
+                                                                         minPixelLayersWithHits=cms.int32(2),                        # PX hits > 2
+                                                                         minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)
-                                                                         maxD0Error = cms.double(100.0),                        # fake cut (requiring 1 PXB hit)     
-                                                                         maxDzError = cms.double(100.0),                        # fake cut (requiring 1 PXB hit)     
-                                                                         minPt = cms.double(0.0),                                    # better for softish events    
+                                                                         maxD0Error = cms.double(100.0),                             # fake cut (requiring 1 PXB hit)
+                                                                         maxDzError = cms.double(100.0),                             # fake cut (requiring 1 PXB hit)
+                                                                         minPt = cms.double(0.0),                                    # better for softish events
                                                                          maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330 
                                                                          trackQuality = cms.string("any")
                                                                          ),
@@ -344,8 +344,9 @@ process.offlinePrimaryVerticesFromRefittedTrks.vertexCollections.maxDistanceToBe
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxNormalizedChi2             = 20
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minSiliconLayersWithHits      = 5
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Significance             = 5.0
-process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Error                    = 100.0
-process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxDzError                    = 100.0
+# as it was prior to https://github.com/cms-sw/cmssw/commit/c8462ae4313b6be3bbce36e45373aa6e87253c59
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Error                    = 1.0
+process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxDzError                    = 1.0
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minPixelLayersWithHits        = 2
 
 ###################################################################


### PR DESCRIPTION
#### PR description:

This PR has three commits:
   * 9dded8b :  adds a script and template (+example) to run the per-run Alignment split vertex validation
   * 83aff3a : adds provision the code to run the PV Validation plotting macro with input luminosity from txt file, when the information is not saved in the input root file
   *  https://github.com/cms-sw/cmssw/commit/c01452eb6bf5f5f8f32faa09b4dc237cf37ccb96 :  restores the values of the  `maxD0Error` and `maxDzError`to the default (=`1.0`) in `RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi`.

#### PR validation:

Relies on existing unit tests. 
The submitter script can be tested in release via:
```bash
submitPVResolutionJobs.py -i PVResolutionExample.ini -D /JetHT/Run2018C-TkAlMinBias-12Nov2019_UL2018-v2/ALCARECO -v
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, though it might be backported later depending on the needs.
