### PR TITLE
move to TrackerTopology

### DIFF
--- a/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
+++ b/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
@@ -40,8 +40,8 @@ public:
   ~TrackingRecoMaterialAnalyser() override;
 
 private:
-  inline bool isDoubleSided(SiStripDetId strip_id) {
-    return ((strip_id.subDetector() != SiStripDetId::UNKNOWN) && strip_id.glued());
+  inline bool isDoubleSided(const TrackerTopology* tTopo, DetId id) {
+    return (tTopo->glued(id));
   }
   TrackTransformer refitter_;
   const edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
@@ -183,6 +183,7 @@ void TrackingRecoMaterialAnalyser::analyze(const edm::Event &event, const edm::E
 
   // Get the TrackerTopology
   setup.get<TrackerTopologyRcd>().get(trk_topology);
+  const TrackerTopology* const tTopo = trk_topology.product();
 
   // Get Tracks
   event.getByToken(tracksToken_, tracks);
@@ -236,7 +237,7 @@ void TrackingRecoMaterialAnalyser::analyze(const edm::Event &event, const edm::E
   //   the track, which is seldom the case, according to the current direction
   TrajectoryStateOnSurface current_tsos;
   DetId current_det;
-  for (auto const &track : *tracks) {
+  for (auto const track : *tracks) {
     if (!selector(track, pv))
       continue;
     auto const &inner = track.innerMomentum();
@@ -295,23 +296,23 @@ void TrackingRecoMaterialAnalyser::analyze(const edm::Event &event, const edm::E
         // scaling of 0.5. The actual plane is built few lines below:
         // http://cmslxr.fnal.gov/dxr/CMSSW_8_0_5/source/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc#287
 
-        if (isDoubleSided(current_det)) {
+        if (isDoubleSided(tTopo,current_det)) {
           LogTrace("TrackingRecoMaterialAnalyser")
-              << "Eta: " << track.eta() << " " << sDETS[current_det.subdetId()] << trk_topology->layer(current_det)
+              << "Eta: " << track.eta() << " " << sDETS[current_det.subdetId()] << tTopo->layer(current_det)
               << " has ori_radLen: " << ori_radLen << " and ori_xi: " << xi << " and has radLen: " << radLen
               << "  and xi: " << xi << endl;
           ori_radLen *= 2.;
           radLen *= 2.;
         }
 
-        histosOriEta_[sDETS[current_det.subdetId()] + to_string(trk_topology->layer(current_det))]->Fill(
+        histosOriEta_[sDETS[current_det.subdetId()] + to_string(tTopo->layer(current_det))]->Fill(
             current_tsos.globalPosition().eta(), ori_radLen);
-        histosEta_[sDETS[current_det.subdetId()] + to_string(trk_topology->layer(current_det))]->Fill(
+        histosEta_[sDETS[current_det.subdetId()] + to_string(tTopo->layer(current_det))]->Fill(
             current_tsos.globalPosition().eta(), radLen);
         histo_RZ_Ori_->Fill(current_tsos.globalPosition().z(), current_tsos.globalPosition().perp(), ori_radLen);
         histo_RZ_->Fill(current_tsos.globalPosition().z(), current_tsos.globalPosition().perp(), radLen);
         LogInfo("TrackingRecoMaterialAnalyser")
-            << "Eta: " << track.eta() << " " << sDETS[current_det.subdetId()] << trk_topology->layer(current_det)
+            << "Eta: " << track.eta() << " " << sDETS[current_det.subdetId()] << tTopo->layer(current_det)
             << " has ori_radLen: " << ori_radLen << " and ori_xi: " << xi << " and has radLen: " << radLen
             << "  and xi: " << xi << endl;
       }

--- a/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
+++ b/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
@@ -40,9 +40,7 @@ public:
   ~TrackingRecoMaterialAnalyser() override;
 
 private:
-  inline bool isDoubleSided(const TrackerTopology* tTopo, DetId id) {
-    return (tTopo->glued(id));
-  }
+  inline bool isDoubleSided(const TrackerTopology *tTopo, DetId id) { return (tTopo->glued(id)); }
   TrackTransformer refitter_;
   const edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
   const edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;
@@ -183,7 +181,7 @@ void TrackingRecoMaterialAnalyser::analyze(const edm::Event &event, const edm::E
 
   // Get the TrackerTopology
   setup.get<TrackerTopologyRcd>().get(trk_topology);
-  const TrackerTopology* const tTopo = trk_topology.product();
+  const TrackerTopology *const tTopo = trk_topology.product();
 
   // Get Tracks
   event.getByToken(tracksToken_, tracks);
@@ -296,7 +294,7 @@ void TrackingRecoMaterialAnalyser::analyze(const edm::Event &event, const edm::E
         // scaling of 0.5. The actual plane is built few lines below:
         // http://cmslxr.fnal.gov/dxr/CMSSW_8_0_5/source/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc#287
 
-        if (isDoubleSided(tTopo,current_det)) {
+        if (isDoubleSided(tTopo, current_det)) {
           LogTrace("TrackingRecoMaterialAnalyser")
               << "Eta: " << track.eta() << " " << sDETS[current_det.subdetId()] << tTopo->layer(current_det)
               << " has ori_radLen: " << ori_radLen << " and ori_xi: " << xi << " and has radLen: " << radLen

--- a/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
+++ b/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
@@ -237,7 +237,7 @@ void TrackingRecoMaterialAnalyser::analyze(const edm::Event &event, const edm::E
   //   the track, which is seldom the case, according to the current direction
   TrajectoryStateOnSurface current_tsos;
   DetId current_det;
-  for (auto const track : *tracks) {
+  for (auto const &track : *tracks) {
     if (!selector(track, pv))
       continue;
     auto const &inner = track.innerMomentum();


### PR DESCRIPTION
#### PR description:
migration to TrackerTopology was missing for this DQM code

#### PR validation:
cmsDriver.py step3 --conditions auto:phase2_realistic_T15 -n 10 --era Phase2C8 --eventcontent RECOSIM,DQM --runUnscheduled -s RAW2DIGI,RECO:reconstruction_trackingOnly,VALIDATION:@trackingOnlyValidation,DQM:@trackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --geometry Extended2026D49 --filein file:step2.root --fileout file:step3.root