### PR TITLE
DQM: Allow end lumi work in DQMOneEDAnalyzer

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -36,6 +36,7 @@ protected:
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
   std::shared_ptr<std::vector<int>> globalBeginLuminosityBlock(const edm::LuminosityBlock &iLumi,
                                                                const edm::EventSetup &c) const override;
+  void globalEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &c) override{};
   void dqmEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &c) override;
 
   void analyzeCTPPSRecord(edm::Event const &event, edm::EventSetup const &eventSetup);

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -36,7 +36,7 @@ protected:
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
   std::shared_ptr<std::vector<int>> globalBeginLuminosityBlock(const edm::LuminosityBlock &iLumi,
                                                                const edm::EventSetup &c) const override;
-  void globalEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &c) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &c) override;
 
   void analyzeCTPPSRecord(edm::Event const &event, edm::EventSetup const &eventSetup);
   void analyzeTracks(edm::Event const &event, edm::EventSetup const &eventSetup);
@@ -537,7 +537,7 @@ std::shared_ptr<std::vector<int>> CTPPSCommonDQMSource::globalBeginLuminosityBlo
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSCommonDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &c) {
+void CTPPSCommonDQMSource::dqmEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &c) {
   auto const &rpstate = *luminosityBlockCache(iLumi.index());
   auto currentLS = iLumi.id().luminosityBlock();
   for (std::vector<int>::size_type i = 0; i < rpstate.size(); i++)

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -76,6 +76,7 @@ protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   std::shared_ptr<dds::Cache> globalBeginLuminosityBlock(const edm::LuminosityBlock&,
                                                          const edm::EventSetup&) const override;
+  void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override{};
   void dqmEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
 private:

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -76,7 +76,7 @@ protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   std::shared_ptr<dds::Cache> globalBeginLuminosityBlock(const edm::LuminosityBlock&,
                                                          const edm::EventSetup&) const override;
-  void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
 private:
   // Constants
@@ -1126,7 +1126,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSDiamondDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup&) {
+void CTPPSDiamondDQMSource::dqmEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup&) {
   auto lumiCache = luminosityBlockCache(iLumi.index());
   for (auto& plot : potPlots_) {
     *(plot.second.hitDistribution2d_lumisection->getTH2F()) = *(lumiCache->hitDistribution2dMap[plot.first]);

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -57,6 +57,7 @@ protected:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   std::shared_ptr<totemds::Cache> globalBeginLuminosityBlock(const edm::LuminosityBlock &,
                                                              const edm::EventSetup &) const override;
+  void globalEndLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override{};
   void dqmEndLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
 
 private:

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -57,7 +57,7 @@ protected:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   std::shared_ptr<totemds::Cache> globalBeginLuminosityBlock(const edm::LuminosityBlock &,
                                                              const edm::EventSetup &) const override;
-  void globalEndLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
 
 private:
   // Constants
@@ -734,7 +734,7 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemTimingDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &) {
+void TotemTimingDQMSource::dqmEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &) {
   auto lumiCache = luminosityBlockCache(iLumi.index());
   for (auto &plot : potPlots_) {
     *(plot.second.hitDistribution2d_lumisection->getTH2F()) = *(lumiCache->hitDistribution2dMap[plot.first]);

--- a/DQM/HcalCommon/interface/DQTask.h
+++ b/DQM/HcalCommon/interface/DQTask.h
@@ -42,6 +42,7 @@ namespace hcaldqm {
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                                edm::EventSetup const &) const override;
+    void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override{};
     void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
   protected:

--- a/DQM/HcalCommon/interface/DQTask.h
+++ b/DQM/HcalCommon/interface/DQTask.h
@@ -42,7 +42,7 @@ namespace hcaldqm {
     void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
     std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                                edm::EventSetup const &) const override;
-    void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+    void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
   protected:
     // protected funcs

--- a/DQM/HcalCommon/src/DQTask.cc
+++ b/DQM/HcalCommon/src/DQTask.cc
@@ -129,7 +129,7 @@ namespace hcaldqm {
     return d;
   }
 
-  void DQTask::globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) { _procLSs++; }
+  void DQTask::dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) { _procLSs++; }
 
   void DQTask::_resetMonitors(UpdateFreq uf) {
     //	reset per event

--- a/DQM/HcalTasks/interface/DigiComparisonTask.h
+++ b/DQM/HcalTasks/interface/DigiComparisonTask.h
@@ -22,7 +22,7 @@ public:
   ~DigiComparisonTask() override {}
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 protected:
   //	funcs

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -34,7 +34,7 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                              edm::EventSetup const &) const override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -35,7 +35,7 @@ public:
         this->_dump();
     }
   }
-  void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 protected:
   //	funcs

--- a/DQM/HcalTasks/interface/NoCQTask.h
+++ b/DQM/HcalTasks/interface/NoCQTask.h
@@ -22,7 +22,7 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                              edm::EventSetup const &) const override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;

--- a/DQM/HcalTasks/interface/PedestalTask.h
+++ b/DQM/HcalTasks/interface/PedestalTask.h
@@ -26,7 +26,7 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                              edm::EventSetup const &) const override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
   void dqmEndRun(edm::Run const &, edm::EventSetup const &) override;
 
 protected:

