### PR TITLE
Make mass replace work with proxy types

### DIFF
--- a/FWCore/ParameterSet/python/MassReplace.py
+++ b/FWCore/ParameterSet/python/MassReplace.py
@@ -20,9 +20,9 @@ class MassSearchReplaceAnyInputTagVisitor(object):
                 if isinstance(value, cms.PSet) or isinstance(value, cms.EDProducer) or isinstance(value, cms.EDAlias):
                     # EDProducer and EDAlias to support SwitchProducer
                     self.doIt(value,base+"."+name)
-                elif isinstance(value, cms.VPSet):
+                elif value.isCompatibleCMSType(cms.VPSet):
                     for (i,ps) in enumerate(value): self.doIt(ps, "%s.%s[%d]"%(base,name,i) )
-                elif isinstance(value, cms.VInputTag):
+                elif value.isCompatibleCMSType(cms.VInputTag):
                     for (i,n) in enumerate(value):
                         # VInputTag can be declared as a list of strings, so ensure that n is formatted correctly
                         n = self.standardizeInputTagFmt(n)
@@ -38,7 +38,7 @@ class MassSearchReplaceAnyInputTagVisitor(object):
                             nrep = n; nrep.moduleLabel = self._paramReplace.moduleLabel
                             if self._verbose:print("Replace %s.%s[%d] %s ==> %s " % (base, name, i, n, nrep))
                             value[i] = nrep
-                elif isinstance(value, cms.InputTag):
+                elif value.isCompatibleCMSType(cms.InputTag):
                     if value == self._paramSearch:
                         if self._verbose:print("Replace %s.%s %s ==> %s " % (base, name, self._paramSearch, self._paramReplace))
                         from copy import deepcopy
@@ -172,7 +172,9 @@ if __name__=="__main__":
                                        nested = cms.PSet(src = cms.InputTag("b"), src2 = cms.InputTag("c"), usrc = cms.untracked.InputTag("b"))
                                        ),
             )
-            p.s = cms.Sequence(p.a*p.b*p.c*p.sp)
+            p.op = cms.EDProducer("op", src = cms.optional.InputTag)
+            p.op.src="b"
+            p.s = cms.Sequence(p.a*p.b*p.c*p.sp*p.op)
             massSearchReplaceAnyInputTag(p.s, cms.InputTag("b"), cms.InputTag("new"))
             self.assertNotEqual(cms.InputTag("new"), p.b.src)
             self.assertEqual(cms.InputTag("new"), p.c.src)
@@ -205,6 +207,7 @@ if __name__=="__main__":
             self.assertEqual(cms.InputTag("new"), p.sp.test2.nested.src)
             self.assertEqual(cms.InputTag("c"), p.sp.test2.nested.src2)
             self.assertEqual(cms.untracked.InputTag("new"), p.sp.test2.nested.usrc)
+            self.assertEqual(cms.InputTag("new"), p.op.src)
 
         def testMassReplaceInputTag(self):
             process1 = cms.Process("test")

--- a/FWCore/ParameterSet/python/MassReplace.py
+++ b/FWCore/ParameterSet/python/MassReplace.py
@@ -22,7 +22,7 @@ class MassSearchReplaceAnyInputTagVisitor(object):
                     self.doIt(value,base+"."+name)
                 elif value.isCompatibleCMSType(cms.VPSet):
                     for (i,ps) in enumerate(value): self.doIt(ps, "%s.%s[%d]"%(base,name,i) )
-                elif value.isCompatibleCMSType(cms.VInputTag):
+                elif value.isCompatibleCMSType(cms.VInputTag) and value:
                     for (i,n) in enumerate(value):
                         # VInputTag can be declared as a list of strings, so ensure that n is formatted correctly
                         n = self.standardizeInputTagFmt(n)
@@ -38,7 +38,7 @@ class MassSearchReplaceAnyInputTagVisitor(object):
                             nrep = n; nrep.moduleLabel = self._paramReplace.moduleLabel
                             if self._verbose:print("Replace %s.%s[%d] %s ==> %s " % (base, name, i, n, nrep))
                             value[i] = nrep
-                elif value.isCompatibleCMSType(cms.InputTag):
+                elif value.isCompatibleCMSType(cms.InputTag) and value:
                     if value == self._paramSearch:
                         if self._verbose:print("Replace %s.%s %s ==> %s " % (base, name, self._paramSearch, self._paramReplace))
                         from copy import deepcopy
@@ -172,8 +172,9 @@ if __name__=="__main__":
                                        nested = cms.PSet(src = cms.InputTag("b"), src2 = cms.InputTag("c"), usrc = cms.untracked.InputTag("b"))
                                        ),
             )
-            p.op = cms.EDProducer("op", src = cms.optional.InputTag)
+            p.op = cms.EDProducer("op", src = cms.optional.InputTag, unset = cms.optional.InputTag, vsrc = cms.optional.VInputTag, vunset = cms.optional.VInputTag)
             p.op.src="b"
+            p.op.vsrc=cms.VInputTag("b")
             p.s = cms.Sequence(p.a*p.b*p.c*p.sp*p.op)
             massSearchReplaceAnyInputTag(p.s, cms.InputTag("b"), cms.InputTag("new"))
             self.assertNotEqual(cms.InputTag("new"), p.b.src)
