### PR TITLE
Add muon ID selectors for packed candidate collections

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -588,6 +588,7 @@
   <class name="edm::Wrapper<pat::GenericParticleRefVector>" />
   <class name="edm::Wrapper<pat::HemisphereRefVector>" />
   <class name="edm::Wrapper<pat::ConversionRefVector>" />
+  <class name="edm::Wrapper<pat::PackedCandidateRefVector>" />
 
   <!-- RefToBase<Candidate> from PATObjects -->
     <!-- With direct Holder -->

--- a/PhysicsTools/PatAlgos/plugins/PackedCandidateMuonSelectorProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedCandidateMuonSelectorProducer.cc
@@ -3,7 +3,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
@@ -12,109 +11,118 @@
 namespace pat {
 
   class PackedCandidateMuonSelectorProducer : public edm::stream::EDProducer<> {
-    typedef edm::ValueMap<bool> BoolMap;
 
   public:
     explicit PackedCandidateMuonSelectorProducer(const edm::ParameterSet& iConfig)
-        : muonToken_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+        : muonToken_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
           candidateToken_(
-              consumes<edm::View<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("candidates"))),
+              consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("candidates"))),
+          candidate2PFToken_(
+              consumes<edm::Association<reco::PFCandidateCollection> >(iConfig.getParameter<edm::InputTag>("candidates"))),
+          track2LostTrackToken_(
+              consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("lostTracks"))),
           muonSelectors_(iConfig.getParameter<std::vector<std::string> >("muonSelectors")),
-          muonIDs_(iConfig.getParameter<std::vector<std::string> >("muonIDs")),
-          maxDeltaR_(iConfig.getUntrackedParameter<double>("maxDeltaR", 1.E-3)),
-          maxDeltaRelPt_(iConfig.getUntrackedParameter<double>("maxDeltaRelPt", 1.E-2)) {
+          muonIDs_(iConfig.getParameter<std::vector<std::string> >("muonIDs")) {
       for (const auto& sel : muonSelectors_) {
-        produces<BoolMap>(sel);
+        produces<pat::PackedCandidateRefVector>("lostTracks"+sel);
+        produces<pat::PackedCandidateRefVector>("pfCandidates"+sel);
       }
       for (const auto& sel : muonIDs_) {
-        muonIDMap_[sel].reset(new StringCutObjectSelector<pat::Muon>("passed('" + sel + "')"));
-        produces<BoolMap>(sel);
+        muonIDMap_[sel].reset(new StringCutObjectSelector<reco::Muon>("passed('" + sel + "')"));
+        produces<pat::PackedCandidateRefVector>("lostTracks"+sel);
+        produces<pat::PackedCandidateRefVector>("pfCandidates"+sel);
       }
     }
-    ~PackedCandidateMuonSelectorProducer() override{};
+    ~PackedCandidateMuonSelectorProducer() = default;
 
     void produce(edm::Event&, const edm::EventSetup&) override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions&);
 
   private:
-    edm::EDGetTokenT<pat::MuonCollection> muonToken_;
-    edm::EDGetTokenT<edm::View<pat::PackedCandidate> > candidateToken_;
-    std::vector<std::string> muonSelectors_;
-    std::vector<std::string> muonIDs_;
-    std::map<std::string, std::unique_ptr<StringCutObjectSelector<pat::Muon> > > muonIDMap_;
-    double maxDeltaR_, maxDeltaRelPt_;
+    const edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+    const edm::EDGetTokenT<pat::PackedCandidateCollection> candidateToken_;
+    const edm::EDGetTokenT<pat::PackedCandidateCollection> lostTrackToken_;
+    const edm::EDGetTokenT<edm::Association<reco::PFCandidateCollection> > candidate2PFToken_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > track2LostTrackToken_;
+    const std::vector<std::string> muonSelectors_;
+    const std::vector<std::string> muonIDs_;
+    std::map<std::string, std::unique_ptr<StringCutObjectSelector<reco::Muon> > > muonIDMap_;
   };
 
 }  // namespace pat
 
 void pat::PackedCandidateMuonSelectorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::Handle<pat::MuonCollection> muons;
-  edm::Handle<edm::View<pat::PackedCandidate> > candidates;
+  const auto& muons = iEvent.get(muonToken_);
+  const auto& candidates = iEvent.getHandle(candidateToken_);
+  const auto& candidate2PF = iEvent.get(candidate2PFToken_);
+  const auto& track2LostTrack = iEvent.get(track2LostTrackToken_);
 
