### PR TITLE
Replaced boost use in CalibFormats/SiStripObjects

### DIFF
--- a/CalibFormats/SiStripObjects/BuildFile.xml
+++ b/CalibFormats/SiStripObjects/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="CondFormats/SiStripObjects"/>
 <use name="CalibTracker/SiStripCommon"/>
 <use name="DataFormats/TrackerCommon"/>
-<use name="boost"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CalibFormats/SiStripObjects/src/SiStripQuality.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripQuality.cc
@@ -14,9 +14,6 @@
 // Needed only for output
 #include "DataFormats/DetId/interface/DetId.h"
 
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-
 SiStripQuality::SiStripQuality()
     : toCleanUp(false),
       FileInPath_("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"),
@@ -147,12 +144,10 @@ void SiStripQuality::add(const RunInfo *runInfo) {
     // Take the list of active feds from RunInfo
     std::vector<int> activeFedsFromRunInfo;
     // Take only Tracker feds (remove all non Tracker)
-    std::remove_copy_if(runInfo->m_fed_in.begin(),
-                        runInfo->m_fed_in.end(),
-                        std::back_inserter(activeFedsFromRunInfo),
-                        !boost::bind(std::logical_and<bool>(),
-                                     boost::bind(std::greater_equal<int>(), _1, int(FEDNumbering::MINSiStripFEDID)),
-                                     boost::bind(std::less_equal<int>(), _1, int(FEDNumbering::MAXSiStripFEDID))));
+    std::remove_copy_if(
+        runInfo->m_fed_in.begin(), runInfo->m_fed_in.end(), std::back_inserter(activeFedsFromRunInfo), [&](int x) {
+          return !((x >= int(FEDNumbering::MINSiStripFEDID)) && (x <= int(FEDNumbering::MAXSiStripFEDID)));
+        });
 
     // Compare the two. If a fedId from RunInfo is not present in the fedCabling
     // we need to get all the corresponding fedChannels and then the single apv


### PR DESCRIPTION
#### PR description:
Replaced boost library use for C++ STL alternatives. The code should have similar behavior. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 