### PR TITLE
Add new ProcessBlock feature to the Framework

### DIFF
--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -52,7 +52,7 @@ namespace edm {
 
     BranchDescription(BranchDescription const& aliasForBranch,
                       std::string const& moduleLabelAlias,
-                      std::string const& poruductInstanceAlias);
+                      std::string const& productInstanceAlias);
 
     ~BranchDescription() {}
 
@@ -142,10 +142,10 @@ namespace edm {
       // This is set if and only if produced_ is true.
       std::string moduleName_;
 
-      // The branch name, which is currently derivable fron the other attributes.
+      // The branch name, which is currently derivable from the other attributes.
       std::string branchName_;
 
-      // The wrapped class name, which is currently derivable fron the other attributes.
+      // The wrapped class name, which is currently derivable from the other attributes.
       std::string wrappedName_;
 
       // For SwitchProducer alias, the label of the aliased-for label; otherwise empty

--- a/DataFormats/Provenance/interface/BranchType.h
+++ b/DataFormats/Provenance/interface/BranchType.h
@@ -27,10 +27,6 @@ namespace edm {
 
   std::string const& BranchTypeToProductProvenanceBranchName(BranchType const& BranchType);
 
-  std::string const& BranchTypeToMajorIndexName(BranchType const& branchType);
-
-  std::string const& BranchTypeToMinorIndexName(BranchType const& branchType);
-
   std::ostream& operator<<(std::ostream& os, BranchType const& branchType);
 
   namespace poolNames {

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -37,7 +37,7 @@ namespace edm {
 
     ProductRegistry();
 
-    // A constructor from the persistent data memebers from another product registry.
+    // A constructor from the persistent data members from another product registry.
     // saves time by not copying the transient components.
     // The constructed registry will be frozen by default.
     explicit ProductRegistry(ProductList const& productList, bool toBeFrozen = true);
@@ -148,6 +148,12 @@ namespace edm {
         return get_underlying_safe(runProductLookup_);
       }
       std::shared_ptr<ProductResolverIndexHelper>& runProductLookup() { return get_underlying_safe(runProductLookup_); }
+      std::shared_ptr<ProductResolverIndexHelper const> processProductLookup() const {
+        return get_underlying_safe(processProductLookup_);
+      }
+      std::shared_ptr<ProductResolverIndexHelper>& processProductLookup() {
+        return get_underlying_safe(processProductLookup_);
+      }
 
       bool frozen_;
       // Is at least one (run), (lumi), (event) persistent product produced this process?
@@ -157,10 +163,12 @@ namespace edm {
       edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>> eventProductLookup_;
       edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>> lumiProductLookup_;
       edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>> runProductLookup_;
+      edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>> processProductLookup_;
 
       ProductResolverIndex eventNextIndexValue_;
       ProductResolverIndex lumiNextIndexValue_;
       ProductResolverIndex runNextIndexValue_;
+      ProductResolverIndex processNextIndexValue_;
 
       std::map<BranchID, ProductResolverIndex> branchIDToIndex_;
 

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -132,43 +132,14 @@ namespace edm {
       Transients();
       void reset();
 
-      std::shared_ptr<ProductResolverIndexHelper const> eventProductLookup() const {
-        return get_underlying_safe(eventProductLookup_);
-      }
-      std::shared_ptr<ProductResolverIndexHelper>& eventProductLookup() {
-        return get_underlying_safe(eventProductLookup_);
-      }
-      std::shared_ptr<ProductResolverIndexHelper const> lumiProductLookup() const {
-        return get_underlying_safe(lumiProductLookup_);
-      }
-      std::shared_ptr<ProductResolverIndexHelper>& lumiProductLookup() {
-        return get_underlying_safe(lumiProductLookup_);
-      }
-      std::shared_ptr<ProductResolverIndexHelper const> runProductLookup() const {
-        return get_underlying_safe(runProductLookup_);
-      }
-      std::shared_ptr<ProductResolverIndexHelper>& runProductLookup() { return get_underlying_safe(runProductLookup_); }
-      std::shared_ptr<ProductResolverIndexHelper const> processProductLookup() const {
-        return get_underlying_safe(processProductLookup_);
-      }
-      std::shared_ptr<ProductResolverIndexHelper>& processProductLookup() {
-        return get_underlying_safe(processProductLookup_);
-      }
-
       bool frozen_;
       // Is at least one (run), (lumi), (event) persistent product produced this process?
       std::array<bool, NumBranchTypes> productProduced_;
       bool anyProductProduced_;
 
-      edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>> eventProductLookup_;
-      edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>> lumiProductLookup_;
-      edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>> runProductLookup_;
-      edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>> processProductLookup_;
+      std::array<edm::propagate_const<std::shared_ptr<ProductResolverIndexHelper>>, NumBranchTypes> productLookups_;
 
-      ProductResolverIndex eventNextIndexValue_;
-      ProductResolverIndex lumiNextIndexValue_;
-      ProductResolverIndex runNextIndexValue_;
-      ProductResolverIndex processNextIndexValue_;
+      std::array<ProductResolverIndex, NumBranchTypes> nextIndexValues_;
 
       std::map<BranchID, ProductResolverIndex> branchIDToIndex_;
 

--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -94,7 +94,7 @@ namespace edm {
     // the arguments or a set of matching indexes using the Matches
     // class. A returned index can have a value that indicates that it
     // is invalid or ambiguous and the client should check for these
-    // values before using the index (see ProductIndexHolder.h).
+    // values before using the index (see ProductResolverIndex.h).
 
     // If no matches are found or the ProductResolverIndexHelper
     // has not been frozen yet, then an invalid index or a Matches

--- a/DataFormats/Provenance/src/BranchType.cc
+++ b/DataFormats/Provenance/src/BranchType.cc
@@ -1,5 +1,7 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include <array>
+#include <cstddef>
 #include <iostream>
 
 namespace edm {
@@ -17,44 +19,40 @@ namespace edm {
     std::string const branchEntryInfo = "BranchEntryInfo";  // backward compatibility
     std::string const productProvenance = "ProductProvenance";
 
-    // Prefixes
-    std::string const process = "ProcessBlock";
-    std::string const run = "Run";
-    std::string const lumi = "LuminosityBlock";
-    std::string const event = "Event";
+    std::array<std::string, NumBranchTypes> const branchTypeNames{{"Event", "LuminosityBlock", "Run", "ProcessBlock"}};
+    std::size_t constexpr eventLumiRunSize = 3;
+    using NameArray = const std::array<std::string, eventLumiRunSize>;
 
-    // Trees, branches, indices
-    std::string const runs = run + 's';
-    std::string const lumis = lumi + 's';
-    std::string const events = event + 's';
+    NameArray treeNames{{branchTypeNames[InEvent] + 's', branchTypeNames[InLumi] + 's', branchTypeNames[InRun] + 's'}};
 
-    std::string const runMeta = run + metaData;
-    std::string const lumiMeta = lumi + metaData;
-    std::string const eventMeta = event + metaData;
+    NameArray metaTreeNames{
+        {branchTypeNames[InEvent] + metaData, branchTypeNames[InLumi] + metaData, branchTypeNames[InRun] + metaData}};
 
-    std::string const runInfo = run + "StatusInformation";      // backward compatibility
-    std::string const lumiInfo = lumi + "StatusInformation";    // backward compatibility
-    std::string const eventInfo = event + "StatusInformation";  // backward compatibility
+    // backward compatibility
+    NameArray infoNames{{branchTypeNames[InEvent] + "StatusInformation",
+                         branchTypeNames[InLumi] + "StatusInformation",
+                         branchTypeNames[InRun] + "StatusInformation"}};
 
-    std::string const runAuxiliary = run + auxiliary;
-    std::string const lumiAuxiliary = lumi + auxiliary;
-    std::string const eventAuxiliary = event + auxiliary;
+    NameArray auxiliaryNames{{branchTypeNames[InEvent] + auxiliary,
+                              branchTypeNames[InLumi] + auxiliary,
+                              branchTypeNames[InRun] + auxiliary}};
 
-    std::string const runProductStatus = run + productStatus;      // backward compatibility
-    std::string const lumiProductStatus = lumi + productStatus;    // backward compatibility
-    std::string const eventProductStatus = event + productStatus;  // backward compatibility
+    // backward compatibility
+    NameArray productStatusNames{{branchTypeNames[InEvent] + productStatus,
+                                  branchTypeNames[InLumi] + productStatus,
+                                  branchTypeNames[InRun] + productStatus}};
 
-    std::string const runEventEntryInfo = run + branchEntryInfo;      // backward compatibility
-    std::string const lumiEventEntryInfo = lumi + branchEntryInfo;    // backward compatibility
-    std::string const eventEventEntryInfo = event + branchEntryInfo;  // backward compatibility
+    // backward compatibility
+    NameArray eventEntryInfoNames{{branchTypeNames[InEvent] + branchEntryInfo,
+                                   branchTypeNames[InLumi] + branchEntryInfo,
+                                   branchTypeNames[InRun] + branchEntryInfo}};
 
-    std::string const runProductProvenance = run + productProvenance;
-    std::string const lumiProductProvenance = lumi + productProvenance;
-    std::string const eventProductProvenance = event + productProvenance;
+    NameArray productProvenanceNames{{branchTypeNames[InEvent] + productProvenance,
+                                      branchTypeNames[InLumi] + productProvenance,
+                                      branchTypeNames[InRun] + productProvenance}};
 
-    std::string const runAux = run + aux;
-    std::string const lumiAux = lumi + aux;
-    std::string const eventAux = event + aux;
+    // backward compatibility
+    NameArray auxNames{{branchTypeNames[InEvent] + aux, branchTypeNames[InLumi] + aux, branchTypeNames[InRun] + aux}};
 
     std::string const entryDescriptionTree = "EntryDescription";
     std::string const entryDescriptionIDBranch = "Hash";
@@ -88,17 +86,14 @@ namespace edm {
     std::string const idToParameterSetBlobsBranch = "IdToParameterSetsBlobs";
   }  // namespace
 
-  std::string const& BranchTypeToString(BranchType const& branchType) {
-    return ((branchType == InEvent) ? event
-                                    : ((branchType == InRun) ? run : ((branchType == InLumi) ? lumi : process)));
-  }
+  std::string const& BranchTypeToString(BranchType const& branchType) { return branchTypeNames[branchType]; }
 
   std::string const& BranchTypeToProductTreeName(BranchType const& branchType) {
     if (branchType >= InProcess) {
       throw Exception(errors::LogicError,
                       "branchType argument out of legal range for the function BranchTypeToProductTreeName");
     }
-    return ((branchType == InEvent) ? events : ((branchType == InRun) ? runs : lumis));
+    return treeNames[branchType];
   }
 
   std::string const& BranchTypeToMetaDataTreeName(BranchType const& branchType) {
@@ -106,51 +101,51 @@ namespace edm {
       throw Exception(errors::LogicError,
                       "branchType argument out of legal range for the function BranchTypeToMetaDataTreeName");
     }
-    return ((branchType == InEvent) ? eventMeta : ((branchType == InRun) ? runMeta : lumiMeta));
+    return metaTreeNames[branchType];
   }
 
-  std::string const& BranchTypeToInfoTreeName(BranchType const& branchType) {  // backward compatibility
+  // backward compatibility
+  std::string const& BranchTypeToInfoTreeName(BranchType const& branchType) {
     if (branchType >= InProcess) {
       throw Exception(errors::LogicError,
                       "branchType argument out of legal range for the function BranchTypeToInfoTreeName");
     }
-    return ((branchType == InEvent) ? eventInfo
-                                    : ((branchType == InRun) ? runInfo : lumiInfo));  // backward compatibility
-  }                                                                                   // backward compatibility
+    return infoNames[branchType];
+  }
 
   std::string const& BranchTypeToAuxiliaryBranchName(BranchType const& branchType) {
     if (branchType >= InProcess) {
       throw Exception(errors::LogicError,
                       "branchType argument out of legal range for the function BranchTypeToAuxiliaryBranchName");
     }
-    return ((branchType == InEvent) ? eventAuxiliary : ((branchType == InRun) ? runAuxiliary : lumiAuxiliary));
+    return auxiliaryNames[branchType];
   }
 
-  std::string const& BranchTypeToAuxBranchName(BranchType const& branchType) {  // backward compatibility
+  // backward compatibility
+  std::string const& BranchTypeToAuxBranchName(BranchType const& branchType) {
     if (branchType >= InProcess) {
       throw Exception(errors::LogicError,
                       "branchType argument out of legal range for the function BranchTypeToAuxBranchName");
     }
-    return ((branchType == InEvent) ? eventAux : ((branchType == InRun) ? runAux : lumiAux));  // backward compatibility
-  }                                                                                            // backward compatibility
+    return auxNames[branchType];
+  }
 
-  std::string const& BranchTypeToProductStatusBranchName(BranchType const& branchType) {  // backward compatibility
+  // backward compatibility
+  std::string const& BranchTypeToProductStatusBranchName(BranchType const& branchType) {
     if (branchType >= InProcess) {
       throw Exception(errors::LogicError,
                       "branchType argument out of legal range for the function BranchTypeToProductStatusBranchName");
     }
-    return ((branchType == InEvent)
-                ? eventProductStatus
-                : ((branchType == InRun) ? runProductStatus : lumiProductStatus));  // backward compatibility
-  }                                                                                 // backward compatibility
+    return productStatusNames[branchType];
+  }
 
+  // backward compatibility
   std::string const& BranchTypeToBranchEntryInfoBranchName(BranchType const& branchType) {
     if (branchType >= InProcess) {
       throw Exception(errors::LogicError,
                       "branchType argument out of legal range for the function BranchTypeToBranchEntryInfoBranchName");
     }
-    return ((branchType == InEvent) ? eventEventEntryInfo
-                                    : ((branchType == InRun) ? runEventEntryInfo : lumiEventEntryInfo));
+    return eventEntryInfoNames[branchType];
   }
 
   std::string const& BranchTypeToProductProvenanceBranchName(BranchType const& branchType) {
@@ -159,8 +154,7 @@ namespace edm {
           errors::LogicError,
           "branchType argument out of legal range for the function BranchTypeToProductProvenanceBranchName");
     }
-    return ((branchType == InEvent) ? eventProductProvenance
-                                    : ((branchType == InRun) ? runProductProvenance : lumiProductProvenance));
+    return productProvenanceNames[branchType];
   }
 
   namespace poolNames {
@@ -234,12 +228,12 @@ namespace edm {
     // Branch on ParameterSets Tree
     std::string const& idToParameterSetBlobsBranchName() { return idToParameterSetBlobsBranch; }
 
-    std::string const& eventTreeName() { return events; }
+    std::string const& eventTreeName() { return treeNames[InEvent]; }
 
-    std::string const& eventMetaDataTreeName() { return eventMeta; }
+    std::string const& eventMetaDataTreeName() { return metaTreeNames[InEvent]; }
 
     std::string const& eventHistoryTreeName() { return eventHistory; }
-    std::string const& luminosityBlockTreeName() { return lumis; }
-    std::string const& runTreeName() { return runs; }
+    std::string const& luminosityBlockTreeName() { return treeNames[InLumi]; }
+    std::string const& runTreeName() { return treeNames[InRun]; }
   }  // namespace poolNames
 }  // namespace edm

--- a/DataFormats/Provenance/src/BranchType.cc
+++ b/DataFormats/Provenance/src/BranchType.cc
@@ -1,4 +1,5 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 #include <iostream>
 
 namespace edm {
@@ -17,6 +18,7 @@ namespace edm {
     std::string const productProvenance = "ProductProvenance";
 
     // Prefixes
+    std::string const process = "ProcessBlock";
     std::string const run = "Run";
     std::string const lumi = "LuminosityBlock";
     std::string const event = "Event";
@@ -49,15 +51,6 @@ namespace edm {
     std::string const runProductProvenance = run + productProvenance;
     std::string const lumiProductProvenance = lumi + productProvenance;
     std::string const eventProductProvenance = event + productProvenance;
-
-    std::string const majorIndex = ".id_.run_";
-    std::string const runMajorIndex = runAuxiliary + majorIndex;
-    std::string const lumiMajorIndex = lumiAuxiliary + majorIndex;
-    std::string const eventMajorIndex = eventAuxiliary + majorIndex;
-
-    std::string const runMinorIndex;  // empty
-    std::string const lumiMinorIndex = lumiAuxiliary + ".id_.luminosityBlock_";
-    std::string const eventMinorIndex = eventAuxiliary + ".id_.event_";
 
     std::string const runAux = run + aux;
     std::string const lumiAux = lumi + aux;
@@ -96,52 +89,78 @@ namespace edm {
   }  // namespace
 
   std::string const& BranchTypeToString(BranchType const& branchType) {
-    return ((branchType == InEvent) ? event : ((branchType == InRun) ? run : lumi));
+    return ((branchType == InEvent) ? event
+                                    : ((branchType == InRun) ? run : ((branchType == InLumi) ? lumi : process)));
   }
 
   std::string const& BranchTypeToProductTreeName(BranchType const& branchType) {
+    if (branchType >= InProcess) {
+      throw Exception(errors::LogicError,
+                      "branchType argument out of legal range for the function BranchTypeToProductTreeName");
+    }
     return ((branchType == InEvent) ? events : ((branchType == InRun) ? runs : lumis));
   }
 
   std::string const& BranchTypeToMetaDataTreeName(BranchType const& branchType) {
+    if (branchType >= InProcess) {
+      throw Exception(errors::LogicError,
+                      "branchType argument out of legal range for the function BranchTypeToMetaDataTreeName");
+    }
     return ((branchType == InEvent) ? eventMeta : ((branchType == InRun) ? runMeta : lumiMeta));
   }
 
   std::string const& BranchTypeToInfoTreeName(BranchType const& branchType) {  // backward compatibility
+    if (branchType >= InProcess) {
+      throw Exception(errors::LogicError,
+                      "branchType argument out of legal range for the function BranchTypeToInfoTreeName");
+    }
     return ((branchType == InEvent) ? eventInfo
                                     : ((branchType == InRun) ? runInfo : lumiInfo));  // backward compatibility
   }                                                                                   // backward compatibility
 
   std::string const& BranchTypeToAuxiliaryBranchName(BranchType const& branchType) {
+    if (branchType >= InProcess) {
+      throw Exception(errors::LogicError,
+                      "branchType argument out of legal range for the function BranchTypeToAuxiliaryBranchName");
+    }
     return ((branchType == InEvent) ? eventAuxiliary : ((branchType == InRun) ? runAuxiliary : lumiAuxiliary));
   }
 
-  std::string const& BranchTypeToAuxBranchName(BranchType const& branchType) {                 // backward compatibility
+  std::string const& BranchTypeToAuxBranchName(BranchType const& branchType) {  // backward compatibility
+    if (branchType >= InProcess) {
+      throw Exception(errors::LogicError,
+                      "branchType argument out of legal range for the function BranchTypeToAuxBranchName");
+    }
     return ((branchType == InEvent) ? eventAux : ((branchType == InRun) ? runAux : lumiAux));  // backward compatibility
   }                                                                                            // backward compatibility
 
   std::string const& BranchTypeToProductStatusBranchName(BranchType const& branchType) {  // backward compatibility
+    if (branchType >= InProcess) {
+      throw Exception(errors::LogicError,
+                      "branchType argument out of legal range for the function BranchTypeToProductStatusBranchName");
+    }
     return ((branchType == InEvent)
                 ? eventProductStatus
                 : ((branchType == InRun) ? runProductStatus : lumiProductStatus));  // backward compatibility
   }                                                                                 // backward compatibility
 
   std::string const& BranchTypeToBranchEntryInfoBranchName(BranchType const& branchType) {
+    if (branchType >= InProcess) {
+      throw Exception(errors::LogicError,
+                      "branchType argument out of legal range for the function BranchTypeToBranchEntryInfoBranchName");
+    }
     return ((branchType == InEvent) ? eventEventEntryInfo
                                     : ((branchType == InRun) ? runEventEntryInfo : lumiEventEntryInfo));
   }
 
   std::string const& BranchTypeToProductProvenanceBranchName(BranchType const& branchType) {
+    if (branchType >= InProcess) {
+      throw Exception(
+          errors::LogicError,
+          "branchType argument out of legal range for the function BranchTypeToProductProvenanceBranchName");
+    }
     return ((branchType == InEvent) ? eventProductProvenance
                                     : ((branchType == InRun) ? runProductProvenance : lumiProductProvenance));
-  }
-
-  std::string const& BranchTypeToMajorIndexName(BranchType const& branchType) {
-    return ((branchType == InEvent) ? eventMajorIndex : ((branchType == InRun) ? runMajorIndex : lumiMajorIndex));
-  }
-
-  std::string const& BranchTypeToMinorIndexName(BranchType const& branchType) {
-    return ((branchType == InEvent) ? eventMinorIndex : ((branchType == InRun) ? runMinorIndex : lumiMinorIndex));
   }
 
   namespace poolNames {

--- a/DataFormats/Provenance/src/BranchType.cc
+++ b/DataFormats/Provenance/src/BranchType.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
-#include "FWCore/Utilities/interface/EDMException.h"
+
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <iostream>
 
@@ -89,71 +90,46 @@ namespace edm {
   std::string const& BranchTypeToString(BranchType const& branchType) { return branchTypeNames[branchType]; }
 
   std::string const& BranchTypeToProductTreeName(BranchType const& branchType) {
-    if (branchType >= InProcess) {
-      throw Exception(errors::LogicError,
-                      "branchType argument out of legal range for the function BranchTypeToProductTreeName");
-    }
+    assert(branchType < eventLumiRunSize);
     return treeNames[branchType];
   }
 
   std::string const& BranchTypeToMetaDataTreeName(BranchType const& branchType) {
-    if (branchType >= InProcess) {
-      throw Exception(errors::LogicError,
-                      "branchType argument out of legal range for the function BranchTypeToMetaDataTreeName");
-    }
+    assert(branchType < eventLumiRunSize);
     return metaTreeNames[branchType];
   }
 
   // backward compatibility
   std::string const& BranchTypeToInfoTreeName(BranchType const& branchType) {
-    if (branchType >= InProcess) {
-      throw Exception(errors::LogicError,
-                      "branchType argument out of legal range for the function BranchTypeToInfoTreeName");
-    }
+    assert(branchType < eventLumiRunSize);
     return infoNames[branchType];
   }
 
   std::string const& BranchTypeToAuxiliaryBranchName(BranchType const& branchType) {
-    if (branchType >= InProcess) {
-      throw Exception(errors::LogicError,
-                      "branchType argument out of legal range for the function BranchTypeToAuxiliaryBranchName");
-    }
+    assert(branchType < eventLumiRunSize);
     return auxiliaryNames[branchType];
   }
 
   // backward compatibility
   std::string const& BranchTypeToAuxBranchName(BranchType const& branchType) {
-    if (branchType >= InProcess) {
-      throw Exception(errors::LogicError,
-                      "branchType argument out of legal range for the function BranchTypeToAuxBranchName");
-    }
+    assert(branchType < eventLumiRunSize);
     return auxNames[branchType];
   }
 
   // backward compatibility
   std::string const& BranchTypeToProductStatusBranchName(BranchType const& branchType) {
-    if (branchType >= InProcess) {
-      throw Exception(errors::LogicError,
-                      "branchType argument out of legal range for the function BranchTypeToProductStatusBranchName");
-    }
+    assert(branchType < eventLumiRunSize);
     return productStatusNames[branchType];
   }
 
   // backward compatibility
   std::string const& BranchTypeToBranchEntryInfoBranchName(BranchType const& branchType) {
-    if (branchType >= InProcess) {
-      throw Exception(errors::LogicError,
-                      "branchType argument out of legal range for the function BranchTypeToBranchEntryInfoBranchName");
-    }
+    assert(branchType < eventLumiRunSize);
     return eventEntryInfoNames[branchType];
   }
 
   std::string const& BranchTypeToProductProvenanceBranchName(BranchType const& branchType) {
-    if (branchType >= InProcess) {
-      throw Exception(
-          errors::LogicError,
-          "branchType argument out of legal range for the function BranchTypeToProductProvenanceBranchName");
-    }
+    assert(branchType < eventLumiRunSize);
     return productProvenanceNames[branchType];
   }
 

--- a/DataFormats/Provenance/src/BranchType.cc
+++ b/DataFormats/Provenance/src/BranchType.cc
@@ -24,36 +24,33 @@ namespace edm {
     std::size_t constexpr eventLumiRunSize = 3;
     using NameArray = const std::array<std::string, eventLumiRunSize>;
 
-    NameArray treeNames{{branchTypeNames[InEvent] + 's', branchTypeNames[InLumi] + 's', branchTypeNames[InRun] + 's'}};
+    NameArray makeNameArray(std::string const& postfix) {
+      static_assert(InEvent == 0);
+      static_assert(InLumi == 1);
+      static_assert(InRun == 2);
+      return NameArray{
+          {branchTypeNames[InEvent] + postfix, branchTypeNames[InLumi] + postfix, branchTypeNames[InRun] + postfix}};
+    }
 
-    NameArray metaTreeNames{
-        {branchTypeNames[InEvent] + metaData, branchTypeNames[InLumi] + metaData, branchTypeNames[InRun] + metaData}};
+    NameArray treeNames{makeNameArray(std::string("s"))};
 
-    // backward compatibility
-    NameArray infoNames{{branchTypeNames[InEvent] + "StatusInformation",
-                         branchTypeNames[InLumi] + "StatusInformation",
-                         branchTypeNames[InRun] + "StatusInformation"}};
-
-    NameArray auxiliaryNames{{branchTypeNames[InEvent] + auxiliary,
-                              branchTypeNames[InLumi] + auxiliary,
-                              branchTypeNames[InRun] + auxiliary}};
+    NameArray metaTreeNames{makeNameArray(metaData)};
 
     // backward compatibility
-    NameArray productStatusNames{{branchTypeNames[InEvent] + productStatus,
-                                  branchTypeNames[InLumi] + productStatus,
-                                  branchTypeNames[InRun] + productStatus}};
+    NameArray infoNames{makeNameArray(std::string("StatusInformation"))};
+
+    NameArray auxiliaryNames{makeNameArray(auxiliary)};
 
     // backward compatibility
-    NameArray eventEntryInfoNames{{branchTypeNames[InEvent] + branchEntryInfo,
-                                   branchTypeNames[InLumi] + branchEntryInfo,
-                                   branchTypeNames[InRun] + branchEntryInfo}};
-
-    NameArray productProvenanceNames{{branchTypeNames[InEvent] + productProvenance,
-                                      branchTypeNames[InLumi] + productProvenance,
-                                      branchTypeNames[InRun] + productProvenance}};
+    NameArray productStatusNames{makeNameArray(productStatus)};
 
     // backward compatibility
-    NameArray auxNames{{branchTypeNames[InEvent] + aux, branchTypeNames[InLumi] + aux, branchTypeNames[InRun] + aux}};
+    NameArray eventEntryInfoNames{makeNameArray(branchEntryInfo)};
+
+    NameArray productProvenanceNames{makeNameArray(productProvenance)};
+
+    // backward compatibility
+    NameArray auxNames{makeNameArray(aux)};
 
     std::string const entryDescriptionTree = "EntryDescription";
     std::string const entryDescriptionIDBranch = "Hash";

--- a/DataFormats/Provenance/src/BranchType.cc
+++ b/DataFormats/Provenance/src/BranchType.cc
@@ -22,35 +22,39 @@ namespace edm {
 
     std::array<std::string, NumBranchTypes> const branchTypeNames{{"Event", "LuminosityBlock", "Run", "ProcessBlock"}};
     std::size_t constexpr eventLumiRunSize = 3;
-    using NameArray = const std::array<std::string, eventLumiRunSize>;
+    using NameArray = std::array<std::string, eventLumiRunSize>;
 
     NameArray makeNameArray(std::string const& postfix) {
       static_assert(InEvent == 0);
       static_assert(InLumi == 1);
       static_assert(InRun == 2);
-      return NameArray{
-          {branchTypeNames[InEvent] + postfix, branchTypeNames[InLumi] + postfix, branchTypeNames[InRun] + postfix}};
+      static_assert(InProcess == 3);
+      NameArray ret;
+      for (auto i = 0U; i != eventLumiRunSize; ++i) {
+        ret[i] = branchTypeNames[i] + postfix;
+      }
+      return ret;
     }
 
-    NameArray treeNames{makeNameArray(std::string("s"))};
+    const NameArray treeNames{makeNameArray(std::string("s"))};
 
-    NameArray metaTreeNames{makeNameArray(metaData)};
-
-    // backward compatibility
-    NameArray infoNames{makeNameArray(std::string("StatusInformation"))};
-
-    NameArray auxiliaryNames{makeNameArray(auxiliary)};
+    const NameArray metaTreeNames{makeNameArray(metaData)};
 
     // backward compatibility
-    NameArray productStatusNames{makeNameArray(productStatus)};
+    const NameArray infoNames{makeNameArray(std::string("StatusInformation"))};
+
+    const NameArray auxiliaryNames{makeNameArray(auxiliary)};
 
     // backward compatibility
-    NameArray eventEntryInfoNames{makeNameArray(branchEntryInfo)};
-
-    NameArray productProvenanceNames{makeNameArray(productProvenance)};
+    const NameArray productStatusNames{makeNameArray(productStatus)};
 
     // backward compatibility
-    NameArray auxNames{makeNameArray(aux)};
+    const NameArray eventEntryInfoNames{makeNameArray(branchEntryInfo)};
+
+    const NameArray productProvenanceNames{makeNameArray(productProvenance)};
+
+    // backward compatibility
+    const NameArray auxNames{makeNameArray(aux)};
 
     std::string const entryDescriptionTree = "EntryDescription";
     std::string const entryDescriptionIDBranch = "Hash";

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -35,15 +35,11 @@ namespace edm {
       : frozen_(false),
         productProduced_(),
         anyProductProduced_(false),
-        eventProductLookup_(new ProductResolverIndexHelper),
-        lumiProductLookup_(new ProductResolverIndexHelper),
-        runProductLookup_(new ProductResolverIndexHelper),
-        processProductLookup_(new ProductResolverIndexHelper),
-        eventNextIndexValue_(0),
-        lumiNextIndexValue_(0),
-        runNextIndexValue_(0),
-        processNextIndexValue_(0),
-
+        productLookups_{{new ProductResolverIndexHelper,
+                         new ProductResolverIndexHelper,
+                         new ProductResolverIndexHelper,
+                         new ProductResolverIndexHelper}},
+        nextIndexValues_(),
         branchIDToIndex_() {
     for (bool& isProduced : productProduced_)
       isProduced = false;
@@ -56,15 +52,10 @@ namespace edm {
     anyProductProduced_ = false;
 
     // propagate_const<T> has no reset() function
-    eventProductLookup_ = std::make_unique<ProductResolverIndexHelper>();
-    lumiProductLookup_ = std::make_unique<ProductResolverIndexHelper>();
-    runProductLookup_ = std::make_unique<ProductResolverIndexHelper>();
-    processProductLookup_ = std::make_unique<ProductResolverIndexHelper>();
-
-    eventNextIndexValue_ = 0;
-    lumiNextIndexValue_ = 0;
-    runNextIndexValue_ = 0;
-    processNextIndexValue_ = 0;
+    for (int i = InEvent; i < NumBranchTypes; ++i) {
+      productLookups_[i] = std::make_unique<ProductResolverIndexHelper>();
+    }
+    nextIndexValues_.fill(0);
 
     branchIDToIndex_.clear();
   }
@@ -151,23 +142,11 @@ namespace edm {
   }
 
   std::shared_ptr<ProductResolverIndexHelper const> ProductRegistry::productLookup(BranchType branchType) const {
-    if (branchType == InEvent)
-      return transient_.eventProductLookup();
-    if (branchType == InLumi)
-      return transient_.lumiProductLookup();
-    if (branchType == InRun)
-      return transient_.runProductLookup();
-    return transient_.processProductLookup();
+    return get_underlying_safe(transient_.productLookups_[branchType]);
   }
 
   std::shared_ptr<ProductResolverIndexHelper> ProductRegistry::productLookup(BranchType branchType) {
-    if (branchType == InEvent)
-      return transient_.eventProductLookup();
-    if (branchType == InLumi)
-      return transient_.lumiProductLookup();
-    if (branchType == InRun)
-      return transient_.runProductLookup();
-    return transient_.processProductLookup();
+    return get_underlying_safe(transient_.productLookups_[branchType]);
   }
 
   void ProductRegistry::setFrozen(bool initializeLookupInfo) {
@@ -464,10 +443,10 @@ namespace edm {
     productLookup(InRun)->setFrozen();
     productLookup(InProcess)->setFrozen();
 
-    transient_.eventNextIndexValue_ = productLookup(InEvent)->nextIndexValue();
-    transient_.lumiNextIndexValue_ = productLookup(InLumi)->nextIndexValue();
-    transient_.runNextIndexValue_ = productLookup(InRun)->nextIndexValue();
-    transient_.processNextIndexValue_ = productLookup(InProcess)->nextIndexValue();
+    for (unsigned int i = InEvent; i < NumBranchTypes; ++i) {
+      BranchType branchType = static_cast<BranchType>(i);
+      transient_.nextIndexValues_[branchType] = productLookup(branchType)->nextIndexValue();
+    }
 
     for (auto const& product : productList_) {
       auto const& desc = product.second;
@@ -586,22 +565,10 @@ namespace edm {
   }
 
   ProductResolverIndex const& ProductRegistry::getNextIndexValue(BranchType branchType) const {
-    if (branchType == InEvent)
-      return transient_.eventNextIndexValue_;
-    if (branchType == InLumi)
-      return transient_.lumiNextIndexValue_;
-    if (branchType == InRun)
-      return transient_.runNextIndexValue_;
-    return transient_.processNextIndexValue_;
+    return transient_.nextIndexValues_[branchType];
   }
 
   ProductResolverIndex& ProductRegistry::nextIndexValue(BranchType branchType) {
-    if (branchType == InEvent)
-      return transient_.eventNextIndexValue_;
-    if (branchType == InLumi)
-      return transient_.lumiNextIndexValue_;
-    if (branchType == InRun)
-      return transient_.runNextIndexValue_;
-    return transient_.processNextIndexValue_;
+    return transient_.nextIndexValues_[branchType];
   }
 }  // namespace edm

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -38,9 +38,11 @@ namespace edm {
         eventProductLookup_(new ProductResolverIndexHelper),
         lumiProductLookup_(new ProductResolverIndexHelper),
         runProductLookup_(new ProductResolverIndexHelper),
+        processProductLookup_(new ProductResolverIndexHelper),
         eventNextIndexValue_(0),
         lumiNextIndexValue_(0),
         runNextIndexValue_(0),
+        processNextIndexValue_(0),
 
         branchIDToIndex_() {
     for (bool& isProduced : productProduced_)
@@ -57,10 +59,12 @@ namespace edm {
     eventProductLookup_ = std::make_unique<ProductResolverIndexHelper>();
     lumiProductLookup_ = std::make_unique<ProductResolverIndexHelper>();
     runProductLookup_ = std::make_unique<ProductResolverIndexHelper>();
+    processProductLookup_ = std::make_unique<ProductResolverIndexHelper>();
 
     eventNextIndexValue_ = 0;
     lumiNextIndexValue_ = 0;
     runNextIndexValue_ = 0;
+    processNextIndexValue_ = 0;
 
     branchIDToIndex_.clear();
   }
@@ -151,7 +155,9 @@ namespace edm {
       return transient_.eventProductLookup();
     if (branchType == InLumi)
       return transient_.lumiProductLookup();
-    return transient_.runProductLookup();
+    if (branchType == InRun)
+      return transient_.runProductLookup();
+    return transient_.processProductLookup();
   }
 
   std::shared_ptr<ProductResolverIndexHelper> ProductRegistry::productLookup(BranchType branchType) {
@@ -159,7 +165,9 @@ namespace edm {
       return transient_.eventProductLookup();
     if (branchType == InLumi)
       return transient_.lumiProductLookup();
-    return transient_.runProductLookup();
+    if (branchType == InRun)
+      return transient_.runProductLookup();
+    return transient_.processProductLookup();
   }
 
   void ProductRegistry::setFrozen(bool initializeLookupInfo) {
@@ -454,10 +462,12 @@ namespace edm {
     productLookup(InEvent)->setFrozen();
     productLookup(InLumi)->setFrozen();
     productLookup(InRun)->setFrozen();
+    productLookup(InProcess)->setFrozen();
 
     transient_.eventNextIndexValue_ = productLookup(InEvent)->nextIndexValue();
     transient_.lumiNextIndexValue_ = productLookup(InLumi)->nextIndexValue();
     transient_.runNextIndexValue_ = productLookup(InRun)->nextIndexValue();
+    transient_.processNextIndexValue_ = productLookup(InProcess)->nextIndexValue();
 
     for (auto const& product : productList_) {
       auto const& desc = product.second;
@@ -580,7 +590,9 @@ namespace edm {
       return transient_.eventNextIndexValue_;
     if (branchType == InLumi)
       return transient_.lumiNextIndexValue_;
-    return transient_.runNextIndexValue_;
+    if (branchType == InRun)
+      return transient_.runNextIndexValue_;
+    return transient_.processNextIndexValue_;
   }
 
   ProductResolverIndex& ProductRegistry::nextIndexValue(BranchType branchType) {
@@ -588,6 +600,8 @@ namespace edm {
       return transient_.eventNextIndexValue_;
     if (branchType == InLumi)
       return transient_.lumiNextIndexValue_;
-    return transient_.runNextIndexValue_;
+    if (branchType == InRun)
+      return transient_.runNextIndexValue_;
+    return transient_.processNextIndexValue_;
   }
 }  // namespace edm

--- a/FWCore/Framework/interface/BranchActionType.h
+++ b/FWCore/Framework/interface/BranchActionType.h
@@ -2,7 +2,7 @@
 #define Framework_BranchActionType_h
 
 /*----------------------------------------------------------------------
-  
+
 BranchActionType: BranchAction
 
 ----------------------------------------------------------------------*/
@@ -12,7 +12,8 @@ namespace edm {
     BranchActionGlobalBegin = 0,
     BranchActionStreamBegin = 1,
     BranchActionStreamEnd = 2,
-    BranchActionGlobalEnd = 3
+    BranchActionGlobalEnd = 3,
+    BranchActionGlobalOther = 4
   };
 }
 #endif

--- a/FWCore/Framework/interface/BranchActionType.h
+++ b/FWCore/Framework/interface/BranchActionType.h
@@ -13,7 +13,7 @@ namespace edm {
     BranchActionStreamBegin = 1,
     BranchActionStreamEnd = 2,
     BranchActionGlobalEnd = 3,
-    BranchActionGlobalOther = 4
+    BranchActionProcessBlockInput = 4
   };
 }
 #endif

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -47,6 +47,7 @@ namespace edm {
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     static bool wantsProcessBlocks() { return false; }
+    static bool wantsInputProcessBlocks() { return false; }
     static bool wantsGlobalRuns() { return true; }
     static bool wantsGlobalLuminosityBlocks() { return true; }
     static bool wantsStreamRuns() { return false; }

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -46,6 +46,7 @@ namespace edm {
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+    static bool wantsProcessBlocks() { return false; }
     static bool wantsGlobalRuns() { return true; }
     static bool wantsGlobalLuminosityBlocks() { return true; }
     static bool wantsStreamRuns() { return false; }
@@ -69,6 +70,9 @@ namespace edm {
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();
+    void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+    void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+    void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
     bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
     bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <cassert>
 
 // user include files
 #include "DataFormats/Provenance/interface/BranchType.h"
@@ -119,10 +120,12 @@ namespace edm {
     }
 
     std::vector<ESProxyIndex> const& esGetTokenIndicesVector(edm::Transition iTrans) const {
+      assert(iTrans < edm::Transition::NumberOfEventSetupTransitions);
       return esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)];
     }
 
     std::vector<ESRecordIndex> const& esGetTokenRecordIndicesVector(edm::Transition iTrans) const {
+      assert(iTrans < edm::Transition::NumberOfEventSetupTransitions);
       return esRecordsToGetFromTransition_[static_cast<unsigned int>(iTrans)];
     }
 
@@ -259,7 +262,7 @@ namespace edm {
     edm::SoATuple<ESTokenLookupInfo, ESProxyIndex> m_esTokenInfo;
     std::array<std::vector<ESProxyIndex>, static_cast<unsigned int>(edm::Transition::NumberOfEventSetupTransitions)>
         esItemsToGetFromTransition_;
-    std::array<std::vector<ESRecordIndex>, static_cast<unsigned int>(edm::Transition::NumberOfTransitions)>
+    std::array<std::vector<ESRecordIndex>, static_cast<unsigned int>(edm::Transition::NumberOfEventSetupTransitions)>
         esRecordsToGetFromTransition_;
     bool frozen_;
     bool containsCurrentProcessAlias_;

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -108,11 +108,14 @@ namespace edm {
     std::vector<ConsumesInfo> consumesInfo() const;
 
     ESProxyIndex const* esGetTokenIndices(edm::Transition iTrans) const {
-      auto const& v = esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)];
-      if (v.empty()) {
-        return nullptr;
+      if (iTrans < edm::Transition::NumberOfEventSetupTransitions) {
+        auto const& v = esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)];
+        if (v.empty()) {
+          return nullptr;
+        }
+        return &(esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)].front());
       }
-      return &(esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)].front());
+      return nullptr;
     }
 
     std::vector<ESProxyIndex> const& esGetTokenIndicesVector(edm::Transition iTrans) const {
@@ -202,6 +205,7 @@ namespace edm {
     void throwBranchMismatch(BranchType, EDGetToken) const;
     void throwBadToken(edm::TypeID const& iType, EDGetToken iToken) const;
     void throwConsumesCallAfterFrozen(TypeToGet const&, InputTag const&) const;
+    void throwESConsumesInProcessBlock() const;
 
     edm::InputTag const& checkIfEmpty(edm::InputTag const& tag);
     // ---------- member data --------------------------------
@@ -253,7 +257,7 @@ namespace edm {
     // inserts in the middle of the data structure.
     enum { kESLookupInfo, kESProxyIndex };
     edm::SoATuple<ESTokenLookupInfo, ESProxyIndex> m_esTokenInfo;
-    std::array<std::vector<ESProxyIndex>, static_cast<unsigned int>(edm::Transition::NumberOfTransitions)>
+    std::array<std::vector<ESProxyIndex>, static_cast<unsigned int>(edm::Transition::NumberOfEventSetupTransitions)>
         esItemsToGetFromTransition_;
     std::array<std::vector<ESRecordIndex>, static_cast<unsigned int>(edm::Transition::NumberOfTransitions)>
         esRecordsToGetFromTransition_;

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -55,6 +55,7 @@ namespace edm {
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+    static bool wantsProcessBlocks() { return false; }
     static bool wantsGlobalRuns() { return true; }
     static bool wantsGlobalLuminosityBlocks() { return true; }
     static bool wantsStreamRuns() { return false; }
@@ -76,6 +77,9 @@ namespace edm {
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();
+    void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+    void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+    void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
     void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
     void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -56,6 +56,7 @@ namespace edm {
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     static bool wantsProcessBlocks() { return false; }
+    static bool wantsInputProcessBlocks() { return false; }
     static bool wantsGlobalRuns() { return true; }
     static bool wantsGlobalLuminosityBlocks() { return true; }
     static bool wantsStreamRuns() { return false; }

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -52,6 +52,7 @@ namespace edm {
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     static bool wantsProcessBlocks() { return false; }
+    static bool wantsInputProcessBlocks() { return false; }
     static bool wantsGlobalRuns() { return true; }
     static bool wantsGlobalLuminosityBlocks() { return true; }
     static bool wantsStreamRuns() { return false; }

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -51,6 +51,7 @@ namespace edm {
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+    static bool wantsProcessBlocks() { return false; }
     static bool wantsGlobalRuns() { return true; }
     static bool wantsGlobalLuminosityBlocks() { return true; }
     static bool wantsStreamRuns() { return false; }
@@ -72,6 +73,9 @@ namespace edm {
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();
+    void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+    void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+    void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
     void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
     void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -246,7 +246,8 @@ namespace edm {
     std::pair<ProcessHistoryID, RunNumber_t> readAndMergeRun();
     void readLuminosityBlock(LuminosityBlockProcessingStatus&);
     int readAndMergeLumi(LuminosityBlockProcessingStatus&);
-    void writeProcessBlockAsync(WaitingTaskHolder, bool isInputProcessBlock = false);
+    using ProcessBlockType = PrincipalCache::ProcessBlockType;
+    void writeProcessBlockAsync(WaitingTaskHolder, ProcessBlockType);
     void writeRunAsync(WaitingTaskHolder,
                        ProcessHistoryID const& phid,
                        RunNumber_t run,

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -216,6 +216,10 @@ namespace edm {
 
     void doErrorStuff();
 
+    void beginProcessBlock(bool& beginProcessBlockSucceeded);
+    void inputProcessBlocks();
+    void endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded);
+
     void beginRun(ProcessHistoryID const& phid,
                   RunNumber_t run,
                   bool& globalBeginSucceeded,
@@ -242,6 +246,7 @@ namespace edm {
     std::pair<ProcessHistoryID, RunNumber_t> readAndMergeRun();
     void readLuminosityBlock(LuminosityBlockProcessingStatus&);
     int readAndMergeLumi(LuminosityBlockProcessingStatus&);
+    void writeProcessBlockAsync(WaitingTaskHolder, bool isInputProcessBlock = false);
     void writeRunAsync(WaitingTaskHolder,
                        ProcessHistoryID const& phid,
                        RunNumber_t run,

--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -34,6 +34,7 @@ class testEventsetup;
 
 namespace edm {
   class ESInputTag;
+  class ProcessBlockTransitionInfo;
   class Schedule;
   class ServiceToken;
   class WaitingTaskHolder;
@@ -72,12 +73,7 @@ namespace edm {
     friend class eventsetup::EventSetupProvider;
     friend class eventsetup::EventSetupRecordProvider;
     friend class ::testEventsetup;
-
-    template <typename Traits, typename P, typename SC>
-    friend void beginGlobalTransitionAsync(WaitingTaskHolder, Schedule&, P&, ServiceToken const&, SC&);
-
-    template <typename Traits, typename P, typename SC>
-    friend void endGlobalTransitionAsync(WaitingTaskHolder, Schedule&, P&, ServiceToken const&, SC&, bool);
+    friend class ProcessBlockTransitionInfo;
 
   protected:
     void addRecordImpl(const eventsetup::EventSetupRecordImpl& iRecord);

--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -34,6 +34,9 @@ class testEventsetup;
 
 namespace edm {
   class ESInputTag;
+  class Schedule;
+  class ServiceToken;
+  class WaitingTaskHolder;
 
   namespace eventsetup {
     class EventSetupProvider;
@@ -69,6 +72,12 @@ namespace edm {
     friend class eventsetup::EventSetupProvider;
     friend class eventsetup::EventSetupRecordProvider;
     friend class ::testEventsetup;
+
+    template <typename Traits, typename P, typename SC>
+    friend void beginGlobalTransitionAsync(WaitingTaskHolder, Schedule&, P&, ServiceToken const&, SC&);
+
+    template <typename Traits, typename P, typename SC>
+    friend void endGlobalTransitionAsync(WaitingTaskHolder, Schedule&, P&, ServiceToken const&, SC&, bool);
 
   protected:
     void addRecordImpl(const eventsetup::EventSetupRecordImpl& iRecord);

--- a/FWCore/Framework/interface/Frameworkfwd.h
+++ b/FWCore/Framework/interface/Frameworkfwd.h
@@ -35,6 +35,8 @@ namespace edm {
   class Principal;
   class PrincipalCache;
   class PrincipalGetAdapter;
+  class ProcessBlock;
+  class ProcessBlockPrincipal;
   class ProcessNameSelector;
   class ProductRegistryHelper;
   class Run;

--- a/FWCore/Framework/interface/FrameworkfwdMostUsed.h
+++ b/FWCore/Framework/interface/FrameworkfwdMostUsed.h
@@ -12,6 +12,7 @@ namespace edm {
   class EventSetup;
   class LuminosityBlock;
   class ParameterSet;
+  class ProcessBlock;
   class Run;
   class StreamID;
 }  // namespace edm

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -120,6 +120,9 @@ namespace edm {
     /// Read next luminosity block (same as a prior lumi)
     void readAndMergeLumi(LuminosityBlockPrincipal& lbp);
 
+    /// Read next process block
+    bool readProcessBlock();
+
     /// Read next file
     std::unique_ptr<FileBlock> readFile();
 

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -432,7 +432,7 @@ namespace edm {
     using TransitionInfoType = ProcessBlockTransitionInfo;
     using Context = GlobalContext;
     static bool constexpr isEvent_ = false;
-    static Transition constexpr transition_ = Transition::BeginProcessBlock;
+    static Transition constexpr transition_ = Transition::AccessInputProcessBlock;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
       return GlobalContext(GlobalContext::Transition::kAccessInputProcessBlock,

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -389,6 +389,7 @@ namespace edm {
     using MyPrincipal = ProcessBlockPrincipal;
     using Context = GlobalContext;
     static bool constexpr isEvent_ = false;
+    static Transition constexpr transition_ = Transition::BeginProcessBlock;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
       return GlobalContext(GlobalContext::Transition::kBeginProcessBlock,
@@ -424,6 +425,7 @@ namespace edm {
     using MyPrincipal = ProcessBlockPrincipal;
     using Context = GlobalContext;
     static bool constexpr isEvent_ = false;
+    static Transition constexpr transition_ = Transition::BeginProcessBlock;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
       return GlobalContext(GlobalContext::Transition::kAccessInputProcessBlock,
@@ -459,6 +461,7 @@ namespace edm {
     using MyPrincipal = ProcessBlockPrincipal;
     using Context = GlobalContext;
     static bool constexpr isEvent_ = false;
+    static Transition constexpr transition_ = Transition::EndProcessBlock;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
       return GlobalContext(GlobalContext::Transition::kEndProcessBlock,

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -15,6 +15,7 @@ OccurrenceTraits:
 #include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
@@ -36,8 +37,8 @@ namespace edm {
   template <>
   class OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> {
   public:
-    typedef EventPrincipal MyPrincipal;
-    typedef StreamContext Context;
+    using MyPrincipal = EventPrincipal;
+    using Context = StreamContext;
     static BranchType constexpr branchType_ = InEvent;
     static bool constexpr begin_ = true;
     static bool constexpr isEvent_ = true;
@@ -68,8 +69,9 @@ namespace edm {
   template <>
   class OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> {
   public:
-    typedef RunPrincipal MyPrincipal;
-    typedef GlobalContext Context;
+    using MyPrincipal = RunPrincipal;
+    using TransitionInfoType = RunTransitionInfo;
+    using Context = GlobalContext;
     static BranchType constexpr branchType_ = InRun;
     static bool constexpr begin_ = true;
     static bool constexpr isEvent_ = false;
@@ -108,8 +110,8 @@ namespace edm {
   template <>
   class OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> {
   public:
-    typedef RunPrincipal MyPrincipal;
-    typedef StreamContext Context;
+    using MyPrincipal = RunPrincipal;
+    using Context = StreamContext;
     static BranchType constexpr branchType_ = InRun;
     static bool constexpr begin_ = true;
     static bool constexpr isEvent_ = false;
@@ -147,8 +149,8 @@ namespace edm {
   template <>
   class OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> {
   public:
-    typedef RunPrincipal MyPrincipal;
-    typedef StreamContext Context;
+    using MyPrincipal = RunPrincipal;
+    using Context = StreamContext;
     static BranchType constexpr branchType_ = InRun;
     static bool constexpr begin_ = false;
     static bool constexpr isEvent_ = false;
@@ -186,8 +188,9 @@ namespace edm {
   template <>
   class OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> {
   public:
-    typedef RunPrincipal MyPrincipal;
-    typedef GlobalContext Context;
+    using MyPrincipal = RunPrincipal;
+    using TransitionInfoType = RunTransitionInfo;
+    using Context = GlobalContext;
     static BranchType constexpr branchType_ = InRun;
     static bool constexpr begin_ = false;
     static bool constexpr isEvent_ = false;
@@ -226,8 +229,9 @@ namespace edm {
   template <>
   class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> {
   public:
-    typedef LuminosityBlockPrincipal MyPrincipal;
-    typedef GlobalContext Context;
+    using MyPrincipal = LuminosityBlockPrincipal;
+    using TransitionInfoType = LumiTransitionInfo;
+    using Context = GlobalContext;
     static BranchType constexpr branchType_ = InLumi;
     static bool constexpr begin_ = true;
     static bool constexpr isEvent_ = false;
@@ -266,8 +270,8 @@ namespace edm {
   template <>
   class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> {
   public:
-    typedef LuminosityBlockPrincipal MyPrincipal;
-    typedef StreamContext Context;
+    using MyPrincipal = LuminosityBlockPrincipal;
+    using Context = StreamContext;
     static BranchType constexpr branchType_ = InLumi;
     static bool constexpr begin_ = true;
     static bool constexpr isEvent_ = false;
@@ -305,8 +309,8 @@ namespace edm {
   template <>
   class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> {
   public:
-    typedef LuminosityBlockPrincipal MyPrincipal;
-    typedef StreamContext Context;
+    using MyPrincipal = LuminosityBlockPrincipal;
+    using Context = StreamContext;
     static BranchType constexpr branchType_ = InLumi;
     static bool constexpr begin_ = false;
     static bool constexpr isEvent_ = false;
@@ -346,8 +350,9 @@ namespace edm {
   template <>
   class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> {
   public:
-    typedef LuminosityBlockPrincipal MyPrincipal;
-    typedef GlobalContext Context;
+    using MyPrincipal = LuminosityBlockPrincipal;
+    using TransitionInfoType = LumiTransitionInfo;
+    using Context = GlobalContext;
     static BranchType constexpr branchType_ = InLumi;
     static bool constexpr begin_ = false;
     static bool constexpr isEvent_ = false;
@@ -387,6 +392,7 @@ namespace edm {
   class OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalBegin> {
   public:
     using MyPrincipal = ProcessBlockPrincipal;
+    using TransitionInfoType = ProcessBlockTransitionInfo;
     using Context = GlobalContext;
     static bool constexpr isEvent_ = false;
     static Transition constexpr transition_ = Transition::BeginProcessBlock;
@@ -423,6 +429,7 @@ namespace edm {
   class OccurrenceTraits<ProcessBlockPrincipal, BranchActionProcessBlockInput> {
   public:
     using MyPrincipal = ProcessBlockPrincipal;
+    using TransitionInfoType = ProcessBlockTransitionInfo;
     using Context = GlobalContext;
     static bool constexpr isEvent_ = false;
     static Transition constexpr transition_ = Transition::BeginProcessBlock;
@@ -459,6 +466,7 @@ namespace edm {
   class OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalEnd> {
   public:
     using MyPrincipal = ProcessBlockPrincipal;
+    using TransitionInfoType = ProcessBlockTransitionInfo;
     using Context = GlobalContext;
     static bool constexpr isEvent_ = false;
     static Transition constexpr transition_ = Transition::EndProcessBlock;

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -419,7 +419,7 @@ namespace edm {
   };
 
   template <>
-  class OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther> {
+  class OccurrenceTraits<ProcessBlockPrincipal, BranchActionProcessBlockInput> {
   public:
     using MyPrincipal = ProcessBlockPrincipal;
     using Context = GlobalContext;

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -12,6 +12,8 @@ OccurrenceTraits:
 #include "FWCore/Framework/interface/BranchActionType.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
+#include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
@@ -380,5 +382,111 @@ namespace edm {
     }
     static const char* transitionName() { return "end global LuminosityBlock"; }
   };
+
+  template <>
+  class OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalBegin> {
+  public:
+    using MyPrincipal = ProcessBlockPrincipal;
+    using Context = GlobalContext;
+    static bool constexpr isEvent_ = false;
+
+    static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
+      return GlobalContext(GlobalContext::Transition::kBeginProcessBlock,
+                           LuminosityBlockID(),
+                           RunIndex::invalidRunIndex(),
+                           LuminosityBlockIndex::invalidLuminosityBlockIndex(),
+                           Timestamp::invalidTimestamp(),
+                           processContext);
+    }
+
+    static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
+      a->preBeginProcessBlockSignal_(*globalContext);
+    }
+    static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
+      a->postBeginProcessBlockSignal_(*globalContext);
+    }
+    static void preModuleSignal(ActivityRegistry* a,
+                                GlobalContext const* globalContext,
+                                ModuleCallingContext const* moduleCallingContext) {
+      a->preModuleBeginProcessBlockSignal_(*globalContext, *moduleCallingContext);
+    }
+    static void postModuleSignal(ActivityRegistry* a,
+                                 GlobalContext const* globalContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
+      a->postModuleBeginProcessBlockSignal_(*globalContext, *moduleCallingContext);
+    }
+    static const char* transitionName() { return "begin ProcessBlock"; }
+  };
+
+  template <>
+  class OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther> {
+  public:
+    using MyPrincipal = ProcessBlockPrincipal;
+    using Context = GlobalContext;
+    static bool constexpr isEvent_ = false;
+
+    static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
+      return GlobalContext(GlobalContext::Transition::kAccessInputProcessBlock,
+                           LuminosityBlockID(),
+                           RunIndex::invalidRunIndex(),
+                           LuminosityBlockIndex::invalidLuminosityBlockIndex(),
+                           Timestamp::invalidTimestamp(),
+                           processContext);
+    }
+
+    static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
+      a->preAccessInputProcessBlockSignal_(*globalContext);
+    }
+    static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
+      a->postAccessInputProcessBlockSignal_(*globalContext);
+    }
+    static void preModuleSignal(ActivityRegistry* a,
+                                GlobalContext const* globalContext,
+                                ModuleCallingContext const* moduleCallingContext) {
+      a->preModuleAccessInputProcessBlockSignal_(*globalContext, *moduleCallingContext);
+    }
+    static void postModuleSignal(ActivityRegistry* a,
+                                 GlobalContext const* globalContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
+      a->postModuleAccessInputProcessBlockSignal_(*globalContext, *moduleCallingContext);
+    }
+    static const char* transitionName() { return "access input ProcessBlock"; }
+  };
+
+  template <>
+  class OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalEnd> {
+  public:
+    using MyPrincipal = ProcessBlockPrincipal;
+    using Context = GlobalContext;
+    static bool constexpr isEvent_ = false;
+
+    static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
+      return GlobalContext(GlobalContext::Transition::kEndProcessBlock,
+                           LuminosityBlockID(),
+                           RunIndex::invalidRunIndex(),
+                           LuminosityBlockIndex::invalidLuminosityBlockIndex(),
+                           Timestamp::invalidTimestamp(),
+                           processContext);
+    }
+
+    static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
+      a->preEndProcessBlockSignal_(*globalContext);
+    }
+    static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
+      a->postEndProcessBlockSignal_(*globalContext);
+    }
+    static void preModuleSignal(ActivityRegistry* a,
+                                GlobalContext const* globalContext,
+                                ModuleCallingContext const* moduleCallingContext) {
+      a->preModuleEndProcessBlockSignal_(*globalContext, *moduleCallingContext);
+    }
+    static void postModuleSignal(ActivityRegistry* a,
+                                 GlobalContext const* globalContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
+      a->postModuleEndProcessBlockSignal_(*globalContext, *moduleCallingContext);
+    }
+    static const char* transitionName() { return "end ProcessBlock"; }
+  };
+
 }  // namespace edm
 #endif

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -80,7 +80,9 @@ namespace edm {
 
     void adjustIndexesAfterProductRegistryAddition();
 
+    void fillPrincipal(DelayedReader* reader);
     void fillPrincipal(ProcessHistoryID const& hist, ProcessHistory const* phr, DelayedReader* reader);
+    void fillPrincipal(std::string const& processNameOfBlock, DelayedReader* reader);
 
     void clearPrincipal();
 

--- a/FWCore/Framework/interface/ProcessBlock.h
+++ b/FWCore/Framework/interface/ProcessBlock.h
@@ -1,0 +1,232 @@
+#ifndef FWCore_Framework_ProcessBlock_h
+#define FWCore_Framework_ProcessBlock_h
+
+/** \class edm::ProcessBlock
+
+\author W. David Dagenhart, created 19 March, 2020
+
+*/
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "FWCore/Framework/interface/PrincipalGetAdapter.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/ProductResolverIndex.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace edm {
+
+  class ModuleCallingContext;
+  class ModuleDescription;
+  class ProcessBlockPrincipal;
+  class ProducerBase;
+
+  namespace stream {
+    template <typename T>
+    class ProducingModuleAdaptorBase;
+  }
+
+  class ProcessBlock {
+  public:
+    ProcessBlock(ProcessBlockPrincipal const&, ModuleDescription const&, ModuleCallingContext const*, bool isAtEnd);
+
+    template <typename PROD>
+    bool getByToken(EDGetToken token, Handle<PROD>& result) const;
+
+    template <typename PROD>
+    bool getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
+
+    template <typename PROD>
+    Handle<PROD> getHandle(EDGetTokenT<PROD> token) const;
+
+    template <typename PROD>
+    PROD const& get(EDGetTokenT<PROD> token) const noexcept(false);
+
+    //Used in conjunction with EDGetToken
+    void setConsumer(EDConsumerBase const* iConsumer) { provRecorder_.setConsumer(iConsumer); }
+
+    void setProducer(ProducerBase const* iProducer);
+
+    /**If you are caching data from the ProcessBlock, you should also keep
+     this number.  If this number changes then you know that
+     the data you have cached is invalid.
+     The value of '0' will never be returned so you can use that to
+     denote that you have not yet checked the value.
+     */
+    using CacheIdentifier_t = unsigned long;
+    CacheIdentifier_t cacheIdentifier() const;
+
+    template <typename PROD>
+    void put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product);
+
+    template <typename PROD>
+    void put(EDPutToken token, std::unique_ptr<PROD> product);
+
+    template <typename PROD, typename... Args>
+    void emplace(EDPutTokenT<PROD> token, Args&&... args);
+
+    template <typename PROD, typename... Args>
+    void emplace(EDPutToken token, Args&&... args);
+
+    ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
+
+  private:
+    ProcessBlockPrincipal const& processBlockPrincipal() const;
+
+    template <typename PROD>
+    void putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
+
+    template <typename PROD, typename... Args>
+    void emplaceImpl(EDPutToken::value_type token, Args&&... args);
+
+    friend class ProducerBase;
+    template <typename T>
+    friend class stream::ProducingModuleAdaptorBase;
+
+    void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut);
+
+    using ProductPtrVec = std::vector<edm::propagate_const<std::unique_ptr<WrapperBase>>>;
+    ProductPtrVec& putProducts() { return putProducts_; }
+    ProductPtrVec const& putProducts() const { return putProducts_; }
+
+    PrincipalGetAdapter provRecorder_;
+    ProductPtrVec putProducts_;
+    ModuleCallingContext const* moduleCallingContext_;
+  };
+
+  template <typename PROD>
+  bool ProcessBlock::getByToken(EDGetToken token, Handle<PROD>& result) const {
+    result.clear();
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
+    if (result.failedToGet()) {
+      return false;
+    }
+    return true;
+  }
+
+  template <typename PROD>
+  bool ProcessBlock::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
+    result.clear();
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
+    if (result.failedToGet()) {
+      return false;
+    }
+    return true;
+  }
+
+  template <typename PROD>
+  Handle<PROD> ProcessBlock::getHandle(EDGetTokenT<PROD> token) const {
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
+    return convert_handle<PROD>(std::move(bh));
+  }
+
+  template <typename PROD>
+  PROD const& ProcessBlock::get(EDGetTokenT<PROD> token) const noexcept(false) {
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
+    return *convert_handle<PROD>(std::move(bh));
+  }
+
+  template <typename PROD>
+  void ProcessBlock::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
+    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct(
+          "ProcessBlock", typeID, provRecorder_.productInstanceLabel(token));
+    }
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("ProcessBlock", typeid(PROD));
+    }
+    putImpl(token.index(), std::move(product));
+  }
+
+  template <typename PROD>
+  void ProcessBlock::put(EDPutToken token, std::unique_ptr<PROD> product) {
+    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct(
+          "ProcessBlock", typeID, provRecorder_.productInstanceLabel(token));
+    }
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("ProcessBlock", typeid(PROD));
+    }
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+    putImpl(token.index(), std::move(product));
+  }
+
+  template <typename PROD, typename... Args>
+  void ProcessBlock::emplace(EDPutTokenT<PROD> token, Args&&... args) {
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("ProcessBlock", typeid(PROD));
+    }
+    emplaceImpl<PROD>(token.index(), std::forward<Args>(args)...);
+  }
+
+  template <typename PROD, typename... Args>
+  void ProcessBlock::emplace(EDPutToken token, Args&&... args) {
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("ProcessBlock", typeid(PROD));
+    }
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+    emplaceImpl<PROD>(token.index(), std::forward<Args>(args)...);
+  }
+
+  template <typename PROD>
+  void ProcessBlock::putImpl(EDPutToken::value_type index, std::unique_ptr<PROD> product) {
+    // The following will call post_insert if T has such a function,
+    // and do nothing if T has no such function.
+    std::conditional_t<detail::has_postinsert<PROD>::value, DoPostInsert<PROD>, DoNotPostInsert<PROD>> maybe_inserter;
+    maybe_inserter(product.get());
+
+    assert(index < putProducts().size());
+
+    std::unique_ptr<Wrapper<PROD>> wp(new Wrapper<PROD>(std::move(product)));
+    putProducts()[index] = std::move(wp);
+  }
+
+  template <typename PROD, typename... Args>
+  void ProcessBlock::emplaceImpl(EDPutToken::value_type index, Args&&... args) {
+    assert(index < putProducts().size());
+
+    std::unique_ptr<Wrapper<PROD>> wp(new Wrapper<PROD>(WrapperBase::Emplace{}, std::forward<Args>(args)...));
+
+    // The following will call post_insert if T has such a function,
+    // and do nothing if T has no such function.
+    std::conditional_t<detail::has_postinsert<PROD>::value, DoPostInsert<PROD>, DoNotPostInsert<PROD>> maybe_inserter;
+    maybe_inserter(&(wp->bareProduct()));
+
+    putProducts()[index] = std::move(wp);
+  }
+
+  template <typename T>
+  T const& get(ProcessBlock const& processBlock, EDGetToken const& token) {
+    Handle<T> handle;
+    processBlock.getByToken(token, handle);
+    // throw if the handle is not valid
+    return *handle.product();
+  }
+
+  template <typename T>
+  T const& get(ProcessBlock const& processBlock, EDGetTokenT<T> const& token) {
+    Handle<T> handle;
+    processBlock.getByToken(token, handle);
+    // throw if the handle is not valid
+    return *handle.product();
+  }
+
+}  // namespace edm
+#endif  // FWCore_Framework_ProcessBlock_h

--- a/FWCore/Framework/interface/ProcessBlockPrincipal.h
+++ b/FWCore/Framework/interface/ProcessBlockPrincipal.h
@@ -35,7 +35,7 @@ namespace edm {
     unsigned int index() { return 0; }
 
   private:
-    unsigned int transitionIndex_() const override;
+    unsigned int transitionIndex_() const final;
 
     std::string processName_;
   };

--- a/FWCore/Framework/interface/ProcessBlockPrincipal.h
+++ b/FWCore/Framework/interface/ProcessBlockPrincipal.h
@@ -1,0 +1,44 @@
+#ifndef FWCore_Framework_ProcessBlockPrincipal_h
+#define FWCore_Framework_ProcessBlockPrincipal_h
+
+/** \class edm::ProcessBlockPrincipal
+
+\author W. David Dagenhart, created 19 March, 2020
+
+*/
+
+#include "FWCore/Framework/interface/Principal.h"
+#include "FWCore/Utilities/interface/ProductResolverIndex.h"
+
+#include <memory>
+#include <string>
+
+namespace edm {
+
+  class ProcessConfiguration;
+  class ProductRegistry;
+  class WrapperBase;
+
+  class ProcessBlockPrincipal : public Principal {
+  public:
+    ProcessBlockPrincipal(std::shared_ptr<ProductRegistry const>,
+                          ProcessConfiguration const&,
+                          bool isForPrimaryProcess = true);
+
+    void fillProcessBlockPrincipal(std::string const& processName, DelayedReader* reader = nullptr);
+
+    std::string const& processName() const { return processName_; }
+
+    void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
+
+    // Should only be 1 ProcessBlock needed at a time (no concurrent ProcessBlocks)
+    unsigned int index() { return 0; }
+
+  private:
+    unsigned int transitionIndex_() const override;
+
+    std::string processName_;
+  };
+}  // namespace edm
+
+#endif  // FWCore_Framework_ProcessBlockPrincipal_h

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -2,7 +2,7 @@
 #define FWCore_Framework_ProducerBase_h
 
 /*----------------------------------------------------------------------
-  
+
 EDProducer: The base class of all "modules" that will insert new
 EDProducts into an Event.
 
@@ -24,6 +24,7 @@ namespace edm {
   class ProductRegistry;
   class Event;
   class LuminosityBlock;
+  class ProcessBlock;
   class Run;
 
   class EDProducer;
@@ -48,6 +49,10 @@ namespace edm {
   namespace producerbasehelper {
     template <typename P>
     struct PrincipalTraits;
+    template <>
+    struct PrincipalTraits<ProcessBlock> {
+      static constexpr int kBranchType = InProcess;
+    };
     template <>
     struct PrincipalTraits<Run> {
       static constexpr int kBranchType = InRun;

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -2,8 +2,8 @@
 #define FWCore_Framework_ProductRegistryHelper_h
 
 /*----------------------------------------------------------------------
-  
-ProductRegistryHelper: 
+
+ProductRegistryHelper:
 
 ----------------------------------------------------------------------*/
 
@@ -162,6 +162,9 @@ namespace edm {
       recordProvenanceList_.push_back(recordProvenance and B == Transition::Event);
       return BranchAliasSetter{typeLabelList_.back(), EDPutToken{index}};
     }
+
+    virtual bool hasAbilityToProduceInBeginProcessBlocks() const { return false; }
+    virtual bool hasAbilityToProduceInEndProcessBlocks() const { return false; }
 
     virtual bool hasAbilityToProduceInBeginRuns() const { return false; }
     virtual bool hasAbilityToProduceInEndRuns() const { return false; }

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -180,6 +180,11 @@ namespace edm {
                        ActivityRegistry*,
                        MergeableRunProductMetadata const*);
 
+    void writeProcessBlockAsync(WaitingTaskHolder iTask,
+                                ProcessBlockPrincipal const&,
+                                ProcessContext const*,
+                                ActivityRegistry*);
+
     // Call closeFile() on all OutputModules.
     void closeOutputFiles();
 

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -32,10 +32,13 @@ namespace edm {
   class EventSetupImpl;
   class HistoryAppender;
   class IOVSyncValue;
+  class LumiTransitionInfo;
   class MergeableRunProductMetadata;
   class ParameterSet;
+  class ProcessBlockTransitionInfo;
   class ProductRegistry;
   class PreallocationConfiguration;
+  class RunTransitionInfo;
   class ThinnedAssociationsHelper;
   class SubProcessParentageHelper;
   class WaitingTaskHolder;
@@ -80,37 +83,22 @@ namespace edm {
                       std::vector<std::shared_ptr<const EventSetupImpl>> const*);
 
     template <typename Traits>
-    void doBeginProcessBlockAsync(WaitingTaskHolder iHolder,
-                                  ProcessBlockPrincipal const& principal,
-                                  IOVSyncValue const&,
-                                  std::vector<std::shared_ptr<const EventSetupImpl>> const*);
+    void doBeginProcessBlockAsync(WaitingTaskHolder iHolder, ProcessBlockTransitionInfo const& iTransitionInfo);
 
     void doEndProcessBlockAsync(WaitingTaskHolder iHolder,
-                                ProcessBlockPrincipal const& principal,
-                                IOVSyncValue const&,
-                                std::vector<std::shared_ptr<const EventSetupImpl>> const*,
+                                ProcessBlockTransitionInfo const& iTransitionInfo,
                                 bool cleaningUpAfterException);
 
-    void doBeginRunAsync(WaitingTaskHolder iHolder,
-                         RunPrincipal const& principal,
-                         IOVSyncValue const& ts,
-                         std::vector<std::shared_ptr<const EventSetupImpl>> const*);
+    void doBeginRunAsync(WaitingTaskHolder iHolder, RunTransitionInfo const& iTransitionInfo);
 
     void doEndRunAsync(WaitingTaskHolder iHolder,
-                       RunPrincipal const& principal,
-                       IOVSyncValue const& ts,
-                       std::vector<std::shared_ptr<const EventSetupImpl>> const*,
+                       RunTransitionInfo const& iTransitionInfo,
                        bool cleaningUpAfterException);
 
-    void doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
-                                     LuminosityBlockPrincipal const& principal,
-                                     IOVSyncValue const& ts,
-                                     std::vector<std::shared_ptr<const EventSetupImpl>> const*);
+    void doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LumiTransitionInfo const& iTransitionInfo);
 
     void doEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
-                                   LuminosityBlockPrincipal const& principal,
-                                   IOVSyncValue const& ts,
-                                   std::vector<std::shared_ptr<const EventSetupImpl>> const*,
+                                   LumiTransitionInfo const& iTransitionInfo,
                                    bool cleaningUpAfterException);
 
     void doBeginStream(unsigned int);

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -79,6 +79,18 @@ namespace edm {
                       EventPrincipal const& principal,
                       std::vector<std::shared_ptr<const EventSetupImpl>> const*);
 
+    template <typename Traits>
+    void doBeginProcessBlockAsync(WaitingTaskHolder iHolder,
+                                  ProcessBlockPrincipal const& principal,
+                                  IOVSyncValue const&,
+                                  std::vector<std::shared_ptr<const EventSetupImpl>> const*);
+
+    void doEndProcessBlockAsync(WaitingTaskHolder iHolder,
+                                ProcessBlockPrincipal const& principal,
+                                IOVSyncValue const&,
+                                std::vector<std::shared_ptr<const EventSetupImpl>> const*,
+                                bool cleaningUpAfterException);
+
     void doBeginRunAsync(WaitingTaskHolder iHolder,
                          RunPrincipal const& principal,
                          IOVSyncValue const& ts,
@@ -129,18 +141,20 @@ namespace edm {
                                          std::vector<std::shared_ptr<const EventSetupImpl>> const*,
                                          bool cleaningUpAfterException);
 
-    // Write the luminosity block
     void writeLumiAsync(WaitingTaskHolder, LuminosityBlockPrincipal&);
 
     void deleteLumiFromCache(LuminosityBlockPrincipal&);
 
-    // Write the run
+    void writeProcessBlockAsync(edm::WaitingTaskHolder task, bool isInputProcessBlock);
+
     void writeRunAsync(WaitingTaskHolder,
                        ProcessHistoryID const& parentPhID,
                        int runNumber,
                        MergeableRunProductMetadata const*);
 
     void deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber);
+
+    void clearProcessBlockPrincipal(bool isInputProcessBlock = false);
 
     // Call closeFile() on all OutputModules.
     void closeOutputFiles() {

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -145,7 +145,8 @@ namespace edm {
 
     void deleteLumiFromCache(LuminosityBlockPrincipal&);
 
-    void writeProcessBlockAsync(edm::WaitingTaskHolder task, bool isInputProcessBlock);
+    using ProcessBlockType = PrincipalCache::ProcessBlockType;
+    void writeProcessBlockAsync(edm::WaitingTaskHolder task, ProcessBlockType);
 
     void writeRunAsync(WaitingTaskHolder,
                        ProcessHistoryID const& parentPhID,
@@ -154,7 +155,7 @@ namespace edm {
 
     void deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber);
 
-    void clearProcessBlockPrincipal(bool isInputProcessBlock = false);
+    void clearProcessBlockPrincipal(ProcessBlockType);
 
     // Call closeFile() on all OutputModules.
     void closeOutputFiles() {

--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -40,6 +40,7 @@ namespace edm {
 #endif
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -39,6 +39,7 @@ namespace edm {
       virtual ~EDAnalyzer() {}
 #endif
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -62,6 +62,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
@@ -95,6 +96,9 @@ namespace edm {
                                       EventSetupImpl const& c,
                                       ModuleCallingContext const*);
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -129,6 +133,9 @@ namespace edm {
       virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
       virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -63,6 +63,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -45,11 +45,19 @@ namespace edm {
       virtual ~EDFilter() = default;
 #endif
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
+
+      bool hasAbilityToProduceInBeginProcessBlocks() const final {
+        return HasAbilityToProduceInBeginProcessBlocks<T...>::value;
+      }
+      bool hasAbilityToProduceInEndProcessBlocks() const final {
+        return HasAbilityToProduceInEndProcessBlocks<T...>::value;
+      }
 
       bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
       bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -46,6 +46,7 @@ namespace edm {
 #endif
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -65,6 +65,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
@@ -99,6 +100,9 @@ namespace edm {
                                       EventSetupImpl const& c,
                                       ModuleCallingContext const*);
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -135,6 +139,9 @@ namespace edm {
       virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
       virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
@@ -144,6 +151,8 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
 
+      virtual void doBeginProcessBlockProduce_(ProcessBlock&);
+      virtual void doEndProcessBlockProduce_(ProcessBlock&);
       virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -66,6 +66,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;

--- a/FWCore/Framework/interface/global/EDProducer.h
+++ b/FWCore/Framework/interface/global/EDProducer.h
@@ -40,11 +40,19 @@ namespace edm {
       EDProducer() = default;
 
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
+
+      bool hasAbilityToProduceInBeginProcessBlocks() const final {
+        return HasAbilityToProduceInBeginProcessBlocks<T...>::value;
+      }
+      bool hasAbilityToProduceInEndProcessBlocks() const final {
+        return HasAbilityToProduceInEndProcessBlocks<T...>::value;
+      }
 
       bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
       bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }

--- a/FWCore/Framework/interface/global/EDProducer.h
+++ b/FWCore/Framework/interface/global/EDProducer.h
@@ -41,6 +41,7 @@ namespace edm {
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -69,6 +69,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -68,6 +68,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
@@ -97,6 +98,9 @@ namespace edm {
                                       EventSetupImpl const& c,
                                       ModuleCallingContext const*);
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -138,6 +142,9 @@ namespace edm {
       virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
       virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
@@ -147,6 +154,8 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
 
+      virtual void doBeginProcessBlockProduce_(ProcessBlock&);
+      virtual void doEndProcessBlockProduce_(ProcessBlock&);
       virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/OutputModule.h
+++ b/FWCore/Framework/interface/global/OutputModule.h
@@ -39,6 +39,7 @@ namespace edm {
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/global/OutputModule.h
+++ b/FWCore/Framework/interface/global/OutputModule.h
@@ -38,6 +38,7 @@ namespace edm {
 #endif
 
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -111,6 +111,7 @@ namespace edm {
       bool wantsGlobalLuminosityBlocks() const { return true; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
       virtual bool wantsStreamLuminosityBlocks() const = 0;
 

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -110,6 +110,7 @@ namespace edm {
       bool wantsGlobalRuns() const { return true; }
       bool wantsGlobalLuminosityBlocks() const { return true; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
       virtual bool wantsStreamLuminosityBlocks() const = 0;
 
@@ -142,6 +143,9 @@ namespace edm {
                                                     ModuleCallingContext const& iModuleCallingContext,
                                                     Principal const& iPrincipal) const {}
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -210,6 +214,7 @@ namespace edm {
 
       void updateBranchIDListsWithKeptAliases();
 
+      void doWriteProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*, MergeableRunProductMetadata const*);
       void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*);
       void doOpenFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/global/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/analyzerAbilityToImplementor.h
@@ -38,8 +38,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::global::impl::ProcessBlockCacheHolder<edm::global::EDAnalyzerBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::global::impl::InputProcessBlockCacheHolder<edm::global::EDAnalyzerBase, C> Type;
       };
 
       template <typename C>
@@ -60,6 +60,11 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::global::impl::LuminosityBlockSummaryCacheHolder<edm::global::EDAnalyzerBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::global::impl::WatchProcessBlock<edm::global::EDAnalyzerBase> Type;
       };
     }  // namespace analyzer
   }    // namespace global

--- a/FWCore/Framework/interface/global/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/analyzerAbilityToImplementor.h
@@ -38,6 +38,11 @@ namespace edm {
       };
 
       template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::global::impl::ProcessBlockCacheHolder<edm::global::EDAnalyzerBase, C> Type;
+      };
+
+      template <typename C>
       struct AbilityToImplementor<edm::RunCache<C>> {
         typedef edm::global::impl::RunCacheHolder<edm::global::EDAnalyzerBase, C> Type;
       };

--- a/FWCore/Framework/interface/global/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/filterAbilityToImplementor.h
@@ -38,6 +38,11 @@ namespace edm {
       };
 
       template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::global::impl::ProcessBlockCacheHolder<edm::global::EDFilterBase, C> Type;
+      };
+
+      template <typename C>
       struct AbilityToImplementor<edm::RunCache<C>> {
         typedef edm::global::impl::RunCacheHolder<edm::global::EDFilterBase, C> Type;
       };
@@ -55,6 +60,16 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::global::impl::LuminosityBlockSummaryCacheHolder<edm::global::EDFilterBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
+        typedef edm::global::impl::BeginProcessBlockProducer<edm::global::EDFilterBase> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::EndProcessBlockProducer> {
+        typedef edm::global::impl::EndProcessBlockProducer<edm::global::EDFilterBase> Type;
       };
 
       template <>

--- a/FWCore/Framework/interface/global/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/filterAbilityToImplementor.h
@@ -38,8 +38,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::global::impl::ProcessBlockCacheHolder<edm::global::EDFilterBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::global::impl::InputProcessBlockCacheHolder<edm::global::EDFilterBase, C> Type;
       };
 
       template <typename C>
@@ -60,6 +60,11 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::global::impl::LuminosityBlockSummaryCacheHolder<edm::global::EDFilterBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::global::impl::WatchProcessBlock<edm::global::EDFilterBase> Type;
       };
 
       template <>

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/ProcessBlockIndex.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
@@ -84,6 +85,41 @@ namespace edm {
 
         //When threaded we will have a container for N items whre N is # of streams
         std::vector<C*> caches_;
+      };
+
+      template <typename T, typename C>
+      class ProcessBlockCacheHolder : public virtual T {
+      public:
+        ProcessBlockCacheHolder() = default;
+        ProcessBlockCacheHolder(ProcessBlockCacheHolder<T, C> const&) = delete;
+        ProcessBlockCacheHolder<T, C>& operator=(ProcessBlockCacheHolder<T, C> const&) = delete;
+        ~ProcessBlockCacheHolder() override {}
+
+      protected:
+        // Not implemented yet
+        // const C* processBlockCache(ProcessBlockIndex index) const { return caches_.at(index).get(); }
+
+      private:
+        void doBeginProcessBlock_(ProcessBlock const& pb) final { beginProcessBlock(pb); }
+
+        // Not yet fully implemented, will never get called
+        void doAccessInputProcessBlock_(ProcessBlock const& pb) final {
+          caches_.push_back(accessInputProcessBlock(pb));
+        }
+
+        void doEndProcessBlock_(ProcessBlock const& pb) final {
+          endProcessBlock(pb);
+          caches_.clear();
+        }
+
+        virtual void beginProcessBlock(ProcessBlock const&) const {}
+
+        // Not yet fully implemented, will never get called
+        virtual std::shared_ptr<C> accessInputProcessBlock(ProcessBlock const&) const { return std::shared_ptr<C>(); }
+
+        virtual void endProcessBlock(ProcessBlock const&) const {}
+
+        std::vector<std::shared_ptr<C>> caches_;
       };
 
       template <typename T, typename C>
@@ -215,6 +251,34 @@ namespace edm {
         //When threaded we will have a container for N items where N is # of simultaneous Lumis
         std::unique_ptr<std::shared_ptr<C>[]> caches_;
         std::mutex mutex_;
+      };
+
+      template <typename T>
+      class BeginProcessBlockProducer : public virtual T {
+      public:
+        BeginProcessBlockProducer() = default;
+        BeginProcessBlockProducer(BeginProcessBlockProducer const&) = delete;
+        BeginProcessBlockProducer& operator=(BeginProcessBlockProducer const&) = delete;
+        ~BeginProcessBlockProducer() noexcept(false) override{};
+
+      private:
+        void doBeginProcessBlockProduce_(ProcessBlock&) final;
+
+        virtual void beginProcessBlockProduce(edm::ProcessBlock&) const = 0;
+      };
+
+      template <typename T>
+      class EndProcessBlockProducer : public virtual T {
+      public:
+        EndProcessBlockProducer() = default;
+        EndProcessBlockProducer(EndProcessBlockProducer const&) = delete;
+        EndProcessBlockProducer& operator=(EndProcessBlockProducer const&) = delete;
+        ~EndProcessBlockProducer() noexcept(false) override{};
+
+      private:
+        void doEndProcessBlockProduce_(ProcessBlock&) final;
+
+        virtual void endProcessBlockProduce(edm::ProcessBlock&) const = 0;
       };
 
       template <typename T>

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -88,36 +88,26 @@ namespace edm {
       };
 
       template <typename T, typename C>
-      class ProcessBlockCacheHolder : public virtual T {
+      class InputProcessBlockCacheHolder : public virtual T {
       public:
-        ProcessBlockCacheHolder() = default;
-        ProcessBlockCacheHolder(ProcessBlockCacheHolder<T, C> const&) = delete;
-        ProcessBlockCacheHolder<T, C>& operator=(ProcessBlockCacheHolder<T, C> const&) = delete;
-        ~ProcessBlockCacheHolder() override {}
+        InputProcessBlockCacheHolder() = default;
+        InputProcessBlockCacheHolder(InputProcessBlockCacheHolder const&) = delete;
+        InputProcessBlockCacheHolder& operator=(InputProcessBlockCacheHolder const&) = delete;
+        ~InputProcessBlockCacheHolder() override {}
 
       protected:
         // Not implemented yet
-        // const C* processBlockCache(ProcessBlockIndex index) const { return caches_.at(index).get(); }
+        // const C* inputProcessBlockCache(ProcessBlockIndex index) const { return caches_.at(index).get(); }
 
       private:
-        void doBeginProcessBlock_(ProcessBlock const& pb) final { beginProcessBlock(pb); }
-
         // Not yet fully implemented, will never get called
+        // THINK ABOUT HOW TO CLEAR CACHES!!!
         void doAccessInputProcessBlock_(ProcessBlock const& pb) final {
           caches_.push_back(accessInputProcessBlock(pb));
         }
 
-        void doEndProcessBlock_(ProcessBlock const& pb) final {
-          endProcessBlock(pb);
-          caches_.clear();
-        }
-
-        virtual void beginProcessBlock(ProcessBlock const&) const {}
-
         // Not yet fully implemented, will never get called
-        virtual std::shared_ptr<C> accessInputProcessBlock(ProcessBlock const&) const { return std::shared_ptr<C>(); }
-
-        virtual void endProcessBlock(ProcessBlock const&) const {}
+        virtual std::shared_ptr<C> accessInputProcessBlock(ProcessBlock const&) const = 0;
 
         std::vector<std::shared_ptr<C>> caches_;
       };
@@ -251,6 +241,22 @@ namespace edm {
         //When threaded we will have a container for N items where N is # of simultaneous Lumis
         std::unique_ptr<std::shared_ptr<C>[]> caches_;
         std::mutex mutex_;
+      };
+
+      template <typename T>
+      class WatchProcessBlock : public virtual T {
+      public:
+        WatchProcessBlock() = default;
+        WatchProcessBlock(WatchProcessBlock const&) = delete;
+        WatchProcessBlock& operator=(WatchProcessBlock const&) = delete;
+        ~WatchProcessBlock() noexcept(false) override {}
+
+      private:
+        void doBeginProcessBlock_(ProcessBlock const&) final;
+        void doEndProcessBlock_(ProcessBlock const&) final;
+
+        virtual void beginProcessBlock(ProcessBlock const&) const {}
+        virtual void endProcessBlock(ProcessBlock const&) const {}
       };
 
       template <typename T>

--- a/FWCore/Framework/interface/global/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/producerAbilityToImplementor.h
@@ -38,8 +38,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::global::impl::ProcessBlockCacheHolder<edm::global::EDProducerBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::global::impl::InputProcessBlockCacheHolder<edm::global::EDProducerBase, C> Type;
       };
 
       template <typename C>
@@ -60,6 +60,11 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::global::impl::LuminosityBlockSummaryCacheHolder<edm::global::EDProducerBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::global::impl::WatchProcessBlock<edm::global::EDProducerBase> Type;
       };
 
       template <>

--- a/FWCore/Framework/interface/global/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/producerAbilityToImplementor.h
@@ -38,6 +38,11 @@ namespace edm {
       };
 
       template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::global::impl::ProcessBlockCacheHolder<edm::global::EDProducerBase, C> Type;
+      };
+
+      template <typename C>
       struct AbilityToImplementor<edm::RunCache<C>> {
         typedef edm::global::impl::RunCacheHolder<edm::global::EDProducerBase, C> Type;
       };
@@ -55,6 +60,16 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::global::impl::LuminosityBlockSummaryCacheHolder<edm::global::EDProducerBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
+        typedef edm::global::impl::BeginProcessBlockProducer<edm::global::EDProducerBase> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::EndProcessBlockProducer> {
+        typedef edm::global::impl::EndProcessBlockProducer<edm::global::EDProducerBase> Type;
       };
 
       template <>

--- a/FWCore/Framework/interface/limited/EDAnalyzer.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzer.h
@@ -41,6 +41,7 @@ namespace edm {
 #endif
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }

--- a/FWCore/Framework/interface/limited/EDAnalyzer.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzer.h
@@ -40,6 +40,7 @@ namespace edm {
       virtual ~EDAnalyzer() {}
 #endif
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -63,6 +63,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
@@ -100,6 +101,9 @@ namespace edm {
                                       EventSetupImpl const& c,
                                       ModuleCallingContext const*);
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -134,6 +138,9 @@ namespace edm {
       virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
       virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -64,6 +64,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;

--- a/FWCore/Framework/interface/limited/EDFilter.h
+++ b/FWCore/Framework/interface/limited/EDFilter.h
@@ -52,10 +52,18 @@ namespace edm {
       virtual ~EDFilter() = default;
 #endif
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
+
+      bool hasAbilityToProduceInBeginProcessBlocks() const final {
+        return HasAbilityToProduceInBeginProcessBlocks<T...>::value;
+      }
+      bool hasAbilityToProduceInEndProcessBlocks() const final {
+        return HasAbilityToProduceInEndProcessBlocks<T...>::value;
+      }
 
       bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
       bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }

--- a/FWCore/Framework/interface/limited/EDFilter.h
+++ b/FWCore/Framework/interface/limited/EDFilter.h
@@ -53,6 +53,7 @@ namespace edm {
 #endif
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -65,6 +65,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
@@ -98,6 +99,9 @@ namespace edm {
                                       EventSetupImpl const& c,
                                       ModuleCallingContext const*);
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -134,6 +138,9 @@ namespace edm {
       virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
       virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
@@ -143,6 +150,8 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
 
+      virtual void doBeginProcessBlockProduce_(ProcessBlock&);
+      virtual void doEndProcessBlockProduce_(ProcessBlock&);
       virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -66,6 +66,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;

--- a/FWCore/Framework/interface/limited/EDProducer.h
+++ b/FWCore/Framework/interface/limited/EDProducer.h
@@ -48,6 +48,7 @@ namespace edm {
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }

--- a/FWCore/Framework/interface/limited/EDProducer.h
+++ b/FWCore/Framework/interface/limited/EDProducer.h
@@ -47,10 +47,18 @@ namespace edm {
                 T>::Type(iPSet)... {}
 
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
+
+      bool hasAbilityToProduceInBeginProcessBlocks() const final {
+        return HasAbilityToProduceInBeginProcessBlocks<T...>::value;
+      }
+      bool hasAbilityToProduceInEndProcessBlocks() const final {
+        return HasAbilityToProduceInEndProcessBlocks<T...>::value;
+      }
 
       bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
       bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -69,6 +69,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -68,6 +68,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
@@ -96,6 +97,9 @@ namespace edm {
                                       EventSetupImpl const& c,
                                       ModuleCallingContext const*);
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -137,6 +141,9 @@ namespace edm {
       virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
       virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
@@ -146,6 +153,8 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
 
+      virtual void doBeginProcessBlockProduce_(ProcessBlock&);
+      virtual void doEndProcessBlockProduce_(ProcessBlock&);
       virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/OutputModule.h
+++ b/FWCore/Framework/interface/limited/OutputModule.h
@@ -39,6 +39,7 @@ namespace edm {
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/limited/OutputModule.h
+++ b/FWCore/Framework/interface/limited/OutputModule.h
@@ -38,6 +38,7 @@ namespace edm {
 #endif
 
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -111,6 +111,7 @@ namespace edm {
       bool wantsGlobalRuns() const { return true; }
       bool wantsGlobalLuminosityBlocks() const { return true; }
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
       virtual bool wantsStreamLuminosityBlocks() const = 0;
 

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -110,6 +110,7 @@ namespace edm {
       //Output modules always need writeRun and writeLumi to be called
       bool wantsGlobalRuns() const { return true; }
       bool wantsGlobalLuminosityBlocks() const { return true; }
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsStreamRuns() const = 0;
       virtual bool wantsStreamLuminosityBlocks() const = 0;
 
@@ -146,6 +147,9 @@ namespace edm {
                                                     ModuleCallingContext const& iModuleCallingContext,
                                                     Principal const& iPrincipal) const {}
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -215,6 +219,7 @@ namespace edm {
 
       void updateBranchIDListsWithKeptAliases();
 
+      void doWriteProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*, MergeableRunProductMetadata const*);
       void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*);
       void doOpenFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/limited/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/analyzerAbilityToImplementor.h
@@ -38,8 +38,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::limited::impl::ProcessBlockCacheHolder<edm::limited::EDAnalyzerBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::limited::impl::InputProcessBlockCacheHolder<edm::limited::EDAnalyzerBase, C> Type;
       };
 
       template <typename C>
@@ -60,6 +60,11 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::EDAnalyzerBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::limited::impl::WatchProcessBlock<edm::limited::EDAnalyzerBase> Type;
       };
     }  // namespace analyzer
   }    // namespace limited

--- a/FWCore/Framework/interface/limited/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/analyzerAbilityToImplementor.h
@@ -38,6 +38,11 @@ namespace edm {
       };
 
       template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::limited::impl::ProcessBlockCacheHolder<edm::limited::EDAnalyzerBase, C> Type;
+      };
+
+      template <typename C>
       struct AbilityToImplementor<edm::RunCache<C>> {
         typedef edm::limited::impl::RunCacheHolder<edm::limited::EDAnalyzerBase, C> Type;
       };

--- a/FWCore/Framework/interface/limited/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/filterAbilityToImplementor.h
@@ -38,8 +38,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::limited::impl::ProcessBlockCacheHolder<edm::limited::EDFilterBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::limited::impl::InputProcessBlockCacheHolder<edm::limited::EDFilterBase, C> Type;
       };
 
       template <typename C>
@@ -60,6 +60,11 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::EDFilterBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::limited::impl::WatchProcessBlock<edm::limited::EDFilterBase> Type;
       };
 
       template <>

--- a/FWCore/Framework/interface/limited/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/filterAbilityToImplementor.h
@@ -38,6 +38,11 @@ namespace edm {
       };
 
       template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::limited::impl::ProcessBlockCacheHolder<edm::limited::EDFilterBase, C> Type;
+      };
+
+      template <typename C>
       struct AbilityToImplementor<edm::RunCache<C>> {
         typedef edm::limited::impl::RunCacheHolder<edm::limited::EDFilterBase, C> Type;
       };
@@ -55,6 +60,16 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::EDFilterBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
+        typedef edm::limited::impl::BeginProcessBlockProducer<edm::limited::EDFilterBase> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::EndProcessBlockProducer> {
+        typedef edm::limited::impl::EndProcessBlockProducer<edm::limited::EDFilterBase> Type;
       };
 
       template <>

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/ProcessBlockIndex.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
@@ -85,6 +86,41 @@ namespace edm {
 
         //When threaded we will have a container for N items whre N is # of streams
         std::vector<C*> caches_;
+      };
+
+      template <typename T, typename C>
+      class ProcessBlockCacheHolder : public virtual T {
+      public:
+        ProcessBlockCacheHolder(edm::ParameterSet const& iPSet) : T(iPSet) {}
+        ProcessBlockCacheHolder(ProcessBlockCacheHolder<T, C> const&) = delete;
+        ProcessBlockCacheHolder<T, C>& operator=(ProcessBlockCacheHolder<T, C> const&) = delete;
+        ~ProcessBlockCacheHolder() noexcept(false) override {}
+
+      protected:
+        // Not implemented yet
+        // const C* processBlockCache(ProcessBlockIndex index) const { return caches_.at(index).get(); }
+
+      private:
+        void doBeginProcessBlock_(ProcessBlock const& pb) final { beginProcessBlock(pb); }
+
+        // Not yet fully implemented, will never get called
+        void doAccessInputProcessBlock_(ProcessBlock const& pb) final {
+          caches_.push_back(accessInputProcessBlock(pb));
+        }
+
+        void doEndProcessBlock_(ProcessBlock const& pb) final {
+          endProcessBlock(pb);
+          caches_.clear();
+        }
+
+        virtual void beginProcessBlock(ProcessBlock const&) const {}
+
+        // Not yet fully implemented, will never get called
+        virtual std::shared_ptr<C> accessInputProcessBlock(ProcessBlock const&) const { return std::shared_ptr<C>(); }
+
+        virtual void endProcessBlock(ProcessBlock const&) const {}
+
+        std::vector<std::shared_ptr<C>> caches_;
       };
 
       template <typename T, typename C>
@@ -216,6 +252,34 @@ namespace edm {
         //When threaded we will have a container for N items where N is # of simultaneous Lumis
         std::unique_ptr<std::shared_ptr<C>[]> caches_;
         std::mutex mutex_;
+      };
+
+      template <typename T>
+      class BeginProcessBlockProducer : public virtual T {
+      public:
+        BeginProcessBlockProducer(edm::ParameterSet const& iPSet) : T(iPSet) {}
+        BeginProcessBlockProducer(BeginProcessBlockProducer const&) = delete;
+        BeginProcessBlockProducer& operator=(BeginProcessBlockProducer const&) = delete;
+        ~BeginProcessBlockProducer() noexcept(false) override{};
+
+      private:
+        void doBeginProcessBlockProduce_(ProcessBlock&) final;
+
+        virtual void beginProcessBlockProduce(edm::ProcessBlock&) const = 0;
+      };
+
+      template <typename T>
+      class EndProcessBlockProducer : public virtual T {
+      public:
+        EndProcessBlockProducer(edm::ParameterSet const& iPSet) : T(iPSet) {}
+        EndProcessBlockProducer(EndProcessBlockProducer const&) = delete;
+        EndProcessBlockProducer& operator=(EndProcessBlockProducer const&) = delete;
+        ~EndProcessBlockProducer() noexcept(false) override{};
+
+      private:
+        void doEndProcessBlockProduce_(ProcessBlock&) final;
+
+        virtual void endProcessBlockProduce(edm::ProcessBlock&) const = 0;
       };
 
       template <typename T>

--- a/FWCore/Framework/interface/limited/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/producerAbilityToImplementor.h
@@ -38,8 +38,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::limited::impl::ProcessBlockCacheHolder<edm::limited::EDProducerBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::limited::impl::InputProcessBlockCacheHolder<edm::limited::EDProducerBase, C> Type;
       };
 
       template <typename C>
@@ -60,6 +60,11 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::EDProducerBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::limited::impl::WatchProcessBlock<edm::limited::EDProducerBase> Type;
       };
 
       template <>

--- a/FWCore/Framework/interface/limited/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/producerAbilityToImplementor.h
@@ -38,6 +38,11 @@ namespace edm {
       };
 
       template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::limited::impl::ProcessBlockCacheHolder<edm::limited::EDProducerBase, C> Type;
+      };
+
+      template <typename C>
       struct AbilityToImplementor<edm::RunCache<C>> {
         typedef edm::limited::impl::RunCacheHolder<edm::limited::EDProducerBase, C> Type;
       };
@@ -55,6 +60,16 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
         typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::EDProducerBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
+        typedef edm::limited::impl::BeginProcessBlockProducer<edm::limited::EDProducerBase> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::EndProcessBlockProducer> {
+        typedef edm::limited::impl::EndProcessBlockProducer<edm::limited::EDProducerBase> Type;
       };
 
       template <>

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -45,6 +45,12 @@ namespace edm {
   };
 
   template <typename T>
+  struct ProcessBlockCache {
+    static constexpr module::Abilities kAbilities = module::Abilities::kProcessBlockCache;
+    typedef T Type;
+  };
+
+  template <typename T>
   struct RunCache {
     static constexpr module::Abilities kAbilities = module::Abilities::kRunCache;
     typedef T Type;
@@ -66,6 +72,16 @@ namespace edm {
   struct LuminosityBlockSummaryCache {
     static constexpr module::Abilities kAbilities = module::Abilities::kLuminosityBlockSummaryCache;
     typedef T Type;
+  };
+
+  struct BeginProcessBlockProducer {
+    static constexpr module::Abilities kAbilities = module::Abilities::kBeginProcessBlockProducer;
+    typedef module::Empty Type;
+  };
+
+  struct EndProcessBlockProducer {
+    static constexpr module::Abilities kAbilities = module::Abilities::kEndProcessBlockProducer;
+    typedef module::Empty Type;
   };
 
   struct BeginRunProducer {
@@ -123,6 +139,13 @@ namespace edm {
   };
 
   template <typename... VArgs>
+  struct WantsProcessBlockTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kProcessBlockCache, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kBeginProcessBlockProducer, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kEndProcessBlockProducer, VArgs...>::kHasIt;
+  };
+
+  template <typename... VArgs>
   struct WantsGlobalRunTransitions {
     static constexpr bool value = CheckAbility<module::Abilities::kRunCache, VArgs...>::kHasIt or
                                   CheckAbility<module::Abilities::kRunSummaryCache, VArgs...>::kHasIt or
@@ -151,9 +174,13 @@ namespace edm {
   };
 
   template <typename... VArgs>
-  struct HasAbilityToProduceInRuns {
-    static constexpr bool value = CheckAbility<module::Abilities::kBeginRunProducer, VArgs...>::kHasIt or
-                                  CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
+  struct HasAbilityToProduceInBeginProcessBlocks {
+    static constexpr bool value = CheckAbility<module::Abilities::kBeginProcessBlockProducer, VArgs...>::kHasIt;
+  };
+
+  template <typename... VArgs>
+  struct HasAbilityToProduceInEndProcessBlocks {
+    static constexpr bool value = CheckAbility<module::Abilities::kEndProcessBlockProducer, VArgs...>::kHasIt;
   };
 
   template <typename... VArgs>
@@ -164,12 +191,6 @@ namespace edm {
   template <typename... VArgs>
   struct HasAbilityToProduceInEndRuns {
     static constexpr bool value = CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
-  };
-
-  template <typename... VArgs>
-  struct HasAbilityToProduceInLumis {
-    static constexpr bool value = CheckAbility<module::Abilities::kBeginLuminosityBlockProducer, VArgs...>::kHasIt or
-                                  CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
   };
 
   template <typename... VArgs>

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -45,8 +45,8 @@ namespace edm {
   };
 
   template <typename T>
-  struct ProcessBlockCache {
-    static constexpr module::Abilities kAbilities = module::Abilities::kProcessBlockCache;
+  struct InputProcessBlockCache {
+    static constexpr module::Abilities kAbilities = module::Abilities::kInputProcessBlockCache;
     typedef T Type;
   };
 
@@ -72,6 +72,11 @@ namespace edm {
   struct LuminosityBlockSummaryCache {
     static constexpr module::Abilities kAbilities = module::Abilities::kLuminosityBlockSummaryCache;
     typedef T Type;
+  };
+
+  struct WatchProcessBlock {
+    static constexpr module::Abilities kAbilities = module::Abilities::kWatchProcessBlock;
+    typedef module::Empty Type;
   };
 
   struct BeginProcessBlockProducer {
@@ -140,9 +145,14 @@ namespace edm {
 
   template <typename... VArgs>
   struct WantsProcessBlockTransitions {
-    static constexpr bool value = CheckAbility<module::Abilities::kProcessBlockCache, VArgs...>::kHasIt or
+    static constexpr bool value = CheckAbility<module::Abilities::kWatchProcessBlock, VArgs...>::kHasIt or
                                   CheckAbility<module::Abilities::kBeginProcessBlockProducer, VArgs...>::kHasIt or
                                   CheckAbility<module::Abilities::kEndProcessBlockProducer, VArgs...>::kHasIt;
+  };
+
+  template <typename... VArgs>
+  struct WantsInputProcessBlockTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kInputProcessBlockCache, VArgs...>::kHasIt;
   };
 
   template <typename... VArgs>

--- a/FWCore/Framework/interface/moduleAbilityEnums.h
+++ b/FWCore/Framework/interface/moduleAbilityEnums.h
@@ -30,11 +30,12 @@ namespace edm {
     enum class Abilities {
       kGlobalCache,
       kStreamCache,
-      kProcessBlockCache,
+      kInputProcessBlockCache,
       kRunCache,
       kLuminosityBlockCache,
       kRunSummaryCache,
       kLuminosityBlockSummaryCache,
+      kWatchProcessBlock,
       kBeginProcessBlockProducer,
       kEndProcessBlockProducer,
       kBeginRunProducer,

--- a/FWCore/Framework/interface/moduleAbilityEnums.h
+++ b/FWCore/Framework/interface/moduleAbilityEnums.h
@@ -30,10 +30,13 @@ namespace edm {
     enum class Abilities {
       kGlobalCache,
       kStreamCache,
+      kProcessBlockCache,
       kRunCache,
       kLuminosityBlockCache,
       kRunSummaryCache,
       kLuminosityBlockSummaryCache,
+      kBeginProcessBlockProducer,
+      kEndProcessBlockProducer,
       kBeginRunProducer,
       kEndRunProducer,
       kBeginLuminosityBlockProducer,

--- a/FWCore/Framework/interface/one/EDAnalyzer.h
+++ b/FWCore/Framework/interface/one/EDAnalyzer.h
@@ -43,6 +43,7 @@ namespace edm {
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/one/EDAnalyzer.h
+++ b/FWCore/Framework/interface/one/EDAnalyzer.h
@@ -42,6 +42,7 @@ namespace edm {
 #endif
 
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -64,6 +64,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return false; }

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -63,6 +63,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return false; }
@@ -84,6 +85,9 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -107,6 +111,9 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob() {}
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doEndRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);

--- a/FWCore/Framework/interface/one/EDFilter.h
+++ b/FWCore/Framework/interface/one/EDFilter.h
@@ -40,6 +40,7 @@ namespace edm {
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/one/EDFilter.h
+++ b/FWCore/Framework/interface/one/EDFilter.h
@@ -39,8 +39,16 @@ namespace edm {
       //virtual ~EDFilter();
 
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
+
+      bool hasAbilityToProduceInBeginProcessBlocks() const final {
+        return HasAbilityToProduceInBeginProcessBlocks<T...>::value;
+      }
+      bool hasAbilityToProduceInEndProcessBlocks() const final {
+        return HasAbilityToProduceInEndProcessBlocks<T...>::value;
+      }
 
       bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
       bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -64,6 +64,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return false; }

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -63,6 +63,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return false; }
@@ -83,6 +84,9 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -110,11 +114,16 @@ namespace edm {
 
       virtual void preallocThreads(unsigned int) {}
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doEndRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
 
+      virtual void doBeginProcessBlockProduce_(ProcessBlock&);
+      virtual void doEndProcessBlockProduce_(ProcessBlock&);
       virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);

--- a/FWCore/Framework/interface/one/EDProducer.h
+++ b/FWCore/Framework/interface/one/EDProducer.h
@@ -44,6 +44,7 @@ namespace edm {
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/one/EDProducer.h
+++ b/FWCore/Framework/interface/one/EDProducer.h
@@ -43,8 +43,16 @@ namespace edm {
       //
 
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
+
+      bool hasAbilityToProduceInBeginProcessBlocks() const final {
+        return HasAbilityToProduceInBeginProcessBlocks<T...>::value;
+      }
+      bool hasAbilityToProduceInEndProcessBlocks() const final {
+        return HasAbilityToProduceInEndProcessBlocks<T...>::value;
+      }
 
       bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
       bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -64,6 +64,7 @@ namespace edm {
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return false; }

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -63,6 +63,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return false; }
@@ -83,6 +84,9 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -110,11 +114,16 @@ namespace edm {
 
       virtual void preallocThreads(unsigned int) {}
 
+      virtual void doBeginProcessBlock_(ProcessBlock const&);
+      virtual void doAccessInputProcessBlock_(ProcessBlock const&);
+      virtual void doEndProcessBlock_(ProcessBlock const&);
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doEndRun_(Run const& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
 
+      virtual void doBeginProcessBlockProduce_(ProcessBlock&);
+      virtual void doEndProcessBlockProduce_(ProcessBlock&);
       virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);

--- a/FWCore/Framework/interface/one/OutputModule.h
+++ b/FWCore/Framework/interface/one/OutputModule.h
@@ -41,6 +41,7 @@ namespace edm {
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
+      bool wantsInputProcessBlocks() const final { return WantsInputProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/one/OutputModule.h
+++ b/FWCore/Framework/interface/one/OutputModule.h
@@ -40,6 +40,7 @@ namespace edm {
 #endif
 
       // ---------- const member functions ---------------------
+      bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -105,6 +105,7 @@ namespace edm {
 
       //Output modules always need writeRun and writeLumi to be called
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return false; }

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -104,6 +104,7 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions&);
 
       //Output modules always need writeRun and writeLumi to be called
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return false; }
@@ -134,6 +135,9 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
       bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
+      void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
       bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
@@ -208,6 +212,7 @@ namespace edm {
 
       virtual SharedResourcesAcquirer createAcquirer();
 
+      void doWriteProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*, MergeableRunProductMetadata const*);
       void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*);
       void doOpenFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/one/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/analyzerAbilityToImplementor.h
@@ -50,6 +50,11 @@ namespace edm {
       };
 
       template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::one::impl::ProcessBlockCacheHolder<edm::one::EDAnalyzerBase, C> Type;
+      };
+
+      template <typename C>
       struct AbilityToImplementor<edm::RunCache<C>> {
         typedef edm::one::impl::RunCacheHolder<edm::one::EDAnalyzerBase, C> Type;
       };

--- a/FWCore/Framework/interface/one/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/analyzerAbilityToImplementor.h
@@ -50,8 +50,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::one::impl::ProcessBlockCacheHolder<edm::one::EDAnalyzerBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::one::impl::InputProcessBlockCacheHolder<edm::one::EDAnalyzerBase, C> Type;
       };
 
       template <typename C>
@@ -62,6 +62,11 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
         typedef edm::one::impl::LuminosityBlockCacheHolder<edm::one::EDAnalyzerBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::one::impl::WatchProcessBlock<edm::one::EDAnalyzerBase> Type;
       };
     }  // namespace analyzer
   }    // namespace one

--- a/FWCore/Framework/interface/one/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/filterAbilityToImplementor.h
@@ -50,6 +50,16 @@ namespace edm {
       };
 
       template <>
+      struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
+        typedef edm::one::impl::BeginProcessBlockProducer<edm::one::EDFilterBase> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::EndProcessBlockProducer> {
+        typedef edm::one::impl::EndProcessBlockProducer<edm::one::EDFilterBase> Type;
+      };
+
+      template <>
       struct AbilityToImplementor<edm::BeginRunProducer> {
         typedef edm::one::impl::BeginRunProducer<edm::one::EDFilterBase> Type;
       };
@@ -67,6 +77,11 @@ namespace edm {
       template <>
       struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
         typedef edm::one::impl::EndLuminosityBlockProducer<edm::one::EDFilterBase> Type;
+      };
+
+      template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::one::impl::ProcessBlockCacheHolder<edm::one::EDFilterBase, C> Type;
       };
 
       template <typename C>

--- a/FWCore/Framework/interface/one/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/filterAbilityToImplementor.h
@@ -50,6 +50,11 @@ namespace edm {
       };
 
       template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::one::impl::WatchProcessBlock<edm::one::EDFilterBase> Type;
+      };
+
+      template <>
       struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
         typedef edm::one::impl::BeginProcessBlockProducer<edm::one::EDFilterBase> Type;
       };
@@ -80,8 +85,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::one::impl::ProcessBlockCacheHolder<edm::one::EDFilterBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::one::impl::InputProcessBlockCacheHolder<edm::one::EDFilterBase, C> Type;
       };
 
       template <typename C>

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"
+#include "FWCore/Utilities/interface/ProcessBlockIndex.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
@@ -103,6 +104,34 @@ namespace edm {
       };
 
       template <typename T>
+      class BeginProcessBlockProducer : public virtual T {
+      public:
+        BeginProcessBlockProducer() = default;
+        BeginProcessBlockProducer(BeginProcessBlockProducer const&) = delete;
+        BeginProcessBlockProducer& operator=(BeginProcessBlockProducer const&) = delete;
+        ~BeginProcessBlockProducer() noexcept(false) override{};
+
+      private:
+        void doBeginProcessBlockProduce_(ProcessBlock&) final;
+
+        virtual void beginProcessBlockProduce(edm::ProcessBlock&) = 0;
+      };
+
+      template <typename T>
+      class EndProcessBlockProducer : public virtual T {
+      public:
+        EndProcessBlockProducer() = default;
+        EndProcessBlockProducer(EndProcessBlockProducer const&) = delete;
+        EndProcessBlockProducer& operator=(EndProcessBlockProducer const&) = delete;
+        ~EndProcessBlockProducer() noexcept(false) override{};
+
+      private:
+        void doEndProcessBlockProduce_(ProcessBlock&) final;
+
+        virtual void endProcessBlockProduce(edm::ProcessBlock&) = 0;
+      };
+
+      template <typename T>
       class BeginRunProducer : public virtual T {
       public:
         BeginRunProducer() = default;
@@ -156,6 +185,41 @@ namespace edm {
         void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) final;
 
         virtual void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) = 0;
+      };
+
+      template <typename T, typename C>
+      class ProcessBlockCacheHolder : public virtual T {
+      public:
+        ProcessBlockCacheHolder() = default;
+        ProcessBlockCacheHolder(ProcessBlockCacheHolder<T, C> const&) = delete;
+        ProcessBlockCacheHolder<T, C>& operator=(ProcessBlockCacheHolder<T, C> const&) = delete;
+        ~ProcessBlockCacheHolder() override {}
+
+      protected:
+        // Not implemented yet
+        // const C* processBlockCache(ProcessBlockIndex index) const { return caches_.at(index).get(); }
+
+      private:
+        void doBeginProcessBlock_(ProcessBlock const& pb) final { beginProcessBlock(pb); }
+
+        // Not yet fully implemented, will never get called
+        void doAccessInputProcessBlock_(ProcessBlock const& pb) final {
+          caches_.push_back(accessInputProcessBlock(pb));
+        }
+
+        void doEndProcessBlock_(ProcessBlock const& pb) final {
+          endProcessBlock(pb);
+          caches_.clear();
+        }
+
+        virtual void beginProcessBlock(ProcessBlock const&) {}
+
+        // Not yet fully implemented, will never get called
+        virtual std::shared_ptr<C> accessInputProcessBlock(ProcessBlock const&) { return std::shared_ptr<C>(); }
+
+        virtual void endProcessBlock(ProcessBlock const&) {}
+
+        std::vector<std::shared_ptr<C>> caches_;
       };
 
       template <typename T, typename C>

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -104,6 +104,22 @@ namespace edm {
       };
 
       template <typename T>
+      class WatchProcessBlock : public virtual T {
+      public:
+        WatchProcessBlock() = default;
+        WatchProcessBlock(WatchProcessBlock const&) = delete;
+        WatchProcessBlock& operator=(WatchProcessBlock const&) = delete;
+        ~WatchProcessBlock() noexcept(false) override {}
+
+      private:
+        void doBeginProcessBlock_(ProcessBlock const&) final;
+        void doEndProcessBlock_(ProcessBlock const&) final;
+
+        virtual void beginProcessBlock(ProcessBlock const&) {}
+        virtual void endProcessBlock(ProcessBlock const&) {}
+      };
+
+      template <typename T>
       class BeginProcessBlockProducer : public virtual T {
       public:
         BeginProcessBlockProducer() = default;
@@ -188,36 +204,26 @@ namespace edm {
       };
 
       template <typename T, typename C>
-      class ProcessBlockCacheHolder : public virtual T {
+      class InputProcessBlockCacheHolder : public virtual T {
       public:
-        ProcessBlockCacheHolder() = default;
-        ProcessBlockCacheHolder(ProcessBlockCacheHolder<T, C> const&) = delete;
-        ProcessBlockCacheHolder<T, C>& operator=(ProcessBlockCacheHolder<T, C> const&) = delete;
-        ~ProcessBlockCacheHolder() override {}
+        InputProcessBlockCacheHolder() = default;
+        InputProcessBlockCacheHolder(InputProcessBlockCacheHolder const&) = delete;
+        InputProcessBlockCacheHolder& operator=(InputProcessBlockCacheHolder const&) = delete;
+        ~InputProcessBlockCacheHolder() override {}
 
       protected:
         // Not implemented yet
-        // const C* processBlockCache(ProcessBlockIndex index) const { return caches_.at(index).get(); }
+        // const C* inputProcessBlockCache(ProcessBlockIndex index) const { return caches_.at(index).get(); }
 
       private:
-        void doBeginProcessBlock_(ProcessBlock const& pb) final { beginProcessBlock(pb); }
-
         // Not yet fully implemented, will never get called
+        // THINK ABOUT HOW CACHES ARE CLEARED!!!
         void doAccessInputProcessBlock_(ProcessBlock const& pb) final {
           caches_.push_back(accessInputProcessBlock(pb));
         }
 
-        void doEndProcessBlock_(ProcessBlock const& pb) final {
-          endProcessBlock(pb);
-          caches_.clear();
-        }
-
-        virtual void beginProcessBlock(ProcessBlock const&) {}
-
         // Not yet fully implemented, will never get called
-        virtual std::shared_ptr<C> accessInputProcessBlock(ProcessBlock const&) { return std::shared_ptr<C>(); }
-
-        virtual void endProcessBlock(ProcessBlock const&) {}
+        virtual std::shared_ptr<C> accessInputProcessBlock(ProcessBlock const&) = 0;
 
         std::vector<std::shared_ptr<C>> caches_;
       };

--- a/FWCore/Framework/interface/one/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/producerAbilityToImplementor.h
@@ -50,6 +50,16 @@ namespace edm {
       };
 
       template <>
+      struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
+        typedef edm::one::impl::BeginProcessBlockProducer<edm::one::EDProducerBase> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::EndProcessBlockProducer> {
+        typedef edm::one::impl::EndProcessBlockProducer<edm::one::EDProducerBase> Type;
+      };
+
+      template <>
       struct AbilityToImplementor<edm::BeginRunProducer> {
         typedef edm::one::impl::BeginRunProducer<edm::one::EDProducerBase> Type;
       };
@@ -67,6 +77,11 @@ namespace edm {
       template <>
       struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
         typedef edm::one::impl::EndLuminosityBlockProducer<edm::one::EDProducerBase> Type;
+      };
+
+      template <typename C>
+      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+        typedef edm::one::impl::ProcessBlockCacheHolder<edm::one::EDProducerBase, C> Type;
       };
 
       template <typename C>

--- a/FWCore/Framework/interface/one/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/producerAbilityToImplementor.h
@@ -50,6 +50,11 @@ namespace edm {
       };
 
       template <>
+      struct AbilityToImplementor<edm::WatchProcessBlock> {
+        typedef edm::one::impl::WatchProcessBlock<edm::one::EDProducerBase> Type;
+      };
+
+      template <>
       struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
         typedef edm::one::impl::BeginProcessBlockProducer<edm::one::EDProducerBase> Type;
       };
@@ -80,8 +85,8 @@ namespace edm {
       };
 
       template <typename C>
-      struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-        typedef edm::one::impl::ProcessBlockCacheHolder<edm::one::EDProducerBase, C> Type;
+      struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+        typedef edm::one::impl::InputProcessBlockCacheHolder<edm::one::EDProducerBase, C> Type;
       };
 
       template <typename C>

--- a/FWCore/Framework/interface/stream/AbilityChecker.h
+++ b/FWCore/Framework/interface/stream/AbilityChecker.h
@@ -38,8 +38,8 @@ namespace edm {
       };
 
       template <typename R, typename... U>
-      struct HasAbility<ProcessBlockCache<R>, U...> : public HasAbility<U...> {
-        static constexpr bool kProcessBlockCache = true;
+      struct HasAbility<InputProcessBlockCache<R>, U...> : public HasAbility<U...> {
+        static constexpr bool kInputProcessBlockCache = true;
       };
 
       template <typename R, typename... U>
@@ -60,6 +60,11 @@ namespace edm {
       template <typename R, typename... U>
       struct HasAbility<LuminosityBlockSummaryCache<R>, U...> : public HasAbility<U...> {
         static constexpr bool kLuminosityBlockSummaryCache = true;
+      };
+
+      template <typename... U>
+      struct HasAbility<edm::WatchProcessBlock, U...> : public HasAbility<U...> {
+        static constexpr bool kWatchProcessBlock = true;
       };
 
       template <typename... U>
@@ -105,11 +110,12 @@ namespace edm {
       template <>
       struct HasAbility<LastCheck> {
         static constexpr bool kGlobalCache = false;
-        static constexpr bool kProcessBlockCache = false;
+        static constexpr bool kInputProcessBlockCache = false;
         static constexpr bool kRunCache = false;
         static constexpr bool kLuminosityBlockCache = false;
         static constexpr bool kRunSummaryCache = false;
         static constexpr bool kLuminosityBlockSummaryCache = false;
+        static constexpr bool kWatchProcessBlock = false;
         static constexpr bool kBeginProcessBlockProducer = false;
         static constexpr bool kEndProcessBlockProducer = false;
         static constexpr bool kBeginRunProducer = false;

--- a/FWCore/Framework/interface/stream/AbilityChecker.h
+++ b/FWCore/Framework/interface/stream/AbilityChecker.h
@@ -38,6 +38,11 @@ namespace edm {
       };
 
       template <typename R, typename... U>
+      struct HasAbility<ProcessBlockCache<R>, U...> : public HasAbility<U...> {
+        static constexpr bool kProcessBlockCache = true;
+      };
+
+      template <typename R, typename... U>
       struct HasAbility<RunCache<R>, U...> : public HasAbility<U...> {
         static constexpr bool kRunCache = true;
       };
@@ -55,6 +60,16 @@ namespace edm {
       template <typename R, typename... U>
       struct HasAbility<LuminosityBlockSummaryCache<R>, U...> : public HasAbility<U...> {
         static constexpr bool kLuminosityBlockSummaryCache = true;
+      };
+
+      template <typename... U>
+      struct HasAbility<edm::BeginProcessBlockProducer, U...> : public HasAbility<U...> {
+        static constexpr bool kBeginProcessBlockProducer = true;
+      };
+
+      template <typename... U>
+      struct HasAbility<edm::EndProcessBlockProducer, U...> : public HasAbility<U...> {
+        static constexpr bool kEndProcessBlockProducer = true;
       };
 
       template <typename... U>
@@ -90,10 +105,13 @@ namespace edm {
       template <>
       struct HasAbility<LastCheck> {
         static constexpr bool kGlobalCache = false;
+        static constexpr bool kProcessBlockCache = false;
         static constexpr bool kRunCache = false;
         static constexpr bool kLuminosityBlockCache = false;
         static constexpr bool kRunSummaryCache = false;
         static constexpr bool kLuminosityBlockSummaryCache = false;
+        static constexpr bool kBeginProcessBlockProducer = false;
+        static constexpr bool kEndProcessBlockProducer = false;
         static constexpr bool kBeginRunProducer = false;
         static constexpr bool kEndRunProducer = false;
         static constexpr bool kBeginLuminosityBlockProducer = false;

--- a/FWCore/Framework/interface/stream/AbilityToImplementor.h
+++ b/FWCore/Framework/interface/stream/AbilityToImplementor.h
@@ -36,8 +36,8 @@ namespace edm {
     };
 
     template <typename C>
-    struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
-      typedef edm::stream::impl::ProcessBlockCacheHolder<C> Type;
+    struct AbilityToImplementor<edm::InputProcessBlockCache<C>> {
+      typedef edm::stream::impl::InputProcessBlockCacheHolder<C> Type;
     };
 
     template <typename C>
@@ -58,6 +58,11 @@ namespace edm {
     template <typename C>
     struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
       typedef edm::stream::impl::LuminosityBlockSummaryCacheHolder<C> Type;
+    };
+
+    template <>
+    struct AbilityToImplementor<edm::WatchProcessBlock> {
+      typedef edm::stream::impl::WatchProcessBlock Type;
     };
 
     template <>

--- a/FWCore/Framework/interface/stream/AbilityToImplementor.h
+++ b/FWCore/Framework/interface/stream/AbilityToImplementor.h
@@ -36,6 +36,11 @@ namespace edm {
     };
 
     template <typename C>
+    struct AbilityToImplementor<edm::ProcessBlockCache<C>> {
+      typedef edm::stream::impl::ProcessBlockCacheHolder<C> Type;
+    };
+
+    template <typename C>
     struct AbilityToImplementor<edm::RunCache<C>> {
       typedef edm::stream::impl::RunCacheHolder<C> Type;
     };
@@ -53,6 +58,16 @@ namespace edm {
     template <typename C>
     struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
       typedef edm::stream::impl::LuminosityBlockSummaryCacheHolder<C> Type;
+    };
+
+    template <>
+    struct AbilityToImplementor<edm::BeginProcessBlockProducer> {
+      typedef edm::stream::impl::BeginProcessBlockProducer Type;
+    };
+
+    template <>
+    struct AbilityToImplementor<edm::EndProcessBlockProducer> {
+      typedef edm::stream::impl::EndProcessBlockProducer Type;
     };
 
     template <>

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -21,6 +21,7 @@
 // system include files
 
 // user include files
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
@@ -63,17 +64,19 @@ namespace edm {
       static void fillDescriptions(ConfigurationDescriptions& descriptions) { T::fillDescriptions(descriptions); }
       static void prevalidate(ConfigurationDescriptions& descriptions) { T::prevalidate(descriptions); }
 
+      bool wantsProcessBlocks() const final { return T::HasAbility::kProcessBlockCache; }
       bool wantsGlobalRuns() const final { return T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache; }
       bool wantsGlobalLuminosityBlocks() const final {
         return T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache;
       }
 
     private:
-      typedef CallGlobal<T> MyGlobal;
-      typedef CallGlobalRun<T> MyGlobalRun;
-      typedef CallGlobalRunSummary<T> MyGlobalRunSummary;
-      typedef CallGlobalLuminosityBlock<T> MyGlobalLuminosityBlock;
-      typedef CallGlobalLuminosityBlockSummary<T> MyGlobalLuminosityBlockSummary;
+      using MyGlobal = CallGlobal<T>;
+      using MyGlobalProcessBlock = CallGlobalProcessBlock<T>;
+      using MyGlobalRun = CallGlobalRun<T>;
+      using MyGlobalRunSummary = CallGlobalRunSummary<T>;
+      using MyGlobalLuminosityBlock = CallGlobalLuminosityBlock<T>;
+      using MyGlobalLuminosityBlockSummary = CallGlobalLuminosityBlockSummary<T>;
 
       void setupStreamModules() final {
         this->createStreamModules([this]() -> EDAnalyzerBase* {
@@ -107,6 +110,33 @@ namespace edm {
         auto s = m_lumiSummaries[iLumi.index()].get();
         std::lock_guard<decltype(m_lumiSummaryLock)> guard(m_lumiSummaryLock);
         MyGlobalLuminosityBlockSummary::streamEndLuminosityBlockSummary(iProd, iLumi, iES, s);
+      }
+
+      void doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kProcessBlockCache) {
+          ProcessBlock processBlock(pbp, moduleDescription(), mcc, false);
+          processBlock.setConsumer(consumer());
+          ProcessBlock const& cnstProcessBlock = processBlock;
+          MyGlobalProcessBlock::beginProcessBlock(cnstProcessBlock, m_global.get());
+        }
+      }
+
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kProcessBlockCache) {
+          ProcessBlock processBlock(pbp, moduleDescription(), mcc, false);
+          processBlock.setConsumer(consumer());
+          ProcessBlock const& cnstProcessBlock = processBlock;
+          MyGlobalProcessBlock::accessInputProcessBlock(cnstProcessBlock, m_global.get());
+        }
+      }
+
+      void doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kProcessBlockCache) {
+          ProcessBlock processBlock(pbp, moduleDescription(), mcc, true);
+          processBlock.setConsumer(consumer());
+          ProcessBlock const& cnstProcessBlock = processBlock;
+          MyGlobalProcessBlock::endProcessBlock(cnstProcessBlock, m_global.get());
+        }
       }
 
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) final {

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -64,7 +64,8 @@ namespace edm {
       static void fillDescriptions(ConfigurationDescriptions& descriptions) { T::fillDescriptions(descriptions); }
       static void prevalidate(ConfigurationDescriptions& descriptions) { T::prevalidate(descriptions); }
 
-      bool wantsProcessBlocks() const final { return T::HasAbility::kProcessBlockCache; }
+      bool wantsProcessBlocks() const final { return T::HasAbility::kWatchProcessBlock; }
+      bool wantsInputProcessBlocks() const final { return T::HasAbility::kInputProcessBlockCache; }
       bool wantsGlobalRuns() const final { return T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache; }
       bool wantsGlobalLuminosityBlocks() const final {
         return T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache;
@@ -72,7 +73,8 @@ namespace edm {
 
     private:
       using MyGlobal = CallGlobal<T>;
-      using MyGlobalProcessBlock = CallGlobalProcessBlock<T>;
+      using MyInputProcessBlock = CallInputProcessBlock<T>;
+      using MyWatchProcessBlock = CallWatchProcessBlock<T>;
       using MyGlobalRun = CallGlobalRun<T>;
       using MyGlobalRunSummary = CallGlobalRunSummary<T>;
       using MyGlobalLuminosityBlock = CallGlobalLuminosityBlock<T>;
@@ -113,29 +115,29 @@ namespace edm {
       }
 
       void doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
-        if constexpr (T::HasAbility::kProcessBlockCache) {
+        if constexpr (T::HasAbility::kWatchProcessBlock) {
           ProcessBlock processBlock(pbp, moduleDescription(), mcc, false);
           processBlock.setConsumer(consumer());
           ProcessBlock const& cnstProcessBlock = processBlock;
-          MyGlobalProcessBlock::beginProcessBlock(cnstProcessBlock, m_global.get());
+          MyWatchProcessBlock::beginProcessBlock(cnstProcessBlock, m_global.get());
         }
       }
 
       void doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
-        if constexpr (T::HasAbility::kProcessBlockCache) {
+        if constexpr (T::HasAbility::kInputProcessBlockCache) {
           ProcessBlock processBlock(pbp, moduleDescription(), mcc, false);
           processBlock.setConsumer(consumer());
           ProcessBlock const& cnstProcessBlock = processBlock;
-          MyGlobalProcessBlock::accessInputProcessBlock(cnstProcessBlock, m_global.get());
+          MyInputProcessBlock::accessInputProcessBlock(cnstProcessBlock, m_global.get());
         }
       }
 
       void doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
-        if constexpr (T::HasAbility::kProcessBlockCache) {
+        if constexpr (T::HasAbility::kWatchProcessBlock) {
           ProcessBlock processBlock(pbp, moduleDescription(), mcc, true);
           processBlock.setConsumer(consumer());
           ProcessBlock const& cnstProcessBlock = processBlock;
-          MyGlobalProcessBlock::endProcessBlock(cnstProcessBlock, m_global.get());
+          MyWatchProcessBlock::endProcessBlock(cnstProcessBlock, m_global.get());
         }
       }
 

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -79,6 +79,7 @@ namespace edm {
       const ModuleDescription& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return true; }

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -78,6 +78,7 @@ namespace edm {
       // ---------- member functions ---------------------------
       const ModuleDescription& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const { return true; }
@@ -155,6 +156,9 @@ namespace edm {
                                                    edm::LuminosityBlock const&,
                                                    edm::EventSetup const&) = 0;
 
+      virtual void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
+      virtual void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
+      virtual void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
       virtual void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*) = 0;
       virtual void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*) = 0;
       virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,

--- a/FWCore/Framework/interface/stream/EDFilter.h
+++ b/FWCore/Framework/interface/stream/EDFilter.h
@@ -58,6 +58,13 @@ namespace edm {
 
       // ---------- member functions ---------------------------
 
+      bool hasAbilityToProduceInBeginProcessBlocks() const final {
+        return HasAbilityToProduceInBeginProcessBlocks<T...>::value;
+      }
+      bool hasAbilityToProduceInEndProcessBlocks() const final {
+        return HasAbilityToProduceInEndProcessBlocks<T...>::value;
+      }
+
       bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
       bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 

--- a/FWCore/Framework/interface/stream/EDProducer.h
+++ b/FWCore/Framework/interface/stream/EDProducer.h
@@ -52,6 +52,13 @@ namespace edm {
 
       typedef AbilityChecker<T...> HasAbility;
 
+      bool hasAbilityToProduceInBeginProcessBlocks() const final {
+        return HasAbilityToProduceInBeginProcessBlocks<T...>::value;
+      }
+      bool hasAbilityToProduceInEndProcessBlocks() const final {
+        return HasAbilityToProduceInEndProcessBlocks<T...>::value;
+      }
+
       bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
       bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -21,6 +21,7 @@
 // system include files
 
 // user include files
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
@@ -51,6 +52,10 @@ namespace edm {
       static void fillDescriptions(ConfigurationDescriptions& descriptions) { T::fillDescriptions(descriptions); }
       static void prevalidate(ConfigurationDescriptions& descriptions) { T::prevalidate(descriptions); }
 
+      bool wantsProcessBlocks() const final {
+        return T::HasAbility::kProcessBlockCache or T::HasAbility::kBeginProcessBlockProducer or
+               T::HasAbility::kEndProcessBlockProducer;
+      }
       bool wantsGlobalRuns() const final {
         return T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer or
                T::HasAbility::kEndRunProducer;
@@ -65,15 +70,18 @@ namespace edm {
       bool hasAccumulator() const final { return T::HasAbility::kAccumulator; }
 
     private:
-      typedef CallGlobal<T> MyGlobal;
-      typedef CallGlobalRun<T> MyGlobalRun;
-      typedef CallGlobalRunSummary<T> MyGlobalRunSummary;
-      typedef CallBeginRunProduce<T> MyBeginRunProduce;
-      typedef CallEndRunProduce<T> MyEndRunProduce;
-      typedef CallGlobalLuminosityBlock<T> MyGlobalLuminosityBlock;
-      typedef CallGlobalLuminosityBlockSummary<T> MyGlobalLuminosityBlockSummary;
-      typedef CallBeginLuminosityBlockProduce<T> MyBeginLuminosityBlockProduce;
-      typedef CallEndLuminosityBlockProduce<T> MyEndLuminosityBlockProduce;
+      using MyGlobal = CallGlobal<T>;
+      using MyGlobalProcessBlock = CallGlobalProcessBlock<T>;
+      using MyBeginProcessBlockProduce = CallBeginProcessBlockProduce<T>;
+      using MyEndProcessBlockProduce = CallEndProcessBlockProduce<T>;
+      using MyGlobalRun = CallGlobalRun<T>;
+      using MyGlobalRunSummary = CallGlobalRunSummary<T>;
+      using MyBeginRunProduce = CallBeginRunProduce<T>;
+      using MyEndRunProduce = CallEndRunProduce<T>;
+      using MyGlobalLuminosityBlock = CallGlobalLuminosityBlock<T>;
+      using MyGlobalLuminosityBlockSummary = CallGlobalLuminosityBlockSummary<T>;
+      using MyBeginLuminosityBlockProduce = CallBeginLuminosityBlockProduce<T>;
+      using MyEndLuminosityBlockProduce = CallEndLuminosityBlockProduce<T>;
 
       void setupStreamModules() final {
         this->createStreamModules([this]() -> M* {
@@ -108,6 +116,43 @@ namespace edm {
         MyGlobalLuminosityBlockSummary::streamEndLuminosityBlockSummary(iProd, iLumi, iES, s);
       }
 
+      void doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kProcessBlockCache or T::HasAbility::kBeginProcessBlockProducer) {
+          ProcessBlock processBlock(pbp, this->moduleDescription(), mcc, false);
+          ProcessBlock const& cnstProcessBlock = processBlock;
+          processBlock.setConsumer(this->consumer());
+          MyGlobalProcessBlock::beginProcessBlock(cnstProcessBlock, m_global.get());
+          if constexpr (T::HasAbility::kBeginProcessBlockProducer) {
+            processBlock.setProducer(this->producer());
+            MyBeginProcessBlockProduce::produce(processBlock, m_global.get());
+            this->commit(processBlock);
+          }
+        }
+      }
+
+      void doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kProcessBlockCache) {
+          ProcessBlock processBlock(pbp, this->moduleDescription(), mcc, false);
+          ProcessBlock const& cnstProcessBlock = processBlock;
+          processBlock.setConsumer(this->consumer());
+          MyGlobalProcessBlock::accessInputProcessBlock(cnstProcessBlock, m_global.get());
+        }
+      }
+
+      void doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kProcessBlockCache or T::HasAbility::kEndProcessBlockProducer) {
+          ProcessBlock processBlock(pbp, this->moduleDescription(), mcc, true);
+          ProcessBlock const& cnstProcessBlock = processBlock;
+          processBlock.setConsumer(this->consumer());
+          MyGlobalProcessBlock::endProcessBlock(cnstProcessBlock, m_global.get());
+          if constexpr (T::HasAbility::kEndProcessBlockProducer) {
+            processBlock.setProducer(this->producer());
+            MyEndProcessBlockProduce::produce(processBlock, m_global.get());
+            this->commit(processBlock);
+          }
+        }
+      }
+
       void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer) {
           Run r(rp, this->moduleDescription(), mcc, false);
@@ -128,6 +173,7 @@ namespace edm {
           }
         }
       }
+
       void doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kEndRunProducer) {
           Run r(rp, this->moduleDescription(), mcc, true);

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -81,6 +81,7 @@ namespace edm {
       const ModuleDescription& moduleDescription() const { return moduleDescription_; }
 
       virtual bool wantsProcessBlocks() const = 0;
+      virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool hasAcquire() const = 0;

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -35,6 +35,7 @@
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
@@ -79,6 +80,7 @@ namespace edm {
       // ---------- member functions ---------------------------
       const ModuleDescription& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool hasAcquire() const = 0;
@@ -125,6 +127,9 @@ namespace edm {
         }
       }
 
+      void commit(ProcessBlock& iProcessBlock) {
+        iProcessBlock.commit_(m_streamModules[0]->indiciesForPutProducts(InProcess));
+      }
       void commit(Run& iRun) { iRun.commit_(m_streamModules[0]->indiciesForPutProducts(InRun)); }
       void commit(LuminosityBlock& iLumi) { iLumi.commit_(m_streamModules[0]->indiciesForPutProducts(InLumi)); }
       template <typename I>
@@ -165,6 +170,9 @@ namespace edm {
                                       ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(T*, edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
 
+      virtual void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
+      virtual void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
+      virtual void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
       virtual void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*) = 0;
       virtual void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*) = 0;
       virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,

--- a/FWCore/Framework/interface/stream/callAbilities.h
+++ b/FWCore/Framework/interface/stream/callAbilities.h
@@ -65,33 +65,23 @@ namespace edm {
     using CallGlobal = CallGlobalImpl<T, T::HasAbility::kGlobalCache>;
 
     //********************************
-    // CallGlobalProcessBlock
+    // CallInputProcessBlock
     //********************************
     template <typename T, bool>
-    struct CallGlobalProcessBlockImpl {
-      static void beginProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache const* iGC) {
-        T::beginProcessBlock(iProcessBlock, iGC);
-      }
-
-      static void accessInputProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache const* iGC) {
+    struct CallInputProcessBlockImpl {
+      static void accessInputProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache* iGC) {
         // This is not fully implemented yet and will never be called
         T::accessInputProcessBlock(iProcessBlock, iGC);
       }
-
-      static void endProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache const* iGC) {
-        T::endProcessBlock(iProcessBlock, iGC);
-      }
     };
 
     template <typename T>
-    struct CallGlobalProcessBlockImpl<T, false> {
-      static void beginProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache const*) {}
-      static void accessInputProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache const*) {}
-      static void endProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache const*) {}
+    struct CallInputProcessBlockImpl<T, false> {
+      static void accessInputProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
     };
 
     template <typename T>
-    using CallGlobalProcessBlock = CallGlobalProcessBlockImpl<T, T::HasAbility::kProcessBlockCache>;
+    using CallInputProcessBlock = CallInputProcessBlockImpl<T, T::HasAbility::kInputProcessBlockCache>;
 
     //********************************
     // CallGlobalRun
@@ -254,18 +244,41 @@ namespace edm {
         CallGlobalLuminosityBlockSummaryImpl<T, T::HasAbility::kLuminosityBlockSummaryCache>;
 
     //********************************
+    // CallWatchProcessBlock
+    //********************************
+    template <typename T, bool>
+    struct CallWatchProcessBlockImpl {
+      static void beginProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache* iGC) {
+        T::beginProcessBlock(iProcessBlock, iGC);
+      }
+
+      static void endProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache* iGC) {
+        T::endProcessBlock(iProcessBlock, iGC);
+      }
+    };
+
+    template <typename T>
+    struct CallWatchProcessBlockImpl<T, false> {
+      static void beginProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
+      static void endProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
+    };
+
+    template <typename T>
+    using CallWatchProcessBlock = CallWatchProcessBlockImpl<T, T::HasAbility::kWatchProcessBlock>;
+
+    //********************************
     // CallBeginProcessBlockProduce
     //********************************
     template <typename T, bool>
     struct CallBeginProcessBlockProduceImpl {
-      static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache const* globalCache) {
+      static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache* globalCache) {
         T::beginProcessBlockProduce(processBlock, globalCache);
       }
     };
 
     template <typename T>
     struct CallBeginProcessBlockProduceImpl<T, false> {
-      static void produce(edm::ProcessBlock&, typename T::GlobalCache const*) {}
+      static void produce(edm::ProcessBlock&, typename T::GlobalCache*) {}
     };
 
     template <typename T>
@@ -276,14 +289,14 @@ namespace edm {
     //********************************
     template <typename T, bool>
     struct CallEndProcessBlockProduceImpl {
-      static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache const* globalCache) {
+      static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache* globalCache) {
         T::endProcessBlockProduce(processBlock, globalCache);
       }
     };
 
     template <typename T>
     struct CallEndProcessBlockProduceImpl<T, false> {
-      static void produce(edm::ProcessBlock&, typename T::GlobalCache const*) {}
+      static void produce(edm::ProcessBlock&, typename T::GlobalCache*) {}
     };
 
     template <typename T>

--- a/FWCore/Framework/interface/stream/callAbilities.h
+++ b/FWCore/Framework/interface/stream/callAbilities.h
@@ -29,6 +29,7 @@ namespace edm {
   class Run;
   class EventSetup;
   class LuminosityBlock;
+  class ProcessBlock;
   namespace stream {
     //********************************
     // CallGlobal
@@ -62,6 +63,36 @@ namespace edm {
 
     template <typename T>
     using CallGlobal = CallGlobalImpl<T, T::HasAbility::kGlobalCache>;
+
+    //********************************
+    // CallGlobalProcessBlock
+    //********************************
+    template <typename T, bool>
+    struct CallGlobalProcessBlockImpl {
+      static void beginProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache const* iGC) {
+        T::beginProcessBlock(iProcessBlock, iGC);
+      }
+
+      static void accessInputProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache const* iGC) {
+        // This is not fully implemented yet and will never be called
+        T::accessInputProcessBlock(iProcessBlock, iGC);
+      }
+
+      static void endProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache const* iGC) {
+        T::endProcessBlock(iProcessBlock, iGC);
+      }
+    };
+
+    template <typename T>
+    struct CallGlobalProcessBlockImpl<T, false> {
+      static void beginProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache const*) {}
+      static void accessInputProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache const*) {}
+      static void endProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache const*) {}
+    };
+
+    template <typename T>
+    using CallGlobalProcessBlock = CallGlobalProcessBlockImpl<T, T::HasAbility::kProcessBlockCache>;
+
     //********************************
     // CallGlobalRun
     //********************************
@@ -221,6 +252,42 @@ namespace edm {
     template <typename T>
     using CallGlobalLuminosityBlockSummary =
         CallGlobalLuminosityBlockSummaryImpl<T, T::HasAbility::kLuminosityBlockSummaryCache>;
+
+    //********************************
+    // CallBeginProcessBlockProduce
+    //********************************
+    template <typename T, bool>
+    struct CallBeginProcessBlockProduceImpl {
+      static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache const* globalCache) {
+        T::beginProcessBlockProduce(processBlock, globalCache);
+      }
+    };
+
+    template <typename T>
+    struct CallBeginProcessBlockProduceImpl<T, false> {
+      static void produce(edm::ProcessBlock&, typename T::GlobalCache const*) {}
+    };
+
+    template <typename T>
+    using CallBeginProcessBlockProduce = CallBeginProcessBlockProduceImpl<T, T::HasAbility::kBeginProcessBlockProducer>;
+
+    //********************************
+    // CallEndProcessBlockProduce
+    //********************************
+    template <typename T, bool>
+    struct CallEndProcessBlockProduceImpl {
+      static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache const* globalCache) {
+        T::endProcessBlockProduce(processBlock, globalCache);
+      }
+    };
+
+    template <typename T>
+    struct CallEndProcessBlockProduceImpl<T, false> {
+      static void produce(edm::ProcessBlock&, typename T::GlobalCache const*) {}
+    };
+
+    template <typename T>
+    using CallEndProcessBlockProduce = CallEndProcessBlockProduceImpl<T, T::HasAbility::kEndProcessBlockProducer>;
 
     //********************************
     // CallBeginRunProduce

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -54,15 +54,15 @@ namespace edm {
       };
 
       template <typename C>
-      class ProcessBlockCacheHolder {
+      class InputProcessBlockCacheHolder {
       public:
-        ProcessBlockCacheHolder() = default;
-        ProcessBlockCacheHolder(ProcessBlockCacheHolder<C> const&) = delete;
-        ProcessBlockCacheHolder<C>& operator=(ProcessBlockCacheHolder<C> const&) = delete;
+        InputProcessBlockCacheHolder() = default;
+        InputProcessBlockCacheHolder(InputProcessBlockCacheHolder const&) = delete;
+        InputProcessBlockCacheHolder& operator=(InputProcessBlockCacheHolder const&) = delete;
         //void setProcessBlockCache(C const* iCache) { cache_ = iCache; }
 
       protected:
-        //C const* processBlockCache() const { return cache_; }
+        //C const* inputProcessBlockCache() const { return cache_; }
 
       private:
         //C const* cache_;
@@ -122,6 +122,16 @@ namespace edm {
         virtual void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, C*) const = 0;
       };
 
+      class WatchProcessBlock {
+      public:
+        WatchProcessBlock() = default;
+        WatchProcessBlock(WatchProcessBlock const&) = delete;
+        WatchProcessBlock& operator=(WatchProcessBlock const&) = delete;
+
+        ///requires the following be defined in the inheriting class
+        ///static void beginProcessBlockProduce(edm::ProcessBlock const&, GlobalCache*);
+      };
+
       class BeginProcessBlockProducer {
       public:
         BeginProcessBlockProducer() = default;
@@ -129,7 +139,7 @@ namespace edm {
         BeginProcessBlockProducer& operator=(BeginProcessBlockProducer const&) = delete;
 
         ///requires the following be defined in the inheriting class
-        ///static void beginProcessBlockProduce(edm::ProcessBlock&, GlobalCache const* );
+        ///static void beginProcessBlockProduce(edm::ProcessBlock&, GlobalCache*);
       };
 
       class EndProcessBlockProducer {
@@ -139,7 +149,7 @@ namespace edm {
         EndProcessBlockProducer& operator=(EndProcessBlockProducer const&) = delete;
 
         ///requires the following be defined in the inheriting class
-        /// static void endProcessBlockProduce(edm::ProcessBlock&, GlobalCache const* )
+        /// static void endProcessBlockProduce(edm::ProcessBlock&, GlobalCache*)
       };
 
       class BeginRunProducer {

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -54,6 +54,21 @@ namespace edm {
       };
 
       template <typename C>
+      class ProcessBlockCacheHolder {
+      public:
+        ProcessBlockCacheHolder() = default;
+        ProcessBlockCacheHolder(ProcessBlockCacheHolder<C> const&) = delete;
+        ProcessBlockCacheHolder<C>& operator=(ProcessBlockCacheHolder<C> const&) = delete;
+        //void setProcessBlockCache(C const* iCache) { cache_ = iCache; }
+
+      protected:
+        //C const* processBlockCache() const { return cache_; }
+
+      private:
+        //C const* cache_;
+      };
+
+      template <typename C>
       class RunCacheHolder {
       public:
         RunCacheHolder() = default;
@@ -105,6 +120,27 @@ namespace edm {
 
       private:
         virtual void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, C*) const = 0;
+      };
+
+      class BeginProcessBlockProducer {
+      public:
+        BeginProcessBlockProducer() = default;
+        BeginProcessBlockProducer(BeginProcessBlockProducer const&) = delete;
+        BeginProcessBlockProducer& operator=(BeginProcessBlockProducer const&) = delete;
+
+        ///requires the following be defined in the inheriting class
+        ///static void beginProcessBlockProduce(edm::ProcessBlock&, GlobalCache const* );
+      };
+
+      class EndProcessBlockProducer {
+      public:
+        EndProcessBlockProducer() = default;
+        EndProcessBlockProducer(EndProcessBlockProducer const&) = delete;
+        EndProcessBlockProducer& operator=(EndProcessBlockProducer const&) = delete;
+
+      private:
+        ///requires the following be defined in the inheriting class
+        /// static void endProcessBlockProduce(edm::ProcessBlock&, GlobalCache const* )
       };
 
       class BeginRunProducer {

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -138,7 +138,6 @@ namespace edm {
         EndProcessBlockProducer(EndProcessBlockProducer const&) = delete;
         EndProcessBlockProducer& operator=(EndProcessBlockProducer const&) = delete;
 
-      private:
         ///requires the following be defined in the inheriting class
         /// static void endProcessBlockProduce(edm::ProcessBlock&, GlobalCache const* )
       };
@@ -159,7 +158,6 @@ namespace edm {
         EndRunProducer(EndRunProducer const&) = delete;
         EndRunProducer& operator=(EndRunProducer const&) = delete;
 
-      private:
         ///requires the following be defined in the inheriting class
         /// static void globalEndRunProduce(edm::Run&, edm::EventSetup const&, RunContext const* )
       };
@@ -170,7 +168,6 @@ namespace edm {
         BeginLuminosityBlockProducer(BeginLuminosityBlockProducer const&) = delete;
         BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
 
-      private:
         ///requires the following be defined in the inheriting class
         ///static void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, LuminosityBlockContext const*)
       };
@@ -181,7 +178,6 @@ namespace edm {
         EndLuminosityBlockProducer(EndLuminosityBlockProducer const&) = delete;
         EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
 
-      private:
         ///requires the following be defined in the inheriting class
         ///static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, LuminosityBlockContext const*)
       };

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -251,6 +251,9 @@ ESTokenIndex EDConsumerBase::recordESConsumes(Transition iTrans,
   m_esTokenInfo.emplace_back(
       ESTokenLookupInfo{iRecord, eventsetup::DataKey{iDataType, iTag.data().c_str()}, startOfComponentName},
       ESProxyIndex{-1});
+  if (iTrans >= edm::Transition::NumberOfEventSetupTransitions) {
+    throwESConsumesInProcessBlock();
+  }
   auto indexForToken = esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)].size();
   esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)].emplace_back(-1 * (index + 1));
   esRecordsToGetFromTransition_[static_cast<unsigned int>(iTrans)].emplace_back();
@@ -410,6 +413,12 @@ void EDConsumerBase::throwConsumesCallAfterFrozen(TypeToGet const& typeToGet, In
                                      << "This must be done in the contructor\n"
                                      << "The product type was: " << typeToGet.type() << "\n"
                                      << "and " << inputTag << "\n";
+}
+
+void EDConsumerBase::throwESConsumesInProcessBlock() const {
+  throw cms::Exception("LogicError")
+      << "A module declared it consumes an EventSetup product during a ProcessBlock transition.\n"
+      << "EventSetup products can only be consumed in Event, Lumi, or Run transitions.\n";
 }
 
 namespace {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -489,7 +489,7 @@ namespace edm {
       principalCache_.insert(std::move(pb));
 
       auto pbForInput = std::make_unique<ProcessBlockPrincipal>(preg(), *processConfiguration_);
-      principalCache_.insertForInput(std::move(pb));
+      principalCache_.insertForInput(std::move(pbForInput));
     }
 
     // fill the subprocesses, if there are any

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -900,7 +900,7 @@ namespace edm {
       DelayedReader* reader = nullptr;
       processBlockPrincipal.fillProcessBlockPrincipal(processConfiguration_->processName(), reader);
 
-      using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther>;
+      using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionProcessBlockInput>;
       auto globalWaitTask = make_empty_waiting_task();
       globalWaitTask->increment_ref_count();
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -875,7 +875,7 @@ namespace edm {
     ProcessBlockPrincipal& processBlockPrincipal = principalCache_.processBlockPrincipal();
     processBlockPrincipal.fillProcessBlockPrincipal(processConfiguration_->processName());
 
-    typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalBegin> Traits;
+    using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalBegin>;
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();
 
@@ -900,7 +900,7 @@ namespace edm {
       DelayedReader* reader = nullptr;
       processBlockPrincipal.fillProcessBlockPrincipal(processConfiguration_->processName(), reader);
 
-      typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther> Traits;
+      using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther>;
       auto globalWaitTask = make_empty_waiting_task();
       globalWaitTask->increment_ref_count();
 
@@ -931,7 +931,7 @@ namespace edm {
   void EventProcessor::endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded) {
     ProcessBlockPrincipal& processBlockPrincipal = principalCache_.processBlockPrincipal();
 
-    typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalEnd> Traits;
+    using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalEnd>;
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();
 
@@ -994,7 +994,7 @@ namespace edm {
       looper_->doStartingNewLoop();
     }
     {
-      typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
+      using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>;
       auto globalWaitTask = make_empty_waiting_task();
       globalWaitTask->increment_ref_count();
       beginGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
@@ -1020,7 +1020,7 @@ namespace edm {
       auto streamLoopWaitTask = make_empty_waiting_task();
       streamLoopWaitTask->increment_ref_count();
 
-      typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Traits;
+      using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>;
 
       beginStreamsTransitionAsync<Traits>(streamLoopWaitTask.get(),
                                           *schedule_,
@@ -1090,7 +1090,7 @@ namespace edm {
       auto streamLoopWaitTask = make_empty_waiting_task();
       streamLoopWaitTask->increment_ref_count();
 
-      typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Traits;
+      using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>;
 
       endStreamsTransitionAsync<Traits>(WaitingTaskHolder(streamLoopWaitTask.get()),
                                         *schedule_,
@@ -1116,7 +1116,7 @@ namespace edm {
       auto globalWaitTask = make_empty_waiting_task();
       globalWaitTask->increment_ref_count();
 
-      typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
+      using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>;
       endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
                                        *schedule_,
                                        runPrincipal,
@@ -1230,7 +1230,7 @@ namespace edm {
                       return;
                     }
                   }
-                  typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Traits;
+                  using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>;
 
                   for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
                     streamQueues_[i].push([this, i, status, holder, ts, &es]() mutable {
@@ -1276,7 +1276,7 @@ namespace edm {
 
           EventSetupImpl const& es = status->eventSetupImpl(esp_->subProcessIndex());
           {
-            typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
+            using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>;
             beginGlobalTransitionAsync<Traits>(beginStreamsHolder,
                                                *schedule_,
                                                lumiPrincipal,
@@ -1460,7 +1460,7 @@ namespace edm {
 
     IOVSyncValue ts(EventID(lp.run(), lp.luminosityBlock(), EventID::maxEventNumber()), lp.beginTime());
 
-    typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
+    using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd>;
 
     endGlobalTransitionAsync<Traits>(WaitingTaskHolder(writeT),
                                      *schedule_,

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -266,6 +266,8 @@ namespace edm {
     }
   }
 
+  bool InputSource::readProcessBlock() { return false; }
+
   void InputSource::readRun_(RunPrincipal& runPrincipal) {
     // Note: For the moment, we do not support saving and restoring the state of the
     // random number generator if random numbers are generated during processing of runs

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -51,14 +51,19 @@ namespace edm {
 
     virtual void openFile(FileBlock const& fb) = 0;
 
+    virtual void writeProcessBlockAsync(WaitingTaskHolder iTask,
+                                        ProcessBlockPrincipal const&,
+                                        ProcessContext const*,
+                                        ActivityRegistry*) = 0;
+
     virtual void writeRunAsync(WaitingTaskHolder iTask,
-                               RunPrincipal const& rp,
+                               RunPrincipal const&,
                                ProcessContext const*,
                                ActivityRegistry*,
                                MergeableRunProductMetadata const*) = 0;
 
     virtual void writeLumiAsync(WaitingTaskHolder iTask,
-                                LuminosityBlockPrincipal const& lbp,
+                                LuminosityBlockPrincipal const&,
                                 ProcessContext const*,
                                 ActivityRegistry*) = 0;
 

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -42,6 +42,11 @@ namespace edm {
 
     void openFile(edm::FileBlock const& fb) override;
 
+    void writeProcessBlockAsync(WaitingTaskHolder iTask,
+                                ProcessBlockPrincipal const&,
+                                ProcessContext const*,
+                                ActivityRegistry*) override;
+
     void writeRunAsync(WaitingTaskHolder iTask,
                        edm::RunPrincipal const& rp,
                        ProcessContext const*,

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -480,9 +480,9 @@ namespace edm {
     fillPrincipal(reader);
 
     std::vector<std::string> const& lookupProcessNames = productLookup_->lookupProcessNames();
-    auto iter = std::find(lookupProcessNames.begin(), lookupProcessNames.end(), processNameOfBlock);
     lookupProcessOrder_.assign(lookupProcessNames.size(), 0);
     if (!lookupProcessOrder_.empty()) {
+      auto iter = std::find(lookupProcessNames.begin(), lookupProcessNames.end(), processNameOfBlock);
       if (iter != lookupProcessNames.end()) {
         lookupProcessOrder_[0] = iter - lookupProcessNames.begin();
       }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -390,15 +390,19 @@ namespace edm {
     applyToResolvers([&iConfigure](ProductResolverBase* iResolver) { iResolver->setupUnscheduled(iConfigure); });
   }
 
-  // Set the principal for the Event, Lumi, or Run.
-  void Principal::fillPrincipal(ProcessHistoryID const& hist,
-                                ProcessHistory const* processHistory,
-                                DelayedReader* reader) {
+  void Principal::fillPrincipal(DelayedReader* reader) {
     //increment identifier here since clearPrincipal isn't called for Run/Lumi
     cacheIdentifier_ = nextIdentifier();
     if (reader) {
       reader_ = reader;
     }
+  }
+
+  // Set the principal for the Event, Lumi, or Run.
+  void Principal::fillPrincipal(ProcessHistoryID const& hist,
+                                ProcessHistory const* processHistory,
+                                DelayedReader* reader) {
+    fillPrincipal(reader);
 
     if (historyAppender_ && productRegistry().anyProductProduced()) {
       if ((not processHistoryPtr_) || (processHistoryIDBeforeConfig_ != hist)) {
@@ -468,6 +472,20 @@ namespace edm {
         ++k;
       }
       orderProcessHistoryID_ = processHistoryID_;
+    }
+  }
+
+  // Set the principal for the ProcessBlock
+  void Principal::fillPrincipal(std::string const& processNameOfBlock, DelayedReader* reader) {
+    fillPrincipal(reader);
+
+    std::vector<std::string> const& lookupProcessNames = productLookup_->lookupProcessNames();
+    auto iter = std::find(lookupProcessNames.begin(), lookupProcessNames.end(), processNameOfBlock);
+    lookupProcessOrder_.assign(lookupProcessNames.size(), 0);
+    if (!lookupProcessOrder_.empty()) {
+      if (iter != lookupProcessNames.end()) {
+        lookupProcessOrder_[0] = iter - lookupProcessNames.begin();
+      }
     }
   }
 
@@ -543,6 +561,10 @@ namespace edm {
                                     EDConsumerBase const* consumer,
                                     SharedResourcesAcquirer* sra,
                                     ModuleCallingContext const* mcc) const {
+    // Not implemented for ProcessBlocks, it might work though, not tested
+    // The other getByLabel function is used for ProcessBlocks by TestProcessor
+    assert(branchType_ != InProcess);
+
     ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer, sra, mcc);
     if (result == nullptr) {
       return BasicHandle(makeHandleExceptionFactory([=]() -> std::shared_ptr<cms::Exception> {
@@ -616,6 +638,9 @@ namespace edm {
                                 EDConsumerBase const* consumer,
                                 SharedResourcesAcquirer* sra,
                                 ModuleCallingContext const* mcc) const {
+    // Not implemented for ProcessBlocks
+    assert(branchType_ != InProcess);
+
     assert(results.empty());
 
     if (UNLIKELY(consumer and (not consumer->registeredToConsumeMany(typeID, branchType())))) {
@@ -789,6 +814,9 @@ namespace edm {
   ProductData const* Principal::findProductByTag(TypeID const& typeID,
                                                  InputTag const& tag,
                                                  ModuleCallingContext const* mcc) const {
+    // Not implemented for ProcessBlocks
+    assert(branchType_ != InProcess);
+
     ProductData const* productData = findProductByLabel(PRODUCT_TYPE, typeID, tag, nullptr, nullptr, mcc);
     return productData;
   }

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -90,6 +91,12 @@ namespace edm {
     }
     run_ = rp->run();
     runPrincipal_ = rp;
+  }
+
+  void PrincipalCache::insert(std::unique_ptr<ProcessBlockPrincipal> pb) { processBlockPrincipal_ = std::move(pb); }
+
+  void PrincipalCache::insertForInput(std::unique_ptr<ProcessBlockPrincipal> pb) {
+    inputProcessBlockPrincipal_ = std::move(pb);
   }
 
   void PrincipalCache::insert(std::unique_ptr<LuminosityBlockPrincipal> lbp) { lumiHolder_.add(std::move(lbp)); }

--- a/FWCore/Framework/src/PrincipalCache.h
+++ b/FWCore/Framework/src/PrincipalCache.h
@@ -36,6 +36,7 @@ Original Author: W. David Dagenhart
 
 namespace edm {
 
+  class ProcessBlockPrincipal;
   class RunPrincipal;
   class LuminosityBlockPrincipal;
   class EventPrincipal;
@@ -50,6 +51,12 @@ namespace edm {
     ~PrincipalCache();
     PrincipalCache(PrincipalCache&&) = default;
 
+    ProcessBlockPrincipal& processBlockPrincipal() const { return *processBlockPrincipal_; }
+    ProcessBlockPrincipal& inputProcessBlockPrincipal() const { return *inputProcessBlockPrincipal_; }
+    ProcessBlockPrincipal& processBlockPrincipal(bool input) const {
+      return input ? *inputProcessBlockPrincipal_ : *processBlockPrincipal_;
+    }
+
     RunPrincipal& runPrincipal(ProcessHistoryID const& phid, RunNumber_t run) const;
     std::shared_ptr<RunPrincipal> const& runPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run) const;
     RunPrincipal& runPrincipal() const;
@@ -63,6 +70,8 @@ namespace edm {
     void merge(std::shared_ptr<RunAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg);
 
     void setNumberOfConcurrentPrincipals(PreallocationConfiguration const&);
+    void insert(std::unique_ptr<ProcessBlockPrincipal>);
+    void insertForInput(std::unique_ptr<ProcessBlockPrincipal>);
     void insert(std::shared_ptr<RunPrincipal> rp);
     void insert(std::unique_ptr<LuminosityBlockPrincipal> lbp);
     void insert(std::shared_ptr<EventPrincipal> ep);
@@ -81,8 +90,10 @@ namespace edm {
     void throwRunMissing() const;
     void throwLumiMissing() const;
 
-    // These are explicitly cleared when finished with the run,
+    // These are explicitly cleared when finished with the processblock, run,
     // lumi, or event
+    std::unique_ptr<ProcessBlockPrincipal> processBlockPrincipal_;
+    std::unique_ptr<ProcessBlockPrincipal> inputProcessBlockPrincipal_;
     std::shared_ptr<RunPrincipal> runPrincipal_;
     edm::ReusableObjectHolder<LuminosityBlockPrincipal> lumiHolder_;
     std::vector<std::shared_ptr<EventPrincipal>> eventPrincipals_;

--- a/FWCore/Framework/src/PrincipalCache.h
+++ b/FWCore/Framework/src/PrincipalCache.h
@@ -53,8 +53,10 @@ namespace edm {
 
     ProcessBlockPrincipal& processBlockPrincipal() const { return *processBlockPrincipal_; }
     ProcessBlockPrincipal& inputProcessBlockPrincipal() const { return *inputProcessBlockPrincipal_; }
-    ProcessBlockPrincipal& processBlockPrincipal(bool input) const {
-      return input ? *inputProcessBlockPrincipal_ : *processBlockPrincipal_;
+
+    enum class ProcessBlockType { New, Input };
+    ProcessBlockPrincipal& processBlockPrincipal(ProcessBlockType processBlockType) const {
+      return processBlockType == ProcessBlockType::Input ? *inputProcessBlockPrincipal_ : *processBlockPrincipal_;
     }
 
     RunPrincipal& runPrincipal(ProcessHistoryID const& phid, RunNumber_t run) const;

--- a/FWCore/Framework/src/ProcessBlock.cc
+++ b/FWCore/Framework/src/ProcessBlock.cc
@@ -1,0 +1,54 @@
+#include "FWCore/Framework/interface/ProcessBlock.h"
+#include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
+
+namespace edm {
+
+  ProcessBlock::ProcessBlock(ProcessBlockPrincipal const& pbp,
+                             ModuleDescription const& md,
+                             ModuleCallingContext const* moduleCallingContext,
+                             bool isAtEnd)
+      : provRecorder_(pbp, md, isAtEnd), moduleCallingContext_(moduleCallingContext) {}
+
+  void ProcessBlock::setProducer(ProducerBase const* iProducer) {
+    provRecorder_.setProducer(iProducer);
+    //set appropriate size
+    putProducts_.resize(provRecorder_.putTokenIndexToProductResolverIndex().size());
+  }
+
+  ProcessBlock::CacheIdentifier_t ProcessBlock::cacheIdentifier() const {
+    return processBlockPrincipal().cacheIdentifier();
+  }
+
+  ProcessBlockPrincipal const& ProcessBlock::processBlockPrincipal() const {
+    return dynamic_cast<ProcessBlockPrincipal const&>(provRecorder_.principal());
+  }
+
+  void ProcessBlock::commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut) {
+    ProcessBlockPrincipal const& pbp = processBlockPrincipal();
+    size_t nPut = 0;
+    for (size_t i = 0; i < putProducts().size(); ++i) {
+      auto& product = get_underlying_safe(putProducts()[i]);
+      if (product) {
+        pbp.put(provRecorder_.putTokenIndexToProductResolverIndex()[i], std::move(product));
+        ++nPut;
+      }
+    }
+
+    auto sz = iShouldPut.size();
+    if (sz != 0 and sz != nPut) {
+      //some were missed
+      auto& principal = provRecorder_.principal();
+      for (auto index : iShouldPut) {
+        auto resolver = principal.getProductResolverByIndex(index);
+        if (not resolver->productResolved() and isEndTransition(provRecorder_.transition()) ==
+                                                    resolver->branchDescription().availableOnlyAtEndTransition()) {
+          resolver->putProduct(std::unique_ptr<WrapperBase>());
+        }
+      }
+    }
+
+    // the cleanup is all or none
+    putProducts().clear();
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/ProcessBlockPrincipal.cc
+++ b/FWCore/Framework/src/ProcessBlockPrincipal.cc
@@ -1,0 +1,31 @@
+#include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
+
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/BranchType.h"
+
+#include <utility>
+
+namespace edm {
+
+  ProcessBlockPrincipal::ProcessBlockPrincipal(std::shared_ptr<ProductRegistry const> reg,
+                                               ProcessConfiguration const& pc,
+                                               bool isForPrimaryProcess)
+      : Principal(reg, reg->productLookup(InProcess), pc, InProcess, nullptr, isForPrimaryProcess) {}
+
+  void ProcessBlockPrincipal::fillProcessBlockPrincipal(std::string const& processNameOfBlock, DelayedReader* reader) {
+    processName_ = processNameOfBlock;
+    fillPrincipal(processNameOfBlock, reader);
+  }
+
+  void ProcessBlockPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const {
+    auto phb = getProductResolverByIndex(index);
+    phb->putProduct(std::move(edp));
+  }
+
+  unsigned int ProcessBlockPrincipal::transitionIndex_() const {
+    // Concurrent ProcessBlocks does not make any sense so just always
+    // return 0 here.
+    return 0;
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -20,12 +20,12 @@ namespace edm {
   ProductRegistryHelper::TypeLabelList const& ProductRegistryHelper::typeLabelList() const { return typeLabelList_; }
 
   namespace {
-    void throwProducesWithoutAbility(const char* runOrLumi, std::string const& productTypeName) {
+    void throwProducesWithoutAbility(const char* transitionName, std::string const& productTypeName) {
       throw edm::Exception(edm::errors::LogicError)
-          << "Module declares it can produce a product of type \'" << productTypeName << "\'\nin a " << runOrLumi
-          << ", but does not have the ability to produce in " << runOrLumi << "s.\n"
-          << "You must add a template parameter of type Begin" << runOrLumi << "Producer\n"
-          << "or End" << runOrLumi << "Producer to the EDProducer or EDFilter base class\n"
+          << "Module declares it can produce a product of type \'" << productTypeName << "\'\nin a " << transitionName
+          << ", but does not have the ability to produce in " << transitionName << "s.\n"
+          << "You must add a template parameter of type " << transitionName << "Producer\n"
+          << "or " << transitionName << "Producer to the EDProducer or EDFilter base class\n"
           << "of the module. Or you could remove the call to the function \'produces\'\n"
           << "(Note legacy modules are not ever allowed to produce in Runs or Lumis)\n";
     }
@@ -50,6 +50,11 @@ namespace edm {
         throwProducesWithoutAbility("BeginLuminosityBlock", p->typeID_.userClassName());
       } else if (p->transition_ == Transition::EndLuminosityBlock && not iProd->hasAbilityToProduceInEndLumis()) {
         throwProducesWithoutAbility("EndLuminosityBlock", p->typeID_.userClassName());
+      } else if (p->transition_ == Transition::BeginProcessBlock &&
+                 not iProd->hasAbilityToProduceInBeginProcessBlocks()) {
+        throwProducesWithoutAbility("BeginProcessBlock", p->typeID_.userClassName());
+      } else if (p->transition_ == Transition::EndProcessBlock && not iProd->hasAbilityToProduceInEndProcessBlocks()) {
+        throwProducesWithoutAbility("EndProcessBlock", p->typeID_.userClassName());
       }
       if (!checkDictionary(missingDictionaries, p->typeID_)) {
         checkDictionaryOfWrappedType(missingDictionaries, p->typeID_);

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -163,17 +163,17 @@ namespace edm {
                                                                         ModuleCallingContext const* mcc) const {
     return resolveProductImpl<true>([this, &principal, mcc]() {
       auto branchType = principal.branchType();
-      if (branchType != InEvent) {
+      if (branchType == InLumi || branchType == InRun) {
         //delayed get has not been allowed with Run or Lumis
         // The file may already be closed so the reader is invalid
         return;
       }
-      if (mcc and (branchType == InEvent) and aux_) {
+      if (mcc and (branchType == InEvent || branchType == InProcess) and aux_) {
         aux_->preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()), *mcc);
       }
 
       auto sentry(make_sentry(mcc, [this, branchType](ModuleCallingContext const* iContext) {
-        if (branchType == InEvent and aux_) {
+        if ((branchType == InEvent || branchType == InProcess) and aux_) {
           aux_->postModuleDelayedGetSignal_.emit(*(iContext->getStreamContext()), *iContext);
         }
       }));

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -48,6 +48,11 @@ namespace edm {
 
     // Mark dropped branches as dropped in the product registry.
     std::set<BranchID> keptBranches;
+    SelectedProducts const& keptVectorP = om.keptProducts()[InProcess];
+    for (auto const& item : keptVectorP) {
+      BranchDescription const& desc = *item.first;
+      keptBranches.insert(desc.branchID());
+    }
     SelectedProducts const& keptVectorR = om.keptProducts()[InRun];
     for (auto const& item : keptVectorR) {
       BranchDescription const& desc = *item.first;

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -413,7 +413,7 @@ namespace edm {
   }
 
   template <>
-  void SubProcess::doBeginProcessBlockAsync<OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther>>(
+  void SubProcess::doBeginProcessBlockAsync<OccurrenceTraits<ProcessBlockPrincipal, BranchActionProcessBlockInput>>(
       WaitingTaskHolder iHolder,
       ProcessBlockPrincipal const& principal,
       IOVSyncValue const&,
@@ -424,7 +424,7 @@ namespace edm {
     processBlockPrincipal.fillProcessBlockPrincipal(principal.processName(), principal.reader());
     propagateProducts(InProcess, principal, processBlockPrincipal);
 
-    using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther>;
+    using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionProcessBlockInput>;
     beginGlobalTransitionAsync<Traits>(
         std::move(iHolder), *schedule_, processBlockPrincipal, serviceToken_, subProcesses_);
   }

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -195,7 +195,7 @@ namespace edm {
       principalCache_.insert(std::move(pb));
 
       auto pbForInput = std::make_unique<ProcessBlockPrincipal>(preg_, *processConfiguration_, false);
-      principalCache_.insertForInput(std::move(pb));
+      principalCache_.insertForInput(std::move(pbForInput));
     }
 
     inUseLumiPrincipals_.resize(preallocConfig.numberOfLuminosityBlocks());

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -424,7 +424,7 @@ namespace edm {
     processBlockPrincipal.fillProcessBlockPrincipal(principal.processName(), principal.reader());
     propagateProducts(InProcess, principal, processBlockPrincipal);
 
-    typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther> Traits;
+    using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther>;
     beginGlobalTransitionAsync<Traits>(
         std::move(iHolder), *schedule_, processBlockPrincipal, serviceToken_, subProcesses_);
   }
@@ -441,7 +441,7 @@ namespace edm {
     processBlockPrincipal.fillProcessBlockPrincipal(processConfiguration_->processName());
     propagateProducts(InProcess, principal, processBlockPrincipal);
 
-    typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalBegin> Traits;
+    using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalBegin>;
     beginGlobalTransitionAsync<Traits>(
         std::move(iHolder), *schedule_, processBlockPrincipal, serviceToken_, subProcesses_);
   }
@@ -454,7 +454,7 @@ namespace edm {
     ProcessBlockPrincipal& processBlockPrincipal = principalCache_.processBlockPrincipal();
     propagateProducts(InProcess, principal, processBlockPrincipal);
 
-    typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalEnd> Traits;
+    using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalEnd>;
     endGlobalTransitionAsync<Traits>(
         std::move(iHolder), *schedule_, processBlockPrincipal, serviceToken_, subProcesses_, cleaningUpAfterException);
   }
@@ -485,7 +485,7 @@ namespace edm {
 
     RunPrincipal& rp = *principalCache_.runPrincipalPtr();
     propagateProducts(InRun, principal, rp);
-    typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
+    using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>;
     beginGlobalTransitionAsync<Traits>(
         std::move(iHolder), *schedule_, rp, ts, esp_->eventSetupImpl(), iEventSetupImpls, serviceToken_, subProcesses_);
   }
@@ -497,7 +497,7 @@ namespace edm {
                                  bool cleaningUpAfterException) {
     RunPrincipal& rp = *principalCache_.runPrincipalPtr();
     propagateProducts(InRun, principal, rp);
-    typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
+    using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>;
     endGlobalTransitionAsync<Traits>(std::move(iHolder),
                                      *schedule_,
                                      rp,
@@ -592,7 +592,7 @@ namespace edm {
     lbpp->setRunPrincipal(principalCache_.runPrincipalPtr());
     LuminosityBlockPrincipal& lbp = *lbpp;
     propagateProducts(InLumi, principal, lbp);
-    typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
+    using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>;
     beginGlobalTransitionAsync<Traits>(std::move(iHolder),
                                        *schedule_,
                                        lbp,
@@ -610,7 +610,7 @@ namespace edm {
                                              bool cleaningUpAfterException) {
     LuminosityBlockPrincipal& lbp = *inUseLumiPrincipals_[principal.index()];
     propagateProducts(InLumi, principal, lbp);
-    typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
+    using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd>;
     endGlobalTransitionAsync<Traits>(std::move(iHolder),
                                      *schedule_,
                                      lbp,
@@ -666,7 +666,7 @@ namespace edm {
                                          RunPrincipal const& principal,
                                          IOVSyncValue const& ts,
                                          std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls) {
-    typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Traits;
+    using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>;
 
     RunPrincipal& rp = *principalCache_.runPrincipalPtr();
 
@@ -688,7 +688,7 @@ namespace edm {
                                        std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls,
                                        bool cleaningUpAfterException) {
     RunPrincipal& rp = *principalCache_.runPrincipalPtr();
-    typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Traits;
+    using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>;
 
     endStreamTransitionAsync<Traits>(std::move(iHolder),
                                      *schedule_,
@@ -708,7 +708,7 @@ namespace edm {
       LuminosityBlockPrincipal const& principal,
       IOVSyncValue const& ts,
       std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls) {
-    typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Traits;
+    using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>;
 
     LuminosityBlockPrincipal& lbp = *inUseLumiPrincipals_[principal.index()];
 
@@ -731,7 +731,7 @@ namespace edm {
       std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls,
       bool cleaningUpAfterException) {
     LuminosityBlockPrincipal& lbp = *inUseLumiPrincipals_[principal.index()];
-    typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Traits;
+    using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>;
     endStreamTransitionAsync<Traits>(std::move(iHolder),
                                      *schedule_,
                                      id,

--- a/FWCore/Framework/src/TransitionInfoTypes.cc
+++ b/FWCore/Framework/src/TransitionInfoTypes.cc
@@ -1,0 +1,11 @@
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/EventSetupImpl.h"
+
+namespace edm {
+
+  EventSetupImpl const& ProcessBlockTransitionInfo::eventSetupImpl() const {
+    static const EventSetupImpl dummyEventSetupImpl;
+    return dummyEventSetupImpl;
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/TransitionInfoTypes.h
+++ b/FWCore/Framework/src/TransitionInfoTypes.h
@@ -1,0 +1,73 @@
+#ifndef FWCore_Framework_TransitionInfoTypes_h
+#define FWCore_Framework_TransitionInfoTypes_h
+//
+// Package:     FWCore/Framework
+//
+/**
+
+ Description: The types here are used by
+ the functions beginGlobalTransitionAsync and
+ endGlobalTransitionAsync. They hold some of the data
+ passed as input arguments to those functions.
+
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  26 June 2020
+
+#include <memory>
+#include <vector>
+
+namespace edm {
+  class EventSetupImpl;
+  class LuminosityBlockPrincipal;
+  class ProcessBlockPrincipal;
+  class RunPrincipal;
+
+  class LumiTransitionInfo {
+  public:
+    LumiTransitionInfo(LuminosityBlockPrincipal& iPrincipal,
+                       EventSetupImpl const& iEventSetupImpl,
+                       std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls)
+        : luminosityBlockPrincipal_(iPrincipal), eventSetupImpl_(iEventSetupImpl), eventSetupImpls_(iEventSetupImpls) {}
+
+    LuminosityBlockPrincipal& principal() { return luminosityBlockPrincipal_; }
+    LuminosityBlockPrincipal const& principal() const { return luminosityBlockPrincipal_; }
+    EventSetupImpl const& eventSetupImpl() const { return eventSetupImpl_; }
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls() const { return eventSetupImpls_; }
+
+  private:
+    LuminosityBlockPrincipal& luminosityBlockPrincipal_;
+    EventSetupImpl const& eventSetupImpl_;
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls_;
+  };
+
+  class RunTransitionInfo {
+  public:
+    RunTransitionInfo(RunPrincipal& iPrincipal, EventSetupImpl const& iEventSetupImpl)
+        : runPrincipal_(iPrincipal), eventSetupImpl_(iEventSetupImpl) {}
+
+    RunPrincipal& principal() { return runPrincipal_; }
+    RunPrincipal const& principal() const { return runPrincipal_; }
+    EventSetupImpl const& eventSetupImpl() const { return eventSetupImpl_; }
+
+  private:
+    RunPrincipal& runPrincipal_;
+    EventSetupImpl const& eventSetupImpl_;
+  };
+
+  class ProcessBlockTransitionInfo {
+  public:
+    ProcessBlockTransitionInfo(ProcessBlockPrincipal& iPrincipal) : processBlockPrincipal_(iPrincipal) {}
+
+    ProcessBlockPrincipal& principal() { return processBlockPrincipal_; }
+    ProcessBlockPrincipal const& principal() const { return processBlockPrincipal_; }
+    EventSetupImpl const& eventSetupImpl() const;
+
+  private:
+    ProcessBlockPrincipal& processBlockPrincipal_;
+  };
+
+};  // namespace edm
+
+#endif

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -19,9 +19,14 @@ struct FileResources {
   ~FileResources() {
     // See the message in catch clause
     CMS_SA_ALLOW try {
-      ep_.respondToCloseInputFile();
-      ep_.closeInputFile(cleaningUpAfterException_);
-      ep_.closeOutputFiles();
+      // Don't try to execute the following sequence of functions twice.
+      // If the sequence was already attempted and failed, then do nothing.
+      if (!closingSequenceAlreadyFailed_) {
+        ep_.respondToCloseInputFile();
+        ep_.closeInputFile(cleaningUpAfterException_);
+        ep_.endProcessBlock(cleaningUpAfterException_, beginProcessBlockSucceeded_);
+        ep_.closeOutputFiles();
+      }
     } catch (...) {
       if (cleaningUpAfterException_ or not ep_.setDeferredException(std::current_exception())) {
         std::string message(
@@ -35,6 +40,8 @@ struct FileResources {
 
   EventProcessor& ep_;
   bool cleaningUpAfterException_ = true;
+  bool closingSequenceAlreadyFailed_ = false;
+  bool beginProcessBlockSucceeded_ = false;
 };
 
 struct RunResources {
@@ -228,6 +235,9 @@ private:
 
     iEP.openOutputFiles();
     filesOpen_ = std::make_unique<FileResources>(iEP);
+
+    iEP.beginProcessBlock(filesOpen_->beginProcessBlockSucceeded_);
+    iEP.inputProcessBlocks();
   }
 
   bool shouldWeCloseOutput(EventProcessor& iEP) {
@@ -242,18 +252,33 @@ private:
 
     iEP.readFile();
     iEP.respondToOpenInputFile();
+
+    iEP.inputProcessBlocks();
   }
 
   void gotoNewInputAndOutputFiles(EventProcessor& iEP) {
-    iEP.respondToCloseInputFile();
-    iEP.closeInputFile(false);
+    // If this is still true when we hit the destructor for
+    // the filesOpen_ object, then we will know an exception
+    // was thrown on one of the following 5 lines.
+    filesOpen_->closingSequenceAlreadyFailed_ = true;
 
+    iEP.respondToCloseInputFile();
+    bool cleaningUpAfterException = false;
+    iEP.closeInputFile(cleaningUpAfterException);
+    iEP.endProcessBlock(cleaningUpAfterException, filesOpen_->beginProcessBlockSucceeded_);
     iEP.closeOutputFiles();
+
+    // Initialize these for the next output file
+    filesOpen_->closingSequenceAlreadyFailed_ = false;
+    filesOpen_->beginProcessBlockSucceeded_ = false;
 
     iEP.readFile();
     iEP.respondToOpenInputFile();
 
     iEP.openOutputFiles();
+
+    iEP.beginProcessBlock(filesOpen_->beginProcessBlockSucceeded_);
+    iEP.inputProcessBlocks();
   }
 
   std::unique_ptr<FileResources> filesOpen_;

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -257,27 +257,30 @@ private:
   }
 
   void gotoNewInputAndOutputFiles(EventProcessor& iEP) {
-    // If this is still true when we hit the destructor for
-    // the filesOpen_ object, then we will know an exception
-    // was thrown on one of the following 5 lines.
-    filesOpen_->closingSequenceAlreadyFailed_ = true;
+    {
+      // If this is still true when we hit the destructor for
+      // the filesOpen_ object, then we will know an exception
+      // was thrown on one of the following 5 lines.
+      filesOpen_->closingSequenceAlreadyFailed_ = true;
 
-    iEP.respondToCloseInputFile();
-    bool cleaningUpAfterException = false;
-    iEP.closeInputFile(cleaningUpAfterException);
-    iEP.endProcessBlock(cleaningUpAfterException, filesOpen_->beginProcessBlockSucceeded_);
-    iEP.closeOutputFiles();
+      iEP.respondToCloseInputFile();
+      bool cleaningUpAfterException = false;
+      iEP.closeInputFile(cleaningUpAfterException);
+      iEP.endProcessBlock(cleaningUpAfterException, filesOpen_->beginProcessBlockSucceeded_);
+      iEP.closeOutputFiles();
 
-    // Initialize these for the next output file
-    filesOpen_->closingSequenceAlreadyFailed_ = false;
-    filesOpen_->beginProcessBlockSucceeded_ = false;
+      filesOpen_->closingSequenceAlreadyFailed_ = false;
+    }
+    {
+      filesOpen_->beginProcessBlockSucceeded_ = false;
 
-    iEP.readFile();
-    iEP.respondToOpenInputFile();
+      iEP.readFile();
+      iEP.respondToOpenInputFile();
 
-    iEP.openOutputFiles();
+      iEP.openOutputFiles();
 
-    iEP.beginProcessBlock(filesOpen_->beginProcessBlockSucceeded_);
+      iEP.beginProcessBlock(filesOpen_->beginProcessBlockSucceeded_);
+    }
     iEP.inputProcessBlocks();
   }
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -277,6 +277,9 @@ namespace edm {
   }
 
   void Worker::esPrefetchAsync(WaitingTask* iTask, EventSetupImpl const& iImpl, Transition iTrans) {
+    if (iTrans >= edm::Transition::NumberOfEventSetupTransitions) {
+      return;
+    }
     auto const& recs = esRecordsToGetFrom(iTrans);
     auto const& items = esItemsToGetFrom(iTrans);
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -156,10 +156,7 @@ namespace edm {
     }
   }
 
-  bool Worker::shouldRethrowException(std::exception_ptr iPtr,
-                                      ParentContext const& parentContext,
-                                      bool isEvent,
-                                      TransitionIDValueBase const& iID) const {
+  bool Worker::shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent) const {
     // NOTE: the warning printed as a result of ignoring or failing
     // a module will only be printed during the full true processing
     // pass of this module
@@ -460,8 +457,7 @@ namespace edm {
       convertException::wrap([&]() { this->implDoAcquire(ep, es, &moduleCallingContext_, holder); });
     } catch (cms::Exception& ex) {
       exceptionContext(ex, &moduleCallingContext_);
-      TransitionIDValue<EventPrincipal> idValue(ep);
-      if (shouldRethrowException(std::current_exception(), parentContext, true, idValue)) {
+      if (shouldRethrowException(std::current_exception(), parentContext, true)) {
         timesRun_.fetch_add(1, std::memory_order_relaxed);
         throw;
       }
@@ -477,8 +473,7 @@ namespace edm {
     std::exception_ptr exceptionPtr;
     if (iEPtr) {
       assert(*iEPtr);
-      TransitionIDValue<EventPrincipal> idValue(ep);
-      if (shouldRethrowException(*iEPtr, parentContext, true, idValue)) {
+      if (shouldRethrowException(*iEPtr, parentContext, true)) {
         exceptionPtr = *iEPtr;
       }
       moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -51,6 +51,7 @@ the worker is reset().
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
@@ -356,7 +357,9 @@ namespace edm {
                        EventSetupImpl const& iEventSetup,
                        edm::Transition);
 
-    bool needsESPrefetching(Transition iTrans) const noexcept { return not esItemsToGetFrom(iTrans).empty(); }
+    bool needsESPrefetching(Transition iTrans) const noexcept {
+      return iTrans < edm::Transition::NumberOfEventSetupTransitions ? not esItemsToGetFrom(iTrans).empty() : false;
+    }
     void esPrefetchAsync(WaitingTask* iHolder, EventSetupImpl const&, Transition);
 
     void emitPostModuleEventPrefetchingSignal() {

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -832,9 +832,9 @@ namespace edm {
       static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }
     };
     template <>
-    class CallImpl<OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther>> {
+    class CallImpl<OccurrenceTraits<ProcessBlockPrincipal, BranchActionProcessBlockInput>> {
     public:
-      typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalOther> Arg;
+      typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionProcessBlockInput> Arg;
       static bool call(Worker* iWorker,
                        StreamID,
                        ProcessBlockPrincipal const& pbp,

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -120,6 +120,7 @@ namespace edm {
     Worker& operator=(Worker const&) = delete;  // Disallow copying and moving
 
     virtual bool wantsProcessBlocks() const = 0;
+    virtual bool wantsInputProcessBlocks() const = 0;
     virtual bool wantsGlobalRuns() const = 0;
     virtual bool wantsGlobalLuminosityBlocks() const = 0;
     virtual bool wantsStreamRuns() const = 0;
@@ -845,7 +846,7 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoAccessInputProcessBlock(pbp, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsProcessBlocks(); }
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsInputProcessBlocks(); }
       static bool needToRunSelection(Worker const* iWorker) { return false; }
       static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
       static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -80,19 +80,23 @@ namespace edm {
 
   void WorkerManager::beginJob(ProductRegistry const& iRegistry,
                                eventsetup::ESRecordsToProxyIndices const& iESIndices) {
+    auto const processBlockLookup = iRegistry.productLookup(InProcess);
     auto const runLookup = iRegistry.productLookup(InRun);
     auto const lumiLookup = iRegistry.productLookup(InLumi);
     auto const eventLookup = iRegistry.productLookup(InEvent);
     if (!allWorkers_.empty()) {
       auto const& processName = allWorkers_[0]->description().processName();
+      auto processBlockModuleToIndicies = processBlockLookup->indiciesForModulesInProcess(processName);
       auto runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
       auto lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);
       auto eventModuleToIndicies = eventLookup->indiciesForModulesInProcess(processName);
       for (auto& worker : allWorkers_) {
+        worker->updateLookup(InProcess, *processBlockLookup);
         worker->updateLookup(InRun, *runLookup);
         worker->updateLookup(InLumi, *lumiLookup);
         worker->updateLookup(InEvent, *eventLookup);
         worker->updateLookup(iESIndices);
+        worker->resolvePutIndicies(InProcess, processBlockModuleToIndicies);
         worker->resolvePutIndicies(InRun, runModuleToIndicies);
         worker->resolvePutIndicies(InLumi, lumiModuleToIndicies);
         worker->resolvePutIndicies(InEvent, eventModuleToIndicies);

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -118,6 +118,11 @@ namespace edm {
   WorkerT<T>::~WorkerT() {}
 
   template <typename T>
+  bool WorkerT<T>::wantsProcessBlocks() const {
+    return module_->wantsProcessBlocks();
+  }
+
+  template <typename T>
   bool WorkerT<T>::wantsGlobalRuns() const {
     return module_->wantsGlobalRuns();
   }
@@ -308,6 +313,24 @@ namespace edm {
   inline void WorkerT<edm::limited::OutputModuleBase>::itemsToGetForSelection(
       std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
     iItems = module_->productsUsedBySelection();
+  }
+
+  template <typename T>
+  bool WorkerT<T>::implDoBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+    module_->doBeginProcessBlock(pbp, mcc);
+    return true;
+  }
+
+  template <typename T>
+  bool WorkerT<T>::implDoAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+    module_->doAccessInputProcessBlock(pbp, mcc);
+    return true;
+  }
+
+  template <typename T>
+  bool WorkerT<T>::implDoEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+    module_->doEndProcessBlock(pbp, mcc);
+    return true;
   }
 
   template <typename T>

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -123,6 +123,11 @@ namespace edm {
   }
 
   template <typename T>
+  bool WorkerT<T>::wantsInputProcessBlocks() const {
+    return module_->wantsInputProcessBlocks();
+  }
+
+  template <typename T>
   bool WorkerT<T>::wantsGlobalRuns() const {
     return module_->wantsGlobalRuns();
   }

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -44,6 +44,7 @@ namespace edm {
     Types moduleType() const override;
 
     bool wantsProcessBlocks() const final;
+    bool wantsInputProcessBlocks() const final;
     bool wantsGlobalRuns() const final;
     bool wantsGlobalLuminosityBlocks() const final;
     bool wantsStreamRuns() const final;

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -43,6 +43,7 @@ namespace edm {
 
     Types moduleType() const override;
 
+    bool wantsProcessBlocks() const final;
     bool wantsGlobalRuns() const final;
     bool wantsGlobalLuminosityBlocks() const final;
     bool wantsStreamRuns() const final;
@@ -91,6 +92,9 @@ namespace edm {
                        WaitingTaskWithArenaHolder& holder) final;
 
     bool implDoPrePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) override;
+    bool implDoBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) override;
+    bool implDoAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) override;
+    bool implDoEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) override;
     bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) override;
     bool implDoStreamBegin(StreamID id,
                            RunPrincipal const& rp,

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/global/EDAnalyzerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -68,6 +69,27 @@ namespace edm {
     void EDAnalyzerBase::doBeginJob() { this->beginJob(); }
 
     void EDAnalyzerBase::doEndJob() { this->endJob(); }
+
+    void EDAnalyzerBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+    }
+
+    void EDAnalyzerBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDAnalyzerBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+    }
 
     void EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
@@ -189,7 +211,9 @@ namespace edm {
     void EDAnalyzerBase::doStreamEndLuminosityBlockSummary_(StreamID id,
                                                             LuminosityBlock const& lbp,
                                                             EventSetup const& c) {}
-
+    void EDAnalyzerBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDAnalyzerBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDAnalyzerBase::doEndProcessBlock_(ProcessBlock const&) {}
     void EDAnalyzerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDAnalyzerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
     void EDAnalyzerBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
@@ -92,6 +93,33 @@ namespace edm {
     void EDFilterBase::doBeginJob() { this->beginJob(); }
 
     void EDFilterBase::doEndJob() { this->endJob(); }
+
+    void EDFilterBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doBeginProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
+
+    void EDFilterBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDFilterBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doEndProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
 
     void EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
@@ -226,6 +254,9 @@ namespace edm {
                                                           LuminosityBlock const& lbp,
                                                           EventSetup const& c) {}
 
+    void EDFilterBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDFilterBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDFilterBase::doEndProcessBlock_(ProcessBlock const&) {}
     void EDFilterBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDFilterBase::doEndRun_(Run const& rp, EventSetup const& c) {}
     void EDFilterBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
@@ -236,6 +267,8 @@ namespace edm {
     void EDFilterBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
     void EDFilterBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
 
+    void EDFilterBase::doBeginProcessBlockProduce_(ProcessBlock&) {}
+    void EDFilterBase::doEndProcessBlockProduce_(ProcessBlock&) {}
     void EDFilterBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
     void EDFilterBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
     void EDFilterBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/global/EDProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -98,6 +99,33 @@ namespace edm {
     void EDProducerBase::doBeginJob() { this->beginJob(); }
 
     void EDProducerBase::doEndJob() { this->endJob(); }
+
+    void EDProducerBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doBeginProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
+
+    void EDProducerBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDProducerBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doEndProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
 
     void EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
@@ -235,6 +263,9 @@ namespace edm {
                                                             LuminosityBlock const& lbp,
                                                             EventSetup const& c) {}
 
+    void EDProducerBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDProducerBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDProducerBase::doEndProcessBlock_(ProcessBlock const&) {}
     void EDProducerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDProducerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
     void EDProducerBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
@@ -245,6 +276,8 @@ namespace edm {
     void EDProducerBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
     void EDProducerBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
 
+    void EDProducerBase::doBeginProcessBlockProduce_(ProcessBlock&) {}
+    void EDProducerBase::doEndProcessBlockProduce_(ProcessBlock&) {}
     void EDProducerBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
     void EDProducerBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
     void EDProducerBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -34,6 +34,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
+#include "FWCore/Reflection/interface/DictionaryTools.h"
 
 namespace edm {
   namespace global {
@@ -157,6 +158,13 @@ namespace edm {
       ProductSelector::checkForDuplicateKeptBranch(desc, trueBranchIDToKeptBranchDesc);
 
       EDGetToken token;
+
+      std::vector<std::string> missingDictionaries;
+      if (!checkDictionary(missingDictionaries, desc.className(), desc.unwrappedType())) {
+        std::string context("Calling OutputModuleBase::keepThisBranch, checking dictionaries for kept types");
+        throwMissingDictionariesException(missingDictionaries, context);
+      }
+
       switch (desc.branchType()) {
         case InEvent: {
           if (desc.produced()) {
@@ -176,6 +184,11 @@ namespace edm {
         case InRun: {
           token = consumes<InRun>(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
                                   InputTag(desc.moduleLabel(), desc.productInstanceName(), desc.processName()));
+          break;
+        }
+        case InProcess: {
+          token = consumes<InProcess>(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
+                                      InputTag(desc.moduleLabel(), desc.productInstanceName(), desc.processName()));
           break;
         }
         default:

--- a/FWCore/Framework/src/global/analyzerImplementors.cc
+++ b/FWCore/Framework/src/global/analyzerImplementors.cc
@@ -1,0 +1,18 @@
+// -*- C++ -*-
+//
+// Implementation:
+//     Explicitly instantiate implementor templates for EDAnalyzerBase
+//
+// Original Author:  W. David Dagenhart
+//         Created:  23 June 2020
+
+#include "FWCore/Framework/src/global/implementorsMethods.h"
+#include "FWCore/Framework/interface/global/EDAnalyzerBase.h"
+
+namespace edm {
+  namespace global {
+    namespace impl {
+      template class WatchProcessBlock<edm::global::EDAnalyzerBase>;
+    }  // namespace impl
+  }    // namespace global
+}  // namespace edm

--- a/FWCore/Framework/src/global/filterImplementors.cc
+++ b/FWCore/Framework/src/global/filterImplementors.cc
@@ -19,6 +19,7 @@
 namespace edm {
   namespace global {
     namespace impl {
+      template class WatchProcessBlock<edm::global::EDFilterBase>;
       template class BeginProcessBlockProducer<edm::global::EDFilterBase>;
       template class EndProcessBlockProducer<edm::global::EDFilterBase>;
       template class BeginRunProducer<edm::global::EDFilterBase>;

--- a/FWCore/Framework/src/global/filterImplementors.cc
+++ b/FWCore/Framework/src/global/filterImplementors.cc
@@ -19,6 +19,8 @@
 namespace edm {
   namespace global {
     namespace impl {
+      template class BeginProcessBlockProducer<edm::global::EDFilterBase>;
+      template class EndProcessBlockProducer<edm::global::EDFilterBase>;
       template class BeginRunProducer<edm::global::EDFilterBase>;
       template class EndRunProducer<edm::global::EDFilterBase>;
       template class BeginLuminosityBlockProducer<edm::global::EDFilterBase>;

--- a/FWCore/Framework/src/global/implementorsMethods.h
+++ b/FWCore/Framework/src/global/implementorsMethods.h
@@ -29,6 +29,17 @@
 namespace edm {
   namespace global {
     namespace impl {
+
+      template <typename T>
+      void WatchProcessBlock<T>::doBeginProcessBlock_(ProcessBlock const& pb) {
+        this->beginProcessBlock(pb);
+      }
+
+      template <typename T>
+      void WatchProcessBlock<T>::doEndProcessBlock_(ProcessBlock const& pb) {
+        this->endProcessBlock(pb);
+      }
+
       template <typename T>
       void BeginProcessBlockProducer<T>::doBeginProcessBlockProduce_(ProcessBlock& pb) {
         this->beginProcessBlockProduce(pb);

--- a/FWCore/Framework/src/global/implementorsMethods.h
+++ b/FWCore/Framework/src/global/implementorsMethods.h
@@ -30,6 +30,16 @@ namespace edm {
   namespace global {
     namespace impl {
       template <typename T>
+      void BeginProcessBlockProducer<T>::doBeginProcessBlockProduce_(ProcessBlock& pb) {
+        this->beginProcessBlockProduce(pb);
+      }
+
+      template <typename T>
+      void EndProcessBlockProducer<T>::doEndProcessBlockProduce_(ProcessBlock& pb) {
+        this->endProcessBlockProduce(pb);
+      }
+
+      template <typename T>
       void BeginRunProducer<T>::doBeginRunProduce_(Run& rp, EventSetup const& c) {
         this->globalBeginRunProduce(rp, c);
       }

--- a/FWCore/Framework/src/global/producerImplementors.cc
+++ b/FWCore/Framework/src/global/producerImplementors.cc
@@ -19,6 +19,7 @@
 namespace edm {
   namespace global {
     namespace impl {
+      template class WatchProcessBlock<edm::global::EDProducerBase>;
       template class BeginProcessBlockProducer<edm::global::EDProducerBase>;
       template class EndProcessBlockProducer<edm::global::EDProducerBase>;
       template class BeginRunProducer<edm::global::EDProducerBase>;

--- a/FWCore/Framework/src/global/producerImplementors.cc
+++ b/FWCore/Framework/src/global/producerImplementors.cc
@@ -19,6 +19,8 @@
 namespace edm {
   namespace global {
     namespace impl {
+      template class BeginProcessBlockProducer<edm::global::EDProducerBase>;
+      template class EndProcessBlockProducer<edm::global::EDProducerBase>;
       template class BeginRunProducer<edm::global::EDProducerBase>;
       template class EndRunProducer<edm::global::EDProducerBase>;
       template class BeginLuminosityBlockProducer<edm::global::EDProducerBase>;

--- a/FWCore/Framework/src/globalTransitionAsync.h
+++ b/FWCore/Framework/src/globalTransitionAsync.h
@@ -18,161 +18,105 @@
 //         Created:  Tue, 06 Sep 2016 16:04:26 GMT
 //
 
-// system include files
-#include "FWCore/Framework/interface/EventSetupImpl.h"
-#include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Framework/interface/Schedule.h"
 #include "FWCore/Framework/interface/SubProcess.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
-#include <memory>
+#include <exception>
+#include <utility>
 #include <vector>
 
-// user include files
-
-// forward declarations
-
 namespace edm {
-  class LuminosityBlockPrincipal;
-  class ProcessBlockPrincipal;
-  class RunPrincipal;
 
   //This is code in common between beginStreamRun and beginGlobalLuminosityBlock
   template <typename T>
-  inline void subProcessDoGlobalBeginTransitionAsync(
-      WaitingTaskHolder iHolder,
-      SubProcess& iSubProcess,
-      LuminosityBlockPrincipal& iPrincipal,
-      IOVSyncValue const& iTS,
-      std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls) {
-    iSubProcess.doBeginLuminosityBlockAsync(std::move(iHolder), iPrincipal, iTS, iEventSetupImpls);
+  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder,
+                                                     SubProcess& iSubProcess,
+                                                     LumiTransitionInfo const& iTransitionInfo) {
+    iSubProcess.doBeginLuminosityBlockAsync(std::move(iHolder), iTransitionInfo);
   }
 
   template <typename T>
-  inline void subProcessDoGlobalBeginTransitionAsync(
-      WaitingTaskHolder iHolder,
-      SubProcess& iSubProcess,
-      RunPrincipal& iPrincipal,
-      IOVSyncValue const& iTS,
-      std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls) {
-    iSubProcess.doBeginRunAsync(std::move(iHolder), iPrincipal, iTS, iEventSetupImpls);
+  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder,
+                                                     SubProcess& iSubProcess,
+                                                     RunTransitionInfo const& iTransitionInfo) {
+    iSubProcess.doBeginRunAsync(std::move(iHolder), iTransitionInfo);
   }
 
   template <typename Traits>
-  inline void subProcessDoGlobalBeginTransitionAsync(
-      WaitingTaskHolder iHolder,
-      SubProcess& iSubProcess,
-      ProcessBlockPrincipal& iPrincipal,
-      IOVSyncValue const& iTS,
-      std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls) {
-    iSubProcess.doBeginProcessBlockAsync<Traits>(std::move(iHolder), iPrincipal, iTS, iEventSetupImpls);
+  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder,
+                                                     SubProcess& iSubProcess,
+                                                     ProcessBlockTransitionInfo const& iTransitionInfo) {
+    iSubProcess.doBeginProcessBlockAsync<Traits>(std::move(iHolder), iTransitionInfo);
   }
 
-  inline void subProcessDoGlobalEndTransitionAsync(
-      WaitingTaskHolder iHolder,
-      SubProcess& iSubProcess,
-      LuminosityBlockPrincipal& iPrincipal,
-      IOVSyncValue const& iTS,
-      std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls,
-      bool cleaningUpAfterException) {
-    iSubProcess.doEndLuminosityBlockAsync(
-        std::move(iHolder), iPrincipal, iTS, iEventSetupImpls, cleaningUpAfterException);
+  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder,
+                                                   SubProcess& iSubProcess,
+                                                   LumiTransitionInfo const& iTransitionInfo,
+                                                   bool cleaningUpAfterException) {
+    iSubProcess.doEndLuminosityBlockAsync(std::move(iHolder), iTransitionInfo, cleaningUpAfterException);
   }
 
-  inline void subProcessDoGlobalEndTransitionAsync(
-      WaitingTaskHolder iHolder,
-      SubProcess& iSubProcess,
-      RunPrincipal& iPrincipal,
-      IOVSyncValue const& iTS,
-      std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls,
-      bool cleaningUpAfterException) {
-    iSubProcess.doEndRunAsync(std::move(iHolder), iPrincipal, iTS, iEventSetupImpls, cleaningUpAfterException);
+  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder,
+                                                   SubProcess& iSubProcess,
+                                                   RunTransitionInfo const& iTransitionInfo,
+                                                   bool cleaningUpAfterException) {
+    iSubProcess.doEndRunAsync(std::move(iHolder), iTransitionInfo, cleaningUpAfterException);
   }
 
-  inline void subProcessDoGlobalEndTransitionAsync(
-      WaitingTaskHolder iHolder,
-      SubProcess& iSubProcess,
-      ProcessBlockPrincipal& iPrincipal,
-      IOVSyncValue const& iTS,
-      std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls,
-      bool cleaningUpAfterException) {
-    iSubProcess.doEndProcessBlockAsync(std::move(iHolder), iPrincipal, iTS, iEventSetupImpls, cleaningUpAfterException);
+  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder,
+                                                   SubProcess& iSubProcess,
+                                                   ProcessBlockTransitionInfo const& iTransitionInfo,
+                                                   bool cleaningUpAfterException) {
+    iSubProcess.doEndProcessBlockAsync(std::move(iHolder), iTransitionInfo, cleaningUpAfterException);
   }
 
-  template <typename Traits, typename P, typename SC>
-  void beginGlobalTransitionAsync(
-      WaitingTaskHolder iWait,
-      Schedule& iSchedule,
-      P& iPrincipal,
-      IOVSyncValue const& iTS,
-      EventSetupImpl const& iES,
-      std::vector<std::shared_ptr<const EventSetupImpl>> const*
-          iEventSetupImpls,  // always null for runs until we enable concurrent run processing
-      ServiceToken const& token,
-      SC& iSubProcesses) {
-    //When we are done processing the global for this process,
-    // we need to run the global for all SubProcesses
-    auto subs = make_waiting_task(
-        tbb::task::allocate_root(),
-        [&iSubProcesses, iWait, &iPrincipal, iTS, iEventSetupImpls](std::exception_ptr const* iPtr) mutable {
-          if (iPtr) {
-            auto excpt = *iPtr;
-            auto delayError =
-                make_waiting_task(tbb::task::allocate_root(),
-                                  [iWait, excpt](std::exception_ptr const*) mutable { iWait.doneWaiting(excpt); });
-            WaitingTaskHolder h(delayError);
-            for (auto& subProcess : iSubProcesses) {
-              subProcessDoGlobalBeginTransitionAsync<Traits>(h, subProcess, iPrincipal, iTS, iEventSetupImpls);
-            }
-          } else {
-            for (auto& subProcess : iSubProcesses) {
-              subProcessDoGlobalBeginTransitionAsync<Traits>(iWait, subProcess, iPrincipal, iTS, iEventSetupImpls);
-            }
-          }
-        });
-
-    WaitingTaskHolder h(subs);
-    iSchedule.processOneGlobalAsync<Traits>(std::move(h), iPrincipal, iES, token);
-  }
-
-  // The only purpose of this function is to create dummy values for the
-  // EventSetup arguments needed by the generic function beginGlobalTransitionsAsync
-  template <typename Traits, typename P, typename SC>
-  void beginGlobalTransitionAsync(
-      WaitingTaskHolder iWait, Schedule& iSchedule, P& iPrincipal, ServiceToken const& token, SC& iSubProcesses) {
-    // There is no EventSetup for ProcessBlock transitions
-    // so we just pass in dummy values that are not used.
-    IOVSyncValue dummyIOVSyncValue;
-    EventSetupImpl dummyEventSetupImpl;
-    std::vector<std::shared_ptr<const EventSetupImpl>> const* dummyEventSetupImpls = nullptr;
-
-    beginGlobalTransitionAsync<Traits, P, SC>(std::move(iWait),
-                                              iSchedule,
-                                              iPrincipal,
-                                              dummyIOVSyncValue,
-                                              dummyEventSetupImpl,
-                                              dummyEventSetupImpls,
-                                              token,
-                                              iSubProcesses);
-  }
-
-  template <typename Traits, typename P, typename SC>
-  void endGlobalTransitionAsync(WaitingTaskHolder iWait,
-                                Schedule& iSchedule,
-                                P& iPrincipal,
-                                IOVSyncValue const& iTS,
-                                EventSetupImpl const& iES,
-                                std::vector<std::shared_ptr<const EventSetupImpl>> const*
-                                    iEventSetupImpls,  // always null for runs until we enable concurrent run processing
-                                ServiceToken const& token,
-                                SC& iSubProcesses,
-                                bool cleaningUpAfterException) {
-    //When we are done processing the global for this process,
+  template <typename Traits>
+  void beginGlobalTransitionAsync(WaitingTaskHolder iWait,
+                                  Schedule& iSchedule,
+                                  typename Traits::TransitionInfoType& transitionInfo,
+                                  ServiceToken const& token,
+                                  std::vector<SubProcess>& iSubProcesses) {
+    // When we are done processing the global for this process,
     // we need to run the global for all SubProcesses
     auto subs =
         make_waiting_task(tbb::task::allocate_root(),
-                          [&iSubProcesses, iWait, &iPrincipal, iTS, iEventSetupImpls, cleaningUpAfterException](
+                          [&iSubProcesses, iWait, info = transitionInfo](std::exception_ptr const* iPtr) mutable {
+                            if (iPtr) {
+                              auto excpt = *iPtr;
+                              auto delayError = make_waiting_task(
+                                  tbb::task::allocate_root(),
+                                  [iWait, excpt](std::exception_ptr const*) mutable { iWait.doneWaiting(excpt); });
+                              WaitingTaskHolder h(delayError);
+                              for (auto& subProcess : iSubProcesses) {
+                                subProcessDoGlobalBeginTransitionAsync<Traits>(h, subProcess, info);
+                              }
+                            } else {
+                              for (auto& subProcess : iSubProcesses) {
+                                subProcessDoGlobalBeginTransitionAsync<Traits>(iWait, subProcess, info);
+                              }
+                            }
+                          });
+
+    WaitingTaskHolder h(subs);
+    iSchedule.processOneGlobalAsync<Traits>(
+        std::move(h), transitionInfo.principal(), transitionInfo.eventSetupImpl(), token);
+  }
+
+  template <typename Traits>
+  void endGlobalTransitionAsync(WaitingTaskHolder iWait,
+                                Schedule& iSchedule,
+                                typename Traits::TransitionInfoType& transitionInfo,
+                                ServiceToken const& token,
+                                std::vector<SubProcess>& iSubProcesses,
+                                bool cleaningUpAfterException) {
+    // When we are done processing the global for this process,
+    // we need to run the global for all SubProcesses
+    auto subs =
+        make_waiting_task(tbb::task::allocate_root(),
+                          [&iSubProcesses, iWait, info = transitionInfo, cleaningUpAfterException](
                               std::exception_ptr const* iPtr) mutable {
                             if (iPtr) {
                               auto excpt = *iPtr;
@@ -181,46 +125,20 @@ namespace edm {
                                   [iWait, excpt](std::exception_ptr const*) mutable { iWait.doneWaiting(excpt); });
                               WaitingTaskHolder h(delayError);
                               for (auto& subProcess : iSubProcesses) {
-                                subProcessDoGlobalEndTransitionAsync(
-                                    h, subProcess, iPrincipal, iTS, iEventSetupImpls, cleaningUpAfterException);
+                                subProcessDoGlobalEndTransitionAsync(h, subProcess, info, cleaningUpAfterException);
                               }
                             } else {
                               for (auto& subProcess : iSubProcesses) {
-                                subProcessDoGlobalEndTransitionAsync(
-                                    iWait, subProcess, iPrincipal, iTS, iEventSetupImpls, cleaningUpAfterException);
+                                subProcessDoGlobalEndTransitionAsync(iWait, subProcess, info, cleaningUpAfterException);
                               }
                             }
                           });
 
     WaitingTaskHolder h(subs);
-    iSchedule.processOneGlobalAsync<Traits>(std::move(h), iPrincipal, iES, token, cleaningUpAfterException);
+    iSchedule.processOneGlobalAsync<Traits>(
+        std::move(h), transitionInfo.principal(), transitionInfo.eventSetupImpl(), token, cleaningUpAfterException);
   }
 
-  // The only purpose of this function is to create dummy values for the
-  // EventSetup arguments needed by the generic function endGlobalTransitionsAsync
-  template <typename Traits, typename P, typename SC>
-  void endGlobalTransitionAsync(WaitingTaskHolder iWait,
-                                Schedule& iSchedule,
-                                P& iPrincipal,
-                                ServiceToken const& token,
-                                SC& iSubProcesses,
-                                bool cleaningUpAfterException) {
-    // There is no EventSetup for ProcessBlock transitions
-    // so we just pass in dummy values that are not used.
-    IOVSyncValue dummyIOVSyncValue;
-    EventSetupImpl dummyEventSetupImpl;
-    std::vector<std::shared_ptr<const EventSetupImpl>> const* dummyEventSetupImpls = nullptr;
-
-    endGlobalTransitionAsync<Traits, P, SC>(std::move(iWait),
-                                            iSchedule,
-                                            iPrincipal,
-                                            dummyIOVSyncValue,
-                                            dummyEventSetupImpl,
-                                            dummyEventSetupImpls,
-                                            token,
-                                            iSubProcesses,
-                                            cleaningUpAfterException);
-  }
 };  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/limited/EDAnalyzerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -69,6 +70,27 @@ namespace edm {
     void EDAnalyzerBase::doBeginJob() { this->beginJob(); }
 
     void EDAnalyzerBase::doEndJob() { this->endJob(); }
+
+    void EDAnalyzerBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+    }
+
+    void EDAnalyzerBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDAnalyzerBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+    }
 
     void EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
@@ -191,6 +213,9 @@ namespace edm {
                                                             LuminosityBlock const& lbp,
                                                             EventSetup const& c) {}
 
+    void EDAnalyzerBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDAnalyzerBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDAnalyzerBase::doEndProcessBlock_(ProcessBlock const&) {}
     void EDAnalyzerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDAnalyzerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
     void EDAnalyzerBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/limited/EDFilterBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -74,6 +75,33 @@ namespace edm {
     void EDFilterBase::doBeginJob() { this->beginJob(); }
 
     void EDFilterBase::doEndJob() { this->endJob(); }
+
+    void EDFilterBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doBeginProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
+
+    void EDFilterBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDFilterBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doEndProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
 
     void EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
@@ -208,6 +236,9 @@ namespace edm {
                                                           LuminosityBlock const& lbp,
                                                           EventSetup const& c) {}
 
+    void EDFilterBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDFilterBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDFilterBase::doEndProcessBlock_(ProcessBlock const&) {}
     void EDFilterBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDFilterBase::doEndRun_(Run const& rp, EventSetup const& c) {}
     void EDFilterBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
@@ -218,6 +249,8 @@ namespace edm {
     void EDFilterBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
     void EDFilterBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
 
+    void EDFilterBase::doBeginProcessBlockProduce_(ProcessBlock&) {}
+    void EDFilterBase::doEndProcessBlockProduce_(ProcessBlock&) {}
     void EDFilterBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
     void EDFilterBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
     void EDFilterBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/limited/EDProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -74,6 +75,33 @@ namespace edm {
     void EDProducerBase::doBeginJob() { this->beginJob(); }
 
     void EDProducerBase::doEndJob() { this->endJob(); }
+
+    void EDProducerBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doBeginProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
+
+    void EDProducerBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDProducerBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doEndProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
 
     void EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
@@ -208,6 +236,9 @@ namespace edm {
                                                             LuminosityBlock const& lbp,
                                                             EventSetup const& c) {}
 
+    void EDProducerBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDProducerBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDProducerBase::doEndProcessBlock_(ProcessBlock const&) {}
     void EDProducerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDProducerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
     void EDProducerBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
@@ -218,6 +249,8 @@ namespace edm {
     void EDProducerBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
     void EDProducerBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
 
+    void EDProducerBase::doBeginProcessBlockProduce_(ProcessBlock&) {}
+    void EDProducerBase::doEndProcessBlockProduce_(ProcessBlock&) {}
     void EDProducerBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
     void EDProducerBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
     void EDProducerBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -34,6 +34,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
+#include "FWCore/Reflection/interface/DictionaryTools.h"
 
 namespace edm {
   namespace limited {
@@ -158,6 +159,13 @@ namespace edm {
       ProductSelector::checkForDuplicateKeptBranch(desc, trueBranchIDToKeptBranchDesc);
 
       EDGetToken token;
+
+      std::vector<std::string> missingDictionaries;
+      if (!checkDictionary(missingDictionaries, desc.className(), desc.unwrappedType())) {
+        std::string context("Calling OutputModuleBase::keepThisBranch, checking dictionaries for kept types");
+        throwMissingDictionariesException(missingDictionaries, context);
+      }
+
       switch (desc.branchType()) {
         case InEvent: {
           if (desc.produced()) {
@@ -177,6 +185,11 @@ namespace edm {
         case InRun: {
           token = consumes<InRun>(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
                                   InputTag(desc.moduleLabel(), desc.productInstanceName(), desc.processName()));
+          break;
+        }
+        case InProcess: {
+          token = consumes<InProcess>(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
+                                      InputTag(desc.moduleLabel(), desc.productInstanceName(), desc.processName()));
           break;
         }
         default:

--- a/FWCore/Framework/src/limited/analyzerImplementors.cc
+++ b/FWCore/Framework/src/limited/analyzerImplementors.cc
@@ -1,0 +1,18 @@
+// -*- C++ -*-
+
+// Implementation:
+//     Explicitly instantiate implementor templates for EDAnalyzerBase
+//
+// Original Author:  W. David Dagenhart
+//         Created:  23 June 2020
+
+#include "FWCore/Framework/src/limited/implementorsMethods.h"
+#include "FWCore/Framework/interface/limited/EDAnalyzerBase.h"
+
+namespace edm {
+  namespace limited {
+    namespace impl {
+      template class WatchProcessBlock<edm::limited::EDAnalyzerBase>;
+    }  // namespace impl
+  }    // namespace limited
+}  // namespace edm

--- a/FWCore/Framework/src/limited/filterImplementors.cc
+++ b/FWCore/Framework/src/limited/filterImplementors.cc
@@ -19,6 +19,7 @@
 namespace edm {
   namespace limited {
     namespace impl {
+      template class WatchProcessBlock<edm::limited::EDFilterBase>;
       template class BeginProcessBlockProducer<edm::limited::EDFilterBase>;
       template class EndProcessBlockProducer<edm::limited::EDFilterBase>;
       template class BeginRunProducer<edm::limited::EDFilterBase>;

--- a/FWCore/Framework/src/limited/filterImplementors.cc
+++ b/FWCore/Framework/src/limited/filterImplementors.cc
@@ -19,6 +19,8 @@
 namespace edm {
   namespace limited {
     namespace impl {
+      template class BeginProcessBlockProducer<edm::limited::EDFilterBase>;
+      template class EndProcessBlockProducer<edm::limited::EDFilterBase>;
       template class BeginRunProducer<edm::limited::EDFilterBase>;
       template class EndRunProducer<edm::limited::EDFilterBase>;
       template class BeginLuminosityBlockProducer<edm::limited::EDFilterBase>;

--- a/FWCore/Framework/src/limited/implementorsMethods.h
+++ b/FWCore/Framework/src/limited/implementorsMethods.h
@@ -29,6 +29,16 @@ namespace edm {
   namespace limited {
     namespace impl {
       template <typename T>
+      void BeginProcessBlockProducer<T>::doBeginProcessBlockProduce_(ProcessBlock& pb) {
+        this->beginProcessBlockProduce(pb);
+      }
+
+      template <typename T>
+      void EndProcessBlockProducer<T>::doEndProcessBlockProduce_(ProcessBlock& pb) {
+        this->endProcessBlockProduce(pb);
+      }
+
+      template <typename T>
       void BeginRunProducer<T>::doBeginRunProduce_(Run& rp, EventSetup const& c) {
         this->globalBeginRunProduce(rp, c);
       }

--- a/FWCore/Framework/src/limited/implementorsMethods.h
+++ b/FWCore/Framework/src/limited/implementorsMethods.h
@@ -29,6 +29,16 @@ namespace edm {
   namespace limited {
     namespace impl {
       template <typename T>
+      void WatchProcessBlock<T>::doBeginProcessBlock_(ProcessBlock const& pb) {
+        this->beginProcessBlock(pb);
+      }
+
+      template <typename T>
+      void WatchProcessBlock<T>::doEndProcessBlock_(ProcessBlock const& pb) {
+        this->endProcessBlock(pb);
+      }
+
+      template <typename T>
       void BeginProcessBlockProducer<T>::doBeginProcessBlockProduce_(ProcessBlock& pb) {
         this->beginProcessBlockProduce(pb);
       }

--- a/FWCore/Framework/src/limited/producerImplementors.cc
+++ b/FWCore/Framework/src/limited/producerImplementors.cc
@@ -19,6 +19,7 @@
 namespace edm {
   namespace limited {
     namespace impl {
+      template class WatchProcessBlock<edm::limited::EDProducerBase>;
       template class BeginProcessBlockProducer<edm::limited::EDProducerBase>;
       template class EndProcessBlockProducer<edm::limited::EDProducerBase>;
       template class BeginRunProducer<edm::limited::EDProducerBase>;

--- a/FWCore/Framework/src/limited/producerImplementors.cc
+++ b/FWCore/Framework/src/limited/producerImplementors.cc
@@ -19,6 +19,8 @@
 namespace edm {
   namespace limited {
     namespace impl {
+      template class BeginProcessBlockProducer<edm::limited::EDProducerBase>;
+      template class EndProcessBlockProducer<edm::limited::EDProducerBase>;
       template class BeginRunProducer<edm::limited::EDProducerBase>;
       template class EndRunProducer<edm::limited::EDProducerBase>;
       template class BeginLuminosityBlockProducer<edm::limited::EDProducerBase>;

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/one/EDAnalyzerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -82,6 +83,27 @@ namespace edm {
     }
     void EDAnalyzerBase::preallocLumis(unsigned int){};
 
+    void EDAnalyzerBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+    }
+
+    void EDAnalyzerBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDAnalyzerBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+    }
+
     void EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
@@ -133,6 +155,10 @@ namespace edm {
     void EDAnalyzerBase::doRespondToCloseInputFile(FileBlock const& fb) {
       //respondToCloseInputFile(fb);
     }
+
+    void EDAnalyzerBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDAnalyzerBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDAnalyzerBase::doEndProcessBlock_(ProcessBlock const&) {}
 
     void EDAnalyzerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDAnalyzerBase::doEndRun_(Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/one/EDFilterBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -82,6 +83,33 @@ namespace edm {
     }
     void EDFilterBase::preallocLumis(unsigned int){};
 
+    void EDFilterBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doBeginProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
+
+    void EDFilterBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDFilterBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doEndProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
+
     void EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
@@ -146,11 +174,16 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
 
+    void EDFilterBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDFilterBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDFilterBase::doEndProcessBlock_(ProcessBlock const&) {}
     void EDFilterBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDFilterBase::doEndRun_(Run const& rp, EventSetup const& c) {}
     void EDFilterBase::doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
     void EDFilterBase::doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
 
+    void EDFilterBase::doBeginProcessBlockProduce_(ProcessBlock&) {}
+    void EDFilterBase::doEndProcessBlockProduce_(ProcessBlock&) {}
     void EDFilterBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
     void EDFilterBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
     void EDFilterBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/one/EDProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -82,6 +83,33 @@ namespace edm {
 
     void EDProducerBase::preallocLumis(unsigned int){};
 
+    void EDProducerBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doBeginProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doBeginProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
+
+    void EDProducerBase::doAccessInputProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doAccessInputProcessBlock_(constProcessBlock);
+    }
+
+    void EDProducerBase::doEndProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
+      ProcessBlock processBlock(pbp, moduleDescription_, mcc, true);
+      processBlock.setConsumer(this);
+      ProcessBlock const& constProcessBlock = processBlock;
+      this->doEndProcessBlock_(constProcessBlock);
+      processBlock.setProducer(this);
+      this->doEndProcessBlockProduce_(processBlock);
+      commit_(processBlock);
+    }
+
     void EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
@@ -146,11 +174,16 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
 
+    void EDProducerBase::doBeginProcessBlock_(ProcessBlock const&) {}
+    void EDProducerBase::doAccessInputProcessBlock_(ProcessBlock const&) {}
+    void EDProducerBase::doEndProcessBlock_(ProcessBlock const&) {}
     void EDProducerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
     void EDProducerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
     void EDProducerBase::doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
     void EDProducerBase::doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
 
+    void EDProducerBase::doBeginProcessBlockProduce_(ProcessBlock&) {}
+    void EDProducerBase::doEndProcessBlockProduce_(ProcessBlock&) {}
     void EDProducerBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
     void EDProducerBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
     void EDProducerBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -170,6 +170,11 @@ namespace edm {
                                   InputTag(desc.moduleLabel(), desc.productInstanceName(), desc.processName()));
           break;
         }
+        case InProcess: {
+          token = consumes<InProcess>(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
+                                      InputTag(desc.moduleLabel(), desc.productInstanceName(), desc.processName()));
+          break;
+        }
         default:
           assert(false);
           break;

--- a/FWCore/Framework/src/one/analyzerImplementors.cc
+++ b/FWCore/Framework/src/one/analyzerImplementors.cc
@@ -22,6 +22,7 @@ namespace edm {
       template class SharedResourcesUser<edm::one::EDAnalyzerBase>;
       template class RunWatcher<edm::one::EDAnalyzerBase>;
       template class LuminosityBlockWatcher<edm::one::EDAnalyzerBase>;
+      template class WatchProcessBlock<edm::one::EDAnalyzerBase>;
     }  // namespace impl
   }    // namespace one
 }  // namespace edm

--- a/FWCore/Framework/src/one/filterImplementors.cc
+++ b/FWCore/Framework/src/one/filterImplementors.cc
@@ -22,6 +22,7 @@ namespace edm {
       template class SharedResourcesUser<edm::one::EDFilterBase>;
       template class RunWatcher<edm::one::EDFilterBase>;
       template class LuminosityBlockWatcher<edm::one::EDFilterBase>;
+      template class WatchProcessBlock<edm::one::EDFilterBase>;
       template class BeginProcessBlockProducer<edm::one::EDFilterBase>;
       template class EndProcessBlockProducer<edm::one::EDFilterBase>;
       template class BeginRunProducer<edm::one::EDFilterBase>;

--- a/FWCore/Framework/src/one/filterImplementors.cc
+++ b/FWCore/Framework/src/one/filterImplementors.cc
@@ -22,6 +22,8 @@ namespace edm {
       template class SharedResourcesUser<edm::one::EDFilterBase>;
       template class RunWatcher<edm::one::EDFilterBase>;
       template class LuminosityBlockWatcher<edm::one::EDFilterBase>;
+      template class BeginProcessBlockProducer<edm::one::EDFilterBase>;
+      template class EndProcessBlockProducer<edm::one::EDFilterBase>;
       template class BeginRunProducer<edm::one::EDFilterBase>;
       template class EndRunProducer<edm::one::EDFilterBase>;
       template class BeginLuminosityBlockProducer<edm::one::EDFilterBase>;

--- a/FWCore/Framework/src/one/implementorsMethods.h
+++ b/FWCore/Framework/src/one/implementorsMethods.h
@@ -65,6 +65,16 @@ namespace edm {
       }
 
       template <typename T>
+      void BeginProcessBlockProducer<T>::doBeginProcessBlockProduce_(ProcessBlock& pb) {
+        this->beginProcessBlockProduce(pb);
+      }
+
+      template <typename T>
+      void EndProcessBlockProducer<T>::doEndProcessBlockProduce_(ProcessBlock& pb) {
+        this->endProcessBlockProduce(pb);
+      }
+
+      template <typename T>
       void BeginRunProducer<T>::doBeginRunProduce_(Run& rp, EventSetup const& c) {
         this->beginRunProduce(rp, c);
       }

--- a/FWCore/Framework/src/one/implementorsMethods.h
+++ b/FWCore/Framework/src/one/implementorsMethods.h
@@ -65,6 +65,16 @@ namespace edm {
       }
 
       template <typename T>
+      void WatchProcessBlock<T>::doBeginProcessBlock_(ProcessBlock const& pb) {
+        this->beginProcessBlock(pb);
+      }
+
+      template <typename T>
+      void WatchProcessBlock<T>::doEndProcessBlock_(ProcessBlock const& pb) {
+        this->endProcessBlock(pb);
+      }
+
+      template <typename T>
       void BeginProcessBlockProducer<T>::doBeginProcessBlockProduce_(ProcessBlock& pb) {
         this->beginProcessBlockProduce(pb);
       }

--- a/FWCore/Framework/src/one/producerImplementors.cc
+++ b/FWCore/Framework/src/one/producerImplementors.cc
@@ -22,6 +22,7 @@ namespace edm {
       template class SharedResourcesUser<edm::one::EDProducerBase>;
       template class RunWatcher<edm::one::EDProducerBase>;
       template class LuminosityBlockWatcher<edm::one::EDProducerBase>;
+      template class WatchProcessBlock<edm::one::EDProducerBase>;
       template class BeginProcessBlockProducer<edm::one::EDProducerBase>;
       template class EndProcessBlockProducer<edm::one::EDProducerBase>;
       template class BeginRunProducer<edm::one::EDProducerBase>;

--- a/FWCore/Framework/src/one/producerImplementors.cc
+++ b/FWCore/Framework/src/one/producerImplementors.cc
@@ -22,6 +22,8 @@ namespace edm {
       template class SharedResourcesUser<edm::one::EDProducerBase>;
       template class RunWatcher<edm::one::EDProducerBase>;
       template class LuminosityBlockWatcher<edm::one::EDProducerBase>;
+      template class BeginProcessBlockProducer<edm::one::EDProducerBase>;
+      template class EndProcessBlockProducer<edm::one::EDProducerBase>;
       template class BeginRunProducer<edm::one::EDProducerBase>;
       template class EndRunProducer<edm::one::EDProducerBase>;
       template class BeginLuminosityBlockProducer<edm::one::EDProducerBase>;

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -205,6 +205,10 @@ namespace edm {
 
   void MockEventProcessor::doErrorStuff() { output_ << "\tdoErrorStuff\n"; }
 
+  void MockEventProcessor::beginProcessBlock(bool& beginProcessBlockSucceeded) {}
+  void MockEventProcessor::inputProcessBlocks() {}
+  void MockEventProcessor::endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded) {}
+
   void MockEventProcessor::beginRun(ProcessHistoryID const& phid,
                                     RunNumber_t run,
                                     bool& globalTransitionSucceeded,

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -51,6 +51,10 @@ namespace edm {
 
     void doErrorStuff();
 
+    void beginProcessBlock(bool& beginProcessBlockSucceeded);
+    void inputProcessBlocks();
+    void endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded);
+
     void beginRun(ProcessHistoryID const& phid,
                   RunNumber_t run,
                   bool& globalTransitionSucceeded,

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -301,7 +301,7 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntAnalyzer : public edm::global::EDAnalyzer<edm::ProcessBlockCache<UnsafeCache>,
+    class ProcessBlockIntAnalyzer : public edm::global::EDAnalyzer<edm::WatchProcessBlock,
                                                                    edm::StreamCache<UnsafeCache>,
                                                                    edm::RunCache<UnsafeCache>> {
     public:

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -1,8 +1,8 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::global::EDAnalyzer modules of 
-edm::*Cache templates 
+Toy edm::global::EDAnalyzer modules of
+edm::*Cache templates
 for testing purposes only.
 
 ----------------------------------------------------------------------*/
@@ -18,6 +18,7 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -300,6 +301,86 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntAnalyzer : public edm::global::EDAnalyzer<edm::ProcessBlockCache<UnsafeCache>> {
+    public:
+      explicit ProcessBlockIntAnalyzer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
+        {
+          auto tag = p.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = p.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+
+        const unsigned int valueToGet = 11;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      void analyze(edm::StreamID iID, edm::Event const&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "analyze before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        {
+          const unsigned int valueToGet = 11;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 21;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntAnalyzer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
   }  // namespace global
 }  // namespace edmtest
 
@@ -308,3 +389,4 @@ DEFINE_FWK_MODULE(edmtest::global::RunIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::global::LumiIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::global::RunSummaryIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::global::LumiSummaryIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::global::ProcessBlockIntAnalyzer);

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -418,7 +418,7 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntFilter : public edm::global::EDFilter<edm::ProcessBlockCache<UnsafeCache>> {
+    class ProcessBlockIntFilter : public edm::global::EDFilter<edm::WatchProcessBlock> {
     public:
       explicit ProcessBlockIntFilter(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
         produces<unsigned int>();

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -1,7 +1,7 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::global::EDFilter modules of 
+Toy edm::global::EDFilter modules of
 edm::*Cache templates and edm::*Producer classes
 for testing purposes only.
 
@@ -18,6 +18,7 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -417,6 +418,187 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntFilter : public edm::global::EDFilter<edm::ProcessBlockCache<UnsafeCache>> {
+    public:
+      explicit ProcessBlockIntFilter(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
+        produces<unsigned int>();
+        {
+          auto tag = p.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = p.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+        const unsigned int valueToGet = 31;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+        return true;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        {
+          const unsigned int valueToGet = 31;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 41;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
+    class TestBeginProcessBlockFilter : public edm::global::EDFilter<edm::BeginProcessBlockProducer> {
+    public:
+      explicit TestBeginProcessBlockFilter(edm::ParameterSet const& p)
+          : trans_(p.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::BeginProcessBlock>("begin")) {
+        produces<unsigned int>();
+
+        auto tag = p.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void beginProcessBlockProduce(edm::ProcessBlock& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockFilter transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+        const unsigned int valueToPutAndGet = 31;
+        processBlock.emplace(token_, valueToPutAndGet);
+
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlockProduce " << m_count;
+        }
+        ++m_count;
+        return true;
+      }
+
+      ~TestBeginProcessBlockFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
+    class TestEndProcessBlockFilter : public edm::global::EDFilter<edm::EndProcessBlockProducer> {
+    public:
+      explicit TestEndProcessBlockFilter(edm::ParameterSet const& p)
+          : trans_(p.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::EndProcessBlock>("end")) {
+        produces<unsigned int>();
+
+        auto tag = p.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        ++m_count;
+        return true;
+      }
+
+      void endProcessBlockProduce(edm::ProcessBlock& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestEndProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        const unsigned int valueToPutAndGet = 41;
+        processBlock.emplace(token_, valueToPutAndGet);
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      ~TestEndProcessBlockFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "~TestEndProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
     class TestBeginRunFilter : public edm::global::EDFilter<edm::RunCache<Dummy>, edm::BeginRunProducer> {
     public:
       explicit TestBeginRunFilter(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
@@ -579,6 +761,9 @@ DEFINE_FWK_MODULE(edmtest::global::RunIntFilter);
 DEFINE_FWK_MODULE(edmtest::global::LumiIntFilter);
 DEFINE_FWK_MODULE(edmtest::global::RunSummaryIntFilter);
 DEFINE_FWK_MODULE(edmtest::global::LumiSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::global::ProcessBlockIntFilter);
+DEFINE_FWK_MODULE(edmtest::global::TestBeginProcessBlockFilter);
+DEFINE_FWK_MODULE(edmtest::global::TestEndProcessBlockFilter);
 DEFINE_FWK_MODULE(edmtest::global::TestBeginRunFilter);
 DEFINE_FWK_MODULE(edmtest::global::TestBeginLumiBlockFilter);
 DEFINE_FWK_MODULE(edmtest::global::TestEndRunFilter);

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -1,7 +1,7 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::global::EDProducer modules of 
+Toy edm::global::EDProducer modules of
 edm::*Cache templates and edm::*Producer classes
 for testing purposes only.
 
@@ -18,6 +18,7 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -462,6 +463,183 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntProducer : public edm::global::EDProducer<edm::ProcessBlockCache<UnsafeCache>> {
+    public:
+      explicit ProcessBlockIntProducer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
+        produces<unsigned int>();
+        {
+          auto tag = p.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = p.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+
+        const unsigned int valueToGet = 11;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        {
+          const unsigned int valueToGet = 11;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 21;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
+    class TestBeginProcessBlockProducer : public edm::global::EDProducer<edm::BeginProcessBlockProducer> {
+    public:
+      explicit TestBeginProcessBlockProducer(edm::ParameterSet const& p)
+          : trans_(p.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::BeginProcessBlock>("begin")) {
+        produces<unsigned int>();
+
+        auto tag = p.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void beginProcessBlockProduce(edm::ProcessBlock& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+        const unsigned int valueToPutAndGet = 11;
+        processBlock.emplace(token_, valueToPutAndGet);
+
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlockProduce " << m_count;
+        }
+        ++m_count;
+      }
+
+      ~TestBeginProcessBlockProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
+    class TestEndProcessBlockProducer : public edm::global::EDProducer<edm::EndProcessBlockProducer> {
+    public:
+      explicit TestEndProcessBlockProducer(edm::ParameterSet const& p)
+          : trans_(p.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::EndProcessBlock>("end")) {
+        produces<unsigned int>();
+
+        auto tag = p.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+      void endProcessBlockProduce(edm::ProcessBlock& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestEndProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        const unsigned int valueToPutAndGet = 21;
+        processBlock.emplace(token_, valueToPutAndGet);
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      ~TestEndProcessBlockProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "~TestEndProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
     class TestBeginRunProducer : public edm::global::EDProducer<edm::RunCache<Dummy>, edm::BeginRunProducer> {
     public:
       explicit TestBeginRunProducer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
@@ -634,6 +812,9 @@ DEFINE_FWK_MODULE(edmtest::global::LumiIntProducer);
 DEFINE_FWK_MODULE(edmtest::global::RunSummaryIntProducer);
 DEFINE_FWK_MODULE(edmtest::global::LumiSummaryIntProducer);
 DEFINE_FWK_MODULE(edmtest::global::LumiSummaryLumiProducer);
+DEFINE_FWK_MODULE(edmtest::global::ProcessBlockIntProducer);
+DEFINE_FWK_MODULE(edmtest::global::TestBeginProcessBlockProducer);
+DEFINE_FWK_MODULE(edmtest::global::TestEndProcessBlockProducer);
 DEFINE_FWK_MODULE(edmtest::global::TestBeginRunProducer);
 DEFINE_FWK_MODULE(edmtest::global::TestEndRunProducer);
 DEFINE_FWK_MODULE(edmtest::global::TestBeginLumiBlockProducer);

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -463,7 +463,7 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntProducer : public edm::global::EDProducer<edm::ProcessBlockCache<UnsafeCache>> {
+    class ProcessBlockIntProducer : public edm::global::EDProducer<edm::WatchProcessBlock> {
     public:
       explicit ProcessBlockIntProducer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
         produces<unsigned int>();

--- a/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
@@ -1,8 +1,8 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::limited::EDAnalyzer modules of 
-edm::*Cache templates 
+Toy edm::limited::EDAnalyzer modules of
+edm::*Cache templates
 for testing purposes only.
 
 ----------------------------------------------------------------------*/
@@ -18,6 +18,7 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -315,6 +316,88 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntAnalyzer : public edm::limited::EDAnalyzer<edm::ProcessBlockCache<UnsafeCache>> {
+    public:
+      explicit ProcessBlockIntAnalyzer(edm::ParameterSet const& pset)
+          : edm::limited::EDAnalyzerBase(pset),
+            edm::limited::EDAnalyzer<edm::ProcessBlockCache<UnsafeCache>>(pset),
+            trans_(pset.getParameter<int>("transitions")) {
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+        const unsigned int valueToGet = 11;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      void analyze(edm::StreamID iID, edm::Event const&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "analyze before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        {
+          const unsigned int valueToGet = 11;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 21;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntAnalyzer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
   }  // namespace limited
 }  // namespace edmtest
 
@@ -323,3 +406,4 @@ DEFINE_FWK_MODULE(edmtest::limited::RunIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::limited::LumiIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::limited::RunSummaryIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::limited::LumiSummaryIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::limited::ProcessBlockIntAnalyzer);

--- a/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
@@ -316,11 +316,11 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntAnalyzer : public edm::limited::EDAnalyzer<edm::ProcessBlockCache<UnsafeCache>> {
+    class ProcessBlockIntAnalyzer : public edm::limited::EDAnalyzer<edm::WatchProcessBlock> {
     public:
       explicit ProcessBlockIntAnalyzer(edm::ParameterSet const& pset)
           : edm::limited::EDAnalyzerBase(pset),
-            edm::limited::EDAnalyzer<edm::ProcessBlockCache<UnsafeCache>>(pset),
+            edm::limited::EDAnalyzer<edm::WatchProcessBlock>(pset),
             trans_(pset.getParameter<int>("transitions")) {
         {
           auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");

--- a/FWCore/Framework/test/stubs/TestLimitedFilters.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedFilters.cc
@@ -1,7 +1,7 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::limited::EDFilter modules of 
+Toy edm::limited::EDFilter modules of
 edm::*Cache templates and edm::*Producer classes
 for testing purposes only.
 
@@ -18,6 +18,7 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -432,6 +433,192 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntFilter : public edm::limited::EDFilter<edm::ProcessBlockCache<UnsafeCache>> {
+    public:
+      explicit ProcessBlockIntFilter(edm::ParameterSet const& pset)
+          : edm::limited::EDFilterBase(pset),
+            edm::limited::EDFilter<edm::ProcessBlockCache<UnsafeCache>>(pset),
+            trans_(pset.getParameter<int>("transitions")) {
+        produces<unsigned int>();
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+        const unsigned int valueToGet = 31;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+        return true;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        {
+          const unsigned int valueToGet = 31;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 41;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
+    class TestBeginProcessBlockFilter : public edm::limited::EDFilter<edm::BeginProcessBlockProducer> {
+    public:
+      explicit TestBeginProcessBlockFilter(edm::ParameterSet const& pset)
+          : edm::limited::EDFilterBase(pset),
+            edm::limited::EDFilter<edm::BeginProcessBlockProducer>(pset),
+            trans_(pset.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::BeginProcessBlock>("begin")) {
+        produces<unsigned int>();
+        auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void beginProcessBlockProduce(edm::ProcessBlock& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockFilter transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+        const unsigned int valueToPutAndGet = 31;
+        processBlock.emplace(token_, valueToPutAndGet);
+
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlockProduce " << m_count;
+        }
+        ++m_count;
+        return true;
+      }
+
+      ~TestBeginProcessBlockFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
+    class TestEndProcessBlockFilter : public edm::limited::EDFilter<edm::EndProcessBlockProducer> {
+    public:
+      explicit TestEndProcessBlockFilter(edm::ParameterSet const& pset)
+          : edm::limited::EDFilterBase(pset),
+            edm::limited::EDFilter<edm::EndProcessBlockProducer>(pset),
+            trans_(pset.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::EndProcessBlock>("end")) {
+        produces<unsigned int>();
+        auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        ++m_count;
+        return true;
+      }
+
+      void endProcessBlockProduce(edm::ProcessBlock& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestEndProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        const unsigned int valueToPutAndGet = 41;
+        processBlock.emplace(token_, valueToPutAndGet);
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      ~TestEndProcessBlockFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "~TestEndProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
     class TestBeginRunFilter : public edm::limited::EDFilter<edm::RunCache<Dummy>, edm::BeginRunProducer> {
     public:
       explicit TestBeginRunFilter(edm::ParameterSet const& p)
@@ -606,6 +793,9 @@ DEFINE_FWK_MODULE(edmtest::limited::RunIntFilter);
 DEFINE_FWK_MODULE(edmtest::limited::LumiIntFilter);
 DEFINE_FWK_MODULE(edmtest::limited::RunSummaryIntFilter);
 DEFINE_FWK_MODULE(edmtest::limited::LumiSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::limited::ProcessBlockIntFilter);
+DEFINE_FWK_MODULE(edmtest::limited::TestBeginProcessBlockFilter);
+DEFINE_FWK_MODULE(edmtest::limited::TestEndProcessBlockFilter);
 DEFINE_FWK_MODULE(edmtest::limited::TestBeginRunFilter);
 DEFINE_FWK_MODULE(edmtest::limited::TestBeginLumiBlockFilter);
 DEFINE_FWK_MODULE(edmtest::limited::TestEndRunFilter);

--- a/FWCore/Framework/test/stubs/TestLimitedFilters.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedFilters.cc
@@ -433,11 +433,11 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntFilter : public edm::limited::EDFilter<edm::ProcessBlockCache<UnsafeCache>> {
+    class ProcessBlockIntFilter : public edm::limited::EDFilter<edm::WatchProcessBlock> {
     public:
       explicit ProcessBlockIntFilter(edm::ParameterSet const& pset)
           : edm::limited::EDFilterBase(pset),
-            edm::limited::EDFilter<edm::ProcessBlockCache<UnsafeCache>>(pset),
+            edm::limited::EDFilter<edm::WatchProcessBlock>(pset),
             trans_(pset.getParameter<int>("transitions")) {
         produces<unsigned int>();
         {

--- a/FWCore/Framework/test/stubs/TestLimitedProducers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedProducers.cc
@@ -1,7 +1,7 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::limited::EDProducer modules of 
+Toy edm::limited::EDProducer modules of
 edm::*Cache templates and edm::*Producer classes
 for testing purposes only.
 
@@ -18,6 +18,7 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -478,6 +479,192 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntProducer : public edm::limited::EDProducer<edm::ProcessBlockCache<UnsafeCache>> {
+    public:
+      explicit ProcessBlockIntProducer(edm::ParameterSet const& pset)
+          : edm::limited::EDProducerBase(pset),
+            edm::limited::EDProducer<edm::ProcessBlockCache<UnsafeCache>>(pset),
+            trans_(pset.getParameter<int>("transitions")) {
+        produces<unsigned int>();
+
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+        const unsigned int valueToGet = 11;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        {
+          const unsigned int valueToGet = 11;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 21;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
+    class TestBeginProcessBlockProducer : public edm::limited::EDProducer<edm::BeginProcessBlockProducer> {
+    public:
+      explicit TestBeginProcessBlockProducer(edm::ParameterSet const& pset)
+          : edm::limited::EDProducerBase(pset),
+            edm::limited::EDProducer<edm::BeginProcessBlockProducer>(pset),
+            trans_(pset.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::BeginProcessBlock>("begin")) {
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void beginProcessBlockProduce(edm::ProcessBlock& processBlock) const override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+
+        const unsigned int valueToPutAndGet = 11;
+        processBlock.emplace(token_, valueToPutAndGet);
+
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlockProduce " << m_count;
+        }
+        ++m_count;
+      }
+
+      ~TestBeginProcessBlockProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
+    class TestEndProcessBlockProducer : public edm::limited::EDProducer<edm::EndProcessBlockProducer> {
+    public:
+      explicit TestEndProcessBlockProducer(edm::ParameterSet const& pset)
+          : edm::limited::EDProducerBase(pset),
+            edm::limited::EDProducer<edm::EndProcessBlockProducer>(pset),
+            trans_(pset.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::EndProcessBlock>("end")) {
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+      void endProcessBlockProduce(edm::ProcessBlock& processBlock) const override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestEndProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+
+        const unsigned int valueToPutAndGet = 21;
+        processBlock.emplace(token_, valueToPutAndGet);
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      ~TestEndProcessBlockProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "~TestEndProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
     class TestBeginRunProducer : public edm::limited::EDProducer<edm::RunCache<Dummy>, edm::BeginRunProducer> {
     public:
       explicit TestBeginRunProducer(edm::ParameterSet const& p)
@@ -664,6 +851,9 @@ DEFINE_FWK_MODULE(edmtest::limited::LumiIntProducer);
 DEFINE_FWK_MODULE(edmtest::limited::RunSummaryIntProducer);
 DEFINE_FWK_MODULE(edmtest::limited::LumiSummaryIntProducer);
 DEFINE_FWK_MODULE(edmtest::limited::LumiSummaryLumiProducer);
+DEFINE_FWK_MODULE(edmtest::limited::ProcessBlockIntProducer);
+DEFINE_FWK_MODULE(edmtest::limited::TestBeginProcessBlockProducer);
+DEFINE_FWK_MODULE(edmtest::limited::TestEndProcessBlockProducer);
 DEFINE_FWK_MODULE(edmtest::limited::TestBeginRunProducer);
 DEFINE_FWK_MODULE(edmtest::limited::TestEndRunProducer);
 DEFINE_FWK_MODULE(edmtest::limited::TestBeginLumiBlockProducer);

--- a/FWCore/Framework/test/stubs/TestLimitedProducers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedProducers.cc
@@ -479,11 +479,11 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntProducer : public edm::limited::EDProducer<edm::ProcessBlockCache<UnsafeCache>> {
+    class ProcessBlockIntProducer : public edm::limited::EDProducer<edm::WatchProcessBlock> {
     public:
       explicit ProcessBlockIntProducer(edm::ParameterSet const& pset)
           : edm::limited::EDProducerBase(pset),
-            edm::limited::EDProducer<edm::ProcessBlockCache<UnsafeCache>>(pset),
+            edm::limited::EDProducer<edm::WatchProcessBlock>(pset),
             trans_(pset.getParameter<int>("transitions")) {
         produces<unsigned int>();
 

--- a/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
@@ -225,7 +225,7 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntAnalyzer : public edm::one::EDAnalyzer<edm::ProcessBlockCache<an::Cache>> {
+    class ProcessBlockIntAnalyzer : public edm::one::EDAnalyzer<edm::WatchProcessBlock> {
     public:
       explicit ProcessBlockIntAnalyzer(edm::ParameterSet const& pset) : trans_(pset.getParameter<int>("transitions")) {
         {

--- a/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
@@ -1,8 +1,8 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::one::EDAnalyzer modules of 
-edm::one cache templates 
+Toy edm::one::EDAnalyzer modules of
+edm::one cache templates
 for testing purposes only.
 
 ----------------------------------------------------------------------*/
@@ -12,6 +12,7 @@ for testing purposes only.
 #include <map>
 #include <functional>
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -224,6 +225,87 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntAnalyzer : public edm::one::EDAnalyzer<edm::ProcessBlockCache<an::Cache>> {
+    public:
+      explicit ProcessBlockIntAnalyzer(edm::ParameterSet const& pset) : trans_(pset.getParameter<int>("transitions")) {
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+
+        const unsigned int valueToGet = 11;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      void analyze(edm::Event const&, edm::EventSetup const&) override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "analyze before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+
+        {
+          const unsigned int valueToGet = 11;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 21;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntAnalyzer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
   }  // namespace one
 }  // namespace edmtest
 
@@ -232,3 +314,4 @@ DEFINE_FWK_MODULE(edmtest::one::WatchRunsAnalyzer);
 DEFINE_FWK_MODULE(edmtest::one::WatchLumiBlocksAnalyzer);
 DEFINE_FWK_MODULE(edmtest::one::RunCacheAnalyzer);
 DEFINE_FWK_MODULE(edmtest::one::LumiBlockCacheAnalyzer);
+DEFINE_FWK_MODULE(edmtest::one::ProcessBlockIntAnalyzer);

--- a/FWCore/Framework/test/stubs/TestOneFilters.cc
+++ b/FWCore/Framework/test/stubs/TestOneFilters.cc
@@ -1,7 +1,7 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::one::EDFilter modules of 
+Toy edm::one::EDFilter modules of
 edm::one cache classes and edm::*Producer classes
 for testing purposes only.
 
@@ -12,6 +12,7 @@ for testing purposes only.
 #include <map>
 #include <functional>
 #include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/src/WorkerT.h"
@@ -228,6 +229,191 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntFilter : public edm::one::EDFilter<edm::ProcessBlockCache<fltr::Cache>> {
+    public:
+      explicit ProcessBlockIntFilter(edm::ParameterSet const& pset) : trans_(pset.getParameter<int>("transitions")) {
+        produces<unsigned int>();
+
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+
+        const unsigned int valueToGet = 31;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      bool filter(edm::Event&, edm::EventSetup const&) override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+        return true;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+
+        {
+          const unsigned int valueToGet = 31;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 41;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
+    class TestBeginProcessBlockFilter : public edm::one::EDFilter<edm::BeginProcessBlockProducer> {
+    public:
+      explicit TestBeginProcessBlockFilter(edm::ParameterSet const& pset)
+          : trans_(pset.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::BeginProcessBlock>("begin")) {
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void beginProcessBlockProduce(edm::ProcessBlock& processBlock) override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockFilter transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+
+        const unsigned int valueToPutAndGet = 31;
+        processBlock.emplace(token_, valueToPutAndGet);
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      bool filter(edm::Event&, edm::EventSetup const&) override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlockProduce " << m_count;
+        }
+        ++m_count;
+        return true;
+      }
+
+      ~TestBeginProcessBlockFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
+    class TestEndProcessBlockFilter : public edm::one::EDFilter<edm::EndProcessBlockProducer> {
+    public:
+      explicit TestEndProcessBlockFilter(edm::ParameterSet const& pset)
+          : trans_(pset.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::EndProcessBlock>("end")) {
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      bool filter(edm::Event&, edm::EventSetup const&) override {
+        ++m_count;
+        return true;
+      }
+
+      void endProcessBlockProduce(edm::ProcessBlock& processBlock) override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestEndProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+
+        const unsigned int valueToPutAndGet = 41;
+        processBlock.emplace(token_, valueToPutAndGet);
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      ~TestEndProcessBlockFilter() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "~TestEndProcessBlockFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
     class BeginRunFilter : public edm::one::EDFilter<edm::one::WatchRuns, edm::BeginRunProducer> {
     public:
       explicit BeginRunFilter(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
@@ -372,6 +558,9 @@ DEFINE_FWK_MODULE(edmtest::one::WatchRunsFilter);
 DEFINE_FWK_MODULE(edmtest::one::WatchLumiBlocksFilter);
 DEFINE_FWK_MODULE(edmtest::one::RunCacheFilter);
 DEFINE_FWK_MODULE(edmtest::one::LumiBlockCacheFilter);
+DEFINE_FWK_MODULE(edmtest::one::ProcessBlockIntFilter);
+DEFINE_FWK_MODULE(edmtest::one::TestBeginProcessBlockFilter);
+DEFINE_FWK_MODULE(edmtest::one::TestEndProcessBlockFilter);
 DEFINE_FWK_MODULE(edmtest::one::BeginRunFilter);
 DEFINE_FWK_MODULE(edmtest::one::BeginLumiBlockFilter);
 DEFINE_FWK_MODULE(edmtest::one::EndRunFilter);

--- a/FWCore/Framework/test/stubs/TestOneFilters.cc
+++ b/FWCore/Framework/test/stubs/TestOneFilters.cc
@@ -229,7 +229,7 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntFilter : public edm::one::EDFilter<edm::ProcessBlockCache<fltr::Cache>> {
+    class ProcessBlockIntFilter : public edm::one::EDFilter<edm::WatchProcessBlock> {
     public:
       explicit ProcessBlockIntFilter(edm::ParameterSet const& pset) : trans_(pset.getParameter<int>("transitions")) {
         produces<unsigned int>();

--- a/FWCore/Framework/test/stubs/TestOneProducers.cc
+++ b/FWCore/Framework/test/stubs/TestOneProducers.cc
@@ -230,7 +230,7 @@ namespace edmtest {
       }
     };
 
-    class ProcessBlockIntProducer : public edm::one::EDProducer<edm::ProcessBlockCache<prdr::Cache>> {
+    class ProcessBlockIntProducer : public edm::one::EDProducer<edm::WatchProcessBlock> {
     public:
       explicit ProcessBlockIntProducer(edm::ParameterSet const& pset) : trans_(pset.getParameter<int>("transitions")) {
         produces<unsigned int>();

--- a/FWCore/Framework/test/stubs/TestOneProducers.cc
+++ b/FWCore/Framework/test/stubs/TestOneProducers.cc
@@ -1,7 +1,7 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::one::EDProducer modules of 
+Toy edm::one::EDProducer modules of
 edm::one cache classes and edm::*Producer classes
 for testing purposes only.
 
@@ -19,6 +19,7 @@ for testing purposes only.
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -229,6 +230,187 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntProducer : public edm::one::EDProducer<edm::ProcessBlockCache<prdr::Cache>> {
+    public:
+      explicit ProcessBlockIntProducer(edm::ParameterSet const& pset) : trans_(pset.getParameter<int>("transitions")) {
+        produces<unsigned int>();
+
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      void beginProcessBlock(edm::ProcessBlock const& processBlock) override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer::begin transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+
+        const unsigned int valueToGet = 11;
+        if (not getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+          }
+        }
+      }
+
+      void produce(edm::Event&, edm::EventSetup const&) override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << m_count;
+        }
+        ++m_count;
+      }
+
+      void endProcessBlock(edm::ProcessBlock const& processBlock) override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer::end transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+
+        {
+          const unsigned int valueToGet = 11;
+          if (not getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 21;
+          if (not getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      ~ProcessBlockIntProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "ProcessBlockIntProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDGetTokenT<unsigned int> getTokenBegin_;
+      edm::EDGetTokenT<unsigned int> getTokenEnd_;
+    };
+
+    class TestBeginProcessBlockProducer : public edm::one::EDProducer<edm::BeginProcessBlockProducer> {
+    public:
+      explicit TestBeginProcessBlockProducer(edm::ParameterSet const& pset)
+          : trans_(pset.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::BeginProcessBlock>("begin")) {
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void beginProcessBlockProduce(edm::ProcessBlock& processBlock) override {
+        if (m_count != 0) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << m_count << " but it was supposed to be " << 0;
+        }
+        ++m_count;
+
+        const unsigned int valueToPutAndGet = 11;
+        processBlock.emplace(token_, valueToPutAndGet);
+
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      void produce(edm::Event&, edm::EventSetup const&) override {
+        if (m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlockProduce " << m_count;
+        }
+        ++m_count;
+      }
+
+      ~TestBeginProcessBlockProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
+    class TestEndProcessBlockProducer : public edm::one::EDProducer<edm::EndProcessBlockProducer> {
+    public:
+      explicit TestEndProcessBlockProducer(edm::ParameterSet const& pset)
+          : trans_(pset.getParameter<int>("transitions")),
+            token_(produces<unsigned int, edm::Transition::EndProcessBlock>("end")) {
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          getToken_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
+      void endProcessBlockProduce(edm::ProcessBlock& processBlock) override {
+        ++m_count;
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "TestEndProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+
+        const unsigned int valueToPutAndGet = 21;
+        processBlock.emplace(token_, valueToPutAndGet);
+        if (not getToken_.isUninitialized()) {
+          if (processBlock.get(getToken_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(getToken_);
+          }
+        }
+      }
+
+      ~TestEndProcessBlockProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "~TestEndProcessBlockProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+
+    private:
+      const unsigned int trans_;
+      mutable std::atomic<unsigned int> m_count{0};
+      edm::EDPutTokenT<unsigned int> token_;
+      edm::EDGetTokenT<unsigned int> getToken_;
+    };
+
     class TestBeginRunProducer : public edm::one::EDProducer<edm::one::WatchRuns, edm::BeginRunProducer> {
     public:
       explicit TestBeginRunProducer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
@@ -394,6 +576,9 @@ DEFINE_FWK_MODULE(edmtest::one::WatchRunsProducer);
 DEFINE_FWK_MODULE(edmtest::one::WatchLumiBlocksProducer);
 DEFINE_FWK_MODULE(edmtest::one::RunCacheProducer);
 DEFINE_FWK_MODULE(edmtest::one::LumiBlockCacheProducer);
+DEFINE_FWK_MODULE(edmtest::one::ProcessBlockIntProducer);
+DEFINE_FWK_MODULE(edmtest::one::TestBeginProcessBlockProducer);
+DEFINE_FWK_MODULE(edmtest::one::TestEndProcessBlockProducer);
 DEFINE_FWK_MODULE(edmtest::one::TestBeginRunProducer);
 DEFINE_FWK_MODULE(edmtest::one::TestBeginLumiBlockProducer);
 DEFINE_FWK_MODULE(edmtest::one::TestEndRunProducer);

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -453,7 +453,7 @@ namespace edmtest {
     };
 
     class ProcessBlockIntAnalyzer
-        : public edm::stream::EDAnalyzer<edm::ProcessBlockCache<Cache>, edm::GlobalCache<TestGlobalCacheAn>> {
+        : public edm::stream::EDAnalyzer<edm::WatchProcessBlock, edm::GlobalCache<TestGlobalCacheAn>> {
     public:
       explicit ProcessBlockIntAnalyzer(edm::ParameterSet const& pset, TestGlobalCacheAn const* testGlobalCache) {
         {
@@ -476,7 +476,7 @@ namespace edmtest {
         return testGlobalCache;
       }
 
-      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheAn const* testGlobalCache) {
+      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheAn* testGlobalCache) {
         if (testGlobalCache->m_count != 0) {
           throw cms::Exception("transitions") << "ProcessBlockIntAnalyzer::begin transitions "
                                               << testGlobalCache->m_count << " but it was supposed to be " << 0;
@@ -492,7 +492,7 @@ namespace edmtest {
         }
       }
 
-      static std::shared_ptr<Cache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCacheAn const*) {
+      static std::shared_ptr<Cache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCacheAn*) {
         return std::make_shared<Cache>();
       }
 
@@ -504,7 +504,7 @@ namespace edmtest {
         ++testGlobalCache->m_count;
       }
 
-      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheAn const* testGlobalCache) {
+      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheAn* testGlobalCache) {
         ++testGlobalCache->m_count;
         if (testGlobalCache->m_count != testGlobalCache->trans_) {
           throw cms::Exception("transitions") << "ProcessBlockIntAnalyzer::end transitions " << testGlobalCache->m_count

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -1,8 +1,8 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::stream::EDAnalyzer modules of 
-edm::*Cache templates 
+Toy edm::stream::EDAnalyzer modules of
+edm::*Cache templates
 for testing purposes only.
 
 ----------------------------------------------------------------------*/
@@ -19,6 +19,7 @@ for testing purposes only.
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -37,9 +38,16 @@ namespace edmtest {
         mutable std::atomic<unsigned int> run;
         mutable std::atomic<unsigned int> lumi;
       };
+      struct TestGlobalCacheAn {
+        CMS_THREAD_SAFE mutable edm::EDGetTokenT<unsigned int> getTokenBegin_;
+        CMS_THREAD_SAFE mutable edm::EDGetTokenT<unsigned int> getTokenEnd_;
+        unsigned int trans_{0};
+        CMS_THREAD_SAFE mutable std::atomic<unsigned int> m_count{0};
+      };
     }  // namespace cache
 
     using Cache = cache::Cache;
+    using TestGlobalCacheAn = cache::TestGlobalCacheAn;
 
     class GlobalIntAnalyzer : public edm::stream::EDAnalyzer<edm::GlobalCache<Cache>> {
     public:
@@ -444,6 +452,101 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntAnalyzer
+        : public edm::stream::EDAnalyzer<edm::ProcessBlockCache<Cache>, edm::GlobalCache<TestGlobalCacheAn>> {
+    public:
+      explicit ProcessBlockIntAnalyzer(edm::ParameterSet const& pset, TestGlobalCacheAn const* testGlobalCache) {
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            testGlobalCache->getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            testGlobalCache->getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      static std::unique_ptr<TestGlobalCacheAn> initializeGlobalCache(edm::ParameterSet const& pset) {
+        auto testGlobalCache = std::make_unique<TestGlobalCacheAn>();
+        testGlobalCache->trans_ = pset.getParameter<int>("transitions");
+        return testGlobalCache;
+      }
+
+      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheAn const* testGlobalCache) {
+        if (testGlobalCache->m_count != 0) {
+          throw cms::Exception("transitions") << "ProcessBlockIntAnalyzer::begin transitions "
+                                              << testGlobalCache->m_count << " but it was supposed to be " << 0;
+        }
+        ++testGlobalCache->m_count;
+
+        const unsigned int valueToGet = 51;
+        if (not testGlobalCache->getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(testGlobalCache->getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
+          }
+        }
+      }
+
+      static std::shared_ptr<Cache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCacheAn const*) {
+        return std::make_shared<Cache>();
+      }
+
+      void analyze(edm::Event const&, edm::EventSetup const&) override {
+        TestGlobalCacheAn const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << testGlobalCache->m_count;
+        }
+        ++testGlobalCache->m_count;
+      }
+
+      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheAn const* testGlobalCache) {
+        ++testGlobalCache->m_count;
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "ProcessBlockIntAnalyzer::end transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+        {
+          const unsigned int valueToGet = 51;
+          if (not testGlobalCache->getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(testGlobalCache->getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 61;
+          if (not testGlobalCache->getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(testGlobalCache->getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      static void globalEndJob(TestGlobalCacheAn* testGlobalCache) {
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockAnalyzer transitions " << testGlobalCache->m_count
+              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+
+      ~ProcessBlockIntAnalyzer() {
+        TestGlobalCacheAn const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "ProcessBlockIntAnalyzer transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+    };
+
   }  // namespace stream
 }  // namespace edmtest
 std::atomic<unsigned int> edmtest::stream::GlobalIntAnalyzer::m_count{0};
@@ -484,3 +587,4 @@ DEFINE_FWK_MODULE(edmtest::stream::RunIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::stream::LumiIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::stream::RunSummaryIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::stream::LumiSummaryIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::stream::ProcessBlockIntAnalyzer);

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -1,7 +1,7 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::stream::EDFilter modules of 
+Toy edm::stream::EDFilter modules of
 edm::*Cache templates and edm::*Producer classes
 for testing purposes only.
 
@@ -19,6 +19,7 @@ for testing purposes only.
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
@@ -35,9 +36,17 @@ namespace edmtest {
         mutable std::atomic<unsigned int> lumi;
       };
 
+      struct TestGlobalCacheFil {
+        CMS_THREAD_SAFE mutable edm::EDPutTokenT<unsigned int> token_;
+        CMS_THREAD_SAFE mutable edm::EDGetTokenT<unsigned int> getTokenBegin_;
+        CMS_THREAD_SAFE mutable edm::EDGetTokenT<unsigned int> getTokenEnd_;
+        unsigned int trans_{0};
+        CMS_THREAD_SAFE mutable std::atomic<unsigned int> m_count{0};
+      };
     }  // namespace cache
 
     using Cache = cache::Cache;
+    using TestGlobalCacheFil = cache::TestGlobalCacheFil;
 
     class GlobalIntFilter : public edm::stream::EDFilter<edm::GlobalCache<Cache>> {
     public:
@@ -428,6 +437,223 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntFilter
+        : public edm::stream::EDFilter<edm::ProcessBlockCache<Cache>, edm::GlobalCache<TestGlobalCacheFil>> {
+    public:
+      explicit ProcessBlockIntFilter(edm::ParameterSet const& pset, TestGlobalCacheFil const* testGlobalCache) {
+        produces<unsigned int>();
+
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            testGlobalCache->getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            testGlobalCache->getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      static std::unique_ptr<TestGlobalCacheFil> initializeGlobalCache(edm::ParameterSet const& pset) {
+        auto testGlobalCache = std::make_unique<TestGlobalCacheFil>();
+        testGlobalCache->trans_ = pset.getParameter<int>("transitions");
+        return testGlobalCache;
+      }
+
+      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheFil const* testGlobalCache) {
+        if (testGlobalCache->m_count != 0) {
+          throw cms::Exception("transitions") << "ProcessBlockIntFilter::begin transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << 0;
+        }
+        ++testGlobalCache->m_count;
+        const unsigned int valueToGet = 71;
+        if (not testGlobalCache->getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(testGlobalCache->getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
+          }
+        }
+      }
+
+      static std::shared_ptr<Cache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCacheFil const*) {
+        return std::make_shared<Cache>();
+      }
+
+      bool filter(edm::Event&, edm::EventSetup const&) override {
+        TestGlobalCacheFil const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << testGlobalCache->m_count;
+        }
+        ++testGlobalCache->m_count;
+        return true;
+      }
+
+      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheFil const* testGlobalCache) {
+        ++testGlobalCache->m_count;
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "ProcessBlockIntFilter::end transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+        {
+          const unsigned int valueToGet = 71;
+          if (not testGlobalCache->getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(testGlobalCache->getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 81;
+          if (not testGlobalCache->getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(testGlobalCache->getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      static void globalEndJob(TestGlobalCacheFil* testGlobalCache) {
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "ProcessBlockIntFilter transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+
+      ~ProcessBlockIntFilter() {
+        TestGlobalCacheFil const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "ProcessBlockIntFilter transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+    };
+
+    class TestBeginProcessBlockFilter
+        : public edm::stream::EDFilter<edm::BeginProcessBlockProducer, edm::GlobalCache<TestGlobalCacheFil>> {
+    public:
+      explicit TestBeginProcessBlockFilter(edm::ParameterSet const& pset, TestGlobalCacheFil const* testGlobalCache) {
+        testGlobalCache->token_ = produces<unsigned int, edm::Transition::BeginProcessBlock>("begin");
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          testGlobalCache->getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      static std::unique_ptr<TestGlobalCacheFil> initializeGlobalCache(edm::ParameterSet const& pset) {
+        auto testGlobalCache = std::make_unique<TestGlobalCacheFil>();
+        testGlobalCache->trans_ = pset.getParameter<int>("transitions");
+        return testGlobalCache;
+      }
+
+      static void beginProcessBlockProduce(edm::ProcessBlock& processBlock, TestGlobalCacheFil const* testGlobalCache) {
+        if (testGlobalCache->m_count != 0) {
+          throw cms::Exception("transitions") << "TestBeginProcessBlockFilter transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << 0;
+        }
+        ++testGlobalCache->m_count;
+
+        const unsigned int valueToPutAndGet = 71;
+        processBlock.emplace(testGlobalCache->token_, valueToPutAndGet);
+
+        if (not testGlobalCache->getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(testGlobalCache->getTokenBegin_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
+          }
+        }
+      }
+
+      bool filter(edm::Event&, edm::EventSetup const&) override {
+        TestGlobalCacheFil const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count < 1u) {
+          throw cms::Exception("out of sequence")
+              << "produce before beginProcessBlockProduce " << testGlobalCache->m_count;
+        }
+        ++testGlobalCache->m_count;
+        return true;
+      }
+
+      static void globalEndJob(TestGlobalCacheFil* testGlobalCache) {
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "TestBeginProcessBlockFilter transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+
+      ~TestBeginProcessBlockFilter() {
+        TestGlobalCacheFil const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "TestBeginProcessBlockFilter transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+    };
+
+    class TestEndProcessBlockFilter
+        : public edm::stream::EDFilter<edm::EndProcessBlockProducer, edm::GlobalCache<TestGlobalCacheFil>> {
+    public:
+      explicit TestEndProcessBlockFilter(edm::ParameterSet const& pset, TestGlobalCacheFil const* testGlobalCache) {
+        testGlobalCache->token_ = produces<unsigned int, edm::Transition::EndProcessBlock>("end");
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          testGlobalCache->getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      static std::unique_ptr<TestGlobalCacheFil> initializeGlobalCache(edm::ParameterSet const& pset) {
+        auto testGlobalCache = std::make_unique<TestGlobalCacheFil>();
+        testGlobalCache->trans_ = pset.getParameter<int>("transitions");
+        return testGlobalCache;
+      }
+
+      bool filter(edm::Event&, edm::EventSetup const&) override {
+        TestGlobalCacheFil const* testGlobalCache = globalCache();
+        ++testGlobalCache->m_count;
+        return true;
+      }
+
+      static void endProcessBlockProduce(edm::ProcessBlock& processBlock, TestGlobalCacheFil const* testGlobalCache) {
+        ++testGlobalCache->m_count;
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "TestEndProcessBlockFilter transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+
+        const unsigned int valueToPutAndGet = 81;
+        processBlock.emplace(testGlobalCache->token_, valueToPutAndGet);
+        if (not testGlobalCache->getTokenEnd_.isUninitialized()) {
+          if (processBlock.get(testGlobalCache->getTokenEnd_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(testGlobalCache->getTokenEnd_);
+          }
+        }
+      }
+
+      static void globalEndJob(TestGlobalCacheFil* testGlobalCache) {
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "TestEndProcessBlockFilter transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+
+      ~TestEndProcessBlockFilter() {
+        TestGlobalCacheFil const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "~TestEndProcessBlockFilter transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+    };
+
     class TestBeginRunFilter : public edm::stream::EDFilter<edm::RunCache<Cache>, edm::BeginRunProducer> {
     public:
       static std::atomic<unsigned int> m_count;
@@ -719,6 +945,9 @@ DEFINE_FWK_MODULE(edmtest::stream::RunIntFilter);
 DEFINE_FWK_MODULE(edmtest::stream::LumiIntFilter);
 DEFINE_FWK_MODULE(edmtest::stream::RunSummaryIntFilter);
 DEFINE_FWK_MODULE(edmtest::stream::LumiSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::stream::ProcessBlockIntFilter);
+DEFINE_FWK_MODULE(edmtest::stream::TestBeginProcessBlockFilter);
+DEFINE_FWK_MODULE(edmtest::stream::TestEndProcessBlockFilter);
 DEFINE_FWK_MODULE(edmtest::stream::TestBeginRunFilter);
 DEFINE_FWK_MODULE(edmtest::stream::TestEndRunFilter);
 DEFINE_FWK_MODULE(edmtest::stream::TestBeginLumiBlockFilter);

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -438,7 +438,7 @@ namespace edmtest {
     };
 
     class ProcessBlockIntFilter
-        : public edm::stream::EDFilter<edm::ProcessBlockCache<Cache>, edm::GlobalCache<TestGlobalCacheFil>> {
+        : public edm::stream::EDFilter<edm::WatchProcessBlock, edm::GlobalCache<TestGlobalCacheFil>> {
     public:
       explicit ProcessBlockIntFilter(edm::ParameterSet const& pset, TestGlobalCacheFil const* testGlobalCache) {
         produces<unsigned int>();
@@ -463,7 +463,7 @@ namespace edmtest {
         return testGlobalCache;
       }
 
-      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheFil const* testGlobalCache) {
+      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheFil* testGlobalCache) {
         if (testGlobalCache->m_count != 0) {
           throw cms::Exception("transitions") << "ProcessBlockIntFilter::begin transitions " << testGlobalCache->m_count
                                               << " but it was supposed to be " << 0;
@@ -478,7 +478,7 @@ namespace edmtest {
         }
       }
 
-      static std::shared_ptr<Cache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCacheFil const*) {
+      static std::shared_ptr<Cache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCacheFil*) {
         return std::make_shared<Cache>();
       }
 
@@ -491,7 +491,7 @@ namespace edmtest {
         return true;
       }
 
-      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheFil const* testGlobalCache) {
+      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCacheFil* testGlobalCache) {
         ++testGlobalCache->m_count;
         if (testGlobalCache->m_count != testGlobalCache->trans_) {
           throw cms::Exception("transitions") << "ProcessBlockIntFilter::end transitions " << testGlobalCache->m_count

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -459,7 +459,7 @@ namespace edmtest {
     };
 
     class ProcessBlockIntProducer
-        : public edm::stream::EDProducer<edm::ProcessBlockCache<UnsafeCache>, edm::GlobalCache<TestGlobalCache>> {
+        : public edm::stream::EDProducer<edm::WatchProcessBlock, edm::GlobalCache<TestGlobalCache>> {
     public:
       explicit ProcessBlockIntProducer(edm::ParameterSet const& pset, TestGlobalCache const* testGlobalCache) {
         produces<unsigned int>();
@@ -484,7 +484,7 @@ namespace edmtest {
         return testGlobalCache;
       }
 
-      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCache const* testGlobalCache) {
+      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCache* testGlobalCache) {
         if (testGlobalCache->m_count != 0) {
           throw cms::Exception("transitions") << "ProcessBlockIntProducer::begin transitions "
                                               << testGlobalCache->m_count << " but it was supposed to be " << 0;
@@ -500,7 +500,7 @@ namespace edmtest {
         }
       }
 
-      static std::shared_ptr<UnsafeCache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCache const*) {
+      static std::shared_ptr<UnsafeCache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCache*) {
         return std::make_shared<UnsafeCache>();
       }
 
@@ -512,7 +512,7 @@ namespace edmtest {
         ++testGlobalCache->m_count;
       }
 
-      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCache const* testGlobalCache) {
+      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCache* testGlobalCache) {
         ++testGlobalCache->m_count;
         if (testGlobalCache->m_count != testGlobalCache->trans_) {
           throw cms::Exception("transitions") << "ProcessBlockIntProducer::end transitions " << testGlobalCache->m_count

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -1,8 +1,8 @@
 
 /*----------------------------------------------------------------------
 
-Toy edm::stream::EDProducer modules of 
-edm::*Cache templates and edm::*Producer classes 
+Toy edm::stream::EDProducer modules of
+edm::*Cache templates and edm::*Producer classes
 for testing purposes only.
 
 ----------------------------------------------------------------------*/
@@ -19,6 +19,7 @@ for testing purposes only.
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
@@ -42,10 +43,19 @@ namespace edmtest {
         unsigned int lumi;
       };
 
+      struct TestGlobalCache {
+        CMS_THREAD_SAFE mutable edm::EDPutTokenT<unsigned int> token_;
+        CMS_THREAD_SAFE mutable edm::EDGetTokenT<unsigned int> getTokenBegin_;
+        CMS_THREAD_SAFE mutable edm::EDGetTokenT<unsigned int> getTokenEnd_;
+        unsigned int trans_{0};
+        CMS_THREAD_SAFE mutable std::atomic<unsigned int> m_count{0};
+      };
+
     }  // namespace cache
 
     using Cache = cache::Cache;
     using UnsafeCache = cache::UnsafeCache;
+    using TestGlobalCache = cache::TestGlobalCache;
 
     class GlobalIntProducer : public edm::stream::EDProducer<edm::GlobalCache<Cache>> {
     public:
@@ -448,6 +458,225 @@ namespace edmtest {
       }
     };
 
+    class ProcessBlockIntProducer
+        : public edm::stream::EDProducer<edm::ProcessBlockCache<UnsafeCache>, edm::GlobalCache<TestGlobalCache>> {
+    public:
+      explicit ProcessBlockIntProducer(edm::ParameterSet const& pset, TestGlobalCache const* testGlobalCache) {
+        produces<unsigned int>();
+
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+          if (not tag.label().empty()) {
+            testGlobalCache->getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+        {
+          auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+          if (not tag.label().empty()) {
+            testGlobalCache->getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+          }
+        }
+      }
+
+      static std::unique_ptr<TestGlobalCache> initializeGlobalCache(edm::ParameterSet const& pset) {
+        auto testGlobalCache = std::make_unique<TestGlobalCache>();
+        testGlobalCache->trans_ = pset.getParameter<int>("transitions");
+        return testGlobalCache;
+      }
+
+      static void beginProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCache const* testGlobalCache) {
+        if (testGlobalCache->m_count != 0) {
+          throw cms::Exception("transitions") << "ProcessBlockIntProducer::begin transitions "
+                                              << testGlobalCache->m_count << " but it was supposed to be " << 0;
+        }
+        ++testGlobalCache->m_count;
+
+        const unsigned int valueToGet = 51;
+        if (not testGlobalCache->getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(testGlobalCache->getTokenBegin_) != valueToGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
+          }
+        }
+      }
+
+      static std::shared_ptr<UnsafeCache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCache const*) {
+        return std::make_shared<UnsafeCache>();
+      }
+
+      void produce(edm::Event&, edm::EventSetup const&) override {
+        TestGlobalCache const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count < 1u) {
+          throw cms::Exception("out of sequence") << "produce before beginProcessBlock " << testGlobalCache->m_count;
+        }
+        ++testGlobalCache->m_count;
+      }
+
+      static void endProcessBlock(edm::ProcessBlock const& processBlock, TestGlobalCache const* testGlobalCache) {
+        ++testGlobalCache->m_count;
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "ProcessBlockIntProducer::end transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+        {
+          const unsigned int valueToGet = 51;
+          if (not testGlobalCache->getTokenBegin_.isUninitialized()) {
+            if (processBlock.get(testGlobalCache->getTokenBegin_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
+            }
+          }
+        }
+        {
+          const unsigned int valueToGet = 61;
+          if (not testGlobalCache->getTokenEnd_.isUninitialized()) {
+            if (processBlock.get(testGlobalCache->getTokenEnd_) != valueToGet) {
+              throw cms::Exception("BadValue")
+                  << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenEnd_);
+            }
+          }
+        }
+      }
+
+      static void globalEndJob(TestGlobalCache* testGlobalCache) {
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << testGlobalCache->m_count
+              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+
+      ~ProcessBlockIntProducer() {
+        TestGlobalCache const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "ProcessBlockIntProducer transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+    };
+
+    class TestBeginProcessBlockProducer
+        : public edm::stream::EDProducer<edm::BeginProcessBlockProducer, edm::GlobalCache<TestGlobalCache>> {
+    public:
+      explicit TestBeginProcessBlockProducer(edm::ParameterSet const& pset, TestGlobalCache const* testGlobalCache) {
+        testGlobalCache->token_ = produces<unsigned int, edm::Transition::BeginProcessBlock>("begin");
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          testGlobalCache->getTokenBegin_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      static std::unique_ptr<TestGlobalCache> initializeGlobalCache(edm::ParameterSet const& pset) {
+        auto testGlobalCache = std::make_unique<TestGlobalCache>();
+        testGlobalCache->trans_ = pset.getParameter<int>("transitions");
+        return testGlobalCache;
+      }
+
+      static void beginProcessBlockProduce(edm::ProcessBlock& processBlock, TestGlobalCache const* testGlobalCache) {
+        if (testGlobalCache->m_count != 0) {
+          throw cms::Exception("transitions") << "TestBeginProcessBlockProducer transitions "
+                                              << testGlobalCache->m_count << " but it was supposed to be " << 0;
+        }
+        ++testGlobalCache->m_count;
+
+        const unsigned int valueToPutAndGet = 51;
+        processBlock.emplace(testGlobalCache->token_, valueToPutAndGet);
+
+        if (not testGlobalCache->getTokenBegin_.isUninitialized()) {
+          if (processBlock.get(testGlobalCache->getTokenBegin_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
+          }
+        }
+      }
+
+      void produce(edm::Event&, edm::EventSetup const&) override {
+        TestGlobalCache const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count < 1u) {
+          throw cms::Exception("out of sequence")
+              << "produce before beginProcessBlockProduce " << testGlobalCache->m_count;
+        }
+        ++testGlobalCache->m_count;
+      }
+
+      static void globalEndJob(TestGlobalCache* testGlobalCache) {
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << testGlobalCache->m_count
+              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+
+      ~TestBeginProcessBlockProducer() {
+        TestGlobalCache const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << testGlobalCache->m_count
+              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+    };
+
+    class TestEndProcessBlockProducer
+        : public edm::stream::EDProducer<edm::EndProcessBlockProducer, edm::GlobalCache<TestGlobalCache>> {
+    public:
+      explicit TestEndProcessBlockProducer(edm::ParameterSet const& pset, TestGlobalCache const* testGlobalCache) {
+        testGlobalCache->token_ = produces<unsigned int, edm::Transition::EndProcessBlock>("end");
+        produces<unsigned int>();
+
+        auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          testGlobalCache->getTokenEnd_ = consumes<unsigned int, edm::InProcess>(tag);
+        }
+      }
+
+      static std::unique_ptr<TestGlobalCache> initializeGlobalCache(edm::ParameterSet const& pset) {
+        auto testGlobalCache = std::make_unique<TestGlobalCache>();
+        testGlobalCache->trans_ = pset.getParameter<int>("transitions");
+        return testGlobalCache;
+      }
+
+      void produce(edm::Event&, edm::EventSetup const&) override {
+        TestGlobalCache const* testGlobalCache = globalCache();
+        ++testGlobalCache->m_count;
+      }
+
+      static void endProcessBlockProduce(edm::ProcessBlock& processBlock, TestGlobalCache const* testGlobalCache) {
+        ++testGlobalCache->m_count;
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "TestEndProcessBlockProducer transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+        const unsigned int valueToPutAndGet = 61;
+        processBlock.emplace(testGlobalCache->token_, valueToPutAndGet);
+
+        if (not testGlobalCache->getTokenEnd_.isUninitialized()) {
+          if (processBlock.get(testGlobalCache->getTokenEnd_) != valueToPutAndGet) {
+            throw cms::Exception("BadValue")
+                << "expected " << valueToPutAndGet << " but got " << processBlock.get(testGlobalCache->getTokenEnd_);
+          }
+        }
+      }
+
+      static void globalEndJob(TestGlobalCache* testGlobalCache) {
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions")
+              << "TestBeginProcessBlockProducer transitions " << testGlobalCache->m_count
+              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+
+      ~TestEndProcessBlockProducer() {
+        TestGlobalCache const* testGlobalCache = globalCache();
+        if (testGlobalCache->m_count != testGlobalCache->trans_) {
+          throw cms::Exception("transitions") << "~TestEndProcessBlockProducer transitions " << testGlobalCache->m_count
+                                              << " but it was supposed to be " << testGlobalCache->trans_;
+        }
+      }
+    };
+
     class TestBeginRunProducer : public edm::stream::EDProducer<edm::RunCache<bool>, edm::BeginRunProducer> {
     public:
       static std::atomic<unsigned int> m_count;
@@ -757,6 +986,9 @@ DEFINE_FWK_MODULE(edmtest::stream::RunIntProducer);
 DEFINE_FWK_MODULE(edmtest::stream::LumiIntProducer);
 DEFINE_FWK_MODULE(edmtest::stream::RunSummaryIntProducer);
 DEFINE_FWK_MODULE(edmtest::stream::LumiSummaryIntProducer);
+DEFINE_FWK_MODULE(edmtest::stream::ProcessBlockIntProducer);
+DEFINE_FWK_MODULE(edmtest::stream::TestBeginProcessBlockProducer);
+DEFINE_FWK_MODULE(edmtest::stream::TestEndProcessBlockProducer);
 DEFINE_FWK_MODULE(edmtest::stream::TestBeginRunProducer);
 DEFINE_FWK_MODULE(edmtest::stream::TestEndRunProducer);
 DEFINE_FWK_MODULE(edmtest::stream::TestBeginLumiBlockProducer);

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -16,6 +16,7 @@ Toy EDProducers of Ints for testing purposes only.
 #include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,6 +27,7 @@ Toy EDProducers of Ints for testing purposes only.
 #include <cassert>
 #include <string>
 #include <vector>
+#include <unistd.h>
 
 namespace edmtest {
 
@@ -492,18 +494,31 @@ namespace edmtest {
                                                              edm::BeginRunProducer,
                                                              edm::BeginLuminosityBlockProducer,
                                                              edm::EndLuminosityBlockProducer,
-                                                             edm::EndRunProducer> {
+                                                             edm::EndRunProducer,
+                                                             edm::BeginProcessBlockProducer,
+                                                             edm::EndProcessBlockProducer> {
   public:
     explicit NonEventIntProducer(edm::ParameterSet const& p)
-        : brToken_{produces<IntProduct, edm::Transition::BeginRun>("beginRun")},
+        : bpbToken_{produces<IntProduct, edm::Transition::BeginProcessBlock>("beginProcessBlock")},
+          brToken_{produces<IntProduct, edm::Transition::BeginRun>("beginRun")},
           blToken_{produces<IntProduct, edm::Transition::BeginLuminosityBlock>("beginLumi")},
           elToken_{produces<IntProduct, edm::Transition::EndLuminosityBlock>("endLumi")},
           erToken_{produces<IntProduct, edm::Transition::EndRun>("endRun")},
+          epbToken_{produces<IntProduct, edm::Transition::EndProcessBlock>("endProcessBlock")},
           value_(p.getParameter<int>("ivalue")),
+          sleepTime_(p.getParameter<unsigned int>("sleepTime")),
+          bpbExpect_{p.getUntrackedParameter<int>("expectBeginProcessBlock")},
           brExpect_{p.getUntrackedParameter<int>("expectBeginRun")},
           blExpect_{p.getUntrackedParameter<int>("expectBeginLuminosityBlock")},
           elExpect_{p.getUntrackedParameter<int>("expectEndLuminosityBlock")},
-          erExpect_{p.getUntrackedParameter<int>("expectEndRun")} {
+          erExpect_{p.getUntrackedParameter<int>("expectEndRun")},
+          epbExpect_{p.getUntrackedParameter<int>("expectEndProcessBlock")} {
+      {
+        auto tag = p.getParameter<edm::InputTag>("consumesBeginProcessBlock");
+        if (not tag.label().empty()) {
+          bpbGet_ = consumes<IntProduct, edm::InProcess>(tag);
+        }
+      }
       {
         auto tag = p.getParameter<edm::InputTag>("consumesBeginRun");
         if (not tag.label().empty()) {
@@ -528,8 +543,16 @@ namespace edmtest {
           erGet_ = consumes<IntProduct, edm::InRun>(tag);
         }
       }
+      {
+        auto tag = p.getParameter<edm::InputTag>("consumesEndProcessBlock");
+        if (not tag.label().empty()) {
+          epbGet_ = consumes<IntProduct, edm::InProcess>(tag);
+        }
+      }
     }
     void accumulate(edm::StreamID iID, edm::Event const& e, edm::EventSetup const& c) const override;
+    void beginProcessBlockProduce(edm::ProcessBlock&) const override;
+    void endProcessBlockProduce(edm::ProcessBlock&) const override;
     void globalBeginRunProduce(edm::Run& e, edm::EventSetup const&) const override;
     void globalEndRunProduce(edm::Run& e, edm::EventSetup const&) const override;
     void globalBeginLuminosityBlockProduce(edm::LuminosityBlock& e, edm::EventSetup const&) const override;
@@ -538,6 +561,11 @@ namespace edmtest {
     static void fillDescriptions(edm::ConfigurationDescriptions& conf) {
       edm::ParameterSetDescription desc;
       desc.add<int>("ivalue", 0);
+      desc.add<unsigned int>("sleepTime", 0);
+      desc.add<edm::InputTag>("consumesBeginProcessBlock", {});
+      desc.addUntracked<int>("expectBeginProcessBlock", 0);
+      desc.add<edm::InputTag>("consumesEndProcessBlock", {});
+      desc.addUntracked<int>("expectEndProcessBlock", 0);
       desc.add<edm::InputTag>("consumesBeginRun", {});
       desc.addUntracked<int>("expectBeginRun", 0);
       desc.add<edm::InputTag>("consumesEndRun", {});
@@ -552,25 +580,53 @@ namespace edmtest {
 
   private:
     void check(IntProduct, int) const;
+    const edm::EDPutTokenT<IntProduct> bpbToken_;
     const edm::EDPutTokenT<IntProduct> brToken_;
     const edm::EDPutTokenT<IntProduct> blToken_;
     const edm::EDPutTokenT<IntProduct> elToken_;
     const edm::EDPutTokenT<IntProduct> erToken_;
+    const edm::EDPutTokenT<IntProduct> epbToken_;
     const int value_;
+    const unsigned int sleepTime_;
+    edm::EDGetTokenT<IntProduct> bpbGet_;
     edm::EDGetTokenT<IntProduct> brGet_;
     edm::EDGetTokenT<IntProduct> blGet_;
     edm::EDGetTokenT<IntProduct> elGet_;
     edm::EDGetTokenT<IntProduct> erGet_;
+    edm::EDGetTokenT<IntProduct> epbGet_;
+    const int bpbExpect_;
     const int brExpect_;
     const int blExpect_;
     const int elExpect_;
     const int erExpect_;
+    const int epbExpect_;
   };
 
   void NonEventIntProducer::accumulate(edm::StreamID iID, edm::Event const& e, edm::EventSetup const&) const {}
+  void NonEventIntProducer::beginProcessBlockProduce(edm::ProcessBlock& processBlock) const {
+    if (not bpbGet_.isUninitialized()) {
+      check(processBlock.get(bpbGet_), bpbExpect_);
+    }
+    if (sleepTime_ > 0) {
+      usleep(sleepTime_);
+    }
+    processBlock.emplace(bpbToken_, value_);
+  }
+  void NonEventIntProducer::endProcessBlockProduce(edm::ProcessBlock& processBlock) const {
+    if (not epbGet_.isUninitialized()) {
+      check(processBlock.get(epbGet_), epbExpect_);
+    }
+    if (sleepTime_ > 0) {
+      usleep(sleepTime_);
+    }
+    processBlock.emplace(epbToken_, value_);
+  }
   void NonEventIntProducer::globalBeginRunProduce(edm::Run& r, edm::EventSetup const&) const {
     if (not brGet_.isUninitialized()) {
       check(r.get(brGet_), brExpect_);
+    }
+    if (sleepTime_ > 0) {
+      usleep(sleepTime_);
     }
     r.emplace(brToken_, value_);
   }
@@ -578,11 +634,17 @@ namespace edmtest {
     if (not erGet_.isUninitialized()) {
       check(r.get(erGet_), erExpect_);
     }
+    if (sleepTime_ > 0) {
+      usleep(sleepTime_);
+    }
     r.emplace(erToken_, value_);
   }
   void NonEventIntProducer::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& l, edm::EventSetup const&) const {
     if (not blGet_.isUninitialized()) {
       check(l.get(blGet_), blExpect_);
+    }
+    if (sleepTime_ > 0) {
+      usleep(sleepTime_);
     }
     l.emplace(blToken_, value_);
   }
@@ -590,12 +652,65 @@ namespace edmtest {
     if (not elGet_.isUninitialized()) {
       check(l.get(elGet_), elExpect_);
     }
+    if (sleepTime_ > 0) {
+      usleep(sleepTime_);
+    }
     l.emplace(elToken_, value_);
   }
   void NonEventIntProducer::check(IntProduct iProd, int iExpect) const {
     if (iExpect != iProd.value) {
       throw cms::Exception("BadValue") << "expected " << iExpect << " but got " << iProd.value;
     }
+  }
+
+  //--------------------------------------------------------------------
+  //
+  // Produces an IntProduct in ProcessBlock at beginProcessBlock
+  //
+  class IntProducerBeginProcessBlock : public edm::global::EDProducer<edm::BeginProcessBlockProducer> {
+  public:
+    explicit IntProducerBeginProcessBlock(edm::ParameterSet const& p)
+        : token_{produces<IntProduct, edm::Transition::BeginProcessBlock>()}, value_(p.getParameter<int>("ivalue")) {}
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {}
+    void beginProcessBlockProduce(edm::ProcessBlock&) const override;
+
+  private:
+    edm::EDPutTokenT<IntProduct> token_;
+    int value_;
+  };
+
+  void IntProducerBeginProcessBlock::beginProcessBlockProduce(edm::ProcessBlock& processBlock) const {
+    processBlock.emplace(token_, value_);
+  }
+
+  //--------------------------------------------------------------------
+  //
+  // Produces an IntProduct in ProcessBlock at endProcessBlock
+  //
+  class IntProducerEndProcessBlock : public edm::global::EDProducer<edm::EndProcessBlockProducer> {
+  public:
+    explicit IntProducerEndProcessBlock(edm::ParameterSet const& p)
+        : token_{produces<IntProduct, edm::Transition::EndProcessBlock>()},
+          token2_{produces<IntProduct, edm::Transition::EndProcessBlock>("two")},
+          token3_{produces<IntProduct, edm::Transition::EndProcessBlock>("three")},
+          token4_{produces<IntProduct, edm::Transition::EndProcessBlock>("four")},
+          value_(p.getParameter<int>("ivalue")) {}
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {}
+    void endProcessBlockProduce(edm::ProcessBlock&) const override;
+
+  private:
+    edm::EDPutTokenT<IntProduct> token_;
+    edm::EDPutToken token2_;
+    edm::EDPutTokenT<IntProduct> token3_;
+    edm::EDPutToken token4_;
+    int value_;
+  };
+
+  void IntProducerEndProcessBlock::endProcessBlockProduce(edm::ProcessBlock& processBlock) const {
+    processBlock.emplace(token_, value_);
+    processBlock.emplace<IntProduct>(token2_, value_ + 2);
+    processBlock.put(token3_, std::make_unique<IntProduct>(value_ + 3));
+    processBlock.put(token4_, std::make_unique<IntProduct>(value_ + 4));
   }
 }  // namespace edmtest
 
@@ -609,6 +724,8 @@ using edmtest::FailingProducer;
 using edmtest::Int16_tProducer;
 using edmtest::IntLegacyProducer;
 using edmtest::IntProducer;
+using edmtest::IntProducerBeginProcessBlock;
+using edmtest::IntProducerEndProcessBlock;
 using edmtest::IntProducerFromTransient;
 using edmtest::ManyIntProducer;
 using edmtest::ManyIntWhenRegisteredProducer;
@@ -632,3 +749,5 @@ DEFINE_FWK_MODULE(AddIntsProducer);
 DEFINE_FWK_MODULE(ManyIntProducer);
 DEFINE_FWK_MODULE(ManyIntWhenRegisteredProducer);
 DEFINE_FWK_MODULE(NonEventIntProducer);
+DEFINE_FWK_MODULE(IntProducerBeginProcessBlock);
+DEFINE_FWK_MODULE(IntProducerEndProcessBlock);

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -608,6 +608,10 @@ namespace edmtest {
       check(processBlock.get(bpbGet_), bpbExpect_);
     }
     if (sleepTime_ > 0) {
+      // These sleeps are here to force modules to run concurrently
+      // in multi-threaded processes. Otherwise, the modules are so
+      // fast it is hard to tell whether a module finishes before the
+      // the Framework starts the next module.
       usleep(sleepTime_);
     }
     processBlock.emplace(bpbToken_, value_);

--- a/FWCore/Framework/test/test_global_modules_cfg.py
+++ b/FWCore/Framework/test/test_global_modules_cfg.py
@@ -24,7 +24,7 @@ process.source = cms.Source("EmptySource",
     timeBetweenEvents = cms.untracked.uint64(1000),
     firstTime = cms.untracked.uint64(1000000),
     numberEventsInRun = cms.untracked.uint32(nEvtRun),
-    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi) 
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi)
 )
 
 process.StreamIntProd = cms.EDProducer("edmtest::global::StreamIntProducer",
@@ -50,6 +50,32 @@ process.RunSumIntProd = cms.EDProducer("edmtest::global::RunSummaryIntProducer",
 process.LumiSumIntProd = cms.EDProducer("edmtest::global::LumiSummaryIntProducer",
     transitions = cms.int32(int(nStreams*(nEvt/nEvtLumi)+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.ProcessBlockIntProd = cms.EDProducer("edmtest::global::ProcessBlockIntProducer",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
+
+process.TestBeginProcessBlockProd = cms.EDProducer("edmtest::global::TestBeginProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("")
+)
+
+process.TestBeginProcessBlockProdRead = cms.EDProducer("edmtest::global::TestBeginProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin")
+)
+
+process.TestEndProcessBlockProd = cms.EDProducer("edmtest::global::TestEndProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("")
+)
+
+process.TestEndProcessBlockProdRead = cms.EDProducer("edmtest::global::TestEndProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
 )
 
 process.TestBeginRunProd = cms.EDProducer("edmtest::global::TestBeginRunProducer",
@@ -93,6 +119,12 @@ process.LumiSumIntAn = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
+process.ProcessBlockIntAn = cms.EDAnalyzer("edmtest::global::ProcessBlockIntAnalyzer",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
+
 process.StreamIntFil = cms.EDFilter("edmtest::global::StreamIntFilter",
     transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2)))
     ,cachevalue = cms.int32(1)
@@ -116,6 +148,32 @@ process.RunSumIntFil = cms.EDFilter("edmtest::global::RunSummaryIntFilter",
 process.LumiSumIntFil = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
     transitions = cms.int32(int(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.ProcessBlockIntFil = cms.EDFilter("edmtest::global::ProcessBlockIntFilter",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockFil" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockFil", "end")
+)
+
+process.TestBeginProcessBlockFil = cms.EDFilter("edmtest::global::TestBeginProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("")
+)
+
+process.TestBeginProcessBlockFilRead = cms.EDFilter("edmtest::global::TestBeginProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockFil" ,"begin")
+)
+
+process.TestEndProcessBlockFil = cms.EDFilter("edmtest::global::TestEndProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("")
+)
+
+process.TestEndProcessBlockFilRead = cms.EDFilter("edmtest::global::TestEndProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockFil", "end")
 )
 
 process.TestBeginRunFil = cms.EDFilter("edmtest::global::TestBeginRunFilter",
@@ -150,4 +208,40 @@ process.testFilterModule = cms.EDFilter("TestFilterModule",
 process.task = cms.Task(process.TestAccumulator1)
 
 
-process.p = cms.Path(process.StreamIntProd+process.RunIntProd+process.LumiIntProd+process.RunSumIntProd+process.LumiSumIntProd+process.TestBeginRunProd+process.TestEndRunProd+process.TestBeginLumiBlockProd+process.TestEndLumiBlockProd+process.StreamIntAn+process.RunIntAn+process.LumiIntAn+process.RunSumIntAn+process.LumiSumIntAn+process.StreamIntFil+process.RunIntFil+process.LumiIntFil+process.RunSumIntFil+process.LumiSumIntFil+process.TestBeginRunFil+process.TestEndRunFil+process.TestBeginLumiBlockFil+process.TestEndLumiBlockFil+process.testFilterModule+process.TestAccumulator2, process.task)
+process.p = cms.Path(process.StreamIntProd +
+                     process.RunIntProd +
+                     process.LumiIntProd +
+                     process.RunSumIntProd +
+                     process.LumiSumIntProd +
+                     process.ProcessBlockIntProd +
+                     process.TestBeginProcessBlockProdRead +
+                     process.TestBeginProcessBlockProd +
+                     process.TestEndProcessBlockProdRead +
+                     process.TestEndProcessBlockProd +
+                     process.TestBeginRunProd +
+                     process.TestEndRunProd +
+                     process.TestBeginLumiBlockProd +
+                     process.TestEndLumiBlockProd +
+                     process.StreamIntAn +
+                     process.RunIntAn +
+                     process.LumiIntAn +
+                     process.RunSumIntAn +
+                     process.LumiSumIntAn +
+                     process.ProcessBlockIntAn +
+                     process.StreamIntFil +
+                     process.RunIntFil +
+                     process.LumiIntFil +
+                     process.RunSumIntFil +
+                     process.LumiSumIntFil +
+                     process.ProcessBlockIntFil +
+                     process.TestBeginProcessBlockFilRead +
+                     process.TestBeginProcessBlockFil +
+                     process.TestEndProcessBlockFilRead +
+                     process.TestEndProcessBlockFil +
+                     process.TestBeginRunFil +
+                     process.TestEndRunFil +
+                     process.TestBeginLumiBlockFil +
+                     process.TestEndLumiBlockFil +
+                     process.testFilterModule +
+                     process.TestAccumulator2,
+                     process.task)

--- a/FWCore/Framework/test/test_global_modules_cfg.py
+++ b/FWCore/Framework/test/test_global_modules_cfg.py
@@ -120,7 +120,7 @@ process.LumiSumIntAn = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
 )
 
 process.ProcessBlockIntAn = cms.EDAnalyzer("edmtest::global::ProcessBlockIntAnalyzer",
-    transitions = cms.int32(int(nEvt + 2)),
+    transitions = cms.int32(652),
     consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
     consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
 )

--- a/FWCore/Framework/test/test_limited_modules_cfg.py
+++ b/FWCore/Framework/test/test_limited_modules_cfg.py
@@ -24,10 +24,8 @@ process.source = cms.Source("EmptySource",
     timeBetweenEvents = cms.untracked.uint64(1000),
     firstTime = cms.untracked.uint64(1000000),
     numberEventsInRun = cms.untracked.uint32(nEvtRun),
-    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi) 
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi)
 )
-
-#process.Tracer = cms.Service("Tracer")
 
 process.StreamIntProd = cms.EDProducer("edmtest::limited::StreamIntProducer",
     concurrencyLimit = cms.untracked.uint32(1),
@@ -57,6 +55,37 @@ process.LumiSumIntProd = cms.EDProducer("edmtest::limited::LumiSummaryIntProduce
                                         concurrencyLimit = cms.untracked.uint32(1),
     transitions = cms.int32(nStreams*int(nEvt/nEvtLumi)+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.ProcessBlockIntProd = cms.EDProducer("edmtest::limited::ProcessBlockIntProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
+
+process.TestBeginProcessBlockProd = cms.EDProducer("edmtest::limited::TestBeginProcessBlockProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("")
+)
+
+process.TestBeginProcessBlockProdRead = cms.EDProducer("edmtest::limited::TestBeginProcessBlockProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin")
+)
+
+process.TestEndProcessBlockProd = cms.EDProducer("edmtest::limited::TestEndProcessBlockProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("")
+)
+
+process.TestEndProcessBlockProdRead = cms.EDProducer("edmtest::limited::TestEndProcessBlockProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
 )
 
 process.TestBeginRunProd = cms.EDProducer("edmtest::limited::TestBeginRunProducer",
@@ -109,6 +138,13 @@ process.LumiSumIntAn = cms.EDAnalyzer("edmtest::limited::LumiSummaryIntAnalyzer"
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
+process.ProcessBlockIntAn = cms.EDAnalyzer("edmtest::limited::ProcessBlockIntAnalyzer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
+
 process.StreamIntFil = cms.EDFilter("edmtest::limited::StreamIntFilter",
                                     concurrencyLimit = cms.untracked.uint32(1),
     transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2*int(nEvt/nEvtLumi)+2))
@@ -137,6 +173,37 @@ process.LumiSumIntFil = cms.EDFilter("edmtest::limited::LumiSummaryIntFilter",
                                      concurrencyLimit = cms.untracked.uint32(1),
     transitions = cms.int32(nEvt+nStreams*(int(nEvt/nEvtLumi)+1)+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.ProcessBlockIntFil = cms.EDFilter("edmtest::limited::ProcessBlockIntFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockFil" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockFil", "end")
+)
+
+process.TestBeginProcessBlockFil = cms.EDFilter("edmtest::limited::TestBeginProcessBlockFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("")
+)
+
+process.TestBeginProcessBlockFilRead = cms.EDFilter("edmtest::limited::TestBeginProcessBlockFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockFil" ,"begin")
+)
+
+process.TestEndProcessBlockFil = cms.EDFilter("edmtest::limited::TestEndProcessBlockFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("")
+)
+
+process.TestEndProcessBlockFilRead = cms.EDFilter("edmtest::limited::TestEndProcessBlockFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockFil", "end")
 )
 
 process.TestBeginRunFil = cms.EDFilter("edmtest::limited::TestBeginRunFilter",
@@ -177,4 +244,40 @@ process.testFilterModule = cms.EDFilter("TestFilterModule",
 process.task = cms.Task(process.TestAccumulator1)
 
 
-process.p = cms.Path(process.StreamIntProd+process.RunIntProd+process.LumiIntProd+process.RunSumIntProd+process.LumiSumIntProd+process.TestBeginRunProd+process.TestEndRunProd+process.TestBeginLumiBlockProd+process.TestEndLumiBlockProd+process.StreamIntAn+process.RunIntAn+process.LumiIntAn+process.RunSumIntAn+process.LumiSumIntAn+process.StreamIntFil+process.RunIntFil+process.LumiIntFil+process.RunSumIntFil+process.LumiSumIntFil+process.TestBeginRunFil+process.TestEndRunFil+process.TestBeginLumiBlockFil+process.TestEndLumiBlockFil+process.testFilterModule+process.TestAccumulator2, process.task)
+process.p = cms.Path(process.StreamIntProd +
+                     process.RunIntProd +
+                     process.LumiIntProd +
+                     process.RunSumIntProd +
+                     process.LumiSumIntProd +
+                     process.ProcessBlockIntProd +
+                     process.TestBeginProcessBlockProd +
+                     process.TestBeginProcessBlockProdRead +
+                     process.TestEndProcessBlockProd +
+                     process.TestEndProcessBlockProdRead +
+                     process.TestBeginRunProd +
+                     process.TestEndRunProd +
+                     process.TestBeginLumiBlockProd +
+                     process.TestEndLumiBlockProd +
+                     process.StreamIntAn +
+                     process.RunIntAn +
+                     process.LumiIntAn +
+                     process.RunSumIntAn +
+                     process.LumiSumIntAn +
+                     process.ProcessBlockIntAn +
+                     process.StreamIntFil +
+                     process.RunIntFil +
+                     process.LumiIntFil +
+                     process.RunSumIntFil +
+                     process.LumiSumIntFil +
+                     process.ProcessBlockIntFil +
+                     process.TestBeginProcessBlockFil +
+                     process.TestBeginProcessBlockFilRead +
+                     process.TestEndProcessBlockFil +
+                     process.TestEndProcessBlockFilRead +
+                     process.TestBeginRunFil +
+                     process.TestEndRunFil +
+                     process.TestBeginLumiBlockFil +
+                     process.TestEndLumiBlockFil +
+                     process.testFilterModule +
+                     process.TestAccumulator2,
+                     process.task)

--- a/FWCore/Framework/test/test_non_event_ordering.sh
+++ b/FWCore/Framework/test/test_non_event_ordering.sh
@@ -9,3 +9,9 @@ cmsRun $TEST_DIR/test_non_event_ordering_beginLumi_cfg.py || die "begin Lumi tes
 cmsRun $TEST_DIR/test_non_event_ordering_beginRun_cfg.py || die "begin Run test failed" $?
 cmsRun $TEST_DIR/test_non_event_ordering_endLumi_cfg.py  || die "end Lumi test failed" $?
 cmsRun $TEST_DIR/test_non_event_ordering_endRun_cfg.py || die "end Run test failed" $?
+echo test_non_event_ordering_beginProcessBlock_cfg.py
+cmsRun $TEST_DIR/test_non_event_ordering_beginProcessBlock_cfg.py || die "begin ProcessBlock test failed" $?
+echo test_non_event_ordering_endProcessBlock_cfg.py
+cmsRun $TEST_DIR/test_non_event_ordering_endProcessBlock_cfg.py || die "end Process block test failed" $?
+echo test_non_event_ordering_multithreaded_cfg.py
+cmsRun $TEST_DIR/test_non_event_ordering_multithreaded_cfg.py || die "multithreaded test failed" $?

--- a/FWCore/Framework/test/test_non_event_ordering.sh
+++ b/FWCore/Framework/test/test_non_event_ordering.sh
@@ -5,9 +5,13 @@ function die { echo $1: status $2 ;  exit $2; }
 
 TEST_DIR=src/FWCore/Framework/test
 
+echo test_non_event_ordering_beginLumi_cfg.py
 cmsRun $TEST_DIR/test_non_event_ordering_beginLumi_cfg.py || die "begin Lumi test failed" $?
+echo test_non_event_ordering_beginRun_cfg.py
 cmsRun $TEST_DIR/test_non_event_ordering_beginRun_cfg.py || die "begin Run test failed" $?
+echo test_non_event_ordering_endLumi_cfg.py
 cmsRun $TEST_DIR/test_non_event_ordering_endLumi_cfg.py  || die "end Lumi test failed" $?
+echo test_non_event_ordering_endRun_cfg.py
 cmsRun $TEST_DIR/test_non_event_ordering_endRun_cfg.py || die "end Run test failed" $?
 echo test_non_event_ordering_beginProcessBlock_cfg.py
 cmsRun $TEST_DIR/test_non_event_ordering_beginProcessBlock_cfg.py || die "begin ProcessBlock test failed" $?

--- a/FWCore/Framework/test/test_non_event_ordering_beginProcessBlock_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_beginProcessBlock_cfg.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 3
+
+process.d = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(1))
+process.b = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(2),
+                           consumesBeginProcessBlock = cms.InputTag("c","beginProcessBlock"),
+                           expectBeginProcessBlock = cms.untracked.int32(3) )
+process.c = cms.EDProducer("NonEventIntProducer", ivalue = cms.int32(3),
+                           consumesBeginProcessBlock = cms.InputTag("d", "beginProcessBlock"),
+                           expectBeginProcessBlock = cms.untracked.int32(1))
+
+process.t = cms.Task(process.d, process.c)
+process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_endProcessBlock_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_endProcessBlock_cfg.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 3
+
+process.d = cms.EDProducer("NonEventIntProducer",
+                           ivalue = cms.int32(1))
+process.b = cms.EDProducer("NonEventIntProducer",
+                           ivalue = cms.int32(2),
+                           consumesEndProcessBlock = cms.InputTag("c","endProcessBlock"),
+                           expectEndProcessBlock = cms.untracked.int32(3) )
+process.c = cms.EDProducer("NonEventIntProducer",
+                           ivalue = cms.int32(3),
+                           consumesEndProcessBlock = cms.InputTag("d", "endProcessBlock"),
+                           expectEndProcessBlock = cms.untracked.int32(1) )
+
+process.t = cms.Task(process.d, process.c)
+process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_non_event_ordering_multithreaded_cfg.py
+++ b/FWCore/Framework/test/test_non_event_ordering_multithreaded_cfg.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.options = cms.untracked.PSet(
+                            numberOfStreams = cms.untracked.uint32(3),
+                            numberOfThreads = cms.untracked.uint32(3)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 3
+
+process.d = cms.EDProducer("NonEventIntProducer",
+                           ivalue = cms.int32(1))
+
+process.b = cms.EDProducer("NonEventIntProducer",
+                           ivalue = cms.int32(2),
+                           sleepTime = cms.uint32(3000),
+                           consumesBeginProcessBlock = cms.InputTag("c","beginProcessBlock"),
+                           expectBeginProcessBlock = cms.untracked.int32(3),
+                           consumesBeginRun = cms.InputTag("c","beginRun"),
+                           expectBeginRun = cms.untracked.int32(3),
+                           consumesBeginLuminosityBlock = cms.InputTag("c","beginLumi"),
+                           expectBeginLuminosityBlock = cms.untracked.int32(3),
+                           consumesEndLuminosityBlock = cms.InputTag("c","endLumi"),
+                           expectEndLuminosityBlock = cms.untracked.int32(3),
+                           consumesEndRun = cms.InputTag("c","endRun"),
+                           expectEndRun = cms.untracked.int32(3),
+                           consumesEndProcessBlock = cms.InputTag("c","endProcessBlock"),
+                           expectEndProcessBlock = cms.untracked.int32(3)
+)
+
+process.c = cms.EDProducer("NonEventIntProducer",
+                           ivalue = cms.int32(3),
+                           sleepTime = cms.uint32(3000),
+                           consumesBeginProcessBlock = cms.InputTag("d","beginProcessBlock"),
+                           expectBeginProcessBlock = cms.untracked.int32(1),
+                           consumesBeginRun = cms.InputTag("d","beginRun"),
+                           expectBeginRun = cms.untracked.int32(1),
+                           consumesBeginLuminosityBlock = cms.InputTag("d","beginLumi"),
+                           expectBeginLuminosityBlock = cms.untracked.int32(1),
+                           consumesEndLuminosityBlock = cms.InputTag("d","endLumi"),
+                           expectEndLuminosityBlock = cms.untracked.int32(1),
+                           consumesEndRun = cms.InputTag("d","endRun"),
+                           expectEndRun = cms.untracked.int32(1),
+                           consumesEndProcessBlock = cms.InputTag("d", "endProcessBlock"),
+                           expectEndProcessBlock = cms.untracked.int32(1)
+)
+
+process.t = cms.Task(process.d, process.c)
+process.p = cms.Path(process.b, process.t)

--- a/FWCore/Framework/test/test_one_modules_cfg.py
+++ b/FWCore/Framework/test/test_one_modules_cfg.py
@@ -23,7 +23,7 @@ process.source = cms.Source("EmptySource",
     timeBetweenEvents = cms.untracked.uint64(10),
     firstTime = cms.untracked.uint64(1000000),
     numberEventsInRun = cms.untracked.uint32(nEvtRun),
-    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi) 
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi)
 )
 
 #process.Tracer = cms.Service("Tracer")
@@ -47,6 +47,32 @@ process.RunCacheProd = cms.EDProducer("edmtest::one::RunCacheProducer",
 process.LumiBlockCacheProd = cms.EDProducer("edmtest::one::LumiBlockCacheProducer",
                                           transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
                                           )
+
+process.ProcessBlockIntProd = cms.EDProducer("edmtest::one::ProcessBlockIntProducer",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
+
+process.TestBeginProcessBlockProd = cms.EDProducer("edmtest::one::TestBeginProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("")
+)
+
+process.TestBeginProcessBlockProdRead = cms.EDProducer("edmtest::one::TestBeginProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin")
+)
+
+process.TestEndProcessBlockProd = cms.EDProducer("edmtest::one::TestEndProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("")
+)
+
+process.TestEndProcessBlockProdRead = cms.EDProducer("edmtest::one::TestEndProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
 
 process.BeginRunProd = cms.EDProducer("edmtest::one::TestBeginRunProducer",
     transitions = cms.int32(nEvt+int(nEvt/nEvtRun))
@@ -85,6 +111,12 @@ process.LumiBlockCacheAn = cms.EDAnalyzer("edmtest::one::LumiBlockCacheAnalyzer"
                                           transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
                                           )
 
+process.ProcessBlockIntAn = cms.EDAnalyzer("edmtest::one::ProcessBlockIntAnalyzer",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
+
 process.SharedResFil = cms.EDFilter("edmtest::one::SharedResourcesFilter",
     transitions = cms.int32(nEvt)
 )
@@ -103,6 +135,32 @@ process.RunCacheFil = cms.EDFilter("edmtest::one::RunCacheFilter",
 process.LumiBlockCacheFil = cms.EDFilter("edmtest::one::LumiBlockCacheFilter",
                                           transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
                                           )
+
+process.ProcessBlockIntFil = cms.EDFilter("edmtest::one::ProcessBlockIntFilter",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockFil" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockFil", "end")
+)
+
+process.TestBeginProcessBlockFil = cms.EDFilter("edmtest::one::TestBeginProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("")
+)
+
+process.TestBeginProcessBlockFilRead = cms.EDFilter("edmtest::one::TestBeginProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockFil" ,"begin")
+)
+
+process.TestEndProcessBlockFil = cms.EDFilter("edmtest::one::TestEndProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("")
+)
+
+process.TestEndProcessBlockFilRead = cms.EDFilter("edmtest::one::TestEndProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockFil", "end")
+)
 
 process.BeginRunFil = cms.EDFilter("edmtest::one::BeginRunFilter",
     transitions = cms.int32(nEvt+int(nEvt/nEvtRun))
@@ -136,6 +194,40 @@ process.testFilterModule = cms.EDFilter("TestFilterModule",
 process.task = cms.Task(process.TestAccumulator1)
 
 
-process.p = cms.Path(process.SharedResProd+process.WatchRunProd+process.WatchLumiBlockProd+process.RunCacheProd+process.LumiBlockCacheProd+process.BeginRunProd+process.BeginLumiBlockProd+process.EndRunProd+process.EndLumiBlockProd+process.SharedResAn+process.WatchRunAn+process.WatchLumiBlockAn+process.RunCacheAn+process.LumiBlockCacheAn+process.SharedResFil+process.WatchRunFil+process.WatchLumiBlockFil+process.RunCacheFil+process.LumiBlockCacheFil+process.BeginRunFil+process.BeginLumiBlockFil+process.EndRunFil+process.EndLumiBlockFil+process.testFilterModule+process.TestAccumulator2, process.task)
-
-
+process.p = cms.Path(process.SharedResProd +
+                     process.WatchRunProd +
+                     process.WatchLumiBlockProd +
+                     process.RunCacheProd +
+                     process.LumiBlockCacheProd +
+                     process.ProcessBlockIntProd +
+                     process.TestBeginProcessBlockProd +
+                     process.TestBeginProcessBlockProdRead +
+                     process.TestEndProcessBlockProd +
+                     process.TestEndProcessBlockProdRead +
+                     process.BeginRunProd +
+                     process.BeginLumiBlockProd +
+                     process.EndRunProd +
+                     process.EndLumiBlockProd +
+                     process.SharedResAn +
+                     process.WatchRunAn +
+                     process.WatchLumiBlockAn +
+                     process.RunCacheAn +
+                     process.LumiBlockCacheAn +
+                     process.ProcessBlockIntAn +
+                     process.SharedResFil +
+                     process.WatchRunFil +
+                     process.WatchLumiBlockFil +
+                     process.RunCacheFil +
+                     process.LumiBlockCacheFil +
+                     process.ProcessBlockIntFil +
+                     process.TestBeginProcessBlockFil +
+                     process.TestBeginProcessBlockFilRead +
+                     process.TestEndProcessBlockFil +
+                     process.TestEndProcessBlockFilRead +
+                     process.BeginRunFil +
+                     process.BeginLumiBlockFil +
+                     process.EndRunFil +
+                     process.EndLumiBlockFil +
+                     process.testFilterModule +
+                     process.TestAccumulator2,
+                     process.task)

--- a/FWCore/Framework/test/test_stream_modules_cfg.py
+++ b/FWCore/Framework/test/test_stream_modules_cfg.py
@@ -22,7 +22,7 @@ process.source = cms.Source("EmptySource",
     timeBetweenEvents = cms.untracked.uint64(1000),
     firstTime = cms.untracked.uint64(1000000),
     numberEventsInRun = cms.untracked.uint32(nEvtRun),
-    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi) 
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi)
 )
 
 #process.Tracer = cms.Service("Tracer")
@@ -51,6 +51,32 @@ process.RunSumIntProd = cms.EDProducer("edmtest::stream::RunSummaryIntProducer",
 process.LumiSumIntProd = cms.EDProducer("edmtest::stream::LumiSummaryIntProducer",
     transitions = cms.int32(nEvt+4*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.ProcessBlockIntProd = cms.EDProducer("edmtest::stream::ProcessBlockIntProducer",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
+
+process.TestBeginProcessBlockProd = cms.EDProducer("edmtest::stream::TestBeginProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("")
+)
+
+process.TestBeginProcessBlockProdRead = cms.EDProducer("edmtest::stream::TestBeginProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin")
+)
+
+process.TestEndProcessBlockProd = cms.EDProducer("edmtest::stream::TestEndProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("")
+)
+
+process.TestEndProcessBlockProdRead = cms.EDProducer("edmtest::stream::TestEndProcessBlockProducer",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
 )
 
 process.TestBeginRunProd = cms.EDProducer("edmtest::stream::TestBeginRunProducer",
@@ -99,6 +125,12 @@ process.LumiSumIntAn = cms.EDAnalyzer("edmtest::stream::LumiSummaryIntAnalyzer",
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
+process.ProcessBlockIntAn = cms.EDAnalyzer("edmtest::stream::ProcessBlockIntAnalyzer",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockProd" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
+)
+
 process.GlobIntFil = cms.EDFilter("edmtest::stream::GlobalIntFilter",
     transitions = cms.int32(nEvt+3)
     ,cachevalue = cms.int32(nEvt)
@@ -123,6 +155,33 @@ process.LumiSumIntFil = cms.EDFilter("edmtest::stream::LumiSummaryIntFilter",
     transitions = cms.int32(nEvt+4*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
+
+process.ProcessBlockIntFil = cms.EDFilter("edmtest::stream::ProcessBlockIntFilter",
+    transitions = cms.int32(int(nEvt + 2)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockFil" ,"begin"),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockFil", "end")
+)
+
+process.TestBeginProcessBlockFil = cms.EDFilter("edmtest::stream::TestBeginProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("")
+)
+
+process.TestBeginProcessBlockFilRead = cms.EDFilter("edmtest::stream::TestBeginProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesBeginProcessBlock = cms.InputTag("TestBeginProcessBlockFil", "begin")
+)
+
+process.TestEndProcessBlockFil = cms.EDFilter("edmtest::stream::TestEndProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("")
+)
+
+process.TestEndProcessBlockFilRead = cms.EDFilter("edmtest::stream::TestEndProcessBlockFilter",
+    transitions = cms.int32(int(nEvt + 1)),
+    consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockFil", "end")
+)
+
 process.TestBeginRunFil = cms.EDFilter("edmtest::stream::TestBeginRunFilter",
     transitions = cms.int32(nEvt+3*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvt)
@@ -158,5 +217,40 @@ process.testFilterModule = cms.EDFilter("TestFilterModule",
 
 process.task = cms.Task(process.TestAccumulator1)
 
-process.p = cms.Path(process.GlobIntProd+process.RunIntProd+process.LumiIntProd+process.RunSumIntProd+process.LumiSumIntProd+process.TestBeginRunProd+process.TestEndRunProd+process.TestBeginLumiBlockProd+process.TestEndLumiBlockProd+process.GlobIntAn+process.RunIntAn+process.LumiIntAn+process.RunSumIntAn+process.LumiSumIntAn+process.GlobIntFil+process.RunIntFil+process.LumiIntFil+process.RunSumIntFil+process.LumiSumIntFil+process.TestBeginRunFil+process.TestEndRunFil+process.TestBeginLumiBlockFil+process.TestEndLumiBlockFil+process.testFilterModule+process.TestAccumulator2, process.task)
-
+process.p = cms.Path(process.GlobIntProd +
+                     process.RunIntProd +
+                     process.LumiIntProd +
+                     process.RunSumIntProd +
+                     process.LumiSumIntProd +
+                     process.ProcessBlockIntProd +
+                     process.TestBeginProcessBlockProdRead +
+                     process.TestBeginProcessBlockProd +
+                     process.TestEndProcessBlockProdRead +
+                     process.TestEndProcessBlockProd +
+                     process.TestBeginRunProd +
+                     process.TestEndRunProd +
+                     process.TestBeginLumiBlockProd +
+                     process.TestEndLumiBlockProd +
+                     process.GlobIntAn +
+                     process.RunIntAn +
+                     process.LumiIntAn +
+                     process.RunSumIntAn +
+                     process.LumiSumIntAn +
+                     process.ProcessBlockIntAn +
+                     process.GlobIntFil +
+                     process.RunIntFil +
+                     process.LumiIntFil +
+                     process.RunSumIntFil +
+                     process.LumiSumIntFil +
+                     process.ProcessBlockIntFil +
+                     process.TestBeginProcessBlockFil +
+                     process.TestBeginProcessBlockFilRead +
+                     process.TestEndProcessBlockFil +
+                     process.TestEndProcessBlockFilRead +
+                     process.TestBeginRunFil +
+                     process.TestEndRunFil +
+                     process.TestBeginLumiBlockFil +
+                     process.TestEndLumiBlockFil +
+                     process.testFilterModule +
+                     process.TestAccumulator2,
+                     process.task)

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -71,6 +71,8 @@ ModuleCallingContext state = Running
 ++++ finished: begin stream for module: stream = 0 label = 'result2' id = 6
 ++++ starting: begin stream for module: stream = 0 label = 'result4' id = 7
 ++++ finished: begin stream for module: stream = 0 label = 'result4' id = 7
+++++ starting: begin process block
+++++ finished: begin process block
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
@@ -547,6 +549,10 @@ ModuleCallingContext state = Running
 ++++ finished: global end run 1 : time = 1000030
 ++++ starting: global write run 1 : time = 1000030
 ++++ finished: global write run 1 : time = 1000030
+++++ starting: end process block
+++++ finished: end process block
+++++ starting: write process block
+++++ finished: write process block
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'get' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -39,6 +39,8 @@
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
+++++ starting: begin process block
+++++ finished: begin process block
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
@@ -179,6 +181,10 @@
 ++++ finished: global end run 1 : time = 1000030
 ++++ starting: global write run 1 : time = 1000030
 ++++ finished: global write run 1 : time = 1000030
+++++ starting: end process block
+++++ finished: end process block
+++++ starting: write process block
+++++ finished: write process block
 ++++ starting: end stream for module: stream = 0 label = 'one' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'one' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'getOne' id = 4

--- a/FWCore/Integration/test/TestFindProduct.cc
+++ b/FWCore/Integration/test/TestFindProduct.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/getProducerParameterSet.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/BranchType.h"
@@ -29,7 +30,12 @@
 #include <vector>
 
 namespace edmtest {
-  class TestFindProduct : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+
+  struct DummyTestFindProduct {};
+
+  class TestFindProduct : public edm::one::EDAnalyzer<edm::one::WatchRuns,
+                                                      edm::one::WatchLuminosityBlocks,
+                                                      edm::ProcessBlockCache<DummyTestFindProduct>> {
   public:
     explicit TestFindProduct(edm::ParameterSet const& pset);
     virtual ~TestFindProduct();
@@ -39,6 +45,8 @@ namespace edmtest {
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
     void beginRun(edm::Run const&, edm::EventSetup const&) override;
     void endRun(edm::Run const&, edm::EventSetup const&) override;
+    void beginProcessBlock(edm::ProcessBlock const&) override;
+    void endProcessBlock(edm::ProcessBlock const&) override;
     void endJob() override;
 
   private:
@@ -52,6 +60,11 @@ namespace edmtest {
     std::vector<edm::InputTag> inputTagsUInt64_;
     std::vector<edm::InputTag> inputTagsEndLumi_;
     std::vector<edm::InputTag> inputTagsEndRun_;
+    std::vector<edm::InputTag> inputTagsBeginProcessBlock_;
+    std::vector<edm::InputTag> inputTagsEndProcessBlock_;
+    std::vector<edm::InputTag> inputTagsEndProcessBlock2_;
+    std::vector<edm::InputTag> inputTagsEndProcessBlock3_;
+    std::vector<edm::InputTag> inputTagsEndProcessBlock4_;
 
     std::vector<edm::EDGetTokenT<IntProduct>> tokens_;
     std::vector<edm::EDGetTokenT<IntProduct>> tokensNotFound_;
@@ -59,6 +72,11 @@ namespace edmtest {
     std::vector<edm::EDGetTokenT<UInt64Product>> tokensUInt64_;
     std::vector<edm::EDGetTokenT<IntProduct>> tokensEndLumi_;
     std::vector<edm::EDGetTokenT<IntProduct>> tokensEndRun_;
+    std::vector<edm::EDGetTokenT<IntProduct>> tokensBeginProcessBlock_;
+    std::vector<edm::EDGetTokenT<IntProduct>> tokensEndProcessBlock_;
+    std::vector<edm::EDGetToken> tokensEndProcessBlock2_;
+    std::vector<edm::EDGetTokenT<IntProduct>> tokensEndProcessBlock3_;
+    std::vector<edm::EDGetTokenT<IntProduct>> tokensEndProcessBlock4_;
   };  // class TestFindProduct
 
   //--------------------------------------------------------------------
@@ -79,6 +97,16 @@ namespace edmtest {
     inputTagsUInt64_ = pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsUInt64", emptyTagVector);
     inputTagsEndLumi_ = pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsEndLumi", emptyTagVector);
     inputTagsEndRun_ = pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsEndRun", emptyTagVector);
+    inputTagsBeginProcessBlock_ =
+        pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsBeginProcessBlock", emptyTagVector);
+    inputTagsEndProcessBlock_ =
+        pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsEndProcessBlock", emptyTagVector);
+    inputTagsEndProcessBlock2_ =
+        pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsEndProcessBlock2", emptyTagVector);
+    inputTagsEndProcessBlock3_ =
+        pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsEndProcessBlock3", emptyTagVector);
+    inputTagsEndProcessBlock4_ =
+        pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsEndProcessBlock4", emptyTagVector);
 
     for (auto const& tag : inputTags_) {
       tokens_.push_back(consumes<IntProduct>(tag));
@@ -97,6 +125,21 @@ namespace edmtest {
     }
     for (auto const& tag : inputTagsEndRun_) {
       tokensEndRun_.push_back(consumes<IntProduct, edm::InRun>(tag));
+    }
+    for (auto const& tag : inputTagsBeginProcessBlock_) {
+      tokensBeginProcessBlock_.push_back(consumes<IntProduct, edm::InProcess>(tag));
+    }
+    for (auto const& tag : inputTagsEndProcessBlock_) {
+      tokensEndProcessBlock_.push_back(consumes<IntProduct, edm::InProcess>(tag));
+    }
+    for (auto const& tag : inputTagsEndProcessBlock2_) {
+      tokensEndProcessBlock2_.push_back(consumes<IntProduct, edm::InProcess>(tag));
+    }
+    for (auto const& tag : inputTagsEndProcessBlock3_) {
+      tokensEndProcessBlock3_.push_back(consumes<IntProduct, edm::InProcess>(tag));
+    }
+    for (auto const& tag : inputTagsEndProcessBlock4_) {
+      tokensEndProcessBlock4_.push_back(consumes<IntProduct, edm::InProcess>(tag));
     }
   }
 
@@ -208,6 +251,44 @@ namespace edmtest {
     for (auto const& token : tokensEndRun_) {
       run.getByToken(token, h);
       sum_ += h->value;
+    }
+  }
+
+  void TestFindProduct::beginProcessBlock(edm::ProcessBlock const& processBlock) {
+    for (auto const& token : tokensBeginProcessBlock_) {
+      sum_ += processBlock.get(token).value;
+    }
+  }
+
+  void TestFindProduct::endProcessBlock(edm::ProcessBlock const& processBlock) {
+    std::vector<int> values;
+    for (auto const& token : tokensEndProcessBlock_) {
+      int value = processBlock.get(token).value;
+      values.push_back(value);
+      sum_ += value;
+    }
+    edm::Handle<IntProduct> h;
+    unsigned int i = 0;
+    for (auto val : values) {
+      if (i < tokensEndProcessBlock2_.size()) {
+        processBlock.getByToken(tokensEndProcessBlock2_[i], h);
+        if (h->value != val + 2) {
+          throw cms::Exception("TestFail") << "TestFindProduct::endProcessBlock 2, received unexpected value";
+        }
+      }
+      if (i < tokensEndProcessBlock3_.size()) {
+        processBlock.getByToken(tokensEndProcessBlock3_[i], h);
+        if (h->value != val + 3) {
+          throw cms::Exception("TestFail") << "TestFindProduct::endProcessBlock 3, received unexpected value";
+        }
+      }
+      if (i < tokensEndProcessBlock4_.size()) {
+        h = processBlock.getHandle(tokensEndProcessBlock4_[i]);
+        if (h->value != val + 4) {
+          throw cms::Exception("TestFail") << "TestFindProduct::endProcessBlock 4, received unexpected value";
+        }
+      }
+      ++i;
     }
   }
 

--- a/FWCore/Integration/test/TestFindProduct.cc
+++ b/FWCore/Integration/test/TestFindProduct.cc
@@ -31,11 +31,8 @@
 
 namespace edmtest {
 
-  struct DummyTestFindProduct {};
-
-  class TestFindProduct : public edm::one::EDAnalyzer<edm::one::WatchRuns,
-                                                      edm::one::WatchLuminosityBlocks,
-                                                      edm::ProcessBlockCache<DummyTestFindProduct>> {
+  class TestFindProduct
+      : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks, edm::WatchProcessBlock> {
   public:
     explicit TestFindProduct(edm::ParameterSet const& pset);
     virtual ~TestFindProduct();

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -42,6 +42,12 @@ pushd ${LOCAL_TMP_DIR}
   echo "testProducesCollector"
   cmsRun -p ${LOCAL_TEST_DIR}/testProducesCollector_cfg.py || die "cmsRun testProducesCollector_cfg.py" $?
 
+  echo "testGetByRunsMode_cfg.py"
+  cmsRun -p ${LOCAL_TEST_DIR}/testGetByRunsMode_cfg.py || die "cmsRun testGetByRunsMode_cfg.py" $?
+
+  echo "testGetByRunsLumisMode_cfg.py"
+  cmsRun -p ${LOCAL_TEST_DIR}/testGetByRunsLumisMode_cfg.py || die "cmsRun testGetByRunsLumisMode_cfg.py" $?
+
 popd
 
 exit 0

--- a/FWCore/Integration/test/testConsumesInfo_cfg.py
+++ b/FWCore/Integration/test/testConsumesInfo_cfg.py
@@ -125,10 +125,32 @@ process.intProducerG = cms.EDProducer("IntProducer", ivalue = cms.int32(1005))
 process.intProducerH = cms.EDProducer("IntProducer", ivalue = cms.int32(1006))
 process.intProducerI = cms.EDProducer("IntProducer", ivalue = cms.int32(1007))
 
+process.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(10000))
+
+process.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(100000))
+
+process.processBlockTest1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag(),
+  expectedSum = cms.untracked.int32(220000),
+  inputTagsBeginProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerBeginProcessBlock"),
+    cms.InputTag("intProducerBeginProcessBlock", "", "PROD1")
+  ),
+  inputTagsEndProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock"),
+    cms.InputTag("intProducerEndProcessBlock", "", "PROD1"),
+  )
+)
+
 process.p = cms.Path(process.intProducer * process.a1 * process.a2 * process.a3 *
                      process.a4 *
                      process.test * process.testView1 *
-                     process.testStreamingProducer * process.testStreamingAnalyzer)
+                     process.testStreamingProducer * process.testStreamingAnalyzer *
+                     process.intProducerBeginProcessBlock *
+                     process.intProducerEndProcessBlock *
+                     process.processBlockTest1
+)
+
 process.p2 = cms.Path(process.intProducer * process.a1 * process.a2 * process.a3)
 
 process.p3 = cms.Path(
@@ -417,4 +439,33 @@ copyProcess.path2 = cms.Path(
   copyProcess.a23 *
   copyProcess.a24 *
   copyProcess.a25
+)
+
+copyProcess.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(10001))
+
+copyProcess.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(100010))
+
+copyProcess.processBlockTest1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag(),
+  expectedSum = cms.untracked.int32(460034),
+  inputTagsBeginProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerBeginProcessBlock"),
+    cms.InputTag("intProducerBeginProcessBlock", "", "PROD1"),
+    cms.InputTag("intProducerBeginProcessBlock", "", "COPY")
+  ),
+  inputTagsEndProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerBeginProcessBlock"),
+    cms.InputTag("intProducerBeginProcessBlock", "", "PROD1"),
+    cms.InputTag("intProducerBeginProcessBlock", "", "COPY"),
+    cms.InputTag("intProducerEndProcessBlock"),
+    cms.InputTag("intProducerEndProcessBlock", "", "PROD1"),
+    cms.InputTag("intProducerEndProcessBlock", "", "COPY"),
+    cms.InputTag("intProducerEndProcessBlock", "", cms.InputTag.currentProcess())
+  )
+)
+
+copyProcess.path3 = cms.Path(
+    copyProcess.intProducerBeginProcessBlock *
+    copyProcess.intProducerEndProcessBlock *
+    copyProcess.processBlockTest1
 )

--- a/FWCore/Integration/test/testGetBy1_cfg.py
+++ b/FWCore/Integration/test/testGetBy1_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PROD1")
 
 process.Tracer = cms.Service('Tracer',
-                             dumpContextForLabels = cms.untracked.vstring('intProducerA'),
+                             dumpContextForLabels = cms.untracked.vstring('intProducerA', 'a1'),
                              dumpNonModuleContext = cms.untracked.bool(True)
 )
 
@@ -45,11 +45,26 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.a1 = cms.EDAnalyzer("TestFindProduct",
   inputTags = cms.untracked.VInputTag( cms.InputTag("source") ),
-  expectedSum = cms.untracked.int32(12),
+  expectedSum = cms.untracked.int32(110012),
   inputTagsNotFound = cms.untracked.VInputTag(
     cms.InputTag("source", processName=cms.InputTag.skipCurrentProcess()),
     cms.InputTag("intProducer", processName=cms.InputTag.skipCurrentProcess()),
     cms.InputTag("intProducerU", processName=cms.InputTag.skipCurrentProcess())
+  ),
+  inputTagsBeginProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerBeginProcessBlock"),
+  ),
+  inputTagsEndProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock"),
+  ),
+  inputTagsEndProcessBlock2 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "two"),
+  ),
+  inputTagsEndProcessBlock3 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "three"),
+  ),
+  inputTagsEndProcessBlock4 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "four"),
   )
 )
 
@@ -83,7 +98,17 @@ process.intVectorProducer = cms.EDProducer("IntVectorProducer",
 
 process.intProducerB = cms.EDProducer("IntProducer", ivalue = cms.int32(1000))
 
-process.t = cms.Task(process.intProducerU, process.intProducerA, process.intProducerB, process.intVectorProducer)
+process.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(10000))
+
+process.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(100000))
+
+process.t = cms.Task(process.intProducerU,
+                     process.intProducerA,
+                     process.intProducerB,
+                     process.intVectorProducer,
+                     process.intProducerBeginProcessBlock,
+                     process.intProducerEndProcessBlock
+)
 
 process.p = cms.Path(process.intProducer * process.a1 * process.a2 * process.a3, process.t)
 

--- a/FWCore/Integration/test/testGetByRunsLumisMode_cfg.py
+++ b/FWCore/Integration/test/testGetByRunsLumisMode_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD2")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testGetBy1.root'
+    ),
+    processingMode=cms.untracked.string('RunsAndLumis')
+)
+
+process.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(10000))
+
+process.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(100000))
+
+process.a1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag(),
+  expectedSum = cms.untracked.int32(110000),
+  inputTagsBeginProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerBeginProcessBlock"),
+  ),
+  inputTagsEndProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock"),
+  ),
+  inputTagsEndProcessBlock2 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "two"),
+  ),
+  inputTagsEndProcessBlock3 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "three"),
+  ),
+  inputTagsEndProcessBlock4 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "four"),
+  )
+)
+
+
+process.p1 = cms.Path(process.intProducerBeginProcessBlock +
+                      process.intProducerEndProcessBlock +
+                      process.a1
+)
+

--- a/FWCore/Integration/test/testGetByRunsMode_cfg.py
+++ b/FWCore/Integration/test/testGetByRunsMode_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD2")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testGetBy1.root'
+    ),
+    processingMode=cms.untracked.string('Runs')
+)
+
+process.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(10000))
+
+process.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(100000))
+
+process.a1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag(),
+  expectedSum = cms.untracked.int32(110000),
+  inputTagsBeginProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerBeginProcessBlock"),
+  ),
+  inputTagsEndProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock"),
+  ),
+  inputTagsEndProcessBlock2 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "two"),
+  ),
+  inputTagsEndProcessBlock3 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "three"),
+  ),
+  inputTagsEndProcessBlock4 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "four"),
+  )
+)
+
+
+process.p1 = cms.Path(process.intProducerBeginProcessBlock +
+                      process.intProducerEndProcessBlock +
+                      process.a1
+)
+

--- a/FWCore/Integration/test/testProcessBlock_cfg.py
+++ b/FWCore/Integration/test/testProcessBlock_cfg.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(1)
+)
+
+process.thingProducer = cms.EDProducer("ThingProducer")
+
+process.path = cms.Path(process.thingProducer)
+

--- a/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
@@ -17,6 +17,9 @@ modules on path p:
   testView1
   testStreamingProducer
   testStreamingAnalyzer
+  intProducerBeginProcessBlock
+  intProducerEndProcessBlock
+  processBlockTest1
 modules on path p2:
   intProducer
   a1
@@ -55,6 +58,9 @@ All modules and modules in the current process whose products they consume:
   IntProducer/'testStreamingProducer'
   ConsumingStreamAnalyzer/'testStreamingAnalyzer' consumes products from these modules:
     IntProducer/'testStreamingProducer'
+  IntProducerBeginProcessBlock/'intProducerBeginProcessBlock'
+  IntProducerEndProcessBlock/'intProducerEndProcessBlock'
+  TestFindProduct/'processBlockTest1'
   IntProducer/'intProducerB'
   IntProducer/'intProducerC'
   IntProducer/'intProducerD'
@@ -78,7 +84,7 @@ All modules and modules in the current process whose products they consume:
   EndPathStatusInserter/'p1ep2'
 All modules (listed by class and label) and all their consumed products.
 Consumed products are listed by type, label, instance, process.
-For products not in the event, 'run' or 'lumi' is added to indicate the TTree they are from.
+For products not in the event, 'processBlock', 'run' or 'lumi' is added to indicate the TTree they are from.
 For products that are declared with mayConsume, 'may consume' is added.
 For products consumed for Views, 'element type' is added
 For products only read from previous processes, 'skip current process' is added
@@ -107,6 +113,13 @@ For products only read from previous processes, 'skip current process' is added
   IntProducer/'testStreamingProducer'
   ConsumingStreamAnalyzer/'testStreamingAnalyzer' consumes:
     edmtest::IntProduct 'testStreamingProducer' '' '', may consume
+  IntProducerBeginProcessBlock/'intProducerBeginProcessBlock'
+  IntProducerEndProcessBlock/'intProducerEndProcessBlock'
+  TestFindProduct/'processBlockTest1' consumes:
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' '', processBlock
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'PROD1', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' '' '', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' '' 'PROD1', processBlock
   IntProducer/'intProducerB'
   IntProducer/'intProducerC'
   IntProducer/'intProducerD'
@@ -118,6 +131,11 @@ For products only read from previous processes, 'skip current process' is added
     edm::TriggerResults 'TriggerResults' '' 'PROD1'
     edmtest::IntProduct 'aliasForInt' '' 'PROD1'
     edmtest::IntProduct 'intProducer' '' 'PROD1'
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'PROD1', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' '' 'PROD1', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' 'four' 'PROD1', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' 'three' 'PROD1', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' 'two' 'PROD1', processBlock
     edmtest::IntProduct 'intProducerU' '' 'PROD1'
     edmtest::IntProduct 'source' '' 'PROD1'
     edmtest::IntProduct 'testManyConsumingProducer' '' 'PROD1'
@@ -148,7 +166,7 @@ All modules and modules in the current process whose products they consume:
   PathStatusInserter/'path1'
 All modules (listed by class and label) and all their consumed products.
 Consumed products are listed by type, label, instance, process.
-For products not in the event, 'run' or 'lumi' is added to indicate the TTree they are from.
+For products not in the event, 'processBlock', 'run' or 'lumi' is added to indicate the TTree they are from.
 For products that are declared with mayConsume, 'may consume' is added.
 For products consumed for Views, 'element type' is added
 For products only read from previous processes, 'skip current process' is added
@@ -164,6 +182,7 @@ paths:
   p3
   path1
   path2
+  path3
 end paths:
   ep1
   ep2
@@ -206,6 +225,10 @@ modules on path path2:
   a23
   a24
   a25
+modules on path path3:
+  intProducerBeginProcessBlock
+  intProducerEndProcessBlock
+  processBlockTest1
 modules on end path ep1:
   intVectorProducer
   testManyConsumingProducer
@@ -265,17 +288,21 @@ All modules and modules in the current process whose products they consume:
     IntProducer/'intProducerC'
     IntProducer/'intProducerF'
     IntProducer/'intProducerG'
+  IntProducerBeginProcessBlock/'intProducerBeginProcessBlock'
+  IntProducerEndProcessBlock/'intProducerEndProcessBlock'
+  TestFindProduct/'processBlockTest1'
   ConsumingIntProducer/'testManyConsumingProducer' consumes products from these modules:
     TriggerResultInserter/'TriggerResults'
   TriggerResultInserter/'TriggerResults'
   PathStatusInserter/'p3'
   PathStatusInserter/'path1'
   PathStatusInserter/'path2'
+  PathStatusInserter/'path3'
   EndPathStatusInserter/'ep1'
   EndPathStatusInserter/'ep2'
 All modules (listed by class and label) and all their consumed products.
 Consumed products are listed by type, label, instance, process.
-For products not in the event, 'run' or 'lumi' is added to indicate the TTree they are from.
+For products not in the event, 'processBlock', 'run' or 'lumi' is added to indicate the TTree they are from.
 For products that are declared with mayConsume, 'may consume' is added.
 For products consumed for Views, 'element type' is added
 For products only read from previous processes, 'skip current process' is added
@@ -379,6 +406,19 @@ For products only read from previous processes, 'skip current process' is added
     edmtest::IntProduct 'intProducerE' '' 'COPY'
     edmtest::IntProduct 'intProducerH' '' 'COPY'
     edmtest::IntProduct 'intProducerQ' 'INSTANCE' 'DOESNOTEXIST'
+  IntProducerBeginProcessBlock/'intProducerBeginProcessBlock'
+  IntProducerEndProcessBlock/'intProducerEndProcessBlock'
+  TestFindProduct/'processBlockTest1' consumes:
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' '', processBlock
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'PROD1', processBlock
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'COPY', processBlock
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' '', processBlock
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'PROD1', processBlock
+    edmtest::IntProduct 'intProducerBeginProcessBlock' '' 'COPY', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' '' '', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' '' 'PROD1', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' '' 'COPY', processBlock
+    edmtest::IntProduct 'intProducerEndProcessBlock' '' 'COPY', processBlock
   ConsumingIntProducer/'testManyConsumingProducer' consumes:
     edm::TriggerResults 'TriggerResults' '' ''
     edm::TriggerResults '' '' ''
@@ -386,6 +426,7 @@ For products only read from previous processes, 'skip current process' is added
   PathStatusInserter/'p3'
   PathStatusInserter/'path1'
   PathStatusInserter/'path2'
+  PathStatusInserter/'path3'
   EndPathStatusInserter/'ep1'
   EndPathStatusInserter/'ep2'
 
@@ -394,6 +435,7 @@ TestFindProduct sum = 300
 TestFindProduct sum = 300
 TestFindProduct sum = 300
 TestFindProduct sum = 33
+TestFindProduct sum = 220000
 TestFindProduct sum = 33
 TestFindProduct sum = 36
 TestFindProduct sum = 36
@@ -422,3 +464,4 @@ TestFindProduct sum = 9015
 TestFindProduct sum = 0
 TestFindProduct sum = 0
 TestFindProduct sum = 45057
+TestFindProduct sum = 460034

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -11,7 +11,9 @@ Module type=IntSource, Module label=source, Parameter Set ID=031810a3ee2992e7936
 ++++ starting: constructing module with label 'intProducer' id = 4
 ++++ finished: constructing module with label 'intProducer' id = 4
 ++++ starting: constructing module with label 'a1' id = 5
+Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
 ++++ finished: constructing module with label 'a1' id = 5
+Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
 ++++ starting: constructing module with label 'a2' id = 6
 ++++ finished: constructing module with label 'a2' id = 6
 ++++ starting: constructing module with label 'a3' id = 7
@@ -24,10 +26,14 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e81
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
 ++++ starting: constructing module with label 'intProducerB' id = 10
 ++++ finished: constructing module with label 'intProducerB' id = 10
-++++ starting: constructing module with label 'intProducerU' id = 11
-++++ finished: constructing module with label 'intProducerU' id = 11
-++++ starting: constructing module with label 'intVectorProducer' id = 12
-++++ finished: constructing module with label 'intVectorProducer' id = 12
+++++ starting: constructing module with label 'intProducerBeginProcessBlock' id = 11
+++++ finished: constructing module with label 'intProducerBeginProcessBlock' id = 11
+++++ starting: constructing module with label 'intProducerEndProcessBlock' id = 12
+++++ finished: constructing module with label 'intProducerEndProcessBlock' id = 12
+++++ starting: constructing module with label 'intProducerU' id = 13
+++++ finished: constructing module with label 'intProducerU' id = 13
+++++ starting: constructing module with label 'intVectorProducer' id = 14
+++++ finished: constructing module with label 'intVectorProducer' id = 14
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
 ++++ starting: begin job for module with label 'intProducerA' id = 9
@@ -36,14 +42,20 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e81
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
 ++++ starting: begin job for module with label 'intProducerB' id = 10
 ++++ finished: begin job for module with label 'intProducerB' id = 10
-++++ starting: begin job for module with label 'intProducerU' id = 11
-++++ finished: begin job for module with label 'intProducerU' id = 11
-++++ starting: begin job for module with label 'intVectorProducer' id = 12
-++++ finished: begin job for module with label 'intVectorProducer' id = 12
+++++ starting: begin job for module with label 'intProducerBeginProcessBlock' id = 11
+++++ finished: begin job for module with label 'intProducerBeginProcessBlock' id = 11
+++++ starting: begin job for module with label 'intProducerEndProcessBlock' id = 12
+++++ finished: begin job for module with label 'intProducerEndProcessBlock' id = 12
+++++ starting: begin job for module with label 'intProducerU' id = 13
+++++ finished: begin job for module with label 'intProducerU' id = 13
+++++ starting: begin job for module with label 'intVectorProducer' id = 14
+++++ finished: begin job for module with label 'intVectorProducer' id = 14
 ++++ starting: begin job for module with label 'intProducer' id = 4
 ++++ finished: begin job for module with label 'intProducer' id = 4
 ++++ starting: begin job for module with label 'a1' id = 5
+Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
 ++++ finished: begin job for module with label 'a1' id = 5
+Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
 ++++ starting: begin job for module with label 'a2' id = 6
 ++++ finished: begin job for module with label 'a2' id = 6
 ++++ starting: begin job for module with label 'a3' id = 7
@@ -61,7 +73,29 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e81
 ++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 4
 ++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 4
 ++++ starting: begin stream for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++ finished: begin stream for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++ starting: begin stream for module: stream = 0 label = 'a2' id = 6
 ++++ finished: begin stream for module: stream = 0 label = 'a2' id = 6
 ++++ starting: begin stream for module: stream = 0 label = 'a3' id = 7
@@ -78,44 +112,128 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e81
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: begin stream for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: begin stream for module: stream = 0 label = 'intProducerB' id = 10
 ++++ finished: begin stream for module: stream = 0 label = 'intProducerB' id = 10
-++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 11
-++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 11
-++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 12
-++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 12
+++++ starting: begin stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 11
+++++ finished: begin stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 11
+++++ starting: begin stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 12
+++++ finished: begin stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 12
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 13
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 13
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 14
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 14
+++++ starting: begin process block
+GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++++ starting: begin process block for module: label = 'intProducerBeginProcessBlock' id = 11
+++++++ finished: begin process block for module: label = 'intProducerBeginProcessBlock' id = 11
+++++++ starting: begin process block for module: label = 'a1' id = 5
+GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++++ finished: begin process block for module: label = 'a1' id = 5
+GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++++ starting: begin process block for module: label = 'intProducerEndProcessBlock' id = 12
+++++++ finished: begin process block for module: label = 'intProducerEndProcessBlock' id = 12
+++++++ starting: begin process block for module: label = 'a2' id = 6
+++++++ finished: begin process block for module: label = 'a2' id = 6
+++++++ starting: begin process block for module: label = 'a3' id = 7
+++++++ finished: begin process block for module: label = 'a3' id = 7
+++++ finished: begin process block
+GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++ starting: begin process block
+GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++ finished: begin process block
+GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++ starting: global begin run for module: label = 'intVectorProducer' id = 12
-++++++ finished: global begin run for module: label = 'intVectorProducer' id = 12
+++++++ starting: global begin run for module: label = 'intVectorProducer' id = 14
+++++++ finished: global begin run for module: label = 'intVectorProducer' id = 14
 ++++++ starting: global begin run for module: label = 'a1' id = 5
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++ finished: global begin run for module: label = 'a1' id = 5
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++ starting: global begin run for module: label = 'a2' id = 6
 ++++++ finished: global begin run for module: label = 'a2' id = 6
 ++++++ starting: global begin run for module: label = 'a3' id = 7
@@ -124,55 +242,55 @@ GlobalContext: transition = BeginRun
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 13
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 13
 ++++++ starting: begin run for module: stream = 0 label = 'intProducerB' id = 10
 ++++++ finished: begin run for module: stream = 0 label = 'intProducerB' id = 10
 ++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ finished: begin run for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 4
 ++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 4
@@ -180,21 +298,21 @@ ModuleCallingContext state = Running
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -202,12 +320,34 @@ StreamContext: StreamID = 0 transition = BeginRun
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 12
-++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 12
+++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 14
+++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 14
 ++++++ starting: global begin lumi for module: label = 'a1' id = 5
+GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++ finished: global begin lumi for module: label = 'a1' id = 5
+GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++ starting: global begin lumi for module: label = 'a2' id = 6
 ++++++ finished: global begin lumi for module: label = 'a2' id = 6
 ++++++ starting: global begin lumi for module: label = 'a3' id = 7
@@ -216,55 +356,55 @@ GlobalContext: transition = BeginLuminosityBlock
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 13
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducerB' id = 10
 ++++++ finished: begin lumi for module: stream = 0 label = 'intProducerB' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 4
 ++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 4
@@ -272,21 +412,21 @@ ModuleCallingContext state = Running
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: source event
 ++++ finished: source event
@@ -294,36 +434,36 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -333,22 +473,74 @@ ModuleCallingContext state = Prefetching
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -358,13 +550,13 @@ ModuleCallingContext state = Prefetching
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -374,13 +566,13 @@ ModuleCallingContext state = Running
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -390,7 +582,7 @@ ModuleCallingContext state = Running
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
@@ -404,12 +596,12 @@ ModuleCallingContext state = Running
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -417,14 +609,14 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 11
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 13
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 10
@@ -437,32 +629,32 @@ PathContext: pathName = p pathID = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: source event
 ++++ finished: source event
@@ -470,36 +662,36 @@ StreamContext: StreamID = 0 transition = Event
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -509,22 +701,74 @@ ModuleCallingContext state = Prefetching
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -534,13 +778,13 @@ ModuleCallingContext state = Prefetching
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -550,13 +794,13 @@ ModuleCallingContext state = Running
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -566,7 +810,7 @@ ModuleCallingContext state = Running
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
@@ -580,12 +824,12 @@ ModuleCallingContext state = Running
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -593,14 +837,14 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 11
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 13
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 10
@@ -613,32 +857,32 @@ PathContext: pathName = p pathID = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: source event
 ++++ finished: source event
@@ -646,36 +890,36 @@ StreamContext: StreamID = 0 transition = Event
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -685,22 +929,74 @@ ModuleCallingContext state = Prefetching
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    PlaceInPathContext 1
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -710,13 +1006,13 @@ ModuleCallingContext state = Prefetching
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -726,13 +1022,13 @@ ModuleCallingContext state = Running
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
@@ -742,7 +1038,7 @@ ModuleCallingContext state = Running
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
@@ -756,12 +1052,12 @@ ModuleCallingContext state = Running
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -769,14 +1065,14 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 11
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 11
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 13
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 13
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 10
@@ -789,66 +1085,66 @@ PathContext: pathName = p pathID = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 13
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducerB' id = 10
 ++++++ finished: end lumi for module: stream = 0 label = 'intProducerB' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ finished: end lumi for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 4
 ++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 4
@@ -856,32 +1152,54 @@ ModuleCallingContext state = Running
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 12
-++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 12
+++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 14
+++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 14
 ++++++ starting: global end lumi for module: label = 'a1' id = 5
+GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++ finished: global end lumi for module: label = 'a1' id = 5
+GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++ starting: global end lumi for module: label = 'a2' id = 6
 ++++++ finished: global end lumi for module: label = 'a2' id = 6
 ++++++ starting: global end lumi for module: label = 'a3' id = 7
@@ -890,27 +1208,27 @@ GlobalContext: transition = EndLuminosityBlock
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = WriteLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: write lumi for module: label = 'out' id = 8
 ++++++ finished: write lumi for module: label = 'out' id = 8
@@ -918,55 +1236,55 @@ GlobalContext: transition = WriteLuminosityBlock
 GlobalContext: transition = WriteLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = WriteLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = WriteLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 11
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 11
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 13
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 13
 ++++++ starting: end run for module: stream = 0 label = 'intProducerB' id = 10
 ++++++ finished: end run for module: stream = 0 label = 'intProducerB' id = 10
 ++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ finished: end run for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 4
 ++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 4
@@ -974,32 +1292,54 @@ ModuleCallingContext state = Running
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: end run: stream = 0 run = 1 time = 0
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: end run: stream = 0 run = 1 time = 0
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++ starting: global end run for module: label = 'intVectorProducer' id = 12
-++++++ finished: global end run for module: label = 'intVectorProducer' id = 12
+++++++ starting: global end run for module: label = 'intVectorProducer' id = 14
+++++++ finished: global end run for module: label = 'intVectorProducer' id = 14
 ++++++ starting: global end run for module: label = 'a1' id = 5
+GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++ finished: global end run for module: label = 'a1' id = 5
+GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++++ starting: global end run for module: label = 'a2' id = 6
 ++++++ finished: global end run for module: label = 'a2' id = 6
 ++++++ starting: global end run for module: label = 'a3' id = 7
@@ -1008,27 +1348,27 @@ GlobalContext: transition = EndRun
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global end run 1 : time = 0
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: global end run 1 : time = 0
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global write run 1 : time = 15000001
 GlobalContext: transition = WriteRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++++ starting: write run for module: label = 'out' id = 8
 ++++++ finished: write run for module: label = 'out' id = 8
@@ -1036,26 +1376,134 @@ GlobalContext: transition = WriteRun
 GlobalContext: transition = WriteRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: global write run 1 : time = 0
 GlobalContext: transition = WriteRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: global write run 1 : time = 0
 GlobalContext: transition = WriteRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++ starting: end process block
+GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++++ starting: end process block for module: label = 'intProducerBeginProcessBlock' id = 11
+++++++ finished: end process block for module: label = 'intProducerBeginProcessBlock' id = 11
+++++++ starting: end process block for module: label = 'intProducerEndProcessBlock' id = 12
+++++++ finished: end process block for module: label = 'intProducerEndProcessBlock' id = 12
+++++++ starting: end process block for module: label = 'a1' id = 5
+GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++++ finished: end process block for module: label = 'a1' id = 5
+GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++++ starting: end process block for module: label = 'a2' id = 6
+++++++ finished: end process block for module: label = 'a2' id = 6
+++++++ starting: end process block for module: label = 'a3' id = 7
+++++++ finished: end process block for module: label = 'a3' id = 7
+++++ finished: end process block
+GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++ starting: end process block
+GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++ finished: end process block
+GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++ starting: write process block
+GlobalContext: transition = WriteProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++++ starting: write process block for module: label = 'out' id = 8
+++++++ finished: write process block for module: label = 'out' id = 8
+++++ finished: write process block
+GlobalContext: transition = WriteProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++ starting: write process block
+GlobalContext: transition = WriteProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
+++++ finished: write process block
+GlobalContext: transition = WriteProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 4
 ++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 4
 ++++ starting: end stream for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++ finished: end stream for module: stream = 0 label = 'a1' id = 5
+StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+ModuleCallingContext state = Running
+    moduleDescription: Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+    StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
+
 ++++ starting: end stream for module: stream = 0 label = 'a2' id = 6
 ++++ finished: end stream for module: stream = 0 label = 'a2' id = 6
 ++++ starting: end stream for module: stream = 0 label = 'a3' id = 7
@@ -1072,47 +1520,57 @@ GlobalContext: transition = WriteRun
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ finished: end stream for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+    ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
 ++++ starting: end stream for module: stream = 0 label = 'intProducerB' id = 10
 ++++ finished: end stream for module: stream = 0 label = 'intProducerB' id = 10
-++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 11
-++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 11
-++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 12
-++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 12
+++++ starting: end stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 11
+++++ finished: end stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 11
+++++ starting: end stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 12
+++++ finished: end stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 12
+++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 13
+++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 13
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 14
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 14
 ++++ starting: end job for module with label 'intProducerA' id = 9
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
 ++++ finished: end job for module with label 'intProducerA' id = 9
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
 ++++ starting: end job for module with label 'intProducerB' id = 10
 ++++ finished: end job for module with label 'intProducerB' id = 10
-++++ starting: end job for module with label 'intProducerU' id = 11
-++++ finished: end job for module with label 'intProducerU' id = 11
-++++ starting: end job for module with label 'intVectorProducer' id = 12
-++++ finished: end job for module with label 'intVectorProducer' id = 12
+++++ starting: end job for module with label 'intProducerBeginProcessBlock' id = 11
+++++ finished: end job for module with label 'intProducerBeginProcessBlock' id = 11
+++++ starting: end job for module with label 'intProducerEndProcessBlock' id = 12
+++++ finished: end job for module with label 'intProducerEndProcessBlock' id = 12
+++++ starting: end job for module with label 'intProducerU' id = 13
+++++ finished: end job for module with label 'intProducerU' id = 13
+++++ starting: end job for module with label 'intVectorProducer' id = 14
+++++ finished: end job for module with label 'intVectorProducer' id = 14
 ++++ starting: end job for module with label 'intProducer' id = 4
 ++++ finished: end job for module with label 'intProducer' id = 4
 ++++ starting: end job for module with label 'a1' id = 5
-TestFindProduct sum = 12
+Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
+TestFindProduct sum = 110012
 ++++ finished: end job for module with label 'a1' id = 5
+Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
 ++++ starting: end job for module with label 'a2' id = 6
 TestFindProduct sum = 300
 ++++ finished: end job for module with label 'a2' id = 6

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -75,6 +75,18 @@ ModuleCallingContext state = Running
 ++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 6
 ++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 7
 ++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 7
+++++ starting: begin process block
+GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
+++++ finished: begin process block
+GlobalContext: transition = BeginProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -767,6 +779,32 @@ GlobalContext: transition = WriteRun
 
 ++++ starting: close input file: lfn = file:testGetBy1.root usedFallBack = 0
 ++++ finished: close input file: lfn = file:testGetBy1.root usedFallBack = 0
+++++ starting: end process block
+GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
+++++ finished: end process block
+GlobalContext: transition = EndProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
+++++ starting: write process block
+GlobalContext: transition = WriteProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
+++++++ starting: write process block for module: label = 'out' id = 5
+++++++ finished: write process block for module: label = 'out' id = 5
+++++ finished: write process block
+GlobalContext: transition = WriteProcessBlock
+    run: 0 luminosityBlock: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -230,6 +230,24 @@
 ++++ finished: begin stream for module: stream = 0 label = 'path4' id = 29
 ++++ starting: begin stream for module: stream = 0 label = 'endPath1' id = 30
 ++++ finished: begin stream for module: stream = 0 label = 'endPath1' id = 30
+++++ starting: begin process block
+++++ finished: begin process block
+++++ starting: begin process block
+++++ finished: begin process block
+++++ starting: begin process block
+++++++ starting: begin process block for module: label = 'getInt' id = 10
+++++++ finished: begin process block for module: label = 'getInt' id = 10
+++++ finished: begin process block
+++++ starting: begin process block
+++++ finished: begin process block
+++++ starting: begin process block
+++++ starting: begin process block
+++++++ starting: begin process block for module: label = 'getInt' id = 35
+++++++ finished: begin process block for module: label = 'getInt' id = 35
+++++ finished: begin process block
+++++++ starting: begin process block for module: label = 'getInt' id = 22
+++++++ finished: begin process block for module: label = 'getInt' id = 22
+++++ finished: begin process block
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -6794,6 +6812,40 @@
 ++++++ starting: write run for module: label = 'out' id = 24
 ++++++ finished: write run for module: label = 'out' id = 24
 ++++ finished: global write run 3 : time = 0
+++++ starting: end process block
+++++ finished: end process block
+++++ starting: end process block
+++++ finished: end process block
+++++ starting: end process block
+++++++ starting: end process block for module: label = 'getInt' id = 10
+++++++ finished: end process block for module: label = 'getInt' id = 10
+++++ finished: end process block
+++++ starting: end process block
+++++ finished: end process block
+++++ starting: end process block
+++++ starting: end process block
+++++++ starting: end process block for module: label = 'getInt' id = 35
+++++++ finished: end process block for module: label = 'getInt' id = 35
+++++ finished: end process block
+++++++ starting: end process block for module: label = 'getInt' id = 22
+++++++ finished: end process block for module: label = 'getInt' id = 22
+++++ finished: end process block
+++++ starting: write process block
+++++ finished: write process block
+++++ starting: write process block
+++++ finished: write process block
+++++ starting: write process block
+++++ finished: write process block
+++++ starting: write process block
+++++ finished: write process block
+++++ starting: write process block
+++++ starting: write process block
+++++++ starting: write process block for module: label = 'out' id = 37
+++++++ finished: write process block for module: label = 'out' id = 37
+++++ finished: write process block
+++++++ starting: write process block for module: label = 'out' id = 24
+++++++ finished: write process block for module: label = 'out' id = 24
+++++ finished: write process block
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 6

--- a/FWCore/MessageService/interface/MessageLogger.h
+++ b/FWCore/MessageService/interface/MessageLogger.h
@@ -114,6 +114,13 @@ namespace edm {
       void preStreamEndLumi(StreamContext const&);
       void postStreamEndLumi(StreamContext const&);
 
+      void preModuleBeginProcessBlock(GlobalContext const&, ModuleCallingContext const&);
+      void postModuleBeginProcessBlock(GlobalContext const&, ModuleCallingContext const&);
+      void preModuleAccessInputProcessBlock(GlobalContext const&, ModuleCallingContext const&);
+      void postModuleAccessInputProcessBlock(GlobalContext const&, ModuleCallingContext const&);
+      void preModuleEndProcessBlock(GlobalContext const&, ModuleCallingContext const&);
+      void postModuleEndProcessBlock(GlobalContext const&, ModuleCallingContext const&);
+
       void preModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const&);
       void postModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const&);
       void preModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const&);
@@ -123,6 +130,13 @@ namespace edm {
       void postModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const&);
       void preModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const&);
       void postModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const&);
+
+      void preBeginProcessBlock(GlobalContext const&);
+      void postBeginProcessBlock(GlobalContext const&);
+      void preAccessInputProcessBlock(GlobalContext const&);
+      void postAccessInputProcessBlock(GlobalContext const&);
+      void preEndProcessBlock(GlobalContext const&);
+      void postEndProcessBlock(GlobalContext const&);
 
       void preGlobalBeginRun(GlobalContext const&);
       void postGlobalBeginRun(GlobalContext const&);

--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -107,8 +107,18 @@ using namespace edm;
 using namespace edm::service;
 
 namespace {
-  constexpr std::array<char const*, 8> s_globalTransitionNames = {
-      {"@beginJob", "@beginRun", "@beginLumi", "@endLumi", "@endRun", "@endJob", "@writeRun", "@writeLumi"}};
+  constexpr std::array<char const*, 12> s_globalTransitionNames = {{"@beginJob",
+                                                                    "@beginProcessBlock",
+                                                                    "@accessInputProcessBlock",
+                                                                    "@beginRun",
+                                                                    "@beginLumi",
+                                                                    "@endLumi",
+                                                                    "@endRun",
+                                                                    "@kEndProcessBlock",
+                                                                    "@endJob",
+                                                                    "@writeProcessBlock",
+                                                                    "@writeRun",
+                                                                    "@writeLumi"}};
 
   constexpr std::array<char const*, 7> s_streamTransitionNames = {{"@beginStream",
                                                                    "@streamBeginRun",
@@ -312,6 +322,13 @@ namespace edm {
       iRegistry.watchPreModuleStreamEndLumi(this, &MessageLogger::preModuleStreamEndLumi);
       iRegistry.watchPostModuleStreamEndLumi(this, &MessageLogger::postModuleStreamEndLumi);
 
+      iRegistry.watchPreModuleBeginProcessBlock(this, &MessageLogger::preModuleBeginProcessBlock);
+      iRegistry.watchPostModuleBeginProcessBlock(this, &MessageLogger::postModuleBeginProcessBlock);
+      iRegistry.watchPreModuleAccessInputProcessBlock(this, &MessageLogger::preModuleAccessInputProcessBlock);
+      iRegistry.watchPostModuleAccessInputProcessBlock(this, &MessageLogger::postModuleAccessInputProcessBlock);
+      iRegistry.watchPreModuleEndProcessBlock(this, &MessageLogger::preModuleEndProcessBlock);
+      iRegistry.watchPostModuleEndProcessBlock(this, &MessageLogger::postModuleEndProcessBlock);
+
       iRegistry.watchPreModuleGlobalBeginRun(this, &MessageLogger::preModuleGlobalBeginRun);
       iRegistry.watchPostModuleGlobalBeginRun(this, &MessageLogger::postModuleGlobalBeginRun);
       iRegistry.watchPreModuleGlobalEndRun(this, &MessageLogger::preModuleGlobalEndRun);
@@ -332,6 +349,13 @@ namespace edm {
       iRegistry.watchPostStreamBeginLumi(this, &MessageLogger::postStreamBeginLumi);
       iRegistry.watchPreStreamEndLumi(this, &MessageLogger::preStreamEndLumi);
       iRegistry.watchPostStreamEndLumi(this, &MessageLogger::postStreamEndLumi);
+
+      iRegistry.watchPreBeginProcessBlock(this, &MessageLogger::preBeginProcessBlock);
+      iRegistry.watchPostBeginProcessBlock(this, &MessageLogger::postBeginProcessBlock);
+      iRegistry.watchPreAccessInputProcessBlock(this, &MessageLogger::preAccessInputProcessBlock);
+      iRegistry.watchPostAccessInputProcessBlock(this, &MessageLogger::postAccessInputProcessBlock);
+      iRegistry.watchPreEndProcessBlock(this, &MessageLogger::preEndProcessBlock);
+      iRegistry.watchPostEndProcessBlock(this, &MessageLogger::postEndProcessBlock);
 
       iRegistry.watchPreGlobalBeginRun(this, &MessageLogger::preGlobalBeginRun);
       iRegistry.watchPostGlobalBeginRun(this, &MessageLogger::postGlobalBeginRun);
@@ -609,6 +633,37 @@ namespace edm {
     }
 
     //Global
+
+    void MessageLogger::preModuleBeginProcessBlock(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+      ModuleDescription const& desc = *mcc.moduleDescription();
+      establishModule(desc, "@beginProcessBlock");
+    }
+
+    void MessageLogger::postModuleBeginProcessBlock(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+      ModuleDescription const& desc = *mcc.moduleDescription();
+      unEstablishModule(desc, "After module BeginProcessBlock");
+    }
+
+    void MessageLogger::preModuleAccessInputProcessBlock(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+      ModuleDescription const& desc = *mcc.moduleDescription();
+      establishModule(desc, "@accessInputProcessBlock");
+    }
+
+    void MessageLogger::postModuleAccessInputProcessBlock(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+      ModuleDescription const& desc = *mcc.moduleDescription();
+      unEstablishModule(desc, "After module AccessInputProcessBlock");
+    }
+
+    void MessageLogger::preModuleEndProcessBlock(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+      ModuleDescription const& desc = *mcc.moduleDescription();
+      establishModule(desc, "@endProcessBlock");
+    }
+
+    void MessageLogger::postModuleEndProcessBlock(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+      ModuleDescription const& desc = *mcc.moduleDescription();
+      unEstablishModule(desc, "After module EndProcessBlock");
+    }
+
     void MessageLogger::preModuleGlobalBeginRun(GlobalContext const& context, ModuleCallingContext const& mod) {
       establishModule(runInfoBegin_ + context.runIndex().value(),
                       mod,
@@ -755,6 +810,33 @@ namespace edm {
     void MessageLogger::postStreamEndLumi(StreamContext const&) {
       edm::MessageDrop::instance()->runEvent = "PostStreamEndLumi";
       edm::MessageDrop::instance()->setSinglet("PostStreamEndLumi");  // changelog 17
+    }
+
+    void MessageLogger::preBeginProcessBlock(GlobalContext const& gc) {
+      edm::MessageDrop::instance()->runEvent = "pre-events";
+      edm::MessageDrop::instance()->setSinglet("BeginProcessBlock");
+    }
+
+    void MessageLogger::postBeginProcessBlock(GlobalContext const& gc) {
+      edm::MessageDrop::instance()->setSinglet("After BeginProcessBlock");
+    }
+
+    void MessageLogger::preAccessInputProcessBlock(GlobalContext const& gc) {
+      edm::MessageDrop::instance()->runEvent = "pre-events";
+      edm::MessageDrop::instance()->setSinglet("AccessInputProcessBlock");
+    }
+
+    void MessageLogger::postAccessInputProcessBlock(GlobalContext const& gc) {
+      edm::MessageDrop::instance()->setSinglet("After AccessInputProcessBlock");
+    }
+
+    void MessageLogger::preEndProcessBlock(GlobalContext const& gc) {
+      edm::MessageDrop::instance()->runEvent = "post-events";
+      edm::MessageDrop::instance()->setSinglet("EndProcessBlock");
+    }
+
+    void MessageLogger::postEndProcessBlock(GlobalContext const& gc) {
+      edm::MessageDrop::instance()->setSinglet("After EndProcessBlock");
     }
 
     void MessageLogger::preGlobalBeginRun(GlobalContext const& iContext)  // change log 14

--- a/FWCore/MessageService/test/UnitTestClient_V.cc
+++ b/FWCore/MessageService/test/UnitTestClient_V.cc
@@ -26,12 +26,22 @@ namespace edmtest {
 
   void UTC_V1::beginRun(edm::Run const& /*unused*/, edm::EventSetup const& /*unused*/) {
     edm::LogInfo("cat_BR") << "T1 beginRun info with identifier " << identifier << " event " << ev;
-    LogDebug("cat_BJ") << "T1 beginRun debug with identifier " << identifier << " event " << ev;
+    LogDebug("cat_BR") << "T1 beginRun debug with identifier " << identifier << " event " << ev;
   }
 
   void UTC_V1::beginLuminosityBlock(edm::LuminosityBlock const& /*unused*/, edm::EventSetup const& /*unused*/) {
     edm::LogWarning("cat_BL") << "T1 beginLumi warning with identifier " << identifier << " event " << ev;
     LogDebug("cat_BL") << "T1 beginLumi debug with identifier " << identifier << " event " << ev;
+  }
+
+  void UTC_V1::beginProcessBlock(edm::ProcessBlock const&) {
+    edm::LogInfo("cat_BPB") << "T1 beginProcessBlock info with identifier " << identifier << " event " << ev;
+    LogDebug("cat_BPB") << "T1 beginProcessBlock debug with identifier " << identifier << " event " << ev;
+  }
+
+  void UTC_V1::endProcessBlock(edm::ProcessBlock const&) {
+    edm::LogInfo("cat_EPB") << "T1 endProcessBlock info with identifier " << identifier << " event " << ev;
+    LogDebug("cat_EPB") << "T1 endProcessBlock debug with identifier " << identifier << " event " << ev;
   }
 
   void UTC_V2::analyze(edm::Event const& /*unused*/

--- a/FWCore/MessageService/test/UnitTestClient_V.h
+++ b/FWCore/MessageService/test/UnitTestClient_V.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -14,17 +15,23 @@ namespace edm {
 
 namespace edmtest {
 
-  class UTC_V1 : public edm::EDAnalyzer {
+  class UTC_V1
+      : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks, edm::ProcessBlockCache<void>> {
   public:
     explicit UTC_V1(edm::ParameterSet const& p) : ev(0) { identifier = p.getUntrackedParameter<int>("identifier", 99); }
 
-    virtual ~UTC_V1() {}
+    ~UTC_V1() override {}
 
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
+    void analyze(edm::Event const& e, edm::EventSetup const& c) override;
 
-    virtual void beginJob();
-    virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-    virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+    void beginJob() override;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {}
+    void endRun(edm::Run const&, edm::EventSetup const&) override {}
+
+    void beginProcessBlock(edm::ProcessBlock const&) override;
+    void endProcessBlock(edm::ProcessBlock const&) override;
 
   private:
     int identifier;
@@ -35,9 +42,9 @@ namespace edmtest {
   public:
     explicit UTC_V2(edm::ParameterSet const& p) : ev(0) { identifier = p.getUntrackedParameter<int>("identifier", 98); }
 
-    virtual ~UTC_V2() {}
+    ~UTC_V2() override {}
 
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
+    void analyze(edm::Event const& e, edm::EventSetup const& c) override;
 
   private:
     int identifier;

--- a/FWCore/MessageService/test/UnitTestClient_V.h
+++ b/FWCore/MessageService/test/UnitTestClient_V.h
@@ -16,7 +16,7 @@ namespace edm {
 namespace edmtest {
 
   class UTC_V1
-      : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks, edm::ProcessBlockCache<void>> {
+      : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks, edm::WatchProcessBlock> {
   public:
     explicit UTC_V1(edm::ParameterSet const& p) : ev(0) { identifier = p.getUntrackedParameter<int>("identifier", 99); }
 

--- a/FWCore/MessageService/test/unit_test_outputs/u33_all.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u33_all.log
@@ -4,6 +4,12 @@ T1 beginJob warning with identifier 11 event 0
 %MSG-w cat_BJ:  UTC_V1:ssm_1b@beginJob pre-events
 T1 beginJob warning with identifier 12 event 0
 %MSG
+%MSG-i cat_BPB:  UTC_V1:ssm_1a@beginProcessBlock pre-events
+T1 beginProcessBlock info with identifier 11 event 0
+%MSG
+%MSG-i cat_BPB:  UTC_V1:ssm_1b@beginProcessBlock pre-events
+T1 beginProcessBlock info with identifier 12 event 0
+%MSG
 %MSG-i cat_BR:  UTC_V1:ssm_1a@beginRun Run: 1
 T1 beginRun info with identifier 11 event 0
 %MSG
@@ -84,6 +90,12 @@ T1 analyze warning with identifier 22 event 1
 %MSG-i cat_A:  UTC_V2:ssm_2b Run: 1 Event: 2
 T1 analyze info with identifier 22 event 1
 %MSG
+%MSG-i cat_EPB:  UTC_V1:ssm_1a@endProcessBlock post-events
+T1 endProcessBlock info with identifier 11 event 2
+%MSG
+%MSG-i cat_EPB:  UTC_V1:ssm_1b@endProcessBlock post-events
+T1 endProcessBlock info with identifier 12 event 2
+%MSG
 
 =============================================
 
@@ -95,20 +107,24 @@ MessageLogger Summary
     2 cat_A                -i UTC_V1:ssm_1a                          2        2
     3 cat_A                -i UTC_V1:ssm_1b                          2        2
     4 cat_A                -i UTC_V2:ssm_2b                          2        2
-    5 cat_BR               -i UTC_V1:ssm_1a@be                       1        1
-    6 cat_BR               -i UTC_V1:ssm_1b@be                       1        1
-    7 cat_A                -w UTC_V1:ssm_1a                          2        2
-    8 cat_A                -w UTC_V1:ssm_1b                          2        2
-    9 cat_A                -w UTC_V2:ssm_2a                          2        2
-   10 cat_A                -w UTC_V2:ssm_2b                          2        2
-   11 cat_BJ               -w UTC_V1:ssm_1a@be                       1        1
-   12 cat_BJ               -w UTC_V1:ssm_1b@be                       1        1
-   13 cat_BL               -w UTC_V1:ssm_1a@be                       1        1
-   14 cat_BL               -w UTC_V1:ssm_1b@be                       1        1
-   15 cat_A                -e UTC_V1:ssm_1a                          2        2
-   16 cat_A                -e UTC_V1:ssm_1b                          2        2
-   17 cat_A                -e UTC_V2:ssm_2a                          2        2
-   18 cat_A                -e UTC_V2:ssm_2b                          2        2
+    5 cat_BPB              -i UTC_V1:ssm_1a@be                       1        1
+    6 cat_BPB              -i UTC_V1:ssm_1b@be                       1        1
+    7 cat_BR               -i UTC_V1:ssm_1a@be                       1        1
+    8 cat_BR               -i UTC_V1:ssm_1b@be                       1        1
+    9 cat_EPB              -i UTC_V1:ssm_1a@en                       1        1
+   10 cat_EPB              -i UTC_V1:ssm_1b@en                       1        1
+   11 cat_A                -w UTC_V1:ssm_1a                          2        2
+   12 cat_A                -w UTC_V1:ssm_1b                          2        2
+   13 cat_A                -w UTC_V2:ssm_2a                          2        2
+   14 cat_A                -w UTC_V2:ssm_2b                          2        2
+   15 cat_BJ               -w UTC_V1:ssm_1a@be                       1        1
+   16 cat_BJ               -w UTC_V1:ssm_1b@be                       1        1
+   17 cat_BL               -w UTC_V1:ssm_1a@be                       1        1
+   18 cat_BL               -w UTC_V1:ssm_1b@be                       1        1
+   19 cat_A                -e UTC_V1:ssm_1a                          2        2
+   20 cat_A                -e UTC_V1:ssm_1b                          2        2
+   21 cat_A                -e UTC_V2:ssm_2a                          2        2
+   22 cat_A                -e UTC_V2:ssm_2b                          2        2
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------
@@ -116,24 +132,28 @@ MessageLogger Summary
     2 cat_A                1/1              1/2              
     3 cat_A                1/1              1/2              
     4 cat_A                1/1              1/2              
-    5 cat_BR               Run: 1                            
-    6 cat_BR               Run: 1                            
-    7 cat_A                1/1              1/2              
-    8 cat_A                1/1              1/2              
-    9 cat_A                1/1              1/2              
-   10 cat_A                1/1              1/2              
-   11 cat_BJ               pre-events                        
-   12 cat_BJ               pre-events                        
-   13 cat_BL               Run: 1 Lumi: 1                    
-   14 cat_BL               Run: 1 Lumi: 1                    
-   15 cat_A                1/1              1/2              
-   16 cat_A                1/1              1/2              
-   17 cat_A                1/1              1/2              
-   18 cat_A                1/1              1/2              
+    5 cat_BPB              pre-events                        
+    6 cat_BPB              pre-events                        
+    7 cat_BR               Run: 1                            
+    8 cat_BR               Run: 1                            
+    9 cat_EPB              post-events                       
+   10 cat_EPB              post-events                       
+   11 cat_A                1/1              1/2              
+   12 cat_A                1/1              1/2              
+   13 cat_A                1/1              1/2              
+   14 cat_A                1/1              1/2              
+   15 cat_BJ               pre-events                        
+   16 cat_BJ               pre-events                        
+   17 cat_BL               Run: 1 Lumi: 1                    
+   18 cat_BL               Run: 1 Lumi: 1                    
+   19 cat_A                1/1              1/2              
+   20 cat_A                1/1              1/2              
+   21 cat_A                1/1              1/2              
+   22 cat_A                1/1              1/2              
 
 Severity    # Occurrences   Total Occurrences
 --------    -------------   -----------------
-Info                   10                  10
+Info                   14                  14
 Warning                12                  12
 Error                   8                   8
 

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -268,6 +268,48 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_2(watchPostModuleEndStream)
 
+    typedef signalslot::Signal<void(GlobalContext const&)> PreBeginProcessBlock;
+    PreBeginProcessBlock preBeginProcessBlockSignal_;
+    void watchPreBeginProcessBlock(PreBeginProcessBlock::slot_type const& iSlot) {
+      preBeginProcessBlockSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPreBeginProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PostBeginProcessBlock;
+    PostBeginProcessBlock postBeginProcessBlockSignal_;
+    void watchPostBeginProcessBlock(PostBeginProcessBlock::slot_type const& iSlot) {
+      postBeginProcessBlockSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostBeginProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PreAccessInputProcessBlock;
+    PreAccessInputProcessBlock preAccessInputProcessBlockSignal_;
+    void watchPreAccessInputProcessBlock(PreAccessInputProcessBlock::slot_type const& iSlot) {
+      preAccessInputProcessBlockSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPreAccessInputProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PostAccessInputProcessBlock;
+    PostAccessInputProcessBlock postAccessInputProcessBlockSignal_;
+    void watchPostAccessInputProcessBlock(PostAccessInputProcessBlock::slot_type const& iSlot) {
+      postAccessInputProcessBlockSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostAccessInputProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PreEndProcessBlock;
+    PreEndProcessBlock preEndProcessBlockSignal_;
+    void watchPreEndProcessBlock(PreEndProcessBlock::slot_type const& iSlot) {
+      preEndProcessBlockSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPreEndProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PostEndProcessBlock;
+    PostEndProcessBlock postEndProcessBlockSignal_;
+    void watchPostEndProcessBlock(PostEndProcessBlock::slot_type const& iSlot) {
+      postEndProcessBlockSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostEndProcessBlock)
+
     typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalBeginRun;
     /// signal is emitted after the Run has been created by the InputSource but before any modules have seen the Run
     PreGlobalBeginRun preGlobalBeginRunSignal_;
@@ -292,6 +334,20 @@ namespace edm {
       postGlobalEndRunSignal_.connect_front(iSlot);
     }
     AR_WATCH_USING_METHOD_1(watchPostGlobalEndRun)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PreWriteProcessBlock;
+    PreWriteProcessBlock preWriteProcessBlockSignal_;
+    void watchPreWriteProcessBlock(PreWriteProcessBlock::slot_type const& iSlot) {
+      preWriteProcessBlockSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPreWriteProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PostWriteProcessBlock;
+    PostWriteProcessBlock postWriteProcessBlockSignal_;
+    void watchPostWriteProcessBlock(PostWriteProcessBlock::slot_type const& iSlot) {
+      postWriteProcessBlockSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostWriteProcessBlock)
 
     typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalWriteRun;
     PreGlobalWriteRun preGlobalWriteRunSignal_;
@@ -782,6 +838,49 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_2(watchPostModuleStreamEndLumi)
 
+    typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleBeginProcessBlock;
+    PreModuleBeginProcessBlock preModuleBeginProcessBlockSignal_;
+    void watchPreModuleBeginProcessBlock(PreModuleBeginProcessBlock::slot_type const& iSlot) {
+      preModuleBeginProcessBlockSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPreModuleBeginProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PostModuleBeginProcessBlock;
+    PostModuleBeginProcessBlock postModuleBeginProcessBlockSignal_;
+    void watchPostModuleBeginProcessBlock(PostModuleBeginProcessBlock::slot_type const& iSlot) {
+      postModuleBeginProcessBlockSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPostModuleBeginProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleAccessInputProcessBlock;
+    PreModuleAccessInputProcessBlock preModuleAccessInputProcessBlockSignal_;
+    void watchPreModuleAccessInputProcessBlock(PreModuleAccessInputProcessBlock::slot_type const& iSlot) {
+      preModuleAccessInputProcessBlockSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPreModuleAccessInputProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)>
+        PostModuleAccessInputProcessBlock;
+    PostModuleAccessInputProcessBlock postModuleAccessInputProcessBlockSignal_;
+    void watchPostModuleAccessInputProcessBlock(PostModuleAccessInputProcessBlock::slot_type const& iSlot) {
+      postModuleAccessInputProcessBlockSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPostModuleAccessInputProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleEndProcessBlock;
+    PreModuleEndProcessBlock preModuleEndProcessBlockSignal_;
+    void watchPreModuleEndProcessBlock(PreModuleEndProcessBlock::slot_type const& iSlot) {
+      preModuleEndProcessBlockSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPreModuleEndProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PostModuleEndProcessBlock;
+    PostModuleEndProcessBlock postModuleEndProcessBlockSignal_;
+    void watchPostModuleEndProcessBlock(PostModuleEndProcessBlock::slot_type const& iSlot) {
+      postModuleEndProcessBlockSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPostModuleEndProcessBlock)
+
     typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleGlobalBeginRun;
     PreModuleGlobalBeginRun preModuleGlobalBeginRunSignal_;
     void watchPreModuleGlobalBeginRun(PreModuleGlobalBeginRun::slot_type const& iSlot) {
@@ -837,6 +936,20 @@ namespace edm {
       postModuleGlobalEndLumiSignal_.connect_front(iSlot);
     }
     AR_WATCH_USING_METHOD_2(watchPostModuleGlobalEndLumi)
+
+    typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleWriteProcessBlock;
+    PreModuleWriteProcessBlock preModuleWriteProcessBlockSignal_;
+    void watchPreModuleWriteProcessBlock(PreModuleWriteProcessBlock::slot_type const& iSlot) {
+      preModuleWriteProcessBlockSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPreModuleWriteProcessBlock)
+
+    typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PostModuleWriteProcessBlock;
+    PostModuleWriteProcessBlock postModuleWriteProcessBlockSignal_;
+    void watchPostModuleWriteProcessBlock(PostModuleWriteProcessBlock::slot_type const& iSlot) {
+      postModuleWriteProcessBlockSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPostModuleWriteProcessBlock)
 
     typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleWriteRun;
     PreModuleWriteRun preModuleWriteRunSignal_;

--- a/FWCore/ServiceRegistry/interface/GlobalContext.h
+++ b/FWCore/ServiceRegistry/interface/GlobalContext.h
@@ -30,11 +30,15 @@ namespace edm {
   public:
     enum class Transition {
       kBeginJob,
+      kBeginProcessBlock,
+      kAccessInputProcessBlock,
       kBeginRun,
       kBeginLuminosityBlock,
       kEndLuminosityBlock,
       kEndRun,
+      kEndProcessBlock,
       kEndJob,
+      kWriteProcessBlock,
       kWriteRun,
       kWriteLuminosityBlock
     };
@@ -49,7 +53,8 @@ namespace edm {
     Transition transition() const { return transition_; }
     bool isAtEndTransition() const {
       return transition() == Transition::kEndLuminosityBlock or transition() == Transition::kEndRun or
-             transition() == Transition::kWriteRun or transition() == Transition::kWriteLuminosityBlock;
+             transition() == Transition::kEndProcessBlock or transition() == Transition::kWriteRun or
+             transition() == Transition::kWriteLuminosityBlock or transition() == Transition::kWriteProcessBlock;
     }
 
     LuminosityBlockID const& luminosityBlockID() const { return luminosityBlockID_; }

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -128,11 +128,23 @@ namespace edm {
     preModuleEndStreamSignal_.connect(std::cref(iOther.preModuleEndStreamSignal_));
     postModuleEndStreamSignal_.connect(std::cref(iOther.postModuleEndStreamSignal_));
 
+    preBeginProcessBlockSignal_.connect(std::cref(iOther.preBeginProcessBlockSignal_));
+    postBeginProcessBlockSignal_.connect(std::cref(iOther.postBeginProcessBlockSignal_));
+
+    preAccessInputProcessBlockSignal_.connect(std::cref(iOther.preAccessInputProcessBlockSignal_));
+    postAccessInputProcessBlockSignal_.connect(std::cref(iOther.postAccessInputProcessBlockSignal_));
+
+    preEndProcessBlockSignal_.connect(std::cref(iOther.preEndProcessBlockSignal_));
+    postEndProcessBlockSignal_.connect(std::cref(iOther.postEndProcessBlockSignal_));
+
     preGlobalBeginRunSignal_.connect(std::cref(iOther.preGlobalBeginRunSignal_));
     postGlobalBeginRunSignal_.connect(std::cref(iOther.postGlobalBeginRunSignal_));
 
     preGlobalEndRunSignal_.connect(std::cref(iOther.preGlobalEndRunSignal_));
     postGlobalEndRunSignal_.connect(std::cref(iOther.postGlobalEndRunSignal_));
+
+    preWriteProcessBlockSignal_.connect(std::cref(iOther.preWriteProcessBlockSignal_));
+    postWriteProcessBlockSignal_.connect(std::cref(iOther.postWriteProcessBlockSignal_));
 
     preGlobalWriteRunSignal_.connect(std::cref(iOther.preGlobalWriteRunSignal_));
     postGlobalWriteRunSignal_.connect(std::cref(iOther.postGlobalWriteRunSignal_));
@@ -230,6 +242,15 @@ namespace edm {
     preModuleStreamEndLumiSignal_.connect(std::cref(iOther.preModuleStreamEndLumiSignal_));
     postModuleStreamEndLumiSignal_.connect(std::cref(iOther.postModuleStreamEndLumiSignal_));
 
+    preModuleBeginProcessBlockSignal_.connect(std::cref(iOther.preModuleBeginProcessBlockSignal_));
+    postModuleBeginProcessBlockSignal_.connect(std::cref(iOther.postModuleBeginProcessBlockSignal_));
+
+    preModuleAccessInputProcessBlockSignal_.connect(std::cref(iOther.preModuleAccessInputProcessBlockSignal_));
+    postModuleAccessInputProcessBlockSignal_.connect(std::cref(iOther.postModuleAccessInputProcessBlockSignal_));
+
+    preModuleEndProcessBlockSignal_.connect(std::cref(iOther.preModuleEndProcessBlockSignal_));
+    postModuleEndProcessBlockSignal_.connect(std::cref(iOther.postModuleEndProcessBlockSignal_));
+
     preModuleGlobalBeginRunSignal_.connect(std::cref(iOther.preModuleGlobalBeginRunSignal_));
     postModuleGlobalBeginRunSignal_.connect(std::cref(iOther.postModuleGlobalBeginRunSignal_));
 
@@ -241,6 +262,9 @@ namespace edm {
 
     preModuleGlobalEndLumiSignal_.connect(std::cref(iOther.preModuleGlobalEndLumiSignal_));
     postModuleGlobalEndLumiSignal_.connect(std::cref(iOther.postModuleGlobalEndLumiSignal_));
+
+    preModuleWriteProcessBlockSignal_.connect(std::cref(iOther.preModuleWriteProcessBlockSignal_));
+    postModuleWriteProcessBlockSignal_.connect(std::cref(iOther.postModuleWriteProcessBlockSignal_));
 
     preModuleWriteRunSignal_.connect(std::cref(iOther.preModuleWriteRunSignal_));
     postModuleWriteRunSignal_.connect(std::cref(iOther.postModuleWriteRunSignal_));
@@ -304,11 +328,23 @@ namespace edm {
     copySlotsToFrom(preModuleEndStreamSignal_, iOther.preModuleEndStreamSignal_);
     copySlotsToFromReverse(postModuleEndStreamSignal_, iOther.postModuleEndStreamSignal_);
 
+    copySlotsToFrom(preBeginProcessBlockSignal_, iOther.preBeginProcessBlockSignal_);
+    copySlotsToFromReverse(postBeginProcessBlockSignal_, iOther.postBeginProcessBlockSignal_);
+
+    copySlotsToFrom(preAccessInputProcessBlockSignal_, iOther.preAccessInputProcessBlockSignal_);
+    copySlotsToFromReverse(postAccessInputProcessBlockSignal_, iOther.postAccessInputProcessBlockSignal_);
+
+    copySlotsToFrom(preEndProcessBlockSignal_, iOther.preEndProcessBlockSignal_);
+    copySlotsToFromReverse(postEndProcessBlockSignal_, iOther.postEndProcessBlockSignal_);
+
     copySlotsToFrom(preGlobalBeginRunSignal_, iOther.preGlobalBeginRunSignal_);
     copySlotsToFromReverse(postGlobalBeginRunSignal_, iOther.postGlobalBeginRunSignal_);
 
     copySlotsToFrom(preGlobalEndRunSignal_, iOther.preGlobalEndRunSignal_);
     copySlotsToFromReverse(postGlobalEndRunSignal_, iOther.postGlobalEndRunSignal_);
+
+    copySlotsToFrom(preWriteProcessBlockSignal_, iOther.preWriteProcessBlockSignal_);
+    copySlotsToFromReverse(postWriteProcessBlockSignal_, iOther.postWriteProcessBlockSignal_);
 
     copySlotsToFrom(preGlobalWriteRunSignal_, iOther.preGlobalWriteRunSignal_);
     copySlotsToFromReverse(postGlobalWriteRunSignal_, iOther.postGlobalWriteRunSignal_);
@@ -411,6 +447,15 @@ namespace edm {
     copySlotsToFrom(preModuleStreamEndLumiSignal_, iOther.preModuleStreamEndLumiSignal_);
     copySlotsToFromReverse(postModuleStreamEndLumiSignal_, iOther.postModuleStreamEndLumiSignal_);
 
+    copySlotsToFrom(preModuleBeginProcessBlockSignal_, iOther.preModuleBeginProcessBlockSignal_);
+    copySlotsToFromReverse(postModuleBeginProcessBlockSignal_, iOther.postModuleBeginProcessBlockSignal_);
+
+    copySlotsToFrom(preModuleAccessInputProcessBlockSignal_, iOther.preModuleAccessInputProcessBlockSignal_);
+    copySlotsToFromReverse(postModuleAccessInputProcessBlockSignal_, iOther.postModuleAccessInputProcessBlockSignal_);
+
+    copySlotsToFrom(preModuleEndProcessBlockSignal_, iOther.preModuleEndProcessBlockSignal_);
+    copySlotsToFromReverse(postModuleEndProcessBlockSignal_, iOther.postModuleEndProcessBlockSignal_);
+
     copySlotsToFrom(preModuleGlobalBeginRunSignal_, iOther.preModuleGlobalBeginRunSignal_);
     copySlotsToFromReverse(postModuleGlobalBeginRunSignal_, iOther.postModuleGlobalBeginRunSignal_);
 
@@ -422,6 +467,9 @@ namespace edm {
 
     copySlotsToFrom(preModuleGlobalEndLumiSignal_, iOther.preModuleGlobalEndLumiSignal_);
     copySlotsToFromReverse(postModuleGlobalEndLumiSignal_, iOther.postModuleGlobalEndLumiSignal_);
+
+    copySlotsToFrom(preModuleWriteProcessBlockSignal_, iOther.preModuleWriteProcessBlockSignal_);
+    copySlotsToFromReverse(postModuleWriteProcessBlockSignal_, iOther.postModuleWriteProcessBlockSignal_);
 
     copySlotsToFrom(preModuleWriteRunSignal_, iOther.preModuleWriteRunSignal_);
     copySlotsToFromReverse(postModuleWriteRunSignal_, iOther.postModuleWriteRunSignal_);

--- a/FWCore/ServiceRegistry/src/GlobalContext.cc
+++ b/FWCore/ServiceRegistry/src/GlobalContext.cc
@@ -99,7 +99,7 @@ namespace edm {
         os << "endJob";
         break;
       case GlobalContext::Transition::kWriteProcessBlock:
-        os << "write ProcessBlock ";
+        os << "write ProcessBlock";
         break;
       case GlobalContext::Transition::kWriteRun:
         os << "write Run " << RunID(gc.luminosityBlockID().run());

--- a/FWCore/ServiceRegistry/src/GlobalContext.cc
+++ b/FWCore/ServiceRegistry/src/GlobalContext.cc
@@ -24,6 +24,12 @@ namespace edm {
       case GlobalContext::Transition::kBeginJob:
         os << "BeginJob";
         break;
+      case GlobalContext::Transition::kBeginProcessBlock:
+        os << "BeginProcessBlock";
+        break;
+      case GlobalContext::Transition::kAccessInputProcessBlock:
+        os << "AccessInputProcessBlock";
+        break;
       case GlobalContext::Transition::kBeginRun:
         os << "BeginRun";
         break;
@@ -36,8 +42,14 @@ namespace edm {
       case GlobalContext::Transition::kEndRun:
         os << "EndRun";
         break;
+      case GlobalContext::Transition::kEndProcessBlock:
+        os << "EndProcessBlock";
+        break;
       case GlobalContext::Transition::kEndJob:
         os << "EndJob";
+        break;
+      case GlobalContext::Transition::kWriteProcessBlock:
+        os << "WriteProcessBlock";
         break;
       case GlobalContext::Transition::kWriteRun:
         os << "WriteRun";
@@ -62,6 +74,12 @@ namespace edm {
       case GlobalContext::Transition::kBeginJob:
         os << "begin Job";
         break;
+      case GlobalContext::Transition::kBeginProcessBlock:
+        os << "begin ProcessBlock";
+        break;
+      case GlobalContext::Transition::kAccessInputProcessBlock:
+        os << "access input ProcessBlock";
+        break;
       case GlobalContext::Transition::kBeginRun:
         os << "global begin Run " << RunID(gc.luminosityBlockID().run());
         break;
@@ -74,8 +92,14 @@ namespace edm {
       case GlobalContext::Transition::kEndRun:
         os << "global end Run " << RunID(gc.luminosityBlockID().run());
         break;
+      case GlobalContext::Transition::kEndProcessBlock:
+        os << "end ProcessBlock";
+        break;
       case GlobalContext::Transition::kEndJob:
         os << "endJob";
+        break;
+      case GlobalContext::Transition::kWriteProcessBlock:
+        os << "write ProcessBlock ";
         break;
       case GlobalContext::Transition::kWriteRun:
         os << "write Run " << RunID(gc.luminosityBlockID().run());

--- a/FWCore/TestProcessor/interface/ProcessBlock.h
+++ b/FWCore/TestProcessor/interface/ProcessBlock.h
@@ -1,0 +1,62 @@
+#ifndef FWCore_TestProcessor_ProcessBlock_h
+#define FWCore_TestProcessor_ProcessBlock_h
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     ProcessBlock
+//
+/**\class edm::test::ProcessBlock
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  28 May 2020
+//
+
+#include <string>
+
+#include "FWCore/TestProcessor/interface/TestHandle.h"
+#include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+namespace edm {
+
+  namespace test {
+
+    class ProcessBlock {
+    public:
+      ProcessBlock(ProcessBlockPrincipal const* iPrincipal, std::string iModuleLabel, std::string iProcessName);
+
+      template <typename T>
+      TestHandle<T> get() const {
+        static const std::string s_null;
+        return get<T>(s_null);
+      }
+
+      template <typename T>
+      TestHandle<T> get(std::string const& iInstanceLabel) const {
+        auto h = principal_->getByLabel(
+            edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), label_, iInstanceLabel, processName_, nullptr, nullptr, nullptr);
+        if (h.failedToGet()) {
+          return TestHandle<T>(std::move(h.whyFailedFactory()));
+        }
+        void const* basicWrapper = h.wrapper();
+        assert(basicWrapper);
+        Wrapper<T> const* wrapper = static_cast<Wrapper<T> const*>(basicWrapper);
+        return TestHandle<T>(wrapper->product());
+      }
+
+    private:
+      ProcessBlockPrincipal const* principal_;
+      std::string label_;
+      std::string processName_;
+    };
+  }  // namespace test
+}  // namespace edm
+
+#endif

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -43,6 +43,7 @@
 
 #include "FWCore/TestProcessor/interface/Event.h"
 #include "FWCore/TestProcessor/interface/LuminosityBlock.h"
+#include "FWCore/TestProcessor/interface/ProcessBlock.h"
 #include "FWCore/TestProcessor/interface/Run.h"
 #include "FWCore/TestProcessor/interface/TestDataProxy.h"
 #include "FWCore/TestProcessor/interface/ESPutTokenT.h"
@@ -156,6 +157,8 @@ namespace edm {
       using Config = TestProcessorConfig;
 
       TestProcessor(Config const& iConfig, ServiceToken iToken = ServiceToken());
+      TestProcessor(const TestProcessor&) = delete;
+      const TestProcessor& operator=(const TestProcessor&) = delete;
       ~TestProcessor() noexcept(false);
 
       /** Run the test. The function arguments are the data products to be added to the
@@ -184,6 +187,14 @@ namespace edm {
         return testEndRunImpl(std::forward<T>(iArgs)...);
       }
 
+      // It makes no sense to pass EventSetup products and at least
+      // for now Runs, Lumis, and ProcessBlocks don't allow passing
+      // in other products. So for now these don't need to be templates
+      // for ProcessBlock.
+      edm::test::ProcessBlock testBeginProcessBlock() { return testBeginProcessBlockImpl(); }
+
+      edm::test::ProcessBlock testEndProcessBlock() { return testEndProcessBlockImpl(); }
+
       /** Run only beginJob and endJob. Once this is used, you should not attempt to run any further tests.
 This simulates a problem happening early in the job which causes processing not to proceed.
    */
@@ -192,19 +203,30 @@ This simulates a problem happening early in the job which causes processing not 
         endJob();
       }
 
+      void testWithNoRuns() {
+        beginJob();
+        beginProcessBlock();
+        endProcessBlock();
+        endJob();
+      }
+
       void testRunWithNoLuminosityBlocks() {
         beginJob();
+        beginProcessBlock();
         beginRun();
         endRun();
+        endProcessBlock();
         endJob();
       }
 
       void testLuminosityBlockWithNoEvents() {
         beginJob();
+        beginProcessBlock();
         beginRun();
         beginLuminosityBlock();
         endLuminosityBlock();
         endRun();
+        endProcessBlock();
         endJob();
       }
       void setRunNumber(edm::RunNumber_t);
@@ -214,10 +236,6 @@ This simulates a problem happening early in the job which causes processing not 
       std::string const& labelOfTestModule() const { return labelOfTestModule_; }
 
     private:
-      TestProcessor(const TestProcessor&) = delete;  // stop default
-
-      const TestProcessor& operator=(const TestProcessor&) = delete;  // stop default
-
       template <typename T, typename... U>
       edm::test::Event testImpl(std::pair<edm::EDPutTokenT<T>, std::unique_ptr<T>>&& iPut, U&&... iArgs) {
         put(std::move(iPut));
@@ -278,15 +296,20 @@ This simulates a problem happening early in the job which causes processing not 
       }
       edm::test::Run testEndRunImpl();
 
+      edm::test::ProcessBlock testBeginProcessBlockImpl();
+      edm::test::ProcessBlock testEndProcessBlockImpl();
+
       void setupProcessing();
       void teardownProcessing();
 
       void beginJob();
+      void beginProcessBlock();
       void beginRun();
       void beginLuminosityBlock();
       void event();
       std::shared_ptr<LuminosityBlockPrincipal> endLuminosityBlock();
       std::shared_ptr<RunPrincipal> endRun();
+      ProcessBlockPrincipal const* endProcessBlock();
       void endJob();
 
       // ---------- member data --------------------------------
@@ -320,6 +343,7 @@ This simulates a problem happening early in the job which causes processing not 
       LuminosityBlockNumber_t lumiNumber_ = 1;
       EventNumber_t eventNumber_ = 1;
       bool beginJobCalled_ = false;
+      bool beginProcessBlockCalled_ = false;
       bool beginRunCalled_ = false;
       bool beginLumiCalled_ = false;
     };

--- a/FWCore/TestProcessor/src/ProcessBlock.cc
+++ b/FWCore/TestProcessor/src/ProcessBlock.cc
@@ -1,0 +1,24 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     ProcessBlock
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  W. David Dagenhart
+//         Created:  28 May 2020
+//
+
+#include "FWCore/TestProcessor/interface/ProcessBlock.h"
+
+namespace edm {
+  namespace test {
+
+    ProcessBlock::ProcessBlock(ProcessBlockPrincipal const* iPrincipal,
+                               std::string iModuleLabel,
+                               std::string iProcessName)
+        : principal_{iPrincipal}, label_{std::move(iModuleLabel)}, processName_{std::move(iProcessName)} {}
+
+  }  // namespace test
+}  // namespace edm

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -25,8 +25,9 @@
 #include "FWCore/Framework/interface/PathsAndConsumesOfModules.h"
 #include "FWCore/Framework/interface/ESRecordsToProxyIndices.h"
 #include "FWCore/Framework/src/EventSetupsController.h"
-#include "FWCore/Framework/src/streamTransitionAsync.h"
 #include "FWCore/Framework/src/globalTransitionAsync.h"
+#include "FWCore/Framework/src/streamTransitionAsync.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/Framework/interface/DelayedReader.h"
 
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -404,12 +405,13 @@ namespace edm {
 
       std::vector<edm::SubProcess> emptyList;
       {
-        typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalBegin> Traits;
+        ProcessBlockTransitionInfo transitionInfo(processBlockPrincipal);
+        using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalBegin>;
         auto globalWaitTask = make_empty_waiting_task();
         globalWaitTask->increment_ref_count();
 
         beginGlobalTransitionAsync<Traits>(
-            WaitingTaskHolder(globalWaitTask.get()), *schedule_, processBlockPrincipal, serviceToken_, emptyList);
+            WaitingTaskHolder(globalWaitTask.get()), *schedule_, transitionInfo, serviceToken_, emptyList);
 
         globalWaitTask->wait_for_all();
         if (globalWaitTask->exceptionPtr() != nullptr) {
@@ -434,17 +436,12 @@ namespace edm {
 
       std::vector<edm::SubProcess> emptyList;
       {
-        typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
+        RunTransitionInfo transitionInfo(runPrincipal, es);
+        using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>;
         auto globalWaitTask = make_empty_waiting_task();
         globalWaitTask->increment_ref_count();
-        beginGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
-                                           *schedule_,
-                                           runPrincipal,
-                                           ts,
-                                           es,
-                                           nullptr,
-                                           serviceToken_,
-                                           emptyList);
+        beginGlobalTransitionAsync<Traits>(
+            WaitingTaskHolder(globalWaitTask.get()), *schedule_, transitionInfo, serviceToken_, emptyList);
         globalWaitTask->wait_for_all();
         if (globalWaitTask->exceptionPtr() != nullptr) {
           std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
@@ -491,17 +488,12 @@ namespace edm {
 
       std::vector<edm::SubProcess> emptyList;
       {
-        typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
+        LumiTransitionInfo transitionInfo(*lumiPrincipal_, es, nullptr);
+        using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>;
         auto globalWaitTask = make_empty_waiting_task();
         globalWaitTask->increment_ref_count();
-        beginGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
-                                           *schedule_,
-                                           *lumiPrincipal_,
-                                           ts,
-                                           es,
-                                           nullptr,
-                                           serviceToken_,
-                                           emptyList);
+        beginGlobalTransitionAsync<Traits>(
+            WaitingTaskHolder(globalWaitTask.get()), *schedule_, transitionInfo, serviceToken_, emptyList);
         globalWaitTask->wait_for_all();
         if (globalWaitTask->exceptionPtr() != nullptr) {
           std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
@@ -610,16 +602,10 @@ namespace edm {
           auto globalWaitTask = make_empty_waiting_task();
           globalWaitTask->increment_ref_count();
 
-          typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
-          endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
-                                           *schedule_,
-                                           *lumiPrincipal,
-                                           ts,
-                                           es,
-                                           nullptr,
-                                           serviceToken_,
-                                           emptyList,
-                                           false);
+          LumiTransitionInfo transitionInfo(*lumiPrincipal, es, nullptr);
+          using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd>;
+          endGlobalTransitionAsync<Traits>(
+              WaitingTaskHolder(globalWaitTask.get()), *schedule_, transitionInfo, serviceToken_, emptyList, false);
           globalWaitTask->wait_for_all();
           if (globalWaitTask->exceptionPtr() != nullptr) {
             std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
@@ -673,16 +659,10 @@ namespace edm {
           auto globalWaitTask = make_empty_waiting_task();
           globalWaitTask->increment_ref_count();
 
-          typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
-          endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
-                                           *schedule_,
-                                           runPrincipal,
-                                           ts,
-                                           es,
-                                           nullptr,
-                                           serviceToken_,
-                                           emptyList,
-                                           false);
+          RunTransitionInfo transitionInfo(runPrincipal, es);
+          using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>;
+          endGlobalTransitionAsync<Traits>(
+              WaitingTaskHolder(globalWaitTask.get()), *schedule_, transitionInfo, serviceToken_, emptyList, false);
           globalWaitTask->wait_for_all();
           if (globalWaitTask->exceptionPtr() != nullptr) {
             std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
@@ -704,13 +684,10 @@ namespace edm {
           auto globalWaitTask = make_empty_waiting_task();
           globalWaitTask->increment_ref_count();
 
-          typedef OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalEnd> Traits;
-          endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
-                                           *schedule_,
-                                           processBlockPrincipal,
-                                           serviceToken_,
-                                           emptyList,
-                                           false);
+          ProcessBlockTransitionInfo transitionInfo(processBlockPrincipal);
+          using Traits = OccurrenceTraits<ProcessBlockPrincipal, BranchActionGlobalEnd>;
+          endGlobalTransitionAsync<Traits>(
+              WaitingTaskHolder(globalWaitTask.get()), *schedule_, transitionInfo, serviceToken_, emptyList, false);
           globalWaitTask->wait_for_all();
           if (globalWaitTask->exceptionPtr() != nullptr) {
             std::rethrow_exception(*(globalWaitTask->exceptionPtr()));

--- a/FWCore/Utilities/interface/BranchType.h
+++ b/FWCore/Utilities/interface/BranchType.h
@@ -1,13 +1,13 @@
 #ifndef FWCore_Utilities_BranchType_h
 #define FWCore_Utilities_BranchType_h
 /*----------------------------------------------------------------------
-  
-BranchType: The type of a Branch (Event, LuminosityBlock, or Run)
+
+BranchType: The type of a Branch (Event, LuminosityBlock, Run, or ProcessBlock)
 
 ----------------------------------------------------------------------*/
 
 namespace edm {
   // Note: These enum values are used as subscripts for a fixed size array, so they must not change.
-  enum BranchType { InEvent = 0, InLumi = 1, InRun = 2, NumBranchTypes };
+  enum BranchType { InEvent = 0, InLumi = 1, InRun = 2, InProcess = 3, NumBranchTypes };
 }  // namespace edm
 #endif

--- a/FWCore/Utilities/interface/ProcessBlockIndex.h
+++ b/FWCore/Utilities/interface/ProcessBlockIndex.h
@@ -1,0 +1,47 @@
+#ifndef FWCore_Utilities_ProcessBlockIndex_h
+#define FWCore_Utilities_ProcessBlockIndex_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     edm::ProcessBlockIndex
+//
+/**\class edm::ProcessBlockIndex
+
+ Description: Identifies a ProcessBlock
+
+ Usage:
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  18 March 2020
+
+namespace edm {
+  class ProcessBlockPrincipal;
+
+  class ProcessBlockIndex {
+  public:
+    ~ProcessBlockIndex() = default;
+    ProcessBlockIndex(const ProcessBlockIndex&) = default;
+    ProcessBlockIndex& operator=(const ProcessBlockIndex&) = default;
+
+    bool operator==(const ProcessBlockIndex& iIndex) const { return value() == iIndex.value(); }
+    operator unsigned int() const { return value_; }
+
+    unsigned int value() const { return value_; }
+
+    static ProcessBlockIndex invalidProcessBlockIndex();
+
+  private:
+    ///Only the ProcessBlockPrincipal is allowed to make one of these
+    friend class ProcessBlockPrincipal;
+    explicit ProcessBlockIndex(unsigned int iIndex) : value_(iIndex) {}
+
+    ProcessBlockIndex() = delete;
+
+    unsigned int value_;
+
+    static const unsigned int invalidValue_;
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/Utilities/interface/Transition.h
+++ b/FWCore/Utilities/interface/Transition.h
@@ -17,6 +17,7 @@ namespace edm {
     EndRun,
     BeginProcessBlock,
     EndProcessBlock,
+    AccessInputProcessBlock,
     NumberOfTransitions,
     NumberOfEventSetupTransitions = BeginProcessBlock
   };

--- a/FWCore/Utilities/interface/Transition.h
+++ b/FWCore/Utilities/interface/Transition.h
@@ -1,7 +1,7 @@
 #ifndef FWCore_Utilities_Transition_h
 #define FWCore_Utilities_Transition_h
 /*----------------------------------------------------------------------
-  
+
 Transition: The allowed framework transitions
 
 ----------------------------------------------------------------------*/
@@ -9,21 +9,33 @@ Transition: The allowed framework transitions
 #include <type_traits>
 
 namespace edm {
-  enum class Transition { Event, BeginLuminosityBlock, EndLuminosityBlock, BeginRun, EndRun, NumberOfTransitions };
+  enum class Transition {
+    Event,
+    BeginLuminosityBlock,
+    EndLuminosityBlock,
+    BeginRun,
+    EndRun,
+    BeginProcessBlock,
+    EndProcessBlock,
+    NumberOfTransitions,
+    NumberOfEventSetupTransitions = 5
+  };
 
   //Useful for converting EndBranchType to BranchType
   constexpr BranchType convertToBranchType(Transition iValue) {
-    constexpr BranchType branches[] = {InEvent, InLumi, InLumi, InRun, InRun};
+    constexpr BranchType branches[] = {InEvent, InLumi, InLumi, InRun, InRun, InProcess, InProcess};
     return branches[static_cast<std::underlying_type<Transition>::type>(iValue)];
   }
 
   constexpr Transition convertToTransition(BranchType iValue) {
-    constexpr Transition trans[] = {Transition::Event, Transition::BeginLuminosityBlock, Transition::BeginRun};
+    constexpr Transition trans[] = {
+        Transition::Event, Transition::BeginLuminosityBlock, Transition::BeginRun, Transition::BeginProcessBlock};
     return trans[iValue];
   }
 
   constexpr bool isEndTransition(Transition iValue) {
-    return iValue == Transition::EndLuminosityBlock or iValue == Transition::EndRun;
+    return iValue == Transition::EndLuminosityBlock or iValue == Transition::EndRun or
+           iValue == Transition::EndProcessBlock;
   }
 
 }  // namespace edm

--- a/FWCore/Utilities/interface/Transition.h
+++ b/FWCore/Utilities/interface/Transition.h
@@ -18,7 +18,7 @@ namespace edm {
     BeginProcessBlock,
     EndProcessBlock,
     NumberOfTransitions,
-    NumberOfEventSetupTransitions = 5
+    NumberOfEventSetupTransitions = BeginProcessBlock
   };
 
   //Useful for converting EndBranchType to BranchType

--- a/FWCore/Utilities/src/ProcessBlockIndex.cc
+++ b/FWCore/Utilities/src/ProcessBlockIndex.cc
@@ -1,0 +1,10 @@
+#include "FWCore/Utilities/interface/ProcessBlockIndex.h"
+
+#include <limits>
+
+namespace edm {
+
+  const unsigned int ProcessBlockIndex::invalidValue_ = std::numeric_limits<unsigned int>::max();
+
+  ProcessBlockIndex ProcessBlockIndex::invalidProcessBlockIndex() { return ProcessBlockIndex(invalidValue_); }
+}  // namespace edm

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -247,6 +247,7 @@ namespace edm {
     treePointers_[InEvent] = &eventTree_;
     treePointers_[InLumi] = &lumiTree_;
     treePointers_[InRun] = &runTree_;
+    treePointers_[InProcess] = nullptr;
 
     // Read the metadata tree.
     // We use a smart pointer so the tree will be deleted after use, and not kept for the life of the file.
@@ -503,6 +504,10 @@ namespace edm {
     for (auto& product : pList) {
       BranchDescription& prod = product.second;
       prod.init();
+      if (prod.branchType() == InProcess) {
+        // ProcessBlock input not implemented yet
+        continue;
+      }
       treePointers_[prod.branchType()]->setPresence(prod, newBranchToOldBranch(prod.branchName()));
     }
 
@@ -559,12 +564,20 @@ namespace edm {
 
       int i = 0;
       for (auto t : treePointers_) {
+        if (t == nullptr) {
+          // ProcessBlock input not implemented yet
+          continue;
+        }
         t->numberOfBranchesToAdd(nBranches[i]);
         ++i;
       }
     }
     for (auto const& product : prodList) {
       BranchDescription const& prod = product.second;
+      if (prod.branchType() == InProcess) {
+        // ProcessBlock input not implemented yet
+        continue;
+      }
       treePointers_[prod.branchType()]->addBranch(prod, newBranchToOldBranch(prod.branchName()));
     }
 
@@ -1200,6 +1213,10 @@ namespace edm {
     // Just to play it safe, zero all pointers to objects in the InputFile to be closed.
     eventHistoryTree_ = nullptr;
     for (auto& treePointer : treePointers_) {
+      if (treePointer == nullptr) {
+        // ProcessBlock input not implemented yet
+        continue;
+      }
       treePointer->close();
       treePointer = nullptr;
     }
@@ -1784,7 +1801,10 @@ namespace edm {
                                    << "of file '" << file_ << "' because it is dependent on a branch\n"
                                    << "that was explicitly dropped.\n";
           }
-          treePointers_[prod.branchType()]->dropBranch(newBranchToOldBranch(prod.branchName()));
+          // ProcessBlock input is not implemented yet
+          if (prod.branchType() != InProcess) {
+            treePointers_[prod.branchType()]->dropBranch(newBranchToOldBranch(prod.branchName()));
+          }
           hasNewlyDroppedBranch_[prod.branchType()] = true;
         }
         ProductRegistry::ProductList::iterator icopy = it;
@@ -1800,7 +1820,7 @@ namespace edm {
       TString tString;
       for (ProductRegistry::ProductList::iterator it = prodList.begin(), itEnd = prodList.end(); it != itEnd;) {
         BranchDescription const& prod = it->second;
-        if (prod.branchType() != InEvent) {
+        if (prod.branchType() != InEvent && prod.branchType() != InProcess) {
           TClass* cp = prod.wrappedType().getClass();
           void* p = cp->New();
           int offset = cp->GetBaseClassOffset(edProductClass_);

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -246,6 +246,10 @@ namespace edm {
   void PoolOutputModule::respondToOpenInputFile(FileBlock const& fb) {
     if (!initializedFromInput_) {
       for (int i = InEvent; i < NumBranchTypes; ++i) {
+        if (i == InProcess) {
+          // ProcessBlock output not implemented yet
+          continue;
+        }
         BranchType branchType = static_cast<BranchType>(i);
         TTree* theInputTree =
             (branchType == InEvent ? fb.tree() : (branchType == InLumi ? fb.lumiTree() : fb.runTree()));

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -148,8 +148,13 @@ namespace edm {
     treePointers_[InEvent] = &eventTree_;
     treePointers_[InLumi] = &lumiTree_;
     treePointers_[InRun] = &runTree_;
+    treePointers_[InProcess] = nullptr;
 
     for (int i = InEvent; i < NumBranchTypes; ++i) {
+      if (i == InProcess) {
+        // Output for ProcessBlocks is not implemented yet.
+        continue;
+      }
       BranchType branchType = static_cast<BranchType>(i);
       RootOutputTree* theTree = treePointers_[branchType];
       for (auto& item : om_->selectedOutputItemList()[branchType]) {
@@ -622,6 +627,10 @@ namespace edm {
     // events/lumis/runs trees. The loop is over all types of data
     // products.
     for (int i = InEvent; i < NumBranchTypes; ++i) {
+      if (i == InProcess) {
+        // Output for ProcessBlocks is not implemented yet.
+        continue;
+      }
       BranchType branchType = static_cast<BranchType>(i);
       setBranchAliases(treePointers_[branchType]->tree(), om_->keptProducts()[branchType]);
       treePointers_[branchType]->writeTree();
@@ -631,6 +640,10 @@ namespace edm {
     // Just to play it safe, zero all pointers to objects in the TFile to be closed.
     metaDataTree_ = parentageTree_ = nullptr;
     for (auto& treePointer : treePointers_) {
+      if (treePointer.get() == nullptr) {
+        // Output for ProcessBlock is not implemented yet
+        continue;
+      }
       treePointer->close();
       treePointer = nullptr;
     }


### PR DESCRIPTION
This introduces the new transitions beginProcessBlock, endProcessBlock, beginProcessBlockProduce, and endProcessBlockProduce. These can be used by producers, filters, and analyzers in a way that is analogous to beginRun, endRun, beginRunProduce, and endRunProduce. These abilities become available when the types ProcessBlockCache, BeginProcessBlockProducer, or EndProcessBlockProducer are passed to the base class of the module as template parameters. These abilities are not available to legacy module types.

The order modules are executed respects product dependencies established with calls to consumes and produces. One module can put products into a ProcessBlock and another module get them.

beginProcessBlock occurs after beginJob and after beginStream, but before any run, lumi or event transitions. endProcessBlock occurs after all run, lumi, and event transitions, but before endStream and endJob. Each occurs only once per job, except in the very unusual case where all output files are closed and new output files opened. In that case only, there will be a pair of end and begin transitions in between the output file close and open.

This is only the first of a series of PRs implementing this feature. Future PRs will add persistency and the ability to access this information from Events, Runs, and Lumis through a cache. With this PR, these abilities cannot be used by OutputModules. That will be added later. (In this PR, the OutputModule part of this is partially implemented. In the code from the EventProcessor to the functions in the OutputModuleBase classes, the implementation is complete. The functions in OutputModuleBase in this PR do nothing. The PoolOutputModule only has the minimal changes required to prevent this PR from breaking it. The next PR will complete the implementation for output.)

Similarly, the implementation is not done in the InputSource. The future transition accessInputProcessBlock is also only partially implemented. (The part in the InputSource is not implemented although the part of the code from EventProcessor down to the modules is complete. Those functions will never get called with the code in this PR.)

There should be no changes in output. After this PR, these new abilities are only used by modules in Core tests. Nothing extra should be running in production jobs and nothing should be modified. You can see the new transitions in the output from the Tracer. There are new signals ActivityRegistry. The MessageLogger is modified to properly handle these new contexts. I expect any performance impact to be negligible until modules start doing nontrivial work in these transitions.

In comments to this PR requesting changes, it would be useful to identify issues that can be handled in future PRs. This PR is already large.

#### PR validation:

There are several new Framework unit tests and extensions to existing Framework unit tests to cover the new abilities. Output from tests in runTheMatrix and relVals should be identical.

I expect there will be conflicts between this PR and #29553 in at least EDConsumerBase. They should not be difficult to resolve though.
