### PR TITLE
TBLayer computeCrossings doesn't allow for some displaced starting points

### DIFF
--- a/RecoTracker/TkDetLayers/src/TBLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TBLayer.cc
@@ -55,7 +55,8 @@ SubLayerCrossings TBLayer::computeCrossings(const TrajectoryStateOnSurface& star
   HelixBarrelCylinderCrossing outerCrossing(
       startPos, startDir, rho, propDir, *theOuterCylinder, HelixBarrelCylinderCrossing::onlyPos);
 
-  if (!innerCrossing.hasSolution() && !outerCrossing.hasSolution()) return SubLayerCrossings();
+  if (!innerCrossing.hasSolution() && !outerCrossing.hasSolution())
+    return SubLayerCrossings();
 
   if (!innerCrossing.hasSolution() && outerCrossing.hasSolution()) {
     innerCrossing = outerCrossing;

--- a/RecoTracker/TkDetLayers/src/TBLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TBLayer.cc
@@ -51,13 +51,17 @@ SubLayerCrossings TBLayer::computeCrossings(const TrajectoryStateOnSurface& star
 
   HelixBarrelCylinderCrossing innerCrossing(
       startPos, startDir, rho, propDir, *theInnerCylinder, HelixBarrelCylinderCrossing::onlyPos);
-  if (!innerCrossing.hasSolution())
-    return SubLayerCrossings();
 
   HelixBarrelCylinderCrossing outerCrossing(
       startPos, startDir, rho, propDir, *theOuterCylinder, HelixBarrelCylinderCrossing::onlyPos);
-  if (!outerCrossing.hasSolution())
-    return SubLayerCrossings();
+
+  if (!innerCrossing.hasSolution() && !outerCrossing.hasSolution()) return SubLayerCrossings();
+
+  if (!innerCrossing.hasSolution() && outerCrossing.hasSolution()) {
+    innerCrossing = outerCrossing;
+  } else if (!outerCrossing.hasSolution() && innerCrossing.hasSolution()) {
+    outerCrossing = innerCrossing;
+  }
 
   GlobalPoint gInnerPoint(innerCrossing.position());
   GlobalPoint gOuterPoint(outerCrossing.position());


### PR DESCRIPTION
When trying to compute expected barrel pixel layer hits for tracks with a displaced starting point, the logic in `TBLayer::computeCrossings` fails to return crossings when the starting point is between the inner and outer cylinders of a pixel layer. In the following plot of barrel pixel layers projected into the transverse plane, the current logic will return crossing points in blue for a dimuon pair originating at the red point, but fails to provide crossing points in the layer just above the red point.

![image](https://user-images.githubusercontent.com/5760027/83843314-98be7280-a6b9-11ea-8ae2-4e7290c1d6ec.png)

This PR modifies the logic to allow for such crossings to be returned by not requiring that both `innerCrossing` and `outerCrossing` have solutions.

In my tests, "prompt" tracks are unaffected.
