### PR TITLE
remove PY3 check as boost now build with python3

### DIFF
--- a/CondCore/AlignmentPlugins/test/BuildFile.xml
+++ b/CondCore/AlignmentPlugins/test/BuildFile.xml
@@ -3,7 +3,4 @@
 <use name="Alignment/CommonAlignment"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <bin file="testTrackerAlignmentPayloadInspector.cpp" name="testTrackerAlignmentPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>

--- a/CondCore/HLTPlugins/test/BuildFile.xml
+++ b/CondCore/HLTPlugins/test/BuildFile.xml
@@ -1,7 +1,4 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
 <bin file="testAlCaRecoTriggerBitsPayloadInspector.cpp" name="testAlCaRecoTriggerBitsPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>

--- a/CondCore/RunInfoPlugins/test/BuildFile.xml
+++ b/CondCore/RunInfoPlugins/test/BuildFile.xml
@@ -1,7 +1,4 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
 <bin file="testRunInfoPayloadInspector.cpp" name="testRunInfoPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>

--- a/CondCore/SiPixelPlugins/test/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/test/BuildFile.xml
@@ -4,7 +4,4 @@
 <use name="CondFormats/SiPixelTransient"/>
 <use name="CalibTracker/SiPixelESProducers"/>
 <bin file="testSiPixelPayloadInspector.cpp" name="testPixelPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>

--- a/CondCore/SiStripPlugins/test/BuildFile.xml
+++ b/CondCore/SiStripPlugins/test/BuildFile.xml
@@ -3,7 +3,4 @@
 <use name="FWCore/PluginManager"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <bin file="testSiStripPayloadInspector.cpp" name="testSiStripPayloadInspector">
-  <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
-  </ifrelease>
 </bin>

--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -10,7 +10,4 @@
 </bin>
 
 <bin file="testPngHistograms.cpp" name="testPngHistograms">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>


### PR DESCRIPTION
Remove PY3 checks for unit tests. This was needed as boost_python was build with python2 while in PY3 IBs the default python was python3. https://github.com/cms-sw/cmsdist/pull/5903 should now build boost python with python3 in PY3 IBs, so there is no need to have these speical conditions in BuildFile.xml
