### PR TITLE
Reduce boost dependency in CondFormats/SiStripObjects

### DIFF
--- a/CondFormats/SiStripObjects/interface/SiStripBaseDelay.h
+++ b/CondFormats/SiStripObjects/interface/SiStripBaseDelay.h
@@ -3,11 +3,10 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <vector>
 #include <algorithm>
 #include <cstdint>
 #include <sstream>
-#include <boost/bind/bind.hpp>
+#include <vector>
 
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
 

--- a/CondFormats/SiStripObjects/src/SiStripBaseDelay.cc
+++ b/CondFormats/SiStripObjects/src/SiStripBaseDelay.cc
@@ -5,15 +5,13 @@
 #include <iostream>
 #include <sstream>
 
-#include <boost/bind.hpp>
-
 bool SiStripBaseDelay::put(const uint32_t detId, const uint16_t coarseDelay, const uint16_t fineDelay) {
   delays_.push_back(Delay(detId, coarseDelay, fineDelay));
   return true;
 }
 
 uint16_t SiStripBaseDelay::coarseDelay(const uint32_t detId) {
-  delayConstIt it = std::find_if(delays_.begin(), delays_.end(), boost::bind(&Delay::detId, _1) == detId);
+  delayConstIt it = std::find_if(delays_.begin(), delays_.end(), [&](auto& x) { return x.detId == detId; });
   if (it != delays_.end()) {
     return it->coarseDelay;
   }
@@ -21,7 +19,7 @@ uint16_t SiStripBaseDelay::coarseDelay(const uint32_t detId) {
 }
 
 uint16_t SiStripBaseDelay::fineDelay(const uint32_t detId) const {
-  delayConstIt it = std::find_if(delays_.begin(), delays_.end(), boost::bind(&Delay::detId, _1) == detId);
+  delayConstIt it = std::find_if(delays_.begin(), delays_.end(), [&](auto& x) { return x.detId == detId; });
   if (it != delays_.end()) {
     return it->fineDelay;
   }
@@ -29,7 +27,7 @@ uint16_t SiStripBaseDelay::fineDelay(const uint32_t detId) const {
 }
 
 double SiStripBaseDelay::delay(const uint32_t detId) const {
-  delayConstIt it = std::find_if(delays_.begin(), delays_.end(), boost::bind(&Delay::detId, _1) == detId);
+  delayConstIt it = std::find_if(delays_.begin(), delays_.end(), [&](auto& x) { return x.detId == detId; });
   if (it != delays_.end()) {
     return makeDelay(it->coarseDelay, it->fineDelay);
   }


### PR DESCRIPTION
#### PR description:
Replaced boost binding for lambda expression. The std::bind version would look less clean. The code should have the same behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 