### PR TITLE
Updates to HCAL Run 3 conditions

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -67,17 +67,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '111X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '112X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '111X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '111X_mcRun3_2021cosmics_realistic_deco_v4',
+    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' :  '111X_mcRun3_2021_realistic_HI_v5',
+    'phase1_2021_realistic_hi' :  '112X_mcRun3_2021_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '111X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v4', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION


#### PR description:

This PR performs several updates to HCAL conditions for Run 3.

HB and HE have been recalibrated using isolated tracks. The energy scale needed adjustment after changes to the local HCAL reconstruction since 2019 and an asymmetry in the HB-HE transition region is fixed. The HcalRespCorrs are updated for all Run 3 scenarios.

In addition, `HcalSiPMParameters`, `HcalPedestals`, and `HcalPedestalWidths` have been updated for 2021 scenarios

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_design_v4/112X_mcRun3_2021_design_v1 

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_realistic_v4/112X_mcRun3_2021_realistic_v1

**2021 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021cosmics_realistic_deco_v4/112X_mcRun3_2021cosmics_realistic_deco_v1 

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_realistic_HI_v5/112X_mcRun3_2021_realistic_HI_v1

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2023_realistic_v4/112X_mcRun3_2023_realistic_v1 

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2024_realistic_v4/112X_mcRun3_2024_realistic_v1 

#### PR validation:

See the June 8 AlCaDB meeting (https://indico.cern.ch/event/927125/) and HN followup (https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4305/1/1.html) for details.

In addition, a technical test was performed:

`runTheMatrix.py -l limited,7.23,159.0,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but may be backported to 11_1_X.
