### PR TITLE
HCAL Run3: removing redundant hbhereco=HBHEIsolatedNoiseReflagger from wf's 

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -236,9 +236,9 @@ DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*muonMonitor
 PostDQMOfflineMiniAOD = cms.Sequence(miniAODDQMSequence*jetMETDQMOfflineSourceMiniAOD*tracksDQMMiniAOD*topPhysicsminiAOD)
 PostDQMOffline = cms.Sequence()
 
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toReplaceWith( PostDQMOfflineMiniAOD, PostDQMOfflineMiniAOD.copyAndExclude([
-    pfMetDQMAnalyzerMiniAOD, pfPuppiMetDQMAnalyzerMiniAOD # No hcalnoise yet
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toReplaceWith( PostDQMOfflineMiniAOD, PostDQMOfflineMiniAOD.copyAndExclude([
+    pfMetDQMAnalyzerMiniAOD, pfPuppiMetDQMAnalyzerMiniAOD # No hcalnoise (yet)
 ]))
 
 from PhysicsTools.NanoAOD.nanoDQM_cff import nanoDQM

--- a/DQMOffline/Hcal/python/HcalDQMOfflineSequence_cff.py
+++ b/DQMOffline/Hcal/python/HcalDQMOfflineSequence_cff.py
@@ -16,6 +16,6 @@ NoiseRatesDQMOffline    = DQMOffline.Hcal.HcalNoiseRatesParam_cfi.hcalNoiseRates
 HcalDQMOfflineSequence = cms.Sequence(NoiseRatesDQMOffline*RecHitsDQMOffline*AllCaloTowersDQMOffline)
 #HcalDQMOfflineSequence = cms.Sequence(NoiseRatesDQMOffline*AllCaloTowersDQMOffline)
 
-_phase2_HcalDQMOfflineSequence = HcalDQMOfflineSequence.copyAndExclude([NoiseRatesDQMOffline])
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toReplaceWith(HcalDQMOfflineSequence, _phase2_HcalDQMOfflineSequence)
+_run3_HcalDQMOfflineSequence = HcalDQMOfflineSequence.copyAndExclude([NoiseRatesDQMOffline])
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toReplaceWith(HcalDQMOfflineSequence, _run3_HcalDQMOfflineSequence)

--- a/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
+++ b/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
@@ -18,6 +18,5 @@ caloJetsForTrk = cms.Sequence(caloJetsForTrkTask)
 from Configuration.Eras.Modifier_pf_badHcalMitigation_cff import pf_badHcalMitigation
 pf_badHcalMitigation.toModify( caloTowerForTrk, missingHcalRescaleFactorForEcal = 1.0 )
 
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify( caloTowerForTrk, hbheInput = cms.InputTag("hbhereco") )
-
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify( caloTowerForTrk, hbheInput = cms.InputTag("hbhereco") )

--- a/RecoLocalCalo/Configuration/python/hcalGlobalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalGlobalReco_cff.py
@@ -6,5 +6,5 @@ hcalGlobalRecoSequence = cms.Sequence(hcalGlobalRecoTask)
 
 from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco as _phase1_hbheprereco
 
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toReplaceWith( hbhereco, _phase1_hbheprereco )
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toReplaceWith( hbhereco, _phase1_hbheprereco ) # >=Run3

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -25,6 +25,7 @@ from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
 # copy for cosmics
 _default_hfreco = hfreco.clone()
 
+#--- Phase1 
 _phase1_hcalLocalRecoTask = hcalLocalRecoTask.copy()
 _phase1_hcalLocalRecoTask.add(hfprereco)
 
@@ -45,12 +46,11 @@ _collapse_hcalLocalRecoTask.add(hbhecollapse)
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
 run2_HECollapse_2018.toReplaceWith(hcalLocalRecoTask, _collapse_hcalLocalRecoTask)
 
-_phase2_hcalLocalRecoTask = hcalLocalRecoTask.copy()
-_phase2_hcalLocalRecoTask.remove(hbheprereco)
-
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toReplaceWith( hcalLocalRecoTask, _phase2_hcalLocalRecoTask )
-
+#--- from >=Run3
+_run3_hcalLocalRecoTask = _phase1_hcalLocalRecoTask.copy()
+_run3_hcalLocalRecoTask.remove(hbheprereco)
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toReplaceWith( hcalLocalRecoTask, _run3_hcalLocalRecoTask )
 
 _fastSim_hcalLocalRecoTask = hcalLocalRecoTask.copyAndExclude([zdcreco])
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/Validation/HcalRecHits/python/hcalRecHitsValidationSequence_cff.py
+++ b/Validation/HcalRecHits/python/hcalRecHitsValidationSequence_cff.py
@@ -13,6 +13,6 @@ hcalRecHitsValidationSequence = cms.Sequence(NoiseRatesValidation*RecHitsValidat
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(hcalRecHitsValidationSequence, hcalRecHitsValidationSequence.copyAndExclude([NoiseRatesValidation]))
 
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-_phase2_hcalRecHitsValidationSequence = hcalRecHitsValidationSequence.copyAndExclude([NoiseRatesValidation])
-phase2_hcal.toReplaceWith(hcalRecHitsValidationSequence, _phase2_hcalRecHitsValidationSequence)
+_run3_hcalRecHitsValidationSequence = hcalRecHitsValidationSequence.copyAndExclude([NoiseRatesValidation])
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toReplaceWith(hcalRecHitsValidationSequence, _run3_hcalRecHitsValidationSequence)


### PR DESCRIPTION
#### PR description:

Existing for Phase2 customization to exclude HBHEIsolatedNoiseReflagger (only relevant for Phase0 HPDs HCAL subdetectors), formerly known as "hbhereco"  producer, has been backported to Run3 to save CPU _and_ disk space: one HBHERecHits collection "hbhereco" now produced instead of two "hbheprereco" + "hbhereco" (effectively identical for >= Run3) previously. 

NB: HLT for Run3 is already using solely "hbhereco"=HBHEPhase1Reconstructor.

#### PR validation:

runTheMatrix.py -l limited  OK 

#### No backport needed
