### PR TITLE
Update offline GT for Run 1 and Run 2 data, including special runs. [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v27',
+    'run1_data'         :   '106X_dataRun2_v28',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v27',
+    'run2_data'         :   '106X_dataRun2_v28',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v25',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v26',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v13',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR updates the offline data global tags to include updates for special runs from:

- beamspot
- PPS
- tracker alignment/APEs.

The global tag diffs are as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v27/106X_dataRun2_v28

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v25/106X_dataRun2_relval_v26


These GT diffs are the same as those in PR #29629 to master.

In contrast to the PR to master, there is no update to `auto:run2_data_HEfail`, as that autoCond key was not introduced until the 11_1_X release series.

No differences are expected in any PR comparison test as only IOVs for special runs are modified.

#### PR validation:

See links found in the HN post at [1]. In addition, a technical test was performed: `runTheMatrix.py -l limited --ibeos`

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4292/2/1.html

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #29629. The backport contains the conditions that are already in use in the Run 2 UL in 10_6_X.