### PR TITLE
Allow ExternalGeneratorFilter to be pickled

### DIFF
--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -15,6 +15,8 @@ class ExternalGeneratorFilter(cms.EDFilter):
         if name == '_external_process_verbose_':
             return self.__dict__['_external_process_verbose_']
         return getattr(self._prod, name)
+    def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): self.__dict__.update(d)
     def clone(self, **params):
         returnValue = ExternalGeneratorFilter.__new__(type(self))
         returnValue.__init__(self._prod.clone())


### PR DESCRIPTION
#### PR description:

The pickle module was failing to unpickle the ExternalGeneratorFilter because it uses `__getattr__` in an incompatible way. Adding explicit `__getstate__` `__setstate__` methods avoids the problem.

#### PR validation:

I created a configuration using ExternalGeneratorFilter then used the pickle module to pickle and unpickle the cms.Process. Without the change the unpickling process failed, with the change it worked.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #30346 
The ExternalGeneratorFilter is being tested in CMSSW_11_1