### PR TITLE
ResonanceDecayFilter:wzAsEquivalent setting for Pythia8Interface (backport 7_1_X)

### DIFF
--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -22,6 +22,7 @@ private:
   bool allNuAsEquivalent_;
   bool udscAsEquivalent_;
   bool udscbAsEquivalent_;
+  bool wzAsEquivalent_;
   std::vector<int> mothers_;
   std::vector<int> daughters_;
   

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -23,7 +23,7 @@ private:
   bool udscAsEquivalent_;
   bool udscbAsEquivalent_;
   bool wzAsEquivalent_;
-  std::vector<int> mothers_;
+  std::set<int> mothers_;
   std::vector<int> daughters_;
   
   std::map<int,int> requestedDaughters_;

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -60,6 +60,7 @@ bool Py8InterfaceBase::readSettings( int )
    fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent",false);
    fMasterGen->settings.addFlag("ResonanceDecayFilter:udscAsEquivalent",false);
    fMasterGen->settings.addFlag("ResonanceDecayFilter:udscbAsEquivalent",false);
+   fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent",false);
    fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers",std::vector<int>(),false,false,0,0);
    fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters",std::vector<int>(),false,false,0,0);   
 

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -84,7 +84,7 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event& process) {
     
     //if no list of mothers is provided, then all particles
     //in hard process and resonance decays are counted together
-    bool validMother = mothers_.size() ? false : true;
+    bool validMother = mothers_.empty();
     for (int id : mothers_) {
       if (mid == std::abs(id)) {
         validMother = true;

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -13,6 +13,7 @@ bool ResonanceDecayFilterHook::initAfterBeams() {
   allNuAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:allNuAsEquivalent");
   udscAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:udscAsEquivalent");
   udscbAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:udscbAsEquivalent");
+  wzAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:wzAsEquivalent");
   mothers_ = settingsPtr->mvec("ResonanceDecayFilter:mothers");
   daughters_ = settingsPtr->mvec("ResonanceDecayFilter:daughters");
   
@@ -35,6 +36,9 @@ bool ResonanceDecayFilterHook::initAfterBeams() {
     }
     if ( (did == 2 || did==3 || did==4 || did==5 ) && udscbAsEquivalent_) {
       did = 1;
+    }
+    if( (did == 23 || did == 24) && wzAsEquivalent_) {
+      did = 23;
     }
 
     ++requestedDaughters_[std::abs(did)];
@@ -72,6 +76,9 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event& process) {
     if ( (did == 2 || did==3 || did==4 || did==5 ) && udscbAsEquivalent_) {
       did = 1;
     } 
+    if( (did == 23 || did == 24) && wzAsEquivalent_) {
+      did = 23;
+    }
     
     int mid = p.mother1()>0 ? std::abs(process[p.mother1()].id()) : 0;
     

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -14,7 +14,9 @@ bool ResonanceDecayFilterHook::initAfterBeams() {
   udscAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:udscAsEquivalent");
   udscbAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:udscbAsEquivalent");
   wzAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:wzAsEquivalent");
-  mothers_ = settingsPtr->mvec("ResonanceDecayFilter:mothers");
+  auto mothers = settingsPtr->mvec("ResonanceDecayFilter:mothers");
+  mothers_.clear();
+  mothers_.insert(mothers.begin(), mothers.end());
   daughters_ = settingsPtr->mvec("ResonanceDecayFilter:daughters");
   
   
@@ -84,17 +86,8 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event& process) {
     
     //if no list of mothers is provided, then all particles
     //in hard process and resonance decays are counted together
-    bool validMother = mothers_.empty();
-    for (int id : mothers_) {
-      if (mid == std::abs(id)) {
-        validMother = true;
-        break;
-      }
-    }
-    
-    if (validMother) {
+    if(mothers_.empty() || mothers_.count(mid) || mothers_.count(-mid))
       ++observedDaughters_[did];
-    }
   }
     
   //check if criteria is satisfied


### PR DESCRIPTION
#### PR description:

Added ResonanceDecayFilter:wzAsEquivalent setting to Pythia8Interface. 

#### PR validation:

code compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is port of #21132 for 7_1_X.
It is needed to produce 2016 HH->bbVV samples to decay H inclusively to a pair of gauge bosons.

@acarvalh