### PR TITLE
check SiPixelArrayBuffer bounds before filling

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelArrayBuffer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelArrayBuffer.h
@@ -63,11 +63,10 @@ int SiPixelArrayBuffer::operator()(int row, int col) const { return pixel_vec[in
 
 int SiPixelArrayBuffer::operator()(const SiPixelCluster::PixelPos& pix) const { return pixel_vec[index(pix)]; }
 
-// unchecked!
-void SiPixelArrayBuffer::set_adc(int row, int col, int adc) { pixel_vec[index(row, col)] = adc; }
+void SiPixelArrayBuffer::set_adc(int row, int col, int adc) { pixel_vec.at(index(row, col)) = adc; }
 
-void SiPixelArrayBuffer::set_adc(const SiPixelCluster::PixelPos& pix, int adc) { pixel_vec[index(pix)] = adc; }
+void SiPixelArrayBuffer::set_adc(const SiPixelCluster::PixelPos& pix, int adc) { pixel_vec.at(index(pix)) = adc; }
 
-void SiPixelArrayBuffer::add_adc(int row, int col, int adc) { pixel_vec[index(row, col)] += adc; }
+void SiPixelArrayBuffer::add_adc(int row, int col, int adc) { pixel_vec.at(index(row, col)) += adc; }
 
 #endif


### PR DESCRIPTION
#### PR description:

Addresses suggestion at https://github.com/cms-sw/cmssw/issues/30215#issuecomment-643389702
Still in draft mode to collect feedback.

#### PR validation:

Passes ` runTheMatrix.py -l limited --ibeos`.
As of `CMSSW_11_2_X_2020-06-14-2300` known to break wf 26234 (see https://github.com/cms-sw/cmssw/issues/30215#issuecomment-643962951 for details).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.
cc:
@tsusa @dkotlins @tvami @duartej 