### PR TITLE
Reduce boost dependency in PhysicsTools/TagAndProbe

### DIFF
--- a/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
+++ b/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
@@ -30,7 +30,6 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 #include <TTree.h>
-#include <boost/utility.hpp>
 
 /** Class that makes a TTree with:
      - variables from a Probe
@@ -133,9 +132,11 @@ namespace tnp {
     mutable std::vector<reco::CandidateBaseRef> passingProbes_;
   };
 
-  // This class inherits from boost::noncopyable, as copying it would break the addresses in the TTree
-  class BaseTreeFiller : boost::noncopyable {
+  // This class is noncopyable, as copying it would break the addresses in the TTree
+  class BaseTreeFiller {
   public:
+    BaseTreeFiller(const BaseTreeFiller &) = delete;
+    BaseTreeFiller &operator=(const BaseTreeFiller &) = delete;
     /// specify the name of the TTree, and the configuration for it
     BaseTreeFiller(const char *name, const edm::ParameterSet &config, edm::ConsumesCollector &&iC)
         : BaseTreeFiller(name, config, iC){};

--- a/PhysicsTools/TagAndProbe/plugins/ProbeTreeProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ProbeTreeProducer.cc
@@ -13,7 +13,6 @@
 
 #include <memory>
 #include <cctype>
-#include "boost/bind.hpp"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -87,7 +86,9 @@ bool ProbeTreeProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
   }
   // sort only if a function was provided
   if (!sortDescendingBy_.empty())
-    sort(selectedProbes.begin(), selectedProbes.end(), boost::bind(&Pair::second, _1) > boost::bind(&Pair::second, _2));
+    sort(selectedProbes.begin(), selectedProbes.end(), [&](auto& arg1, auto& arg2) {
+      return arg1.second > arg2.second;
+    });
   // fill the first maxProbes_ into the tree
   for (size_t i = 0; i < (maxProbes_ < 0 ? selectedProbes.size() : std::min((size_t)maxProbes_, selectedProbes.size()));
        ++i) {


### PR DESCRIPTION
#### PR description:
Replaced boost binding for a lambda expression.
Removed the boost::noncopyable inheritance from BaseTreeFiller, and deleted copy constructor and copy operation instead. 
The code should have the same behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 