### PR TITLE
Update valid condition for GEM pads and clusters

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigi.h
@@ -4,33 +4,41 @@
 /** \class GEMPadDigi
  *
  * Digi for GEM-CSC trigger pads
- *  
+ *
  * \author Vadim Khotilovich
  *
  */
+
+#include "DataFormats/MuonDetId/interface/GEMSubDetId.h"
 
 #include <cstdint>
 #include <iosfwd>
 
 class GEMPadDigi {
 public:
-  explicit GEMPadDigi(int pad, int bx);
+  enum InValid { ME0InValid = 255, GE11InValid = 255, GE21InValid = 511 };
+
+  explicit GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11);
   GEMPadDigi();
 
   bool operator==(const GEMPadDigi& digi) const;
   bool operator!=(const GEMPadDigi& digi) const;
   bool operator<(const GEMPadDigi& digi) const;
+  // only depends on the "InValid" enum so it also
+  // works on unpacked data
   bool isValid() const;
 
   // return the pad number. counts from 0.
-  int pad() const { return pad_; }
-  int bx() const { return bx_; }
+  uint16_t pad() const { return pad_; }
+  int16_t bx() const { return bx_; }
+  GEMSubDetId::Station station() const { return station_; }
 
   void print() const;
 
 private:
   uint16_t pad_;
   int16_t bx_;
+  GEMSubDetId::Station station_;
 };
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi);

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -10,28 +10,38 @@
  *
  */
 
+#include "DataFormats/MuonDetId/interface/GEMSubDetId.h"
+
 #include <cstdint>
 #include <iosfwd>
 #include <vector>
 
 class GEMPadDigiCluster {
 public:
-  explicit GEMPadDigiCluster(std::vector<uint16_t> pads, int bx);
+  enum InValid { GE11InValid = 255, GE21InValid = 511 };
+
+  explicit GEMPadDigiCluster(std::vector<uint16_t> pads,
+                             int16_t bx,
+                             enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11);
   GEMPadDigiCluster();
 
   bool operator==(const GEMPadDigiCluster& digi) const;
   bool operator!=(const GEMPadDigiCluster& digi) const;
   bool operator<(const GEMPadDigiCluster& digi) const;
+  // only depends on the "InValid" enum so it also
+  // works on unpacked data
   bool isValid() const;
 
   const std::vector<uint16_t>& pads() const { return v_; }
   int bx() const { return bx_; }
+  GEMSubDetId::Station station() const { return station_; }
 
   void print() const;
 
 private:
   std::vector<uint16_t> v_;
   int32_t bx_;
+  GEMSubDetId::Station station_;
 };
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi);

--- a/DataFormats/GEMDigi/src/GEMPadDigi.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigi.cc
@@ -1,12 +1,15 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include <iostream>
 
-GEMPadDigi::GEMPadDigi(int pad, int bx) : pad_(pad), bx_(bx) {}
+GEMPadDigi::GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station)
+    : pad_(pad), bx_(bx), station_(station) {}
 
-GEMPadDigi::GEMPadDigi() : pad_(65535), bx_(-99) {}
+GEMPadDigi::GEMPadDigi() : pad_(GE11InValid), bx_(-99), station_(GEMSubDetId::Station::GE11) {}
 
 // Comparison
-bool GEMPadDigi::operator==(const GEMPadDigi& digi) const { return pad_ == digi.pad() and bx_ == digi.bx(); }
+bool GEMPadDigi::operator==(const GEMPadDigi& digi) const {
+  return pad_ == digi.pad() and bx_ == digi.bx() and station_ == digi.station();
+}
 
 // Comparison
 bool GEMPadDigi::operator!=(const GEMPadDigi& digi) const { return pad_ != digi.pad() or bx_ != digi.bx(); }
@@ -19,7 +22,15 @@ bool GEMPadDigi::operator<(const GEMPadDigi& digi) const {
     return digi.bx() < bx_;
 }
 
-bool GEMPadDigi::isValid() const { return bx_ != -99 and pad_ != 65535; }
+bool GEMPadDigi::isValid() const {
+  uint16_t invalid = GE11InValid;
+  if (station_ == GEMSubDetId::Station::ME0) {
+    invalid = ME0InValid;
+  } else if (station_ == GEMSubDetId::Station::GE21) {
+    invalid = GE21InValid;
+  }
+  return pad_ != invalid;
+}
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi) {
   return o << " GEMPadDigi Pad = " << digi.pad() << " bx = " << digi.bx();

--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -1,13 +1,14 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include <iostream>
 
-GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads, int bx) : v_(pads), bx_(bx) {}
+GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads, int16_t bx, enum GEMSubDetId::Station station)
+    : v_(pads), bx_(bx), station_(station) {}
 
-GEMPadDigiCluster::GEMPadDigiCluster() : v_(std::vector<uint16_t>()), bx_(-99) {}
+GEMPadDigiCluster::GEMPadDigiCluster() : v_(std::vector<uint16_t>()), bx_(-99), station_(GEMSubDetId::Station::GE11) {}
 
 // Comparison
 bool GEMPadDigiCluster::operator==(const GEMPadDigiCluster& digi) const {
-  return v_ == digi.pads() and bx_ == digi.bx();
+  return v_ == digi.pads() and bx_ == digi.bx() and station_ == digi.station();
 }
 
 // Comparison