--- a/DQM/HcalTasks/interface/QIE10Task.h
+++ b/DQM/HcalTasks/interface/QIE10Task.h
@@ -25,7 +25,7 @@ public:
   ~QIE10Task() override {}
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 protected:
   void _process(edm::Event const&, edm::EventSetup const&) override;

--- a/DQM/HcalTasks/interface/QIE11Task.h
+++ b/DQM/HcalTasks/interface/QIE11Task.h
@@ -25,7 +25,7 @@ public:
   ~QIE11Task() override {}
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 protected:
   void _process(edm::Event const&, edm::EventSetup const&) override;

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -29,7 +29,7 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                              edm::EventSetup const &) const override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;

--- a/DQM/HcalTasks/interface/RecHitTask.h
+++ b/DQM/HcalTasks/interface/RecHitTask.h
@@ -31,7 +31,7 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                              edm::EventSetup const &) const override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;

--- a/DQM/HcalTasks/interface/TPComparisonTask.h
+++ b/DQM/HcalTasks/interface/TPComparisonTask.h
@@ -23,7 +23,7 @@ public:
   ~TPComparisonTask() override {}
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 protected:
   //	funcs

--- a/DQM/HcalTasks/interface/TPTask.h
+++ b/DQM/HcalTasks/interface/TPTask.h
@@ -27,7 +27,7 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                              edm::EventSetup const &) const override;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;

--- a/DQM/HcalTasks/interface/UMNioTask.h
+++ b/DQM/HcalTasks/interface/UMNioTask.h
@@ -32,7 +32,7 @@ public:
         return;
     }
   }
-  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 protected:
   //	funcs

--- a/DQM/HcalTasks/plugins/DigiComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/DigiComparisonTask.cc
@@ -211,10 +211,10 @@ DigiComparisonTask::DigiComparisonTask(edm::ParameterSet const& ps) : DQTask(ps)
   }
 }
 
-/* virtual */ void DigiComparisonTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb,
+/* virtual */ void DigiComparisonTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb,
                                                                 edm::EventSetup const& es) {
   //	in the end always
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(DigiComparisonTask);

--- a/DQM/HcalTasks/plugins/DigiComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/DigiComparisonTask.cc
@@ -212,7 +212,7 @@ DigiComparisonTask::DigiComparisonTask(edm::ParameterSet const& ps) : DQTask(ps)
 }
 
 /* virtual */ void DigiComparisonTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb,
