### PR TITLE
Reduce boost dependency in RecoTracker/TkDetLayers

### DIFF
--- a/RecoTracker/TkDetLayers/src/CompositeTECPetal.cc
+++ b/RecoTracker/TkDetLayers/src/CompositeTECPetal.cc
@@ -14,11 +14,10 @@
 #include "TkDetUtil.h"
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
 
-#include <boost/function.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
-#include <numeric>
+#include <functional>
 #include <iterator>
+#include <numeric>
 
 using namespace std;
 
@@ -39,7 +38,7 @@ namespace {
       std::transform(dets.begin(),
                      dets.end(),
                      boundaries.begin(),
-                     boost::bind(&GlobalPoint::perp, boost::bind(&GeometricSearchDet::position, _1)));
+                     std::bind(&GlobalPoint::perp, std::bind(&GeometricSearchDet::position, std::placeholders::_1)));
       std::adjacent_difference(boundaries.begin(), boundaries.end(), boundaries.begin(), Mean());
     }
 

--- a/RecoTracker/TkDetLayers/src/CompositeTECWedge.cc
+++ b/RecoTracker/TkDetLayers/src/CompositeTECWedge.cc
@@ -15,7 +15,6 @@
 
 #include "TkDetUtil.h"
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
-#include <boost/function.hpp>
 
 using namespace std;
 

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
@@ -16,8 +16,6 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "DataFormats/Common/interface/Trie.h"
-#include <boost/function.hpp>
-#include <boost/bind.hpp>
 
 using namespace std;
 

--- a/RecoTracker/TkDetLayers/src/Phase2EndcapRing.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2EndcapRing.cc
@@ -14,7 +14,6 @@
 
 #include "TkDetUtil.h"
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
-#include <boost/function.hpp>
 
 using namespace std;
 

--- a/RecoTracker/TkDetLayers/src/TIDRing.cc
+++ b/RecoTracker/TkDetLayers/src/TIDRing.cc
@@ -15,7 +15,6 @@
 
 #include "TkDetUtil.h"
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
-#include <boost/function.hpp>
 
 using namespace std;
 


### PR DESCRIPTION
#### PR description:
Replaced boost::bind for std::bind.
Removed unused headers.
The code should have the same behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 