### PR TITLE
Import ClusterShapeHitFilterESProducer_cfi explicitly in SiPixelPhase1OfflineDQM_source_cff

### DIFF
--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -20,6 +20,9 @@ from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
 #Summary maps
 from DQM.SiPixelPhase1Summary.SiPixelPhase1Summary_cfi import *
 
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
+
 PerModule.enabled = False
 IsOffline.enabled=True
 


### PR DESCRIPTION
#### PR description:

The workflow 138.1 fails in IBs because the `ClusterShapeHitFilterESProducer_cfi` is not imported/loaded by `ALCA` step anymore. This PR proposes to import the `ClusterShapeHitFilterESProducer` explicitly in `SiPixelPhase1OfflineDQM_source_cff` to guarantee that the ESProducer is available.

Resolves #30140.

#### PR validation:

Workflow 138.1 runs.
