### PR TITLE
Revert change causing regression in DAQ/HLT JSON input parsing (11X backport)

### DIFF
--- a/EventFilter/Utilities/src/json_reader.cpp
+++ b/EventFilter/Utilities/src/json_reader.cpp
@@ -430,7 +430,7 @@ namespace Json {
       while (token.type_ == tokenComment && ok) {
         ok = readToken(token);
       }
-      bool badTokenType = (token.type_ == tokenArraySeparator || token.type_ == tokenArrayEnd);
+      bool badTokenType = (token.type_ == tokenArraySeparator && token.type_ == tokenArrayEnd);
       if (!ok || badTokenType) {
         return addErrorAndRecover("Missing ',' or ']' in array declaration", token, tokenArrayEnd);
       }

--- a/EventFilter/Utilities/src/json_reader.cpp
+++ b/EventFilter/Utilities/src/json_reader.cpp
@@ -430,7 +430,8 @@ namespace Json {
       while (token.type_ == tokenComment && ok) {
         ok = readToken(token);
       }
-      if (!ok) {
+      bool badTokenType = (token.type_ != tokenArraySeparator && token.type_ != tokenArrayEnd);
+      if (!ok || badTokenType) {
         return addErrorAndRecover("Missing ',' or ']' in array declaration", token, tokenArrayEnd);
       }
       if (token.type_ == tokenArrayEnd)

--- a/EventFilter/Utilities/src/json_reader.cpp
+++ b/EventFilter/Utilities/src/json_reader.cpp
@@ -430,8 +430,7 @@ namespace Json {
       while (token.type_ == tokenComment && ok) {
         ok = readToken(token);
       }
-      bool badTokenType = (token.type_ == tokenArraySeparator && token.type_ == tokenArrayEnd);
-      if (!ok || badTokenType) {
+      if (!ok) {
         return addErrorAndRecover("Missing ',' or ']' in array declaration", token, tokenArrayEnd);
       }
       if (token.type_ == tokenArrayEnd)


### PR DESCRIPTION
## PR description:
Reverts json_reader.cpp modification which was part of this commit:
d030f66

Fixes a bug that currently prevents 11_1_X release line from running in DAQ/HLT.

More information and description in #30315 of which this PR is a backport.
