### PR TITLE
DAQ: support for FRD file header with file locking

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -108,7 +108,12 @@ namespace evf {
     void removeFile(unsigned int ls, unsigned int index);
     void removeFile(std::string);
 
-    FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, uint64_t& lockWaitTime, bool& setExceptionState);
+    FileStatus updateFuLock(unsigned int& ls,
+                            std::string& nextFile,
+                            uint32_t& fsize,
+                            uint16_t& rawHeaderSize,
+                            uint64_t& lockWaitTime,
+                            bool& setExceptionState);
     void tryInitializeFuLockFile();
     unsigned int getRunNumber() const { return run_; }
     void lockInitLock();
@@ -179,7 +184,13 @@ namespace evf {
     static struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid);
 
   private:
-    bool bumpFile(unsigned int& ls, unsigned int& index, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, int maxLS, bool& setExceptionState);
+    bool bumpFile(unsigned int& ls,
+                  unsigned int& index,
+                  std::string& nextFile,
+                  uint32_t& fsize,
+                  uint16_t& rawHeaderSize,
+                  int maxLS,
+                  bool& setExceptionState);
     void openFULockfileStream(bool create);
     std::string inputFileNameStem(const unsigned int ls, const unsigned int index) const;
     std::string outputFileNameStem(const unsigned int ls, std::string const& stream) const;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -108,7 +108,7 @@ namespace evf {
     void removeFile(unsigned int ls, unsigned int index);
     void removeFile(std::string);
 
-    FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, uint64_t& lockWaitTime);
+    FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, uint64_t& lockWaitTime, bool& setExceptionState);
     void tryInitializeFuLockFile();
     unsigned int getRunNumber() const { return run_; }
     void lockInitLock();
@@ -179,7 +179,7 @@ namespace evf {
     static struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid);
 
   private:
-    bool bumpFile(unsigned int& ls, unsigned int& index, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, int maxLS);
+    bool bumpFile(unsigned int& ls, unsigned int& index, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, int maxLS, bool& setExceptionState);
     void openFULockfileStream(bool create);
     std::string inputFileNameStem(const unsigned int ls, const unsigned int index) const;
     std::string outputFileNameStem(const unsigned int ls, std::string const& stream) const;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -108,7 +108,7 @@ namespace evf {
     void removeFile(unsigned int ls, unsigned int index);
     void removeFile(std::string);
 
-    FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint64_t& lockWaitTime);
+    FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, uint64_t& lockWaitTime);
     void tryInitializeFuLockFile();
     unsigned int getRunNumber() const { return run_; }
     void lockInitLock();
@@ -132,12 +132,14 @@ namespace evf {
                                   bool requireHeader,
                                   bool retry,
                                   bool closeFile);
