### PR TITLE
Add new MVA tau ID for phase II

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -349,7 +349,6 @@ def miniAOD_customizeCommon(process):
     (run2_miniAOD_94XFall17 | run2_miniAOD_UL).toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithRetrainedMVATauID
         )
-
     #-- Adding DeepTauID
     # deepTau v2p1
     _updatedTauName = 'slimmedTausDeepIDsv2p1'

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -361,7 +361,7 @@ def miniAOD_customizeCommon(process):
         toKeep = ['deepTau2017v2p1']
     )
     from Configuration.Eras.Modifier_phase2_common_cff import phase2_common #Phase2 Tau MVA
-    phase2_common.toModify(tauIdEmbedder.toKeep, func=lambda t:t.append('newDMwLTwGJPhase2')) #Phase2 Tau MVA
+    phase2_common.toModify(tauIdEmbedder.toKeep, func=lambda t:t.append('newDMPhase2v1')) #Phase2 Tau MVA
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)
     delattr(process, 'slimmedTaus')
@@ -371,7 +371,7 @@ def miniAOD_customizeCommon(process):
     )
     process.deepTauIDTask = cms.Task(process.deepTau2017v2p1, process.slimmedTaus)
     task.add(process.deepTauIDTask)
-    if 'newDMwLTwGJPhase2' in tauIdEmbedder.toKeep:
+    if 'newDMPhase2v1' in tauIdEmbedder.toKeep:
         process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw.PATTauProducer=_noUpdatedTauName
         process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2.PATTauProducer=_noUpdatedTauName
         task.add(process.rerunIsolationMVADBnewDMwLTPhase2Task)

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -349,6 +349,7 @@ def miniAOD_customizeCommon(process):
     (run2_miniAOD_94XFall17 | run2_miniAOD_UL).toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithRetrainedMVATauID
         )
+
     #-- Adding DeepTauID
     # deepTau v2p1
     _updatedTauName = 'slimmedTausDeepIDsv2p1'

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -1,4 +1,3 @@
-
 import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -357,10 +357,7 @@ def miniAOD_customizeCommon(process):
     tauIdEmbedder = tauIdConfig.TauIDEmbedder(
         process, debug = False,
         updatedTauName = _updatedTauName,
-        #toKeep = ['deepTau2017v2p1', 'newDMwLTwGJPhase2']
-        #toKeep = ['deepTau2017v2p1', 'newDM2016v1']
         toKeep = ['deepTau2017v2p1']
-        #toKeep = ['newDMwLTwGJPhase2']
     )
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -357,7 +357,10 @@ def miniAOD_customizeCommon(process):
     tauIdEmbedder = tauIdConfig.TauIDEmbedder(
         process, debug = False,
         updatedTauName = _updatedTauName,
+        #toKeep = ['deepTau2017v2p1', 'newDMwLTwGJPhase2']
+        #toKeep = ['deepTau2017v2p1', 'newDM2016v1']
         toKeep = ['deepTau2017v2p1']
+        #toKeep = ['newDMwLTwGJPhase2']
     )
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -359,57 +359,20 @@ def miniAOD_customizeCommon(process):
         updatedTauName = _updatedTauName,
         toKeep = ['deepTau2017v2p1']
     )
-    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common #Phase 2 Tau MVA
-    phase2_common.toModify(tauIdEmbedder, tauIdEmbedder.toKeep.append('newDMwLTwGJPhase2')) #Phase 2 Tau MVA
+    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common #Phase2 Tau MVA
+    phase2_common.toModify(tauIdEmbedder, tauIdEmbedder.toKeep.append('newDMwLTwGJPhase2')) #Phase2 Tau MVA
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)
     delattr(process, 'slimmedTaus')
     process.deepTau2017v2p1.taus = _noUpdatedTauName
+    phase2_common.toModify(process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw, PATTauProducer=_noUpdatedTauName) #Phase2 Tau MVA
+    phase2_common.toModify(process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2, PATTauProducer=_noUpdatedTauName) #Phase2 Tau MVA
     process.slimmedTaus = getattr(process, _updatedTauName).clone(
         src = _noUpdatedTauName
     )
     process.deepTauIDTask = cms.Task(process.deepTau2017v2p1, process.slimmedTaus)
     task.add(process.deepTauIDTask)
-
-    #Phase 2 Tau MVA
-    from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import patDiscriminationByIsolationMVArun2v1raw, patDiscriminationByIsolationMVArun2v1
-    from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
-    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-        PATTauProducer = cms.InputTag(_noUpdatedTauName),
-        Prediscriminants = noPrediscriminants,
-        loadMVAfromDB = cms.bool(True),
-        mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-        mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
-        verbosity = cms.int32(0)
-    )
-    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
-        PATTauProducer = cms.InputTag(_noUpdatedTauName),
-        Prediscriminants = noPrediscriminants,
-        toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
-        loadMVAfromDB = cms.bool(True),
-        mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
-        mapping = cms.VPSet(
-            cms.PSet(
-                category = cms.uint32(0),
-                cut = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-                variable = cms.string("pt"),
-               )
-            ),
-        workingPoints = cms.vstring(
-            "_WPEff95",
-            "_WPEff90",
-            "_WPEff80",
-            "_WPEff70",
-            "_WPEff60",
-            "_WPEff50",
-            "_WPEff40"
-        )
-    )
-    process.rerunIsolationMVADBnewDMwLTPhase2Task = cms.Task(
-        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
-        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
-    )
-    phase2_common.toModify(task, func=lambda t: t.add(process.rerunIsolationMVADBnewDMwLTPhase2Task))
+    phase2_common.toModify(process.deepTauIDTask, func=lambda t: process.deepTauIDTask.add(process.rerunIsolationMVADBnewDMwLTPhase2Task)) #Phase2 Tau MVA
 
     #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -359,6 +359,8 @@ def miniAOD_customizeCommon(process):
         updatedTauName = _updatedTauName,
         toKeep = ['deepTau2017v2p1']
     )
+    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common #Phase 2 Tau MVA
+    phase2_common.toModify(tauIdEmbedder, tauIdEmbedder.toKeep.append('newDMwLTwGJPhase2')) #Phase 2 Tau MVA
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)
     delattr(process, 'slimmedTaus')
@@ -368,6 +370,46 @@ def miniAOD_customizeCommon(process):
     )
     process.deepTauIDTask = cms.Task(process.deepTau2017v2p1, process.slimmedTaus)
     task.add(process.deepTauIDTask)
+
+    #Phase 2 Tau MVA
+    from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import patDiscriminationByIsolationMVArun2v1raw, patDiscriminationByIsolationMVArun2v1
+    from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
+    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
+        PATTauProducer = cms.InputTag(_noUpdatedTauName),
+        Prediscriminants = noPrediscriminants,
+        loadMVAfromDB = cms.bool(True),
+        mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+        mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
+        verbosity = cms.int32(0)
+    )
+    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
+        PATTauProducer = cms.InputTag(_noUpdatedTauName),
+        Prediscriminants = noPrediscriminants,
+        toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
+        loadMVAfromDB = cms.bool(True),
+        mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
+        mapping = cms.VPSet(
+            cms.PSet(
+                category = cms.uint32(0),
+                cut = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+                variable = cms.string("pt"),
+               )
+            ),
+        workingPoints = cms.vstring(
+            "_WPEff95",
+            "_WPEff90",
+            "_WPEff80",
+            "_WPEff70",
+            "_WPEff60",
+            "_WPEff50",
+            "_WPEff40"
+        )
+    )
+    process.rerunIsolationMVADBnewDMwLTPhase2Task = cms.Task(
+        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
+        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
+    )
+    phase2_common.toModify(task, func=lambda t: t.add(process.rerunIsolationMVADBnewDMwLTPhase2Task))
 
     #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -1,3 +1,4 @@
+
 import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
@@ -360,19 +361,20 @@ def miniAOD_customizeCommon(process):
         toKeep = ['deepTau2017v2p1']
     )
     from Configuration.Eras.Modifier_phase2_common_cff import phase2_common #Phase2 Tau MVA
-    phase2_common.toModify(tauIdEmbedder, tauIdEmbedder.toKeep.append('newDMwLTwGJPhase2')) #Phase2 Tau MVA
+    phase2_common.toModify(tauIdEmbedder.toKeep, func=lambda t:t.append('newDMwLTwGJPhase2')) #Phase2 Tau MVA
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)
     delattr(process, 'slimmedTaus')
     process.deepTau2017v2p1.taus = _noUpdatedTauName
-    phase2_common.toModify(process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw, PATTauProducer=_noUpdatedTauName) #Phase2 Tau MVA
-    phase2_common.toModify(process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2, PATTauProducer=_noUpdatedTauName) #Phase2 Tau MVA
     process.slimmedTaus = getattr(process, _updatedTauName).clone(
         src = _noUpdatedTauName
     )
     process.deepTauIDTask = cms.Task(process.deepTau2017v2p1, process.slimmedTaus)
     task.add(process.deepTauIDTask)
-    phase2_common.toModify(process.deepTauIDTask, func=lambda t: process.deepTauIDTask.add(process.rerunIsolationMVADBnewDMwLTPhase2Task)) #Phase2 Tau MVA
+    if 'newDMwLTwGJPhase2' in tauIdEmbedder.toKeep:
+        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw.PATTauProducer=_noUpdatedTauName
+        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2.PATTauProducer=_noUpdatedTauName
+        task.add(process.rerunIsolationMVADBnewDMwLTPhase2Task)
 
     #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -317,12 +317,12 @@ for ver2017 in tauIdDiscrMVA_2017_version:
 
 # MVAIso Phase2
 import os
-loadRecoTauTagMVAsFromSQLiteDB_phase2 = loadRecoTauTagMVAsFromPrepDB.clone(
-    connect = 'sqlite_file:'+os.getenv('CMSSW_BASE')+'/src/RecoTauTag/RecoTau/data/RecoTauTag_MVAs_2020Mar25.db',
-    toGet   = cms.VPSet()
-)
+#loadRecoTauTagMVAsFromSQLiteDB_phase2 = loadRecoTauTagMVAsFromPrepDB.clone(
+#    connect = 'sqlite_file:'+os.getenv('CMSSW_BASE')+'/src/RecoTauTag/RecoTau/data/RecoTauTag_MVAs_2020Mar25.db',
+#    toGet   = cms.VPSet()
+#)
 for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
-    loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+    loadRecoTauTagMVAsFromPrepDB.toGet.append(
         cms.PSet(
             record = cms.string('GBRWrapperRcd'),
             tag = cms.string("RecoTauTag_%s" % (gbrForestName)),
@@ -330,14 +330,14 @@ for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
         )
     )
     for WP in tauIdDiscrMVA_WPs_phase2[training].keys():
-        loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+        loadRecoTauTagMVAsFromPrepDB.toGet.append(
             cms.PSet(
                 record = cms.string('PhysicsTGraphPayloadRcd'),
                 tag = cms.string("RecoTauTag_%s_WP%s" % (gbrForestName, WP)),
                 label = cms.untracked.string("RecoTauTag_%s_WP%s" % (gbrForestName, WP))
             )
          )
