### PR TITLE
Sonic client for Triton server

### DIFF
--- a/HeterogeneousCore/SonicCore/README.md
+++ b/HeterogeneousCore/SonicCore/README.md
@@ -86,6 +86,8 @@ The generic `SonicClient*` should be replaced with one of the available modes:
 
 In addition, as indicated, the input and output data types must be specified.
 (If both types are the same, only the input type needs to be specified.)
+The client constructor can optionally provide a value for `clientName_`,
+which will be used in output messages alongside the debug name set by the producers.
 
 In all cases, the implementation of `evaluate()` must call `finish()`.
 For the `Sync` and `PseudoAsync` modes, `finish()` should be called at the end of `evaluate()`.

--- a/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
@@ -16,8 +16,14 @@ public:
   //destructor
   virtual ~SonicClientBase() = default;
 
-  void setDebugName(const std::string& debugName) { debugName_ = debugName; }
+  void setDebugName(const std::string& debugName) {
+    debugName_ = debugName;
+    fullDebugName_ = debugName_;
+    if (!clientName_.empty())
+      fullDebugName_ += ":" + clientName_;
+  }
   const std::string& debugName() const { return debugName_; }
+  const std::string& clientName() const { return clientName_; }
 
   //main operation
   virtual void dispatch(edm::WaitingTaskWithArenaHolder holder) = 0;
@@ -54,8 +60,8 @@ protected:
     }
     if (!debugName_.empty()) {
       auto t1 = std::chrono::high_resolution_clock::now();
-      edm::LogInfo(debugName_) << "Client time: "
-                               << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0_).count();
+      edm::LogInfo(fullDebugName_) << "Client time: "
+                                   << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0_).count();
     }
     holder_.doneWaiting(eptr);
   }
@@ -65,7 +71,7 @@ protected:
   edm::WaitingTaskWithArenaHolder holder_;
 
   //for logging/debugging
-  std::string debugName_;
+  std::string clientName_, debugName_, fullDebugName_;
   std::chrono::time_point<std::chrono::high_resolution_clock> t0_;
 };
 

--- a/HeterogeneousCore/SonicTriton/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="FWCore/Utilities"/>
+<use name="HeterogeneousCore/SonicCore"/>
+<use name="triton-inference-server"/>
+<use name="protobuf"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -13,15 +13,12 @@
 
 #include "request_grpc.h"
 
-//avoid possible collisions in global namespace
-namespace {
-  namespace ni = nvidia::inferenceserver;
-  namespace nic = ni::client;
-}  // namespace
-
 template <typename Client>
 class TritonClient : public Client {
 public:
+  using ModelStatus = nvidia::inferenceserver::ModelStatus;
+  using InferContext = nvidia::inferenceserver::client::InferContext;
+
   struct ServerSideStats {
     uint64_t request_count_;
     uint64_t cumul_time_ns_;
@@ -33,7 +30,7 @@ public:
   TritonClient(const edm::ParameterSet& params);
 
   //helper
-  bool getResults(const nic::InferContext::Result& result);
+  bool getResults(const InferContext::Result& result);
 
   //accessors
   const std::vector<int64_t>& dimsInput() const { return dimsInput_; }
@@ -68,12 +65,12 @@ protected:
   bool setup();
 
   //helper to turn triton error into warning
-  bool wrap(const nic::Error& err, const std::string& msg, bool stop = false) const;
+  bool wrap(const nvidia::inferenceserver::client::Error& err, const std::string& msg, bool stop = false) const;
 
   void reportServerSideStats(const ServerSideStats& stats) const;
-  ServerSideStats summarizeServerStats(const ni::ModelStatus& start_status, const ni::ModelStatus& end_status) const;
+  ServerSideStats summarizeServerStats(const ModelStatus& start_status, const ModelStatus& end_status) const;
 
-  ni::ModelStatus getServerSideStatus() const;
+  ModelStatus getServerSideStatus() const;
 
   //members
   std::string url_;
@@ -88,11 +85,11 @@ protected:
   bool verbose_;
   unsigned allowedTries_;
 
-  std::unique_ptr<nic::InferContext> context_;
-  std::unique_ptr<nic::ServerStatusContext> serverCtx_;
-  std::unique_ptr<nic::InferContext::Options> options_;
-  std::shared_ptr<nic::InferContext::Input> nicInput_;
-  std::shared_ptr<nic::InferContext::Output> nicOutput_;
+  std::unique_ptr<InferContext> context_;
+  std::unique_ptr<nvidia::inferenceserver::client::ServerStatusContext> serverCtx_;
+  std::unique_ptr<InferContext::Options> options_;
+  std::shared_ptr<InferContext::Input> nicInput_;
+  std::shared_ptr<InferContext::Output> nicOutput_;
 };
 
 using TritonClientSync = TritonClient<SonicClientSync<std::vector<float>>>;

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -47,14 +47,15 @@ public:
     edm::ParameterSetDescription descClient;
     descClient.add<unsigned>("nInput");
     descClient.add<unsigned>("nOutput");
-    descClient.add<unsigned>("batchSize");
-    descClient.add<std::string>("address");
-    descClient.add<unsigned>("port");
-    descClient.add<unsigned>("timeout");
     descClient.add<std::string>("modelName");
     descClient.add<int>("modelVersion", -1);
-    descClient.add<bool>("verbose", false);
-    descClient.add<unsigned>("allowedTries", 0);
+	//server parameters should not affect the physics results
+    descClient.addUntracked<unsigned>("batchSize");
+    descClient.addUntracked<std::string>("address");
+    descClient.addUntracked<unsigned>("port");
+    descClient.addUntracked<unsigned>("timeout");
+    descClient.addUntracked<bool>("verbose", false);
+    descClient.addUntracked<unsigned>("allowedTries", 0);
     iDesc.add<edm::ParameterSetDescription>("Client", descClient);
   }
 

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -49,7 +49,7 @@ public:
     descClient.add<unsigned>("nOutput");
     descClient.add<std::string>("modelName");
     descClient.add<int>("modelVersion", -1);
-	//server parameters should not affect the physics results
+    //server parameters should not affect the physics results
     descClient.addUntracked<unsigned>("batchSize");
     descClient.addUntracked<std::string>("address");
     descClient.addUntracked<unsigned>("port");
@@ -93,5 +93,14 @@ protected:
 using TritonClientSync = TritonClient<SonicClientSync<std::vector<float>>>;
 using TritonClientPseudoAsync = TritonClient<SonicClientPseudoAsync<std::vector<float>>>;
 using TritonClientAsync = TritonClient<SonicClientAsync<std::vector<float>>>;
+
+//avoid ""explicit specialization after instantiation" error
+template <>
+void TritonClientAsync::evaluate();
+
+//explicit template instantiation declarations
+extern template class TritonClient<SonicClientSync<std::vector<float>>>;
+extern template class TritonClient<SonicClientAsync<std::vector<float>>>;
+extern template class TritonClient<SonicClientPseudoAsync<std::vector<float>>>;
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -13,8 +13,11 @@
 
 #include "request_grpc.h"
 
-namespace ni = nvidia::inferenceserver;
-namespace nic = ni::client;
+//avoid possible collisions in global namespace
+namespace {
+  namespace ni = nvidia::inferenceserver;
+  namespace nic = ni::client;
+}  // namespace
 
 template <typename Client>
 class TritonClient : public Client {
@@ -30,7 +33,7 @@ public:
   TritonClient(const edm::ParameterSet& params);
 
   //helper
-  bool getResults(const std::unique_ptr<nic::InferContext::Result>& result);
+  bool getResults(const nic::InferContext::Result& result);
 
   //accessors
   unsigned nInput() const { return nInput_; }
@@ -86,8 +89,8 @@ protected:
   std::shared_ptr<nic::InferContext::Input> nicInput_;
 };
 
