### PR TITLE
Improve Pixel Templates Payload Inspector messages

### DIFF
--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <numeric>
+#include <fstream>      // std::ifstream
 #include <string>
 #include <boost/tokenizer.hpp>
 #include <boost/range/adaptor/indexed.hpp>

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <numeric>
-#include <fstream>      // std::ifstream
+#include <fstream>  // std::ifstream
 #include <string>
 #include <boost/tokenizer.hpp>
 #include <boost/range/adaptor/indexed.hpp>

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -276,14 +276,22 @@ namespace {
         }
 
         std::map<unsigned int, short> templMap = payload->getTemplateIDs();
-        if (templMap.size() != SiPixelPI::phase1size) {
+        if (templMap.size() == SiPixelPI::phase0size || templMap.size() > SiPixelPI::phase1size) {
           edm::LogError("SiPixelTemplateDBObject_PayloadInspector")
-              << "SiPixelTempateLA maps are not supported for non-Phase1 Pixel geometries !";
+              << "There are " << templMap.size()
+              << " DetIds in this payload. SiPixelTempate Lorentz Angle maps are not supported for non-Phase1 Pixel "
+                 "geometries !";
           TCanvas canvas("Canv", "Canv", 1200, 1000);
           SiPixelPI::displayNotSupported(canvas, templMap.size());
           std::string fileName(m_imageFileName);
           canvas.SaveAs(fileName.c_str());
           return false;
+        } else {
+          if (templMap.size() < SiPixelPI::phase1size) {
+            edm::LogWarning("SiPixelTemplateDBObject_PayloadInspector")
+                << "\n ********* WARNING! ********* \n There are " << templMap.size() << " DetIds in this payload !"
+                << "\n **************************** \n";
+          }
         }
 
         for (auto const& entry : templMap) {
@@ -354,14 +362,22 @@ namespace {
         }
 
         std::map<unsigned int, short> templMap = payload->getTemplateIDs();
-        if (templMap.size() != SiPixelPI::phase1size) {
+
+        if (templMap.size() == SiPixelPI::phase0size || templMap.size() > SiPixelPI::phase1size) {
           edm::LogError("SiPixelTemplateDBObject_PayloadInspector")
-              << "SiPixelTempateIDs maps are not supported for non-Phase1 Pixel geometries !";
+              << "There are " << templMap.size()
+              << " DetIds in this payload. SiPixelTempateIDs maps are not supported for non-Phase1 Pixel geometries !";
           TCanvas canvas("Canv", "Canv", 1200, 1000);
           SiPixelPI::displayNotSupported(canvas, templMap.size());
           std::string fileName(m_imageFileName);
           canvas.SaveAs(fileName.c_str());
           return false;
+        } else {
+          if (templMap.size() < SiPixelPI::phase1size) {
+            edm::LogWarning("SiPixelTemplateDBObject_PayloadInspector")
+                << "\n ********* WARNING! ********* \n There are " << templMap.size() << " DetIds in this payload !"
+                << "\n **************************** \n";
+          }
         }
 
         /*


### PR DESCRIPTION
#### PR description:

Small technical update, in order not to forego the case in which a certain template payload has less entries than expected for phase-1 detector, but more than phase-0, which means certain `DetIds` were not populated.
The use-case is documented [here](https://hypernews.cern.ch/HyperNews/CMS/get/tk-alignment/1899.htm).
I profit of this PR to add a missing include `CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h` which prevents to use the file from other packages.

#### PR validation:

See e-mail thread at: https://hypernews.cern.ch/HyperNews/CMS/get/tk-alignment/1899.html

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.

