### PR TITLE
Reduce boost dependency in RecoTauTag/RecoTau

### DIFF
--- a/RecoTauTag/RecoTau/plugins/RecoTauGenericJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauGenericJetRegionProducer.cc
@@ -8,8 +8,6 @@
  *
  */
 
-#include <boost/bind.hpp>
-
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Common/interface/Association.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -10,9 +10,8 @@
  *
  */
 #include <algorithm>
+#include <functional>
 #include <memory>
-
-#include "boost/bind.hpp"
 
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 
@@ -136,8 +135,7 @@ namespace reco {
       if (combineStrips_ && output.size() > 1) {
         PiZeroVector stripCombinations;
         // Sort the output by descending pt
-        output.sort(
-            output.begin(), output.end(), boost::bind(&RecoTauPiZero::pt, _1) > boost::bind(&RecoTauPiZero::pt, _2));
+        output.sort(output.begin(), output.end(), [&](auto& arg1, auto& arg2) { return arg1.pt() > arg2.pt(); });
         // Get the end of interesting set of strips to try and combine
         PiZeroVector::const_iterator end_iter = takeNElements(output.begin(), output.end(), maxStrips_);
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -12,9 +12,8 @@
  */
 
 #include <algorithm>
+#include <functional>
 #include <memory>
-
-#include "boost/bind.hpp"
 
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 
@@ -303,8 +302,7 @@ namespace reco {
       if (combineStrips_ && output.size() > 1) {
         PiZeroVector stripCombinations;
         // Sort the output by descending pt
-        output.sort(
-            output.begin(), output.end(), boost::bind(&RecoTauPiZero::pt, _1) > boost::bind(&RecoTauPiZero::pt, _2));
+        output.sort(output.begin(), output.end(), [&](auto& arg1, auto& arg2) { return arg1.pt() > arg2.pt(); });
         // Get the end of interesting set of strips to try and combine
         PiZeroVector::const_iterator end_iter = takeNElements(output.begin(), output.end(), maxStrips_);
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -12,9 +12,8 @@
  */
 
 #include <algorithm>
+#include <functional>
 #include <memory>
-
-#include "boost/bind.hpp"
 
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 
@@ -334,8 +333,7 @@ namespace reco {
       if (combineStrips_ && output.size() > 1) {
         PiZeroVector stripCombinations;
         // Sort the output by descending pt
-        output.sort(
-            output.begin(), output.end(), boost::bind(&RecoTauPiZero::pt, _1) > boost::bind(&RecoTauPiZero::pt, _2));
+        output.sort(output.begin(), output.end(), [&](auto& arg1, auto& arg2) { return arg1.pt() > arg2.pt(); });
         // Get the end of interesting set of strips to try and combine
         PiZeroVector::const_iterator end_iter = takeNElements(output.begin(), output.end(), maxStrips_);
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -16,8 +16,6 @@
  *          Christian Veelken (LLR)
  *
  */
-#include "boost/bind.hpp"
-#include <boost/ptr_container/ptr_vector.hpp>
 
 #include <algorithm>
 #include <functional>
@@ -198,7 +196,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
           (*builder)(jetRef, chargedHadrons, piZeros, uniqueRegionalCands));
 
       // Make sure all taus have their jetref set correctly
-      std::for_each(taus.begin(), taus.end(), boost::bind(&reco::PFTau::setjetRef, _1, reco::JetBaseRef(jetRef)));
+      std::for_each(taus.begin(), taus.end(), [&](auto& arg) { arg.setjetRef(reco::JetBaseRef(jetRef)); });
       // Copy without selection
       if (!outputSelector_.get()) {
         output->insert(output->end(), taus.begin(), taus.end());

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminantCutMultiplexer.cc
@@ -14,7 +14,6 @@
  * collection.
  *
  */
-#include <boost/foreach.hpp>
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -1,7 +1,6 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h"
 
 #include <functional>
-#include <boost/foreach.hpp>
 
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"


### PR DESCRIPTION
#### PR description:
Replaced boost bindings for lambda expressions.
Removed unused boost headers.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 