### PR TITLE
Phase2-hgx249 Add 2 variations of V11 geometry for the boundary radii which separate different types

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcal/v11m20/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/hgcal/v11m20/hgcal.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="hgcal.xml" eval="true">
+  <Constant name="WaferSize"             value="166.4408*mm"/>
+  <Constant name="WaferThickness"        value="0.31*mm"/>
+  <Constant name="SensorSeparation"      value="1.00*mm"/>
+  <Constant name="MouseBite"             value="5.00*mm"/>
+  <Constant name="CellThicknessFine"     value="0.12*mm"/>
+  <Constant name="CellThicknessCoarse1"  value="0.20*mm"/>
+  <Constant name="CellThicknessCoarse2"  value="0.30*mm"/>
+  <Constant name="ScintillatorThickness" value="3.88*mm"/>
+  <Constant name="NumberOfCellsFine"     value="12"/>
+  <Constant name="NumberOfCellsCoarse"   value="8"/>
+  <Constant name="FirstMixedLayer"       value="9"/>
+  <Constant name="rad100200P0"           value="-1.60163E-06"/>
+  <Constant name="rad100200P1"           value="2.50640E-03"/>
+  <Constant name="rad100200P2"           value="-1.46943E+00"/>
+  <Constant name="rad100200P3"           value="3.82025E+02"/>
+  <Constant name="rad100200P4"           value="-3.707690E+04"/>
+  <Constant name="rad200300P0"           value="-4.43240E-07"/>
+  <Constant name="rad200300P1"           value="7.70078E-04"/>
+  <Constant name="rad200300P2"           value="-4.97013E-01"/>
+  <Constant name="rad200300P3"           value="1.40778E+02"/>
+  <Constant name="rad200300P4"           value="-1.46540E+04"/>
+  <Constant name="zMinForRadPar"         value="335.0*cm"/>
+  <Constant name="ChoiceType"            value="0"/>
+  <Constant name="NCornerCut"            value="2"/>
+  <Constant name="FracAreaMin"           value="0.2"/>
+  <Constant name="radMixL0"              value="1537.0*mm"/>
+  <Constant name="radMixL1"              value="1537.0*mm"/>
+  <Constant name="radMixL2"              value="1537.0*mm"/>
+  <Constant name="radMixL3"              value="1537.0*mm"/>
+  <Constant name="radMixL4"              value="1378.2*mm"/>
+  <Constant name="radMixL5"              value="1378.2*mm"/>
+  <Constant name="radMixL6"              value="1183.0*mm"/>
+  <Constant name="radMixL7"              value="1183.0*mm"/>
+  <Constant name="radMixL8"              value="1183.0*mm"/>
+  <Constant name="radMixL9"              value="1183.0*mm"/>
+  <Constant name="radMixL10"             value="1037.8*mm"/>
+  <Constant name="radMixL11"             value="1037.8*mm"/>
+  <Constant name="radMixL12"             value="1037.8*mm"/>
+  <Constant name="radMixL13"             value="1037.8*mm"/>
+  <Constant name="slope1"                value="[etaMax:slope]"/>
+  <Constant name="slope2"                value="[caloBase:slope20]"/>
+  <Constant name="slope3"                value="[caloBase:slope30]"/>
+  <Constant name="zHGCal0"               value="[caloBase:ZposV0]"/>
+  <Constant name="zHGCal1"               value="3210.5*mm"/>
+  <Constant name="zHGCal2"               value="3625.1*mm"/>
+  <Constant name="zHGCal3"               value="[caloBase:Zpos310]"/>
+  <Constant name="zHGCal4"               value="3893.4*mm"/>
+  <Constant name="zHGCal5"               value="4066.1*mm"/>
+  <Constant name="zHGCal6"               value="[caloBase:Zpos340]"/>
+  <Constant name="zHGCal7"               value="[caloBase:Zpos360]"/>
+  <Constant name="zHGCal8"               value="4562.0*mm"/>
+  <Constant name="zHGCal9"               value="5051.8*mm"/>
+  <Constant name="zHGCal10"              value="5139.1*mm"/>
+  <Constant name="zHGCal11"              value="[caloBase:Zpos390]"/>
+  <Constant name="zHGCal12"              value="[caloBase:Zpos40]"/>
+  <Constant name="rMinHGCal1"            value="[caloBase:Rmin30]"/>
+  <Constant name="rMinHGCal2"            value="[caloBase:Rmin31]"/> 
+  <Constant name="rMinHGCal3"            value="[caloBase:Rmin33]"/>    
+  <Constant name="rMinHGCal4"            value="[caloBase:Rmin34]"/>
+  <Constant name="rMinHGCal5"            value="[caloBase:Rmin36]"/>
+  <Constant name="rMaxHGCal1"            value="1523.3*mm"/>
+  <Constant name="rMaxHGCal2"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal2]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal3"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal3]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal4"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal4]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal8"            value="2624.6*mm"/>
+  <Constant name="rMaxHGCal40"           value="([rMaxHGCal8]+[slope3]*
+						([zHGCal4]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal5"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal5]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal6"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal6]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal7"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal7]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal9"            value="2484.9*mm"/>
+  <Constant name="zHGCalEE1"             value="[zHGCal1]"/>
+  <Constant name="zHGCalEE2"             value="[zHGCal2]"/>
+  <Constant name="rMinHGCalEE1"          value="287.5*mm"/>
+  <Constant name="rMaxHGCalEE1"          value="[rMaxHGCal1]"/>
+  <Constant name="rMaxHGCalEE2"          value="[rMaxHGCal2]"/>
+  <Constant name="zHGCalHEsil1"          value="[zHGCal2]"/>
+  <Constant name="zHGCalHEsil2"          value="[zHGCal4]"/>
+  <Constant name="zHGCalHEsil3"          value="[zHGCal5]"/>
+  <Constant name="rMinHGCalHEsil1"       value="334.9*mm"/>
+  <Constant name="rMaxHGCalHEsil1"       value="[rMaxHGCal2]"/>
+  <Constant name="rMaxHGCalHEsil2"       value="[rMaxHGCal4]"/>
+  <Constant name="rMaxHGCalHEsil3"       value="[rMaxHGCal40]"/>
+  <Constant name="rMaxHGCalHEsil4"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEsil3]-[zHGCal8]))"/>
+  <Constant name="zHGCalHEmix1"          value="[zHGCal5]"/>
+  <Constant name="zHGCalHEmix2"          value="[zHGCal6]"/>
+  <Constant name="zHGCalHEmix3"          value="[zHGCal7]"/>
+  <Constant name="zHGCalHEmix4"          value="[zHGCal8]"/>
+  <Constant name="zHGCalHEmix5"          value="[zHGCal9]"/>
+  <Constant name="zHGCalHEmix6"          value="[zHGCal10]"/>
+  <Constant name="rMinHGCalHEmix1"       value="386.7*mm"/>
+  <Constant name="rMinHGCalHEmix2"       value="502.3*mm"/>
+  <Constant name="rMaxHGCalHEmix1"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix1]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix2"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix2]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix3"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix3]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix4"       value="[rMaxHGCal8]"/>
+  <Constant name="rMaxHGCalHEmix5"       value="[rMaxHGCal9]"/>
+</ConstantsSection>
+
+<SolidSection label="hgcal.xml">
+  <Polycone name="HGCalService" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[caloBase:Zpos30]"  rMin="[caloBase:Rmin30]" rMax="[caloBase:Rmax30]"/>
+    <ZSection z="[caloBase:Zpos310]" rMin="[caloBase:Rmin30]" rMax="[caloBase:Rmax310]"/>
+    <ZSection z="[caloBase:Zpos310]" rMin="[caloBase:Rmin31]" rMax="[caloBase:Rmax310]"/>
+    <ZSection z="[caloBase:ZposV1]"  rMin="[caloBase:Rmin31]" rMax="[caloBase:RposV1]"/>
+    <ZSection z="[caloBase:Zpos340]" rMin="[caloBase:Rmin31]" rMax="[caloBase:Rmax340]"/>
+    <ZSection z="[caloBase:Zpos340]" rMin="[caloBase:Rmin33]" rMax="[caloBase:Rmax340]"/>
+    <ZSection z="[caloBase:Zpos360]" rMin="[caloBase:Rmin33]" rMax="[caloBase:Rmax360]"/>
+    <ZSection z="[caloBase:Zpos360]" rMin="[caloBase:Rmin34]" rMax="[caloBase:Rmax360]"/>
+    <ZSection z="[caloBase:ZposV2]"  rMin="[caloBase:Rmin34]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos390]" rMin="[caloBase:Rmin34]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos390]" rMin="[caloBase:Rmin36]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos40]"  rMin="[caloBase:Rmin36]" rMax="[caloBase:RposV2]"/>
+  </Polycone>
+  <Polycone name="HGCal" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal0]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal1]"/>
+    <ZSection z="[zHGCal1]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal3]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal3]"/>
+    <ZSection z="[zHGCal4]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal4]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal5]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal3]"   rMax="[rMaxHGCal5]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal3]"   rMax="[rMaxHGCal7]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal7]"/>
+    <ZSection z="[zHGCal8]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal8]"/>
+    <ZSection z="[zHGCal9]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal8]"/>
+    <ZSection z="[zHGCal9]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal4]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal5]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal12]"  rMin="[rMinHGCal5]"   rMax="[rMaxHGCal9]"/>
+  </Polycone>
+  <Polycone name="HGCalEE" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalEE1]" rMin="[rMinHGCalEE1]"  rMax="[rMaxHGCalEE1]"/>
+    <ZSection z="[zHGCalEE2]" rMin="[rMinHGCalEE1]"  rMax="[rMaxHGCalEE2]"/>
+  </Polycone>
+  <Polycone name="HGCalEEsup" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalEE1]" rMin="[rMinHGCal1]"  rMax="[rMinHGCalEE1]"/>
+    <ZSection z="[zHGCalEE2]" rMin="[rMinHGCal1]"  rMax="[rMinHGCalEE1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsil" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalHEsil1]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil1]"/>
+    <ZSection z="[zHGCalHEsil2]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil2]"/>
+    <ZSection z="[zHGCalHEsil3]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil4]"/>
+  </Polycone>
+  <Polycone name="HGCalHEmix" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalHEmix1]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEmix1]"/>
+    <ZSection z="[zHGCalHEmix2]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEmix2]"/>
+    <ZSection z="[zHGCalHEmix2]" rMin="[rMinHGCalHEmix1]" rMax="[rMaxHGCalHEmix2]"/>
+    <ZSection z="[zHGCalHEmix3]" rMin="[rMinHGCalHEmix1]" rMax="[rMaxHGCalHEmix3]"/>
+    <ZSection z="[zHGCalHEmix3]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix3]"/>
+    <ZSection z="[zHGCalHEmix4]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix4]"/>
+    <ZSection z="[zHGCalHEmix5]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix4]"/>
+    <ZSection z="[zHGCalHEmix5]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix5]"/>
+    <ZSection z="[zHGCalHEmix6]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix5]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup1" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal2]"   rMin="[rMinHGCal1]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal1]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal2]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal2]" rMax="[rMinHGCalHEsil1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup2" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal3]" rMax="[rMinHGCalHEmix1]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal3]" rMax="[rMinHGCalHEmix1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup3" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal4]" rMax="[rMinHGCalHEmix2]"/>
+    <ZSection z="[zHGCal10]"  rMin="[rMinHGCal4]" rMax="[rMinHGCalHEmix2]"/>
+  </Polycone>
+  <Polycone name="HGCalBackPlate" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal10]"  rMin="[rMinHGCal4]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal4]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal5]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal12]"  rMin="[rMinHGCal5]" rMax="[rMaxHGCal9]"/>
+  </Polycone>
+</SolidSection>
+
+<LogicalPartSection label="hgcal.xml">
+  <LogicalPart name="HGCalService" category="unspecified">
+    <rSolid name="HGCalService"/>
+    <rMaterial name="caloBase:CEService"/>
+  </LogicalPart>
+  <LogicalPart name="HGCal" category="unspecified">
+    <rSolid name="HGCal"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalEE" category="unspecified">
+    <rSolid name="HGCalEE"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsil" category="unspecified">
+    <rSolid name="HGCalHEsil"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEmix" category="unspecified">
+    <rSolid name="HGCalHEmix"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalEEsup" category="unspecified">
+    <rSolid name="HGCalEEsup"/>
+    <rMaterial name="materials:Aluminium"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup1" category="unspecified">
+    <rSolid name="HGCalHEsup1"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup2" category="unspecified">
+    <rSolid name="HGCalHEsup2"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup3" category="unspecified">
+    <rSolid name="HGCalHEsup3"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalBackPlate" category="unspecified">
+    <rSolid name="HGCalBackPlate"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="hgcal.xml">
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOECRear"/>
+    <rChild name="hgcal:HGCalService"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalEE"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCalService"/>
+    <rChild name="hgcal:HGCal"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsil"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEmix"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalEEsup"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup1"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup3"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalBackPlate"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcal/v11m20/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/hgcal/v11m20/hgcal.xml
@@ -22,7 +22,7 @@
   <Constant name="rad200300P1"           value="7.70078E-04"/>
   <Constant name="rad200300P2"           value="-4.97013E-01"/>
   <Constant name="rad200300P3"           value="1.40778E+02"/>
