### PR TITLE
Reduce boost use in EventFilter/Utilities

### DIFF
--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -107,12 +107,6 @@ void RawEventFileWriterForBU::doOutputEvent(FRDEventMsgView const& msg) {
   //  cms::Adler32((const char*) msg.startAddress(), msg.size(), adlera_, adlerb_);
 }
 
-void RawEventFileWriterForBU::doOutputEventFragment(unsigned char* dataPtr, unsigned long dataSize) {
-  throw cms::Exception("RawEventFileWriterForBU", "doOutputEventFragment") << "Unsupported output mode ";
-
-  //cms::Adler32((const char*) dataPtr, dataSize, adlera_, adlerb_);
-}
-
 void RawEventFileWriterForBU::initialize(std::string const& destinationDir, std::string const& name, int ls) {
   destinationDir_ = destinationDir;
 

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -12,8 +12,10 @@
 #include <cstdio>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
-#include "boost/shared_array.hpp"
+#include <memory>
+#include <vector>
 
 class RawEventFileWriterForBU {
 public:
@@ -22,9 +24,7 @@ public:
   ~RawEventFileWriterForBU();
 
   void doOutputEvent(FRDEventMsgView const& msg);
-  void doOutputEvent(boost::shared_array<unsigned char>& msg){};
-  void doOutputEventFragment(unsigned char* dataPtr, unsigned long dataSize);
-  //void doFlushFile();
+
   uint32 adler32() const { return (adlerb_ << 16) | adlera_; }
 
   void start() {}


### PR DESCRIPTION
#### PR description:
Replaced boost library use for C++ STL alternatives. A shared_ptr to a std::vector should have similar behavior as a boost::shared_vector.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 