### PR TITLE
[Payload Inspector]  Remove PY3 check as boost will be built with python3

### DIFF
--- a/CondCore/AlignmentPlugins/test/BuildFile.xml
+++ b/CondCore/AlignmentPlugins/test/BuildFile.xml
@@ -3,7 +3,4 @@
 <use name="Alignment/CommonAlignment"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <bin file="testTrackerAlignmentPayloadInspector.cpp" name="testTrackerAlignmentPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>

--- a/CondCore/HLTPlugins/test/BuildFile.xml
+++ b/CondCore/HLTPlugins/test/BuildFile.xml
@@ -1,7 +1,4 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
 <bin file="testAlCaRecoTriggerBitsPayloadInspector.cpp" name="testAlCaRecoTriggerBitsPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>

--- a/CondCore/RunInfoPlugins/test/BuildFile.xml
+++ b/CondCore/RunInfoPlugins/test/BuildFile.xml
@@ -1,7 +1,4 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
 <bin file="testRunInfoPayloadInspector.cpp" name="testRunInfoPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>

--- a/CondCore/SiPixelPlugins/test/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/test/BuildFile.xml
@@ -4,7 +4,4 @@
 <use name="CondFormats/SiPixelTransient"/>
 <use name="CalibTracker/SiPixelESProducers"/>
 <bin file="testSiPixelPayloadInspector.cpp" name="testPixelPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -145,5 +145,11 @@ int main(int argc, char** argv) {
   histo19.process(connectionString, PI::mk_input(tag, end, end));
   edm::LogPrint("testSiPixelPayloadInspector") << histo19.data() << std::endl;
 
+  inputs.clear();
+#if PY_MAJOR_VERSION >= 3
+  // TODO I don't know why this Py_INCREF is necessary...
+  Py_INCREF(inputs.ptr());
+#endif
+
   Py_Finalize();
 }

--- a/CondCore/SiStripPlugins/test/BuildFile.xml
+++ b/CondCore/SiStripPlugins/test/BuildFile.xml
@@ -3,7 +3,4 @@
 <use name="FWCore/PluginManager"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <bin file="testSiStripPayloadInspector.cpp" name="testSiStripPayloadInspector">
-  <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
-  </ifrelease>
 </bin>

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -142,5 +142,11 @@ int main(int argc, char** argv) {
   histo14.process(connectionString, PI::mk_input(tag, start, start));
   std::cout << histo14.data() << std::endl;
 
+  inputs.clear();
+#if PY_MAJOR_VERSION >= 3
+  // TODO I don't know why this Py_INCREF is necessary...
+  Py_INCREF(inputs.ptr());
+#endif
+
   Py_Finalize();
 }

--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -10,7 +10,4 @@
 </bin>
 
 <bin file="testPngHistograms.cpp" name="testPngHistograms">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>


### PR DESCRIPTION
#### PR description:
**EDIT**: This PR now contains also #30099.

   * commit b2430de8c062709523a64ab5501ff9a9e9fcd7d9 Remove PY3 checks for unit tests. This was needed as boost_python was build with python2 while in PY3 IBs the default python was python3. cms-sw/cmsdist#5903 should now build boost python with python3 in PY3 IBs, so there is no need to have these speical conditions in BuildFile.xml

   * commit 47db651f030e95acade42adda7cecc0088f92980 This is an attempt to fix issue reported at https://github.com/cms-sw/cmssw/pull/30099#issuecomment-638596697.

#### PR validation:

I tested the fix with the recipe proposed here: https://github.com/cms-sw/cmssw/pull/30099#issuecomment-638733475 
```
/cvmfs/cms-ib.cern.ch/cms-bot/test-prs.sh cms-sw/cmssw#30099 cms-sw/cmsdist#5903
cd CMSSW_11_2_PY3_X_2020-06-03-2300/
cmsenv
scram build -j 8
test/slc7_amd64_gcc820/testSiStripPayloadInspector
```

and it runs fine with the fix. 
I also tested it in the main branch in `CMSSW_11_2_X_2020-06-10-2300` and it runs fine.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.
