### PR TITLE
Fix for the recently updated HI event content

### DIFF
--- a/Configuration/EventContent/python/EventContentHeavyIons_cff.py
+++ b/Configuration/EventContent/python/EventContentHeavyIons_cff.py
@@ -14,12 +14,7 @@ from RecoHI.Configuration.RecoHI_EventContent_cff import *       # heavy ion rec
 
 
 #RAW
-RAWEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-	'keep FEDRawDataCollection_rawDataRepacker_*_*',
-        'keep FEDRawDataCollection_hybridRawDataRepacker_*_*',
-        'keep FEDRawDataCollection_virginRawDataRepacker_*_*')
-)
+RAWEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
 
 #RECO
 RECOEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
@@ -28,11 +23,12 @@ RECOEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
 AODEventContent.outputCommands.extend(RecoHIAOD.outputCommands)
 
 #RAWSIM
-RAWSIMEventContent.outputCommands.extend(RAWEventContent.outputCommands)
+RAWSIMEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
 RAWSIMEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RAWSIMHLT
-RAWSIMHLTEventContent.outputCommands.extend(RAWSIMEventContent.outputCommands)
+RAWSIMHLTEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+RAWSIMHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RECOSIM
 RECOSIMEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
@@ -44,28 +40,35 @@ AODSIMEventContent.outputCommands.extend(HiMixAOD.outputCommands)
 
 #FEVT (RAW + RECO)
 FEVTEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTEventContent.outputCommands.extend(RAWEventContent.outputCommands)
+FEVTEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
 
 #FEVTHLTALL (FEVT + all HLT)
-FEVTHLTALLEventContent.outputCommands.extend(FEVTEventContent.outputCommands)
+FEVTHLTALLEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
+FEVTHLTALLEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
 
 #FEVTSIM (RAWSIM + RECOSIM)
-FEVTSIMEventContent.outputCommands.extend(FEVTEventContent.outputCommands)
+FEVTSIMEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
+FEVTSIMEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
 FEVTSIMEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RAW DEBUG(e.g. mergedtruth from trackingParticles) 
-RAWDEBUGEventContent.outputCommands.extend(RAWEventContent.outputCommands)
+RAWDEBUGEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
 RAWDEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RAW HLT DEBUG 
-RAWDEBUGHLTEventContent.outputCommands.extend(RAWDEBUGEventContent.outputCommands)
+RAWDEBUGHLTEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+RAWDEBUGHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RECO DEBUG  
 RECODEBUGEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
 RECODEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #FEVT DEBUG 
-FEVTDEBUGEventContent.outputCommands.extend(FEVTSIMEventContent.outputCommands)
+FEVTDEBUGEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
+FEVTDEBUGEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+FEVTDEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #FEVT HLT DEBUG  
-FEVTDEBUGHLTEventContent.outputCommands.extend(FEVTSIMEventContent.outputCommands)
+FEVTDEBUGHLTEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
+FEVTDEBUGHLTEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+FEVTDEBUGHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)

--- a/Configuration/EventContent/python/EventContentHeavyIons_cff.py
+++ b/Configuration/EventContent/python/EventContentHeavyIons_cff.py
@@ -14,7 +14,11 @@ from RecoHI.Configuration.RecoHI_EventContent_cff import *       # heavy ion rec
 
 
 #RAW
-RAWEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+RecoHIRAWOutput=cms.untracked.vstring(
+	'keep FEDRawDataCollection_rawDataRepacker_*_*',
+        'keep FEDRawDataCollection_hybridRawDataRepacker_*_*',
+        'keep FEDRawDataCollection_virginRawDataRepacker_*_*')
+RAWEventContent.outputCommands.extend(RecoHIRAWOutput)
 
 #RECO
 RECOEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
@@ -23,11 +27,11 @@ RECOEventContent.outputCommands.extend(RecoHIRECO.outputCommands)
 AODEventContent.outputCommands.extend(RecoHIAOD.outputCommands)
 
 #RAWSIM
-RAWSIMEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+RAWSIMEventContent.outputCommands.extend(RecoHIRAWOutput)
 RAWSIMEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RAWSIMHLT
-RAWSIMHLTEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+RAWSIMHLTEventContent.outputCommands.extend(RecoHIRAWOutput)
 RAWSIMHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RECOSIM
