### PR TITLE
drop type specs in RecoMuon

### DIFF
--- a/RecoMuon/GlobalMuonProducer/python/globalMuons_cff.py
+++ b/RecoMuon/GlobalMuonProducer/python/globalMuons_cff.py
@@ -13,24 +13,22 @@ from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilderWithoutRe
 from TrackingTools.TrackRefitter.TracksToTrajectories_cff import *
 from RecoMuon.GlobalMuonProducer.globalMuons_cfi import *
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-Chi2EstimatorForMuRefit = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
-Chi2EstimatorForMuRefit.ComponentName = cms.string('Chi2EstimatorForMuRefit')
-Chi2EstimatorForMuRefit.nSigma = 3.0
-Chi2EstimatorForMuRefit.MaxChi2 = 100000.0
-
+Chi2EstimatorForMuRefit = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = 'Chi2EstimatorForMuRefit',
+    nSigma        = 3.0,
+    MaxChi2       = 100000.0
+)
 
 from TrackingTools.TrackFitters.TrackFitters_cff import *
 GlbMuKFFitter = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
-    ComponentName = cms.string('GlbMuKFFitter'),
-    Estimator = cms.string('Chi2EstimatorForMuRefit'),
-    Propagator = cms.string('SmartPropagatorAnyRK'),
-    Updator = cms.string('KFUpdator'),
-    minHits = cms.int32(3)
+    ComponentName = 'GlbMuKFFitter',
+    Estimator     = 'Chi2EstimatorForMuRefit',
+    Propagator    = 'SmartPropagatorAnyRK',
+    Updator       = 'KFUpdator',
+    minHits       = 3
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 # FastSim doesn't use Runge Kute for propagation
 fastSim.toModify(GlbMuKFFitter,
-                 Propagator = "SmartPropagatorAny")
-
-
+                 Propagator = 'SmartPropagatorAny')

--- a/RecoMuon/GlobalMuonProducer/python/globalMuons_cfi.py
+++ b/RecoMuon/GlobalMuonProducer/python/globalMuons_cfi.py
@@ -13,8 +13,8 @@ globalMuons = cms.EDProducer("GlobalMuonProducer",
     MuonCollectionLabel = cms.InputTag("standAloneMuons","UpdatedAtVtx")
 )
 
-globalMuons.GLBTrajBuilderParameters.GlobalMuonTrackMatcher.Propagator = cms.string('SmartPropagatorRK')
-globalMuons.GLBTrajBuilderParameters.TrackTransformer.Propagator = cms.string('SmartPropagatorAnyRK') 
+globalMuons.GLBTrajBuilderParameters.GlobalMuonTrackMatcher.Propagator = 'SmartPropagatorRK'
+globalMuons.GLBTrajBuilderParameters.TrackTransformer.Propagator = 'SmartPropagatorAnyRK' 
 
 # FastSim has no template fit on tracker hits
 # FastSim doesn't use Runge Kute for propagation
@@ -28,4 +28,3 @@ fastSim.toModify(globalMuons,
                                                 GlobalMuonTrackMatcher = dict(Propagator = 'SmartPropagator') 
                                                 )
 )
-

--- a/RecoMuon/GlobalMuonProducer/python/globalMuons_cfi.py
+++ b/RecoMuon/GlobalMuonProducer/python/globalMuons_cfi.py
@@ -13,8 +13,8 @@ globalMuons = cms.EDProducer("GlobalMuonProducer",
     MuonCollectionLabel = cms.InputTag("standAloneMuons","UpdatedAtVtx")
 )
 
-globalMuons.GLBTrajBuilderParameters.GlobalMuonTrackMatcher.Propagator = 'SmartPropagatorRK'
-globalMuons.GLBTrajBuilderParameters.TrackTransformer.Propagator = 'SmartPropagatorAnyRK' 
+globalMuons.GLBTrajBuilderParameters.GlobalMuonTrackMatcher.Propagator = cms.string('SmartPropagatorRK')
+globalMuons.GLBTrajBuilderParameters.TrackTransformer.Propagator = cms.string('SmartPropagatorAnyRK')
 
 # FastSim has no template fit on tracker hits
 # FastSim doesn't use Runge Kute for propagation

