### PR TITLE
add phase2_ecal to internalUseMods

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -52,7 +52,7 @@ class Eras (object):
                            'run2_CSC_2018',
                            'phase2_common', 'phase2_tracker',
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing', 'phase2_hgcalV9', 'phase2_hfnose', 'phase2_hgcalV10', 'phase2_hgcalV11',
-                           'phase2_timing_layer', 'phase2_hcal',
+                           'phase2_timing_layer', 'phase2_hcal', 'phase2_ecal',
                            'phase2_trigger',
                            'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigation', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',


### PR DESCRIPTION
#### PR description:

This was apparently an oversight when the `phase2_ecal` Modifier was introduced.

#### PR validation:

Ran `python Configuration/StandardSequences/python/Eras.py`
