### PR TITLE
Improve if condition to identify a Process PSet in HLTConfigProvider

### DIFF
--- a/HLTrigger/HLTcore/src/HLTConfigProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigProvider.cc
@@ -165,7 +165,7 @@ void HLTConfigProvider::init(const std::string& processName) {
   const edm::pset::Registry::const_iterator rb(registry_->begin());
   const edm::pset::Registry::const_iterator re(registry_->end());
   for (edm::pset::Registry::const_iterator i = rb; i != re; ++i) {
-    if (i->second.exists("@process_name")) {
+    if (i->second.existsAs<string>("@process_name", true) and i->second.existsAs<vector<string>>("@paths", true)) {
       const std::string pName(i->second.getParameter<string>("@process_name"));
       pNames += pName + " ";
       if (pName == processName) {


### PR DESCRIPTION
#### PR description:

SwitchProducer PSet contains an untracked `@process_name` (added in https://github.com/cms-sw/cmssw/pull/29435), and the `getParameter("@processName")` in `HLTConfigProvider?  leads to an exception with that PSet. This PR proposes to improve the condition to check for a tracked string, and also require that the PSet has a tracked `@paths` to reduce further chances of accepting unexpected PSets.

Fixes the failures in 4.53, 136.731, 136.793, 136.874 reported in https://github.com/cms-sw/cmssw/pull/27983#issuecomment-645695958.

#### PR validation:

Workflow 4.53 runs on top of CMSSW_11_1_X_2020-06-17-1100+#27983+the commit in this PR