### PR TITLE
Reduce boost use in RecoLocalTracker/SiStripRecHitConverter

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -18,9 +18,8 @@
 class GluedGeomDet;
 
 #include <cfloat>
+#include <functional>
 #include <memory>
-
-#include <boost/function.hpp>
 
 class SiStripRecHitMatcher {
 public:
@@ -31,7 +30,7 @@ public:
   typedef std::vector<const SiStripRecHit2D*> SimpleHitCollection;
   typedef SimpleHitCollection::const_iterator SimpleHitIterator;
 
-  typedef boost::function<void(SiStripMatchedRecHit2D const&)> Collector;
+  typedef std::function<void(SiStripMatchedRecHit2D const&)> Collector;
 
   typedef std::pair<LocalPoint, LocalPoint> StripPosition;
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -8,7 +8,7 @@
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 
 #include "TrackingTools/TransientTrackingRecHit/interface/HelpertRecHit2DLocalPos.h"
-#include <boost/bind.hpp>
+#include <functional>
 
 #include <DataFormats/TrackingRecHit/interface/AlignmentPositionError.h>
 
@@ -45,7 +45,8 @@ void SiStripRecHitMatcher::match(const SiStripRecHit2D* monoRH,
                                  std::vector<SiStripMatchedRecHit2D*>& collector,
                                  const GluedGeomDet* gluedDet,
                                  LocalVector trackdirection) const {
-  Collector result(boost::bind(&pb1, boost::ref(collector), boost::bind(&SiStripMatchedRecHit2D::clone, _1)));
+  Collector result(
+      std::bind(&pb1, std::ref(collector), std::bind(&SiStripMatchedRecHit2D::clone, std::placeholders::_1)));
   match(monoRH, begin, end, result, gluedDet, trackdirection);
 }
 
@@ -55,7 +56,7 @@ void SiStripRecHitMatcher::match(const SiStripRecHit2D* monoRH,
                                  CollectorMatched& collector,
                                  const GluedGeomDet* gluedDet,
                                  LocalVector trackdirection) const {
-  Collector result(boost::bind(pb2, boost::ref(collector), _1));
+  Collector result(std::bind(pb2, std::ref(collector), std::placeholders::_1));
   match(monoRH, begin, end, result, gluedDet, trackdirection);
 }
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPE.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPE.cc
@@ -2,8 +2,6 @@
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/CommonTopologies/interface/TkRadialStripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
-#include "boost/bind.hpp"
-#include "boost/lambda/lambda.hpp"
 #include <algorithm>
 #include <cmath>
 #include <cassert>
@@ -38,11 +36,9 @@ StripCPE::StripCPE(edm::ParameterSet& conf,
   modules["W7"] = SiStripModuleGeometry::W7;
 
   const unsigned size =
-      static_cast<unsigned int>(max_element(modules.begin(),
-                                            modules.end(),
-                                            boost::bind(&map_t::value_type::second, boost::lambda::_1) <
-                                                boost::bind(&map_t::value_type::second, boost::lambda::_2))
-                                    ->second) +
+      static_cast<unsigned int>(
+          max_element(modules.begin(), modules.end(), [&](auto& arg1, auto& arg2) { return arg1.second < arg2.second; })
+              ->second) +
       1;
   xtalk1.resize(size);
   xtalk2.resize(size);

--- a/RecoLocalTracker/SiStripRecHitConverter/src/VVIObj.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/VVIObj.cc
@@ -20,7 +20,7 @@
 
 #include <cmath>
 #include <algorithm>
-#include <boost/bind.hpp>
+#include <functional>
 
 namespace sistripvvi {
 
@@ -85,7 +85,7 @@ namespace sistripvvi {
     }
     ul = lq - 6.5;
     //	double (*fp2)(double) = reinterpret_cast<double(*)(double)>(&VVIObj::f2);
-    VVIObjDetails::dzero(ll, ul, u, rv, 1.e-5, 1000, boost::bind(&VVIObjDetails::f2, _1, h_));
+    VVIObjDetails::dzero(ll, ul, u, rv, 1.e-5, 1000, std::bind(&VVIObjDetails::f2, std::placeholders::_1, h_));
     q = 1. / u;
     t1_ = h4 * q - h5 - (beta2 * q + 1) * (log((fabs(u))) + VVIObjDetails::expint(u)) + exp(-u) * q;
     t_ = t1_ - t0_;
@@ -98,7 +98,7 @@ namespace sistripvvi {
     h_[2] = h6 * omega_;
     h_[3] = omega_ * 1.5707963250000001;
     //	double (*fp1)(double) = reinterpret_cast<double(*)(double)>(&VVIObj::f1);
-    VVIObjDetails::dzero(5., 155., x0_, rv, 1.e-5, 1000, boost::bind(&VVIObjDetails::f1, _1, h_));
+    VVIObjDetails::dzero(5., 155., x0_, rv, 1.e-5, 1000, std::bind(&VVIObjDetails::f1, std::placeholders::_1, h_));
     n = x0_ + 1.;
     d = exp(kappa * (beta2 * (.57721566 - h5) + 1.)) * .31830988654751274;
     a_[n - 1] = 0.;


### PR DESCRIPTION
#### PR description:
Replaced boost usage for standard alternatives.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 