### PR TITLE
Update of  SimTransport/PPSProtonTransport for Run 3

### DIFF
--- a/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
@@ -56,16 +56,15 @@ protected:
 
   double fPPSRegionStart_45;
   double fPPSRegionStart_56;
-  double fCrossingAngle_45;
-  double fCrossingAngle_56;
+  double fCrossingAngleX_45;
+  double fCrossingAngleX_56;
+  double fCrossingAngleY_45;
+  double fCrossingAngleY_56;
 
   double beamMomentum_;
   double beamEnergy_;
   double etaCut_;
   double momentumCut_;
-  double fVtxMeanX;
-  double fVtxMeanY;
-  double fVtxMeanZ;
 
   double m_sigmaSTX;
   double m_sigmaSTY;

--- a/SimTransport/PPSProtonTransport/interface/HectorTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/HectorTransport.h
@@ -41,6 +41,8 @@ public:
 
 private:
   bool m_verbosity;
+  bool produceHitsRelativeToBeam_;
+
   static constexpr double fPPSBeamLineLength_ = 250.;  // default beam line length
 
   //!propagate the particles through a beamline to PPS

--- a/SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h
@@ -35,6 +35,8 @@ private:
   edm::ESHandle<LHCInfo> lhcInfo_;
   edm::ESHandle<CTPPSBeamParameters> beamParameters_;
   edm::ESHandle<LHCInterpolatedOpticalFunctionsSetCollection> opticalFunctions_;
+  unsigned int optFunctionId45_;
+  unsigned int optFunctionId56_;
 
   bool useEmpiricalApertures_;
   double empiricalAperture45_xi0_int_, empiricalAperture45_xi0_slp_, empiricalAperture45_a_int_,

--- a/SimTransport/PPSProtonTransport/python/HectorTransport_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/HectorTransport_cfi.py
@@ -127,7 +127,7 @@ hector_2017 = cms.PSet(
               Nominal_2017_beta40cm
 )
 