-                                                                edm::EventSetup const& es) {
+                                                             edm::EventSetup const& es) {
   //	in the end always
   DQTask::dqmEndLuminosityBlock(lb, es);
 }

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -1418,7 +1418,7 @@ std::shared_ptr<hcaldqm::Cache> DigiTask::globalBeginLuminosityBlock(edm::Lumino
   return DQTask::globalBeginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void DigiTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+/* virtual */ void DigiTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   auto lumiCache = luminosityBlockCache(lb.index());
   _currentLS = lumiCache->currentLS;
   _evsPerLS = lumiCache->EvtCntLS;
@@ -1540,7 +1540,7 @@ std::shared_ptr<hcaldqm::Cache> DigiTask::globalBeginLuminosityBlock(edm::Lumino
   _xBadCapid.reset();
 
   //	in the end always do the DQTask::endLumi
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(DigiTask);

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -800,7 +800,7 @@ void LaserTask::processLaserMon(edm::Handle<QIE10DigiCollection>& col, std::vect
   }
 }
 
-/* virtual */ void LaserTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+/* virtual */ void LaserTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   auto lumiCache = luminosityBlockCache(lb.index());
   _currentLS = lumiCache->currentLS;
 
@@ -808,7 +808,7 @@ void LaserTask::processLaserMon(edm::Handle<QIE10DigiCollection>& col, std::vect
     return;
   this->_dump();
 
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 /* virtual */ bool LaserTask::_isApplicable(edm::Event const& e) {

--- a/DQM/HcalTasks/plugins/NoCQTask.cc
+++ b/DQM/HcalTasks/plugins/NoCQTask.cc
@@ -130,8 +130,8 @@ std::shared_ptr<hcaldqm::Cache> NoCQTask::globalBeginLuminosityBlock(edm::Lumino
   return DQTask::globalBeginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void NoCQTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
-  DQTask::globalEndLuminosityBlock(lb, es);
+/* virtual */ void NoCQTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(NoCQTask);

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -937,7 +937,7 @@ std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::Lu
     return;
 }
 
-/* virtual */ void PedestalTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+/* virtual */ void PedestalTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   auto lumiCache = luminosityBlockCache(lb.index());
   _currentLS = lumiCache->currentLS;
   _xQuality.reset();
@@ -947,7 +947,7 @@ std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::Lu
     return;
   this->_dump();
 
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 /* virtual */ void PedestalTask::_process(edm::Event const& e, edm::EventSetup const& es) {

--- a/DQM/HcalTasks/plugins/QIE10Task.cc
+++ b/DQM/HcalTasks/plugins/QIE10Task.cc
@@ -154,9 +154,9 @@ QIE10Task::QIE10Task(edm::ParameterSet const& ps) : DQTask(ps) {
   _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
 }
 
-/* virtual */ void QIE10Task::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+/* virtual */ void QIE10Task::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   //	finish
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 /* virtual */ void QIE10Task::_process(edm::Event const& e, edm::EventSetup const&) {

--- a/DQM/HcalTasks/plugins/QIE11Task.cc
+++ b/DQM/HcalTasks/plugins/QIE11Task.cc
@@ -159,9 +159,9 @@ QIE11Task::QIE11Task(edm::ParameterSet const& ps) : DQTask(ps) {
   _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap, _filter_C34);
 }
 
-/* virtual */ void QIE11Task::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+/* virtual */ void QIE11Task::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   //	finish
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 /* virtual */ void QIE11Task::_process(edm::Event const& e, edm::EventSetup const&) {

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -421,7 +421,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
   //	_cSummaryvsLS.extendAxisRange(_currentLS);
 }
 
-/* virtual */ void RawTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+/* virtual */ void RawTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   auto lumiCache = luminosityBlockCache(lb.index());
   _currentLS = lumiCache->currentLS;
   _evsPerLS = lumiCache->EvtCntLS;
@@ -490,7 +490,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
   _xBadQLS.reset();
 
   //	in the end always do the DQTask::endLumi
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(RawTask);

--- a/DQM/HcalTasks/plugins/RecHitTask.cc
+++ b/DQM/HcalTasks/plugins/RecHitTask.cc
@@ -868,7 +868,7 @@ std::shared_ptr<hcaldqm::Cache> RecHitTask::globalBeginLuminosityBlock(edm::Lumi
   return DQTask::globalBeginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void RecHitTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+/* virtual */ void RecHitTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   if (_ptype != fOnline)
     return;
 
@@ -941,7 +941,7 @@ std::shared_ptr<hcaldqm::Cache> RecHitTask::globalBeginLuminosityBlock(edm::Lumi
   }
 
   //	in the end always do the DQTask::endLumi
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(RecHitTask);

--- a/DQM/HcalTasks/plugins/TPComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/TPComparisonTask.cc
@@ -245,10 +245,10 @@ TPComparisonTask::TPComparisonTask(edm::ParameterSet const& ps) : DQTask(ps) {
   }
 }
 
-/* virtual */ void TPComparisonTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb,
+/* virtual */ void TPComparisonTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb,
                                                               edm::EventSetup const& es) {
   //	in the end always
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(TPComparisonTask);

--- a/DQM/HcalTasks/plugins/TPComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/TPComparisonTask.cc
@@ -245,8 +245,7 @@ TPComparisonTask::TPComparisonTask(edm::ParameterSet const& ps) : DQTask(ps) {
   }
 }
 
-/* virtual */ void TPComparisonTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb,
-                                                              edm::EventSetup const& es) {
+/* virtual */ void TPComparisonTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   //	in the end always
   DQTask::dqmEndLuminosityBlock(lb, es);
 }

--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -1195,7 +1195,7 @@ std::shared_ptr<hcaldqm::Cache> TPTask::globalBeginLuminosityBlock(edm::Luminosi
   return DQTask::globalBeginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void TPTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+/* virtual */ void TPTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   if (_ptype != fOnline)
     return;
 
@@ -1285,7 +1285,7 @@ std::shared_ptr<hcaldqm::Cache> TPTask::globalBeginLuminosityBlock(edm::Luminosi
   _xEmulTotal.reset();
 
   //	in the end always do the DQTask::endLumi
-  DQTask::globalEndLuminosityBlock(lb, es);
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(TPTask);

--- a/DQM/HcalTasks/plugins/UMNioTask.cc
+++ b/DQM/HcalTasks/plugins/UMNioTask.cc
@@ -131,8 +131,8 @@ int UMNioTask::getOrbitGapIndex(uint8_t eventType, uint32_t laserType) {
     _cTotalChargeProfile.fill(it->id(), _currentLS, sumQ);
   }
 }
-/* virtual */ void UMNioTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
-  DQTask::globalEndLuminosityBlock(lb, es);
+/* virtual */ void UMNioTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::dqmEndLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(UMNioTask);

--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -62,6 +62,7 @@ protected:
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) override;
   std::shared_ptr<l1tderct::Empty> globalBeginLuminosityBlock(const edm::LuminosityBlock&,
                                                               const edm::EventSetup&) const override;
+  void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final {}
   void dqmEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final {}
   void readFEDVector(MonitorElement*, const edm::EventSetup&) const;
 

--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -62,7 +62,7 @@ protected:
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) override;
   std::shared_ptr<l1tderct::Empty> globalBeginLuminosityBlock(const edm::LuminosityBlock&,
                                                               const edm::EventSetup&) const override;
-  void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final {}
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final {}
   void readFEDVector(MonitorElement*, const edm::EventSetup&) const;
 
 private:

--- a/DQM/Physics/src/QcdLowPtDQM.cc
+++ b/DQM/Physics/src/QcdLowPtDQM.cc
@@ -918,7 +918,7 @@ std::shared_ptr<qlpd::Cache> QcdLowPtDQM::globalBeginLuminosityBlock(const Lumin
   return std::shared_ptr<qlpd::Cache>();
 }
 
-void QcdLowPtDQM::globalEndLuminosityBlock(const LuminosityBlock &l, const EventSetup &iSetup) {
+void QcdLowPtDQM::dqmEndLuminosityBlock(const LuminosityBlock &l, const EventSetup &iSetup) {
   // Update various histograms.
   repSummary_->Fill(1.);
   repSumMap_->Fill(0.5, 0.5, 1.);

--- a/DQM/Physics/src/QcdLowPtDQM.cc
+++ b/DQM/Physics/src/QcdLowPtDQM.cc
@@ -913,11 +913,6 @@ void QcdLowPtDQM::filldNdeta(const TH3F *AlphaTracklets,
   }
 }
 
-std::shared_ptr<qlpd::Cache> QcdLowPtDQM::globalBeginLuminosityBlock(const LuminosityBlock &,
-                                                                     const EventSetup &) const {
-  return std::shared_ptr<qlpd::Cache>();
-}
-
 void QcdLowPtDQM::dqmEndLuminosityBlock(const LuminosityBlock &l, const EventSetup &iSetup) {
   // Update various histograms.
   repSummary_->Fill(1.);

--- a/DQM/Physics/src/QcdLowPtDQM.h
+++ b/DQM/Physics/src/QcdLowPtDQM.h
@@ -126,7 +126,7 @@ public:
   void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) override;
   std::shared_ptr<qlpd::Cache> globalBeginLuminosityBlock(const edm::LuminosityBlock &,
                                                           const edm::EventSetup &) const override;
-  void globalEndLuminosityBlock(const edm::LuminosityBlock &l, const edm::EventSetup &iSetup) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock &l, const edm::EventSetup &iSetup) override;
   void dqmEndRun(const edm::Run &r, const edm::EventSetup &iSetup) override;
 
 private:

--- a/DQM/Physics/src/QcdLowPtDQM.h
+++ b/DQM/Physics/src/QcdLowPtDQM.h
@@ -19,11 +19,7 @@ class TH1F;
 class TH2F;
 class TH3F;
 
-namespace qlpd {
-  struct Cache {};
-}  // namespace qlpd
-
-class QcdLowPtDQM : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<qlpd::Cache>> {
+class QcdLowPtDQM : public DQMOneEDAnalyzer<> {
 public:
   class Pixel {
   public:
@@ -124,8 +120,6 @@ public:
   void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) override;
-  std::shared_ptr<qlpd::Cache> globalBeginLuminosityBlock(const edm::LuminosityBlock &,
-                                                          const edm::EventSetup &) const override;
   void dqmEndLuminosityBlock(const edm::LuminosityBlock &l, const edm::EventSetup &iSetup) override;
   void dqmEndRun(const edm::Run &r, const edm::EventSetup &iSetup) override;
 

--- a/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
@@ -38,6 +38,7 @@ public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   std::shared_ptr<bool> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
                                                    const edm::EventSetup& iSetup) const override;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override{};
   void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& iSetup) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;

--- a/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
@@ -38,7 +38,7 @@ public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   std::shared_ptr<bool> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
                                                    const edm::EventSetup& iSetup) const override;
