### PR TITLE
Move EDProducers to Task from electron MiniAOD validation sequence

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -28,7 +28,7 @@ from Validation.RecoMuon.muonValidationHLT_cff import *
 from Validation.EventGenerator.BasicGenValidation_cff import *
 # miniAOD
 from Validation.RecoParticleFlow.miniAODValidation_cff import *
-from Validation.RecoEgamma.photonMiniAODValidationTask_cff import *
+from Validation.RecoEgamma.photonMiniAODValidationSequence_cff import *
 from Validation.RecoEgamma.egammaValidationMiniAOD_cff import *
 from Validation.RecoTau.RecoTauValidation_cff import *
 
@@ -36,10 +36,9 @@ prevalidationNoHLT = cms.Sequence( cms.SequencePlaceholder("mix") * globalPreval
 prevalidation = cms.Sequence( cms.SequencePlaceholder("mix") * globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
-prevalidationMiniAODTask = cms.Task(photonMiniAODValidationTask)
 prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence 
-                                    * egammaValidationMiniAOD * produceDenoms
-                                    , prevalidationMiniAODTask)
+                                    * photonMiniAODValidationSequence * egammaValidationMiniAOD
+                                    * produceDenoms)
 
 _prevalidation_fastsim = prevalidation.copy()
 for _entry in [hltassociation]:

--- a/Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
@@ -12,5 +12,6 @@ miniAODElectronIsolation = _egmElectronIsolationCITK.clone()
 miniAODElectronIsolation.srcToIsolate = cms.InputTag("slimmedElectrons")
 miniAODElectronIsolation.srcForIsolationCone = cms.InputTag("packedPFCandidates")
 
-electronValidationSequenceMiniAOD = cms.Sequence( egmElectronIsolationCITK + miniAODElectronIsolation + ElectronIsolation + electronMcSignalValidatorMiniAOD )
+electronValidationTaskMiniAOD = cms.Task(egmElectronIsolationCITK, miniAODElectronIsolation, ElectronIsolation)
+electronValidationSequenceMiniAOD = cms.Sequence(electronMcSignalValidatorMiniAOD, electronValidationTaskMiniAOD)
 

--- a/Validation/RecoEgamma/python/photonMiniAODValidationSequence_cff.py
+++ b/Validation/RecoEgamma/python/photonMiniAODValidationSequence_cff.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoEgamma.photonValidatorMiniAOD_cfi import *
 
 
-photonMiniAODValidationTask = cms.Task(photonValidationMiniAOD)
+photonMiniAODValidationSequence = cms.Sequence(photonValidationMiniAOD)
 
 


### PR DESCRIPTION
#### PR description:

This PR reverts a commit https://github.com/cms-sw/cmssw/pull/29630/commits/afd436e21c41fc34678c93a528691b78d27993d2 of #29630 because moving the `photonValidationMiniAOD` to a Task was
* not the correct fix for "unrunnable schedule" error (many 1325.X workflows are failing in IBs with `ProductNotFound` exception (*))
* Accumulator EDProducers should be kept in a Sequence if it is possible that the Sequence is used in conjunction with EDFilters
  * understanding whether that is the case here would require complete understanding of all DQM and validation sequences in all possible use cases

This PR proposes to move the (non-Accumulator) EDProducers in without ix`electronValidationSequenceMiniAOD` to a Task instead. Then they can be run in any order (respecting data dependencies) without constraints from the Sequence ordering (fixing "unrunnable schedule), and not run if there are no consumers (fixing `ProductNotFound` errors in 1325.X).

(*)
```
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 19 event: 1802 stream: 1
   [1] Running path 'prevalidation_step'
   [2] Calling method for module CITKPFIsolationSumProducer/'egmElectronIsolationCITK'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for a container with elements of type: reco::Candidate
Looking for module label: gedGsfElectronsTmp
Looking for productInstanceName: 
```

#### PR validation:

Limited matrix and workflows `1325.5,1325.51,1325.516,1325.5161,1325.517,1325.518` run.