### PR TITLE
[GEOMETRY] Fixes needed for UBSAN

### DIFF
--- a/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
@@ -17,6 +17,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <sstream> // for ostringstream
 
 typedef EZArrayFL<GlobalPoint> CornersVec;
 
@@ -45,10 +46,10 @@ EcalPreshowerCellParameterDump::EcalPreshowerCellParameterDump(const edm::Parame
     for (short iz = 0; iz < 2; ++iz) {
       short zside = 2 * iz - 1;
       for (short lay = 1; lay <= 2; ++lay) {
-        char name[20], title[40];
-        sprintf(name, "hist%d%d", iz, lay);
-        sprintf(title, "y vs. x (zside = %d,layer = %d)", zside, lay);
-        hist_.emplace_back(fs->make<TH2D>(name, title, 5000, -125.0, 125.0, 5000, -125.0, 125.0));
+        std::ostringstream name, title;
+        name << "hist" << iz << lay;
+        title << "y vs. x (zside = "<<zside<<",layer = "<<lay<<")";
+        hist_.emplace_back(fs->make<TH2D>(name.str().c_str(), title.str().c_str(), 5000, -125.0, 125.0, 5000, -125.0, 125.0));
       }
     }
   }

--- a/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
@@ -17,7 +17,7 @@
 
 #include <iomanip>
 #include <iostream>
-#include <sstream> // for ostringstream
+#include <sstream>  // for ostringstream
 
 typedef EZArrayFL<GlobalPoint> CornersVec;
 
@@ -48,8 +48,9 @@ EcalPreshowerCellParameterDump::EcalPreshowerCellParameterDump(const edm::Parame
       for (short lay = 1; lay <= 2; ++lay) {
         std::ostringstream name, title;
         name << "hist" << iz << lay;
-        title << "y vs. x (zside = "<<zside<<",layer = "<<lay<<")";
-        hist_.emplace_back(fs->make<TH2D>(name.str().c_str(), title.str().c_str(), 5000, -125.0, 125.0, 5000, -125.0, 125.0));
+        title << "y vs. x (zside = " << zside << ",layer = " << lay << ")";
+        hist_.emplace_back(
+            fs->make<TH2D>(name.str().c_str(), title.str().c_str(), 5000, -125.0, 125.0, 5000, -125.0, 125.0));
       }
     }
   }

--- a/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
@@ -42,9 +42,9 @@ EcalPreshowerCellParameterDump::EcalPreshowerCellParameterDump(const edm::Parame
 
   if (debug_) {
     edm::Service<TFileService> fs;
-    for (int iz = 0; iz < 2; ++iz) {
-      int zside = 2 * iz - 1;
-      for (int lay = 1; lay <= 2; ++lay) {
+    for (short iz = 0; iz < 2; ++iz) {
+      short zside = 2 * iz - 1;
+      for (short lay = 1; lay <= 2; ++lay) {
         char name[20], title[40];
         sprintf(name, "hist%d%d", iz, lay);
         sprintf(title, "y vs. x (zside = %d,layer = %d)", zside, lay);


### PR DESCRIPTION
#### PR description:

Use a smaller data type to represent these small numbers. This should fix the UBSAN build errors

```
Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc:49:23: error: '%d' directive writing between 1 and 10 bytes into a region of size between 6 and 15 [-Werror=format-overflow=]
          sprintf(name, "hist%d%d", iz, lay);
```

#### PR validation:

Successfully built for UBSAN and normal IBs 