--- a/RecoMuon/L2MuonSeedGenerator/python/L2OfflineMuonSeeds_cfi.py
+++ b/RecoMuon/L2MuonSeedGenerator/python/L2OfflineMuonSeeds_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoMuon.MuonSeedGenerator.ancientMuonSeed_cfi import *
 
 L2OfflineMuonSeeds = ancientMuonSeed.clone(
-    CSCRecSegmentLabel = cms.InputTag("hltCscSegments"),
-    DTRecSegmentLabel = cms.InputTag("hltDt4DSegments")
-    )
-
+    CSCRecSegmentLabel = 'hltCscSegments',
+    DTRecSegmentLabel  = 'hltDt4DSegments'
+)

--- a/RecoMuon/MuonIdentification/python/cosmics_id.py
+++ b/RecoMuon/MuonIdentification/python/cosmics_id.py
@@ -10,19 +10,19 @@ cosmicsVetoSeeds = cms.EDProducer("TrajectorySeedFromMuonProducer"
 
 from RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff import *
 cosmicsVetoTrackCandidates = copy.deepcopy(ckfTrackCandidatesP5)
-cosmicsVetoTrackCandidates.src = cms.InputTag("cosmicsVetoSeeds")
+cosmicsVetoTrackCandidates.src = "cosmicsVetoSeeds"
 cosmicsVetoTrackCandidates.doSeedingRegionRebuilding = False
 cosmicsVetoTrackCandidates.RedundantSeedCleaner = "none"
 
 from RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff import *
 cosmicsVetoTracksRaw = copy.deepcopy(ctfWithMaterialTracksCosmics)
-cosmicsVetoTracksRaw.src = cms.InputTag("cosmicsVetoTrackCandidates")
+cosmicsVetoTracksRaw.src = "cosmicsVetoTrackCandidates"
 # need to clone FittingSmootherRKP5 if I want to change its parameters
 # process.FittingSmootherRKP5.EstimateCut = cms.double(-1.0) # turn off the OutlierRejection
 
 from RecoTracker.FinalTrackSelectors.cosmictrackSelector_cfi import *
 cosmicsVetoTracks = cosmictrackSelector.clone(
-    src = cms.InputTag("cosmicsVetoTracksRaw")
+    src = "cosmicsVetoTracksRaw"
 )
 
 from RecoMuon.MuonIdentification.muonCosmicCompatibility_cfi import *

--- a/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
+++ b/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
@@ -14,11 +14,11 @@ earlyMuons = muons1stStep.clone(
     fillGlobalTrackRefits  = False,
     fillIsolation = False,
     fillTrackerKink = False,
+    TrackAssociatorParameters = dict(
+	useHO   = False,
+	useEcal = False,
+	useHcal = False)
 )
-earlyMuons.TrackAssociatorParameters.useHO   = False
-earlyMuons.TrackAssociatorParameters.useEcal = False
-earlyMuons.TrackAssociatorParameters.useHcal = False
-
 earlyDisplacedMuons = earlyMuons.clone(
     inputCollectionLabels = ['earlyGeneralTracks','displacedStandAloneMuons:']
 )

--- a/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
+++ b/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoMuon.MuonIdentification.muons1stStep_cfi import muons1stStep
 
 earlyMuons = muons1stStep.clone(
-    inputCollectionTypes = cms.vstring('inner tracks','outer tracks'),
-    inputCollectionLabels = cms.VInputTag(cms.InputTag("earlyGeneralTracks"),cms.InputTag("standAloneMuons","UpdatedAtVtx")),
+    inputCollectionTypes = ['inner tracks','outer tracks'],
+    inputCollectionLabels = ['earlyGeneralTracks', 'standAloneMuons:UpdatedAtVtx'],
     minP         = 3.0, # was 2.5
     minPt        = 2.0, # was 0.5
     minPCaloMuon = 3.0, # was 1.0
@@ -13,12 +13,12 @@ earlyMuons = muons1stStep.clone(
     fillGlobalTrackQuality = False,
     fillGlobalTrackRefits  = False,
     fillIsolation = False,
-    fillTrackerKink = False)
-
-earlyMuons.TrackAssociatorParameters.useHO   = cms.bool(False)
-earlyMuons.TrackAssociatorParameters.useEcal = cms.bool(False)
-earlyMuons.TrackAssociatorParameters.useHcal = cms.bool(False)
+    fillTrackerKink = False,
+)
+earlyMuons.TrackAssociatorParameters.useHO   = False
+earlyMuons.TrackAssociatorParameters.useEcal = False
+earlyMuons.TrackAssociatorParameters.useHcal = False
 
 earlyDisplacedMuons = earlyMuons.clone(
-    inputCollectionLabels = cms.VInputTag(cms.InputTag("earlyGeneralTracks"),cms.InputTag("displacedStandAloneMuons","")),
-    )
+    inputCollectionLabels = ['earlyGeneralTracks','displacedStandAloneMuons:']
+)

