### PR TITLE
[HGC trigger] V10/V11 e/g ID + calibration and concentrator module sums

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalProcessorBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalProcessorBase.h
@@ -11,8 +11,11 @@
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"
 
+#include <utility>
+
 typedef HGCalProcessorBaseT<HGCalDigiCollection, l1t::HGCalTriggerCellBxCollection> HGCalVFEProcessorBase;
-typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>, l1t::HGCalTriggerCellBxCollection>
+typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>,
+                            std::pair<l1t::HGCalTriggerCellBxCollection, l1t::HGCalTriggerSumsBxCollection> >
     HGCalConcentratorProcessorBase;
 typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>, l1t::HGCalClusterBxCollection>
     HGCalBackendLayer1ProcessorBase;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorBestChoiceImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorBestChoiceImpl.h
@@ -13,7 +13,8 @@ public:
   void select(unsigned nLinks,
               unsigned nWafers,
               const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
-              std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
+              std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput,
+              std::vector<l1t::HGCalTriggerCell>& trigCellVecNotSelected);
 
   void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -6,10 +6,13 @@
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorBestChoiceImpl.h"
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h"
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h"
+#include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorTrigSumImpl.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
+
+#include <utility>
 
 class HGCalConcentratorProcessorSelection : public HGCalConcentratorProcessorBase {
 private:
@@ -19,7 +22,7 @@ public:
   HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf);
 
   void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& triggerCellCollInput,
-           l1t::HGCalTriggerCellBxCollection& triggerCellCollOutput,
+           std::pair<l1t::HGCalTriggerCellBxCollection, l1t::HGCalTriggerSumsBxCollection>& triggerCollOutput,
            const edm::EventSetup& es) override;
 
 private:
@@ -34,6 +37,7 @@ private:
   std::unique_ptr<HGCalConcentratorBestChoiceImpl> bestChoiceImpl_;
   std::unique_ptr<HGCalConcentratorSuperTriggerCellImpl> superTriggerCellImpl_;
   std::unique_ptr<HGCalConcentratorCoarsenerImpl> coarsenerImpl_;
+  std::unique_ptr<HGCalConcentratorTrigSumImpl> trigSumImpl_;
 
   HGCalTriggerTools triggerTools_;
 };

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorThresholdImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorThresholdImpl.h
@@ -11,7 +11,8 @@ public:
   HGCalConcentratorThresholdImpl(const edm::ParameterSet& conf);
 
   void select(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
-              std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
+              std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput,
+              std::vector<l1t::HGCalTriggerCell>& trigCellVecNotSelected);
 
   void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorTrigSumImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorTrigSumImpl.h
@@ -13,7 +13,7 @@ public:
 
   void doSum(uint32_t module_id,
              const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
-             std::vector<l1t::HGCalTriggerSums>& trigSumsVecOutput);
+             std::vector<l1t::HGCalTriggerSums>& trigSumsVecOutput) const;
 
   void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorTrigSumImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorTrigSumImpl.h
