### PR TITLE
Updated L1T tags to address CMSSW issue #29237 [11_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,11 +16,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_v3',
+    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_v7',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '110X_mcRun2_asymptotic_v6',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_v9',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v5',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v8',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2


### PR DESCRIPTION
#### PR description:

This PR is a backport of #30151. The GT diffs are identical to those in the PR to master:

**2016 MC pre-VFP**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_preVFP_v3/110X_mcRun2_asymptotic_preVFP_v7 

**2016 MC post-VFP**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_v6/110X_mcRun2_asymptotic_v9 

**2016 cosmics (tracker deco mode) MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2cosmics_startup_deco_v5/110X_mcRun2cosmics_startup_deco_v8 

In all three cases, the differences with respect to the corresponding GTs in the master branch is the addition of `AlCaRecoTriggerBitsRcd` in 11_1_X:

**2016 MC pre-VFP**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_preVFP_v7/111X_mcRun2_asymptotic_preVFP_v1  

**2016 MC post-VFP**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_v9/111X_mcRun2_asymptotic_v1 

**2016 cosmics (tracker deco mode) MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2cosmics_startup_deco_v8/111X_mcRun2cosmics_startup_deco_v1  

#### PR validation:

See the description of PR #30151 for details. In addition, a technical test was performed:

`runTheMatrix.py -l limited --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #30151. These updated conditions correct the L1T simulation for 2016 MC and these changes are needed to avoid the irreproducibility described in issue #29237.