@@ -23,7 +24,17 @@ bool GEMPadDigiCluster::operator<(const GEMPadDigiCluster& digi) const {
     return digi.bx() < bx_;
 }
 
-bool GEMPadDigiCluster::isValid() const { return !v_.empty() and bx_ != -99; }
+bool GEMPadDigiCluster::isValid() const {
+  // empty clusters are always invalid
+  if (v_.empty())
+    return false;
+
+  uint16_t invalid = GE11InValid;
+  if (station_ == GEMSubDetId::Station::GE21) {
+    invalid = GE21InValid;
+  }
+  return v_[0] != invalid;
+}
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi) {
   o << " bx: " << digi.bx() << " pads: ";

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -6,33 +6,35 @@
 </class>
 <class name="std::vector<GEMDigi>"/>
 <class name="std::map<GEMDetId,std::vector<GEMDigi> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMDigi>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMDigi> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<GEMDetId,GEMDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMDigi> >" splitLevel="0"/>
 
-<class name="GEMPadDigi" ClassVersion="12">
+<class name="GEMPadDigi" ClassVersion="13">
  <version ClassVersion="11" checksum="426510066"/>
  <version ClassVersion="12" checksum="3838591655"/>
+ <version ClassVersion="13" checksum="2944221332"/>
 </class>
 <class name="std::vector<GEMPadDigi>"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigi> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMPadDigi>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigi> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<GEMDetId,GEMPadDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigi> >" splitLevel="0"/>
 
-<class name="GEMPadDigiCluster" ClassVersion="10">
+<class name="GEMPadDigiCluster" ClassVersion="11">
  <version ClassVersion="10" checksum="2569340006"/>
+ <version ClassVersion="11" checksum="3372991553"/>
 </class>
 <class name="std::vector<GEMPadDigiCluster>"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigiCluster> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMPadDigiCluster>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigiCluster> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<GEMDetId,GEMPadDigiCluster>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigiCluster> >" splitLevel="0"/>
 
 <class name="GEMCoPadDigi" ClassVersion="12">
  <version ClassVersion="12" checksum="2678638706"/>
 </class>
 <class name="std::vector<GEMCoPadDigi>"/>
 <class name="std::map<GEMDetId,std::vector<GEMCoPadDigi> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMCoPadDigi>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMCoPadDigi> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<GEMDetId,GEMCoPadDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMCoPadDigi> >" splitLevel="0"/>
 
 <class name="ME0DigiPreReco" ClassVersion="13">
  <version ClassVersion="10" checksum="79088950"/>
@@ -42,35 +44,35 @@
 </class>
 <class name="std::vector<ME0DigiPreReco>"/>
 <class name="std::map<ME0DetId,std::vector<ME0DigiPreReco> >"/>
-<class name="MuonDigiCollection<ME0DetId,ME0DigiPreReco>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0DigiPreReco> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<ME0DetId,ME0DigiPreReco>"/>
+<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0DigiPreReco> >" splitLevel="0"/>
 <class name="std::map<ME0DetId,std::vector<int> >"/>
-<class name="MuonDigiCollection<ME0DetId,int>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,int> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<ME0DetId,int>"/>
+<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,int> >" splitLevel="0"/>
 
 <class name="ME0Digi" ClassVersion="10">
  <version ClassVersion="10" checksum="1661999658"/>
 </class>
 <class name="std::vector<ME0Digi>"/>
 <class name="std::map<ME0DetId,std::vector<ME0Digi> >"/>
-<class name="MuonDigiCollection<ME0DetId,ME0Digi>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0Digi> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<ME0DetId,ME0Digi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0Digi> >" splitLevel="0"/>
 
 <class name="ME0PadDigi" ClassVersion="10">
  <version ClassVersion="10" checksum="598250098"/>
 </class>
 <class name="std::vector<ME0PadDigi>"/>
 <class name="std::map<ME0DetId,std::vector<ME0PadDigi> >"/>
-<class name="MuonDigiCollection<ME0DetId,ME0PadDigi>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0PadDigi> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<ME0DetId,ME0PadDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0PadDigi> >" splitLevel="0"/>
 
 <class name="ME0PadDigiCluster" ClassVersion="10">
  <version ClassVersion="10" checksum="3867685231"/>
 </class>
 <class name="std::vector<ME0PadDigiCluster>"/>
 <class name="std::map<ME0DetId,std::vector<ME0PadDigiCluster> >"/>
-<class name="MuonDigiCollection<ME0DetId,ME0PadDigiCluster>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0PadDigiCluster> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<ME0DetId,ME0PadDigiCluster>"/>
+<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0PadDigiCluster> >" splitLevel="0"/>
 
 <class name="ME0TriggerDigi" ClassVersion="12">
  <version ClassVersion="10" checksum="2020160691"/>
@@ -79,7 +81,7 @@
 </class>
 <class name="std::vector<ME0TriggerDigi>"/>
 <class name="std::map<ME0DetId,std::vector<ME0TriggerDigi> >"/>
-<class name="MuonDigiCollection<ME0DetId,ME0TriggerDigi>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0TriggerDigi> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<ME0DetId,ME0TriggerDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0TriggerDigi> >" splitLevel="0"/>
 
 </lcgdict>

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -2,13 +2,14 @@
 #define DataFormats_MuonDetId_GEMDetId_h
 
 /** \class GEMDetId
- * 
+ *
  *  DetUnit identifier for GEMs
  *
  */
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "DataFormats/MuonDetId/interface/GEMSubDetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <iosfwd>
@@ -165,25 +166,25 @@ public:
   constexpr int region() const { return (static_cast<int>((id_ >> RegionStartBit) & RegionMask) + minRegionId); }
 
   /** Ring id: GEM are installed only on ring 1
-      the ring is the group of chambers with same r (distance of beam axis) 
+      the ring is the group of chambers with same r (distance of beam axis)
       and increasing phi */
   constexpr int ring() const { return (static_cast<int>((id_ >> RingStartBit) & RingMask) + minRingId); }
 
   /** Station id : the station is the set of chambers at same disk */
   constexpr int station() const { return (static_cast<int>((id_ >> StationStartBit) & StationMask) + minStationId0); }
 
-  /** Chamber id: it identifies a chamber in a ring it goes from 1 to 36 
+  /** Chamber id: it identifies a chamber in a ring it goes from 1 to 36
       for GE1 and GE2 and 1 to 18 for ME0 */
   constexpr int chamber() const {
     return (static_cast<int>((id_ >> ChamberStartBit) & ChamberMask) + (minChamberId + 1));
   }
 
-  /** Layer id: each station have two layers of chambers for GE1 and GE2: 
-      layer 1 is the inner chamber and layer 2 is the outer chamber 
+  /** Layer id: each station have two layers of chambers for GE1 and GE2:
+      layer 1 is the inner chamber and layer 2 is the outer chamber
       For ME0 there are 6 layers of chambers */
   constexpr int layer() const { return (static_cast<int>((id_ >> LayerStartBit) & LayerMask) + minLayerId); }
 
-  /** Roll id  (also known as eta partition): each chamber is divided along 
+  /** Roll id  (also known as eta partition): each chamber is divided along
       the strip direction in  several parts  (rolls) GEM up to 12 */
   constexpr int roll() const {
     return (static_cast<int>((id_ >> RollStartBit) & RollMask));  // value 0 is used as wild card

--- a/DataFormats/MuonDetId/interface/GEMSubDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMSubDetId.h
@@ -1,0 +1,24 @@
+#ifndef DataFormats_MuonDetId_GEMSubDetId_h
+#define DataFormats_MuonDetId_GEMSubDetId_h
+
+/** \class GEMSubDetId
+ *
+ */
+
+#include <cstdint>
+
+class GEMSubDetId {
+public:
+  enum class Station { ME0 = 0, GE11 = 1, GE21 = 2 };
+  static Station station(uint16_t st) {
+    Station returnValue = Station::GE11;
+    if (st == 0) {
+      returnValue = Station::ME0;
+    } else if (st == 2) {
+      returnValue = Station::GE21;
+    }
+    return returnValue;
+  };
+};
+
+#endif

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -196,7 +196,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
           cl.push_back((*d).pad());
         } else {
           // put the current cluster in the proto collection
-          GEMPadDigiCluster pad_cluster(cl, startBX);
+          GEMPadDigiCluster pad_cluster(cl, startBX, GEMSubDetId::station(part->id().station()));
 
           all_pad_clusters.emplace_back(pad_cluster);
 
@@ -210,7 +210,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
 
     // put the last cluster in the proto collection
     if (pads.first != pads.second) {
-      GEMPadDigiCluster pad_cluster(cl, startBX);
+      GEMPadDigiCluster pad_cluster(cl, startBX, GEMSubDetId::station(part->id().station()));
       all_pad_clusters.emplace_back(pad_cluster);
     }
     proto_clusters.emplace(part->id(), all_pad_clusters);

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -96,7 +96,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(d.first, d.second);
+      GEMPadDigi pad_digi(d.first, d.second, GEMSubDetId::station(p->id().station()));
       out_pads.insertDigi(p->id(), pad_digi);
     }
   }


### PR DESCRIPTION
#### PR description:

Update valid condition for GEM pads and clusters according to [DN-20-016, page 28](https://gitlab.cern.ch/tdr/notes/DN-20-016/blob/master/temp/DN-20-016_temp.pdf). In short: ME0 pad 255, GE1/1 pad 255 and GE2/1 pad 511 are considered invalid. This PR also fixes a minor bug in the GEM-CSC trigger that excluded GE1/1 or GE2/1 zero pads.

#### PR validation:

Tested with WF 27434.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@jshlee @hyunyong 