### PR TITLE
Replaced boost for standard alternatives in PhysicsTools/Utilities

### DIFF
--- a/PhysicsTools/Utilities/interface/Composition.h
+++ b/PhysicsTools/Utilities/interface/Composition.h
@@ -1,6 +1,5 @@
 #ifndef PhysicsTools_Utilities_Composition_h
 #define PhysicsTools_Utilities_Composition_h
-#include <boost/static_assert.hpp>
 
 namespace funct {
   template <typename A, typename B>

--- a/PhysicsTools/Utilities/interface/Function.h
+++ b/PhysicsTools/Utilities/interface/Function.h
@@ -2,7 +2,6 @@
 #define PhysicsTools_Utilities_Function_h
 #include "PhysicsTools/Utilities/interface/Variables.h"
 #include "PhysicsTools/Utilities/interface/Expression.h"
-#include <boost/mpl/for_each.hpp>
 
 namespace funct {
 

--- a/PhysicsTools/Utilities/interface/Power.h
+++ b/PhysicsTools/Utilities/interface/Power.h
@@ -1,6 +1,5 @@
 #ifndef PhysicsTools_Utilities_Power_h
 #define PhysicsTools_Utilities_Power_h
-#include <boost/static_assert.hpp>
 #include <cmath>
 
 namespace funct {

--- a/PhysicsTools/Utilities/interface/Product.h
+++ b/PhysicsTools/Utilities/interface/Product.h
@@ -1,6 +1,5 @@
 #ifndef PhysicsTools_Utilities_Product_h
 #define PhysicsTools_Utilities_Product_h
-#include <boost/static_assert.hpp>
 
 namespace funct {
   template <typename A, typename B>

--- a/PhysicsTools/Utilities/interface/Ratio.h
+++ b/PhysicsTools/Utilities/interface/Ratio.h
@@ -1,6 +1,5 @@
 #ifndef PhysicsTools_Utilities_Ratio_h
 #define PhysicsTools_Utilities_Ratio_h
-#include <boost/static_assert.hpp>
 
 namespace funct {
   template <typename A, typename B>

--- a/PhysicsTools/Utilities/interface/RooFitFunction.h
+++ b/PhysicsTools/Utilities/interface/RooFitFunction.h
@@ -4,9 +4,9 @@
 #include "RooAbsReal.h"
 #include "RooRealProxy.h"
 #include "RooAbsReal.h"
-#include <vector>
-#include <boost/type_traits.hpp>
 #include <iostream>
+#include <vector>
+
 namespace root {
   struct no_args;
 

--- a/PhysicsTools/Utilities/interface/SimplifyProduct.h
+++ b/PhysicsTools/Utilities/interface/SimplifyProduct.h
@@ -5,7 +5,6 @@
 #include "PhysicsTools/Utilities/interface/Fraction.h"
 #include "PhysicsTools/Utilities/interface/DecomposePower.h"
 #include "PhysicsTools/Utilities/interface/ParametricTrait.h"
-#include <boost/mpl/if.hpp>
 #include <type_traits>
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
@@ -178,7 +177,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return f; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return g; }
-      enum { value = not::std::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     struct prod2 {
       typedef G A;
@@ -189,10 +188,12 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return g; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return f; }
-      enum { value = not::std::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
 
-    typedef typename ::boost::mpl::if_<prod1, prod1, typename ::boost::mpl::if_<prod2, prod2, prod0>::type>::type prod;
+    typedef
+        typename std::conditional<prod1::value, prod1, typename std::conditional<prod2::value, prod2, prod0>::type>::type
+            prod;
     typedef typename AuxProduct<prod>::type type;
     inline static type combine(const ProductStruct<F, G>& fg, const H& h) {
       const F& f = fg._1;

--- a/PhysicsTools/Utilities/interface/SimplifyRatio.h
+++ b/PhysicsTools/Utilities/interface/SimplifyRatio.h
@@ -11,7 +11,6 @@
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
 
-#include <boost/mpl/if.hpp>
 #include <type_traits>
 
 namespace funct {
@@ -177,7 +176,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return f; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return g; }
-      enum { value = not::std::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     struct prod2 {
       typedef G A;
@@ -188,10 +187,12 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return g; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return f; }
-      enum { value = not::std::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
 
-    typedef typename ::boost::mpl::if_<prod1, prod1, typename ::boost::mpl::if_<prod2, prod2, prod0>::type>::type prod;
+    typedef
+        typename std::conditional<prod1::value, prod1, typename std::conditional<prod2::value, prod2, prod0>::type>::type
+            prod;
     typedef typename AuxProductRatio<prod>::type type;
     inline static type combine(const PROD_S(F, G) & fg, const H& h) {
       const F& f = fg._1;
@@ -243,7 +244,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return f; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return g; }
-      enum { value = not::std::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     struct prod2 {
       typedef G A;
@@ -254,10 +255,12 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return g; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return f; }
-      enum { value = not::std::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
 
-    typedef typename ::boost::mpl::if_<prod1, prod1, typename ::boost::mpl::if_<prod2, prod2, prod0>::type>::type prod;
+    typedef
+        typename std::conditional<prod1::value, prod1, typename std::conditional<prod2::value, prod2, prod0>::type>::type
+            prod;
     typedef typename AuxProductRatio2<prod>::type type;
     inline static type combine(const H& h, const PROD_S(F, G) & fg) {
       const F& f = fg._1;
@@ -293,12 +296,12 @@ namespace funct {
     struct ratio1 {
       typedef RATIO_S(A, C) base;
       typedef RATIO(A, C) type;
-      enum { value = not::std::is_same<type, base>::value };
+      enum { value = not ::std::is_same<type, base>::value };
     };
     struct ratio2 {
       typedef RATIO_S(B, C) base;
       typedef RATIO(B, C) type;
-      enum { value = not::std::is_same<type, base>::value };
+      enum { value = not ::std::is_same<type, base>::value };
     };
     typedef AuxSumRatio<A, B, C, ratio1::value or ratio2::value> aux;
     typedef typename aux::type type;

--- a/PhysicsTools/Utilities/interface/SimplifySum.h
+++ b/PhysicsTools/Utilities/interface/SimplifySum.h
@@ -8,7 +8,6 @@
 #include "PhysicsTools/Utilities/interface/DecomposeProduct.h"
 #include "PhysicsTools/Utilities/interface/ParametricTrait.h"
 #include <type_traits>
-#include <boost/mpl/if.hpp>
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
 
@@ -140,7 +139,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return f; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return g; }
-      enum { value = not::std::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     struct prod2 {
       typedef G A;
@@ -151,10 +150,12 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return g; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return f; }
-      enum { value = not::std::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
 
-    typedef typename ::boost::mpl::if_<prod1, prod1, typename ::boost::mpl::if_<prod2, prod2, prod0>::type>::type prod;
+    typedef
+        typename std::conditional<prod1::value, prod1, typename std::conditional<prod2::value, prod2, prod0>::type>::type
+            prod;
     typedef typename AuxSum<prod>::type type;
     inline static type combine(const SUM_S(F, G) & fg, const H& h) {
       const F& f = fg._1;

--- a/PhysicsTools/Utilities/interface/SimplifyTrigonometric.h
+++ b/PhysicsTools/Utilities/interface/SimplifyTrigonometric.h
@@ -10,8 +10,6 @@
 #include "PhysicsTools/Utilities/interface/Ratio.h"
 #include "PhysicsTools/Utilities/interface/Sum.h"
 #include "PhysicsTools/Utilities/interface/ParametricTrait.h"
-#include <boost/mpl/if.hpp>
-
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
 
 namespace funct {
@@ -107,7 +105,7 @@ namespace funct {
   };
 
   TEMPL(N2T1) struct SimpifyS2C2Sum<n, m, A, false> {
-    static const int p = ::boost::mpl::if_c<(n < m), ::boost::mpl::int_<n>, ::boost::mpl::int_<m> >::type::value;
+    static constexpr int p = n < m ? n : m;
     typedef SUM(SUM(PROD(NUM(n - p), SIN2(A)), PROD(NUM(m - p), COS2(A))), NUM(p)) type;
     COMBINE(PROD(NUM(n), SIN2(A)), PROD(NUM(m), COS2(A)), (num<n - p>() * _1._2 + num<m - p>() * _2._2) + num<p>());
   };

--- a/PhysicsTools/Utilities/test/testSimplifications.cc
+++ b/PhysicsTools/Utilities/test/testSimplifications.cc
@@ -2,8 +2,7 @@
 #include "PhysicsTools/Utilities/interface/Simplify.h"
 #include "PhysicsTools/Utilities/interface/Fraction.h"
 #include "PhysicsTools/Utilities/interface/Variables.h"
-#include <boost/static_assert.hpp>
-#include <boost/type_traits.hpp>
+#include <type_traits>
 
 class testSimplifications : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testSimplifications);
@@ -20,7 +19,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testSimplifications);
 
 void testSimplifications::checkAll() {
   using namespace funct;
-  using namespace boost;
+  using namespace std;
   static_assert((is_same<Sum<Numerical<2>, Numerical<3> >::type, Numerical<5> >::value));
 
   static_assert((is_same<Difference<Numerical<2>, Numerical<3> >::type, Numerical<-1> >::value));


### PR DESCRIPTION
#### PR description:
Replaced boost library use for C++ STL alternatives. The code should have similar behavior. 
Also removed some includes that were unused. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 