@@ -1,0 +1,24 @@
+#ifndef __L1Trigger_L1THGCal_HGCalConcentratorTrigSumImpl_h__
+#define __L1Trigger_L1THGCal_HGCalConcentratorTrigSumImpl_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+#include <vector>
+
+class HGCalConcentratorTrigSumImpl {
+public:
+  HGCalConcentratorTrigSumImpl(const edm::ParameterSet& conf);
+
+  void doSum(uint32_t module_id,
+             const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
+             std::vector<l1t::HGCalTriggerSums>& trigSumsVecOutput);
+
+  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+
+private:
+  HGCalTriggerTools triggerTools_;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/plugins/HGCalConcentratorProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalConcentratorProducer.cc
@@ -14,6 +14,7 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
 #include <memory>
+#include <utility>
 
 class HGCalConcentratorProducer : public edm::stream::EDProducer<> {
 public:
@@ -54,16 +55,14 @@ void HGCalConcentratorProducer::beginRun(const edm::Run& /*run*/, const edm::Eve
 
 void HGCalConcentratorProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   // Output collections
-  auto cc_trigcell_output = std::make_unique<l1t::HGCalTriggerCellBxCollection>();
-  auto cc_trigsums_output = std::make_unique<l1t::HGCalTriggerSumsBxCollection>();
+  std::pair<l1t::HGCalTriggerCellBxCollection, l1t::HGCalTriggerSumsBxCollection> cc_output;
 
   // Input collections
   edm::Handle<l1t::HGCalTriggerCellBxCollection> trigCellBxColl;
 
   e.getByToken(input_cell_, trigCellBxColl);
-  concentratorProcess_->run(trigCellBxColl, *cc_trigcell_output, es);
+  concentratorProcess_->run(trigCellBxColl, cc_output, es);
   // Put in the event
-  // At the moment the HGCalTriggerSumsBxCollection is empty
-  e.put(std::move(cc_trigcell_output), concentratorProcess_->name());
-  e.put(std::move(cc_trigsums_output), concentratorProcess_->name());
+  e.put(std::make_unique<l1t::HGCalTriggerCellBxCollection>(std::move(cc_output.first)), concentratorProcess_->name());
+  e.put(std::make_unique<l1t::HGCalTriggerSumsBxCollection>(std::move(cc_output.second)), concentratorProcess_->name());
 }

--- a/L1Trigger/L1THGCal/python/egammaIdentification.py
+++ b/L1Trigger/L1THGCal/python/egammaIdentification.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 
 inputs_small = ['cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean']
 inputs_large = ['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot']
@@ -75,7 +76,8 @@ working_points_drnn_dbscan = [
 input_features_histomax = {
         "v8_352":inputs_small,
         "v9_370":inputs_large,
-        "v9_394":inputs_large
+        "v9_394":inputs_large,
+        "v10_3151":inputs_large
         }
 
 bdt_weights_histomax = {
@@ -96,6 +98,12 @@ bdt_weights_histomax = {
                 'L1Trigger/L1THGCal/data/egamma_id_histomax_394_loweta_v0.xml',
                 # High eta
                 'L1Trigger/L1THGCal/data/egamma_id_histomax_394_higheta_v0.xml'
+                ],
+        "v10_3151":[ #trained using TPG software version 3.15.1
+                # Low eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_3151_loweta_v0.xml',
+                # High eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_3151_higheta_v0.xml'
                 ]
         }
 
@@ -128,7 +136,7 @@ working_points_histomax = {
                 {
                 '900':0.7078400, #epsilon_b = 3.5%
                 '950':-0.0239623, #epsilon_b = 6.9%
-                '975':-0.7045071, #epsilon_b = 11.6% 
+                '975':-0.7045071, #epsilon_b = 11.6%
                 '995':-0.9811426, #epsilon_b = 26.1%
                 }
              ],
@@ -144,8 +152,24 @@ working_points_histomax = {
                 {
                 '900':0.8825340, #epsilon_b = 1.0%
                 '950':0.2856039, #epsilon_b = 1.7%
-                '975':-0.5274948, #epsilon_b = 2.8% 
+                '975':-0.5274948, #epsilon_b = 2.8%
                 '995':-0.9864445, #epsilon_b = 7.6%
+                }
+             ],
+        "v10_3151": [
+                # Low eta
+                {
+                 '900': 0.9903189,
+                 '950': 0.9646683,
+                 '975': 0.8292287,
+                 '995': -0.7099538,
+                },
+                # High eta
+                {
+                 '900': 0.9932326,
+                 '950': 0.9611762,
+                 '975': 0.7616282,
+                 '995': -0.9163715,
                 }
              ]
         }
@@ -190,5 +214,13 @@ phase2_hgcalV9.toModify(egamma_identification_histomax,
         Weights=cms.vstring(bdt_weights_histomax['v9_394']),
         WorkingPoints=cms.vdouble(
                 [wps[eff] for wps,eff in zip(working_points_histomax['v9_394'],tight_wp)]
+                )
+        )
+
+phase2_hgcalV10.toModify(egamma_identification_histomax,
+        Inputs=cms.vstring(input_features_histomax['v10_3151']),
+        Weights=cms.vstring(bdt_weights_histomax['v10_3151']),
+        WorkingPoints=cms.vdouble(
+                [wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)]
                 )
         )

--- a/L1Trigger/L1THGCal/python/egammaIdentification.py
+++ b/L1Trigger/L1THGCal/python/egammaIdentification.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
+from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
 
 inputs_small = ['cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean']
 inputs_large = ['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot']
@@ -218,6 +219,14 @@ phase2_hgcalV9.toModify(egamma_identification_histomax,
         )
 
 phase2_hgcalV10.toModify(egamma_identification_histomax,
+        Inputs=cms.vstring(input_features_histomax['v10_3151']),
+        Weights=cms.vstring(bdt_weights_histomax['v10_3151']),
+        WorkingPoints=cms.vdouble(
+                [wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)]
+                )
+        )
+
+phase2_hgcalV11.toModify(egamma_identification_histomax,
         Inputs=cms.vstring(input_features_histomax['v10_3151']),
         Weights=cms.vstring(bdt_weights_histomax['v10_3151']),
         WorkingPoints=cms.vdouble(

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -145,21 +145,21 @@ histoMax_C3d_params = cms.PSet(
 
 
 energy_interpretations_em = cms.PSet(type = cms.string('HGCalTriggerClusterInterpretationEM'),
-                                     layer_containment_corrs = cms.vdouble(0., 0., 1.6144949, 0.92495334, 1.0820811, 0.9753549, 0.9742881, 1.0634482, 1.0599478, 0.9376349, 0.92587173, 0.8003076, 1.0417082, 1.7032381, 2.),
-                                     scale_correction_coeff = cms.vdouble(16.68182373, -8.487143517),
+                                     layer_containment_corrs = cms.vdouble(0., 0.0, 1.38, 0.97, 1.11, 0.92, 1.06, 1.01, 1.06, 0.89, 1.0, 1.06, 0.89, 1.62, 1.83),
+                                     scale_correction_coeff = cms.vdouble(-27.15, 53.94),
                                      dr_bylayer = cms.vdouble([0.015]*15)
                                      )
 
 phase2_hgcalV10.toModify(
         energy_interpretations_em,
-        layer_containment_corrs=cms.vdouble(0., 0.0, 2.0, 2.0, 0.63, 0.5, 1.91, 0.5, 1.3, 1.27, 0.66, 0.76, 0.78, 2.0, 2.0),
-        scale_correction_coeff=cms.vdouble(-43.074539, 76.823082),
+        layer_containment_corrs=cms.vdouble(0., 0.0, 1.73, 0.97, 1.08, 1.1, 1.01, 0.96, 1.18, 0.98, 1.05, 0.99, 0.89, 1.75, 2.0),
+        scale_correction_coeff=cms.vdouble(-27.53, 53.92),
         )
 
 phase2_hgcalV11.toModify(
         energy_interpretations_em,
-        layer_containment_corrs=cms.vdouble(0., 0.0, 2.0, 1.29, 0.5, 1.73, 0.5, 1.25, 1.46, 0.75, 0.68, 0.5, 1.89, 1.83, 1.71),
-        scale_correction_coeff=cms.vdouble(-41.7769, 80.5795),
+        layer_containment_corrs=cms.vdouble(0., 0.0, 1.28, 1.09, 1.0, 1.07, 1.09, 1.04, 1.0, 1.09, 1.07, 1.03, 0.93, 1.4, 1.89),
+        scale_correction_coeff=cms.vdouble(-24.96, 52.99),
         )
 
 

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -6,6 +6,7 @@ from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_drnn_c
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
+from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 
 
@@ -149,10 +150,17 @@ energy_interpretations_em = cms.PSet(type = cms.string('HGCalTriggerClusterInter
                                      dr_bylayer = cms.vdouble([0.015]*15)
                                      )
 
-phase2_hgcalV10.toModify(energy_interpretations_em,
-                         layer_containment_corrs=cms.vdouble(0., 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.),
-                         scale_correction_coeff=cms.vdouble(0., 0.),
-                         )
+phase2_hgcalV10.toModify(
+        energy_interpretations_em,
+        layer_containment_corrs=cms.vdouble(0., 0.0, 2.0, 2.0, 0.63, 0.5, 1.91, 0.5, 1.3, 1.27, 0.66, 0.76, 0.78, 2.0, 2.0),
+        scale_correction_coeff=cms.vdouble(-43.074539, 76.823082),
+        )
+
+phase2_hgcalV11.toModify(
+        energy_interpretations_em,
+        layer_containment_corrs=cms.vdouble(0., 0.0, 2.0, 1.29, 0.5, 1.73, 0.5, 1.25, 1.46, 0.75, 0.68, 0.5, 1.89, 1.83, 1.71),
+        scale_correction_coeff=cms.vdouble(-41.7769, 80.5795),
+        )
 
 
 energy_interpretations = cms.VPSet(energy_interpretations_em)

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorBestChoiceImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorBestChoiceImpl.cc
@@ -15,8 +15,10 @@ HGCalConcentratorBestChoiceImpl::HGCalConcentratorBestChoiceImpl(const edm::Para
 void HGCalConcentratorBestChoiceImpl::select(unsigned nLinks,
                                              unsigned nWafers,
                                              const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
-                                             std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) {
+                                             std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput,
+                                             std::vector<l1t::HGCalTriggerCell>& trigCellVecNotSelected) {
   trigCellVecOutput = trigCellVecInput;
+  trigCellVecNotSelected.resize(0);
   // sort, reverse order
   std::sort(
       trigCellVecOutput.begin(),
@@ -36,6 +38,10 @@ void HGCalConcentratorBestChoiceImpl::select(unsigned nLinks,
                                       << " NWafers=" << nWafers << " and NLinks=" << nLinks;
   }
   // keep only N trigger cells
-  if (trigCellVecOutput.size() > nData)
+  if (trigCellVecOutput.size() > nData) {
+    // store the last cells (not selected)
+    std::move(trigCellVecOutput.begin() + nData, trigCellVecOutput.end(), std::back_inserter(trigCellVecNotSelected));
+    // keep only N trigger cells
     trigCellVecOutput.resize(nData);
+  }
 }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorThresholdImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorThresholdImpl.cc
@@ -5,12 +5,15 @@ HGCalConcentratorThresholdImpl::HGCalConcentratorThresholdImpl(const edm::Parame
       threshold_scintillator_(conf.getParameter<double>("threshold_scintillator")) {}
 
 void HGCalConcentratorThresholdImpl::select(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
-                                            std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) {
+                                            std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput,
+                                            std::vector<l1t::HGCalTriggerCell>& trigCellVecNotSelected) {
   for (const auto& trigCell : trigCellVecInput) {
     bool isScintillator = triggerTools_.isScintillator(trigCell.detId());
     double threshold = (isScintillator ? threshold_scintillator_ : threshold_silicon_);
     if (trigCell.mipPt() >= threshold) {
       trigCellVecOutput.push_back(trigCell);
+    } else {
+      trigCellVecNotSelected.push_back(trigCell);
     }
   }
 }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorTrigSumImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorTrigSumImpl.cc
@@ -1,0 +1,31 @@
+#include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorTrigSumImpl.h"
+
+HGCalConcentratorTrigSumImpl::HGCalConcentratorTrigSumImpl(const edm::ParameterSet& conf) {}
+
+void HGCalConcentratorTrigSumImpl::doSum(uint32_t module_id,
+                                         const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
+                                         std::vector<l1t::HGCalTriggerSums>& trigSumsVecOutput) {
+  double ptsum = 0;
+  double mipptsum = 0;
+  double hwptsum = 0;
+
+  for (const auto& trigCell : trigCellVecInput) {
+    // detId selection is already done in HGCalConcentratorProcessorSelection:
+    // here we do not worry about it and assume all cells are from the same module
+    ptsum += trigCell.pt();
+    mipptsum += trigCell.mipPt();
+    hwptsum += trigCell.hwPt();
+  }
+  if (!trigCellVecInput.empty()) {
+    GlobalPoint module_pos = triggerTools_.getTriggerGeometry()->getModulePosition(module_id);
+
+    math::PtEtaPhiMLorentzVector p4(ptsum, module_pos.eta(), module_pos.phi(), 0);
+    l1t::HGCalTriggerSums ts;
+    ts.setP4(p4);
+    ts.setDetId(module_id);
+    ts.setPosition(module_pos);
+    ts.setMipPt(mipptsum);
+    ts.setHwPt(hwptsum);
+    trigSumsVecOutput.push_back(ts);
+  }
+}

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorTrigSumImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorTrigSumImpl.cc
@@ -4,7 +4,7 @@ HGCalConcentratorTrigSumImpl::HGCalConcentratorTrigSumImpl(const edm::ParameterS
 
 void HGCalConcentratorTrigSumImpl::doSum(uint32_t module_id,
                                          const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
-                                         std::vector<l1t::HGCalTriggerSums>& trigSumsVecOutput) {
+                                         std::vector<l1t::HGCalTriggerSums>& trigSumsVecOutput) const {
   double ptsum = 0;
   double mipptsum = 0;
   double hwptsum = 0;

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerSums.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerSums.cc
@@ -1,0 +1,177 @@
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalTriggerNtupleHGCTriggerSums : public HGCalTriggerNtupleBase {
+public:
+  HGCalTriggerNtupleHGCTriggerSums(const edm::ParameterSet& conf);
+  ~HGCalTriggerNtupleHGCTriggerSums() override{};
+  void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+  void fill(const edm::Event& e, const edm::EventSetup& es) final;
+
+private:
+  void clear() final;
+
+  HGCalTriggerTools triggerTools_;
+
+  edm::EDGetToken trigger_sums_token_;
+  edm::ESHandle<HGCalTriggerGeometryBase> geometry_;
+
+  static constexpr unsigned kPanelOffset_ = 0;
+  static constexpr unsigned kPanelMask_ = 0x7F;
+  static constexpr unsigned kSectorOffset_ = 7;
+  static constexpr unsigned kSectorMask_ = 0x7;
+
+  int ts_n_;
+  std::vector<uint32_t> ts_id_;
+  std::vector<int> ts_subdet_;
+  std::vector<int> ts_side_;
+  std::vector<int> ts_layer_;
+  std::vector<int> ts_panel_number_;
+  std::vector<int> ts_panel_sector_;
+  std::vector<int> ts_wafer_;
+  std::vector<int> ts_wafertype_;
+  std::vector<uint32_t> ts_data_;
+  std::vector<float> ts_mipPt_;
+  std::vector<float> ts_pt_;
+  std::vector<float> ts_energy_;
+  std::vector<float> ts_eta_;
+  std::vector<float> ts_phi_;
+  std::vector<float> ts_x_;
+  std::vector<float> ts_y_;
+  std::vector<float> ts_z_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleHGCTriggerSums, "HGCalTriggerNtupleHGCTriggerSums");
+
+HGCalTriggerNtupleHGCTriggerSums::HGCalTriggerNtupleHGCTriggerSums(const edm::ParameterSet& conf)
+    : HGCalTriggerNtupleBase(conf) {}
+
+void HGCalTriggerNtupleHGCTriggerSums::initialize(TTree& tree,
+                                                  const edm::ParameterSet& conf,
+                                                  edm::ConsumesCollector&& collector) {
+  trigger_sums_token_ =
+      collector.consumes<l1t::HGCalTriggerSumsBxCollection>(conf.getParameter<edm::InputTag>("TriggerSums"));
+
+  std::string prefix(conf.getUntrackedParameter<std::string>("Prefix", "ts"));
+
+  std::string bname;
+  auto withPrefix([&prefix, &bname](char const* vname) -> char const* {
+    bname = prefix + "_" + vname;
+    return bname.c_str();
+  });
+
+  tree.Branch(withPrefix("n"), &ts_n_, (prefix + "_n/I").c_str());
+  tree.Branch(withPrefix("id"), &ts_id_);
+  tree.Branch(withPrefix("subdet"), &ts_subdet_);
+  tree.Branch(withPrefix("zside"), &ts_side_);
+  tree.Branch(withPrefix("layer"), &ts_layer_);
+  tree.Branch(withPrefix("wafer"), &ts_wafer_);
+  tree.Branch(withPrefix("wafertype"), &ts_wafertype_);
+  tree.Branch(withPrefix("panel_number"), &ts_panel_number_);
+  tree.Branch(withPrefix("panel_sector"), &ts_panel_sector_);
+  tree.Branch(withPrefix("data"), &ts_data_);
+  tree.Branch(withPrefix("pt"), &ts_pt_);
+  tree.Branch(withPrefix("mipPt"), &ts_mipPt_);
+  tree.Branch(withPrefix("energy"), &ts_energy_);
+  tree.Branch(withPrefix("eta"), &ts_eta_);
+  tree.Branch(withPrefix("phi"), &ts_phi_);
+  tree.Branch(withPrefix("x"), &ts_x_);
+  tree.Branch(withPrefix("y"), &ts_y_);
+  tree.Branch(withPrefix("z"), &ts_z_);
+}
+
+void HGCalTriggerNtupleHGCTriggerSums::fill(const edm::Event& e, const edm::EventSetup& es) {
+  // retrieve trigger cells
+  edm::Handle<l1t::HGCalTriggerSumsBxCollection> trigger_sums_h;
+  e.getByToken(trigger_sums_token_, trigger_sums_h);
+  const l1t::HGCalTriggerSumsBxCollection& trigger_sums = *trigger_sums_h;
+
+  // retrieve geometry
+  es.get<CaloGeometryRecord>().get(geometry_);
+
+  triggerTools_.eventSetup(es);
+
+  clear();
+  for (auto ts_itr = trigger_sums.begin(0); ts_itr != trigger_sums.end(0); ts_itr++) {
+    if (ts_itr->pt() > 0) {
+      ts_n_++;
+      // hardware data
+      DetId panelId(ts_itr->detId());
+      int panel_sector = -999;
+      int panel_number = -999;
+      if (panelId.det() == DetId::Forward) {
+        HGCalDetId panelIdHGCal(panelId);
+        if (panelId.subdetId() == ForwardSubdetector::HGCHEB) {
+          panel_number = panelIdHGCal.wafer();
+        } else {
+          panel_sector = (panelIdHGCal.wafer() >> kSectorOffset_) & kSectorMask_;
+          panel_number = (panelIdHGCal.wafer() >> kPanelOffset_) & kPanelMask_;
+        }
+      } else if (panelId.det() == DetId::HGCalHSc) {
+        HGCScintillatorDetId panelIdSci(panelId);
+        panel_sector = panelIdSci.iphi();
+        panel_number = panelIdSci.ietaAbs();
+      }
+      ts_panel_number_.emplace_back(panel_number);
+      ts_panel_sector_.emplace_back(panel_sector);
+      ts_id_.emplace_back(ts_itr->detId());
+      ts_side_.emplace_back(triggerTools_.zside(panelId));
+      ts_layer_.emplace_back(triggerTools_.layerWithOffset(panelId));
+      // V9 detids
+      if (panelId.det() == DetId::HGCalTrigger) {
+        HGCalTriggerDetId idv9(panelId);
+        ts_subdet_.emplace_back(idv9.subdet());
+        ts_wafertype_.emplace_back(idv9.type());
+      } else if (panelId.det() == DetId::HGCalHSc) {
+        HGCScintillatorDetId idv9(panelId);
+        ts_subdet_.emplace_back(idv9.subdet());
+        ts_wafertype_.emplace_back(idv9.type());
+      }
+      // V8 detids
+      else {
+        HGCalDetId idv8(panelId);
+        ts_subdet_.emplace_back(panelId.subdetId());
+        ts_wafer_.emplace_back(idv8.wafer());
+        ts_wafertype_.emplace_back(idv8.waferType());
+      }
+      ts_data_.emplace_back(ts_itr->hwPt());
+      ts_mipPt_.emplace_back(ts_itr->mipPt());
+      // physical values
+      ts_pt_.emplace_back(ts_itr->pt());
+      ts_energy_.emplace_back(ts_itr->energy());
+      ts_eta_.emplace_back(ts_itr->eta());
+      ts_phi_.emplace_back(ts_itr->phi());
+      ts_x_.emplace_back(ts_itr->position().x());
+      ts_y_.emplace_back(ts_itr->position().y());
+      ts_z_.emplace_back(ts_itr->position().z());
+    }
+  }
+}
+
+void HGCalTriggerNtupleHGCTriggerSums::clear() {
+  ts_n_ = 0;
+  ts_id_.clear();
+  ts_subdet_.clear();
+  ts_side_.clear();
+  ts_layer_.clear();
+  ts_wafer_.clear();
+  ts_wafertype_.clear();
+  ts_panel_number_.clear();
+  ts_panel_sector_.clear();
+  ts_data_.clear();
+  ts_mipPt_.clear();
+  ts_pt_.clear();
+  ts_energy_.clear();
+  ts_eta_.clear();
+  ts_phi_.clear();
+  ts_x_.clear();
+  ts_y_.clear();
+  ts_z_.clear();
+}

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
@@ -69,6 +69,11 @@ ntuple_triggercells = cms.PSet(
     FilterCellsInMulticlusters = cms.bool(False)
 )
 
+ntuple_triggersums = cms.PSet(
+    NtupleName = cms.string('HGCalTriggerNtupleHGCTriggerSums'),
+    TriggerSums = cms.InputTag('hgcalConcentratorProducer:HGCalConcentratorProcessorSelection'),
+)
+
 ntuple_clusters = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleHGCClusters'),
     Clusters = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering'),
@@ -104,6 +109,7 @@ hgcalTriggerNtuplizer = cms.EDAnalyzer(
         ntuple_gentau,
         ntuple_digis,
         ntuple_triggercells,
+        ntuple_triggersums,
         ntuple_multiclusters,
         ntuple_towers
     )


### PR DESCRIPTION
#### PR description:
- Add e/gamma identification BDT and e/gamma energy corrections for the V10 and V11 geometries (@cerminar )
- Implement module sums of unselected trigger cells in the concentrator (@echapon )

Depends on external cms-data/L1Trigger-L1THGCal#18

#### PR validation:

Standard tests with different worflows have been run:
```
 runTheMatrix.py -w upgrade -l 20034.0 --maxSteps=2
 runTheMatrix.py -w upgrade -l 20434.0 --maxSteps=2
 runTheMatrix.py -w upgrade -l 22034.0 --maxSteps=2
 runTheMatrix.py -w upgrade -l 22434.0 --maxSteps=2
 runTheMatrix.py -w upgrade -l 27034.0 --maxSteps=2
```
Physics performance studies have also been done.
