### PR TITLE
drop type specs in RecoLocalMuon and RecoMuon/Configuration

### DIFF
--- a/RecoLocalMuon/RPCRecHit/python/rpcRecHits_cfi.py
+++ b/RecoLocalMuon/RPCRecHit/python/rpcRecHits_cfi.py
@@ -15,4 +15,4 @@ rpcRecHits = cms.EDProducer("RPCRecHitProducer",
 
 #disabling DIGI2RAW,RAW2DIGI chain for Phase2
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toModify(rpcRecHits, rpcDigiLabel = cms.InputTag('simMuonRPCDigis'))
+phase2_muon.toModify(rpcRecHits, rpcDigiLabel = 'simMuonRPCDigis')

--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -8,50 +8,50 @@ from  RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff import *
 
 from TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi import Chi2MeasurementEstimator as _Chi2MeasurementEstimator
 duplicateDisplaceTrackCandidatesChi2Est = _Chi2MeasurementEstimator.clone(
-    ComponentName = "duplicateDisplacedTrackCandidatesChi2Est",
-    MaxChi2 = 100,
+    ComponentName = 'duplicateDisplacedTrackCandidatesChi2Est',
+    MaxChi2 = 100
 )
 
 #for displaced global muons                                      
 duplicateDisplacedTrackCandidates = DuplicateTrackMerger.clone(
-    source=cms.InputTag("preDuplicateMergingDisplacedTracks"),
-    useInnermostState  = cms.bool(True),
-    ttrhBuilderName    = cms.string("WithAngleAndTemplate"),
-    chi2EstimatorName = "duplicateDisplacedTrackCandidatesChi2Est"
-    )
+    source='preDuplicateMergingDisplacedTracks',
+    useInnermostState  = True,
+    ttrhBuilderName    = 'WithAngleAndTemplate',
+    chi2EstimatorName = 'duplicateDisplacedTrackCandidatesChi2Est'
+)
 #for displaced global muons
 mergedDuplicateDisplacedTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = cms.InputTag("duplicateDisplacedTrackCandidates","candidates"),
-    )
+    src = 'duplicateDisplacedTrackCandidates:candidates'
+)
 
 
 #for displaced global muons
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
-duplicateDisplacedTrackClassifier = TrackCutClassifier.clone()
-duplicateDisplacedTrackClassifier.src='mergedDuplicateDisplacedTracks'
-duplicateDisplacedTrackClassifier.mva.minPixelHits = [0,0,0]
-duplicateDisplacedTrackClassifier.mva.maxChi2 = [9999.,9999.,9999.]
-duplicateDisplacedTrackClassifier.mva.maxChi2n = [9999.,9999.,9999.]
-duplicateDisplacedTrackClassifier.mva.minLayers = [0,0,0]
-duplicateDisplacedTrackClassifier.mva.min3DLayers = [0,0,0]
-duplicateDisplacedTrackClassifier.mva.maxLostLayers = [99,99,99]
-
+duplicateDisplacedTrackClassifier = TrackCutClassifier.clone(
+    src = 'mergedDuplicateDisplacedTracks',
+    mva.minPixelHits  = [0,0,0],
+    mva.maxChi2       = [9999.,9999.,9999.],
+    mva.maxChi2n      = [9999.,9999.,9999.],
+    mva.minLayers     = [0,0,0],
+    mva.min3DLayers   = [0,0,0],
+    mva.maxLostLayers = [99,99,99]
+)
 
 #for displaced global muons
 displacedTracks = DuplicateListMerger.clone(
-    originalSource = cms.InputTag("preDuplicateMergingDisplacedTracks"),
-    originalMVAVals = cms.InputTag("preDuplicateMergingDisplacedTracks","MVAValues"),
-    mergedSource = cms.InputTag("mergedDuplicateDisplacedTracks"),
-    mergedMVAVals = cms.InputTag("duplicateDisplacedTrackClassifier","MVAValues"),
-    candidateSource = cms.InputTag("duplicateDisplacedTrackCandidates","candidates"),
-    candidateComponents = cms.InputTag("duplicateDisplacedTrackCandidates","candidateMap")
-    )
+    originalSource      = 'preDuplicateMergingDisplacedTracks',
+    originalMVAVals     = 'preDuplicateMergingDisplacedTracks:MVAValues',
+    mergedSource        = 'mergedDuplicateDisplacedTracks',
+    mergedMVAVals       = 'duplicateDisplacedTrackClassifier:MVAValues',
+    candidateSource     = 'duplicateDisplacedTrackCandidates:candidates',
+    candidateComponents = 'duplicateDisplacedTrackCandidates:candidateMap'
+)
+
 #for displaced global muons
 displacedTracksTask = cms.Task(
     duplicateDisplacedTrackCandidates,
     mergedDuplicateDisplacedTracks,
     duplicateDisplacedTrackClassifier,
     displacedTracks
-    )
+)
 displacedTracksSequence = cms.Sequence(displacedTracksTask)
-

--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -19,23 +19,24 @@ duplicateDisplacedTrackCandidates = DuplicateTrackMerger.clone(
     ttrhBuilderName    = 'WithAngleAndTemplate',
     chi2EstimatorName = 'duplicateDisplacedTrackCandidatesChi2Est'
 )
+
 #for displaced global muons
 mergedDuplicateDisplacedTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = 'duplicateDisplacedTrackCandidates:candidates'
 )
 
-
 #for displaced global muons
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 duplicateDisplacedTrackClassifier = TrackCutClassifier.clone(
-    src = 'mergedDuplicateDisplacedTracks'
+    src = 'mergedDuplicateDisplacedTracks',
+    mva = dict(
+	minPixelHits = [0,0,0],
+	maxChi2 = [9999.,9999.,9999.],
+	maxChi2n = [9999.,9999.,9999.],
+	minLayers = [0,0,0],
+	min3DLayers = [0,0,0],
+	maxLostLayers = [99,99,99])
 )
