### PR TITLE
Drop ALCARECOEcalCalElectronCalibDQM 

### DIFF
--- a/DQMOffline/Configuration/python/ALCARECOEcalCalDQM_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOEcalCalDQM_cff.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 #import DQMOffline.CalibCalo.MonitorAlCaEcalPhisym_cfi
 import DQMOffline.CalibCalo.MonitorAlCaEcalPi0_cfi
-import DQMOffline.CalibCalo.MonitorAlCaEcalEleCalib_cfi
+#import DQMOffline.CalibCalo.MonitorAlCaEcalEleCalib_cfi
 
 #ALCARECOEcalCalPhisymDQM = DQMOffline.CalibCalo.MonitorAlCaEcalPhisym_cfi.EcalPhiSymMonDQM.clone()
 
 ALCARECOEcalCalPi0CalibDQM =  DQMOffline.CalibCalo.MonitorAlCaEcalPi0_cfi.EcalPi0MonDQM.clone()
 ALCARECOEcalCalEtaCalibDQM =  DQMOffline.CalibCalo.MonitorAlCaEcalPi0_cfi.EcalPi0MonDQM.clone()
-ALCARECOEcalCalElectronCalibDQM =  DQMOffline.CalibCalo.MonitorAlCaEcalEleCalib_cfi.EcalEleCalibMon.clone()
+#ALCARECOEcalCalElectronCalibDQM =  DQMOffline.CalibCalo.MonitorAlCaEcalEleCalib_cfi.EcalEleCalibMon.clone()
 


### PR DESCRIPTION
#### PR description:

Drop ALCARECOEcalCalElectronCalibDQM after approval by ECAL PDG. Plots not being used and the module was causing warnings in the logs.