--- a/RecoMuon/MuonIdentification/python/muonSelectionTypeValueMapProducer_cff.py
+++ b/RecoMuon/MuonIdentification/python/muonSelectionTypeValueMapProducer_cff.py
@@ -2,63 +2,82 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoMuon.MuonIdentification.muonSelectionTypeValueMapProducer_cfi import *
 
-muidTrackerMuonArbitrated = muonSelectionTypeValueMapProducer.clone()
-muidTrackerMuonArbitrated.selectionType = cms.string("TrackerMuonArbitrated")
-#
-muidAllArbitrated = muonSelectionTypeValueMapProducer.clone()
-muidAllArbitrated.selectionType = cms.string("AllArbitrated")
-#
-muidGlobalMuonPromptTight = muonSelectionTypeValueMapProducer.clone()
-muidGlobalMuonPromptTight.selectionType = cms.string("GlobalMuonPromptTight")
-#
-muidTMLastStationLoose = muonSelectionTypeValueMapProducer.clone()
-muidTMLastStationLoose.selectionType = cms.string("TMLastStationLoose")
-#
-muidTMLastStationTight = muonSelectionTypeValueMapProducer.clone()
-muidTMLastStationTight.selectionType = cms.string("TMLastStationTight")
-#
-muidTM2DCompatibilityLoose = muonSelectionTypeValueMapProducer.clone()
-muidTM2DCompatibilityLoose.selectionType = cms.string("TM2DCompatibilityLoose")
-#
-muidTM2DCompatibilityTight = muonSelectionTypeValueMapProducer.clone()
-muidTM2DCompatibilityTight.selectionType = cms.string("TM2DCompatibilityTight")
-#
-muidTMOneStationLoose = muonSelectionTypeValueMapProducer.clone()
-muidTMOneStationLoose.selectionType = cms.string("TMOneStationLoose")
-#
-muidTMOneStationTight = muonSelectionTypeValueMapProducer.clone()
-muidTMOneStationTight.selectionType = cms.string("TMOneStationTight")
-#
-muidTMLastStationOptimizedLowPtLoose = muonSelectionTypeValueMapProducer.clone()
-muidTMLastStationOptimizedLowPtLoose.selectionType = cms.string("TMLastStationOptimizedLowPtLoose")
-#
-muidTMLastStationOptimizedLowPtTight = muonSelectionTypeValueMapProducer.clone()
-muidTMLastStationOptimizedLowPtTight.selectionType = cms.string("TMLastStationOptimizedLowPtTight")
-#
-muidGMTkChiCompatibility = muonSelectionTypeValueMapProducer.clone()
-muidGMTkChiCompatibility.selectionType = cms.string("GMTkChiCompatibility")
-#
-muidGMStaChiCompatibility = muonSelectionTypeValueMapProducer.clone()
-muidGMStaChiCompatibility.selectionType = cms.string("GMStaChiCompatibility")
-#
-muidGMTkKinkTight = muonSelectionTypeValueMapProducer.clone()
-muidGMTkKinkTight.selectionType = cms.string("GMTkKinkTight")
-#
-muidTMLastStationAngLoose = muonSelectionTypeValueMapProducer.clone()
-muidTMLastStationAngLoose.selectionType = cms.string("TMLastStationAngLoose")
-#
-muidTMLastStationAngTight = muonSelectionTypeValueMapProducer.clone()
-muidTMLastStationAngTight.selectionType = cms.string("TMLastStationAngTight")
-#
-muidTMOneStationAngLoose = muonSelectionTypeValueMapProducer.clone()
-muidTMOneStationAngLoose.selectionType = cms.string("TMOneStationAngLoose")
-#
-muidTMOneStationAngTight = muonSelectionTypeValueMapProducer.clone()
-muidTMOneStationAngTight.selectionType = cms.string("TMOneStationAngTight")
-#
-muidRPCMuLoose = muonSelectionTypeValueMapProducer.clone()
-muidRPCMuLoose.selectionType = cms.string("RPCMuLoose")
-#
+muidTrackerMuonArbitrated = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TrackerMuonArbitrated'
+)
+
+muidAllArbitrated = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'AllArbitrated'
+)
+
+muidGlobalMuonPromptTight = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'GlobalMuonPromptTight'
+)
+
+muidTMLastStationLoose = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMLastStationLoose'
+)
+
+muidTMLastStationTight = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMLastStationTight'
+)
+
+muidTM2DCompatibilityLoose = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TM2DCompatibilityLoose'
+)
+
+muidTM2DCompatibilityTight = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TM2DCompatibilityTight'
+)
+
+muidTMOneStationLoose = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMOneStationLoose'
+)
+
+muidTMOneStationTight = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMOneStationTight'
+)
+
+muidTMLastStationOptimizedLowPtLoose = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMLastStationOptimizedLowPtLoose'
+)
+
+muidTMLastStationOptimizedLowPtTight = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMLastStationOptimizedLowPtTight'
+)
+
+muidGMTkChiCompatibility = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'GMTkChiCompatibility'
+)
+
+muidGMStaChiCompatibility = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'GMStaChiCompatibility'
+)
+
+muidGMTkKinkTight = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'GMTkKinkTight'
+)
+
+muidTMLastStationAngLoose = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMLastStationAngLoose'
+)
+
+muidTMLastStationAngTight = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMLastStationAngTight'
+)
+
+muidTMOneStationAngLoose = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMOneStationAngLoose'
+)
+
+muidTMOneStationAngTight = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'TMOneStationAngTight'
+)
+
+muidRPCMuLoose = muonSelectionTypeValueMapProducer.clone(
+    selectionType = 'RPCMuLoose'
+)
+
 muonSelectionTypeTask = cms.Task(
     muidTrackerMuonArbitrated
     ,muidAllArbitrated

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -90,9 +90,9 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
 )
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toModify( muons1stStep, TrackAssociatorParameters = dict(useGEM = cms.bool(True) ) )
+run3_GEM.toModify( muons1stStep, TrackAssociatorParameters = dict(useGEM = True ) )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toModify( muons1stStep, TrackAssociatorParameters = dict(useME0 = cms.bool(True) ) )
+phase2_muon.toModify( muons1stStep, TrackAssociatorParameters = dict(useME0 = True ) )
 
 muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
                                 inputCollection = cms.InputTag("muons1stStep")
