### PR TITLE
Remove invalid usage of TrajectorySeed::recHits()

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
@@ -5,7 +5,6 @@
 // Geometry
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 //
-#include "RecoTracker/MeasurementDet/interface/StartingLayerFinder.h"
 #include "RecoTracker/MeasurementDet/interface/LayerCollector.h"
 //
 
@@ -111,9 +110,7 @@ void ConversionSeedFinder::findLayers(const FreeTrajectoryState& traj) {
 
   StraightLinePropagator prop(&(*theMF_), alongMomentum);
 
-  StartingLayerFinder starter(&prop, this->getMeasurementTracker());
-
-  LayerCollector collector(theNavigationSchool_, &prop, &starter, 5., 5.);
+  LayerCollector collector(theNavigationSchool_, &prop, this->getMeasurementTracker(), 5., 5.);
 
   theLayerList_ = collector.allLayers(traj);
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
@@ -1,7 +1,6 @@
 #include "RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.h"
 
 #include <Geometry/Records/interface/GlobalTrackingGeometryRecord.h>
-//#include <RecoTracker/Record/interface/TrackerRecoGeometryRecord.h>
 #include <RecoTracker/Record/interface/CkfComponentsRecord.h>
 #include <MagneticField/Records/interface/IdealMagneticFieldRecord.h>
 #include <TrackingTools/Records/interface/TrackingComponentsRecord.h>
@@ -15,7 +14,6 @@
 
 #include <RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h>
 
-#include "RecoTracker/MeasurementDet/interface/StartingLayerFinder.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"

--- a/RecoTracker/MeasurementDet/interface/LayerCollector.h
+++ b/RecoTracker/MeasurementDet/interface/LayerCollector.h
@@ -25,26 +25,27 @@ private:
 public:
   LayerCollector(NavigationSchool const* aSchool,
                  const Propagator* aPropagator,
-                 const StartingLayerFinder* aFinder,
+                 const MeasurementTracker* tracker,
                  float dr,
                  float dz)
-      : theSchool(aSchool), thePropagator(aPropagator), theStartingLayerFinder(aFinder), theDeltaR(dr), theDeltaZ(dz) {}
-
-  ~LayerCollector() {}
+      : theSchool(aSchool),
+        thePropagator(aPropagator),
+        theStartingLayerFinder{*aPropagator, *tracker},
+        theDeltaR(dr),
+        theDeltaZ(dz) {}
 
   std::vector<const DetLayer*> allLayers(const FTS& aFts) const;
   std::vector<const BarrelDetLayer*> barrelLayers(const FTS& aFts) const;
   std::vector<const ForwardDetLayer*> forwardLayers(const FTS& aFts) const;
 
   const Propagator* propagator() const { return thePropagator; }
-  const StartingLayerFinder* finder() const { return theStartingLayerFinder; }
   float deltaR() const { return theDeltaR; }
   float deltaZ() const { return theDeltaZ; }
 
 private:
   NavigationSchool const* theSchool;
   const Propagator* thePropagator;
-  const StartingLayerFinder* theStartingLayerFinder;
+  const StartingLayerFinder theStartingLayerFinder;
   float theDeltaR;
   float theDeltaZ;
 

--- a/RecoTracker/MeasurementDet/interface/StartingLayerFinder.h
+++ b/RecoTracker/MeasurementDet/interface/StartingLayerFinder.h
@@ -22,52 +22,29 @@
  *  have a DetLayer
  */
 
-class PTrajectoryStateOnDet;
-
 class StartingLayerFinder {
-private:
-  typedef FreeTrajectoryState FTS;
-  typedef TrajectoryStateOnSurface TSOS;
-  typedef std::pair<float, float> Range;
-
 public:
-  StartingLayerFinder(const Propagator* aPropagator, const MeasurementTracker* tracker)
-      :
-
-        thePropagator(aPropagator),
+  StartingLayerFinder(Propagator const& aPropagator, MeasurementTracker const& tracker)
+      : thePropagator(aPropagator),
         theMeasurementTracker(tracker),
-        thePixelLayersValid(false),
-        theFirstPixelBarrelLayer(nullptr),
         theFirstNegPixelFwdLayer(0),
         theFirstPosPixelFwdLayer(0) {}
 
-  ~StartingLayerFinder() {}
+  std::vector<const DetLayer*> operator()(const FreeTrajectoryState& aFts, float dr, float dz) const;
 
-  std::vector<const DetLayer*> startingLayers(const FTS& aFts, float dr, float dz) const;
-
-  std::vector<const DetLayer*> startingLayers(const TrajectorySeed& aSeed) const;
-
+private:
   const BarrelDetLayer* firstPixelBarrelLayer() const;
   const std::vector<const ForwardDetLayer*> firstNegPixelFwdLayer() const;
   const std::vector<const ForwardDetLayer*> firstPosPixelFwdLayer() const;
 
-  const Propagator* propagator() const { return thePropagator; }
-
-private:
-  const Propagator* thePropagator;
-  const MeasurementTracker* theMeasurementTracker;
-  mutable bool thePixelLayersValid;
-  mutable const BarrelDetLayer* theFirstPixelBarrelLayer;
+  Propagator const& thePropagator;
+  MeasurementTracker const& theMeasurementTracker;
+  mutable bool thePixelLayersValid = false;
+  mutable const BarrelDetLayer* theFirstPixelBarrelLayer = nullptr;
   mutable std::vector<const ForwardDetLayer*> theFirstNegPixelFwdLayer;
   mutable std::vector<const ForwardDetLayer*> theFirstPosPixelFwdLayer;
 
   void checkPixelLayers() const;
-
-  inline bool rangesIntersect(const Range& a, const Range& b) const {
-    if (a.first > b.second || b.first > a.second)
-      return false;
-    else
-      return true;
-  }
 };
-#endif  //TR_StartingLayerFinder_H_
+
+#endif

--- a/RecoTracker/MeasurementDet/src/LayerCollector.cc
+++ b/RecoTracker/MeasurementDet/src/LayerCollector.cc
@@ -9,7 +9,7 @@ vector<const DetLayer*> LayerCollector::allLayers(const FTS& aFts) const {
 
   FTS myFts(aFts.parameters());
 
-  vector<const DetLayer*> nextLayers = finder()->startingLayers(myFts, deltaR(), deltaZ());
+  vector<const DetLayer*> nextLayers = theStartingLayerFinder(myFts, deltaR(), deltaZ());
 
   vector<const DetLayer*> dummy;
 

--- a/Validation/RecoMuon/src/MuonSeedTrack.cc
+++ b/Validation/RecoMuon/src/MuonSeedTrack.cc
@@ -189,36 +189,10 @@ pair<bool, reco::Track> MuonSeedTrack::buildTrackAtPCA(const TrajectorySeed& see
   math::XYZVector persistentMomentum(p.x(), p.y(), p.z());
 
   double dummyNDOF = 1.0;
-  //double ndof = computeNDOF(seed);
   double dummyChi2 = 1.0;
 
   reco::Track track(
       dummyChi2, dummyNDOF, persistentPCA, persistentMomentum, ftsAtVtx.charge(), ftsAtVtx.curvilinearError());
 
   return pair<bool, reco::Track>(true, track);
-}
-
-/*!
- * Calculates number of degrees of freedom for the TrajectorySeed
- */
-double MuonSeedTrack::computeNDOF(const TrajectorySeed& trajectory) const {
-  const string metname = "MuonSeedTrack";
-
-  auto recHits1 = (trajectory.recHits().begin());
-  auto recHits2 = (trajectory.recHits().end());
-
-  double ndof = 0.;
-
-  if ((*recHits1).isValid())
-    ndof += (*recHits1).dimension();
-  if ((*recHits2).isValid())
-    ndof += (*recHits2).dimension();
-
-  //const Trajectory::RecHitContainer transRecHits = trajectory.recHits();
-  //for(Trajectory::RecHitContainer::const_iterator rechit = transRecHits.begin();
-  //  rechit != transRecHits.end(); ++rechit)
-  //if ((*rechit)->isValid()) ndof += (*rechit)->dimension();
-
-  // FIXME! in case of Boff is dof - 4
-  return max(ndof - 5., 0.);
 }

--- a/Validation/RecoMuon/src/MuonSeedTrack.h
+++ b/Validation/RecoMuon/src/MuonSeedTrack.h
@@ -70,9 +70,6 @@ private:
     theAlias = alias;
   }
 
-  /// compute the TrajectorySeed's degree of freedom
-  double computeNDOF(const TrajectorySeed&) const;
-
   /// Build a track at the PCA WITHOUT any vertex constriant
   std::pair<bool, reco::Track> buildTrackAtPCA(const TrajectorySeed&) const;
 


### PR DESCRIPTION
#### PR description:

This is sort of a followup to https://github.com/cms-sw/cmssw/pull/29971, in which I spotted some undefined behaviour in code that uses the `TrajectorySeed::recHits()`. The `end()` iterator is dereferenced in there, which gives garbage results.

 Rather than trying to fix this, I suggest to just remove the problematic code. It is unused and probably not important, otherwise the bug would have been found before. Do you agree with this procedure?

I hope I understood this correctly that there is a bug, otherwise please correct me.

#### PR validation:

CMSSW compiles and matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.