### PR TITLE
Add tracking-only and pixel tracking-only workflows for Run 3 (11.1.x)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -29,7 +29,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #        (Patatrack ECAL-only: TTbar - on CPU, on GPU, both, auto)
 #        (Patatrack HCAL-only: TTbar - on CPU, on GPU, both, auto)
 #   2021 (ZMM, TTbar, ZEE, MinBias, TTbar PU, TTbar PU premix, ZEE PU, TTbar design)
-#        (TTbar trackingMkFit)
+#        (TTbar trackingOnly, pixelTrackingOnly, trackingMkFit)
 #        (Patatrack pixel-only: ZMM - on CPU, on GPU, both, auto)
 #        (Patatrack pixel-only: TTbar - on CPU, on GPU, both, auto)
 #        (Patatrack ECAL-only: TTbar - on CPU, on GPU, both, auto)
@@ -51,7 +51,7 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            10824.511,10824.512, # 10824.513,10824.514,
            # 10824.521,10824.522,10824.523,10824.524,
            11650.0,11634.0,11646.0,11640.0,11834.0,11834.99,11846.0,12024.0,
-           11634.7,
+           11634.1,11634.5,11634.7,
            11650.501,11650.502, # 11650.503,11650.504,
            11634.501,11634.502, # 11634.503,11634.504,
            11634.511,11634.512, # 11634.513,11634.514,

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -252,7 +252,7 @@ class UpgradeWorkflow_pixelTrackingOnly(UpgradeWorkflowTracking):
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
         elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'}, stepDict[step][k]])
     def condition_(self, fragment, stepList, key, hasHarvest):
-        return '2017' in key or '2018' in key
+        return '2017' in key or '2018' in key or '2021' in key
 upgradeWFs['pixelTrackingOnly'] = UpgradeWorkflow_pixelTrackingOnly(
     steps = [
         'RecoFull',


### PR DESCRIPTION
#### PR description:

Add tracking-only and pixel tracking-only workflows for Run 3.

#### PR validation:
```
runTheMatrix.py -l 11634.1,11634.5 -j4
...
11634.1_TTbar_14TeV+TTbar_14TeV_TuneCP5_2021_GenSimFull+DigiFull_2021+RecoFull_trackingOnly_2021+HARVESTFull_trackingOnly_2021 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 23 10:04:26 2020-date Tue Jun 23 09:53:43 2020; exit: 0 0 0 0
11634.5_TTbar_14TeV+TTbar_14TeV_TuneCP5_2021_GenSimFull+DigiFull_2021+RecoFull_pixelTrackingOnly_2021+HARVESTFull_pixelTrackingOnly_2021 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 23 10:03:29 2020-date Tue Jun 23 09:53:44 2020; exit: 0 0 0 0
2 2 2 2 tests passed, 0 0 0 0 failed
```