### PR TITLE
Reduce boost in Calibration/HcalCalibAlgos/test

### DIFF
--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
@@ -13,11 +13,12 @@
 #include "TFile.h"
 #include "TClonesArray.h"
 #include "TObjString.h"
+
 #include <iostream>
-#include <vector>
-#include <set>
 #include <map>
-#include <boost/regex.hpp>
+#include <regex>
+#include <set>
+#include <vector>
 
 inline void HERE(const char* msg) {
   if (0 && msg)
@@ -123,9 +124,9 @@ double getNeutralPVCorr(double eta, int intNPV, double area, bool isMC_) {
 // -------------------------------------------------
 
 inline unsigned int helper_findTrigger(const std::vector<std::string>& list, const std::string& name) {
-  boost::regex re(std::string("^(") + name + "|" + name + "_v\\d*)$");
+  std::regex re(std::string("^(") + name + "|" + name + "_v\\d*)$");
   for (unsigned int i = 0, n = list.size(); i < n; ++i) {
-    if (boost::regex_match(list[i], re))
+    if (std::regex_match(list[i], re))
       return i;
   }
   return list.size();


### PR DESCRIPTION
#### PR description:
Replaced boost::regex for std::regex, they should have similar behavior and performance.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 