### PR TITLE
Rewrite ALCT trigger patterns as 2D vector (ACLUT-2)

### DIFF
--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -48,6 +48,7 @@ public:
   // Both ALCT and CLCTs have patterns. CLCTs have a better granularity than ALCTs, thus more patterns
   enum Pattern_Info {
     NUM_ALCT_PATTERNS = 3,
+    ALCT_PATTERN_WIDTH = 5,
     NUM_CLCT_PATTERNS = 11,
     CLCT_PATTERN_WIDTH = 11,
     // Max number of wires participating in a pattern

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -160,7 +160,7 @@ protected:
   static const unsigned int def_l1a_window_width;
 
   /** Chosen pattern mask. */
-  int pattern_mask[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
+  CSCPatternBank::LCTPatterns alct_pattern_ = {};
 
   /** Load pattern mask defined by configuration into pattern_mask */
   void loadPatternMask();

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -152,7 +152,7 @@ protected:
   bool ispretrig[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
   // actual LUT used
-  CSCPatternBank::CLCTPatterns clct_pattern_ = {};
+  CSCPatternBank::LCTPatterns clct_pattern_ = {};
 
   // we use these next ones to address the various bits inside the array that's
   // used to make the cathode LCTs.

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h
@@ -10,26 +10,21 @@
 
 class CSCPatternBank {
 public:
-  typedef std::vector<std::vector<std::vector<int> > > CLCTPatterns;
-
-  typedef int ALCTPatterns[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
+  // typedef used for both ALCT and CLCT
+  typedef std::vector<std::vector<std::vector<int> > > LCTPatterns;
 
   /** Pre-defined ALCT patterns. */
 
-  // This is the pattern envelope, which is used to define the collision
-  // patterns A and B.
-  static const int alct_pattern_envelope[CSCConstants::MAX_WIRES_IN_PATTERN];
-
   // key wire offsets for ME1 and ME2 are the same
   // offsets for ME3 and ME4 are the same
-  static const int alct_keywire_offset[2][CSCConstants::MAX_WIRES_IN_PATTERN];
+  static const int alct_keywire_offset_[2][CSCConstants::ALCT_PATTERN_WIDTH];
 
   // Since the test beams in 2003, both collision patterns are "completely
   // open".  This is our current default.
-  static const ALCTPatterns alct_pattern_mask_open;
+  static const LCTPatterns alct_pattern_legacy_;
 
   // Special option for narrow pattern for ring 1 stations
-  static const ALCTPatterns alct_pattern_mask_r1;
+  static const LCTPatterns alct_pattern_r1_;
 
   /** Pre-defined CLCT patterns. */
 
@@ -39,10 +34,10 @@ public:
   // Bend of 0 is right/straight and bend of 1 is left.
   // The pattern maximum width is the last number in the the 6th layer
   // Use during Run-1 and Run-2
-  static const CLCTPatterns clct_pattern_legacy_;
+  static const LCTPatterns clct_pattern_legacy_;
 
   // New patterns for Run-3
-  static const CLCTPatterns clct_pattern_run3_;
+  static const LCTPatterns clct_pattern_run3_;
 
   // half strip offsets per layer for each half strip in the pattern envelope
   static const int clct_pattern_offset_[CSCConstants::CLCT_PATTERN_WIDTH];

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCAnodeLCTAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCAnodeLCTAnalyzer.cc
@@ -95,12 +95,11 @@ vector<CSCAnodeLayerInfo> CSCAnodeLCTAnalyzer::lctDigis(const CSCALCTDigi& alct,
     }
 
     // Loop over all the wires in a pattern.
-    int mask;
-    for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++) {
-      if (CSCPatternBank::alct_pattern_envelope[i_wire] == i_layer) {
-        mask = CSCPatternBank::alct_pattern_mask_open[alct_pattern][i_wire];
-        if (mask == 1) {
-          int wire = alct_keywire + CSCPatternBank::alct_keywire_offset[MESelection][i_wire];
+    for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; ++i_layer) {
+      for (int i_wire = 0; i_wire < CSCConstants::ALCT_PATTERN_WIDTH; ++i_wire) {
+        // check the mask
+        if (CSCPatternBank::alct_pattern_legacy_[alct_pattern][i_layer][i_wire]) {
+          int wire = alct_keywire + CSCPatternBank::alct_keywire_offset_[MESelection][i_wire];
           if (wire >= 0 && wire < CSCConstants::MAX_NUM_WIRES) {
             // Check if there is a "good" Digi on this wire.
             if (digiMap.count(wire) > 0) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -108,12 +108,10 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor() : CSCBaseboard() {
 
 void CSCAnodeLCTProcessor::loadPatternMask() {
   // Load appropriate pattern mask.
-  for (int i_patt = 0; i_patt < CSCConstants::NUM_ALCT_PATTERNS; i_patt++) {
-    for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++) {
-      pattern_mask[i_patt][i_wire] = CSCPatternBank::alct_pattern_mask_open[i_patt][i_wire];
-      if (narrow_mask_r1 && (theRing == 1 || theRing == 4))
-        pattern_mask[i_patt][i_wire] = CSCPatternBank::alct_pattern_mask_r1[i_patt][i_wire];
-    }
+  if (narrow_mask_r1 && (theRing == 1 || theRing == 4)) {
+    alct_pattern_ = CSCPatternBank::alct_pattern_r1_;
+  } else {
+    alct_pattern_ = CSCPatternBank::alct_pattern_legacy_;
   }
 }
 
@@ -544,38 +542,43 @@ bool CSCAnodeLCTProcessor::preTrigger(const int key_wire, const int start_bx) {
   unsigned int stop_bx = fifo_tbins - drift_delay;
   for (unsigned int bx_time = start_bx; bx_time < stop_bx; bx_time++) {
     for (int i_pattern = 0; i_pattern < CSCConstants::NUM_ALCT_PATTERNS; i_pattern++) {
+
+      // initialize the hit layers
       for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++)
         hit_layer[i_layer] = false;
       layers_hit = 0;
 
-      for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++) {
-        if (pattern_mask[i_pattern][i_wire] != 0) {
-          this_layer = CSCPatternBank::alct_pattern_envelope[i_wire];
-          this_wire = CSCPatternBank::alct_keywire_offset[MESelection][i_wire] + key_wire;
-          if ((this_wire >= 0) && (this_wire < numWireGroups)) {
-            // Perform bit operation to see if pulse is 1 at a certain bx_time.
-            if (((pulse[this_layer][this_wire] >> bx_time) & 1) == 1) {
-              // Store number of layers hit.
-              if (hit_layer[this_layer] == false) {
-                hit_layer[this_layer] = true;
-                layers_hit++;
-              }
-
-              // See if number of layers hit is greater than or equal to
-              // pretrig_thresh.
-              if (layers_hit >= pretrig_thresh[i_pattern]) {
-                first_bx[key_wire] = bx_time;
-                if (infoV > 1) {
-                  LogTrace("CSCAnodeLCTProcessor") << "Pretrigger was satisfied for wire: " << key_wire
-                                                   << " pattern: " << i_pattern << " bx_time: " << bx_time;
+      // now run over all layers and wires
+      for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
+        for (int i_wire = 0; i_wire < CSCConstants::ALCT_PATTERN_WIDTH; i_wire++) {
+          // check if the hit is valid
+          if (alct_pattern_[i_pattern][i_layer][i_wire] != 0) {
+            this_wire = CSCPatternBank::alct_keywire_offset_[MESelection][i_wire] + key_wire;
+            if ((this_wire >= 0) && (this_wire < numWireGroups)) {
+              // Perform bit operation to see if pulse is 1 at a certain bx_time.
+              if (((pulse[i_layer][this_wire] >> bx_time) & 1) == 1) {
+                // Store number of layers hit.
+                if (hit_layer[i_layer] == false) {
+                  hit_layer[i_layer] = true;
+                  layers_hit++;
                 }
-                // make a new pre-trigger
-                nPreTriggers++;
-                // make a new pre-trigger digi
-                // useful for calculating DAQ rates
-                thePreTriggerDigis.emplace_back(
-                    CSCALCTPreTriggerDigi(1, layers_hit - 3, 0, 0, this_wire, bx_time, nPreTriggers));
-                return true;
+
+                // See if number of layers hit is greater than or equal to
+                // pretrig_thresh.
+                if (layers_hit >= pretrig_thresh[i_pattern]) {
+                  first_bx[key_wire] = bx_time;
+                  if (infoV > 1) {
+                    LogTrace("CSCAnodeLCTProcessor") << "Pretrigger was satisfied for wire: " << key_wire
+                                                     << " pattern: " << i_pattern << " bx_time: " << bx_time;
+                  }
+                  // make a new pre-trigger
+                  nPreTriggers++;
+                  // make a new pre-trigger digi
+                  // useful for calculating DAQ rates
+                  thePreTriggerDigis.emplace_back(
+                                                  CSCALCTPreTriggerDigi(1, layers_hit - 3, 0, 0, this_wire, bx_time, nPreTriggers));
+                  return true;
+                }
               }
             }
           }
@@ -602,6 +605,8 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
 
   for (int i_pattern = 0; i_pattern < CSCConstants::NUM_ALCT_PATTERNS; i_pattern++) {
     temp_quality = 0;
+
+    // initialize the hit layers
     for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++)
       hit_layer[i_layer] = false;
 
@@ -609,44 +614,45 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
     std::multiset<int> mset_for_median;
     mset_for_median.clear();
 
-    for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++) {
-      if (pattern_mask[i_pattern][i_wire] != 0) {
-        this_layer = CSCPatternBank::alct_pattern_envelope[i_wire];
-        delta_wire = CSCPatternBank::alct_keywire_offset[MESelection][i_wire];
-        this_wire = delta_wire + key_wire;
-        if ((this_wire >= 0) && (this_wire < numWireGroups)) {
-          // Wait a drift_delay time later and look for layers hit in
-          // the pattern.
-          if (((pulse[this_layer][this_wire] >> (first_bx[key_wire] + drift_delay)) & 1) == 1) {
-            // If layer has never had a hit before, then increment number
-            // of layer hits.
-            if (hit_layer[this_layer] == false) {
-              temp_quality++;
-              // keep track of which layers already had hits.
-              hit_layer[this_layer] = true;
-              if (infoV > 1)
-                LogTrace("CSCAnodeLCTProcessor")
+    for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
+      for (int i_wire = 0; i_wire < CSCConstants::ALCT_PATTERN_WIDTH; i_wire++) {
+        if (alct_pattern_[i_pattern][i_layer][i_wire] != 0) {
+          delta_wire = CSCPatternBank::alct_keywire_offset_[MESelection][i_wire];
+          this_wire = delta_wire + key_wire;
+          if ((this_wire >= 0) && (this_wire < numWireGroups)) {
+            // Wait a drift_delay time later and look for layers hit in
+            // the pattern.
+            if (((pulse[i_layer][this_wire] >> (first_bx[key_wire] + drift_delay)) & 1) == 1) {
+              // If layer has never had a hit before, then increment number
+              // of layer hits.
+              if (hit_layer[i_layer] == false) {
+                temp_quality++;
+                // keep track of which layers already had hits.
+                hit_layer[i_layer] = true;
+                if (infoV > 1)
+                  LogTrace("CSCAnodeLCTProcessor")
                     << "bx_time: " << first_bx[key_wire] << " pattern: " << i_pattern << " keywire: " << key_wire
-                    << " layer: " << this_layer << " quality: " << temp_quality;
-            }
-
-            // for averaged time use only the closest WGs around the key WG
-            if (abs(delta_wire) < 2) {
-              // find at what bx did pulse on this wire&layer start
-              // use hit_pesrist constraint on how far back we can go
-              int first_bx_layer = first_bx[key_wire] + drift_delay;
-              for (unsigned int dbx = 0; dbx < hit_persist; dbx++) {
-                if (((pulse[this_layer][this_wire] >> (first_bx_layer - 1)) & 1) == 1)
-                  first_bx_layer--;
-                else
-                  break;
+                    << " layer: " << i_layer << " quality: " << temp_quality;
               }
-              times_sum += (double)first_bx_layer;
-              num_pattern_hits += 1.;
-              mset_for_median.insert(first_bx_layer);
-              if (infoV > 2)
-                LogTrace("CSCAnodeLCTProcessor") << " 1st bx in layer: " << first_bx_layer << " sum bx: " << times_sum
-                                                 << " #pat. hits: " << num_pattern_hits;
+
+              // for averaged time use only the closest WGs around the key WG
+              if (abs(delta_wire) < 2) {
+                // find at what bx did pulse on this wire&layer start
+                // use hit_pesrist constraint on how far back we can go
+                int first_bx_layer = first_bx[key_wire] + drift_delay;
+                for (unsigned int dbx = 0; dbx < hit_persist; dbx++) {
+                  if (((pulse[i_layer][this_wire] >> (first_bx_layer - 1)) & 1) == 1)
+                    first_bx_layer--;
+                  else
+                    break;
+                }
+                times_sum += (double)first_bx_layer;
+                num_pattern_hits += 1.;
+                mset_for_median.insert(first_bx_layer);
+                if (infoV > 2)
+                  LogTrace("CSCAnodeLCTProcessor") << " 1st bx in layer: " << first_bx_layer << " sum bx: " << times_sum
+                                                   << " #pat. hits: " << num_pattern_hits;
+              }
             }
           }
         }
@@ -1323,17 +1329,18 @@ void CSCAnodeLCTProcessor::showPatterns(const int key_wire) {
       strstrm_header << ((32 - i) % 10);
     }
     LogTrace("CSCAnodeLCTProcessor") << strstrm_header.str();
-    for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++) {
-      if (pattern_mask[i_pattern][i_wire] != 0) {
-        std::ostringstream strstrm_pulse;
-        int this_layer = CSCPatternBank::alct_pattern_envelope[i_wire];
-        int this_wire = CSCPatternBank::alct_keywire_offset[MESelection][i_wire] + key_wire;
-        if (this_wire >= 0 && this_wire < numWireGroups) {
-          for (int i = 1; i <= 32; i++) {
-            strstrm_pulse << ((pulse[this_layer][this_wire] >> (32 - i)) & 1);
+    for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
+      for (int i_wire = 0; i_wire < CSCConstants::ALCT_PATTERN_WIDTH; i_wire++) {
+        if (alct_pattern_[i_pattern][i_layer][i_wire]) {
+          std::ostringstream strstrm_pulse;
+          int this_wire = CSCPatternBank::alct_keywire_offset_[MESelection][i_wire] + key_wire;
+          if (this_wire >= 0 && this_wire < numWireGroups) {
+            for (int i = 1; i <= 32; i++) {
+              strstrm_pulse << ((pulse[i_layer][this_wire] >> (32 - i)) & 1);
+            }
+            LogTrace("CSCAnodeLCTProcessor")
+              << strstrm_pulse.str() << " on layer " << i_layer << " wire " << this_wire;
           }
-          LogTrace("CSCAnodeLCTProcessor")
-              << strstrm_pulse.str() << " on layer " << this_layer << " wire " << this_wire;
         }
       }
     }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -527,7 +527,7 @@ bool CSCAnodeLCTProcessor::preTrigger(const int key_wire, const int start_bx) {
 
   unsigned int layers_hit;
   bool hit_layer[CSCConstants::NUM_LAYERS];
-  int this_layer, this_wire;
+  int this_wire;
   // If nplanes_hit_accel_pretrig is 0, the firmware uses the value
   // of nplanes_hit_pretrig instead.
   const unsigned int nplanes_hit_pretrig_acc =
@@ -542,7 +542,6 @@ bool CSCAnodeLCTProcessor::preTrigger(const int key_wire, const int start_bx) {
   unsigned int stop_bx = fifo_tbins - drift_delay;
   for (unsigned int bx_time = start_bx; bx_time < stop_bx; bx_time++) {
     for (int i_pattern = 0; i_pattern < CSCConstants::NUM_ALCT_PATTERNS; i_pattern++) {
-
       // initialize the hit layers
       for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++)
         hit_layer[i_layer] = false;
@@ -576,7 +575,7 @@ bool CSCAnodeLCTProcessor::preTrigger(const int key_wire, const int start_bx) {
                   // make a new pre-trigger digi
                   // useful for calculating DAQ rates
                   thePreTriggerDigis.emplace_back(
-                                                  CSCALCTPreTriggerDigi(1, layers_hit - 3, 0, 0, this_wire, bx_time, nPreTriggers));
+                      CSCALCTPreTriggerDigi(1, layers_hit - 3, 0, 0, this_wire, bx_time, nPreTriggers));
                   return true;
                 }
               }
@@ -594,7 +593,7 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
   bool trigger = false;
   bool hit_layer[CSCConstants::NUM_LAYERS];
   unsigned int temp_quality;
-  int this_layer, this_wire, delta_wire;
+  int this_wire, delta_wire;
   // If nplanes_hit_accel_pattern is 0, the firmware uses the value
   // of nplanes_hit_pattern instead.
   const unsigned int nplanes_hit_pattern_acc =
@@ -631,8 +630,8 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
                 hit_layer[i_layer] = true;
                 if (infoV > 1)
                   LogTrace("CSCAnodeLCTProcessor")
-                    << "bx_time: " << first_bx[key_wire] << " pattern: " << i_pattern << " keywire: " << key_wire
-                    << " layer: " << i_layer << " quality: " << temp_quality;
+                      << "bx_time: " << first_bx[key_wire] << " pattern: " << i_pattern << " keywire: " << key_wire
+                      << " layer: " << i_layer << " quality: " << temp_quality;
               }
 
               // for averaged time use only the closest WGs around the key WG
@@ -1338,8 +1337,7 @@ void CSCAnodeLCTProcessor::showPatterns(const int key_wire) {
             for (int i = 1; i <= 32; i++) {
               strstrm_pulse << ((pulse[i_layer][this_wire] >> (32 - i)) & 1);
             }
-            LogTrace("CSCAnodeLCTProcessor")
-              << strstrm_pulse.str() << " on layer " << i_layer << " wire " << this_wire;
+            LogTrace("CSCAnodeLCTProcessor") << strstrm_pulse.str() << " on layer " << i_layer << " wire " << this_wire;
           }
         }
       }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -551,13 +551,13 @@ bool CSCAnodeLCTProcessor::preTrigger(const int key_wire, const int start_bx) {
       for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
         for (int i_wire = 0; i_wire < CSCConstants::ALCT_PATTERN_WIDTH; i_wire++) {
           // check if the hit is valid
-          if (alct_pattern_[i_pattern][i_layer][i_wire] != 0) {
+          if (alct_pattern_[i_pattern][i_layer][i_wire]) {
             this_wire = CSCPatternBank::alct_keywire_offset_[MESelection][i_wire] + key_wire;
             if ((this_wire >= 0) && (this_wire < numWireGroups)) {
               // Perform bit operation to see if pulse is 1 at a certain bx_time.
               if (((pulse[i_layer][this_wire] >> bx_time) & 1) == 1) {
                 // Store number of layers hit.
-                if (hit_layer[i_layer] == false) {
+                if (!hit_layer[i_layer]) {
                   hit_layer[i_layer] = true;
                   layers_hit++;
                 }
@@ -615,7 +615,8 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
 
     for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
       for (int i_wire = 0; i_wire < CSCConstants::ALCT_PATTERN_WIDTH; i_wire++) {
-        if (alct_pattern_[i_pattern][i_layer][i_wire] != 0) {
+        // check if the hit is valid
+        if (alct_pattern_[i_pattern][i_layer][i_wire]) {
           delta_wire = CSCPatternBank::alct_keywire_offset_[MESelection][i_wire];
           this_wire = delta_wire + key_wire;
           if ((this_wire >= 0) && (this_wire < numWireGroups)) {
@@ -624,7 +625,7 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
             if (((pulse[i_layer][this_wire] >> (first_bx[key_wire] + drift_delay)) & 1) == 1) {
               // If layer has never had a hit before, then increment number
               // of layer hits.
-              if (hit_layer[i_layer] == false) {
+              if (!hit_layer[i_layer]) {
                 temp_quality++;
                 // keep track of which layers already had hits.
                 hit_layer[i_layer] = true;
@@ -1330,6 +1331,7 @@ void CSCAnodeLCTProcessor::showPatterns(const int key_wire) {
     LogTrace("CSCAnodeLCTProcessor") << strstrm_header.str();
     for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
       for (int i_wire = 0; i_wire < CSCConstants::ALCT_PATTERN_WIDTH; i_wire++) {
+        // check if the hit is valid
         if (alct_pattern_[i_pattern][i_layer][i_wire]) {
           std::ostringstream strstrm_pulse;
           int this_wire = CSCPatternBank::alct_keywire_offset_[MESelection][i_wire] + key_wire;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCPatternBank.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCPatternBank.cc
@@ -1,40 +1,68 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h"
 
-const int CSCPatternBank::alct_pattern_envelope[CSCConstants::MAX_WIRES_IN_PATTERN] = {
-    0, 0, 0, 1, 1, 2, 3, 3, 4, 4, 4, 5, 5, 5};
-
-const int CSCPatternBank::alct_keywire_offset[2][CSCConstants::MAX_WIRES_IN_PATTERN] = {
+const int CSCPatternBank::alct_keywire_offset_[2][CSCConstants::ALCT_PATTERN_WIDTH] = {
     //Keywire offset for ME1 and ME2
-    {-2, -1, 0, -1, 0, 0, 0, 1, 0, 1, 2, 0, 1, 2},
+    {-2, -1, 0, 1, 2},
 
     //Keywire offset for ME3 and ME4
-    {2, 1, 0, 1, 0, 0, 0, -1, 0, -1, -2, 0, -1, -2}};
+    {2, 1, 0, -1, -2}};
 
-const int CSCPatternBank::alct_pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN] = {
+const CSCPatternBank::LCTPatterns CSCPatternBank::alct_pattern_legacy_ = {
     // Accelerator pattern
     // For beam-halo muons or displaced muons from long-lived particles
-    {0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 0},
+  {{0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0}},
 
-    // Collision pattern A
-    {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+  // Collision pattern A
+  {{1, 1, 1, 0, 0},
+   {0, 1, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 1, 0},
+   {0, 0, 1, 1, 1},
+   {0, 0, 1, 1, 1}},
 
-    // Collision pattern B
-    {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}};
+  // Collision pattern B
+  {{1, 1, 1, 0, 0},
+   {0, 1, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 1, 0},
+   {0, 0, 1, 1, 1},
+   {0, 0, 1, 1, 1}}};
 
-const int CSCPatternBank::alct_pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN] = {
-    // Accelerator pattern
-    {0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 0},
+const CSCPatternBank::LCTPatterns CSCPatternBank::alct_pattern_r1_ = {
+  // Accelerator pattern
+  {{0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0}},
 
-    // Collision pattern A
-    {0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0},
+  // Collision pattern A
+  {{0, 1, 1, 0, 0},
+   {0, 1, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 1, 0},
+   {0, 0, 1, 1, 0}},
 
-    // Collision pattern B
-    {0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0}};
+  // Collision pattern B
+  {{0, 1, 1, 0, 0},
+   {0, 1, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 0, 0},
+   {0, 0, 1, 1, 0},
+   {0, 0, 1, 1, 0}}
+};
 
 const int CSCPatternBank::clct_pattern_offset_[CSCConstants::CLCT_PATTERN_WIDTH] = {
     -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5};
 
-const CSCPatternBank::CLCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
+const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
     // pid=0: no pattern found
     {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -133,7 +161,7 @@ const CSCPatternBank::CLCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
     // pid's=B-F are not yet defined
 };
 
-const CSCPatternBank::CLCTPatterns CSCPatternBank::clct_pattern_run3_ = {
+const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_run3_ = {
     // pid 0
     {
         {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1},

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCPatternBank.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCPatternBank.cc
@@ -10,54 +10,23 @@ const int CSCPatternBank::alct_keywire_offset_[2][CSCConstants::ALCT_PATTERN_WID
 const CSCPatternBank::LCTPatterns CSCPatternBank::alct_pattern_legacy_ = {
     // Accelerator pattern
     // For beam-halo muons or displaced muons from long-lived particles
-  {{0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0}},
+    {{0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}},
 
-  // Collision pattern A
-  {{1, 1, 1, 0, 0},
-   {0, 1, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 1, 0},
-   {0, 0, 1, 1, 1},
-   {0, 0, 1, 1, 1}},
+    // Collision pattern A
+    {{1, 1, 1, 0, 0}, {0, 1, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 1, 0}, {0, 0, 1, 1, 1}, {0, 0, 1, 1, 1}},
 
-  // Collision pattern B
-  {{1, 1, 1, 0, 0},
-   {0, 1, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 1, 0},
-   {0, 0, 1, 1, 1},
-   {0, 0, 1, 1, 1}}};
+    // Collision pattern B
+    {{1, 1, 1, 0, 0}, {0, 1, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 1, 0}, {0, 0, 1, 1, 1}, {0, 0, 1, 1, 1}}};
 
 const CSCPatternBank::LCTPatterns CSCPatternBank::alct_pattern_r1_ = {
-  // Accelerator pattern
-  {{0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0}},
+    // Accelerator pattern
+    {{0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}},
 
-  // Collision pattern A
-  {{0, 1, 1, 0, 0},
-   {0, 1, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 1, 0},
-   {0, 0, 1, 1, 0}},
+    // Collision pattern A
+    {{0, 1, 1, 0, 0}, {0, 1, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 1, 0}, {0, 0, 1, 1, 0}},
 
-  // Collision pattern B
-  {{0, 1, 1, 0, 0},
-   {0, 1, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 0, 0},
-   {0, 0, 1, 1, 0},
-   {0, 0, 1, 1, 0}}
-};
+    // Collision pattern B
+    {{0, 1, 1, 0, 0}, {0, 1, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 1, 1, 0}, {0, 0, 1, 1, 0}}};
 
 const int CSCPatternBank::clct_pattern_offset_[CSCConstants::CLCT_PATTERN_WIDTH] = {
     -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5};


### PR DESCRIPTION
#### PR description:

Similar PR as #https://github.com/cms-sw/cmssw/pull/28846. ALCT patterns are rewritten as 2D vectors instead of 1D arrays. This allows us to implement an algorithm similar to CCLUT #30103 in the ALCT processor for Phase-2 studies. As this PR merely rewrites the patterns in a more convenient format, there should no changes in any of the workflows.

Note: `code-format` rewrote the [ALCT patterns](https://github.com/cms-sw/cmssw/compare/master...dildick:from-CMSSW_11_2_X_2020-06-02-2300-recast-alct-patterns?expand=1#diff-a7b633e207161fd21666160aff6ed802) as a single line instead. Originally I wrote

```
    // Collision pattern A                                                                                                                                  
    {{1, 1, 1, 0, 0},
     {0, 1, 1, 0, 0},
     {0, 0, 1, 0, 0},
     {0, 0, 1, 1, 0},
     {0, 0, 1, 1, 1},
     {0, 0, 1, 1, 1}},
```

#### PR validation:

Tested with WF 27434.0.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 