-    loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+    loadRecoTauTagMVAsFromPrepDB.toGet.append(
         cms.PSet(
             record = cms.string('PhysicsTFormulaPayloadRcd'),
             tag = cms.string("RecoTauTag_%s_mvaOutput_normalization" % (gbrForestName)),

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -43,6 +43,9 @@ tauIdDiscrMVA_trainings_run2_2017 = {
     'tauIdMVAIsoDBnewDMwLT2017' : "tauIdMVAIsoDBnewDMwLT2017",
     'tauIdMVAIsoDBoldDMdR0p3wLT2017' : "tauIdMVAIsoDBoldDMdR0p3wLT2017",
 }
+tauIdDiscrMVA_trainings_phase2 = {
+    'tauIdMVAIsoPhase2' : "tauIdMVAIsoPhase2",
+}
 tauIdDiscrMVA_WPs = {
     'tauIdMVAoldDMwoLT' : {
         'Eff90' : "oldDMwoLTEff90",
@@ -174,6 +177,17 @@ tauIdDiscrMVA_WPs_run2_2017 = {
         'Eff40' : "DBoldDMdR0p3wLTEff40"
     }
 }
+tauIdDiscrMVA_WPs_phase2 = {
+    'tauIdMVAIsoPhase2' : {
+        'Eff95' : "Phase2Eff95",
+        'Eff90' : "Phase2Eff90",
+        'Eff80' : "Phase2Eff80",
+        'Eff70' : "Phase2Eff70",
+        'Eff60' : "Phase2Eff60",
+        'Eff50' : "Phase2Eff50",
+        'Eff40' : "Phase2Eff40"
+    }
+}
 tauIdDiscrMVA_mvaOutput_normalizations = {
     'tauIdMVAoldDMwoLT' : "mvaOutput_normalization_oldDMwoLT",
     'tauIdMVAoldDMwLT'  : "mvaOutput_normalization_oldDMwLT",
@@ -197,6 +211,10 @@ tauIdDiscrMVA_mvaOutput_normalizations_run2_2017 = {
     'tauIdMVAIsoDBnewDMwLT2017' : "mvaOutput_normalization",
     'tauIdMVAIsoDBoldDMdR0p3wLT2017' : "mvaOutput_normalization"
 }
+tauIdDiscrMVA_mvaOutput_normalizations_phase2 = {
+    'tauIdMVAIsoPhase2' : "mvaOutput_normalization",
+}
+
 tauIdDiscrMVA_version = "v1"
 for training, gbrForestName in tauIdDiscrMVA_trainings.items():
     loadRecoTauTagMVAsFromPrepDB.toGet.append(
@@ -296,6 +314,36 @@ for ver2017 in tauIdDiscrMVA_2017_version:
                 label = cms.untracked.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, ver2017))
 	    )
         )
+
+# MVAIso Phase2
+import os
+loadRecoTauTagMVAsFromSQLiteDB_phase2 = loadRecoTauTagMVAsFromPrepDB.clone(
+    connect = 'sqlite_file:'+os.getenv('CMSSW_BASE')+'/src/RecoTauTag/RecoTau/data/RecoTauTag_MVAs_2020Mar25.db',
+    toGet   = cms.VPSet()
+)
+for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
+    loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+        cms.PSet(
+            record = cms.string('GBRWrapperRcd'),
+            tag = cms.string("RecoTauTag_%s" % (gbrForestName)),
+            label = cms.untracked.string("RecoTauTag_%s" % (gbrForestName))
+        )
+    )
+    for WP in tauIdDiscrMVA_WPs_phase2[training].keys():
+        loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+            cms.PSet(
+                record = cms.string('PhysicsTGraphPayloadRcd'),
+                tag = cms.string("RecoTauTag_%s_WP%s" % (gbrForestName, WP)),
+                label = cms.untracked.string("RecoTauTag_%s_WP%s" % (gbrForestName, WP))
+            )
+         )
+    loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+        cms.PSet(
+            record = cms.string('PhysicsTFormulaPayloadRcd'),
+            tag = cms.string("RecoTauTag_%s_mvaOutput_normalization" % (gbrForestName)),
+            label = cms.untracked.string("RecoTauTag_%s_mvaOutput_normalization" % (gbrForestName))
+       )
+    )
 
 ####
 ## register anti-electron discriminator MVA

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -316,11 +316,6 @@ for ver2017 in tauIdDiscrMVA_2017_version:
         )
 
 # MVAIso Phase2
