### PR TITLE
fix direct access to tau ID container

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -414,9 +414,10 @@ void PATTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
               try {
                 int i = std::stoi(prov_ID_label);
                 if (prov_cfg_label == "direct_rawValues")
-                  idcfg.second.second = -i;
+                  idcfg.second.second = -1 - i;
                 else
                   idcfg.second.second = i;
+                found = true;
               } catch (std::invalid_argument const& e) {
                 throw cms::Exception("Configuration") << "PATTauProducer: Direct access to ID container requested, so "
                                                          "argument of 'idLabel' must be convertable to int!\n";

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -592,9 +592,10 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
           try {
             int i = std::stoi(prov_ID_label);
             if (prov_cfg_label == "direct_rawValues")
-              currentDiscriminatorContainerToken_[idx].second = -i;
+              currentDiscriminatorContainerToken_[idx].second = -1 - i;
             else
               currentDiscriminatorContainerToken_[idx].second = i;
+            found = true;
           } catch (std::invalid_argument const& e) {
             throw cms::Exception("Configuration") << "TauTagValidation: Direct access to ID container requested, so "
                                                      "argument of 'idLabel' must be convertable to int!\n";


### PR DESCRIPTION
#### PR description:

This PR fixes the index mapping for direct access to tau ID containers. The functionality is only for private use and test purposes and does not concern existing workflows.
The fixed lines can be compared to the regular workflows some lines above, which are using provenance, e.g. https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc#L405-L409 and are supposed to follow the same logic of the internal index mapping.

#### PR validation:

compiles, no further checks run due to simplicity of changes