-typedef TritonClient<SonicClientSync<std::vector<float>>> TritonClientSync;
-typedef TritonClient<SonicClientPseudoAsync<std::vector<float>>> TritonClientPseudoAsync;
-typedef TritonClient<SonicClientAsync<std::vector<float>>> TritonClientAsync;
+using TritonClientSync = TritonClient<SonicClientSync<std::vector<float>>>;
+using TritonClientPseudoAsync = TritonClient<SonicClientPseudoAsync<std::vector<float>>>;
+using TritonClientAsync = TritonClient<SonicClientAsync<std::vector<float>>>;
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -68,7 +68,7 @@ protected:
   bool setup();
 
   //helper to turn triton error into warning
-  bool wrap(const nic::Error& err, const std::string& msg) const;
+  bool wrap(const nic::Error& err, const std::string& msg, bool stop=false) const;
 
   void reportServerSideStats(const ServerSideStats& stats) const;
   ServerSideStats summarizeServerStats(const ni::ModelStatus& start_status, const ni::ModelStatus& end_status) const;

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -36,6 +36,8 @@ public:
   bool getResults(const nic::InferContext::Result& result);
 
   //accessors
+  const std::vector<int64_t>& dimsInput() const { return dimsInput_; }
+  const std::vector<int64_t>& dimsOutput() const { return dimsOutput_; }
   unsigned nInput() const { return nInput_; }
   unsigned nOutput() const { return nOutput_; }
   unsigned batchSize() const { return batchSize_; }
@@ -45,8 +47,6 @@ public:
   //for fillDescriptions
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     edm::ParameterSetDescription descClient;
-    descClient.add<unsigned>("nInput");
-    descClient.add<unsigned>("nOutput");
     descClient.add<std::string>("modelName");
     descClient.add<int>("modelVersion", -1);
     //server parameters should not affect the physics results
@@ -68,7 +68,7 @@ protected:
   bool setup();
 
   //helper to turn triton error into warning
-  bool wrap(const nic::Error& err, const std::string& msg, bool stop=false) const;
+  bool wrap(const nic::Error& err, const std::string& msg, bool stop = false) const;
 
   void reportServerSideStats(const ServerSideStats& stats) const;
   ServerSideStats summarizeServerStats(const ni::ModelStatus& start_status, const ni::ModelStatus& end_status) const;
@@ -81,6 +81,8 @@ protected:
   std::string modelName_;
   int modelVersion_;
   unsigned batchSize_;
