### PR TITLE
Move Cosmics During Collisions Reconstruction to ALCARECO 

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmicsInCollisions_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmicsInCollisions_cff.py
@@ -24,8 +24,11 @@ ALCARECOTkAlCosmicsInCollisionsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.
     DebugOn      = cms.untracked.bool(False)
 )
 
+#_________________________ Cosmic During Collisions__________________________________
+from RecoTracker.SpecialSeedGenerators.cosmicDC_cff import *
+
 #________________________________Track selection____________________________________
-# AlCaReco for track based alignment using Cosmic muons reconstructed by Combinatorial Track Finder
+# AlCaReco for track based alignment using Cosmic muons reconstructed by Cosmics during collisions
 import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
 ALCARECOTkAlCosmicsInCollisions = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
     src = 'cosmicDCTracks',
@@ -49,4 +52,4 @@ ALCARECOTkAlCosmicsInCollisions = Alignment.CommonAlignmentProducer.AlignmentTra
     )
 
 #________________________________Sequences____________________________________
-seqALCARECOTkAlCosmicsInCollisions = cms.Sequence(ALCARECOTkAlCosmicsInCollisionsHLT+ALCARECOTkAlCosmicsInCollisionsDCSFilter+ALCARECOTkAlCosmicsInCollisions)
+seqALCARECOTkAlCosmicsInCollisions = cms.Sequence(cosmicDCTracksSeq*ALCARECOTkAlCosmicsInCollisionsHLT+ALCARECOTkAlCosmicsInCollisionsDCSFilter+ALCARECOTkAlCosmicsInCollisions)

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -49,9 +49,6 @@ from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 
 from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 
-# Cosmic During Collisions
-from RecoTracker.SpecialSeedGenerators.cosmicDC_cff import *
-
 # Low pT electrons
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronSequence_cff import *
 
@@ -176,7 +173,6 @@ highlevelrecoTask = cms.Task(egammaHighLevelRecoPrePFTask,
                              recoPFMETTask,
                              PFTauTask,
                              reducedRecHitsTask,
-                             cosmicDCTracksSeqTask,
                              lowPtGsfElectronTask,
                              conversionOpenTrackTask,
                              gsfTracksOpenConversions
@@ -197,7 +193,7 @@ _highlevelreco_HITask.add(hiClusterCompatibility)
 pp_on_AA_2018.toReplaceWith(highlevelrecoTask,highlevelrecoTask.copyAndExclude([PFTauTask]))
 
 # not commisoned and not relevant in FastSim (?):
-_fastSim_highlevelrecoTask = highlevelrecoTask.copyAndExclude([cosmicDCTracksSeqTask,muoncosmichighlevelrecoTask])
+_fastSim_highlevelrecoTask = highlevelrecoTask.copyAndExclude([muoncosmichighlevelrecoTask])
 fastSim.toReplaceWith(highlevelrecoTask,_fastSim_highlevelrecoTask)
 
 

--- a/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
@@ -34,10 +34,7 @@ RecoTrackerRECO = cms.PSet(
         'keep recoTrackExtras_conversionStepTracks_*_*', 
         'keep TrackingRecHitsOwned_conversionStepTracks_*_*',
         'keep *_ctfPixelLess_*_*', 
-        'keep *_dedxTruncated40_*_*',
-        'keep recoTracks_cosmicDCTracks_*_*',
-        'keep recoTrackExtras_cosmicDCTracks_*_*',
-        'keep TrackingRecHitsOwned_cosmicDCTracks_*_*'
+        'keep *_dedxTruncated40_*_*'
     )
 )
 RecoTrackerRECO.outputCommands.extend(RecoTrackerAOD.outputCommands)

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -22,9 +22,31 @@ cosmicDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_
 )
 
 # Ckf pattern
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff
+Chi2MeasurementEstimatorForCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.Chi2MeasurementEstimatorForP5.clone(
+    ComponentName = cms.string('Chi2MeasurementEstimatorForCDC'),
+    MaxDisplacement = 500
+)
+
+ckfBaseTrajectoryFilterCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.ckfBaseTrajectoryFilterP5.clone(
+    maxLostHits = 10,
+    maxConsecLostHits = 10
+)
+
+GroupedCkfTrajectoryBuilderCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.GroupedCkfTrajectoryBuilderP5.clone(
+    maxCand = 3,
+    estimator = 'Chi2MeasurementEstimatorForCDC',
+    trajectoryFilter = cms.PSet(
+        refToPSet_ = cms.string('ckfBaseTrajectoryFilterCDC')
+    )
+)
+
 import RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff
 cosmicDCCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff.ckfTrackCandidatesP5.clone(
     src = cms.InputTag( "cosmicDCSeeds" ),
+    TrajectoryBuilderPSet = cms.PSet(
+        refToPSet_ = cms.string('GroupedCkfTrajectoryBuilderCDC')
+    )
 )
 
 # Track producer

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -14,11 +14,11 @@ hitCollectorForCosmicDCSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstim
 )
 cosmicDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
     src = cms.InputTag("muonsFromCosmics"),
-    cut = cms.string("pt > 2 && abs(eta)<1.2 && phi<0"),
+    cut = cms.string("p > 3 && abs(eta)<1.6 && phi<0"),
     hitCollector = cms.string('hitCollectorForCosmicDCSeeds'),
     fromVertex = cms.bool(False),
-    maxEtaForTOB = cms.double(1.5),
-    minEtaForTEC = cms.double(0.7),
+    maxEtaForTOB = cms.double(2.5),
+    minEtaForTEC = cms.double(0.0),
 )
 
 # Ckf pattern


### PR DESCRIPTION
#### PR description:

The goal of this PR is two-fold:
   * move the CDC (Cosmics During Collisions) reconstruction out of the standard (p-p) reconstruction sequence and include it into the `TkAlCosmicsInCollisions` ALCARECO. This in turn allows to freely change the parameters in order to optimize for efficiency / acceptance at the cost of increase of timing, as the ALCARECO will be run only on the `NoBPTX` dataset and not in dense events where the seeding and candidate building explodes.
   *  thanks to the first point, the seeding and track building parameters have been optimized. Optimization has been done in order to increase the reconstruction efficiency of real interfill cosmics tracks undergoing the CDC reco.

#### PR validation:

The results of the parameter optimization have been presented [here](https://indico.cern.ch/event/879451/contributions/3873497/attachments/2045049/3425922/FollowUp_Cosmics_during_Collisions.pdf). The setup chosen here is corresponding to `TEST13`.
Detailed timing studies on the various setups have been produced by @mtosi and are collected in this [spreadsheet](https://docs.google.com/spreadsheets/d/1j4X3wbI6CbgSVHQKl8CU-ToU2gyZLaZcnT86hRR79uI/edit#gid=0).

This branch has also been technically tested by running the following command.
```
cmsDriver.py stepTest --conditions auto:run2_data -s RAW2DIGI,L1Reco,RECO,ALCA:TkAlCosmicsInCollisions --process reRECO --data --era Run2_2018 --eventcontent RECO,ALCARECO --scenario pp --datatier RECO,ALCARECO --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 -n 10000 --dasquery='file dataset=/NoBPTX/Run2018B-v1/RAW site=T2_CH_CERN' --nThreads=8 --no_exec
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.
cc:
@mtosi, @connorpa @vbotta 
