### PR TITLE
Protection against invalid pointers in UniqueMerger added.

### DIFF
--- a/CommonTools/UtilAlgos/interface/UniqueMerger.h
+++ b/CommonTools/UtilAlgos/interface/UniqueMerger.h
@@ -20,14 +20,13 @@
  * 
  */
 
-#include <typeinfo>
-#include <iostream>
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/transform.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/CloneTrait.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>
 
 template <typename InputCollection,

--- a/CommonTools/UtilAlgos/interface/UniqueMerger.h
+++ b/CommonTools/UtilAlgos/interface/UniqueMerger.h
@@ -5,7 +5,8 @@
  * Merges an arbitrary number of collections
  * into a single collection, without duplicates. Based on logic from Merger.h.
  * This class template differs from Merger.h in that it uses a set instead of std::vector.
- * This requires the OutputCollection type to be sortable, which allows us to search for elements downstream efficiently.
+ * This requires the OutputCollection type to be sortable, 
+ * which allows us to search for elements downstream efficiently.
  *
  * Template parameters:
  * - C : collection type
@@ -14,16 +15,18 @@
  *
  * \author Lauren Hay
  *
- * \version $Revision: 1.1 $
+ * \version $Revision: 1.2 $
  *
  * 
  */
+
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/transform.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/CloneTrait.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>
 
 template <typename InputCollection,
@@ -65,7 +68,10 @@ void UniqueMerger<InputCollection, OutputCollection, P>::produce(edm::StreamID,
     edm::Handle<InputCollection> h;
     evt.getByToken(*s, h);
     for (typename InputCollection::const_iterator c = h->begin(); c != h->end(); ++c) {
-      coll_set.emplace(P::clone(*c));
+      if (P::clone(*c).isNonnull() && P::clone(*c).isAvailable() ) {
+	coll_set.emplace(P::clone(*c));
+	}
+      else { edm::LogWarning ("InvalidPointer") <<  "Found an invalid pointer. Will not merge to collection." << std::endl; }
     }
   }
   std::unique_ptr<OutputCollection> coll(new OutputCollection(coll_set.size()));

--- a/CommonTools/UtilAlgos/interface/UniqueMerger.h
+++ b/CommonTools/UtilAlgos/interface/UniqueMerger.h
@@ -61,17 +61,18 @@ UniqueMerger<InputCollection, OutputCollection, P>::~UniqueMerger() {}
 
 template <typename InputCollection, typename OutputCollection, typename P>
 void UniqueMerger<InputCollection, OutputCollection, P>::produce(edm::StreamID,
-                                                              edm::Event& evt,
-                                                              const edm::EventSetup&) const {
+                                                                 edm::Event& evt,
+                                                                 const edm::EventSetup&) const {
   set_type coll_set;
   for (typename vtoken::const_iterator s = srcToken_.begin(); s != srcToken_.end(); ++s) {
     edm::Handle<InputCollection> h;
     evt.getByToken(*s, h);
     for (typename InputCollection::const_iterator c = h->begin(); c != h->end(); ++c) {
-      if (P::clone(*c).isNonnull() && P::clone(*c).isAvailable() ) {
-	coll_set.emplace(P::clone(*c));
-	}
-      else { edm::LogWarning ("InvalidPointer") <<  "Found an invalid pointer. Will not merge to collection." << std::endl; }
+      if (P::clone(*c).isNonnull() && P::clone(*c).isAvailable()) {
+        coll_set.emplace(P::clone(*c));
+      } else {
+        edm::LogWarning("InvalidPointer") << "Found an invalid pointer. Will not merge to collection." << std::endl;
+      }
     }
   }
   std::unique_ptr<OutputCollection> coll(new OutputCollection(coll_set.size()));

--- a/CommonTools/UtilAlgos/interface/UniqueMerger.h
+++ b/CommonTools/UtilAlgos/interface/UniqueMerger.h
@@ -53,7 +53,7 @@ private:
 template <typename InputCollection, typename OutputCollection, typename P>
 UniqueMerger<InputCollection, OutputCollection, P>::UniqueMerger(const edm::ParameterSet& par)
     : srcToken_(edm::vector_transform(par.template getParameter<std::vector<edm::InputTag> >("src"),
-                                      [this](edm::InputTag const& tag) { return consumes<InputCollection>(tag); })){
+                                      [this](edm::InputTag const& tag) { return consumes<InputCollection>(tag); })) {
   produces<OutputCollection>();
 }
 
@@ -62,16 +62,16 @@ UniqueMerger<InputCollection, OutputCollection, P>::~UniqueMerger() {}
 
 template <typename InputCollection, typename OutputCollection, typename P>
 void UniqueMerger<InputCollection, OutputCollection, P>::produce(edm::StreamID,
-                                                              edm::Event& evt,
-                                                              const edm::EventSetup&) const {
+                                                                 edm::Event& evt,
+                                                                 const edm::EventSetup&) const {
   set_type coll_set;
   for (auto const& s : srcToken_) {
     edm::Handle<InputCollection> h;
     evt.getByToken(s, h);
     for (typename InputCollection::const_iterator c = h->begin(); c != h->end(); ++c) {
-    if (c->isNonnull() && c->isAvailable()){
-	coll_set.emplace(P::clone(*c));
-	}
+      if (c->isNonnull() && c->isAvailable()) {
+        coll_set.emplace(P::clone(*c));
+      }
     }
   }
   std::unique_ptr<OutputCollection> coll(new OutputCollection(coll_set.size()));


### PR DESCRIPTION
#### PR description:

Second attempt at fixing issue reported  here #30112.  First attempt was #30114 by @rappoccio , but the suggestion by @gpetruc was to move the protection upstream.

#### PR validation:

Ran test on a specific event that was known to throw the error.

