### PR TITLE
drop type specs in RecoMuon and RecoTracker

### DIFF
--- a/RecoMuon/TrackingTools/python/MuonServiceProxy_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonServiceProxy_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-
 from TrackingTools.GeomPropagators.StraightLinePropagator_cfi import *
 from TrackingTools.MaterialEffects.MaterialPropagator_cfi import *
 from TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi import *
@@ -48,11 +47,11 @@ MuonServiceProxy = cms.PSet(
 # run3_GEM
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify(MuonServiceProxy,
-    ServiceParameters = dict(GEMLayers = cms.untracked.bool(True))
+    ServiceParameters = dict(GEMLayers = True)
 )
 
 # phase2_muon
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(MuonServiceProxy,
-    ServiceParameters = dict(ME0Layers = cms.bool(True))
+    ServiceParameters = dict(ME0Layers = True)
 )

--- a/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
@@ -4,32 +4,34 @@ from TrackingTools.KalmanUpdators.KFUpdatorESProducer_cfi import *
 from TrackingTools.GeomPropagators.SmartPropagator_cff import *
 from RecoMuon.TrackingTools.MuonUpdatorAtVertex_cff import *
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-Chi2EstimatorForMuonTrackLoader = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
-Chi2EstimatorForMuonTrackLoader.ComponentName = cms.string('Chi2EstimatorForMuonTrackLoader')
-Chi2EstimatorForMuonTrackLoader.nSigma = 3.0
-Chi2EstimatorForMuonTrackLoader.MaxChi2 = 100000.0
+Chi2EstimatorForMuonTrackLoader = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = 'Chi2EstimatorForMuonTrackLoader',
+    nSigma = 3.0,
+    MaxChi2 = 100000.0
+)
 
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
 KFSmootherForMuonTrackLoader = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
-    errorRescaling = cms.double(10.0),
-    minHits = cms.int32(3),
-    ComponentName = cms.string('KFSmootherForMuonTrackLoader'),
-    Estimator = cms.string('Chi2EstimatorForMuonTrackLoader'),
-    Updator = cms.string('KFUpdator'),
-    Propagator = cms.string('SmartPropagatorAnyRK')
+    errorRescaling = 10.0,
+    minHits        = 3,
+    ComponentName  = 'KFSmootherForMuonTrackLoader',
+    Estimator      = 'Chi2EstimatorForMuonTrackLoader',
+    Updator        = 'KFUpdator',
+    Propagator     = 'SmartPropagatorAnyRK'
 )
+
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 # FastSim doesn't use Runge Kute for propagation
 fastSim.toModify(KFSmootherForMuonTrackLoader,
                  Propagator = "SmartPropagatorAny")
 
 KFSmootherForMuonTrackLoaderL3 = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
-    errorRescaling = cms.double(10.0),
-    minHits = cms.int32(3),
-    ComponentName = cms.string('KFSmootherForMuonTrackLoaderL3'),
-    Estimator = cms.string('Chi2EstimatorForMuonTrackLoader'),
-    Updator = cms.string('KFUpdator'),
-    Propagator = cms.string('SmartPropagatorAnyOpposite')
+    errorRescaling = 10.0,
+    minHits        = 3,
+    ComponentName  = 'KFSmootherForMuonTrackLoaderL3',
+    Estimator      = 'Chi2EstimatorForMuonTrackLoader',
+    Updator        = 'KFUpdator',
+    Propagator     = 'SmartPropagatorAnyOpposite'
 )
 
 MuonTrackLoaderForSTA = cms.PSet(
@@ -87,4 +89,3 @@ MuonTrackLoaderForCosmic = cms.PSet(
         TTRHBuilder = cms.string('WithAngleAndTemplate')
     )
 )
-

--- a/RecoTracker/CkfPattern/python/CkfTrackCandidatesBHM_cff.py
+++ b/RecoTracker/CkfPattern/python/CkfTrackCandidatesBHM_cff.py
@@ -2,30 +2,31 @@ import FWCore.ParameterSet.Config as cms
 
 #special propagator
 from TrackingTools.GeomPropagators.BeamHaloPropagator_cff import *
-
 from RecoTracker.CkfPattern.CkfTrajectoryBuilder_cff import *
 import  TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-ckfTrajectoryFilterBeamHaloMuon = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone()
-import copy
 from RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi import *