-import os
-#loadRecoTauTagMVAsFromSQLiteDB_phase2 = loadRecoTauTagMVAsFromPrepDB.clone(
-#    connect = 'sqlite_file:'+os.getenv('CMSSW_BASE')+'/src/RecoTauTag/RecoTau/data/RecoTauTag_MVAs_2020Mar25.db',
-#    toGet   = cms.VPSet()
-#)
 for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
     loadRecoTauTagMVAsFromPrepDB.toGet.append(
         cms.PSet(

--- a/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
@@ -65,7 +65,8 @@ namespace reco {
       kPWoldDMwLT,
       kPWnewDMwLT,
       kDBoldDMwLTwGJ,
-      kDBnewDMwLTwGJ
+      kDBnewDMwLTwGJ,
+      kPhase2
     };
     bool fillIsoMVARun2Inputs(float* mvaInput,
                               const pat::Tau& tau,

--- a/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
@@ -66,7 +66,7 @@ namespace reco {
       kPWnewDMwLT,
       kDBoldDMwLTwGJ,
       kDBnewDMwLTwGJ,
-      kPhase2
+      kDBnewDMwLTwGJPhase2
     };
     bool fillIsoMVARun2Inputs(float* mvaInput,
                               const pat::Tau& tau,

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -123,7 +123,7 @@ namespace reco {
                  mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ)
           mvaInput_ = new float[23];
         else if (mvaOpt_ == kDBnewDMwLTwGJPhase2)
-           mvaInput_ = new float[30];
+          mvaInput_ = new float[30];
         else
           assert(0);
 

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -109,6 +109,8 @@ namespace reco {
           mvaOpt_ = kDBoldDMwLTwGJ;
         else if (mvaOpt_string == "DBnewDMwLTwGJ")
           mvaOpt_ = kDBnewDMwLTwGJ;
+        else if (mvaOpt_string == "Phase2")
+          mvaOpt_ = kPhase2;
         else
           throw cms::Exception("PATTauDiscriminationByMVAIsolationRun2")
               << " Invalid Configuration Parameter 'mvaOpt' = " << mvaOpt_string << " !!\n";
@@ -120,6 +122,8 @@ namespace reco {
         else if (mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT || mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ||
                  mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ)
           mvaInput_ = new float[23];
+        else if (mvaOpt_ == kPhase2)
+           mvaInput_ = new float[30];
         else
           assert(0);
 

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -109,8 +109,8 @@ namespace reco {
           mvaOpt_ = kDBoldDMwLTwGJ;
         else if (mvaOpt_string == "DBnewDMwLTwGJ")
           mvaOpt_ = kDBnewDMwLTwGJ;
-        else if (mvaOpt_string == "Phase2")
-          mvaOpt_ = kPhase2;
+        else if (mvaOpt_string == "DBnewDMwLTwGJPhase2")
+          mvaOpt_ = kDBnewDMwLTwGJPhase2;
         else
           throw cms::Exception("PATTauDiscriminationByMVAIsolationRun2")
               << " Invalid Configuration Parameter 'mvaOpt' = " << mvaOpt_string << " !!\n";
@@ -122,7 +122,7 @@ namespace reco {
         else if (mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT || mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ||
                  mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ)
           mvaInput_ = new float[23];
-        else if (mvaOpt_ == kPhase2)
+        else if (mvaOpt_ == kDBnewDMwLTwGJPhase2)
            mvaInput_ = new float[30];
         else
           assert(0);

--- a/RecoTauTag/RecoTau/plugins/rerunMVAIsolationOnMiniAOD_Phase2.cc
+++ b/RecoTauTag/RecoTau/plugins/rerunMVAIsolationOnMiniAOD_Phase2.cc
@@ -1,0 +1,226 @@
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+//#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "TH1D.h"
+#include "TH2D.h"
+#include "TGraphAsymmErrors.h"
+
+class rerunMVAIsolationOnMiniAOD_Phase2 : public edm::EDAnalyzer {
+public:
+  explicit rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet&);
+private:
+   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+   virtual void endJob() override;
+
+   edm::EDGetTokenT<pat::TauCollection> tauToken_;
+ 
+   TH1D *h_raw_bkg, *h_raw_sig;
+ 
+   TH1D *h_pt_denom_bkg, *h_pt_denom_sig;
+   TH1D *h_pt_num_bkg[7], *h_pt_num_sig[7];
+   TGraphAsymmErrors *eff[7], *fak[7];
+   
+   TH1D *h_inc_denom_bkg, *h_inc_num_bkg;
+   TH1D *h_inc_denom_sig, *h_inc_num_sig;
+   TGraphAsymmErrors *inceff, *incfak;
+
+   TH2D *h2_denom_bkg, *h2_denom_sig;
+   TH2D *h2_num_bkg[7], *h2_num_sig[7];
+   TH2D *eff2[7], *fak2[7];
+
+   bool haveGenJets;
+   edm::EDGetTokenT<std::vector<reco::GenJet>> genJetToken_;   
+   //bool haveGenVisTaus;
+   //edm::EDGetTokenT<pat::CompositeCandidateCollection> genVisTauToken_;
+   bool haveGenParticles;
+   edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticleToken_;
+};
+
+rerunMVAIsolationOnMiniAOD_Phase2::rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet& iConfig)
+{
+   tauToken_ = consumes<pat::TauCollection>(edm::InputTag("newTauIDsEmbedded"));
+ 
+   haveGenJets = false;
+   if (iConfig.existsAs<edm::InputTag>("genJetCollection")) {  
+      haveGenJets = true;
+      genJetToken_ = consumes<std::vector<reco::GenJet>>(iConfig.getParameter<edm::InputTag>("genJetCollection"));
+   }
+   //haveGenVisTaus = false;
+   //if (iConfig.existsAs<edm::InputTag>("genVisTauCollection")) {
+   //   haveGenVisTaus = true;
+   //   genVisTauToken_ = consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("genVisTauCollection"));
+   //}
+   haveGenParticles = false;
+   if (iConfig.existsAs<edm::InputTag>("genParticleCollection")) {
+      haveGenParticles = true;
+      genParticleToken_ = consumes<std::vector<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticleCollection"));
+   }
+
+   edm::Service<TFileService> fileService;
+   h_raw_sig = fileService->make<TH1D>("h_raw_sig", ";BDT output;taus / 0.02", 110, -1.1, 1.1);
+   h_raw_bkg = fileService->make<TH1D>("h_raw_bkg", ";BDT output;taus / 0.02", 110, -1.1, 1.1);
+   
+   h_inc_num_sig = fileService->make<TH1D>("h_inc_num_sig", ";working point;taus / bin", 7, 0.5, 7.5);
+   h_inc_denom_sig = fileService->make<TH1D>("h_inc_denom_sig", ";working point;taus / bin", 7, 0.5, 7.5);
+   h_inc_num_bkg = fileService->make<TH1D>("h_inc_num_bkg", ";working point;taus / bin", 7, 0.5, 7.5);
+   h_inc_denom_bkg = fileService->make<TH1D>("h_inc_denom_bkg", ";working point;taus / bin", 7, 0.5, 7.5);
+   inceff = fileService->make<TGraphAsymmErrors>(7);
+   inceff->SetName("inceff");
+   incfak = fileService->make<TGraphAsymmErrors>(7);
+   incfak->SetName("incfak");
+
+   const int n = 10;
+   const double x[n+1] = {20., 25.4196, 32.3079, 41.0627, 52.19, 66.3325, 84.3074, 107.153, 136.19, 173.095, 220.};
+   h_pt_denom_sig = fileService->make<TH1D>("h_pt_denom_sig", ";p_{T} [GeV];taus / bin", n, x);
+   h_pt_denom_bkg = fileService->make<TH1D>("h_pt_denom_bkg", ";p_{T} [GeV];taus / bin", n, x);
+   for (int i = 0; i < 7; ++i) {
+      const TString tag = TString::Itoa(i, 10);
+      h_pt_num_sig[i] = fileService->make<TH1D>("h_pt_num_sig_"+tag, ";p_{T} [GeV];taus / bin", n, x);
+      h_pt_num_bkg[i] = fileService->make<TH1D>("h_pt_num_bkg_"+tag, ";p_{T} [GeV];taus / bin", n, x);
+      eff[i] = fileService->make<TGraphAsymmErrors>(10);
+      eff[i]->SetName("eff_"+TString::Itoa(i, 10));
+      fak[i] = fileService->make<TGraphAsymmErrors>(10);
+      fak[i]->SetName("fak_"+TString::Itoa(i, 10));
+   }
+   const double xeta[4] = {0., 1.5, 2.3, 3.};
+   const double xpt[3] = {20., 50., 220.};
+   h2_denom_sig = fileService->make<TH2D>("h2_denom_sig", ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+   h2_denom_bkg = fileService->make<TH2D>("h2_denom_bkg", ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+   for (int i = 0; i < 7; ++i) {
+      const TString tag = TString::Itoa(i, 10);
+      h2_num_sig[i] = fileService->make<TH2D>("h2_num_sig_"+tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+      h2_num_sig[i]->Sumw2();
+      h2_num_bkg[i] = fileService->make<TH2D>("h2_num_bkg_"+tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+      h2_num_bkg[i]->Sumw2();
+      eff2[i] = fileService->make<TH2D>("eff2_"+tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+      eff2[i]->Sumw2();
+      fak2[i] = fileService->make<TH2D>("fak2_"+tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);  
+      fak2[i]->Sumw2();
+   }
+}
+
+void rerunMVAIsolationOnMiniAOD_Phase2::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   edm::Handle<pat::TauCollection> taus;
+   iEvent.getByToken(tauToken_, taus);
+
+   edm::Handle<std::vector<reco::GenJet>> genJets;
+   if (haveGenJets) iEvent.getByToken(genJetToken_, genJets);
+
+   //edm::Handle<pat::CompositeCandidateCollection> genVisTaus;
+   //if (haveGenVisTaus) iEvent.getByToken(genVisTauToken_, genVisTaus);
+
+   edm::Handle<std::vector<reco::GenParticle>> genParticles;
+   if (haveGenParticles) iEvent.getByToken(genParticleToken_, genParticles);
+ 
+   for (auto i = taus->begin(); i != taus->end(); ++i) {
+      
+      const double pt = i->pt();
+      const double eta = std::abs(i->eta());
+      if (pt<20. || pt>=220. || eta>=3.) continue;
+      if (!i->tauID("decayModeFindingNewDMs")) continue;
+
+      bool isPU = false;
+      if (haveGenJets) {
+         double mindr_jet = 9.;
+         for (auto j = genJets->begin(); j != genJets->end(); ++j) {
+            if (reco::deltaR(*i, *j)<mindr_jet) {
+               mindr_jet = reco::deltaR(*i, *j);
+            }
+         }
+         if (mindr_jet>=0.4) isPU = true;
+      }
+      if (isPU) continue;
+
+      //bool isSig = false;
+      //if (haveGenVisTaus) {
+      //   double mindr = 99.;
+      //   for (auto j = genVisTaus->begin(); j != genVisTaus->end(); ++j) {
+      //      if (std::abs(j->pdgId())==15 && reco::deltaR(*i, *j)<mindr) {
+      //         mindr = reco::deltaR(*i, *j);
+      //      }
+      //   }
+      //   if (mindr<0.4) isSig = true;
+      //}
+
+      bool isSig = false;
+      if (haveGenParticles) {
+         double mindr_e = 99.;
+         double mindr_m = 99.;
+         double mindr_t = 99.;
+         for (auto j = genParticles->begin(); j != genParticles->end(); ++j) {
+            const double dr = reco::deltaR(*i, *j);
+            const int pdgid = std::abs(j->pdgId());
+            if (pdgid==11 && j->status()==1 && dr<mindr_e) mindr_e = dr;
+            if (pdgid==13 && j->status()==1 && dr<mindr_m) mindr_m = dr;
+            if (pdgid==15 && j->isLastCopy() && dr<mindr_t) mindr_t = dr;
+         }
+         if (mindr_e>=0.4 && mindr_m>=0.4 && mindr_t<0.5) isSig = true;
+      }
+
+      const double byIsolationMVAPhase2raw = i->tauID("byIsolationMVAPhase2raw");
+      double wp[7];
+      wp[0] = i->tauID("byVVLooseIsolationMVAPhase2New");
+      wp[1] = i->tauID("byVLooseIsolationMVAPhase2New");
+      wp[2] = i->tauID("byLooseIsolationMVAPhase2New");
+      wp[3] = i->tauID("byMediumIsolationMVAPhase2New");
+      wp[4] = i->tauID("byTightIsolationMVAPhase2New");
+      wp[5] = i->tauID("byVTightIsolationMVAPhase2New");
+      wp[6] = i->tauID("byVVTightIsolationMVAPhase2New");
+      
+      if (isSig) {
+         h_raw_sig->Fill(byIsolationMVAPhase2raw);
+         h_pt_denom_sig->Fill(pt);
+         h2_denom_sig->Fill(eta, pt);
+         for (int j = 0; j < 7; ++j) {
+            h_inc_denom_sig->Fill(j+1);
+            if (wp[j]) {
+               h_inc_num_sig->Fill(j+1);
+               h_pt_num_sig[j]->Fill(pt);
+               h2_num_sig[j]->Fill(eta, pt);
+            }
+         }
+      } else {
+         h_raw_bkg->Fill(byIsolationMVAPhase2raw);
+         h_pt_denom_bkg->Fill(pt);
+         h2_denom_bkg->Fill(eta, pt);
+         for (int j = 0; j < 7; ++j) {
+            h_inc_denom_bkg->Fill(j+1);
+            if (wp[j]) {
+               h_inc_num_bkg->Fill(j+1);
+               h_pt_num_bkg[j]->Fill(pt);
+               h2_num_bkg[j]->Fill(eta, pt);
+            }
+         }
+      }
+   }
+
+}
+
+void rerunMVAIsolationOnMiniAOD_Phase2::endJob()
+{
+   inceff->Divide(h_inc_num_sig, h_inc_denom_sig, "e0");
+   inceff->SetTitle(";working point;tagging efficiency");
+   incfak->Divide(h_inc_num_bkg, h_inc_denom_bkg, "e0");
+   incfak->SetTitle(";working point;tagging efficiency");
+   for (int i = 0; i < 7; ++i) {
+      eff[i]->Divide(h_pt_num_sig[i], h_pt_denom_sig, "e0");
+      eff[i]->SetTitle(";p_{T} [GeV];tagging efficiency");
+      fak[i]->Divide(h_pt_num_bkg[i], h_pt_denom_bkg, "e0");
+      fak[i]->SetTitle(";p_{T} [GeV];tagging efficiency");
+      eff2[i]->Divide(h2_num_sig[i], h2_denom_sig, 1., 1., "B");
+      eff2[i]->SetTitle("tagging efficiency;|eta|;p_{T} [GeV]");
+      fak2[i]->Divide(h2_num_bkg[i], h2_denom_bkg, 1., 1., "B");
+      fak2[i]->SetTitle("tagging efficiency;|eta|;p_{T} [GeV]");
+   }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(rerunMVAIsolationOnMiniAOD_Phase2);
+

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -12,7 +12,8 @@ class TauIDEmbedder(object):
         "2017v1", "2017v2", "newDM2017v2", "dR0p32017v2", "2016v1", "newDM2016v1",
         "deepTau2017v1", "deepTau2017v2", "deepTau2017v2p1",
         "DPFTau_2016_v0", "DPFTau_2016_v1",
-        "againstEle2018", "newDMwLTwGJPhase2"
+        "againstEle2018",
+        "newDMwLTwGJPhase2"
     ]
 
     def __init__(self, process, debug = False,
@@ -900,7 +901,7 @@ class TauIDEmbedder(object):
                     "_WPEff40"
                 )
             )
-            self.rerunIsolationMVADBnewDMwLTPhase2Task = self.cms.Task(
+            self.process.rerunIsolationMVADBnewDMwLTPhase2Task = self.cms.Task(
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
             )

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -869,20 +869,20 @@ class TauIDEmbedder(object):
             def tauIDMVAinputs(module, wp):
                 return cms.PSet(inputTag = cms.InputTag(module), workingPointIndex = cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = cms.InputTag('slimmedTaus'),
+                PATTauProducer = 'slimmedTaus',
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = cms.bool(True),
-                mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-                mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
-                verbosity = cms.int32(0)
+                loadMVAfromDB = True,
+                mvaName = 'RecoTauTag_tauIdMVAIsoPhase2',
+                mvaOpt = 'DBnewDMwLTwGJPhase2',
+                verbosity = 0
             )
 
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
-                PATTauProducer = cms.InputTag('slimmedTaus'),
+                PATTauProducer = 'slimmedTaus',
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
-                loadMVAfromDB = cms.bool(True),
-                mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
+                toMultiplex = 'rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw',
+                loadMVAfromDB = True,
+                mvaOutput_normalization = 'RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization',
                 mapping = cms.VPSet(
                     cms.PSet(
                         category = cms.uint32(0),

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -13,7 +13,7 @@ class TauIDEmbedder(object):
         "deepTau2017v1", "deepTau2017v2", "deepTau2017v2p1",
         "DPFTau_2016_v0", "DPFTau_2016_v1",
         "againstEle2018",
-        "newDMwLTwGJPhase2"
+        "newDMPhase2v1"
     ]
 
     def __init__(self, process, debug = False,
@@ -864,8 +864,8 @@ class TauIDEmbedder(object):
             )
             tauIDSources =_tauIDSourcesWithAgainistEle.clone()
 
-        if "newDMwLTwGJPhase2" in self.toKeep:
-            if self.debug: print ("Adding newDMwLTwGJPhase2 ID")
+        if "newDMPhase2v1" in self.toKeep:
+            if self.debug: print ("Adding newDMPhase2v1 ID")
             def tauIDMVAinputs(module, wp):
                 return cms.PSet(inputTag = cms.InputTag(module), workingPointIndex = cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -867,33 +867,30 @@ class TauIDEmbedder(object):
         if "newDMwLTwGJPhase2" in self.toKeep:
             if self.debug: print ("Adding newDMwLTwGJPhase2 ID")
             def tauIDMVAinputs(module, wp):
-                return self.cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
+                return cms.PSet(inputTag = cms.InputTag(module), workingPointIndex = cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
-#                PATTauProducer = self.cms.InputTag(self.updatedTauName),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = self.cms.bool(True),
-                mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-                mvaOpt = self.cms.string("DBnewDMwLTwGJPhase2"),
-                verbosity = self.cms.int32(0)
+                loadMVAfromDB = cms.bool(True),
+                mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+                mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
+                verbosity = cms.int32(0)
             )
 
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
-                #PATTauProducer = self.cms.InputTag(self.updatedTauName),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                #toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2'),
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
-                loadMVAfromDB = self.cms.bool(True),
-                mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-                        variable = self.cms.string("pt"),
+                toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
+                loadMVAfromDB = cms.bool(True),
+                mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
+                mapping = cms.VPSet(
+                    cms.PSet(
+                        category = cms.uint32(0),
+                        cut = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+                        variable = cms.string("pt"),
                     )
                 ),
-                workingPoints = self.cms.vstring(
+                workingPoints = cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -903,12 +900,12 @@ class TauIDEmbedder(object):
                     "_WPEff40"
                 )
             )
-            self.process.rerunIsolationMVADBnewDMwLTPhase2Task = self.cms.Task(
+            self.process.rerunIsolationMVADBnewDMwLTPhase2Task = cms.Task(
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
             )
             self.process.rerunMvaIsolationTask.add(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
+            self.process.rerunMvaIsolationSequence += cms.Sequence(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
 
             tauIDSources.byIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw")
             tauIDSources.byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95")

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -864,6 +864,7 @@ class TauIDEmbedder(object):
             tauIDSources =_tauIDSourcesWithAgainistEle.clone()
 
         if "newDMwLTwGJPhase2" in self.toKeep:
+            if self.debug: print ("Adding newDMwLTwGJPhase2 ID")
             def tauIDMVAinputs(module, wp):
                 return self.cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -870,6 +870,7 @@ class TauIDEmbedder(object):
                 return self.cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
                 PATTauProducer = self.cms.InputTag('slimmedTaus'),
+#                PATTauProducer = self.cms.InputTag(self.updatedTauName),
                 Prediscriminants = noPrediscriminants,
                 loadMVAfromDB = self.cms.bool(True),
                 mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
@@ -879,6 +880,7 @@ class TauIDEmbedder(object):
 
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
                 PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                #PATTauProducer = self.cms.InputTag(self.updatedTauName),
                 Prediscriminants = noPrediscriminants,
                 #toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2'),
                 toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
@@ -905,8 +907,8 @@ class TauIDEmbedder(object):
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
             )
-            self.process.rerunMvaIsolationTask.add(self.rerunIsolationMVADBnewDMwLTPhase2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationMVADBnewDMwLTPhase2Task)
+            self.process.rerunMvaIsolationTask.add(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
+            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
 
             tauIDSources.byIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw")
             tauIDSources.byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95")

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -196,7 +196,7 @@ namespace reco {
             mvaOpt == kDBnewDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
             tauDecayMode == 10 || tauDecayMode == 11))) {
-        
+
         float chargedIsoPtSum = tau.tauID(nameCharged);
         float neutralIsoPtSum = tau.tauID(nameNeutral);
         float puCorrPtSum = tau.tauID(namePu);

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -192,11 +192,10 @@ namespace reco {
       if (((mvaOpt == kOldDMwoLT || mvaOpt == kOldDMwLT || mvaOpt == kDBoldDMwLT || mvaOpt == kPWoldDMwLT ||
             mvaOpt == kDBoldDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 10)) ||
-          ((mvaOpt==kPhase2 || mvaOpt == kNewDMwoLT || mvaOpt == kNewDMwLT || mvaOpt == kDBnewDMwLT || mvaOpt == kPWnewDMwLT ||
+          ((mvaOpt==kDBnewDMwLTwGJPhase2 || mvaOpt == kNewDMwoLT || mvaOpt == kNewDMwLT || mvaOpt == kDBnewDMwLT || mvaOpt == kPWnewDMwLT ||
             mvaOpt == kDBnewDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
             tauDecayMode == 10 || tauDecayMode == 11))) {
-
         float chargedIsoPtSum = tau.tauID(nameCharged);
         float neutralIsoPtSum = tau.tauID(nameNeutral);
         float puCorrPtSum = tau.tauID(namePu);
@@ -236,7 +235,7 @@ namespace reco {
           }
         }
 
-      if (mvaOpt == kPhase2) {
+      if (mvaOpt == kDBnewDMwLTwGJPhase2) {
          mvaInput[0] = tau.pt();
          mvaInput[1] = abs(tau.eta());
          mvaInput[2] = chargedIsoPtSum; //tauID("chargedIsoPtSum");

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -188,6 +188,7 @@ namespace reco {
                               const std::string& nameOutside,
                               const std::string& nameFootprint) {
       int tauDecayMode = tau.decayMode();
+      const float mTau = 1.77682;
 
       if (((mvaOpt == kOldDMwoLT || mvaOpt == kOldDMwLT || mvaOpt == kDBoldDMwLT || mvaOpt == kPWoldDMwLT ||
             mvaOpt == kDBoldDMwLTwGJ) &&
@@ -221,7 +222,6 @@ namespace reco {
         // Difference between measured and maximally allowed Gottfried-Jackson angle
         float gjAngleDiff = -999;
         if (tauDecayMode == 10) {
-          double mTau = 1.77682;
           double mAOne = tau.p4().M();
           double pAOneMag = tau.p();
           double argumentThetaGJmax = (std::pow(mTau, 2) - std::pow(mAOne, 2)) / (2 * mTau * pAOneMag);
@@ -249,7 +249,7 @@ namespace reco {
           float sigCands_pt = 0.;
           float sigCands_dr, sigCands_deta, sigCands_dphi;
           sigCands_dr = sigCands_deta = sigCands_dphi = 0.;
-          for (auto& j : tau.signalGammaCands()) {
+          for (const auto& j : tau.signalGammaCands()) {
             const float dr = reco::deltaR(tau, *j);
             const float deta = std::abs(tau.eta() - j->eta());
             const float dphi = std::abs(reco::deltaPhi(tau.phi(), j->phi()));
@@ -269,7 +269,7 @@ namespace reco {
           float isoCands_pt = 0.;
           float isoCands_dr, isoCands_deta, isoCands_dphi;
           isoCands_dr = isoCands_deta = isoCands_dphi = 0.;
-          for (auto& j : tau.isolationGammaCands()) {
+          for (const auto& j : tau.isolationGammaCands()) {
             const float dr = reco::deltaR(tau, *j);
             const float deta = std::abs(tau.eta() - j->eta());
             const float dphi = std::abs(reco::deltaPhi(tau.phi(), j->phi()));
@@ -310,7 +310,6 @@ namespace reco {
           float thetaGJmax, thetaGJ;
           thetaGJmax = thetaGJ = 0.;
           if (decayDistMag > 0.) {
-            const float mTau = 1.77686;
             const float mAOne = tau.p4().M();
             const float pAOneMag = tau.p();
             thetaGJmax = (mTau * mTau - mAOne * mAOne) / (2. * mTau * pAOneMag);

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -302,14 +302,13 @@ namespace reco {
           mvaInput[19] = tau.ip3d() >= 0. ? +1 : -1;
           mvaInput[20] = sqrt(std::abs(tau.ip3d()));
           mvaInput[21] = std::abs(tau.ip3d_Sig());
-          mvaInput[22] = tau.hasSecondaryVertex();
+          mvaInput[22] = (tau.hasSecondaryVertex()) ? 1. : 0.;
           mvaInput[23] = decayDistMag;  //sqrt(tau.flightLength().Mag2());
           mvaInput[24] = tau.flightLengthSig();
           mvaInput[25] = leadingTrackChi2;  //tau.leadingTrackNormChi2();
 
           float thetaGJmax, thetaGJ;
-          thetaGJmax = thetaGJ = 0.;
-          if (decayDistMag > 0.) {
+          if (decayDistMag > 0. && tau.hasSecondaryVertex()) {
             const float mAOne = tau.p4().M();
             const float pAOneMag = tau.p();
             thetaGJmax = (mTau * mTau - mAOne * mAOne) / (2. * mTau * pAOneMag);
@@ -318,15 +317,15 @@ namespace reco {
                        tau.pz() * tau.flightLength().z()) /
                       (pAOneMag * decayDistMag);
             thetaGJ = acos(thetaGJ);
+            if (std::isnan(thetaGJ))
+              thetaGJ = -16.;
+            if (std::isnan(thetaGJmax))
+              thetaGJmax = -11.;
           } else {
             thetaGJ = -15.;
             thetaGJmax = -10.;
           }
-          if (std::isnan(thetaGJ))
-            thetaGJ = -16.;
-          if (std::isnan(thetaGJmax))
-            thetaGJmax = -11.;
-          mvaInput[26] = tau.hasSecondaryVertex() ? thetaGJ - thetaGJmax : -5.;
+          mvaInput[26] = thetaGJ - thetaGJmax;
 
           mvaInput[27] = 0;
           mvaInput[28] = 10.;

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -329,16 +329,16 @@ namespace reco {
          mvaInput[27] = 0;
          mvaInput[28] = 10.;
          mvaInput[29] = 10.;
-         const pat::PackedCandidate* patcand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand);
-         if (patcand->hasTrackDetails()) {
-            const float trackdxy = patcand->dxy();
-            const float trackdxyerr = patcand->dxyError();
-            mvaInput[27] = trackdxy>=0.?+1:-1;
-            mvaInput[28] = sqrt(std::abs(trackdxy));
-            mvaInput[29] = std::abs(trackdxy/trackdxyerror);
-         }
+         if (tau.leadChargedHadrCand().isNonnull()) {
+            if (tau.leadChargedHadrCand()->bestTrack()) {
+               const float trackdxy = tau.leadChargedHadrCand()->bestTrack()->dxy();
+               const float trackdxy_err = tau.leadChargedHadrCand()->bestTrack()->dxyError();
+               mvaInput[27] = trackdxy>=0.?+1:-1;
+               mvaInput[28] = sqrt(std::abs(trackdxy));
+               mvaInput[29] = std::abs(trackdxy/trackdxy_err);
+            }
+        }
       }
-
         if (mvaOpt == kOldDMwoLT || mvaOpt == kNewDMwoLT) {
           mvaInput[0] = std::log(std::max(1.f, (float)tau.pt()));
           mvaInput[1] = std::abs((float)tau.eta());

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -329,13 +329,13 @@ namespace reco {
          mvaInput[27] = 0;
          mvaInput[28] = 10.;
          mvaInput[29] = 10.;
-         if (tau.leadChargedHadrCand().isNonnull()) {
-            if (tau.leadChargedHadrCand()->bestTrack()) {
-               const float trackdxy = tau.leadChargedHadrCand()->bestTrack()->dxy();
-               mvaInput[27] = trackdxy>=0.?+1:-1;
-               mvaInput[28] = sqrt(std::abs(trackdxy));
-               mvaInput[29] = std::abs(trackdxy/tau.leadChargedHadrCand()->bestTrack()->dxyError());
-            }
+         const pat::PackedCandidate* patcand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand);
+         if (patcand->hasTrackDetails()) {
+            const float trackdxy = patcand->dxy();
+            const float trackdxyerr = patcand->dxyError();
+            mvaInput[27] = trackdxy>=0.?+1:-1;
+            mvaInput[28] = sqrt(std::abs(trackdxy));
+            mvaInput[29] = std::abs(trackdxy/trackdxyerror);
          }
       }
 

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -238,7 +238,7 @@ namespace reco {
 
       if (mvaOpt == kDBnewDMwLTwGJPhase2) {
          mvaInput[0] = tau.pt();
-         mvaInput[1] = abs(tau.eta());
+         mvaInput[1] = std::abs(tau.eta());
          mvaInput[2] = chargedIsoPtSum; //tauID("chargedIsoPtSum");
          mvaInput[3] = neutralIsoPtSum; //tauID("neutralIsoPtSum");
          mvaInput[4] = puCorrPtSum; //tauID("puCorrPtSum");
@@ -298,11 +298,11 @@ namespace reco {
          e>0. ? e=tau.ecalEnergy()/e : e=-1.;
          mvaInput[15] = e;
          mvaInput[16] = tau.dxy()>=0.?+1:-1;
-         mvaInput[17] = sqrt(abs(tau.dxy()));
-         mvaInput[18] = abs(tau.dxy_Sig());
+         mvaInput[17] = sqrt(std::abs(tau.dxy()));
+         mvaInput[18] = std::abs(tau.dxy_Sig());
          mvaInput[19] = tau.ip3d()>=0.?+1:-1;
-         mvaInput[20] = sqrt(abs(tau.ip3d()));
-         mvaInput[21] = abs(tau.ip3d_Sig());
+         mvaInput[20] = sqrt(std::abs(tau.ip3d()));
+         mvaInput[21] = std::abs(tau.ip3d_Sig());
          mvaInput[22] = tau.hasSecondaryVertex();
          mvaInput[23] = decayDistMag; //sqrt(tau.flightLength().Mag2());
          mvaInput[24] = tau.flightLengthSig();
@@ -333,10 +333,10 @@ namespace reco {
             if (tau.leadChargedHadrCand()->bestTrack()) {
                const float trackdxy = tau.leadChargedHadrCand()->bestTrack()->dxy();
                mvaInput[27] = trackdxy>=0.?+1:-1;
-               mvaInput[28] = sqrt(abs(trackdxy));
-               mvaInput[29] = abs(trackdxy/tau.leadChargedHadrCand()->bestTrack()->dxyError());
+               mvaInput[28] = sqrt(std::abs(trackdxy));
+               mvaInput[29] = std::abs(trackdxy/tau.leadChargedHadrCand()->bestTrack()->dxyError());
             }
-        }
+         }
       }
 
         if (mvaOpt == kOldDMwoLT || mvaOpt == kNewDMwoLT) {

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -196,6 +196,7 @@ namespace reco {
             mvaOpt == kDBnewDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
             tauDecayMode == 10 || tauDecayMode == 11))) {
+        
         float chargedIsoPtSum = tau.tauID(nameCharged);
         float neutralIsoPtSum = tau.tauID(nameNeutral);
         float puCorrPtSum = tau.tauID(namePu);

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -192,11 +192,10 @@ namespace reco {
       if (((mvaOpt == kOldDMwoLT || mvaOpt == kOldDMwLT || mvaOpt == kDBoldDMwLT || mvaOpt == kPWoldDMwLT ||
             mvaOpt == kDBoldDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 10)) ||
-          ((mvaOpt==kDBnewDMwLTwGJPhase2 || mvaOpt == kNewDMwoLT || mvaOpt == kNewDMwLT || mvaOpt == kDBnewDMwLT || mvaOpt == kPWnewDMwLT ||
-            mvaOpt == kDBnewDMwLTwGJ) &&
+          ((mvaOpt == kDBnewDMwLTwGJPhase2 || mvaOpt == kNewDMwoLT || mvaOpt == kNewDMwLT || mvaOpt == kDBnewDMwLT ||
+            mvaOpt == kPWnewDMwLT || mvaOpt == kDBnewDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
             tauDecayMode == 10 || tauDecayMode == 11))) {
-
         float chargedIsoPtSum = tau.tauID(nameCharged);
         float neutralIsoPtSum = tau.tauID(nameNeutral);
         float puCorrPtSum = tau.tauID(namePu);
@@ -236,21 +235,21 @@ namespace reco {
           }
         }
 
-      if (mvaOpt == kDBnewDMwLTwGJPhase2) {
-         mvaInput[0] = tau.pt();
-         mvaInput[1] = std::abs(tau.eta());
-         mvaInput[2] = chargedIsoPtSum; //tauID("chargedIsoPtSum");
-         mvaInput[3] = neutralIsoPtSum; //tauID("neutralIsoPtSum");
-         mvaInput[4] = puCorrPtSum; //tauID("puCorrPtSum");
-         mvaInput[5] = photonPtSumOutsideSignalCone; //tauID("photonPtSumOutsideSignalCone");
-         mvaInput[7] = tauDecayMode; //tau.decayMode();
-         mvaInput[7] = tau.signalGammaCands().size();
-         mvaInput[8] = tau.isolationGammaCands().size();
+        if (mvaOpt == kDBnewDMwLTwGJPhase2) {
+          mvaInput[0] = tau.pt();
+          mvaInput[1] = std::abs(tau.eta());
+          mvaInput[2] = chargedIsoPtSum;               //tauID("chargedIsoPtSum");
+          mvaInput[3] = neutralIsoPtSum;               //tauID("neutralIsoPtSum");
+          mvaInput[4] = puCorrPtSum;                   //tauID("puCorrPtSum");
+          mvaInput[5] = photonPtSumOutsideSignalCone;  //tauID("photonPtSumOutsideSignalCone");
+          mvaInput[7] = tauDecayMode;                  //tau.decayMode();
+          mvaInput[7] = tau.signalGammaCands().size();
+          mvaInput[8] = tau.isolationGammaCands().size();
 
-         float sigCands_pt = 0.;
-         float sigCands_dr, sigCands_deta, sigCands_dphi;
-         sigCands_dr = sigCands_deta = sigCands_dphi = 0.;
-         for (auto & j : tau.signalGammaCands()) {
+          float sigCands_pt = 0.;
+          float sigCands_dr, sigCands_deta, sigCands_dphi;
+          sigCands_dr = sigCands_deta = sigCands_dphi = 0.;
+          for (auto& j : tau.signalGammaCands()) {
             const float dr = reco::deltaR(tau, *j);
             const float deta = std::abs(tau.eta() - j->eta());
             const float dphi = std::abs(reco::deltaPhi(tau.phi(), j->phi()));
@@ -259,18 +258,18 @@ namespace reco {
             sigCands_deta += deta * pt_;
             sigCands_dphi += dphi * pt_;
             sigCands_pt += pt_;
-         }
-         if (sigCands_pt>0.) {
+          }
+          if (sigCands_pt > 0.) {
             sigCands_dr = sigCands_dr / sigCands_pt;
             sigCands_deta = sigCands_deta / sigCands_pt;
             sigCands_dphi = sigCands_dphi / sigCands_pt;
-         } else {
+          } else {
             sigCands_dr = sigCands_deta = sigCands_dphi = -0.1;
-         }
-         float isoCands_pt = 0.;
-         float isoCands_dr, isoCands_deta, isoCands_dphi;
-         isoCands_dr = isoCands_deta = isoCands_dphi = 0.;
-         for (auto& j : tau.isolationGammaCands()) {
+          }
+          float isoCands_pt = 0.;
+          float isoCands_dr, isoCands_deta, isoCands_dphi;
+          isoCands_dr = isoCands_deta = isoCands_dphi = 0.;
+          for (auto& j : tau.isolationGammaCands()) {
             const float dr = reco::deltaR(tau, *j);
             const float deta = std::abs(tau.eta() - j->eta());
             const float dphi = std::abs(reco::deltaPhi(tau.phi(), j->phi()));
@@ -279,66 +278,70 @@ namespace reco {
             isoCands_deta += deta * pt_;
             isoCands_dphi += dphi * pt_;
             isoCands_pt += pt_;
-         }
-         if (isoCands_pt>0.) {
+          }
+          if (isoCands_pt > 0.) {
             isoCands_dr = isoCands_dr / isoCands_pt;
             isoCands_deta = isoCands_deta / isoCands_pt;
             isoCands_dphi = isoCands_dphi / isoCands_pt;
-         } else {
+          } else {
             isoCands_dr = isoCands_deta = isoCands_dphi = -0.1;
-         }
-         mvaInput[9] = isoCands_deta;
-         mvaInput[10] = isoCands_dphi;
-         mvaInput[11] = isoCands_dr;
-         mvaInput[12] = sigCands_deta;
-         mvaInput[13] = sigCands_dphi;
-         mvaInput[14] = sigCands_dr;
-         
-         float e = tau.hcalEnergy()+tau.ecalEnergy();
-         e>0. ? e=tau.ecalEnergy()/e : e=-1.;
-         mvaInput[15] = e;
-         mvaInput[16] = tau.dxy()>=0.?+1:-1;
-         mvaInput[17] = sqrt(std::abs(tau.dxy()));
-         mvaInput[18] = std::abs(tau.dxy_Sig());
-         mvaInput[19] = tau.ip3d()>=0.?+1:-1;
-         mvaInput[20] = sqrt(std::abs(tau.ip3d()));
-         mvaInput[21] = std::abs(tau.ip3d_Sig());
-         mvaInput[22] = tau.hasSecondaryVertex();
-         mvaInput[23] = decayDistMag; //sqrt(tau.flightLength().Mag2());
-         mvaInput[24] = tau.flightLengthSig();
-         mvaInput[25] = leadingTrackChi2; //tau.leadingTrackNormChi2();
+          }
+          mvaInput[9] = isoCands_deta;
+          mvaInput[10] = isoCands_dphi;
+          mvaInput[11] = isoCands_dr;
+          mvaInput[12] = sigCands_deta;
+          mvaInput[13] = sigCands_dphi;
+          mvaInput[14] = sigCands_dr;
 
-         float thetaGJmax, thetaGJ;
-         thetaGJmax = thetaGJ = 0.;
-         if (decayDistMag>0.) {
+          float e = tau.hcalEnergy() + tau.ecalEnergy();
+          e > 0. ? e = tau.ecalEnergy() / e : e = -1.;
+          mvaInput[15] = e;
+          mvaInput[16] = tau.dxy() >= 0. ? +1 : -1;
+          mvaInput[17] = sqrt(std::abs(tau.dxy()));
+          mvaInput[18] = std::abs(tau.dxy_Sig());
+          mvaInput[19] = tau.ip3d() >= 0. ? +1 : -1;
+          mvaInput[20] = sqrt(std::abs(tau.ip3d()));
+          mvaInput[21] = std::abs(tau.ip3d_Sig());
+          mvaInput[22] = tau.hasSecondaryVertex();
+          mvaInput[23] = decayDistMag;  //sqrt(tau.flightLength().Mag2());
+          mvaInput[24] = tau.flightLengthSig();
+          mvaInput[25] = leadingTrackChi2;  //tau.leadingTrackNormChi2();
+
+          float thetaGJmax, thetaGJ;
+          thetaGJmax = thetaGJ = 0.;
+          if (decayDistMag > 0.) {
             const float mTau = 1.77686;
             const float mAOne = tau.p4().M();
             const float pAOneMag = tau.p();
-            thetaGJmax = (mTau*mTau - mAOne*mAOne) / ( 2. * mTau * pAOneMag);
+            thetaGJmax = (mTau * mTau - mAOne * mAOne) / (2. * mTau * pAOneMag);
             thetaGJmax = asin(thetaGJmax);
-            thetaGJ = (tau.px()*tau.flightLength().x() + tau.py()*tau.flightLength().y() + tau.pz()*tau.flightLength().z()) / (pAOneMag * decayDistMag);
+            thetaGJ = (tau.px() * tau.flightLength().x() + tau.py() * tau.flightLength().y() +
+                       tau.pz() * tau.flightLength().z()) /
+                      (pAOneMag * decayDistMag);
             thetaGJ = acos(thetaGJ);
-         } else {
+          } else {
             thetaGJ = -15.;
             thetaGJmax = -10.;
-         }
-         if (std::isnan(thetaGJ)) thetaGJ = -16.;
-         if (std::isnan(thetaGJmax)) thetaGJmax = -11.;
-         mvaInput[26] = tau.hasSecondaryVertex()?thetaGJ-thetaGJmax:-5.;
+          }
+          if (std::isnan(thetaGJ))
+            thetaGJ = -16.;
+          if (std::isnan(thetaGJmax))
+            thetaGJmax = -11.;
+          mvaInput[26] = tau.hasSecondaryVertex() ? thetaGJ - thetaGJmax : -5.;
 
-         mvaInput[27] = 0;
-         mvaInput[28] = 10.;
-         mvaInput[29] = 10.;
-         if (tau.leadChargedHadrCand().isNonnull()) {
+          mvaInput[27] = 0;
+          mvaInput[28] = 10.;
+          mvaInput[29] = 10.;
+          if (tau.leadChargedHadrCand().isNonnull()) {
             if (tau.leadChargedHadrCand()->bestTrack()) {
-               const float trackdxy = tau.leadChargedHadrCand()->bestTrack()->dxy();
-               const float trackdxy_err = tau.leadChargedHadrCand()->bestTrack()->dxyError();
-               mvaInput[27] = trackdxy>=0.?+1:-1;
-               mvaInput[28] = sqrt(std::abs(trackdxy));
-               mvaInput[29] = std::abs(trackdxy/trackdxy_err);
+              const float trackdxy = tau.leadChargedHadrCand()->bestTrack()->dxy();
+              const float trackdxy_err = tau.leadChargedHadrCand()->bestTrack()->dxyError();
+              mvaInput[27] = trackdxy >= 0. ? +1 : -1;
+              mvaInput[28] = sqrt(std::abs(trackdxy));
+              mvaInput[29] = std::abs(trackdxy / trackdxy_err);
             }
+          }
         }
-      }
         if (mvaOpt == kOldDMwoLT || mvaOpt == kNewDMwoLT) {
           mvaInput[0] = std::log(std::max(1.f, (float)tau.pt()));
           mvaInput[1] = std::abs((float)tau.eta());

--- a/RecoTauTag/RecoTau/test/BuildFile.xml
+++ b/RecoTauTag/RecoTau/test/BuildFile.xml
@@ -18,6 +18,21 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
+<library name="rerunMVAIsolationOnMiniAOD_Phase2" file="rerunMVAIsolationOnMiniAOD_Phase2.cc">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="DataFormats/PatCandidates"/>
+  <use name="DataFormats/TauReco"/>
+  <use name="RecoTauTag/RecoTau"/>
+  <use name="PhysicsTools/PatAlgos"/>
+  <use name="PhysicsTools/UtilAlgos"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="clhep"/>
+  <use name="root"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+
 <environment>
   <bin file="runtestRecoTauTagRecoTau.cpp">
     <flags TEST_RUNNER_ARGS=" /bin/bash RecoTauTag/RecoTau/test runtests.sh"/>

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
@@ -12,181 +12,180 @@
 
 class rerunMVAIsolationOnMiniAOD_Phase2 : public edm::EDAnalyzer {
 public:
-  explicit rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet&);
+  explicit rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet &);
+
 private:
-   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-   virtual void endJob() override;
+  virtual void analyze(const edm::Event &, const edm::EventSetup &) override;
+  virtual void endJob() override;
 
-   edm::EDGetTokenT<std::vector<pat::Tau>> tauToken_;
+  edm::EDGetTokenT<std::vector<pat::Tau>> tauToken_;
 
-   TH1D *h_raw_bkg, *h_raw_sig;
- 
-   TH1D *h_pt_denom_bkg, *h_pt_denom_sig;
-   TH1D *h_pt_num_bkg[7], *h_pt_num_sig[7];
-   TGraphAsymmErrors *eff[7], *fak[7];
-   
-   TH1D *h_inc_denom_bkg, *h_inc_num_bkg;
-   TH1D *h_inc_denom_sig, *h_inc_num_sig;
-   TGraphAsymmErrors *inceff, *incfak;
+  TH1D *h_raw_bkg, *h_raw_sig;
 
-   TH2D *h2_denom_bkg, *h2_denom_sig;
-   TH2D *h2_num_bkg[7], *h2_num_sig[7];
-   TH2D *eff2[7], *fak2[7];
+  TH1D *h_pt_denom_bkg, *h_pt_denom_sig;
+  TH1D *h_pt_num_bkg[7], *h_pt_num_sig[7];
+  TGraphAsymmErrors *eff[7], *fak[7];
 
-   bool haveGenJets;
-   edm::EDGetTokenT<std::vector<reco::GenJet>> genJetToken_;   
+  TH1D *h_inc_denom_bkg, *h_inc_num_bkg;
+  TH1D *h_inc_denom_sig, *h_inc_num_sig;
+  TGraphAsymmErrors *inceff, *incfak;
+
+  TH2D *h2_denom_bkg, *h2_denom_sig;
+  TH2D *h2_num_bkg[7], *h2_num_sig[7];
+  TH2D *eff2[7], *fak2[7];
+
+  bool haveGenJets;
+  edm::EDGetTokenT<std::vector<reco::GenJet>> genJetToken_;
 };
 
-rerunMVAIsolationOnMiniAOD_Phase2::rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet& iConfig)
-{
-   tauToken_ = consumes<pat::TauCollection>(iConfig.getParameter<edm::InputTag>("tauCollection"));
- 
-   haveGenJets = false;
-   if (iConfig.existsAs<edm::InputTag>("genJetCollection")) {  
-      haveGenJets = true;
-      genJetToken_ = consumes<std::vector<reco::GenJet>>(iConfig.getParameter<edm::InputTag>("genJetCollection"));
-   }
+rerunMVAIsolationOnMiniAOD_Phase2::rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet &iConfig) {
+  tauToken_ = consumes<pat::TauCollection>(iConfig.getParameter<edm::InputTag>("tauCollection"));
 
-   edm::Service<TFileService> fileService;
-   h_raw_sig = fileService->make<TH1D>("h_raw_sig", ";BDT output;taus / 0.02", 110, -1.1, 1.1);
-   h_raw_bkg = fileService->make<TH1D>("h_raw_bkg", ";BDT output;taus / 0.02", 110, -1.1, 1.1);
-   
-   h_inc_num_sig = fileService->make<TH1D>("h_inc_num_sig", ";working point;taus / bin", 7, 0.5, 7.5);
-   h_inc_denom_sig = fileService->make<TH1D>("h_inc_denom_sig", ";working point;taus / bin", 7, 0.5, 7.5);
-   h_inc_num_bkg = fileService->make<TH1D>("h_inc_num_bkg", ";working point;taus / bin", 7, 0.5, 7.5);
-   h_inc_denom_bkg = fileService->make<TH1D>("h_inc_denom_bkg", ";working point;taus / bin", 7, 0.5, 7.5);
-   inceff = fileService->make<TGraphAsymmErrors>(7);
-   inceff->SetName("inceff");
-   incfak = fileService->make<TGraphAsymmErrors>(7);
-   incfak->SetName("incfak");
+  haveGenJets = false;
+  if (iConfig.existsAs<edm::InputTag>("genJetCollection")) {
+    haveGenJets = true;
+    genJetToken_ = consumes<std::vector<reco::GenJet>>(iConfig.getParameter<edm::InputTag>("genJetCollection"));
+  }
 
-   const int n = 10;
-   const double x[n+1] = {20., 25.4196, 32.3079, 41.0627, 52.19, 66.3325, 84.3074, 107.153, 136.19, 173.095, 220.};
-   h_pt_denom_sig = fileService->make<TH1D>("h_pt_denom_sig", ";p_{T} [GeV];taus / bin", n, x);
-   h_pt_denom_bkg = fileService->make<TH1D>("h_pt_denom_bkg", ";p_{T} [GeV];taus / bin", n, x);
-   for (int i = 0; i < 7; ++i) {
-      const TString tag = TString::Itoa(i, 10);
-      h_pt_num_sig[i] = fileService->make<TH1D>("h_pt_num_sig_"+tag, ";p_{T} [GeV];taus / bin", n, x);
-      h_pt_num_bkg[i] = fileService->make<TH1D>("h_pt_num_bkg_"+tag, ";p_{T} [GeV];taus / bin", n, x);
-      eff[i] = fileService->make<TGraphAsymmErrors>(10);
-      eff[i]->SetName("eff_"+TString::Itoa(i, 10));
-      fak[i] = fileService->make<TGraphAsymmErrors>(10);
-      fak[i]->SetName("fak_"+TString::Itoa(i, 10));
-   }
-   const double xeta[4] = {0., 1.5, 2.3, 3.};
-   const double xpt[3] = {20., 50., 220.};
-   h2_denom_sig = fileService->make<TH2D>("h2_denom_sig", ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
-   h2_denom_bkg = fileService->make<TH2D>("h2_denom_bkg", ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
-   for (int i = 0; i < 7; ++i) {
-      const TString tag = TString::Itoa(i, 10);
-      h2_num_sig[i] = fileService->make<TH2D>("h2_num_sig_"+tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
-      h2_num_sig[i]->Sumw2();
-      h2_num_bkg[i] = fileService->make<TH2D>("h2_num_bkg_"+tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
-      h2_num_bkg[i]->Sumw2();
-      eff2[i] = fileService->make<TH2D>("eff2_"+tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
-      eff2[i]->Sumw2();
-      fak2[i] = fileService->make<TH2D>("fak2_"+tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);  
-      fak2[i]->Sumw2();
-   }
+  edm::Service<TFileService> fileService;
+  h_raw_sig = fileService->make<TH1D>("h_raw_sig", ";BDT output;taus / 0.02", 110, -1.1, 1.1);
+  h_raw_bkg = fileService->make<TH1D>("h_raw_bkg", ";BDT output;taus / 0.02", 110, -1.1, 1.1);
+
+  h_inc_num_sig = fileService->make<TH1D>("h_inc_num_sig", ";working point;taus / bin", 7, 0.5, 7.5);
+  h_inc_denom_sig = fileService->make<TH1D>("h_inc_denom_sig", ";working point;taus / bin", 7, 0.5, 7.5);
+  h_inc_num_bkg = fileService->make<TH1D>("h_inc_num_bkg", ";working point;taus / bin", 7, 0.5, 7.5);
+  h_inc_denom_bkg = fileService->make<TH1D>("h_inc_denom_bkg", ";working point;taus / bin", 7, 0.5, 7.5);
+  inceff = fileService->make<TGraphAsymmErrors>(7);
+  inceff->SetName("inceff");
+  incfak = fileService->make<TGraphAsymmErrors>(7);
+  incfak->SetName("incfak");
+
+  const int n = 10;
+  const double x[n + 1] = {20., 25.4196, 32.3079, 41.0627, 52.19, 66.3325, 84.3074, 107.153, 136.19, 173.095, 220.};
+  h_pt_denom_sig = fileService->make<TH1D>("h_pt_denom_sig", ";p_{T} [GeV];taus / bin", n, x);
+  h_pt_denom_bkg = fileService->make<TH1D>("h_pt_denom_bkg", ";p_{T} [GeV];taus / bin", n, x);
+  for (int i = 0; i < 7; ++i) {
+    const TString tag = TString::Itoa(i, 10);
+    h_pt_num_sig[i] = fileService->make<TH1D>("h_pt_num_sig_" + tag, ";p_{T} [GeV];taus / bin", n, x);
+    h_pt_num_bkg[i] = fileService->make<TH1D>("h_pt_num_bkg_" + tag, ";p_{T} [GeV];taus / bin", n, x);
+    eff[i] = fileService->make<TGraphAsymmErrors>(10);
+    eff[i]->SetName("eff_" + TString::Itoa(i, 10));
+    fak[i] = fileService->make<TGraphAsymmErrors>(10);
+    fak[i]->SetName("fak_" + TString::Itoa(i, 10));
+  }
+  const double xeta[4] = {0., 1.5, 2.3, 3.};
+  const double xpt[3] = {20., 50., 220.};
+  h2_denom_sig = fileService->make<TH2D>("h2_denom_sig", ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+  h2_denom_bkg = fileService->make<TH2D>("h2_denom_bkg", ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+  for (int i = 0; i < 7; ++i) {
+    const TString tag = TString::Itoa(i, 10);
+    h2_num_sig[i] = fileService->make<TH2D>("h2_num_sig_" + tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+    h2_num_sig[i]->Sumw2();
+    h2_num_bkg[i] = fileService->make<TH2D>("h2_num_bkg_" + tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+    h2_num_bkg[i]->Sumw2();
+    eff2[i] = fileService->make<TH2D>("eff2_" + tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+    eff2[i]->Sumw2();
+    fak2[i] = fileService->make<TH2D>("fak2_" + tag, ";|#eta|;p_{T} [GeV]", 3, xeta, 2, xpt);
+    fak2[i]->Sumw2();
+  }
 }
 
-void rerunMVAIsolationOnMiniAOD_Phase2::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   edm::Handle<pat::TauCollection> taus;
-   iEvent.getByToken(tauToken_, taus);
+void rerunMVAIsolationOnMiniAOD_Phase2::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  edm::Handle<pat::TauCollection> taus;
+  iEvent.getByToken(tauToken_, taus);
 
-   const bool isRealData = iEvent.isRealData();
+  const bool isRealData = iEvent.isRealData();
 
-   edm::Handle<std::vector<reco::GenJet>> genJets;
-   if (!isRealData && haveGenJets) {
-      iEvent.getByToken(genJetToken_, genJets);
-   } else {
-      haveGenJets = false;
-   }
-   
-   for (auto i = taus->begin(); i != taus->end(); ++i) {
-      
-      const double pt = i->pt();
-      const double eta = std::abs(i->eta());
-      if (pt<20. || pt>=220. || eta>=3.) continue;
-      if (!i->tauID("decayModeFindingNewDMs")) continue;
+  edm::Handle<std::vector<reco::GenJet>> genJets;
+  if (!isRealData && haveGenJets) {
+    iEvent.getByToken(genJetToken_, genJets);
+  } else {
+    haveGenJets = false;
+  }
 
-      bool isPU = false;
-      if (haveGenJets) {
-         double mindr_jet = 9.;
-         for (auto j = genJets->begin(); j != genJets->end(); ++j) {
-            if (reco::deltaR(*i, *j)<mindr_jet) {
-               mindr_jet = reco::deltaR(*i, *j);
-            }
-         }
-         if (mindr_jet>=0.4) isPU = true;
+  for (auto i = taus->begin(); i != taus->end(); ++i) {
+    const double pt = i->pt();
+    const double eta = std::abs(i->eta());
+    if (pt < 20. || pt >= 220. || eta >= 3.)
+      continue;
+    if (!i->tauID("decayModeFindingNewDMs"))
+      continue;
+
+    bool isPU = false;
+    if (haveGenJets) {
+      double mindr_jet = 9.;
+      for (auto j = genJets->begin(); j != genJets->end(); ++j) {
+        if (reco::deltaR(*i, *j) < mindr_jet) {
+          mindr_jet = reco::deltaR(*i, *j);
+        }
       }
-      if (isPU) continue;
+      if (mindr_jet >= 0.4)
+        isPU = true;
+    }
+    if (isPU)
+      continue;
 
-      bool isSig = false;
-      if (!isRealData) {
-         if (i->genJet()) {
-            isSig = true;
-         }
+    bool isSig = false;
+    if (!isRealData) {
+      if (i->genJet()) {
+        isSig = true;
       }
+    }
 
-      const double byIsolationMVAPhase2raw = i->tauID("ByIsolationMVADBnewDMwLTPhase2raw");
-      double wp[7];
-      wp[0] = i->tauID("byVVLooseIsolationMVADBnewDMwLTPhase2");
-      wp[1] = i->tauID("byVLooseIsolationMVADBnewDMwLTPhase2");
-      wp[2] = i->tauID("byLooseIsolationMVADBnewDMwLTPhase2");
-      wp[3] = i->tauID("byMediumIsolationMVADBnewDMwLTPhase2");
-      wp[4] = i->tauID("byTightIsolationMVADBnewDMwLTPhase2");
-      wp[5] = i->tauID("byVTightIsolationMVADBnewDMwLTPhase2");
-      wp[6] = i->tauID("byVVTightIsolationMVADBnewDMwLTPhase2");
-      
-      if (isSig) {
-         h_raw_sig->Fill(byIsolationMVAPhase2raw);
-         h_pt_denom_sig->Fill(pt);
-         h2_denom_sig->Fill(eta, pt);
-         for (int j = 0; j < 7; ++j) {
-            h_inc_denom_sig->Fill(j+1);
-            if (wp[j]) {
-               h_inc_num_sig->Fill(j+1);
-               h_pt_num_sig[j]->Fill(pt);
-               h2_num_sig[j]->Fill(eta, pt);
-            }
-         }
-      } else {
-         h_raw_bkg->Fill(byIsolationMVAPhase2raw);
-         h_pt_denom_bkg->Fill(pt);
-         h2_denom_bkg->Fill(eta, pt);
-         for (int j = 0; j < 7; ++j) {
-            h_inc_denom_bkg->Fill(j+1);
-            if (wp[j]) {
-               h_inc_num_bkg->Fill(j+1);
-               h_pt_num_bkg[j]->Fill(pt);
-               h2_num_bkg[j]->Fill(eta, pt);
-            }
-         }
+    const double byIsolationMVAPhase2raw = i->tauID("ByIsolationMVADBnewDMwLTPhase2raw");
+    double wp[7];
+    wp[0] = i->tauID("byVVLooseIsolationMVADBnewDMwLTPhase2");
+    wp[1] = i->tauID("byVLooseIsolationMVADBnewDMwLTPhase2");
+    wp[2] = i->tauID("byLooseIsolationMVADBnewDMwLTPhase2");
+    wp[3] = i->tauID("byMediumIsolationMVADBnewDMwLTPhase2");
+    wp[4] = i->tauID("byTightIsolationMVADBnewDMwLTPhase2");
+    wp[5] = i->tauID("byVTightIsolationMVADBnewDMwLTPhase2");
+    wp[6] = i->tauID("byVVTightIsolationMVADBnewDMwLTPhase2");
+
+    if (isSig) {
+      h_raw_sig->Fill(byIsolationMVAPhase2raw);
+      h_pt_denom_sig->Fill(pt);
+      h2_denom_sig->Fill(eta, pt);
+      for (int j = 0; j < 7; ++j) {
+        h_inc_denom_sig->Fill(j + 1);
+        if (wp[j]) {
+          h_inc_num_sig->Fill(j + 1);
+          h_pt_num_sig[j]->Fill(pt);
+          h2_num_sig[j]->Fill(eta, pt);
+        }
       }
-   }
-
+    } else {
+      h_raw_bkg->Fill(byIsolationMVAPhase2raw);
+      h_pt_denom_bkg->Fill(pt);
+      h2_denom_bkg->Fill(eta, pt);
+      for (int j = 0; j < 7; ++j) {
+        h_inc_denom_bkg->Fill(j + 1);
+        if (wp[j]) {
+          h_inc_num_bkg->Fill(j + 1);
+          h_pt_num_bkg[j]->Fill(pt);
+          h2_num_bkg[j]->Fill(eta, pt);
+        }
+      }
+    }
+  }
 }
 
-void rerunMVAIsolationOnMiniAOD_Phase2::endJob()
-{
-   inceff->Divide(h_inc_num_sig, h_inc_denom_sig, "e0");
-   inceff->SetTitle(";working point;tagging efficiency");
-   incfak->Divide(h_inc_num_bkg, h_inc_denom_bkg, "e0");
-   incfak->SetTitle(";working point;tagging efficiency");
-   for (int i = 0; i < 7; ++i) {
-      eff[i]->Divide(h_pt_num_sig[i], h_pt_denom_sig, "e0");
-      eff[i]->SetTitle(";p_{T} [GeV];tagging efficiency");
-      fak[i]->Divide(h_pt_num_bkg[i], h_pt_denom_bkg, "e0");
-      fak[i]->SetTitle(";p_{T} [GeV];tagging efficiency");
-      eff2[i]->Divide(h2_num_sig[i], h2_denom_sig, 1., 1., "B");
-      eff2[i]->SetTitle("tagging efficiency;|eta|;p_{T} [GeV]");
-      fak2[i]->Divide(h2_num_bkg[i], h2_denom_bkg, 1., 1., "B");
-      fak2[i]->SetTitle("tagging efficiency;|eta|;p_{T} [GeV]");
-   }
+void rerunMVAIsolationOnMiniAOD_Phase2::endJob() {
+  inceff->Divide(h_inc_num_sig, h_inc_denom_sig, "e0");
+  inceff->SetTitle(";working point;tagging efficiency");
+  incfak->Divide(h_inc_num_bkg, h_inc_denom_bkg, "e0");
+  incfak->SetTitle(";working point;tagging efficiency");
+  for (int i = 0; i < 7; ++i) {
+    eff[i]->Divide(h_pt_num_sig[i], h_pt_denom_sig, "e0");
+    eff[i]->SetTitle(";p_{T} [GeV];tagging efficiency");
+    fak[i]->Divide(h_pt_num_bkg[i], h_pt_denom_bkg, "e0");
+    fak[i]->SetTitle(";p_{T} [GeV];tagging efficiency");
+    eff2[i]->Divide(h2_num_sig[i], h2_denom_sig, 1., 1., "B");
+    eff2[i]->SetTitle("tagging efficiency;|eta|;p_{T} [GeV]");
+    fak2[i]->Divide(h2_num_bkg[i], h2_denom_bkg, 1., 1., "B");
+    fak2[i]->SetTitle("tagging efficiency;|eta|;p_{T} [GeV]");
+  }
 }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(rerunMVAIsolationOnMiniAOD_Phase2);
-

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
@@ -10,7 +10,7 @@
 #include "TH2D.h"
 #include "TGraphAsymmErrors.h"
 
-class rerunMVAIsolationOnMiniAOD_Phase2 : public edm::EDAnalyzer {
+class rerunMVAIsolationOnMiniAOD_Phase2 : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet &);
 
@@ -132,7 +132,7 @@ void rerunMVAIsolationOnMiniAOD_Phase2::analyze(const edm::Event &iEvent, const 
       }
     }
 
-    const double byIsolationMVAPhase2raw = i->tauID("ByIsolationMVADBnewDMwLTPhase2raw");
+    const double byIsolationMVAPhase2raw = i->tauID("byIsolationMVADBnewDMwLTPhase2raw");
     double wp[7];
     wp[0] = i->tauID("byVVLooseIsolationMVADBnewDMwLTPhase2");
     wp[1] = i->tauID("byVLooseIsolationMVADBnewDMwLTPhase2");

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
@@ -1,10 +1,10 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "DataFormats/JetReco/interface/GenJet.h"
 
 #include "TH1D.h"
 #include "TH2D.h"
@@ -16,6 +16,8 @@ public:
 private:
    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
    virtual void endJob() override;
+
+   edm::EDGetTokenT<std::vector<pat::Tau>> tauToken_;
 
    TH1D *h_raw_bkg, *h_raw_sig;
  
@@ -33,7 +35,6 @@ private:
 
    bool haveGenJets;
    edm::EDGetTokenT<std::vector<reco::GenJet>> genJetToken_;   
-   edm::EDGetTokenT<std::vector<pat::Tau>> tauToken_;
 };
 
 rerunMVAIsolationOnMiniAOD_Phase2::rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet& iConfig)

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
@@ -1,11 +1,10 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-//#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
-#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
 
 #include "TH1D.h"
 #include "TH2D.h"
@@ -18,8 +17,6 @@ private:
    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
    virtual void endJob() override;
 
-   edm::EDGetTokenT<pat::TauCollection> tauToken_;
- 
    TH1D *h_raw_bkg, *h_raw_sig;
  
    TH1D *h_pt_denom_bkg, *h_pt_denom_sig;
@@ -36,30 +33,17 @@ private:
 
    bool haveGenJets;
    edm::EDGetTokenT<std::vector<reco::GenJet>> genJetToken_;   
-   //bool haveGenVisTaus;
-   //edm::EDGetTokenT<pat::CompositeCandidateCollection> genVisTauToken_;
-   bool haveGenParticles;
-   edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticleToken_;
+   edm::EDGetTokenT<std::vector<pat::Tau>> tauToken_;
 };
 
 rerunMVAIsolationOnMiniAOD_Phase2::rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet& iConfig)
 {
-   tauToken_ = consumes<pat::TauCollection>(edm::InputTag("newTauIDsEmbedded"));
+   tauToken_ = consumes<pat::TauCollection>(iConfig.getParameter<edm::InputTag>("tauCollection"));
  
    haveGenJets = false;
    if (iConfig.existsAs<edm::InputTag>("genJetCollection")) {  
       haveGenJets = true;
       genJetToken_ = consumes<std::vector<reco::GenJet>>(iConfig.getParameter<edm::InputTag>("genJetCollection"));
-   }
-   //haveGenVisTaus = false;
-   //if (iConfig.existsAs<edm::InputTag>("genVisTauCollection")) {
-   //   haveGenVisTaus = true;
-   //   genVisTauToken_ = consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("genVisTauCollection"));
-   //}
-   haveGenParticles = false;
-   if (iConfig.existsAs<edm::InputTag>("genParticleCollection")) {
-      haveGenParticles = true;
-      genParticleToken_ = consumes<std::vector<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticleCollection"));
    }
 
    edm::Service<TFileService> fileService;
@@ -110,15 +94,15 @@ void rerunMVAIsolationOnMiniAOD_Phase2::analyze(const edm::Event& iEvent, const 
    edm::Handle<pat::TauCollection> taus;
    iEvent.getByToken(tauToken_, taus);
 
+   const bool isRealData = iEvent.isRealData();
+
    edm::Handle<std::vector<reco::GenJet>> genJets;
-   if (haveGenJets) iEvent.getByToken(genJetToken_, genJets);
-
-   //edm::Handle<pat::CompositeCandidateCollection> genVisTaus;
-   //if (haveGenVisTaus) iEvent.getByToken(genVisTauToken_, genVisTaus);
-
-   edm::Handle<std::vector<reco::GenParticle>> genParticles;
-   if (haveGenParticles) iEvent.getByToken(genParticleToken_, genParticles);
- 
+   if (!isRealData && haveGenJets) {
+      iEvent.getByToken(genJetToken_, genJets);
+   } else {
+      haveGenJets = false;
+   }
+   
    for (auto i = taus->begin(); i != taus->end(); ++i) {
       
       const double pt = i->pt();
@@ -138,41 +122,22 @@ void rerunMVAIsolationOnMiniAOD_Phase2::analyze(const edm::Event& iEvent, const 
       }
       if (isPU) continue;
 
-      //bool isSig = false;
-      //if (haveGenVisTaus) {
-      //   double mindr = 99.;
-      //   for (auto j = genVisTaus->begin(); j != genVisTaus->end(); ++j) {
-      //      if (std::abs(j->pdgId())==15 && reco::deltaR(*i, *j)<mindr) {
-      //         mindr = reco::deltaR(*i, *j);
-      //      }
-      //   }
-      //   if (mindr<0.4) isSig = true;
-      //}
-
       bool isSig = false;
-      if (haveGenParticles) {
-         double mindr_e = 99.;
-         double mindr_m = 99.;
-         double mindr_t = 99.;
-         for (auto j = genParticles->begin(); j != genParticles->end(); ++j) {
-            const double dr = reco::deltaR(*i, *j);
-            const int pdgid = std::abs(j->pdgId());
-            if (pdgid==11 && j->status()==1 && dr<mindr_e) mindr_e = dr;
-            if (pdgid==13 && j->status()==1 && dr<mindr_m) mindr_m = dr;
-            if (pdgid==15 && j->isLastCopy() && dr<mindr_t) mindr_t = dr;
+      if (!isRealData) {
+         if (i->genJet()) {
+            isSig = true;
          }
-         if (mindr_e>=0.4 && mindr_m>=0.4 && mindr_t<0.5) isSig = true;
       }
 
-      const double byIsolationMVAPhase2raw = i->tauID("byIsolationMVAPhase2raw");
+      const double byIsolationMVAPhase2raw = i->tauID("ByIsolationMVADBnewDMwLTPhase2raw");
       double wp[7];
-      wp[0] = i->tauID("byVVLooseIsolationMVAPhase2New");
-      wp[1] = i->tauID("byVLooseIsolationMVAPhase2New");
-      wp[2] = i->tauID("byLooseIsolationMVAPhase2New");
-      wp[3] = i->tauID("byMediumIsolationMVAPhase2New");
-      wp[4] = i->tauID("byTightIsolationMVAPhase2New");
-      wp[5] = i->tauID("byVTightIsolationMVAPhase2New");
-      wp[6] = i->tauID("byVVTightIsolationMVAPhase2New");
+      wp[0] = i->tauID("byVVLooseIsolationMVADBnewDMwLTPhase2");
+      wp[1] = i->tauID("byVLooseIsolationMVADBnewDMwLTPhase2");
+      wp[2] = i->tauID("byLooseIsolationMVADBnewDMwLTPhase2");
+      wp[3] = i->tauID("byMediumIsolationMVADBnewDMwLTPhase2");
+      wp[4] = i->tauID("byTightIsolationMVADBnewDMwLTPhase2");
+      wp[5] = i->tauID("byVTightIsolationMVADBnewDMwLTPhase2");
+      wp[6] = i->tauID("byVVTightIsolationMVADBnewDMwLTPhase2");
       
       if (isSig) {
          h_raw_sig->Fill(byIsolationMVAPhase2raw);

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -80,7 +80,7 @@ def tauIDMVAinputs(module, wp):
 embedID = cms.EDProducer("PATTauIDEmbedder",
     src = cms.InputTag('slimmedTaus'),
     tauIDSources = cms.PSet(
-        ByIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw"),
+        byIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw"),
         byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95"),
         byVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff90"),
         byLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff80"),

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -8,22 +8,24 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2023_realistic_v2')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
+#process.Tracer = cms.Service("Tracer")
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10000)
+    input = cms.untracked.int32(1000)
 )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
-        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
+        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
+        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
     )
 )
 
 process.TFileService = cms.Service("TFileService",
-    #fileName = cms.string('output_QCD_Phase2.root')
-    fileName = cms.string('output_VBFHToTauTau_Phase2.root')
+    fileName = cms.string('output_QCD_Phase2.root')
+    #fileName = cms.string('output_VBFHToTauTau_Phase2.root')
 )
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
@@ -31,21 +33,22 @@ from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
 
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
-process.rerunDiscriminationByIsolationMVAPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
+
+process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
     PATTauProducer = cms.InputTag('slimmedTaus'),
     Prediscriminants = noPrediscriminants,
     loadMVAfromDB = cms.bool(True),
     #loadMVAfromDB = cms.bool(False),
     #inputFileName = cms.FileInPath("gbrDiscriminationByIsolationMVAPhase2.root"),
     mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-    mvaOpt = cms.string("Phase2"),
+    mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
     verbosity = cms.int32(0)
 )
 
-process.rerunDiscriminationByIsolationMVAPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
+process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
     PATTauProducer = cms.InputTag('slimmedTaus'),
     Prediscriminants = noPrediscriminants,
-    toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVAPhase2raw'),
+    toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
     loadMVAfromDB = cms.bool(True),
     #loadMVAfromDB = cms.bool(False),
     #inputFileName = cms.FileInPath("wpDiscriminationByIsolationMVAPhase2_tauIdMVAIsoPhase2.root"),
@@ -69,8 +72,8 @@ process.rerunDiscriminationByIsolationMVAPhase2 = patDiscriminationByIsolationMV
 )
 
 process.rerunMvaIsolation2Seq_Phase2 = cms.Sequence(
-    process.rerunDiscriminationByIsolationMVAPhase2raw
-    * process.rerunDiscriminationByIsolationMVAPhase2
+   process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw
+   *process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
 )
 
 # embed new id's into tau
@@ -79,49 +82,27 @@ def tauIDMVAinputs(module, wp):
 embedID = cms.EDProducer("PATTauIDEmbedder",
     src = cms.InputTag('slimmedTaus'),
     tauIDSources = cms.PSet(
-        byIsolationMVAPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "raw"),
-        byVVLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff95"),
-        byVLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff90"),
-        byLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff80"),
-        byMediumIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff70"),
-        byTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff60"),
-        byVTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff50"),
-        byVVTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff40")
+        ByIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw"),
+        byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95"),
+        byVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff90"),
+        byLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff80"),
+        byMediumIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff70"),
+        byTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff60"),
+        byVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff50"),
+        byVVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff40")
     ),
 )
 setattr(process, "newTauIDsEmbedded", embedID)
 
-## added for mvaIsolation on miniAOD testing
-#process.out = cms.OutputModule("PoolOutputModule",
-#    fileName = cms.untracked.string(filetag+'_miniaod.root'),
-#    ## save only events passing the full path
-#    SelectEvents = cms.untracked.PSet( SelectEvents = cms.vstring('p') ),
-#    ## save PAT output; you need a '*' to unpack the list of commands
-#    ##'patEventContent'
-#    outputCommands = cms.untracked.vstring(
-#        'drop *',
-#        'keep *_newTauIDsEmbedded_*_*',
-#        'keep *_prunedGenParticles_*_*'
-#    )
-#)
-
-#process.genVisTauProducer = cms.EDProducer("GenVisTauProducer",
-#    genParticleCollection = cms.InputTag("prunedGenParticles")
-#)
-
 process.rerunMVAIsolationOnMiniAOD_Phase2 = cms.EDAnalyzer(
     'rerunMVAIsolationOnMiniAOD_Phase2',
+    tauCollection = cms.InputTag("newTauIDsEmbedded"),
     genJetCollection = cms.InputTag("slimmedGenJets"), #comment out to run on data
-    #genVisTauCollection = cms.InputTag("genVisTauProducer:genVisTaus"), #comment out if running on data
-    genParticleCollection  = cms.InputTag("prunedGenParticles") #comment out to run on data
 )
 
 process.p = cms.Path(
     process.rerunMvaIsolation2Seq_Phase2
-    *process.newTauIDsEmbedded
-    #*process.genVisTauProducer
-    *process.rerunMVAIsolationOnMiniAOD_Phase2
+    * process.newTauIDsEmbedded
+    * process.rerunMVAIsolationOnMiniAOD_Phase2
 )
-
-#process.outpath = cms.EndPath(process.out)
 

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -1,0 +1,127 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("rerunMVAIsolationOnMiniAODPhase2")
+
+process.load('Configuration.Geometry.GeometryExtended2026D41Reco_cff')
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2023_realistic_v2')
+process.load("Configuration.StandardSequences.MagneticField_cff")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
+        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
+    )
+)
+
+process.TFileService = cms.Service("TFileService",
+    #fileName = cms.string('output_QCD_Phase2.root')
+    fileName = cms.string('output_VBFHToTauTau_Phase2.root')
+)
+
+from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
+### Load PoolDBESSource with mapping to payloads
+process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
+
+from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
+process.rerunDiscriminationByIsolationMVAPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
+    PATTauProducer = cms.InputTag('slimmedTaus'),
+    Prediscriminants = noPrediscriminants,
+    loadMVAfromDB = cms.bool(True),
+    #loadMVAfromDB = cms.bool(False),
+    #inputFileName = cms.FileInPath("gbrDiscriminationByIsolationMVAPhase2.root"),
+    mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+    mvaOpt = cms.string("Phase2"),
+    verbosity = cms.int32(0)
+)
+
+process.rerunDiscriminationByIsolationMVAPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
+    PATTauProducer = cms.InputTag('slimmedTaus'),
+    Prediscriminants = noPrediscriminants,
+    toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVAPhase2raw'),
+    loadMVAfromDB = cms.bool(True),
+    #loadMVAfromDB = cms.bool(False),
+    #inputFileName = cms.FileInPath("wpDiscriminationByIsolationMVAPhase2_tauIdMVAIsoPhase2.root"),
+    mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
+    mapping = cms.VPSet(
+        cms.PSet(
+            category = cms.uint32(0),
+            cut = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+            variable = cms.string("pt"),
+        )
+    ),
+    workingPoints = cms.vstring(
+        "_WPEff95",
+        "_WPEff90",
+        "_WPEff80",
+        "_WPEff70",
+        "_WPEff60",
+        "_WPEff50",
+        "_WPEff40"
+    )
+)
+
+process.rerunMvaIsolation2Seq_Phase2 = cms.Sequence(
+    process.rerunDiscriminationByIsolationMVAPhase2raw
+    * process.rerunDiscriminationByIsolationMVAPhase2
+)
+
+# embed new id's into tau
+def tauIDMVAinputs(module, wp):
+    return cms.PSet(inputTag = cms.InputTag(module), workingPointIndex = cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(process, module).workingPoints.index(wp)))
+embedID = cms.EDProducer("PATTauIDEmbedder",
+    src = cms.InputTag('slimmedTaus'),
+    tauIDSources = cms.PSet(
+        byIsolationMVAPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "raw"),
+        byVVLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff95"),
+        byVLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff90"),
+        byLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff80"),
+        byMediumIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff70"),
+        byTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff60"),
+        byVTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff50"),
+        byVVTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff40")
+    ),
+)
+setattr(process, "newTauIDsEmbedded", embedID)
+
+## added for mvaIsolation on miniAOD testing
+#process.out = cms.OutputModule("PoolOutputModule",
+#    fileName = cms.untracked.string(filetag+'_miniaod.root'),
+#    ## save only events passing the full path
+#    SelectEvents = cms.untracked.PSet( SelectEvents = cms.vstring('p') ),
+#    ## save PAT output; you need a '*' to unpack the list of commands
+#    ##'patEventContent'
+#    outputCommands = cms.untracked.vstring(
+#        'drop *',
+#        'keep *_newTauIDsEmbedded_*_*',
+#        'keep *_prunedGenParticles_*_*'
+#    )
+#)
+
+#process.genVisTauProducer = cms.EDProducer("GenVisTauProducer",
+#    genParticleCollection = cms.InputTag("prunedGenParticles")
+#)
+
+process.rerunMVAIsolationOnMiniAOD_Phase2 = cms.EDAnalyzer(
+    'rerunMVAIsolationOnMiniAOD_Phase2',
+    genJetCollection = cms.InputTag("slimmedGenJets"), #comment out to run on data
+    #genVisTauCollection = cms.InputTag("genVisTauProducer:genVisTaus"), #comment out if running on data
+    genParticleCollection  = cms.InputTag("prunedGenParticles") #comment out to run on data
+)
+
+process.p = cms.Path(
+    process.rerunMvaIsolation2Seq_Phase2
+    *process.newTauIDsEmbedded
+    #*process.genVisTauProducer
+    *process.rerunMVAIsolationOnMiniAOD_Phase2
+)
+
+#process.outpath = cms.EndPath(process.out)
+

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -33,24 +33,24 @@ process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
 
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
 process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-    PATTauProducer = cms.InputTag('slimmedTaus'),
+    PATTauProducer = 'slimmedTaus',
     Prediscriminants = noPrediscriminants,
-    loadMVAfromDB = cms.bool(True),
-    #loadMVAfromDB = cms.bool(False),
-    #inputFileName = cms.FileInPath("gbrDiscriminationByIsolationMVAPhase2.root"),
-    mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-    mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
-    verbosity = cms.int32(0)
+    loadMVAfromDB = True,
+    #loadMVAfromDB = False,
+    #inputFileName = 'gbrDiscriminationByIsolationMVAPhase2.root',
+    mvaName = 'RecoTauTag_tauIdMVAIsoPhase2',
+    mvaOpt = 'DBnewDMwLTwGJPhase2',
+    verbosity = 0
 )
 
 process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
-    PATTauProducer = cms.InputTag('slimmedTaus'),
+    PATTauProducer = 'slimmedTaus',
     Prediscriminants = noPrediscriminants,
-    toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
-    loadMVAfromDB = cms.bool(True),
-    #loadMVAfromDB = cms.bool(False),
-    #inputFileName = cms.FileInPath("wpDiscriminationByIsolationMVAPhase2_tauIdMVAIsoPhase2.root"),
-    mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
+    toMultiplex = 'rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw',
+    loadMVAfromDB = True,
+    #loadMVAfromDB = False,
+    #inputFileName = 'wpDiscriminationByIsolationMVAPhase2_tauIdMVAIsoPhase2.root',
+    mvaOutput_normalization = 'RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization',
     mapping = cms.VPSet(
         cms.PSet(
             category = cms.uint32(0),

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -32,7 +32,6 @@ from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
 
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
-
 process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
     PATTauProducer = cms.InputTag('slimmedTaus'),
     Prediscriminants = noPrediscriminants,

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -10,22 +10,22 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 
 #process.Tracer = cms.Service("Tracer")
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000)
+    input = cms.untracked.int32(10000)
 )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
-        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
+        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
+        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
     )
 )
 
 process.TFileService = cms.Service("TFileService",
-    fileName = cms.string('output_QCD_Phase2.root')
-    #fileName = cms.string('output_VBFHToTauTau_Phase2.root')
+    #fileName = cms.string('output_QCD_Phase2.root')
+    fileName = cms.string('output_VBFHToTauTau_Phase2.root')
 )
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -11,7 +11,6 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 #process.Tracer = cms.Service("Tracer")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10000)
 )
@@ -72,8 +71,8 @@ process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByI
 )
 
 process.rerunMvaIsolation2Seq_Phase2 = cms.Sequence(
-   process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw
-   *process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
+    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw
+    * process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
 )
 
 # embed new id's into tau


### PR DESCRIPTION
#### PR description:

Adds new MVA tau ID for phase II to be run on miniAOD.
Presentation: https://indico.cern.ch/event/884712/contributions/3736447/attachments/1981798/3300601/TauIDPhase2_05022020.pdf
Adds a dedicated test analyzer.
Adds production of the ID to the miniAOD sequence triggered by a phase II modifier.

Test command to run the miniAOD sequence with phase II modifier:
`cmsDriver.py miniAOD2026 --filein root://eoscms.cern.ch//eos/cms/store/relval/CMSSW_11_1_0_pre8/RelValTTbar_14TeV/GEN-SIM-RECO/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/FF37C15C-1A4E-794E-B39F-B9B5D1860DAF.root --fileout file:MiniAOD2026.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions auto:phase2_realistic_T14 --step PAT --nThreads 4 --geometry Extended2026D49 --scenario pp --era Phase2C8 -n 2`

#### PR validation:

- Test command shown above successfully runs miniAOD creating the phaseII ID
- compiles
- code checks pass
- format checks pass
- unit tests pass
- limited matrix tests pass
