### PR TITLE
Reduce boost in Fireworks/Core

### DIFF
--- a/Fireworks/Core/interface/FWGUIManager.h
+++ b/Fireworks/Core/interface/FWGUIManager.h
@@ -19,13 +19,14 @@
 //
 
 // system include files
+#include <functional>
 #include <map>
-#include <boost/function.hpp>
+#include <memory>
+
 #include <sigc++/sigc++.h>
 #include "Rtypes.h"
 #include "GuiTypes.h"
 #include "TGFileDialog.h"
-#include <memory>
 
 // user include files
 #include "Fireworks/Core/interface/FWConfigurable.h"
@@ -94,7 +95,7 @@ namespace fireworks {
 class FWGUIManager : public FWConfigurable {
   // typedefs
 public:
-  typedef boost::function2<FWViewBase*, TEveWindowSlot*, const std::string&> ViewBuildFunctor;
+  typedef std::function<FWViewBase*(TEveWindowSlot*, const std::string&)> ViewBuildFunctor;
   typedef std::map<std::string, ViewBuildFunctor> NameToViewBuilder;
 
 private:

--- a/Fireworks/Core/interface/FWTriggerTableView.h
+++ b/Fireworks/Core/interface/FWTriggerTableView.h
@@ -13,8 +13,6 @@
 #include "Fireworks/Core/interface/FWViewBase.h"
 #include "Fireworks/Core/interface/FWStringParameter.h"
 
-#include <boost/unordered_map.hpp>
-
 // forward declarations
 class TGFrame;
 class TGCompositeFrame;

--- a/Fireworks/Core/src/CmsShowTaskExecutor.h
+++ b/Fireworks/Core/src/CmsShowTaskExecutor.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
-#include <boost/function.hpp>
 #include <deque>
+#include <functional>
 
 // user include files
 #include "Fireworks/Core/src/CmsShowTaskExecutorBase.h"
@@ -32,7 +32,7 @@ public:
   CmsShowTaskExecutor();
   ~CmsShowTaskExecutor() override;
 
-  typedef boost::function0<void> TaskFunctor;
+  typedef std::function<void()> TaskFunctor;
   // ---------- const member functions ---------------------
 
   // ---------- static member functions --------------------


### PR DESCRIPTION
#### PR description:
Replaced boost library use for C++ STL alternatives. Replaced boost::function for std::function. The code should have similar behavior. 
Also removed a header that was unused. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 