-# clone the trajectory builder
-CkfTrajectoryBuilderBeamHalo = copy.deepcopy(CkfTrajectoryBuilder)
-import copy
 from RecoTracker.CkfPattern.CkfTrackCandidates_cfi import *
+
+ckfTrajectoryFilterBeamHaloMuon = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 4,
+    minPt               = 0.1,
+    maxLostHits         = 3,
+    maxConsecLostHits   = 2
+)
+
+# clone the trajectory builder
+CkfTrajectoryBuilderBeamHalo = CkfTrajectoryBuilder.clone(
+    propagatorAlong = 'BeamHaloPropagatorAlong',
+    propagatorOpposite = 'BeamHaloPropagatorOpposite',
+    trajectoryFilter = dict(refToPSet_ = 'ckfTrajectoryFilterBeamHaloMuon')
+)
+
 # generate CTF track candidates ############
-beamhaloTrackCandidates = copy.deepcopy(ckfTrackCandidates)
-
-ckfTrajectoryFilterBeamHaloMuon.minimumNumberOfHits = 4
-ckfTrajectoryFilterBeamHaloMuon.minPt = 0.1
-ckfTrajectoryFilterBeamHaloMuon.maxLostHits = 3
-ckfTrajectoryFilterBeamHaloMuon.maxConsecLostHits = 2
-
-CkfTrajectoryBuilderBeamHalo.propagatorAlong = 'BeamHaloPropagatorAlong'
-CkfTrajectoryBuilderBeamHalo.propagatorOpposite = 'BeamHaloPropagatorOpposite'
-CkfTrajectoryBuilderBeamHalo.trajectoryFilter.refToPSet_ = 'ckfTrajectoryFilterBeamHaloMuon'
-beamhaloTrackCandidates.src = cms.InputTag('beamhaloTrackerSeeds')
-beamhaloTrackCandidates.NavigationSchool = 'BeamHaloNavigationSchool'
-beamhaloTrackCandidates.TransientInitialStateEstimatorParameters.propagatorAlongTISE = 'BeamHaloPropagatorAlong'
-beamhaloTrackCandidates.TransientInitialStateEstimatorParameters.propagatorOppositeTISE = 'BeamHaloPropagatorOpposite'
-beamhaloTrackCandidates.TrajectoryBuilderPSet.refToPSet_ = 'CkfTrajectoryBuilderBeamHalo'
-
+beamhaloTrackCandidates = ckfTrackCandidates.clone(
+   src = 'beamhaloTrackerSeeds',
+   NavigationSchool = 'BeamHaloNavigationSchool',
+   TransientInitialStateEstimatorParameters = dict(
+	propagatorAlongTISE = 'BeamHaloPropagatorAlong',
+	propagatorOppositeTISE = 'BeamHaloPropagatorOpposite'),
+   TrajectoryBuilderPSet = dict(refToPSet_ = 'CkfTrajectoryBuilderBeamHalo')
+)

--- a/RecoTracker/CkfPattern/python/CkfTrackCandidatesPixelLess_cff.py
+++ b/RecoTracker/CkfPattern/python/CkfTrackCandidatesPixelLess_cff.py
@@ -10,9 +10,6 @@ from RecoTracker.TkNavigation.NavigationSchoolESProducer_cff import *
 # generate CTF track candidates ############
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi 
 ckfTrackCandidatesPixelLess = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('GroupedCkfTrajectoryBuilder')),
-    src = cms.InputTag('globalPixelLessSeeds')
-    )
-
-
-
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'GroupedCkfTrajectoryBuilder'),
+    src = 'globalPixelLessSeeds'
+)

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilderP5_cff.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilderP5_cff.py
@@ -8,13 +8,15 @@ import FWCore.ParameterSet.Config as cms
 from TrackingTools.KalmanUpdators.KFUpdatorESProducer_cfi import *
 # Chi2MeasurementEstimatorESProducer
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-Chi2MeasurementEstimatorForP5 = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
-Chi2MeasurementEstimatorForP5.ComponentName = 'Chi2MeasurementEstimatorForP5'
-Chi2MeasurementEstimatorForP5.MaxChi2 = 100.
-Chi2MeasurementEstimatorForP5.nSigma = 4.
-Chi2MeasurementEstimatorForP5.MaxDisplacement = 100
-Chi2MeasurementEstimatorForP5.MaxSagitta=-1
-Chi2MeasurementEstimatorForP5.MinPtForHitRecoveryInGluedDet=100000
+Chi2MeasurementEstimatorForP5 = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName   = 'Chi2MeasurementEstimatorForP5',
+    MaxChi2         = 100.,
+    nSigma          = 4.,
+    MaxDisplacement = 100,
+    MaxSagitta      = -1,
+    MinPtForHitRecoveryInGluedDet=100000
+)
+
 # PropagatorWithMaterialESProducer
 from TrackingTools.MaterialEffects.MaterialPropagator_cfi import *
 # PropagatorWithMaterialESProducer
