### PR TITLE
Reduce boost in CalibTracker/SiStripLorentzAngle

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
@@ -7,6 +7,7 @@
 #include <TFile.h>
 #include <boost/lexical_cast.hpp>
 #include <fstream>
+#include <regex>
 
 namespace sistrip {
 
@@ -62,12 +63,12 @@ namespace sistrip {
       std::string label;
       {
         std::cout << ensemble.first << std::endl;
-        boost::regex format(".*(T[IO]B)_layer(\\d)([as])_(.*)");
-        if (boost::regex_match(ensemble.first, format)) {
-          const bool TIB = "TIB" == boost::regex_replace(ensemble.first, format, "\\1");
-          const bool stereo = "s" == boost::regex_replace(ensemble.first, format, "\\3");
-          const unsigned layer = boost::lexical_cast<unsigned>(boost::regex_replace(ensemble.first, format, "\\2"));
-          label = boost::regex_replace(ensemble.first, format, "\\4");
+        std::regex format(".*(T[IO]B)_layer(\\d)([as])_(.*)");
+        if (std::regex_match(ensemble.first, format)) {
+          const bool TIB = "TIB" == std::regex_replace(ensemble.first, format, "\\1");
+          const bool stereo = "s" == std::regex_replace(ensemble.first, format, "\\3");
+          const unsigned layer = boost::lexical_cast<unsigned>(std::regex_replace(ensemble.first, format, "\\2"));
+          label = std::regex_replace(ensemble.first, format, "\\4");
           index = LA_Filler_Fitter::layer_index(TIB, stereo, layer);
 
           calibrations[label].slopes[index] = line.second.first;

--- a/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
@@ -6,6 +6,7 @@
 #include <boost/lexical_cast.hpp>
 #include <TChain.h>
 #include <TFile.h>
+#include <regex>
 
 namespace sistrip {
 
@@ -70,7 +71,7 @@ namespace sistrip {
         calibrate(calibration_key(result.first, method), result.second);
         std::string label =
             laff.layerLabel(result.first) + granularity(MODULESUMMARY) + LA_Filler_Fitter::method(method);
-        label = boost::regex_replace(label, boost::regex("layer"), "");
+        label = std::regex_replace(label, std::regex("layer"), "");
 
         const double mu_H = -result.second.calMeasured.first / result.second.field;
         const double sigma_mu_H = result.second.calMeasured.second / result.second.field;
@@ -179,10 +180,10 @@ namespace sistrip {
 
   std::pair<uint32_t, LA_Filler_Fitter::Method> MeasureLA::calibration_key(
       const std::string layer, const LA_Filler_Fitter::Method method) const {
-    boost::regex format(".*(T[IO]B)_layer(\\d)([as]).*");
-    const bool isTIB = "TIB" == boost::regex_replace(layer, format, "\\1");
-    const bool stereo = "s" == boost::regex_replace(layer, format, "\\3");
-    const unsigned layerNum = boost::lexical_cast<unsigned>(boost::regex_replace(layer, format, "\\2"));
+    std::regex format(".*(T[IO]B)_layer(\\d)([as]).*");
+    const bool isTIB = "TIB" == std::regex_replace(layer, format, "\\1");
+    const bool stereo = "s" == std::regex_replace(layer, format, "\\3");
+    const unsigned layerNum = boost::lexical_cast<unsigned>(std::regex_replace(layer, format, "\\2"));
     return std::make_pair(LA_Filler_Fitter::layer_index(isTIB, stereo, layerNum), method);
   }
 

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
@@ -3,7 +3,6 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include <cmath>
-#include <boost/lexical_cast.hpp>
 
 void LA_Filler_Fitter::fill(TTree* tree, Book& book) const {
   TTREE_FOREACH_ENTRY(tree) {

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <cmath>
-#include <boost/regex.hpp>
+#include <regex>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/erase.hpp>
 #include <TF1.h>
@@ -62,7 +62,7 @@ std::map<uint32_t, LA_Filler_Fitter::Result> LA_Filler_Fitter::module_results(co
   std::map<uint32_t, Result> results;
   for (Book::const_iterator it = book.begin(".*_module\\d*" + method(m)); it != book.end(); ++it) {
     const uint32_t detid = boost::lexical_cast<uint32_t>(
-        boost::regex_replace(it->first, boost::regex(".*_module(\\d*)_.*"), std::string("\\1")));
+        std::regex_replace(it->first, std::regex(".*_module(\\d*)_.*"), std::string("\\1")));
     results[detid] = result(m, it->first, book);
   }
   return results;
@@ -81,7 +81,7 @@ std::map<std::string, std::vector<LA_Filler_Fitter::Result> > LA_Filler_Fitter::
                                                                                                  const Method m) {
   std::map<std::string, std::vector<Result> > results;
   for (Book::const_iterator it = book.begin(".*_sample.*" + method(m)); it != book.end(); ++it) {
-    const std::string name = boost::regex_replace(it->first, boost::regex("sample\\d*_"), "");
+    const std::string name = std::regex_replace(it->first, std::regex("sample\\d*_"), "");
     results[name].push_back(result(m, it->first, book));
   }
   return results;
@@ -136,7 +136,7 @@ std::map<std::string, std::vector<LA_Filler_Fitter::EnsembleSummary> > LA_Filler
     s.pull = std::make_pair<float, float>(pull->GetFunction("gaus")->GetParameter(2),
                                           pull->GetFunction("gaus")->GetParError(2));
 
-    const std::string name = boost::regex_replace(base, boost::regex("ensembleBin\\d*_"), "");
+    const std::string name = std::regex_replace(base, std::regex("ensembleBin\\d*_"), "");
     summary[name].push_back(s);
   }
   return summary;


### PR DESCRIPTION
#### PR description:
Replaced boost::regex for std::regex, they should have similar behaviour.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 