### PR TITLE
fix cmssw patch version for non-standard IBs e.g ROOT6, DEVEL

### DIFF
--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -67,10 +67,10 @@ class TauIDEmbedder(object):
         """returns '(release, subversion, patch)' (without 'CMSSW_')"""
         v = klass.get_cmssw_version().split("CMSSW_")[1].split("_")[0:3]
         if debug: print ("get_cmssw_version_number:", v)
-        if v[2] == "X":
-            patch = -1
-        else:
+        try:
             patch = int(v[2])
+        except:
+            patch = -1
         return int(v[0]), int(v[1]), patch
 
     @staticmethod


### PR DESCRIPTION
#### PR description:

This fixes the unit test failure (added  by #29976 ) in non-standard IBs (e.g DEVEL, ROOT6 etc). Code here https://github.com/cms-tau-pog/cmssw/blob/7aaf1ab52d1f044b47e43ce446576a726fb2970e/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py#L70 Assumes that that patch version of cmssw is either `X` or a number but for non-standard IBs it could be `ROOT6`, `DEVEL` etc. The change proposed here should fix this.

#### PR validation:

Build and successfully run unit test locally for both standard and non-standard IBs.