@@ -40,23 +44,23 @@ AODSIMEventContent.outputCommands.extend(HiMixAOD.outputCommands)
 
 #FEVT (RAW + RECO)
 FEVTEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+FEVTEventContent.outputCommands.extend(RecoHIRAWOutput)
 
 #FEVTHLTALL (FEVT + all HLT)
 FEVTHLTALLEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTHLTALLEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+FEVTHLTALLEventContent.outputCommands.extend(RecoHIRAWOutput)
 
 #FEVTSIM (RAWSIM + RECOSIM)
 FEVTSIMEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTSIMEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+FEVTSIMEventContent.outputCommands.extend(RecoHIRAWOutput)
 FEVTSIMEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RAW DEBUG(e.g. mergedtruth from trackingParticles) 
-RAWDEBUGEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+RAWDEBUGEventContent.outputCommands.extend(RecoHIRAWOutput)
 RAWDEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RAW HLT DEBUG 
-RAWDEBUGHLTEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+RAWDEBUGHLTEventContent.outputCommands.extend(RecoHIRAWOutput)
 RAWDEBUGHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #RECO DEBUG  
@@ -65,10 +69,10 @@ RECODEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #FEVT DEBUG 
 FEVTDEBUGEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTDEBUGEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+FEVTDEBUGEventContent.outputCommands.extend(RecoHIRAWOutput)
 FEVTDEBUGEventContent.outputCommands.extend(HiMixRAW.outputCommands)
 
 #FEVT HLT DEBUG  
 FEVTDEBUGHLTEventContent.outputCommands.extend(RecoHIFEVT.outputCommands)
-FEVTDEBUGHLTEventContent.outputCommands.extend(RecoHIRAW.outputCommands)
+FEVTDEBUGHLTEventContent.outputCommands.extend(RecoHIRAWOutput)
 FEVTDEBUGHLTEventContent.outputCommands.extend(HiMixRAW.outputCommands)

--- a/RecoHI/Configuration/python/RecoHI_EventContent_cff.py
+++ b/RecoHI/Configuration/python/RecoHI_EventContent_cff.py
@@ -45,3 +45,13 @@ RecoHIFEVT.outputCommands.extend(RecoHiEgammaFEVT.outputCommands)
 RecoHIFEVT.outputCommands.extend(RecoHiEvtPlaneFEVT.outputCommands)
 RecoHIFEVT.outputCommands.extend(RecoHiCentralityFEVT.outputCommands)
 RecoHIFEVT.outputCommands.extend(RecoHiMuonFEVT.outputCommands)
+
+# RAW content
+RecoHIRAWOutput=cms.untracked.vstring(
+	'keep FEDRawDataCollection_rawDataRepacker_*_*',
+        'keep FEDRawDataCollection_hybridRawDataRepacker_*_*',
+        'keep FEDRawDataCollection_virginRawDataRepacker_*_*')
+RecoHIRAW = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoHIRAW.outputCommands.extend(RecoHIRAWOutput)

--- a/RecoHI/Configuration/python/RecoHI_EventContent_cff.py
+++ b/RecoHI/Configuration/python/RecoHI_EventContent_cff.py
@@ -46,12 +46,3 @@ RecoHIFEVT.outputCommands.extend(RecoHiEvtPlaneFEVT.outputCommands)
 RecoHIFEVT.outputCommands.extend(RecoHiCentralityFEVT.outputCommands)
 RecoHIFEVT.outputCommands.extend(RecoHiMuonFEVT.outputCommands)
 
-# RAW content
-RecoHIRAWOutput=cms.untracked.vstring(
-	'keep FEDRawDataCollection_rawDataRepacker_*_*',
-        'keep FEDRawDataCollection_hybridRawDataRepacker_*_*',
-        'keep FEDRawDataCollection_virginRawDataRepacker_*_*')
-RecoHIRAW = cms.PSet(
-    outputCommands = cms.untracked.vstring()
-)
-RecoHIRAW.outputCommands.extend(RecoHIRAWOutput)


### PR DESCRIPTION
#### PR description:

In the restructuring campaign for the reconstruction related event contents, PR #29990 updated the HI ones. In doing so, however, we overlooked the fact that all new event contents started with a "drop *" statement: when more than one of them is put in a row, the "drop *" statement of the second one reset the previous content.

This was noticed in the IB since CMSSW_11_2_X_2020-06-02-2300, and reported in issue #30095.

This PR reports back those event contents which were broken in the previous implementation, and solves that issue.

@jeongeun 

#### PR validation:

Workflows 140.0 and 150.0 now run without errors