### PR TITLE
Reduce boost dependency in GeneratorInterface/LHEInterface

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
@@ -7,7 +7,6 @@
 #include <string>
 #include <sstream>
 #include <fstream>
-#include <boost/algorithm/string.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -31,8 +31,6 @@ Implementation:
 #include <sys/resource.h>
 #include "tbb/task_arena.h"
 
-#include "boost/bind.hpp"
-
 #include "boost/ptr_container/ptr_deque.hpp"
 
 // user include files
@@ -184,7 +182,7 @@ void ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   }
   std::for_each(partonLevel_->weights().begin(),
                 partonLevel_->weights().end(),
-                boost::bind(&LHEEventProduct::addWeight, product.get(), _1));
+                std::bind(&LHEEventProduct::addWeight, product.get(), std::placeholders::_1));
   product->setScales(partonLevel_->scales());
   if (nPartonMapping_.empty()) {
     product->setNpLO(partonLevel_->npLO());
@@ -219,7 +217,7 @@ void ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   std::for_each(partonLevel_->getComments().begin(),
                 partonLevel_->getComments().end(),
-                boost::bind(&LHEEventProduct::addComment, product.get(), _1));
+                std::bind(&LHEEventProduct::addComment, product.get(), std::placeholders::_1));
 
   iEvent.put(std::move(product));
 
@@ -227,10 +225,10 @@ void ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     std::unique_ptr<LHERunInfoProduct> product(new LHERunInfoProduct(*runInfo_->getHEPRUP()));
     std::for_each(runInfo_->getHeaders().begin(),
                   runInfo_->getHeaders().end(),
-                  boost::bind(&LHERunInfoProduct::addHeader, product.get(), _1));
+                  std::bind(&LHERunInfoProduct::addHeader, product.get(), std::placeholders::_1));
     std::for_each(runInfo_->getComments().begin(),
                   runInfo_->getComments().end(),
-                  boost::bind(&LHERunInfoProduct::addComment, product.get(), _1));
+                  std::bind(&LHERunInfoProduct::addComment, product.get(), std::placeholders::_1));
 
     if (!runInfoProducts_.empty()) {
       runInfoProducts_.front().mergeProduct(*product);
@@ -348,10 +346,10 @@ void ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& 
     std::unique_ptr<LHERunInfoProduct> product(new LHERunInfoProduct(*runInfo_->getHEPRUP()));
     std::for_each(runInfo_->getHeaders().begin(),
                   runInfo_->getHeaders().end(),
-                  boost::bind(&LHERunInfoProduct::addHeader, product.get(), _1));
+                  std::bind(&LHERunInfoProduct::addHeader, product.get(), std::placeholders::_1));
     std::for_each(runInfo_->getComments().begin(),
                   runInfo_->getComments().end(),
-                  boost::bind(&LHERunInfoProduct::addComment, product.get(), _1));
+                  std::bind(&LHERunInfoProduct::addComment, product.get(), std::placeholders::_1));
 
     // keep a copy around in case of merging
     runInfoProducts_.push_back(new LHERunInfoProduct(*product));

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -4,8 +4,6 @@
 #include <string>
 #include <memory>
 
-#include <boost/bind.hpp>
-
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
@@ -147,13 +145,13 @@ void LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
   }
   std::for_each(partonLevel_->weights().begin(),
                 partonLevel_->weights().end(),
-                boost::bind(&LHEEventProduct::addWeight, product.get(), _1));
+                std::bind(&LHEEventProduct::addWeight, product.get(), std::placeholders::_1));
   product->setScales(partonLevel_->scales());
   product->setNpLO(partonLevel_->npLO());
   product->setNpNLO(partonLevel_->npNLO());
   std::for_each(partonLevel_->getComments().begin(),
                 partonLevel_->getComments().end(),
-                boost::bind(&LHEEventProduct::addComment, product.get(), _1));
+                std::bind(&LHEEventProduct::addComment, product.get(), std::placeholders::_1));
 
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<LHEEventProduct>(std::move(product)));
   eventPrincipal.put(lheProvenanceHelper_.eventProductBranchDescription_,

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -8,8 +8,6 @@
 #include <vector>
 #include <cstdio>
 
-#include <boost/bind.hpp>
-
 #include <xercesc/sax2/Attributes.hpp>
 #include <xercesc/dom/DOM.hpp>
 
@@ -27,8 +25,6 @@
 #include "Utilities/StorageFactory/interface/StorageFactory.h"
 
 #include "XMLUtils.h"
-
-#include "boost/lexical_cast.hpp"
 
 XERCES_CPP_NAMESPACE_USE
 
@@ -490,7 +486,7 @@ namespace lhef {
 
           std::for_each(handler->headers.begin(),
                         handler->headers.end(),
-                        boost::bind(&LHERunInfo::addHeader, curRunInfo.get(), _1));
+                        std::bind(&LHERunInfo::addHeader, curRunInfo.get(), std::placeholders::_1));
           handler->headers.clear();
         } break;
 

--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -8,8 +8,6 @@
 #include <cmath>
 #include <cstring>
 
-#include <boost/bind.hpp>
-
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include <xercesc/sax/HandlerBase.hpp>


### PR DESCRIPTION
#### PR description:
Replaced boost binding for std::bind. The code should have the same behavior.
Also deleted some headers that were unused. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 