-  void globalEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& iSetup) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& iSetup) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
 

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -275,7 +275,7 @@ std::shared_ptr<bool> SiStripMonitorDigi::globalBeginLuminosityBlock(const edm::
 }
 
 //--------------------------------------------------------------------------------------------
-void SiStripMonitorDigi::globalEndLuminosityBlock(const edm::LuminosityBlock& lb, const edm::EventSetup& es) {
+void SiStripMonitorDigi::dqmEndLuminosityBlock(const edm::LuminosityBlock& lb, const edm::EventSetup& es) {
   unsigned int currentLS = lb.id().luminosityBlock();
   const bool isStableBeams = luminosityBlockCache(lb.index());
   if (subdetswitchtotdigifailureon && isStableBeams && !SBTransitionDone) {

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
@@ -518,8 +518,7 @@ std::shared_ptr<sifedmon::LumiErrors> SiStripFEDMonitorPlugin::globalBeginLumino
   return lumiErrors;
 }
 
-void SiStripFEDMonitorPlugin::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumi,
-                                                       const edm::EventSetup& iSetup) {
+void SiStripFEDMonitorPlugin::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& iSetup) {
   auto lumiErrors = luminosityBlockCache(lumi.index());
   if (enableFEDerrLumi_ && lumiErrfac_) {
     for (unsigned int iD(0); iD < lumiErrors->nTotal.size(); iD++) {

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
@@ -77,7 +77,7 @@ private:
   std::shared_ptr<sifedmon::LumiErrors> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
                                                                    const edm::EventSetup& iSetup) const override;
 
-  void globalEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& iSetup) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& iSetup) override;
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
@@ -518,7 +518,7 @@ std::shared_ptr<sifedmon::LumiErrors> SiStripFEDMonitorPlugin::globalBeginLumino
   return lumiErrors;
 }
 
-void SiStripFEDMonitorPlugin::globalEndLuminosityBlock(const edm::LuminosityBlock& lumi,
+void SiStripFEDMonitorPlugin::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumi,
                                                        const edm::EventSetup& iSetup) {
   auto lumiErrors = luminosityBlockCache(lumi.index());
   if (enableFEDerrLumi_ && lumiErrfac_) {

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
@@ -77,6 +77,7 @@ private:
   std::shared_ptr<sifedmon::LumiErrors> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
                                                                    const edm::EventSetup& iSetup) const override;
 
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override{};
   void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& iSetup) override;
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;

--- a/DQM/TrigXMonitor/interface/L1Scalers.h
+++ b/DQM/TrigXMonitor/interface/L1Scalers.h
@@ -13,18 +13,12 @@
 #define MAX_LUMI_SEG 2000
 #define MAX_LUMI_BIN 400
 
