### PR TITLE
Move creation of vector outside a loop to avoid useless (de)allocations

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -137,9 +137,10 @@ std::vector<SeedWithInfo> PixelHitMatcher::operator()(const std::vector<const Tr
   std::vector<TrajectoryStateOnSurface> vTsos;
   vTsos.reserve(allSeedsSize);
 
+  std::vector<GlobalPoint> hitGpMap;
   for (const auto seeds : seedsV) {
     for (const auto &seed : *seeds) {
-      std::vector<GlobalPoint> hitGpMap;
+      hitGpMap.clear();
       if (seed.nHits() > 9) {
         edm::LogWarning("GsfElectronAlgo|UnexpectedSeed") << "We cannot deal with seeds having more than 9 hits.";
         continue;


### PR DESCRIPTION
This PR is a simple performance optimisation, which moves outside of a hot double loop the creation of a std::vector. The result is more than 1% speedup of the full phase-2 reco. No change in physics performance expected.
See:

 - before: https://dpiparo.web.cern.ch/dpiparo/cgi-bin/igprof-navigator/step3_RAW2DIGI_L1Reco_RECO_RECOSIM_200.pp/63
 - after: https://dpiparo.web.cern.ch/dpiparo/cgi-bin/igprof-navigator/step3_RAW2DIGI_L1Reco_RECO_RECOSIM_200_opt.pp/74
