### PR TITLE
[Pixel 3D digitizer] Boundary row/col check in digitizer

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -310,8 +310,8 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
     // away is probably showing some backward problem worth it to track.
     // This is also correcting out of bounds migrated charge from diffusion.
     // The charge will be moved to the edge of the row/column.
-    current_pixel.first  = std::clamp(current_pixel.first, float(0.0), (nrows-1)+pix_rounding);
-    current_pixel.second = std::clamp(current_pixel.second, float(0.0), (ncolumns-1)+pix_rounding);
+    current_pixel.first = std::clamp(current_pixel.first, float(0.0), (nrows - 1) + pix_rounding);
+    current_pixel.second = std::clamp(current_pixel.second, float(0.0), (ncolumns - 1) + pix_rounding);
 
     const auto current_pixel_int = std::make_pair(std::floor(current_pixel.first), std::floor(current_pixel.second));
 


### PR DESCRIPTION
#### PR description:
This PR fixes the issue spotted and described at #30215 .

The digitizer checks that the estimated row/col for each group of carriers is inside the expected limits. More details at  #30215

#### PR validation:
Check successfully with workflows  26234.0 and 24834.0 (geometries 2026D55 and 2026D54, IT with 3D pixels).