### PR TITLE
Make CSC{AL,CL}CTDigi::getHits() to return by const reference instead of a copy

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -115,7 +115,7 @@ public:
   void setRun3(const bool isRun3);
 
   // wire hits in this ALCT
-  WireContainer getHits() const { return hits_; }
+  const WireContainer& getHits() const { return hits_; }
 
   void setHits(const WireContainer& hits) { hits_ = hits; }
 

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -127,7 +127,7 @@ public:
   void setCompCode(const int16_t code) { compCode_ = code; }
 
   // comparator hits in this CLCT
-  ComparatorContainer getHits() const { return hits_; }
+  const ComparatorContainer& getHits() const { return hits_; }
 
   void setHits(const ComparatorContainer& hits) { hits_ = hits; }
 


### PR DESCRIPTION
#### PR description:

This PR proposes to change `CSCCLCTDigi::getHits()` to return `CSCCLCTDigi::ComparatorContainer` (vector of vector of `uint16_t`) by a const reference instead of a copy. This change fixes a clang warning in `Validation/MuonCSCDigis/src/CSCStubMatcher.cc`
```
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/6038296c716a87387818187cfd4f57eb/opt/cmssw/slc7_amd64_gcc820/cms/cmssw/CMSSW_11_2_CLANG_X_2020-06-14-2300/src/Validation/MuonCSCDigis/src/CSCStubMatcher.cc:140:39: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
           for (const auto& clctComp : (*c).getHits()[layer - 1]) {
                                      ^~~~~~~~~~~~~~
1 warning generated.
```
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc820/CMSSW_11_2_CLANG_X_2020-06-14-2300/Validation/MuonCSCDigis

The `CSCALCTDigi::getHits()` is changed accordingly.

#### PR validation:

Code compiles, with clang without warnings.