### PR TITLE
Reduce boost dependency in DQM/CSCMonitorModule

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Configuration.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Configuration.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <sstream>
+#include <functional>
 
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include <xercesc/dom/DOMNodeList.hpp>
@@ -43,9 +44,6 @@
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
-
-#include <boost/function.hpp>
-#include <boost/bind.hpp>
 
 #include <boost/timer.hpp>
 
@@ -256,26 +254,26 @@ namespace cscdqm {
         */
 
     /** Get MO Globally */
-    boost::function<bool(const HistoDef& histoT, MonitorObject*&)> fnGetHisto;
+    std::function<bool(const HistoDef& histoT, MonitorObject*&)> fnGetHisto;
 
     /** Pointers to Cache Functions */
-    boost::function<bool(const HistoId id, MonitorObject*& mo)> fnGetCacheEMUHisto;
-    boost::function<bool(const HistoId id, const HwId& id1, MonitorObject*& mo)> fnGetCacheFEDHisto;
-    boost::function<bool(const HistoId id, const HwId& id1, MonitorObject*& mo)> fnGetCacheDDUHisto;
-    boost::function<bool(const HistoId id, const HwId& id1, const HwId& id2, const HwId& id3, MonitorObject*& mo)>
+    std::function<bool(const HistoId id, MonitorObject*& mo)> fnGetCacheEMUHisto;
+    std::function<bool(const HistoId id, const HwId& id1, MonitorObject*& mo)> fnGetCacheFEDHisto;
+    std::function<bool(const HistoId id, const HwId& id1, MonitorObject*& mo)> fnGetCacheDDUHisto;
+    std::function<bool(const HistoId id, const HwId& id1, const HwId& id2, const HwId& id3, MonitorObject*& mo)>
         fnGetCacheCSCHisto;
-    boost::function<bool(const HistoId id, MonitorObject*& mo)> fnGetCacheParHisto;
-    boost::function<void(const HistoDef& histoT, MonitorObject*&)> fnPutHisto;
-    boost::function<bool(unsigned int&, unsigned int&, unsigned int&)> fnNextBookedCSC;
-    boost::function<bool(unsigned int&, unsigned int&)> fnIsBookedCSC;
-    boost::function<bool(unsigned int&)> fnIsBookedDDU;
-    boost::function<bool(unsigned int&)> fnIsBookedFED;
+    std::function<bool(const HistoId id, MonitorObject*& mo)> fnGetCacheParHisto;
+    std::function<void(const HistoDef& histoT, MonitorObject*&)> fnPutHisto;
+    std::function<bool(unsigned int&, unsigned int&, unsigned int&)> fnNextBookedCSC;
+    std::function<bool(unsigned int&, unsigned int&)> fnIsBookedCSC;
+    std::function<bool(unsigned int&)> fnIsBookedDDU;
+    std::function<bool(unsigned int&)> fnIsBookedFED;
 
     /** Pointer to Collection Book Function */
-    boost::function<MonitorObject*(const HistoBookRequest&)> fnBook;
+    std::function<MonitorObject*(const HistoBookRequest&)> fnBook;
 
     /** Pointer to CSC Det Id function */
-    boost::function<bool(const unsigned int, const unsigned int, CSCDetId&)> fnGetCSCDetId;
+    std::function<bool(const unsigned int, const unsigned int, CSCDetId&)> fnGetCSCDetId;
 
     /** Parameter Getters */
     BOOST_PP_SEQ_FOR_EACH_I(CONFIG_PARAMETER_GETTER_MACRO, _, CONFIG_PARAMETERS_SEQ)

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Dispatcher.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Dispatcher.cc
@@ -57,25 +57,38 @@ namespace cscdqm {
     provider = p_provider;
 
     /** Link/share Cache methods to function pointers in configuration */
-    config->fnGetCacheEMUHisto = boost::bind(&Cache::getEMU, &cache, _1, _2);
-    config->fnGetCacheFEDHisto = boost::bind(&Cache::getFED, &cache, _1, _2, _3);
-    config->fnGetCacheDDUHisto = boost::bind(&Cache::getDDU, &cache, _1, _2, _3);
-    config->fnGetCacheCSCHisto = boost::bind(&Cache::getCSC, &cache, _1, _2, _3, _4, _5);
-    config->fnGetCacheParHisto = boost::bind(&Cache::getPar, &cache, _1, _2);
-    config->fnPutHisto = boost::bind(&Cache::put, &cache, _1, _2);
-    config->fnNextBookedCSC = boost::bind(&Cache::nextBookedCSC, &cache, _1, _2, _3);
-    config->fnIsBookedCSC = boost::bind(&Cache::isBookedCSC, &cache, _1, _2);
-    config->fnIsBookedDDU = boost::bind(&Cache::isBookedDDU, &cache, _1);
-    config->fnIsBookedFED = boost::bind(&Cache::isBookedFED, &cache, _1);
+    config->fnGetCacheEMUHisto = std::bind(&Cache::getEMU, &cache, std::placeholders::_1, std::placeholders::_2);
+    config->fnGetCacheFEDHisto =
+        std::bind(&Cache::getFED, &cache, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+    config->fnGetCacheDDUHisto =
+        std::bind(&Cache::getDDU, &cache, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+    config->fnGetCacheCSCHisto = std::bind(&Cache::getCSC,
+                                           &cache,
+                                           std::placeholders::_1,
+                                           std::placeholders::_2,
+                                           std::placeholders::_3,
+                                           std::placeholders::_4,
+                                           std::placeholders::_5);
+    config->fnGetCacheParHisto = std::bind(&Cache::getPar, &cache, std::placeholders::_1, std::placeholders::_2);
+    config->fnPutHisto = std::bind(&Cache::put, &cache, std::placeholders::_1, std::placeholders::_2);
+    config->fnNextBookedCSC =
+        std::bind(&Cache::nextBookedCSC, &cache, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+    config->fnIsBookedCSC = std::bind(&Cache::isBookedCSC, &cache, std::placeholders::_1, std::placeholders::_2);
+    config->fnIsBookedDDU = std::bind(&Cache::isBookedDDU, &cache, std::placeholders::_1);
+    config->fnIsBookedFED = std::bind(&Cache::isBookedFED, &cache, std::placeholders::_1);
 
     /** Link/share local functions */
-    config->fnGetHisto = boost::bind(&Dispatcher::getHisto, this, _1, _2);
+    config->fnGetHisto = std::bind(&Dispatcher::getHisto, this, std::placeholders::_1, std::placeholders::_2);
 
     /** Link/share getCSCDetId function */
-    config->fnGetCSCDetId = boost::bind(&MonitorObjectProvider::getCSCDetId, provider, _1, _2, _3);
+    config->fnGetCSCDetId = std::bind(&MonitorObjectProvider::getCSCDetId,
+                                      provider,
+                                      std::placeholders::_1,
+                                      std::placeholders::_2,
+                                      std::placeholders::_3);
 
     /** Link/share booking function */
-    config->fnBook = boost::bind(&MonitorObjectProvider::bookMonitorObject, provider, _1);
+    config->fnBook = std::bind(&MonitorObjectProvider::bookMonitorObject, provider, std::placeholders::_1);
   }
 
   /**
@@ -244,10 +257,10 @@ namespace cscdqm {
   void Dispatcher::updateFractionAndEfficiencyHistos() {
     LockType lock(processorFract.mutex);
     if (config->getFRAEFF_SEPARATE_THREAD()) {
-      boost::function<void()> fnUpdate =
-          boost::bind(&EventProcessorMutex::updateFractionAndEfficiencyHistos, &processorFract);
+      std::function<void()> fnUpdate =
+          std::bind(&EventProcessorMutex::updateFractionAndEfficiencyHistos, &processorFract);
 #ifdef DQMMT
-      threads.create_thread(boost::ref(fnUpdate));
+      threads.create_thread(std::ref(fnUpdate));
 #else
       fnUpdate();
 #endif
@@ -263,10 +276,10 @@ namespace cscdqm {
   void Dispatcher::processStandby(HWStandbyType& standby) {
     LockType lock(processorFract.mutex);
     if (config->getFRAEFF_SEPARATE_THREAD()) {
-      boost::function<void(HWStandbyType&)> fnUpdate =
-          boost::bind(&EventProcessorMutex::processStandby, &processorFract, _1);
+      std::function<void(HWStandbyType&)> fnUpdate =
+          std::bind(&EventProcessorMutex::processStandby, &processorFract, std::placeholders::_1);
 #ifdef DQMMT
-      threads.create_thread(boost::ref(fnUpdate));
+      threads.create_thread(std::ref(fnUpdate));
 #else
       fnUpdate(standby);
 #endif


### PR DESCRIPTION
#### PR description:
Replaced boost::bind for std::bind..
Replaced boost::function for std::function.
Replaced boost::ref for std::ref.
The code should have the same behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 