### PR TITLE
GE2/1 pads with 16 eta partitions & option to send overflow GEM clusters

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -27,6 +27,8 @@ GEMCoPadProcessor::GEMCoPadProcessor() : theRegion(1), theStation(1), theChamber
 void GEMCoPadProcessor::clear() { gemCoPadV.clear(); }
 
 std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_pads) {
+  clear();  
+    
   // Build coincidences
   for (auto det_range = in_pads->begin(); det_range != in_pads->end(); ++det_range) {
     const GEMDetId& id = (*det_range).first;

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -27,8 +27,8 @@ GEMCoPadProcessor::GEMCoPadProcessor() : theRegion(1), theStation(1), theChamber
 void GEMCoPadProcessor::clear() { gemCoPadV.clear(); }
 
 std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_pads) {
-  clear();  
-    
+  clear();
+
   // Build coincidences
   for (auto det_range = in_pads->begin(); det_range != in_pads->end(); ++det_range) {
     const GEMDetId& id = (*det_range).first;

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -143,7 +143,7 @@ void GEMPadDigiClusterProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<unsigned int>("nOHGE11", 2);
   desc.add<unsigned int>("nOHGE21", 4);
   desc.add<unsigned int>("maxClusterSize", 8);
-  desc.add<unsigned int>("sendOverflowClusters", false);
+  desc.add<bool>("sendOverflowClusters", false);
 
   descriptions.add("simMuonGEMPadDigiClustersDef", desc);
 }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -108,6 +108,7 @@ private:
   unsigned int nOHGE11_;
   unsigned int nOHGE21_;
   unsigned int maxClusterSize_;
+  bool sendOverflowClusters_;
 
   const GEMGeometry* geometry_;
 };
@@ -119,6 +120,12 @@ GEMPadDigiClusterProducer::GEMPadDigiClusterProducer(const edm::ParameterSet& ps
   nOHGE11_ = ps.getParameter<unsigned int>("nOHGE11");
   nOHGE21_ = ps.getParameter<unsigned int>("nOHGE21");
   maxClusterSize_ = ps.getParameter<unsigned int>("maxClusterSize");
+  sendOverflowClusters_ = ps.getParameter<bool>("sendOverflowClusters");
+
+  if (sendOverflowClusters_) {
+    maxClustersOHGE11_ *= 2;
+    maxClustersOHGE21_ *= 2;
+  }
 
   pad_token_ = consumes<GEMPadDigiCollection>(pads_);
 
@@ -136,6 +143,7 @@ void GEMPadDigiClusterProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<unsigned int>("nOHGE11", 2);
   desc.add<unsigned int>("nOHGE21", 4);
   desc.add<unsigned int>("maxClusterSize", 8);
+  desc.add<unsigned int>("sendOverflowClusters", false);
 
   descriptions.add("simMuonGEMPadDigiClustersDef", desc);
 }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -81,7 +81,8 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
   // build the pads
   buildPads(*(hdigis.product()), *pPads);
-  if (use16GE21_) buildPads16GE21(*(hdigis.product()), *pPads);
+  if (use16GE21_)
+    buildPads16GE21(*(hdigis.product()), *pPads);
 
   // store them in the event
   e.put(std::move(pPads));
@@ -89,10 +90,10 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
 void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
   for (const auto& p : geometry_->etaPartitions()) {
-
     // when using the GE2/1 geometry with 16 eta partitions
     // ->ignore GE2/1
-    if (use16GE21_ and p->id().station() == 2) continue;
+    if (use16GE21_ and p->id().station() == 2)
+      continue;
 
     // set of <pad, bx> pairs, sorted first by pad then by bx
     std::set<std::pair<int, int> > proto_pads;
@@ -115,14 +116,15 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
 
 void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
   for (const auto& p : geometry_->etaPartitions()) {
-
     // when using the GE2/1 geometry with 16 eta partitions
     // ->ignore GE1/1
-    if (p->id().station() == 1) continue;
+    if (p->id().station() == 1)
+      continue;
 
     // ignore eta partition with even numbers
     // these are included in the odd numbered pads
-    if (p->id().roll() % 2 == 0) continue;
+    if (p->id().roll() % 2 == 0)
+      continue;
 
     // set of <pad, bx> pairs, sorted first by pad then by bx
     std::set<std::pair<int, int> > proto_pads;
@@ -131,8 +133,8 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
     // and stuff them into a set of unique pads (equivalent of OR operation)
     auto digis = det_digis.get(p->id());
 
-    GEMDetId gemId2(p->id().region(), p->id().ring(), p->id().station(),
-                    p->id().layer(), p->id().chamber(), p->id().roll() - 1);
+    GEMDetId gemId2(
+        p->id().region(), p->id().ring(), p->id().station(), p->id().layer(), p->id().chamber(), p->id().roll() - 1);
     auto digis2 = det_digis.get(gemId2);
 
     for (auto d = digis.first; d != digis.second; ++d) {

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -134,7 +134,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
     auto digis = det_digis.get(p->id());
 
     GEMDetId gemId2(
-        p->id().region(), p->id().ring(), p->id().station(), p->id().layer(), p->id().chamber(), p->id().roll() - 1);
+        p->id().region(), p->id().ring(), p->id().station(), p->id().layer(), p->id().chamber(), p->id().roll() + 1);
     auto digis2 = det_digis.get(gemId2);
 
     for (auto d = digis.first; d != digis.second; ++d) {

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -35,16 +35,19 @@ public:
 
 private:
   void buildPads(const GEMDigiCollection& digis, GEMPadDigiCollection& out_pads) const;
+  void buildPads16GE21(const GEMDigiCollection& digis, GEMPadDigiCollection& out_pads) const;
 
   /// Name of input digi Collection
   edm::EDGetTokenT<GEMDigiCollection> digi_token_;
   edm::InputTag digis_;
+  bool use16GE21_;
 
   const GEMGeometry* geometry_;
 };
 
 GEMPadDigiProducer::GEMPadDigiProducer(const edm::ParameterSet& ps) : geometry_(nullptr) {
   digis_ = ps.getParameter<edm::InputTag>("InputCollection");
+  use16GE21_ = ps.getParameter<bool>("use16GE21");
 
   digi_token_ = consumes<GEMDigiCollection>(digis_);
 
@@ -57,6 +60,8 @@ GEMPadDigiProducer::~GEMPadDigiProducer() {}
 void GEMPadDigiProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("InputCollection", edm::InputTag("simMuonGEMDigis"));
+  // GE2/1 geometry with 16 eta partitions
+  desc.add<bool>("use16GE21", false);
 
   descriptions.add("simMuonGEMPadDigisDef", desc);
 }
@@ -76,6 +81,7 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
   // build the pads
   buildPads(*(hdigis.product()), *pPads);
+  if (use16GE21_) buildPads16GE21(*(hdigis.product()), *pPads);
 
   // store them in the event
   e.put(std::move(pPads));
@@ -83,6 +89,11 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
 void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
   for (const auto& p : geometry_->etaPartitions()) {
+
+    // when using the GE2/1 geometry with 16 eta partitions
+    // ->ignore GE2/1
+    if (use16GE21_ and p->id().station() == 2) continue;
+
     // set of <pad, bx> pairs, sorted first by pad then by bx
     std::set<std::pair<int, int> > proto_pads;
 
@@ -92,6 +103,45 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
     for (auto d = digis.first; d != digis.second; ++d) {
       int pad_num = static_cast<int>(p->padOfStrip(d->strip()));
       proto_pads.emplace(pad_num, d->bx());
+    }
+
+    // fill the output collections
+    for (const auto& d : proto_pads) {
+      GEMPadDigi pad_digi(d.first, d.second);
+      out_pads.insertDigi(p->id(), pad_digi);
+    }
+  }
+}
+
+void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
+  for (const auto& p : geometry_->etaPartitions()) {
+
+    // when using the GE2/1 geometry with 16 eta partitions
+    // ->ignore GE1/1
+    if (p->id().station() == 1) continue;
+
+    // ignore eta partition with even numbers
+    // these are included in the odd numbered pads
+    if (p->id().roll() % 2 == 0) continue;
+
+    // set of <pad, bx> pairs, sorted first by pad then by bx
+    std::set<std::pair<int, int> > proto_pads;
+
+    // walk over digis in the first partition,
+    // and stuff them into a set of unique pads (equivalent of OR operation)
+    auto digis = det_digis.get(p->id());
+
+    GEMDetId gemId2(p->id().region(), p->id().ring(), p->id().station(),
+                    p->id().layer(), p->id().chamber(), p->id().roll() - 1);
+    auto digis2 = det_digis.get(gemId2);
+
+    for (auto d = digis.first; d != digis.second; ++d) {
+      // check if the strip digi in the eta partition below also has a digi
+      for (auto d2 = digis2.first; d2 != digis2.second; ++d2) {
+        if (d->strip() == d2->strip()) {
+          proto_pads.emplace(d->strip(), d->bx());
+        }
+      }
     }
 
     // fill the output collections


### PR DESCRIPTION
#### PR description:

The GE2/1 will soon have 16 eta partitions in CMSSW to reflect the updated design. This PR defines a new pad builder for this particular geometry (not enabled yet). See also PR https://github.com/cms-sw/cmssw/pull/29440.

Also, the GE1/1 and GE2/1 on-chamber optohybrid to off-chamber backend (CTP7/ATCA) communication protocol will have an option to send overflow clusters in the next bunch crossing. This effectively increases the bandwidth by up to a factor 2. See https://gitlab.cern.ch/tdr/notes/DN-20-016/blob/master/temp/DN-20-016_temp.pdf, page 29. This option is also not enabled yet. 

EDIT: while checking the performance on Run-3 samples I noticed that a GEM copad vector was not cleared for each new event.

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

FYI @watson-ij @jshlee 