@@ -208,6 +209,7 @@ if __name__=="__main__":
             self.assertEqual(cms.InputTag("c"), p.sp.test2.nested.src2)
             self.assertEqual(cms.untracked.InputTag("new"), p.sp.test2.nested.usrc)
             self.assertEqual(cms.InputTag("new"), p.op.src)
+            self.assertEqual(cms.InputTag("new"), p.op.vsrc[0])
 
         def testMassReplaceInputTag(self):
             process1 = cms.Process("test")

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -84,7 +84,9 @@ class _ParameterTypeBase(object):
         return self._isFrozen 
     def setIsFrozen(self):
         self._isFrozen = True
-
+    def isCompatibleCMSType(self,aType):
+        return isinstance(self,aType)
+ 
 class _SimpleParameterTypeBase(_ParameterTypeBase):
     """base class for parameter classes which only hold a single value"""
     def __init__(self,value):

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -79,6 +79,11 @@ class _ProxyParameter(_ParameterTypeBase):
         if not _ParameterTypeBase.isTracked(self):
             v = untracked(v)
         return v
+    def isCompatibleCMSType(self,aType):
+        v = self.__dict__.get('_ProxyParameter__value',None)
+        if v is not None:
+            return v.isCompatibleCMSType(aType)
+        return self.__type == aType
 
 class _RequiredParameter(_ProxyParameter):
     @staticmethod
@@ -624,22 +629,22 @@ class InputTag(_ParameterTypeBase):
         return True
     def __eq__(self,other):
         return ((self.__moduleLabel,self.__productInstance,self.__processName) ==
-                (other.__moduleLabel,other.__productInstance,other.__processName))
+                (other.moduleLabel,other.productInstanceLabel,other.processName))
     def __ne__(self,other):
         return ((self.__moduleLabel,self.__productInstance,self.__processName) !=
-                (other.__moduleLabel,other.__productInstance,other.__processName))
+                (other.moduleLabel,other.productInstanceLabel,other.processName))
     def __lt__(self,other):
         return ((self.__moduleLabel,self.__productInstance,self.__processName) <
-                (other.__moduleLabel,other.__productInstance,other.__processName))
+                (other.moduleLabel,other.productInstanceLabel,other.processName))
     def __gt__(self,other):
         return ((self.__moduleLabel,self.__productInstance,self.__processName) >
-                (other.__moduleLabel,other.__productInstance,other.__processName))
+                (other.moduleLabel,other.productInstanceLabel,other.processName))
     def __le__(self,other):
         return ((self.__moduleLabel,self.__productInstance,self.__processName) <=
-                (other.__moduleLabel,other.__productInstance,other.__processName))
+                (other.moduleLabel,other.productInstanceLabel,other.processName))
     def __ge__(self,other):
         return ((self.__moduleLabel,self.__productInstance,self.__processName) >=
-                (other.__moduleLabel,other.__productInstance,other.__processName))
+                (other.moduleLabel,other.productInstanceLabel,other.processName))
 
 
     def value(self):
@@ -1624,6 +1629,8 @@ if __name__ == "__main__":
             self.assertEqual(p1.dumpPython(), 'cms.PSet(\n    anInt = cms.required.untracked.int32\n)')
             p1.anInt = 6
             self.assertEqual(p1.dumpPython(), 'cms.PSet(\n    anInt = cms.untracked.int32(6)\n)')
+            self.assert_(p1.anInt.isCompatibleCMSType(int32))
+            self.failIf(p1.anInt.isCompatibleCMSType(uint32))
             p1 = PSet(allowAnyLabel_ = required.int32)
             self.failIf(p1.hasParameter(['allowAnyLabel_']))
             p1.foo = 3
@@ -1656,6 +1663,8 @@ if __name__ == "__main__":
             self.assertEqual(p1.dumpPython(), 'cms.PSet(\n    anInt = cms.optional.untracked.int32\n)')
             p1.anInt = 6
             self.assertEqual(p1.dumpPython(), 'cms.PSet(\n    anInt = cms.untracked.int32(6)\n)')
+            self.assert_(p1.anInt.isCompatibleCMSType(int32))
+            self.failIf(p1.anInt.isCompatibleCMSType(uint32))
             p1 = PSet(f = required.vint32)
             self.failIf(p1.f)
             p1.f = []
@@ -1668,11 +1677,15 @@ if __name__ == "__main__":
             self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.required.allowed(cms.int32,cms.string)\n)')
             p1.aValue = 1
             self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.int32(1)\n)')
+            self.assert_(p1.aValue.isCompatibleCMSType(int32))
+            self.failIf(p1.aValue.isCompatibleCMSType(uint32))
             self.assertRaises(ValueError,setattr(p1,'aValue',PSet()))
             p1 = PSet(aValue = required.allowed(int32, string))
             self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.required.allowed(cms.int32,cms.string)\n)')
             p1.aValue = "foo"
             self.assertEqual(p1.dumpPython(),"cms.PSet(\n    aValue = cms.string('foo')\n)")
+            self.assert_(p1.aValue.isCompatibleCMSType(string))
+            self.failIf(p1.aValue.isCompatibleCMSType(uint32))
 
             p1 = PSet(aValue = required.untracked.allowed(int32, string))
             self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.required.untracked.allowed(cms.int32,cms.string)\n)')


### PR DESCRIPTION
#### PR description:

Adding isCompatibleCMSType allows handling of proxy types in mass search functions involving InputTags

#### PR validation:

The unit tests pass.