### PR TITLE
Update offline GT for Run 1 and Run 2 data, including special runs. [11_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v12',
+    'run1_data'         :   '110X_dataRun2_v13',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v12',
+    'run2_data'         :   '110X_dataRun2_v13',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v12',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v13',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR updates the offline data global tags to include updates for special runs from:

- beamspot
- PPS
- tracker alignment/APEs.

The global tag diffs are as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v12/110X_dataRun2_v13

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v12/110X_dataRun2_relval_v13

These GT diffs are the same as those in PR #29629 to master.

In contrast to the PR to master, there is no update to `auto:run2_data_HEfail`, as that autoCond key was not introduced until the 11_1_X release series.

No differences are expected in any PR comparison test as only IOVs for special runs are modified.

#### PR validation:

See links found in the HN post at [1]. In addition, a technical test was performed: `runTheMatrix.py -l limited --ibeos`

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4292/2/1.html

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #29629. The backport is intended primarily to avoid any potential confusion that might arise from these conditions being used in 10_6_X for the UL as well as in 11_1_X and later, but not 11_0_X.