### PR TITLE
Keep GEMDigiSimLinks after the DIGI step

### DIFF
--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -55,23 +55,23 @@ SimMuonPREMIX = cms.PSet(
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonGEMDigis_*_*'] )
-run2_GEM_2017.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
-run2_GEM_2017.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+run2_GEM_2017.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep *DigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+run2_GEM_2017.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep *DigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 run2_GEM_2017.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_mix_g4SimHitsMuonGEMHits_*'] )
 
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonGEMDigis_*_*'] )
-run3_GEM.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
-run3_GEM.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+run3_GEM.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep *DigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+run3_GEM.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep *DigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 run3_GEM.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_mix_g4SimHitsMuonGEMHits_*'] )
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0PseudoDigis_*_*',
                                                                                             'keep *_simMuonME0PseudoReDigis_*_*',
                                                                                             'keep *_simMuonME0Digis_*_*'] )
-phase2_muon.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
-phase2_muon.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
+phase2_muon.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep *DigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
+phase2_muon.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep *DigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
 phase2_muon.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_mix_g4SimHitsMuonME0Hits_*'] )
 
 


### PR DESCRIPTION
#### PR description:

RAW and RECO simulated data currently keep the `StripDigiSimLink` objects for GEMs. They are actually not that useful. However, the `GEMDigiSimLink` is much more useful as it properly links the GEM `SimHit` with the `GEMDigi` This PR adds it to the event content after the DIGI step. The size is about the same as the `StripDigiSimLink`. After running WF 23234.0:

<PRE>
-bash-4.2$ edmEventSize -a -v step2.root | grep GEM
GEMDigiSimLinkedmDetSetVector_simMuonME0Digis_ME0_HLT. 15540 5387.4
GEMDigiSimLinkedmDetSetVector_simMuonGEMDigis_GEM_HLT. 14341 4546.3
StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_GEM_HLT. 14279.2 4508.1
</PRE>

If the `GEMDigiSimLink` takes up too much space, I would propose to drop `StripDigiSimLink`, which is not used in the simulation AFAIK.

#### PR validation:

Tested with WF 23234.0

@jshlee 