### PR TITLE
Reduce boost dependency in PhysicsTools/PatAlgos

### DIFF
--- a/PhysicsTools/PatAlgos/interface/MultiIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/MultiIsolator.h
@@ -4,17 +4,17 @@
 #include "DataFormats/Common/interface/View.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
-
 #include "PhysicsTools/PatAlgos/interface/BaseIsolator.h"
-#include "boost/ptr_container/ptr_vector.hpp"
-
 #include "DataFormats/PatCandidates/interface/Isolation.h"
+
+#include <memory>
+#include <vector>
 
 namespace pat {
   namespace helper {
     class MultiIsolator {
     public:
-      typedef std::vector<std::pair<pat::IsolationKeys, float> > IsolationValuePairs;
+      typedef std::vector<std::pair<pat::IsolationKeys, float>> IsolationValuePairs;
       MultiIsolator() {}
       MultiIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC, bool cuts = true);
       ~MultiIsolator() {}
@@ -55,7 +55,7 @@ namespace pat {
       bool enabled() const { return !isolators_.empty(); }
 
     private:
-      boost::ptr_vector<BaseIsolator> isolators_;
+      std::vector<std::unique_ptr<BaseIsolator>> isolators_;
       std::vector<uint32_t> masks_;
       std::vector<pat::IsolationKeys> keys_;
     };
@@ -65,7 +65,7 @@ namespace pat {
       uint32_t retval = 0;
       edm::RefToBase<T> rb = coll.refAt(idx);  // edm::Ptr<T> in a shiny new future to come one remote day ;-)
       for (size_t i = 0, n = isolators_.size(); i < n; ++i) {
-        if (!isolators_[i].test(rb))
+        if (!isolators_[i]->test(rb))
           retval |= masks_[i];
       }
       return retval;
@@ -76,7 +76,7 @@ namespace pat {
       isolations.resize(isolators_.size());
       for (size_t i = 0, n = isolators_.size(); i < n; ++i) {
         isolations[i].first = keys_[i];
-        isolations[i].second = isolators_[i].getValue(rb);
+        isolations[i].second = isolators_[i]->getValue(rb);
       }
     }
 

--- a/PhysicsTools/PatAlgos/src/MultiIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/MultiIsolator.cc
@@ -52,7 +52,7 @@ MultiIsolator::MultiIsolator(const edm::ParameterSet &conf, edm::ConsumesCollect
 }
 
 void MultiIsolator::addIsolator(BaseIsolator *iso, uint32_t mask, pat::IsolationKeys key) {
-  isolators_.push_back(iso);
+  isolators_.emplace_back(iso);
   masks_.push_back(mask);
   keys_.push_back(key);
 }
@@ -77,21 +77,21 @@ void MultiIsolator::addIsolator(
 }
 
 void MultiIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
-  for (boost::ptr_vector<BaseIsolator>::iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
-    it->beginEvent(event, eventSetup);
+  for (auto it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
+    (*it)->beginEvent(event, eventSetup);
   }
 }
 
 void MultiIsolator::endEvent() {
-  for (boost::ptr_vector<BaseIsolator>::iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
-    it->endEvent();
+  for (auto it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
+    (*it)->endEvent();
   }
 }
 
 void MultiIsolator::print(std::ostream &out) const {
-  for (boost::ptr_vector<BaseIsolator>::const_iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
+  for (auto it = isolators_.cbegin(), ed = isolators_.end(); it != ed; ++it) {
     out << " * ";
-    it->print(out);
+    (*it)->print(out);
     out << ": Flag " << pat::Flags::bitToString(masks_[it - isolators_.begin()]) << "\n";
   }
   out << "\n";

--- a/PhysicsTools/PatUtils/interface/EventHypothesisTools.h
+++ b/PhysicsTools/PatUtils/interface/EventHypothesisTools.h
@@ -1,9 +1,11 @@
 #ifndef PhysicsTools_PatUtils_interface_EventHypothesisTools_h
 #define PhysicsTools_PatUtils_interface_EventHypothesisTools_h
 
-#include "boost/ptr_container/ptr_vector.hpp"
 #include "DataFormats/PatCandidates/interface/EventHypothesis.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include <memory>
+#include <vector>
 
 namespace pat {
   namespace eventhypothesis {
@@ -15,13 +17,13 @@ namespace pat {
       AndFilter(ParticleFilter *f1, ParticleFilter *f2);
       ~AndFilter() override {}
       AndFilter &operator&=(ParticleFilter *filter) {
-        filters_.push_back(filter);
+        filters_.emplace_back(filter);
         return *this;
       }
       bool operator()(const CandRefType &cand, const std::string &role) const override;
 
     private:
-      boost::ptr_vector<ParticleFilter> filters_;
+      std::vector<std::unique_ptr<ParticleFilter>> filters_;
     };
 
     /** Does the OR of some filters. OWNS the pointers to the filters */
@@ -31,13 +33,13 @@ namespace pat {
       OrFilter(ParticleFilter *f1, ParticleFilter *f2);
       ~OrFilter() override {}
       OrFilter &operator&=(ParticleFilter *filter) {
-        filters_.push_back(filter);
+        filters_.emplace_back(filter);
         return *this;
       }
       bool operator()(const CandRefType &cand, const std::string &role) const override;
 
     private:
-      boost::ptr_vector<ParticleFilter> filters_;
+      std::vector<std::unique_ptr<ParticleFilter>> filters_;
     };
 
     class ByPdgId : public ParticleFilter {

--- a/PhysicsTools/PatUtils/src/EventHypothesisTools.cc
+++ b/PhysicsTools/PatUtils/src/EventHypothesisTools.cc
@@ -1,14 +1,15 @@
+
 #include "PhysicsTools/PatUtils/interface/EventHypothesisTools.h"
 
 using namespace pat::eventhypothesis;
 
 AndFilter::AndFilter(ParticleFilter *f1, ParticleFilter *f2) : filters_(2) {
-  filters_.push_back(f1);
-  filters_.push_back(f2);
+  filters_.emplace_back(f1);
+  filters_.emplace_back(f2);
 }
 
 bool AndFilter::operator()(const CandRefType &cand, const std::string &role) const {
-  for (boost::ptr_vector<ParticleFilter>::const_iterator it = filters_.begin(); it != filters_.end(); ++it) {
+  for (const auto &it : filters_) {
     if (!(*it)(cand, role))
       return false;
   }
@@ -16,12 +17,12 @@ bool AndFilter::operator()(const CandRefType &cand, const std::string &role) con
 }
 
 OrFilter::OrFilter(ParticleFilter *f1, ParticleFilter *f2) : filters_(2) {
-  filters_.push_back(f1);
-  filters_.push_back(f2);
+  filters_.emplace_back(f1);
+  filters_.emplace_back(f2);
 }
 
 bool OrFilter::operator()(const CandRefType &cand, const std::string &role) const {
-  for (boost::ptr_vector<ParticleFilter>::const_iterator it = filters_.begin(); it != filters_.end(); ++it) {
+  for (const auto &it : filters_) {
     if ((*it)(cand, role))
       return true;
   }


### PR DESCRIPTION
#### PR description:
Changed boost::ptr_vector for std::vector<std::unique_ptr<>>
The code should have the same behavior.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 