### PR TITLE
Add SA checker to report calls to edm::eventsetup::EventSetupRecord::<>get() function template instantiations.

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -86,8 +86,8 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
       "optional.EDMPluginDumper", "Dumps macro DEFINE_EDM_PLUGIN types", "no docs");
   registry.addChecker<clangcms::ThrUnsafeFCallChecker>(
       "cms.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions", "no docs");
-  registry.addChecker<clangcms::ESRGetChecker>("threadsafety.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
-
+  registry.addChecker<clangcms::ESRGetChecker>(
+      "threadsafety.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
 }
 
 extern "C" const char clang_analyzerAPIVersionString[] = CLANG_ANALYZER_API_VERSION_STRING;

--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -22,6 +22,7 @@
 #include "FunctionDumper.h"
 #include "EDMPluginDumper.h"
 #include "ThrUnsafeFCallChecker.h"
+#include "ESRecordGetChecker.h"
 
 #include <clang/StaticAnalyzer/Frontend/CheckerRegistry.h>
 
@@ -85,6 +86,8 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
       "optional.EDMPluginDumper", "Dumps macro DEFINE_EDM_PLUGIN types", "no docs");
   registry.addChecker<clangcms::ThrUnsafeFCallChecker>(
       "cms.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions", "no docs");
+  registry.addChecker<clangcms::ESRGetChecker>("threadsafety.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
+
 }
 
 extern "C" const char clang_analyzerAPIVersionString[] = CLANG_ANALYZER_API_VERSION_STRING;

--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
@@ -1,0 +1,97 @@
+#include "ESRecordGetChecker.h"
+using namespace clang;
+using namespace ento;
+using namespace llvm;
+
+namespace clangcms {
+
+  class ESRWalker : public clang::StmtVisitor<ESRWalker> {
+    const CheckerBase *Checker;
+    clang::ento::BugReporter &BR;
+    clang::AnalysisDeclContext *AC;
+
+  public:
+    ESRWalker(const CheckerBase *checker, clang::ento::BugReporter &br, clang::AnalysisDeclContext *ac)
+        : Checker(checker), BR(br), AC(ac) {}
+
+    void VisitChildren(clang::Stmt *S);
+    void VisitStmt(clang::Stmt *S) { VisitChildren(S); }
+    void VisitCXXMemberCallExpr(clang::CXXMemberCallExpr *CE);
+  };
+
+  void ESRWalker::VisitChildren(clang::Stmt *S) {
+    for (clang::Stmt::child_iterator I = S->child_begin(), E = S->child_end(); I != E; ++I)
+      if (clang::Stmt *child = *I) {
+        Visit(child);
+      }
+  }
+
+  void ESRWalker::VisitCXXMemberCallExpr(CXXMemberCallExpr *CE) {
+    LangOptions LangOpts;
+    LangOpts.CPlusPlus = true;
+    PrintingPolicy Policy(LangOpts);
+    const Decl *D = AC->getDecl();
+    std::string dname = "";
+    if (const NamedDecl *ND = llvm::dyn_cast_or_null<NamedDecl>(D))
+      dname = ND->getQualifiedNameAsString();
+    if (dname == "edm::eventsetup::EventSetupRecord::get")
+      return;
+    CXXMethodDecl *MD = CE->getMethodDecl();
+    if (!MD)
+      return;
+    std::string mname = MD->getQualifiedNameAsString();
+    if (mname == "edm::eventsetup::EventSetupRecord::get") {
+      std::string mname = MD->getQualifiedNameAsString();
+      llvm::SmallString<100> buf;
+      llvm::raw_svector_ostream os(buf);
+      os << "function '";
+      llvm::dyn_cast<CXXMethodDecl>(D)->getNameForDiagnostic(os, Policy, true);
+      os << "' ";
+      os << "calls function '";
+      MD->getNameForDiagnostic(os, Policy, true);
+      for (auto I = CE->arg_begin(), E = CE->arg_end(); I != E; ++I) {
+        QualType QT = (*I)->getType();
+        std::string qtname = QT.getAsString();
+        //if (qtname == "edm::Event" || qtname == "const edm::Event" || qtname == "edm::Event *" ||
+        //    qtname == "const edm::Event *") {
+          os << "' with argument of type '" << qtname;
+          PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
+          BugType *BT = new BugType(Checker, "EventSetupRecord::get function called", "ThreadSafety");
+          std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
+          R->addRange(CE->getSourceRange());
+          BR.emitReport(std::move(R));
+	  //}
+      }
+      os << "'";
+    }
+  }
+
+
+  void ESRGetChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager &mgr, BugReporter &BR) const {
+    const SourceManager &SM = BR.getSourceManager();
+    PathDiagnosticLocation DLoc = PathDiagnosticLocation::createBegin(MD, SM);
+    if (SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()))
+      return;
+    if (!MD->doesThisDeclarationHaveABody())
+      return;
+    ESRWalker walker(this, BR, mgr.getAnalysisDeclContext(MD));
+    walker.Visit(MD->getBody());
+    return;
+  }
+  
+  void ESRGetChecker::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManager &mgr, BugReporter &BR) const {
+    const clang::SourceManager &SM = BR.getSourceManager();
+    clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::createBegin(TD, SM);
+    if (SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()))
+      return;
+
+    for (auto I = TD->spec_begin(), E = TD->spec_end(); I != E; ++I) {
+      if (I->doesThisDeclarationHaveABody()) {
+        ESRWalker walker(this, BR, mgr.getAnalysisDeclContext(*I));
+        walker.Visit(I->getBody());
+      }
+    }
+    return;
+  }
+
+}  // namespace clangcms