@@ -36,16 +38,18 @@ import RecoTracker.MeasurementDet.MeasurementTrackerESProducer_cfi
 # trajectory filtering
 from TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff import *
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-ckfBaseTrajectoryFilterP5 = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone()
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
-ckfBaseTrajectoryFilterP5.minPt = 0.5
-ckfBaseTrajectoryFilterP5.maxLostHits = 4
-ckfBaseTrajectoryFilterP5.maxConsecLostHits = 3
+ckfBaseTrajectoryFilterP5 = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minPt             = 0.5,
+    maxLostHits       = 4,
+    maxConsecLostHits = 3
+)
 #replace ckfBaseTrajectoryFilterP5.minimumNumberOfHits =  4
 #
-GroupedCkfTrajectoryBuilderP5 = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone()
 ##CTF_P5_MeasurementTracker.ComponentName = 'CTF_P5' # useless duplication of MeasurementTracker
 ##GroupedCkfTrajectoryBuilderP5.MeasurementTrackerName = 'CTF_P5' # useless duplication of MeasurementTracker
-GroupedCkfTrajectoryBuilderP5.trajectoryFilter.refToPSet_ = 'ckfBaseTrajectoryFilterP5'
-GroupedCkfTrajectoryBuilderP5.maxCand = 1
-GroupedCkfTrajectoryBuilderP5.estimator = cms.string('Chi2MeasurementEstimatorForP5')
+GroupedCkfTrajectoryBuilderP5 = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    trajectoryFilter = dict(refToPSet_ = 'ckfBaseTrajectoryFilterP5'),
+    maxCand = 1,
+    estimator = 'Chi2MeasurementEstimatorForP5'
+)

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
@@ -4,16 +4,16 @@ from RecoTracker.ConversionSeedGenerators.PhotonConversionTrajectorySeedProducer
 
 from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
 conv2Clusters = trackClusterRemover.clone(
-  maxChi2               = cms.double(30.0),
-  trajectories          = cms.InputTag("convStepTracks"),
-  pixelClusters         = cms.InputTag("siPixelClusters"),
-  stripClusters         = cms.InputTag("siStripClusters"),
-  oldClusterRemovalInfo = cms.InputTag("convClusters"),
-  overrideTrkQuals      = cms.InputTag('convStepSelector','convStep'),
-  TrackQuality          = cms.string('highPurity'),
+    maxChi2               = 30.0,
+    trajectories          = 'convStepTracks',
+    pixelClusters         = 'siPixelClusters',
+    stripClusters         = 'siStripClusters',
+    oldClusterRemovalInfo = 'convClusters',
+    overrideTrkQuals      = 'convStepSelector:convStep',
+    TrackQuality          = 'highPurity'
 )
 
