### PR TITLE
Fix for incorrect Run 3 HLT JEC [11_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,15 +68,15 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '110X_mcRun3_2021_design_v7', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '110X_mcRun3_2021_design_v8', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v9', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v10', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v6',
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v9', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v10', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v9', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v10', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #30221. The GT diffs are the same as in the PR to master.

Negative HLT jet energies [have been reported](https://groups.cern.ch/group/cms-hlt/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fcms%2Dhlt%2FLists%2FArchive%2FNegative%20jet%20energies%20in%20HLT%20PF%20corrected%20jets%20for%20Run%203%20MC&FolderCTID=0x012002005CF9F426540B9C4D8205911CC3985E98) in Run-3 samples. The problem has been traced to the fact that Run-3 GTs currently load the 2016 HLT JECs, while it should actually make use of the 2017 HLT JECs.

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_design_v7/110X_mcRun3_2021_design_v8

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_realistic_v9/110X_mcRun3_2021_realistic_v10

**2021 cosmic (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021cosmics_realistic_deco_v6/110X_mcRun3_2021cosmics_realistic_deco_v7

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2023_realistic_v9/110X_mcRun3_2023_realistic_v10


**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2023_realistic_v9/110X_mcRun3_2023_realistic_v10

Note that the 2021 heavy ion scenario was introduced in 11_1_X, so there is no 2021 heavy ion GT here.

#### PR validation:

Tests were performed with a candidate GT to ensure that the fix behaves as expected.

See the following presentations for details:

https://indico.cern.ch/event/915728/contributions/3850261/subcontributions/305633/attachments/2045906/3431055/200527_jme_hltJECs.pdf
https://cernbox.cern.ch/index.php/s/L6Sxh48hsyhq2m0

In addition, a technical test is performed:

`runTheMatrix.py -l limited,7.23,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #30221. It is needed because the HLT JEC conditions currently used in the Run-3 GTs are incorrect.