-namespace l1s {
-  struct Empty {};
-}  // namespace l1s
-class L1Scalers : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<l1s::Empty>> {
+class L1Scalers : public DQMOneEDAnalyzer<> {
 public:
   L1Scalers(const edm::ParameterSet &ps);
   ~L1Scalers() override{};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-  /// DQM Client Diagnostic should be performed here:
-  std::shared_ptr<l1s::Empty> globalBeginLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
-                                                         const edm::EventSetup &c) const final;
   void dqmEndLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override;
 
 private:

--- a/DQM/TrigXMonitor/interface/L1Scalers.h
+++ b/DQM/TrigXMonitor/interface/L1Scalers.h
@@ -25,7 +25,7 @@ public:
   /// DQM Client Diagnostic should be performed here:
   std::shared_ptr<l1s::Empty> globalBeginLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
                                                          const edm::EventSetup &c) const final;
-  void globalEndLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override;
 
 private:
   int nev_;  // Number of events processed

--- a/DQM/TrigXMonitor/src/L1Scalers.cc
+++ b/DQM/TrigXMonitor/src/L1Scalers.cc
@@ -411,11 +411,6 @@ void L1Scalers::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   return;
 }
 
-std::shared_ptr<l1s::Empty> L1Scalers::globalBeginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-                                                                  const edm::EventSetup& c) const {
-  return std::shared_ptr<l1s::Empty>();
-}
-
 void L1Scalers::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) {
   nLumiBlock_->Fill(lumiSeg.id().luminosityBlock());
 }

--- a/DQM/TrigXMonitor/src/L1Scalers.cc
+++ b/DQM/TrigXMonitor/src/L1Scalers.cc
@@ -416,6 +416,6 @@ std::shared_ptr<l1s::Empty> L1Scalers::globalBeginLuminosityBlock(const edm::Lum
   return std::shared_ptr<l1s::Empty>();
 }
 
-void L1Scalers::globalEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) {
+void L1Scalers::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) {
   nLumiBlock_->Fill(lumiSeg.id().luminosityBlock());
 }

--- a/DQMOffline/L1Trigger/interface/L1TSync_Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TSync_Offline.h
@@ -111,6 +111,7 @@ protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;  // Analyze
   std::shared_ptr<ltso::LSValid> globalBeginLuminosityBlock(edm::LuminosityBlock const& lumiBlock,
                                                             edm::EventSetup const& c) const final;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) final {}
   void dqmEndLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) final {}
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) override;

--- a/DQMOffline/L1Trigger/interface/L1TSync_Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TSync_Offline.h
@@ -111,7 +111,7 @@ protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;  // Analyze
   std::shared_ptr<ltso::LSValid> globalBeginLuminosityBlock(edm::LuminosityBlock const& lumiBlock,
                                                             edm::EventSetup const& c) const final;
-  void globalEndLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) final {}
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) final {}
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) override;
 

--- a/DQMServices/Core/interface/DQMOneEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMOneEDAnalyzer.h
@@ -81,7 +81,8 @@ public:
   // This could safely be used, and might need to be used to get some types of
   // products, but it will *only* be called if subsystem code adds a lumi cache.
   // For consistency, we use endLuminosityBlockProduce and ban this.
-  void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final{};
+  // TODO: for technical reasons, it is quite hard to make this final.
+  //void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final{};
 
   // Subsystems could safely override this, but any changes to MEs would not be
   // noticeable since the product was made already.

--- a/DQMServices/Core/interface/DQMOneEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMOneEDAnalyzer.h
@@ -81,7 +81,7 @@ public:
   // This could safely be used, and might need to be used to get some types of
   // products, but it will *only* be called if subsystem code adds a lumi cache.
   // For consistency, we use endLuminosityBlockProduce and ban this.
-  virtual void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final{};
+  void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final{};
 
   // Subsystems could safely override this, but any changes to MEs would not be
   // noticeable since the product was made already.

--- a/DQMServices/Demo/test/TestDQMEDAnalyzer.cc
+++ b/DQMServices/Demo/test/TestDQMEDAnalyzer.cc
@@ -175,6 +175,37 @@ private:
 };
 DEFINE_FWK_MODULE(TestDQMOneFillRunEDAnalyzer);
 