-duplicateDisplacedTrackClassifier.mva.minPixelHits = [0,0,0]
-duplicateDisplacedTrackClassifier.mva.maxChi2 = [9999.,9999.,9999.]
-duplicateDisplacedTrackClassifier.mva.maxChi2n = [9999.,9999.,9999.]
-duplicateDisplacedTrackClassifier.mva.minLayers = [0,0,0]
-duplicateDisplacedTrackClassifier.mva.min3DLayers = [0,0,0]
-duplicateDisplacedTrackClassifier.mva.maxLostLayers = [99,99,99]
 
 #for displaced global muons
 displacedTracks = DuplicateListMerger.clone(

--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -28,14 +28,14 @@ mergedDuplicateDisplacedTracks = RecoTracker.TrackProducer.TrackProducer_cfi.Tra
 #for displaced global muons
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 duplicateDisplacedTrackClassifier = TrackCutClassifier.clone(
-    src = 'mergedDuplicateDisplacedTracks',
-    mva.minPixelHits  = [0,0,0],
-    mva.maxChi2       = [9999.,9999.,9999.],
-    mva.maxChi2n      = [9999.,9999.,9999.],
-    mva.minLayers     = [0,0,0],
-    mva.min3DLayers   = [0,0,0],
-    mva.maxLostLayers = [99,99,99]
+    src = 'mergedDuplicateDisplacedTracks'
 )
+duplicateDisplacedTrackClassifier.mva.minPixelHits = [0,0,0]
+duplicateDisplacedTrackClassifier.mva.maxChi2 = [9999.,9999.,9999.]
+duplicateDisplacedTrackClassifier.mva.maxChi2n = [9999.,9999.,9999.]
+duplicateDisplacedTrackClassifier.mva.minLayers = [0,0,0]
+duplicateDisplacedTrackClassifier.mva.min3DLayers = [0,0,0]
+duplicateDisplacedTrackClassifier.mva.maxLostLayers = [99,99,99]
 
 #for displaced global muons
 displacedTracks = DuplicateListMerger.clone(

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -33,14 +33,18 @@ muons = muons1stStep.clone(
                             'tev dyt'],
     fillIsolation = True,
     fillGlobalTrackQuality = True,
+
+    TrackExtractorPSet = dict(
+	# need to modify track selection as well (not clear to what)
+	inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'),
+
+    CaloExtractorPSet = dict(
+	CenterConeOnCalIntersection = True,
+	# set wide cone until the code is made to compute this wrt CalIntersection
+	DR_Max = 1.0),
 )
 muons.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
 muons.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
-# need to modify track selection as well (not clear to what)
-muons.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'
-muons.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-muons.CaloExtractorPSet.DR_Max = 1.0
 
 #similar to what's in pp configuration
 muonsFromCosmics = muons1stStep.clone(
@@ -48,9 +52,11 @@ muonsFromCosmics = muons1stStep.clone(
     inputCollectionTypes = ['outer tracks'],
     fillIsolation = False,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+
+    TrackExtractorPSet = dict(
+	inputTrackCollection = 'cosmicMuons')
 )
-muonsFromCosmics.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons'
 muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
 muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
@@ -62,7 +68,6 @@ STAmuontrackingforcosmics = cms.Sequence(STAmuontrackingforcosmicsTask)
 # Stand Alone Tracking plus global tracking
 muontrackingforcosmicsTask = cms.Task(STAmuontrackingforcosmicsTask,globalCosmicMuons)
 muontrackingforcosmics = cms.Sequence(muontrackingforcosmicsTask)
-
 
 # Muon Isolation sequence
 from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
@@ -97,15 +102,17 @@ muonrecoforcosmics = cms.Sequence(muonrecoforcosmicsTask)
 # 1 leg mode
 # Stand alone muon track producer
 cosmicMuons1Leg = cosmicMuons.clone(
-    MuonSeedCollectionLabel = 'CosmicMuonSeed'
+    MuonSeedCollectionLabel = 'CosmicMuonSeed',
+    TrajectoryBuilderParameters = dict(
+	BuildTraversingMuon = True)
 )
-cosmicMuons1Leg.TrajectoryBuilderParameters.BuildTraversingMuon = True
 
 # Global muon track producer
 globalCosmicMuons1Leg = globalCosmicMuons.clone(
-    MuonCollectionLabel = 'cosmicMuons1Leg'
+    MuonCollectionLabel = 'cosmicMuons1Leg',
+    TrajectoryBuilderParameters = dict(
+	TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
 )
-globalCosmicMuons1Leg.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
 
 # Muon Id producer
 muons1Leg = muons1stStep.clone(
@@ -143,15 +150,17 @@ CosmicMuonSeedWitht0Correction = CosmicMuonSeed.clone(
 # Stand alone muon track producer
 cosmicMuonsWitht0Correction = cosmicMuons.clone(
     MuonSeedCollectionLabel = 'CosmicMuonSeedWitht0Correction',
+    TrajectoryBuilderParameters = dict(
+	BuildTraversingMuon = False,
+	DTRecSegmentLabel = 'dt4DSegmentsT0Seg')
 )
-cosmicMuonsWitht0Correction.TrajectoryBuilderParameters.BuildTraversingMuon = False
-cosmicMuonsWitht0Correction.TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DSegmentsT0Seg'
 
 # Global muon track producer
 globalCosmicMuonsWitht0Correction = globalCosmicMuons.clone(
-    MuonCollectionLabel = 'cosmicMuonsWitht0Correction'
+    MuonCollectionLabel = 'cosmicMuonsWitht0Correction',
+    TrajectoryBuilderParameters = dict(
+	TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
 )
-globalCosmicMuonsWitht0Correction.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
 
 # Muon Id producer
 muonsWitht0Correction = muons1stStep.clone(
@@ -161,14 +170,18 @@ muonsWitht0Correction = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+
+    TrackExtractorPSet = dict(
+	inputTrackCollection = 'ctfWithMaterialTracksP5'),
+
+    CaloExtractorPSet = dict(
+	CenterConeOnCalIntersection = True,
+	# set wide cone until the code is made to compute this wrt CalIntersection
+	DR_Max = 1.0)
 )
 muonsWitht0Correction.TimingFillerParameters.DTTimingParameters.UseSegmentT0 = True
 muonsWitht0Correction.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DSegmentsT0Seg'
-muonsWitht0Correction.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
-muonsWitht0Correction.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-muonsWitht0Correction.CaloExtractorPSet.DR_Max = 1.0
 
 #Sequences
 
@@ -202,16 +215,18 @@ CosmicMuonSeedEndCapsOnly = CosmicMuonSeed.clone(
 
 # Stand alone muon track producer
 cosmicMuonsEndCapsOnly = cosmicMuons.clone(
-    MuonSeedCollectionLabel = 'CosmicMuonSeedEndCapsOnly'
+    MuonSeedCollectionLabel = 'CosmicMuonSeedEndCapsOnly',
+    TrajectoryBuilderParameters = dict(
+	EnableDTMeasurement = False)
 )
-cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.EnableDTMeasurement = False
 cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.MuonNavigationParameters.Barrel = False
 
 # Global muon track producer
 globalBeamHaloMuonEndCapslOnly = globalCosmicMuons.clone(
     MuonCollectionLabel = 'cosmicMuonsEndCapsOnly'
 )
-globalBeamHaloMuonEndCapslOnly.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'beamhaloTracks'
+cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.EnableDTMeasurement = False
+cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.MuonNavigationParameters.Barrel = False
 
 # Muon Id producer
 muonsBeamHaloEndCapsOnly = muons1stStep.clone(
@@ -221,12 +236,16 @@ muonsBeamHaloEndCapsOnly = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+
+    TrackExtractorPSet = dict(
+	inputTrackCollection = 'ctfWithMaterialTracksP5'),
+
+    CaloExtractorPSet = dict(
+	CenterConeOnCalIntersection = True,
+	# set wide cone until the code is made to compute this wrt CalIntersection
+	DR_Max = 1.0)
 )
-muonsBeamHaloEndCapsOnly.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
-muonsBeamHaloEndCapsOnly.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-muonsBeamHaloEndCapsOnly.CaloExtractorPSet.DR_Max = 1.0
 
 # Sequences
 muonrecoBeamHaloEndCapsOnlyTask = cms.Task(CosmicMuonSeedEndCapsOnly,
@@ -240,14 +259,17 @@ muonrecoBeamHaloEndCapsOnly = cms.Sequence(muonrecoBeamHaloEndCapsOnlyTask)
 ## Full detector but NO RPC ##
 
 # Stand alone muon track producer
-cosmicMuonsNoRPC = cosmicMuons.clone()
-cosmicMuonsNoRPC.TrajectoryBuilderParameters.EnableRPCMeasurement = False
+cosmicMuonsNoRPC = cosmicMuons.clone(
+    TrajectoryBuilderParameters = dict(
+	EnableRPCMeasurement = False)
+)
 
 # Global muon track producer
 globalCosmicMuonsNoRPC = globalCosmicMuons.clone(
-    MuonCollectionLabel = 'cosmicMuonsNoRPC'
+    MuonCollectionLabel = 'cosmicMuonsNoRPC',
+    TrajectoryBuilderParameters = dict(
+	TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
 )
-globalCosmicMuonsNoRPC.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
 
 # Muon Id producer
 muonsNoRPC = muons1stStep.clone(
@@ -257,12 +279,16 @@ muonsNoRPC = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+
+    TrackExtractorPSet = dict(
+	inputTrackCollection = 'ctfWithMaterialTracksP5'),
+
+    CaloExtractorPSet = dict(
+	CenterConeOnCalIntersection = True,
+	# set wide cone until the code is made to compute this wrt CalIntersection
+	DR_Max = 1.0)
 )
-muonsNoRPC.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
-muonsNoRPC.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-muonsNoRPC.CaloExtractorPSet.DR_Max = 1.0
 
 #Sequences
 
@@ -280,9 +306,10 @@ muonrecoforcosmicsNoRPC = cms.Sequence(muonrecoforcosmicsNoRPCTask)
 
 # Global muon track producer
 globalCosmicSplitMuons = globalCosmicMuons.clone(
-    MuonCollectionLabel = 'cosmicMuons'
+    MuonCollectionLabel = 'cosmicMuons',
+    TrajectoryBuilderParameters = dict(
+	TkTrackCollectionLabel = 'splittedTracksP5')
 )
-globalCosmicSplitMuons.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'splittedTracksP5'
 
 # Muon Id producer
 splitMuons = muons1stStep.clone(
@@ -292,12 +319,16 @@ splitMuons = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+
+    TrackExtractorPSet = dict(
+	inputTrackCollection = 'splittedTracksP5'),
+
+    CaloExtractorPSet = dict(
+	CenterConeOnCalIntersection = True,
+	# set wide cone until the code is made to compute this wrt CalIntersection
+	DR_Max = 1.0)
 )
-splitMuons.TrackExtractorPSet.inputTrackCollection = 'splittedTracksP5'
-splitMuons.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-splitMuons.CaloExtractorPSet.DR_Max = 1.0
 
 #Sequences
 
@@ -318,12 +349,16 @@ lhcSTAMuons = muons1stStep.clone(
     inputCollectionTypes = ['outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+
+    TrackExtractorPSet = dict(
+	inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'),
+
+    CaloExtractorPSet = dict(
+	CenterConeOnCalIntersection = True,
+        # set wide cone until the code is made to compute this wrt CalIntersection
+        DR_Max = 1.0)
 )
-lhcSTAMuons.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'
-lhcSTAMuons.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-lhcSTAMuons.CaloExtractorPSet.DR_Max = 1.0
 
 # Final sequence
 muonRecoLHCTask = cms.Task(ancientMuonSeed,

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -17,33 +17,44 @@ globalCosmicMuons.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithM
 # Muon Id producer
 from RecoMuon.MuonIdentification.muonIdProducerSequence_cff import *
 
-muons = muons1stStep.clone()
+muons = muons1stStep.clone(
+    inputCollectionLabels = ['ctfWithMaterialTracksP5LHCNavigation', 
+                             'globalCosmicMuons', 
+                             'cosmicMuons', 
+                             'tevMuons:firstHit',
+                             'tevMuons:picky',
+                             'tevMuons:dyt'],
 
-muons.inputCollectionLabels = ['ctfWithMaterialTracksP5LHCNavigation', 'globalCosmicMuons', 'cosmicMuons', "tevMuons:firstHit","tevMuons:picky","tevMuons:dyt"]
-muons.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks', 'tev firstHit', 'tev picky', 'tev dyt']
-muons.fillIsolation = True
-muons.fillGlobalTrackQuality = True
-muons.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muons.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
-# need to modify track selection as well (not clear to what)
-muons.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'
-muons.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-muons.CaloExtractorPSet.DR_Max = 1.0
+    inputCollectionTypes = ['inner tracks', 
+                            'links', 
+                            'outer tracks', 
+                            'tev firstHit', 
+                            'tev picky', 
+                            'tev dyt'],
+    fillIsolation = True,
+    fillGlobalTrackQuality = True,
+    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
+    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999,
+    # need to modify track selection as well (not clear to what)
+    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation',
+    CaloExtractorPSet.CenterConeOnCalIntersection = True,
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet.DR_Max = 1.0
+)
 
 #similar to what's in pp configuration
-muonsFromCosmics = muons1stStep.clone()
-muonsFromCosmics.inputCollectionLabels = ['cosmicMuons']
-muonsFromCosmics.inputCollectionTypes = ['outer tracks']
-muonsFromCosmics.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons'
-muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
-muonsFromCosmics.fillIsolation = False
-muonsFromCosmics.fillGlobalTrackQuality = False
-muonsFromCosmics.fillGlobalTrackRefits = False
+muonsFromCosmics = muons1stStep.clone(
+    inputCollectionLabels = ['cosmicMuons'],
+    inputCollectionTypes = ['outer tracks'],
+    TrackExtractorPSet.inputTrackCollection = 'cosmicMuons',
+    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
+    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999,
+    fillIsolation = False,
+    fillGlobalTrackQuality = False,
+    fillGlobalTrackRefits = False
+)
 
 ## Sequences
-
 # Stand Alone Tracking
 STAmuontrackingforcosmicsTask = cms.Task(CosmicMuonSeed,cosmicMuons)
 STAmuontrackingforcosmics = cms.Sequence(STAmuontrackingforcosmicsTask)
@@ -52,24 +63,23 @@ STAmuontrackingforcosmics = cms.Sequence(STAmuontrackingforcosmicsTask)
 muontrackingforcosmicsTask = cms.Task(STAmuontrackingforcosmicsTask,globalCosmicMuons)
 muontrackingforcosmics = cms.Sequence(muontrackingforcosmicsTask)
 
+
 # Muon Isolation sequence
 from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
 # muisodeposits based on "muons"
 # we are using copy extractors now
-muIsoDepositTk.inputTags = cms.VInputTag(cms.InputTag("muons:tracker"))
-muIsoDepositJets. inputTags = cms.VInputTag(cms.InputTag("muons:jets"))
-muIsoDepositCalByAssociatorTowers.inputTags = cms.VInputTag(cms.InputTag("muons:ecal"), cms.InputTag("muons:hcal"), cms.InputTag("muons:ho"))
-
-
+muIsoDepositTk.inputTags = 'muons:tracker'
+muIsoDepositJets.inputTags = 'muons:jets'
+muIsoDepositCalByAssociatorTowers.inputTags = ['muons:ecal', 'muons:hcal', 'muons:ho']
 
 # TeV refinement
 from RecoMuon.GlobalMuonProducer.tevMuons_cfi import *
-tevMuons.MuonCollectionLabel = "globalCosmicMuons"
-tevMuons.RefitterParameters.PropDirForCosmics = cms.bool(True)
+tevMuons.MuonCollectionLabel = 'globalCosmicMuons'
+tevMuons.RefitterParameters.PropDirForCosmics = True
 
 # Glb Track Quality
 from RecoMuon.GlobalTrackingTools.GlobalTrackQuality_cfi import *
-glbTrackQual.InputCollection = "globalCosmicMuons"
+glbTrackQual.InputCollection = 'globalCosmicMuons'
 
 # all muons id
 allmuonsTask = cms.Task(glbTrackQual,
@@ -85,26 +95,31 @@ muonrecoforcosmicsTask = cms.Task(muontrackingforcosmicsTask,
 muonrecoforcosmics = cms.Sequence(muonrecoforcosmicsTask)
 
 # 1 leg mode
-
 # Stand alone muon track producer
-cosmicMuons1Leg = cosmicMuons.clone()
-cosmicMuons1Leg.TrajectoryBuilderParameters.BuildTraversingMuon = True
-cosmicMuons1Leg.MuonSeedCollectionLabel = 'CosmicMuonSeed'
+cosmicMuons1Leg = cosmicMuons.clone(
+    TrajectoryBuilderParameters.BuildTraversingMuon = True,
+    MuonSeedCollectionLabel = 'CosmicMuonSeed'
+)
 
 # Global muon track producer
-globalCosmicMuons1Leg = globalCosmicMuons.clone()
-globalCosmicMuons1Leg.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
-globalCosmicMuons1Leg.MuonCollectionLabel = 'cosmicMuons1Leg'
+globalCosmicMuons1Leg = globalCosmicMuons.clone(
+    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5',
+    MuonCollectionLabel = 'cosmicMuons1Leg'
+)
 
 # Muon Id producer
-muons1Leg = muons1stStep.clone()
-muons1Leg.inputCollectionLabels = ['ctfWithMaterialTracksP5', 'globalCosmicMuons1Leg', 'cosmicMuons1Leg']
-muons1Leg.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks']
-muons1Leg.fillIsolation = False
-muons1Leg.fillGlobalTrackQuality = False
-muons1Leg.fillGlobalTrackRefits = False
-muons1Leg.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muons1Leg.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
+muons1Leg = muons1stStep.clone(
+    inputCollectionLabels = ['ctfWithMaterialTracksP5', 
+                             'globalCosmicMuons1Leg', 
+                             'cosmicMuons1Leg'],
+    inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
+    fillIsolation = False,
+    fillGlobalTrackQuality = False,
+    fillGlobalTrackRefits = False,
+    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
+    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
+)
+
 # Sequences
 
 # Stand Alone Tracking
@@ -121,35 +136,41 @@ muonrecoforcosmics1LegTask = cms.Task(muontrackingforcosmics1LegTask,muons1Leg)
 # t0 Corrections
 
 # Seed generator
-CosmicMuonSeedWitht0Correction = CosmicMuonSeed.clone()
-CosmicMuonSeedWitht0Correction.DTRecSegmentLabel = 'dt4DSegmentsT0Seg'
+CosmicMuonSeedWitht0Correction = CosmicMuonSeed.clone(
+    DTRecSegmentLabel = 'dt4DSegmentsT0Seg'
+)
 
 # Stand alone muon track producer
-cosmicMuonsWitht0Correction = cosmicMuons.clone()
-cosmicMuonsWitht0Correction.TrajectoryBuilderParameters.BuildTraversingMuon = False
-cosmicMuonsWitht0Correction.MuonSeedCollectionLabel = 'CosmicMuonSeedWitht0Correction'
-cosmicMuonsWitht0Correction.TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DSegmentsT0Seg'
+cosmicMuonsWitht0Correction = cosmicMuons.clone(
+    TrajectoryBuilderParameters.BuildTraversingMuon = False,
+    MuonSeedCollectionLabel = 'CosmicMuonSeedWitht0Correction',
+    TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DSegmentsT0Seg'
+)
 
 # Global muon track producer
-globalCosmicMuonsWitht0Correction = globalCosmicMuons.clone()
-globalCosmicMuonsWitht0Correction.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
-globalCosmicMuonsWitht0Correction.MuonCollectionLabel = 'cosmicMuonsWitht0Correction'
+globalCosmicMuonsWitht0Correction = globalCosmicMuons.clone(
+    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5',
+    MuonCollectionLabel = 'cosmicMuonsWitht0Correction'
+)
 
 # Muon Id producer
-muonsWitht0Correction = muons1stStep.clone()
-muonsWitht0Correction.inputCollectionLabels = ['ctfWithMaterialTracksP5', 'globalCosmicMuonsWitht0Correction', 'cosmicMuonsWitht0Correction']
-muonsWitht0Correction.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks']
-muonsWitht0Correction.fillIsolation = True
-muonsWitht0Correction.fillGlobalTrackQuality = False
-muonsWitht0Correction.TimingFillerParameters.DTTimingParameters.UseSegmentT0 = True
-muonsWitht0Correction.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DSegmentsT0Seg'
-muonsWitht0Correction.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
-muonsWitht0Correction.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-muonsWitht0Correction.CaloExtractorPSet.DR_Max = 1.0
-muonsWitht0Correction.fillGlobalTrackRefits = False
-#Sequences
+muonsWitht0Correction = muons1stStep.clone(
+    inputCollectionLabels = ['ctfWithMaterialTracksP5', 
+                             'globalCosmicMuonsWitht0Correction', 
+                             'cosmicMuonsWitht0Correction'],
+    inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
+    fillIsolation = True,
+    fillGlobalTrackQuality = False,
+    TimingFillerParameters.DTTimingParameters.UseSegmentT0 = True,
+    TimingFillerParameters.MatchParameters.DTsegments = 'dt4DSegmentsT0Seg',
+    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5',
+    CaloExtractorPSet.CenterConeOnCalIntersection = True,
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet.DR_Max = 1.0,
+    fillGlobalTrackRefits = False
+)
 
+#Sequences
 
 # Stand Alone Tracking
 STAmuontrackingforcosmicsWitht0CorrectionTask = cms.Task(CosmicMuonSeedWitht0Correction,cosmicMuonsWitht0Correction)
@@ -175,32 +196,37 @@ muonRecoGR = cms.Sequence(muonRecoGRTask)
 # Beam halo in Encaps only. GLB reco only is needed
 
 # Seed generator 
-CosmicMuonSeedEndCapsOnly = CosmicMuonSeed.clone()
-CosmicMuonSeedEndCapsOnly.EnableDTMeasurement = False
+CosmicMuonSeedEndCapsOnly = CosmicMuonSeed.clone(
+    EnableDTMeasurement = False
+)
 
 # Stand alone muon track producer
-cosmicMuonsEndCapsOnly = cosmicMuons.clone()
-cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.EnableDTMeasurement = False
-cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.MuonNavigationParameters.Barrel = False
-cosmicMuonsEndCapsOnly.MuonSeedCollectionLabel = 'CosmicMuonSeedEndCapsOnly'
+cosmicMuonsEndCapsOnly = cosmicMuons.clone(
+    TrajectoryBuilderParameters.EnableDTMeasurement = False,
+    TrajectoryBuilderParameters.MuonNavigationParameters.Barrel = False,
+    MuonSeedCollectionLabel = 'CosmicMuonSeedEndCapsOnly'
+)
 
 # Global muon track producer
-globalBeamHaloMuonEndCapslOnly = globalCosmicMuons.clone()
-globalBeamHaloMuonEndCapslOnly.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'beamhaloTracks'
-globalBeamHaloMuonEndCapslOnly.MuonCollectionLabel = 'cosmicMuonsEndCapsOnly'
-
+globalBeamHaloMuonEndCapslOnly = globalCosmicMuons.clone(
+    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'beamhaloTracks',
+    MuonCollectionLabel = 'cosmicMuonsEndCapsOnly'
+)
 
 # Muon Id producer
-muonsBeamHaloEndCapsOnly = muons1stStep.clone()           
-muonsBeamHaloEndCapsOnly.inputCollectionLabels = ['beamhaloTracks', 'globalBeamHaloMuonEndCapslOnly', 'cosmicMuonsEndCapsOnly']
-muonsBeamHaloEndCapsOnly.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks']
-muonsBeamHaloEndCapsOnly.fillIsolation = True
-muonsBeamHaloEndCapsOnly.fillGlobalTrackQuality = False
-muonsBeamHaloEndCapsOnly.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
-muonsBeamHaloEndCapsOnly.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-muonsBeamHaloEndCapsOnly.CaloExtractorPSet.DR_Max = 1.0
-muonsBeamHaloEndCapsOnly.fillGlobalTrackRefits = False
+muonsBeamHaloEndCapsOnly = muons1stStep.clone(
+    inputCollectionLabels = ['beamhaloTracks', 
+                             'globalBeamHaloMuonEndCapslOnly', 
+                             'cosmicMuonsEndCapsOnly'],
+    inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
+    fillIsolation = True,
+    fillGlobalTrackQuality = False,
+    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5',
+    CaloExtractorPSet.CenterConeOnCalIntersection = True,
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet.DR_Max = 1.0,
+    fillGlobalTrackRefits = False
+)
 
 # Sequences
 muonrecoBeamHaloEndCapsOnlyTask = cms.Task(CosmicMuonSeedEndCapsOnly,
@@ -214,25 +240,29 @@ muonrecoBeamHaloEndCapsOnly = cms.Sequence(muonrecoBeamHaloEndCapsOnlyTask)
 ## Full detector but NO RPC ##
 
 # Stand alone muon track producer
-cosmicMuonsNoRPC = cosmicMuons.clone()
-cosmicMuonsNoRPC.TrajectoryBuilderParameters.EnableRPCMeasurement = False
-
+cosmicMuonsNoRPC = cosmicMuons.clone(
+    TrajectoryBuilderParameters.EnableRPCMeasurement = False
+)
 # Global muon track producer
-globalCosmicMuonsNoRPC = globalCosmicMuons.clone()
-globalCosmicMuonsNoRPC.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
-globalCosmicMuonsNoRPC.MuonCollectionLabel = 'cosmicMuonsNoRPC'
+globalCosmicMuonsNoRPC = globalCosmicMuons.clone(
+    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5',
+    MuonCollectionLabel = 'cosmicMuonsNoRPC'
+)
 
 # Muon Id producer
-muonsNoRPC = muons1stStep.clone()
-muonsNoRPC.inputCollectionLabels = ['ctfWithMaterialTracksP5', 'globalCosmicMuonsNoRPC', 'cosmicMuonsNoRPC']
-muonsNoRPC.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks']
-muonsNoRPC.fillIsolation = True
-muonsNoRPC.fillGlobalTrackQuality = False
-muonsNoRPC.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
-muonsNoRPC.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-muonsNoRPC.CaloExtractorPSet.DR_Max = 1.0
-muonsNoRPC.fillGlobalTrackRefits = False
+muonsNoRPC = muons1stStep.clone(
+    inputCollectionLabels = ['ctfWithMaterialTracksP5',
+                             'globalCosmicMuonsNoRPC', 
+                             'cosmicMuonsNoRPC'],
+    inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
+    fillIsolation = True,
+    fillGlobalTrackQuality = False,
+    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5',
+    CaloExtractorPSet.CenterConeOnCalIntersection = True,
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet.DR_Max = 1.0,
+    fillGlobalTrackRefits = False
+)
 
 #Sequences
 
@@ -249,22 +279,25 @@ muonrecoforcosmicsNoRPC = cms.Sequence(muonrecoforcosmicsNoRPCTask)
 ## Split Tracks  ##
 
 # Global muon track producer
-globalCosmicSplitMuons = globalCosmicMuons.clone()
-globalCosmicSplitMuons.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'splittedTracksP5'
-globalCosmicSplitMuons.MuonCollectionLabel = 'cosmicMuons'
+globalCosmicSplitMuons = globalCosmicMuons.clone(
+    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'splittedTracksP5',
+    MuonCollectionLabel = 'cosmicMuons'
+)
 
 # Muon Id producer
-
-splitMuons = muons1stStep.clone()
-splitMuons.inputCollectionLabels = ['splittedTracksP5', 'globalCosmicSplitMuons', 'cosmicMuons']
-splitMuons.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks']
-splitMuons.fillIsolation = True
-splitMuons.fillGlobalTrackQuality = False
-splitMuons.TrackExtractorPSet.inputTrackCollection = 'splittedTracksP5'
-splitMuons.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-splitMuons.CaloExtractorPSet.DR_Max = 1.0
-splitMuons.fillGlobalTrackRefits = False
+splitMuons = muons1stStep.clone(
+    inputCollectionLabels = ['splittedTracksP5', 
+                             'globalCosmicSplitMuons', 
+                             'cosmicMuons'],
+    inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
+    fillIsolation = True,
+    fillGlobalTrackQuality = False,
+    TrackExtractorPSet.inputTrackCollection = 'splittedTracksP5',
+    CaloExtractorPSet.CenterConeOnCalIntersection = True,
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet.DR_Max = 1.0,
+    fillGlobalTrackRefits = False
+)
 
 #Sequences
 
@@ -280,16 +313,17 @@ muonrecoforsplitcosmics = cms.Sequence(muonrecoforsplitcosmicsTask)
 from RecoMuon.Configuration.RecoMuonPPonly_cff import *
 
 # Muon Id producer
-lhcSTAMuons = muons1stStep.clone()
-lhcSTAMuons.inputCollectionLabels = ['standAloneMuons']
-lhcSTAMuons.inputCollectionTypes = ['outer tracks']
-lhcSTAMuons.fillIsolation = True
-lhcSTAMuons.fillGlobalTrackQuality = False
-lhcSTAMuons.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'
-lhcSTAMuons.CaloExtractorPSet.CenterConeOnCalIntersection = True
-# set wide cone until the code is made to compute this wrt CalIntersection
-lhcSTAMuons.CaloExtractorPSet.DR_Max = 1.0
-lhcSTAMuons.fillGlobalTrackRefits = False
+lhcSTAMuons = muons1stStep.clone(
+    inputCollectionLabels = ['standAloneMuons'],
+    inputCollectionTypes = ['outer tracks'],
+    fillIsolation = True,
+    fillGlobalTrackQuality = False,
+    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation',
+    CaloExtractorPSet.CenterConeOnCalIntersection = True,
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet.DR_Max = 1.0,
+    fillGlobalTrackRefits = False
+)
 
 # Final sequence
 muonRecoLHCTask = cms.Task(ancientMuonSeed,
@@ -297,10 +331,7 @@ muonRecoLHCTask = cms.Task(ancientMuonSeed,
                            lhcSTAMuons)
 muonRecoLHC = cms.Sequence(muonRecoLHCTask)
 
-
-
 ########################### SEQUENCE TO BE ADDED in ReconstructionGR_cff ##############################################
-
 muonRecoGRTask = cms.Task(muonrecoforcosmicsTask,
                           muonRecoGRTask,
                           muonrecoBeamHaloEndCapsOnlyTask,
@@ -308,10 +339,4 @@ muonRecoGRTask = cms.Task(muonrecoforcosmicsTask,
                           muonrecoforsplitcosmicsTask,
                           muonRecoLHCTask)
 muonRecoGR = cms.Sequence(muonRecoGRTask)
-
 #######################################################################################################################
-
-
-
-
-

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -73,9 +73,9 @@ muontrackingforcosmics = cms.Sequence(muontrackingforcosmicsTask)
 from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
 # muisodeposits based on "muons"
 # we are using copy extractors now
-muIsoDepositTk.inputTags = cms.VInputTag(cms.InputTag('muons:tracker'))
-muIsoDepositJets.inputTags = cms.VInputTag(cms.InputTag('muons:jets'))
-muIsoDepositCalByAssociatorTowers.inputTags = cms.VInputTag(cms.InputTag('muons:ecal'), cms.InputTag('muons:hcal'), cms.InputTag('muons:ho'))
+muIsoDepositTk.inputTags = ['muons:tracker']
+muIsoDepositJets.inputTags = ['muons:jets']
+muIsoDepositCalByAssociatorTowers.inputTags = ['muons:ecal', 'muons:hcal', 'muons:ho']
 
 # TeV refinement
 from RecoMuon.GlobalMuonProducer.tevMuons_cfi import *

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -33,18 +33,14 @@ muons = muons1stStep.clone(
                             'tev dyt'],
     fillIsolation = True,
     fillGlobalTrackQuality = True,
-
-    TrackExtractorPSet = dict(
-	# need to modify track selection as well (not clear to what)
-	inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'),
-
-    CaloExtractorPSet = dict(
-	CenterConeOnCalIntersection = True,
-	# set wide cone until the code is made to compute this wrt CalIntersection
-	DR_Max = 1.0),
+    # need to modify track selection as well (not clear to what)
+    TrackExtractorPSet = dict(inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'),
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet = dict(CenterConeOnCalIntersection = True, DR_Max = 1.0),
+    TimingFillerParameters = dict(
+	DTTimingParameters = dict(PruneCut = 9999),
+	CSCTimingParameters = dict(PruneCut = 9999))
 )
-muons.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muons.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 #similar to what's in pp configuration
 muonsFromCosmics = muons1stStep.clone(
@@ -53,12 +49,11 @@ muonsFromCosmics = muons1stStep.clone(
     fillIsolation = False,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False,
-
-    TrackExtractorPSet = dict(
-	inputTrackCollection = 'cosmicMuons')
+    TrackExtractorPSet = dict(inputTrackCollection = 'cosmicMuons'),
+    TimingFillerParameters = dict(
+	DTTimingParameters = dict(PruneCut = 9999),
+	CSCTimingParameters = dict(PruneCut = 9999))
 )
-muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 ## Sequences
 # Stand Alone Tracking
@@ -103,15 +98,13 @@ muonrecoforcosmics = cms.Sequence(muonrecoforcosmicsTask)
 # Stand alone muon track producer
 cosmicMuons1Leg = cosmicMuons.clone(
     MuonSeedCollectionLabel = 'CosmicMuonSeed',
-    TrajectoryBuilderParameters = dict(
-	BuildTraversingMuon = True)
+    TrajectoryBuilderParameters = dict(BuildTraversingMuon = True)
 )
 
 # Global muon track producer
 globalCosmicMuons1Leg = globalCosmicMuons.clone(
     MuonCollectionLabel = 'cosmicMuons1Leg',
-    TrajectoryBuilderParameters = dict(
-	TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
+    TrajectoryBuilderParameters = dict(TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
 )
 
 # Muon Id producer
@@ -122,13 +115,13 @@ muons1Leg = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = False,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+    TimingFillerParameters = dict(
+        DTTimingParameters = dict(PruneCut = 9999),
+        CSCTimingParameters = dict(PruneCut = 9999))
 )
-muons1Leg.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muons1Leg.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 # Sequences
-
 # Stand Alone Tracking
 STAmuontrackingforcosmics1LegTask = cms.Task(CosmicMuonSeed,cosmicMuons1Leg)
 
@@ -150,16 +143,13 @@ CosmicMuonSeedWitht0Correction = CosmicMuonSeed.clone(
 # Stand alone muon track producer
 cosmicMuonsWitht0Correction = cosmicMuons.clone(
     MuonSeedCollectionLabel = 'CosmicMuonSeedWitht0Correction',
-    TrajectoryBuilderParameters = dict(
-	BuildTraversingMuon = False,
-	DTRecSegmentLabel = 'dt4DSegmentsT0Seg')
+    TrajectoryBuilderParameters = dict(BuildTraversingMuon = False, DTRecSegmentLabel = 'dt4DSegmentsT0Seg')
 )
 
 # Global muon track producer
 globalCosmicMuonsWitht0Correction = globalCosmicMuons.clone(
     MuonCollectionLabel = 'cosmicMuonsWitht0Correction',
-    TrajectoryBuilderParameters = dict(
-	TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
+    TrajectoryBuilderParameters = dict(TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
 )
 
 # Muon Id producer
@@ -171,20 +161,15 @@ muonsWitht0Correction = muons1stStep.clone(
     fillIsolation = True,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False,
-
-    TrackExtractorPSet = dict(
-	inputTrackCollection = 'ctfWithMaterialTracksP5'),
-
-    CaloExtractorPSet = dict(
-	CenterConeOnCalIntersection = True,
-	# set wide cone until the code is made to compute this wrt CalIntersection
-	DR_Max = 1.0)
+    TrackExtractorPSet = dict(inputTrackCollection = 'ctfWithMaterialTracksP5'),
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet = dict(CenterConeOnCalIntersection = True, DR_Max = 1.0),
+    TimingFillerParameters = dict(
+	DTTimingParameters = dict(UseSegmentT0 = True),
+	MatchParameters = dict(DTsegments = 'dt4DSegmentsT0Seg'))
 )
-muonsWitht0Correction.TimingFillerParameters.DTTimingParameters.UseSegmentT0 = True
-muonsWitht0Correction.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DSegmentsT0Seg'
 
 #Sequences
-
 # Stand Alone Tracking
 STAmuontrackingforcosmicsWitht0CorrectionTask = cms.Task(CosmicMuonSeedWitht0Correction,cosmicMuonsWitht0Correction)
 STAmuontrackingforcosmicsWitht0Correction = cms.Sequence(STAmuontrackingforcosmicsWitht0CorrectionTask)
@@ -217,16 +202,14 @@ CosmicMuonSeedEndCapsOnly = CosmicMuonSeed.clone(
 cosmicMuonsEndCapsOnly = cosmicMuons.clone(
     MuonSeedCollectionLabel = 'CosmicMuonSeedEndCapsOnly',
     TrajectoryBuilderParameters = dict(
-	EnableDTMeasurement = False)
+	EnableDTMeasurement = False,
+	MuonNavigationParameters = dict(Barrel = False))
 )
-cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.MuonNavigationParameters.Barrel = False
 
 # Global muon track producer
 globalBeamHaloMuonEndCapslOnly = globalCosmicMuons.clone(
     MuonCollectionLabel = 'cosmicMuonsEndCapsOnly'
 )
-cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.EnableDTMeasurement = False
-cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.MuonNavigationParameters.Barrel = False
 
 # Muon Id producer
 muonsBeamHaloEndCapsOnly = muons1stStep.clone(
@@ -237,14 +220,9 @@ muonsBeamHaloEndCapsOnly = muons1stStep.clone(
     fillIsolation = True,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False,
-
-    TrackExtractorPSet = dict(
-	inputTrackCollection = 'ctfWithMaterialTracksP5'),
-
-    CaloExtractorPSet = dict(
-	CenterConeOnCalIntersection = True,
-	# set wide cone until the code is made to compute this wrt CalIntersection
-	DR_Max = 1.0)
+    TrackExtractorPSet = dict(inputTrackCollection = 'ctfWithMaterialTracksP5'),
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet = dict(CenterConeOnCalIntersection = True, DR_Max = 1.0)
 )
 
 # Sequences
@@ -260,15 +238,13 @@ muonrecoBeamHaloEndCapsOnly = cms.Sequence(muonrecoBeamHaloEndCapsOnlyTask)
 
 # Stand alone muon track producer
 cosmicMuonsNoRPC = cosmicMuons.clone(
-    TrajectoryBuilderParameters = dict(
-	EnableRPCMeasurement = False)
+    TrajectoryBuilderParameters = dict(EnableRPCMeasurement = False)
 )
 
 # Global muon track producer
 globalCosmicMuonsNoRPC = globalCosmicMuons.clone(
     MuonCollectionLabel = 'cosmicMuonsNoRPC',
-    TrajectoryBuilderParameters = dict(
-	TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
+    TrajectoryBuilderParameters = dict(TkTrackCollectionLabel = 'ctfWithMaterialTracksP5')
 )
 
 # Muon Id producer
@@ -280,14 +256,9 @@ muonsNoRPC = muons1stStep.clone(
     fillIsolation = True,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False,
-
-    TrackExtractorPSet = dict(
-	inputTrackCollection = 'ctfWithMaterialTracksP5'),
-
-    CaloExtractorPSet = dict(
-	CenterConeOnCalIntersection = True,
-	# set wide cone until the code is made to compute this wrt CalIntersection
-	DR_Max = 1.0)
+    TrackExtractorPSet = dict(inputTrackCollection = 'ctfWithMaterialTracksP5'),
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet = dict(CenterConeOnCalIntersection = True, DR_Max = 1.0)
 )
 
 #Sequences
@@ -307,8 +278,7 @@ muonrecoforcosmicsNoRPC = cms.Sequence(muonrecoforcosmicsNoRPCTask)
 # Global muon track producer
 globalCosmicSplitMuons = globalCosmicMuons.clone(
     MuonCollectionLabel = 'cosmicMuons',
-    TrajectoryBuilderParameters = dict(
-	TkTrackCollectionLabel = 'splittedTracksP5')
+    TrajectoryBuilderParameters = dict(TkTrackCollectionLabel = 'splittedTracksP5')
 )
 
 # Muon Id producer
@@ -320,14 +290,9 @@ splitMuons = muons1stStep.clone(
     fillIsolation = True,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False,
-
-    TrackExtractorPSet = dict(
-	inputTrackCollection = 'splittedTracksP5'),
-
-    CaloExtractorPSet = dict(
-	CenterConeOnCalIntersection = True,
-	# set wide cone until the code is made to compute this wrt CalIntersection
-	DR_Max = 1.0)
+    TrackExtractorPSet = dict(inputTrackCollection = 'splittedTracksP5'),
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet = dict(CenterConeOnCalIntersection = True, DR_Max = 1.0)
 )
 
 #Sequences
@@ -350,14 +315,9 @@ lhcSTAMuons = muons1stStep.clone(
     fillIsolation = True,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False,
-
-    TrackExtractorPSet = dict(
-	inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'),
-
-    CaloExtractorPSet = dict(
-	CenterConeOnCalIntersection = True,
-        # set wide cone until the code is made to compute this wrt CalIntersection
-        DR_Max = 1.0)
+    TrackExtractorPSet = dict(inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'),
+    # set wide cone until the code is made to compute this wrt CalIntersection
+    CaloExtractorPSet = dict(CenterConeOnCalIntersection = True, DR_Max = 1.0)
 )
 
 # Final sequence

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -33,26 +33,26 @@ muons = muons1stStep.clone(
                             'tev dyt'],
     fillIsolation = True,
     fillGlobalTrackQuality = True,
-    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
-    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999,
-    # need to modify track selection as well (not clear to what)
-    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation',
-    CaloExtractorPSet.CenterConeOnCalIntersection = True,
-    # set wide cone until the code is made to compute this wrt CalIntersection
-    CaloExtractorPSet.DR_Max = 1.0
 )
+muons.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
+muons.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
+# need to modify track selection as well (not clear to what)
+muons.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'
+muons.CaloExtractorPSet.CenterConeOnCalIntersection = True
+# set wide cone until the code is made to compute this wrt CalIntersection
+muons.CaloExtractorPSet.DR_Max = 1.0
 
 #similar to what's in pp configuration
 muonsFromCosmics = muons1stStep.clone(
     inputCollectionLabels = ['cosmicMuons'],
     inputCollectionTypes = ['outer tracks'],
-    TrackExtractorPSet.inputTrackCollection = 'cosmicMuons',
-    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
-    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999,
     fillIsolation = False,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False
 )
+muonsFromCosmics.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons'
+muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
+muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 ## Sequences
 # Stand Alone Tracking
@@ -68,9 +68,9 @@ muontrackingforcosmics = cms.Sequence(muontrackingforcosmicsTask)
 from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
 # muisodeposits based on "muons"
 # we are using copy extractors now
-muIsoDepositTk.inputTags = 'muons:tracker'
-muIsoDepositJets.inputTags = 'muons:jets'
-muIsoDepositCalByAssociatorTowers.inputTags = ['muons:ecal', 'muons:hcal', 'muons:ho']
+muIsoDepositTk.inputTags = cms.VInputTag(cms.InputTag('muons:tracker'))
+muIsoDepositJets.inputTags = cms.VInputTag(cms.InputTag('muons:jets'))
+muIsoDepositCalByAssociatorTowers.inputTags = cms.VInputTag(cms.InputTag('muons:ecal'), cms.InputTag('muons:hcal'), cms.InputTag('muons:ho'))
 
 # TeV refinement
 from RecoMuon.GlobalMuonProducer.tevMuons_cfi import *
@@ -97,15 +97,15 @@ muonrecoforcosmics = cms.Sequence(muonrecoforcosmicsTask)
 # 1 leg mode
 # Stand alone muon track producer
 cosmicMuons1Leg = cosmicMuons.clone(
-    TrajectoryBuilderParameters.BuildTraversingMuon = True,
     MuonSeedCollectionLabel = 'CosmicMuonSeed'
 )
+cosmicMuons1Leg.TrajectoryBuilderParameters.BuildTraversingMuon = True
 
 # Global muon track producer
 globalCosmicMuons1Leg = globalCosmicMuons.clone(
-    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5',
     MuonCollectionLabel = 'cosmicMuons1Leg'
 )
+globalCosmicMuons1Leg.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
 
 # Muon Id producer
 muons1Leg = muons1stStep.clone(
@@ -115,10 +115,10 @@ muons1Leg = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = False,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False,
-    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
-    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
+    fillGlobalTrackRefits = False
 )
+muons1Leg.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
+muons1Leg.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 # Sequences
 
@@ -142,16 +142,16 @@ CosmicMuonSeedWitht0Correction = CosmicMuonSeed.clone(
 
 # Stand alone muon track producer
 cosmicMuonsWitht0Correction = cosmicMuons.clone(
-    TrajectoryBuilderParameters.BuildTraversingMuon = False,
     MuonSeedCollectionLabel = 'CosmicMuonSeedWitht0Correction',
-    TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DSegmentsT0Seg'
 )
+cosmicMuonsWitht0Correction.TrajectoryBuilderParameters.BuildTraversingMuon = False
+cosmicMuonsWitht0Correction.TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DSegmentsT0Seg'
 
 # Global muon track producer
 globalCosmicMuonsWitht0Correction = globalCosmicMuons.clone(
-    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5',
     MuonCollectionLabel = 'cosmicMuonsWitht0Correction'
 )
+globalCosmicMuonsWitht0Correction.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
 
 # Muon Id producer
 muonsWitht0Correction = muons1stStep.clone(
@@ -161,14 +161,14 @@ muonsWitht0Correction = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    TimingFillerParameters.DTTimingParameters.UseSegmentT0 = True,
-    TimingFillerParameters.MatchParameters.DTsegments = 'dt4DSegmentsT0Seg',
-    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5',
-    CaloExtractorPSet.CenterConeOnCalIntersection = True,
-    # set wide cone until the code is made to compute this wrt CalIntersection
-    CaloExtractorPSet.DR_Max = 1.0,
     fillGlobalTrackRefits = False
 )
+muonsWitht0Correction.TimingFillerParameters.DTTimingParameters.UseSegmentT0 = True
+muonsWitht0Correction.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DSegmentsT0Seg'
+muonsWitht0Correction.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
+muonsWitht0Correction.CaloExtractorPSet.CenterConeOnCalIntersection = True
+# set wide cone until the code is made to compute this wrt CalIntersection
+muonsWitht0Correction.CaloExtractorPSet.DR_Max = 1.0
 
 #Sequences
 
@@ -202,16 +202,16 @@ CosmicMuonSeedEndCapsOnly = CosmicMuonSeed.clone(
 
 # Stand alone muon track producer
 cosmicMuonsEndCapsOnly = cosmicMuons.clone(
-    TrajectoryBuilderParameters.EnableDTMeasurement = False,
-    TrajectoryBuilderParameters.MuonNavigationParameters.Barrel = False,
     MuonSeedCollectionLabel = 'CosmicMuonSeedEndCapsOnly'
 )
+cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.EnableDTMeasurement = False
+cosmicMuonsEndCapsOnly.TrajectoryBuilderParameters.MuonNavigationParameters.Barrel = False
 
 # Global muon track producer
 globalBeamHaloMuonEndCapslOnly = globalCosmicMuons.clone(
-    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'beamhaloTracks',
     MuonCollectionLabel = 'cosmicMuonsEndCapsOnly'
 )
+globalBeamHaloMuonEndCapslOnly.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'beamhaloTracks'
 
 # Muon Id producer
 muonsBeamHaloEndCapsOnly = muons1stStep.clone(
@@ -221,12 +221,12 @@ muonsBeamHaloEndCapsOnly = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5',
-    CaloExtractorPSet.CenterConeOnCalIntersection = True,
-    # set wide cone until the code is made to compute this wrt CalIntersection
-    CaloExtractorPSet.DR_Max = 1.0,
     fillGlobalTrackRefits = False
 )
+muonsBeamHaloEndCapsOnly.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
+muonsBeamHaloEndCapsOnly.CaloExtractorPSet.CenterConeOnCalIntersection = True
+# set wide cone until the code is made to compute this wrt CalIntersection
+muonsBeamHaloEndCapsOnly.CaloExtractorPSet.DR_Max = 1.0
 
 # Sequences
 muonrecoBeamHaloEndCapsOnlyTask = cms.Task(CosmicMuonSeedEndCapsOnly,
@@ -240,14 +240,14 @@ muonrecoBeamHaloEndCapsOnly = cms.Sequence(muonrecoBeamHaloEndCapsOnlyTask)
 ## Full detector but NO RPC ##
 
 # Stand alone muon track producer
-cosmicMuonsNoRPC = cosmicMuons.clone(
-    TrajectoryBuilderParameters.EnableRPCMeasurement = False
-)
+cosmicMuonsNoRPC = cosmicMuons.clone()
+cosmicMuonsNoRPC.TrajectoryBuilderParameters.EnableRPCMeasurement = False
+
 # Global muon track producer
 globalCosmicMuonsNoRPC = globalCosmicMuons.clone(
-    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5',
     MuonCollectionLabel = 'cosmicMuonsNoRPC'
 )
+globalCosmicMuonsNoRPC.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'ctfWithMaterialTracksP5'
 
 # Muon Id producer
 muonsNoRPC = muons1stStep.clone(
@@ -257,12 +257,12 @@ muonsNoRPC = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5',
-    CaloExtractorPSet.CenterConeOnCalIntersection = True,
-    # set wide cone until the code is made to compute this wrt CalIntersection
-    CaloExtractorPSet.DR_Max = 1.0,
     fillGlobalTrackRefits = False
 )
+muonsNoRPC.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5'
+muonsNoRPC.CaloExtractorPSet.CenterConeOnCalIntersection = True
+# set wide cone until the code is made to compute this wrt CalIntersection
+muonsNoRPC.CaloExtractorPSet.DR_Max = 1.0
 
 #Sequences
 
@@ -280,9 +280,9 @@ muonrecoforcosmicsNoRPC = cms.Sequence(muonrecoforcosmicsNoRPCTask)
 
 # Global muon track producer
 globalCosmicSplitMuons = globalCosmicMuons.clone(
-    TrajectoryBuilderParameters.TkTrackCollectionLabel = 'splittedTracksP5',
     MuonCollectionLabel = 'cosmicMuons'
 )
+globalCosmicSplitMuons.TrajectoryBuilderParameters.TkTrackCollectionLabel = 'splittedTracksP5'
 
 # Muon Id producer
 splitMuons = muons1stStep.clone(
@@ -292,12 +292,12 @@ splitMuons = muons1stStep.clone(
     inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    TrackExtractorPSet.inputTrackCollection = 'splittedTracksP5',
-    CaloExtractorPSet.CenterConeOnCalIntersection = True,
-    # set wide cone until the code is made to compute this wrt CalIntersection
-    CaloExtractorPSet.DR_Max = 1.0,
     fillGlobalTrackRefits = False
 )
+splitMuons.TrackExtractorPSet.inputTrackCollection = 'splittedTracksP5'
+splitMuons.CaloExtractorPSet.CenterConeOnCalIntersection = True
+# set wide cone until the code is made to compute this wrt CalIntersection
+splitMuons.CaloExtractorPSet.DR_Max = 1.0
 
 #Sequences
 
@@ -318,12 +318,12 @@ lhcSTAMuons = muons1stStep.clone(
     inputCollectionTypes = ['outer tracks'],
     fillIsolation = True,
     fillGlobalTrackQuality = False,
-    TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation',
-    CaloExtractorPSet.CenterConeOnCalIntersection = True,
-    # set wide cone until the code is made to compute this wrt CalIntersection
-    CaloExtractorPSet.DR_Max = 1.0,
     fillGlobalTrackRefits = False
 )
+lhcSTAMuons.TrackExtractorPSet.inputTrackCollection = 'ctfWithMaterialTracksP5LHCNavigation'
+lhcSTAMuons.CaloExtractorPSet.CenterConeOnCalIntersection = True
+# set wide cone until the code is made to compute this wrt CalIntersection
+lhcSTAMuons.CaloExtractorPSet.DR_Max = 1.0
 
 # Final sequence
 muonRecoLHCTask = cms.Task(ancientMuonSeed,

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -21,7 +21,6 @@ displacedStandAloneMuons = standAloneMuons.clone(
     MuonTrajectoryBuilder = 'StandAloneMuonTrajectoryBuilder',
     TrackLoaderParameters = dict(VertexConstraint = False)
 )
-#displacedStandAloneMuons.TrackLoaderParameters.VertexConstraint = False 
 
 # Global muon track producer
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -17,9 +17,9 @@ displacedMuonSeeds = CosmicMuonSeed.clone(
 
 displacedStandAloneMuons = standAloneMuons.clone(
     InputObjects = 'displacedMuonSeeds',
-    MuonTrajectoryBuilder = 'StandAloneMuonTrajectoryBuilder',
-    TrackLoaderParameters.VertexConstraint = False 
+    MuonTrajectoryBuilder = 'StandAloneMuonTrajectoryBuilder'
 )
+displacedStandAloneMuons.TrackLoaderParameters.VertexConstraint = False 
 
 # Global muon track producer
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -11,20 +11,23 @@ refittedStandAloneMuons.STATrajBuilderParameters.DoRefit = True
 
 # Displaced SA muons
 from RecoMuon.MuonSeedGenerator.CosmicMuonSeedProducer_cfi import *
-displacedMuonSeeds = CosmicMuonSeed.clone()
-displacedMuonSeeds.ForcePointDown = False
+displacedMuonSeeds = CosmicMuonSeed.clone(
+    ForcePointDown = False
+)
 
-displacedStandAloneMuons = standAloneMuons.clone()
-displacedStandAloneMuons.InputObjects = cms.InputTag("displacedMuonSeeds")
-displacedStandAloneMuons.MuonTrajectoryBuilder = cms.string("StandAloneMuonTrajectoryBuilder")
-displacedStandAloneMuons.TrackLoaderParameters.VertexConstraint = cms.bool(False) 
+displacedStandAloneMuons = standAloneMuons.clone(
+    InputObjects = 'displacedMuonSeeds',
+    MuonTrajectoryBuilder = 'StandAloneMuonTrajectoryBuilder',
+    TrackLoaderParameters.VertexConstraint = False 
+)
 
 # Global muon track producer
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *
 from RecoMuon.Configuration.iterativeTkDisplaced_cff import *
-displacedGlobalMuons = globalMuons.clone()
-displacedGlobalMuons.MuonCollectionLabel = cms.InputTag("displacedStandAloneMuons","")
-displacedGlobalMuons.TrackerCollectionLabel = cms.InputTag("displacedTracks")
+displacedGlobalMuons = globalMuons.clone(
+    MuonCollectionLabel = 'displacedStandAloneMuons:',
+    TrackerCollectionLabel = 'displacedTracks'
+)
 
 # TeV refinement
 from RecoMuon.GlobalMuonProducer.tevMuons_cfi import *
@@ -48,7 +51,11 @@ from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 # Muon Tracking sequence
-standalonemuontrackingTask = cms.Task(standAloneMuons,refittedStandAloneMuons,displacedMuonSeeds,displacedStandAloneMuons,standAloneMuonSeedsTask)
+standalonemuontrackingTask = cms.Task(standAloneMuons,
+                                      refittedStandAloneMuons,
+                                      displacedMuonSeeds,
+                                      displacedStandAloneMuons,
+                                      standAloneMuonSeedsTask)
 standalonemuontracking = cms.Sequence(standalonemuontrackingTask)
 # not commisoned and not relevant in FastSim (?):
 fastSim.toReplaceWith(standalonemuontrackingTask,standalonemuontrackingTask.copyAndExclude([displacedMuonSeeds,displacedStandAloneMuons]))
@@ -80,7 +87,10 @@ muonrecoComplete = cms.Sequence(muonreco_plus_isolationTask,muonSelectionTypeTas
 
 #from RecoMuon.MuonIdentification.earlyMuons_cfi import earlyMuons
 
-muonGlobalRecoTask = cms.Task(globalmuontrackingTask,muonIdProducerTask,muonSelectionTypeTask,muIsolationTask)
+muonGlobalRecoTask = cms.Task(globalmuontrackingTask,
+                              muonIdProducerTask,
+                              muonSelectionTypeTask,
+                              muIsolationTask)
 muonGlobalReco = cms.Sequence(muonGlobalRecoTask)
 
 # ... instead, the sequences will be run in the following order:

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -6,9 +6,10 @@ from RecoMuon.MuonSeedGenerator.standAloneMuonSeeds_cff import *
 from RecoMuon.StandAloneMuonProducer.standAloneMuons_cff import *
 
 # refitted stand-alone muons.
-refittedStandAloneMuons = standAloneMuons.clone()
-refittedStandAloneMuons.STATrajBuilderParameters.DoRefit = True
-
+refittedStandAloneMuons = standAloneMuons.clone(
+    STATrajBuilderParameters = dict(DoRefit = True)
+)
+#refittedStandAloneMuons.STATrajBuilderParameters.DoRefit = True
 # Displaced SA muons
 from RecoMuon.MuonSeedGenerator.CosmicMuonSeedProducer_cfi import *
 displacedMuonSeeds = CosmicMuonSeed.clone(
@@ -17,9 +18,10 @@ displacedMuonSeeds = CosmicMuonSeed.clone(
 
 displacedStandAloneMuons = standAloneMuons.clone(
     InputObjects = 'displacedMuonSeeds',
-    MuonTrajectoryBuilder = 'StandAloneMuonTrajectoryBuilder'
+    MuonTrajectoryBuilder = 'StandAloneMuonTrajectoryBuilder',
+    TrackLoaderParameters = dict(VertexConstraint = False)
 )
-displacedStandAloneMuons.TrackLoaderParameters.VertexConstraint = False 
+#displacedStandAloneMuons.TrackLoaderParameters.VertexConstraint = False 
 
 # Global muon track producer
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *

--- a/RecoMuon/Configuration/python/RecoMuon_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_cff.py
@@ -19,10 +19,14 @@ muonsFromCosmics = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clo
     inputCollectionTypes = ['outer tracks'],
     fillIsolation = False,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+
+    TrackAssociatorParameters = dict(
+	DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'),
+
+    TrackExtractorPSet = dict(
+	inputTrackCollection = 'cosmicMuons')
 )
-muonsFromCosmics.TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'
-muonsFromCosmics.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons'
 muonsFromCosmics.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments'
 muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
 muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
@@ -36,11 +40,13 @@ muoncosmicreco2legsHighLevel = cms.Sequence(muoncosmicreco2legsHighLevelTask)
 # 1 Leg type
 # Stand alone muon track producer
 cosmicMuons1Leg = cosmicMuons.clone(
-    MuonSeedCollectionLabel = 'CosmicMuonSeed'
+    MuonSeedCollectionLabel = 'CosmicMuonSeed',
+
+    TrajectoryBuilderParameters = dict(
+	BuildTraversingMuon = True,
+	Strict1Leg = True,
+	DTRecSegmentLabel = 'dt4DCosmicSegments')
 )
-cosmicMuons1Leg.TrajectoryBuilderParameters.BuildTraversingMuon = True
-cosmicMuons1Leg.TrajectoryBuilderParameters.Strict1Leg = True
-cosmicMuons1Leg.TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DCosmicSegments'
 
 # Muon Id producer
 muonsFromCosmics1Leg = muons1stStep.clone(
@@ -48,10 +54,14 @@ muonsFromCosmics1Leg = muons1stStep.clone(
     inputCollectionTypes = ['outer tracks'],
     fillIsolation = False,
     fillGlobalTrackQuality = False,
-    fillGlobalTrackRefits = False
+    fillGlobalTrackRefits = False,
+
+    TrackAssociatorParameters = dict(
+	DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'),
+
+    TrackExtractorPSet = dict(
+	inputTrackCollection = 'cosmicMuons1Leg')
 )
-muonsFromCosmics1Leg.TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'
-muonsFromCosmics1Leg.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons1Leg'
 muonsFromCosmics1Leg.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments'
 muonsFromCosmics1Leg.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
 muonsFromCosmics1Leg.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999

--- a/RecoMuon/Configuration/python/RecoMuon_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_cff.py
@@ -20,16 +20,13 @@ muonsFromCosmics = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clo
     fillIsolation = False,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False,
-
-    TrackAssociatorParameters = dict(
-	DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'),
-
-    TrackExtractorPSet = dict(
-	inputTrackCollection = 'cosmicMuons')
+    TrackAssociatorParameters = dict(DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'),
+    TrackExtractorPSet = dict(inputTrackCollection = 'cosmicMuons'),
+    TimingFillerParameters = dict(
+	MatchParameters = dict(DTsegments = 'dt4DCosmicSegments'),
+	DTTimingParameters = dict(PruneCut = 9999),
+	CSCTimingParameters = dict(PruneCut = 9999))
 )
-muonsFromCosmics.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments'
-muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 #add regional cosmic tracks here
 muoncosmicreco2legsSTATask = cms.Task(CosmicMuonSeed,cosmicMuons)
@@ -41,10 +38,9 @@ muoncosmicreco2legsHighLevel = cms.Sequence(muoncosmicreco2legsHighLevelTask)
 # Stand alone muon track producer
 cosmicMuons1Leg = cosmicMuons.clone(
     MuonSeedCollectionLabel = 'CosmicMuonSeed',
-
     TrajectoryBuilderParameters = dict(
-	BuildTraversingMuon = True,
-	Strict1Leg = True,
+	BuildTraversingMuon = True, 
+	Strict1Leg = True, 
 	DTRecSegmentLabel = 'dt4DCosmicSegments')
 )
 
@@ -55,16 +51,13 @@ muonsFromCosmics1Leg = muons1stStep.clone(
     fillIsolation = False,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False,
-
-    TrackAssociatorParameters = dict(
-	DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'),
-
-    TrackExtractorPSet = dict(
-	inputTrackCollection = 'cosmicMuons1Leg')
+    TrackAssociatorParameters = dict(DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'),
+    TrackExtractorPSet = dict(inputTrackCollection = 'cosmicMuons1Leg'),
+    TimingFillerParameters = dict(
+        MatchParameters = dict(DTsegments = 'dt4DCosmicSegments'),
+        DTTimingParameters = dict(PruneCut = 9999),
+        CSCTimingParameters = dict(PruneCut = 9999))
 )
-muonsFromCosmics1Leg.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments'
-muonsFromCosmics1Leg.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muonsFromCosmics1Leg.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 muoncosmicreco1legSTATask = cms.Task(CosmicMuonSeed,cosmicMuons1Leg)
 muoncosmicreco1legSTA = cms.Sequence(muoncosmicreco1legSTATask)

--- a/RecoMuon/Configuration/python/RecoMuon_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_cff.py
@@ -14,17 +14,18 @@ from RecoMuon.CosmicMuonProducer.cosmicMuons_cff import *
 cosmicMuons.TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DCosmicSegments'
 
 # Muon Id producer
-muonsFromCosmics = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clone()
-muonsFromCosmics.inputCollectionLabels = ['cosmicMuons']
-muonsFromCosmics.inputCollectionTypes = ['outer tracks']
-muonsFromCosmics.TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'
-muonsFromCosmics.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons'
-muonsFromCosmics.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments'
-muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
-muonsFromCosmics.fillIsolation = False
-muonsFromCosmics.fillGlobalTrackQuality = False
-muonsFromCosmics.fillGlobalTrackRefits = False
+muonsFromCosmics = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clone(
+    inputCollectionLabels = ['cosmicMuons'],
+    inputCollectionTypes = ['outer tracks'],
+    TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments',
+    TrackExtractorPSet.inputTrackCollection = 'cosmicMuons',
+    TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments',
+    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
+    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999,
+    fillIsolation = False,
+    fillGlobalTrackQuality = False,
+    fillGlobalTrackRefits = False
+)
 
 #add regional cosmic tracks here
 muoncosmicreco2legsSTATask = cms.Task(CosmicMuonSeed,cosmicMuons)
@@ -34,24 +35,27 @@ muoncosmicreco2legsHighLevel = cms.Sequence(muoncosmicreco2legsHighLevelTask)
 
 # 1 Leg type
 # Stand alone muon track producer
-cosmicMuons1Leg = cosmicMuons.clone()
-cosmicMuons1Leg.TrajectoryBuilderParameters.BuildTraversingMuon = True
-cosmicMuons1Leg.TrajectoryBuilderParameters.Strict1Leg = True
-cosmicMuons1Leg.TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DCosmicSegments'
-cosmicMuons1Leg.MuonSeedCollectionLabel = 'CosmicMuonSeed'
+cosmicMuons1Leg = cosmicMuons.clone(
+    TrajectoryBuilderParameters.BuildTraversingMuon = True,
+    TrajectoryBuilderParameters.Strict1Leg = True,
+    TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DCosmicSegments',
+    MuonSeedCollectionLabel = 'CosmicMuonSeed'
+)
 
 # Muon Id producer
-muonsFromCosmics1Leg = muons1stStep.clone()
-muonsFromCosmics1Leg.inputCollectionLabels = ['cosmicMuons1Leg']
-muonsFromCosmics1Leg.inputCollectionTypes = ['outer tracks']
-muonsFromCosmics1Leg.TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'
-muonsFromCosmics1Leg.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons1Leg'
-muonsFromCosmics1Leg.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments'
-muonsFromCosmics1Leg.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
-muonsFromCosmics1Leg.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
-muonsFromCosmics1Leg.fillIsolation = False
-muonsFromCosmics1Leg.fillGlobalTrackQuality = False
-muonsFromCosmics1Leg.fillGlobalTrackRefits = False
+muonsFromCosmics1Leg = muons1stStep.clone(
+    inputCollectionLabels = ['cosmicMuons1Leg'],
+    inputCollectionTypes = ['outer tracks'],
+    TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments',
+    TrackExtractorPSet.inputTrackCollection = 'cosmicMuons1Leg',
+    TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments',
+    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
+    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999,
+    fillIsolation = False,
+    fillGlobalTrackQuality = False,
+    fillGlobalTrackRefits = False
+)
+
 muoncosmicreco1legSTATask = cms.Task(CosmicMuonSeed,cosmicMuons1Leg)
 muoncosmicreco1legSTA = cms.Sequence(muoncosmicreco1legSTATask)
 muoncosmicreco1legHighLevelTask = cms.Task(muonsFromCosmics1Leg)
@@ -61,6 +65,7 @@ muoncosmicrecoTask = cms.Task(muoncosmicreco2legsSTATask,muoncosmicreco1legSTATa
 muoncosmicreco = cms.Sequence(muoncosmicrecoTask)
 muoncosmichighlevelrecoTask = cms.Task(muoncosmicreco2legsHighLevelTask,muoncosmicreco1legHighLevelTask,cosmicsMuonIdTask)
 muoncosmichighlevelreco = cms.Sequence(muoncosmichighlevelrecoTask)
+
 #### High level sequence (i.e., post PF reconstruction) ###
 from RecoMuon.MuonIdentification.muons_cfi import *
 from RecoMuon.MuonIsolation.muonPFIsolation_cff import *

--- a/RecoMuon/Configuration/python/RecoMuon_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_cff.py
@@ -17,15 +17,15 @@ cosmicMuons.TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DCosmicSegments'
 muonsFromCosmics = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clone(
     inputCollectionLabels = ['cosmicMuons'],
     inputCollectionTypes = ['outer tracks'],
-    TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments',
-    TrackExtractorPSet.inputTrackCollection = 'cosmicMuons',
-    TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments',
-    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
-    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999,
     fillIsolation = False,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False
 )
+muonsFromCosmics.TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'
+muonsFromCosmics.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons'
+muonsFromCosmics.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments'
+muonsFromCosmics.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
+muonsFromCosmics.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 #add regional cosmic tracks here
 muoncosmicreco2legsSTATask = cms.Task(CosmicMuonSeed,cosmicMuons)
@@ -36,25 +36,25 @@ muoncosmicreco2legsHighLevel = cms.Sequence(muoncosmicreco2legsHighLevelTask)
 # 1 Leg type
 # Stand alone muon track producer
 cosmicMuons1Leg = cosmicMuons.clone(
-    TrajectoryBuilderParameters.BuildTraversingMuon = True,
-    TrajectoryBuilderParameters.Strict1Leg = True,
-    TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DCosmicSegments',
     MuonSeedCollectionLabel = 'CosmicMuonSeed'
 )
+cosmicMuons1Leg.TrajectoryBuilderParameters.BuildTraversingMuon = True
+cosmicMuons1Leg.TrajectoryBuilderParameters.Strict1Leg = True
+cosmicMuons1Leg.TrajectoryBuilderParameters.DTRecSegmentLabel = 'dt4DCosmicSegments'
 
 # Muon Id producer
 muonsFromCosmics1Leg = muons1stStep.clone(
     inputCollectionLabels = ['cosmicMuons1Leg'],
     inputCollectionTypes = ['outer tracks'],
-    TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments',
-    TrackExtractorPSet.inputTrackCollection = 'cosmicMuons1Leg',
-    TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments',
-    TimingFillerParameters.DTTimingParameters.PruneCut = 9999,
-    TimingFillerParameters.CSCTimingParameters.PruneCut = 9999,
     fillIsolation = False,
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits = False
 )
+muonsFromCosmics1Leg.TrackAssociatorParameters.DTRecSegment4DCollectionLabel = 'dt4DCosmicSegments'
+muonsFromCosmics1Leg.TrackExtractorPSet.inputTrackCollection = 'cosmicMuons1Leg'
+muonsFromCosmics1Leg.TimingFillerParameters.MatchParameters.DTsegments = 'dt4DCosmicSegments'
+muonsFromCosmics1Leg.TimingFillerParameters.DTTimingParameters.PruneCut = 9999
+muonsFromCosmics1Leg.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 
 muoncosmicreco1legSTATask = cms.Task(CosmicMuonSeed,cosmicMuons1Leg)
 muoncosmicreco1legSTA = cms.Sequence(muoncosmicreco1legSTATask)

--- a/RecoMuon/Configuration/python/SETRecoMuon_cff.py
+++ b/RecoMuon/Configuration/python/SETRecoMuon_cff.py
@@ -5,16 +5,19 @@ from RecoMuon.MuonSeedGenerator.SETMuonSeed_cff import *
 from RecoMuon.StandAloneMuonProducer.standAloneMuons_cff import standAloneSETMuons
 
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *
-globalSETMuons = globalMuons.clone()
-globalSETMuons.MuonCollectionLabel = cms.InputTag("standAloneSETMuons","UpdatedAtVtx")
-
+globalSETMuons = globalMuons.clone(
+    MuonCollectionLabel = 'standAloneSETMuons:UpdatedAtVtx'
+)
 muontracking_with_SET_Task = cms.Task(SETMuonSeed,standAloneSETMuons,globalSETMuons)
 muontracking_with_SET = cms.Sequence(muontracking_with_SET_Task)
-from RecoMuon.MuonIdentification.muonIdProducerSequence_cff import *
-muonsWithSET = muons1stStep.clone()
-muonsWithSET.inputCollectionLabels = ['generalTracks', 'globalSETMuons', cms.InputTag('standAloneSETMuons','UpdatedAtVtx')] 
-muonsWithSET.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks']   
 
+from RecoMuon.MuonIdentification.muonIdProducerSequence_cff import *
+muonsWithSET = muons1stStep.clone(
+    inputCollectionLabels = ['generalTracks', 
+                             'globalSETMuons', 
+                             'standAloneSETMuons:UpdatedAtVtx'],
+    inputCollectionTypes = ['inner tracks', 'links', 'outer tracks']
+)
 #muonreco_with_SET = cms.Sequence(muontracking_with_SET*muonsWithSET)
 #run only the tracking part for SET, after that it should be merged with the main ones at some point
 muonreco_with_SET_Task = cms.Task(muontracking_with_SET_Task)

--- a/RecoMuon/Configuration/python/preDuplicateMergingDisplacedTracks_cfi.py
+++ b/RecoMuon/Configuration/python/preDuplicateMergingDisplacedTracks_cfi.py
@@ -2,18 +2,14 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
-preDuplicateMergingDisplacedTracks = TrackCollectionMerger.clone()
-preDuplicateMergingDisplacedTracks.trackProducers = [
-    "muonSeededTracksInOut",
-    "muonSeededTracksOutInDisplaced",
-    ]
-preDuplicateMergingDisplacedTracks.inputClassifiers =[
-   "muonSeededTracksInOutClassifier",
-   "muonSeededTracksOutInDisplacedClassifier"
-   ]
-
-preDuplicateMergingDisplacedTracks.foundHitBonus  = 100.0
-preDuplicateMergingDisplacedTracks.lostHitPenalty =   1.0
+preDuplicateMergingDisplacedTracks = TrackCollectionMerger.clone(
+    trackProducers   = ['muonSeededTracksInOut',
+                        'muonSeededTracksOutInDisplaced'],
+    inputClassifiers = ['muonSeededTracksInOutClassifier',
+                        'muonSeededTracksOutInDisplacedClassifier'],
+    foundHitBonus  = 100.0,
+    lostHitPenalty =   1.0
+)
 
 # For Phase2PU140 tracking, take out muonSeededTracksInOut because the
 # cut-selector module is technically incompatible with this one. Since
@@ -22,7 +18,6 @@ preDuplicateMergingDisplacedTracks.lostHitPenalty =   1.0
 # situation.
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(preDuplicateMergingDisplacedTracks,
-    trackProducers = [x for x in preDuplicateMergingDisplacedTracks.trackProducers if x != "muonSeededTracksInOut"],
-    inputClassifiers = [x for x in preDuplicateMergingDisplacedTracks.inputClassifiers if x != "muonSeededTracksInOutClassifier"],
+    trackProducers = [x for x in preDuplicateMergingDisplacedTracks.trackProducers if x != 'muonSeededTracksInOut'],
+    inputClassifiers = [x for x in preDuplicateMergingDisplacedTracks.inputClassifiers if x != 'muonSeededTracksInOutClassifier'],
 )
-


### PR DESCRIPTION
#### PR description: Update the safer syntax for existing parameter
(The references were [PR#29979](https://github.com/cms-sw/cmssw/pull/29979), [PR#30147](https://github.com/cms-sw/cmssw/pull/30147).)
RecoLocalMuon and RecoMuon/Configuration were considered in this PR.

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).