### PR TITLE
Reduce boost in Fireworks/Core

### DIFF
--- a/Fireworks/Core/interface/FWGUIManager.h
+++ b/Fireworks/Core/interface/FWGUIManager.h
@@ -19,13 +19,14 @@
 //
 
 // system include files
+#include <functional>
 #include <map>
-#include <boost/function.hpp>
+#include <memory>
+
 #include <sigc++/sigc++.h>
 #include "Rtypes.h"
 #include "GuiTypes.h"
 #include "TGFileDialog.h"
-#include <memory>
 
 // user include files
 #include "Fireworks/Core/interface/FWConfigurable.h"
@@ -94,7 +95,7 @@ namespace fireworks {
 class FWGUIManager : public FWConfigurable {
   // typedefs
 public:
-  typedef boost::function2<FWViewBase*, TEveWindowSlot*, const std::string&> ViewBuildFunctor;
+  typedef std::function<FWViewBase*(TEveWindowSlot*, const std::string&)> ViewBuildFunctor;
   typedef std::map<std::string, ViewBuildFunctor> NameToViewBuilder;
 
 private:

--- a/Fireworks/Core/interface/FWTriggerTableView.h
+++ b/Fireworks/Core/interface/FWTriggerTableView.h
@@ -13,8 +13,6 @@
 #include "Fireworks/Core/interface/FWViewBase.h"
 #include "Fireworks/Core/interface/FWStringParameter.h"
 
-#include <boost/unordered_map.hpp>
-
 // forward declarations
 class TGFrame;
 class TGCompositeFrame;

--- a/Fireworks/Core/src/CSGContinuousAction.cc
+++ b/Fireworks/Core/src/CSGContinuousAction.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 #include "TGMenu.h"
 
 // user include files
@@ -38,7 +38,7 @@ CSGContinuousAction::CSGContinuousAction(CSGActionSupervisor* iSupervisor, const
       m_runningDownPic(nullptr),
       m_button(nullptr),
       m_isRunning(false) {
-  activated.connect(boost::bind(&CSGContinuousAction::switchMode, this));
+  activated.connect(std::bind(&CSGContinuousAction::switchMode, this));
 }
 
 void CSGContinuousAction::createCustomIconsButton(TGCompositeFrame* p,

--- a/Fireworks/Core/src/CmsShowCommon.cc
+++ b/Fireworks/Core/src/CmsShowCommon.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 #include <iostream>
 // user include files
 
@@ -69,10 +69,10 @@ CmsShowCommon::CmsShowCommon(fireworks::Context* c)
         new FWLongParameter(this, name, long(colorManager()->geomColor(FWGeomColorIndex(i))), 1000l, 1100l);
   }
 
-  m_trackBreak.changed_.connect(boost::bind(&CmsShowCommon::setTrackBreakMode, this));
+  m_trackBreak.changed_.connect(std::bind(&CmsShowCommon::setTrackBreakMode, this));
   m_palette.set(m_context->colorManager()->getPalette());
-  m_drawBreakPoints.changed_.connect(boost::bind(&CmsShowCommon::setDrawBreakMarkers, this));
-  m_gamma.changed_.connect(boost::bind(&CmsShowCommon::setGamma, this));
+  m_drawBreakPoints.changed_.connect(std::bind(&CmsShowCommon::setDrawBreakMarkers, this));
+  m_gamma.changed_.connect(std::bind(&CmsShowCommon::setGamma, this));
 
   m_lightColorSet.StdLightBackground();
   m_darkColorSet.StdDarkBackground();

--- a/Fireworks/Core/src/CmsShowCommonPopup.cc
+++ b/Fireworks/Core/src/CmsShowCommonPopup.cc
@@ -27,7 +27,7 @@
 #include "Fireworks/Core/interface/FWEventItemsManager.h"
 #include "Fireworks/Core/interface/FWEventItem.h"
 
-#include <boost/bind.hpp>
+#include <functional>
 
 CmsShowCommonPopup::CmsShowCommonPopup(CmsShowCommon* model, const TGWindow* p, UInt_t w, UInt_t h)
     : TGTransientFrame(gClient->GetDefaultRoot(), p, w, h),
@@ -112,7 +112,7 @@ CmsShowCommonPopup::CmsShowCommonPopup(CmsShowCommon* model, const TGWindow* p, 
     //   printf("QWE %d %s\n", i, ((TGFrameElement*)f->GetList()->At(i))->fFrame->ClassName());
     // m_combo = static_cast<TGComboBox*>(f->GetList()->At(1));
     m_combo = static_cast<TGComboBox*>(static_cast<TGFrameElement*>(f->GetList()->At(0))->fFrame);
-    m_common->m_palette.changed_.connect(boost::bind(&CmsShowCommonPopup::setPaletteGUI, this));
+    m_common->m_palette.changed_.connect(std::bind(&CmsShowCommonPopup::setPaletteGUI, this));
 
     TGCompositeFrame* hf = new TGHorizontalFrame(vf2);
     vf2->AddFrame(hf, new TGLayoutHints(kLHintsExpandX));

--- a/Fireworks/Core/src/CmsShowEDI.cc
+++ b/Fireworks/Core/src/CmsShowEDI.cc
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <sstream>
 #include <sigc++/sigc++.h>
-#include <boost/bind.hpp>
+#include <functional>
 #include "TClass.h"
 #include "TGFrame.h"
 #include "TGTab.h"
@@ -70,7 +70,7 @@ CmsShowEDI::CmsShowEDI(const TGWindow* p, UInt_t w, UInt_t h, FWSelectionManager
   m_selectionManager = selMgr;
   SetCleanup(kDeepCleanup);
 
-  m_selectionManager->itemSelectionChanged_.connect(boost::bind(&CmsShowEDI::fillEDIFrame, this));
+  m_selectionManager->itemSelectionChanged_.connect(std::bind(&CmsShowEDI::fillEDIFrame, this));
 
   TGVerticalFrame* vf = new TGVerticalFrame(this);
   AddFrame(vf, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
@@ -292,10 +292,10 @@ void CmsShowEDI::fillEDIFrame() {
       updateLayerControls();
       m_layerEntry->SetState(kTRUE);
       m_displayChangedConn =
-          m_item->defaultDisplayPropertiesChanged_.connect(boost::bind(&CmsShowEDI::updateDisplay, this));
-      m_modelChangedConn = m_item->changed_.connect(boost::bind(&CmsShowEDI::updateFilter, this));
+          m_item->defaultDisplayPropertiesChanged_.connect(std::bind(&CmsShowEDI::updateDisplay, this));
+      m_modelChangedConn = m_item->changed_.connect(std::bind(&CmsShowEDI::updateFilter, this));
       //    m_selectionChangedConn = m_selectionManager->selectionChanged_.connect(boost::bind(&CmsShowEDI::updateSelection, this));
-      m_destroyedConn = m_item->goingToBeDestroyed_.connect(boost::bind(&CmsShowEDI::disconnectAll, this));
+      m_destroyedConn = m_item->goingToBeDestroyed_.connect(std::bind(&CmsShowEDI::disconnectAll, this));
 
       clearPBFrame();
       m_item->getConfig()->populateFrame(m_settersFrame);

--- a/Fireworks/Core/src/CmsShowMainBase.cc
+++ b/Fireworks/Core/src/CmsShowMainBase.cc
@@ -5,7 +5,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "TGLWidget.h"
 #include "TGMsgBox.h"
@@ -77,7 +77,7 @@ void CmsShowMainBase::setupActions() {
   // init TGSlider state before signals are connected
   m_guiManager->setDelayBetweenEvents(m_playDelay);
 
-  m_navigatorPtr->newEvent_.connect(boost::bind(&CmsShowMainBase::eventChangedSlot, this));
+  m_navigatorPtr->newEvent_.connect(std::bind(&CmsShowMainBase::eventChangedSlot, this));
   if (m_guiManager->getAction(cmsshow::sNextEvent) != nullptr)
     m_guiManager->getAction(cmsshow::sNextEvent)->activated.connect(sigc::mem_fun(*this, &CmsShowMainBase::doNextEvent));
   if (m_guiManager->getAction(cmsshow::sPreviousEvent) != nullptr)
@@ -92,16 +92,18 @@ void CmsShowMainBase::setupActions() {
   if (m_guiManager->getAction(cmsshow::sQuit) != nullptr)
     m_guiManager->getAction(cmsshow::sQuit)->activated.connect(sigc::mem_fun(*this, &CmsShowMainBase::quit));
 
-  m_guiManager->changedEventId_.connect(boost::bind(&CmsShowMainBase::goToRunEvent, this, _1, _2, _3));
+  m_guiManager->changedEventId_.connect(std::bind(
+      &CmsShowMainBase::goToRunEvent, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
   m_guiManager->playEventsAction()->started_.connect(sigc::mem_fun(*this, &CmsShowMainBase::playForward));
   m_guiManager->playEventsBackwardsAction()->started_.connect(sigc::mem_fun(*this, &CmsShowMainBase::playBackward));
   m_guiManager->loopAction()->started_.connect(sigc::mem_fun(*this, &CmsShowMainBase::setPlayLoopImp));
   m_guiManager->loopAction()->stopped_.connect(sigc::mem_fun(*this, &CmsShowMainBase::unsetPlayLoopImp));
-  m_guiManager->changedDelayBetweenEvents_.connect(boost::bind(&CmsShowMainBase::setPlayDelay, this, _1));
+  m_guiManager->changedDelayBetweenEvents_.connect(
+      std::bind(&CmsShowMainBase::setPlayDelay, this, std::placeholders::_1));
   m_guiManager->playEventsAction()->stopped_.connect(sigc::mem_fun(*this, &CmsShowMainBase::stopPlaying));
   m_guiManager->playEventsBackwardsAction()->stopped_.connect(sigc::mem_fun(*this, &CmsShowMainBase::stopPlaying));
 
-  m_autoLoadTimer->timeout_.connect(boost::bind(&CmsShowMainBase::autoLoadNewEvent, this));
+  m_autoLoadTimer->timeout_.connect(std::bind(&CmsShowMainBase::autoLoadNewEvent, this));
 }
 
 void CmsShowMainBase::setupViewManagers() {
@@ -114,7 +116,7 @@ void CmsShowMainBase::setupViewManagers() {
   auto tableViewManager = std::make_shared<FWTableViewManager>(guiManager());
   configurationManager()->add(std::string("Tables"), tableViewManager.get());
   viewManager()->add(tableViewManager);
-  eiManager()->goingToClearItems_.connect(boost::bind(&FWTableViewManager::removeAllItems, tableViewManager.get()));
+  eiManager()->goingToClearItems_.connect(std::bind(&FWTableViewManager::removeAllItems, tableViewManager.get()));
 
   auto triggerTableViewManager = std::make_shared<FWTriggerTableViewManager>(guiManager());
   configurationManager()->add(std::string("TriggerTables"), triggerTableViewManager.get());
@@ -205,23 +207,27 @@ void CmsShowMainBase::setup(FWNavigatorBase *navigator,
   m_contextPtr->initEveElements();
   m_guiManager.reset(new FWGUIManager(m_contextPtr, m_viewManager.get(), m_navigatorPtr));
 
-  m_eiManager->newItem_.connect(boost::bind(&FWModelChangeManager::newItemSlot, m_changeManager.get(), _1));
+  m_eiManager->newItem_.connect(
+      std::bind(&FWModelChangeManager::newItemSlot, m_changeManager.get(), std::placeholders::_1));
 
-  m_eiManager->newItem_.connect(boost::bind(&FWViewManagerManager::registerEventItem, m_viewManager.get(), _1));
+  m_eiManager->newItem_.connect(
+      std::bind(&FWViewManagerManager::registerEventItem, m_viewManager.get(), std::placeholders::_1));
   m_configurationManager->add("EventItems", m_eiManager.get());
   m_configurationManager->add("GUI", m_guiManager.get());
   m_configurationManager->add("EventNavigator", m_navigatorPtr);
   m_configurationManager->add("CommonPreferences",
                               m_contextPtr->commonPrefs());  // must be after GUIManager in alphabetical order
 
-  m_guiManager->writeToConfigurationFile_.connect(boost::bind(&CmsShowMainBase::writeToConfigFile, this, _1));
+  m_guiManager->writeToConfigurationFile_.connect(
+      std::bind(&CmsShowMainBase::writeToConfigFile, this, std::placeholders::_1));
 
-  m_guiManager->loadFromConfigurationFile_.connect(boost::bind(&CmsShowMainBase::reloadConfiguration, this, _1));
+  m_guiManager->loadFromConfigurationFile_.connect(
+      std::bind(&CmsShowMainBase::reloadConfiguration, this, std::placeholders::_1));
   m_guiManager->loadPartialFromConfigurationFile_.connect(
-      boost::bind(&CmsShowMainBase::partialLoadConfiguration, this, _1));
+      std::bind(&CmsShowMainBase::partialLoadConfiguration, this, std::placeholders::_1));
 
   m_guiManager->writePartialToConfigurationFile_.connect(
-      boost::bind(&CmsShowMainBase::partialWriteToConfigFile, this, _1));
+      std::bind(&CmsShowMainBase::partialWriteToConfigFile, this, std::placeholders::_1));
 
   std::string macPath(gSystem->Getenv("CMSSW_BASE"));
   macPath += "/src/Fireworks/Core/macros";
@@ -233,7 +239,7 @@ void CmsShowMainBase::setup(FWNavigatorBase *navigator,
   }
   gROOT->SetMacroPath((std::string("./:") + macPath).c_str());
 
-  m_startupTasks->tasksCompleted_.connect(boost::bind(&FWGUIManager::clearStatus, m_guiManager.get()));
+  m_startupTasks->tasksCompleted_.connect(std::bind(&FWGUIManager::clearStatus, m_guiManager.get()));
 }
 
 void CmsShowMainBase::writeToConfigFile(const std::string &name) {

--- a/Fireworks/Core/src/CmsShowModelPopup.cc
+++ b/Fireworks/Core/src/CmsShowModelPopup.cc
@@ -16,7 +16,7 @@
 #include <set>
 #include <cassert>
 #include <sigc++/sigc++.h>
-#include <boost/bind.hpp>
+#include <functional>
 #include "TClass.h"
 #include "TGFrame.h"
 #include "TGButton.h"
@@ -61,7 +61,8 @@ CmsShowModelPopup::CmsShowModelPopup(FWDetailViewManager *iManager,
       m_detailViewManager(iManager),
       m_colorManager(iColorMgr),
       m_dialogBuilder(nullptr) {
-  m_changes = iSelMgr->selectionChanged_.connect(boost::bind(&CmsShowModelPopup::fillModelPopup, this, _1));
+  m_changes =
+      iSelMgr->selectionChanged_.connect(std::bind(&CmsShowModelPopup::fillModelPopup, this, std::placeholders::_1));
 
   SetCleanup(kDeepCleanup);
 
@@ -223,8 +224,8 @@ void CmsShowModelPopup::fillModelPopup(const FWSelectionManager &iSelMgr) {
   m_colorSelectWidget->SetEnabled(kTRUE);
   m_isVisibleButton->SetEnabled(kTRUE);
 
-  m_modelChangedConn = item->changed_.connect(boost::bind(&CmsShowModelPopup::updateDisplay, this));
-  m_destroyedConn = item->goingToBeDestroyed_.connect(boost::bind(&CmsShowModelPopup::disconnectAll, this));
+  m_modelChangedConn = item->changed_.connect(std::bind(&CmsShowModelPopup::updateDisplay, this));
+  m_destroyedConn = item->goingToBeDestroyed_.connect(std::bind(&CmsShowModelPopup::disconnectAll, this));
 
   Resize(GetDefaultSize());
   Layout();

--- a/Fireworks/Core/src/CmsShowNavigator.cc
+++ b/Fireworks/Core/src/CmsShowNavigator.cc
@@ -10,7 +10,7 @@
 #include "Fireworks/Core/interface/FWEventItem.h"
 
 // system include files
-#include "boost/bind.hpp"
+#include <functional>
 #include "boost/regex.hpp"
 #include "TROOT.h"
 #include "TTree.h"
@@ -58,7 +58,7 @@ CmsShowNavigator::CmsShowNavigator(const CmsShowMain& main)
       m_main(main),
       m_guiFilter(nullptr) {
   m_guiFilter = new FWGUIEventFilter(this);
-  filterStateChanged_.connect(boost::bind(&FWGUIEventFilter::updateFilterStateLabel, m_guiFilter, _1));
+  filterStateChanged_.connect(std::bind(&FWGUIEventFilter::updateFilterStateLabel, m_guiFilter, std::placeholders::_1));
 }
 
 CmsShowNavigator::~CmsShowNavigator() { delete m_guiFilter; }

--- a/Fireworks/Core/src/CmsShowTaskExecutor.h
+++ b/Fireworks/Core/src/CmsShowTaskExecutor.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
-#include <boost/function.hpp>
 #include <deque>
+#include <functional>
 
 // user include files
 #include "Fireworks/Core/src/CmsShowTaskExecutorBase.h"
@@ -32,7 +32,7 @@ public:
   CmsShowTaskExecutor();
   ~CmsShowTaskExecutor() override;
 
-  typedef boost::function0<void> TaskFunctor;
+  typedef std::function<void()> TaskFunctor;
   // ---------- const member functions ---------------------
 
   // ---------- static member functions --------------------

--- a/Fireworks/Core/src/CmsShowViewPopup.cc
+++ b/Fireworks/Core/src/CmsShowViewPopup.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 #include <cassert>
 #include "TGLabel.h"
 #include "TGButton.h"
@@ -51,7 +51,7 @@ CmsShowViewPopup::CmsShowViewPopup(
       m_colorManager(iCMgr),
       m_viewBase(nullptr),
       m_eveWindow(nullptr) {
-  m_colorManager->colorsHaveChanged_.connect(boost::bind(&CmsShowViewPopup::backgroundColorWasChanged, this));
+  m_colorManager->colorsHaveChanged_.connect(std::bind(&CmsShowViewPopup::backgroundColorWasChanged, this));
 
   SetCleanup(kDeepCleanup);
 

--- a/Fireworks/Core/src/Context.cc
+++ b/Fireworks/Core/src/Context.cc
@@ -24,7 +24,7 @@
 #include "Fireworks/Core/interface/FWBeamSpot.h"
 #include "Fireworks/Core/interface/CmsShowCommon.h"
 
-#include <boost/bind.hpp>
+#include <functional>
 
 using namespace fireworks;
 

--- a/Fireworks/Core/src/FW3DView.cc
+++ b/Fireworks/Core/src/FW3DView.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "TGLViewer.h"

--- a/Fireworks/Core/src/FW3DViewBase.cc
+++ b/Fireworks/Core/src/FW3DViewBase.cc
@@ -9,7 +9,7 @@
 // Original Author:  Chris Jones
 //         Created:  Thu Feb 21 11:22:41 EST 2008
 //
-#include <boost/bind.hpp>
+#include <functional>
 #include <string>
 #include <algorithm>
 
@@ -130,14 +130,14 @@ FW3DViewBase::FW3DViewBase(TEveWindowSlot* iParent, FWViewType::EType typeId, un
   m_showMuonBarrel.addEntry(0, "Hide");
   m_showMuonBarrel.addEntry(1, "Simplified");
   m_showMuonBarrel.addEntry(2, "Full");
-  m_showMuonBarrel.changed_.connect(boost::bind(&FW3DViewBase::showMuonBarrel, this, _1));
+  m_showMuonBarrel.changed_.connect(std::bind(&FW3DViewBase::showMuonBarrel, this, std::placeholders::_1));
 
   m_rnrStyle.addEntry(TGLRnrCtx::kFill, "Fill");
   m_rnrStyle.addEntry(TGLRnrCtx::kOutline, "Outline");
   m_rnrStyle.addEntry(TGLRnrCtx::kWireFrame, "WireFrame");
-  m_rnrStyle.changed_.connect(boost::bind(&FW3DViewBase::rnrStyle, this, _1));
+  m_rnrStyle.changed_.connect(std::bind(&FW3DViewBase::rnrStyle, this, std::placeholders::_1));
 
-  m_selectable.changed_.connect(boost::bind(&FW3DViewBase::selectable, this, _1));
+  m_selectable.changed_.connect(std::bind(&FW3DViewBase::selectable, this, std::placeholders::_1));
 
   m_cameraType.addEntry(TGLViewer::kCameraPerspXOZ, "PerspXOZ");
   m_cameraType.addEntry(TGLViewer::kCameraOrthoXOY, "OrthoXOY");
@@ -146,16 +146,16 @@ FW3DViewBase::FW3DViewBase(TEveWindowSlot* iParent, FWViewType::EType typeId, un
   m_cameraType.addEntry(TGLViewer::kCameraOrthoXnOY, "OrthoXnOY");
   m_cameraType.addEntry(TGLViewer::kCameraOrthoXnOZ, "OrthoXnOZ");
   m_cameraType.addEntry(TGLViewer::kCameraOrthoZnOY, "OrthoZnOY");
-  m_cameraType.changed_.connect(boost::bind(&FW3DViewBase::setCameraType, this, _1));
+  m_cameraType.changed_.connect(std::bind(&FW3DViewBase::setCameraType, this, std::placeholders::_1));
 
-  m_clipEnable.changed_.connect(boost::bind(&FW3DViewBase::enableSceneClip, this, _1));
-  m_clipTheta.changed_.connect(boost::bind(&FW3DViewBase::updateClipPlanes, this, false));
-  m_clipPhi.changed_.connect(boost::bind(&FW3DViewBase::updateClipPlanes, this, false));
-  m_clipDelta1.changed_.connect(boost::bind(&FW3DViewBase::updateClipPlanes, this, false));
-  m_clipDelta2.changed_.connect(boost::bind(&FW3DViewBase::updateClipPlanes, this, false));
-  m_clipAppexOffset.changed_.connect(boost::bind(&FW3DViewBase::updateClipPlanes, this, false));
-  m_clipHGCalLayerBegin.changed_.connect(boost::bind(&FW3DViewBase::updateHGCalVisibility, this, false));
-  m_clipHGCalLayerEnd.changed_.connect(boost::bind(&FW3DViewBase::updateHGCalVisibility, this, false));
+  m_clipEnable.changed_.connect(std::bind(&FW3DViewBase::enableSceneClip, this, std::placeholders::_1));
+  m_clipTheta.changed_.connect(std::bind(&FW3DViewBase::updateClipPlanes, this, false));
+  m_clipPhi.changed_.connect(std::bind(&FW3DViewBase::updateClipPlanes, this, false));
+  m_clipDelta1.changed_.connect(std::bind(&FW3DViewBase::updateClipPlanes, this, false));
+  m_clipDelta2.changed_.connect(std::bind(&FW3DViewBase::updateClipPlanes, this, false));
+  m_clipAppexOffset.changed_.connect(std::bind(&FW3DViewBase::updateClipPlanes, this, false));
+  m_clipHGCalLayerBegin.changed_.connect(std::bind(&FW3DViewBase::updateHGCalVisibility, this, false));
+  m_clipHGCalLayerEnd.changed_.connect(std::bind(&FW3DViewBase::updateHGCalVisibility, this, false));
 
   m_ecalBarrel = new TEveBoxSet("ecalBarrel");
   m_ecalBarrel->UseSingleColor();
@@ -172,15 +172,17 @@ void FW3DViewBase::setContext(const fireworks::Context& context) {
   m_geometry = new FW3DViewGeometry(context);
   geoScene()->AddElement(m_geometry);
 
-  m_showPixelBarrel.changed_.connect(boost::bind(&FW3DViewGeometry::showPixelBarrel, m_geometry, _1));
-  m_showPixelEndcap.changed_.connect(boost::bind(&FW3DViewGeometry::showPixelEndcap, m_geometry, _1));
-  m_showTrackerBarrel.changed_.connect(boost::bind(&FW3DViewGeometry::showTrackerBarrel, m_geometry, _1));
-  m_showTrackerEndcap.changed_.connect(boost::bind(&FW3DViewGeometry::showTrackerEndcap, m_geometry, _1));
-  m_showHGCalEE.changed_.connect(boost::bind(&FW3DViewGeometry::showHGCalEE, m_geometry, _1));
-  m_showHGCalHSi.changed_.connect(boost::bind(&FW3DViewGeometry::showHGCalHSi, m_geometry, _1));
-  m_showHGCalHSc.changed_.connect(boost::bind(&FW3DViewGeometry::showHGCalHSc, m_geometry, _1));
-  m_showMuonEndcap.changed_.connect(boost::bind(&FW3DViewGeometry::showMuonEndcap, m_geometry, _1));
-  m_showEcalBarrel.changed_.connect(boost::bind(&FW3DViewBase::showEcalBarrel, this, _1));
+  m_showPixelBarrel.changed_.connect(std::bind(&FW3DViewGeometry::showPixelBarrel, m_geometry, std::placeholders::_1));
+  m_showPixelEndcap.changed_.connect(std::bind(&FW3DViewGeometry::showPixelEndcap, m_geometry, std::placeholders::_1));
+  m_showTrackerBarrel.changed_.connect(
+      std::bind(&FW3DViewGeometry::showTrackerBarrel, m_geometry, std::placeholders::_1));
+  m_showTrackerEndcap.changed_.connect(
+      std::bind(&FW3DViewGeometry::showTrackerEndcap, m_geometry, std::placeholders::_1));
+  m_showHGCalEE.changed_.connect(std::bind(&FW3DViewGeometry::showHGCalEE, m_geometry, std::placeholders::_1));
+  m_showHGCalHSi.changed_.connect(std::bind(&FW3DViewGeometry::showHGCalHSi, m_geometry, std::placeholders::_1));
+  m_showHGCalHSc.changed_.connect(std::bind(&FW3DViewGeometry::showHGCalHSc, m_geometry, std::placeholders::_1));
+  m_showMuonEndcap.changed_.connect(std::bind(&FW3DViewGeometry::showMuonEndcap, m_geometry, std::placeholders::_1));
+  m_showEcalBarrel.changed_.connect(std::bind(&FW3DViewBase::showEcalBarrel, this, std::placeholders::_1));
 
   // don't clip event scene --  ideally, would have TGLClipNoClip in root
   TGLClipPlane* c = new TGLClipPlane();

--- a/Fireworks/Core/src/FWCollectionSummaryTableManager.cc
+++ b/Fireworks/Core/src/FWCollectionSummaryTableManager.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <sstream>
-#include <boost/bind.hpp>
+#include <functional>
 #include "TClass.h"
 
 // user include files
@@ -40,8 +40,8 @@ FWCollectionSummaryTableManager::FWCollectionSummaryTableManager(FWEventItem* iI
       m_renderer(iContext, iHighlightContext),
       m_bodyRenderer(iContext, iHighlightContext, FWTextTableCellRenderer::kJustifyRight),
       m_widget(iWidget) {
-  m_collection->changed_.connect(boost::bind(&FWTableManagerBase::dataChanged, this));
-  m_collection->itemChanged_.connect(boost::bind(&FWCollectionSummaryTableManager::dataChanged, this));
+  m_collection->changed_.connect(std::bind(&FWTableManagerBase::dataChanged, this));
+  m_collection->itemChanged_.connect(std::bind(&FWCollectionSummaryTableManager::dataChanged, this));
 
   //try to find the default columns
   std::vector<std::pair<std::string, std::string> > s_names;

--- a/Fireworks/Core/src/FWCollectionSummaryWidget.cc
+++ b/Fireworks/Core/src/FWCollectionSummaryWidget.cc
@@ -13,7 +13,7 @@
 // system include files
 #include <iostream>
 #include <vector>
-#include <boost/bind.hpp>
+#include <functional>
 #include "TGButton.h"
 #include "TGResourcePool.h"
 #include "TVirtualX.h"
@@ -41,7 +41,8 @@ struct FWCollectionSummaryWidgetConnectionHolder {
   std::vector<sigc::connection> m_connections;
 
   ~FWCollectionSummaryWidgetConnectionHolder() {
-    for_each(m_connections.begin(), m_connections.end(), boost::bind(&sigc::connection::disconnect, _1));
+    for_each(
+        m_connections.begin(), m_connections.end(), std::bind(&sigc::connection::disconnect, std::placeholders::_1));
   }
   void push_back(const sigc::connection& iC) { m_connections.push_back(iC); }
   void reserve(size_t iSize) { m_connections.reserve(iSize); }
@@ -296,11 +297,11 @@ FWCollectionSummaryWidget::FWCollectionSummaryWidget(TGFrame* iParent, FWEventIt
 
   m_connectionHolder->reserve(3);
   m_connectionHolder->push_back(m_collection->defaultDisplayPropertiesChanged_.connect(
-      boost::bind(&FWCollectionSummaryWidget::displayChanged, this)));
+      std::bind(&FWCollectionSummaryWidget::displayChanged, this)));
   m_connectionHolder->push_back(
-      m_collection->itemChanged_.connect(boost::bind(&FWCollectionSummaryWidget::itemChanged, this)));
+      m_collection->itemChanged_.connect(std::bind(&FWCollectionSummaryWidget::itemChanged, this)));
   m_connectionHolder->push_back(
-      m_collection->filterChanged_.connect(boost::bind(&FWCollectionSummaryWidget::itemChanged, this)));
+      m_collection->filterChanged_.connect(std::bind(&FWCollectionSummaryWidget::itemChanged, this)));
 
   MapSubwindows();
   Layout();

--- a/Fireworks/Core/src/FWColorSelect.cc
+++ b/Fireworks/Core/src/FWColorSelect.cc
@@ -10,7 +10,7 @@
     After creation, connect to signal method ColorSelected(Pixel_t) in
     FWColorSelect to receive colour changes.
  */
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "TGLayout.h"
 #include "TGClient.h"
@@ -300,7 +300,7 @@ FWColorSelect::FWColorSelect(
   fFireworksPopup->InitContent(fLabel.c_str(), colors);
   fFireworksPopup->Connect("ColorSelected(Color_t)", "FWColorSelect", this, "SetColorByIndex(Color_t)");
 
-  fColorManager->colorsHaveChanged_.connect(boost::bind(&FWColorSelect::UpdateColors, this));
+  fColorManager->colorsHaveChanged_.connect(std::bind(&FWColorSelect::UpdateColors, this));
 }
 
 FWColorSelect::~FWColorSelect() { delete fFireworksPopup; }

--- a/Fireworks/Core/src/FWConfiguration.cc
+++ b/Fireworks/Core/src/FWConfiguration.cc
@@ -13,8 +13,7 @@
 // system include files
 #include <stdexcept>
 #include <algorithm>
-#include <boost/bind.hpp>
-
+#include <functional>
 // user include files
 #include "Fireworks/Core/interface/FWConfiguration.h"
 
@@ -125,9 +124,12 @@ const FWConfiguration* FWConfiguration::valueForKey(const std::string& iKey) con
   if (not m_keyValues) {
     throw std::runtime_error("valueForKey fails becuase no key/values set");
   }
-  KeyValues::iterator itFind = std::find_if(m_keyValues->begin(),
-                                            m_keyValues->end(),
-                                            boost::bind(&std::pair<std::string, FWConfiguration>::first, _1) == iKey);
+  KeyValues::iterator itFind =
+      std::find_if(m_keyValues->begin(),
+                   m_keyValues->end(),
+                   std::bind(std::equal_to<void>(),
+                             std::bind(&std::pair<std::string, FWConfiguration>::first, std::placeholders::_1),
+                             iKey));
   if (itFind == m_keyValues->end()) {
     return nullptr;
   }

--- a/Fireworks/Core/src/FWDetailViewManager.cc
+++ b/Fireworks/Core/src/FWDetailViewManager.cc
@@ -11,7 +11,7 @@
 //
 
 #include <cstdio>
-#include <boost/bind.hpp>
+#include <functional>
 #include <algorithm>
 #include <sstream>
 
@@ -52,7 +52,7 @@ FWDetailViewManager::FWDetailViewManager(fireworks::Context* iCtx) : m_context(i
   // force white background for all embedded canvases
   gROOT->SetStyle("Plain");
 
-  m_context->colorManager()->colorsHaveChanged_.connect(boost::bind(&FWDetailViewManager::colorsChanged, this));
+  m_context->colorManager()->colorsHaveChanged_.connect(std::bind(&FWDetailViewManager::colorsChanged, this));
   gEve->GetWindowManager()->Connect(
       "WindowDeleted(TEveWindow*)", "FWDetailViewManager", this, "eveWindowDestroyed(TEveWindow*)");
 }
@@ -142,7 +142,7 @@ std::vector<std::string> FWDetailViewManager::findViewersFor(const std::string& 
   std::transform(all.begin(),
                  all.end(),
                  std::inserter(detailViews, detailViews.begin()),
-                 boost::bind(&edmplugin::PluginInfo::name_, _1));
+                 std::bind(&edmplugin::PluginInfo::name_, std::placeholders::_1));
   unsigned int closestMatch = 0xFFFFFFFF;
 
   for (std::set<std::string>::iterator it = detailViews.begin(), itEnd = detailViews.end(); it != itEnd; ++it) {

--- a/Fireworks/Core/src/FWEveView.cc
+++ b/Fireworks/Core/src/FWEveView.cc
@@ -11,7 +11,7 @@
 //
 
 #include <RVersion.h>
-#include <boost/bind.hpp>
+#include <functional>
 #include <stdexcept>
 #include <string>
 
@@ -137,28 +137,28 @@ FWEveView::FWEveView(TEveWindowSlot* iParent, FWViewType::EType type, unsigned i
   m_eventInfoLevel.addEntry(1, "Run / event");
   m_eventInfoLevel.addEntry(2, "Run / event / lumi");
   m_eventInfoLevel.addEntry(3, "Full");
-  m_eventInfoLevel.changed_.connect(boost::bind(&FWEventAnnotation::setLevel, m_overlayEventInfo, _1));
+  m_eventInfoLevel.changed_.connect(std::bind(&FWEventAnnotation::setLevel, m_overlayEventInfo, std::placeholders::_1));
 
   m_overlayLogo = new CmsAnnotation(embeddedViewer, 0.02, 0.98);
   m_overlayLogo->setVisible(false);
-  m_drawCMSLogo.changed_.connect(boost::bind(&CmsAnnotation::setVisible, m_overlayLogo, _1));
+  m_drawCMSLogo.changed_.connect(std::bind(&CmsAnnotation::setVisible, m_overlayLogo, std::placeholders::_1));
 
   m_cameraGuide = new TGLCameraGuide(0.9, 0.1, 0.08);
   m_cameraGuide->SetState(TGLOverlayElement::kInvisible);
   embeddedViewer->AddOverlayElement(m_cameraGuide);
-  m_showCameraGuide.changed_.connect(boost::bind(&FWEveView::cameraGuideChanged, this));
+  m_showCameraGuide.changed_.connect(std::bind(&FWEveView::cameraGuideChanged, this));
 
-  m_pointSmooth.changed_.connect(boost::bind(&FWEveView::pointLineScalesChanged, this));
-  m_pointSize.changed_.connect(boost::bind(&FWEveView::pointLineScalesChanged, this));
-  m_lineSmooth.changed_.connect(boost::bind(&FWEveView::pointLineScalesChanged, this));
-  m_lineWidth.changed_.connect(boost::bind(&FWEveView::pointLineScalesChanged, this));
-  m_lineOutlineScale.changed_.connect(boost::bind(&FWEveView::pointLineScalesChanged, this));
-  m_lineWireframeScale.changed_.connect(boost::bind(&FWEveView::pointLineScalesChanged, this));
+  m_pointSmooth.changed_.connect(std::bind(&FWEveView::pointLineScalesChanged, this));
+  m_pointSize.changed_.connect(std::bind(&FWEveView::pointLineScalesChanged, this));
+  m_lineSmooth.changed_.connect(std::bind(&FWEveView::pointLineScalesChanged, this));
+  m_lineWidth.changed_.connect(std::bind(&FWEveView::pointLineScalesChanged, this));
+  m_lineOutlineScale.changed_.connect(std::bind(&FWEveView::pointLineScalesChanged, this));
+  m_lineWireframeScale.changed_.connect(std::bind(&FWEveView::pointLineScalesChanged, this));
 
   // create scale for view  ..
   m_viewContext->setEnergyScale(m_localEnergyScale.get());
-  m_useGlobalEnergyScale.changed_.connect(boost::bind(&FWEveView::useGlobalEnergyScaleChanged, this));
-  m_localEnergyScale->parameterChanged_.connect(boost::bind(&FWEveView::setupEnergyScale, this));
+  m_useGlobalEnergyScale.changed_.connect(std::bind(&FWEveView::useGlobalEnergyScaleChanged, this));
+  m_localEnergyScale->parameterChanged_.connect(std::bind(&FWEveView::setupEnergyScale, this));
 }
 
 FWEveView::~FWEveView() {

--- a/Fireworks/Core/src/FWEveViewManager.cc
+++ b/Fireworks/Core/src/FWEveViewManager.cc
@@ -12,7 +12,7 @@
 
 // system include files
 
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "TEveManager.h"
@@ -84,7 +84,7 @@ FWEveViewManager::FWEveViewManager(FWGUIManager* iGUIMgr) : FWViewManagerBase() 
   std::transform(available.begin(),
                  available.end(),
                  std::inserter(builders, builders.begin()),
-                 boost::bind(&edmplugin::PluginInfo::name_, _1));
+                 std::bind(&edmplugin::PluginInfo::name_, std::placeholders::_1));
 
   if (edmplugin::PluginManager::get()->categoryToInfos().end() !=
       edmplugin::PluginManager::get()->categoryToInfos().find(FWProxyBuilderFactory::get()->category())) {
@@ -93,7 +93,7 @@ FWEveViewManager::FWEveViewManager(FWGUIManager* iGUIMgr) : FWViewManagerBase() 
     std::transform(available.begin(),
                    available.end(),
                    std::inserter(builders, builders.begin()),
-                   boost::bind(&edmplugin::PluginInfo::name_, _1));
+                   std::bind(&edmplugin::PluginInfo::name_, std::placeholders::_1));
   }
 
   for (std::set<std::string>::iterator it = builders.begin(), itEnd = builders.end(); it != itEnd; ++it) {
@@ -110,7 +110,8 @@ FWEveViewManager::FWEveViewManager(FWGUIManager* iGUIMgr) : FWViewManagerBase() 
   m_views.resize(FWViewType::kTypeSize);
 
   // view construction called via GUI mng
-  FWGUIManager::ViewBuildFunctor f = boost::bind(&FWEveViewManager::buildView, this, _1, _2);
+  FWGUIManager::ViewBuildFunctor f =
+      std::bind(&FWEveViewManager::buildView, this, std::placeholders::_1, std::placeholders::_2);
   for (int i = 0; i < FWViewType::kTypeSize; i++) {
     if (i == FWViewType::kTable || i == FWViewType::kTableHLT || i == FWViewType::kTableL1)
       continue;
@@ -220,9 +221,9 @@ void FWEveViewManager::newItem(const FWEventItem* iItem) {
     // printf("FWEveViewManager::makeProxyBuilderFor NEW builder %s \n", builderName.c_str());
 
     builder->setItem(iItem);
-    iItem->changed_.connect(boost::bind(&FWEveViewManager::modelChanges, this, _1));
-    iItem->goingToBeDestroyed_.connect(boost::bind(&FWEveViewManager::removeItem, this, _1));
-    iItem->itemChanged_.connect(boost::bind(&FWEveViewManager::itemChanged, this, _1));
+    iItem->changed_.connect(std::bind(&FWEveViewManager::modelChanges, this, std::placeholders::_1));
+    iItem->goingToBeDestroyed_.connect(std::bind(&FWEveViewManager::removeItem, this, std::placeholders::_1));
+    iItem->itemChanged_.connect(std::bind(&FWEveViewManager::itemChanged, this, std::placeholders::_1));
 
     // 3.
     // This calud be opaque to the user. I would pass a reference to the m_interactionLists to
@@ -359,7 +360,7 @@ FWEveView* FWEveViewManager::finishViewCreate(std::shared_ptr<FWEveView> view) {
     }
   }
 
-  view->beingDestroyed_.connect(boost::bind(&FWEveViewManager::beingDestroyed, this, _1));
+  view->beingDestroyed_.connect(std::bind(&FWEveViewManager::beingDestroyed, this, std::placeholders::_1));
 
   view->setupEnergyScale();  // notify PB for energy scale
 
@@ -505,8 +506,8 @@ void FWEveViewManager::removeItem(const FWEventItem* item) {
 void FWEveViewManager::setContext(const fireworks::Context* x) {
   FWViewManagerBase::setContext(x);
   x->commonPrefs()->getEnergyScale()->parameterChanged_.connect(
-      boost::bind(&FWEveViewManager::globalEnergyScaleChanged, this));
-  x->commonPrefs()->eventCenterChanged_.connect(boost::bind(&FWEveViewManager::eventCenterChanged, this));
+      std::bind(&FWEveViewManager::globalEnergyScaleChanged, this));
+  x->commonPrefs()->eventCenterChanged_.connect(std::bind(&FWEveViewManager::eventCenterChanged, this));
 }
 
 void FWEveViewManager::globalEnergyScaleChanged() {

--- a/Fireworks/Core/src/FWEventItemsManager.cc
+++ b/Fireworks/Core/src/FWEventItemsManager.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <sstream>
-#include <boost/bind.hpp>
+#include <functional>
 #include "TClass.h"
 
 // user include files
@@ -88,7 +88,7 @@ FWEventItem* FWEventItemsManager::add(const FWPhysicsObjectDesc& iItem, const FW
 
   m_items.push_back(new FWEventItem(m_context, m_items.size(), m_accessorFactory->accessorFor(temp.type()), temp, pbc));
   newItem_(m_items.back());
-  m_items.back()->goingToBeDestroyed_.connect(boost::bind(&FWEventItemsManager::removeItem, this, _1));
+  m_items.back()->goingToBeDestroyed_.connect(std::bind(&FWEventItemsManager::removeItem, this, std::placeholders::_1));
   if (doSetEvent && m_event) {
     FWChangeSentry sentry(*m_changeManager);
     m_items.back()->setEvent(m_event);

--- a/Fireworks/Core/src/FWFileEntry.cc
+++ b/Fireworks/Core/src/FWFileEntry.cc
@@ -30,7 +30,7 @@
 
 #include "Fireworks/Core/src/FWTTreeCache.h"
 
-#include <boost/bind.hpp>
+#include <functional>
 
 FWFileEntry::FWFileEntry(const std::string& name, bool checkVersion, bool checkGT)
     : m_name(name),
@@ -203,8 +203,8 @@ void FWFileEntry::openFile(bool checkVersion, bool checkGlobalTag) {
 
   // Connect to collection add/remove signals
   FWEventItemsManager* eiMng = (FWEventItemsManager*)FWGUIManager::getGUIManager()->getContext()->eventItemsManager();
-  eiMng->newItem_.connect(boost::bind(&FWFileEntry::NewEventItemCallIn, this, _1));
-  eiMng->removingItem_.connect(boost::bind(&FWFileEntry::RemovingEventItemCallIn, this, _1));
+  eiMng->newItem_.connect(std::bind(&FWFileEntry::NewEventItemCallIn, this, std::placeholders::_1));
+  eiMng->removingItem_.connect(std::bind(&FWFileEntry::RemovingEventItemCallIn, this, std::placeholders::_1));
   // no need to connect to goingToClearItems_ ... individual removes are emitted.
 
   if (m_event->size() == 0)

--- a/Fireworks/Core/src/FWGUIEventDataAdder.cc
+++ b/Fireworks/Core/src/FWGUIEventDataAdder.cc
@@ -13,7 +13,7 @@
 // system include files
 #include <iostream>
 #include <sigc++/signal.h>
-#include <boost/bind.hpp>
+#include <functional>
 #include <algorithm>
 #include <cctype>
 #include <string>
@@ -321,7 +321,7 @@ FWGUIEventDataAdder::FWGUIEventDataAdder(UInt_t iWidth,
                                          TGFrame *iParent,
                                          FWJobMetadataManager *iMetadataManager)
     : m_manager(iManager), m_metadataManager(iMetadataManager), m_parentFrame(iParent) {
-  m_metadataManager->metadataChanged_.connect(boost::bind(&FWGUIEventDataAdder::metadataUpdatedSlot, this));
+  m_metadataManager->metadataChanged_.connect(std::bind(&FWGUIEventDataAdder::metadataUpdatedSlot, this));
   createWindow();
 }
 
@@ -443,7 +443,8 @@ void FWGUIEventDataAdder::updateFilterString(const char *str) {
 
 void FWGUIEventDataAdder::createWindow() {
   m_tableManager = new DataAdderTableManager(m_metadataManager);
-  m_tableManager->indexSelected_.connect(boost::bind(&FWGUIEventDataAdder::newIndexSelected, this, _1));
+  m_tableManager->indexSelected_.connect(
+      std::bind(&FWGUIEventDataAdder::newIndexSelected, this, std::placeholders::_1));
 
   m_frame = new TGTransientFrame(gClient->GetDefaultRoot(), m_parentFrame, 600, 400);
   m_frame->Connect("CloseWindow()", "FWGUIEventDataAdder", this, "windowIsClosing()");

--- a/Fireworks/Core/src/FWGUIManager.cc
+++ b/Fireworks/Core/src/FWGUIManager.cc
@@ -9,7 +9,7 @@
 // Original Author:  Chris Jones
 //         Created:  Mon Feb 11 11:06:40 EST 2008
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 #include <stdexcept>
 #include <iostream>
 #include <cstdio>
@@ -124,9 +124,9 @@ FWGUIManager::FWGUIManager(fireworks::Context* ctx, const FWViewManagerManager* 
   measureWMOffsets();
 
   FWEventItemsManager* im = (FWEventItemsManager*)m_context->eventItemsManager();
-  im->newItem_.connect(boost::bind(&FWGUIManager::newItem, this, _1));
+  im->newItem_.connect(std::bind(&FWGUIManager::newItem, this, std::placeholders::_1));
 
-  m_context->colorManager()->colorsHaveChangedFinished_.connect(boost::bind(&FWGUIManager::finishUpColorChange, this));
+  m_context->colorManager()->colorsHaveChangedFinished_.connect(std::bind(&FWGUIManager::finishUpColorChange, this));
 
   TEveCompositeFrame::IconBarCreator_foo foo = &FWGUIManager::makeGUIsubview;
   TEveCompositeFrame::SetupFrameMarkup(foo, 20, 4, false);
@@ -148,7 +148,7 @@ FWGUIManager::FWGUIManager(fireworks::Context* ctx, const FWViewManagerManager* 
 
       bool separator = (i == FWViewType::kGlimpse || i == FWViewType::kTableHLT || i == FWViewType::kLegoPFECAL);
       CSGAction* action = m_cmsShowMainFrame->createNewViewerAction(FWViewType::idToName(i), separator);
-      action->activated.connect(boost::bind(&FWGUIManager::newViewSlot, this, FWViewType::idToName(i)));
+      action->activated.connect(std::bind(&FWGUIManager::newViewSlot, this, FWViewType::idToName(i)));
     }
 
     m_detailViewManager = new FWDetailViewManager(m_context);
@@ -168,7 +168,7 @@ FWGUIManager::FWGUIManager(fireworks::Context* ctx, const FWViewManagerManager* 
         ->activated.connect(sigc::mem_fun(*this, &FWGUIManager::promptForSaveConfigurationFile));
     getAction(cmsshow::sSavePartialConfigAs)
         ->activated.connect(sigc::mem_fun(*this, &FWGUIManager::promptForPartialSaveConfigurationFile));
-    getAction(cmsshow::sShowEventDisplayInsp)->activated.connect(boost::bind(&FWGUIManager::showEDIFrame, this, -1));
+    getAction(cmsshow::sShowEventDisplayInsp)->activated.connect(std::bind(&FWGUIManager::showEDIFrame, this, -1));
     getAction(cmsshow::sShowMainViewCtl)->activated.connect(sigc::mem_fun(*m_guiManager, &FWGUIManager::showViewPopup));
     getAction(cmsshow::sShowObjInsp)->activated.connect(sigc::mem_fun(*m_guiManager, &FWGUIManager::showModelPopup));
 
@@ -189,7 +189,7 @@ FWGUIManager::FWGUIManager(fireworks::Context* ctx, const FWViewManagerManager* 
 
     // toolbar special widget with non-void actions
     m_cmsShowMainFrame->m_delaySliderListener->valueChanged_.connect(
-        boost::bind(&FWGUIManager::delaySliderChanged, this, _1));
+        std::bind(&FWGUIManager::delaySliderChanged, this, std::placeholders::_1));
 
     TQObject::Connect(m_cmsShowMainFrame->m_runEntry, "ReturnPressed()", "FWGUIManager", this, "runIdChanged()");
     TQObject::Connect(m_cmsShowMainFrame->m_lumiEntry, "ReturnPressed()", "FWGUIManager", this, "lumiIdChanged()");
@@ -219,10 +219,10 @@ FWGUIManager::FWGUIManager(fireworks::Context* ctx, const FWViewManagerManager* 
 }
 
 void FWGUIManager::connectSubviewAreaSignals(FWGUISubviewArea* a) {
-  a->goingToBeDestroyed_.connect(boost::bind(&FWGUIManager::subviewIsBeingDestroyed, this, _1));
-  a->selected_.connect(boost::bind(&FWGUIManager::subviewInfoSelected, this, _1));
-  a->unselected_.connect(boost::bind(&FWGUIManager::subviewInfoUnselected, this, _1));
-  a->swap_.connect(boost::bind(&FWGUIManager::subviewSwapped, this, _1));
+  a->goingToBeDestroyed_.connect(std::bind(&FWGUIManager::subviewIsBeingDestroyed, this, std::placeholders::_1));
+  a->selected_.connect(std::bind(&FWGUIManager::subviewInfoSelected, this, std::placeholders::_1));
+  a->unselected_.connect(std::bind(&FWGUIManager::subviewInfoUnselected, this, std::placeholders::_1));
+  a->swap_.connect(std::bind(&FWGUIManager::subviewSwapped, this, std::placeholders::_1));
 }
 
 //
@@ -299,8 +299,8 @@ FWGUIManager::ViewMap_i FWGUIManager::createView(const std::string& iName, TEveW
   FWViewBase* viewBase = itFind->second(slot, iName);
   //in future, get context from 'view'
   FWViewContextMenuHandlerBase* base = viewBase->contextMenuHandler();
-  viewBase->openSelectedModelContextMenu_.connect(
-      boost::bind(&FWGUIManager::showSelectedModelContextMenu, m_guiManager, _1, _2, base));
+  viewBase->openSelectedModelContextMenu_.connect(std::bind(
+      &FWGUIManager::showSelectedModelContextMenu, m_guiManager, std::placeholders::_1, std::placeholders::_2, base));
 
   TEveWindow* eveWindow = ef->GetEveWindow();
   eveWindow->SetElementName(iName.c_str());
@@ -450,7 +450,7 @@ void FWGUIManager::subviewIsBeingDestroyed(FWGUISubviewArea* sva) {
     setViewPopup(nullptr);
 
   CmsShowTaskExecutor::TaskFunctor f;
-  f = boost::bind(&FWGUIManager::subviewDestroy, this, sva);
+  f = std::bind(&FWGUIManager::subviewDestroy, this, sva);
   m_tasks->addTask(f);
   m_tasks->startDoingTasks();
 }

--- a/Fireworks/Core/src/FWGeometryTableManagerBase.cc
+++ b/Fireworks/Core/src/FWGeometryTableManagerBase.cc
@@ -14,7 +14,7 @@
 
 // user include files
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 #include <stack>
 #ifdef PERFTOOL_GEO_TABLE
 #include <google/profiler.h>

--- a/Fireworks/Core/src/FWGeometryTableView.cc
+++ b/Fireworks/Core/src/FWGeometryTableView.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "Fireworks/Core/src/FWGeometryTableView.h"
@@ -204,21 +204,21 @@ FWGeometryTableView::FWGeometryTableView(TEveWindowSlot* iParent, FWColorManager
   m_mode.addEntry(kNode, "Node");
   m_mode.addEntry(kVolume, "Volume");
 
-  m_mode.changed_.connect(boost::bind(&FWGeometryTableView::refreshTable3D, this));
-  m_autoExpand.changed_.connect(boost::bind(&FWGeometryTableView::autoExpandCallback, this));
-  m_visLevel.changed_.connect(boost::bind(&FWGeometryTableView::refreshTable3D, this));
+  m_mode.changed_.connect(std::bind(&FWGeometryTableView::refreshTable3D, this));
+  m_autoExpand.changed_.connect(std::bind(&FWGeometryTableView::autoExpandCallback, this));
+  m_visLevel.changed_.connect(std::bind(&FWGeometryTableView::refreshTable3D, this));
 
-  m_visLevelFilter.changed_.connect(boost::bind(&FWGeometryTableView::refreshTable3D, this));
+  m_visLevelFilter.changed_.connect(std::bind(&FWGeometryTableView::refreshTable3D, this));
 
-  m_disableTopNode.changed_.connect(boost::bind(&FWGeometryTableView::updateVisibilityTopNode, this));
+  m_disableTopNode.changed_.connect(std::bind(&FWGeometryTableView::updateVisibilityTopNode, this));
   postConst();
 
   m_proximityAlgo.addEntry(kBBoxCenter, "BBox center");
   m_proximityAlgo.addEntry(kBBoxSurface, "BBox surface");
 
-  m_selectRegion.changed_.connect(boost::bind(&FWGeometryTableView::checkRegionOfInterest, this));
-  m_regionRadius.changed_.connect(boost::bind(&FWGeometryTableView::checkRegionOfInterest, this));
-  m_proximityAlgo.changed_.connect(boost::bind(&FWGeometryTableView::checkRegionOfInterest, this));
+  m_selectRegion.changed_.connect(std::bind(&FWGeometryTableView::checkRegionOfInterest, this));
+  m_regionRadius.changed_.connect(std::bind(&FWGeometryTableView::checkRegionOfInterest, this));
+  m_proximityAlgo.changed_.connect(std::bind(&FWGeometryTableView::checkRegionOfInterest, this));
 }
 
 FWGeometryTableView::~FWGeometryTableView() {}

--- a/Fireworks/Core/src/FWGeometryTableViewBase.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewBase.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include <boost/bind.hpp>
+#include <functional>
 #include <boost/regex.hpp>
 
 #include "Fireworks/Core/interface/FWGeometryTableViewBase.h"
@@ -174,10 +174,10 @@ FWGeometryTableViewBase::FWGeometryTableViewBase(TEveWindowSlot* iParent,
 
   xf->AddFrame(m_frame, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-  m_parentTransparencyFactor.changed_.connect(boost::bind(&FWGeometryTableViewBase::refreshTable3D, this));
-  m_leafTransparencyFactor.changed_.connect(boost::bind(&FWGeometryTableViewBase::refreshTable3D, this));
-  m_minParentTransparency.changed_.connect(boost::bind(&FWGeometryTableViewBase::refreshTable3D, this));
-  m_minLeafTransparency.changed_.connect(boost::bind(&FWGeometryTableViewBase::refreshTable3D, this));
+  m_parentTransparencyFactor.changed_.connect(std::bind(&FWGeometryTableViewBase::refreshTable3D, this));
+  m_leafTransparencyFactor.changed_.connect(std::bind(&FWGeometryTableViewBase::refreshTable3D, this));
+  m_minParentTransparency.changed_.connect(std::bind(&FWGeometryTableViewBase::refreshTable3D, this));
+  m_minLeafTransparency.changed_.connect(std::bind(&FWGeometryTableViewBase::refreshTable3D, this));
 }
 
 void FWGeometryTableViewBase::postConst() {

--- a/Fireworks/Core/src/FWGeometryTableViewManager.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewManager.cc
@@ -10,7 +10,7 @@
 //         Created:  Fri Jul  8 00:40:37 CEST 2011
 //
 
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "TFile.h"
 #include "TSystem.h"
@@ -33,7 +33,7 @@ TGeoManager* FWGeometryTableViewManager_GetGeoManager() { return FWGeometryTable
 FWGeometryTableViewManager::FWGeometryTableViewManager(FWGUIManager* iGUIMgr, std::string fileName, std::string geoName)
     : FWViewManagerBase(), m_fileName(fileName), m_TGeoName(geoName) {
   FWGUIManager::ViewBuildFunctor f;
-  f = boost::bind(&FWGeometryTableViewManager::buildView, this, _1, _2);
+  f = std::bind(&FWGeometryTableViewManager::buildView, this, std::placeholders::_1, std::placeholders::_2);
   iGUIMgr->registerViewBuilder(FWViewType::idToName(FWViewType::kGeometryTable), f);
   iGUIMgr->registerViewBuilder(FWViewType::idToName(FWViewType::kOverlapTable), f);
 }
@@ -54,7 +54,7 @@ FWViewBase* FWGeometryTableViewManager::buildView(TEveWindowSlot* iParent, const
 
   view->setBackgroundColor();
   m_views.push_back(std::shared_ptr<FWGeometryTableViewBase>(view));
-  view->beingDestroyed_.connect(boost::bind(&FWGeometryTableViewManager::beingDestroyed, this, _1));
+  view->beingDestroyed_.connect(std::bind(&FWGeometryTableViewManager::beingDestroyed, this, std::placeholders::_1));
 
   return view.get();
 }

--- a/Fireworks/Core/src/FWGlimpseView.cc
+++ b/Fireworks/Core/src/FWGlimpseView.cc
@@ -10,7 +10,7 @@
 //         Created:  Thu Feb 21 11:22:41 EST 2008
 //
 
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "TGLPerspectiveCamera.h"
 #include "TGLViewer.h"
@@ -69,8 +69,8 @@ FWGlimpseView::FWGlimpseView(TEveWindowSlot* iParent, FWViewType::EType typeId)
 
   TGLViewer* ev = viewerGL();
   ev->SetCurrentCamera(TGLViewer::kCameraPerspXOZ);
-  m_showAxes.changed_.connect(boost::bind(&FWGlimpseView::showAxes, this));
-  m_showCylinder.changed_.connect(boost::bind(&FWGlimpseView::showCylinder, this));
+  m_showAxes.changed_.connect(std::bind(&FWGlimpseView::showAxes, this));
+  m_showCylinder.changed_.connect(std::bind(&FWGlimpseView::showCylinder, this));
 }
 
 FWGlimpseView::~FWGlimpseView() {}

--- a/Fireworks/Core/src/FWLegoViewBase.cc
+++ b/Fireworks/Core/src/FWLegoViewBase.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "TAxis.h"
 #include "TH2.h"
@@ -70,12 +70,12 @@ FWLegoViewBase::FWLegoViewBase(TEveWindowSlot* iParent, FWViewType::EType typeId
   if (typeId == FWViewType::kLegoHF)
     m_cell2DMode.set(2);  // different default for HF view
 
-  m_autoRebin.changed_.connect(boost::bind(&FWLegoViewBase::setAutoRebin, this));
-  m_pixelsPerBin.changed_.connect(boost::bind(&FWLegoViewBase::setPixelsPerBin, this));
-  m_drawValuesIn2D.changed_.connect(boost::bind(&FWLegoViewBase::setFontSizein2D, this));
-  m_showOverlay.changed_.connect(boost::bind(&FWLegoViewBase::showOverlay, this));
-  m_projectionMode.changed_.connect(boost::bind(&FWLegoViewBase::setProjectionMode, this));
-  m_cell2DMode.changed_.connect(boost::bind(&FWLegoViewBase::setCell2DMode, this));
+  m_autoRebin.changed_.connect(std::bind(&FWLegoViewBase::setAutoRebin, this));
+  m_pixelsPerBin.changed_.connect(std::bind(&FWLegoViewBase::setPixelsPerBin, this));
+  m_drawValuesIn2D.changed_.connect(std::bind(&FWLegoViewBase::setFontSizein2D, this));
+  m_showOverlay.changed_.connect(std::bind(&FWLegoViewBase::showOverlay, this));
+  m_projectionMode.changed_.connect(std::bind(&FWLegoViewBase::setProjectionMode, this));
+  m_cell2DMode.changed_.connect(std::bind(&FWLegoViewBase::setCell2DMode, this));
 }
 
 FWLegoViewBase::~FWLegoViewBase() {

--- a/Fireworks/Core/src/FWOverlapTableView.cc
+++ b/Fireworks/Core/src/FWOverlapTableView.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "Fireworks/Core/src/FWOverlapTableView.h"
@@ -145,12 +145,12 @@ FWOverlapTableView::FWOverlapTableView(TEveWindowSlot* iParent, FWColorManager* 
   m_marker->SetPickable(kTRUE);
   m_marker->SetOwnIds(kTRUE);
 
-  m_drawPoints.changed_.connect(boost::bind(&FWOverlapTableView::drawPoints, this));
-  m_pointSize.changed_.connect(boost::bind(&FWOverlapTableView::pointSize, this));
-  m_rnrOverlap.changed_.connect(boost::bind(&FWOverlapTableView::refreshTable3D, this));
-  m_overlapMarkerColor.changed_.connect(boost::bind(&FWOverlapTableView::refreshTable3D, this));
-  m_extrusionMarkerColor.changed_.connect(boost::bind(&FWOverlapTableView::refreshTable3D, this));
-  m_rnrExtrusion.changed_.connect(boost::bind(&FWGeometryTableViewBase::refreshTable3D, this));
+  m_drawPoints.changed_.connect(std::bind(&FWOverlapTableView::drawPoints, this));
+  m_pointSize.changed_.connect(std::bind(&FWOverlapTableView::pointSize, this));
+  m_rnrOverlap.changed_.connect(std::bind(&FWOverlapTableView::refreshTable3D, this));
+  m_overlapMarkerColor.changed_.connect(std::bind(&FWOverlapTableView::refreshTable3D, this));
+  m_extrusionMarkerColor.changed_.connect(std::bind(&FWOverlapTableView::refreshTable3D, this));
+  m_rnrExtrusion.changed_.connect(std::bind(&FWGeometryTableViewBase::refreshTable3D, this));
 
   postConst();
 }

--- a/Fireworks/Core/src/FWParameterSetterBase.cc
+++ b/Fireworks/Core/src/FWParameterSetterBase.cc
@@ -16,7 +16,7 @@
 
 #include <cassert>
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "FWCore/Utilities/interface/TypeID.h"
@@ -131,7 +131,7 @@ std::shared_ptr<FWParameterSetterBase> FWParameterSetterBase::makeSetterFor(FWPa
   FWParameterSetterBase* p = static_cast<FWParameterSetterBase*>(setterObj.address());
   //Make a shared pointer to the base class that uses a destructor for the derived class, in order to match the above construct call.
   std::shared_ptr<FWParameterSetterBase> ptr(
-      p, boost::bind(&edm::TypeWithDict::destruct, itFind->second, setterObj.address(), true));
+      p, std::bind(&edm::TypeWithDict::destruct, itFind->second, setterObj.address(), true));
   return ptr;
 }
 

--- a/Fireworks/Core/src/FWProxyBuilderBase.cc
+++ b/Fireworks/Core/src/FWProxyBuilderBase.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "TEveElement.h"
@@ -254,7 +254,7 @@ TEveElementList* FWProxyBuilderBase::createProduct(const FWViewType::EType viewT
   m_products.push_back(product);
   if (viewContext) {
     product->m_scaleConnection =
-        viewContext->scaleChanged_.connect(boost::bind(&FWProxyBuilderBase::scaleChanged, this, _1));
+        viewContext->scaleChanged_.connect(std::bind(&FWProxyBuilderBase::scaleChanged, this, std::placeholders::_1));
   }
 
   if (item()) {

--- a/Fireworks/Core/src/FWProxyBuilderConfiguration.cc
+++ b/Fireworks/Core/src/FWProxyBuilderConfiguration.cc
@@ -15,7 +15,7 @@
 // user include files
 #include <iostream>
 #include <stdexcept>
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "TGFrame.h"
 
@@ -95,7 +95,7 @@ FWGenericParameter<T>* FWProxyBuilderConfiguration::assertParam(const std::strin
     if (varConfig)
       mode->setFrom(*varConfig);
   }
-  mode->changed_.connect(boost::bind(&FWEventItem::proxyConfigChanged, (FWEventItem*)m_item, m_keepEntries));
+  mode->changed_.connect(std::bind(&FWEventItem::proxyConfigChanged, (FWEventItem*)m_item, m_keepEntries));
   return mode;
 }
 
@@ -115,7 +115,7 @@ FWGenericParameterWithRange<T>* FWProxyBuilderConfiguration::assertParam(const s
   if (varConfig)
     mode->setFrom(*varConfig);
 
-  mode->changed_.connect(boost::bind(&FWEventItem::proxyConfigChanged, (FWEventItem*)m_item, m_keepEntries));
+  mode->changed_.connect(std::bind(&FWEventItem::proxyConfigChanged, (FWEventItem*)m_item, m_keepEntries));
   return mode;
 }
 

--- a/Fireworks/Core/src/FWRPZView.cc
+++ b/Fireworks/Core/src/FWRPZView.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <stdexcept>
-#include <boost/bind.hpp>
+#include <functional>
 #include <memory>
 
 #include "TGLViewer.h"
@@ -103,26 +103,26 @@ FWRPZView::FWRPZView(TEveWindowSlot* iParent, FWViewType::EType id)
   m_axes = new TEveProjectionAxes(m_projMgr);
   m_axes->SetRnrState(m_showProjectionAxes.value());
   m_axes->SetLabelSize(m_projectionAxesLabelSize.value());
-  m_showProjectionAxes.changed_.connect(boost::bind(&FWRPZView::showProjectionAxes, this));
-  m_projectionAxesLabelSize.changed_.connect(boost::bind(&FWRPZView::projectionAxesLabelSize, this));
+  m_showProjectionAxes.changed_.connect(std::bind(&FWRPZView::showProjectionAxes, this));
+  m_projectionAxesLabelSize.changed_.connect(std::bind(&FWRPZView::projectionAxesLabelSize, this));
   eventScene()->AddElement(m_axes);
 
   if (id != FWViewType::kRhoZ) {
     m_showEndcaps = new FWBoolParameter(this, "Include EndCaps", true);
-    m_showEndcaps->changed_.connect(boost::bind(&FWRPZView::setEtaRng, this));
+    m_showEndcaps->changed_.connect(std::bind(&FWRPZView::setEtaRng, this));
     m_showHF = new FWBoolParameter(this, "Include HF", true);
-    m_showHF->changed_.connect(boost::bind(&FWRPZView::setEtaRng, this));
+    m_showHF->changed_.connect(std::bind(&FWRPZView::setEtaRng, this));
   }
 
-  m_shiftOrigin.changed_.connect(boost::bind(&FWRPZView::doShiftOriginToBeamSpot, this));
+  m_shiftOrigin.changed_.connect(std::bind(&FWRPZView::doShiftOriginToBeamSpot, this));
 
-  m_fishEyeDistortion.changed_.connect(boost::bind(&FWRPZView::doFishEyeDistortion, this));
+  m_fishEyeDistortion.changed_.connect(std::bind(&FWRPZView::doFishEyeDistortion, this));
 
-  m_fishEyeR.changed_.connect(boost::bind(&FWRPZView::doFishEyeDistortion, this));
+  m_fishEyeR.changed_.connect(std::bind(&FWRPZView::doFishEyeDistortion, this));
 
-  m_caloDistortion.changed_.connect(boost::bind(&FWRPZView::doPreScaleDistortion, this));
-  m_muonDistortion.changed_.connect(boost::bind(&FWRPZView::doPreScaleDistortion, this));
-  m_compressMuon.changed_.connect(boost::bind(&FWRPZView::doCompression, this, _1));
+  m_caloDistortion.changed_.connect(std::bind(&FWRPZView::doPreScaleDistortion, this));
+  m_muonDistortion.changed_.connect(std::bind(&FWRPZView::doPreScaleDistortion, this));
+  m_compressMuon.changed_.connect(std::bind(&FWRPZView::doCompression, this, std::placeholders::_1));
 }
 
 FWRPZView::~FWRPZView() {
@@ -160,13 +160,17 @@ void FWRPZView::setContext(const fireworks::Context& ctx) {
   m_calo->SetAutoRange(false);
   m_calo->SetScaleAbs(true);
 
-  m_showPixelBarrel.changed_.connect(boost::bind(&FWRPZViewGeometry::showPixelBarrel, m_geometryList, _1));
-  m_showPixelEndcap.changed_.connect(boost::bind(&FWRPZViewGeometry::showPixelEndcap, m_geometryList, _1));
-  m_showTrackerBarrel.changed_.connect(boost::bind(&FWRPZViewGeometry::showTrackerBarrel, m_geometryList, _1));
-  m_showTrackerEndcap.changed_.connect(boost::bind(&FWRPZViewGeometry::showTrackerEndcap, m_geometryList, _1));
-  m_showRpcEndcap.changed_.connect(boost::bind(&FWRPZViewGeometry::showRpcEndcap, m_geometryList, _1));
-  m_showGEM.changed_.connect(boost::bind(&FWRPZViewGeometry::showGEM, m_geometryList, _1));
-  m_showME0.changed_.connect(boost::bind(&FWRPZViewGeometry::showME0, m_geometryList, _1));
+  m_showPixelBarrel.changed_.connect(
+      std::bind(&FWRPZViewGeometry::showPixelBarrel, m_geometryList, std::placeholders::_1));
+  m_showPixelEndcap.changed_.connect(
+      std::bind(&FWRPZViewGeometry::showPixelEndcap, m_geometryList, std::placeholders::_1));
+  m_showTrackerBarrel.changed_.connect(
+      std::bind(&FWRPZViewGeometry::showTrackerBarrel, m_geometryList, std::placeholders::_1));
+  m_showTrackerEndcap.changed_.connect(
+      std::bind(&FWRPZViewGeometry::showTrackerEndcap, m_geometryList, std::placeholders::_1));
+  m_showRpcEndcap.changed_.connect(std::bind(&FWRPZViewGeometry::showRpcEndcap, m_geometryList, std::placeholders::_1));
+  m_showGEM.changed_.connect(std::bind(&FWRPZViewGeometry::showGEM, m_geometryList, std::placeholders::_1));
+  m_showME0.changed_.connect(std::bind(&FWRPZViewGeometry::showME0, m_geometryList, std::placeholders::_1));
 }
 
 void FWRPZView::eventBegin() {
@@ -282,8 +286,8 @@ void FWRPZView::importElements(TEveElement* iChildren, float iLayer, TEveElement
   float oldLayer = m_projMgr->GetCurrentDepth();
   m_projMgr->SetCurrentDepth(iLayer);
   //make sure current depth is reset even if an exception is thrown
-  std::shared_ptr<TEveProjectionManager> sentry(m_projMgr,
-                                                boost::bind(&TEveProjectionManager::SetCurrentDepth, _1, oldLayer));
+  std::shared_ptr<TEveProjectionManager> sentry(
+      m_projMgr, std::bind(&TEveProjectionManager::SetCurrentDepth, std::placeholders::_1, oldLayer));
   m_projMgr->ImportElements(iChildren, iProjectedParent);
 }
 

--- a/Fireworks/Core/src/FWSelectionManager.cc
+++ b/Fireworks/Core/src/FWSelectionManager.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 #include <iostream>
 #include <cassert>
 
@@ -33,7 +33,7 @@
 //
 FWSelectionManager::FWSelectionManager(FWModelChangeManager* iCM) : m_changeManager(iCM), m_wasChanged(false) {
   assert(nullptr != m_changeManager);
-  m_changeManager->changeSignalsAreDone_.connect(boost::bind(&FWSelectionManager::finishedAllSelections, this));
+  m_changeManager->changeSignalsAreDone_.connect(std::bind(&FWSelectionManager::finishedAllSelections, this));
 }
 
 // FWSelectionManager::FWSelectionManager(const FWSelectionManager& rhs)
@@ -109,7 +109,7 @@ void FWSelectionManager::select(const FWModelId& iId) {
       // as part of the itemChange message from the ChangeManager
       // This way if more than one Item has changed, we still only send one 'selectionChanged' message
       m_itemConnectionCount[iId.item()->id()].second =
-          iId.item()->preItemChanged_.connect(boost::bind(&FWSelectionManager::itemChanged, this, _1));
+          iId.item()->preItemChanged_.connect(std::bind(&FWSelectionManager::itemChanged, this, std::placeholders::_1));
     }
   }
 }

--- a/Fireworks/Core/src/FWSummaryManager.cc
+++ b/Fireworks/Core/src/FWSummaryManager.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "TGFrame.h"
 
@@ -47,17 +47,17 @@ FWSummaryManager::FWSummaryManager(TGFrame* iParent,
                                    FWModelChangeManager* cm,
                                    FWColorManager* colorm)
     : m_guiManager(gm), m_colorManager(colorm), m_itemChanged(false) {
-  colorm->colorsHaveChanged_.connect(boost::bind(&FWSummaryManager::colorsChanged, this));
-  sm->selectionChanged_.connect(boost::bind(&FWSummaryManager::selectionChanged, this, _1));
-  eim->newItem_.connect(boost::bind(&FWSummaryManager::newItem, this, _1));
-  eim->goingToClearItems_.connect(boost::bind(&FWSummaryManager::removeAllItems, this));
-  eim->goingToClearItems_.connect(boost::bind(&FWModelChangeManager::itemsGoingToBeClearedSlot, cm));
+  colorm->colorsHaveChanged_.connect(std::bind(&FWSummaryManager::colorsChanged, this));
+  sm->selectionChanged_.connect(std::bind(&FWSummaryManager::selectionChanged, this, std::placeholders::_1));
+  eim->newItem_.connect(std::bind(&FWSummaryManager::newItem, this, std::placeholders::_1));
+  eim->goingToClearItems_.connect(std::bind(&FWSummaryManager::removeAllItems, this));
+  eim->goingToClearItems_.connect(std::bind(&FWModelChangeManager::itemsGoingToBeClearedSlot, cm));
 
   m_pack = new TGVerticalFrame(iParent);
   m_pack->SetLayoutManager(new FWCompactVerticalLayout(m_pack));
   const unsigned int backgroundColor = 0x2f2f2f;
   m_pack->SetBackgroundColor(backgroundColor);
-  cm->changeSignalsAreDone_.connect(boost::bind(&FWSummaryManager::changesDone, this));
+  cm->changeSignalsAreDone_.connect(std::bind(&FWSummaryManager::changesDone, this));
 }
 
 // FWSummaryManager::FWSummaryManager(const FWSummaryManager& rhs)
@@ -89,8 +89,8 @@ void FWSummaryManager::newItem(FWEventItem* iItem) {
   m_collectionWidgets.push_back(lst);
   bool backgroundIsWhite = m_colorManager->backgroundColorIndex() == FWColorManager::kWhiteIndex;
   lst->setBackgroundToWhite(backgroundIsWhite);
-  iItem->goingToBeDestroyed_.connect(boost::bind(&FWSummaryManager::itemDestroyed, this, _1));
-  iItem->itemChanged_.connect(boost::bind(&FWSummaryManager::itemChanged, this, _1));
+  iItem->goingToBeDestroyed_.connect(std::bind(&FWSummaryManager::itemDestroyed, this, std::placeholders::_1));
+  iItem->itemChanged_.connect(std::bind(&FWSummaryManager::itemChanged, this, std::placeholders::_1));
   lst->Connect("requestForInfo(FWEventItem*)", "FWSummaryManager", this, "requestForInfo(FWEventItem*)");
   lst->Connect("requestForFilter(FWEventItem*)", "FWSummaryManager", this, "requestForFilter(FWEventItem*)");
   lst->Connect("requestForErrorInfo(FWEventItem*)", "FWSummaryManager", this, "requestForError(FWEventItem*)");

--- a/Fireworks/Core/src/FWTableViewManager.cc
+++ b/Fireworks/Core/src/FWTableViewManager.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 #include <algorithm>
 
 #include "TEveManager.h"
@@ -44,7 +44,7 @@
 //
 FWTableViewManager::FWTableViewManager(FWGUIManager *iGUIMgr) : FWViewManagerBase() {
   FWGUIManager::ViewBuildFunctor f;
-  f = boost::bind(&FWTableViewManager::buildView, this, _1, _2);
+  f = std::bind(&FWTableViewManager::buildView, this, std::placeholders::_1, std::placeholders::_2);
   iGUIMgr->registerViewBuilder(FWViewType::idToName(FWViewType::kTable), f);
 
   // ---------- for some object types, we have default table contents ----------
@@ -343,7 +343,7 @@ class FWViewBase *FWTableViewManager::buildView(TEveWindowSlot *iParent, const s
   auto view = std::make_shared<FWTableView>(iParent, this);
   view->setBackgroundColor(colorManager().background());
   m_views.push_back(view);
-  view->beingDestroyed_.connect(boost::bind(&FWTableViewManager::beingDestroyed, this, _1));
+  view->beingDestroyed_.connect(std::bind(&FWTableViewManager::beingDestroyed, this, std::placeholders::_1));
   return view.get();
 }
 
@@ -358,7 +358,7 @@ void FWTableViewManager::beingDestroyed(const FWViewBase *iView) {
 
 void FWTableViewManager::newItem(const FWEventItem *iItem) {
   m_items.push_back(iItem);
-  iItem->goingToBeDestroyed_.connect(boost::bind(&FWTableViewManager::destroyItem, this, _1));
+  iItem->goingToBeDestroyed_.connect(std::bind(&FWTableViewManager::destroyItem, this, std::placeholders::_1));
   notifyViews();
 }
 

--- a/Fireworks/Core/src/FWTriggerTableView.cc
+++ b/Fireworks/Core/src/FWTriggerTableView.cc
@@ -8,7 +8,7 @@
 #include <fstream>
 #include <cassert>
 
-#include "boost/bind.hpp"
+#include <functional>
 
 #include "TEveWindow.h"
 #include "TGComboBox.h"
@@ -51,7 +51,7 @@ FWTriggerTableView::FWTriggerTableView(TEveWindowSlot* iParent, FWViewType::ETyp
       m_vert(nullptr),
       m_tableWidget(nullptr),
       m_processList(nullptr) {
-  m_regex.changed_.connect(boost::bind(&FWTriggerTableView::dataChanged, this));
+  m_regex.changed_.connect(std::bind(&FWTriggerTableView::dataChanged, this));
 
   m_eveWindow = iParent->MakeFrame(nullptr);
   TGCompositeFrame* frame = m_eveWindow->GetGUICompositeFrame();

--- a/Fireworks/Core/src/FWTriggerTableViewManager.cc
+++ b/Fireworks/Core/src/FWTriggerTableViewManager.cc
@@ -13,7 +13,7 @@
 // system include files
 #include <cassert>
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 
@@ -28,7 +28,7 @@
 
 FWTriggerTableViewManager::FWTriggerTableViewManager(FWGUIManager* iGUIMgr) : FWViewManagerBase() {
   FWGUIManager::ViewBuildFunctor f;
-  f = boost::bind(&FWTriggerTableViewManager::buildView, this, _1, _2);
+  f = std::bind(&FWTriggerTableViewManager::buildView, this, std::placeholders::_1, std::placeholders::_2);
   iGUIMgr->registerViewBuilder(FWViewType::idToName(FWViewType::kTableHLT), f);
   iGUIMgr->registerViewBuilder(FWViewType::idToName(FWViewType::kTableL1), f);
 }
@@ -47,7 +47,7 @@ class FWViewBase* FWTriggerTableViewManager::buildView(TEveWindowSlot* iParent, 
 
   view->setBackgroundColor(colorManager().background());
   m_views.push_back(std::shared_ptr<FWTriggerTableView>(view));
-  view->beingDestroyed_.connect(boost::bind(&FWTriggerTableViewManager::beingDestroyed, this, _1));
+  view->beingDestroyed_.connect(std::bind(&FWTriggerTableViewManager::beingDestroyed, this, std::placeholders::_1));
   return view.get();
 }
 

--- a/Fireworks/Core/src/FWViewEnergyScale.cc
+++ b/Fireworks/Core/src/FWViewEnergyScale.cc
@@ -12,7 +12,7 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "Rtypes.h"
 #include "TMath.h"
@@ -34,10 +34,10 @@ FWViewEnergyScale::FWViewEnergyScale(std::string name, int version)
   m_scaleMode.addEntry(kAutoScale, "AutomaticScale");
   m_scaleMode.addEntry(kCombinedScale, "CombinedScale");
 
-  m_scaleMode.changed_.connect(boost::bind(&FWViewEnergyScale::scaleParameterChanged, this));
-  m_fixedValToHeight.changed_.connect(boost::bind(&FWViewEnergyScale::scaleParameterChanged, this));
-  m_maxTowerHeight.changed_.connect(boost::bind(&FWViewEnergyScale::scaleParameterChanged, this));
-  m_plotEt.changed_.connect(boost::bind(&FWViewEnergyScale::scaleParameterChanged, this));
+  m_scaleMode.changed_.connect(std::bind(&FWViewEnergyScale::scaleParameterChanged, this));
+  m_fixedValToHeight.changed_.connect(std::bind(&FWViewEnergyScale::scaleParameterChanged, this));
+  m_maxTowerHeight.changed_.connect(std::bind(&FWViewEnergyScale::scaleParameterChanged, this));
+  m_plotEt.changed_.connect(std::bind(&FWViewEnergyScale::scaleParameterChanged, this));
 }
 
 FWViewEnergyScale::~FWViewEnergyScale() {}

--- a/Fireworks/Core/src/FWViewGeometryList.cc
+++ b/Fireworks/Core/src/FWViewGeometryList.cc
@@ -10,7 +10,7 @@
 //         Created:  Tue Sep 14 13:28:13 CEST 2010
 //
 
-#include <boost/bind.hpp>
+#include <functional>
 #include "TEveScene.h"
 #include "TEveManager.h"
 #include "TEveCompound.h"
@@ -31,9 +31,9 @@ FWViewGeometryList::FWViewGeometryList(const fireworks::Context& context, bool p
     m_colorComp[i]->CSCApplyMainTransparencyToMatchingChildren();
   }
   m_colorConnection =
-      context.colorManager()->geomColorsHaveChanged_.connect(boost::bind(&FWViewGeometryList::updateColors, this));
+      context.colorManager()->geomColorsHaveChanged_.connect(std::bind(&FWViewGeometryList::updateColors, this));
   m_transpConnection = context.colorManager()->geomTransparencyHaveChanged_.connect(
-      boost::bind(&FWViewGeometryList::updateTransparency, this, _1));
+      std::bind(&FWViewGeometryList::updateTransparency, this, std::placeholders::_1));
 }
 
 FWViewGeometryList::~FWViewGeometryList() {

--- a/Fireworks/Core/src/FWViewManagerBase.cc
+++ b/Fireworks/Core/src/FWViewManagerBase.cc
@@ -15,7 +15,7 @@
 #include "TROOT.h"
 #include <cassert>
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "Fireworks/Core/interface/FWViewManagerBase.h"
@@ -99,14 +99,14 @@ void FWViewManagerBase::colorsChangedSlot() { this->colorsChanged(); }
 void FWViewManagerBase::setChangeManager(FWModelChangeManager* iCM) {
   assert(nullptr != iCM);
   m_changeManager = iCM;
-  m_changeManager->changeSignalsAreComing_.connect(boost::bind(&FWViewManagerBase::modelChangesComing, this));
-  m_changeManager->changeSignalsAreDone_.connect(boost::bind(&FWViewManagerBase::modelChangesDone, this));
+  m_changeManager->changeSignalsAreComing_.connect(std::bind(&FWViewManagerBase::modelChangesComing, this));
+  m_changeManager->changeSignalsAreDone_.connect(std::bind(&FWViewManagerBase::modelChangesDone, this));
 }
 
 void FWViewManagerBase::setColorManager(FWColorManager* iCM) {
   assert(nullptr != iCM);
   m_colorManager = iCM;
-  m_colorManager->colorsHaveChanged_.connect(boost::bind(&FWViewManagerBase::colorsChanged, this));
+  m_colorManager->colorsHaveChanged_.connect(std::bind(&FWViewManagerBase::colorsChanged, this));
   //make sure to pickup any changes that occurred earlier
   colorsChanged();
 }

--- a/Fireworks/Core/src/FWViewManagerManager.cc
+++ b/Fireworks/Core/src/FWViewManagerManager.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <iostream>
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "Fireworks/Core/interface/FWViewManagerManager.h"
@@ -75,7 +75,7 @@ void FWViewManagerManager::registerEventItem(const FWEventItem* iItem) {
     return;
   }
   m_typeToItems[iItem->name()] = iItem;
-  iItem->goingToBeDestroyed_.connect(boost::bind(&FWViewManagerManager::removeEventItem, this, _1));
+  iItem->goingToBeDestroyed_.connect(std::bind(&FWViewManagerManager::removeEventItem, this, std::placeholders::_1));
 
   //std::map<std::string, std::vector<std::string> >::iterator itFind = m_typeToBuilders.find(iItem->name());
   for (std::vector<std::shared_ptr<FWViewManagerBase> >::iterator itVM = m_viewManagers.begin();


### PR DESCRIPTION
#### PR description:
Replaced boost library use for C++ STL alternatives. Replaced boost::function for std::function and boost::bind for std::bind. The code should have similar behavior. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 