@@ -103,8 +103,3 @@ pp_on_AA_2018.toModify(muons1stStep, minPt = 0.8)
 
 from Configuration.ProcessModifiers.recoFromReco_cff import recoFromReco
 recoFromReco.toModify(muons1stStep,fillShowerDigis = False)
-
-
-
-
-   

--- a/RecoMuon/MuonSeedGenerator/python/ancientMuonSeed_cfi.py
+++ b/RecoMuon/MuonSeedGenerator/python/ancientMuonSeed_cfi.py
@@ -25,4 +25,4 @@ ancientMuonSeed = cms.EDProducer("MuonSeedGenerator",
 
 # phase2 ME0
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toModify(ancientMuonSeed, EnableME0Measurement = cms.bool(True))
+phase2_muon.toModify(ancientMuonSeed, EnableME0Measurement = True)

--- a/RecoMuon/StandAloneMuonProducer/python/standAloneMuons_cff.py
+++ b/RecoMuon/StandAloneMuonProducer/python/standAloneMuons_cff.py
@@ -8,35 +8,31 @@ import FWCore.ParameterSet.Config as cms
 #
 #
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-EstimatorForSTA = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
+EstimatorForSTA = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = 'Chi2STA',
+    MaxChi2 = 1000.
+)
 
-EstimatorForSTA.ComponentName = 'Chi2STA'
-EstimatorForSTA.MaxChi2 = 1000.
-#
-#
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
-KFTrajectoryFitterForSTA = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone()
+KFTrajectoryFitterForSTA = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
+    ComponentName = 'KFFitterSTA',
+    Propagator = 'SteppingHelixPropagatorAny',
+    Estimator = 'Chi2STA'
+)
 
