### PR TITLE
WireDigi container in ALCT (ACLUT-1)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -12,10 +12,13 @@
 #include <cstdint>
 #include <iosfwd>
 #include <limits>
+#include <vector>
 
 class CSCALCTDigi {
 public:
   enum class Version { Legacy = 0, Run3 };
+
+  typedef std::vector<std::vector<uint16_t>> WireContainer;
 
   /// Constructors
   CSCALCTDigi(const uint16_t valid,
@@ -111,6 +114,11 @@ public:
 
   void setRun3(const bool isRun3);
 
+  // wire hits in this ALCT
+  WireContainer getHits() const { return hits_; }
+
+  void setHits(const WireContainer& hits) { hits_ = hits; }
+
 private:
   uint16_t valid_;
   uint16_t quality_;
@@ -126,6 +134,8 @@ private:
   uint16_t hmt_;
 
   Version version_;
+  // which hits are in this ALCT?
+  WireContainer hits_;
 };
 
 std::ostream& operator<<(std::ostream& o, const CSCALCTDigi& digi);

--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -11,6 +11,8 @@
 #include <iomanip>
 #include <iostream>
 
+enum Pattern_Info { NUM_LAYERS = 6, ALCT_PATTERN_WIDTH = 5 };
+
 using namespace std;
 
 /// Constructors
@@ -31,7 +33,12 @@ CSCALCTDigi::CSCALCTDigi(const uint16_t valid,
       bx_(bx),
       trknmb_(trknmb),
       hmt_(hmt),
-      version_(version) {}
+      version_(version) {
+  hits_.resize(NUM_LAYERS);
+  for (auto& p : hits_) {
+    p.resize(ALCT_PATTERN_WIDTH);
+  }
+}
 
 /// Default
 CSCALCTDigi::CSCALCTDigi() {
@@ -50,6 +57,10 @@ void CSCALCTDigi::clear() {
   trknmb_ = 0;
   fullbx_ = 0;
   hmt_ = 0;
+  hits_.resize(NUM_LAYERS);
+  for (auto& p : hits_) {
+    p.resize(ALCT_PATTERN_WIDTH);
+  }
 }
 
 uint16_t CSCALCTDigi::getHMT() const { return (isRun3() ? hmt_ : std::numeric_limits<uint16_t>::max()); }

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -29,7 +29,8 @@
    <class name="CSCCLCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="1207676078"/>
    </class>
-   <class name="CSCALCTDigi" ClassVersion="11">
+   <class name="CSCALCTDigi" ClassVersion="12">
+     <version ClassVersion="12" checksum="2762007033"/>
      <version ClassVersion="11" checksum="4162193785"/>
      <version ClassVersion="10" checksum="817473300"/>
    </class>


### PR DESCRIPTION
#### PR description:

This PR introduces a simple 2D container in the ALCT object to keep track of which anode wire digi hits were used in the construction. Similar as what is done for CLCTs here https://github.com/cms-sw/cmssw/pull/29205. In a separate PR I'll update the emulator so that the wire digis are stored.

#### PR validation:

Tested with WF 27434.0.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A