-conv2LayerPairs = cms.EDProducer("SeedingLayersEDProducer",
+conv2LayerPairs = cms.EDProducer('SeedingLayersEDProducer',
                                 layerList = cms.vstring('BPix1+BPix2', 
 
                                                         'BPix2+BPix3', 
@@ -99,27 +99,27 @@ conv2LayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                     ),
                                 TIB1 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TIB2 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TIB3 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TIB4 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TID1 = cms.PSet(
                                     useSimpleRphiHitsCleaner = cms.bool(False),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     useRingSlector = cms.bool(True),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
                                     maxRing = cms.int32(2),
@@ -128,7 +128,7 @@ conv2LayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                     ),
                                 TID2 = cms.PSet(
                                     useSimpleRphiHitsCleaner = cms.bool(False),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     useRingSlector = cms.bool(True),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
                                     maxRing = cms.int32(2),
@@ -137,7 +137,7 @@ conv2LayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                     ),
                                 TID3 = cms.PSet(
                                     useSimpleRphiHitsCleaner = cms.bool(False),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     useRingSlector = cms.bool(True),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
                                     maxRing = cms.int32(2),
@@ -147,42 +147,42 @@ conv2LayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                 TEC = cms.PSet(
                                     useSimpleRphiHitsCleaner = cms.bool(False),
                                     minRing = cms.int32(1),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     useRingSlector = cms.bool(True),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHitUnmatched'),
                                     maxRing = cms.int32(7),
-                                    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+                                    stereoRecHits = cms.InputTag('siStripMatchedRecHits','stereoRecHitUnmatched'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TOB1 = cms.PSet(
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TOB2 = cms.PSet(
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TOB3 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TOB4 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TOB5 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TOB6 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     )
                                 )
@@ -197,48 +197,46 @@ photonConvTrajSeedFromQuadruplets.primaryVerticesTag = cms.InputTag('pixelVertic
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 conv2CkfTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
-        maxLostHits = 1,
-        minimumNumberOfHits = 3,
-        minPt = 0.1
-    )
+    maxLostHits         = 1,
+    minimumNumberOfHits = 3,
+    minPt               = 0.1
+)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 conv2CkfTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('conv2CkfTrajectoryFilter')),
     minNrOfHitsForRebuild = 3,
-    clustersToSkip = cms.InputTag('conv2Clusters'),
-    maxCand = 2
-    )
+    clustersToSkip        = cms.InputTag('conv2Clusters'),
+    maxCand               = 2
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 conv2TrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('photonConvTrajSeedFromQuadruplets:conv2SeedCandidates'),
+    src = 'photonConvTrajSeedFromQuadruplets:conv2SeedCandidates',
     TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('conv2CkfTrajectoryBuilder'))
 )
 
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff
 conv2StepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFittingSmootherWithOutliersRejectionAndRK.clone(
     ComponentName = 'conv2StepFitterSmoother',
-    EstimateCut = 30,
-    Smoother = cms.string('conv2StepRKSmoother')
-    )
+    EstimateCut   = 30,
+    Smoother      = 'conv2StepRKSmoother'
+)
     
 conv2StepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.RKTrajectorySmoother.clone(
-    ComponentName = cms.string('conv2StepRKSmoother'),
+    ComponentName = 'conv2StepRKSmoother',
     errorRescaling = 10.0
-    )
-
-        
+)
+       
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 conv2StepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = 'conv2TrackCandidates',
-    AlgorithmName = cms.string('conversionStep'),
+    AlgorithmName = 'conversionStep',
     Fitter = 'conv2StepFitterSmoother',
-    )
-
+)
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 conv2StepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
@@ -283,8 +281,8 @@ conv2StepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multi
             d0_par2 = ( 5., 8.0 ),
             dz_par2 = ( 5., 8.0 )
             ),
-        ) #end of vpset
-    ) #end of clone
+    ) #end of vpset
+) #end of clone
 
 Conv2StepTask = cms.Task( conv2Clusters 
                          , conv2LayerPairs

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
@@ -205,7 +205,7 @@ conv2CkfTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cf
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 conv2CkfTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('conv2CkfTrajectoryFilter')),
+    trajectoryFilter = dict(refToPSet_ = 'conv2CkfTrajectoryFilter'),
     minNrOfHitsForRebuild = 3,
     clustersToSkip        = cms.InputTag('conv2Clusters'),
     maxCand               = 2
@@ -215,7 +215,7 @@ conv2CkfTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_c
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 conv2TrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'photonConvTrajSeedFromQuadruplets:conv2SeedCandidates',
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('conv2CkfTrajectoryBuilder'))
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'conv2CkfTrajectoryBuilder')
 )
 
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -271,14 +271,14 @@ convStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.
     MaxChi2          = 30.0,
     MaxDisplacement  = 100,
     MaxSagitta       = -1.,
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string( 'SiStripClusterChargeCutTight'))
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
 )
 
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 _convCkfTrajectoryBuilderBase = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('convCkfTrajectoryFilter')),
+    trajectoryFilter = dict(refToPSet_ = 'convCkfTrajectoryFilter'),
     minNrOfHitsForRebuild = 3,
     maxCand = 1
 )
