### PR TITLE
Reduce boost dependency in IOPool/Streamer

### DIFF
--- a/IOPool/Streamer/bin/BuildFile.xml
+++ b/IOPool/Streamer/bin/BuildFile.xml
@@ -6,7 +6,6 @@
 
   <bin file="CalcAdler32.cpp">
     <use name="FWCore/Utilities"/>
-    <use name="boost"/>
   </bin>
 
 </environment>

--- a/IOPool/Streamer/bin/CalcAdler32.cpp
+++ b/IOPool/Streamer/bin/CalcAdler32.cpp
@@ -1,7 +1,7 @@
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
 
-#include "boost/shared_array.hpp"
+#include <memory>
 
 #include <fstream>
 #include <iostream>
@@ -23,7 +23,7 @@ int main(int argc, char* argv[]) {
   std::ifstream::pos_type size = file.tellg();
   file.seekg(0, std::ios::beg);
 
-  boost::shared_array<char> ptr(new char[1024 * 1024]);
+  auto ptr = std::make_unique<char[]>(1024 * 1024);
   uint32_t a = 1, b = 0;
 
   std::ifstream::pos_type rsize = 0;


### PR DESCRIPTION
#### PR description:
Replaced boost library use for C++ STL alternatives. A shared_ptr to a std::vector should have similar behavior as a boost::shared_vector.
I also used unique_ptr instead of shared_ptr, since it seems like there's no need to use a shared_ptr.
note:
I've not found references to ELmapDump (so maybe it could be deleted)

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 