### PR TITLE
Herwig7p2 mpi settings

### DIFF
--- a/Configuration/Generator/python/Herwig7Settings/Herwig7CH2TuneSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7CH2TuneSettings_cfi.py
@@ -28,16 +28,13 @@ herwig7CH2SettingsBlock = cms.PSet(
         ),
     herwig7CH2AlphaS = cms.vstring(
         'cd /Herwig/Shower',
-        'set AlphaQCD:AlphaMZ 0.118',
+        'set AlphaQCD:AlphaIn 0.118',
         'cd /'
         ),
     herwig7CH2MPISettings = cms.vstring(
-        'read snippets/SoftModel.in',
         'set /Herwig/Hadronization/ColourReconnector:ReconnectionProbability 0.479',
         'set /Herwig/UnderlyingEvent/MPIHandler:pTmin0 3.138',
         'set /Herwig/UnderlyingEvent/MPIHandler:InvRadius 1.174',
         'set /Herwig/UnderlyingEvent/MPIHandler:Power 0.1203',
-        'set /Herwig/Partons/RemnantDecayer:ladderPower -0.08',
-        'set /Herwig/Partons/RemnantDecayer:ladderNorm 0.95',
                                 )
 )

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7CH3TuneSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7CH3TuneSettings_cfi.py
@@ -36,7 +36,5 @@ herwig7CH3SettingsBlock = cms.PSet(
         'set /Herwig/UnderlyingEvent/MPIHandler:pTmin0 3.04',
         'set /Herwig/UnderlyingEvent/MPIHandler:InvRadius 1.284',
         'set /Herwig/UnderlyingEvent/MPIHandler:Power 0.1362',
-        'set /Herwig/Partons/RemnantDecayer:ladderPower -0.08',
-        'set /Herwig/Partons/RemnantDecayer:ladderNorm 0.95',
                                 )
 )

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7CH3TuneSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7CH3TuneSettings_cfi.py
@@ -28,11 +28,10 @@ herwig7CH3SettingsBlock = cms.PSet(
         ),
     herwig7CH3AlphaS = cms.vstring(
         'cd /Herwig/Shower',
-        'set AlphaQCD:AlphaMZ 0.118',
+        'set AlphaQCD:AlphaIn 0.118',
         'cd /'
         ),
     herwig7CH3MPISettings = cms.vstring(
-        'read snippets/SoftModel.in',
         'set /Herwig/Hadronization/ColourReconnector:ReconnectionProbability 0.4712',
         'set /Herwig/UnderlyingEvent/MPIHandler:pTmin0 3.04',
         'set /Herwig/UnderlyingEvent/MPIHandler:InvRadius 1.284',

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7_7p1SettingsFor7p2_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7_7p1SettingsFor7p2_cfi.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+herwig7p1SettingsFor7p2Block = cms.PSet(
+    hw_7p1SettingsFor7p2 = cms.vstring(
+        # Recoil scheme. Dot product + veto scheme is new default in 7.2
+        # Q2 was default in 7.1
+        'read snippets/Tune-Q2.in',
+
+        # Baryonic CR is default in 7.2
+        # Plain CR was used in 7.1 and for CH tunes
+        'set /Herwig/Hadronization/ColourReconnector:Algorithm Plain',
+
+        # Changes energy extrapolation of pt_min
+        # Default in 7.2 is PowerModified, offset/minimum for low com (200 GeV)
+        # Power was default in 7.1.
+        'set /Herwig/UnderlyingEvent/MPIHandler:EnergyExtrapolation Power',
+
+        # In 7p2, don't allow MB events to start from sea quarks
+        # 7p1 allowed this to happen.  Has effect/bias on MB distributions (makes them softer)
+        'set /Herwig/MatrixElements/MEMinBias:OnlyValence 0',
+
+        # Soft ladder transverse momentum sampled from gaussian tail below ptmin for first particle
+        # Remainder are sampled flat below the pt of the first particle
+        # In 7.1, all particles were sampled from gaussian tail, option 0
+        'set /Herwig/Partons/RemnantDecayer:PtDistribution 0',
+
+        # ladderMult is now constant wrt energy.
+        # Parametrisation cannot be changed back to energy dependent form in Herwig7.1
+        #  Set to value for 13 TeV from CH3
+        'set /Herwig/Partons/RemnantDecayer:ladderMult 0.63',
+        'set /Herwig/Partons/RemnantDecayer:ladderbFactor 0.0',
+
+        # Diffraction ratio from CH3 in 7p1
+        # Taken from log files stating diffractive and non-diffractive cross section
+        'set /Herwig/UnderlyingEvent/MPIHandler:DiffractiveRatio 0.21',
+        )
+)


### PR DESCRIPTION
#### PR description:

Updating Herwig7 MPI settings for Herwig7.2

- Rename of AlphaMZ to AlphaIn
- Remove redundant/obsolete settings in tune configs
- Added additional settings block that replicate the MPI model of Herwig7.1 in Herwig7.2, which is required for using the CH tunes.

#### PR validation:

Tested by generating MB events locally with these settings.  Validation and details of the changes were presented at the [GEN meeting on 25th May 2020](https://indico.cern.ch/event/916119/#3-ch3-with-herwig-72)
