### PR TITLE
HCAL - HB TDC digi default to non-packed backport to 11_0_X

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -285,7 +285,7 @@ void HcalDigiToRawuHTR::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.addUntracked<int>("Verbosity", 0);
   desc.add<int>("tdc1", 4);
   desc.add<int>("tdc2", 20);
-  desc.add<bool>("packHBTDC", true);
+  desc.add<bool>("packHBTDC", false);
   desc.add<std::string>("ElectronicsMap", "");
   desc.add<edm::InputTag>("QIE10", edm::InputTag("simHcalDigis", "HFQIE10DigiCollection"));
   desc.add<edm::InputTag>("QIE11", edm::InputTag("simHcalDigis", "HBHEQIE11DigiCollection"));


### PR DESCRIPTION
Backporting to 11_0_X:

This is HCAL DPG request. The previous default TDC value was packed/compressed, forcing people to make separate MC production requests with customized commands to unpack the value for hcal TDC studies. By changing this default behavior all centrally produced samples using this release and above will be available for hcal TDC studies without having to ask for separate production.

Since currently TDC value is not used anywhere else in the cmssw, this change won't affect anything else.
