### PR TITLE
embed hi photon isolation in pat::photon userdata

### DIFF
--- a/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
+++ b/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
@@ -83,12 +83,12 @@ public:
   using ValMapToken = edm::EDGetTokenT<edm::ValueMap<MapType>>;
   using ValueMaps = std::unordered_map<std::string, ValMapToken>;
   struct electron_config {
-    edm::EDGetTokenT<edm::View<pat::Electron>> tok_electron_src;
+    edm::EDGetTokenT<edm::View<reco::GsfElectron>> tok_electron_src;
     ValueMaps tok_valuemaps;
   };
 
   struct photon_config {
-    edm::EDGetTokenT<edm::View<pat::Photon>> tok_photon_src;
+    edm::EDGetTokenT<edm::View<reco::Photon>> tok_photon_src;
     ValueMaps tok_valuemaps;
   };
 
@@ -123,7 +123,7 @@ EGExtraInfoModifierFromValueMaps<MapType, OutputType>::EGExtraInfoModifierFromVa
     const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
     if (electrons.exists(electronSrc))
       e_conf.tok_electron_src =
-          cc.consumes<edm::View<pat::Electron>>(electrons.getParameter<edm::InputTag>(electronSrc));
+          cc.consumes<edm::View<reco::GsfElectron>>(electrons.getParameter<edm::InputTag>(electronSrc));
 
     const std::vector<std::string> parameters = electrons.getParameterNames();
     for (const std::string& name : parameters) {
@@ -137,7 +137,7 @@ EGExtraInfoModifierFromValueMaps<MapType, OutputType>::EGExtraInfoModifierFromVa
   if (conf.exists("photon_config")) {
     const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
     if (photons.exists(photonSrc))
-      ph_conf.tok_photon_src = cc.consumes<edm::View<pat::Photon>>(photons.getParameter<edm::InputTag>(photonSrc));
+      ph_conf.tok_photon_src = cc.consumes<edm::View<reco::Photon>>(photons.getParameter<edm::InputTag>(photonSrc));
     const std::vector<std::string> parameters = photons.getParameterNames();
     for (const std::string& name : parameters) {
       if (std::string(photonSrc) == name)
@@ -160,7 +160,7 @@ void EGExtraInfoModifierFromValueMaps<MapType, OutputType>::setEvent(const edm::
   ele_idx = pho_idx = 0;
 
   if (!e_conf.tok_electron_src.isUninitialized()) {
-    edm::Handle<edm::View<pat::Electron>> eles;
+    edm::Handle<edm::View<reco::GsfElectron>> eles;
     evt.getByToken(e_conf.tok_electron_src, eles);
 
     eles_by_oop.resize(eles->size());
@@ -171,7 +171,7 @@ void EGExtraInfoModifierFromValueMaps<MapType, OutputType>::setEvent(const edm::
     evt.getByToken(itr.second, ele_vmaps[itr.second.index()]);
 
   if (!ph_conf.tok_photon_src.isUninitialized()) {
-    edm::Handle<edm::View<pat::Photon>> phos;
+    edm::Handle<edm::View<reco::Photon>> phos;
     evt.getByToken(ph_conf.tok_photon_src, phos);
 
     phos_by_oop.resize(phos->size());

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromValueMaps.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromValueMaps.cc
@@ -1,5 +1,7 @@
 #include "RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h"
 
+#include "DataFormats/EgammaCandidates/interface/HIPhotonIsolation.h"
+
 using EGExtraInfoModifierFromFloatValueMaps = EGExtraInfoModifierFromValueMaps<float>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
                   EGExtraInfoModifierFromFloatValueMaps,
@@ -27,6 +29,11 @@ using EGExtraInfoModifierFromUIntToIntValueMaps = EGExtraInfoModifierFromValueMa
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
                   EGExtraInfoModifierFromUIntToIntValueMaps,
                   "EGExtraInfoModifierFromUIntToIntValueMaps");
+
+using EGExtraInfoModifierFromHIPhotonIsolationValueMaps = EGExtraInfoModifierFromValueMaps<reco::HIPhotonIsolation>;
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
+                  EGExtraInfoModifierFromHIPhotonIsolationValueMaps,
+                  "EGExtraInfoModifierFromHIPhotonIsolationValueMaps");
 
 #include "DataFormats/PatCandidates/interface/VIDCutFlowResult.h"
 using EGExtraInfoModifierFromVIDCutFlowResultValueMaps = EGExtraInfoModifierFromValueMaps<vid::CutFlowResult>;

--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -170,4 +170,5 @@ run2_miniAOD_80XLegacy.toModify(egamma_modifications,appendEgamma8XLegacyAppenda
 run2_miniAOD_80XLegacy.toModify(egamma_modifications,prependEgamma8XObjectUpdateModifier)
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(egamma_modifications, appendEgammaHIPhotonIsolationModifier)
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(egamma_modifications, appendEgammaHIPhotonIsolationModifier)

--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -136,6 +136,16 @@ egamma8XLegacyEtScaleSysModifier = cms.PSet(
         )
     )
 
+# modifier for photon isolation used in heavy ions
+egammaHIPhotonIsolationModifier = cms.PSet(
+    modifierName = cms.string('EGExtraInfoModifierFromHIPhotonIsolationValueMaps'),
+    electron_config = cms.PSet(),
+    photon_config = cms.PSet(
+        photonSrc = cms.InputTag("gedPhotons"),
+        photonIsolationHI = cms.InputTag("photonIsolationHIProducerppGED")
+        )
+    )
+
 def appendReducedEgammaEnergyScaleAndSmearingModifier(modifiers):
     modifiers.append(reducedEgammaEnergyScaleAndSmearingModifier)
 
@@ -146,6 +156,9 @@ def appendEgamma8XLegacyAppendableModifiers (modifiers):
     modifiers.append(reducedEgammaEnergyScaleAndSmearingModifier)
     modifiers.append(egamma8XLegacyEtScaleSysModifier)
 
+def appendEgammaHIPhotonIsolationModifier(modifiers):
+    modifiers.append(egammaHIPhotonIsolationModifier)
+
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 (run2_miniAOD_94XFall17 | run2_miniAOD_UL).toModify(egamma_modifications,appendReducedEgammaEnergyScaleAndSmearingModifier)
@@ -155,3 +168,6 @@ from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_
 run2_miniAOD_80XLegacy.toModify(egamma9X105XUpdateModifier,allowGsfTrackForConvs = True)
 run2_miniAOD_80XLegacy.toModify(egamma_modifications,appendEgamma8XLegacyAppendableModifiers)
 run2_miniAOD_80XLegacy.toModify(egamma_modifications,prependEgamma8XObjectUpdateModifier)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(egamma_modifications, appendEgammaHIPhotonIsolationModifier)


### PR DESCRIPTION
this PR takes the HI-style photon isolation information, which are stored in RECO as valuemaps, and adds it to the userdata of the PAT photons. the change is applied to the pp_on_AA_2018 and pp_on_PbPb_run3 eras.

the existing code is modified slightly to allow the reco::Photon collection to also be used as input, because the isolation valuemaps are keyed by that collection. the changes should not affect usage in pp, since edm::View allows both reco:: and pat:: collections to be read.

tested with the 158/159 workflows that the information can be stored and read out.

@mandrenguyen 