@@ -296,7 +296,7 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 convTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'photonConvTrajSeedFromSingleLeg:convSeedCandidates',
     clustersToSkip =  cms.InputTag('convClusters'),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('convCkfTrajectoryBuilder'))
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'convCkfTrajectoryBuilder')
 )
 
 trackingPhase2PU140.toModify(convTrackCandidates,
@@ -388,31 +388,22 @@ ConvStep = cms.Sequence( ConvStepTask )
 # in RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff change:
 ###
 #conversionStepTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-#    TrackProducers = cms.VInputTag(cms.InputTag('convStepTracks')),
-#    hasSelector=cms.vint32(1),
-#    selectedTrackQuals = cms.VInputTag(cms.InputTag('convStepSelector','convStep')
-#                                       ),
-#    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(1), pQual=cms.bool(True) )
-#                             ),
+#    TrackProducers = 'convStepTracks',
+#    hasSelector=1,
+#    selectedTrackQuals = 'convStepSelector:convStep',
+#    setsToMerge = dict( tLists = 1, pQual = True ),
 #    copyExtras = True,
-#    makeReKeyedSeeds = cms.untracked.bool(False)
+#    makeReKeyedSeeds = False
 #    )
 ###
 # TO this:
 ###
 #conversionStepTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-#    TrackProducers = cms.VInputTag(
-#                                   cms.InputTag('convStepTracks'),
-#                                   cms.InputTag('conv2StepTracks')
-#                                   ),
-#    hasSelector=cms.vint32(1,1),
-#    selectedTrackQuals = cms.VInputTag(
-#                                       cms.InputTag('convStepSelector','convStep'),
-#                                       cms.InputTag('conv2StepSelector','conv2Step')
-#                                       ),
-#    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )
-#                             ),
+#    TrackProducers = ['convStepTracks', 'conv2StepTracks'],
+#    hasSelector = [1,1],
+#    selectedTrackQuals = ['convStepSelector:convStep', 'conv2StepSelector:conv2Step'],
+#    setsToMerge = dict( tLists = [0,1], pQual = True ),
 #    copyExtras = True,
-#    makeReKeyedSeeds = cms.untracked.bool(False)
+#    makeReKeyedSeeds = False
 #    )
 ###

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -7,15 +7,16 @@ from RecoTracker.ConversionSeedGenerators.ConversionStep2_cff import *
 
 from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
 _convClustersBase = _trackClusterRemover.clone(
-  maxChi2               = cms.double(30.0),
-  trajectories          = cms.InputTag("tobTecStepTracks"),
-  pixelClusters         = cms.InputTag("siPixelClusters"),
-  stripClusters         = cms.InputTag("siStripClusters"),
-  oldClusterRemovalInfo = cms.InputTag("tobTecStepClusters"),
-  TrackQuality          = cms.string('highPurity'),
+    maxChi2               = 30.0,
+    trajectories          = 'tobTecStepTracks',
+    pixelClusters         = 'siPixelClusters',
+    stripClusters         = 'siStripClusters',
+    oldClusterRemovalInfo = 'tobTecStepClusters',
+    TrackQuality          = 'highPurity'
 )
+
 convClusters = _convClustersBase.clone(
-  trackClassifier       = cms.InputTag('tobTecStep',"QualityMasks"),
+    trackClassifier       = 'tobTecStep:QualityMasks',
 )
 
 
@@ -24,15 +25,14 @@ from RecoLocalTracker.SubCollectionProducers.phase2trackClusterRemover_cfi impor
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toReplaceWith(convClusters, _phase2trackClusterRemover.clone(
     maxChi2                                  = 30.0,
-    phase2pixelClusters                      = "siPixelClusters",
-    phase2OTClusters                         = "siPhase2Clusters",
+    phase2pixelClusters                      = 'siPixelClusters',
+    phase2OTClusters                         = 'siPhase2Clusters',
     TrackQuality                             = 'highPurity',
     minNumberOfLayersWithMeasBeforeFiltering = 0,
-    trajectories                             = cms.InputTag("detachedQuadStepTracks"),
-    oldClusterRemovalInfo                    = cms.InputTag("detachedQuadStepClusters"),
-    overrideTrkQuals                         = cms.InputTag("detachedQuadStepSelector","detachedQuadStepTrk"),
-    )
-)
+    trajectories                             = 'detachedQuadStepTracks',
+    oldClusterRemovalInfo                    = 'detachedQuadStepClusters',
+    overrideTrkQuals                         = 'detachedQuadStepSelector:detachedQuadStepTrk'
+))
 
 _convLayerPairsStripOnlyLayers = ['TIB1+TID1_pos', 
                                  'TIB1+TID1_neg', 
@@ -121,7 +121,7 @@ _convLayerPairsLayerList.extend(_convLayerPairsStripOnlyLayers)
                                                         
     
              
-convLayerPairs = cms.EDProducer("SeedingLayersEDProducer",
+convLayerPairs = cms.EDProducer('SeedingLayersEDProducer',
                                 layerList = cms.vstring(_convLayerPairsLayerList),
                                 BPix = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'),
@@ -135,17 +135,17 @@ convLayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                     ),
                                 TIB = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 MTIB = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 TID = cms.PSet(
                                     useSimpleRphiHitsCleaner = cms.bool(False),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     useRingSlector = cms.bool(True),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
                                     maxRing = cms.int32(2),
@@ -155,22 +155,22 @@ convLayerPairs = cms.EDProducer("SeedingLayersEDProducer",
                                 TEC = cms.PSet(
                                     useSimpleRphiHitsCleaner = cms.bool(False),
                                     minRing = cms.int32(1),
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     useRingSlector = cms.bool(True),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHitUnmatched'),
                                     maxRing = cms.int32(7),
-                                    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+                                    stereoRecHits = cms.InputTag('siStripMatchedRecHits','stereoRecHitUnmatched'),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 TOB = cms.PSet(
-                                    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+                                    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 MTOB = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-                                    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+                                    rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 )
@@ -207,7 +207,7 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(convLayerPairs, layerList = cms.vstring(_convLayerPairsLayerListPhaseI))
 
 
-trackingPhase2PU140.toReplaceWith(convLayerPairs, cms.EDProducer("SeedingLayersEDProducer",
+trackingPhase2PU140.toReplaceWith(convLayerPairs, cms.EDProducer('SeedingLayersEDProducer',
                                 layerList = cms.vstring('BPix1+BPix2',
                                                         'BPix2+BPix3',
                                                         'BPix3+BPix4',
@@ -249,7 +249,7 @@ photonConvTrajSeedFromSingleLeg.primaryVerticesTag = cms.InputTag('firstStepPrim
 #photonConvTrajSeedFromQuadruplets.TrackRefitter = cms.InputTag('generalTracks')
 #photonConvTrajSeedFromQuadruplets.primaryVerticesTag = cms.InputTag('pixelVertices')
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
-trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag   = "pixelVertices")
+trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag   = 'pixelVertices')
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(photonConvTrajSeedFromSingleLeg, vtxMinDoF = 999999.)
     
@@ -258,20 +258,20 @@ pp_on_AA_2018.toModify(photonConvTrajSeedFromSingleLeg, vtxMinDoF = 999999.)
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 convCkfTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
-        maxLostHits = 1,
+        maxLostHits         = 1,
         minimumNumberOfHits = 3,
-        minPt = 0.1
-    )
+        minPt               = 0.1
+)
 
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 convStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('convStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(30.0),
-    MaxDisplacement = cms.double(100),
-    MaxSagitta = cms.double(-1.),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+    ComponentName    = 'convStepChi2Est',
+    nSigma           = 3.0,
+    MaxChi2          = 30.0,
+    MaxDisplacement  = 100,
+    MaxSagitta       = -1.,
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string( 'SiStripClusterChargeCutTight'))
 )
 
 
@@ -280,47 +280,50 @@ import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 _convCkfTrajectoryBuilderBase = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('convCkfTrajectoryFilter')),
     minNrOfHitsForRebuild = 3,
-    maxCand = 1,
+    maxCand = 1
 )
+
 convCkfTrajectoryBuilder = _convCkfTrajectoryBuilderBase.clone(
-    estimator = cms.string('convStepChi2Est')
-    )
+    estimator = 'convStepChi2Est'
+)
+
 trackingPhase2PU140.toReplaceWith(convCkfTrajectoryBuilder, _convCkfTrajectoryBuilderBase.clone(
-    maxCand = 2,
+    maxCand = 2
 ))
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 convTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('photonConvTrajSeedFromSingleLeg:convSeedCandidates'),
-    clustersToSkip = cms.InputTag('convClusters'),
+    src = 'photonConvTrajSeedFromSingleLeg:convSeedCandidates',
+    clustersToSkip =  cms.InputTag('convClusters'),
     TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('convCkfTrajectoryBuilder'))
 )
+
 trackingPhase2PU140.toModify(convTrackCandidates,
     clustersToSkip = None,
-    phase2clustersToSkip = cms.InputTag("convClusters")
+    phase2clustersToSkip = cms.InputTag('convClusters')
 )
 
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff
 convStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFittingSmootherWithOutliersRejectionAndRK.clone(
     ComponentName = 'convStepFitterSmoother',
-    EstimateCut = 30,
-    Smoother = cms.string('convStepRKSmoother')
-    )
+    EstimateCut   = 30,
+    Smoother      = 'convStepRKSmoother'
+)
     
 convStepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.RKTrajectorySmoother.clone(
-    ComponentName = cms.string('convStepRKSmoother'),
+    ComponentName  = 'convStepRKSmoother',
     errorRescaling = 10.0
-    )
+)
 
         
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 convStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     src = 'convTrackCandidates',
-    AlgorithmName = cms.string('conversionStep'),
-    Fitter = 'convStepFitterSmoother',
-    )
+    AlgorithmName = 'conversionStep',
+    Fitter = 'convStepFitterSmoother'
+)
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
@@ -366,8 +369,8 @@ convStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiT
             d0_par2 = ( 5., 8.0 ),
             dz_par2 = ( 5., 8.0 )
             ),
