### PR TITLE
change boost::noncopyable for standard alternatives

### DIFF
--- a/CommonTools/Utils/src/MethodInvoker.h
+++ b/CommonTools/Utils/src/MethodInvoker.h
@@ -8,8 +8,6 @@
 #include "FWCore/Reflection/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
-#include <boost/utility.hpp>
-
 #include <map>
 #include <vector>
 
@@ -62,7 +60,7 @@ namespace reco {
     /// - it owns also the object in which to store the result
     /// - it handles by itself the popping out of Refs and Ptrs
     /// in this way, it can map 1-1 to a name and set of args
-    struct SingleInvoker : boost::noncopyable {
+    struct SingleInvoker {
     private:  // Private Data Members
       method::TypeCode retType_;
       std::vector<MethodInvoker> invokers_;
@@ -72,6 +70,9 @@ namespace reco {
       bool isRefGet_;
 
     public:
+      SingleInvoker(const SingleInvoker&) = delete;
+      SingleInvoker& operator=(const SingleInvoker&) = delete;
+
       SingleInvoker(const edm::TypeWithDict&, const std::string& name, const std::vector<AnyMethodArgument>& args);
       ~SingleInvoker();
 

--- a/DataFormats/Common/interface/MultiAssociation.h
+++ b/DataFormats/Common/interface/MultiAssociation.h
@@ -51,7 +51,6 @@
 #include <vector>
 #include <map>
 #include <memory>
-#include <boost/utility.hpp>
 #include <boost/range.hpp>
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
@@ -99,8 +98,11 @@ namespace edm {
       /// It requires to fill items in strict key order.
       /// You can have a single FastFiller for a given map at time
       /// You can't access the map for this collection while filling it
-      class FastFiller : boost::noncopyable {
+      class FastFiller {
       public:
+        FastFiller(const FastFiller &) = delete;
+        FastFiller &operator=(const FastFiller &) = delete;
+
         /// Make a filler for a collection with a given product id and size
         FastFiller(IndexRangeAssociation &assoc, ProductID id, unsigned int size);
 

--- a/FWCore/ParameterSet/interface/ParameterSetConverter.h
+++ b/FWCore/ParameterSet/interface/ParameterSetConverter.h
@@ -7,7 +7,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include "boost/utility.hpp"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ParameterSetBlob.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -38,7 +37,7 @@ namespace edm {
   // Class ParameterSetConverter
 
   typedef std::map<ParameterSetID, ParameterSetBlob> ParameterSetMap;
-  class ParameterSetConverter : private boost::noncopyable {
+  class ParameterSetConverter {
   public:
     typedef std::list<std::string> StringList;
     typedef std::map<std::string, std::string> StringMap;
@@ -48,6 +47,9 @@ namespace edm {
                           ParameterSetIdConverter& idConverter,
                           bool alreadyByReference);
     ~ParameterSetConverter();
+    ParameterSetConverter(const ParameterSetConverter&) = delete;
+    ParameterSetConverter& operator=(const ParameterSetConverter&) = delete;
+
     ParameterSetIdConverter const& parameterSetIdConverter() const { return parameterSetIdConverter_; }
 
   private:

--- a/SimMuon/CSCDigitizer/src/CSCDigitizer.h
+++ b/SimMuon/CSCDigitizer/src/CSCDigitizer.h
@@ -20,7 +20,6 @@
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
-#include <boost/utility.hpp>
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
@@ -38,14 +37,16 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class CSCDigitizer : public boost::noncopyable {
+class CSCDigitizer {
 public:
   typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
 
+  ~CSCDigitizer();
+  CSCDigitizer(const CSCDigitizer &) = delete;
+  CSCDigitizer &operator=(const CSCDigitizer &) = delete;
+
   /// configurable parameters
   explicit CSCDigitizer(const edm::ParameterSet &p);
-
-  ~CSCDigitizer();
 
   /**  digitize
    */


### PR DESCRIPTION
#### PR description:
Removed the boost::noncopyable inheritance, and deleted copy constructor and copy operation instead. 
The code should have the same behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 