### PR TITLE
Updated L1T tags to address CMSSW issue #29237 [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,11 +16,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '106X_mcRun2_design_v7',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'           :   '106X_mcRun2_asymptotic_preVFP_v3',
+    'run2_mc_pre_vfp'   :   '106X_mcRun2_asymptotic_preVFP_v8',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '106X_mcRun2_asymptotic_v9',
+    'run2_mc'           :   '106X_mcRun2_asymptotic_v13',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v6',
+    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2


### PR DESCRIPTION
#### PR description:

In principle, this is just a backport of PR #30151. But it also corresponds to the GT content already in use in the 2016 UL production:

- [2016 pre-VFP](https://twiki.cern.ch/twiki/bin/view/CMS/PdmVLegacy2016preVFPAnalysis): 106X_mcRun2_asymptotic_preVFP_v8
- [2016 post-VFP](https://twiki.cern.ch/twiki/bin/view/CMS/PdmVLegacy2016postVFPAnalysis): 106X_mcRun2_asymptotic_v13

In addition, a corresponding cosmic GT is provided.

The GT diffs with respect to the previous version are the same for each of the three GTs:

**2016 pre-VFP asymptotic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_preVFP_v3/106X_mcRun2_asymptotic_preVFP_v8

**2016 post-VFP asymptotic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_v9/106X_mcRun2_asymptotic_v13

**2016 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2cosmics_startup_deco_v6/106X_mcRun2cosmics_startup_deco_v7

#### PR validation:

See PR #30151 for details. In addition, a technical test was performed:

`runTheMatrix.py -l limited,7.22 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of PR #30151.