### PR TITLE
Reduce boost dependency in Utilities/XrdAdaptor

### DIFF
--- a/Utilities/XrdAdaptor/src/QualityMetric.h
+++ b/Utilities/XrdAdaptor/src/QualityMetric.h
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include "tbb/concurrent_unordered_map.h"
-#include <boost/utility.hpp>
 
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
@@ -18,13 +17,16 @@ namespace XrdAdaptor {
   class QualityMetricSource;
   class QualityMetricUniqueSource;
 
-  class QualityMetricWatch : boost::noncopyable {
+  class QualityMetricWatch {
     friend class QualityMetricSource;
 
   public:
     QualityMetricWatch() : m_parent1(nullptr), m_parent2(nullptr) {}
     QualityMetricWatch(QualityMetricWatch &&);
     ~QualityMetricWatch();
+
+    QualityMetricWatch(const QualityMetricWatch &) = delete;
+    QualityMetricWatch &operator=(const QualityMetricWatch &) = delete;
 
     void swap(QualityMetricWatch &);
 
@@ -35,12 +37,15 @@ namespace XrdAdaptor {
     edm::propagate_const<QualityMetric *> m_parent2;
   };
 
-  class QualityMetric : boost::noncopyable {
+  class QualityMetric {
     friend class QualityMetricWatch;
 
   public:
     QualityMetric(timespec now, int default_value = 260);
     unsigned get();
+
+    QualityMetric(const QualityMetric &) = delete;
+    QualityMetric &operator=(const QualityMetric &) = delete;
 
   private:
     void finishWatch(timespec now, int ms);

--- a/Utilities/XrdAdaptor/src/XrdRequest.h
+++ b/Utilities/XrdAdaptor/src/XrdRequest.h
@@ -4,7 +4,6 @@
 #include <future>
 #include <vector>
 
-#include <boost/utility.hpp>
 #include <XrdCl/XrdClXRootDResponses.hh>
 
 #include "Utilities/StorageFactory/interface/Storage.h"
@@ -20,10 +19,13 @@ namespace XrdAdaptor {
 
   class XrdReadStatistics;
 
-  class ClientRequest : boost::noncopyable, public XrdCl::ResponseHandler {
+  class ClientRequest : public XrdCl::ResponseHandler {
     friend class Source;
 
   public:
+    ClientRequest(const ClientRequest &) = delete;
+    ClientRequest &operator=(const ClientRequest &) = delete;
+
     ClientRequest(RequestManager &manager, void *into, IOSize size, IOOffset off)
         : m_failure_count(0), m_into(into), m_size(size), m_off(off), m_iolist(nullptr), m_manager(manager) {}
 

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -66,7 +66,7 @@ long long timeDiffMS(const timespec &a, const timespec &b) {
  * We do not care about the response of sending the monitoring information;
  * this handler class simply frees any returned buffer to prevent memory leaks.
  */
-class SendMonitoringInfoHandler : boost::noncopyable, public XrdCl::ResponseHandler {
+class SendMonitoringInfoHandler : public XrdCl::ResponseHandler {
   void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
     if (response) {
       XrdCl::Buffer *buffer = nullptr;
@@ -78,6 +78,11 @@ class SendMonitoringInfoHandler : boost::noncopyable, public XrdCl::ResponseHand
     delete response;
     delete status;
   }
+
+public:
+  SendMonitoringInfoHandler(const SendMonitoringInfoHandler &) = delete;
+  SendMonitoringInfoHandler &operator=(const SendMonitoringInfoHandler &) = delete;
+  SendMonitoringInfoHandler() = default;
 };
 
 CMS_THREAD_SAFE SendMonitoringInfoHandler nullHandler;

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -8,7 +8,6 @@
 #include <random>
 #include <sys/stat.h>
 
-#include <boost/utility.hpp>
 #include "tbb/concurrent_unordered_set.h"
 
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -42,8 +41,11 @@ namespace XrdAdaptor {
     uint16_t m_code;
   };
 
-  class RequestManager : boost::noncopyable {
+  class RequestManager {
   public:
+    RequestManager(const RequestManager &) = delete;
+    RequestManager &operator=(const RequestManager &) = delete;
+
     static const unsigned int XRD_DEFAULT_TIMEOUT = 3 * 60;
 
     virtual ~RequestManager() = default;
@@ -232,8 +234,11 @@ namespace XrdAdaptor {
 
     std::atomic<unsigned> m_excluded_active_count;
 
-    class OpenHandler : boost::noncopyable, public XrdCl::ResponseHandler {
+    class OpenHandler : public XrdCl::ResponseHandler {
     public:
+      OpenHandler(const OpenHandler &) = delete;
+      OpenHandler &operator=(const OpenHandler &) = delete;
+
       static std::shared_ptr<OpenHandler> getInstance(std::weak_ptr<RequestManager> manager) {
         OpenHandler *instance_ptr = new OpenHandler(manager);
         std::shared_ptr<OpenHandler> instance(instance_ptr);

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -36,8 +36,11 @@ using namespace XrdAdaptor;
 // inactive anyway!) can even timeout.  Rather than wait around for
 // a few minutes in the main thread, this class asynchronously closes
 // and deletes the XrdCl::File
-class DelayedClose : boost::noncopyable, public XrdCl::ResponseHandler {
+class DelayedClose : public XrdCl::ResponseHandler {
 public:
+  DelayedClose(const DelayedClose &) = delete;
+  DelayedClose &operator=(const DelayedClose &) = delete;
+
   DelayedClose(std::shared_ptr<XrdCl::File> fh, const std::string &id, const std::string &site)
       : m_fh(std::move(fh)), m_id(id), m_site(site) {
     if (m_fh && m_fh->IsOpen()) {

--- a/Utilities/XrdAdaptor/src/XrdSource.h
+++ b/Utilities/XrdAdaptor/src/XrdSource.h
@@ -7,8 +7,6 @@
 #include <memory>
 #include <vector>
 
-#include <boost/utility.hpp>
-
 #include "QualityMetric.h"
 
 namespace XrdCl {
@@ -22,8 +20,11 @@ namespace XrdAdaptor {
   class XrdSiteStatistics;
   class XrdStatisticsService;
 
-  class Source : public std::enable_shared_from_this<Source>, boost::noncopyable {
+  class Source : public std::enable_shared_from_this<Source> {
   public:
+    Source(const Source &) = delete;
+    Source &operator=(const Source &) = delete;
+
     Source(timespec now, std::unique_ptr<XrdCl::File> fileHandle, const std::string &exclude);
 
     ~Source();


### PR DESCRIPTION
#### PR description:
Removed the boost::noncopyable inheritance, and deleted copy constructor and copy operation instead. 
The code should have the same behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 