### PR TITLE
fix typo in provenance access by L1TTauOffline

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -678,7 +678,7 @@ void L1TTauOffline::getProbeTaus(const edm::Event& iEvent,
       {
         const edm::Provenance* prov = antiele.provenance();
         const std::vector<std::string> psetsFromProvenance =
-            edm::parameterSet(*prov, iEvent.processHistory()).getParameter<std::vector<std::string>>("workingsPoints");
+            edm::parameterSet(*prov, iEvent.processHistory()).getParameter<std::vector<std::string>>("workingPoints");
         for (uint i = 0; i < psetsFromProvenance.size(); i++) {
           if (psetsFromProvenance[i] == AntiEleWP_)
             AntiEleWPIndex_ = i;


### PR DESCRIPTION
#### PR description:

This PR addresses issue #30324 
It fixes a typo to call the right name of the targeted provenance config parameter, which is this one: https://github.com/cms-sw/cmssw/blob/master/RecoTauTag/Configuration/python/HPSPFTaus_cff.py#L287

This should probably be backported to CMSSW_11_1_X

#### PR validation:

-