-KFTrajectoryFitterForSTA.ComponentName = 'KFFitterSTA'
-KFTrajectoryFitterForSTA.Propagator = 'SteppingHelixPropagatorAny'
-KFTrajectoryFitterForSTA.Estimator = 'Chi2STA'
-#
-#
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
-KFTrajectorySmootherForSTA = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone()
+KFTrajectorySmootherForSTA = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
+    ComponentName = 'KFSmootherSTA',
+    Propagator = 'SteppingHelixPropagatorOpposite',
+    Estimator = 'Chi2STA'
+)
 
-KFTrajectorySmootherForSTA.ComponentName = 'KFSmootherSTA'
-KFTrajectorySmootherForSTA.Propagator = 'SteppingHelixPropagatorOpposite'
-KFTrajectorySmootherForSTA.Estimator = 'Chi2STA'
-#
-#
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
-KFFittingSmootheForSTA = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone()
+KFFittingSmootheForSTA = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
+    ComponentName = 'KFFitterSmootherSTA',
+    Fitter = 'KFFitterSTA',
+    Smoother = 'KFSmootherSTA'
+)
 
-KFFittingSmootheForSTA.ComponentName = 'KFFitterSmootherSTA'
-KFFittingSmootheForSTA.Fitter = 'KFFitterSTA'
-KFFittingSmootheForSTA.Smoother = 'KFSmootherSTA'
-#
-#
 # Stand Alone Muons Producer
 from RecoMuon.StandAloneMuonProducer.standAloneMuons_cfi import *

--- a/RecoMuon/StandAloneMuonProducer/python/standAloneMuons_cfi.py
+++ b/RecoMuon/StandAloneMuonProducer/python/standAloneMuons_cfi.py
@@ -108,13 +108,13 @@ standAloneSETMuons = cms.EDProducer("StandAloneMuonProducer",
     )
                                     )
 
-_enableGEMMeasurement = dict( EnableGEMMeasurement = cms.bool(True) )
+_enableGEMMeasurement = dict( EnableGEMMeasurement = True )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( standAloneMuons, STATrajBuilderParameters = dict(
     FilterParameters = _enableGEMMeasurement, 
     BWFilterParameters = _enableGEMMeasurement ) )
 
-_enableME0Measurement = dict( EnableME0Measurement = cms.bool(True) )
+_enableME0Measurement = dict( EnableME0Measurement = True )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( standAloneMuons, STATrajBuilderParameters = dict(
     FilterParameters = _enableME0Measurement,

--- a/RecoMuon/TrackerSeedGenerator/python/TSGFromL1_cff.py
+++ b/RecoMuon/TrackerSeedGenerator/python/TSGFromL1_cff.py
@@ -15,8 +15,7 @@ from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelPairs_cfi import *
 from RecoMuon.TrackerSeedGenerator.TSGFromL1_cfi import *
 from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi import *
 import RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi
-myTTRHBuilderWithoutAngleSeedsFromL1Muon = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone()
-myTTRHBuilderWithoutAngleSeedsFromL1Muon.StripCPE = 'Fake'
-myTTRHBuilderWithoutAngleSeedsFromL1Muon.ComponentName = 'PixelTTRHBuilderWithoutAngleSeedsFromL1Muon'
-
-
+myTTRHBuilderWithoutAngleSeedsFromL1Muon = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone(
+    StripCPE = 'Fake',
+    ComponentName = 'PixelTTRHBuilderWithoutAngleSeedsFromL1Muon'
+)


### PR DESCRIPTION
#### PR description: Update the safer syntax for existing parameter
Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#29979](https://github.com/cms-sw/cmssw/pull/29979), [PR#30147](https://github.com/cms-sw/cmssw/pull/30147).)

RecoMuon/{GlobalMuonProducer, StandAloneMuonProducer, MuonIdentification, MuonSeedGenerator, L2MuonSeedGenerator, TrackerSeedGenerator} were considered in this PR.

RecoMuon/Configuration can found in previous [PR#30270](https://github.com/cms-sw/cmssw/pull/30270).


#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).