### PR TITLE
Updated L1T tags to address CMSSW issue #29237

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,11 +16,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_v5',
+    'run2_mc_pre_vfp'   :   '111X_mcRun2_asymptotic_preVFP_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '110X_mcRun2_asymptotic_v8',
+    'run2_mc'           :   '111X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v7',
+    'run2_mc_cosmics'   :   '111X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,11 +16,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_v4',
+    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '110X_mcRun2_asymptotic_v7',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_v8',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v6',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2


### PR DESCRIPTION
#### PR description:

This PR updates several L1T tags to address CMSSW issue #29237. The GT differences are as follows:

**2016 pre-VFP MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_preVFP_v4/110X_mcRun2_asymptotic_preVFP_v5

**2016 post-VFP MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_v7/110X_mcRun2_asymptotic_v8

**2016 deco-mode cosmic MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2cosmics_startup_deco_v6/110X_mcRun2cosmics_startup_deco_v7

For the first two tags, the GT differences with respect to the 10_6_X ultra-legacy GTs already in use are as follows:

**2016 pre-VFP MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_preVFP_v8/110X_mcRun2_asymptotic_preVFP_v5

**2016 post-VFP MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_v13/110X_mcRun2_asymptotic_v8

None of these differences are relevant: they include moving the AlCaReco trigger bits to the GT, adding the tau payloads to the GT and removing three obsolete pixel records.

Attn: @jiafulow @hjkwon260 @davignon @dinyar 

#### PR validation:

These tags are already in use in the run 2 UL production. More details can be found in the documentation for issue #29237.

In addition, a technical test was performed:

`runTheMatrix.py -l limited,1325.516 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported verbatim to 11_1_X and 11_0_X, which is the reason for retaining the GT prefix "110X". In addition, a 10_6_X backport that includes all other remaining UL updates will be generated.