-hector_2018 = cms.Pset(
+hector_2018 = cms.PSet(
               baseHectorParameters,
               Nominal_2017_beta30cm  # CHANGE THIS WHEN THE PROPER ONE GET READY
 )

--- a/SimTransport/PPSProtonTransport/python/HectorTransport_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/HectorTransport_cfi.py
@@ -2,13 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from SimG4Core.Application.hectorParameter_cfi import *
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic25ns13TeV2016CollisionVtxSmearingParameters
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic25ns13TeVEarly2017CollisionVtxSmearingParameters
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic25ns13TeVEarly2018CollisionVtxSmearingParameters
-
-
 baseHectorParameters = cms.PSet(
                 TransportMethod = cms.string('Hector'),
+                produceHitsRelativeToBeam = cms.bool(True),
                 ApplyZShift = cms.bool(True)
 )
 
@@ -16,8 +12,10 @@ Totem_PreTS2_2016 = cms.PSet(
         #TotemBeamLine = cms.bool(True),
         Beam1Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB1_Beta0.40_6.5TeV_CR191.541_PreTS2_TOTEM.tfs'),
         Beam2Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB2_Beta0.40_6.5TeV_CR179.394_PreTS2_TOTEM.tfs'),
-        halfCrossingAngleSector45  = cms.double(191.541), #in mrad
-        halfCrossingAngleSector56  = cms.double(179.394), #in mrad
+        halfCrossingAngleXSector45  = cms.double(191.541), #in mrad / Beam 1
+        halfCrossingAngleYSector45  = cms.double(0.), #in mrad / Beam 1
+        halfCrossingAngleXSector56  = cms.double(179.394), #in mrad / Beam 2
+        halfCrossingAngleYSector56  = cms.double(0.), #in mrad / Beam 2
         BeamEnergyDispersion = cms.double(1.11e-4),     ## beam energy dispersion (GeV); if =0.0 the default(=0.79) is used
         BeamDivergenceX = cms.double(135.071),     ## x angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
         BeamDivergenceY = cms.double(135.071),      ## y angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
@@ -26,16 +24,15 @@ Totem_PreTS2_2016 = cms.PSet(
         BeamEnergy = cms.double(6500.0),
         BeamXatIP      = cms.untracked.double(0.),
         BeamYatIP      = cms.untracked.double(0.),
-        VtxMeanX  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.X0,
-        VtxMeanY  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.Y0,
-        VtxMeanZ  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.Z0
 )
 Validated_PreTS2_2016 = cms.PSet(
         #TotemBeamLine = cms.bool(False),
         Beam1Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB1_Beta0.40_6.5TeV_CR191.541_PreTS2.tfs'),
         Beam2Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB2_Beta0.40_6.5TeV_CR179.394_PreTS2.tfs'),
-        halfCrossingAngleSector45  = cms.double(191.541), #in mrad
-        halfCrossingAngleSector56  = cms.double(179.394), #in mrad
+        halfCrossingAngleXSector45  = cms.double(191.541), #in mrad / Beam 1
+        halfCrossingAngleYSector45  = cms.double(0.), #in mrad / Beam 1
+        halfCrossingAngleXSector56  = cms.double(179.394), #in mrad / Beam 2
+        halfCrossingAngleYSector56  = cms.double(0.), #in mrad / Beam 2
         BeamEnergyDispersion = cms.double(1.11e-4),     ## beam energy dispersion (GeV); if =0.0 the default(=0.79) is used
         BeamDivergenceX = cms.double(135.071),     ## x angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
         BeamDivergenceY = cms.double(135.071),      ## y angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
@@ -44,56 +41,15 @@ Validated_PreTS2_2016 = cms.PSet(
         BeamEnergy = cms.double(6500.0),
         #BeamXatIP = cms.untracked.double(0.499), # if not given, will take the CMS average vertex position
         #BeamYatIP = cms.untracked.double(-0.190), # if not given, will take the CMS average vertex position
-        VtxMeanX  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.X0,
-        VtxMeanY  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.Y0,
-        VtxMeanZ  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.Z0
-)
-
-# Beam parameter for Nominal 2017 optics
-Nominal_2017_beta40cm = cms.PSet(
-        #TotemBeamLine = cms.bool(False),
-        Beam1Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB1_Beta0.40_6.5TeV_CR150_Nominal_2017.tfs'),
-        Beam2Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB2_Beta0.40_6.5TeV_CR150_Nominal_2017.tfs'),
-        halfCrossingAngleSector45  = cms.double(150.), #in mrad
-        halfCrossingAngleSector56  = cms.double(150.), #in mrad
-        BeamEnergyDispersion = cms.double(1.11e-4),     ## beam energy dispersion (GeV); if =0.0 the default(=0.79) is used
-        BeamDivergenceX = cms.double(30.04),     ## x angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
-        BeamDivergenceY = cms.double(30.04),      ## y angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
-        BeamSigmaX  = cms.double(12.01),
-        BeamSigmaY  = cms.double(12.01),
-        BeamEnergy = cms.double(6500.0),
-        BeamXatIP      = cms.untracked.double(0.),
-        BeamYatIP      = cms.untracked.double(0.),
-        VtxMeanX  = Realistic25ns13TeVEarly2017CollisionVtxSmearingParameters.X0,
-        VtxMeanY  = Realistic25ns13TeVEarly2017CollisionVtxSmearingParameters.Y0,
-        VtxMeanZ  = Realistic25ns13TeVEarly2017CollisionVtxSmearingParameters.Z0
-)
-#
-Nominal_2017_beta30cm = cms.PSet(
-        #TotemBeamLine = cms.bool(False),
-        Beam1Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB1_Beta0.30_6.5TeV_CR175_Nominal_2017.tfs'),
-        Beam2Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB2_Beta0.30_6.5TeV_CR175_Nominal_2017.tfs'),
-        halfCrossingAngleSector45  = cms.double(175.), #in mrad
-        halfCrossingAngleSector56  = cms.double(175.), #in mrad
-        BeamEnergyDispersion = cms.double(1.11e-4),     ## beam energy dispersion (GeV); if =0.0 the default(=0.79) is used
-        BeamDivergenceX = cms.double(34.68),     ## x angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
-        BeamDivergenceY = cms.double(34.68),      ## y angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
-        BeamSigmaX  = cms.double(10.40),
-        BeamSigmaY  = cms.double(10.40),
-        BeamEnergy = cms.double(6500.0),
-        BeamXatIP      = cms.untracked.double(0.),
-        BeamYatIP      = cms.untracked.double(0.),
-        VtxMeanX  = Realistic25ns13TeVEarly2017CollisionVtxSmearingParameters.X0,
-        VtxMeanY  = Realistic25ns13TeVEarly2017CollisionVtxSmearingParameters.Y0,
-        VtxMeanZ  = Realistic25ns13TeVEarly2017CollisionVtxSmearingParameters.Z0
 )
 # Beam parametes for Nominal 2016
 Nominal_2016 = cms.PSet(
-        #TotemBeamLine = cms.bool(False),
         Beam1Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB1_Beta0.40_6.5TeV_CR185_Nominal_2016.tfs'),
         Beam2Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB2_Beta0.40_6.5TeV_CR185_Nominal_2016.tfs'),
-        hasfCrossingAngleSector45  = cms.double(185.), #in mrad / Beam 1
-        halfCrossingAngleSector56  = cms.double(185.), #in mrad / Beam 2
+        halfCrossingAngleXSector45  = cms.double(185.), #in mrad / Beam 1
+        halfCrossingAngleYSector45  = cms.double(0.), #in mrad / Beam 1
+        halfCrossingAngleXSector56  = cms.double(185.), #in mrad / Beam 2
+        halfCrossingAngleYSector56  = cms.double(0.), #in mrad / Beam 2
         BeamEnergyDispersion = cms.double(1.11e-4),     ## beam energy dispersion (GeV); if =0.0 the default(=0.79) is used
         BeamDivergenceX = cms.double(35.54),     ## x angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
         BeamDivergenceY = cms.double(35.54),      ## y angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
@@ -102,22 +58,81 @@ Nominal_2016 = cms.PSet(
         BeamEnergy = cms.double(6500.0),
         BeamXatIP      = cms.untracked.double(0.),
         BeamYatIP      = cms.untracked.double(0.),
-        VtxMeanX  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.X0,
-        VtxMeanY  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.Y0,
-        VtxMeanZ  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.Z0
 )
+
+# Beam parameter for Nominal 2017 optics
+Nominal_2017_beta40cm = cms.PSet(
+        #TotemBeamLine = cms.bool(False),
+        Beam1Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB1_Beta0.40_6.5TeV_CR150_Nominal_2017.tfs'),
+        Beam2Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB2_Beta0.40_6.5TeV_CR150_Nominal_2017.tfs'),
+        halfCrossingAngleXSector45  = cms.double(150.), #in mrad / Beam 1
+        halfCrossingAngleYSector45  = cms.double(0.), #in mrad / Beam 1
+        halfCrossingAngleXSector56  = cms.double(150.), #in mrad / Beam 2
+        halfCrossingAngleYSector56  = cms.double(0.), #in mrad / Beam 2
+        BeamEnergyDispersion = cms.double(1.11e-4),     ## beam energy dispersion (GeV); if =0.0 the default(=0.79) is used
+        BeamDivergenceX = cms.double(30.04),     ## x angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
+        BeamDivergenceY = cms.double(30.04),      ## y angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
+        BeamSigmaX  = cms.double(12.01),
+        BeamSigmaY  = cms.double(12.01),
+        BeamEnergy = cms.double(6500.0),
+        BeamXatIP      = cms.untracked.double(0.),
+        BeamYatIP      = cms.untracked.double(0.),
+)
+#
+Nominal_2017_beta30cm = cms.PSet(
+        #TotemBeamLine = cms.bool(False),
+        Beam1Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB1_Beta0.30_6.5TeV_CR175_Nominal_2017.tfs'),
+        Beam2Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB2_Beta0.30_6.5TeV_CR175_Nominal_2017.tfs'),
+        halfCrossingAngleXSector45  = cms.double(175.), #in mrad / Beam 1
+        halfCrossingAngleYSector45  = cms.double(0.), #in mrad / Beam 1
+        halfCrossingAngleXSector56  = cms.double(175.), #in mrad / Beam 2
+        halfCrossingAngleYSector56  = cms.double(0.), #in mrad / Beam 2
+        BeamEnergyDispersion = cms.double(1.11e-4),     ## beam energy dispersion (GeV); if =0.0 the default(=0.79) is used
+        BeamDivergenceX = cms.double(34.68),     ## x angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
+        BeamDivergenceY = cms.double(34.68),      ## y angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
+        BeamSigmaX  = cms.double(10.40),
+        BeamSigmaY  = cms.double(10.40),
+        BeamEnergy = cms.double(6500.0),
+        BeamXatIP      = cms.untracked.double(0.),
+        BeamYatIP      = cms.untracked.double(0.),
+)
+
+Nominal_RunIII =  cms.PSet(
+        #TotemBeamLine = cms.bool(False),
+        Beam1Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB1_Beta0.15_7TeV_CR250_HLLHCv1.4.tfs'),
+        Beam2Filename = cms.string('SimTransport/PPSProtonTransport/data/LHCB2_Beta0.15_7TeV_CR250_HLLHCv1.4.tfs'),
+        halfCrossingAngleXSector45  = cms.double(0.04), #in mrad / Beam 1
+        halfCrossingAngleYSector45  = cms.double(250.1), #in mrad / Beam 1
+        halfCrossingAngleXSector56  = cms.double(0.150), #in mrad / Beam 2
+        halfCrossingAngleYSector56  = cms.double(-250.), #in mrad / Beam 2
+        BeamEnergyDispersion = cms.double(1.e-3),     ## beam energy dispersion (GeV); if =0.0 the default(=0.79) is used
+        BeamDivergenceX = cms.double(47.32),     ## x angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
+        BeamDivergenceY = cms.double(47.25),      ## y angle dispersion at IP (urad); if =0.0 the default(=30.23) is used
+        BeamSigmaX  = cms.double(7.08),
+        BeamSigmaY  = cms.double(7.09),
+        BeamEnergy = cms.double(7000.0),
+        BeamXatIP      = cms.untracked.double(-750.),
+        BeamYatIP      = cms.untracked.double(0.),
+)
+
+# choose default optics for each year
 
 hector_2016 = cms.PSet(
               baseHectorParameters,
-              Validated_PreTS2_2016,
+              Nominal_2016,
 )
 
-hector_2017_beta40  = cms.PSet(
+hector_2017 = cms.PSet(
               baseHectorParameters,
               Nominal_2017_beta40cm
 )
 
-hector_2017_beta30  = cms.PSet(
+hector_2018 = cms.Pset(
               baseHectorParameters,
-              Nominal_2017_beta30cm
+              Nominal_2017_beta30cm  # CHANGE THIS WHEN THE PROPER ONE GET READY
+)
+
+hector_2021 = cms.PSet(
+              baseHectorParameters,
+              Nominal_RunIII
 )

--- a/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
@@ -5,10 +5,11 @@ from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cfi import *
 from CalibPPS.ESProducers.ctppsInterpolatedOpticalFunctionsESSource_cfi import *
 ctppsInterpolatedOpticalFunctionsESSource.lhcInfoLabel = ""
 
+
+# For optical functions from root file, when they are not yet in the database, use the definitino below
+"""
 from SimTransport.PPSProtonTransport.OpticalFunctionsConfig_cfi import *
 
-# For optical functions from root file, use the definitino below
-"""
 _opticsConfig = cms.PSet(
                     defaultCrossingAngle=cms.double(0.0),
                     es_source = cms.PSet()

--- a/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
@@ -1,15 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 # beam optics
-#from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cfi import *
-from CalibPPS.ESProducers.ctppsOpticalFunctionsESSource_cfi import *
-from CalibPPS.ESProducers.ctppsBeamParametersESSource_cfi import *
-
+from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cfi import *
 from CalibPPS.ESProducers.ctppsInterpolatedOpticalFunctionsESSource_cfi import *
 ctppsInterpolatedOpticalFunctionsESSource.lhcInfoLabel = ""
 
 from SimTransport.PPSProtonTransport.OpticalFunctionsConfig_cfi import *
 
+# For optical functions from root file, use the definitino below
+"""
 _opticsConfig = cms.PSet(
                     defaultCrossingAngle=cms.double(0.0),
                     es_source = cms.PSet()
@@ -30,10 +29,10 @@ ctpps_2021.toReplaceWith(_opticsConfig, opticalfunctionsTransportSetup_2021.opti
 ctppsBeamParametersESSource.halfXangleX45 = _opticsConfig.defaultCrossingAngle
 ctppsBeamParametersESSource.halfXangleX56 = _opticsConfig.defaultCrossingAngle
 ctppsOpticalFunctionsESSource.configuration.append(_opticsConfig.es_source)
-
 # clean up to avoid spreading uneeded modules up in the configuration chain
 del _opticsConfig
 del opticalfunctionsTransportSetup_2016
 del opticalfunctionsTransportSetup_2018
 del opticalfunctionsTransportSetup_2017
 del opticalfunctionsTransportSetup_2021
+"""

--- a/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
@@ -10,29 +10,6 @@ ctppsInterpolatedOpticalFunctionsESSource.lhcInfoLabel = ""
 
 from SimTransport.PPSProtonTransport.OpticalFunctionsConfig_cfi import *
 
-from CondCore.CondDB.CondDB_cfi import *
-ppsDBESSource = cms.ESSource("PoolDBESSource",
-    label = cms.string(""),
-    validityRange = cms.EventRange("0:min - 999999:max"),
-    beamEnergy = cms.double(6500),
-    xangle = cms.double(-1),
-    timetype = cms.untracked.string('runnumber'),
-    DumpStat=cms.untracked.bool(False),
-    toGet = cms.VPSet(
-                cms.PSet(
-                    record = cms.string('LHCInfoRcd'),
-                    tag = cms.string("LHCInfoEndFill_prompt_v2"),  #  FrontierProd
-                    connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-                ),
-                cms.PSet(
-                    record = cms.string('CTPPSOpticsRcd'),
-                    tag = cms.string("PPSOpticalFunctions_offline_v6"),
-                    connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-                )
-            )
-)
-es_prefer_ppsDBESSource = cms.ESPrefer("PoolDBESSource","ppsDBESSource")
-
 _opticsConfig = cms.PSet(
                     defaultCrossingAngle=cms.double(0.0),
                     es_source = cms.PSet()

--- a/SimTransport/PPSProtonTransport/python/PPSTransport_cff.py
+++ b/SimTransport/PPSProtonTransport/python/PPSTransport_cff.py
@@ -15,7 +15,7 @@ from SimTransport.PPSProtonTransport.OpticalFunctionsConfig_cfi import opticalfu
 
 _LHCTransportPSet = cms.PSet()
 
-# so far, it is not yet defined the optic for 2017 and 2018, if needed, change the config for these year to the 2016 one
+# To configure the optical function parameter, use _opticalfunctionsTransportSetup_XXXX.es_source
 
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 ctpps_2016.toReplaceWith(_LHCTransportPSet, _hector_2016)
@@ -24,7 +24,7 @@ from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 ctpps_2017.toReplaceWith(_LHCTransportPSet, _hector_2017)
 
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
-ctpps_2018.toReplaceWith(_LHCTransportPSet, _hector_2018)
+ctpps_2018.toReplaceWith(_LHCTransportPSet,_hector_2018)
 
 from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
 ctpps_2021.toReplaceWith(_LHCTransportPSet, _hector_2021) # there is no LHCInfo tag for Run3 yet, force to use a nonDB propagation

--- a/SimTransport/PPSProtonTransport/python/PPSTransport_cff.py
+++ b/SimTransport/PPSProtonTransport/python/PPSTransport_cff.py
@@ -1,20 +1,13 @@
 import FWCore.ParameterSet.Config as cms
-from SimG4Core.Application.g4SimHits_cfi import *
-g4SimHits.Generator.MinEtaCut = cms.double(-13.0)
-g4SimHits.Generator.MaxEtaCut = cms.double( 13.0)
-g4SimHits.Generator.HepMCProductLabel   = 'LHCTransport'
-g4SimHits.SteppingAction.MaxTrackTime = cms.double(2000.0)
-g4SimHits.StackingAction.MaxTrackTime = cms.double(2000.0)
-
-from IOMC.RandomEngine.IOMC_cff import *
-RandomNumberGeneratorService.LHCTransport.engineName   = cms.untracked.string('TRandom3')
 
 #
 # to avoid higher level moodules to import uneeded objects, import module as _module
 #
 from SimTransport.PPSProtonTransport.CommonParameters_cfi import commonParameters as _commonParameters
 from SimTransport.PPSProtonTransport.HectorTransport_cfi import hector_2016 as _hector_2016
-from SimTransport.PPSProtonTransport.TotemTransport_cfi import totemTransportSetup_2016  as _totemTransportSetup_2016 
+from SimTransport.PPSProtonTransport.HectorTransport_cfi import hector_2016 as _hector_2017
+from SimTransport.PPSProtonTransport.HectorTransport_cfi import hector_2016 as _hector_2018
+from SimTransport.PPSProtonTransport.HectorTransport_cfi import hector_2021 as _hector_2021
 from SimTransport.PPSProtonTransport.OpticalFunctionsConfig_cfi import opticalfunctionsTransportSetup_2016 as _opticalfunctionsTransportSetup_2016
 from SimTransport.PPSProtonTransport.OpticalFunctionsConfig_cfi import opticalfunctionsTransportSetup_2017 as _opticalfunctionsTransportSetup_2017
 from SimTransport.PPSProtonTransport.OpticalFunctionsConfig_cfi import opticalfunctionsTransportSetup_2018 as _opticalfunctionsTransportSetup_2018
@@ -25,16 +18,15 @@ _LHCTransportPSet = cms.PSet()
 # so far, it is not yet defined the optic for 2017 and 2018, if needed, change the config for these year to the 2016 one
 
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-#ctpps_2016.toReplaceWith(LHCTransportPSet, _totemTransportSetup_2016)
-ctpps_2016.toReplaceWith(_LHCTransportPSet, _opticalfunctionsTransportSetup_2016.optics_parameters)
+ctpps_2016.toReplaceWith(_LHCTransportPSet, _hector_2016)
 
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
-ctpps_2017.toReplaceWith(_LHCTransportPSet, _opticalfunctionsTransportSetup_2017.optics_parameters)
+ctpps_2017.toReplaceWith(_LHCTransportPSet, _hector_2017)
 
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
-ctpps_2018.toReplaceWith(_LHCTransportPSet, _opticalfunctionsTransportSetup_2018.optics_parameters)
+ctpps_2018.toReplaceWith(_LHCTransportPSet, _hector_2018)
 
 from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
-ctpps_2021.toReplaceWith(_LHCTransportPSet, _opticalfunctionsTransportSetup_2021.optics_parameters)
+ctpps_2021.toReplaceWith(_LHCTransportPSet, _hector_2021) # there is no LHCInfo tag for Run3 yet, force to use a nonDB propagation
 
 LHCTransport = cms.EDProducer("PPSSimTrackProducer",_commonParameters,_LHCTransportPSet)

--- a/SimTransport/PPSProtonTransport/python/TotemTransport_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/TotemTransport_cfi.py
@@ -23,9 +23,6 @@ BeamConditions2016 = cms.PSet(
     #BeamYatIP = cms.untracked.double(-0.190), # if not given, will take the CMS average vertex position
     # in m, should be consistent with geometry xml definitions
     BeampipeApertureRadius = cms.double(0.04), # in meter
-    VtxMeanX  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.X0,
-    VtxMeanY  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.Y0,
-    VtxMeanZ  = Realistic25ns13TeV2016CollisionVtxSmearingParameters.Z0,
     BeamSigmaX = cms.double(20.),
     BeamSigmaY = cms.double(20.)
 )

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -36,7 +36,7 @@ void BaseProtonTransport::ApplyBeamCorrection(TLorentzVector& p_out) {
     theta = TMath::Pi() - theta;
 
   if (MODE == TransportMode::TOTEM)
-    thetax += (p_out.Pz() > 0) ? fCrossingAngle_45 * urad : fCrossingAngle_56 * urad;
+    thetax += (p_out.Pz() > 0) ? fCrossingAngleX_45 * urad : fCrossingAngleX_56 * urad;
 
   double dtheta_x = (double)CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTX);
   double dtheta_y = (double)CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTY);


### PR DESCRIPTION
#### PR description:

In the process of integrating the PPS geometry into the CMS extended, it was noticed a possible failure due to missing LHC condition for Run 3. The solution implemented before to avoid it could cause a clash with eventual user redefinition of es_sources to access LHCInfo DB. For the time being, it was changed to use nominal optics while a better solution is not ready.

This PR is required to  unhold  PR #29916

#### PR validation:
scram b runtests           -> Ok
scram b code-checks   -> Ok
scram b code-format   -> Ok

runTheMatrix.py -l limited -i all --ibeos  
               ---->  36 35 33 26 16 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
