### PR TITLE
Reduce boost dependency in CondCore/PopCon

### DIFF
--- a/CondCore/PopCon/interface/PopCon.h
+++ b/CondCore/PopCon/interface/PopCon.h
@@ -1,4 +1,3 @@
-
 #ifndef POPCON_POPCON_H
 #define POPCON_POPCON_H
 //
@@ -15,10 +14,10 @@
 
 #include "CondCore/CondDB/interface/Time.h"
 
-#include <boost/bind.hpp>
 #include <algorithm>
-#include <vector>
+#include <functional>
 #include <string>
+#include <vector>
 
 #include <iostream>
 
@@ -122,10 +121,10 @@ namespace popcon {
 
     std::for_each(payloads.begin(),
                   payloads.end(),
-                  boost::bind(&popcon::PopCon::writeOne<value_type>,
-                              this,
-                              boost::bind(&Container::value_type::payload, _1),
-                              boost::bind(&Container::value_type::time, _1)));
+                  std::bind(&popcon::PopCon::writeOne<value_type>,
+                            this,
+                            std::bind(&Container::value_type::payload, std::placeholders::_1),
+                            std::bind(&Container::value_type::time, std::placeholders::_1)));
 
     finalize(payloads.empty() ? Time_t(0) : payloads.back().time);
   }

--- a/CondCore/PopCon/interface/PopConSourceHandler.h
+++ b/CondCore/PopCon/interface/PopConSourceHandler.h
@@ -4,11 +4,11 @@
 #include "CondCore/CondDB/interface/Session.h"
 #include "CondCore/CondDB/interface/Time.h"
 
-#include <boost/bind.hpp>
 #include <algorithm>
+#include <functional>
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace cond {
   class Summary;
@@ -120,9 +120,9 @@ namespace popcon {
     void sort() {
       std::sort(m_triplets.begin(),
                 m_triplets.end(),
-                boost::bind(std::less<cond::Time_t>(),
-                            boost::bind(&Container::value_type::time, _1),
-                            boost::bind(&Container::value_type::time, _2)));
+                std::bind(std::less<cond::Time_t>(),
+                          std::bind(&Container::value_type::time, std::placeholders::_1),
+                          std::bind(&Container::value_type::time, std::placeholders::_2)));
     }
 
     // make sure to create a new one each time...
@@ -133,11 +133,11 @@ namespace popcon {
     void convertFromOld() {
       std::for_each(m_to_transfer.begin(),
                     m_to_transfer.end(),
-                    boost::bind(&self::add,
-                                this,
-                                boost::bind(&OldContainer::value_type::first, _1),
-                                boost::bind(&self::dummySummary, this, _1),
-                                boost::bind(&OldContainer::value_type::second, _1)));
+                    std::bind(&self::add,
+                              this,
+                              std::bind(&OldContainer::value_type::first, std::placeholders::_1),
+                              std::bind(&self::dummySummary, this, std::placeholders::_1),
+                              std::bind(&OldContainer::value_type::second, std::placeholders::_1)));
     }
 
   protected:


### PR DESCRIPTION
#### PR description:
Replaced boost binding for stl library ones. The code should behave identically.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 