### PR TITLE
edm::Range interface to TrackCandidate recHits

### DIFF
--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -601,7 +601,7 @@ void TrackBuildingAnalyzer::analyze(const edm::Event& iEvent,
   //double qoverp       = tsAtClosestApproachTrackCand.trackStateAtPCA().charge()/p.mag();
   //double theta        = p.theta();
   //double lambda       = M_PI/2-p.theta();
-  double numberOfHits = candidate.recHits().second - candidate.recHits().first;
+  double numberOfHits = candidate.nRecHits();
   double dxy = (-v.x() * sin(p.phi()) + v.y() * cos(p.phi()));
 
   double dz = v.z() - (v.x() * p.x() + v.y() * p.y()) / p.perp() * p.z() / p.perp();

--- a/DataFormats/TrackCandidate/interface/TrackCandidate.h
+++ b/DataFormats/TrackCandidate/interface/TrackCandidate.h
@@ -6,6 +6,7 @@
 #include "DataFormats/TrackReco/interface/TrajectoryStopReasons.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "FWCore/Utilities/interface/Range.h"
 
 #include <utility>
 
@@ -23,8 +24,6 @@ only the second is compulsory,the other three can be empty / not present
 class TrackCandidate {
 public:
   typedef edm::OwnVector<TrackingRecHit> RecHitContainer;
-  typedef RecHitContainer::const_iterator const_iterator;
-  typedef std::pair<const_iterator, const_iterator> range;
 
   TrackCandidate()
       : rh_(), seed_(), state_(), seedRef_(), nLoops_(0), stopReason_((uint8_t)StopReason::UNINITIALIZED) {}
@@ -55,7 +54,8 @@ public:
 
   PTrajectoryStateOnDet const& trajectoryStateOnDet() const { return state_; }
 
-  range recHits() const { return std::make_pair(rh_.begin(), rh_.end()); }
+  edm::Range<RecHitContainer::const_iterator> recHits() const { return {rh_.begin(), rh_.end()}; }
+  auto nRecHits() const { return rh_.size(); }
 
   TrajectorySeed const& seed() const { return seed_; }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -131,7 +131,6 @@ void TrackProducerWithSCAssociation::produce(edm::Event& theEvent, const edm::Ev
       for (TrackCandidateCollection::const_iterator i = theTCCollection->begin(); i != theTCCollection->end(); i++) {
         const TrackCandidate* theTC = &(*i);
         PTrajectoryStateOnDet state = theTC->trajectoryStateOnDet();
-        const TrackCandidate::range& recHitVec = theTC->recHits();
         const TrajectorySeed& seed = theTC->seed();
 
         //convert PTrajectoryStateOnDet to TrajectoryStateOnSurface
@@ -148,8 +147,8 @@ void TrackProducerWithSCAssociation::produce(edm::Event& theEvent, const edm::Ev
 
         float ndof = 0;
 
-        for (edm::OwnVector<TrackingRecHit>::const_iterator i = recHitVec.first; i != recHitVec.second; i++) {
-          hits.push_back(theBuilder.product()->build(&(*i)));
+        for (auto const& recHit : theTC->recHits()) {
+          hits.push_back(theBuilder.product()->build(&recHit));
         }
 
         //build Track

--- a/RecoTracker/DebugTools/plugins/TestHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestHits.cc
@@ -204,7 +204,6 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
     const TrackCandidate* theTC = &(*i);
     PTrajectoryStateOnDet state = theTC->trajectoryStateOnDet();
-    const TrackCandidate::range& recHitVec = theTC->recHits();
 
     //convert PTrajectoryStateOnDet to TrajectoryStateOnSurface
 
@@ -218,8 +217,8 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
     //convert the TrackingRecHit vector to a TransientTrackingRecHit vector
     TransientTrackingRecHit::RecHitContainer hits;
 
-    for (edm::OwnVector<TrackingRecHit>::const_iterator i = recHitVec.first; i != recHitVec.second; i++) {
-      hits.push_back(theBuilder->build(&(*i)));
+    for (auto const& recHit : theTC->recHits()) {
+      hits.push_back(theBuilder->build(&recHit));
     }
 
     //call the fitter

--- a/RecoTracker/DebugTools/plugins/TestSmoothHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestSmoothHits.cc
@@ -205,7 +205,6 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 
     const TrackCandidate* theTC = &(*i);
     PTrajectoryStateOnDet state = theTC->trajectoryStateOnDet();
-    const TrackCandidate::range& recHitVec = theTC->recHits();
 
     //convert PTrajectoryStateOnDet to TrajectoryStateOnSurface
 
@@ -219,8 +218,8 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     //convert the TrackingRecHit vector to a TransientTrackingRecHit vector
     TransientTrackingRecHit::RecHitContainer hits;
 
-    for (edm::OwnVector<TrackingRecHit>::const_iterator i = recHitVec.first; i != recHitVec.second; i++) {
-      hits.push_back(theBuilder->build(&(*i)));
+    for (auto const& recHit : theTC->recHits()) {
+      hits.push_back(theBuilder->build(&recHit));
     }
 
     //call the fitter

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
@@ -411,10 +411,9 @@ namespace reco {
 
 #ifdef EDM_ML_DEBUG
       LogDebug("CosmicTrackSplitter") << "   dumping the hits now: ";
-      for (TrackCandidate::range hitR = cand.recHits(); hitR.first != hitR.second; ++hitR.first) {
-        auto const &tmp = *hitR.first;
-        LogTrace("CosmicTrackSplitter") << "     hit detid = " << hitR.first->geographicalId().rawId()
-                                        << ", type  = " << typeid(tmp).name();
+      for (auto const &hit : cand.recHits()) {
+        LogTrace("CosmicTrackSplitter") << "     hit detid = " << hit.geographicalId().rawId()
+                                        << ", type  = " << typeid(hit).name();
       }
 #endif
 

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -159,7 +159,7 @@ namespace {
         continue;  // at least "loose"  ( FIXME: take cut value from CutSelector)
 
       // if( ChiSquaredProbability(matchedTrack.chi2(),matchedTrack.ndof()) < minTrkProbCut_)continue;
-      int dHits = (cand.recHits().second - cand.recHits().first) - matchedTrack.recHitsSize();
+      int dHits = cand.nRecHits() - matchedTrack.recHitsSize();
       if (dHits > diffHitsCut_)
         continue;
       matches.push_back(std::array<int, 3>{{i, candidateComponents[cInd].first, candidateComponents[cInd].second}});

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCandidateTopBottomHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCandidateTopBottomHitFilter.cc
@@ -76,18 +76,17 @@ void TrackCandidateTopBottomHitFilter::produce(edm::Event& iEvent, const edm::Ev
   auto pOut = std::make_unique<TrackCandidateCollection>();
   for (TrackCandidateCollection::const_iterator it = pIn->begin(); it != pIn->end(); ++it) {
     PTrajectoryStateOnDet state = it->trajectoryStateOnDet();
-    TrackCandidate::range oldhits = it->recHits();
     TrajectorySeed seed = it->seed();
     TrackCandidate::RecHitContainer hits;
-    for (TrackCandidate::RecHitContainer::const_iterator hit = oldhits.first; hit != oldhits.second; ++hit) {
-      if (hit->isValid()) {
-        double hitY = theBuilder->build(&*hit)->globalPosition().y();
+    for (auto const& hit : it->recHits()) {
+      if (hit.isValid()) {
+        double hitY = theBuilder->build(&hit)->globalPosition().y();
         if (seedY * hitY > 0)
-          hits.push_back(hit->clone());
+          hits.push_back(hit.clone());
         else
           break;
       } else
-        hits.push_back(hit->clone());
+        hits.push_back(hit.clone());
     }
     if (hits.size() >= 3) {
       TrackCandidate newTC(hits, seed, state);

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
@@ -45,7 +45,6 @@ void TrackProducerAlgorithm<T>::runWithCandidate(const TrackingGeometry* theG,
   int ntc = 0;
   for (auto const& theTC : theTCCollection) {
     PTrajectoryStateOnDet const& state = theTC.trajectoryStateOnDet();
-    const TrackCandidate::range& recHitVec = theTC.recHits();
     const TrajectorySeed& seed = theTC.seed();
 
     //convert PTrajectoryStateOnDet to TrajectoryStateOnSurface
@@ -61,8 +60,8 @@ void TrackProducerAlgorithm<T>::runWithCandidate(const TrackingGeometry* theG,
 
     float ndof = 0;
     //  we assume are transient...
-    for (auto i = recHitVec.first; i != recHitVec.second; ++i) {
-      hits.push_back((*i).cloneSH());  // major waste, will be soon fitted and recloned...
+    for (auto const& recHit : theTC.recHits()) {
+      hits.push_back(recHit.cloneSH());  // major waste, will be soon fitted and recloned...
     }
 
     stopReason_ = theTC.stopReason();

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -14,7 +14,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/Range.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
@@ -34,15 +33,6 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-
-namespace {
-  TrajectorySeed::RecHitRange getHits(const TrajectorySeed &seed) { return seed.recHits(); }
-  TrajectorySeed::RecHitRange getHits(const TrackCandidate &seed) {
-    auto range = seed.recHits();
-    return edm::Range{range.first, range.second};
-  }
-}  // namespace
 
 template <class T>
 class FakeTrackProducer : public edm::stream::EDProducer<> {
@@ -113,7 +103,7 @@ void FakeTrackProducer<T>::produce(edm::Event &iEvent, const edm::EventSetup &iS
     reco::Track::Vector p(gp.x(), gp.y(), gp.z());
     int charge = state.localParameters().charge();
     out->push_back(reco::Track(1.0, 1.0, x, p, charge, reco::Track::CovarianceMatrix()));
-    auto hits = getHits(mu);
+    auto hits = mu.recHits();
     out->back().appendHits(hits.begin(), hits.end(), ttopo);
     // Now Track Extra
     const TrackingRecHit *hit0 = &*hits.begin();


### PR DESCRIPTION
#### PR description:

A little follow-up to https://github.com/cms-sw/cmssw/pull/29971, making the interface to the recHits of different classes more consistent and adapted for range-based loops. That makes also these overloaded functions in `FakeTrackProducers` unnecessary:

https://github.com/cms-sw/cmssw/pull/30361/files#diff-11165275dc0c3719761c168a2845339fL39

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backports intended.