+    bool rawFileHasHeader(std::string const& rawSourcePath, uint16_t& rawHeaderSize);
     int grabNextJsonFromRaw(std::string const& rawSourcePath,
                             int& rawFd,
                             uint16_t& rawHeaderSize,
                             int64_t& fileSizeFromHeader,
                             bool& fileFound,
-                            uint32_t serverLS);
+                            uint32_t serverLS,
+                            bool closeFile);
     int grabNextJsonFile(std::string const& jsonSourcePath,
                          std::string const& rawSourcePath,
                          int64_t& fileSizeFromJson,
@@ -177,7 +179,7 @@ namespace evf {
     static struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid);
 
   private:
-    bool bumpFile(unsigned int& ls, unsigned int& index, std::string& nextFile, uint32_t& fsize, int maxLS);
+    bool bumpFile(unsigned int& ls, unsigned int& index, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, int maxLS);
     void openFULockfileStream(bool create);
     std::string inputFileNameStem(const unsigned int ls, const unsigned int index) const;
     std::string outputFileNameStem(const unsigned int ls, std::string const& stream) const;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -647,7 +647,7 @@ namespace evf {
             edm::LogError("EvFDaqDirector")
                 << "seek on fu read/write lock for updating failed with error " << strerror(errno);
             setExceptionState = true;
-            return noFile; 
+            return noFile;
           }
         } else if (currentLs < readLs) {
           //there is no new file in next LS (yet), but lock file can be updated to the next LS
@@ -663,7 +663,7 @@ namespace evf {
             edm::LogError("EvFDaqDirector")
                 << "seek on fu read/write lock for updating failed with error " << strerror(errno);
             setExceptionState = true;
-            return noFile; 
+            return noFile;
           }
         }
       } else {
@@ -770,8 +770,13 @@ namespace evf {
     return boost::lexical_cast<int>(data);
   }
 
-  bool EvFDaqDirector::bumpFile(
-      unsigned int& ls, unsigned int& index, std::string& nextFile, uint32_t& fsize, uint16_t& rawHeaderSize, int maxLS, bool& setExceptionState) {
+  bool EvFDaqDirector::bumpFile(unsigned int& ls,
+                                unsigned int& index,
+                                std::string& nextFile,
+                                uint32_t& fsize,
+                                uint16_t& rawHeaderSize,
+                                int maxLS,
+                                bool& setExceptionState) {
     if (previousFileSize_ != 0) {
       if (!fms_) {
         fms_ = (FastMonitoringService*)(edm::Service<evf::MicroStateService>().operator->());
@@ -800,7 +805,6 @@ namespace evf {
     }
     // 2. No file -> lumi ended? (and how many?)
     else {
-
       // 3. No file -> check for standalone raw file
       std::string nextFileRaw = getRawFilePath(ls, index);
       if (stat(nextFileRaw.c_str(), &buf) == 0 && rawFileHasHeader(nextFileRaw, rawHeaderSize)) {
@@ -808,7 +812,7 @@ namespace evf {
         nextFile = nextFileRaw;
         return true;
       }
- 
+
       std::string BUEoLSFile = getEoLSFilePathOnBU(ls);
 
       if (stat(BUEoLSFile.c_str(), &buf) == 0) {
@@ -1045,11 +1049,10 @@ namespace evf {
   }
 
   bool EvFDaqDirector::rawFileHasHeader(std::string const& rawSourcePath, uint16_t& rawHeaderSize) {
-
-    int infile; 
+    int infile;
     if ((infile = ::open(rawSourcePath.c_str(), O_RDONLY)) < 0) {
-      edm::LogWarning("EvFDaqDirector")
-          << "rawFileHasHeader - failed to open input file -: " << rawSourcePath << " : " << strerror(errno);
+      edm::LogWarning("EvFDaqDirector") << "rawFileHasHeader - failed to open input file -: " << rawSourcePath << " : "
+                                        << strerror(errno);
       return false;
     }
     constexpr std::size_t buf_sz = sizeof(FRDFileHeader_v1);  //try to read v1 FRD header size
@@ -1075,7 +1078,7 @@ namespace evf {
 
     close(infile);
 
-    if (frd_version>0) {
+    if (frd_version > 0) {
       rawHeaderSize = fileHead.headerSize_;
       return true;
     }

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -167,7 +167,7 @@ FedRawDataInputSource::~FedRawDataInputSource() {
   //delete any remaining open files
   for (auto it = filesToDelete_.begin(); it != filesToDelete_.end(); it++)
     it->second.reset();
-  
+
   if (startedSupervisorThread_) {
     readSupervisorThread_->join();
   } else {
@@ -838,7 +838,8 @@ void FedRawDataInputSource::readSupervisor() {
             ls = lsFromRaw;
         }
       } else if (!useFileBroker_)
-        status = daqDirector_->updateFuLock(ls, nextFile, fileSizeIndex, rawHeaderSize, thisLockWaitTimeUs, setExceptionState_);
+        status = daqDirector_->updateFuLock(
+            ls, nextFile, fileSizeIndex, rawHeaderSize, thisLockWaitTimeUs, setExceptionState_);
       else {
         status = daqDirector_->getNextFromFileBroker(currentLumiSection,
                                                      ls,
@@ -876,7 +877,8 @@ void FedRawDataInputSource::readSupervisor() {
           fms_->setInStateSup(evf::FastMonitoringThread::inRunEnd);
         usleep(100000);
         //now all files should have appeared in ramdisk, check again if any raw files were left behind
-        status = daqDirector_->updateFuLock(ls, nextFile, fileSizeIndex, rawHeaderSize, thisLockWaitTimeUs, setExceptionState_);
+        status = daqDirector_->updateFuLock(
+            ls, nextFile, fileSizeIndex, rawHeaderSize, thisLockWaitTimeUs, setExceptionState_);
         if (currentLumiSection != ls && status == evf::EvFDaqDirector::runEnded)
           status = evf::EvFDaqDirector::noFile;
       }
@@ -1006,14 +1008,13 @@ void FedRawDataInputSource::readSupervisor() {
             int rawFdEmpty = -1;
             uint16_t rawHeaderCheck;
             bool fileFound;
-            eventsInNewFile = daqDirector_->grabNextJsonFromRaw(nextFile, rawFdEmpty, rawHeaderCheck, fileSizeFromMetadata, fileFound, 0, true);
-            assert(fileFound && rawHeaderCheck==rawHeaderSize);
+            eventsInNewFile = daqDirector_->grabNextJsonFromRaw(
+                nextFile, rawFdEmpty, rawHeaderCheck, fileSizeFromMetadata, fileFound, 0, true);
+            assert(fileFound && rawHeaderCheck == rawHeaderSize);
             daqDirector_->unlockFULocal();
-          }
-          else
+          } else
             eventsInNewFile = daqDirector_->grabNextJsonFileAndUnlock(nextFile);
-        }
-        else
+        } else
           eventsInNewFile = serverEventsInNewFile;
         assert(eventsInNewFile >= 0);
         assert((eventsInNewFile > 0) ==
@@ -1408,12 +1409,11 @@ void FedRawDataInputSource::readNextChunkIntoBuffer(InputFile* file) {
 
   if (fileDescriptor_ < 0) {
     bufferInputRead_ = 0;
-    if (file->rawFd_ == -1) { 
+    if (file->rawFd_ == -1) {
       fileDescriptor_ = open(file->fileName_.c_str(), O_RDONLY);
       if (file->rawHeaderSize_)
         lseek(fileDescriptor_, file->rawHeaderSize_, SEEK_SET);
-    }
-    else
+    } else
       fileDescriptor_ = file->rawFd_;
 
     //skip header size in destination buffer (chunk position was already adjusted)
@@ -1429,7 +1429,9 @@ void FedRawDataInputSource::readNextChunkIntoBuffer(InputFile* file) {
     }
     //fill chunk (skipping file header if present)
     for (unsigned int i = 0; i < readBlocks_; i++) {
-      const ssize_t last = ::read(fileDescriptor_, (void*)(file->chunks_[0]->buf_ + existingSize), eventChunkBlock_ - (i==readBlocks_ -1 ? existingSize : 0));
+      const ssize_t last = ::read(fileDescriptor_,
+                                  (void*)(file->chunks_[0]->buf_ + existingSize),
+                                  eventChunkBlock_ - (i == readBlocks_ - 1 ? existingSize : 0));
       bufferInputRead_ += last;
       existingSize += last;
     }
@@ -1449,7 +1451,7 @@ void FedRawDataInputSource::readNextChunkIntoBuffer(InputFile* file) {
 
       //calculate amount of data that can be added
       const uint32_t blockcount = file->chunkPosition_ / eventChunkBlock_;
-      const uint32_t leftsize =  file->chunkPosition_ % eventChunkBlock_;
+      const uint32_t leftsize = file->chunkPosition_ % eventChunkBlock_;
 
       for (uint32_t i = 0; i < blockcount; i++) {
         const ssize_t last =

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -838,7 +838,7 @@ void FedRawDataInputSource::readSupervisor() {
             ls = lsFromRaw;
         }
       } else if (!useFileBroker_)
-        status = daqDirector_->updateFuLock(ls, nextFile, fileSizeIndex, rawHeaderSize, thisLockWaitTimeUs);
+        status = daqDirector_->updateFuLock(ls, nextFile, fileSizeIndex, rawHeaderSize, thisLockWaitTimeUs, setExceptionState_);
       else {
         status = daqDirector_->getNextFromFileBroker(currentLumiSection,
                                                      ls,
@@ -876,7 +876,7 @@ void FedRawDataInputSource::readSupervisor() {
           fms_->setInStateSup(evf::FastMonitoringThread::inRunEnd);
         usleep(100000);
         //now all files should have appeared in ramdisk, check again if any raw files were left behind
-        status = daqDirector_->updateFuLock(ls, nextFile, fileSizeIndex, rawHeaderSize, thisLockWaitTimeUs);
+        status = daqDirector_->updateFuLock(ls, nextFile, fileSizeIndex, rawHeaderSize, thisLockWaitTimeUs, setExceptionState_);
         if (currentLumiSection != ls && status == evf::EvFDaqDirector::runEnded)
           status = evf::EvFDaqDirector::noFile;
       }


### PR DESCRIPTION


#### PR description:

- raw (FRD) file format for DAQ3 has recently been modified to include metadata in the header, so json files can be removed (due to 2 MB block constraint in huge-page ramdisk). Initially support was added with file broker mode. Now it is added to the file-locking mode which is used in testing and in Hilton.
- Support for the file header is also added to the single-buffer mode.
- Error handling in file locking mode is improved. It also allows unit test to catch problem in case JSON (raw) files can not be found. Since throwing exception is an issue in separate file discovery thread used by input source, error condition is propagated to the main thread instead of throwing directly.

PR includes also two bug fixes:
 - unique_ptr release() calls do not execute destructor of allocated object wrapped with unique_ptr. This created a (small) memory leak and also caused processed files to not be deleted in single-threaded input source mode (which is available, but not used by default in production setup).

 - in the check of non-opened fd value comparision was with 0, it should be compared with -1.

#### PR validation:

Verified to work correctly in DAQ test system in single-buffered/multi-buffered running modes, with file broker/locking, and with/without file header (and combinations).


