### PR TITLE
Improvements to SiStrip Payload Inspector

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -291,7 +291,7 @@ namespace {
 
       auto ltx = TLatex();
       ltx.SetTextFont(62);
-      ltx.SetTextSize(0.05);
+      ltx.SetTextSize(0.045);
       ltx.SetTextAlign(11);
 
       std::unique_ptr<TLegend> legend = std::make_unique<TLegend>(0.50, 0.25, 0.80, 0.35);

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -217,10 +217,196 @@ namespace {
     TrackerTopology m_trackerTopo;
   };
 
+  /************************************************
+    Plot SiStripLorentz Angle averages by partition comparison
+  *************************************************/
+
+  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
+  class SiStripLorentzAngleComparatorByRegionBase
+      : public cond::payloadInspector::PlotImage<SiStripLorentzAngle, nIOVs, ntags> {
+  public:
+    SiStripLorentzAngleComparatorByRegionBase()
+        : cond::payloadInspector::PlotImage<SiStripLorentzAngle, nIOVs, ntags>(
+              "SiStripLorentzAngle By Region Comparison"),
+          m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
+
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<SiStripLorentzAngle> f_payload = this->fetchPayload(std::get<1>(firstiov));
+      std::shared_ptr<SiStripLorentzAngle> l_payload = this->fetchPayload(std::get<1>(lastiov));
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      //=========================
+      TCanvas canvas("Partion summary", "partition summary", 1200, 1000);
+      canvas.cd();
+      canvas.SetBottomMargin(0.18);
+      canvas.SetLeftMargin(0.13);
+      canvas.SetRightMargin(0.03);
+      canvas.SetTopMargin(0.05);
+      canvas.Modified();
+
+      std::vector<int> boundaries;
+      std::shared_ptr<TH1F> h_first;
+      std::shared_ptr<TH1F> h_last;
+
+      fillTheHistogram(f_payload, h_first, boundaries, 0);
+      fillTheHistogram(l_payload, h_last, boundaries, 1);
+
+      canvas.cd();
+      h_first->Draw("HIST");
+      h_last->Draw("Psame");
+
+      canvas.Update();
+
+      TLine l[boundaries.size()];
+      unsigned int i = 0;
+      for (const auto &line : boundaries) {
+        l[i] = TLine(h_first->GetBinLowEdge(line), canvas.GetUymin(), h_first->GetBinLowEdge(line), canvas.GetUymax());
+        l[i].SetLineWidth(1);
+        l[i].SetLineStyle(9);
+        l[i].SetLineColor(2);
+        l[i].Draw("same");
+        i++;
+      }
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+
+      std::unique_ptr<TLegend> legend = std::make_unique<TLegend>(0.50, 0.25, 0.80, 0.35);
+      if (this->m_plotAnnotations.ntags == 2) {
+        legend->AddEntry(h_last.get(), ("#color[2]{" + tagname2 + "}").c_str(), "P");
+        legend->AddEntry(h_first.get(), ("#color[4]{" + tagname1 + "}").c_str(), "L");
+        legend->SetTextSize(0.024);
+        ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                         1 - gPad->GetTopMargin() + 0.01,
+                         ("IOV : #color[4]{" + std::to_string(std::get<0>(firstiov)) + "} vs #color[2]{" +
+                          std::to_string(std::get<0>(lastiov)) + "}")
+                             .c_str());
+      } else {
+        legend->AddEntry(h_last.get(), ("IOV: #color[2]{" + lastIOVsince + "}").c_str(), "P");
+        legend->AddEntry(h_first.get(), ("IOV: #color[4]{" + firstIOVsince + "}").c_str(), "L");
+        legend->SetTextSize(0.040);
+        ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.01, ("Tag: " + tagname1).c_str());
+
+        legend->SetLineColor(kBlack);
+      }
+      legend->Draw("same");
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+  private:
+    TrackerTopology m_trackerTopo;
+
+    void fillTheHistogram(const std::shared_ptr<SiStripLorentzAngle> &payload,
+                          std::shared_ptr<TH1F> &hist,
+                          std::vector<int> &boundaries,
+                          unsigned int index = 0) {
+      SiStripDetSummary summaryLA{&m_trackerTopo};
+      auto LAMap_ = payload->getLorentzAngles();
+      for (const auto &element : LAMap_) {
+        summaryLA.add(element.first, element.second);
+      }
+
+      auto map = summaryLA.getCounts();
+      hist = std::make_shared<TH1F>(
+          (Form("byRegion_%i", index)), ";; average SiStrip Lorentz Angle #mu_{H} [1/T]", map.size(), 0., map.size());
+
+      hist->SetStats(false);
+      if (index == 0) {
+        hist->SetLineColor(kBlue);
+        hist->SetMarkerColor(kBlue);
+        hist->SetLineWidth(2);
+        hist->SetMarkerStyle(kFourSquaresX);
+      } else {
+        hist->SetMarkerStyle(kFourSquaresX);
+        hist->SetLineColor(kRed);
+        hist->SetMarkerColor(kRed);
+      }
+      unsigned int iBin = 0;
+
+      std::string detector;
+      std::string currentDetector;
+
+      for (const auto &element : map) {
+        iBin++;
+        int count = element.second.count;
+        double mean = (element.second.mean) / count;
+
+        if (currentDetector.empty())
+          currentDetector = "TIB";
+
+        switch ((element.first) / 1000) {
+          case 1:
+            detector = "TIB";
+            break;
+          case 2:
+            detector = "TOB";
+            break;
+          case 3:
+            detector = "TEC";
+            break;
+          case 4:
+            detector = "TID";
+            break;
+        }
+
+        hist->SetBinContent(iBin, mean);
+        hist->GetXaxis()->SetBinLabel(iBin, SiStripPI::regionType(element.first).second);
+        hist->GetXaxis()->LabelsOption("v");
+
+        if (detector != currentDetector) {
+          if (index == 0) {
+            boundaries.push_back(iBin);
+          }
+          currentDetector = detector;
+        }
+      }
+
+      hist->GetYaxis()->SetTitleSize(0.04);
+      hist->GetYaxis()->SetTitleOffset(1.55);
+      hist->GetYaxis()->CenterTitle(true);
+      hist->GetYaxis()->SetRangeUser(0., hist->GetMaximum() * 1.30);
+      hist->SetMarkerSize(2);
+    }
+  };
+
+  using SiStripLorentzAngleByRegionCompareSingleTag =
+      SiStripLorentzAngleComparatorByRegionBase<1, cond::payloadInspector::MULTI_IOV>;
+  using SiStripLorentzAngleByRegionCompareTwoTags =
+      SiStripLorentzAngleComparatorByRegionBase<2, cond::payloadInspector::SINGLE_IOV>;
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(SiStripLorentzAngle) {
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleValue);
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngle_TrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleByRegionCompareSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleByRegionCompareTwoTags);
 }

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -51,14 +51,14 @@ namespace {
     test class
   *************************************************/
 
-  class SiStripNoisesTest : public cond::payloadInspector::Histogram1D<SiStripNoises> {
+  class SiStripNoisesTest
+      : public cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripNoisesTest()
-        : cond::payloadInspector::Histogram1D<SiStripNoises>("SiStrip Noise test", "SiStrip Noise test", 10, 0.0, 10.0),
+        : cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Noise test", "SiStrip Noise test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      Base::setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -261,13 +261,12 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripNoiseValue : public cond::payloadInspector::Histogram1D<SiStripNoises> {
+  class SiStripNoiseValue
+      : public cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripNoiseValue()
-        : cond::payloadInspector::Histogram1D<SiStripNoises>(
-              "SiStrip Noise values", "SiStrip Noise values", 100, 0.0, 10.0) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Noise values", "SiStrip Noise values", 100, 0.0, 10.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -296,13 +295,13 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripNoiseValuePerDetId : public cond::payloadInspector::Histogram1D<SiStripNoises> {
+  class SiStripNoiseValuePerDetId
+      : public cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripNoiseValuePerDetId()
-        : cond::payloadInspector::Histogram1D<SiStripNoises>(
+        : cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
               "SiStrip Noise values per DetId", "SiStrip Noise values per DetId", 100, 0.0, 10.0) {
       cond::payloadInspector::PlotBase::addInputParam("DetId");
-      Base::setSingleIov(true);
     }
 
     bool fill() override {
@@ -335,14 +334,16 @@ namespace {
 
   // inherit from one of the predefined plot class: PlotImage
   template <SiStripPI::OpMode op_mode_>
-  class SiStripNoiseDistribution : public cond::payloadInspector::PlotImage<SiStripNoises> {
+  class SiStripNoiseDistribution
+      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
   public:
-    SiStripNoiseDistribution() : cond::payloadInspector::PlotImage<SiStripNoises>("SiStrip Noise values") {
-      setSingleIov(true);
+    SiStripNoiseDistribution()
+        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>("SiStrip Noise values") {
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
 
       TGaxis::SetMaxDigits(3);
       gStyle->SetOptStat("emr");
@@ -788,16 +789,16 @@ namespace {
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripNoiseTrackerMap : public cond::payloadInspector::PlotImage<SiStripNoises> {
+  class SiStripNoiseTrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripNoiseTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripNoises>("Tracker Map of SiStripNoise " + estimatorType(est) +
-                                                           " per module") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of SiStripNoise " + estimatorType(est) + " per module") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripNoises> payload = fetchPayload(std::get<1>(iov));
 
       std::string titleMap =
@@ -1055,17 +1056,18 @@ namespace {
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripNoiseByRegion : public cond::payloadInspector::PlotImage<SiStripNoises> {
+  class SiStripNoiseByRegion
+      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripNoiseByRegion()
-        : cond::payloadInspector::PlotImage<SiStripNoises>("SiStrip Noise " + estimatorType(est) + " by Region"),
+        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Noise " + estimatorType(est) + " by Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripNoises> payload = fetchPayload(std::get<1>(iov));
 
       SiStripDetSummary summaryNoise{&m_trackerTopo};
@@ -1385,15 +1387,16 @@ namespace {
   /************************************************
     Noise linearity
   *************************************************/
-  class SiStripNoiseLinearity : public cond::payloadInspector::PlotImage<SiStripNoises> {
+  class SiStripNoiseLinearity
+      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripNoiseLinearity()
-        : cond::payloadInspector::PlotImage<SiStripNoises>("Linearity of Strip Noise as a fuction of strip length") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
+              "Linearity of Strip Noise as a fuction of strip length") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripNoises> payload = fetchPayload(std::get<1>(iov));
 
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -143,7 +143,7 @@ namespace {
 
       // determine how the plot will be paginated
       auto sides = getClosestFactors(the_detids.size());
-      edm::LogPrint("SiStripNoisePerDetId") <<"Aspect ratio: " << sides.first << ":" << sides.second << std::endl;
+      edm::LogPrint("SiStripNoisePerDetId") << "Aspect ratio: " << sides.first << ":" << sides.second << std::endl;
 
       if (payload.get()) {
         //=========================
@@ -153,11 +153,12 @@ namespace {
         SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
         for (const auto& the_detid : the_detids) {
-	  edm::LogPrint("SiStripNoisePerDetId") <<"DetId:" << the_detid << std::endl;
+          edm::LogPrint("SiStripNoisePerDetId") << "DetId:" << the_detid << std::endl;
 
           unsigned int nAPVs = reader->getNumberOfApvsAndStripLength(the_detid).first;
-	  if(nAPVs==0) nAPVs=6;
-	  v_nAPVs.push_back(nAPVs);
+          if (nAPVs == 0)
+            nAPVs = 6;
+          v_nAPVs.push_back(nAPVs);
 
           auto histo =
               std::make_shared<TH1F>(Form("Noise profile_%s", std::to_string(the_detid).c_str()),
@@ -170,14 +171,14 @@ namespace {
           histo->SetStats(false);
           histo->SetTitle("");
 
-	  if(the_detid!=0xFFFFFFFF){
-	    fillHisto(payload,histo,the_detid);
-	  } else {
-	    auto allDetIds = reader->getAllDetIds();
-	    for(const auto& id : allDetIds) {
-	      fillHisto(payload,histo,id);
-	    }
-	  }
+          if (the_detid != 0xFFFFFFFF) {
+            fillHisto(payload, histo, the_detid);
+          } else {
+            auto allDetIds = reader->getAllDetIds();
+            for (const auto& id : allDetIds) {
+              fillHisto(payload, histo, id);
+            }
+          }
 
           SiStripPI::makeNicePlotStyle(histo.get());
           histo->GetYaxis()->SetTitleOffset(1.0);
@@ -255,13 +256,13 @@ namespace {
       return std::make_pair(testNum, input / testNum);
     }
 
-    void fillHisto(const std::shared_ptr<SiStripNoises> payload, std::shared_ptr<TH1F>& histo, uint32_t the_detid){
+    void fillHisto(const std::shared_ptr<SiStripNoises> payload, std::shared_ptr<TH1F>& histo, uint32_t the_detid) {
       int nstrip = 0;
       SiStripNoises::Range range = payload->getRange(the_detid);
       for (int it = 0; it < (range.second - range.first) * 8 / 9; ++it) {
-	auto noise = payload->getNoise(it, range);
-	nstrip++;
-	histo->AddBinContent(nstrip, noise);
+        auto noise = payload->getNoise(it, range);
+        nstrip++;
+        histo->AddBinContent(nstrip, noise);
       }  // end of loop on strips
     }
   };

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <iostream>
 #include <iomanip>
+#include <boost/tokenizer.hpp>
 
 // include ROOT
 #include "TH2F.h"
@@ -99,90 +100,159 @@ namespace {
     SiStrip Pedestals Profile of 1 IOV for one selected DetId
   *************************************************/
 
-  class SiStripPedestalPerDetId : public cond::payloadInspector::PlotImage<SiStripPedestals> {
+  class SiStripPedestalPerDetId
+      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripPedestalPerDetId()
-        : cond::payloadInspector::PlotImage<SiStripPedestals>("SiStrip Pedestal values per DetId") {
-      cond::payloadInspector::PlotBase::addInputParam("DetId");
-      setSingleIov(true);
+        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Pedestal values per DetId") {
+      cond::payloadInspector::PlotBase::addInputParam("DetIds");
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      auto tagname = tag.name;
+      std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
 
-      unsigned int the_detid(0xFFFFFFFF);
+      std::vector<uint32_t> the_detids = {};
 
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
-      auto ip = paramValues.find("DetId");
+      auto ip = paramValues.find("DetIds");
       if (ip != paramValues.end()) {
-        the_detid = boost::lexical_cast<unsigned int>(ip->second);
+        auto input = boost::lexical_cast<std::string>(ip->second);
+        typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+        boost::char_separator<char> sep{","};
+        tokenizer tok{input, sep};
+        for (const auto& t : tok) {
+          the_detids.push_back(atoi(t.c_str()));
+        }
+      } else {
+        edm::LogWarning("SiStripNoisePerDetId")
+            << "\n WARNING!!!! \n The needed parameter DetIds has not been passed. Will use all Strip DetIds! \n\n";
+        the_detids.push_back(0xFFFFFFFF);
+        return false;
       }
 
-      std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
+      size_t ndets = the_detids.size();
+      std::vector<std::shared_ptr<TH1F>> hpedestal;
+      std::vector<std::shared_ptr<TLegend>> legends;
+      std::vector<unsigned int> v_nAPVs;
+      std::vector<std::vector<std::shared_ptr<TLine>>> lines;
+      hpedestal.reserve(ndets);
+      legends.reserve(ndets);
+
+      //int side = nextPerfectSquare(the_detids.size());
+      auto sides = getClosestFactors(the_detids.size());
+      std::cout << sides.first << ":" << sides.second << std::endl;
+
       if (payload.get()) {
         //=========================
-        TCanvas canvas("ByDetId", "ByDetId", 1200, 1000);
-
+        TCanvas canvas("ByDetId", "ByDetId", sides.second * 800, sides.first * 600);
+        canvas.Divide(sides.second, sides.first);
         edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
         SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
-        unsigned int nAPVs = reader->getNumberOfApvsAndStripLength(the_detid).first;
 
-        auto hnoise = std::unique_ptr<TH1F>(
-            new TH1F("Pedestal profile",
-                     Form("SiStrip Pedestal profile for DetId: %s;Strip number;SiStrip Pedestal [ADC counts]",
-                          std::to_string(the_detid).c_str()),
-                     128 * nAPVs,
-                     -0.5,
-                     (128 * nAPVs) - 0.5));
-        hnoise->SetStats(false);
+        for (const auto& the_detid : the_detids) {
+          std::cout << the_detid << std::endl;
 
-        std::vector<uint32_t> detid;
-        payload->getDetIds(detid);
+          unsigned int nAPVs = reader->getNumberOfApvsAndStripLength(the_detid).first;
+          v_nAPVs.push_back(nAPVs);
 
-        int nstrip = 0;
-        SiStripPedestals::Range range = payload->getRange(the_detid);
-        for (int it = 0; it < (range.second - range.first) * 8 / 10; ++it) {
-          auto noise = payload->getPed(it, range);
-          nstrip++;
-          hnoise->SetBinContent(nstrip, noise);
-        }  // end of loop on strips
+          auto histo = std::make_shared<TH1F>(
+              Form("Pedestal profile %s", std::to_string(the_detid).c_str()),
+              Form("SiStrip Pedestal profile for DetId: %s;Strip number;SiStrip Pedestal [ADC counts]",
+                   std::to_string(the_detid).c_str()),
+              128 * nAPVs,
+              -0.5,
+              (128 * nAPVs) - 0.5);
 
-        canvas.cd();
-        canvas.SetBottomMargin(0.11);
-        canvas.SetTopMargin(0.07);
-        canvas.SetLeftMargin(0.13);
-        canvas.SetRightMargin(0.05);
-        hnoise->Draw();
-        hnoise->GetYaxis()->SetRangeUser(0, hnoise->GetMaximum() * 1.2);
-        //hnoise->Draw("Psame");
-        canvas.Update();
+          histo->SetStats(false);
+          histo->SetTitle("");
 
-        std::vector<int> boundaries;
-        for (size_t b = 0; b < nAPVs; b++)
-          boundaries.push_back(b * 128);
+          int nstrip = 0;
+          SiStripPedestals::Range range = payload->getRange(the_detid);
+          for (int it = 0; it < (range.second - range.first) * 8 / 10; ++it) {
+            auto pedestal = payload->getPed(it, range);
+            nstrip++;
+            histo->SetBinContent(nstrip, pedestal);
+          }  // end of loop on strips
 
-        TLine l[nAPVs];
-        unsigned int i = 0;
-        for (const auto& line : boundaries) {
-          l[i] = TLine(hnoise->GetBinLowEdge(line), canvas.GetUymin(), hnoise->GetBinLowEdge(line), canvas.GetUymax());
-          l[i].SetLineWidth(1);
-          l[i].SetLineStyle(9);
-          l[i].SetLineColor(2);
-          l[i].Draw("same");
-          i++;
+          SiStripPI::makeNicePlotStyle(histo.get());
+          histo->GetYaxis()->SetTitleOffset(1.0);
+          hpedestal.push_back(histo);
+        }  // loop on the detids
+
+        for (size_t index = 0; index < ndets; index++) {
+          canvas.cd(index + 1);
+          canvas.cd(index + 1)->SetBottomMargin(0.11);
+          canvas.cd(index + 1)->SetTopMargin(0.06);
+          canvas.cd(index + 1)->SetLeftMargin(0.10);
+          canvas.cd(index + 1)->SetRightMargin(0.02);
+          hpedestal.at(index)->Draw();
+          hpedestal.at(index)->GetYaxis()->SetRangeUser(0, hpedestal.at(index)->GetMaximum() * 1.2);
+          canvas.cd(index)->Update();
+
+          std::vector<int> boundaries;
+          for (size_t b = 0; b < v_nAPVs.at(index); b++) {
+            boundaries.push_back(b * 128);
+          }
+
+          std::vector<std::shared_ptr<TLine>> linesVec;
+          for (const auto& bound : boundaries) {
+            auto line = std::make_shared<TLine>(hpedestal.at(index)->GetBinLowEdge(bound),
+                                                canvas.cd(index + 1)->GetUymin(),
+                                                hpedestal.at(index)->GetBinLowEdge(bound),
+                                                canvas.cd(index + 1)->GetUymax());
+            line->SetLineWidth(1);
+            line->SetLineStyle(9);
+            line->SetLineColor(2);
+            linesVec.push_back(line);
+          }
+          lines.push_back(linesVec);
+
+          for (const auto& line : lines.at(index)) {
+            line->Draw("same");
+          }
+
+          canvas.cd(index + 1);
+
+          auto ltx = TLatex();
+          ltx.SetTextFont(62);
+          ltx.SetTextSize(0.05);
+          ltx.SetTextAlign(11);
+          ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                           1 - gPad->GetTopMargin() + 0.01,
+                           Form("SiStrip Noise profile for DetId %s", std::to_string(the_detids[index]).c_str()));
+
+          legends.push_back(std::make_shared<TLegend>(0.52, 0.83, 0.95, 0.93));
+          legends.at(index)->SetHeader(tagname.c_str(), "C");  // option "C" allows to center the header
+          legends.at(index)->AddEntry(
+              hpedestal.at(index).get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
+          legends.at(index)->SetTextSize(0.025);
+          legends.at(index)->Draw("same");
         }
-
-        TLegend legend = TLegend(0.52, 0.82, 0.95, 0.93);
-        legend.SetHeader((std::get<1>(iov)).c_str(), "C");  // option "C" allows to center the header
-        legend.AddEntry(hnoise.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
-        legend.SetTextSize(0.025);
-        legend.Draw("same");
 
         std::string fileName(m_imageFileName);
         canvas.SaveAs(fileName.c_str());
       }  // payload
       return true;
     }  // fill
+
+  private:
+    int nextPerfectSquare(int N) { return std::floor(sqrt(N)) + 1; }
+
+    std::pair<int, int> getClosestFactors(int input) {
+      if ((input % 2 != 0) && input > 1) {
+        input += 1;
+      }
+
+      int testNum = (int)sqrt(input);
+      while (input % testNum != 0) {
+        testNum--;
+      }
+      return std::make_pair(testNum, input / testNum);
+    }
   };
 
   /************************************************
@@ -270,7 +340,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
 
       TGaxis::SetMaxDigits(3);
@@ -389,8 +459,8 @@ namespace {
     SiStripPedestalDistributionComparisonBase()
         : cond::payloadInspector::PlotImage<SiStripPedestals>("SiStrip Pedestal values comparison") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
 
       // make absolute sure the IOVs are sortd by since
       std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
@@ -604,7 +674,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
 
@@ -663,7 +733,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
 
@@ -750,7 +820,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
 

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -141,7 +141,7 @@ namespace {
       legends.reserve(ndets);
 
       auto sides = getClosestFactors(the_detids.size());
-      edm::LogPrint("SiStripPedestalPerDetId") <<"Aspect ratio: " << sides.first << ":" << sides.second << std::endl;
+      edm::LogPrint("SiStripPedestalPerDetId") << "Aspect ratio: " << sides.first << ":" << sides.second << std::endl;
 
       if (payload.get()) {
         //=========================
@@ -151,10 +151,11 @@ namespace {
         SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
         for (const auto& the_detid : the_detids) {
-	  edm::LogPrint("SiStripNoisePerDetId") <<"DetId:" << the_detid << std::endl;
+          edm::LogPrint("SiStripNoisePerDetId") << "DetId:" << the_detid << std::endl;
 
           unsigned int nAPVs = reader->getNumberOfApvsAndStripLength(the_detid).first;
-	  if(nAPVs==0) nAPVs=6;
+          if (nAPVs == 0)
+            nAPVs = 6;
           v_nAPVs.push_back(nAPVs);
 
           auto histo = std::make_shared<TH1F>(
@@ -168,15 +169,15 @@ namespace {
           histo->SetStats(false);
           histo->SetTitle("");
 
-	  if(the_detid!=0xFFFFFFFF){
-	    fillHisto(payload,histo,the_detid);
-	  } else {
-	    auto allDetIds = reader->getAllDetIds();
-	    for(const auto& id : allDetIds) {
-	      fillHisto(payload,histo,id);
-	    }
-	  }
-         
+          if (the_detid != 0xFFFFFFFF) {
+            fillHisto(payload, histo, the_detid);
+          } else {
+            auto allDetIds = reader->getAllDetIds();
+            for (const auto& id : allDetIds) {
+              fillHisto(payload, histo, id);
+            }
+          }
+
           SiStripPI::makeNicePlotStyle(histo.get());
           histo->GetYaxis()->SetTitleOffset(1.0);
           hpedestal.push_back(histo);
@@ -253,16 +254,15 @@ namespace {
       return std::make_pair(testNum, input / testNum);
     }
 
-    void fillHisto(const std::shared_ptr<SiStripPedestals> payload, std::shared_ptr<TH1F>& histo, uint32_t the_detid){
+    void fillHisto(const std::shared_ptr<SiStripPedestals> payload, std::shared_ptr<TH1F>& histo, uint32_t the_detid) {
       int nstrip = 0;
       SiStripPedestals::Range range = payload->getRange(the_detid);
       for (int it = 0; it < (range.second - range.first) * 8 / 10; ++it) {
-	auto pedestal = payload->getPed(it, range);
-	nstrip++;
-	histo->AddBinContent(nstrip, pedestal);
+        auto pedestal = payload->getPed(it, range);
+        nstrip++;
+        histo->AddBinContent(nstrip, pedestal);
       }  // end of loop on strips
     }
-
   };
 
   /************************************************

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -50,15 +50,14 @@ namespace {
     test class
   *************************************************/
 
-  class SiStripPedestalsTest : public cond::payloadInspector::Histogram1D<SiStripPedestals> {
+  class SiStripPedestalsTest
+      : public cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripPedestalsTest()
-        : cond::payloadInspector::Histogram1D<SiStripPedestals>(
+        : cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
               "SiStrip Pedestals test", "SiStrip Pedestals test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      Base::setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -260,13 +259,12 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripPedestalsValue : public cond::payloadInspector::Histogram1D<SiStripPedestals> {
+  class SiStripPedestalsValue
+      : public cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripPedestalsValue()
-        : cond::payloadInspector::Histogram1D<SiStripPedestals>(
-              "SiStrip Pedestals values", "SiStrip Pedestals values", 300, 0.0, 300.0) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Pedestals values", "SiStrip Pedestals values", 300, 0.0, 300.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -295,13 +293,13 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripPedestalsValuePerDetId : public cond::payloadInspector::Histogram1D<SiStripPedestals> {
+  class SiStripPedestalsValuePerDetId
+      : public cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripPedestalsValuePerDetId()
-        : cond::payloadInspector::Histogram1D<SiStripPedestals>(
+        : cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
               "SiStrip Pedestal values per DetId", "SiStrip Pedestal values per DetId", 100, 0.0, 10.0) {
       cond::payloadInspector::PlotBase::addInputParam("DetId");
-      Base::setSingleIov(true);
     }
 
     bool fill() override {
@@ -334,15 +332,16 @@ namespace {
 
   // inherit from one of the predefined plot class: PlotImage
   template <SiStripPI::OpMode op_mode_>
-  class SiStripPedestalDistribution : public cond::payloadInspector::PlotImage<SiStripPedestals> {
+  class SiStripPedestalDistribution
+      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
   public:
-    SiStripPedestalDistribution() : cond::payloadInspector::PlotImage<SiStripPedestals>("SiStrip Pedestal values") {
-      setSingleIov(true);
-    }
+    SiStripPedestalDistribution()
+        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Pedestal values") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
-
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       TGaxis::SetMaxDigits(3);
       gStyle->SetOptStat("emr");
 
@@ -666,16 +665,16 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class PlotImage
-  class SiStripZeroPedestalsFraction_TrackerMap : public cond::payloadInspector::PlotImage<SiStripPedestals> {
+  class SiStripZeroPedestalsFraction_TrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripZeroPedestalsFraction_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripPedestals>(
-              "Tracker Map of Zero SiStripPedestals fraction per module") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of Zero SiStripPedestals fraction per module") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
 
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
@@ -725,16 +724,16 @@ namespace {
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripPedestalsTrackerMap : public cond::payloadInspector::PlotImage<SiStripPedestals> {
+  class SiStripPedestalsTrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripPedestalsTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripPedestals>("Tracker Map of SiStripPedestals " + estimatorType(est) +
-                                                              " per module") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of SiStripPedestals " + estimatorType(est) + " per module") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
 
       std::string titleMap =
@@ -811,17 +810,18 @@ namespace {
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripPedestalsByRegion : public cond::payloadInspector::PlotImage<SiStripPedestals> {
+  class SiStripPedestalsByRegion
+      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripPedestalsByRegion()
-        : cond::payloadInspector::PlotImage<SiStripPedestals>("SiStrip Pedestals " + estimatorType(est) + " by Region"),
+        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Pedestals " + estimatorType(est) + " by Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
 
       SiStripDetSummary summaryPedestals{&m_trackerTopo};

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -45,6 +45,17 @@ getPayloadData.py \
 mv *.png $W_DIR/results/SiStripLorentzAngleByRegion.png
 
 ######################
+# Test Lorentz Angle Comparison
+######################
+getPayloadData.py \
+    --plugin pluginSiStripLorentzAngle_PayloadInspector \
+    --plot plot_SiStripLorentzAngleByRegionCompareSingleTag \
+    --tag SiStripLorentzAngleDeco_GR10_v1_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "400000"}' \
+    --db Prod --test ;
+
+######################
 # Test Backplane correction
 ######################
 getPayloadData.py \

--- a/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
@@ -35,6 +35,18 @@ getPayloadData.py \
     --input_params '{"DetId":"470065830"}' \
     --test ;
 
+####################
+# Multiple DetIds
+####################
+getPayloadData.py --plugin pluginSiStripNoises_PayloadInspector \
+    --plot plot_SiStripNoisePerDetId \
+    --tag SiStripNoise_v2_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "303420", "end_iov": "303420"}' \
+    --db Prod \
+    --input_params '{"DetIds":"470065830,369121594,369124670,470177668"}' \
+    --test ;
+
 estimators=(Mean Min Max RMS)
 plotTypes=(Strip APV Module)
 partition=(TIB TOB TEC TID)

--- a/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
@@ -35,6 +35,19 @@ getPayloadData.py \
     --input_params '{"DetId":"470065830"}' \
     --test ;
 
+####################
+# Multiple DetIds
+####################
+getPayloadData.py \
+    --plugin pluginSiStripPedestals_PayloadInspector \
+    --plot plot_SiStripPedestalPerDetId \
+    --tag SiStripPedestals_GR10_v2_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "303420", "end_iov": "303420"}' \
+    --db Prod \
+    --input_params '{"DetIds":"470065830,369121594,369124670,470177668"}' \
+    --test ;
+
 estimators=(Mean Min Max RMS)
 plotTypes=(Strip APV Module)
 

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
   edm::LogPrint("testSiStripPayloadInspector") << histo11.data() << std::endl;
 
   SiStripPedestalPerDetId histoPedestalForDetId;
-  inputs["DetIds"]+=",470065830,369121594,369124670,470177668"; // add a bunch of other DetIds
+  inputs["DetIds"] += ",470065830,369121594,369124670,470177668";  // add a bunch of other DetIds
   histoPedestalForDetId.setInputParamValues(inputs);
   histoPedestalForDetId.process(connectionString, PI::mk_input(tag, start, start));
   edm::LogPrint("testSiStripPayloadInspector") << histoPedestalForDetId.data() << std::endl;

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -111,6 +111,7 @@ int main(int argc, char** argv) {
   edm::LogPrint("testSiStripPayloadInspector") << histo11.data() << std::endl;
 
   SiStripPedestalPerDetId histoPedestalForDetId;
+  inputs["DetIds"]+=",470065830,369121594,369124670,470177668"; // add a bunch of other DetIds
   histoPedestalForDetId.setInputParamValues(inputs);
   histoPedestalForDetId.process(connectionString, PI::mk_input(tag, start, start));
   edm::LogPrint("testSiStripPayloadInspector") << histoPedestalForDetId.data() << std::endl;

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -34,39 +34,39 @@ int main(int argc, char** argv) {
   cond::Time_t end = boost::lexical_cast<unsigned long long>(285368);
   boost::python::dict inputs;
 
-  std::cout << "## Exercising Gains plots " << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << "## Exercising Gains plots " << std::endl;
 
   SiStripApvGainsAverageTrackerMap histo1;
   histo1.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo1.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo1.data() << std::endl;
 
   SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap histo2;
   inputs["nsigma"] = "1";
   histo2.setInputParamValues(inputs);
   histo2.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo2.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo2.data() << std::endl;
 
   SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap histo3;
   inputs["nsigma"] = "1";
   histo3.setInputParamValues(inputs);
   histo3.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo3.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo3.data() << std::endl;
 
   SiStripApvGainsValuesComparatorSingleTag histo4;
   histo4.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo4.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo4.data() << std::endl;
 
   SiStripApvGainsComparatorSingleTag histo5;
   histo5.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo5.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo5.data() << std::endl;
 
   SiStripApvGainsComparatorByRegionSingleTag histo6;
   histo6.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo6.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo6.data() << std::endl;
 
   SiStripApvGainsRatioComparatorByRegionSingleTag histo7;
   histo7.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo7.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo7.data() << std::endl;
 
   // Noise
 
@@ -74,25 +74,25 @@ int main(int argc, char** argv) {
   start = boost::lexical_cast<unsigned long long>(312968);
   end = boost::lexical_cast<unsigned long long>(313120);
 
-  std::cout << "## Exercising Noise plots " << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << "## Exercising Noise plots " << std::endl;
 
   SiStripNoiseValuePerAPV histo8;
   histo8.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo8.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo8.data() << std::endl;
 
   SiStripNoiseValueComparisonPerAPVSingleTag histo9;
   histo9.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo9.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo9.data() << std::endl;
 
   SiStripNoiseComparatorMeanByRegionSingleTag histoCompareMeanByRegion;
   histoCompareMeanByRegion.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histoCompareMeanByRegion.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histoCompareMeanByRegion.data() << std::endl;
 
   SiStripNoisePerDetId histoNoiseForDetId;
-  inputs["DetId"] = "470148232";
+  inputs["DetIds"] = "470148232";
   histoNoiseForDetId.setInputParamValues(inputs);
   histoNoiseForDetId.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histoNoiseForDetId.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histoNoiseForDetId.data() << std::endl;
 
   // Pedestals
 
@@ -100,20 +100,20 @@ int main(int argc, char** argv) {
   start = boost::lexical_cast<unsigned long long>(303420);
   end = boost::lexical_cast<unsigned long long>(313120);
 
-  std::cout << "## Exercising Pedestal plots " << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << "## Exercising Pedestal plots " << std::endl;
 
   SiStripPedestalValuePerStrip histo10;
   histo10.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo10.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo10.data() << std::endl;
 
   SiStripPedestalValueComparisonPerModuleSingleTag histo11;
   histo11.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo11.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo11.data() << std::endl;
 
   SiStripPedestalPerDetId histoPedestalForDetId;
   histoPedestalForDetId.setInputParamValues(inputs);
   histoPedestalForDetId.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histoPedestalForDetId.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histoPedestalForDetId.data() << std::endl;
 
   //Latency
 
@@ -121,26 +121,26 @@ int main(int argc, char** argv) {
   start = boost::lexical_cast<unsigned long long>(315347);
   end = boost::lexical_cast<unsigned long long>(316675);
 
-  std::cout << "## Exercising Latency plots " << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << "## Exercising Latency plots " << std::endl;
 
   SiStripLatencyMode histo12;
   histo12.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo12.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo12.data() << std::endl;
 
   SiStripLatencyModeHistory histo13;
   histo13.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo13.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo13.data() << std::endl;
 
   //Threshold
   tag = "SiStripThreshold_v1_prompt";
   start = boost::lexical_cast<unsigned long long>(315352);
   end = boost::lexical_cast<unsigned long long>(315460);
 
-  std::cout << "## Exercising Threshold plots " << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << "## Exercising Threshold plots " << std::endl;
 
   SiStripThresholdValueHigh histo14;
   histo14.process(connectionString, PI::mk_input(tag, start, start));
-  std::cout << histo14.data() << std::endl;
+  edm::LogPrint("testSiStripPayloadInspector") << histo14.data() << std::endl;
 
   Py_Finalize();
 }


### PR DESCRIPTION
#### PR description:

This PR has three main topics:
   * introduce a comparison plot for Strip LA values between two tags or between two IOVs of the same tag:

![E20FB447-A73C-E94D-87BF-EFB1A9364789](https://user-images.githubusercontent.com/5082376/84302022-fc7eea80-ab54-11ea-8984-a627022ac2ff.png)
  * extend the `SiStripNoisePerDetId` and `SiStripPedestalPerDetId` in order to be able to plot more than one `DetId` at a time.

![3C346EFF-52BB-B143-8042-42567EB38CC9](https://user-images.githubusercontent.com/5082376/84302716-0c4afe80-ab56-11ea-8532-d8ef6235378f.png)

  * percolate the usage of the new class templates defined at https://github.com/cms-sw/cmssw/pull/29622

#### PR validation:

Relies on the existing (and augmented) unit tests.
All the plots have also been checked by hand.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.