### PR TITLE
Revert change causing regression in DAQ/HLT JSON input parsing

### DIFF
--- a/EventFilter/Utilities/src/json_reader.cpp
+++ b/EventFilter/Utilities/src/json_reader.cpp
@@ -430,7 +430,7 @@ namespace Json {
       while (token.type_ == tokenComment && ok) {
         ok = readToken(token);
       }
-      bool badTokenType = (token.type_ == tokenArraySeparator || token.type_ == tokenArrayEnd);
+      bool badTokenType = (token.type_ == tokenArraySeparator && token.type_ == tokenArrayEnd);
       if (!ok || badTokenType) {
         return addErrorAndRecover("Missing ',' or ']' in array declaration", token, tokenArrayEnd);
       }

--- a/EventFilter/Utilities/src/json_reader.cpp
+++ b/EventFilter/Utilities/src/json_reader.cpp
@@ -430,7 +430,8 @@ namespace Json {
       while (token.type_ == tokenComment && ok) {
         ok = readToken(token);
       }
-      if (!ok) {
+      bool badTokenType = (token.type_ != tokenArraySeparator && token.type_ != tokenArrayEnd);
+      if (!ok || badTokenType) {
         return addErrorAndRecover("Missing ',' or ']' in array declaration", token, tokenArrayEnd);
       }
       if (token.type_ == tokenArrayEnd)

--- a/EventFilter/Utilities/src/json_reader.cpp
+++ b/EventFilter/Utilities/src/json_reader.cpp
@@ -430,8 +430,7 @@ namespace Json {
       while (token.type_ == tokenComment && ok) {
         ok = readToken(token);
       }
-      bool badTokenType = (token.type_ == tokenArraySeparator && token.type_ == tokenArrayEnd);
-      if (!ok || badTokenType) {
+      if (!ok) {
         return addErrorAndRecover("Missing ',' or ']' in array declaration", token, tokenArrayEnd);
       }
       if (token.type_ == tokenArrayEnd)


### PR DESCRIPTION
#### PR description:
Reverts json_reader.cpp modification which was part of this commit:
https://github.com/cms-sw/cmssw/commit/d030f663df51846c06f626488b8dfa2490d187bd

According to description, this commit fixes CLANG-10 warnings, however it seems to change behavior as well. Running with it creates this error (see below for test script description):
```
%MSG-e EvFDaqDirector:  (NoModuleName) 19-Jun-2020 20:37:32 CEST pre-events
grabNextFile Failed to deserialize JSON file -: "./data/run000100/run000100_ls0001_index000000_pid28154.jsn"
ERROR:
* Line 2, Column 20
  Missing ',' or ']' in array declaration
CONTENT:
{
   "data" : [ "20" ],
   "definition" : "./ramdisk//run000100/jsd/rawData.jsd",
   "source" : "lxplus709.cern.ch_28075"
}
.
%MSG
%MSG-e EvFDaqDirector:  (NoModuleName) 19-Jun-2020 20:37:32 CEST pre-events
grabNextFile runtime Exception -: Cannot deserialize input JSON file
%MSG
cmsRun: /tmp/smorovic/CMSSW_11_1_0_pre8/src/EventFilter/Utilities/src/FedRawDataInputSource.cc:1013: void FedRawDataInputSource::readSupervisor(): Assertion `eventsInNewFile >= 0' failed.
```
Assertion is consequence of the previous failure.

#### PR validation:
Tested manually and traced to be introduced between CMSSW_11_1_0_pre7 and CMSSW_11_1_0_pre8.
Test scripts in EventFilter/Utilities/test:
 - startBU.py (terminate manually after 10 seconds) and startFU.py, or
 - LocalRunBUFU.sh (with a log file in /tmp)

Failure mode is currently not covered with any automatic unit tests, as there have been issues implementing and running those reliably with DAQ file locking mechanism (also, for Run3 use of JSON files at HLT input stage is being phased out).

Equivalent PR will be created also for 11_1_X branch because currently this breaks release use in DAQ/HLT.