### PR TITLE
GEN-only NanoAOD configs (NanoGEN) and cmsDriver support

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -937,6 +937,7 @@ class ConfigBuilder(object):
         self.RECOSIMDefaultCFF="Configuration/StandardSequences/RecoSim_cff"
         self.PATDefaultCFF="Configuration/StandardSequences/PAT_cff"
         self.NANODefaultCFF="PhysicsTools/NanoAOD/nano_cff"
+        self.NANOGENDefaultCFF="PhysicsTools/NanoAOD/nanogen_cff"
         self.EIDefaultCFF=None
         self.SKIMDefaultCFF="Configuration/StandardSequences/Skims_cff"
         self.POSTRECODefaultCFF="Configuration/StandardSequences/PostRecoGenerator_cff"
@@ -986,6 +987,8 @@ class ConfigBuilder(object):
         self.REPACKDefaultSeq='DigiToRawRepack'
         self.PATDefaultSeq='miniAOD'
         self.PATGENDefaultSeq='miniGEN'
+        #TODO: Check based of file input
+        self.NANOGENDefaultSeq='nanogenSequence' if any([x in self.stepMap for x in ['LHE', 'GEN', 'AOD']]) else 'nanogenMiniSequence' 
         self.NANODefaultSeq='nanoSequence'
 
         self.EVTCONTDefaultCFF="Configuration/EventContent/EventContent_cff"
@@ -1689,6 +1692,17 @@ class ConfigBuilder(object):
                 self._options.customise_commands = self._options.customise_commands + " \n"
             self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
 
+    def prepare_NANOGEN(self, sequence = "nanoAOD"):
+        ''' Enrich the schedule with NANOGEN '''
+        # TODO: Need to modify this based on the input file type
+        fromGen = any([x in self.stepMap for x in ['LHE', 'GEN', 'AOD']])
+        self.loadDefaultOrSpecifiedCFF(sequence,self.NANOGENDefaultCFF)
+        self.scheduleSequence(sequence.split('.')[-1],'nanoAOD_step')
+        custom = "customizeNanoGEN" if fromGen else "customizeNanoGENFromMini"
+        if self._options.runUnscheduled:
+            self._options.customisation_file_unsch.insert(0, '.'.join([self.NANOGENDefaultCFF, custom]))
+        else:
+            self._options.customisation_file.insert(0, '.'.join([self.NANOGENDefaultCFF, custom]))
 
     def prepare_EI(self, sequence = None):
         ''' Enrich the schedule with event interpretation '''

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -988,7 +988,7 @@ class ConfigBuilder(object):
         self.PATDefaultSeq='miniAOD'
         self.PATGENDefaultSeq='miniGEN'
         #TODO: Check based of file input
-        self.NANOGENDefaultSeq='nanogenSequence' if any([x in self.stepMap for x in ['LHE', 'GEN', 'AOD']]) else 'nanogenMiniSequence' 
+        self.NANOGENDefaultSeq='nanogenSequence'
         self.NANODefaultSeq='nanoSequence'
 
         self.EVTCONTDefaultCFF="Configuration/EventContent/EventContent_cff"

--- a/PhysicsTools/NanoAOD/python/NanoAODEDMEventContent_cff.py
+++ b/PhysicsTools/NanoAOD/python/NanoAODEDMEventContent_cff.py
@@ -19,3 +19,7 @@ NANOAODSIMEventContent = NanoAODEDMEventContent.clone(
     compressionLevel = cms.untracked.int32(9),
     compressionAlgorithm = cms.untracked.string("LZMA"),
 )
+NANOAODGENEventContent = NanoAODEDMEventContent.clone(
+    compressionLevel = cms.untracked.int32(9),
+    compressionAlgorithm = cms.untracked.string("LZMA"),
+)

