### PR TITLE
Add edm::Principal::getByToken to skipped functions regex

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -9,7 +9,7 @@ fre = re.compile("function")
 
 statics = set()
 toplevelfuncs = set()
-skipfunc = re.compile("(edm::(LuminosityBlock::|Run::|Event::)getBy(Label|Token))|(fwlite::|edm::EDProductGetter::getIt|edm::Event::|edm::eventsetup::EventSetupRecord::get|edm::eventsetup::DataProxy::getImpl|edm::EventPrincipal::unscheduledFill|edm::ServiceRegistry::get|edm::eventsetup::EventSetupRecord::getImplementation|edm::eventsetup::EventSetupRecord::getFromProxy|edm::eventsetup::DataProxy::get|edm::serviceregistry::ServicesManager::MakerHolder::add|(cond::service::PoolDBOutputService::(writeOne|appendSinceTime|tagInfo))|edm::EventProcessor::|edm::SubProcess::)")
+skipfunc = re.compile("(edm::(LuminosityBlock::|Run::|Event::|Principal::)getBy(Label|Token))|(fwlite::|edm::EDProductGetter::getIt|edm::Event::|edm::eventsetup::EventSetupRecord::get|edm::eventsetup::DataProxy::getImpl|edm::EventPrincipal::unscheduledFill|edm::ServiceRegistry::get|edm::eventsetup::EventSetupRecord::getImplementation|edm::eventsetup::EventSetupRecord::getFromProxy|edm::eventsetup::DataProxy::get|edm::serviceregistry::ServicesManager::MakerHolder::add|(cond::service::PoolDBOutputService::(writeOne|appendSinceTime|tagInfo))|edm::EventProcessor::|edm::SubProcess::)")
 skipfuncs=set()
 
 import networkx as nx


### PR DESCRIPTION
```
Hi Patrick,
	The algorithm we are using to do the static analysis checks for modules is generally very helpful. I have found a case where it is giving a false positive and was wondering if you could update the code to avoid that case? An example is

In call stack '  CompareGeneratorResultsAnalyzer::globalBeginLuminosityBlock() const calls function  edm::LuminosityBlock::get<class GenLumiInfoHeader>() const calls function  edm::PrincipalGetAdapter::getByToken_() const calls function  edm::Principal::getByToken() const calls function  edm::ProductResolverBase::resolveProduct() const calls function  edm::ProductResolverBase::resolveProduct_() const virtual calls function  edm::UnscheduledProductResolver::resolveProduct_() const calls function  edm::Worker::doWork<class edm::OccurrenceTraits<class edm::EventPrincipal, BranchActionStreamBegin>>() calls function  edm::Worker::runModule<class edm::OccurrenceTraits<class edm::EventPrincipal, BranchActionStreamBegin>>() calls function  edm::workerhelper::CallImpl<edm::OccurrenceTraits<edm::EventPrincipal, BranchActionStreamBegin> >::call() calls function  edm::Worker::implDo() virtual calls function  edm::WorkerT<edm::one::OutputModuleBase>::implDo() calls function  edm::one::OutputModuleBase::doEvent() calls function  edm::one::OutputModuleBase::write() virtual calls function  RawEventOutputModuleForBU::write() calls function  crc32c() calls function  crc32c_hw() static variable  crc32c_long' is accessed , 'CompareGeneratorResultsAnalyzer::globalBeginLuminosityBlock() const' overrides 'edm::global::impl::LuminosityBlockCacheHolder<edm::global::EDAnalyzerBase, cgra::DummyCache>::globalBeginLuminosityBlock() const virtual'

The false positive comes from the chain where a particular virtual function could theoretically be called, but in reality never is:

edm::PrincipalGetAdapter::getByToken_() const calls function  edm::Principal::getByToken() const calls function  edm::ProductResolverBase::resolveProduct() const calls function  edm::ProductResolverBase::resolveProduct_() const virtual calls function  edm::UnscheduledProductResolver::resolveProduct_() ...

My suggestion is to filter out any call chain containing edm::Principal::getByToken().

	Thanks,
		Chris
```