### PR TITLE
[RECONSTRUCTION] Fixes needed for UBSAN

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/plugins/BuildFile.xml
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="RecoLocalCalo/HcalRecAlgos"/>
+<use name="Geometry/HcalTowerAlgo"/>
 <library file="*.cc" name="RecoLocalCaloHcalRecAlgosPlugin">
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

Added missing dependency to fix UBSAN IBs build errors. Dependency is needed due to the use of `HcalGeometry`

```
plugins/HcalChannelPropertiesEP.cc:#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
plugins/HcalChannelPropertiesEP.cc:      const HcalGeometry* hcalGeom = static_cast<const HcalGeometry*>(geom.getSubdetectorGeometry(DetId::Hcal, subd));
```

#### PR validation:

Successfully built for UBSAN and normal IBs 