### PR TITLE
Faster mahi pulse shape initialization

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -443,32 +443,54 @@ float MahiFit::calculateChiSq() const {
       .squaredNorm();
 }
 
-void MahiFit::setPulseShapeTemplate(const HcalPulseShapes::Shape& ps,
-                                    bool hasTimeInfo,
+void MahiFit::setPulseShapeTemplate(const int pulseShapeId,
+                                    const HcalPulseShapes& ps,
+                                    const bool hasTimeInfo,
                                     const HcalTimeSlew* hcalTimeSlewDelay,
-                                    unsigned int nSamples) {
-  if (!(&ps == currentPulseShape_)) {
+                                    const unsigned int nSamples) {
+  if (hcalTimeSlewDelay != hcalTimeSlewDelay_) {
+    assert(hcalTimeSlewDelay);
     hcalTimeSlewDelay_ = hcalTimeSlewDelay;
     tsDelay1GeV_ = hcalTimeSlewDelay->delay(1.0, slewFlavor_);
-
-    resetPulseShapeTemplate(ps, hasTimeInfo, nSamples);
-    currentPulseShape_ = &ps;
   }
-}
 
-void MahiFit::resetPulseShapeTemplate(const HcalPulseShapes::Shape& ps, bool hasTimeInfo, unsigned int nSamples) {
-  ++cntsetPulseShape_;
-
-  // only the pulse shape itself from PulseShapeFunctor is used for Mahi
-  // the uncertainty terms calculated inside PulseShapeFunctor are used for Method 2 only
-  psfPtr_.reset(new FitterFuncs::PulseShapeFunctor(ps, false, false, false, 1, 0, 0, HcalConst::maxSamples));
+  if (pulseShapeId != currentPulseShapeId_) {
+    resetPulseShapeTemplate(pulseShapeId, ps, nSamples);
+  }
 
   // 1 sigma time constraint
   nnlsWork_.dt = hasTimeInfo ? timeSigmaSiPM_ : timeSigmaHPD_;
 
-  nnlsWork_.tsSize = nSamples;
-  nnlsWork_.amplitudes.resize(nnlsWork_.tsSize);
-  nnlsWork_.noiseTerms.resize(nnlsWork_.tsSize);
+  if (nnlsWork_.tsSize != nSamples) {
+    nnlsWork_.tsSize = nSamples;
+    nnlsWork_.amplitudes.resize(nSamples);
+    nnlsWork_.noiseTerms.resize(nSamples);
+  }
+}
+
+void MahiFit::resetPulseShapeTemplate(const int pulseShapeId,
+                                      const HcalPulseShapes& ps,
+                                      const unsigned int /* nSamples */) {
+  ++cntsetPulseShape_;
+
+  psfPtr_ = nullptr;
+  for (auto& elem : knownPulseShapes_) {
+    if (elem.first == pulseShapeId) {
+      psfPtr_ = &*elem.second;
+      break;
+    }
+  }
+
+  if (!psfPtr_) {
+    // only the pulse shape itself from PulseShapeFunctor is used for Mahi
+    // the uncertainty terms calculated inside PulseShapeFunctor are used for Method 2 only
+    auto p = std::make_shared<FitterFuncs::PulseShapeFunctor>(
+        ps.getShape(pulseShapeId), false, false, false, 1, 0, 0, HcalConst::maxSamples);
+    knownPulseShapes_.push_back(std::make_pair(pulseShapeId, p));
+    psfPtr_ = &*p;
+  }
+
+  currentPulseShapeId_ = pulseShapeId;
 }
 
 void MahiFit::nnlsUnconstrainParameter(Index idxp) const {

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -486,7 +486,7 @@ void MahiFit::resetPulseShapeTemplate(const int pulseShapeId,
     // the uncertainty terms calculated inside PulseShapeFunctor are used for Method 2 only
     auto p = std::make_shared<FitterFuncs::PulseShapeFunctor>(
         ps.getShape(pulseShapeId), false, false, false, 1, 0, 0, HcalConst::maxSamples);
-    knownPulseShapes_.push_back(std::make_pair(pulseShapeId, p));
+    knownPulseShapes_.emplace_back(pulseShapeId, p);
     psfPtr_ = &*p;
   }
 

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -103,7 +103,7 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
 
   if (mahi) {
     mahiOOTpuCorr_->setPulseShapeTemplate(
-        theHcalPulseShapes_.getShape(info.recoShape()), info.hasTimeInfo(), hcalTimeSlew_delay_, info.nSamples());
+        info.recoShape(), theHcalPulseShapes_, info.hasTimeInfo(), hcalTimeSlew_delay_, info.nSamples());
     mahi->phase1Apply(info, m4E, m4T, m4UseTriple, m4chi2);
     m4E *= hbminusCorrectionFactor(channelId, m4E, isData);
   }

--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -240,7 +240,7 @@ void MahiDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
     const MahiFit* mahi = mahi_.get();
     mahi_->setPulseShapeTemplate(
-        theHcalPulseShapes_.getShape(hci.recoShape()), hci.hasTimeInfo(), hcalTimeSlewDelay, hci.nSamples());
+        hci.recoShape(), theHcalPulseShapes_, hci.hasTimeInfo(), hcalTimeSlewDelay, hci.nSamples());
     MahiDebugInfo mdi;
     // initialize energies so that the values in the previous iteration are not stored
     mdi.mahiEnergy = 0;


### PR DESCRIPTION
#### PR description:

MAHI now memoizes PulseShapeFunctor objects instead of recreating them every time a different pulse shape is encountered. Only a few different pulse shapes exist (corresponding to different SiPM/HPD types), so std::vector is used to hold the collection instead of std::map.

No changes in the relval results expected.

#### PR validation:

The usual runTheMatrix tests were run