### PR TITLE
Add GEM to MuonRecoAnalyzer

### DIFF
--- a/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
@@ -189,4 +189,4 @@ private:
   bool IsminiAOD;
   std::string theFolder;
 };
-#endif // DQMOffline_Muon_MuonRecoAnalyzer_h
+#endif  // DQMOffline_Muon_MuonRecoAnalyzer_h

--- a/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
@@ -1,6 +1,5 @@
-#ifndef MuonRecoAnalyzer_H
-#define MuonRecoAnalyzer_H
-
+#ifndef DQMOffline_Muon_MuonRecoAnalyzer_h
+#define DQMOffline_Muon_MuonRecoAnalyzer_h
 /** \class MuRecoAnalyzer
  *
  *  DQM monitoring source for muon reco track
@@ -59,6 +58,8 @@ private:
   // Switch for verbosity
   std::string metname;
   bool doMVA;
+  bool useGEM;
+  int maxGEMhitsSoftMuonMVA;
 
   //histo binning parameters
   int etaBin;
@@ -147,6 +148,7 @@ private:
   MonitorElement* trkRelChi2SoftMuonMVA;
   MonitorElement* vDThitsSoftMuonMVA;
   MonitorElement* vCSChitsSoftMuonMVA;
+  MonitorElement* vGEMhitsSoftMuonMVA;
   MonitorElement* timeAtIpInOutSoftMuonMVA;
   MonitorElement* timeAtIpInOutErrSoftMuonMVA;
   MonitorElement* getMuonHitsPerStationSoftMuonMVA;
@@ -187,4 +189,4 @@ private:
   bool IsminiAOD;
   std::string theFolder;
 };
-#endif
+#endif // DQMOffline_Muon_MuonRecoAnalyzer_h

--- a/DQMOffline/Muon/python/muonRecoAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonRecoAnalyzer_cfi.py
@@ -10,6 +10,8 @@ muonRecoAnalyzer = DQMEDAnalyzer('MuonRecoAnalyzer',
                                   inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
                                   IsminiAOD            = cms.bool( False ),
                                   doMVA                = cms.bool( False ),
+                                  useGEM               = cms.untracked.bool(False),
+                                  maxGEMhitsSoftMuonMVA = cms.untracked.int32(6),
                                   # histograms parameters
                                   thetaBin = cms.int32(100),
                                   thetaMin = cms.double(0.0),
@@ -55,6 +57,8 @@ muonRecoAnalyzer_miniAOD = DQMEDAnalyzer('MuonRecoAnalyzer',
                                           inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
                                           IsminiAOD            = cms.bool( True ),
                                           doMVA                = cms.bool( False ),
+                                          useGEM               = cms.untracked.bool(False),
+                                          maxGEMhitsSoftMuonMVA = cms.untracked.int32(6),
                                           # histograms parameters
                                           thetaBin = cms.int32(100),
                                           thetaMin = cms.double(0.0),
@@ -93,3 +97,11 @@ muonRecoAnalyzer_miniAOD = DQMEDAnalyzer('MuonRecoAnalyzer',
                                           tunePMax = cms.double(1.0),
                                           folder = cms.string("Muons_miniAOD/MuonRecoAnalyzer")
                                           )
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+run3_GEM.toModify(muonRecoAnalyzer, useGEM=cms.untracked.bool(True))
+run3_GEM.toModify(muonRecoAnalyzer_miniAOD, useGEM=cms.untracked.bool(True))
+
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
+phase2_GEM.toModify(muonRecoAnalyzer, maxGEMhitsSoftMuonMVA=cms.untracked.int32(22))
+phase2_GEM.toModify(muonRecoAnalyzer_miniAOD, maxGEMhitsSoftMuonMVA=cms.untracked.int32(22))

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -21,6 +21,9 @@ MuonRecoAnalyzer::MuonRecoAnalyzer(const edm::ParameterSet& pSet) {
   // Input booleans
   IsminiAOD = parameters.getParameter<bool>("IsminiAOD");
   doMVA = parameters.getParameter<bool>("doMVA");
+  useGEM = parameters.getUntrackedParameter<bool>("useGEM");
+  maxGEMhitsSoftMuonMVA = parameters.getUntrackedParameter<int>("maxGEMhitsSoftMuonMVA");
+
   // the services:
   theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >(parameters.getParameter<edm::InputTag>("MuonCollection"));
   theVertexLabel_ = consumes<reco::VertexCollection>(pSet.getParameter<InputTag>("inputTagVertex"));
@@ -312,6 +315,12 @@ void MuonRecoAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   trkRelChi2SoftMuonMVA = ibooker.book1D("trkRelChi2SoftMuonMVA", "trkRelChi2", 50, 0, 1.2);
   vDThitsSoftMuonMVA = ibooker.book1D("vDThitsSoftMuonMVA", "vDThits", 50, 0, 50);
   vCSChitsSoftMuonMVA = ibooker.book1D("vCSChitsSoftMuonMVA", "vCSChits", 50, 0, 50);
+  if (useGEM) {
+    vGEMhitsSoftMuonMVA = ibooker.book1D("vGEMhitsSoftMuonMVA", "vGEMhits", maxGEMhitsSoftMuonMVA, 0, maxGEMhitsSoftMuonMVA);
+    vGEMhitsSoftMuonMVA->setXTitle("Number of Valid GEM Hits of Global Muon");
+  } else {
+    vGEMhitsSoftMuonMVA = nullptr;
+  }
   timeAtIpInOutSoftMuonMVA = ibooker.book1D("timeAtIpInOutSoftMuonMVA", "timeAtIpInOut", 50, -10.0, 10.0);
   timeAtIpInOutErrSoftMuonMVA = ibooker.book1D("timeAtIpInOutErrSoftMuonMVA", "timeAtIpInOutErr", 50, 0, 3.5);
   getMuonHitsPerStationSoftMuonMVA =
@@ -705,6 +714,9 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       trkRelChi2SoftMuonMVA->Fill(muonQuality.trkRelChi2);
       vDThitsSoftMuonMVA->Fill(gHits.numberOfValidMuonDTHits());
       vCSChitsSoftMuonMVA->Fill(gHits.numberOfValidMuonCSCHits());
+      if (useGEM) {
+        vGEMhitsSoftMuonMVA->Fill(gHits.numberOfValidMuonGEMHits());
+      }
       timeAtIpInOutSoftMuonMVA->Fill(muon->time().timeAtIpInOut);
       timeAtIpInOutErrSoftMuonMVA->Fill(muon->time().timeAtIpInOutErr);
       //getMuonHitsPerStationSoftMuonMVA->Fill(gTrack);

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -316,7 +316,8 @@ void MuonRecoAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   vDThitsSoftMuonMVA = ibooker.book1D("vDThitsSoftMuonMVA", "vDThits", 50, 0, 50);
   vCSChitsSoftMuonMVA = ibooker.book1D("vCSChitsSoftMuonMVA", "vCSChits", 50, 0, 50);
   if (useGEM) {
-    vGEMhitsSoftMuonMVA = ibooker.book1D("vGEMhitsSoftMuonMVA", "vGEMhits", maxGEMhitsSoftMuonMVA, 0, maxGEMhitsSoftMuonMVA);
+    vGEMhitsSoftMuonMVA =
+        ibooker.book1D("vGEMhitsSoftMuonMVA", "vGEMhits", maxGEMhitsSoftMuonMVA, 0, maxGEMhitsSoftMuonMVA);
     vGEMhitsSoftMuonMVA->setXTitle("Number of Valid GEM Hits of Global Muon");
   } else {
     vGEMhitsSoftMuonMVA = nullptr;


### PR DESCRIPTION
#### PR description:
Add a plot about the number of valid GEM hits of the global muon for GEM Offline DQM. DT/CSC-version of the plot is already included.

#### PR validation:
This PR was tested with workflow 11611.0 and 27411.0.

Plots can be found on page 2 of the following link.
https://indico.cern.ch/event/924681/contributions/3885765/attachments/2049065/3436092/GEM_DPG_200601_Offline_DQM.pdf

@jshlee 

