### PR TITLE
Store anode wire hits in ALCT (ACLUT-3)

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -198,7 +198,11 @@ protected:
   // enum used in the wire hit assignment
   enum ALCT_WireInfo { INVALID_WIRE = 65535 };
 
+  // remove the invalid wires from the container
   void cleanWireContainer(CSCALCTDigi::WireContainer& wireHits) const;
+
+  //  set the wire hit container
+  void setWireContainer(CSCALCTDigi&, CSCALCTDigi::WireContainer& wireHits) const;
 
   /* This function looks for LCTs on the previous and next wires.  If one
      exists and it has a better quality and a bx_time up to 4 clocks earlier

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -192,7 +192,13 @@ protected:
   /* See if there is a pattern that satisfies nplanes_hit_pattern number of
      layers hit for either the accelerator or collision patterns.  Use
      the pattern with the best quality. */
-  bool patternDetection(const int key_wire);
+  bool patternDetection(const int key_wire,
+                        std::map<int, std::map<int, CSCALCTDigi::WireContainer> >& hits_in_patterns);
+
+  // enum used in the wire hit assignment
+  enum ALCT_WireInfo { INVALID_WIRE = 65535 };
+
+  void cleanWireContainer(CSCALCTDigi::WireContainer& wireHits) const;
 
   /* This function looks for LCTs on the previous and next wires.  If one
      exists and it has a better quality and a bx_time up to 4 clocks earlier

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -327,14 +327,8 @@ void CSCAnodeLCTProcessor::run(const std::vector<int> wire[CSCConstants::NUM_LAY
               int valid = (ghost_cleared[0] == 0) ? 1 : 0;  //cancelled, valid=0, otherwise it is 1
               CSCALCTDigi newALCT(valid, quality[i_wire][0], 1, 0, i_wire, bx);
 
-              // get the comparator hits for this pattern
-              auto wireHits = hits_in_patterns[i_wire][0];
-
-              // purge the wire digi collection
-              cleanWireContainer(wireHits);
-
-              // set the hit collection
-              newALCT.setHits(wireHits);
+              // set the wire digis for this pattern
+              setWireContainer(newALCT, hits_in_patterns[i_wire][0]);
 
               lct_list.push_back(newALCT);
               ALCTContainer_[bx][ALCTIndex_[bx]] = newALCT;
@@ -349,14 +343,8 @@ void CSCAnodeLCTProcessor::run(const std::vector<int> wire[CSCConstants::NUM_LAY
 
               CSCALCTDigi newALCT(valid, quality[i_wire][1], 0, quality[i_wire][2], i_wire, bx);
 
-              // get the comparator hits for this pattern
-              auto wireHits = hits_in_patterns[i_wire][1];
-
-              // purge the wire digi collection
-              cleanWireContainer(wireHits);
-
-              // set the hit collection
-              newALCT.setHits(wireHits);
+              // set the wire digis for this pattern
+              setWireContainer(newALCT, hits_in_patterns[i_wire][1]);
 
               lct_list.push_back(newALCT);
               ALCTContainer_[bx][ALCTIndex_[bx]] = newALCT;
@@ -638,6 +626,7 @@ bool CSCAnodeLCTProcessor::patternDetection(
 
     // clear a single pattern!
     CSCALCTDigi::WireContainer hits_single_pattern;
+    hits_single_pattern.clear();
     hits_single_pattern.resize(CSCConstants::NUM_LAYERS);
     for (auto& p : hits_single_pattern) {
       p.resize(CSCConstants::ALCT_PATTERN_WIDTH, INVALID_WIRE);
@@ -1403,4 +1392,12 @@ void CSCAnodeLCTProcessor::cleanWireContainer(CSCALCTDigi::WireContainer& wireHi
         std::remove_if(p.begin(), p.end(), [](unsigned i) -> bool { return i == CSCAnodeLCTProcessor::INVALID_WIRE; }),
         p.end());
   }
+}
+
+void CSCAnodeLCTProcessor::setWireContainer(CSCALCTDigi& alct, CSCALCTDigi::WireContainer& wireHits) const {
+  // clean the wire digi container
+  cleanWireContainer(wireHits);
+
+  // set the hit container
+  alct.setHits(wireHits);
 }


### PR DESCRIPTION
#### PR description:

This PR stores the anode wire hits in the ALCT data format, so one can do detailed studies of the performance of the ALCT algorithm for Run-3 or Phase-2 (e.g. displaced muons, close-by muons, hadronic showers,...). It also allows for new logic to be developed aimed at enhancing the ALCT position resolution for Phase-2.

The PR is similar to #29233, and builds on top of https://github.com/cms-sw/cmssw/pull/30104 (which has yet to be merged). 

#### PR validation:

Tested with WF 20434.0 and on 100 single muon gun events

```
cmsDriver.py Configuration/Generator/python/SingleMuPt10_pythia8_cfi.py \
--fileout file:step1.root --mc \
--eventcontent FEVTDEBUG --datatier GEN-SIM --conditions auto:phase1_2021_realistic \
--beamspot Run3RoundOptics25ns13TeVLowSigmaZ --step GEN,SIM --geometry DB:Extended \
--era Run3 --python_filename SingleMu_GEN_SIM.py --no_exec   -n 10

cmsDriver.py step2.py --filein file:step1.root --fileout file:step2.root --mc \
--eventcontent FEVTDEBUG --datatier GEN-SIM-DIGI-L1 --conditions auto:phase1_2021_realistic \
--step DIGI:pdigi_valid,L1 --geometry DB:Extended \
--era Run3 --python_filename step2_DIGI_L1.py --no_exec   -n 10
```

Somewhat verbose output of the simulation of a single pattern that ultimately produced an ALCT can be found below. 
```
Finding pattern
Layer 1
	Wire 0, valid, wireN 93, OK in pattern
	Wire 1, valid, wireN 92, OK in pattern, HIT!
	Wire 2, valid, wireN 91, OK in pattern, HIT!
	Wire 3
	Wire 4
Layer 2
	Wire 0
	Wire 1, valid, wireN 92, OK in pattern
	Wire 2, valid, wireN 91, OK in pattern, HIT!
	Wire 3
	Wire 4
Layer 3
	Wire 0
	Wire 1
	Wire 2, valid, wireN 91, OK in pattern, HIT!
	Wire 3
	Wire 4
Layer 4
	Wire 0
	Wire 1
	Wire 2, valid, wireN 91, OK in pattern
	Wire 3, valid, wireN 90, OK in pattern, HIT!
	Wire 4
Layer 5
	Wire 0
	Wire 1
	Wire 2, valid, wireN 91, OK in pattern
	Wire 3, valid, wireN 90, OK in pattern, HIT!
	Wire 4, valid, wireN 89, OK in pattern, HIT!
Layer 6
	Wire 0
	Wire 1
	Wire 2, valid, wireN 91, OK in pattern
	Wire 3, valid, wireN 90, OK in pattern
	Wire 4, valid, wireN 89, OK in pattern, HIT!

Printing hits for keyWire 91 bx 8
Layer 1
	92	91
Layer 2
	91
Layer 3
	91
Layer 4
	90
Layer 5
	90	89
Layer 6
	89
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 