-  <Constant name="rad200300P4"           value="-1.46540E+04"/>
+  <Constant name="rad200300P4"           value="-1.46340E+04"/>
   <Constant name="zMinForRadPar"         value="335.0*cm"/>
   <Constant name="ChoiceType"            value="0"/>
   <Constant name="NCornerCut"            value="2"/>

--- a/Geometry/HGCalCommonData/data/hgcal/v11p20/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/hgcal/v11p20/hgcal.xml
@@ -22,7 +22,7 @@
   <Constant name="rad200300P1"           value="7.70078E-04"/>
   <Constant name="rad200300P2"           value="-4.97013E-01"/>
   <Constant name="rad200300P3"           value="1.40778E+02"/>
-  <Constant name="rad200300P4"           value="-1.46140E+04"/>
+  <Constant name="rad200300P4"           value="-1.46340E+04"/>
   <Constant name="zMinForRadPar"         value="335.0*cm"/>
   <Constant name="ChoiceType"            value="0"/>
   <Constant name="NCornerCut"            value="2"/>

--- a/Geometry/HGCalCommonData/data/hgcal/v11p20/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/hgcal/v11p20/hgcal.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="hgcal.xml" eval="true">
+  <Constant name="WaferSize"             value="166.4408*mm"/>
+  <Constant name="WaferThickness"        value="0.31*mm"/>
+  <Constant name="SensorSeparation"      value="1.00*mm"/>
+  <Constant name="MouseBite"             value="5.00*mm"/>
+  <Constant name="CellThicknessFine"     value="0.12*mm"/>
+  <Constant name="CellThicknessCoarse1"  value="0.20*mm"/>
+  <Constant name="CellThicknessCoarse2"  value="0.30*mm"/>
+  <Constant name="ScintillatorThickness" value="3.88*mm"/>
+  <Constant name="NumberOfCellsFine"     value="12"/>
+  <Constant name="NumberOfCellsCoarse"   value="8"/>
+  <Constant name="FirstMixedLayer"       value="9"/>
+  <Constant name="rad100200P0"           value="-1.60163E-06"/>
+  <Constant name="rad100200P1"           value="2.50640E-03"/>
+  <Constant name="rad100200P2"           value="-1.46943E+00"/>
+  <Constant name="rad100200P3"           value="3.82025E+02"/>
+  <Constant name="rad100200P4"           value="-3.703690E+04"/>
+  <Constant name="rad200300P0"           value="-4.43240E-07"/>
+  <Constant name="rad200300P1"           value="7.70078E-04"/>
+  <Constant name="rad200300P2"           value="-4.97013E-01"/>
+  <Constant name="rad200300P3"           value="1.40778E+02"/>
+  <Constant name="rad200300P4"           value="-1.46140E+04"/>
+  <Constant name="zMinForRadPar"         value="335.0*cm"/>
+  <Constant name="ChoiceType"            value="0"/>
+  <Constant name="NCornerCut"            value="2"/>
+  <Constant name="FracAreaMin"           value="0.2"/>
+  <Constant name="radMixL0"              value="1537.0*mm"/>
+  <Constant name="radMixL1"              value="1537.0*mm"/>
+  <Constant name="radMixL2"              value="1537.0*mm"/>
+  <Constant name="radMixL3"              value="1537.0*mm"/>
+  <Constant name="radMixL4"              value="1378.2*mm"/>
+  <Constant name="radMixL5"              value="1378.2*mm"/>
+  <Constant name="radMixL6"              value="1183.0*mm"/>
+  <Constant name="radMixL7"              value="1183.0*mm"/>
+  <Constant name="radMixL8"              value="1183.0*mm"/>
+  <Constant name="radMixL9"              value="1183.0*mm"/>
+  <Constant name="radMixL10"             value="1037.8*mm"/>
+  <Constant name="radMixL11"             value="1037.8*mm"/>
+  <Constant name="radMixL12"             value="1037.8*mm"/>
+  <Constant name="radMixL13"             value="1037.8*mm"/>
+  <Constant name="slope1"                value="[etaMax:slope]"/>
+  <Constant name="slope2"                value="[caloBase:slope20]"/>
+  <Constant name="slope3"                value="[caloBase:slope30]"/>
+  <Constant name="zHGCal0"               value="[caloBase:ZposV0]"/>
+  <Constant name="zHGCal1"               value="3210.5*mm"/>
+  <Constant name="zHGCal2"               value="3625.1*mm"/>
+  <Constant name="zHGCal3"               value="[caloBase:Zpos310]"/>
+  <Constant name="zHGCal4"               value="3893.4*mm"/>
+  <Constant name="zHGCal5"               value="4066.1*mm"/>
+  <Constant name="zHGCal6"               value="[caloBase:Zpos340]"/>
+  <Constant name="zHGCal7"               value="[caloBase:Zpos360]"/>
+  <Constant name="zHGCal8"               value="4562.0*mm"/>
+  <Constant name="zHGCal9"               value="5051.8*mm"/>
+  <Constant name="zHGCal10"              value="5139.1*mm"/>
+  <Constant name="zHGCal11"              value="[caloBase:Zpos390]"/>
+  <Constant name="zHGCal12"              value="[caloBase:Zpos40]"/>
+  <Constant name="rMinHGCal1"            value="[caloBase:Rmin30]"/>
+  <Constant name="rMinHGCal2"            value="[caloBase:Rmin31]"/> 
+  <Constant name="rMinHGCal3"            value="[caloBase:Rmin33]"/>    
+  <Constant name="rMinHGCal4"            value="[caloBase:Rmin34]"/>
+  <Constant name="rMinHGCal5"            value="[caloBase:Rmin36]"/>
+  <Constant name="rMaxHGCal1"            value="1523.3*mm"/>
+  <Constant name="rMaxHGCal2"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal2]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal3"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal3]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal4"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal4]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal8"            value="2624.6*mm"/>
+  <Constant name="rMaxHGCal40"           value="([rMaxHGCal8]+[slope3]*
+						([zHGCal4]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal5"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal5]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal6"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal6]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal7"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal7]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal9"            value="2484.9*mm"/>
+  <Constant name="zHGCalEE1"             value="[zHGCal1]"/>
+  <Constant name="zHGCalEE2"             value="[zHGCal2]"/>
+  <Constant name="rMinHGCalEE1"          value="287.5*mm"/>
+  <Constant name="rMaxHGCalEE1"          value="[rMaxHGCal1]"/>
+  <Constant name="rMaxHGCalEE2"          value="[rMaxHGCal2]"/>
+  <Constant name="zHGCalHEsil1"          value="[zHGCal2]"/>
+  <Constant name="zHGCalHEsil2"          value="[zHGCal4]"/>
+  <Constant name="zHGCalHEsil3"          value="[zHGCal5]"/>
+  <Constant name="rMinHGCalHEsil1"       value="334.9*mm"/>
+  <Constant name="rMaxHGCalHEsil1"       value="[rMaxHGCal2]"/>
+  <Constant name="rMaxHGCalHEsil2"       value="[rMaxHGCal4]"/>
+  <Constant name="rMaxHGCalHEsil3"       value="[rMaxHGCal40]"/>
+  <Constant name="rMaxHGCalHEsil4"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEsil3]-[zHGCal8]))"/>
+  <Constant name="zHGCalHEmix1"          value="[zHGCal5]"/>
+  <Constant name="zHGCalHEmix2"          value="[zHGCal6]"/>
+  <Constant name="zHGCalHEmix3"          value="[zHGCal7]"/>
+  <Constant name="zHGCalHEmix4"          value="[zHGCal8]"/>
+  <Constant name="zHGCalHEmix5"          value="[zHGCal9]"/>
+  <Constant name="zHGCalHEmix6"          value="[zHGCal10]"/>
+  <Constant name="rMinHGCalHEmix1"       value="386.7*mm"/>
+  <Constant name="rMinHGCalHEmix2"       value="502.3*mm"/>
+  <Constant name="rMaxHGCalHEmix1"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix1]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix2"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix2]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix3"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix3]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix4"       value="[rMaxHGCal8]"/>
+  <Constant name="rMaxHGCalHEmix5"       value="[rMaxHGCal9]"/>
+</ConstantsSection>
+
+<SolidSection label="hgcal.xml">
+  <Polycone name="HGCalService" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[caloBase:Zpos30]"  rMin="[caloBase:Rmin30]" rMax="[caloBase:Rmax30]"/>
+    <ZSection z="[caloBase:Zpos310]" rMin="[caloBase:Rmin30]" rMax="[caloBase:Rmax310]"/>
+    <ZSection z="[caloBase:Zpos310]" rMin="[caloBase:Rmin31]" rMax="[caloBase:Rmax310]"/>
+    <ZSection z="[caloBase:ZposV1]"  rMin="[caloBase:Rmin31]" rMax="[caloBase:RposV1]"/>
+    <ZSection z="[caloBase:Zpos340]" rMin="[caloBase:Rmin31]" rMax="[caloBase:Rmax340]"/>
+    <ZSection z="[caloBase:Zpos340]" rMin="[caloBase:Rmin33]" rMax="[caloBase:Rmax340]"/>
+    <ZSection z="[caloBase:Zpos360]" rMin="[caloBase:Rmin33]" rMax="[caloBase:Rmax360]"/>
+    <ZSection z="[caloBase:Zpos360]" rMin="[caloBase:Rmin34]" rMax="[caloBase:Rmax360]"/>
+    <ZSection z="[caloBase:ZposV2]"  rMin="[caloBase:Rmin34]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos390]" rMin="[caloBase:Rmin34]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos390]" rMin="[caloBase:Rmin36]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos40]"  rMin="[caloBase:Rmin36]" rMax="[caloBase:RposV2]"/>
+  </Polycone>
+  <Polycone name="HGCal" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal0]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal1]"/>
+    <ZSection z="[zHGCal1]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal3]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal3]"/>
+    <ZSection z="[zHGCal4]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal4]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal5]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal3]"   rMax="[rMaxHGCal5]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal3]"   rMax="[rMaxHGCal7]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal7]"/>
+    <ZSection z="[zHGCal8]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal8]"/>
+    <ZSection z="[zHGCal9]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal8]"/>
+    <ZSection z="[zHGCal9]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal4]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal5]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal12]"  rMin="[rMinHGCal5]"   rMax="[rMaxHGCal9]"/>
+  </Polycone>
+  <Polycone name="HGCalEE" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalEE1]" rMin="[rMinHGCalEE1]"  rMax="[rMaxHGCalEE1]"/>
+    <ZSection z="[zHGCalEE2]" rMin="[rMinHGCalEE1]"  rMax="[rMaxHGCalEE2]"/>
+  </Polycone>
+  <Polycone name="HGCalEEsup" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalEE1]" rMin="[rMinHGCal1]"  rMax="[rMinHGCalEE1]"/>
+    <ZSection z="[zHGCalEE2]" rMin="[rMinHGCal1]"  rMax="[rMinHGCalEE1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsil" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalHEsil1]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil1]"/>
+    <ZSection z="[zHGCalHEsil2]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil2]"/>
+    <ZSection z="[zHGCalHEsil3]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil4]"/>
+  </Polycone>
+  <Polycone name="HGCalHEmix" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalHEmix1]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEmix1]"/>
+    <ZSection z="[zHGCalHEmix2]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEmix2]"/>
+    <ZSection z="[zHGCalHEmix2]" rMin="[rMinHGCalHEmix1]" rMax="[rMaxHGCalHEmix2]"/>
+    <ZSection z="[zHGCalHEmix3]" rMin="[rMinHGCalHEmix1]" rMax="[rMaxHGCalHEmix3]"/>
+    <ZSection z="[zHGCalHEmix3]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix3]"/>
+    <ZSection z="[zHGCalHEmix4]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix4]"/>
+    <ZSection z="[zHGCalHEmix5]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix4]"/>
+    <ZSection z="[zHGCalHEmix5]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix5]"/>
+    <ZSection z="[zHGCalHEmix6]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix5]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup1" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal2]"   rMin="[rMinHGCal1]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal1]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal2]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal2]" rMax="[rMinHGCalHEsil1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup2" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal3]" rMax="[rMinHGCalHEmix1]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal3]" rMax="[rMinHGCalHEmix1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup3" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal4]" rMax="[rMinHGCalHEmix2]"/>
+    <ZSection z="[zHGCal10]"  rMin="[rMinHGCal4]" rMax="[rMinHGCalHEmix2]"/>
+  </Polycone>
+  <Polycone name="HGCalBackPlate" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal10]"  rMin="[rMinHGCal4]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal4]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal5]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal12]"  rMin="[rMinHGCal5]" rMax="[rMaxHGCal9]"/>
+  </Polycone>
+</SolidSection>
+
+<LogicalPartSection label="hgcal.xml">
+  <LogicalPart name="HGCalService" category="unspecified">
+    <rSolid name="HGCalService"/>
+    <rMaterial name="caloBase:CEService"/>
+  </LogicalPart>
+  <LogicalPart name="HGCal" category="unspecified">
+    <rSolid name="HGCal"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalEE" category="unspecified">
+    <rSolid name="HGCalEE"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsil" category="unspecified">
+    <rSolid name="HGCalHEsil"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEmix" category="unspecified">
+    <rSolid name="HGCalHEmix"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalEEsup" category="unspecified">
+    <rSolid name="HGCalEEsup"/>
+    <rMaterial name="materials:Aluminium"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup1" category="unspecified">
+    <rSolid name="HGCalHEsup1"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup2" category="unspecified">
+    <rSolid name="HGCalHEsup2"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup3" category="unspecified">
+    <rSolid name="HGCalHEsup3"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalBackPlate" category="unspecified">
+    <rSolid name="HGCalBackPlate"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="hgcal.xml">
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOECRear"/>
+    <rChild name="hgcal:HGCalService"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalEE"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCalService"/>
+    <rChild name="hgcal:HGCal"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsil"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEmix"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalEEsup"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup1"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup3"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalBackPlate"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/HGCalCommonData/src/HGCalWaferType.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferType.cc
@@ -47,7 +47,7 @@ int HGCalWaferType::getType(double xpos, double ypos, double zpos) {
   yc[4] = ypos - R_;
   xc[5] = xpos + r_;
   yc[5] = ypos - 0.5 * R_;
-  auto rv = rLimits(zpos);
+  const auto & rv = rLimits(zpos);
   std::vector<int> fine, coarse;
   for (unsigned int k = 0; k < HGCalParameters::k_CornerSize; ++k) {
     double rpos = std::sqrt(xc[k] * xc[k] + yc[k] * yc[k]);
@@ -86,7 +86,7 @@ int HGCalWaferType::getType(double xpos, double ypos, double zpos) {
         ycn.emplace_back(yc[k1]);
         if (!ok) {
           double rr = (type == -1) ? rv.first : rv.second;
-          auto xy = intersection(k1, k2, xc, yc, xpos, ypos, rr);
+          const auto & xy = intersection(k1, k2, xc, yc, xpos, ypos, rr);
           xcn.emplace_back(xy.first);
           ycn.emplace_back(xy.second);
         }

--- a/Geometry/HGCalCommonData/src/HGCalWaferType.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferType.cc
@@ -47,7 +47,7 @@ int HGCalWaferType::getType(double xpos, double ypos, double zpos) {
   yc[4] = ypos - R_;
   xc[5] = xpos + r_;
   yc[5] = ypos - 0.5 * R_;
-  const auto & rv = rLimits(zpos);
+  const auto& rv = rLimits(zpos);
   std::vector<int> fine, coarse;
   for (unsigned int k = 0; k < HGCalParameters::k_CornerSize; ++k) {
     double rpos = std::sqrt(xc[k] * xc[k] + yc[k] * yc[k]);
@@ -86,7 +86,7 @@ int HGCalWaferType::getType(double xpos, double ypos, double zpos) {
         ycn.emplace_back(yc[k1]);
         if (!ok) {
           double rr = (type == -1) ? rv.first : rv.second;
-          const auto & xy = intersection(k1, k2, xc, yc, xpos, ypos, rr);
+          const auto& xy = intersection(k1, k2, xc, yc, xpos, ypos, rr);
           xcn.emplace_back(xy.first);
           ycn.emplace_back(xy.second);
         }

--- a/Geometry/HGCalCommonData/src/HGCalWaferType.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferType.cc
@@ -148,7 +148,8 @@ std::pair<double, double> HGCalWaferType::intersection(
     dist[i] = ((xx[i] - xpos) * (xx[i] - xpos)) + ((yy[i] - ypos) * (yy[i] - ypos));
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "HGCalWaferType: InterSection " << dist[0] << ":" << xx[0] << ":" << yy[0] << " vs " << dist[1] << ":" << xx[1] << ":" << yy[1];
+  edm::LogVerbatim("HGCalGeom") << "HGCalWaferType: InterSection " << dist[0] << ":" << xx[0] << ":" << yy[0] << " vs "
+                                << dist[1] << ":" << xx[1] << ":" << yy[1];
 #endif
   if (dist[0] > dist[1])
     return std::make_pair(xx[1], yy[1]);

--- a/Geometry/HGCalCommonData/src/HGCalWaferType.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferType.cc
@@ -47,7 +47,7 @@ int HGCalWaferType::getType(double xpos, double ypos, double zpos) {
   yc[4] = ypos - R_;
   xc[5] = xpos + r_;
   yc[5] = ypos - 0.5 * R_;
-  std::pair<double, double> rv = rLimits(zpos);
+  auto rv = rLimits(zpos);
   std::vector<int> fine, coarse;
   for (unsigned int k = 0; k < HGCalParameters::k_CornerSize; ++k) {
     double rpos = std::sqrt(xc[k] * xc[k] + yc[k] * yc[k]);
@@ -86,7 +86,7 @@ int HGCalWaferType::getType(double xpos, double ypos, double zpos) {
         ycn.emplace_back(yc[k1]);
         if (!ok) {
           double rr = (type == -1) ? rv.first : rv.second;
-          std::pair<double, double> xy = intersection(k1, k2, xc, yc, xpos, ypos, rr);
+          auto xy = intersection(k1, k2, xc, yc, xpos, ypos, rr);
           xcn.emplace_back(xy.first);
           ycn.emplace_back(xy.second);
         }
@@ -116,12 +116,17 @@ std::pair<double, double> HGCalWaferType::rLimits(double zpos) {
     rcoarse *= zz;
     rcoarse += rad200_[i];
   }
-  return std::pair<double, double>(rfine * HGCalParameters::k_ScaleToDDD, rcoarse * HGCalParameters::k_ScaleToDDD);
+  rfine *= HGCalParameters::k_ScaleToDDD;
+  rcoarse *= HGCalParameters::k_ScaleToDDD;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalWaferType: Z " << zpos << ":" << zz << " R " << rfine << ":" << rcoarse;
+#endif
+  return std::make_pair(rfine, rcoarse);
 }
 
 double HGCalWaferType::areaPolygon(std::vector<double> const& x, std::vector<double> const& y) {
   double area = 0.0;
-  int n = x.size();
+  int n = static_cast<int>(x.size());
   int j = n - 1;
   for (int i = 0; i < n; ++i) {
     area += ((x[j] + x[i]) * (y[i] - y[j]));
@@ -142,8 +147,11 @@ std::pair<double, double> HGCalWaferType::intersection(
     xx[i] = (slope * yy[i] + interc);
     dist[i] = ((xx[i] - xpos) * (xx[i] - xpos)) + ((yy[i] - ypos) * (yy[i] - ypos));
   }
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalWaferType: InterSection " << dist[0] << ":" << xx[0] << ":" << yy[0] << " vs " << dist[1] << ":" << xx[1] << ":" << yy[1];
+#endif
   if (dist[0] > dist[1])
-    return std::pair<double, double>(xx[1], yy[1]);
+    return std::make_pair(xx[1], yy[1]);
   else
-    return std::pair<double, double>(xx[0], yy[0]);
+    return std::make_pair(xx[0], yy[0]);
 }


### PR DESCRIPTION
#### PR description:

Add 2 variations of V11 geometry for the boundary radii which separate different types of wafers

#### PR validation:

Tested by constructing the geometries with test cfg files

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special