### PR TITLE
Correct 2018 HEfail GT and correct GT naming [11_1_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -47,25 +47,25 @@ autoCond = {
     # GlobalTag for Run3 data relvals
     'run3_data_promptlike'     :   '110X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '110X_mc2017_design_v3',
+    'phase1_2017_design'       :  '111X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '110X_mc2017_realistic_v4',
+    'phase1_2017_realistic'    :  '111X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '110X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      :  '111X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' :  '111X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '110X_upgrade2018_design_v4',
+    'phase1_2018_design'       :  '111X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v9',
+    'phase1_2018_realistic'    :  '111X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v7',
+    'phase1_2018_realistic_HEfail' :  '111X_upgrade2018_realistic_HEfail_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '111X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v7',
+    'phase1_2018_cosmics_peak' :   '111X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '111X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

This is a trivial backport of PR #30286. 

It corrects the 2018 realistic HEfail GT so that it differs from the standard 2018 realistic scenario only by the HCAL tags needed to simulate the failure of HEM15 and HEM16:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_realistic_v1/111X_upgrade2018_realistic_HEfail_v1

It also makes several technical changes; see the description of PR #30286 for details.

#### PR validation:

A technical test has been performed:

`runTheMatrix.py -l limited,10424.0,7.21,11224.0,11024.2,7.4 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of PR #30286. It is needed so that 110X and 111X GT queues--which have different contents for these scenarios--can be maintained independently.