### PR TITLE
Removed boost use in DQM/SiStripMonitorHardware

### DIFF
--- a/DQM/SiStripMonitorHardware/BuildFile.xml
+++ b/DQM/SiStripMonitorHardware/BuildFile.xml
@@ -14,7 +14,6 @@
 <use name="CommonTools/UtilAlgos"/>
 <use name="EventFilter/SiStripRawToDigi"/>
 <use name="DQM/SiStripCommon"/>
-<use name="boost"/>
 <use name="CondFormats/DataRecord"/>
 <use name="DPGAnalysis/SiStripTools"/>
 <use name="CommonTools/TrackerMap"/>

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
@@ -2,7 +2,7 @@
 #include "DQM/SiStripMonitorHardware/interface/SiStripFEDEmulator.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "boost/bind.hpp"
+#include <functional>
 
 using edm::LogError;
 using edm::LogInfo;
@@ -195,7 +195,7 @@ namespace sistrip {
     transform(cmSubtrDetSetData.begin(),
               cmSubtrDetSetData.end(),
               back_inserter(cmSubtrRawDigis),
-              boost::bind(&SiStripRawDigi::adc, _1));
+              std::bind(&SiStripRawDigi::adc, std::placeholders::_1));
     algorithms->suppressor->suppress(cmSubtrRawDigis, 0, zsDetSetData);
 
   }  //end of FEDEmulator::zeroSuppress method.

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
@@ -20,10 +20,10 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
+#include <cstdint>
 #include <memory>
 #include <string>
-#include "boost/scoped_array.hpp"
-#include <cstdint>
+#include <vector>
 
 using edm::LogError;
 using edm::LogInfo;
@@ -102,7 +102,7 @@ namespace sistrip {
     pSummary->bx(fedBxNumber);
     //create a fake trigger FED buffer to take comissioning parameters from
     const int maxTriggerFedBufferSize = 84;
-    boost::scoped_array<uint32_t> fakeTriggerFedData(new uint32_t[maxTriggerFedBufferSize]);
+    std::vector<uint32_t> fakeTriggerFedData(maxTriggerFedBufferSize);
     for (uint8_t i = 0; i < maxTriggerFedBufferSize; ++i) {
       fakeTriggerFedData[i] = 0;
     }
@@ -115,7 +115,7 @@ namespace sistrip {
     //set the run type
     fakeTriggerFedData[10] = runType_;
     //fill the summarry using trigger FED buffer  with no data
-    pSummary->commissioningInfo(fakeTriggerFedData.get(), fedEventNumber);
+    pSummary->commissioningInfo(fakeTriggerFedData.data(), fedEventNumber);
 
     //store in event
     event.put(std::move(pSummary));


### PR DESCRIPTION
#### PR description:
Replaced boost binding for std::bind.
Replaced boost::scoped_array for std::vector, since the array has only a size of 84, the replacement shouldn't produce a noticeable difference in performance.

The code should have the same behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 