### PR TITLE
Update of L1 tracking (matching PR #30168)

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
@@ -36,6 +36,8 @@ namespace trklet {
     void findAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr);
 
     void openFile(bool first, std::string filebase);
+    
+    static size_t find_nth(const std::string& haystack, size_t pos, const std::string& needle, size_t nth);
 
   protected:
     std::string name_;

--- a/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
@@ -36,7 +36,7 @@ namespace trklet {
     void findAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr);
 
     void openFile(bool first, std::string filebase);
-    
+
     static size_t find_nth(const std::string& haystack, size_t pos, const std::string& needle, size_t nth);
 
   protected:

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -182,7 +182,7 @@ namespace trklet {
 
     std::string geomext() const {
       if (combined_)
-	return "hourglassCombined";
+        return "hourglassCombined";
       return extended_ ? "hourglassExtended" : "hourglass";
     }
 
@@ -371,7 +371,7 @@ namespace trklet {
     unsigned int nbitszprojderL123_{10};
     unsigned int nbitszprojderL456_{9};
 
-    unsigned int nbendbitsmedisk_{4}; // Always 4 bits even for PS disk hits, for HLS compatibility
+    unsigned int nbendbitsmedisk_{4};  // Always 4 bits even for PS disk hits, for HLS compatibility
 
     std::set<unsigned int> useseeding_{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 
@@ -523,12 +523,12 @@ namespace trklet {
 
     //rphi cuts for layers - the column is the seedindex
     std::array<std::array<double, N_SEED>, N_LAYER> rphimatchcut_{
-        {{{0.0,  0.1,  0.07, 0.08, 0.07, 0.05, 0.0,  0.05, 0.08, 0.15, 0.125, 0.15}},  //Layer 1
-         {{0.0,  0.0,  0.06, 0.08, 0.05, 0.0,  0.0,  0.0,  0.0,  0.1,  0.0,   0.0}},         //Layer 2
-         {{0.1,  0.0,  0.0,  0.08, 0.0,  0.0,  0.0,  0.0,  0.0,  0.08, 0.0,   0.0}},          //Layer 3
-         {{0.19, 0.19, 0.0,  0.05, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,   0.0}},         //Layer 4
-         {{0.4,  0.4,  0.08, 0.0,  0.0,  0.0,  0.0,  0.0,  0.08, 0.0,  0.0,   0.0}},          //Layer 5
-         {{0.5,  0.0,  0.19, 0.0,  0.0,  0.0,  0.0,  0.0,  0.2,  0.0,  0.0,   0.0}}}};         //Layer 6
+        {{{0.0, 0.1, 0.07, 0.08, 0.07, 0.05, 0.0, 0.05, 0.08, 0.15, 0.125, 0.15}},  //Layer 1
+         {{0.0, 0.0, 0.06, 0.08, 0.05, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0}},         //Layer 2
+         {{0.1, 0.0, 0.0, 0.08, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08, 0.0, 0.0}},          //Layer 3
+         {{0.19, 0.19, 0.0, 0.05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}},         //Layer 4
+         {{0.4, 0.4, 0.08, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08, 0.0, 0.0, 0.0}},          //Layer 5
+         {{0.5, 0.0, 0.19, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2, 0.0, 0.0, 0.0}}}};         //Layer 6
 
     //z cuts for layers - the column is the seedindex
     std::array<std::array<double, N_SEED>, N_LAYER> zmatchcut_{

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -42,6 +42,8 @@ namespace trklet {
     std::string const& processingModulesFile() const { return processingModulesFile_; }
     std::string const& memoryModulesFile() const { return memoryModulesFile_; }
     std::string const& wiresFile() const { return wiresFile_; }
+    std::string const& tableTEDFile() const { return tableTEDFile_; }
+    std::string const& tableTREFile() const { return tableTREFile_; }
 
     void setDTCLinkFile(std::string DTCLinkFileName) { DTCLinkFile_ = DTCLinkFileName; }
     void setModuleCablingFile(std::string moduleCablingFileName) { moduleCablingFile_ = moduleCablingFileName; }
@@ -54,6 +56,8 @@ namespace trklet {
     }
     void setMemoryModulesFile(std::string memoryModulesFileName) { memoryModulesFile_ = memoryModulesFileName; }
     void setWiresFile(std::string wiresFileName) { wiresFile_ = wiresFileName; }
+    void setTableTEDFile(std::string tableTEDFileName) { tableTEDFile_ = tableTEDFileName; }
+    void setTableTREFile(std::string tableTREFileName) { tableTREFile_ = tableTREFileName; }
 
     unsigned int nzbitsstub(unsigned int layerdisk) const { return nzbitsstub_[layerdisk]; }
     unsigned int nphibitsstub(unsigned int layerdisk) const { return nphibitsstub_[layerdisk]; }
@@ -64,6 +68,8 @@ namespace trklet {
     unsigned int nbitsphiprojderL456() const { return nbitsphiprojderL456_; }
     unsigned int nbitszprojderL123() const { return nbitszprojderL123_; }
     unsigned int nbitszprojderL456() const { return nbitszprojderL456_; }
+
+    unsigned int nbendbitsmedisk() const { return nbendbitsmedisk_; }
 
     bool useSeed(unsigned int iSeed) const { return useseeding_.find(iSeed) != useseeding_.end(); }
     unsigned int nbitsvmte(unsigned int inner, unsigned int iSeed) const { return nbitsvmte_[inner][iSeed]; }
@@ -172,8 +178,13 @@ namespace trklet {
     unsigned int MEBinsBits() const { return MEBinsBits_; }
     unsigned int MEBins() const { return 1u << MEBinsBits_; }
     unsigned int MEBinsDisks() const { return MEBinsDisks_; }
+    unsigned int maxStubsPerBin() const { return maxStubsPerBin_; }
 
-    std::string geomext() const { return extended_ ? "hourglassExtended" : "hourglass"; }
+    std::string geomext() const {
+      if (combined_)
+	return "hourglassCombined";
+      return extended_ ? "hourglassExtended" : "hourglass";
+    }
 
     bool exactderivatives() const { return exactderivatives_; }
     bool exactderivativesforfloating() const { return exactderivativesforfloating_; }
@@ -184,6 +195,7 @@ namespace trklet {
     std::string removalType() const { return removalType_; }
     std::string mergeComparison() const { return mergeComparison_; }
     bool doKF() const { return doKF_; }
+    bool doMultipleMatches() const { return doMultipleMatches_; }
     bool fakefit() const { return fakefit_; }
 
     // configurable
@@ -192,6 +204,8 @@ namespace trklet {
 
     bool extended() const { return extended_; }
     void setExtended(bool extended) { extended_ = extended; }
+    bool combined() const { return combined_; }
+    void setCombined(bool combined) { combined_ = combined; }
 
     double bfield() const { return bfield_; }
     void setBfield(double bfield) { bfield_ = bfield; }
@@ -332,6 +346,8 @@ namespace trklet {
     std::string processingModulesFile_;
     std::string memoryModulesFile_;
     std::string wiresFile_;
+    std::string tableTEDFile_;
+    std::string tableTREFile_;
 
     double rcrit_{55.0};  // critical radius for the hourglass configuration
 
@@ -354,6 +370,8 @@ namespace trklet {
     unsigned int nbitsphiprojderL456_{10};
     unsigned int nbitszprojderL123_{10};
     unsigned int nbitszprojderL456_{9};
+
+    unsigned int nbendbitsmedisk_{4}; // Always 4 bits even for PS disk hits, for HLS compatibility
 
     std::set<unsigned int> useseeding_{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 
@@ -466,7 +484,7 @@ namespace trklet {
          {{5, 4, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4}},    //outer
          {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4}}}};  //outermost (triplets only)
 
-    std::array<std::array<unsigned int, N_SEED>, 3> lutwidthtab_{{{{10, 11, 11, 11, 11, 11, 11, 11, 0, 0, 11, 0}},
+    std::array<std::array<unsigned int, N_SEED>, 3> lutwidthtab_{{{{10, 10, 10, 10, 10, 10, 10, 10, 0, 0, 11, 0}},
                                                                   {{6, 6, 6, 6, 10, 10, 10, 10, 0, 0, 6, 0}},
                                                                   {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 6}}}};
 
@@ -505,12 +523,12 @@ namespace trklet {
 
     //rphi cuts for layers - the column is the seedindex
     std::array<std::array<double, N_SEED>, N_LAYER> rphimatchcut_{
-        {{{0.0, 0.1, 0.07, 0.08, 0.07, 0.05, 0.0, 0.05, 0.08, 0.15, 0.125, 0.15}},  //Layer 1
-         {{0.0, 0.0, 0.06, 0.08, 0.05, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0}},         //Layer 2
-         {{0.1, 0.0, 0.0, 0.08, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08, 0.0, 0.0}},          //Layer 3
-         {{0.19, 0.19, 0.0, 0.05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}},         //Layer 4
-         {{0.4, 0.4, 0.08, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08, 0.0, 0.0, 0.0}},          //Layer 5
-         {{0.5, 0.0, 0.19, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2, 0.0, 0.0, 0.0}}}};         //Layer 6
+        {{{0.0,  0.1,  0.07, 0.08, 0.07, 0.05, 0.0,  0.05, 0.08, 0.15, 0.125, 0.15}},  //Layer 1
+         {{0.0,  0.0,  0.06, 0.08, 0.05, 0.0,  0.0,  0.0,  0.0,  0.1,  0.0,   0.0}},         //Layer 2
+         {{0.1,  0.0,  0.0,  0.08, 0.0,  0.0,  0.0,  0.0,  0.0,  0.08, 0.0,   0.0}},          //Layer 3
+         {{0.19, 0.19, 0.0,  0.05, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,   0.0}},         //Layer 4
+         {{0.4,  0.4,  0.08, 0.0,  0.0,  0.0,  0.0,  0.0,  0.08, 0.0,  0.0,   0.0}},          //Layer 5
+         {{0.5,  0.0,  0.19, 0.0,  0.0,  0.0,  0.0,  0.0,  0.2,  0.0,  0.0,   0.0}}}};         //Layer 6
 
     //z cuts for layers - the column is the seedindex
     std::array<std::array<double, N_SEED>, N_LAYER> zmatchcut_{
@@ -553,8 +571,11 @@ namespace trklet {
          {{3.6, 3.8, 0.0, 0.0, 3.6, 0.0, 3.5, 3.8, 0.0, 0.0, 3.0, 3.0}},    //disk 4
          {{0.0, 0.0, 0.0, 0.0, 3.6, 3.4, 3.7, 0.0, 0.0, 0.0, 0.0, 3.0}}}};  //disk 5
 
+    //Offset to the maximum number of steps in each processing step. Set to 0 for standard
+    //trunction. Set to large value, e.g. 10000 to remove truncation
     unsigned int maxstepoffset_{10000};
 
+    //Default number of processing steps for one event
     std::unordered_map<std::string, unsigned int> maxstep_{{"Link", 108},
                                                            {"MC", 108},
                                                            {"ME", 108},
@@ -566,6 +587,7 @@ namespace trklet {
                                                            {"TRE", 108},
                                                            {"VMR", 108}};
 
+    // If set to true this will generate debub printout in text files
     std::unordered_map<std::string, bool> writeMonitorData_{{"IL", false},
                                                             {"TE", false},
                                                             {"CT", false},
@@ -643,6 +665,7 @@ namespace trklet {
 
     unsigned int MEBinsBits_{3};
     unsigned int MEBinsDisks_{8};  //on each side
+    unsigned int maxStubsPerBin_{16};
 
     // Options for chisq fit
     bool exactderivatives_{false};
@@ -671,11 +694,18 @@ namespace trklet {
     std::string mergeComparison_{""};
 #endif
 
+    // When false, match calculator does not save multiple matches, even when doKF=true.
+    // This is a temporary fix for compatibilty with HLS. We will need to implement multiple match
+    // printing in emulator eventually, possibly after CMSSW-integration inspired rewrites
+    // Use false when generating HLS files, use true when doing full hybrid tracking
+    bool doMultipleMatches_{true};
+
     // if true, run a dummy fit, producing TTracks directly from output of tracklet pattern reco stage
     bool fakefit_{false};
 
     unsigned int nHelixPar_{4};  // 4 or 5 param helix fit
     bool extended_{false};       // turn on displaced tracking
+    bool combined_{false};       // use combined TP (TE+TC) and MP (PR+ME+MC) configuration
 
     std::string skimfile_{""};  //if not empty events will be written out in ascii format to this file
 

--- a/L1Trigger/TrackFindingTracklet/interface/VMStubTE.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMStubTE.h
@@ -37,7 +37,6 @@ namespace trklet {
 
   private:
     FPGAWord finephi_;
-    FPGAWord finerz_;
     FPGAWord bend_;
     FPGAWord vmbits_;
     FPGAWord allStubIndex_;

--- a/L1Trigger/TrackFindingTracklet/interface/VMStubsMEMemory.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMStubsMEMemory.h
@@ -19,7 +19,11 @@ namespace trklet {
 
     ~VMStubsMEMemory() override = default;
 
-    void addStub(VMStubME stub, unsigned int bin) { binnedstubs_[bin].push_back(stub); }
+    void addStub(VMStubME stub, unsigned int bin) {
+      if (binnedstubs_[bin].size() < settings_.maxStubsPerBin()) {
+        binnedstubs_[bin].push_back(stub);
+      }
+    }
 
     unsigned int nStubsBin(unsigned int bin) const {
       assert(bin < binnedstubs_.size());

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -151,9 +151,11 @@ private:
 
   edm::FileInPath DTCLinkFile;
   edm::FileInPath moduleCablingFile;
-
   edm::FileInPath DTCLinkLayerDiskFile;
 
+  edm::FileInPath tableTEDFile;
+  edm::FileInPath tableTREFile;
+  
   string asciiEventOutName_;
   std::ofstream asciiEventOut_;
 
@@ -230,12 +232,17 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
 
   DTCLinkFile = iConfig.getParameter<edm::FileInPath>("DTCLinkFile");
   moduleCablingFile = iConfig.getParameter<edm::FileInPath>("moduleCablingFile");
-
   DTCLinkLayerDiskFile = iConfig.getParameter<edm::FileInPath>("DTCLinkLayerDiskFile");
-
+  
   extended_ = iConfig.getParameter<bool>("Extended");
   nHelixPar_ = iConfig.getParameter<unsigned int>("Hnpar");
 
+  if (extended_) {
+    tableTEDFile = iConfig.getParameter<edm::FileInPath>("tableTEDFile");
+    tableTREFile = iConfig.getParameter<edm::FileInPath>("tableTREFile");
+  }
+
+  
   // --------------------------------------------------------------------------------
   // set options in Settings based on inputs from configuration files
   // --------------------------------------------------------------------------------
@@ -250,6 +257,11 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   settings.setProcessingModulesFile(processingModulesFile.fullPath());
   settings.setMemoryModulesFile(memoryModulesFile.fullPath());
   settings.setWiresFile(wiresFile.fullPath());
+  
+  if (extended_) {
+    settings.setTableTEDFile(tableTEDFile.fullPath());
+    settings.setTableTREFile(tableTREFile.fullPath());
+  }
 
   eventnum = 0;
   if (not asciiEventOutName_.empty()) {
@@ -264,6 +276,10 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
                                  << "\n process modules : " << processingModulesFile.fullPath()
                                  << "\n memory modules :  " << memoryModulesFile.fullPath()
                                  << "\n wires          :  " << wiresFile.fullPath();
+    if (extended_) {
+      edm::LogVerbatim("Tracklet") << "table_TED    :  " << tableTEDFile.fullPath()
+				   << "\n table_TRE    :  " << tableTREFile.fullPath();
+    }
   }
 }
 
@@ -554,7 +570,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       LocalPoint clustlp_outer = topol_outer->localPosition(coords_outer);
       GlobalPoint posStub_outer = theGeomDet_outer->surface().toGlobal(clustlp_outer);
 
-      bool isFlipped = !(posStub_outer.mag() < posStub_inner.mag());
+      bool isFlipped = (posStub_outer.mag() < posStub_inner.mag());
 
       // -----------------------------------------------------
       // correct sign for stubs in negative endcap

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -155,7 +155,7 @@ private:
 
   edm::FileInPath tableTEDFile;
   edm::FileInPath tableTREFile;
-  
+
   string asciiEventOutName_;
   std::ofstream asciiEventOut_;
 
@@ -233,7 +233,7 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   DTCLinkFile = iConfig.getParameter<edm::FileInPath>("DTCLinkFile");
   moduleCablingFile = iConfig.getParameter<edm::FileInPath>("moduleCablingFile");
   DTCLinkLayerDiskFile = iConfig.getParameter<edm::FileInPath>("DTCLinkLayerDiskFile");
-  
+
   extended_ = iConfig.getParameter<bool>("Extended");
   nHelixPar_ = iConfig.getParameter<unsigned int>("Hnpar");
 
@@ -242,7 +242,6 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
     tableTREFile = iConfig.getParameter<edm::FileInPath>("tableTREFile");
   }
 
-  
   // --------------------------------------------------------------------------------
   // set options in Settings based on inputs from configuration files
   // --------------------------------------------------------------------------------
@@ -257,7 +256,7 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   settings.setProcessingModulesFile(processingModulesFile.fullPath());
   settings.setMemoryModulesFile(memoryModulesFile.fullPath());
   settings.setWiresFile(wiresFile.fullPath());
-  
+
   if (extended_) {
     settings.setTableTEDFile(tableTEDFile.fullPath());
     settings.setTableTREFile(tableTREFile.fullPath());
@@ -278,7 +277,7 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
                                  << "\n wires          :  " << wiresFile.fullPath();
     if (extended_) {
       edm::LogVerbatim("Tracklet") << "table_TED    :  " << tableTEDFile.fullPath()
-				   << "\n table_TRE    :  " << tableTREFile.fullPath();
+                                   << "\n table_TRE    :  " << tableTREFile.fullPath();
     }
   }
 }

--- a/L1Trigger/TrackFindingTracklet/python/Tracklet_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/Tracklet_cfi.py
@@ -27,5 +27,8 @@ TTTracksFromExtendedTrackletEmulation = TTTracksFromTrackletEmulation.clone(
                                                memoryModulesFile  = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/memorymodules_hourglassExtended.dat'),
                                                processingModulesFile  = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/processingmodules_hourglassExtended.dat'),
                                                wiresFile  = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglassExtended.dat'),
+                                               # specifying where the TrackletEngineDisplaced(TED)/TripletEngine(TRE) tables are located
+                                               tableTEDFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/table_TED/table_TED_D1PHIA1_D2PHIA1.txt'),
+                                               tableTREFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/table_TRE/table_TRE_D1AD2A_1.txt')
     )
 

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -981,7 +981,8 @@ void FitTrack::execute() {
       nMatchesUniq++;
 
     if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << getName() << " : nMatches = " << nMatches << " " << asinh(bestTracklet->t());
+      edm::LogVerbatim("Tracklet") << getName() << " : nMatches = " << nMatches << " nMatchesUniq = " << nMatchesUniq
+				   << " " << asinh(bestTracklet->t());
     }
 
     std::vector<const Stub*> trackstublist;

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -277,7 +277,7 @@ void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std:
       }
     }
 
-    for (unsigned int d1 = 1; d1 <= N_DISK; d1++) {
+    for (int d1 = 1; d1 <= N_DISK; d1++) {
       int d = d1;
 
       // skip F/B5 if there's already a L2 match
@@ -286,7 +286,7 @@ void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std:
 
       if (tracklet->fpgat().value() < 0.0)
         d = -d1;
-      if (d == tracklet->disk() || d == tracklet->disk2()) {
+      if (d1 == abs(tracklet->disk()) || d1 == abs(tracklet->disk()) + 1) {
         dmatches.set(2 * d1 - 1);
         diskmask |= (1 << (2 * (N_DISK - d1) + 1));
         alpha[ndisks] = 0.0;

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -982,7 +982,7 @@ void FitTrack::execute() {
 
     if (settings_.debugTracklet()) {
       edm::LogVerbatim("Tracklet") << getName() << " : nMatches = " << nMatches << " nMatchesUniq = " << nMatchesUniq
-				   << " " << asinh(bestTracklet->t());
+                                   << " " << asinh(bestTracklet->t());
     }
 
     std::vector<const Stub*> trackstublist;

--- a/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
@@ -10,15 +10,13 @@ using namespace trklet;
 
 FullMatchMemory::FullMatchMemory(string name, Settings const& settings, unsigned int iSector)
     : MemoryBase(name, settings, iSector) {
-  if (settings_.extended()) {
-    initLayerDisk(10, layer_, disk_);
-  } else {
-    initLayerDisk(8, layer_, disk_);
-  }
+  size_t pos=find_nth(name,0,"_",1);
+  assert(pos!=string::npos);
+  initLayerDisk(pos+1, layer_, disk_);
 }
 
 void FullMatchMemory::addMatch(Tracklet* tracklet, const Stub* stub) {
-  if (!settings_.doKF()) {  //When using KF we allow multiple matches
+  if (!settings_.doKF() || !settings_.doMultipleMatches()) {  //When using KF we allow multiple matches
     for (auto& match : matches_) {
       if (match.first == tracklet) {  //Better match, replace
         match.second = stub;

--- a/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
@@ -10,9 +10,9 @@ using namespace trklet;
 
 FullMatchMemory::FullMatchMemory(string name, Settings const& settings, unsigned int iSector)
     : MemoryBase(name, settings, iSector) {
-  size_t pos=find_nth(name,0,"_",1);
-  assert(pos!=string::npos);
-  initLayerDisk(pos+1, layer_, disk_);
+  size_t pos = find_nth(name, 0, "_", 1);
+  assert(pos != string::npos);
+  initLayerDisk(pos + 1, layer_, disk_);
 }
 
 void FullMatchMemory::addMatch(Tracklet* tracklet, const Stub* stub) {

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -47,8 +47,10 @@ void MatchEngineUnit::step() {
 
   int deltaphi = stubfinephi - projfinephi_;
 
+  
   bool dphicut = (abs(deltaphi) < 3) || (abs(deltaphi) > 5);  //TODO - need better implementations
-
+  dphicut=true; //Not used until cuts cleaned up
+  
   if (!barrel_)
     dphicut = true;
 

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -47,10 +47,9 @@ void MatchEngineUnit::step() {
 
   int deltaphi = stubfinephi - projfinephi_;
 
-  
   bool dphicut = (abs(deltaphi) < 3) || (abs(deltaphi) > 5);  //TODO - need better implementations
-  dphicut=true; //Not used until cuts cleaned up
-  
+  dphicut = true;                                             //Not used until cuts cleaned up
+
   if (!barrel_)
     dphicut = true;
 

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -246,8 +246,11 @@ void MatchProcessor::execute() {
         iprojmem++;
       } else if (iproj < projMem->nTracklets()) {
         if (!inputProjBuffer_.almostfull()) {
+	  if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " have projection in memory : "<<projMem->getName();
+          }
+	  
           Tracklet* proj = projMem->getTracklet(iproj);
-
           FPGAWord fpgaphi = barrel_ ? proj->fpgaphiproj(layer_) : proj->fpgaphiprojdisk(disk_);
 
           int iphi = (fpgaphi.value() >> (fpgaphi.nbits() - nvmbits_)) & (nvmbins_ - 1);
@@ -314,6 +317,10 @@ void MatchProcessor::execute() {
         ProjectionTemp tmpProj = inputProjBuffer_.read();
         VMStubsMEMemory* stubmem = vmstubs_[tmpProj.iphi()];
 
+	if (settings_.debugTracklet()) {
+	  edm::LogVerbatim("Tracklet") << getName()<<" adding projection to match engine";
+	}
+
         matchengines_[iME].init(stubmem,
                                 tmpProj.slot(),
                                 tmpProj.projrinv(),
@@ -356,7 +363,12 @@ void MatchProcessor::execute() {
       oldTracklet = tracklet;
 
       bool match = matchCalculator(tracklet, fpgastub);
+      
+      if (settings_.debugTracklet()&&match) {
+	edm::LogVerbatim("Tracklet") << getName() << " have match";
+      }
 
+      
       countall++;
       if (match)
         countsel++;

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -246,10 +246,10 @@ void MatchProcessor::execute() {
         iprojmem++;
       } else if (iproj < projMem->nTracklets()) {
         if (!inputProjBuffer_.almostfull()) {
-	  if (settings_.debugTracklet()) {
-            edm::LogVerbatim("Tracklet") << getName() << " have projection in memory : "<<projMem->getName();
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " have projection in memory : " << projMem->getName();
           }
-	  
+
           Tracklet* proj = projMem->getTracklet(iproj);
           FPGAWord fpgaphi = barrel_ ? proj->fpgaphiproj(layer_) : proj->fpgaphiprojdisk(disk_);
 
@@ -317,9 +317,9 @@ void MatchProcessor::execute() {
         ProjectionTemp tmpProj = inputProjBuffer_.read();
         VMStubsMEMemory* stubmem = vmstubs_[tmpProj.iphi()];
 
-	if (settings_.debugTracklet()) {
-	  edm::LogVerbatim("Tracklet") << getName()<<" adding projection to match engine";
-	}
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << getName() << " adding projection to match engine";
+        }
 
         matchengines_[iME].init(stubmem,
                                 tmpProj.slot(),
@@ -363,12 +363,11 @@ void MatchProcessor::execute() {
       oldTracklet = tracklet;
 
       bool match = matchCalculator(tracklet, fpgastub);
-      
-      if (settings_.debugTracklet()&&match) {
-	edm::LogVerbatim("Tracklet") << getName() << " have match";
+
+      if (settings_.debugTracklet() && match) {
+        edm::LogVerbatim("Tracklet") << getName() << " have match";
       }
 
-      
       countall++;
       if (match)
         countsel++;

--- a/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
@@ -104,3 +104,9 @@ void MemoryBase::openFile(bool first, std::string filebase) {
   if (bx_ > 7)
     bx_ = 0;
 }
+
+size_t MemoryBase::find_nth(const string& haystack, size_t pos, const string& needle, size_t nth) {
+    size_t found_pos = haystack.find(needle, pos);
+    if(0 == nth || string::npos == found_pos)  return found_pos;
+    return find_nth(haystack, found_pos+1, needle, nth-1);
+}

--- a/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
@@ -106,7 +106,8 @@ void MemoryBase::openFile(bool first, std::string filebase) {
 }
 
 size_t MemoryBase::find_nth(const string& haystack, size_t pos, const string& needle, size_t nth) {
-    size_t found_pos = haystack.find(needle, pos);
-    if(0 == nth || string::npos == found_pos)  return found_pos;
-    return find_nth(haystack, found_pos+1, needle, nth-1);
+  size_t found_pos = haystack.find(needle, pos);
+  if (0 == nth || string::npos == found_pos)
+    return found_pos;
+  return find_nth(haystack, found_pos + 1, needle, nth - 1);
 }

--- a/L1Trigger/TrackFindingTracklet/src/ProcessBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProcessBase.cc
@@ -93,7 +93,7 @@ void ProcessBase::initLayerDisksandISeed(unsigned int& layerdisk1, unsigned int&
     }
   }
 
-  if (name_.substr(0, 3) == "TC_") {
+  if ((name_.substr(0, 3) == "TC_") || (name_.substr(0, 3) == "TP_")) {
     if (name_[3] == 'L') {
       layerdisk1 = name_[4] - '1';
     } else if (name_[3] == 'D') {

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -67,7 +67,8 @@ void PurgeDuplicate::addInput(MemoryBase* memory, std::string input) {
                                   "trackin8",
                                   "trackin9",
                                   "trackin10",
-                                  "trackin11"};
+                                  "trackin11",
+                                  "trackin12"};
   if (inputs.find(input) != inputs.end()) {
     auto* tmp = dynamic_cast<TrackFitMemory*>(memory);
     assert(tmp != nullptr);

--- a/L1Trigger/TrackFindingTracklet/src/Track.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Track.cc
@@ -48,5 +48,7 @@ double Track::phi0(Settings const& settings) const {
     phimin -= 2 * M_PI;
   double phioffset = phimin;
 
-  return ipars_.phi0() * settings.kphi0pars() + phioffset;
+  double phi0 = ipars_.phi0() * settings.kphi0pars() + phioffset;
+  phi0 = reco::reduceRange(phi0);
+  return phi0;
 }

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -209,8 +209,9 @@ std::string Tracklet::trackletparstr() {
     if (middleFPGAStub_) {
       str += middleFPGAStub_->stubindex().str() + "|";
     }
-    str += outerFPGAStub_->stubindex().str() + "|" + fpgapars_.rinv().str() + "|" + fpgapars_.phi0().str() + "|" +
-           fpgapars_.d0().str() + "|" + fpgapars_.z0().str() + "|" + fpgapars_.t().str();
+    str += outerFPGAStub_->stubindex().str() + "|" + fpgapars_.rinv().str() + "|" + fpgapars_.phi0().str() + "|";
+    if (middleFPGAStub_) str += fpgapars_.d0().str() + "|";
+    str += fpgapars_.z0().str() + "|" + fpgapars_.t().str();
     return str;
   }
 }

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -210,7 +210,8 @@ std::string Tracklet::trackletparstr() {
       str += middleFPGAStub_->stubindex().str() + "|";
     }
     str += outerFPGAStub_->stubindex().str() + "|" + fpgapars_.rinv().str() + "|" + fpgapars_.phi0().str() + "|";
-    if (middleFPGAStub_) str += fpgapars_.d0().str() + "|";
+    if (middleFPGAStub_)
+      str += fpgapars_.d0().str() + "|";
     str += fpgapars_.z0().str() + "|" + fpgapars_.t().str();
     return str;
   }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
@@ -1075,7 +1075,7 @@ bool TrackletCalculatorBase::diskSeeding(const Stub* innerFPGAStub,
                                     true);
 
   if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "Found tracklet for seed = " << iSeed_ << " " << tracklet << " " << iSector_;
+    edm::LogVerbatim("Tracklet") << "Found tracklet for disk seed = " << iSeed_ << " " << tracklet << " " << iSector_;
   }
 
   tracklet->setTrackletIndex(trackletpars_->nTracklets());

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -1367,7 +1367,7 @@ void TrackletCalculatorDisplaced::exactproj(double rproj,
   zproj = z0 + t * std::abs(rho * beta);
 
   //not exact, but close
-  phider = -0.5 * rinv / sqrt(1 - pow(0.5 * rproj * rinv, 2)) - d0 / (rproj * rproj);
+  phider = -0.5 * rinv / sqrt(1 - pow(0.5 * rproj * rinv, 2)) + d0 / (rproj * rproj);
   zder = t / sqrt(1 - pow(0.5 * rproj * rinv, 2));
 
   if (settings_.debugTracklet()) {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -528,7 +528,7 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
       continue;
     if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
       continue;
-    
+
     //check that phi projection is in range
     if (iphiproj[i] >= (1 << settings_.nphibitsstub(N_LAYER - 1)) - 1)
       continue;
@@ -590,7 +590,7 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
         continue;
       if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
         continue;
-      
+
       //check r projection in range
       if (rprojdiskapprox[i] < settings_.rmindisk() || rprojdiskapprox[i] > settings_.rmaxdisk())
         continue;
@@ -1402,7 +1402,7 @@ void TrackletCalculatorDisplaced::exactprojdisk(double zproj,
 
   phiproj = atan2(y, x);
 
-  phiproj = reco::reduceRange(phiproj - phimin_ );
+  phiproj = reco::reduceRange(phiproj - phimin_);
 
   rproj = sqrt(x * x + y * y);
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -13,8 +13,6 @@
 using namespace std;
 using namespace trklet;
 
-constexpr double triplet_phioffset = 0.171;
-
 TrackletCalculatorDisplaced::TrackletCalculatorDisplaced(string name,
                                                          Settings const& settings,
                                                          Globals* global,
@@ -301,11 +299,6 @@ bool TrackletCalculatorDisplaced::addLayerProj(Tracklet* tracklet, int layer) {
   FPGAWord fpgaz = tracklet->fpgazproj(layer);
   FPGAWord fpgaphi = tracklet->fpgaphiproj(layer);
 
-  if (fpgaphi.atExtreme())
-    edm::LogProblem("Tracklet") << "at extreme! " << fpgaphi.value();
-
-  assert(!fpgaphi.atExtreme());
-
   if (fpgaz.atExtreme())
     return false;
 
@@ -349,6 +342,9 @@ void TrackletCalculatorDisplaced::addProjectionDisk(int disk,
     return;
   }
   assert(trackletprojs != nullptr);
+  if (settings_.debugTracklet()) {
+    edm::LogVerbatim("Tracklet") << getName() << " adding projection to " << trackletprojs->getName();
+  }
   trackletprojs->addProj(tracklet);
 }
 
@@ -430,7 +426,6 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
   double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
 
   //TODO: implement the actual integer calculation
-  phi0 -= triplet_phioffset;
 
   //store the approcximate results
   rinvapprox = rinv;
@@ -440,7 +435,6 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
   z0approx = z0;
 
   for (unsigned int i = 0; i < toR_.size(); ++i) {
-    phiproj[i] -= triplet_phioffset;
     phiprojapprox[i] = phiproj[i];
     zprojapprox[i] = zproj[i];
     phiderapprox[i] = phider[i];
@@ -448,7 +442,6 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
   }
 
   for (unsigned int i = 0; i < toZ_.size(); ++i) {
-    phiprojdisk[i] -= triplet_phioffset;
     phiprojdiskapprox[i] = phiprojdisk[i];
     rprojdiskapprox[i] = rprojdisk[i];
     phiderdiskapprox[i] = phiderdisk[i];
@@ -535,7 +528,7 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
       continue;
     if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
       continue;
-
+    
     //check that phi projection is in range
     if (iphiproj[i] >= (1 << settings_.nphibitsstub(N_LAYER - 1)) - 1)
       continue;
@@ -597,7 +590,7 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
         continue;
       if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
         continue;
-
+      
       //check r projection in range
       if (rprojdiskapprox[i] < settings_.rmindisk() || rprojdiskapprox[i] > settings_.rmaxdisk())
         continue;
@@ -775,8 +768,6 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
 
   //TODO: implement the actual integer calculation
 
-  phi0 -= triplet_phioffset;
-
   //store the approcximate results
   rinvapprox = rinv;
   phi0approx = phi0;
@@ -785,7 +776,6 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
   z0approx = z0;
 
   for (unsigned int i = 0; i < toR_.size(); ++i) {
-    phiproj[i] -= triplet_phioffset;
     phiprojapprox[i] = phiproj[i];
     zprojapprox[i] = zproj[i];
     phiderapprox[i] = phider[i];
@@ -793,7 +783,6 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
   }
 
   for (unsigned int i = 0; i < toZ_.size(); ++i) {
-    phiprojdisk[i] -= triplet_phioffset;
     phiprojdiskapprox[i] = phiprojdisk[i];
     rprojdiskapprox[i] = rprojdisk[i];
     phiderdiskapprox[i] = phiderdisk[i];
@@ -990,7 +979,7 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
                                     it,
                                     layerprojs,
                                     diskprojs,
-                                    false);
+                                    true);
 
   if (settings_.debugTracklet()) {
     edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName()
@@ -1105,8 +1094,6 @@ bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
 
   //TODO: implement the actual integer calculation
 
-  phi0 -= triplet_phioffset;
-
   //store the approcximate results
   rinvapprox = rinv;
   phi0approx = phi0;
@@ -1115,7 +1102,6 @@ bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
   z0approx = z0;
 
   for (unsigned int i = 0; i < toR_.size(); ++i) {
-    phiproj[i] -= triplet_phioffset;
     phiprojapprox[i] = phiproj[i];
     zprojapprox[i] = zproj[i];
     phiderapprox[i] = phider[i];
@@ -1123,7 +1109,6 @@ bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
   }
 
   for (unsigned int i = 0; i < toZ_.size(); ++i) {
-    phiprojdisk[i] -= triplet_phioffset;
     phiprojdiskapprox[i] = phiprojdisk[i];
     rprojdiskapprox[i] = rprojdisk[i];
     phiderdiskapprox[i] = phiderdisk[i];
@@ -1417,7 +1402,8 @@ void TrackletCalculatorDisplaced::exactprojdisk(double zproj,
 
   phiproj = atan2(y, x);
 
-  phiproj = reco::reduceRange(phiproj - phimin_ + (phimax_ - phimin_) / 6.0);
+  phiproj = reco::reduceRange(phiproj - phimin_ );
+
   rproj = sqrt(x * x + y * y);
 
   phider = c / t / (x * x + y * y) * (rho + x0 * cos(phiV + c * beta) + y0 * sin(phiV + c * beta));
@@ -1481,7 +1467,8 @@ void TrackletCalculatorDisplaced::exacttracklet(double r1,
   rinv = 1. / R1;
   phi0 = 0.5 * M_PI + atan2(y0, x0);
 
-  phi0 += -phimin_ + (phimax_ - phimin_) / 6.0;
+  phi0 -= phimin_;
+
   d0 = -R1 + sqrt(x0 * x0 + y0 * y0);
   //sign of rinv:
   double dphi = reco::reduceRange(phi3 - atan2(y0, x0));

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
@@ -261,14 +261,12 @@ void TrackletEngineDisplaced::execute() {
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
                                              << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule());
               }
-              //if (!settings_.writeTripletTables())
-	      //	continue;
             }
 
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName())||true) {
+              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName()) || true) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -343,15 +341,13 @@ void TrackletEngineDisplaced::execute() {
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
                                              << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule());
               }
-              //if (!settings_.writeTripletTables())
-	      //continue;
             }
 
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding disk-disk pair in " << getName();
 
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName())||true) {
+              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName()) || true) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -400,8 +396,8 @@ void TrackletEngineDisplaced::readTables() {
 
   string tablePath = settings_.tableTEDFile();
   unsigned int finddir = tablePath.find("table_TED_");
-  tableName = tablePath.substr(0,finddir) + "table_" + name_ + ".txt";
-  
+  tableName = tablePath.substr(0, finddir) + "table_" + name_ + ".txt";
+
   fin.open(tableName, ifstream::in);
   if (!fin) {
     throw cms::Exception("BadConfig") << "TripletEngine::readTables, file " << tableName << " not known";

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
@@ -261,14 +261,14 @@ void TrackletEngineDisplaced::execute() {
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
                                              << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule());
               }
-              if (!settings_.writeTripletTables())
-                continue;
+              //if (!settings_.writeTripletTables())
+	      //	continue;
             }
 
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName())) {
+              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName())||true) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -343,15 +343,15 @@ void TrackletEngineDisplaced::execute() {
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
                                              << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule());
               }
-              if (!settings_.writeTripletTables())
-                continue;
+              //if (!settings_.writeTripletTables())
+	      //continue;
             }
 
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding disk-disk pair in " << getName();
 
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName())) {
+              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName())||true) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -398,8 +398,10 @@ void TrackletEngineDisplaced::readTables() {
   ifstream fin;
   string tableName, line, word;
 
-  tableName = "../data/table_TED/table_" + name_ + ".txt";
-
+  string tablePath = settings_.tableTEDFile();
+  unsigned int finddir = tablePath.find("table_TED_");
+  tableName = tablePath.substr(0,finddir) + "table_" + name_ + ".txt";
+  
   fin.open(tableName, ifstream::in);
   if (!fin) {
     throw cms::Exception("BadConfig") << "TripletEngine::readTables, file " << tableName << " not known";

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -476,7 +476,7 @@ void TrackletEventProcessor::event(SLHCEvent& ev) {
   FTTimer_.start();
   for (unsigned int k = 0; k < N_SECTOR; k++) {
     sectors_[k]->executeFT();
-#ifndef USEHYBRID //don't try to print these memories if running hybrid
+#ifndef USEHYBRID  //don't try to print these memories if running hybrid
     if ((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) {
       sectors_[k]->writeTF(first);
     }
@@ -488,7 +488,7 @@ void TrackletEventProcessor::event(SLHCEvent& ev) {
   PDTimer_.start();
   for (unsigned int k = 0; k < N_SECTOR; k++) {
     sectors_[k]->executePD(tracks_);
-#ifndef USEHYBRID //don't try to print these memories if running hybrid
+#ifndef USEHYBRID  //don't try to print these memories if running hybrid
     if (((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) ||
         settings_->writeMonitorData("CT")) {
       sectors_[k]->writeCT(first);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
@@ -35,6 +35,8 @@ TrackletProcessor::TrackletProcessor(string name, Settings const& settings, Glob
     trackletprojdisks_.push_back(tmp);
   }
 
+  initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
+  
   layer_ = 0;
   disk_ = 0;
 
@@ -453,28 +455,24 @@ void TrackletProcessor::execute() {
               if (rbin - rbinfirst > rdiffmax)
                 continue;
 
-              unsigned int irouterbin = vmbits >> 2;
-
+	      int rzbin = outervmstub.vmbits().bits(0, 3);
+	      
               FPGAWord iphiinnerbin = innervmstub.finephi();
               FPGAWord iphiouterbin = outervmstub.finephi();
 
-              unsigned int index = (irouterbin << (outerphibits_ + innerphibits_)) +
-                                   (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
+	      unsigned int index = (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
 
-              assert(index < phitable_[phiindex].size());
-              if (!phitable_[phiindex][index]) {
-                if (settings_.debugTracklet()) {
-                  edm::LogVerbatim("Tracklet") << "Stub pair rejected because of tracklet pt cut";
-                }
-                continue;
-              }
-
+	      if (iSeed_ >= 4) {  //Also use r-position
+		int ir = ((ibin & 3) << 1) + (rzbin >> 2);
+		index = (index << 3) + ir;
+	      }
+	      
               FPGAWord innerbend = innervmstub.bend();
               FPGAWord outerbend = outervmstub.bend();
 
               unsigned int ptinnerindex = (index << innerbend.nbits()) + innerbend.value();
               unsigned int ptouterindex = (index << outerbend.nbits()) + outerbend.value();
-
+	      
               assert(ptinnerindex < pttableinner_[phiindex].size());
               assert(ptouterindex < pttableouter_[phiindex].size());
 
@@ -487,7 +485,6 @@ void TrackletProcessor::execute() {
                       << " pass : " << pttableinner_[phiindex][ptinnerindex] << " "
                       << pttableouter_[phiindex][ptouterindex];
                 }
-                continue;
               }
 
               if (settings_.debugTracklet())
@@ -710,7 +707,7 @@ void TrackletProcessor::setVMPhiBin() {
 
     if ((disk_ == 1 && layer_ == 0) || (disk_ == 3 && layer_ == 0)) {
       innerphibits_ = settings_.nfinephi(0, iSeed_);
-      outerphibits_ = settings_.nfinephi(0, iSeed_);
+      outerphibits_ = settings_.nfinephi(1, iSeed_);
 
       int outerrbits = 3;
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
@@ -462,9 +462,10 @@ void TrackletProcessor::execute() {
 
               unsigned int index = (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
 
-              if (iSeed_ >= 4) {  //Also use r-position
-                int ir = ((ibin & 3) << 1) + (rzbin >> 2);
-                index = (index << 3) + ir;
+              constexpr unsigned int n_barrelseed = 3;
+              if (iSeed_ > n_barrelseed) {  //Also use r-position for disk/overlap seeds
+                int ir = ((ibin & n_barrelseed) << 1) + (rzbin >> 2);
+                index = (index << n_barrelseed) + ir;
               }
 
               FPGAWord innerbend = innervmstub.bend();

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
@@ -36,7 +36,7 @@ TrackletProcessor::TrackletProcessor(string name, Settings const& settings, Glob
   }
 
   initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
-  
+
   layer_ = 0;
   disk_ = 0;
 
@@ -455,24 +455,24 @@ void TrackletProcessor::execute() {
               if (rbin - rbinfirst > rdiffmax)
                 continue;
 
-	      int rzbin = outervmstub.vmbits().bits(0, 3);
-	      
+              int rzbin = outervmstub.vmbits().bits(0, 3);
+
               FPGAWord iphiinnerbin = innervmstub.finephi();
               FPGAWord iphiouterbin = outervmstub.finephi();
 
-	      unsigned int index = (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
+              unsigned int index = (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
 
-	      if (iSeed_ >= 4) {  //Also use r-position
-		int ir = ((ibin & 3) << 1) + (rzbin >> 2);
-		index = (index << 3) + ir;
-	      }
-	      
+              if (iSeed_ >= 4) {  //Also use r-position
+                int ir = ((ibin & 3) << 1) + (rzbin >> 2);
+                index = (index << 3) + ir;
+              }
+
               FPGAWord innerbend = innervmstub.bend();
               FPGAWord outerbend = outervmstub.bend();
 
               unsigned int ptinnerindex = (index << innerbend.nbits()) + innerbend.value();
               unsigned int ptouterindex = (index << outerbend.nbits()) + outerbend.value();
-	      
+
               assert(ptinnerindex < pttableinner_[phiindex].size());
               assert(ptouterindex < pttableouter_[phiindex].size());
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
@@ -8,11 +8,11 @@ using namespace trklet;
 
 TrackletProjectionsMemory::TrackletProjectionsMemory(string name, Settings const& settings, unsigned int iSector)
     : MemoryBase(name, settings, iSector) {
-  if (settings_.extended()) {
-    initLayerDisk(14, layer_, disk_);
-  } else {
-    initLayerDisk(12, layer_, disk_);
-  }
+
+  size_t pos=find_nth(name,0,"_",1);
+  assert(pos!=string::npos);
+  initLayerDisk(pos+1, layer_, disk_);
+
 }
 
 void TrackletProjectionsMemory::addProj(Tracklet* tracklet) {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
@@ -8,11 +8,9 @@ using namespace trklet;
 
 TrackletProjectionsMemory::TrackletProjectionsMemory(string name, Settings const& settings, unsigned int iSector)
     : MemoryBase(name, settings, iSector) {
-
-  size_t pos=find_nth(name,0,"_",1);
-  assert(pos!=string::npos);
-  initLayerDisk(pos+1, layer_, disk_);
-
+  size_t pos = find_nth(name, 0, "_", 1);
+  assert(pos != string::npos);
+  initLayerDisk(pos + 1, layer_, disk_);
 }
 
 void TrackletProjectionsMemory::addProj(Tracklet* tracklet) {

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
@@ -156,7 +156,8 @@ void TripletEngine::execute() {
       auto secondvmstub = stubpairs_.at(i)->getVMStub2(j);
 
       if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
-        int lookupbits = (int)((firstvmstub.vmbits().value() >> 10) & 1023);
+        constexpr unsigned int vmbitshift = 10;
+        int lookupbits = (int)((firstvmstub.vmbits().value() >> vmbitshift) & 1023);  //1023=2^vmbitshift-1
         int newbin = (lookupbits & 127);
         int bin = newbin / 8;
 
@@ -293,8 +294,6 @@ void TripletEngine::execute() {
                       << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule()) << " "
                       << benddecode(thirdvmstub.bend().value(), thirdvmstub.isPSmodule());
                 }
-                //if (!settings_.writeTripletTables())
-                //  continue;
               }
               if (settings_.writeTripletTables())
                 table_[index] = true;
@@ -377,8 +376,6 @@ void TripletEngine::execute() {
                       << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule()) << " "
                       << benddecode(thirdvmstub.bend().value(), thirdvmstub.isPSmodule());
                 }
-                //if (!settings_.writeTripletTables())
-                //  continue;
               }
               if (settings_.writeTripletTables())
                 table_[index] = true;

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
@@ -243,7 +243,7 @@ void TripletEngine::execute() {
       }
 
       else if (disk2_ == 2 && layer3_ == 2) {
-        int lookupbits = (int)((firstvmstub.vmbits().value() >> 9) & 1023);
+        int lookupbits = (int)((firstvmstub.vmbits().value() >> 10) & 1023);
         int newbin = (lookupbits & 127);
         int bin = newbin / 8;
 
@@ -261,6 +261,7 @@ void TripletEngine::execute() {
             vmsteSuffix = vmsteSuffix.substr(0, vmsteSuffix.find_last_of('n'));
             if (stubpairs_.at(i)->getLastPartOfName() != vmsteSuffix)
               continue;
+
             for (unsigned int l = 0; l < thirdvmstubs_.at(k)->nVMStubsBinned(ibin); l++) {
               if (countall >= settings_.maxStep("TRE"))
                 break;
@@ -288,12 +289,12 @@ void TripletEngine::execute() {
               if (!table_[index]) {
                 if (settings_.debugTracklet()) {
                   edm::LogVerbatim("Tracklet")
-                      << "Stub pair rejected because of stub pt cut bends : "
+                      << "Stub triplet rejected because of stub pt cut bends : "
                       << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule()) << " "
                       << benddecode(thirdvmstub.bend().value(), thirdvmstub.isPSmodule());
                 }
-                if (!settings_.writeTripletTables())
-                  continue;
+                //if (!settings_.writeTripletTables())
+                //  continue;
               }
               if (settings_.writeTripletTables())
                 table_[index] = true;
@@ -337,7 +338,6 @@ void TripletEngine::execute() {
             vmsteSuffix = vmsteSuffix.substr(0, vmsteSuffix.find_last_of('n'));
             if (stubpairs_.at(i)->getLastPartOfName() != vmsteSuffix)
               continue;
-            assert(thirdvmstubs_.at(k)->nVMStubsBinned(ibin) == thirdvmstubs_.at(k)->nVMStubsBinned(ibin));
             for (unsigned int l = 0; l < thirdvmstubs_.at(k)->nVMStubsBinned(ibin); l++) {
               if (countall >= settings_.maxStep("TRE"))
                 break;
@@ -377,8 +377,8 @@ void TripletEngine::execute() {
                       << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule()) << " "
                       << benddecode(thirdvmstub.bend().value(), thirdvmstub.isPSmodule());
                 }
-                if (!settings_.writeTripletTables())
-                  continue;
+                //if (!settings_.writeTripletTables())
+                //  continue;
               }
               if (settings_.writeTripletTables())
                 table_[index] = true;
@@ -438,8 +438,10 @@ void TripletEngine::readTables() {
   string tableName, word;
   unsigned num;
 
-  tableName = "../data/table_TRE/table_" + name_ + ".txt";
-
+  string tablePath = settings_.tableTREFile();
+  unsigned int finddir = tablePath.find("table_TRE_");
+  tableName = tablePath.substr(0,finddir) + "table_" + name_ + ".txt";
+  
   fin.open(tableName, ifstream::in);
   if (!fin) {
     throw cms::Exception("BadConfig") << "TripletEngine::readTables, file " << tableName << " not known";

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
@@ -440,8 +440,8 @@ void TripletEngine::readTables() {
 
   string tablePath = settings_.tableTREFile();
   unsigned int finddir = tablePath.find("table_TRE_");
-  tableName = tablePath.substr(0,finddir) + "table_" + name_ + ".txt";
-  
+  tableName = tablePath.substr(0, finddir) + "table_" + name_ + ".txt";
+
   fin.open(tableName, ifstream::in);
   if (!fin) {
     throw cms::Exception("BadConfig") << "TripletEngine::readTables, file " << tableName << " not known";

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -222,12 +222,17 @@ void VMRouter::execute() {
         vmbin += 8;
       int rzfine = melut & 7;
 
+      // pad disk PS bend word with a '0' in MSB so that all disk bends have 4 bits (for HLS compatibility)
+      int nbendbits = stub->bend().nbits();
+      if (layerdisk_ >= N_LAYER) 
+        nbendbits = settings_.nbendbitsmedisk();
+
       VMStubME vmstub(
           stub,
           stub->iphivmFineBins(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_)),
                                settings_.nbitsvmme(layerdisk_)),
           FPGAWord(rzfine, 3, true, __LINE__, __FILE__),
-          stub->bend(),
+          FPGAWord(stub->bend().value(), nbendbits, true, __LINE__, __FILE__),
           allStubIndex);
 
       assert(vmstubsMEPHI_[ivmPlus] != nullptr);

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -224,7 +224,7 @@ void VMRouter::execute() {
 
       // pad disk PS bend word with a '0' in MSB so that all disk bends have 4 bits (for HLS compatibility)
       int nbendbits = stub->bend().nbits();
-      if (layerdisk_ >= N_LAYER) 
+      if (layerdisk_ >= N_LAYER)
         nbendbits = settings_.nbendbitsmedisk();
 
       VMStubME vmstub(

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
@@ -211,8 +211,9 @@ int VMRouterTable::getLookup(unsigned int layerdisk, double z, double r, int ise
     int rbin2 = NBINS * (rmax - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
 
     if (iseed == 10) {
-      rbin1 = NBINS * (rmin - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
-      rbin2 = NBINS * (rmax - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+      double rminspec=40.0;
+      rbin1 = NBINS * (rmin - rminspec) / (settings_.rmaxdisk() - rminspec);
+      rbin2 = NBINS * (rmax - rminspec) / (settings_.rmaxdisk() - rminspec);
     }
 
     if (rbin2 >= NBINS)

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
@@ -211,7 +211,7 @@ int VMRouterTable::getLookup(unsigned int layerdisk, double z, double r, int ise
     int rbin2 = NBINS * (rmax - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
 
     if (iseed == 10) {
-      double rminspec = 40.0;
+      constexpr double rminspec = 40.0;
       rbin1 = NBINS * (rmin - rminspec) / (settings_.rmaxdisk() - rminspec);
       rbin2 = NBINS * (rmax - rminspec) / (settings_.rmaxdisk() - rminspec);
     }

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
@@ -211,7 +211,7 @@ int VMRouterTable::getLookup(unsigned int layerdisk, double z, double r, int ise
     int rbin2 = NBINS * (rmax - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
 
     if (iseed == 10) {
-      double rminspec=40.0;
+      double rminspec = 40.0;
       rbin1 = NBINS * (rmin - rminspec) / (settings_.rmaxdisk() - rminspec);
       rbin2 = NBINS * (rmax - rminspec) / (settings_.rmaxdisk() - rminspec);
     }

--- a/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc
@@ -77,15 +77,21 @@ bool VMStubsTEMemory::addVMStub(VMStubTE vmstub, int bin) {
       assert(bin < 4);
       if (negdisk)
         bin += 4;
+      if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+        return false;
       stubsbinnedvm_[bin].push_back(vmstub);
       if (settings_.debugTracklet())
         edm::LogVerbatim("Tracklet") << getName() << " Stub in disk = " << disk_ << "  in bin = " << bin;
     } else if (layer_ == 2) {
+      if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+        return false;
       stubsbinnedvm_[bin].push_back(vmstub);
     }
   } else {
     if (vmstub.stub()->isBarrel()) {
       if (!isinner_) {
+        if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+          return false;
         stubsbinnedvm_[bin].push_back(vmstub);
       }
 
@@ -94,12 +100,16 @@ bool VMStubsTEMemory::addVMStub(VMStubTE vmstub, int bin) {
         assert(bin < 4);
         if (negdisk)
           bin += 4;
+        if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+          return false;
         stubsbinnedvm_[bin].push_back(vmstub);
       }
     }
   }
   if (settings_.debugTracklet())
     edm::LogVerbatim("Tracklet") << "Adding stubs to " << getName();
+  if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+    return false;
   stubsvm_.push_back(vmstub);
   return true;
 }

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -119,7 +119,7 @@ elif (L1TRKALGO == 'TRACKLET'):
 elif (L1TRKALGO == 'TMTT'):
     print "\n WARNING - this is not a recommended algorithm! Please use HYBRID (HYBRID_DISPLACED)! \n"
     process.load("L1Trigger.TrackFindingTMTT.TMTrackProducer_Ultimate_cff")
-    L1TRK_PROC  =  process.TMTrackProducer    
+    L1TRK_PROC  =  process.TMTrackProducer
     L1TRK_NAME  = "TMTrackProducer"
     L1TRK_LABEL = "TML1TracksKF4ParamsComb"
     L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigis"

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -93,6 +93,7 @@ if (L1TRKALGO == 'HYBRID'):
     NHELIXPAR = 4
     L1TRK_NAME  = "TTTracksFromTrackletEmulation"
     L1TRK_LABEL = "Level1TTTracks"
+    L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigis"
 
 # HYBRID: extended tracking
 elif (L1TRKALGO == 'HYBRID_DISPLACED'):
@@ -101,6 +102,7 @@ elif (L1TRKALGO == 'HYBRID_DISPLACED'):
     NHELIXPAR = 5
     L1TRK_NAME  = "TTTracksFromExtendedTrackletEmulation"
     L1TRK_LABEL = "Level1TTTracks"
+    L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigisExtended"
     
 # LEGACY ALGORITHM (EXPERTS ONLY): TRACKLET  
 elif (L1TRKALGO == 'TRACKLET'):
@@ -111,14 +113,17 @@ elif (L1TRKALGO == 'TRACKLET'):
     NHELIXPAR = 4
     L1TRK_NAME  = "TTTracksFromTrackletEmulation"
     L1TRK_LABEL = "Level1TTTracks"
+    L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigis"
 
 # LEGACY ALGORITHM (EXPERTS ONLY): TMTT  
 elif (L1TRKALGO == 'TMTT'):
     print "\n WARNING - this is not a recommended algorithm! Please use HYBRID (HYBRID_DISPLACED)! \n"
     process.load("L1Trigger.TrackFindingTMTT.TMTrackProducer_Ultimate_cff")
-    L1TRK_PROC  =  process.TMTrackProducer
+    L1TRK_PROC  =  process.TMTrackProducer    
     L1TRK_NAME  = "TMTrackProducer"
     L1TRK_LABEL = "TML1TracksKF4ParamsComb"
+    L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigis"
+    NHELIXPAR = 4
     L1TRK_PROC.EnableMCtruth = cms.bool(False) # Reduce CPU use by disabling internal histos.
     L1TRK_PROC.EnableHistos  = cms.bool(False)
     process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
@@ -126,7 +131,6 @@ elif (L1TRKALGO == 'TMTT'):
     process.TTTrackAssociatorFromPixelDigis.TTTracks = cms.VInputTag( cms.InputTag(L1TRK_NAME, L1TRK_LABEL) )
     process.TTTracksEmulation = cms.Path(process.offlineBeamSpot*L1TRK_PROC)
     process.TTTracksEmulationWithTruth = cms.Path(process.offlineBeamSpot*L1TRK_PROC*process.TrackTriggerAssociatorTracks)
-    NHELIXPAR = 4
 
 else:
     print "ERROR: Unknown L1TRKALGO option"
@@ -154,15 +158,15 @@ process.L1TrackNtuple = cms.EDAnalyzer('L1TrackNtupleMaker',
                                        TP_minPt = cms.double(2.0),       # only save TPs with pt > X GeV
                                        TP_maxEta = cms.double(2.5),      # only save TPs with |eta| < X
                                        TP_maxZ0 = cms.double(30.0),      # only save TPs with |z0| < X cm
-                                       L1TrackInputTag = cms.InputTag(L1TRK_NAME, L1TRK_LABEL), # TTTrack input
-                                       MCTruthTrackInputTag = cms.InputTag("TTTrackAssociatorFromPixelDigis", L1TRK_LABEL),  ## MCTruth input 
+                                       L1TrackInputTag = cms.InputTag(L1TRK_NAME, L1TRK_LABEL),         # TTTrack input
+                                       MCTruthTrackInputTag = cms.InputTag(L1TRUTH_NAME, L1TRK_LABEL),  # MCTruth input 
                                        # other input collections
                                        L1StubInputTag = cms.InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"),
                                        MCTruthClusterInputTag = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
                                        MCTruthStubInputTag = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),
                                        TrackingParticleInputTag = cms.InputTag("mix", "MergedTrackTruth"),
                                        TrackingVertexInputTag = cms.InputTag("mix", "MergedTrackTruth"),
-                                       ## tracking in jets stuff (--> requires AK4 genjet collection present!)
+                                       # tracking in jets (--> requires AK4 genjet collection present!)
                                        TrackingInJets = cms.bool(False),
                                        GenJetInputTag = cms.InputTag("ak4GenJets", ""),
                                        )


### PR DESCRIPTION
This is an identical update as PR #30168 (for reference, description below) but to CMSSW_11_2_X instead of CMSSW_11_1_X . 

------
This PR contains fixes for the L1 tracking for the HLT TDR:

(1) The update restores the expected pt resolution for high-pt particles (a bug had been introduced during the CMSSW integration).
(2) It allows to run the displaced ("extended") version of the L1 tracking w/o having to be in a particular directory (using edm::fileInPath), to make sure it could run in central production.
------