-  iEvent.getByToken(muonToken_, muons);
-  iEvent.getByToken(candidateToken_, candidates);
-
-  const auto& nCand = candidates->size();
-
-  std::map<std::string, std::vector<bool> > muonSelMap;
+  std::map<std::string, std::unique_ptr<pat::PackedCandidateRefVector> > lostTrackMap, candMap;
   for (const auto& sel : muonSelectors_) {
-    muonSelMap[sel] = std::vector<bool>(nCand, false);
+    lostTrackMap.emplace(sel, new pat::PackedCandidateRefVector());
+    candMap.emplace(sel, new pat::PackedCandidateRefVector());
   }
   for (const auto& sel : muonIDs_) {
-    muonSelMap[sel] = std::vector<bool>(nCand, false);
+    lostTrackMap.emplace(sel, new pat::PackedCandidateRefVector());
+    candMap.emplace(sel, new pat::PackedCandidateRefVector());
   }
 
   // loop over muons
-  for (const auto& muon : *muons) {
+  for (const auto& muon : muons) {
+    const auto& muonTrack = muon.innerTrack();
     // ignore muons without high purity inner track
-    if (muon.innerTrack().isNull() || !muon.innerTrack()->quality(reco::TrackBase::qualityByName("highPurity")))
+    if (muonTrack.isNull() || !muonTrack->quality(reco::TrackBase::qualityByName("highPurity")))
       continue;
 
-    // find candidate associated to muon
-    const auto& muonTrack = *muon.innerTrack();
-    for (size_t i = 0; i < nCand; i++) {
-      const auto& cand = candidates->refAt(i);
-      // ignore neutral candidates or without track
-      if (cand->charge() == 0 || !cand->hasTrackDetails())
-        continue;
+    // find lost track associated to muon
+    const auto& lostTrack = track2LostTrack[muonTrack];
+    if (lostTrack.isNonnull()) {
+      for (const auto& sel : muonSelectors_) {
+        if (muon::isGoodMuon(muon, muon::selectionTypeFromString(sel))) lostTrackMap[sel]->push_back(lostTrack);
+      }
+      for (const auto& sel : muonIDs_) {
+        if ((*muonIDMap_.at(sel))(muon)) lostTrackMap[sel]->push_back(lostTrack);
+      }
+      continue;
+    }
 
+    // find PF candidate associated to muon
+    for (size_t i = 0; i < candidates->size(); i++) {
+      const auto& cand = pat::PackedCandidateRef(candidates, i);
+      const auto& candTrack = candidate2PF[cand]->trackRef();
       // check if candidate and muon are compatible
-      const auto& candTrack = cand->pseudoTrack();
-      if (muonTrack.charge() == candTrack.charge() && muonTrack.numberOfValidHits() == candTrack.numberOfValidHits() &&
-          reco::deltaR(muonTrack.eta(), muonTrack.phi(), candTrack.eta(), candTrack.phi()) < maxDeltaR_ &&
-          std::abs((muonTrack.pt() - candTrack.pt()) / muonTrack.pt()) < maxDeltaRelPt_) {
-        // fill muon selector map
+      if (candTrack.isNonnull() && muonTrack.id() == candTrack.id()) {
         for (const auto& sel : muonSelectors_) {
-          muonSelMap[sel][i] = muon.muonID(sel);
+          if (muon::isGoodMuon(muon, muon::selectionTypeFromString(sel))) candMap[sel]->push_back(cand);
         }
         for (const auto& sel : muonIDs_) {
-          muonSelMap[sel][i] = (*muonIDMap_.at(sel))(muon);
+          if ((*muonIDMap_.at(sel))(muon)) candMap[sel]->push_back(cand);
         }
         break;
       }
     }
   }
 
-  // fill the value maps
-  for (const auto& s : muonSelMap) {
-    std::unique_ptr<BoolMap> valueMap(new BoolMap());
-    BoolMap::Filler filler(*valueMap);
-    filler.insert(candidates, s.second.begin(), s.second.end());
-    filler.fill();
-    iEvent.put(std::move(valueMap), s.first);
+  for (auto& s : lostTrackMap) {
+    iEvent.put(std::move(s.second), "lostTracks"+s.first);
+  }
+  for (auto& s : candMap) {
+    iEvent.put(std::move(s.second), "pfCandidates"+s.first);
   }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void pat::PackedCandidateMuonSelectorProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("muons", edm::InputTag("patMuons"))->setComment("muon input collection");
+  desc.add<edm::InputTag>("muons", edm::InputTag("muons"))->setComment("muon input collection");
   desc.add<edm::InputTag>("candidates", edm::InputTag("packedPFCandidates"))
-      ->setComment("packed candidate input collection");
-  desc.add<std::vector<std::string> >("muonSelectors", {})->setComment("muon selectors");
+      ->setComment("packed PF candidate input collection");
+  desc.add<edm::InputTag>("lostTracks", edm::InputTag("lostTracks"))
+      ->setComment("lost track input collection");
+  desc.add<std::vector<std::string> >("muonSelectors", {"AllTrackerMuons", "TMOneStationTight"})->setComment("muon selectors");
   desc.add<std::vector<std::string> >("muonIDs", {})->setComment("muon IDs");
-  descriptions.add("packedPFCandidateMuonID", desc);
+  descriptions.add("packedCandidateMuonID", desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PackedCandidateMuonSelectorProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedCandidateMuonSelectorProducer.cc
@@ -1,0 +1,123 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
+
+namespace pat {
+
+  class PackedCandidateMuonSelectorProducer : public edm::stream::EDProducer<> {
+
+    typedef edm::ValueMap<bool> BoolMap;
+
+    public:
+
+      explicit PackedCandidateMuonSelectorProducer(const edm::ParameterSet & iConfig):
+          muonToken_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+          candidateToken_(consumes<edm::View<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("candidates"))),
+          muonSelectors_(iConfig.getParameter<std::vector<std::string> >("muonSelectors")),
+          muonIDs_(iConfig.getParameter<std::vector<std::string> >("muonIDs"))
+      {
+        for (const auto& sel : muonSelectors_) {
+          produces<BoolMap>(sel);
+        }
+        for (const auto& sel : muonIDs_) {
+          muonIDMap_[sel].reset(new StringCutObjectSelector<pat::Muon>("passed('"+sel+"')"));
+          produces<BoolMap>(sel);
+        }
+      }
+      ~PackedCandidateMuonSelectorProducer() override {};
+
+      void produce(edm::Event&, const edm::EventSetup&) override;
+
+      static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+    private:
+
+      edm::EDGetTokenT<pat::MuonCollection> muonToken_;
+      edm::EDGetTokenT<edm::View<pat::PackedCandidate> > candidateToken_;
+      std::vector<std::string> muonSelectors_;
+      std::vector<std::string> muonIDs_;
+      std::map<std::string, std::unique_ptr<StringCutObjectSelector<pat::Muon> > > muonIDMap_;
+
+  };
+
+}
+
+void pat::PackedCandidateMuonSelectorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<pat::MuonCollection> muons;
+  edm::Handle<edm::View<pat::PackedCandidate> > candidates;
+
+  iEvent.getByToken(muonToken_, muons);
+  iEvent.getByToken(candidateToken_, candidates);
+
+  const auto& nCand = candidates->size();
+
+  std::map<std::string, std::vector<bool> > muonSelMap;
+  for (const auto& sel : muonSelectors_) {
+    muonSelMap[sel] = std::vector<bool>(nCand, false);
+  }
+  for (const auto& sel : muonIDs_) {
+    muonSelMap[sel] = std::vector<bool>(nCand, false);
+  }
+
+  // loop over muons
+  for (const auto& muon : *muons) {
+    // ignore muons without high purity inner track
+    if (muon.innerTrack().isNull() ||
+        !muon.innerTrack()->quality(reco::TrackBase::qualityByName("highPurity"))) continue;
+
+    // find candidate associated to muon
+    const auto& muonTrack = *muon.innerTrack();
+    for (size_t i = 0; i < nCand; i++) {
+      const auto& cand = candidates->refAt(i);
+      // ignore neutral candidates or without track
+      if (cand->charge()==0 || !cand->hasTrackDetails()) continue;
+
+      // check if candidate and muon are compatible
+      const auto& candTrack = cand->pseudoTrack();
+      if (muonTrack.charge()==candTrack.charge() &&
+          muonTrack.numberOfValidHits()==candTrack.numberOfValidHits() &&
+          std::abs(muonTrack.eta()-candTrack.eta())<1E-3 &&
+          std::abs(muonTrack.phi()-candTrack.phi())<1E-3 &&
+          std::abs((muonTrack.pt()-candTrack.pt())/muonTrack.pt())<1E-2) {
+        // fill muon selector map
+        for (const auto& sel : muonSelectors_) {
+          muonSelMap[sel][i] = muon.muonID(sel);
+        }
+        for (const auto& sel : muonIDs_) {
+          muonSelMap[sel][i] = (*muonIDMap_.at(sel))(muon);
+        }
+        break;
+      }
+    }
+  }
+
+  // fill the value maps
+  for (const auto& s : muonSelMap) {
+    std::unique_ptr<BoolMap> valueMap(new BoolMap());
+    BoolMap::Filler filler(*valueMap);
+    filler.insert(candidates, s.second.begin(), s.second.end());
+    filler.fill();
+    iEvent.put(std::move(valueMap), s.first);
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void pat::PackedCandidateMuonSelectorProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("muons", edm::InputTag("patMuons"))->setComment("muon input collection");
+  desc.add<edm::InputTag>("candidates", edm::InputTag("packedPFCandidates"))->setComment("packed candidate input collection");
+  desc.add<std::vector<std::string> >("muonSelectors", {})->setComment("muon selectors");
+  desc.add<std::vector<std::string> >("muonIDs", {})->setComment("muon IDs");
+  descriptions.add("packedPFCandidateMuonID", desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace pat;
+DEFINE_FWK_MODULE(PackedCandidateMuonSelectorProducer);

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -134,6 +134,11 @@ from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _run3_common_extraCommands)
 # --- 
 
+_pp_on_AA_extraCommands = ['keep *_packedCandidateMuonID_*_*']
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _pp_on_AA_extraCommands)
+
 MicroEventContentMC = cms.PSet(
     outputCommands = cms.untracked.vstring(MicroEventContent.outputCommands)
 )
@@ -171,11 +176,3 @@ phase2_hgcal.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.
 _phase2_timing_extraCommands = ["keep *_offlineSlimmedPrimaryVertices4D_*_*"]
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _phase2_timing_extraCommands)
-
-_pp_on_AA_extraCommands = [
-    'keep booledmValueMap_*MuonID_*_*',
-]
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _pp_on_AA_extraCommands)
-(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _pp_on_AA_extraCommands + ['keep *_heavyIon_*_*'])

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -171,3 +171,11 @@ phase2_hgcal.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.
 _phase2_timing_extraCommands = ["keep *_offlineSlimmedPrimaryVertices4D_*_*"]
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _phase2_timing_extraCommands)
+
+_pp_on_AA_extraCommands = [
+    'keep booledmValueMap_*MuonID_*_*',
+]
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _pp_on_AA_extraCommands)
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _pp_on_AA_extraCommands + ['keep *_heavyIon_*_*'])

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -63,10 +63,8 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))
 
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-from PhysicsTools.PatAlgos.packedPFCandidateMuonID_cfi import packedPFCandidateMuonID
-(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(packedPFCandidateMuonID, muonSelectors = cms.vstring(["AllTrackerMuons", "TMOneStationTight"]))
-lostTrackMuonID = packedPFCandidateMuonID.clone(candidates = cms.InputTag("lostTracks"))
-(pp_on_AA_2018 | pp_on_PbPb_run3).toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), packedPFCandidateMuonID, lostTrackMuonID))
+from PhysicsTools.PatAlgos.packedCandidateMuonID_cfi import packedCandidateMuonID
+(pp_on_AA_2018 | pp_on_PbPb_run3).toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), packedCandidateMuonID))
 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 _phase2_timing_slimmingTask = cms.Task(slimmingTask.copy(),

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -62,6 +62,12 @@ slimmingTask = cms.Task(
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+from PhysicsTools.PatAlgos.packedPFCandidateMuonID_cfi import packedPFCandidateMuonID
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(packedPFCandidateMuonID, muonSelectors = cms.vstring(["AllTrackerMuons", "TMOneStationTight"]))
+lostTrackMuonID = packedPFCandidateMuonID.clone(candidates = cms.InputTag("lostTracks"))
+(pp_on_AA_2018 | pp_on_PbPb_run3).toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), packedPFCandidateMuonID, lostTrackMuonID))
+
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 _phase2_timing_slimmingTask = cms.Task(slimmingTask.copy(),
                                        offlineSlimmedPrimaryVertices4D)


### PR DESCRIPTION
#### PR description:

This PR adds muon ID selectors (isTrackerMuon and TMOneStationTight), as PackedCandidateRefVectors,  associated the packedPFCandidates and lostTracks collections.

These are part of the HIN developments for MiniAOD event content.

Running over ~1000 events from the HIDoubleMuon PD of 2018 PbPb data, the average compressed size of the output collections (PackedCandidateRefVectors) were ~9 bytes/event for packedPFCandidates and ~6 bytes/event for lostTracks.

#### PR validation:

Tested with workflow 159

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@mandrenguyen 
