### PR TITLE
add missing dependencies to DataFormats/EgammaTrackReco

### DIFF
--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,7 +1,11 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/EgammaReco"/>
+<use name="DataFormats/CaloRecHit"/>
+<use name="DataFormats/TrackCandidate"/>
+<use name="DataFormats/TrackingRecHit"/>
 <use name="clhepheader"/>
 <export>
   <lib name="1"/>
 </export>
+


### PR DESCRIPTION
Modules IB shows errors due to missing DataFormats/CaloRecHit dependency in DataFormats/EgammaTrackReco. I've added that and the other missing dependencies.