### PR TITLE
Add missing include for std::vector

### DIFF
--- a/SimDataFormats/TrackerDigiSimLink/interface/StripCompactDigiSimLinks.h
+++ b/SimDataFormats/TrackerDigiSimLink/interface/StripCompactDigiSimLinks.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <algorithm>
+#include <vector>
 #include <boost/range.hpp>
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include <cstdint>


### PR DESCRIPTION
#### PR description:

While testing latest root we get a build error [a]. This PR proposes to add the missing `vector` header.
[a]
```
In file included from /data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_11_2_ROOT6_X_2020-06-17-2300/src/SimDataFormats/TrackerDigiSimLink/src/StripCompactDigiSimLinks.cc:1:
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_11_2_ROOT6_X_2020-06-17-2300/src/SimDataFormats/TrackerDigiSimLink/interface/StripCompactDigiSimLinks.h:24:39: error: ISO C++ forbids declaration of 'type name' with no type [-fpermissive]
   typedef boost::sub_range<const std::vector<HitRecord> > Links;
                                       ^~~~~~
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_11_2_ROOT6_X_2020-06-17-2300/src/SimDataFormats/TrackerDigiSimLink/interface/StripCompactDigiSimLinks.h:24:57: error: template argument 1 is invalid
   typedef boost::sub_range<const std::vector<HitRecord> > Links;

```
