### PR TITLE
CLCT comparator code calculation (CCLUT-5)

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/README.md
+++ b/L1Trigger/CSCTriggerPrimitives/README.md
@@ -25,7 +25,7 @@ The C++ code is located in `L1Trigger/CSCTriggerPrimitives/src/` and `L1Trigger/
 
 The `plugins/` directory contains the producer module `CSCTriggerPrimitivesProducer`. The `CSCTriggerPrimitivesReader` should be used for firmware vs emulator comparisons.
 
-The `src/` directory contains the builder `CSCTriggerPrimitivesBuilder`, processors (`CSCAnodeLCTProcessor`,  `CSCCathodeLCTProcessor`, `GEMCoPadProcessor`), motherboards (`CSCMotherboard` and similar names), a muon port card (`CSCMuonPortCard`), auxiliary classes to produce and access look-up-tables (`CSCUpgradeMotherboardLUT` and `CSCUpgradeMotherboardLUTGenerator`) and a module to fit a straight line to comparator digis (`CSCComparatorDigiFitter`). Trigger patterns are stored in `CSCPatternBank`.
+The `src/` directory contains the builder `CSCTriggerPrimitivesBuilder`, processors (`CSCAnodeLCTProcessor`,  `CSCCathodeLCTProcessor`, `GEMCoPadProcessor`), motherboards (`CSCMotherboard` and similar names), a muon port card (`CSCMuonPortCard`), auxiliary classes to produce and access look-up-tables (`CSCUpgradeMotherboardLUT` and `CSCUpgradeMotherboardLUTGenerator`). Trigger patterns are stored in `CSCPatternBank`.
 
 The `CSCTriggerPrimitivesBuilder` instantiates the TMBs for each chamber and the MPCs for each trigger sector. TMBs and MPC are organized in trigger sectors. A trigger sector has 9 associated TMBs and a single MPC. Once instantiated, the TMBs are configured and run according to settings defined `cscTriggerPrimitiveDigis_cfi` (see Configuration). After running the TMB the ALCT/CLCT/LCT collections are read out and put into the event. After all TMBs are run, the MPCs produce LCTs to be sent to the OMTF and EMTF.
 
@@ -37,7 +37,7 @@ The `CSCMuonPortCard` class collects LCTs from a trigger sector and relays them 
 
 The `CSCUpgradeMotherboardLUTGenerator` and `CSCUpgradeMotherboardLUT` produce and contain look-up-tables that are used in the CSC upgrade algorithm and/or the GEM-CSC algorithm.
 
-The `CSCComparatorDigiFitter` is a relatively new feature in CSC trigger. It fits a straight line to a set of comparator digis associated to an LCT. The fitted LCT position has a resolution which is better by about a factor 2 than for non-fitted LCTs. This module will at some point be integrated into the `CSCCathodeLCTProcessor` to produce CLCTs with a better position resolution. Better LCT position is critical to reconstruct L1 muons for displaced signatures, one of the cornerstones of the Phase-2 muon upgrade.
+A new class is `CSCComparatorCodeLUT` which provides access to look-up-tables for improved local bending and position in Run-3 (CCLUT). Better LCT position and bending is critical to reconstruct L1 muons for displaced signatures, one of the cornerstones of the Phase-2 muon upgrade.
 
 The `test/` directory contains python configuration to test the CSC local trigger and analyzer the data.
 
@@ -96,3 +96,8 @@ Recent work includes:
 * The removal of outdated classes `CSCTriggerGeometry` and `CSCTriggerGeomManager` (https://github.com/cms-sw/cmssw/pull/21655)
 * The removal of a lot of outdated code (https://github.com/cms-sw/cmssw/pull/24171), which was used for very early MC studies (early 2000s) or to emulate beam-test data from the Magnet Test and Cosmic Challenge (MTCC - 2006). In case you need to look back at this code, please look at the [CMSSW_10_2_X branch](https://github.com/cms-sw/cmssw/tree/CMSSW_10_2_X/L1Trigger/CSCTriggerPrimitives).
 * The removal of an outdated DQM module (https://github.com/cms-sw/cmssw/pull/24196).
+* The removal of pre-2007 code (https://github.com/cms-sw/cmssw/pull/24254)
+* Implementation of a common baseboard class (https://github.com/cms-sw/cmssw/pull/24403)
+* Update GE1/1-ME1/1 and GE2/1-ME2/1 local triggers (https://github.com/cms-sw/cmssw/pull/27957, https://github.com/cms-sw/cmssw/pull/28334, https://github.com/cms-sw/cmssw/pull/28605)
+* Improvements to the CLCT algorithm following data vs emulator studies Summer and Fall of 2018 (https://github.com/cms-sw/cmssw/pull/25165)
+* Implementation of the CCLUT algorithm (https://github.com/cms-sw/cmssw/pull/28044, https://github.com/cms-sw/cmssw/pull/28600, https://github.com/cms-sw/cmssw/pull/29205, https://github.com/cms-sw/cmssw/pull/28846)

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -219,9 +219,6 @@ protected:
   unsigned int nbits_position_cc_;
   unsigned int nbits_slope_cc_;
 
-  // which hits per CLCT?
-  PulseArray hitsCLCT[99];
-
   /** Default values of configuration parameters. */
   static const unsigned int def_fifo_tbins, def_fifo_pretrig;
   static const unsigned int def_hit_persist, def_drift_delay;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -34,8 +34,11 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h"
+#include "L1Trigger/CSCTriggerPrimitives/interface/CSCComparatorCodeLUT.h"
 
 #include <vector>
+#include <array>
+#include <string>
 
 class CSCCathodeLCTProcessor : public CSCBaseboard {
 public:
@@ -88,6 +91,10 @@ protected:
   /** LCTs in this chamber, as found by the processor. */
   CSCCLCTDigi CLCTContainer_[CSCConstants::MAX_CLCT_TBINS][CSCConstants::MAX_CLCTS_PER_PROCESSOR];
 
+  // unique pointers to the luts
+  std::array<std::unique_ptr<CSCComparatorCodeLUT>, 5> lutpos_;
+  std::array<std::unique_ptr<CSCComparatorCodeLUT>, 5> lutslope_;
+
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);
   void getDigis(const CSCComparatorDigiCollection* compdc, const CSCDetId& id);
@@ -125,7 +132,7 @@ protected:
   // enum used in the comparator code logic
   enum CLCT_CompCode { INVALID_HALFSTRIP = 65535 };
 
-  void cleanComparatorContainer(CSCCLCTDigi::ComparatorContainer& compHits) const;
+  void cleanComparatorContainer(CSCCLCTDigi& lct) const;
 
   /* Mark the half-strips around the best half-strip as busy */
   void markBusyKeys(const int best_hstrip, const int best_patid, int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
@@ -137,6 +144,19 @@ protected:
   /** Dump half-strip digis */
   void dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
                  const int nStrips) const;
+
+  // --------Functions for the comparator code algorith for Run-3 ---------//
+  //calculates the id based on location of hits
+  int calculateComparatorCode(const std::array<std::array<int, 3>, 6>& halfStripPattern) const;
+
+  // sets the 1/4 and 1/8 strip bits given a floating point position offset
+  void calculatePositionCC(float offset, uint16_t& halfstrip, bool& quartstrip, bool& eightstrip) const;
+
+  // converts the floating point slope into integer slope
+  int calculateSlopeCC(float slope, int nBits) const;
+
+  // runs the CCLUT procedure
+  void runCCLUT(CSCCLCTDigi& digi) const;
 
   //--------------------------- Member variables -----------------------------
 
@@ -196,6 +216,8 @@ protected:
   // Use the new patterns according to the comparator code format
   bool use_run3_patterns_;
   bool use_comparator_codes_;
+  unsigned int nbits_position_cc_;
+  unsigned int nbits_slope_cc_;
 
   // which hits per CLCT?
   PulseArray hitsCLCT[99];
@@ -207,6 +229,9 @@ protected:
   static const unsigned int def_nplanes_hit_pattern;
   static const unsigned int def_pid_thresh_pretrig, def_min_separation;
   static const unsigned int def_tmb_l1a_window_size;
+
+  std::vector<std::string> positionLUTFiles_;
+  std::vector<std::string> slopeLUTFiles_;
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCComparatorCodeLUT.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCComparatorCodeLUT.h
@@ -1,0 +1,67 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_CSCComparatorCodeLUT
+#define L1Trigger_CSCTriggerPrimitives_CSCComparatorCodeLUT
+
+#include <fstream>
+#include <sstream>
+#include <bitset>
+#include <iostream>
+#include <vector>
+#include <limits>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class CSCComparatorCodeLUT {
+public:
+  enum ReadCodes {
+    SUCCESS = 0,
+    NO_ENTRIES = 1,
+    DUP_ENTRIES = 2,
+    MISS_ENTRIES = 3,
+    MAX_ADDRESS_OUTOFRANGE = 4,
+    NO_HEADER = 5
+  };
+
+  /* CSCComparatorCodeLUT(); */
+  explicit CSCComparatorCodeLUT(const std::string&);
+  /* explicit CSCComparatorCodeLUT(l1t::LUT*); */
+  ~CSCComparatorCodeLUT() {}
+
+  float lookup(int code) const;
+  float lookupPacked(const int input) const;
+
+  // populates the map.
+  void initialize();
+
+  unsigned checkedInput(unsigned in, unsigned maxWidth) const;
+
+  // I/O functions
+  void save(std::ofstream& output);
+  int load(const std::string& inFileName);
+
+  float data(unsigned int address) const;
+  int read(std::istream& stream);
+  void write(std::ostream& stream) const;
+
+  unsigned int nrBitsAddress() const { return nrBitsAddress_; }
+  unsigned int nrBitsData() const { return nrBitsData_; }
+  //following the convention of vector::size()
+  unsigned int maxSize() const;
+  bool empty() const { return data_.empty(); }
+
+private:
+  int readHeader(std::istream&);
+
+  unsigned int nrBitsAddress_;  //technically redundant with addressMask
+  unsigned int nrBitsData_;     //technically redundant with dataMask
+  unsigned int addressMask_;
+  unsigned int dataMask_;
+
+  std::vector<float> data_;
+
+  int m_codeInWidth;
+  unsigned m_outWidth;
+  bool m_initialized;
+};
+
+#endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -118,6 +118,9 @@ protected:
   unsigned int highMultiplicityBits_;
   bool useHighMultiplicityBits_;
 
+  // Use the new patterns according to the comparator code format
+  bool use_run3_patterns_;
+
   /** Default values of configuration parameters. */
   static const unsigned int def_mpc_block_me1a;
   static const unsigned int def_alct_trig_enable, def_clct_trig_enable;

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -500,32 +500,20 @@ run2_common.toModify( cscTriggerPrimitiveDigis,
                       commonParam = dict(gangedME1a = False),
                       )
 
-## Run-3 CSC-only: new LCT data format
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify( cscTriggerPrimitiveDigis,
-                      commonParam = dict(isSLHC = True,
-                                         runME11Up = cms.bool(True),
-                                         enableAlctSLHC = cms.bool(False)),
-                      ## EMTF will take of this
-                      tmbSLHC = dict(ignoreAlctCrossClct = cms.bool(False)),
-                      clctSLHC = dict(
-                          clctNplanesHitPattern = 4,
-                      ),
-                   )
-
-## Run3: GEM-CSC ILT in ME1/1
+## GEM-CSC ILT in ME1/1
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscTriggerPrimitiveDigis,
                    GEMPadDigiProducer = cms.InputTag("simMuonGEMPadDigis"),
                    GEMPadDigiClusterProducer = cms.InputTag("simMuonGEMPadDigiClusters"),
-                   commonParam = dict(runME11ILT = cms.bool(True),
-                                      useClusters = cms.bool(False)),
-                   clctSLHC = dict(
-                       clctNplanesHitPattern = 3,
-                   ),
+                   commonParam = dict(isSLHC = True,
+                                      runME11Up = cms.bool(True),
+                                      runME11ILT = cms.bool(True),
+                                      useClusters = cms.bool(False),
+                                      enableAlctSLHC = cms.bool(True)),
+                   clctSLHC = dict(clctNplanesHitPattern = 3),
                    me11tmbSLHCGEM = me11tmbSLHCGEM,
                    copadParamGE11 = copadParamGE11
-)
+                   )
 
 ## GEM-CSC ILT in ME2/1, CSC in ME3/1 and ME4/1
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
@@ -534,6 +522,7 @@ phase2_muon.toModify( cscTriggerPrimitiveDigis,
                                          runME21ILT = cms.bool(True),
                                          runME31Up = cms.bool(True),
                                          runME41Up = cms.bool(True)),
+                      tmbSLHC = dict(ignoreAlctCrossClct = cms.bool(False)),
                       clctSLHC = dict(useDynamicStateMachineZone = cms.bool(True)),
                       alctSLHCME21 = cscTriggerPrimitiveDigis.alctSLHC.clone(alctNplanesHitPattern = 3),
                       clctSLHCME21 = cscTriggerPrimitiveDigis.clctSLHC.clone(clctNplanesHitPattern = 3),

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -28,6 +28,22 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
     # Write out pre-triggers
     savePreTriggers = cms.bool(False),
 
+    positionLUTFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat0_ideal_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat1_ideal_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat2_ideal_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat3_ideal_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat4_ideal_v1.txt"
+    ),
+
+    slopeLUTFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat0_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat1_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat2_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat3_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat4_v1.txt"
+    ),
+
     # Parameters common for all boards
     commonParam = cms.PSet(
         # Master flag for SLHC studies
@@ -165,6 +181,8 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         useRun3Patterns = cms.bool(False),
 
         useComparatorCodes = cms.bool(False),
+        nBitsPositionCC = cms.uint32(10),
+        nBitsSlopeCC = cms.uint32(5)
     ),
 
     # Parameters for CLCT processors: SLHC studies
@@ -211,6 +229,9 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         useRun3Patterns = cms.bool(False),
 
         useComparatorCodes = cms.bool(False),
+
+        nBitsPositionCC = cms.uint32(10),
+        nBitsSlopeCC = cms.uint32(5)
     ),
 
     tmbParam = cms.PSet(
@@ -479,20 +500,32 @@ run2_common.toModify( cscTriggerPrimitiveDigis,
                       commonParam = dict(gangedME1a = False),
                       )
 
-## GEM-CSC ILT in ME1/1
+## Run-3 CSC-only: new LCT data format
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify( cscTriggerPrimitiveDigis,
+                      commonParam = dict(isSLHC = True,
+                                         runME11Up = cms.bool(True),
+                                         enableAlctSLHC = cms.bool(False)),
+                      ## EMTF will take of this
+                      tmbSLHC = dict(ignoreAlctCrossClct = cms.bool(False)),
+                      clctSLHC = dict(
+                          clctNplanesHitPattern = 4,
+                      ),
+                   )
+
+## Run3: GEM-CSC ILT in ME1/1
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscTriggerPrimitiveDigis,
                    GEMPadDigiProducer = cms.InputTag("simMuonGEMPadDigis"),
                    GEMPadDigiClusterProducer = cms.InputTag("simMuonGEMPadDigiClusters"),
-                   commonParam = dict(isSLHC = True,
-                                      runME11Up = cms.bool(True),
-                                      runME11ILT = cms.bool(True),
-                                      useClusters = cms.bool(False),
-                                      enableAlctSLHC = cms.bool(True)),
-                   clctSLHC = dict(clctNplanesHitPattern = 3),
+                   commonParam = dict(runME11ILT = cms.bool(True),
+                                      useClusters = cms.bool(False)),
+                   clctSLHC = dict(
+                       clctNplanesHitPattern = 3,
+                   ),
                    me11tmbSLHCGEM = me11tmbSLHCGEM,
                    copadParamGE11 = copadParamGE11
-                   )
+)
 
 ## GEM-CSC ILT in ME2/1, CSC in ME3/1 and ME4/1
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
@@ -501,7 +534,6 @@ phase2_muon.toModify( cscTriggerPrimitiveDigis,
                                          runME21ILT = cms.bool(True),
                                          runME31Up = cms.bool(True),
                                          runME41Up = cms.bool(True)),
-                      tmbSLHC = dict(ignoreAlctCrossClct = cms.bool(False)),
                       clctSLHC = dict(useDynamicStateMachineZone = cms.bool(True)),
                       alctSLHCME21 = cscTriggerPrimitiveDigis.alctSLHC.clone(alctNplanesHitPattern = 3),
                       clctSLHCME21 = cscTriggerPrimitiveDigis.clctSLHC.clone(clctNplanesHitPattern = 3),

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1008,11 +1008,13 @@ void CSCCathodeLCTProcessor::markBusyKeys(const int best_hstrip,
 }  // markBusyKeys -- TMB-07 version.
 
 void CSCCathodeLCTProcessor::cleanComparatorContainer(CSCCLCTDigi& clct) const {
-  for (auto& p : clct.getHits()) {
+  CSCCLCTDigi::ComparatorContainer newHits = clct.getHits();
+  for (auto& p : newHits) {
     p.erase(std::remove_if(
                 p.begin(), p.end(), [](unsigned i) -> bool { return i == CSCCathodeLCTProcessor::INVALID_HALFSTRIP; }),
             p.end());
   }
+  clct.setHits(newHits);
 }
 
 // --------------------------------------------------------------------------

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCComparatorCodeLUT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCComparatorCodeLUT.cc
@@ -1,0 +1,159 @@
+#include "L1Trigger/CSCTriggerPrimitives/interface/CSCComparatorCodeLUT.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+CSCComparatorCodeLUT::CSCComparatorCodeLUT(const std::string& fname)
+    : nrBitsAddress_(0), nrBitsData_(0), addressMask_(0), dataMask_(0), data_(), m_codeInWidth(12), m_outWidth(32) {
+  if (fname != std::string("")) {
+    load(fname);
+  } else {
+    initialize();
+  }
+}
+
+// I/O functions
+void CSCComparatorCodeLUT::save(std::ofstream& output) { write(output); }
+
+float CSCComparatorCodeLUT::data(unsigned int address) const {
+  return (address & addressMask_) < data_.size() ? data_[address] : 0;
+}
+
+int CSCComparatorCodeLUT::load(const std::string& inFileName) {
+  std::ifstream fstream;
+  fstream.open(edm::FileInPath(inFileName.c_str()).fullPath());
+  if (!fstream.good()) {
+    fstream.close();
+    throw cms::Exception("FileOpenError") << "Failed to open LUT file: " << inFileName;
+  }
+  int readCode = read(fstream);
+
+  m_initialized = true;
+  fstream.close();
+
+  return readCode;
+}
+
+float CSCComparatorCodeLUT::lookup(int code) const {
+  if (m_initialized) {
+    return lookupPacked(code);
+  }
+  return 0;
+}
+
+float CSCComparatorCodeLUT::lookupPacked(const int input) const {
+  if (m_initialized) {
+    return data((unsigned int)input);
+  }
+  throw cms::Exception("Uninitialized") << "If you're not loading a LUT from file you need to implement lookupPacked.";
+  return 0;
+}
+
+void CSCComparatorCodeLUT::initialize() {
+  if (empty()) {
+    std::stringstream stream;
+    stream << "#<header> V1 " << m_codeInWidth << " " << m_outWidth << " </header> " << std::endl;
+    for (int in = 0; in < (1 << m_codeInWidth); ++in) {
+      int out = lookup(in);
+      stream << in << " " << out << std::endl;
+    }
+    read(stream);
+  }
+  m_initialized = true;
+}
+
+unsigned CSCComparatorCodeLUT::checkedInput(unsigned in, unsigned maxWidth) const {
+  unsigned maxIn = (1 << maxWidth) - 1;
+  return (in < maxIn ? in : maxIn);
+}
+
+int CSCComparatorCodeLUT::read(std::istream& stream) {
+  data_.clear();
+
+  int readHeaderCode = readHeader(stream);
+  if (readHeaderCode != SUCCESS)
+    return readHeaderCode;
+
+  std::vector<std::pair<unsigned int, float> > entries;
+  unsigned int maxAddress = addressMask_;
+  std::string line;
+
+  while (std::getline(stream, line)) {
+    line.erase(std::find(line.begin(), line.end(), '#'), line.end());  //ignore comments
+    std::istringstream lineStream(line);
+    std::pair<unsigned int, float> entry;
+    while (lineStream >> entry.first >> entry.second) {
+      entry.first &= addressMask_;
+      // entry.second &= dataMask_;
+      entries.push_back(entry);
+      if (entry.first > maxAddress || maxAddress == addressMask_)
+        maxAddress = entry.first;
+    }
+  }
+  std::sort(entries.begin(), entries.end());
+  if (entries.empty()) {
+    //log the error we read nothing
+    return NO_ENTRIES;
+  }
+  //this check is redundant as dups are also picked up by the next check but might make for easier debugging
+  if (std::adjacent_find(entries.begin(), entries.end(), [](auto const& a, auto const& b) {
+        return a.first == b.first;
+      }) != entries.end()) {
+    //log the error that we have duplicate addresses once masked
+    return DUP_ENTRIES;
+  }
+  if (entries.front().first != 0 ||
+      std::adjacent_find(entries.begin(), entries.end(), [](auto const& a, auto const& b) {
+        return a.first + 1 != b.first;
+      }) != entries.end()) {
+    //log the error that we have a missing entry
+    return MISS_ENTRIES;
+  }
+
+  if (maxAddress != std::numeric_limits<unsigned int>::max())
+    data_.resize(maxAddress + 1, 0);
+  else {
+    //log the error that we have more addresses than we can deal with (which is 4gb so something probably has gone wrong anyways)
+    return MAX_ADDRESS_OUTOFRANGE;
+  }
+
+  std::transform(entries.begin(), entries.end(), data_.begin(), [](auto const& x) { return x.second; });
+  return SUCCESS;
+}
+
+void CSCComparatorCodeLUT::write(std::ostream& stream) const {
+  stream << "#<header> V1 " << nrBitsAddress_ << " " << nrBitsData_ << " </header> " << std::endl;
+  for (unsigned int address = 0; address < data_.size(); address++) {
+    stream << (address & addressMask_) << " " << data(address) << std::endl;
+  }
+}
+
+unsigned int CSCComparatorCodeLUT::maxSize() const {
+  return addressMask_ == std::numeric_limits<unsigned int>::max() ? addressMask_ : addressMask_ + 1;
+}
+
+int CSCComparatorCodeLUT::readHeader(std::istream& stream) {
+  int startPos = stream.tellg();  //we are going to reset to this position before we exit
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (line.find("#<header>") == 0) {  //line
+      std::istringstream lineStream(line);
+
+      std::string version;      //currently not doing anything with this
+      std::string headerField;  //currently not doing anything with this
+      if (lineStream >> headerField >> version >> nrBitsAddress_ >> nrBitsData_) {
+        addressMask_ = nrBitsAddress_ != 32 ? (0x1 << nrBitsAddress_) - 1 : ~0x0;
+        dataMask_ = (0x1 << nrBitsData_) - 1;
+        stream.seekg(startPos);
+        return SUCCESS;
+      }
+    }
+  }
+
+  nrBitsAddress_ = 0;
+  nrBitsData_ = 0;
+  addressMask_ = (0x1 << nrBitsAddress_) - 1;
+  dataMask_ = (0x1 << nrBitsData_) - 1;
+
+  stream.seekg(startPos);
+  return NO_HEADER;
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -189,10 +189,6 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
                                    << " detid " << cscId_ << " with wiregroup " << keyWG << "keyStrip " << keyStrip
                                    << " \n";
 
-  // in Run-3 we plan to use the synchronization error bit
-  // to denote the presence of exotic signatures in the chamber
-  unsigned int syncErr = useHighMultiplicityBits_ ? highMultiplicityBits_ : 0;
-
   // fill the rest of the properties
   thisLCT.setTrknmb(trknmb);
   thisLCT.setValid(valid);
@@ -204,8 +200,13 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
   thisLCT.setBX(bx);
   thisLCT.setMPCLink(0);
   thisLCT.setBX0(0);
-  thisLCT.setSyncErr(syncErr);
+  // Not used in Run-2. Will not be assigned in Run-3
+  thisLCT.setSyncErr(0);
   thisLCT.setCSCID(theTrigChamber);
+  thisLCT.setRun3(true);
+  // in Run-3 we plan to denote the presence of exotic signatures in the chamber
+  if (useHighMultiplicityBits_)
+    thisLCT.setHMT(highMultiplicityBits_);
 
   // future work: add a section that produces LCTs according
   // to the new LCT dataformat (not yet defined)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -478,7 +478,7 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
                                                    int type,
                                                    int trknmb) const {
   // CLCT pattern number
-  unsigned int pattern = encodePattern(cLCT.getPattern());
+  unsigned int pattern = use_run3_patterns_ ? 0 : encodePattern(cLCT.getPattern());
 
   // LCT quality number
   unsigned int quality = findQuality(aLCT, cLCT);
@@ -486,9 +486,8 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
   // Bunch crossing: get it from cathode LCT if anode LCT is not there.
   int bx = aLCT.isValid() ? aLCT.getBX() : cLCT.getBX();
 
-  // in Run-3 we plan to use the synchronization error bit
-  // to denote the presence of exotic signatures in the chamber
-  unsigned int syncErr = useHighMultiplicityBits_ ? highMultiplicityBits_ : 0;
+  // Not used in Run-2. Will not be assigned in Run-3
+  unsigned int syncErr = 0;
 
   // construct correlated LCT
   CSCCorrelatedLCTDigi thisLCT(trknmb,
@@ -504,6 +503,14 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
                                syncErr,
                                theTrigChamber);
   thisLCT.setType(type);
+
+  if (use_run3_patterns_) {
+    thisLCT.setRun3(true);
+    // in Run-3 we plan to denote the presence of exotic signatures in the chamber
+    if (useHighMultiplicityBits_)
+      thisLCT.setHMT(highMultiplicityBits_);
+  }
+
   // make sure to shift the ALCT BX from 8 to 3 and the CLCT BX from 8 to 7!
   thisLCT.setALCT(getBXShiftedALCT(aLCT));
   thisLCT.setCLCT(getBXShiftedCLCT(cLCT));

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -329,13 +329,18 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
             thisLCT.setFullBX(fbx);
 
             // get the comparator hits for this pattern
-            auto compHits = hits_in_patterns[best_hs][keystrip_data[ilct][CLCT_PATTERN]];
-
-            // purge the comparator digi collection from the obsolete "65535" entries...
-            cleanComparatorContainer(compHits);
+            const auto& compHits = hits_in_patterns[best_hs][keystrip_data[ilct][CLCT_PATTERN]];
 
             // set the hit collection
             thisLCT.setHits(compHits);
+
+            // do the CCLUT procedures
+            if (use_comparator_codes_) {
+              runCCLUT(thisLCT);
+            }
+
+            // purge the comparator digi collection from the obsolete "65535" entries...
+            cleanComparatorContainer(thisLCT);
 
             // put the CLCT into the collection
             lctList.push_back(thisLCT);


### PR DESCRIPTION
#### PR description:

This PR introduces the comparator code calculation in the CLCT processor (actually part of the OTMB/TMB firmware logic). Run-3 will use new CLCT patterns which, in combination with the CCLUT algorithm, allow for a more precise determination of LCT position and bending in the CSC local trigger. More information on the CCLUT algorithm and CSC trigger data formats can be found here: https://gitlab.cern.ch/tdr/notes/DN-20-016/blob/master/temp/DN-20-016_temp.pdf. The CCLUT algorithm uses a new `CSCComparatorCodeLUT` object that loads the LUTs in txt format. I do not yet have an actual position offset/slope LUT generator, but plan to add that in a follow-up PR.

The PR is the fifth in a series following https://github.com/cms-sw/cmssw/pull/29233, https://github.com/cms-sw/cmssw/pull/29205, https://github.com/cms-sw/cmssw/pull/28846 and https://github.com/cms-sw/cmssw/pull/28600. A related PR is this one https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/1 where the LUTs are introduced for position offset and slope. 

To be clear: the code is not enabled yet - and won't be for quite some time as it requires precise coordination between EMTF, OMTF, DQM, packer/unpacker etc. There should be no differences in any of the workflows (and I didn't see any in local tests).

#### PR validation:

Tested with WF 27434.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 