+class TestDQMOneFillLumiEDAnalyzer : public DQMOneEDAnalyzer<> {
+public:
+  explicit TestDQMOneFillLumiEDAnalyzer(const edm::ParameterSet& iConfig)
+      : mymes_(iConfig.getParameter<std::string>("folder"), iConfig.getParameter<int>("howmany")),
+        myvalue_(iConfig.getParameter<double>("value")) {}
+
+  ~TestDQMOneFillLumiEDAnalyzer() override{};
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("folder", "One/testonefilllumi")->setComment("Where to put all the histograms");
+    desc.add<int>("howmany", 1)->setComment("How many copies of each ME to put");
+    desc.add<double>("value", 1)->setComment("Which value to use on the third axis (first two are lumi and run)");
+    descriptions.add("testonefilllumi", desc);
+  }
+
+private:
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override {
+    mymes_.bookall(ibooker);
+  }
+
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override {}
+  void dqmEndLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const&) override {
+    mymes_.fillall(lumi.luminosityBlock(), lumi.run(), myvalue_);
+  }
+
+  BookerFiller<DQMStore::IBooker, MonitorElement, /* DOLUMI */ true> mymes_;
+  double myvalue_;
+};
+DEFINE_FWK_MODULE(TestDQMOneFillLumiEDAnalyzer);
+
 class TestDQMOneLumiEDAnalyzer : public DQMOneLumiEDAnalyzer<> {
 public:
   explicit TestDQMOneLumiEDAnalyzer(const edm::ParameterSet& iConfig)

--- a/DQMServices/Demo/test/run_analyzers_cfg.py
+++ b/DQMServices/Demo/test/run_analyzers_cfg.py
@@ -7,6 +7,7 @@ process.MessageLogger = cms.Service("MessageLogger")
 process.load("DQMServices.Demo.test_cfi")
 process.load("DQMServices.Demo.testone_cfi")
 process.load("DQMServices.Demo.testonefillrun_cfi")
+process.load("DQMServices.Demo.testonefilllumi_cfi")
 process.load("DQMServices.Demo.testonelumi_cfi")
 process.load("DQMServices.Demo.testonelumifilllumi_cfi")
 process.load("DQMServices.Demo.testglobal_cfi")
@@ -16,7 +17,8 @@ process.load("DQMServices.Demo.testlegacyfilllumi_cfi")
 process.test_general = cms.Sequence(process.test 
                                   + process.testglobal)
 process.test_one     = cms.Sequence(process.testone
-                                  + process.testonefillrun)
+                                  + process.testonefillrun
+                                  + process.testonefilllumi)
 process.test_legacy  = cms.Sequence(process.testonelumi + process.testonelumifilllumi
                                   + process.testlegacy + process.testlegacyfillrun + process.testlegacyfilllumi)
 

--- a/DQMServices/Demo/test/runtests.sh
+++ b/DQMServices/Demo/test/runtests.sh
@@ -10,23 +10,23 @@ fi
 
 # 1. Run a very simple configuration with all module types.
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=alltypes.root numberEventsInRun=100 numberEventsInLuminosityBlock=20 nEvents=100
-# actually we'd expect 99, but the MEs by legacy modules are booked with JOB scope and cannot be saved to DQMIO.
-[ 66 = $(dqmiolistmes.py alltypes.root -r 1 | wc -l) ]
-[ 66 = $(dqmiolistmes.py alltypes.root -r 1 -l 1 | wc -l) ]
+# actually we'd expect more, but the MEs by legacy modules are booked with JOB scope and cannot be saved to DQMIO.
+[ 77 = $(dqmiolistmes.py alltypes.root -r 1 | wc -l) ]
+[ 77 = $(dqmiolistmes.py alltypes.root -r 1 -l 1 | wc -l) ]
 # this is deeply related to what the analyzers actually do.
 # again, the legacy modules output is not saved.
 # most run histos (4 modules * 9 types) fill on every event and should have 100 entries.
-# the scalar MEs should have the last lumi number (5) (5 float + 5 int)
-# testonefilllumi also should have 5 entries in the histograms (9 more)
+# the scalar MEs should have the last lumi number (5) (6 float + 6 int)
+# testone(lumi)filllumi also should have 5 entries in the histograms (2*9 more)
 # the "fillrun" module should have one entry in the histograms (9 total) and 0 in the scalars (2 total)
-[ "0: 1, 0.0: 1, 1: 9, 100: 36, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 --summary)" ]
-# per lumi we see 20 in most histograms (4*9), and the current lumi number in the scalars (6 modules * 2).
-# the two fillumi modules should have one entry in each of the lumi histograms, (2*9 total)
-[ "1: 24, 1.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 1 --summary)" ]
-[ "1: 18, 2: 6, 2.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 2 --summary)" ]
-[ "1: 18, 20: 36, 3: 6, 3.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 3 --summary)" ]
-[ "1: 18, 20: 36, 4: 6, 4.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 4 --summary)" ]
-[ "1: 18, 20: 36, 5: 6, 5.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 5 --summary)" ]
+[ "0: 1, 0.0: 1, 1: 9, 100: 36, 5: 24, 5.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 --summary)" ]
+# per lumi we see 20 in most histograms (4*9), and the current lumi number in the scalars (7 modules * 2).
+# the three fillumi modules should have one entry in each of the lumi histograms, (3*9 total)
+[ "1: 34, 1.0: 7, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 1 --summary)" ]
+[ "1: 27, 2: 7, 2.0: 7, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 2 --summary)" ]
+[ "1: 27, 20: 36, 3: 7, 3.0: 7" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 3 --summary)" ]
+[ "1: 27, 20: 36, 4: 7, 4.0: 7" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 4 --summary)" ]
+[ "1: 27, 20: 36, 5: 7, 5.0: 7" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 5 --summary)" ]
 # just make sure we are not off by one
 [ "" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 6 --summary)" ]
 
@@ -42,12 +42,12 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=nolegacy-cl.root numberEvent
 # same math as above, just a few less modules, and more events.
 for f in nolegacy.root nolegacy-mt.root nolegacy-cl.root
 do
