### PR TITLE
MuonSensitiveDetectors migration to DD4HEP

### DIFF
--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -5,7 +5,6 @@
 #include "SimG4CMS/Muon/interface/MuonGEMFrameRotation.h"
 #include "SimG4CMS/Muon/interface/MuonME0FrameRotation.h"
 #include "Geometry/MuonNumbering/interface/MuonSubDetector.h"
-#include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 
 #include "SimG4CMS/Muon/interface/SimHitPrinter.h"
 #include "SimDataFormats/TrackingHit/interface/UpdatablePSimHit.h"


### PR DESCRIPTION
#### PR description:

The migration took place automatically thanks to @bsunanda 's PR #29632 . This PR will delete the dependence of the MuonDDDConstants.h file from 
SimG4CMS/​Muon/​src/MuonSensitiveDetector.cc as requested by @cvuosalo 

#### PR validation:

Two validation steps have been performed:

1) cmsRun SimG4CMS/Muon/test/runMuon_cfg.py 

no errors

2) runTheMatrix.py -l 25202.1

25202.1_TTbar_13+TTbar_13+DIGIUP15APVSimu_PU25+RECOUP15_PU25+HARVESTUP15_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Jun 17 10:11:35 2020-date Wed Jun 17 09:50:44 2020; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

nothing special


