### PR TITLE
TBLayer computeCrossings doesn't allow for some displaced starting points

### DIFF
--- a/RecoTracker/TkDetLayers/src/TBLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TBLayer.cc
@@ -49,14 +49,16 @@ SubLayerCrossings TBLayer::computeCrossings(const TrajectoryStateOnSurface& star
   GlobalVector startDir(startingState.globalMomentum());
   double rho(startingState.transverseCurvature());
 
+  bool inBetween = ((theOuterCylinder->position() - startPos).perp() < theOuterCylinder->radius()) &&
+                   ((theInnerCylinder->position() - startPos).perp() > theInnerCylinder->radius());
+
   HelixBarrelCylinderCrossing innerCrossing(
       startPos, startDir, rho, propDir, *theInnerCylinder, HelixBarrelCylinderCrossing::onlyPos);
+  if (!inBetween && !innerCrossing.hasSolution())
+    return SubLayerCrossings();
 
   HelixBarrelCylinderCrossing outerCrossing(
       startPos, startDir, rho, propDir, *theOuterCylinder, HelixBarrelCylinderCrossing::onlyPos);
-
-  if (!innerCrossing.hasSolution() && !outerCrossing.hasSolution())
-    return SubLayerCrossings();
 
   if (!innerCrossing.hasSolution() && outerCrossing.hasSolution()) {
     innerCrossing = outerCrossing;

--- a/RecoTracker/TkDetLayers/src/TBLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TBLayer.cc
@@ -51,13 +51,18 @@ SubLayerCrossings TBLayer::computeCrossings(const TrajectoryStateOnSurface& star
 
   HelixBarrelCylinderCrossing innerCrossing(
       startPos, startDir, rho, propDir, *theInnerCylinder, HelixBarrelCylinderCrossing::onlyPos);
-  if (!innerCrossing.hasSolution())
-    return SubLayerCrossings();
 
   HelixBarrelCylinderCrossing outerCrossing(
       startPos, startDir, rho, propDir, *theOuterCylinder, HelixBarrelCylinderCrossing::onlyPos);
-  if (!outerCrossing.hasSolution())
+
+  if (!innerCrossing.hasSolution() && !outerCrossing.hasSolution())
     return SubLayerCrossings();
+
+  if (!innerCrossing.hasSolution() && outerCrossing.hasSolution()) {
+    innerCrossing = outerCrossing;
+  } else if (!outerCrossing.hasSolution() && innerCrossing.hasSolution()) {
+    outerCrossing = innerCrossing;
+  }
 
   GlobalPoint gInnerPoint(innerCrossing.position());
   GlobalPoint gOuterPoint(outerCrossing.position());


### PR DESCRIPTION
When trying to compute expected barrel pixel layer hits for tracks with a displaced starting point, the logic in TBLayer::computeCrossings fails to return crossings when the starting point is between the inner and outer cylinders of a pixel layer. In the following plot of barrel pixel layers projected into the transverse plane, the current logic will return crossing points in blue for a dimuon pair originating at the red point, but fails to provide crossing points in the layer just above the red point.

![image](https://user-images.githubusercontent.com/5760027/83901373-82db9c80-a70f-11ea-83e2-39a30a0807c2.png)

This PR modifies the logic to allow for such crossings to be returned by not requiring that both innerCrossing and outerCrossing have solutions.

In my tests, "prompt" tracks are unaffected.