### PR TITLE
[Phase2 3D digitizer] Fix digi links

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -411,14 +411,16 @@ void Pixel3DDigitizerAlgorithm::induce_signal(const PSimHit& hit,
 
     float corr_time = hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv;
     if (makeDigiSimLinks_) {
-      the_signal[channel] += DigitizerUtility::Amplitude(pt.amplitude(), &hit, pt.amplitude(), corr_time, hitIndex, tofBin);
+      the_signal[channel] +=
+          DigitizerUtility::Amplitude(pt.amplitude(), &hit, pt.amplitude(), corr_time, hitIndex, tofBin);
     } else {
       the_signal[channel] += DigitizerUtility::Amplitude(pt.amplitude(), nullptr, pt.amplitude());
     }
 
     LogDebug("Pixel3DDigitizerAlgorithm::induce_signal")
         << " Induce charge at row,col:" << rowcol << " N_electrons:" << pt.amplitude() << " [Channel:" << channel
-        << "]\n   [Accumulated signal in this channel:" << the_signal[channel].ampl() << "] " 
-        <<  " Global index linked PSimHit:" << hitIndex;;
+        << "]\n   [Accumulated signal in this channel:" << the_signal[channel].ampl() << "] "
+        << " Global index linked PSimHit:" << hitIndex;
+    ;
   }
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -94,7 +94,7 @@ void Pixel3DDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_it
     LogDebug("Pixel3DDigitizerAlgorithm:: Geant4 hit info: ")
         << (*it).particleType() << " " << (*it).pabs() << " " << (*it).energyLoss() << " " << (*it).tof() << " "
         << (*it).trackId() << " " << (*it).processType() << " " << (*it).detUnitId() << (*it).entryPoint() << " "
-        << (*it).exitPoint();
+        << (*it).exitPoint() << " Global index for PSimHit:" << simHitGlobalIndex;
 
     // Convert the simhit position into global to check if the simhit was
     // produced within a given time-window
@@ -409,14 +409,16 @@ void Pixel3DDigitizerAlgorithm::induce_signal(const PSimHit& hit,
     MeasurementPoint rowcol(pt.position().x(), pt.position().y());
     const int channel = topo.channel(topo.localPosition(rowcol));
 
+    float corr_time = hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv;
     if (makeDigiSimLinks_) {
-      the_signal[channel] += DigitizerUtility::Amplitude(pt.amplitude(), &hit, pt.amplitude(), hitIndex, tofBin);
+      the_signal[channel] += DigitizerUtility::Amplitude(pt.amplitude(), &hit, pt.amplitude(), corr_time, hitIndex, tofBin);
     } else {
       the_signal[channel] += DigitizerUtility::Amplitude(pt.amplitude(), nullptr, pt.amplitude());
     }
 
     LogDebug("Pixel3DDigitizerAlgorithm::induce_signal")
         << " Induce charge at row,col:" << rowcol << " N_electrons:" << pt.amplitude() << " [Channel:" << channel
-        << "]\n   [Accumulated signal in this channel:" << the_signal[channel].ampl() << "]";
+        << "]\n   [Accumulated signal in this channel:" << the_signal[channel].ampl() << "] " 
+        <<  " Global index linked PSimHit:" << hitIndex;;
   }
 }

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -258,6 +258,11 @@ _premixStage1ModifyDict = dict(
         AddInefficiency = False,
         AddThresholdSmearing = False,
     ),
+    Pixel3DDigitizerAlgorithm = dict(
+        AddNoisyPixels = False,
+        AddInefficiency = False,
+        AddThresholdSmearing = False,
+    ),
     PSPDigitizerAlgorithm = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,


### PR DESCRIPTION
#### PR description:

A recent modification in the signature of  `DigitizerUtility::Amplitude` (https://github.com/cms-sw/cmssw/commit/158d94357e1a4ca1789f658f3b4e71f554434657,) was not properly propagated into the ```Pixel3DDigitizerAlgorithm``` class, and introduced a bug when linking the simulated energy deposits with the created digi.

Please take a look to the commit https://github.com/cms-sw/cmssw/commit/158d94357e1a4ca1789f658f3b4e71f554434657, for details about the described modifications affecting the pixel3 digi class .

This fix will assign the correct PSimHit. to the created Digi for the pixel 3d digitizer.

The PR also incorporates a fix for a missing entry in the pixel3d digitizer configuration (a fix made by  @mmusich ).

@emiglior and @skinnari as conveners of the simulation/optimisation for phase2 group are aware and agree with this PR. 
Adding @suchandradutta for the concerned modifications.

#### PR validation:
No issues has been spotted during the performed tests (following procedures from https://cms-sw.github.io/PRWorkflow.html)