-        ) #end of vpset
-    ) #end of clone
+    ) #end of vpset
+) #end of clone
 
 ConvStepTask = cms.Task( convClusters 
                          , convLayerPairs
@@ -387,7 +390,7 @@ ConvStep = cms.Sequence( ConvStepTask )
 #conversionStepTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
 #    TrackProducers = cms.VInputTag(cms.InputTag('convStepTracks')),
 #    hasSelector=cms.vint32(1),
-#    selectedTrackQuals = cms.VInputTag(cms.InputTag("convStepSelector","convStep")
+#    selectedTrackQuals = cms.VInputTag(cms.InputTag('convStepSelector','convStep')
 #                                       ),
 #    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(1), pQual=cms.bool(True) )
 #                             ),
@@ -404,8 +407,8 @@ ConvStep = cms.Sequence( ConvStepTask )
 #                                   ),
 #    hasSelector=cms.vint32(1,1),
 #    selectedTrackQuals = cms.VInputTag(
-#                                       cms.InputTag("convStepSelector","convStep"),
-#                                       cms.InputTag("conv2StepSelector","conv2Step")
+#                                       cms.InputTag('convStepSelector','convStep'),
+#                                       cms.InputTag('conv2StepSelector','conv2Step')
 #                                       ),
 #    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )
 #                             ),

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-
 from RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi import seedGeneratorFromRegionHitsEDProducer 
 CommonClusterCheckPSet = seedGeneratorFromRegionHitsEDProducer.ClusterCheckPSet
 
@@ -66,7 +65,8 @@ trackingPhase2PU140.toModify(photonConvTrajSeedFromSingleLeg,
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 peripheralPbPb.toModify(photonConvTrajSeedFromSingleLeg,
                         ClusterCheckPSet = dict(cut = "strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)")
-                        )
+)
+
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 (pp_on_XeXe_2017 | pp_on_AA_2018 ).toModify(photonConvTrajSeedFromSingleLeg,
@@ -74,7 +74,7 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
                                                      cut = "strip < 1000000 && pixel < 100000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/2.)"
                                                      ),
                              OrderedHitsFactoryPSet = dict(maxElement = 100000)
-                             )
+)
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 (pp_on_XeXe_2017 | pp_on_AA_2018 ).toModify(photonConvTrajSeedFromSingleLeg,
                RegionFactoryPSet = dict(ComponentName = 'GlobalTrackingRegionWithVerticesProducer',
@@ -86,4 +86,4 @@ from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import g
                                                           scalingEndNPix = 1#essentially turn off immediately 
                                                          ),
                                         )
-               )
+)


### PR DESCRIPTION
#### PR description: Update the safer syntax for existing parameter
Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#29979](https://github.com/cms-sw/cmssw/pull/29979), [PR#30147](https://github.com/cms-sw/cmssw/pull/30147).)

In this PR, 8 files updated. 
- RecoMuon/{TrackingTools}  2 files   
(previous RecoMuon updates can be found : [PR#30270](https://github.com/cms-sw/cmssw/pull/30270), [PR#30271](https://github.com/cms-sw/cmssw/pull/30271).)
- RecoTracker/{CkfPattern} 3 files 
- RecoTracker/{ConversionSeedGenerators} 3 files


#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).