--- a/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
+++ b/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
+    genEvent = cms.InputTag("generator"),
+    genLumiInfoHeader = cms.InputTag("generator"),
+    lheInfo = cms.VInputTag(cms.InputTag("externalLHEProducer"), cms.InputTag("source")),
+    preferredPDFs = cms.VPSet( # see https://lhapdf.hepforge.org/pdfsets.html
+        cms.PSet( name = cms.string("PDF4LHC15_nnlo_30_pdfas"), lhaid = cms.uint32(91400) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_hessian_pdfas"), lhaid = cms.uint32(306000) ),
+        cms.PSet( name = cms.string("NNPDF30_nlo_as_0118"), lhaid = cms.uint32(260000) ), # for some 92X samples. Note that the nominal weight, 260000, is not included in the LHE ...
+        cms.PSet( name = cms.string("NNPDF30_lo_as_0130"), lhaid = cms.uint32(262000) ), # some MLM 80X samples have only this (e.g. /store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/120000/02A210D6-F5C3-E611-B570-008CFA197BD4.root )
+        cms.PSet( name = cms.string("NNPDF30_nlo_nf_4_pdfas"), lhaid = cms.uint32(292000) ), # some FXFX 80X samples have only this (e.g. WWTo1L1Nu2Q, WWTo4Q)
+        cms.PSet( name = cms.string("NNPDF30_nlo_nf_5_pdfas"), lhaid = cms.uint32(292200) ), # some FXFX 80X samples have only this (e.g. DYJetsToLL_Pt, WJetsToLNu_Pt, DYJetsToNuNu_Pt)
+    ),
+    namedWeightIDs = cms.vstring(),
+    namedWeightLabels = cms.vstring(),
+    lheWeightPrecision = cms.int32(14),
+    maxPdfWeights = cms.uint32(150), 
+    debug = cms.untracked.bool(False),
+)

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -11,6 +11,7 @@ from PhysicsTools.NanoAOD.extraflags_cff import *
 from PhysicsTools.NanoAOD.ttbarCategorization_cff import *
 from PhysicsTools.NanoAOD.genparticles_cff import *
 from PhysicsTools.NanoAOD.particlelevel_cff import *
+from PhysicsTools.NanoAOD.genWeightsTable_cfi import *
 from PhysicsTools.NanoAOD.vertices_cff import *
 from PhysicsTools.NanoAOD.met_cff import *
 from PhysicsTools.NanoAOD.triggerObjects_cff import *
@@ -93,25 +94,6 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016: # to be updated wh
     )
 
 
-genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
-    genEvent = cms.InputTag("generator"),
-    genLumiInfoHeader = cms.InputTag("generator"),
-    lheInfo = cms.VInputTag(cms.InputTag("externalLHEProducer"), cms.InputTag("source")),
-    preferredPDFs = cms.VPSet( # see https://lhapdf.hepforge.org/pdfsets.html
-        cms.PSet( name = cms.string("PDF4LHC15_nnlo_30_pdfas"), lhaid = cms.uint32(91400) ),
-        cms.PSet( name = cms.string("NNPDF31_nnlo_hessian_pdfas"), lhaid = cms.uint32(306000) ),
-        cms.PSet( name = cms.string("NNPDF30_nlo_as_0118"), lhaid = cms.uint32(260000) ), # for some 92X samples. Note that the nominal weight, 260000, is not included in the LHE ...
-        cms.PSet( name = cms.string("NNPDF30_lo_as_0130"), lhaid = cms.uint32(262000) ), # some MLM 80X samples have only this (e.g. /store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/120000/02A210D6-F5C3-E611-B570-008CFA197BD4.root )
-        cms.PSet( name = cms.string("NNPDF30_nlo_nf_4_pdfas"), lhaid = cms.uint32(292000) ), # some FXFX 80X samples have only this (e.g. WWTo1L1Nu2Q, WWTo4Q)
-        cms.PSet( name = cms.string("NNPDF30_nlo_nf_5_pdfas"), lhaid = cms.uint32(292200) ), # some FXFX 80X samples have only this (e.g. DYJetsToLL_Pt, WJetsToLNu_Pt, DYJetsToNuNu_Pt)
-        cms.PSet( name = cms.string("NNPDF31_lo_as_0130"), lhaid = cms.uint32(315200) ), # SUSY signal samples use this
-    ),
-    namedWeightIDs = cms.vstring(),
-    namedWeightLabels = cms.vstring(),
-    lheWeightPrecision = cms.int32(14),
-    maxPdfWeights = cms.uint32(150), 
-    debug = cms.untracked.bool(False),
-)
 lheInfoTable = cms.EDProducer("LHETablesProducer",
     lheInfo = cms.VInputTag(cms.InputTag("externalLHEProducer"), cms.InputTag("source")),
     precision = cms.int32(14),

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -118,6 +118,9 @@ def customizeNanoGEN(process):
     process.genParticleTable.src = "genParticles"
     process.patJetPartons.particles = "genParticles"
     process.particleLevel.src = "generatorSmeared"
+    process.particleLevel.particleMaxEta = 999.
+    process.particleLevel.lepMinPt = 0.
+    process.particleLevel.lepMaxEta = 999.
     process.rivetProducerHTXS.HepMCCollection = "generatorSmeared"
 
     process.genJetTable.src = "ak4GenJets"

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -4,6 +4,7 @@ from PhysicsTools.NanoAOD.globals_cff import *
 from PhysicsTools.NanoAOD.genparticles_cff import *
 from PhysicsTools.NanoAOD.particlelevel_cff import *
 from PhysicsTools.NanoAOD.lheInfoTable_cfi import *
+from PhysicsTools.NanoAOD.genWeightsTable_cfi import *
 
 nanoMetadata = cms.EDProducer("UniqueStringProducer",
     strings = cms.PSet(
@@ -43,6 +44,7 @@ nanogenSequence = cms.Sequence(
     rivetProducerHTXS+
     particleLevelTables+
     metGenTable+
+    genWeightsTable+
     lheInfoTable
 )
 
@@ -69,6 +71,7 @@ nanogenMiniSequence = cms.Sequence(
     rivetProducerHTXS+
     particleLevelTables+
     metGenTable+
+    genWeightsTable+
     lheInfoTable
 )
 
@@ -91,6 +94,7 @@ NANOAODGENoutput = cms.OutputModule("NanoAODOutputModule",
 
 def customizeNanoGENFromMini(process):
     process.lheInfoTable.storeLHEParticles = True
+    process.lheInfoTable.precision = 14
     process.genParticleTable.src = "prunedGenParticles"
     process.patJetPartons.particles = "prunedGenParticles"
     process.particleLevel.src = "genParticles2HepMC:unsmeared"
@@ -110,6 +114,7 @@ def customizeNanoGENFromMini(process):
 
 def customizeNanoGEN(process):
     process.lheInfoTable.storeLHEParticles = True
+    process.lheInfoTable.precision = 14
     process.genParticleTable.src = "genParticles"
     process.patJetPartons.particles = "genParticles"
     process.particleLevel.src = "generatorSmeared"

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -1,0 +1,128 @@
+from PhysicsTools.NanoAOD.taus_cff import *
+from PhysicsTools.NanoAOD.jets_cff import *
+from PhysicsTools.NanoAOD.globals_cff import *
+from PhysicsTools.NanoAOD.genparticles_cff import *
+from PhysicsTools.NanoAOD.particlelevel_cff import *
+from PhysicsTools.NanoAOD.lheInfoTable_cfi import *
+
+nanoMetadata = cms.EDProducer("UniqueStringProducer",
+    strings = cms.PSet(
+        tag = cms.string("untagged"),
+    )
+)
+
+metGenTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("genMetTrue"),
+    name = cms.string("GenMET"),
+    doc = cms.string("Gen MET"),
+    singleton = cms.bool(True),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+       pt  = Var("pt",  float, doc="pt", precision=10),
+       phi = Var("phi", float, doc="phi", precision=10),
+    ),
+)
+
+nanogenSequence = cms.Sequence(
+    nanoMetadata+
+    particleLevel+
+    genJetTable+
+    patJetPartons+
+    genJetFlavourAssociation+
+    genJetFlavourTable+
+    genJetAK8Table+
+    genJetAK8FlavourAssociation+
+    genJetAK8FlavourTable+
+    tauGenJets+
+    tauGenJetsSelectorAllHadrons+
+    genVisTaus+
+    genVisTauTable+
+    genTable+
+    genParticleTables+
+    tautagger+
+    rivetProducerHTXS+
+    particleLevelTables+
+    metGenTable+
+    lheInfoTable
+)
+
+nanogenMiniSequence = cms.Sequence(
+    nanoMetadata+
+    mergedGenParticles+
+    genParticles2HepMC+
+    particleLevel+
+    genJetTable+
+    patJetPartons+
+    genJetFlavourAssociation+
+    genJetFlavourTable+
+    genJetAK8Table+
+    genJetAK8FlavourAssociation+
+    genJetAK8FlavourTable+
+    tauGenJets+
+    tauGenJetsSelectorAllHadrons+
+    genVisTaus+
+    genVisTauTable+
+    genTable+
+    genParticleTables+
+    tautagger+
+    genParticles2HepMCHiggsVtx+
+    rivetProducerHTXS+
+    particleLevelTables+
+    metGenTable+
+    lheInfoTable
+)
+
+NANOAODGENoutput = cms.OutputModule("NanoAODOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(9),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('NANOAODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('nanogen.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        "keep nanoaodFlatTable_*Table_*_*",     # event data
+        "keep String_*_genModel_*",  # generator model data
+        "keep nanoaodMergeableCounterTable_*Table_*_*", # accumulated per/run or per/lumi data
+        "keep nanoaodUniqueString_nanoMetadata_*_*",   # basic metadata
+    )
+)
+
+def customizeNanoGENFromMini(process):
+    process.lheInfoTable.storeLHEParticles = True
+    process.genParticleTable.src = "prunedGenParticles"
+    process.patJetPartons.particles = "prunedGenParticles"
+    process.particleLevel.src = "genParticles2HepMC:unsmeared"
+    process.rivetProducerHTXS.HepMCCollection = "genParticles2HepMCHiggsVtx:unsmeared"
+
+    process.genJetTable.src = "slimmedGenJets"
+    process.genJetFlavourAssociation.jets = process.genJetTable.src
+    process.genJetFlavourTable.src = process.genJetTable.src
+    process.genJetFlavourTable.jetFlavourInfos = "genJetFlavourAssociation"
+    process.genJetAK8Table.src = "slimmedGenJetsAK8"
+    process.genJetAK8FlavourAssociation.jets = process.genJetAK8Table.src
+    process.genJetAK8FlavourTable.src = process.genJetAK8Table.src
+    process.tauGenJets.GenParticles = "prunedGenParticles"
+    process.genVisTaus.srcGenParticles = "prunedGenParticles"
+
+    return process
+
+def customizeNanoGEN(process):
+    process.lheInfoTable.storeLHEParticles = True
+    process.genParticleTable.src = "genParticles"
+    process.patJetPartons.particles = "genParticles"
+    process.particleLevel.src = "generatorSmeared"
+    process.rivetProducerHTXS.HepMCCollection = "generatorSmeared"
+
+    process.genJetTable.src = "ak4GenJets"
+    process.genJetFlavourAssociation.jets = process.genJetTable.src
+    process.genJetFlavourTable.src = process.genJetTable.src
+    process.genJetFlavourTable.jetFlavourInfos = "genJetFlavourAssociation"
+    process.genJetAK8Table.src = "ak8GenJets"
+    process.genJetAK8FlavourAssociation.jets = process.genJetAK8Table.src
+    process.genJetAK8FlavourTable.src = process.genJetAK8Table.src
+    process.tauGenJets.GenParticles = "genParticles"
+    process.genVisTaus.srcGenParticles = "genParticles"
+
+    return process

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -48,33 +48,6 @@ nanogenSequence = cms.Sequence(
     lheInfoTable
 )
 
-nanogenMiniSequence = cms.Sequence(
-    nanoMetadata+
-    mergedGenParticles+
-    genParticles2HepMC+
-    particleLevel+
-    genJetTable+
-    patJetPartons+
-    genJetFlavourAssociation+
-    genJetFlavourTable+
-    genJetAK8Table+
-    genJetAK8FlavourAssociation+
-    genJetAK8FlavourTable+
-    tauGenJets+
-    tauGenJetsSelectorAllHadrons+
-    genVisTaus+
-    genVisTauTable+
-    genTable+
-    genParticleTables+
-    tautagger+
-    genParticles2HepMCHiggsVtx+
-    rivetProducerHTXS+
-    particleLevelTables+
-    metGenTable+
-    genWeightsTable+
-    lheInfoTable
-)
-
 NANOAODGENoutput = cms.OutputModule("NanoAODOutputModule",
     compressionAlgorithm = cms.untracked.string('LZMA'),
     compressionLevel = cms.untracked.int32(9),
@@ -105,6 +78,10 @@ def nanoGenCommonCustomize(process):
     process.genJetFlavourTable.jetFlavourInfos = "genJetFlavourAssociation"
 
 def customizeNanoGENFromMini(process):
+    process.nanoAOD_step.insert(0, process.genParticles2HepMCHiggsVtx)
+    process.nanoAOD_step.insert(0, process.genParticles2HepMC)
+    process.nanoAOD_step.insert(0, process.mergedGenParticles)
+
     process.rivetProducerHTXS.HepMCCollection = "genParticles2HepMCHiggsVtx:unsmeared"
     process.genParticleTable.src = "prunedGenParticles"
     process.patJetPartons.particles = "prunedGenParticles"


### PR DESCRIPTION
#### PR description:

Configuration files to produce only the GEN branches of NanoAOD for a convenient and standardized ntuple format for gen analysis. cmsDriver support to produce directly from a gridpack, or from a MiniAOD file, or anything in between.

#### PR validation:

Has been tested by generating quite a few samples privately. Some configs and cmsDriver commands tested here: https://github.com/kdlong/WMassNanoGen

Additionally configurability is still a work in progress. Small amount of restructuring of configs should be approved by NanoAOD experts