-  [ "0: 1, 0.0: 1, 1: 9, 1000: 27, 5: 3, 5.0: 3" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 --summary)" ]
-  [ "1: 2, 1.0: 2, 200: 18" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 1 --summary)" ]
-  [ "2: 2, 2.0: 2, 200: 18" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 2 --summary)" ]
-  [ "200: 18, 3: 2, 3.0: 2" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 3 --summary)" ]
-  [ "200: 18, 4: 2, 4.0: 2" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 4 --summary)" ]
-  [ "200: 18, 5: 2, 5.0: 2" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 5 --summary)" ]
+  [ "0: 1, 0.0: 1, 1: 9, 1000: 27, 5: 13, 5.0: 4" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 --summary)" ]
+  [ "1: 12, 1.0: 3, 200: 18" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 1 --summary)" ]
+  [ "1: 9, 2: 3, 2.0: 3, 200: 18" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 2 --summary)" ]
+  [ "1: 9, 200: 18, 3: 3, 3.0: 3" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 3 --summary)" ]
+  [ "1: 9, 200: 18, 4: 3, 4.0: 3" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 4 --summary)" ]
+  [ "1: 9, 200: 18, 5: 3, 5.0: 3" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 5 --summary)" ]
   [ "" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 6 --summary)" ]
 done
 
@@ -89,9 +89,9 @@ cmp <($LOCAL_TEST_DIR/dqmiodumpentries.py multirun.root -r 1 -l 2) <($LOCAL_TEST
 
 # 7. Try writing a TDirectory file.
 cmsRun $LOCAL_TEST_DIR/run_harvesters_cfg.py inputFiles=alltypes.root nomodules=True legacyoutput=True reScope=JOB
-# this number is rather messy: we have 66 per-lumi objecs (harvested), 66 per-run objects (no legacy output), one folder for each set of 11, 
+# this number is rather messy: we have 77 per-lumi objects (harvested), 77 per-run objects (no legacy output), one folder for each set of 11, 
 # plus some higher-level folders and the ProvInfo hierarchy create by the FileSaver.
-[ 161 = $(rootlist DQM_V0001_R000000001__Harvesting__DQMTests__DQMIO.root | wc -l) ]
+[ 185 = $(rootlist DQM_V0001_R000000001__Harvesting__DQMTests__DQMIO.root | wc -l) ]
 
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py numberEventsInRun=100 numberEventsInLuminosityBlock=20 nEvents=100 legacyoutput=True
 # we expect only the (per-job) legacy histograms here: 3*11 objects in 3 folders, plus 9 more for ProvInfo and higher-level folders.
@@ -101,25 +101,25 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py numberEventsInRun=100 numberEventsIn
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py numberEventsInRun=300 numberEventsInLuminosityBlock=100 nEvents=1200 protobufoutput=True
 
 cmsRun $LOCAL_TEST_DIR/run_harvesters_cfg.py inputFiles=./run000001 outfile=pbdata.root nomodules=True protobufinput=True
-[ 99 = $(dqmiolistmes.py pbdata.root -r 1 | wc -l) ]
-[ 66 = $(dqmiolistmes.py pbdata.root -r 1 -l 1 | wc -l) ]
+[ 110 = $(dqmiolistmes.py pbdata.root -r 1 | wc -l) ]
+[ 77 = $(dqmiolistmes.py pbdata.root -r 1 -l 1 | wc -l) ]
 
 # this will potentially mess up statistics (we should only fastHadd *within* a lumisection, not *across*), but should technically work.
 fastHadd add -o streamDQMHistograms.pb run000001/run000001_ls*_streamDQMHistograms.pb
 # the output format is different from the harvesting above, this is a not-DQM-formatted TDirectory file.
 fastHadd convert -o streamDQMHistograms.root streamDQMHistograms.pb
-# here we expect all (incl. legacy) MEs (99+66), plus folders (14 + 4 higher-level)
-[ 184 = $(rootlist streamDQMHistograms.root | wc -l) ]
+# here we expect all (incl. legacy) MEs (110+77), plus folders (17 + 4 higher-level)
+[ 208 = $(rootlist streamDQMHistograms.root | wc -l) ]
 
 
 # 9. Try writing online files. This is really TDirectory files, but written via a different module.
 # Note that this does not really need to support multiple runs, but it appears it does.
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py numberEventsInRun=300 numberEventsInLuminosityBlock=100 nEvents=1200 onlineoutput=True
-# here we expect full per-run output (99 objects), no per-lumi MEs, plus folders (9 + 10 higher-level).
-[ 118 = $(rootlist DQM_V0001_UNKNOWN_R000000001.root | wc -l) ]
-[ 118 = $(rootlist DQM_V0001_UNKNOWN_R000000002.root | wc -l) ]
-[ 118 = $(rootlist DQM_V0001_UNKNOWN_R000000003.root | wc -l) ]
-[ 118 = $(rootlist DQM_V0001_UNKNOWN_R000000004.root | wc -l) ]
+# here we expect full per-run output (110 objects), no per-lumi MEs, plus folders (10 + 10 higher-level).
+[ 130 = $(rootlist DQM_V0001_UNKNOWN_R000000001.root | wc -l) ]
+[ 130 = $(rootlist DQM_V0001_UNKNOWN_R000000002.root | wc -l) ]
+[ 130 = $(rootlist DQM_V0001_UNKNOWN_R000000003.root | wc -l) ]
+[ 130 = $(rootlist DQM_V0001_UNKNOWN_R000000004.root | wc -l) ]
 
 
 # 10. Try running some harvesting modules and check if their output makes it out.
@@ -130,15 +130,15 @@ cmsRun $LOCAL_TEST_DIR/run_harvesters_cfg.py inputFiles=part1.root inputFiles=pa
 # 11. Try MEtoEDM and EDMtoME.
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=metoedm.root numberEventsInRun=100 numberEventsInLuminosityBlock=20 nEvents=100 metoedmoutput=True
 cmsRun $LOCAL_TEST_DIR/run_harvesters_cfg.py outfile=edmtome.root inputFiles=metoedm.root nomodules=True metoedminput=True
-[ 66 = $(dqmiolistmes.py edmtome.root -r 1 | wc -l) ]
-[ 66 = $(dqmiolistmes.py edmtome.root -r 1 -l 1 | wc -l) ]
+[ 77 = $(dqmiolistmes.py edmtome.root -r 1 | wc -l) ]
+[ 77 = $(dqmiolistmes.py edmtome.root -r 1 -l 1 | wc -l) ]
 # again, no legacy module (run) output here due to JOB scope for legacy modules
-[ "0: 1, 0.0: 1, 1: 9, 100: 36, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 --summary)" ]
-[ "1: 24, 1.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 1 --summary)" ]
-[ "1: 18, 2: 6, 2.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 2 --summary)" ]
-[ "1: 18, 20: 36, 3: 6, 3.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 3 --summary)" ]
-[ "1: 18, 20: 36, 4: 6, 4.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 4 --summary)" ]
-[ "1: 18, 20: 36, 5: 6, 5.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 5 --summary)" ]
+[ "0: 1, 0.0: 1, 1: 9, 100: 36, 5: 24, 5.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 --summary)" ]
+[ "1: 34, 1.0: 7, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 1 --summary)" ]
+[ "1: 27, 2: 7, 2.0: 7, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 2 --summary)" ]
+[ "1: 27, 20: 36, 3: 7, 3.0: 7" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 3 --summary)" ]
+[ "1: 27, 20: 36, 4: 7, 4.0: 7" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 4 --summary)" ]
+[ "1: 27, 20: 36, 5: 7, 5.0: 7" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 5 --summary)" ]
 [ "" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 6 --summary)" ]
 
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=part1_metoedm.root metoedmoutput=True numberEventsInRun=300 numberEventsInLuminosityBlock=100 nEvents=50               # 1st half of 1st lumi
@@ -157,9 +157,9 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=empty.root howmany=0 legacyo
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=empty.root howmany=0 protobufoutput=True
 # nLumisections might be a bit buggy (off by one) in EDM, but is fine here.
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=noevents.root processingMode='RunsAndLumis' nLumisections=20
-[ 66 = $(dqmiolistmes.py noevents.root -r 1 | wc -l) ]
-[ 66 = $(dqmiolistmes.py noevents.root -r 1 -l 1 | wc -l) ]
-[ 66 = $(dqmiolistmes.py noevents.root -r 2 | wc -l) ]
-[ 66 = $(dqmiolistmes.py noevents.root -r 2 -l 2 | wc -l) ]
+[ 77 = $(dqmiolistmes.py noevents.root -r 1 | wc -l) ]
+[ 77 = $(dqmiolistmes.py noevents.root -r 1 -l 1 | wc -l) ]
+[ 77 = $(dqmiolistmes.py noevents.root -r 2 | wc -l) ]
+[ 77 = $(dqmiolistmes.py noevents.root -r 2 -l 2 | wc -l) ]
 
 

--- a/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
+++ b/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
@@ -35,7 +35,7 @@ namespace dqm {
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
     std::shared_ptr<rdm::Empty> globalBeginLuminosityBlock(edm::LuminosityBlock const &lumi,
                                                            edm::EventSetup const &eSetup) const override;
-    void globalEndLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &eSetup) final {}
+    void dqmEndLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &eSetup) final {}
     void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override{};
 
     void analyzeFile(std::string fn, unsigned int run, unsigned int lumi, std::string label) const;