+  std::vector<int64_t> dimsInput_;
+  std::vector<int64_t> dimsOutput_;
   unsigned nInput_;
   unsigned nOutput_;
   bool verbose_;

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -19,12 +19,6 @@ namespace nic = ni::client;
 template <typename Client>
 class TritonClient : public Client {
 public:
-  enum class Severity {
-    None = 0,
-    Low = 1,
-    High = 2,
-  };
-
   struct ServerSideStats {
     uint64_t request_count_;
     uint64_t cumul_time_ns_;
@@ -36,7 +30,7 @@ public:
   TritonClient(const edm::ParameterSet& params);
 
   //helper
-  std::exception_ptr getResults(const std::unique_ptr<nic::InferContext::Result>& result);
+  bool getResults(const std::unique_ptr<nic::InferContext::Result>& result);
 
   //accessors
   unsigned nInput() const { return nInput_; }
@@ -57,7 +51,6 @@ public:
     descClient.add<std::string>("modelName");
     descClient.add<int>("modelVersion", -1);
     descClient.add<bool>("verbose", false);
-    descClient.add<int>("minSeverityExit", 0);
     descClient.add<unsigned>("allowedTries", 0);
     iDesc.add<edm::ParameterSetDescription>("Client", descClient);
   }
@@ -68,10 +61,10 @@ protected:
   void evaluate() override;
 
   //helper for common ops
-  std::exception_ptr setup();
+  bool setup();
 
-  //helper to turn triton error into exception
-  std::exception_ptr wrap(const nic::Error& err, const std::string& msg, Severity sev) const;
+  //helper to turn triton error into warning
+  bool wrap(const nic::Error& err, const std::string& msg) const;
 
   void reportServerSideStats(const ServerSideStats& stats) const;
   ServerSideStats summarizeServerStats(const ni::ModelStatus& start_status, const ni::ModelStatus& end_status) const;
@@ -87,7 +80,6 @@ protected:
   unsigned nInput_;
   unsigned nOutput_;
   bool verbose_;
-  Severity minSeverityExit_;
   unsigned allowedTries_;
   std::unique_ptr<nic::InferContext> context_;
   std::unique_ptr<nic::ServerStatusContext> serverCtx_;

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -85,9 +85,12 @@ protected:
   unsigned nOutput_;
   bool verbose_;
   unsigned allowedTries_;
+
   std::unique_ptr<nic::InferContext> context_;
   std::unique_ptr<nic::ServerStatusContext> serverCtx_;
+  std::unique_ptr<nic::InferContext::Options> options_;
   std::shared_ptr<nic::InferContext::Input> nicInput_;
+  std::shared_ptr<nic::InferContext::Output> nicOutput_;
 };
 
 using TritonClientSync = TritonClient<SonicClientSync<std::vector<float>>>;

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -1,0 +1,101 @@
+#ifndef HeterogeneousCore_SonicTriton_TritonClient
+#define HeterogeneousCore_SonicTriton_TritonClient
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicClientSync.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicClientPseudoAsync.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicClientAsync.h"
+
+#include <vector>
+#include <string>
+#include <exception>
+
+#include "request_grpc.h"
+
+namespace ni = nvidia::inferenceserver;
+namespace nic = ni::client;
+
+template <typename Client>
+class TritonClient : public Client {
+public:
+  enum class Severity {
+    None = 0,
+    Low = 1,
+    High = 2,
+  };
+
+  struct ServerSideStats {
+    uint64_t request_count_;
+    uint64_t cumul_time_ns_;
+    uint64_t queue_time_ns_;
+    uint64_t compute_time_ns_;
+  };
+
+  //constructor
+  TritonClient(const edm::ParameterSet& params);
+
+  //helper
+  std::exception_ptr getResults(const std::unique_ptr<nic::InferContext::Result>& result);
+
+  //accessors
+  unsigned nInput() const { return nInput_; }
+  unsigned nOutput() const { return nOutput_; }
+  unsigned batchSize() const { return batchSize_; }
+  bool verbose() const { return verbose_; }
+  void setBatchSize(unsigned bsize) { batchSize_ = bsize; }
+
+  //for fillDescriptions
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    edm::ParameterSetDescription descClient;
+    descClient.add<unsigned>("nInput");
+    descClient.add<unsigned>("nOutput");
+    descClient.add<unsigned>("batchSize");
+    descClient.add<std::string>("address");
+    descClient.add<unsigned>("port");
+    descClient.add<unsigned>("timeout");
+    descClient.add<std::string>("modelName");
+    descClient.add<int>("modelVersion", -1);
+    descClient.add<bool>("verbose", false);
+    descClient.add<int>("minSeverityExit", 0);
+    descClient.add<unsigned>("allowedTries", 0);
+    iDesc.add<edm::ParameterSetDescription>("Client", descClient);
+  }
+
+protected:
+  unsigned allowedTries() const override { return allowedTries_; }
+
+  void evaluate() override;
+
+  //helper for common ops
+  std::exception_ptr setup();
+
+  //helper to turn triton error into exception
+  std::exception_ptr wrap(const nic::Error& err, const std::string& msg, Severity sev) const;
+
+  void reportServerSideStats(const ServerSideStats& stats) const;
+  ServerSideStats summarizeServerStats(const ni::ModelStatus& start_status, const ni::ModelStatus& end_status) const;
+
+  ni::ModelStatus getServerSideStatus() const;
+
+  //members
+  std::string url_;
+  unsigned timeout_;
+  std::string modelName_;
+  int modelVersion_;
+  unsigned batchSize_;
+  unsigned nInput_;
+  unsigned nOutput_;
+  bool verbose_;
+  Severity minSeverityExit_;
+  unsigned allowedTries_;
+  std::unique_ptr<nic::InferContext> context_;
+  std::unique_ptr<nic::ServerStatusContext> serverCtx_;
+  std::shared_ptr<nic::InferContext::Input> nicInput_;
+};
+
+typedef TritonClient<SonicClientSync<std::vector<float>>> TritonClientSync;
+typedef TritonClient<SonicClientPseudoAsync<std::vector<float>>> TritonClientPseudoAsync;
+typedef TritonClient<SonicClientAsync<std::vector<float>>> TritonClientAsync;
+
+#endif

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -127,7 +127,7 @@ bool TritonClient<Client>::getResults(const nic::InferContext::Result& result) {
 template <typename Client>
 void TritonClient<Client>::evaluate() {
   //in case there is nothing to process
-  if (this->batchSize_ == 0) {
+  if (batchSize_ == 0) {
     this->finish(true);
     return;
   }
@@ -157,11 +157,11 @@ void TritonClient<Client>::evaluate() {
     edm::LogInfo(this->fullDebugName_) << "Remote time: "
                                        << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
 
-  const auto& end_status = this->getServerSideStatus();
+  const auto& end_status = getServerSideStatus();
 
-  if (this->verbose()) {
-    const auto& stats = this->summarizeServerStats(start_status, end_status);
-    this->reportServerSideStats(stats);
+  if (verbose()) {
+    const auto& stats = summarizeServerStats(start_status, end_status);
+    reportServerSideStats(stats);
   }
 
   status = getResults(*results.begin()->second);
@@ -173,7 +173,7 @@ void TritonClient<Client>::evaluate() {
 template <>
 void TritonClientAsync::evaluate() {
   //in case there is nothing to process
-  if (this->batchSize_ == 0) {
+  if (batchSize_ == 0) {
     this->finish(true);
     return;
   }
@@ -196,30 +196,30 @@ void TritonClientAsync::evaluate() {
         //get results
         bool status = true;
         std::map<std::string, std::unique_ptr<nic::InferContext::Result>> results;
-        status = this->wrap(ctx->GetAsyncRunResults(request, &results), "evaluate(): unable to get result");
+        status = wrap(ctx->GetAsyncRunResults(request, &results), "evaluate(): unable to get result");
         if (!status) {
-          this->output_.resize(nOutput_ * batchSize_, 0.f);
-          this->finish(false);
+          output_.resize(nOutput_ * batchSize_, 0.f);
+          finish(false);
           return;
         }
         auto t2 = std::chrono::high_resolution_clock::now();
 
-        if (!this->debugName_.empty())
-          edm::LogInfo(this->fullDebugName_)
+        if (!debugName_.empty())
+          edm::LogInfo(fullDebugName_)
               << "Remote time: " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
 
-        const auto& end_status = this->getServerSideStatus();
+        const auto& end_status = getServerSideStatus();
 
-        if (this->verbose()) {
-          const auto& stats = this->summarizeServerStats(start_status, end_status);
-          this->reportServerSideStats(stats);
+        if (verbose()) {
+          const auto& stats = summarizeServerStats(start_status, end_status);
+          reportServerSideStats(stats);
         }
 
         //check result
-        status = this->getResults(*results.begin()->second);
+        status = getResults(*results.begin()->second);
 
         //finish
-        this->finish(status);
+        finish(status);
       }),
            "evaluate(): unable to launch async run");
 

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -18,7 +18,8 @@ namespace nic = ni::client;
 
 template <typename Client>
 TritonClient<Client>::TritonClient(const edm::ParameterSet& params)
-    : url_(params.getUntrackedParameter<std::string>("address") + ":" + std::to_string(params.getUntrackedParameter<unsigned>("port"))),
+    : url_(params.getUntrackedParameter<std::string>("address") + ":" +
+           std::to_string(params.getUntrackedParameter<unsigned>("port"))),
       timeout_(params.getUntrackedParameter<unsigned>("timeout")),
       modelName_(params.getParameter<std::string>("modelName")),
       modelVersion_(params.getParameter<int>("modelVersion")),
@@ -205,8 +206,8 @@ void TritonClientAsync::evaluate() {
         auto t2 = std::chrono::high_resolution_clock::now();
 
         if (!debugName_.empty())
-          edm::LogInfo(fullDebugName_)
-              << "Remote time: " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+          edm::LogInfo(fullDebugName_) << "Remote time: "
+                                       << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
 
         const auto& end_status = getServerSideStatus();
 

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -27,63 +27,51 @@ TritonClient<Client>::TritonClient(const edm::ParameterSet& params)
       nInput_(params.getParameter<unsigned>("nInput")),
       nOutput_(params.getParameter<unsigned>("nOutput")),
       verbose_(params.getParameter<bool>("verbose")),
-      minSeverityExit_(static_cast<Severity>(params.getParameter<int>("minSeverityExit"))),
       allowedTries_(params.getParameter<unsigned>("allowedTries")) {
   this->clientName_ = "TritonClient";
 }
 
 template <typename Client>
-std::exception_ptr TritonClient<Client>::wrap(const nic::Error& err, const std::string& msg, Severity sev) const {
-  std::exception_ptr eptr;
+bool TritonClient<Client>::wrap(const nic::Error& err, const std::string& msg) const {
   if (!err.IsOk()) {
-    if (sev > minSeverityExit_) {
-      cms::Exception ex("TritonServerFailure");
-      ex << msg << ": " << err;
-      eptr = make_exception_ptr(ex);
-    } else {
-      //just emit warning
-      edm::LogWarning("TritonServerWarning") << msg << ": " << err;
-    }
+    //emit warning
+    edm::LogWarning("TritonServerWarning") << msg << ": " << err;
   }
-  return eptr;
+  return err.IsOk();
 }
 
 template <typename Client>
-std::exception_ptr TritonClient<Client>::setup() {
-  std::exception_ptr exptr{};
+bool TritonClient<Client>::setup() {
+  bool status = true;
 
-  exptr = wrap(nic::InferGrpcContext::Create(&context_, url_, modelName_, modelVersion_, false),
-               "setup(): unable to create inference context",
-               Severity::High);
-  if (exptr)
-    return exptr;
+  status = wrap(nic::InferGrpcContext::Create(&context_, url_, modelName_, modelVersion_, false),
+                "setup(): unable to create inference context");
+  if (!status)
+    return status;
 
   //only used for monitoring
   bool has_server = false;
   if (verbose_) {
-    auto server_err = nic::ServerStatusGrpcContext::Create(&serverCtx_, url_, false);
-    wrap(server_err, "setup(): unable to create server context", Severity::None);
-    has_server = server_err.IsOk();
+    bool has_server = wrap(nic::ServerStatusGrpcContext::Create(&serverCtx_, url_, false),
+                           "setup(): unable to create server context");
   }
   if (!has_server)
     serverCtx_ = nullptr;
 
   std::unique_ptr<nic::InferContext::Options> options;
-  exptr = wrap(nic::InferContext::Options::Create(&options),
-               "setup(): unable to create inference context options",
-               Severity::Low);
-  if (exptr)
-    return exptr;
+  status = wrap(nic::InferContext::Options::Create(&options), "setup(): unable to create inference context options");
+  if (!status)
+    return status;
 
   options->SetBatchSize(batchSize_);
   for (const auto& output : context_->Outputs()) {
-    exptr = wrap(options->AddRawResult(output), "setup(): unable to add raw result", Severity::Low);
-    if (exptr)
-      return exptr;
+    status = wrap(options->AddRawResult(output), "setup(): unable to add raw result");
+    if (!status)
+      return status;
   }
-  exptr = wrap(context_->SetRunOptions(*options), "setup(): unable to set run options", Severity::Low);
-  if (exptr)
-    return exptr;
+  status = wrap(context_->SetRunOptions(*options), "setup(): unable to set run options");
+  if (!status)
+    return status;
 
   const auto& nicInputs = context_->Inputs();
   nicInput_ = nicInputs[0];
@@ -93,35 +81,33 @@ std::exception_ptr TritonClient<Client>::setup() {
   std::vector<int64_t> input_shape;
   for (unsigned i0 = 0; i0 < batchSize_; i0++) {
     float* arr = &(this->input_.data()[i0 * nInput_]);
-    exptr = wrap(nicInput_->SetRaw(reinterpret_cast<const uint8_t*>(arr), nInput_ * sizeof(float)),
-                 "setup(): unable to set data for batch entry " + std::to_string(i0),
-                 Severity::High);
-    if (exptr)
-      return exptr;
+    status = wrap(nicInput_->SetRaw(reinterpret_cast<const uint8_t*>(arr), nInput_ * sizeof(float)),
+                  "setup(): unable to set data for batch entry " + std::to_string(i0));
+    if (!status)
+      return status;
   }
   auto t2 = std::chrono::high_resolution_clock::now();
   if (!this->debugName_.empty())
     edm::LogInfo(this->fullDebugName_) << "Input array time: "
                                        << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
 
-  //should be empty
-  return exptr;
+  //should be true
+  return status;
 }
 
 template <typename Client>
-std::exception_ptr TritonClient<Client>::getResults(const std::unique_ptr<nic::InferContext::Result>& result) {
-  std::exception_ptr exptr{};
+bool TritonClient<Client>::getResults(const std::unique_ptr<nic::InferContext::Result>& result) {
+  bool status = true;
 
   auto t1 = std::chrono::high_resolution_clock::now();
   this->output_.resize(nOutput_ * batchSize_, 0.f);
   for (unsigned i0 = 0; i0 < batchSize_; i0++) {
     const uint8_t* r0;
     size_t content_byte_size;
-    exptr = wrap(result->GetRaw(i0, &r0, &content_byte_size),
-                 "getResults(): unable to get raw for entry " + std::to_string(i0),
-                 Severity::High);
-    if (exptr)
-      return exptr;
+    status = wrap(result->GetRaw(i0, &r0, &content_byte_size),
+                  "getResults(): unable to get raw for entry " + std::to_string(i0));
+    if (!status)
+      return status;
     const float* lVal = reinterpret_cast<const float*>(r0);
     std::memcpy(&this->output_[i0 * nOutput_], lVal, nOutput_ * sizeof(float));
   }
@@ -130,8 +116,8 @@ std::exception_ptr TritonClient<Client>::getResults(const std::unique_ptr<nic::I
     edm::LogInfo(this->fullDebugName_) << "Output array time: "
                                        << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
 
-  //should be empty
-  return exptr;
+  //should be true
+  return status;
 }
 
 //default case for sync and pseudo async
@@ -144,9 +130,9 @@ void TritonClient<Client>::evaluate() {
   }
 
   //common operations first
-  auto exptr = setup();
-  if (exptr) {
-    this->finish(false, exptr);
+  bool status = setup();
+  if (!status) {
+    this->finish(false);
     return;
   }
 
@@ -156,10 +142,10 @@ void TritonClient<Client>::evaluate() {
   //blocking call
   auto t1 = std::chrono::high_resolution_clock::now();
   std::map<std::string, std::unique_ptr<nic::InferContext::Result>> results;
-  exptr = wrap(context_->Run(&results), "evaluate(): unable to run and/or get result", Severity::High);
-  if (exptr) {
+  status = wrap(context_->Run(&results), "evaluate(): unable to run and/or get result");
+  if (!status) {
     this->output_.resize(nOutput_ * batchSize_, 0.f);
-    this->finish(false, exptr);
+    this->finish(false);
     return;
   }
 
@@ -175,9 +161,9 @@ void TritonClient<Client>::evaluate() {
     this->reportServerSideStats(stats);
   }
 
-  exptr = getResults(results.begin()->second);
+  status = getResults(results.begin()->second);
 
-  this->finish(exptr == nullptr, exptr);
+  this->finish(status);
 }
 
 //specialization for true async
@@ -190,9 +176,9 @@ void TritonClientAsync::evaluate() {
   }
 
   //common operations first
-  auto exptr = setup();
-  if (exptr) {
-    this->finish(false, exptr);
+  bool status = setup();
+  if (!status) {
+    this->finish(false);
     return;
   }
 
@@ -201,42 +187,42 @@ void TritonClientAsync::evaluate() {
 
   //non-blocking call
   auto t1 = std::chrono::high_resolution_clock::now();
-  exptr = wrap(context_->AsyncRun([t1, start_status, this](nic::InferContext* ctx,
-                                                           const std::shared_ptr<nic::InferContext::Request>& request) {
-    //get results
-    std::map<std::string, std::unique_ptr<nic::InferContext::Result>> results;
-    auto exptr =
-        this->wrap(ctx->GetAsyncRunResults(request, &results), "evaluate(): unable to get result", Severity::High);
-    if (exptr) {
-      this->output_.resize(nOutput_ * batchSize_, 0.f);
-      this->finish(false, exptr);
-      return;
-    }
-    auto t2 = std::chrono::high_resolution_clock::now();
+  status =
+      wrap(context_->AsyncRun([t1, start_status, this](nic::InferContext* ctx,
+                                                       const std::shared_ptr<nic::InferContext::Request>& request) {
+        //get results
+        bool status = true;
+        std::map<std::string, std::unique_ptr<nic::InferContext::Result>> results;
+        status = this->wrap(ctx->GetAsyncRunResults(request, &results), "evaluate(): unable to get result");
+        if (!status) {
+          this->output_.resize(nOutput_ * batchSize_, 0.f);
+          this->finish(false);
+          return;
+        }
+        auto t2 = std::chrono::high_resolution_clock::now();
 
-    if (!this->debugName_.empty())
-      edm::LogInfo(this->fullDebugName_) << "Remote time: "
-                                         << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+        if (!this->debugName_.empty())
+          edm::LogInfo(this->fullDebugName_)
+              << "Remote time: " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
 
-    const auto& end_status = this->getServerSideStatus();
+        const auto& end_status = this->getServerSideStatus();
 
-    if (this->verbose()) {
-      const auto& stats = this->summarizeServerStats(start_status, end_status);
-      this->reportServerSideStats(stats);
-    }
+        if (this->verbose()) {
+          const auto& stats = this->summarizeServerStats(start_status, end_status);
+          this->reportServerSideStats(stats);
+        }
 
-    //check result
-    exptr = this->getResults(results.begin()->second);
+        //check result
+        status = this->getResults(results.begin()->second);
 
-    //finish
-    this->finish(exptr == nullptr, exptr);
-  }),
-               "evaluate(): unable to launch async run",
-               Severity::High);
+        //finish
+        this->finish(status);
+      }),
+           "evaluate(): unable to launch async run");
 
   //if AsyncRun failed, finish() wasn't called
-  if (exptr)
-    this->finish(false, exptr);
+  if (!status)
+    this->finish(false);
 }
 
 template <typename Client>

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -1,0 +1,332 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
+
+#include "request_grpc.h"
+
+#include <string>
+#include <cmath>
+#include <chrono>
+#include <exception>
+#include <sstream>
+#include <cstring>
+
+namespace ni = nvidia::inferenceserver;
+namespace nic = ni::client;
+
+//based on https://github.com/NVIDIA/triton-inference-server/blob/v1.12.0/src/clients/c++/examples/simple_callback_client.cc
+
+template <typename Client>
+TritonClient<Client>::TritonClient(const edm::ParameterSet& params)
+    : Client(),
+      url_(params.getParameter<std::string>("address") + ":" + std::to_string(params.getParameter<unsigned>("port"))),
+      timeout_(params.getParameter<unsigned>("timeout")),
+      modelName_(params.getParameter<std::string>("modelName")),
+      modelVersion_(params.getParameter<int>("modelVersion")),
+      batchSize_(params.getParameter<unsigned>("batchSize")),
+      nInput_(params.getParameter<unsigned>("nInput")),
+      nOutput_(params.getParameter<unsigned>("nOutput")),
+      verbose_(params.getParameter<bool>("verbose")),
+      minSeverityExit_(static_cast<Severity>(params.getParameter<int>("minSeverityExit"))),
+      allowedTries_(params.getParameter<unsigned>("allowedTries")) {
+  this->clientName_ = "TritonClient";
+}
+
+template <typename Client>
+std::exception_ptr TritonClient<Client>::wrap(const nic::Error& err, const std::string& msg, Severity sev) const {
+  std::exception_ptr eptr;
+  if (!err.IsOk()) {
+    if (sev > minSeverityExit_) {
+      cms::Exception ex("TritonServerFailure");
+      ex << msg << ": " << err;
+      eptr = make_exception_ptr(ex);
+    } else {
+      //just emit warning
+      edm::LogWarning("TritonServerWarning") << msg << ": " << err;
+    }
+  }
+  return eptr;
+}
+
+template <typename Client>
+std::exception_ptr TritonClient<Client>::setup() {
+  std::exception_ptr exptr{};
+
+  exptr = wrap(nic::InferGrpcContext::Create(&context_, url_, modelName_, modelVersion_, false),
+               "setup(): unable to create inference context",
+               Severity::High);
+  if (exptr)
+    return exptr;
+
+  //only used for monitoring
+  bool has_server = false;
+  if (verbose_) {
+    auto server_err = nic::ServerStatusGrpcContext::Create(&serverCtx_, url_, false);
+    wrap(server_err, "setup(): unable to create server context", Severity::None);
+    has_server = server_err.IsOk();
+  }
+  if (!has_server)
+    serverCtx_ = nullptr;
+
+  std::unique_ptr<nic::InferContext::Options> options;
+  exptr = wrap(nic::InferContext::Options::Create(&options),
+               "setup(): unable to create inference context options",
+               Severity::Low);
+  if (exptr)
+    return exptr;
+
+  options->SetBatchSize(batchSize_);
+  for (const auto& output : context_->Outputs()) {
+    exptr = wrap(options->AddRawResult(output), "setup(): unable to add raw result", Severity::Low);
+    if (exptr)
+      return exptr;
+  }
+  exptr = wrap(context_->SetRunOptions(*options), "setup(): unable to set run options", Severity::Low);
+  if (exptr)
+    return exptr;
+
+  const auto& nicInputs = context_->Inputs();
+  nicInput_ = nicInputs[0];
+  nicInput_->Reset();
+
+  auto t1 = std::chrono::high_resolution_clock::now();
+  std::vector<int64_t> input_shape;
+  for (unsigned i0 = 0; i0 < batchSize_; i0++) {
+    float* arr = &(this->input_.data()[i0 * nInput_]);
+    exptr = wrap(nicInput_->SetRaw(reinterpret_cast<const uint8_t*>(arr), nInput_ * sizeof(float)),
+                 "setup(): unable to set data for batch entry " + std::to_string(i0),
+                 Severity::High);
+    if (exptr)
+      return exptr;
+  }
+  auto t2 = std::chrono::high_resolution_clock::now();
+  if (!this->debugName_.empty())
+    edm::LogInfo(this->fullDebugName_) << "Input array time: "
+                                       << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+
+  //should be empty
+  return exptr;
+}
+
+template <typename Client>
+std::exception_ptr TritonClient<Client>::getResults(const std::unique_ptr<nic::InferContext::Result>& result) {
+  std::exception_ptr exptr{};
+
+  auto t1 = std::chrono::high_resolution_clock::now();
+  this->output_.resize(nOutput_ * batchSize_, 0.f);
+  for (unsigned i0 = 0; i0 < batchSize_; i0++) {
+    const uint8_t* r0;
+    size_t content_byte_size;
+    exptr = wrap(result->GetRaw(i0, &r0, &content_byte_size),
+                 "getResults(): unable to get raw for entry " + std::to_string(i0),
+                 Severity::High);
+    if (exptr)
+      return exptr;
+    const float* lVal = reinterpret_cast<const float*>(r0);
+    std::memcpy(&this->output_[i0 * nOutput_], lVal, nOutput_ * sizeof(float));
+  }
+  auto t2 = std::chrono::high_resolution_clock::now();
+  if (!this->debugName_.empty())
+    edm::LogInfo(this->fullDebugName_) << "Output array time: "
+                                       << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+
+  //should be empty
+  return exptr;
+}
+
+//default case for sync and pseudo async
+template <typename Client>
+void TritonClient<Client>::evaluate() {
+  //in case there is nothing to process
+  if (this->batchSize_ == 0) {
+    this->finish(true);
+    return;
+  }
+
+  //common operations first
+  auto exptr = setup();
+  if (exptr) {
+    this->finish(false, exptr);
+    return;
+  }
+
+  // Get the status of the server prior to the request being made.
+  const auto& start_status = getServerSideStatus();
+
+  //blocking call
+  auto t1 = std::chrono::high_resolution_clock::now();
+  std::map<std::string, std::unique_ptr<nic::InferContext::Result>> results;
+  exptr = wrap(context_->Run(&results), "evaluate(): unable to run and/or get result", Severity::High);
+  if (exptr) {
+    this->output_.resize(nOutput_ * batchSize_, 0.f);
+    this->finish(false, exptr);
+    return;
+  }
+
+  auto t2 = std::chrono::high_resolution_clock::now();
+  if (!this->debugName_.empty())
+    edm::LogInfo(this->fullDebugName_) << "Remote time: "
+                                       << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+
+  const auto& end_status = this->getServerSideStatus();
+
+  if (this->verbose()) {
+    const auto& stats = this->summarizeServerStats(start_status, end_status);
+    this->reportServerSideStats(stats);
+  }
+
+  exptr = getResults(results.begin()->second);
+
+  this->finish(exptr == nullptr, exptr);
+}
+
+//specialization for true async
+template <>
+void TritonClientAsync::evaluate() {
+  //in case there is nothing to process
+  if (this->batchSize_ == 0) {
+    this->finish(true);
+    return;
+  }
+
+  //common operations first
+  auto exptr = setup();
+  if (exptr) {
+    this->finish(false, exptr);
+    return;
+  }
+
+  // Get the status of the server prior to the request being made.
+  const auto& start_status = getServerSideStatus();
+
+  //non-blocking call
+  auto t1 = std::chrono::high_resolution_clock::now();
+  exptr = wrap(context_->AsyncRun([t1, start_status, this](nic::InferContext* ctx,
+                                                           const std::shared_ptr<nic::InferContext::Request>& request) {
+    //get results
+    std::map<std::string, std::unique_ptr<nic::InferContext::Result>> results;
+    auto exptr =
+        this->wrap(ctx->GetAsyncRunResults(request, &results), "evaluate(): unable to get result", Severity::High);
+    if (exptr) {
+      this->output_.resize(nOutput_ * batchSize_, 0.f);
+      this->finish(false, exptr);
+      return;
+    }
+    auto t2 = std::chrono::high_resolution_clock::now();
+
+    if (!this->debugName_.empty())
+      edm::LogInfo(this->fullDebugName_) << "Remote time: "
+                                         << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+
+    const auto& end_status = this->getServerSideStatus();
+
+    if (this->verbose()) {
+      const auto& stats = this->summarizeServerStats(start_status, end_status);
+      this->reportServerSideStats(stats);
+    }
+
+    //check result
+    exptr = this->getResults(results.begin()->second);
+
+    //finish
+    this->finish(exptr == nullptr, exptr);
+  }),
+               "evaluate(): unable to launch async run",
+               Severity::High);
+
+  //if AsyncRun failed, finish() wasn't called
+  if (exptr)
+    this->finish(false, exptr);
+}
+
+template <typename Client>
+void TritonClient<Client>::reportServerSideStats(const typename TritonClient<Client>::ServerSideStats& stats) const {
+  std::stringstream msg;
+
+  // https://github.com/NVIDIA/tensorrt-inference-server/blob/v1.12.0/src/clients/c++/perf_client/inference_profiler.cc
+  const uint64_t count = stats.request_count_;
+  msg << "  Request count: " << count;
+
+  if (count > 0) {
+    auto get_avg_us = [count](uint64_t tval) {
+      constexpr uint64_t us_to_ns = 1000;
+      return tval / us_to_ns / count;
+    };
+
+    const uint64_t cumul_avg_us = get_avg_us(stats.cumul_time_ns_);
+    const uint64_t queue_avg_us = get_avg_us(stats.queue_time_ns_);
+    const uint64_t compute_avg_us = get_avg_us(stats.compute_time_ns_);
+    const uint64_t overhead =
+        (cumul_avg_us > queue_avg_us + compute_avg_us) ? (cumul_avg_us - queue_avg_us - compute_avg_us) : 0;
+
+    msg << "\n"
+        << "  Avg request latency: " << cumul_avg_us << " usec"
+        << "\n"
+        << "  (overhead " << overhead << " usec + "
+        << "queue " << queue_avg_us << " usec + "
+        << "compute " << compute_avg_us << " usec)" << std::endl;
+  }
+
+  if (!this->debugName_.empty())
+    edm::LogInfo(this->fullDebugName_) << msg.str();
+}
+
+template <typename Client>
+typename TritonClient<Client>::ServerSideStats TritonClient<Client>::summarizeServerStats(
+    const ni::ModelStatus& start_status, const ni::ModelStatus& end_status) const {
+  // If model_version is -1 then look in the end status to find the
+  // latest (highest valued version) and use that as the version.
+  int64_t status_model_version = 0;
+  if (modelVersion_ < 0) {
+    for (const auto& vp : end_status.version_status()) {
+      status_model_version = std::max(status_model_version, vp.first);
+    }
+  } else
+    status_model_version = modelVersion_;
+
+  typename TritonClient<Client>::ServerSideStats server_stats;
+  auto vend_itr = end_status.version_status().find(status_model_version);
+  if (vend_itr != end_status.version_status().end()) {
+    auto end_itr = vend_itr->second.infer_stats().find(batchSize_);
+    if (end_itr != vend_itr->second.infer_stats().end()) {
+      uint64_t start_count = 0;
+      uint64_t start_cumul_time_ns = 0;
+      uint64_t start_queue_time_ns = 0;
+      uint64_t start_compute_time_ns = 0;
+
+      auto vstart_itr = start_status.version_status().find(status_model_version);
+      if (vstart_itr != start_status.version_status().end()) {
+        auto start_itr = vstart_itr->second.infer_stats().find(batchSize_);
+        if (start_itr != vstart_itr->second.infer_stats().end()) {
+          start_count = start_itr->second.success().count();
+          start_cumul_time_ns = start_itr->second.success().total_time_ns();
+          start_queue_time_ns = start_itr->second.queue().total_time_ns();
+          start_compute_time_ns = start_itr->second.compute().total_time_ns();
+        }
+      }
+
+      server_stats.request_count_ = end_itr->second.success().count() - start_count;
+      server_stats.cumul_time_ns_ = end_itr->second.success().total_time_ns() - start_cumul_time_ns;
+      server_stats.queue_time_ns_ = end_itr->second.queue().total_time_ns() - start_queue_time_ns;
+      server_stats.compute_time_ns_ = end_itr->second.compute().total_time_ns() - start_compute_time_ns;
+    }
+  }
+  return server_stats;
+}
+
+template <typename Client>
+ni::ModelStatus TritonClient<Client>::getServerSideStatus() const {
+  if (serverCtx_) {
+    ni::ServerStatus server_status;
+    serverCtx_->GetServerStatus(&server_status);
+    auto itr = server_status.model_status().find(modelName_);
+    if (itr != server_status.model_status().end())
+      return itr->second;
+  }
+  return ni::ModelStatus{};
+}
+
+//explicit template instantiations
+template class TritonClient<SonicClientSync<std::vector<float>>>;
+template class TritonClient<SonicClientAsync<std::vector<float>>>;
+template class TritonClient<SonicClientPseudoAsync<std::vector<float>>>;

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -18,15 +18,15 @@ namespace nic = ni::client;
 
 template <typename Client>
 TritonClient<Client>::TritonClient(const edm::ParameterSet& params)
-    : url_(params.getParameter<std::string>("address") + ":" + std::to_string(params.getParameter<unsigned>("port"))),
-      timeout_(params.getParameter<unsigned>("timeout")),
+    : url_(params.getUntrackedParameter<std::string>("address") + ":" + std::to_string(params.getUntrackedParameter<unsigned>("port"))),
+      timeout_(params.getUntrackedParameter<unsigned>("timeout")),
       modelName_(params.getParameter<std::string>("modelName")),
       modelVersion_(params.getParameter<int>("modelVersion")),
-      batchSize_(params.getParameter<unsigned>("batchSize")),
+      batchSize_(params.getUntrackedParameter<unsigned>("batchSize")),
       nInput_(params.getParameter<unsigned>("nInput")),
       nOutput_(params.getParameter<unsigned>("nOutput")),
-      verbose_(params.getParameter<bool>("verbose")),
-      allowedTries_(params.getParameter<unsigned>("allowedTries")) {
+      verbose_(params.getUntrackedParameter<bool>("verbose")),
+      allowedTries_(params.getUntrackedParameter<unsigned>("allowedTries")) {
   this->clientName_ = "TritonClient";
 }
 

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -56,11 +56,13 @@ TritonClient<Client>::TritonClient(const edm::ParameterSet& params)
 
   //connect to the server
   wrap(nic::InferGrpcContext::Create(&context_, url_, modelName_, modelVersion_, false),
-       "setup(): unable to create inference context",
+       "TritonClient(): unable to create inference context",
        true);
 
   //get options
-  wrap(nic::InferContext::Options::Create(&options_), "setup(): unable to create inference context options", true);
+  wrap(nic::InferContext::Options::Create(&options_),
+       "TritonClient(): unable to create inference context options",
+       true);
 
   //get input and output (which know their sizes)
   const auto& nicInputs = context_->Inputs();
@@ -123,7 +125,7 @@ TritonClient<Client>::TritonClient(const edm::ParameterSet& params)
                                     << "Model output: " << output_str;
 
     has_server = wrap(nic::ServerStatusGrpcContext::Create(&serverCtx_, url_, false),
-                      "setup(): unable to create server context");
+                      "TritonClient(): unable to create server context");
   }
   if (!has_server)
     serverCtx_ = nullptr;

--- a/HeterogeneousCore/SonicTriton/test/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<flags EDM_PLUGIN="1"/>
+<use name="HeterogeneousCore/SonicCore"/>
+<use name="HeterogeneousCore/SonicTriton"/>
+<library file="*.cc" name="testHeterogenousCoreSonicTriton"/>

--- a/HeterogeneousCore/SonicTriton/test/README.md
+++ b/HeterogeneousCore/SonicTriton/test/README.md
@@ -1,0 +1,27 @@
+# SONIC TritonClient tests
+
+A test producer `TritonImageProducer` is available.
+It generates an arbitrary image for ResNet50 inference and prints the resulting classifications.
+
+To run the tests, a local Triton server can be started using Docker.
+(This may require superuser permission.)
+
+First, the relevant data should be downloaded from Nvidia:
+```
+./fetch_model.sh
+```
+
+Execute this Docker command to launch the local server (corresponding to the client version v1.12.0):
+```
+docker run -d --rm --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 -p8000:8000 -p8001:8001 -p8002:8002 -v${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models:/models nvcr.io/nvidia/tritonserver:20.03-py3 trtserver --model-repository=/models
+```
+
+If the machine has Nvidia GPUs, the flag `--gpus all` can be added to the command.
+Otherwise, the server will perform inference using the CPU (slower).
+
+The default local server address is `0.0.0.0`.
+
+Run the test:
+```
+cmsRun imageTest.py maxEvents=1
+```

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -41,7 +41,7 @@ public:
     //check the results
     findTopN(iOutput);
   }
-  ~TritonImageProducer() override {}
+  ~TritonImageProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -80,9 +80,9 @@ private:
   std::vector<std::string> imageList_;
 };
 
-typedef TritonImageProducer<TritonClientSync> TritonImageProducerSync;
-typedef TritonImageProducer<TritonClientAsync> TritonImageProducerAsync;
-typedef TritonImageProducer<TritonClientPseudoAsync> TritonImageProducerPseudoAsync;
+using TritonImageProducerSync = TritonImageProducer<TritonClientSync>;
+using TritonImageProducerAsync = TritonImageProducer<TritonClientAsync>;
+using TritonImageProducerPseudoAsync = TritonImageProducer<TritonClientPseudoAsync>;
 
 DEFINE_FWK_MODULE(TritonImageProducerSync);
 DEFINE_FWK_MODULE(TritonImageProducerAsync);

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -12,75 +12,72 @@
 #include <map>
 
 template <typename Client>
-class TritonImageProducer : public SonicEDProducer<Client>
-{
-	public:
-		//needed because base class has dependent scope
-		using typename SonicEDProducer<Client>::Input;
-		using typename SonicEDProducer<Client>::Output;
-		explicit TritonImageProducer(edm::ParameterSet const& cfg) :
-			SonicEDProducer<Client>(cfg),
-			topN_(cfg.getParameter<unsigned>("topN"))
-		{
-			//for debugging
-			this->setDebugName("TritonImageProducer");
-			//load score list
-			std::string imageListFile(cfg.getParameter<std::string>("imageList"));
-			std::ifstream ifile(imageListFile);
-			if(ifile.is_open()){
-				std::string line;
-				while(std::getline(ifile,line)){
-					imageList_.push_back(line);
-				}
-			}
-			else {
-				throw cms::Exception("MissingFile") << "Could not open image list file: " << imageListFile;
-			}
-		}
-		void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
-			// create an npix x npix x ncol image w/ arbitrary color value
-			iInput.resize(client_.nInput()*client_.batchSize(),0.5f);
-		}
-		void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
-			//check the results
-			findTopN(iOutput);
-		}
-		~TritonImageProducer() override {}
+class TritonImageProducer : public SonicEDProducer<Client> {
+public:
+  //needed because base class has dependent scope
+  using typename SonicEDProducer<Client>::Input;
+  using typename SonicEDProducer<Client>::Output;
+  explicit TritonImageProducer(edm::ParameterSet const& cfg)
+      : SonicEDProducer<Client>(cfg), topN_(cfg.getParameter<unsigned>("topN")) {
+    //for debugging
+    this->setDebugName("TritonImageProducer");
+    //load score list
+    std::string imageListFile(cfg.getParameter<std::string>("imageList"));
+    std::ifstream ifile(imageListFile);
+    if (ifile.is_open()) {
+      std::string line;
+      while (std::getline(ifile, line)) {
+        imageList_.push_back(line);
+      }
+    } else {
+      throw cms::Exception("MissingFile") << "Could not open image list file: " << imageListFile;
+    }
+  }
+  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
+    // create an npix x npix x ncol image w/ arbitrary color value
+    iInput.resize(client_.nInput() * client_.batchSize(), 0.5f);
+  }
+  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
+    //check the results
+    findTopN(iOutput);
+  }
+  ~TritonImageProducer() override {}
 
-		static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-			edm::ParameterSetDescription desc;
-			Client::fillPSetDescription(desc);
-			desc.add<unsigned>("topN",5);
-			desc.add<std::string>("imageList");
-			//to ensure distinct cfi names
-			descriptions.addWithDefaultLabel(desc);
-		}
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    Client::fillPSetDescription(desc);
+    desc.add<unsigned>("topN", 5);
+    desc.add<std::string>("imageList");
+    //to ensure distinct cfi names
+    descriptions.addWithDefaultLabel(desc);
+  }
 
-	private:
-		using SonicEDProducer<Client>::client_;
-		void findTopN(const std::vector<float>& scores, unsigned n=5) const {
-			auto dim = client_.nOutput();
-			for(unsigned i0 = 0; i0 < client_.batchSize(); i0++) {
-				//match score to type by index, then put in largest-first map
-				std::map<float,std::string,std::greater<float>> score_map;
-				for(unsigned i = 0; i < std::min((unsigned)dim,(unsigned)imageList_.size()); ++i){
-					score_map.emplace(scores[i0*dim+i],imageList_[i]);
-				}
-				//get top n
-				std::stringstream msg;
-				msg << "Scores for jet " << i0 << ":\n";
-				unsigned counter = 0;
-				for(const auto& item: score_map){
-					msg << item.second << " : " << item.first << "\n";
-					++counter;
-					if(counter>=topN_) break;
-				}
-				edm::LogInfo(client_.debugName()) << msg.str();
-			}
-		}
+private:
+  using SonicEDProducer<Client>::client_;
+  void findTopN(const std::vector<float>& scores, unsigned n = 5) const {
+    auto dim = client_.nOutput();
+    for (unsigned i0 = 0; i0 < client_.batchSize(); i0++) {
+      //match score to type by index, then put in largest-first map
+      std::map<float, std::string, std::greater<float>> score_map;
+      for (unsigned i = 0; i < std::min((unsigned)dim, (unsigned)imageList_.size()); ++i) {
+        score_map.emplace(scores[i0 * dim + i], imageList_[i]);
+      }
+      //get top n
+      std::stringstream msg;
+      msg << "Scores for jet " << i0 << ":\n";
+      unsigned counter = 0;
+      for (const auto& item : score_map) {
+        msg << item.second << " : " << item.first << "\n";
+        ++counter;
+        if (counter >= topN_)
+          break;
+      }
+      edm::LogInfo(client_.debugName()) << msg.str();
+    }
+  }
 
-		unsigned topN_;
-		std::vector<std::string> imageList_;
+  unsigned topN_;
+  std::vector<std::string> imageList_;
 };
 
 typedef TritonImageProducer<TritonClientSync> TritonImageProducerSync;

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -1,0 +1,92 @@
+#include "HeterogeneousCore/SonicCore/interface/SonicEDProducer.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <sstream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <map>
+
+template <typename Client>
+class TritonImageProducer : public SonicEDProducer<Client>
+{
+	public:
+		//needed because base class has dependent scope
+		using typename SonicEDProducer<Client>::Input;
+		using typename SonicEDProducer<Client>::Output;
+		explicit TritonImageProducer(edm::ParameterSet const& cfg) :
+			SonicEDProducer<Client>(cfg),
+			topN_(cfg.getParameter<unsigned>("topN"))
+		{
+			//for debugging
+			this->setDebugName("TritonImageProducer");
+			//load score list
+			std::string imageListFile(cfg.getParameter<std::string>("imageList"));
+			std::ifstream ifile(imageListFile);
+			if(ifile.is_open()){
+				std::string line;
+				while(std::getline(ifile,line)){
+					imageList_.push_back(line);
+				}
+			}
+			else {
+				throw cms::Exception("MissingFile") << "Could not open image list file: " << imageListFile;
+			}
+		}
+		void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
+			// create an npix x npix x ncol image w/ arbitrary color value
+			iInput.resize(client_.nInput()*client_.batchSize(),0.5f);
+		}
+		void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
+			//check the results
+			findTopN(iOutput);
+		}
+		~TritonImageProducer() override {}
+
+		static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+			edm::ParameterSetDescription desc;
+			Client::fillPSetDescription(desc);
+			desc.add<unsigned>("topN",5);
+			desc.add<std::string>("imageList");
+			//to ensure distinct cfi names
+			descriptions.addWithDefaultLabel(desc);
+		}
+
+	private:
+		using SonicEDProducer<Client>::client_;
+		void findTopN(const std::vector<float>& scores, unsigned n=5) const {
+			auto dim = client_.nOutput();
+			for(unsigned i0 = 0; i0 < client_.batchSize(); i0++) {
+				//match score to type by index, then put in largest-first map
+				std::map<float,std::string,std::greater<float>> score_map;
+				for(unsigned i = 0; i < std::min((unsigned)dim,(unsigned)imageList_.size()); ++i){
+					score_map.emplace(scores[i0*dim+i],imageList_[i]);
+				}
+				//get top n
+				std::stringstream msg;
+				msg << "Scores for jet " << i0 << ":\n";
+				unsigned counter = 0;
+				for(const auto& item: score_map){
+					msg << item.second << " : " << item.first << "\n";
+					++counter;
+					if(counter>=topN_) break;
+				}
+				edm::LogInfo(client_.debugName()) << msg.str();
+			}
+		}
+
+		unsigned topN_;
+		std::vector<std::string> imageList_;
+};
+
+typedef TritonImageProducer<TritonClientSync> TritonImageProducerSync;
+typedef TritonImageProducer<TritonClientAsync> TritonImageProducerAsync;
+typedef TritonImageProducer<TritonClientPseudoAsync> TritonImageProducerPseudoAsync;
+
+DEFINE_FWK_MODULE(TritonImageProducerSync);
+DEFINE_FWK_MODULE(TritonImageProducerAsync);
+DEFINE_FWK_MODULE(TritonImageProducerPseudoAsync);

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -64,7 +64,7 @@ private:
       }
       //get top n
       std::stringstream msg;
-      msg << "Scores for jet " << i0 << ":\n";
+      msg << "Scores for image " << i0 << ":\n";
       unsigned counter = 0;
       for (const auto& item : score_map) {
         msg << item.second << " : " << item.first << "\n";

--- a/HeterogeneousCore/SonicTriton/test/fetch_model.sh
+++ b/HeterogeneousCore/SonicTriton/test/fetch_model.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# borrowed from https://github.com/NVIDIA/triton-inference-server/tree/master/docs/examples
+
+TRITON_VERSION=$(scram tool info triton-inference-server | grep "Version : " | cut -d' ' -f3)
+
+MODEL_DIR=../data/models/resnet50_netdef
+mkdir -p $MODEL_DIR
+cd $MODEL_DIR
+
+wget https://github.com/NVIDIA/triton-inference-server/raw/v${TRITON_VERSION}/docs/examples/model_repository/resnet50_netdef/config.pbtxt
+wget https://github.com/NVIDIA/triton-inference-server/raw/v${TRITON_VERSION}/docs/examples/model_repository/resnet50_netdef/resnet50_labels.txt
+
+mkdir -p 1
+
+wget -O 1/model.netdef http://download.caffe2.ai.s3.amazonaws.com/models/resnet50/predict_net.pb
+wget -O 1/init_model.netdef http://download.caffe2.ai.s3.amazonaws.com/models/resnet50/init_net.pb

--- a/HeterogeneousCore/SonicTriton/test/imageTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/imageTest_cfg.py
@@ -70,6 +70,6 @@ for msg in keep_msgs:
     )
 
 if options.threads>0:
-    if not hasattr(process,"options"): process.options = cms.untracked.PSet()
-    process.options.numberOfThreads = cms.untracked.uint32(options.threads)
-    process.options.numberOfStreams = cms.untracked.uint32(options.streams if options.streams>0 else 0)
+    process.options.numberOfThreads = options.threads
+    process.options.numberOfStreams = options.streams
+

--- a/HeterogeneousCore/SonicTriton/test/imageTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/imageTest_cfg.py
@@ -37,15 +37,10 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxE
 
 process.source = cms.Source("EmptySource")
 
-# enforce consistent input size
-_ncol = 3
-_npix = 224
 process.TritonImageProducer = cms.EDProducer(allowed_modes[options.mode],
     topN = cms.uint32(5),
     imageList = cms.string("../data/models/resnet50_netdef/resnet50_labels.txt"),
     Client = cms.PSet(
-        nInput  = cms.uint32(_npix*_npix*_ncol),
-        nOutput = cms.uint32(1000),
         batchSize = cms.untracked.uint32(options.batchSize),
         address = cms.untracked.string(options.address),
         port = cms.untracked.uint32(options.port),
@@ -64,7 +59,7 @@ process.p = cms.Path(
 
 process.load('FWCore/MessageService/MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 500
-keep_msgs = ['TritonImageProducer','TritonImageProducer:TritonClient']
+keep_msgs = ['TritonImageProducer','TritonImageProducer:TritonClient','TritonClient']
 for msg in keep_msgs:
     process.MessageLogger.categories.append(msg)
     setattr(process.MessageLogger.cerr,msg,

--- a/HeterogeneousCore/SonicTriton/test/imageTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/imageTest_cfg.py
@@ -1,0 +1,80 @@
+from FWCore.ParameterSet.VarParsing import VarParsing
+import FWCore.ParameterSet.Config as cms
+import os, sys, json
+
+options = VarParsing("analysis")
+options.register("address", "0.0.0.0", VarParsing.multiplicity.singleton, VarParsing.varType.string)
+options.register("port", 8001, VarParsing.multiplicity.singleton, VarParsing.varType.int)
+options.register("timeout", 30, VarParsing.multiplicity.singleton, VarParsing.varType.int)
+options.register("params", "", VarParsing.multiplicity.singleton, VarParsing.varType.string)
+options.register("threads", 1, VarParsing.multiplicity.singleton, VarParsing.varType.int)
+options.register("streams", 0, VarParsing.multiplicity.singleton, VarParsing.varType.int)
+options.register("batchSize", 1, VarParsing.multiplicity.singleton, VarParsing.varType.int)
+options.register("modelName","resnet50_netdef", VarParsing.multiplicity.singleton, VarParsing.varType.string)
+options.register("mode","PseudoAsync", VarParsing.multiplicity.singleton, VarParsing.varType.string)
+options.register("verbose", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.parseArguments()
+
+if len(options.params)>0:
+    with open(options.params,'r') as pfile:
+        pdict = json.load(pfile)
+    options.address = pdict["address"]
+    options.port = int(pdict["port"])
+    print("server = "+options.address+":"+str(options.port))
+
+# check mode
+allowed_modes = {
+    "Async": "TritonImageProducerAsync",
+    "Sync": "TritonImageProducerSync",
+    "PseudoAsync": "TritonImageProducerPseudoAsync",
+}
+if options.mode not in allowed_modes:
+    raise ValueError("Unknown mode: "+options.mode)
+
+process = cms.Process('imageTest')
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
+
+process.source = cms.Source("EmptySource")
+
+# enforce consistent input size
+_ncol = 3
+_npix = 224
+process.TritonImageProducer = cms.EDProducer(allowed_modes[options.mode],
+    topN = cms.uint32(5),
+    imageList = cms.string("../data/models/resnet50_netdef/resnet50_labels.txt"),
+    Client = cms.PSet(
+        nInput  = cms.uint32(_npix*_npix*_ncol),
+        nOutput = cms.uint32(1000),
+        batchSize = cms.untracked.uint32(options.batchSize),
+        address = cms.untracked.string(options.address),
+        port = cms.untracked.uint32(options.port),
+        timeout = cms.untracked.uint32(options.timeout),
+        modelName = cms.string("resnet50_netdef"),
+        modelVersion = cms.int32(-1),
+        verbose = cms.untracked.bool(options.verbose),
+        allowedTries = cms.untracked.uint32(0),
+    )
+)
+
+# Let it run
+process.p = cms.Path(
+    process.TritonImageProducer
+)
+
+process.load('FWCore/MessageService/MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 500
+keep_msgs = ['TritonImageProducer','TritonImageProducer:TritonClient']
+for msg in keep_msgs:
+    process.MessageLogger.categories.append(msg)
+    setattr(process.MessageLogger.cerr,msg,
+        cms.untracked.PSet(
+            optionalPSet = cms.untracked.bool(True),
+            limit = cms.untracked.int32(10000000),
+        )
+    )
+
+if options.threads>0:
+    if not hasattr(process,"options"): process.options = cms.untracked.PSet()
+    process.options.numberOfThreads = cms.untracked.uint32(options.threads)
+    process.options.numberOfStreams = cms.untracked.uint32(options.streams if options.streams>0 else 0)


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmsdist/pull/5868 added triton-inference-server as a CMSSW external. This PR adds the corresponding Sonic client to communicate with Triton servers (following up on #29141 and #29503).

Details:

Triton commands may return an `Error` object. These objects are wrapped and converted into warnings (if the command was not successful). In addition, an unsuccessful command causes the current evaluation to stop (execution will also stop if retries are not allowed).

Optionally, additional reporting from the server side can be enabled using the `verbosity` flag.

The client can select different models on the server by name and version number. The model information (input and output dimensions and sizes) is automatically obtained from the server and can be printed using the `verbosity` flag. Multiple inferences can be done at once by setting the `batchSize` and concatenating all of the input data. (`batchSize` can be changed on a per-event basis if desired.)

A forthcoming PR will add functionality to transmit fixed-point data to a custom FPGA server that recognizes Triton calls. (Currently, models with multiple named inputs and/or outputs and models with variable-size dimensions are not supported. This support will be added in the future if and when relevant examples are available.)

#### PR validation:

Ran the `TritonImageProducer` using the Docker test setup. Tested both success and failure conditions, and observed desired behavior and output.

attn: @violatingcp @drankincms @nhanvtran @jeffkrupa @jmduarte @lgray 