### PR TITLE
drop type specs in  RecoLocalCalo and RecoLocalTracker

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -246,6 +246,6 @@ HGCalRecHit = cms.EDProducer(
 
 # For silicon the order is: CE_E_120um, CE_E_200um, CE_E_300um, CE_H_120um, CE_H_200um, CE_H_300um
 phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = [0.759,0.760,0.773, 1.0, 1.0, 1.0] ) 
-phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.77, 0.77, 0.77, 0.84, 0.84, 0.84] , sciThicknessCorrection =  cms.double(0.90) ) 
+phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.77, 0.77, 0.77, 0.84, 0.84, 0.84] , sciThicknessCorrection =  0.90 ) 
 
 phase2_hfnose.toModify( HGCalRecHit , thicknessNoseCorrection = [0.759,0.760,0.773])

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -18,7 +18,6 @@ hgcalLayerClusters.plugin.fcPerEle = cms.double(fC_per_ele)
 hgcalLayerClusters.plugin.noises = cms.PSet(refToPSet_ = cms.string('HGCAL_noises'))
 hgcalLayerClusters.plugin.noiseMip = hgchebackDigitizer.digiCfg.noise
 
-
 hgcalLayerClustersHFNose = hgcalLayerClusters_.clone(
     detector = 'HFNose',
     timeOffset = hfnoseDigitizer.tofDelay,

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -29,7 +29,7 @@ from RecoLocalCalo.HcalRecAlgos.hcalRecAlgos_cfi import hcalRecAlgos
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
-    phase = cms.uint32(1),
+    phase = 1,
     SeverityLevels = {
         2 : dict( RecHitFlags = cms.vstring('HBHEIsolatedNoise',
                                             'HFAnomalousHit'

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEIsolatedNoiseReflagger_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEIsolatedNoiseReflagger_cfi.py
@@ -61,7 +61,7 @@ hbhereco = cms.EDProducer(
  )
 
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
-run2_HEPlan1_2017.toModify(hbhereco, hbheInput = cms.InputTag('hbheplan1'))
+run2_HEPlan1_2017.toModify(hbhereco, hbheInput = 'hbheplan1')
 
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
-run2_HECollapse_2018.toModify(hbhereco, hbheInput = cms.InputTag('hbhecollapse'))
+run2_HECollapse_2018.toModify(hbhereco, hbheInput = 'hbhecollapse')

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -110,7 +110,7 @@ hbheprereco = cms.EDProducer(
 hbheprereco.pulseShapeParametersQIE8.TrianglePeakTS = cms.uint32(10000)
 
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
-run2_HE_2017.toModify(hbheprereco, saveEffectivePedestal = cms.bool(True))
+run2_HE_2017.toModify(hbheprereco, saveEffectivePedestal = True)
 
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-run3_HB.toModify(hbheprereco, algorithm = dict(applyLegacyHBMCorrection = cms.bool(False)))
+run3_HB.toModify(hbheprereco, algorithm = dict(applyLegacyHBMCorrection = False))

--- a/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEGeometricESProducer_cfi.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEGeometricESProducer_cfi.py
@@ -4,5 +4,5 @@ from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *
 
 phase2StripCPEGeometricESProducer = phase2StripCPEESProducer.clone()
 #phase2StripCPEGeometricESProducer.ComponentName = cms.string('Phase2StripCPEGeometric')
-phase2StripCPEGeometricESProducer.ComponentType = cms.string('Phase2StripCPEGeometric')
+phase2StripCPEGeometricESProducer.ComponentType = 'Phase2StripCPEGeometric'
 phase2StripCPEGeometricESProducer.parameters    = cms.PSet()

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
@@ -15,8 +15,8 @@ siStripClusters = cms.EDProducer("SiStripClusterizer",
 # This part has to be clean up when they will be officially removed from the entire flow
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(siStripClusters, # FIXME
-  DigiProducersList = cms.VInputTag( cms.InputTag('simSiStripDigis','ZeroSuppressed'),
-                                     cms.InputTag('siStripZeroSuppression','VirginRaw'),
-                                     cms.InputTag('siStripZeroSuppression','ProcessedRaw'),
-                                     cms.InputTag('siStripZeroSuppression','ScopeMode'))
+  DigiProducersList = cms.VInputTag( 'simSiStripDigis:ZeroSuppressed',
+                                     'siStripZeroSuppression:VirginRaw',
+                                     'siStripZeroSuppression:ProcessedRaw',
+                                     'siStripZeroSuppression:ScopeMode')
 )

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
@@ -18,5 +18,5 @@ phase2_tracker.toModify(siStripClusters, # FIXME
   DigiProducersList = [ 'simSiStripDigis:ZeroSuppressed',
                         'siStripZeroSuppression:VirginRaw',
                         'siStripZeroSuppression:ProcessedRaw',
-                        'siStripZeroSuppression:ScopeMode')
+                        'siStripZeroSuppression:ScopeMode']
 )

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
@@ -15,8 +15,8 @@ siStripClusters = cms.EDProducer("SiStripClusterizer",
 # This part has to be clean up when they will be officially removed from the entire flow
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(siStripClusters, # FIXME
-  DigiProducersList = cms.VInputTag( 'simSiStripDigis:ZeroSuppressed',
-                                     'siStripZeroSuppression:VirginRaw',
-                                     'siStripZeroSuppression:ProcessedRaw',
-                                     'siStripZeroSuppression:ScopeMode')
+  DigiProducersList = [ 'simSiStripDigis:ZeroSuppressed',
+                        'siStripZeroSuppression:VirginRaw',
+                        'siStripZeroSuppression:ProcessedRaw',
+                        'siStripZeroSuppression:ScopeMode')
 )

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPE_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPE_cfi.py
@@ -1,9 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEESProducer_cfi import *
-StripCPEESProducer = stripCPEESProducer.clone()
-StripCPEESProducer.ComponentName = 'SimpleStripCPE'
-StripCPEESProducer.ComponentType = 'SimpleStripCPE'
-StripCPEESProducer.parameters    = cms.PSet()
-
-
+StripCPEESProducer = stripCPEESProducer.clone(
+     ComponentName = 'SimpleStripCPE',
+     ComponentType = 'SimpleStripCPE',
+     parameters    = cms.PSet()
+)

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPE_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPE_cfi.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEESProducer_cfi import *
 StripCPEESProducer = stripCPEESProducer.clone()
-StripCPEESProducer.ComponentName = cms.string('SimpleStripCPE')
-StripCPEESProducer.ComponentType = cms.string('SimpleStripCPE')
+StripCPEESProducer.ComponentName = 'SimpleStripCPE'
+StripCPEESProducer.ComponentType = 'SimpleStripCPE'
 StripCPEESProducer.parameters    = cms.PSet()
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEfromTrackAngle_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEfromTrackAngle_cfi.py
@@ -1,21 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEESProducer_cfi import *
-StripCPEfromTrackAngleESProducer = stripCPEESProducer.clone()
-StripCPEfromTrackAngleESProducer.ComponentName = cms.string('StripCPEfromTrackAngle')
-StripCPEfromTrackAngleESProducer.ComponentType = cms.string('StripCPEfromTrackAngle')
-StripCPEfromTrackAngleESProducer.parameters    = cms.PSet(
-   mLC_P0         = cms.double(-.326),
-   mLC_P1         = cms.double( .618),
-   mLC_P2         = cms.double( .300),
-   mTIB_P0        = cms.double(-.742),
-   mTIB_P1        = cms.double( .202),
-   mTOB_P0        = cms.double(-1.026),
-   mTOB_P1        = cms.double( .253),
-   mTID_P0        = cms.double(-1.427),
-   mTID_P1        = cms.double( .433),
-   mTEC_P0        = cms.double(-1.885),
-   mTEC_P1        = cms.double( .471),
-   useLegacyError = cms.bool(False),
-   maxChgOneMIP   = cms.double(6000.)
+StripCPEfromTrackAngleESProducer = stripCPEESProducer.clone(
+     ComponentName = 'StripCPEfromTrackAngle',
+     ComponentType = 'StripCPEfromTrackAngle',
+     parameters    = cms.PSet(
+	   mLC_P0         = cms.double(-.326),
+	   mLC_P1         = cms.double( .618),
+	   mLC_P2         = cms.double( .300),
+	   mTIB_P0        = cms.double(-.742),
+	   mTIB_P1        = cms.double( .202),
+	   mTOB_P0        = cms.double(-1.026),
+	   mTOB_P1        = cms.double( .253),
+	   mTID_P0        = cms.double(-1.427),
+	   mTID_P1        = cms.double( .433),
+	   mTEC_P0        = cms.double(-1.885),
+	   mTEC_P1        = cms.double( .471),
+	   useLegacyError = cms.bool(False),
+	   maxChgOneMIP   = cms.double(6000.)
+     )
 )

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEgeometric_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEgeometric_cfi.py
@@ -5,11 +5,11 @@ StripCPEgeometricESProducer = stripCPEESProducer.clone(
      ComponentName = 'StripCPEgeometric',
      ComponentType = 'StripCPEgeometric',
      parameters    = cms.PSet(
-        TanDiffusionAngle            = 0.01,
-        ThicknessRelativeUncertainty = 0.02,
-        NoiseThreshold               = 2.3,
-        MaybeNoiseThreshold          = 3.5,
-        UncertaintyScaling           = 1.42,
-        MinimumUncertainty           = 0.01
+        TanDiffusionAngle            = cms.double(0.01),
+        ThicknessRelativeUncertainty = cms.double(0.02),
+        NoiseThreshold               = cms.double(2.3),
+        MaybeNoiseThreshold          = cms.double(3.5),
+        UncertaintyScaling           = cms.double(1.42),
+        MinimumUncertainty           = cms.double(0.01)
      )
 )

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEgeometric_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEgeometric_cfi.py
@@ -1,14 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEESProducer_cfi import *
-StripCPEgeometricESProducer = stripCPEESProducer.clone()
-StripCPEgeometricESProducer.ComponentName = cms.string('StripCPEgeometric')
-StripCPEgeometricESProducer.ComponentType = cms.string('StripCPEgeometric')
-StripCPEgeometricESProducer.parameters    = cms.PSet(
-   TanDiffusionAngle            = cms.double(0.01),
-   ThicknessRelativeUncertainty = cms.double(0.02),
-   NoiseThreshold               = cms.double(2.3),
-   MaybeNoiseThreshold          = cms.double(3.5),
-   UncertaintyScaling           = cms.double(1.42),
-   MinimumUncertainty           = cms.double(0.01)
+StripCPEgeometricESProducer = stripCPEESProducer.clone(
+     ComponentName = 'StripCPEgeometric'
+     ComponentType = 'StripCPEgeometric'
+     parameters    = cms.PSet(
+        TanDiffusionAngle            = 0.01,
+        ThicknessRelativeUncertainty = 0.02,
+        NoiseThreshold               = 2.3,
+        MaybeNoiseThreshold          = 3.5,
+        UncertaintyScaling           = 1.42,
+        MinimumUncertainty           = 0.01
+     )
 )

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEgeometric_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEgeometric_cfi.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEESProducer_cfi import *
 StripCPEgeometricESProducer = stripCPEESProducer.clone(
-     ComponentName = 'StripCPEgeometric'
-     ComponentType = 'StripCPEgeometric'
+     ComponentName = 'StripCPEgeometric',
+     ComponentType = 'StripCPEgeometric',
      parameters    = cms.PSet(
         TanDiffusionAngle            = 0.01,
         ThicknessRelativeUncertainty = 0.02,


### PR DESCRIPTION
#### PR description: Update the safer syntax for existing parameter
(The reference was [PR#29979](https://github.com/cms-sw/cmssw/pull/29979))
Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).