--- a/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
+++ b/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
@@ -35,6 +35,7 @@ namespace dqm {
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
     std::shared_ptr<rdm::Empty> globalBeginLuminosityBlock(edm::LuminosityBlock const &lumi,
                                                            edm::EventSetup const &eSetup) const override;
+    void globalEndLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &eSetup) final {}
     void dqmEndLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &eSetup) final {}
     void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override{};
 


### PR DESCRIPTION
#### PR description:

This PR adds `dqmEndLuminosityBlock` to `DQMOneEDAnalyzer`.

Turns out we can set `EndLuminosityBlockProducer` without using `WatchLuminosityBlocks`?
(Edit: no, this also blocks concurrent lumis. Back to the drawing board then.)

That gives an option to enable `dqmEndLuminosityBlock` by default.

This is once again risky, since the semantics now are subtly different compared to 2018:
The same callbacks exist, but events of multiple lumis can arrive alternatingly.
This could lead to subtle bugs. The good thing is, we have eliminated almost
all usages of the old API, so we know there are not many places where such bugs
could happen.

`globalEndLuminosityBlock` in DQM modules is banned in favor of `dqmEndLuminosityBlock` now for consistency, and all existing users changed. The semantics might be slightly different (the EDM docs hint that some lumi products might not be availale in `ennLuminosityBlockProduce`, but in `globalEndLuminostyBlock`, let's see if this survives validation.

#### PR validation:

Compiles.

Further validation needed. 