--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
@@ -63,7 +63,6 @@ namespace clangcms {
     }
   }
 
-
   void ESRGetChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager &mgr, BugReporter &BR) const {
     const SourceManager &SM = BR.getSourceManager();
     PathDiagnosticLocation DLoc = PathDiagnosticLocation::createBegin(MD, SM);
@@ -75,7 +74,7 @@ namespace clangcms {
     walker.Visit(MD->getBody());
     return;
   }
-  
+
   void ESRGetChecker::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManager &mgr, BugReporter &BR) const {
     const clang::SourceManager &SM = BR.getSourceManager();
     clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::createBegin(TD, SM);

--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
@@ -52,15 +52,12 @@ namespace clangcms {
       for (auto I = CE->arg_begin(), E = CE->arg_end(); I != E; ++I) {
         QualType QT = (*I)->getType();
         std::string qtname = QT.getAsString();
-        //if (qtname == "edm::Event" || qtname == "const edm::Event" || qtname == "edm::Event *" ||
-        //    qtname == "const edm::Event *") {
-          os << "' with argument of type '" << qtname;
-          PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-          BugType *BT = new BugType(Checker, "EventSetupRecord::get function called", "ThreadSafety");
-          std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
-          R->addRange(CE->getSourceRange());
-          BR.emitReport(std::move(R));
-	  //}
+        os << "' with argument of type '" << qtname;
+        PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
+        BugType *BT = new BugType(Checker, "EventSetupRecord::get function called", "ThreadSafety");
+        std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
+        R->addRange(CE->getSourceRange());
+        BR.emitReport(std::move(R));
       }
       os << "'";
     }

--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.h
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.h
@@ -21,9 +21,8 @@
 namespace clangcms {
 
   class ESRGetChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXMethodDecl>,
-						    clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> >  {
+                                                    clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> > {
   public:
-
     void checkASTDecl(const clang::CXXMethodDecl *CMD,
                       clang::ento::AnalysisManager &mgr,
                       clang::ento::BugReporter &BR) const;
@@ -31,7 +30,7 @@ namespace clangcms {
     void checkASTDecl(const clang::FunctionTemplateDecl *TD,
                       clang::ento::AnalysisManager &mgr,
                       clang::ento::BugReporter &BR) const;
-    
+
   private:
     CmsException m_exception;
   };

--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.h
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.h
@@ -1,0 +1,40 @@
+#ifndef Utilities_StaticAnalyzers_ESRGetChecker_h
+#define Utilities_StaticAnalyzers_ESRGetChecker_h
+#include <clang/AST/DeclCXX.h>
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclTemplate.h>
+#include <clang/AST/StmtVisitor.h>
+#include <clang/AST/ParentMap.h>
+#include <clang/Analysis/CFGStmtMap.h>
+#include <clang/Analysis/CallGraph.h>
+#include <llvm/Support/SaveAndRestore.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/AnalysisManager.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h>
+#include <clang/StaticAnalyzer/Core/Checker.h>
+#include <clang/StaticAnalyzer/Core/BugReporter/BugReporter.h>
+#include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
+#include <llvm/ADT/SmallString.h>
+
+#include "CmsException.h"
+#include "CmsSupport.h"
+
+namespace clangcms {
+
+  class ESRGetChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXMethodDecl>,
+						    clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> >  {
+  public:
+
+    void checkASTDecl(const clang::CXXMethodDecl *CMD,
+                      clang::ento::AnalysisManager &mgr,
+                      clang::ento::BugReporter &BR) const;
+
+    void checkASTDecl(const clang::FunctionTemplateDecl *TD,
+                      clang::ento::AnalysisManager &mgr,
+                      clang::ento::BugReporter &BR) const;
+    
+  private:
+    CmsException m_exception;
+  };
+
+}  // namespace clangcms
+#endif


### PR DESCRIPTION


#### PR description:
Add SA checker to report calls to edm::eventsetup::EventSetupRecord::<>get() function template instantiations.
<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:
Run SA checker
<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
