### PR TITLE
Remove CondFormats from DataFormats

### DIFF
--- a/CondFormats/L1TObjects/interface/L1GtDefinitions.h
+++ b/CondFormats/L1TObjects/interface/L1GtDefinitions.h
@@ -22,6 +22,7 @@
 #include <string>
 
 // user include files
+#include "DataFormats/L1GlobalTrigger/interface/L1GtDefinitions.h"
 
 /// board types in GT
 enum L1GtBoardType { GTFE, FDL, PSB, GMT, TCS, TIM, BoardNull };
@@ -88,26 +89,6 @@ std::string l1GtPsbQuadEnumToString(const L1GtPsbQuad&);
 /// TypeBptx: BPTX (logical result only; definition in BPTX system)
 /// TypeExternal: external conditions (logical result only; definition in L1 GT external systems)
 /// Type2CorrWithOverlapRemoval: three particles, first two with spatial correlations among them, third used for removal if overlap
-enum L1GtConditionType {
-  TypeNull,
-  Type1s,
-  Type2s,
-  Type2wsc,
-  Type2cor,
-  Type3s,
-  Type4s,
-  TypeETM,
-  TypeETT,
-  TypeHTT,
-  TypeHTM,
-  TypeJetCounts,
-  TypeCastor,
-  TypeHfBitCounts,
-  TypeHfRingEtSums,
-  TypeBptx,
-  TypeExternal,
-  Type2corWithOverlapRemoval
-};
 
 struct L1GtConditionTypeStringToEnum {
   const char* label;
@@ -117,21 +98,6 @@ struct L1GtConditionTypeStringToEnum {
 L1GtConditionType l1GtConditionTypeStringToEnum(const std::string&);
 std::string l1GtConditionTypeEnumToString(const L1GtConditionType&);
 
-/// condition categories
-enum L1GtConditionCategory {
-  CondNull,
-  CondMuon,
-  CondCalo,
-  CondEnergySum,
-  CondJetCounts,
-  CondCorrelation,
-  CondCastor,
-  CondHfBitCounts,
-  CondHfRingEtSums,
-  CondBptx,
-  CondExternal,
-  CondCorrelationWithOverlapRemoval
-};
 
 struct L1GtConditionCategoryStringToEnum {
   const char* label;

--- a/CondFormats/L1TObjects/interface/L1GtDefinitions.h
+++ b/CondFormats/L1TObjects/interface/L1GtDefinitions.h
@@ -98,7 +98,6 @@ struct L1GtConditionTypeStringToEnum {
 L1GtConditionType l1GtConditionTypeStringToEnum(const std::string&);
 std::string l1GtConditionTypeEnumToString(const L1GtConditionType&);
 
-
 struct L1GtConditionCategoryStringToEnum {
   const char* label;
   L1GtConditionCategory value;

--- a/DataFormats/L1GlobalTrigger/interface/L1GtDefinitions.h
+++ b/DataFormats/L1GlobalTrigger/interface/L1GtDefinitions.h
@@ -1,0 +1,41 @@
+#ifndef DataFormats_L1GlobalTrigger_L1GtDefinitions_h
+#define DataFormats_L1GlobalTrigger_L1GtDefinitions_h
+
+enum L1GtConditionType {
+  TypeNull,
+  Type1s,
+  Type2s,
+  Type2wsc,
+  Type2cor,
+  Type3s,
+  Type4s,
+  TypeETM,
+  TypeETT,
+  TypeHTT,
+  TypeHTM,
+  TypeJetCounts,
+  TypeCastor,
+  TypeHfBitCounts,
+  TypeHfRingEtSums,
+  TypeBptx,
+  TypeExternal,
+  Type2corWithOverlapRemoval
+};
+
+/// condition categories
+enum L1GtConditionCategory {
+  CondNull,
+  CondMuon,
+  CondCalo,
+  CondEnergySum,
+  CondJetCounts,
+  CondCorrelation,
+  CondCastor,
+  CondHfBitCounts,
+  CondHfRingEtSums,
+  CondBptx,
+  CondExternal,
+  CondCorrelationWithOverlapRemoval
+};
+
+#endif

--- a/DataFormats/PatCandidates/BuildFile.xml
+++ b/DataFormats/PatCandidates/BuildFile.xml
@@ -12,7 +12,7 @@
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/BTauReco"/>
-<use name="CondFormats/L1TObjects"/>
+<use name="DataFormats/L1GlobalTrigger"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/HLTReco"/>
 <use name="DataFormats/CaloTowers"/>

--- a/DataFormats/PatCandidates/interface/TriggerCondition.h
+++ b/DataFormats/PatCandidates/interface/TriggerCondition.h
@@ -26,7 +26,7 @@
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefVectorIterator.h"
-#include "CondFormats/L1TObjects/interface/L1GtFwd.h"
+#include "DataFormats/L1GlobalTrigger/interface/L1GtDefinitions.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 
 namespace pat {

--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -17,6 +17,7 @@
 <use name="IOPool/Provenance"/>
 <use name="DQMServices/Core"/>
 <use name="CondFormats/BTauObjects"/>
+<use name="CondFormats/L1TObjects"/>
 <use name="CondTools/BTau"/>
 <use name="fastjet"/>
 <use name="fastjet-contrib"/>


### PR DESCRIPTION
Minimal move of some enums out of CondFormats/L1TObjects into DataFormats. Removes the incorrect dependency of DataFormats on CondFormats.