### PR TITLE
New Package - Phase2 L1TTrackMatch

### DIFF
--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -64,4 +64,38 @@ _phase2_siml1emulator = SimL1EmulatorTask.copy()
 _phase2_siml1emulator.add(hgcalTriggerPrimitivesTask)
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator )
+#phase2_hgcal.toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator )
+
+from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
+(phase2_hgcal & ~phase2_hgcalV11).toReplaceWith( SimL1EmulatorTask, _phase2_siml1emulator )
+
+#%% # Barrel EGamma
+#%% # ########################################################################
+from L1Trigger.L1CaloTrigger.L1EGammaCrystalsEmulatorProducer_cfi import *
+_phase2_siml1emulator.add(L1EGammaClusterEmuProducer)
+
+from L1Trigger.L1CaloTrigger.l1EGammaEEProducer_cfi import *
+_phase2_siml1emulator.add(l1EGammaEEProducer)
+
+# Tk + StandaloneObj, including L1TkPrimaryVertex
+# ########################################################################
+from L1Trigger.L1TTrackMatch.L1TkObjectProducers_cff import *
+
+_phase2_siml1emulator.add(L1TkPrimaryVertex)
+
+_phase2_siml1emulator.add(L1TkElectronsCrystal)
+_phase2_siml1emulator.add(L1TkElectronsLooseCrystal)
+_phase2_siml1emulator.add(L1TkElectronsEllipticMatchCrystal)
+_phase2_siml1emulator.add(L1TkIsoElectronsCrystal)
+_phase2_siml1emulator.add(L1TkPhotonsCrystal)
+
+_phase2_siml1emulator.add(L1TkElectronsHGC)
+_phase2_siml1emulator.add(L1TkElectronsEllipticMatchHGC)
+_phase2_siml1emulator.add(L1TkIsoElectronsHGC)
+_phase2_siml1emulator.add(L1TkPhotonsHGC)
+
+_phase2_siml1emulator.add( L1TkMuons )
+
+
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
+phase2_trigger.toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator)

--- a/L1Trigger/L1TTrackMatch/BuildFile.xml
+++ b/L1Trigger/L1TTrackMatch/BuildFile.xml
@@ -1,0 +1,8 @@
+<use   name="DataFormats/L1Trigger"/>
+<use   name="DataFormats/L1TrackTrigger"/>
+<use   name="DataFormats/L1TCorrelator"/>
+<use   name="L1Trigger/L1TMuon"/>
+<use   name="clhep"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/L1Trigger/L1TTrackMatch/BuildFile.xml
+++ b/L1Trigger/L1TTrackMatch/BuildFile.xml
@@ -1,8 +1,16 @@
+<use   name="FWCore/MessageLogger"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="DataFormats/L1Trigger"/>
 <use   name="DataFormats/L1TrackTrigger"/>
 <use   name="DataFormats/L1TCorrelator"/>
+<use   name="DataFormats/L1TMuon"/>
+<use   name="DataFormats/GeometryVector"/>
+<use   name="DataFormats/Math"/>
 <use   name="L1Trigger/L1TMuon"/>
+<use   name="L1Trigger/L1TMuonEndCap"/>
 <use   name="clhep"/>
+<use   name="root"/>
+<use   name="rootrflx"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/L1Trigger/L1TTrackMatch/interface/L1TkElectronEtComparator.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkElectronEtComparator.h
@@ -1,5 +1,5 @@
-#ifndef L1TTrackMatch_L1TkElectronEtComparator_HH
-#define L1TTrackMatch_L1TkElectronEtComparator_HH
+#ifndef L1Trigger_L1TTrackMatch_L1TkElectronEtComparator_HH
+#define L1Trigger_L1TTrackMatch_L1TkElectronEtComparator_HH
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 
 namespace L1TkElectron {

--- a/L1Trigger/L1TTrackMatch/interface/L1TkElectronEtComparator.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkElectronEtComparator.h
@@ -1,0 +1,23 @@
+#ifndef L1TTrackMatch_L1TkElectronEtComparator_HH
+#define L1TTrackMatch_L1TkElectronEtComparator_HH
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+
+namespace L1TkElectron {
+  class EtComparator {
+  public:
+    bool operator()(const l1t::EGamma& a, const l1t::EGamma& b) const {
+      double et_a = 0.0;
+      double et_b = 0.0;
+      double cosh_a_eta = cosh(a.eta());
+      double cosh_b_eta = cosh(b.eta());
+
+      if (cosh_a_eta > 0.0)
+        et_a = a.energy() / cosh_a_eta;
+      if (cosh_b_eta > 0.0)
+        et_b = b.energy() / cosh_b_eta;
+
+      return et_a > et_b;
+    }
+  };
+}  // namespace L1TkElectron
+#endif

--- a/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
@@ -1,0 +1,24 @@
+#ifndef L1TTrackMatch_L1TkElectronTrackMatchAlgo_HH
+#define L1TTrackMatch_L1TkElectronTrackMatchAlgo_HH
+
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace L1TkElectronTrackMatchAlgo {
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollection;
+  void doMatch(BXVector<l1t::EGamma>::const_iterator egIter,
+               const edm::Ptr<L1TTTrackType>& pTrk,
+               double& dph,
+               double& dr,
+               double& deta);
+  void doMatch(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk, double& dph, double& dr, double& deta);
+
+  double deltaR(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
+  double deltaPhi(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
+  double deltaEta(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
+  GlobalPoint calorimeterPosition(double phi, double eta, double e);
+
+}  // namespace L1TkElectronTrackMatchAlgo
+#endif

--- a/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
@@ -1,5 +1,5 @@
-#ifndef L1TTrackMatch_L1TkElectronTrackMatchAlgo_HH
-#define L1TTrackMatch_L1TkElectronTrackMatchAlgo_HH
+#ifndef L1Trigger_L1TTrackMatch_L1TkElectronTrackMatchAlgo_HH
+#define L1Trigger_L1TTrackMatch_L1TkElectronTrackMatchAlgo_HH
 
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"

--- a/L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h
@@ -56,9 +56,7 @@ public:
   }
   void set_safety_factor(float sf) { set_safety_factor(sf, sf); }
   void set_sf_initialrelax(float sf) { set_sf_initialrelax(sf, sf); }
-  void set_do_relax_factor(bool val) {
-    do_relax_factor_ = val;
-  }
+  void set_do_relax_factor(bool val) { do_relax_factor_ = val; }
 
   void set_do_trk_qual_presel(bool val) { track_qual_presel_ = val; }
 

--- a/L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h
@@ -1,0 +1,150 @@
+#ifndef L1TTrackMatch_L1TKMUCORRDYNAMICWINDOWS_H
+#define L1TTrackMatch_L1TKMUCORRDYNAMICWINDOWS_H
+
+#include "TFile.h"
+#include <array>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <cmath>
+
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1TMuon/interface/EMTFTrack.h"
+#include "DataFormats/Math/interface/angle_units.h"
+
+#include "L1Trigger/L1TTrackMatch/interface/MuMatchWindow.h"
+#include "L1Trigger/L1TMuonEndCap/interface/Common.h"
+
+class L1TkMuCorrDynamicWindows {
+public:
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
+
+  L1TkMuCorrDynamicWindows(std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi);
+  L1TkMuCorrDynamicWindows(
+      std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, TFile* fIn_theta_S1, TFile* fIn_phi_S1);
+  ~L1TkMuCorrDynamicWindows() {}
+  std::vector<int> find_match(
+      const EMTFTrackCollection& l1mus,
+      const L1TTTrackCollectionType& l1trks);  // gives a vector with the idxs of muons for each L1TTT
+  std::vector<int> find_match_stub(
+      const EMTFHitCollection& l1mus,
+      const L1TTTrackCollectionType& l1trks,
+      const int& station,
+      bool requireBX0 = true);  // gives a vector with the idxs of muon stubs from station "station" for each L1TTT
+
+  // ------------------------------
+  static std::vector<double> prepare_corr_bounds(const string& fname, const string& hname);
+
+  void set_safety_factor(float sf_l, float sf_h) {
+    safety_factor_l_ = sf_l;
+    safety_factor_h_ = sf_h;
+    // std::cout << "L1TkMuCorrDynamicWindows : safety factor LOW is " << safety_factor_l_ << std::endl;
+    // std::cout << "L1TkMuCorrDynamicWindows : safety factor HIGH is " << safety_factor_h_ << std::endl;
+  }
+  void set_sf_initialrelax(float sf_l, float sf_h) {
+    initial_sf_l_ = sf_l;
+    initial_sf_h_ = sf_h;
+    // std::cout << "L1TkMuCorrDynamicWindows : initial relax safety factor LOW is " << initial_sf_l_ << std::endl;
+    // std::cout << "L1TkMuCorrDynamicWindows : initial relax safety factor HIGH is " << initial_sf_h_ << std::endl;
+  }
+  void set_relaxation_pattern(float pt_start, float pt_end) {
+    pt_start_ = pt_start;
+    pt_end_ = pt_end;
+    // std::cout << "L1TkMuCorrDynamicWindows : set relaxing from " << pt_start_ << " to " << pt_end_ << std::endl;
+  }
+  void set_safety_factor(float sf) { set_safety_factor(sf, sf); }
+  void set_sf_initialrelax(float sf) { set_sf_initialrelax(sf, sf); }
+  void set_do_relax_factor(bool val) {
+    do_relax_factor_ = val;
+    // std::cout << "L1TkMuCorrDynamicWindows : set do_relax to " << std::boolalpha << do_relax_factor_ << std::noboolalpha << std::endl;
+  }
+
+  void set_do_trk_qual_presel(bool val) { track_qual_presel_ = val; }
+
+  // setters for trk
+  void set_n_trk_par(int val) { nTrkPars_ = val; }
+  void set_min_trk_p(float val) { min_trk_p_ = val; }
+  void set_max_trk_aeta(float val) { max_trk_aeta_ = val; }
+  void set_max_trk_chi2(float val) { max_trk_chi2_ = val; }
+  void set_min_trk_nstubs(int val) { min_trk_nstubs_ = val; }
+
+  // getters for trk
+  const int n_trk_par() { return nTrkPars_; }
+  const float min_trk_p() { return min_trk_p_; }
+  const float max_trk_aeta() { return max_trk_aeta_; }
+  const float max_trk_chi2() { return max_trk_chi2_; }
+  const int min_trk_nstubs() { return min_trk_nstubs_; }
+
+private:
+  int findBin(double val);
+
+  // resolves ambiguities to give max 1 tkmu per EMTF
+  // if a pointer to narbitrated is passed, this vector is filled with the number of tracks arbitrated that were matched to the same EMTF
+  std::vector<int> make_unique_coll(const unsigned int& l1musSize,
+                                    const L1TTTrackCollectionType& l1trks,
+                                    const std::vector<int>& matches);
+
+  // converters
+  double deg_to_rad(double x) { return (x * angle_units::degPerRad); }
+
+  double eta_to_theta(double x) {
+    //  give theta in rad
+    return (2. * atan(exp(-1. * x)));
+  }
+
+  double to_mpio2_pio2(double x) {
+    //  put the angle in radians between -pi/2 and pi/2
+    while (x >= 0.5 * M_PI)
+      x -= M_PI;
+    while (x < -0.5 * M_PI)
+      x += M_PI;
+    return x;
+  }
+
+  double to_mpi_pi(double x) {
+    while (x >= M_PI)
+      x -= 2. * M_PI;
+    while (x < -M_PI)
+      x += 2. * M_PI;
+    return x;
+  }
+
+  double sf_progressive(double x, double xstart, double xstop, double ystart, double ystop) {
+    if (x < xstart)
+      return ystart;
+    if (x >= xstart && x < xstop)
+      return ystart + (x - xstart) * (ystop - ystart) / (xstop - xstart);
+    return ystop;
+  }
+
+  int nbins_;                   // counts the number of MatchWindow = bounds_.size() - 1
+  std::vector<double> bounds_;  // counts the boundaries of the MatchWindow (in eta/theta)
+  std::vector<MuMatchWindow> wdws_theta_;
+  std::vector<MuMatchWindow> wdws_phi_;
+  std::vector<MuMatchWindow> wdws_theta_S1_;
+  std::vector<MuMatchWindow> wdws_phi_S1_;
+  float safety_factor_l_;   // increase the lower theta/phi threshold by this fractions
+  float safety_factor_h_;   // increase the upper theta/phi threshold by this fractions
+  float initial_sf_l_;      // the start of the relaxation
+  float initial_sf_h_;      // the start of the relaxation
+  float pt_start_;          // the relaxation of the threshold
+  float pt_end_;            // the relaxation of the threshold
+  bool do_relax_factor_;    // true if applying the linear relaxation
+  bool track_qual_presel_;  // if true, apply the track preselection
+
+  // trk configurable params
+  int nTrkPars_;        // 4
+  float min_trk_p_;     // 3.5
+  float max_trk_aeta_;  // 2.5
+  float max_trk_chi2_;  // 100
+  int min_trk_nstubs_;  // 4
+};
+
+#endif

--- a/L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h
@@ -1,5 +1,5 @@
-#ifndef L1TTrackMatch_L1TKMUCORRDYNAMICWINDOWS_H
-#define L1TTrackMatch_L1TKMUCORRDYNAMICWINDOWS_H
+#ifndef L1Trigger_L1TTrackMatch_L1TKMUCORRDYNAMICWINDOWS_H
+#define L1Trigger_L1TTrackMatch_L1TKMUCORRDYNAMICWINDOWS_H
 
 #include "TFile.h"
 #include <array>
@@ -26,9 +26,9 @@ public:
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
 
-  L1TkMuCorrDynamicWindows(std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi);
+  L1TkMuCorrDynamicWindows(const std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi);
   L1TkMuCorrDynamicWindows(
-      std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, TFile* fIn_theta_S1, TFile* fIn_phi_S1);
+      const std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, TFile* fIn_theta_S1, TFile* fIn_phi_S1);
   ~L1TkMuCorrDynamicWindows() {}
   std::vector<int> find_match(
       const EMTFTrackCollection& l1mus,
@@ -45,25 +45,19 @@ public:
   void set_safety_factor(float sf_l, float sf_h) {
     safety_factor_l_ = sf_l;
     safety_factor_h_ = sf_h;
-    // std::cout << "L1TkMuCorrDynamicWindows : safety factor LOW is " << safety_factor_l_ << std::endl;
-    // std::cout << "L1TkMuCorrDynamicWindows : safety factor HIGH is " << safety_factor_h_ << std::endl;
   }
   void set_sf_initialrelax(float sf_l, float sf_h) {
     initial_sf_l_ = sf_l;
     initial_sf_h_ = sf_h;
-    // std::cout << "L1TkMuCorrDynamicWindows : initial relax safety factor LOW is " << initial_sf_l_ << std::endl;
-    // std::cout << "L1TkMuCorrDynamicWindows : initial relax safety factor HIGH is " << initial_sf_h_ << std::endl;
   }
   void set_relaxation_pattern(float pt_start, float pt_end) {
     pt_start_ = pt_start;
     pt_end_ = pt_end;
-    // std::cout << "L1TkMuCorrDynamicWindows : set relaxing from " << pt_start_ << " to " << pt_end_ << std::endl;
   }
   void set_safety_factor(float sf) { set_safety_factor(sf, sf); }
   void set_sf_initialrelax(float sf) { set_sf_initialrelax(sf, sf); }
   void set_do_relax_factor(bool val) {
     do_relax_factor_ = val;
-    // std::cout << "L1TkMuCorrDynamicWindows : set do_relax to " << std::boolalpha << do_relax_factor_ << std::noboolalpha << std::endl;
   }
 
   void set_do_trk_qual_presel(bool val) { track_qual_presel_ = val; }

--- a/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h
@@ -1,5 +1,5 @@
-#ifndef L1TTrackMatch_L1TKMUMANTRA_H
-#define L1TTrackMatch_L1TKMUMANTRA_H
+#ifndef L1Trigger_L1TTrackMatch_L1TKMUMANTRA_H
+#define L1Trigger_L1TTrackMatch_L1TKMUMANTRA_H
 
 /*
 ** class  : GenericDataFormat
@@ -42,7 +42,6 @@ namespace L1TkMuMantraDF {
 #include <string>
 #include <utility>
 #include "L1Trigger/L1TTrackMatch/interface/MuMatchWindow.h"
-#include "TFile.h"
 #include <cmath>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -50,7 +49,7 @@ namespace L1TkMuMantraDF {
 
 class L1TkMuMantra {
 public:
-  L1TkMuMantra(std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, std::string name);
+  L1TkMuMantra(const std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, std::string name);
   ~L1TkMuMantra(){};
 
   // returns a vector with the same size of muons, each with an index to the matched L1 track, or -1 if no match is found
@@ -121,12 +120,6 @@ private:
 
   float safety_factor_l_;  // increase the lower theta/phi threshold by this fractions w.r.t. the center
   float safety_factor_h_;  // increase the upper theta/phi threshold by this fractions w.r.t. the center
-
-  // float initial_sf_l_; // the start of the relaxation
-  // float initial_sf_h_; // the start of the relaxation
-  // float pt_start_; // the relaxation of the threshold
-  // float pt_end_; // the relaxation of the threshold
-  // bool  do_relax_factor_; // true if applying the linear relaxation
 
   enum sortParType {
     kMaxPt,      // pick the highest pt track matched

--- a/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h
@@ -1,0 +1,141 @@
+#ifndef L1TTrackMatch_L1TKMUMANTRA_H
+#define L1TTrackMatch_L1TKMUMANTRA_H
+
+/*
+** class  : GenericDataFormat
+** author : L.Cadamuro (UF)
+** date   : 4/11/2019
+** brief  : very generic structs to be used as inputs to the correlator
+**        : to make sure that Mantra can handle muons and tracks from all the detectors
+*/
+
+namespace L1TkMuMantraDF {
+
+  struct track_df {
+    double pt;     // GeV
+    double eta;    // rad, -inf / +inf
+    double theta;  // rad, 0 -> +90-90
+    double phi;    // rad, -pi / + pi
+    int nstubs;    //
+    double chi2;   //
+    int charge;    // -1. +1
+  };
+
+  struct muon_df {
+    double pt;     // GeV
+    double eta;    // rad, -inf / +inf
+    double theta;  // rad, 0 -> +90-90
+    double phi;    // rad, -pi / + pi
+    int charge;    // -1. +1
+  };
+}  // namespace L1TkMuMantraDF
+
+/*
+** class  : L1TkMuMantra
+** author : L.Cadamuro (UF)
+** date   : 4/11/2019
+** brief  : correlates muons and tracks using pre-encoded windows
+*/
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <utility>
+#include "L1Trigger/L1TTrackMatch/interface/MuMatchWindow.h"
+#include "TFile.h"
+#include <cmath>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/angle_units.h"
+
+class L1TkMuMantra {
+public:
+  L1TkMuMantra(std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, std::string name);
+  ~L1TkMuMantra(){};
+
+  // returns a vector with the same size of muons, each with an index to the matched L1 track, or -1 if no match is found
+  std::vector<int> find_match(const std::vector<L1TkMuMantraDF::track_df>& tracks,
+                              const std::vector<L1TkMuMantraDF::muon_df>& muons);
+
+  void test(double eta, double pt);
+
+  void relax_windows(double& low, double cent, double& high);  // will modify low and high
+
+  void set_safety_factor(float sf_l, float sf_h) {
+    safety_factor_l_ = sf_l;
+    safety_factor_h_ = sf_h;
+    if (verbosity_ > 0)
+      LogTrace("L1TkMuMantra") << name_ << " safety factor LOW is " << safety_factor_l_ << std::endl;
+    if (verbosity_ > 0)
+      LogTrace("L1TkMuMantra") << name_ << " safety factor HIGH is " << safety_factor_h_ << std::endl;
+  }
+
+  int sign(double x) {
+    if (x == 0)
+      return 1;
+    return (0 < x) - (x < 0);
+  }
+
+  void setArbitrationType(std::string type);  // MaxPt, MinDeltaPt
+
+  // static functions, meant to be used from outside to interface with MAnTra
+  static std::vector<double> prepare_corr_bounds(std::string fname, std::string hname);
+
+  // converters
+  static double deg_to_rad(double x) { return (x * angle_units::degPerRad); }
+
+  static double eta_to_theta(double x) {
+    //  give theta in rad
+    return (2. * atan(exp(-1. * x)));
+  }
+
+  static double to_mpio2_pio2(double x) {
+    //  put the angle in radians between -pi/2 and pi/2
+    while (x >= 0.5 * M_PI)
+      x -= M_PI;
+    while (x < -0.5 * M_PI)
+      x += M_PI;
+    return x;
+  }
+
+  static double to_mpi_pi(double x) {
+    while (x >= M_PI)
+      x -= 2. * M_PI;
+    while (x < -M_PI)
+      x += 2. * M_PI;
+    return x;
+  }
+
+private:
+  int findBin(double val);
+
+  std::string name_;
+
+  int nbins_;                   // counts the number of MuMatchWindow = bounds_.size() - 1
+  std::vector<double> bounds_;  // counts the boundaries of the MuMatchWindow (in eta/theta)
+  std::vector<MuMatchWindow> wdws_theta_;
+  std::vector<MuMatchWindow> wdws_phi_;
+
+  int min_nstubs = 4;     // >= min_nstubs
+  double max_chi2 = 100;  // < max_chi2
+
+  float safety_factor_l_;  // increase the lower theta/phi threshold by this fractions w.r.t. the center
+  float safety_factor_h_;  // increase the upper theta/phi threshold by this fractions w.r.t. the center
+
+  // float initial_sf_l_; // the start of the relaxation
+  // float initial_sf_h_; // the start of the relaxation
+  // float pt_start_; // the relaxation of the threshold
+  // float pt_end_; // the relaxation of the threshold
+  // bool  do_relax_factor_; // true if applying the linear relaxation
+
+  enum sortParType {
+    kMaxPt,      // pick the highest pt track matched
+    kMinDeltaPt  // pick the track with the smallest pt difference w.r.t the muon
+  };
+
+  sortParType sort_type_;
+
+  int verbosity_ = 0;
+};
+
+#endif  // L1TKMUMANTRA_H

--- a/L1Trigger/L1TTrackMatch/interface/MuMatchWindow.h
+++ b/L1Trigger/L1TTrackMatch/interface/MuMatchWindow.h
@@ -1,5 +1,5 @@
-#ifndef L1TTrackMatch_MUMATCHWINDOW_H
-#define L1TTrackMatch_MUMATCHWINDOW_H
+#ifndef L1Trigger_L1TTrackMatch_MUMATCHWINDOW_H
+#define L1Trigger_L1TTrackMatch_MUMATCHWINDOW_H
 
 #include "TF1.h"
 #include <string>

--- a/L1Trigger/L1TTrackMatch/interface/MuMatchWindow.h
+++ b/L1Trigger/L1TTrackMatch/interface/MuMatchWindow.h
@@ -1,0 +1,44 @@
+#ifndef L1TTrackMatch_MUMATCHWINDOW_H
+#define L1TTrackMatch_MUMATCHWINDOW_H
+
+#include "TF1.h"
+#include <string>
+#include <memory>
+#include <iostream>
+
+/*
+** class  : MuMatchWindow
+** author : L.Cadamuro (UF)
+** date   : 25/12/2018
+** brief  : encodes the lower, central, and upper bounds to match a track to a muon
+**          to be flexible, limits are given as strings to create a TF1 function
+*/
+
+class MuMatchWindow {
+public:
+  MuMatchWindow();
+  MuMatchWindow(std::string name);
+  ~MuMatchWindow();
+  void SetName(std::string name) { name_ = name; }
+
+  void SetLower(std::string formula);
+  void SetCentral(std::string formula);
+  void SetUpper(std::string formula);
+
+  void SetLower(TF1* formula);
+  void SetCentral(TF1* formula);
+  void SetUpper(TF1* formula);
+
+  // bool matches (double pt);
+  const double bound_low(double pt) { return fLow_->Eval(pt); }
+  const double bound_cent(double pt) { return fCent_->Eval(pt); }
+  const double bound_high(double pt) { return fHigh_->Eval(pt); }
+
+private:
+  std::string name_;
+  std::shared_ptr<TF1> fLow_;
+  std::shared_ptr<TF1> fCent_;
+  std::shared_ptr<TF1> fHigh_;
+};
+
+#endif

--- a/L1Trigger/L1TTrackMatch/interface/pTFrom2Stubs.h
+++ b/L1Trigger/L1TTrackMatch/interface/pTFrom2Stubs.h
@@ -1,0 +1,11 @@
+#ifndef L1TTrackMatch_pTFrom2Stubs_HH
+#define L1TTrackMatch_pTFrom2Stubs_HH
+
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace pTFrom2Stubs {
+  float rInvFrom2(std::vector<TTTrack<Ref_Phase2TrackerDigi_> >::const_iterator trk, const TrackerGeometry* tkGeometry);
+  float pTFrom2(std::vector<TTTrack<Ref_Phase2TrackerDigi_> >::const_iterator trk, const TrackerGeometry* tkGeometry);
+}  // namespace pTFrom2Stubs
+#endif

--- a/L1Trigger/L1TTrackMatch/interface/pTFrom2Stubs.h
+++ b/L1Trigger/L1TTrackMatch/interface/pTFrom2Stubs.h
@@ -1,5 +1,5 @@
-#ifndef L1TTrackMatch_pTFrom2Stubs_HH
-#define L1TTrackMatch_pTFrom2Stubs_HH
+#ifndef L1Trigger_L1TTrackMatch_pTFrom2Stubs_HH
+#define L1Trigger_L1TTrackMatch_pTFrom2Stubs_HH
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"

--- a/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
+++ b/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
@@ -1,0 +1,18 @@
+<library   file="*.cc" name="L1TrackTriggerPlugins">
+<use   name="Geometry/TrackerNumberingBuilder"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
+<use   name="Geometry/Records"/>
+<use   name="Geometry/CommonDetUnit"/>
+<use   name="MagneticField/Records"/>
+<use   name="L1Trigger/L1TTrackMatch"/>
+<use   name="SimGeneral/HepPDTRecord"/>
+<use   name="CommonTools/BaseParticlePropagator"/>
+<use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="PhysicsTools/UtilAlgos"/>
+<use   name="CommonTools/UtilAlgos"/>
+<use   name="DataFormats/L1TrackTrigger"/>
+<use   name="L1Trigger/TrackTrigger"/>
+<use   name="hepmc"/>
+<use   name="root"/>
+<flags   EDM_PLUGIN="1"/>
+</library>

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
@@ -1,0 +1,344 @@
+// -*- C++ -*-
+//
+/**\class L1TkElectronTrackMatchAlgo
+
+ Description: Producer of a TkElectron, for the algorithm matching a L1Track to the L1EG object
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+// Matching Algorithm
+#include "L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkElectronEtComparator.h"
+#include "L1Trigger/L1TTrackMatch/interface/pTFrom2Stubs.h"
+
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+
+#include <string>
+
+static constexpr float EB_MaxEta = 0.9;
+
+using namespace l1t;
+
+//
+// class declaration
+//
+
+class L1TkElectronTrackProducer : public edm::stream::EDProducer<> {
+public:
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
+
+  explicit L1TkElectronTrackProducer(const edm::ParameterSet&);
+  ~L1TkElectronTrackProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  //void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  //void endJob() override;
+
+  float isolation(const edm::Handle<L1TTTrackCollectionType>& trkHandle, int match_index);
+  double getPtScaledCut(double pt, std::vector<double>& parameters);
+  bool selectMatchedTrack(double& d_r, double& d_phi, double& d_eta, double& tk_pt, float& eg_eta);
+
+  // ----------member data ---------------------------
+  std::string label;
+
+  float etMin_;  // min ET in GeV of L1EG objects
+
+  float dRMin_;
+  float dRMax_;
+  float pTMinTra_;
+  float maxChi2IsoTracks_;
+  unsigned int minNStubsIsoTracks_;
+
+  bool primaryVtxConstrain_;  // use the primary vertex (default = false)
+  float deltaZ_;              // | z_track - z_ref_track | < deltaZ_ in cm.
+                              // Used only when primaryVtxConstrain_ = True.
+  float isoCut_;
+  bool relativeIsolation_;
+
+  float trkQualityChi2_;
+  bool useTwoStubsPT_;
+  float trkQualityPtMin_;
+  std::vector<double> dPhiCutoff_;
+  std::vector<double> dRCutoff_;
+  std::vector<double> dEtaCutoff_;
+  std::string matchType_;
+
+  const edm::EDGetTokenT<EGammaBxCollection> egToken;
+  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken;
+};
+
+//
+// constructors and destructor
+//
+L1TkElectronTrackProducer::L1TkElectronTrackProducer(const edm::ParameterSet& iConfig)
+    : egToken(consumes<EGammaBxCollection>(iConfig.getParameter<edm::InputTag>("L1EGammaInputTag"))),
+      trackToken(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
+          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))) {
+  // label of the collection produced
+  // e.g. EG or IsoEG if all objects are kept
+  // EGIsoTrk or IsoEGIsoTrk if only the EG or IsoEG
+  // objects that pass a cut RelIso < isoCut_ are written
+  // in the new collection.
+  label = iConfig.getParameter<std::string>("label");
+
+  etMin_ = (float)iConfig.getParameter<double>("ETmin");
+
+  // parameters for the calculation of the isolation :
+  pTMinTra_ = (float)iConfig.getParameter<double>("PTMINTRA");
+  dRMin_ = (float)iConfig.getParameter<double>("DRmin");
+  dRMax_ = (float)iConfig.getParameter<double>("DRmax");
+  deltaZ_ = (float)iConfig.getParameter<double>("DeltaZ");
+  maxChi2IsoTracks_ = iConfig.getParameter<double>("maxChi2IsoTracks");
+  minNStubsIsoTracks_ = iConfig.getParameter<int>("minNStubsIsoTracks");
+  // cut applied on the isolation (if this number is <= 0, no cut is applied)
+  isoCut_ = (float)iConfig.getParameter<double>("IsoCut");
+  relativeIsolation_ = iConfig.getParameter<bool>("RelativeIsolation");
+
+  // parameters to select tracks to match with L1EG
+  trkQualityChi2_ = (float)iConfig.getParameter<double>("TrackChi2");
+  trkQualityPtMin_ = (float)iConfig.getParameter<double>("TrackMinPt");
+  useTwoStubsPT_ = iConfig.getParameter<bool>("useTwoStubsPT");
+  dPhiCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaPhi");
+  dRCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaR");
+  dEtaCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaEta");
+  matchType_ = iConfig.getParameter<std::string>("TrackEGammaMatchType");
+
+  produces<TkElectronCollection>(label);
+}
+
+L1TkElectronTrackProducer::~L1TkElectronTrackProducer() {}
+
+// ------------ method called to produce the data  ------------
+void L1TkElectronTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::unique_ptr<TkElectronCollection> result(new TkElectronCollection);
+
+  // geometry needed to call pTFrom2Stubs
+  edm::ESHandle<TrackerGeometry> geomHandle;
+  iSetup.get<TrackerDigiGeometryRecord>().get("idealForDigi", geomHandle);
+  const TrackerGeometry* tGeom = geomHandle.product();
+
+  // the L1EGamma objects
+  edm::Handle<EGammaBxCollection> eGammaHandle;
+  iEvent.getByToken(egToken, eGammaHandle);
+  EGammaBxCollection eGammaCollection = (*eGammaHandle.product());
+  EGammaBxCollection::const_iterator egIter;
+
+  // the L1Tracks
+  edm::Handle<L1TTTrackCollectionType> L1TTTrackHandle;
+  iEvent.getByToken(trackToken, L1TTTrackHandle);
+  L1TTTrackCollectionType::const_iterator trackIter;
+
+  if (!eGammaHandle.isValid()) {
+    throw cms::Exception("L1TkElectronTrackProducer")
+        << "\nWarning: L1EmCollection not found in the event. Exit" << std::endl;
+    return;
+  }
+  if (!L1TTTrackHandle.isValid()) {
+    throw cms::Exception("TkEmProducer") << "\nWarning: L1TTTrackCollectionType not found in the event. Exit."
+                                         << std::endl;
+    return;
+  }
+
+  int ieg = 0;
+  for (egIter = eGammaCollection.begin(0); egIter != eGammaCollection.end(0); ++egIter) {  // considering BX = only
+    edm::Ref<EGammaBxCollection> EGammaRef(eGammaHandle, ieg);
+    ieg++;
+
+    float e_ele = egIter->energy();
+    float eta_ele = egIter->eta();
+    float et_ele = 0;
+    float cosh_eta_ele = cosh(eta_ele);
+    if (cosh_eta_ele > 0.0)
+      et_ele = e_ele / cosh_eta_ele;
+    else
+      et_ele = -1.0;
+    if (etMin_ > 0.0 && et_ele <= etMin_)
+      continue;
+    // match the L1EG object with a L1Track
+    float drmin = 999;
+    int itr = 0;
+    int itrack = -1;
+    for (trackIter = L1TTTrackHandle->begin(); trackIter != L1TTTrackHandle->end(); ++trackIter) {
+      edm::Ptr<L1TTTrackType> L1TrackPtr(L1TTTrackHandle, itr);
+      double trkPt_fit = trackIter->momentum().perp();
+      double trkPt_stubs = pTFrom2Stubs::pTFrom2(trackIter, tGeom);
+      double trkPt = trkPt_fit;
+      if (useTwoStubsPT_)
+        trkPt = trkPt_stubs;
+
+      if (trkPt > trkQualityPtMin_ && trackIter->chi2() < trkQualityChi2_) {
+        double dPhi = 99.;
+        double dR = 99.;
+        double dEta = 99.;
+        L1TkElectronTrackMatchAlgo::doMatch(egIter, L1TrackPtr, dPhi, dR, dEta);
+        if (dR < drmin && selectMatchedTrack(dR, dPhi, dEta, trkPt, eta_ele)) {
+          drmin = dR;
+          itrack = itr;
+        }
+      }
+      itr++;
+    }
+    if (itrack >= 0) {
+      edm::Ptr<L1TTTrackType> matchedL1TrackPtr(L1TTTrackHandle, itrack);
+
+      const math::XYZTLorentzVector P4 = egIter->p4();
+      float trkisol = isolation(L1TTTrackHandle, itrack);
+      if (relativeIsolation_ && et_ele > 0.0) {  // relative isolation
+        trkisol = trkisol / et_ele;
+      }
+
+      TkElectron trkEm(P4, EGammaRef, matchedL1TrackPtr, trkisol);
+
+      trkEm.setTrackCurvature(matchedL1TrackPtr->rInv());  // should this have npars? 4? 5?
+
+      //std::cout<<matchedL1TrackPtr->rInv()<<"  "<<matchedL1TrackPtr->rInv(4)<<"   "<<matchedL1TrackPtr->rInv()<<std::endl;
+
+      if (isoCut_ <= 0) {
+        // write the L1TkEm particle to the collection,
+        // irrespective of its relative isolation
+        result->push_back(trkEm);
+      } else {
+        // the object is written to the collection only
+        // if it passes the isolation cut
+        if (trkisol <= isoCut_)
+          result->push_back(trkEm);
+      }
+    }
+
+  }  // end loop over EGamma objects
+
+  iEvent.put(std::move(result), label);
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+//void L1TkElectronTrackProducer::beginJob() {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+//void L1TkElectronTrackProducer::endJob() {}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1TkElectronTrackProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkElectronTrackProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkElectronTrackProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkElectronTrackProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1TkElectronTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+// method to calculate isolation
+float L1TkElectronTrackProducer::isolation(const edm::Handle<L1TTTrackCollectionType>& trkHandle, int match_index) {
+  edm::Ptr<L1TTTrackType> matchedTrkPtr(trkHandle, match_index);
+  L1TTTrackCollectionType::const_iterator trackIter;
+
+  float sumPt = 0.0;
+  int itr = 0;
+
+  float dRMin2 = dRMin_ * dRMin_;
+  float dRMax2 = dRMax_ * dRMax_;
+
+  for (trackIter = trkHandle->begin(); trackIter != trkHandle->end(); ++trackIter) {
+    if (itr++ != match_index) {
+      if (trackIter->chi2() > maxChi2IsoTracks_ || trackIter->momentum().perp() <= pTMinTra_ ||
+          trackIter->getStubRefs().size() < minNStubsIsoTracks_) {
+        continue;
+      }
+
+      float dZ = std::abs(trackIter->POCA().z() - matchedTrkPtr->POCA().z());
+
+      float phi1 = trackIter->momentum().phi();
+      float phi2 = matchedTrkPtr->momentum().phi();
+      float dPhi = reco::deltaPhi(phi1, phi2);
+      float dEta = (trackIter->momentum().eta() - matchedTrkPtr->momentum().eta());
+      float dR2 = (dPhi * dPhi + dEta * dEta);
+
+      if (dR2 > dRMin2 && dR2 < dRMax2 && dZ < deltaZ_ && trackIter->momentum().perp() > pTMinTra_) {
+        sumPt += trackIter->momentum().perp();
+      }
+    }
+  }
+
+  return sumPt;
+}
+double L1TkElectronTrackProducer::getPtScaledCut(double pt, std::vector<double>& parameters) {
+  return (parameters[0] + parameters[1] * exp(parameters[2] * pt));
+}
+bool L1TkElectronTrackProducer::selectMatchedTrack(
+    double& d_r, double& d_phi, double& d_eta, double& tk_pt, float& eg_eta) {
+  if (matchType_ == "PtDependentCut") {
+    if (std::abs(d_phi) < getPtScaledCut(tk_pt, dPhiCutoff_) && d_r < getPtScaledCut(tk_pt, dRCutoff_))
+      return true;
+  } else {
+    double deta_max = dEtaCutoff_[0];
+    if (std::abs(eg_eta) < EB_MaxEta)
+      deta_max = dEtaCutoff_[1];
+    double dphi_max = dPhiCutoff_[0];
+    if ((d_eta / deta_max) * (d_eta / deta_max) + (d_phi / dphi_max) * (d_phi / dphi_max) < 1)
+      return true;
+  }
+  return false;
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkElectronTrackProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
@@ -1,0 +1,392 @@
+// -*- C++ -*-
+//
+//
+// dummy producer for a TkEm
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "DataFormats/L1TCorrelator/interface/TkEmFwd.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkPrimaryVertex.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+// for L1Tracks:
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+#include <string>
+#include <cmath>
+
+static constexpr float EtaECal = 1.479;
+static constexpr float REcal = 129.;
+static constexpr float ZEcal = 315.4;
+using namespace l1t;
+//
+// class declaration
+//
+
+class L1TkEmParticleProducer : public edm::EDProducer {
+public:
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
+
+  explicit L1TkEmParticleProducer(const edm::ParameterSet&);
+  ~L1TkEmParticleProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  float DeltaPhi(float phi1, float phi2);
+  float deltaR(float eta1, float eta2, float phi1, float phi2);
+  float CorrectedEta(float eta, float zv);
+
+private:
+  void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+  //virtual void endRun(edm::Run&, edm::EventSetup const&);
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+  //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+  // ----------member data ---------------------------
+
+  std::string label;
+
+  float etMin_;  // min ET in GeV of L1EG objects
+
+  float zMax_;  // |z_track| < zMax_ in cm
+  float chi2Max_;
+  float dRMin_;
+  float dRMax_;
+  float pTMinTra_;
+  bool primaryVtxConstrain_;  // use the primary vertex (default = false)
+                              //bool DeltaZConstrain;	// use z = z of the leading track within DR < dRMax_;
+  float deltaZMax_;           // | z_track - z_primaryvtx | < deltaZMax_ in cm.
+                              // Used only when primaryVtxConstrain_ = True.
+  float isoCut_;
+  bool relativeIsolation_;
+
+  const edm::EDGetTokenT<EGammaBxCollection> egToken;
+  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken;
+  const edm::EDGetTokenT<TkPrimaryVertexCollection> vertexToken;
+};
+
+//
+// constructors and destructor
+//
+L1TkEmParticleProducer::L1TkEmParticleProducer(const edm::ParameterSet& iConfig)
+    : egToken(consumes<EGammaBxCollection>(iConfig.getParameter<edm::InputTag>("L1EGammaInputTag"))),
+      trackToken(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
+          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))),
+      vertexToken(consumes<TkPrimaryVertexCollection>(iConfig.getParameter<edm::InputTag>("L1VertexInputTag"))) {
+  label = iConfig.getParameter<std::string>("label");  // label of the collection produced
+  // e.g. EG or IsoEG if all objects are kept
+  // EGIsoTrk or IsoEGIsoTrk if only the EG or IsoEG
+  // objects that pass a cut RelIso < isoCut_ are written
+  // in the new collection.
+
+  etMin_ = (float)iConfig.getParameter<double>("ETmin");
+
+  // parameters for the calculation of the isolation :
+  zMax_ = (float)iConfig.getParameter<double>("ZMAX");
+  chi2Max_ = (float)iConfig.getParameter<double>("CHI2MAX");
+  pTMinTra_ = (float)iConfig.getParameter<double>("PTMINTRA");
+  dRMin_ = (float)iConfig.getParameter<double>("DRmin");
+  dRMax_ = (float)iConfig.getParameter<double>("DRmax");
+  primaryVtxConstrain_ = iConfig.getParameter<bool>("PrimaryVtxConstrain");
+  //DeltaZConstrain = iConfig.getParameter<bool>("DeltaZConstrain");
+  deltaZMax_ = (float)iConfig.getParameter<double>("DeltaZMax");
+  // cut applied on the isolation (if this number is <= 0, no cut is applied)
+  isoCut_ = (float)iConfig.getParameter<double>("IsoCut");
+  relativeIsolation_ = iConfig.getParameter<bool>("RelativeIsolation");
+
+  produces<TkEmCollection>(label);
+}
+
+L1TkEmParticleProducer::~L1TkEmParticleProducer() {}
+
+// ------------ method called to produce the data  ------------
+void L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  std::unique_ptr<TkEmCollection> result(new TkEmCollection);
+
+  // the L1EGamma objects
+  edm::Handle<EGammaBxCollection> eGammaHandle;
+  iEvent.getByToken(egToken, eGammaHandle);
+  EGammaBxCollection eGammaCollection = (*eGammaHandle.product());
+  EGammaBxCollection::const_iterator egIter;
+
+  // the L1Tracks
+  edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > L1TTTrackHandle;
+  iEvent.getByToken(trackToken, L1TTTrackHandle);
+  L1TTTrackCollectionType::const_iterator trackIter;
+
+  // the primary vertex (used only if primaryVtxConstrain_ = true)
+  float zvtxL1tk = -999;
+  //if (primaryVtxConstrain_) {
+  edm::Handle<TkPrimaryVertexCollection> L1VertexHandle;
+  iEvent.getByToken(vertexToken, L1VertexHandle);
+  if (!L1VertexHandle.isValid()) {
+    LogWarning("L1TkEmParticleProducer")
+        << "Warning: TkPrimaryVertexCollection not found in the event. Won't use any PrimaryVertex constraint."
+        << std::endl;
+    primaryVtxConstrain_ = false;
+  } else {
+    std::vector<TkPrimaryVertex>::const_iterator vtxIter = L1VertexHandle->begin();
+    // by convention, the first vertex in the collection is the one that should
+    // be used by default
+    zvtxL1tk = vtxIter->zvertex();
+  }
+  //}
+
+  if (!L1TTTrackHandle.isValid()) {
+    LogError("L1TkEmParticleProducer") << "\nWarning: L1TTTrackCollectionType not found in the event. Exit."
+                                       << std::endl;
+    return;
+  }
+
+  // Now loop over the L1EGamma objects
+
+  if (!eGammaHandle.isValid()) {
+    LogError("L1TkEmParticleProducer") << "\nWarning: L1EmCollection not found in the event. Exit." << std::endl;
+    return;
+  }
+
+  int ieg = 0;
+  for (egIter = eGammaCollection.begin(0); egIter != eGammaCollection.end(0); ++egIter)  // considering BX = only
+  {
+    edm::Ref<EGammaBxCollection> EGammaRef(eGammaHandle, ieg);
+    ieg++;
+
+    float eta = egIter->eta();
+    // The eta of the L1EG object is seen from (0,0,0).
+    // if primaryVtxConstrain_ = true, and for the PV constrained iso, use the zvtxL1tk to correct the eta(L1EG)
+    // that is used in the calculation of DeltaR.
+    float etaPV = CorrectedEta((float)eta, zvtxL1tk);
+
+    float phi = egIter->phi();
+    float et = egIter->et();
+
+    if (et < etMin_)
+      continue;
+
+    // calculate the isolation of the L1EG object with
+    // respect to L1Tracks.
+
+    float trkisol = -999;
+    float sumPt = 0;
+    float sumPtPV = 0;
+    float trkisolPV = -999;
+
+    //std::cout << " here an EG w et = " << et << std::endl;
+
+    //float z_leadingTrack = -999;
+    //float Pt_leadingTrack = -999;
+
+    /*
+	if (DeltaZConstrain) {
+	// first loop over the tracks to find the leading one in DR < dRMax_
+	for (trackIter = L1TTTrackHandle->begin(); trackIter != L1TTTrackHandle->end(); ++trackIter) {
+	float Pt = trackIter->momentum().perp();
+	float Eta = trackIter->momentum().eta();
+	float Phi = trackIter->momentum().phi();
+	float z  = trackIter->POCA().z();
+	if (fabs(z) > zMax_) continue;
+	if (Pt < pTMinTra_) continue;
+	float chi2 = trackIter->chi2();
+	if (chi2 > chi2Max_) continue;
+	float dr = deltaR(Eta, eta, Phi,phi);
+	if (dr < dRMax_) {
+	if (Pt > Pt_leadingTrack) {
+	Pt_leadingTrack = Pt;
+	z_leadingTrack = z;
+	}
+	}
+	} // end loop over the tracks
+	} // endif DeltaZConstrain
+      */
+
+    for (trackIter = L1TTTrackHandle->begin(); trackIter != L1TTTrackHandle->end(); ++trackIter) {
+      float Pt = trackIter->momentum().perp();
+      float Eta = trackIter->momentum().eta();
+      float Phi = trackIter->momentum().phi();
+      float z = trackIter->POCA().z();
+      if (fabs(z) > zMax_)
+        continue;
+      if (Pt < pTMinTra_)
+        continue;
+      float chi2 = trackIter->chi2();
+      if (chi2 > chi2Max_)
+        continue;
+
+      float dr = deltaR(Eta, eta, Phi, phi);
+      if (dr < dRMax_ && dr >= dRMin_) {
+        //std::cout << " a track in the cone, z Pt = " << z << " " << Pt << std::endl;
+        sumPt += Pt;
+      }
+
+      if (zvtxL1tk > -999 && fabs(z - zvtxL1tk) >= deltaZMax_)
+        continue;  // Now, PV constrained trackSum:
+
+      dr = deltaR(Eta, etaPV, Phi, phi);  // recompute using the corrected eta
+
+      if (dr < dRMax_ && dr >= dRMin_) {
+        sumPtPV += Pt;
+      }
+    }  // end loop over tracks
+
+    if (relativeIsolation_) {
+      if (et > 0) {
+        trkisol = sumPt / et;
+        trkisolPV = sumPtPV / et;
+      }       // relative isolation
+    } else {  // absolute isolation
+      trkisol = sumPt;
+      trkisolPV = sumPtPV;
+    }
+
+    float isolation = trkisol;
+    if (primaryVtxConstrain_) {
+      isolation = trkisolPV;
+    }
+
+    const math::XYZTLorentzVector P4 = egIter->p4();
+    TkEm trkEm(P4, EGammaRef, trkisol, trkisolPV);
+
+    if (isoCut_ <= 0) {
+      // write the L1TkEm particle to the collection,
+      // irrespective of its relative isolation
+      result->push_back(trkEm);
+    } else {
+      // the object is written to the collection only
+      // if it passes the isolation cut
+      if (isolation <= isoCut_)
+        result->push_back(trkEm);
+    }
+
+  }  // end loop over EGamma objects
+
+  iEvent.put(std::move(result), label);
+}
+
+// --------------------------------------------------------------------------------------
+
+float L1TkEmParticleProducer::CorrectedEta(float eta, float zv) {
+  // Correct the eta of the L1EG object once we know the zvertex
+
+  bool IsBarrel = (fabs(eta) < EtaECal);
+
+  float theta = 2. * atan(exp(-eta));
+  if (theta < 0)
+    theta = theta + M_PI;
+  float tantheta = tan(theta);
+
+  float delta;
+  if (IsBarrel) {
+    delta = REcal / tantheta;
+  } else {
+    if (theta > 0)
+      delta = ZEcal;
+    if (theta < 0)
+      delta = -ZEcal;
+  }
+
+  float tanthetaprime = delta * tantheta / (delta - zv);
+
+  float thetaprime = atan(tanthetaprime);
+  if (thetaprime < 0)
+    thetaprime = thetaprime + M_PI;
+
+  float etaprime = -log(tan(thetaprime / 2.));
+  return etaprime;
+}
+
+// --------------------------------------------------------------------------------------
+
+float L1TkEmParticleProducer::DeltaPhi(float phi1, float phi2) {
+  // dPhi between 0 and Pi
+  float dphi = phi1 - phi2;
+  if (dphi < 0)
+    dphi = dphi + 2. * M_PI;
+  if (dphi > M_PI)
+    dphi = 2. * M_PI - dphi;
+  return dphi;
+}
+
+// --------------------------------------------------------------------------------------
+
+float L1TkEmParticleProducer::deltaR(float eta1, float eta2, float phi1, float phi2) {
+  float deta = eta1 - eta2;
+  float dphi = DeltaPhi(phi1, phi2);
+  float DR = sqrt(deta * deta + dphi * dphi);
+  return DR;
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void L1TkEmParticleProducer::beginJob() {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void L1TkEmParticleProducer::endJob() {}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1TkEmParticleProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkEmParticleProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkEmParticleProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkEmParticleProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1TkEmParticleProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkEmParticleProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
@@ -1,0 +1,385 @@
+// -*- C++ -*-
+//
+//
+// Original Author:  Emmanuelle Perez,40 1-A28,+41227671915,
+//         Created:  Tue Nov 12 17:03:19 CET 2013
+// $Id$
+//
+//
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+////////////////////////////
+// DETECTOR GEOMETRY HEADERS
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkPrimaryVertex.h"
+
+////////////////////////////
+// HepMC products
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "TH1F.h"
+
+using namespace l1t;
+
+//
+// class declaration
+//
+
+class L1TkFastVertexProducer : public edm::EDProducer {
+public:
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
+
+  explicit L1TkFastVertexProducer(const edm::ParameterSet&);
+  ~L1TkFastVertexProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+
+  // ----------member data ---------------------------
+
+  float zMax_;   // in cm
+  float DeltaZ;  // in cm
+  float chi2Max_;
+  float pTMinTra_;  // in GeV
+
+  float pTMax_;       // in GeV, saturation / truncation value
+  int highPtTracks_;  // saturate or truncate
+
+  int nStubsmin_;    // minimum number of stubs
+  int nStubsPSmin_;  // minimum number of stubs in PS modules
+
+  int nBinning_;  // number of bins used in the temp histogram
+
+  bool monteCarloVertex_;  //
+                           //const StackedTrackerGeometry*                   theStackedGeometry;
+
+  bool doPtComp_;
+  bool doTightChi2_;
+
+  int weight_;  // weight (power) of pT 0 , 1, 2
+
+  TH1F* htmp_;
+  TH1F* htmp_weight_;
+
+  const edm::EDGetTokenT<edm::HepMCProduct> hepmcToken;
+  const edm::EDGetTokenT<std::vector<reco::GenParticle> > genparticleToken;
+  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+L1TkFastVertexProducer::L1TkFastVertexProducer(const edm::ParameterSet& iConfig)
+    : hepmcToken(consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("HepMCInputTag"))),
+      genparticleToken(
+          consumes<std::vector<reco::GenParticle> >(iConfig.getParameter<edm::InputTag>("GenParticleInputTag"))),
+      trackToken(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
+          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))) {
+  zMax_ = (float)iConfig.getParameter<double>("ZMAX");
+  chi2Max_ = (float)iConfig.getParameter<double>("CHI2MAX");
+  pTMinTra_ = (float)iConfig.getParameter<double>("PTMINTRA");
+
+  pTMax_ = (float)iConfig.getParameter<double>("PTMAX");
+  highPtTracks_ = iConfig.getParameter<int>("HighPtTracks");
+
+  nStubsmin_ = iConfig.getParameter<int>("nStubsmin");
+  nStubsPSmin_ = iConfig.getParameter<int>("nStubsPSmin");
+  nBinning_ = iConfig.getParameter<int>("nBinning");
+
+  monteCarloVertex_ = iConfig.getParameter<bool>("MonteCarloVertex");
+  doPtComp_ = iConfig.getParameter<bool>("doPtComp");
+  doTightChi2_ = iConfig.getParameter<bool>("doTightChi2");
+
+  weight_ = iConfig.getParameter<int>("WEIGHT");
+
+  int nbins = nBinning_;  // should be odd
+  float xmin = -30;
+  float xmax = +30;
+
+  htmp_ = new TH1F("htmp_", ";z (cm); Tracks", nbins, xmin, xmax);
+  htmp_weight_ = new TH1F("htmp_weight_", ";z (cm); Tracks", nbins, xmin, xmax);
+
+  produces<TkPrimaryVertexCollection>();
+}
+
+L1TkFastVertexProducer::~L1TkFastVertexProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  std::unique_ptr<TkPrimaryVertexCollection> result(new TkPrimaryVertexCollection);
+
+  // Tracker Topology
+  edm::ESHandle<TrackerTopology> tTopoHandle_;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle_);
+  const TrackerTopology* tTopo = tTopoHandle_.product();
+
+  htmp_->Reset();
+  htmp_weight_->Reset();
+
+  // ----------------------------------------------------------------------
+
+  if (monteCarloVertex_) {
+    // MC info  ... retrieve the zvertex
+    edm::Handle<edm::HepMCProduct> HepMCEvt;
+    iEvent.getByToken(hepmcToken, HepMCEvt);
+
+    edm::Handle<std::vector<reco::GenParticle> > GenParticleHandle;
+    iEvent.getByToken(genparticleToken, GenParticleHandle);
+
+    const double mm = 0.1;
+    float zvtx_gen = -999;
+
+    if (HepMCEvt.isValid()) {
+      // using HepMCEvt
+
+      const HepMC::GenEvent* MCEvt = HepMCEvt->GetEvent();
+      for (HepMC::GenEvent::vertex_const_iterator ivertex = MCEvt->vertices_begin(); ivertex != MCEvt->vertices_end();
+           ++ivertex) {
+        bool hasParentVertex = false;
+
+        // Loop over the parents looking to see if they are coming from a production vertex
+        for (HepMC::GenVertex::particle_iterator iparent = (*ivertex)->particles_begin(HepMC::parents);
+             iparent != (*ivertex)->particles_end(HepMC::parents);
+             ++iparent)
+          if ((*iparent)->production_vertex()) {
+            hasParentVertex = true;
+            break;
+          }
+
+        // Reject those vertices with parent vertices
+        if (hasParentVertex)
+          continue;
+        // Get the position of the vertex
+        HepMC::FourVector pos = (*ivertex)->position();
+        zvtx_gen = pos.z() * mm;
+        break;  // there should be one single primary vertex
+      }         // end loop over gen vertices
+
+    } else if (GenParticleHandle.isValid()) {
+      std::vector<reco::GenParticle>::const_iterator genpartIter;
+      for (genpartIter = GenParticleHandle->begin(); genpartIter != GenParticleHandle->end(); ++genpartIter) {
+        int status = genpartIter->status();
+        if (status != 3)
+          continue;
+        if (genpartIter->numberOfMothers() == 0)
+          continue;  // the incoming hadrons
+        float part_zvertex = genpartIter->vz();
+        zvtx_gen = part_zvertex;
+        break;  //
+      }
+    } else {
+      throw cms::Exception("L1TkFastVertexProducer")
+          << "\nerror: try to retrieve the MC vertex (monteCarloVertex_ = True) "
+          << "\nbut the input file contains neither edm::HepMCProduct>  nor vector<reco::GenParticle>. Exit"
+          << std::endl;
+    }
+
+    //     std::cout<<zvtx_gen<<endl;
+
+    TkPrimaryVertex genvtx(zvtx_gen, -999.);
+
+    result->push_back(genvtx);
+    iEvent.put(std::move(result));
+    return;
+  }
+
+  edm::Handle<L1TTTrackCollectionType> L1TTTrackHandle;
+  iEvent.getByToken(trackToken, L1TTTrackHandle);
+
+  if (!L1TTTrackHandle.isValid()) {
+    throw cms::Exception("L1TkFastVertexProducer")
+        << "\nWarning: L1TkTrackCollection with not found in the event. Exit" << std::endl;
+    return;
+  }
+
+  L1TTTrackCollectionType::const_iterator trackIter;
+  for (trackIter = L1TTTrackHandle->begin(); trackIter != L1TTTrackHandle->end(); ++trackIter) {
+    float z = trackIter->POCA().z();
+    float chi2 = trackIter->chi2();
+    float pt = trackIter->momentum().perp();
+    float eta = trackIter->momentum().eta();
+
+    //..............................................................
+    float wt = pow(pt, weight_);  // calculating the weight for tks in as pt^0,pt^1 or pt^2 based on weight_
+
+    if (fabs(z) > zMax_)
+      continue;
+    if (chi2 > chi2Max_)
+      continue;
+    if (pt < pTMinTra_)
+      continue;
+
+    // saturation or truncation :
+    if (pTMax_ > 0 && pt > pTMax_) {
+      if (highPtTracks_ == 0)
+        continue;  // ignore this track
+      if (highPtTracks_ == 1)
+        pt = pTMax_;  // saturate
+    }
+
+    // get the number of stubs and the number of stubs in PS layers
+    float nPS = 0.;  // number of stubs in PS modules
+    float nstubs = 0;
+
+    // get pointers to stubs associated to the L1 track
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+        theStubs = trackIter->getStubRefs();
+
+    int tmp_trk_nstub = (int)theStubs.size();
+    if (tmp_trk_nstub < 0) {
+      LogTrace("L1TkFastVertexProducer")
+          << " ... could not retrieve the vector of stubs in L1TkFastVertexProducer::SumPtVertex " << std::endl;
+      continue;
+    }
+
+    // loop over the stubs
+    for (unsigned int istub = 0; istub < (unsigned int)theStubs.size(); istub++) {
+      nstubs++;
+      bool isPS = false;
+      DetId detId(theStubs.at(istub)->getDetId());
+      if (detId.det() == DetId::Detector::Tracker) {
+        if (detId.subdetId() == StripSubdetector::TOB && tTopo->tobLayer(detId) <= 3)
+          isPS = true;
+        else if (detId.subdetId() == StripSubdetector::TID && tTopo->tidRing(detId) <= 9)
+          isPS = true;
+      }
+      if (isPS)
+        nPS++;
+    }  // end loop over stubs
+    if (nstubs < nStubsmin_)
+      continue;
+    if (nPS < nStubsPSmin_)
+      continue;
+
+    // quality cuts from Louise S, based on the pt-stub compatibility (June 20, 2014)
+    int trk_nstub = (int)trackIter->getStubRefs().size();
+    float chi2dof = chi2 / (2 * trk_nstub - 4);
+
+    if (doPtComp_) {
+      float trk_consistency = trackIter->stubPtConsistency();
+      //if (trk_nstub < 4) continue;	// done earlier
+      //if (chi2 > 100.0) continue;	// done earlier
+      if (trk_nstub == 4) {
+        if (fabs(eta) < 2.2 && trk_consistency > 10)
+          continue;
+        else if (fabs(eta) > 2.2 && chi2dof > 5.0)
+          continue;
+      }
+    }
+    if (doTightChi2_) {
+      if (pt > 10.0 && chi2dof > 5.0)
+        continue;
+    }
+
+    htmp_->Fill(z);
+    htmp_weight_->Fill(z, wt);  // changed from "pt" to "wt" which is some power of pt (0,1 or 2)
+
+  }  // end loop over tracks
+
+  // sliding windows... maximize bin i + i-1  + i+1
+
+  float zvtx_sliding = -999;
+  float sigma_max = -999;
+  int nb = htmp_->GetNbinsX();
+  for (int i = 2; i <= nb - 1; i++) {
+    float a0 = htmp_->GetBinContent(i - 1);
+    float a1 = htmp_->GetBinContent(i);
+    float a2 = htmp_->GetBinContent(i + 1);
+    float sigma = a0 + a1 + a2;
+    if (sigma > sigma_max) {
+      sigma_max = sigma;
+      float z0 = htmp_->GetBinCenter(i - 1);
+      float z1 = htmp_->GetBinCenter(i);
+      float z2 = htmp_->GetBinCenter(i + 1);
+      zvtx_sliding = (a0 * z0 + a1 * z1 + a2 * z2) / sigma;
+    }
+  }
+
+  zvtx_sliding = -999;
+  sigma_max = -999;
+  for (int i = 2; i <= nb - 1; i++) {
+    float a0 = htmp_weight_->GetBinContent(i - 1);
+    float a1 = htmp_weight_->GetBinContent(i);
+    float a2 = htmp_weight_->GetBinContent(i + 1);
+    float sigma = a0 + a1 + a2;
+    if (sigma > sigma_max) {
+      sigma_max = sigma;
+      float z0 = htmp_weight_->GetBinCenter(i - 1);
+      float z1 = htmp_weight_->GetBinCenter(i);
+      float z2 = htmp_weight_->GetBinCenter(i + 1);
+      zvtx_sliding = (a0 * z0 + a1 * z1 + a2 * z2) / sigma;
+    }
+  }
+
+  TkPrimaryVertex vtx4(zvtx_sliding, sigma_max);
+
+  result->push_back(vtx4);
+
+  iEvent.put(std::move(result));
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void L1TkFastVertexProducer::beginJob() {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void L1TkFastVertexProducer::endJob() {}
+
+// ------------ method called when starting to processes a run  ------------
+//void L1TkFastVertexProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup) {}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1TkFastVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkFastVertexProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
@@ -247,7 +247,7 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     //..............................................................
     float wt = pow(pt, weight_);  // calculating the weight for tks in as pt^0,pt^1 or pt^2 based on weight_
 
-    if (fabs(z) > zMax_)
+    if (std::abs(z) > zMax_)
       continue;
     if (chi2 > chi2Max_)
       continue;
@@ -267,7 +267,7 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     float nstubs = 0;
 
     // get pointers to stubs associated to the L1 track
-    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+    const std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > > &
         theStubs = trackIter->getStubRefs();
 
     int tmp_trk_nstub = (int)theStubs.size();
@@ -305,9 +305,9 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
       //if (trk_nstub < 4) continue;	// done earlier
       //if (chi2 > 100.0) continue;	// done earlier
       if (trk_nstub == 4) {
-        if (fabs(eta) < 2.2 && trk_consistency > 10)
+        if (std::abs(eta) < 2.2 && trk_consistency > 10)
           continue;
-        else if (fabs(eta) > 2.2 && chi2dof > 5.0)
+        else if (std::abs(eta) > 2.2 && chi2dof > 5.0)
           continue;
       }
     }

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
@@ -267,7 +267,7 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     float nstubs = 0;
 
     // get pointers to stubs associated to the L1 track
-    const std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > > &
+    const std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >&
         theStubs = trackIter->getStubRefs();
 
     int tmp_trk_nstub = (int)theStubs.size();

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -37,6 +37,9 @@ static constexpr float phi_scale = 2 * M_PI / 576.;
 static constexpr float dr2_cutoff = 0.3;
 static constexpr float matching_factor_eta = 3.;
 static constexpr float matching_factor_phi = 4.;
+static constexpr float min_mu_propagator_p = 3.5;
+static constexpr float min_mu_propagator_barrel_pT = 3.5;
+static constexpr float max_mu_propagator_eta = 2.5;
 
 using namespace l1t;
 
@@ -550,11 +553,11 @@ L1TkMuonProducer::PropState L1TkMuonProducer::propagateToGMT(const L1TkMuonProdu
     tk_z = 0;
 
   L1TkMuonProducer::PropState dest;
-  if (tk_p < 3.5)
+  if (tk_p < min_mu_propagator_p)
     return dest;
-  if (tk_aeta < 1.1 && tk_pt < 3.5)
+  if (tk_aeta < 1.1 && tk_pt < min_mu_propagator_barrel_pT)
     return dest;
-  if (tk_aeta > 2.5)
+  if (tk_aeta > max_mu_propagator_eta)
     return dest;
 
   //0th order:

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -1,0 +1,720 @@
+// input: L1TkTracks and  RegionalMuonCand (standalone with component details)
+// match the two and produce a collection of TkMuon
+// eventually, this should be made modular and allow to swap out different algorithms
+
+// user include files
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+#include "L1Trigger/L1TMuon/interface/MicroGMTConfiguration.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h"
+#include "L1Trigger/L1TMuonEndCap/interface/Common.h"
+
+// system include files
+#include <memory>
+#include <string>
+
+static constexpr float mu_mass = 0.105658369;
+static constexpr int barrel_MTF_region = 1;
+static constexpr int overlap_MTF_region = 2;
+static constexpr int endcap_MTF_region = 3;
+static constexpr float eta_scale = 0.010875;
+static constexpr float phi_scale = 2 * M_PI / 576.;
+static constexpr float dr2_cutoff = 0.3;
+static constexpr float matching_factor_eta = 3.;
+static constexpr float matching_factor_phi = 4.;
+
+using namespace l1t;
+
+class L1TkMuonProducer : public edm::EDProducer {
+public:
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
+
+  struct PropState {  //something simple, imagine it's hardware emulation
+    PropState() : pt(-99), eta(-99), phi(-99), sigmaPt(-99), sigmaEta(-99), sigmaPhi(-99), valid(false) {}
+    float pt;
+    float eta;
+    float phi;
+    float sigmaPt;
+    float sigmaEta;
+    float sigmaPhi;
+    bool valid;
+  };
+
+  enum AlgoType { kTP = 1, kDynamicWindows = 2, kMantra = 3 };
+
+  explicit L1TkMuonProducer(const edm::ParameterSet&);
+  ~L1TkMuonProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  PropState propagateToGMT(const L1TTTrackType& l1tk) const;
+  double sigmaEtaTP(const RegionalMuonCand& mu) const;
+  double sigmaPhiTP(const RegionalMuonCand& mu) const;
+
+  // the TP algorithm
+  void runOnMTFCollection_v1(const edm::Handle<RegionalMuonCandBxCollection>&,
+                             const edm::Handle<L1TTTrackCollectionType>&,
+                             TkMuonCollection& tkMuons,
+                             const int detector) const;
+
+  // algo for endcap regions using dynamic windows for making the match
+  void runOnMTFCollection_v2(const edm::Handle<EMTFTrackCollection>&,
+                             const edm::Handle<L1TTTrackCollectionType>&,
+                             TkMuonCollection& tkMuons) const;
+
+  // given the matching indexes, build the output collection of track muons
+  void build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
+                               const std::vector<int>& matches,
+                               const edm::Handle<L1TTTrackCollectionType>& l1tksH,
+                               const edm::Handle<RegionalMuonCandBxCollection>& muonH,
+                               int detector) const;
+
+  // as above, but for the TkMu that were built from a EMTFCollection - do not produce a valid muon ref
+  void build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
+                               const std::vector<int>& matches,
+                               const edm::Handle<L1TTTrackCollectionType>& l1tksH,
+                               int detector) const;
+
+  // dump and convert tracks to the format needed for the MAnTra correlator
+  std::vector<L1TkMuMantraDF::track_df> product_to_trkvec(const L1TTTrackCollectionType& l1tks);  // tracks
+  // regional muon finder
+  std::vector<L1TkMuMantraDF::muon_df> product_to_muvec(const RegionalMuonCandBxCollection& l1mtfs);
+  // endcap muon finder - eventually to be moved to regional candidate
+  std::vector<L1TkMuMantraDF::muon_df> product_to_muvec(const EMTFTrackCollection& l1mus);
+
+  float etaMin_;
+  float etaMax_;
+  float zMax_;  // |z_track| < zMax_ in cm
+  float chi2Max_;
+  float pTMinTra_;
+  float dRMax_;
+  int nStubsmin_;  // minimum number of stubs
+  bool correctGMTPropForTkZ_;
+  bool use5ParameterFit_;
+  bool useTPMatchWindows_;
+
+  AlgoType bmtfMatchAlgoVersion_;
+  AlgoType omtfMatchAlgoVersion_;
+  AlgoType emtfMatchAlgoVersion_;
+
+  std::unique_ptr<L1TkMuCorrDynamicWindows> dwcorr_;
+
+  std::unique_ptr<L1TkMuMantra> mantracorr_barr_;
+  std::unique_ptr<L1TkMuMantra> mantracorr_ovrl_;
+  std::unique_ptr<L1TkMuMantra> mantracorr_endc_;
+  int mantra_n_trk_par_;
+
+  const edm::EDGetTokenT<RegionalMuonCandBxCollection> bmtfToken_;
+  const edm::EDGetTokenT<RegionalMuonCandBxCollection> omtfToken_;
+  const edm::EDGetTokenT<RegionalMuonCandBxCollection> emtfToken_;
+  // the track collection, directly from the EMTF and not formatted by GT
+  const edm::EDGetTokenT<EMTFTrackCollection> emtfTCToken_;
+  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken;
+};
+
+L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
+    : etaMin_((float)iConfig.getParameter<double>("ETAMIN")),
+      etaMax_((float)iConfig.getParameter<double>("ETAMAX")),
+      zMax_((float)iConfig.getParameter<double>("ZMAX")),
+      chi2Max_((float)iConfig.getParameter<double>("CHI2MAX")),
+      pTMinTra_((float)iConfig.getParameter<double>("PTMINTRA")),
+      dRMax_((float)iConfig.getParameter<double>("DRmax")),
+      nStubsmin_(iConfig.getParameter<int>("nStubsmin")),
+      // --- mantra corr params
+      mantra_n_trk_par_(iConfig.getParameter<int>("mantra_n_trk_par")),
+      bmtfToken_(consumes<RegionalMuonCandBxCollection>(iConfig.getParameter<edm::InputTag>("L1BMTFInputTag"))),
+      omtfToken_(consumes<RegionalMuonCandBxCollection>(iConfig.getParameter<edm::InputTag>("L1OMTFInputTag"))),
+      emtfToken_(consumes<RegionalMuonCandBxCollection>(iConfig.getParameter<edm::InputTag>("L1EMTFInputTag"))),
+      emtfTCToken_(consumes<EMTFTrackCollection>(iConfig.getParameter<edm::InputTag>("L1EMTFTrackCollectionInputTag"))),
+      trackToken(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
+          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))) {
+  // --------------------- configuration of the muon algorithm type
+
+  std::string bmtfMatchAlgoVersionString = iConfig.getParameter<std::string>("bmtfMatchAlgoVersion");
+  std::transform(bmtfMatchAlgoVersionString.begin(),
+                 bmtfMatchAlgoVersionString.end(),
+                 bmtfMatchAlgoVersionString.begin(),
+                 ::tolower);  // make lowercase
+
+  std::string omtfMatchAlgoVersionString = iConfig.getParameter<std::string>("omtfMatchAlgoVersion");
+  std::transform(omtfMatchAlgoVersionString.begin(),
+                 omtfMatchAlgoVersionString.end(),
+                 omtfMatchAlgoVersionString.begin(),
+                 ::tolower);  // make lowercase
+
+  std::string emtfMatchAlgoVersionString = iConfig.getParameter<std::string>("emtfMatchAlgoVersion");
+  std::transform(emtfMatchAlgoVersionString.begin(),
+                 emtfMatchAlgoVersionString.end(),
+                 emtfMatchAlgoVersionString.begin(),
+                 ::tolower);  // make lowercase
+
+  if (bmtfMatchAlgoVersionString == "tp")
+    bmtfMatchAlgoVersion_ = kTP;
+  else if (bmtfMatchAlgoVersionString == "mantra")
+    bmtfMatchAlgoVersion_ = kMantra;
+  else
+    throw cms::Exception("TkMuAlgoConfig")
+        << "the ID " << bmtfMatchAlgoVersionString << " of the BMTF algo matcher passed is invalid\n";
+
+  //
+
+  if (omtfMatchAlgoVersionString == "tp")
+    omtfMatchAlgoVersion_ = kTP;
+  else if (omtfMatchAlgoVersionString == "mantra")
+    omtfMatchAlgoVersion_ = kMantra;
+  else
+    throw cms::Exception("TkMuAlgoConfig")
+        << "the ID " << omtfMatchAlgoVersionString << " of the OMTF algo matcher passed is invalid\n";
+
+  //
+
+  if (emtfMatchAlgoVersionString == "tp")
+    emtfMatchAlgoVersion_ = kTP;
+  else if (emtfMatchAlgoVersionString == "dynamicwindows")
+    emtfMatchAlgoVersion_ = kDynamicWindows;
+  else if (emtfMatchAlgoVersionString == "mantra")
+    emtfMatchAlgoVersion_ = kMantra;
+  else
+    throw cms::Exception("TkMuAlgoConfig")
+        << "the ID " << emtfMatchAlgoVersionString << " of the EMTF algo matcher passed is invalid\n";
+
+  correctGMTPropForTkZ_ = iConfig.getParameter<bool>("correctGMTPropForTkZ");
+
+  use5ParameterFit_ = iConfig.getParameter<bool>("use5ParameterFit");
+  useTPMatchWindows_ = iConfig.getParameter<bool>("useTPMatchWindows");
+  produces<TkMuonCollection>();
+
+  // initializations
+  if (emtfMatchAlgoVersion_ == kDynamicWindows) {
+    // FIXME: to merge eventually into an unique file with bith phi and theta boundaries
+    std::string fIn_bounds_name = iConfig.getParameter<edm::FileInPath>("emtfcorr_boundaries").fullPath();
+    std::string fIn_theta_name = iConfig.getParameter<edm::FileInPath>("emtfcorr_theta_windows").fullPath();
+    std::string fIn_phi_name = iConfig.getParameter<edm::FileInPath>("emtfcorr_phi_windows").fullPath();
+    auto bounds = L1TkMuCorrDynamicWindows::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
+    TFile* fIn_theta = TFile::Open(fIn_theta_name.c_str());
+    TFile* fIn_phi = TFile::Open(fIn_phi_name.c_str());
+    dwcorr_ = std::make_unique<L1TkMuCorrDynamicWindows>(bounds, fIn_theta, fIn_phi);
+
+    // files can be closed since the correlator code clones the TF1s
+    fIn_theta->Close();
+    fIn_phi->Close();
+
+    // FIXME: more initialisation using the parameters passed from the cfg
+    dwcorr_->set_safety_factor(iConfig.getParameter<double>("final_window_factor"));
+    dwcorr_->set_sf_initialrelax(iConfig.getParameter<double>("initial_window_factor"));
+
+    dwcorr_->set_relaxation_pattern(iConfig.getParameter<double>("pt_start_relax"),
+                                    iConfig.getParameter<double>("pt_end_relax"));
+
+    dwcorr_->set_do_relax_factor(iConfig.getParameter<bool>("do_relax_factors"));
+
+    //
+    dwcorr_->set_n_trk_par(iConfig.getParameter<int>("n_trk_par"));
+    dwcorr_->set_min_trk_p(iConfig.getParameter<double>("min_trk_p"));
+    dwcorr_->set_max_trk_aeta(iConfig.getParameter<double>("max_trk_aeta"));
+    dwcorr_->set_max_trk_chi2(iConfig.getParameter<double>("max_trk_chi2"));
+    dwcorr_->set_min_trk_nstubs(iConfig.getParameter<int>("min_trk_nstubs"));
+    dwcorr_->set_do_trk_qual_presel(true);
+  }
+
+  if (bmtfMatchAlgoVersion_ == kMantra) {
+    std::string fIn_bounds_name = iConfig.getParameter<edm::FileInPath>("mantra_bmtfcorr_boundaries").fullPath();
+    std::string fIn_theta_name = iConfig.getParameter<edm::FileInPath>("mantra_bmtfcorr_theta_windows").fullPath();
+    std::string fIn_phi_name = iConfig.getParameter<edm::FileInPath>("mantra_bmtfcorr_phi_windows").fullPath();
+
+    auto bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
+
+    TFile* fIn_theta = TFile::Open(fIn_theta_name.c_str());
+    TFile* fIn_phi = TFile::Open(fIn_phi_name.c_str());
+
+    mantracorr_barr_ = std::make_unique<L1TkMuMantra>(bounds, fIn_theta, fIn_phi, "mantra_barrel");
+
+    fIn_theta->Close();
+    fIn_phi->Close();
+
+    // settings : NB : now hardcoded, could be read from cfg
+    mantracorr_barr_->set_safety_factor(0.5, 0.5);
+    mantracorr_barr_->setArbitrationType("MaxPt");
+  }
+
+  if (omtfMatchAlgoVersion_ == kMantra) {
+    std::string fIn_bounds_name = iConfig.getParameter<edm::FileInPath>("mantra_omtfcorr_boundaries").fullPath();
+    std::string fIn_theta_name = iConfig.getParameter<edm::FileInPath>("mantra_omtfcorr_theta_windows").fullPath();
+    std::string fIn_phi_name = iConfig.getParameter<edm::FileInPath>("mantra_omtfcorr_phi_windows").fullPath();
+
+    auto bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
+
+    TFile* fIn_theta = TFile::Open(fIn_theta_name.c_str());
+    TFile* fIn_phi = TFile::Open(fIn_phi_name.c_str());
+
+    mantracorr_ovrl_ = std::make_unique<L1TkMuMantra>(bounds, fIn_theta, fIn_phi, "mantra_overlap");
+
+    fIn_theta->Close();
+    fIn_phi->Close();
+
+    // settings : NB : now hardcoded, could be read from cfg
+    mantracorr_ovrl_->set_safety_factor(0.5, 0.5);
+    mantracorr_ovrl_->setArbitrationType("MaxPt");
+  }
+
+  if (emtfMatchAlgoVersion_ == kMantra) {
+    std::string fIn_bounds_name = iConfig.getParameter<edm::FileInPath>("mantra_emtfcorr_boundaries").fullPath();
+    std::string fIn_theta_name = iConfig.getParameter<edm::FileInPath>("mantra_emtfcorr_theta_windows").fullPath();
+    std::string fIn_phi_name = iConfig.getParameter<edm::FileInPath>("mantra_emtfcorr_phi_windows").fullPath();
+
+    auto bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
+
+    TFile* fIn_theta = TFile::Open(fIn_theta_name.c_str());
+    TFile* fIn_phi = TFile::Open(fIn_phi_name.c_str());
+
+    mantracorr_endc_ = std::make_unique<L1TkMuMantra>(bounds, fIn_theta, fIn_phi, "mantra_endcap");
+
+    fIn_theta->Close();
+    fIn_phi->Close();
+
+    // settings : NB : now hardcoded, could be read from cfg
+    mantracorr_endc_->set_safety_factor(0.5, 0.5);
+    mantracorr_endc_->setArbitrationType("MaxPt");
+  }
+}
+
+L1TkMuonProducer::~L1TkMuonProducer() {}
+
+// ------------ method called to produce the data  ------------
+void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // the L1Mu objects
+  edm::Handle<RegionalMuonCandBxCollection> l1bmtfH;
+  edm::Handle<RegionalMuonCandBxCollection> l1omtfH;
+  edm::Handle<RegionalMuonCandBxCollection> l1emtfH;
+  edm::Handle<EMTFTrackCollection> l1emtfTCH;
+
+  iEvent.getByToken(bmtfToken_, l1bmtfH);
+  iEvent.getByToken(omtfToken_, l1omtfH);
+  iEvent.getByToken(emtfToken_, l1emtfH);
+  iEvent.getByToken(emtfTCToken_, l1emtfTCH);
+
+  // the L1Tracks
+  edm::Handle<L1TTTrackCollectionType> l1tksH;
+  iEvent.getByToken(trackToken, l1tksH);
+
+  TkMuonCollection oc_bmtf_tkmuon;
+  TkMuonCollection oc_omtf_tkmuon;
+  TkMuonCollection oc_emtf_tkmuon;
+
+  std::vector<L1TkMuMantraDF::track_df> mantradf_tracks;  // if needed, just encode once for all trk finders
+  if (bmtfMatchAlgoVersion_ == kMantra || omtfMatchAlgoVersion_ == kMantra || emtfMatchAlgoVersion_ == kMantra) {
+    mantradf_tracks = product_to_trkvec(*l1tksH.product());
+  }
+
+  // process each of the MTF collections separately! -- we don't want to filter the muons
+
+  // ----------------------------------------------------- barrel
+  if (bmtfMatchAlgoVersion_ == kTP)
+    runOnMTFCollection_v1(l1bmtfH, l1tksH, oc_bmtf_tkmuon, barrel_MTF_region);
+  else if (bmtfMatchAlgoVersion_ == kMantra) {
+    auto muons = product_to_muvec(*l1bmtfH.product());
+    auto match_idx = mantracorr_barr_->find_match(mantradf_tracks, muons);
+    build_tkMuons_from_idxs(oc_bmtf_tkmuon, match_idx, l1tksH, l1bmtfH, barrel_MTF_region);
+  } else
+    throw cms::Exception("TkMuAlgoConfig") << " barrel : trying to run an invalid algorithm version "
+                                           << bmtfMatchAlgoVersion_ << " (this should never happen)\n";
+
+  // ----------------------------------------------------- overlap
+  if (omtfMatchAlgoVersion_ == kTP)
+    runOnMTFCollection_v1(l1omtfH, l1tksH, oc_omtf_tkmuon, overlap_MTF_region);
+  else if (omtfMatchAlgoVersion_ == kMantra) {
+    auto muons = product_to_muvec(*l1omtfH.product());
+    auto match_idx = mantracorr_ovrl_->find_match(mantradf_tracks, muons);
+    build_tkMuons_from_idxs(oc_omtf_tkmuon, match_idx, l1tksH, l1omtfH, overlap_MTF_region);
+  } else
+    throw cms::Exception("TkMuAlgoConfig") << " overlap : trying to run an invalid algorithm version "
+                                           << omtfMatchAlgoVersion_ << " (this should never happen)\n";
+
+  // ----------------------------------------------------- endcap
+  if (emtfMatchAlgoVersion_ == kTP)
+    runOnMTFCollection_v1(l1emtfH, l1tksH, oc_emtf_tkmuon, endcap_MTF_region);
+  else if (emtfMatchAlgoVersion_ == kDynamicWindows)
+    runOnMTFCollection_v2(l1emtfTCH, l1tksH, oc_emtf_tkmuon);
+  else if (emtfMatchAlgoVersion_ == kMantra) {
+    auto muons = product_to_muvec(*l1emtfTCH.product());
+    auto match_idx = mantracorr_endc_->find_match(mantradf_tracks, muons);
+    build_tkMuons_from_idxs(oc_emtf_tkmuon, match_idx, l1tksH, endcap_MTF_region);
+  } else
+    throw cms::Exception("TkMuAlgoConfig") << "endcap : trying to run an invalid algorithm version "
+                                           << emtfMatchAlgoVersion_ << " (this should never happen)\n";
+
+  // now combine all trk muons into a single output collection!
+  auto oc_tkmuon = std::make_unique<TkMuonCollection>();
+  for (const auto& p : {oc_bmtf_tkmuon, oc_omtf_tkmuon, oc_emtf_tkmuon}) {
+    oc_tkmuon->insert(oc_tkmuon->end(), p.begin(), p.end());
+  }
+
+  // put the new track+muon objects in the event!
+  iEvent.put(std::move(oc_tkmuon));
+};
+
+void L1TkMuonProducer::runOnMTFCollection_v1(const edm::Handle<RegionalMuonCandBxCollection>& muonH,
+                                             const edm::Handle<L1TTTrackCollectionType>& l1tksH,
+                                             TkMuonCollection& tkMuons,
+                                             const int detector) const {
+  const L1TTTrackCollectionType& l1tks = (*l1tksH.product());
+  const RegionalMuonCandBxCollection& l1mtfs = (*muonH.product());
+
+  int imu = 0;
+  for (auto l1mu = l1mtfs.begin(0); l1mu != l1mtfs.end(0); ++l1mu) {  // considering BX = only
+
+    edm::Ref<RegionalMuonCandBxCollection> l1muRef(muonH, imu);
+    imu++;
+
+    float l1mu_eta = l1mu->hwEta() * eta_scale;
+    // get the global phi
+    float l1mu_phi =
+        MicroGMTConfiguration::calcGlobalPhi(l1mu->hwPhi(), l1mu->trackFinderType(), l1mu->processor()) * phi_scale;
+
+    float l1mu_feta = fabs(l1mu_eta);
+    if (l1mu_feta < etaMin_)
+      continue;
+    if (l1mu_feta > etaMax_)
+      continue;
+
+    float drmin = 999;
+    float ptmax = -1;
+    if (ptmax < 0)
+      ptmax = -1;  // dummy
+
+    PropState matchProp;
+    int match_idx = -1;
+    int il1tk = -1;
+
+    int nTracksMatch = 0;
+
+    for (const auto& l1tk : l1tks) {
+      il1tk++;
+
+      float l1tk_pt = l1tk.momentum().perp();
+      if (l1tk_pt < pTMinTra_)
+        continue;
+
+      float l1tk_z = l1tk.POCA().z();
+      if (fabs(l1tk_z) > zMax_)
+        continue;
+
+      float l1tk_chi2 = l1tk.chi2();
+      if (l1tk_chi2 > chi2Max_)
+        continue;
+
+      int l1tk_nstubs = l1tk.getStubRefs().size();
+      if (l1tk_nstubs < nStubsmin_)
+        continue;
+
+      float l1tk_eta = l1tk.momentum().eta();
+      float l1tk_phi = l1tk.momentum().phi();
+
+      float dr2 = deltaR2(l1mu_eta, l1mu_phi, l1tk_eta, l1tk_phi);
+      if (dr2 > dr2_cutoff)
+        continue;
+
+      nTracksMatch++;
+
+      const PropState& pstate = propagateToGMT(l1tk);
+      if (!pstate.valid)
+        continue;
+
+      float dr2prop = deltaR2(l1mu_eta, l1mu_phi, pstate.eta, pstate.phi);
+      // FIXME: check if this matching procedure can be improved with
+      // a pT dependent dR window
+      if (dr2prop < drmin) {
+        drmin = dr2prop;
+        match_idx = il1tk;
+        matchProp = pstate;
+      }
+    }  // over l1tks
+
+    LogDebug("L1TkMuonProducer") << "matching index is " << match_idx;
+    if (match_idx >= 0) {
+      const L1TTTrackType& matchTk = l1tks[match_idx];
+
+      float sigmaEta = sigmaEtaTP(*l1mu);
+      float sigmaPhi = sigmaPhiTP(*l1mu);
+
+      float etaCut = matching_factor_eta * sqrt(sigmaEta * sigmaEta + matchProp.sigmaEta * matchProp.sigmaEta);
+      float phiCut = matching_factor_phi * sqrt(sigmaPhi * sigmaPhi + matchProp.sigmaPhi * matchProp.sigmaPhi);
+
+      float dEta = std::abs(matchProp.eta - l1mu_eta);
+      float dPhi = std::abs(deltaPhi(matchProp.phi, l1mu_phi));
+
+      bool matchCondition = useTPMatchWindows_ ? dEta < etaCut && dPhi < phiCut : drmin < dRMax_;
+
+      if (matchCondition) {
+        edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, match_idx);
+
+        const auto& p3 = matchTk.momentum();
+        float p4e = sqrt(mu_mass * mu_mass + p3.mag2());
+
+        math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
+
+        const auto& tkv3 = matchTk.POCA();
+        math::XYZPoint v3(tkv3.x(), tkv3.y(), tkv3.z());  // why is this defined?
+
+        float trkisol = -999;
+
+        TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);
+
+        l1tkmu.setTrackCurvature(matchTk.rInv());
+        l1tkmu.setTrkzVtx((float)tkv3.z());
+        l1tkmu.setdR(drmin);
+        l1tkmu.setNTracksMatched(nTracksMatch);
+        l1tkmu.setMuonDetector(detector);
+        tkMuons.push_back(l1tkmu);
+      }
+    }
+  }  //over l1mus
+}
+
+void L1TkMuonProducer::runOnMTFCollection_v2(const edm::Handle<EMTFTrackCollection>& muonH,
+                                             const edm::Handle<L1TTTrackCollectionType>& l1tksH,
+                                             TkMuonCollection& tkMuons) const {
+  const EMTFTrackCollection& l1mus = (*muonH.product());
+  const L1TTTrackCollectionType& l1trks = (*l1tksH.product());
+  auto corr_mu_idxs = dwcorr_->find_match(l1mus, l1trks);
+  // it's a vector with as many entries as the L1TT vector.
+  // >= 0 : the idx in the EMTF vector of matched mu
+  // < 0: no match
+
+  // sanity check
+  if (corr_mu_idxs.size() != l1trks.size())
+    throw cms::Exception("TkMuAlgoOutput")
+        << "the size of tkmu indices does not match the size of input trk collection\n";
+
+  for (uint il1ttrack = 0; il1ttrack < corr_mu_idxs.size(); ++il1ttrack) {
+    int emtf_idx = corr_mu_idxs.at(il1ttrack);
+    if (emtf_idx < 0)
+      continue;
+
+    const L1TTTrackType& matchTk = l1trks[il1ttrack];
+    const auto& p3 = matchTk.momentum();
+    const auto& tkv3 = matchTk.POCA();
+    float p4e = sqrt(mu_mass * mu_mass + p3.mag2());
+    math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
+
+    edm::Ref<RegionalMuonCandBxCollection> l1muRef;
+    edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, il1ttrack);
+    float trkisol = -999;  // now doing as in the TP algo
+    TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);
+    l1tkmu.setTrackCurvature(matchTk.rInv());
+    l1tkmu.setTrkzVtx((float)tkv3.z());
+    l1tkmu.setMuonDetector(endcap_MTF_region);
+    tkMuons.push_back(l1tkmu);
+  }
+
+  return;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1TkMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+L1TkMuonProducer::PropState L1TkMuonProducer::propagateToGMT(const L1TkMuonProducer::L1TTTrackType& tk) const {
+  auto p3 = tk.momentum();
+  float tk_pt = p3.perp();
+  float tk_p = p3.mag();
+  float tk_eta = p3.eta();
+  float tk_aeta = std::abs(tk_eta);
+  float tk_phi = p3.phi();
+  float tk_q = tk.rInv() > 0 ? 1. : -1.;
+  float tk_z = tk.POCA().z();
+  if (!correctGMTPropForTkZ_)
+    tk_z = 0;
+
+  L1TkMuonProducer::PropState dest;
+  if (tk_p < 3.5)
+    return dest;
+  if (tk_aeta < 1.1 && tk_pt < 3.5)
+    return dest;
+  if (tk_aeta > 2.5)
+    return dest;
+
+  //0th order:
+  dest.valid = true;
+
+  float dzCorrPhi = 1.;
+  float deta = 0;
+  float etaProp = tk_aeta;
+
+  if (tk_aeta < 1.1) {
+    etaProp = 1.1;
+    deta = tk_z / 550. / cosh(tk_aeta);
+  } else {
+    float delta = tk_z / 850.;  //roughly scales as distance to 2nd station
+    if (tk_eta > 0)
+      delta *= -1;
+    dzCorrPhi = 1. + delta;
+
+    float zOzs = tk_z / 850.;
+    if (tk_eta > 0)
+      deta = zOzs / (1. - zOzs);
+    else
+      deta = zOzs / (1. + zOzs);
+    deta = deta * tanh(tk_eta);
+  }
+  float resPhi = tk_phi - 1.464 * tk_q * cosh(1.7) / cosh(etaProp) / tk_pt * dzCorrPhi - M_PI / 144.;
+  if (resPhi > M_PI)
+    resPhi -= 2. * M_PI;
+  if (resPhi < -M_PI)
+    resPhi += 2. * M_PI;
+
+  dest.eta = tk_eta + deta;
+  dest.phi = resPhi;
+  dest.pt = tk_pt;  //not corrected for eloss
+
+  dest.sigmaEta = 0.100 / tk_pt;  //multiple scattering term
+  dest.sigmaPhi = 0.106 / tk_pt;  //need a better estimate for these
+  return dest;
+}
+
+double L1TkMuonProducer::sigmaEtaTP(const RegionalMuonCand& l1mu) const {
+  float l1mu_eta = l1mu.hwEta() * eta_scale;
+  if (std::abs(l1mu_eta) <= 1.55)
+    return 0.0288;
+  else if (std::abs(l1mu_eta) > 1.55 && std::abs(l1mu_eta) <= 1.65)
+    return 0.025;
+  else if (std::abs(l1mu_eta) > 1.65 && std::abs(l1mu_eta) <= 2.4)
+    return 0.0144;
+  return 0.0288;
+}
+
+double L1TkMuonProducer::sigmaPhiTP(const RegionalMuonCand& mu) const { return 0.0126; }
+
+// ------------------------------------------------------------------------------------------------------------
+
+std::vector<L1TkMuMantraDF::track_df> L1TkMuonProducer::product_to_trkvec(const L1TTTrackCollectionType& l1tks) {
+  std::vector<L1TkMuMantraDF::track_df> result(l1tks.size());
+  for (uint itrk = 0; itrk < l1tks.size(); ++itrk) {
+    auto& trk = l1tks.at(itrk);
+
+    result.at(itrk).pt = trk.momentum().perp();
+    result.at(itrk).eta = trk.momentum().eta();
+    result.at(itrk).theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(trk.momentum().eta()));
+    result.at(itrk).phi = trk.momentum().phi();
+    result.at(itrk).nstubs = trk.getStubRefs().size();
+    result.at(itrk).chi2 = trk.chi2();
+    result.at(itrk).charge = (trk.rInv() > 0 ? 1 : -1);
+  }
+
+  return result;
+}
+
+std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const RegionalMuonCandBxCollection& l1mtfs) {
+  std::vector<L1TkMuMantraDF::muon_df> result;
+  for (auto l1mu = l1mtfs.begin(0); l1mu != l1mtfs.end(0); ++l1mu)  // considering BX = 0 only
+  {
+    L1TkMuMantraDF::muon_df this_mu;
+    this_mu.pt = l1mu->hwPt() * 0.5;
+    this_mu.eta = l1mu->hwEta() * eta_scale;
+    this_mu.theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(l1mu->hwEta() * eta_scale));
+    this_mu.phi =
+        MicroGMTConfiguration::calcGlobalPhi(l1mu->hwPhi(), l1mu->trackFinderType(), l1mu->processor()) * phi_scale;
+    this_mu.charge = (l1mu->hwSign() == 0 ? 1 : -1);  // charge sign bit (charge = (-1)^(sign))
+    result.push_back(this_mu);
+  }
+  return result;
+}
+
+std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const EMTFTrackCollection& l1mus) {
+  std::vector<L1TkMuMantraDF::muon_df> result(l1mus.size());
+  for (uint imu = 0; imu < l1mus.size(); ++imu) {
+    auto& mu = l1mus.at(imu);
+    result.at(imu).pt = mu.Pt();
+    result.at(imu).eta = mu.Eta();
+    result.at(imu).theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(mu.Eta()));
+    result.at(imu).phi = L1TkMuMantra::deg_to_rad(mu.Phi_glob());
+    result.at(imu).charge = mu.Charge();
+  }
+  return result;
+}
+
+void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
+                                               const std::vector<int>& matches,
+                                               const edm::Handle<L1TTTrackCollectionType>& l1tksH,
+                                               const edm::Handle<RegionalMuonCandBxCollection>& muonH,
+                                               int detector) const {
+  for (uint imatch = 0; imatch < matches.size(); ++imatch) {
+    int match_trk_idx = matches.at(imatch);
+    if (match_trk_idx < 0)
+      continue;  // this muon was not matched to any candidate
+
+    // take properties of the track
+    const L1TTTrackType& matchTk = (*l1tksH.product())[match_trk_idx];
+    const auto& p3 = matchTk.momentum();
+    const auto& tkv3 = matchTk.POCA();
+    float p4e = sqrt(mu_mass * mu_mass + p3.mag2());
+    math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
+
+    edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, match_trk_idx);
+    edm::Ref<RegionalMuonCandBxCollection> l1muRef(muonH, imatch);
+
+    float trkisol = -999;
+    TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);
+    l1tkmu.setTrackCurvature(matchTk.rInv());
+    l1tkmu.setTrkzVtx((float)tkv3.z());
+    l1tkmu.setMuonDetector(detector);
+    tkMuons.push_back(l1tkmu);
+  }
+  return;
+}
+
+void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
+                                               const std::vector<int>& matches,
+                                               const edm::Handle<L1TTTrackCollectionType>& l1tksH,
+                                               int detector) const {
+  for (uint imatch = 0; imatch < matches.size(); ++imatch) {
+    int match_trk_idx = matches.at(imatch);
+    if (match_trk_idx < 0)
+      continue;  // this muon was not matched to any candidate
+
+    // take properties of the track
+    const L1TTTrackType& matchTk = (*l1tksH.product())[match_trk_idx];
+    const auto& p3 = matchTk.momentum();
+    const auto& tkv3 = matchTk.POCA();
+    float p4e = sqrt(mu_mass * mu_mass + p3.mag2());
+    math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
+
+    edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, match_trk_idx);
+    edm::Ref<RegionalMuonCandBxCollection>
+        l1muRef;  // NOTE: this is the only difference from the function above, but could not find a way to make a conditional constructor
+
+    float trkisol = -999;
+    TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);
+    l1tkmu.setTrackCurvature(matchTk.rInv());
+    l1tkmu.setTrkzVtx((float)tkv3.z());
+    l1tkmu.setMuonDetector(detector);
+    tkMuons.push_back(l1tkmu);
+  }
+  return;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkMuonProducer);

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -1,0 +1,92 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
+	  label = cms.string("EG"),	# labels the collection of L1TkEmParticleProducer that is produced.
+		# (not really needed actually)
+    L1EGammaInputTag = cms.InputTag("simCaloStage2Digis",""),
+    # Only the L1EG objects that have ET > ETmin in GeV
+    # are considered. ETmin < 0 means that no cut is applied.
+    ETmin = cms.double( -1.0 ),             
+    L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+    # Quality cuts on Track and Track L1EG matching criteria
+    TrackChi2           = cms.double(1e10), # minimum Chi2 to select tracks
+    TrackMinPt          = cms.double(10.0), # minimum Pt to select tracks
+	useTwoStubsPT       = cms.bool( False ),
+    TrackEGammaMatchType = cms.string("PtDependentCut"),
+    TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0), # functional Delta Phi cut parameters to match Track with L1EG objects
+    TrackEGammaDeltaR   = cms.vdouble(0.08, 0.0, 0.0), # functional Delta R cut parameters to match Track with L1EG objects
+    # Delta Eta cutoff to match Track with L1EG objects
+    # are considered. (unused in default configuration)
+    TrackEGammaDeltaEta = cms.vdouble(1e10, 0.0, 0.0), 
+	  RelativeIsolation = cms.bool( True ),	# default = True. The isolation variable is relative if True,
+						# else absolute.
+    # Cut on the (Trk-based) isolation: only the L1TkEmParticle for which
+    # the isolation is below RelIsoCut are written into
+    # the output collection. When RelIsoCut < 0, no cut is applied.
+		# When RelativeIsolation = False, IsoCut is in GeV.
+    # Determination of the isolation w.r.t. L1Tracks :
+    IsoCut = cms.double( -0.10 ), 		
+    PTMINTRA = cms.double( 2. ),	# in GeV
+	  DRmin = cms.double( 0.03),
+	  DRmax = cms.double( 0.2 ),
+    maxChi2IsoTracks = cms.double(1e10), # max chi2 cut for a track to be considered for isolation computation
+    minNStubsIsoTracks = cms.int32(0), # min cut on # of stubs for a track to be considered for isolation computation
+	  DeltaZ = cms.double( 0.6 )    # in cm. Used for tracks to be used isolation calculation
+)
+L1TkIsoElectrons = L1TkElectrons.clone()
+L1TkIsoElectrons.IsoCut = cms.double( 0.10 )
+# for  LowPt Electron
+L1TkElectronsLoose = L1TkElectrons.clone()
+L1TkElectronsLoose.TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0)
+L1TkElectronsLoose.TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0)
+L1TkElectronsLoose.TrackMinPt = cms.double( 3.0 )
+
+
+#### Additional collections that right now only the menu team is using - to be renamed/redefined by the EGamma group
+# The important change is the EG seed -> PhaseII instead of PhaseI
+
+#barrel
+L1TkElectronsCrystal = L1TkElectrons.clone()
+L1TkElectronsCrystal.L1EGammaInputTag = cms.InputTag("L1EGammaClusterEmuProducer",)
+L1TkElectronsCrystal.IsoCut = cms.double(-0.1)
+
+L1TkIsoElectronsCrystal=L1TkElectronsCrystal.clone()
+L1TkIsoElectronsCrystal.IsoCut = cms.double(0.1)
+
+L1TkElectronsLooseCrystal = L1TkElectronsCrystal.clone()
+L1TkElectronsLooseCrystal.TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0)
+L1TkElectronsLooseCrystal.TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0)
+L1TkElectronsLooseCrystal.TrackMinPt = cms.double( 3.0 )
+
+L1TkElectronsEllipticMatchCrystal = L1TkElectronsCrystal.clone()
+# L1TkElectronsEllipticMatchCrystal.L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
+L1TkElectronsEllipticMatchCrystal.TrackEGammaMatchType = cms.string("EllipticalCut")
+L1TkElectronsEllipticMatchCrystal.TrackEGammaDeltaEta = cms.vdouble(0.015, 0.025,1e10)
+
+
+
+#endcap
+L1TkElectronsHGC=L1TkElectrons.clone()
+L1TkElectronsHGC.L1EGammaInputTag = cms.InputTag("l1EGammaEEProducer","L1EGammaCollectionBXVWithCuts")
+L1TkElectronsHGC.IsoCut = cms.double(-0.1)
+
+
+L1TkElectronsEllipticMatchHGC = L1TkElectronsHGC.clone()
+# L1TkElectronsEllipticMatchHGC.L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
+L1TkElectronsEllipticMatchHGC.TrackEGammaMatchType = cms.string("EllipticalCut")
+L1TkElectronsEllipticMatchHGC.TrackEGammaDeltaEta = cms.vdouble(0.0075, 0.0075,1e10)
+L1TkElectronsEllipticMatchHGC.maxChi2IsoTracks = cms.double(100)
+L1TkElectronsEllipticMatchHGC.minNStubsIsoTracks = cms.int32(4)
+
+
+L1TkIsoElectronsHGC=L1TkElectronsHGC.clone()
+L1TkIsoElectronsHGC.DRmax = cms.double(0.4)
+L1TkIsoElectronsHGC.DeltaZ = cms.double(1.0)
+L1TkIsoElectronsHGC.maxChi2IsoTracks = cms.double(100)
+L1TkIsoElectronsHGC.minNStubsIsoTracks = cms.int32(4)
+L1TkIsoElectronsHGC.IsoCut = cms.double(0.1)
+
+L1TkElectronsLooseHGC = L1TkElectronsHGC.clone()
+L1TkElectronsLooseHGC.TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0)
+L1TkElectronsLooseHGC.TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0)
+L1TkElectronsLooseHGC.TrackMinPt = cms.double( 3.0 )

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -33,60 +33,70 @@ L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
     minNStubsIsoTracks = cms.int32(0), # min cut on # of stubs for a track to be considered for isolation computation
 	  DeltaZ = cms.double( 0.6 )    # in cm. Used for tracks to be used isolation calculation
 )
-L1TkIsoElectrons = L1TkElectrons.clone()
-L1TkIsoElectrons.IsoCut = cms.double( 0.10 )
+L1TkIsoElectrons = L1TkElectrons.clone(
+    IsoCut = cms.double( 0.10 )
+)
 # for  LowPt Electron
-L1TkElectronsLoose = L1TkElectrons.clone()
-L1TkElectronsLoose.TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0)
-L1TkElectronsLoose.TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0)
-L1TkElectronsLoose.TrackMinPt = cms.double( 3.0 )
+L1TkElectronsLoose = L1TkElectrons.clone(
+    TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0),
+    TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0),
+    TrackMinPt = cms.double( 3.0 )
+)
 
 
 #### Additional collections that right now only the menu team is using - to be renamed/redefined by the EGamma group
 # The important change is the EG seed -> PhaseII instead of PhaseI
 
 #barrel
-L1TkElectronsCrystal = L1TkElectrons.clone()
-L1TkElectronsCrystal.L1EGammaInputTag = cms.InputTag("L1EGammaClusterEmuProducer",)
-L1TkElectronsCrystal.IsoCut = cms.double(-0.1)
+L1TkElectronsCrystal = L1TkElectrons.clone(
+    L1EGammaInputTag = cms.InputTag("L1EGammaClusterEmuProducer"),
+    IsoCut = cms.double(-0.1)
+)
 
-L1TkIsoElectronsCrystal=L1TkElectronsCrystal.clone()
-L1TkIsoElectronsCrystal.IsoCut = cms.double(0.1)
+L1TkIsoElectronsCrystal=L1TkElectronsCrystal.clone(
+    IsoCut = cms.double(0.1)
+)
 
-L1TkElectronsLooseCrystal = L1TkElectronsCrystal.clone()
-L1TkElectronsLooseCrystal.TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0)
-L1TkElectronsLooseCrystal.TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0)
-L1TkElectronsLooseCrystal.TrackMinPt = cms.double( 3.0 )
+L1TkElectronsLooseCrystal = L1TkElectronsCrystal.clone(
+    TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0),
+    TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0),
+    TrackMinPt = cms.double( 3.0 )
+)
 
-L1TkElectronsEllipticMatchCrystal = L1TkElectronsCrystal.clone()
-# L1TkElectronsEllipticMatchCrystal.L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
-L1TkElectronsEllipticMatchCrystal.TrackEGammaMatchType = cms.string("EllipticalCut")
-L1TkElectronsEllipticMatchCrystal.TrackEGammaDeltaEta = cms.vdouble(0.015, 0.025,1e10)
+L1TkElectronsEllipticMatchCrystal = L1TkElectronsCrystal.clone(
+#     L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+    TrackEGammaMatchType = cms.string("EllipticalCut"),
+    TrackEGammaDeltaEta = cms.vdouble(0.015, 0.025,1e10)
+)
 
 
 
 #endcap
-L1TkElectronsHGC=L1TkElectrons.clone()
-L1TkElectronsHGC.L1EGammaInputTag = cms.InputTag("l1EGammaEEProducer","L1EGammaCollectionBXVWithCuts")
-L1TkElectronsHGC.IsoCut = cms.double(-0.1)
+L1TkElectronsHGC=L1TkElectrons.clone(
+    L1EGammaInputTag = cms.InputTag("l1EGammaEEProducer","L1EGammaCollectionBXVWithCuts"),
+    IsoCut = cms.double(-0.1)
+)
 
 
-L1TkElectronsEllipticMatchHGC = L1TkElectronsHGC.clone()
-# L1TkElectronsEllipticMatchHGC.L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
-L1TkElectronsEllipticMatchHGC.TrackEGammaMatchType = cms.string("EllipticalCut")
-L1TkElectronsEllipticMatchHGC.TrackEGammaDeltaEta = cms.vdouble(0.0075, 0.0075,1e10)
-L1TkElectronsEllipticMatchHGC.maxChi2IsoTracks = cms.double(100)
-L1TkElectronsEllipticMatchHGC.minNStubsIsoTracks = cms.int32(4)
+L1TkElectronsEllipticMatchHGC = L1TkElectronsHGC.clone(
+#     L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+    TrackEGammaMatchType = cms.string("EllipticalCut"),
+    TrackEGammaDeltaEta = cms.vdouble(0.0075, 0.0075,1e10),
+    maxChi2IsoTracks = cms.double(100),
+    minNStubsIsoTracks = cms.int32(4)
+)
 
 
-L1TkIsoElectronsHGC=L1TkElectronsHGC.clone()
-L1TkIsoElectronsHGC.DRmax = cms.double(0.4)
-L1TkIsoElectronsHGC.DeltaZ = cms.double(1.0)
-L1TkIsoElectronsHGC.maxChi2IsoTracks = cms.double(100)
-L1TkIsoElectronsHGC.minNStubsIsoTracks = cms.int32(4)
-L1TkIsoElectronsHGC.IsoCut = cms.double(0.1)
+L1TkIsoElectronsHGC=L1TkElectronsHGC.clone(
+    DRmax = cms.double(0.4),
+    DeltaZ = cms.double(1.0),
+    maxChi2IsoTracks = cms.double(100),
+    minNStubsIsoTracks = cms.int32(4),
+    IsoCut = cms.double(0.1)
+ )
 
-L1TkElectronsLooseHGC = L1TkElectronsHGC.clone()
-L1TkElectronsLooseHGC.TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0)
-L1TkElectronsLooseHGC.TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0)
-L1TkElectronsLooseHGC.TrackMinPt = cms.double( 3.0 )
+L1TkElectronsLooseHGC = L1TkElectronsHGC.clone(
+    TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0),
+    TrackEGammaDeltaR = cms.vdouble(0.12, 0.0, 0.0),
+    TrackMinPt = cms.double( 3.0 )
+)

--- a/L1Trigger/L1TTrackMatch/python/L1TkEmParticleProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkEmParticleProducer_cfi.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkPhotons = cms.EDProducer("L1TkEmParticleProducer",
+        label = cms.string("EG"), 	# labels the collection of L1TkEmParticleProducer that is produced
+					# (not really needed actually)
+        L1EGammaInputTag = cms.InputTag("simCaloStage2Digis",""),
+                                                # When the standard sequences are used :
+                                                #   - for the Run-1 algo, use ("l1extraParticles","NonIsolated")
+                                                #     or ("l1extraParticles","Isolated")
+                                                #   - for the "old stage-2" algo (2x2 clustering), use 
+                                                #     ("SLHCL1ExtraParticles","EGamma") or ("SLHCL1ExtraParticles","IsoEGamma")
+                                                #   - for the new clustering algorithm of Jean-Baptiste et al,
+                                                #     use ("SLHCL1ExtraParticlesNewClustering","IsoEGamma") or
+                                                #     ("SLHCL1ExtraParticlesNewClustering","EGamma").
+        ETmin = cms.double( -1 ),               # Only the L1EG objects that have ET > ETmin in GeV
+                                                # are considered. ETmin < 0 means that no cut is applied.
+        RelativeIsolation = cms.bool( True ),   # default = True. The isolation variable is relative if True,
+                                                # else absolute.
+        IsoCut = cms.double( 0.23 ),             # Cut on the (Trk-based) isolation: only the L1TkEmParticle for which
+                                                # the isolation is below RelIsoCut are written into
+                                                # the output collection. When RelIsoCut < 0, no cut is applied.
+                                                # When RelativeIsolation = False, IsoCut is in GeV.
+           # Determination of the isolation w.r.t. L1Tracks :
+     	L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+        ZMAX = cms.double( 25. ),       # in cm
+        CHI2MAX = cms.double( 100. ),
+        PTMINTRA = cms.double( 2. ),    # in GeV
+        DRmin = cms.double( 0.07),
+        DRmax = cms.double( 0.30 ),
+        PrimaryVtxConstrain = cms.bool( False ),  # default = False
+						  # if set to True, the default isolation is the PV constrained one, where L1TkPrimaryVertex is used to constrain
+						  # the tracks entering in the calculation of the isolation 
+                                      # if set to False, the isolation is computed and stored, but not used 
+        #DeltaZConstrain = cms.bool( False ),  # default = False
+                                                  # if set to True, constrain to the z of the leading
+						  # track within DR < DRmax
+        DeltaZMax = cms.double( 0.6 ),    # in cm. Used only to compute the isolation with PrimaryVtxConstrain 
+        L1VertexInputTag = cms.InputTag("L1TkPrimaryVertex"),     # in cm. Used to compute the isolation with PrimaryVtxConstrain 
+)
+
+
+L1TkPhotonsTightIsol = L1TkPhotons.clone()
+L1TkPhotonsTightIsol.IsoCut = cms.double( 0.10)
+
+#### Additional collections that right now only the menu team is using - to be renamed/redefined by the EGamma group
+# The important change is the EG seed -> PhaseII instead of PhaseI
+
+L1TkPhotonsCrystal=L1TkPhotons.clone()
+L1TkPhotonsCrystal.L1EGammaInputTag = cms.InputTag("L1EGammaClusterEmuProducer", )
+L1TkPhotonsCrystal.IsoCut = cms.double(-0.1)
+
+
+L1TkPhotonsHGC=L1TkPhotons.clone()
+L1TkPhotonsHGC.L1EGammaInputTag = cms.InputTag("l1EGammaEEProducer","L1EGammaCollectionBXVWithCuts")
+L1TkPhotonsHGC.IsoCut = cms.double(-0.1)
+
+

--- a/L1Trigger/L1TTrackMatch/python/L1TkMuonProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkMuonProducer_cfi.py
@@ -1,0 +1,75 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkMuons = cms.EDProducer("L1TkMuonProducer",
+    ###############################################
+    ## switches that control the algos for the regions
+    bmtfMatchAlgoVersion = cms.string( 'TP' ),
+    omtfMatchAlgoVersion = cms.string( 'MAnTra' ),
+    emtfMatchAlgoVersion = cms.string( 'MAnTra' ),
+    ############################################### common stuff
+    L1BMTFInputTag  = cms.InputTag("simKBmtfDigis","BMTF"),
+    L1OMTFInputTag  = cms.InputTag("simOmtfDigis","OMTF"),
+    L1EMTFInputTag  = cms.InputTag("simEmtfDigis","EMTF"),
+    L1EMTFTrackCollectionInputTag = cms.InputTag("simEmtfDigis"),
+    L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+    ###############################################
+    ############################################### TP algo
+    ETAMIN = cms.double(0),
+    ETAMAX = cms.double(5.),        # no cut
+    ZMAX = cms.double( 25. ),       # in cm
+    CHI2MAX = cms.double( 100. ),
+    PTMINTRA = cms.double( 2. ),    # in GeV
+    DRmax = cms.double( 0.5 ),
+    nStubsmin = cms.int32( 4 ),        # minimum number of stubs
+#    closest = cms.bool( True ),
+    correctGMTPropForTkZ = cms.bool(True),
+    use5ParameterFit = cms.bool(False), #use 4-pars by defaults
+    useTPMatchWindows = cms.bool(True),
+    # emtfMatchAlgoVersion = cms.int32( 1 ),        # version of matching EMTF with Trackes (1 or 2)
+    ###############################################
+    ############################################### DynamicWindows algo
+    ##### parameters for the DynamicWindows algo - eventually to put in a separate file, that will override some dummy defaults
+    emtfcorr_boundaries     = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_endcap/matching_windows_boundaries.root'),
+    emtfcorr_theta_windows  = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_endcap/matching_windows_theta_q99.root'),
+    emtfcorr_phi_windows    = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_endcap/matching_windows_phi_q99.root'),
+    ## block to control the evolution of the matching window vs pt
+    ## if do_relax_factors = False ==> global scale of upper and lower boundaries by "final_window_factor"
+    ## if do_relax_factors = True  ==> progressive linear scale, the factor is
+    ##      - initial_window_factor for pt <= pt_start_relax
+    ##      - final_window_factor for pt >= pt_end_relax
+    ##      - and a linear interpolation in the middle
+    ## facror = 0 --> no changes to the window size
+    initial_window_factor   = cms.double(0.0),
+    final_window_factor     = cms.double(0.5),
+    pt_start_relax          = cms.double(2.0),
+    pt_end_relax            = cms.double(6.0),
+    do_relax_factors        = cms.bool(True),
+    ##
+    n_trk_par      = cms.int32(4), # 4 or 5
+    min_trk_p      = cms.double(3.5),
+    max_trk_aeta   = cms.double(2.5),
+    max_trk_chi2   = cms.double(100.0),
+    min_trk_nstubs = cms.int32(4),
+    ###############################################
+    ############################################### Mantra algo
+    ## please NOTE that as of 6/11/2019, only these parameters are effectively used for the MAnTra correlator
+    #
+    mantra_n_trk_par               = cms.int32(4), # 4 or 5
+    #
+    mantra_bmtfcorr_boundaries     = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_barrel/matching_windows_boundaries.root'),
+    mantra_bmtfcorr_theta_windows  = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_barrel/matching_windows_theta_q99.root'),
+    mantra_bmtfcorr_phi_windows    = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_barrel/matching_windows_phi_q99.root'),
+    #
+    mantra_omtfcorr_boundaries     = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_overlap/matching_windows_boundaries.root'),
+    mantra_omtfcorr_theta_windows  = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_overlap/matching_windows_theta_q99.root'),
+    mantra_omtfcorr_phi_windows    = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_overlap/matching_windows_phi_q99.root'),
+    #
+    mantra_emtfcorr_boundaries     = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_endcap/matching_windows_boundaries.root'),
+    mantra_emtfcorr_theta_windows  = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_endcap/matching_windows_theta_q99.root'),
+    mantra_emtfcorr_phi_windows    = cms.FileInPath('L1Trigger/L1TMuon/data/MAnTra_data/matching_windows_endcap/matching_windows_phi_q99.root'),
+)
+
+L1TkMuonsTP = L1TkMuons.clone(
+    emtfMatchAlgoVersion='TP',
+    useTPMatchWindows = True
+)

--- a/L1Trigger/L1TTrackMatch/python/L1TkObjectProducers_cff.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkObjectProducers_cff.py
@@ -1,0 +1,78 @@
+import FWCore.ParameterSet.Config as cms
+
+# Phase II EG seeds, Barrel (Crystal):
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkElectronsCrystal
+pL1TkElectronsCrystal = cms.Path( L1TkElectronsCrystal )
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkElectronsEllipticMatchCrystal
+pL1TkElectronsEllipticMatchCrystal = cms.Path( L1TkElectronsEllipticMatchCrystal )
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkElectronsLooseCrystal
+pL1TkElectronsLooseCrystal = cms.Path( L1TkElectronsLooseCrystal )
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkIsoElectronsCrystal
+pL1TkIsoElectronsCrystal = cms.Path( L1TkIsoElectronsCrystal )
+
+from L1Trigger.L1TTrackMatch.L1TkEmParticleProducer_cfi import L1TkPhotonsCrystal
+pL1TkPhotonsCrystal = cms.Path( L1TkPhotonsCrystal )
+
+#+ from L1Trigger.L1TTrackMatch.L1WP2ElectronProducer_cfi import L1WP2Electrons
+#+ pL1WP2Electrons = cms.Path( L1WP2Electrons)
+
+# Phase II EG seeds, Endcap (HGC):
+# Two objects for now to follow 2017 discussions, merging collections would be nice...
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkElectronsHGC
+pL1TkElectronsHGC = cms.Path( L1TkElectronsHGC )
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkElectronsEllipticMatchHGC
+pL1TkElectronsEllipticMatchHGC = cms.Path( L1TkElectronsEllipticMatchHGC )
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkIsoElectronsHGC
+pL1TkIsoElectronsHGC = cms.Path( L1TkIsoElectronsHGC )
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkElectronsLooseHGC
+pL1TkElectronsLooseHGC = cms.Path( L1TkElectronsLooseHGC )
+
+from L1Trigger.L1TTrackMatch.L1TkEmParticleProducer_cfi import L1TkPhotonsHGC
+pL1TkPhotonsHGC = cms.Path( L1TkPhotonsHGC )
+
+
+#Other tk Objects
+
+# from L1Trigger.L1TTrackMatch.L1TrackerJetProducer_cfi import L1TrackerJets
+# pL1TrackerJets = cms.Path( L1TrackerJets)
+
+# from L1Trigger.TwoLayerJets.TwoLayerJets_cfi import TwoLayerJets
+# pL1TwoLayerJets = cms.Path( TwoLayerJets)
+
+# from L1Trigger.L1TTrackMatch.L1TkCaloJetProducer_cfi import L1TkCaloJets
+# pL1TkCaloJets = cms.Path( L1TkCaloJets)
+
+from L1Trigger.L1TTrackMatch.L1TkPrimaryVertexProducer_cfi import L1TkPrimaryVertex
+pL1TkPrimaryVertex = cms.Path( L1TkPrimaryVertex )
+
+# from L1Trigger.L1TTrackMatch.L1TrackerEtMissProducer_cfi import L1TrackerEtMiss
+# pL1TrkMET = cms.Path( L1TrackerEtMiss )
+
+# from L1Trigger.L1TTrackMatch.L1TkHTMissProducer_cfi import L1TkCaloHTMissVtx, L1TrackerHTMiss
+# pL1TkCaloHTMissVtx = cms.Path( L1TkCaloHTMissVtx )
+# pL1TrackerHTMiss = cms.Path( L1TrackerHTMiss )
+
+from L1Trigger.L1TTrackMatch.L1TkMuonProducer_cfi import L1TkMuons, L1TkMuonsTP
+pL1TkMuon = cms.Path( L1TkMuons * L1TkMuonsTP )
+
+# from L1Trigger.L1TTrackMatch.L1TkGlbMuonProducer_cfi import L1TkGlbMuons
+# pL1TkGlbMuon = cms.Path( L1TkGlbMuons )
+
+# from L1Trigger.L1TTrackMatch.L1TkTauFromCaloProducer_cfi import L1TkTauFromCalo
+# pL1TkTauFromCalo = cms.Path( L1TkTauFromCalo )
+
+# from L1Trigger.Phase2L1Taus.L1TrkTauParticleProducer_cfi import L1TrkTaus
+# L1TrackerTaus = L1TrkTaus.clone()
+
+# from L1Trigger.Phase2L1Taus.L1TkEGTauParticleProducer_cfi import L1TkEGTaus
+
+# from L1Trigger.Phase2L1Taus.L1CaloTkTauParticleProducer_cfi import L1CaloTkTaus
+# L1TkCaloTaus = L1CaloTkTaus.clone()

--- a/L1Trigger/L1TTrackMatch/python/L1TkPrimaryVertexProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkPrimaryVertexProducer_cfi.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkPrimaryVertex = cms.EDProducer('L1TkFastVertexProducer',
+
+#
+# Default parameters used for the plots for the TP
+#
+     HepMCInputTag = cms.InputTag("generator"),
+     GenParticleInputTag = cms.InputTag("genParticles",""),
+     L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+     ZMAX = cms.double ( 25. ) ,        # in cm
+     CHI2MAX = cms.double( 100. ),
+     PTMINTRA = cms.double( 2.),        # PTMIN of L1Tracks, in GeV
+     nStubsmin = cms.int32( 4 ) ,       # minimum number of stubs
+     nStubsPSmin = cms.int32( 3 ),       # minimum number of stubs in PS modules 
+     nBinning = cms.int32( 601 ),        # number of bins for the temp histo (from -30 cm to + 30 cm)
+     PTMAX = cms.double( 50. ),          # in GeV. When PTMAX > 0, tracks with PT above PTMAX are considered as
+					 # mismeasured and are treated according to HighPtTracks below.
+					 # When PTMAX < 0, no special treatment is done for high PT tracks.
+					 # If PTMAX < 0, no saturation or truncation is done.
+     HighPtTracks = cms.int32( 0 ),	 # when = 0 : truncation. Tracks with PT above PTMAX are ignored 
+					 # when = 1 : saturation. Tracks with PT above PTMAX are set to PT=PTMAX.
+     MonteCarloVertex = cms.bool( False ),    #  when True: dont run the vxt finding algo but pick up the MC generated vtx
+     doPtComp = cms.bool( True ),       # track-stubs PT compatibility cut
+     doTightChi2 = cms.bool( False ),    # chi2dof < 5 for tracks with PT > 10
+     WEIGHT = cms.int32(1)            # WEIGHT can be set to 0, 1 or 2 for unweighted, pT weighted
+                                      # or pT2 weighted tracks respectively.
+
+#
+# Other working point which works better for H -> TauTau,
+# cf talk by Moshan Ather, Dec 12, 2014:
+
+#     WEIGHT = cms.int32(2),
+#     PTMAX = cms.double( 25. ),
+#     nStubsmin = cms.int32( 5 ),
+#     HighPtTracks = cms.int32( 1),
+#     doPtComp = cms.bool( False ),     
+#     CHI2MAX = cms.double( 20 )
+#
+
+)

--- a/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
@@ -16,6 +16,10 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h"
 namespace L1TkElectronTrackMatchAlgo {
+
+  float constexpr max_eb_eta = 1.479;
+  float constexpr max_eb_z = 315.4;
+  float constexpr eb_rperp = 129.0;
   // ------------ match EGamma and Track
   void doMatch(l1t::EGammaBxCollection::const_iterator egIter,
                const edm::Ptr<L1TTTrackType>& pTrk,
@@ -74,17 +78,16 @@ namespace L1TkElectronTrackMatchAlgo {
     double depth = 0.89 * (7.7 + log(e));
     double theta = 2 * atan(exp(-1 * eta));
     double r = 0;
-    if (fabs(eta) > 1.479) {
-      double ecalZ = 315.4 * fabs(eta) / eta;
+    if (fabs(eta) > max_eb_eta) {
+      double ecalZ = max_eb_z * fabs(eta) / eta;
 
       r = ecalZ / cos(2 * atan(exp(-1 * eta))) + depth;
       x = r * cos(phi) * sin(theta);
       y = r * sin(phi) * sin(theta);
       z = r * cos(theta);
     } else {
-      double rperp = 129.0;
-      double zface = sqrt(cos(theta) * cos(theta) / (1 - cos(theta) * cos(theta)) * rperp * rperp);
-      r = sqrt(rperp * rperp + zface * zface) + depth;
+      double zface = sqrt(cos(theta) * cos(theta) / (1 - cos(theta) * cos(theta)) * eb_rperp * eb_rperp);
+      r = sqrt(eb_rperp * eb_rperp + zface * zface) + depth;
       x = r * cos(phi) * sin(theta);
       y = r * sin(phi) * sin(theta);
       z = r * cos(theta);

--- a/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
@@ -1,0 +1,96 @@
+// -*- C++ -*-
+//
+//
+/**\class L1TkElectronTrackMatchAlgo 
+
+ Description: Algorithm to match L1EGamma oject with L1Track candidates
+
+ Implementation:
+     [Notes on implementation]
+*/
+
+// system include files
+#include <memory>
+#include <cmath>
+
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h"
+namespace L1TkElectronTrackMatchAlgo {
+  // ------------ match EGamma and Track
+  void doMatch(l1t::EGammaBxCollection::const_iterator egIter,
+               const edm::Ptr<L1TTTrackType>& pTrk,
+               double& dph,
+               double& dr,
+               double& deta) {
+    GlobalPoint egPos = L1TkElectronTrackMatchAlgo::calorimeterPosition(egIter->phi(), egIter->eta(), egIter->energy());
+    dph = L1TkElectronTrackMatchAlgo::deltaPhi(egPos, pTrk);
+    dr = L1TkElectronTrackMatchAlgo::deltaR(egPos, pTrk);
+    deta = L1TkElectronTrackMatchAlgo::deltaEta(egPos, pTrk);
+  }
+  // ------------ match EGamma and Track
+  void doMatch(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk, double& dph, double& dr, double& deta) {
+    dph = L1TkElectronTrackMatchAlgo::deltaPhi(epos, pTrk);
+    dr = L1TkElectronTrackMatchAlgo::deltaR(epos, pTrk);
+    deta = L1TkElectronTrackMatchAlgo::deltaEta(epos, pTrk);
+  }
+  // --------------- calculate deltaR between Track and EGamma object
+  double deltaPhi(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk) {
+    double er = epos.perp();
+    double curv = pTrk->rInv();
+
+    double dphi_curv = (asin(er * curv / (2.0)));
+    double trk_phi_ecal = reco::deltaPhi(pTrk->momentum().phi(), dphi_curv);
+
+    double dphi = reco::deltaPhi(trk_phi_ecal, epos.phi());
+    return dphi;
+  }
+  // --------------- calculate deltaPhi between Track and EGamma object
+  double deltaR(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk) {
+    //double dPhi = fabs(reco::deltaPhi(epos.phi(), pTrk->momentum().phi()));
+    double dPhi = L1TkElectronTrackMatchAlgo::deltaPhi(epos, pTrk);
+    double dEta = deltaEta(epos, pTrk);
+    return sqrt(dPhi * dPhi + dEta * dEta);
+  }
+  // --------------- calculate deltaEta between Track and EGamma object
+  double deltaEta(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk) {
+    double corr_eta = 999.0;
+    double er = epos.perp();
+    double ez = epos.z();
+    double z0 = pTrk->POCA().z();
+    double theta = 0.0;
+    if (ez >= 0)
+      theta = atan(er / fabs(ez - z0));
+    else
+      theta = M_PI - atan(er / fabs(ez - z0));
+    corr_eta = -1.0 * log(tan(theta / 2.0));
+    double deleta = (corr_eta - pTrk->momentum().eta());
+    return deleta;
+  }
+  // -------------- get Calorimeter position
+  GlobalPoint calorimeterPosition(double phi, double eta, double e) {
+    double x = 0.;
+    double y = 0.;
+    double z = 0.;
+    double depth = 0.89 * (7.7 + log(e));
+    double theta = 2 * atan(exp(-1 * eta));
+    double r = 0;
+    if (fabs(eta) > 1.479) {
+      double ecalZ = 315.4 * fabs(eta) / eta;
+
+      r = ecalZ / cos(2 * atan(exp(-1 * eta))) + depth;
+      x = r * cos(phi) * sin(theta);
+      y = r * sin(phi) * sin(theta);
+      z = r * cos(theta);
+    } else {
+      double rperp = 129.0;
+      double zface = sqrt(cos(theta) * cos(theta) / (1 - cos(theta) * cos(theta)) * rperp * rperp);
+      r = sqrt(rperp * rperp + zface * zface) + depth;
+      x = r * cos(phi) * sin(theta);
+      y = r * sin(phi) * sin(theta);
+      z = r * cos(theta);
+    }
+    GlobalPoint pos(x, y, z);
+    return pos;
+  }
+
+}  // namespace L1TkElectronTrackMatchAlgo

--- a/L1Trigger/L1TTrackMatch/src/L1TkMuCorrDynamicWindows.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkMuCorrDynamicWindows.cc
@@ -4,7 +4,7 @@
 #include "TH1.h"
 #include "TH2.h"
 
-L1TkMuCorrDynamicWindows::L1TkMuCorrDynamicWindows(std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi)
+L1TkMuCorrDynamicWindows::L1TkMuCorrDynamicWindows(const std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi)
     : wdws_theta_(bounds.size() - 1, MuMatchWindow()),
       wdws_phi_(bounds.size() - 1, MuMatchWindow()),
       wdws_theta_S1_(bounds.size() - 1, MuMatchWindow()),
@@ -56,7 +56,7 @@ L1TkMuCorrDynamicWindows::L1TkMuCorrDynamicWindows(std::vector<double>& bounds, 
 }
 
 L1TkMuCorrDynamicWindows::L1TkMuCorrDynamicWindows(
-    std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, TFile* fIn_theta_S1, TFile* fIn_phi_S1)
+    const std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, TFile* fIn_theta_S1, TFile* fIn_phi_S1)
     : wdws_theta_(bounds.size() - 1, MuMatchWindow()),
       wdws_phi_(bounds.size() - 1, MuMatchWindow()),
       wdws_theta_S1_(bounds.size() - 1, MuMatchWindow()),
@@ -213,7 +213,7 @@ std::vector<int> L1TkMuCorrDynamicWindows::find_match(const EMTFTrackCollection&
           adphi <= (1 + sf_h) * wdws_phi_.at(ibin).bound_high(trk_pt) && dphi * trk_charge < 0 &&  // sign requirement
           // rndm > 0.5
           true)
-        matched.push_back(std::make_tuple(dtheta, adphi, std::distance(l1mus.begin(), l1muit)));
+        matched.emplace_back(dtheta, adphi, std::distance(l1mus.begin(), l1muit));
     }
 
     if (reject_trk)
@@ -313,7 +313,7 @@ std::vector<int> L1TkMuCorrDynamicWindows::find_match_stub(const EMTFHitCollecti
           adphi <= (1 + sf_h) * wdws_phi_S1_.at(ibin).bound_high(trk_pt) &&
           dphi * trk_charge < 0 &&  // sign requirement
           true)
-        matched.push_back(std::make_tuple(dtheta, adphi, std::distance(l1mus.begin(), l1muit)));
+        matched.emplace_back(dtheta, adphi, std::distance(l1mus.begin(), l1muit));
 
       if (hit_station == 2 && dtheta > (1 - sf_l) * wdws_theta_.at(ibin).bound_low(trk_pt) &&
           dtheta <= (1 + sf_h) * wdws_theta_.at(ibin).bound_high(trk_pt) &&
@@ -321,7 +321,7 @@ std::vector<int> L1TkMuCorrDynamicWindows::find_match_stub(const EMTFHitCollecti
           adphi <= (1 + sf_h) * wdws_phi_.at(ibin).bound_high(trk_pt) && dphi * trk_charge < 0 &&  // sign requirement
           // rndm > 0.5
           true)
-        matched.push_back(std::make_tuple(dtheta, adphi, std::distance(l1mus.begin(), l1muit)));
+        matched.emplace_back(dtheta, adphi, std::distance(l1mus.begin(), l1muit));
     }
 
     if (reject_trk)
@@ -387,6 +387,9 @@ std::vector<int> L1TkMuCorrDynamicWindows::make_unique_coll(const unsigned int& 
 std::vector<double> L1TkMuCorrDynamicWindows::prepare_corr_bounds(const string& fname, const string& hname) {
   // find the boundaries of the match windoww
   TFile* fIn = TFile::Open(fname.c_str());
+  if (fIn == nullptr) {
+    throw cms::Exception("L1TkMuMantra") << "Can't find file " << fname << " to derive bounds.\n";
+  }
   TH2* h_test = (TH2*)fIn->Get(hname.c_str());
   if (h_test == nullptr) {
     throw cms::Exception("L1TkMuCorrDynamicWindows")

--- a/L1Trigger/L1TTrackMatch/src/L1TkMuCorrDynamicWindows.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkMuCorrDynamicWindows.cc
@@ -1,0 +1,403 @@
+#include "L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h"
+
+// ROOT includes
+#include "TH1.h"
+#include "TH2.h"
+
+L1TkMuCorrDynamicWindows::L1TkMuCorrDynamicWindows(std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi)
+    : wdws_theta_(bounds.size() - 1, MuMatchWindow()),
+      wdws_phi_(bounds.size() - 1, MuMatchWindow()),
+      wdws_theta_S1_(bounds.size() - 1, MuMatchWindow()),
+      wdws_phi_S1_(bounds.size() - 1, MuMatchWindow()) {
+  set_safety_factor(0.5);
+  set_sf_initialrelax(0.0);
+  set_relaxation_pattern(2.0, 6.0);
+  set_do_relax_factor(true);
+
+  track_qual_presel_ = true;
+
+  nbins_ = bounds.size() - 1;
+  bounds_ = bounds;
+
+  // now load in memory the TF1 fits
+
+  for (int ib = 0; ib < nbins_; ++ib) {
+    std::string wdn;
+    std::string nml;
+    std::string nmh;
+    TF1* fl;
+    TF1* fh;
+
+    // Station 2
+    wdn = std::string("wdw_theta_") + std::to_string(ib + 1);
+    nml = std::string("fit_low_") + std::to_string(ib + 1);
+    nmh = std::string("fit_high_") + std::to_string(ib + 1);
+    fl = (TF1*)fIn_theta->Get(nml.c_str());
+    fh = (TF1*)fIn_theta->Get(nmh.c_str());
+    if (fl == nullptr || fh == nullptr)
+      throw cms::Exception("L1TkMuCorrDynamicWindows")
+          << "TF1 named " << nml << " or " << nmh << " not found in file " << fIn_theta->GetName() << ".\n";
+    wdws_theta_.at(ib).SetName(wdn);
+    wdws_theta_.at(ib).SetLower(fl);
+    wdws_theta_.at(ib).SetUpper(fh);
+
+    wdn = std::string("wdw_phi_") + std::to_string(ib + 1);
+    nml = std::string("fit_low_") + std::to_string(ib + 1);
+    nmh = std::string("fit_high_") + std::to_string(ib + 1);
+    fl = (TF1*)fIn_phi->Get(nml.c_str());
+    fh = (TF1*)fIn_phi->Get(nmh.c_str());
+    if (fl == nullptr || fh == nullptr)
+      throw cms::Exception("L1TkMuCorrDynamicWindows")
+          << "TF1 named " << nml << " or " << nmh << " not found in file " << fIn_theta->GetName() << ".\n";
+    wdws_phi_.at(ib).SetName(wdn);
+    wdws_phi_.at(ib).SetLower(fl);
+    wdws_phi_.at(ib).SetUpper(fh);
+  }
+}
+
+L1TkMuCorrDynamicWindows::L1TkMuCorrDynamicWindows(
+    std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, TFile* fIn_theta_S1, TFile* fIn_phi_S1)
+    : wdws_theta_(bounds.size() - 1, MuMatchWindow()),
+      wdws_phi_(bounds.size() - 1, MuMatchWindow()),
+      wdws_theta_S1_(bounds.size() - 1, MuMatchWindow()),
+      wdws_phi_S1_(bounds.size() - 1, MuMatchWindow()) {
+  set_safety_factor(0.0);
+  set_sf_initialrelax(0.0);
+  set_relaxation_pattern(2.0, 6.0);
+  set_do_relax_factor(true);
+
+  track_qual_presel_ = true;
+
+  nbins_ = bounds.size() - 1;
+  bounds_ = bounds;
+
+  // now load in memory the TF1 fits
+
+  for (int ib = 0; ib < nbins_; ++ib) {
+    std::string wdn;
+    std::string nml;
+    std::string nmh;
+    TF1* fl;
+    TF1* fh;
+
+    // Station 2
+    wdn = std::string("wdw_theta_") + std::to_string(ib + 1);
+    nml = std::string("fit_low_") + std::to_string(ib + 1);
+    nmh = std::string("fit_high_") + std::to_string(ib + 1);
+    fl = (TF1*)fIn_theta->Get(nml.c_str());
+    fh = (TF1*)fIn_theta->Get(nmh.c_str());
+    if (fl == nullptr || fh == nullptr)
+      throw cms::Exception("L1TkMuCorrDynamicWindows")
+          << "TF1 named " << nml << " or " << nmh << " not found in file " << fIn_theta->GetName() << ".\n";
+    wdws_theta_.at(ib).SetName(wdn);
+    wdws_theta_.at(ib).SetLower(fl);
+    wdws_theta_.at(ib).SetUpper(fh);
+
+    wdn = std::string("wdw_phi_") + std::to_string(ib + 1);
+    nml = std::string("fit_low_") + std::to_string(ib + 1);
+    nmh = std::string("fit_high_") + std::to_string(ib + 1);
+    fl = (TF1*)fIn_phi->Get(nml.c_str());
+    fh = (TF1*)fIn_phi->Get(nmh.c_str());
+    if (fl == nullptr || fh == nullptr)
+      throw cms::Exception("L1TkMuCorrDynamicWindows")
+          << "TF1 named " << nml << " or " << nmh << " not found in file " << fIn_theta->GetName() << ".\n";
+    wdws_phi_.at(ib).SetName(wdn);
+    wdws_phi_.at(ib).SetLower(fl);
+    wdws_phi_.at(ib).SetUpper(fh);
+
+    // Station 1 - MW's don't have to exist for TkMuon correlator
+    // It is only needed for TkMuStub
+    wdn = std::string("wdw_theta_") + std::to_string(ib + 1);
+    nml = std::string("fit_low_") + std::to_string(ib + 1);
+    nmh = std::string("fit_high_") + std::to_string(ib + 1);
+    fl = (TF1*)fIn_theta_S1->Get(nml.c_str());
+    fh = (TF1*)fIn_theta_S1->Get(nmh.c_str());
+    if (fl == nullptr || fh == nullptr)
+      throw cms::Exception("L1TkMuCorrDynamicWindows")
+          << "TF1 named " << nml << " or " << nmh << " not found in file " << fIn_theta->GetName() << ".\n";
+    wdws_theta_S1_.at(ib).SetName(wdn);
+    wdws_theta_S1_.at(ib).SetLower(fl);
+    wdws_theta_S1_.at(ib).SetUpper(fh);
+
+    wdn = std::string("wdw_phi_") + std::to_string(ib + 1);
+    nml = std::string("fit_low_") + std::to_string(ib + 1);
+    nmh = std::string("fit_high_") + std::to_string(ib + 1);
+    fl = (TF1*)fIn_phi_S1->Get(nml.c_str());
+    fh = (TF1*)fIn_phi_S1->Get(nmh.c_str());
+    if (fl == nullptr || fh == nullptr)
+      throw cms::Exception("L1TkMuCorrDynamicWindows")
+          << "TF1 named " << nml << " or " << nmh << " not found in file " << fIn_theta->GetName() << ".\n";
+    wdws_phi_S1_.at(ib).SetName(wdn);
+    wdws_phi_S1_.at(ib).SetLower(fl);
+    wdws_phi_S1_.at(ib).SetUpper(fh);
+  }
+}
+
+int L1TkMuCorrDynamicWindows::findBin(double val) {
+  // not the most efficient, nor the most elegant implementation for now
+  if (val < bounds_.at(0))
+    return 0;
+  if (val >= bounds_.back())
+    return (nbins_ - 1);  // i.e. bounds_size() -2
+
+  for (uint ib = 0; ib < bounds_.size() - 1; ++ib) {
+    if (val >= bounds_.at(ib) && val < bounds_.at(ib + 1))
+      return ib;
+  }
+
+  //"Something strange happened at val.
+  throw cms::Exception("L1TkMuCorrDynamicWindows") << "Can't find bin.\n";
+  return 0;
+}
+
+std::vector<int> L1TkMuCorrDynamicWindows::find_match(const EMTFTrackCollection& l1mus,
+                                                      const L1TTTrackCollectionType& l1trks) {
+  std::vector<int> out(l1trks.size());
+  for (auto l1trkit = l1trks.begin(); l1trkit != l1trks.end(); ++l1trkit) {
+    float trk_pt = l1trkit->momentum().perp();
+    float trk_p = l1trkit->momentum().mag();
+    float trk_aeta = std::abs(l1trkit->momentum().eta());
+    float trk_theta = to_mpio2_pio2(eta_to_theta(l1trkit->momentum().eta()));
+    float trk_phi = l1trkit->momentum().phi();
+    int trk_charge = (l1trkit->rInv() > 0 ? 1 : -1);
+
+    // porting some selections from the MuonTrackCorr finder
+    // https://github.com/cms-l1t-offline/cmssw/blob/l1t-phase2-932-v1.6/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc#L264
+    // in future, make preselections confiuguable
+    bool reject_trk = false;
+    if (trk_p < min_trk_p_)
+      reject_trk = true;
+    if (trk_aeta > max_trk_aeta_)
+      reject_trk = true;
+    if (track_qual_presel_) {
+      float l1tk_chi2 = l1trkit->chi2();
+      int l1tk_nstubs = l1trkit->getStubRefs().size();
+      if (l1tk_chi2 >= max_trk_chi2_)
+        reject_trk = true;
+      if (l1tk_nstubs < min_trk_nstubs_)
+        reject_trk = true;
+    }
+
+    int ibin = findBin(trk_aeta);
+
+    std::vector<std::tuple<float, float, int>> matched;  // dtheta, dphi, idx
+    // loop on muons to see which match
+    for (auto l1muit = l1mus.begin(); l1muit != l1mus.end(); ++l1muit) {
+      // match only muons in the central bx - as the track collection refers anyway to bx 0 only
+      if (l1muit->BX() != 0)
+        continue;
+
+      // putting everything in rad
+      float emtf_theta = to_mpio2_pio2(eta_to_theta(l1muit->Eta()));
+      float emtf_phi = deg_to_rad(l1muit->Phi_glob());
+
+      float dtheta = std::abs(emtf_theta - trk_theta);
+      float dphi = to_mpi_pi(emtf_phi - trk_phi);
+      float adphi = std::abs(dphi);
+
+      double sf_l;
+      double sf_h;
+      if (do_relax_factor_) {
+        sf_l = sf_progressive(trk_pt, pt_start_, pt_end_, initial_sf_l_, safety_factor_l_);
+        sf_h = sf_progressive(trk_pt, pt_start_, pt_end_, initial_sf_h_, safety_factor_h_);
+      } else {
+        sf_l = safety_factor_l_;
+        sf_h = safety_factor_h_;
+      }
+
+      if (
+          // emtf_theta * trk_theta > 0 &&
+          dtheta > (1 - sf_l) * wdws_theta_.at(ibin).bound_low(trk_pt) &&
+          dtheta <= (1 + sf_h) * wdws_theta_.at(ibin).bound_high(trk_pt) &&
+          adphi > (1 - sf_l) * wdws_phi_.at(ibin).bound_low(trk_pt) &&
+          adphi <= (1 + sf_h) * wdws_phi_.at(ibin).bound_high(trk_pt) && dphi * trk_charge < 0 &&  // sign requirement
+          // rndm > 0.5
+          true)
+        matched.push_back(std::make_tuple(dtheta, adphi, std::distance(l1mus.begin(), l1muit)));
+    }
+
+    if (reject_trk)
+      matched.clear();  // quick fix - to be optimised to avoid the operations above
+
+    if (matched.empty())
+      out.at(std::distance(l1trks.begin(), l1trkit)) = -1;
+    else {
+      std::sort(matched.begin(), matched.end());  // closest in theta, then in phi
+      out.at(std::distance(l1trks.begin(), l1trkit)) = std::get<2>(matched.at(0));
+    }
+  }
+
+  // now convert out to a unique set
+  return make_unique_coll(l1mus.size(), l1trks, out);
+}
+
+std::vector<int> L1TkMuCorrDynamicWindows::find_match_stub(const EMTFHitCollection& l1mus,
+                                                           const L1TTTrackCollectionType& l1trks,
+                                                           const int& station,
+                                                           bool requireBX0) {
+  std::vector<int> out(l1trks.size());
+  for (auto l1trkit = l1trks.begin(); l1trkit != l1trks.end(); ++l1trkit) {
+    float trk_pt = l1trkit->momentum().perp();
+    float trk_p = l1trkit->momentum().mag();
+    float trk_aeta = std::abs(l1trkit->momentum().eta());
+    float trk_theta = to_mpio2_pio2(eta_to_theta(l1trkit->momentum().eta()));
+    float trk_phi = l1trkit->momentum().phi();
+    int trk_charge = (l1trkit->rInv() > 0 ? 1 : -1);
+
+    // porting some selections from the MuonTrackCorr finder
+    // https://github.com/cms-l1t-offline/cmssw/blob/l1t-phase2-932-v1.6/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc#L264
+    // for future: make preselections confiuguable
+    bool reject_trk = false;
+    if (trk_p < min_trk_p_)
+      reject_trk = true;
+    if (trk_aeta > max_trk_aeta_)
+      reject_trk = true;
+    if (track_qual_presel_) {
+      float l1tk_chi2 = l1trkit->chi2();
+      int l1tk_nstubs = l1trkit->getStubRefs().size();
+      if (l1tk_chi2 >= max_trk_chi2_)
+        reject_trk = true;
+      if (l1tk_nstubs < min_trk_nstubs_)
+        reject_trk = true;
+    }
+
+    int ibin = findBin(trk_aeta);
+
+    std::vector<std::tuple<float, float, int>> matched;  // dtheta, dphi, idx
+    // loop on stubs to see which match
+    for (auto l1muit = l1mus.begin(); l1muit != l1mus.end(); ++l1muit) {
+      if (!(l1muit->Is_CSC() || l1muit->Is_RPC()))
+        continue;
+
+      int hit_station = l1muit->Station();
+      // match only stubs in the central bx - as the track collection refers anyway to bx 0 only
+      if (requireBX0 && l1muit->BX() != 0)
+        continue;
+
+      // allow only track matching to stubs from the given station, station= 1,2,3,4
+      if (station < 5 && hit_station != station)
+        continue;
+      // in case of station=12 allow track matching to stubs from either station 1 or 2.
+      else if (station == 12 && hit_station > 2)  // good for tkMuStub12
+        continue;
+      // in case of station=123 allow track matching to stubs from either station 1, 2, or 3.
+      else if (station == 123 && hit_station > 3)  // good for tkMuStub123
+        continue;
+      // in case of station=1234 allow track matching to stubs from either station 1, 2, 3, or 4.
+      else if (station == 1234 && hit_station > 4)  // good for tkMuStub1234
+        continue;
+
+      float emtf_theta = to_mpio2_pio2(eta_to_theta(l1muit->Eta_sim()));
+      float emtf_phi = deg_to_rad(l1muit->Phi_sim());
+
+      float dtheta = std::abs(emtf_theta - trk_theta);
+      float dphi = to_mpi_pi(emtf_phi - trk_phi);
+      float adphi = std::abs(dphi);
+
+      double sf_l;
+      double sf_h;
+      if (do_relax_factor_) {
+        sf_l = sf_progressive(trk_pt, pt_start_, pt_end_, initial_sf_l_, safety_factor_l_);
+        sf_h = sf_progressive(trk_pt, pt_start_, pt_end_, initial_sf_h_, safety_factor_h_);
+      } else {
+        sf_l = safety_factor_l_;
+        sf_h = safety_factor_h_;
+      }
+
+      if (hit_station == 1 &&
+          //if hit in station 1 use these  matching windows for checking
+
+          dtheta > (1 - sf_l) * wdws_theta_S1_.at(ibin).bound_low(trk_pt) &&
+          dtheta <= (1 + sf_h) * wdws_theta_S1_.at(ibin).bound_high(trk_pt) &&
+          adphi > (1 - sf_l) * wdws_phi_S1_.at(ibin).bound_low(trk_pt) &&
+          adphi <= (1 + sf_h) * wdws_phi_S1_.at(ibin).bound_high(trk_pt) &&
+          dphi * trk_charge < 0 &&  // sign requirement
+          true)
+        matched.push_back(std::make_tuple(dtheta, adphi, std::distance(l1mus.begin(), l1muit)));
+
+      if (hit_station == 2 && dtheta > (1 - sf_l) * wdws_theta_.at(ibin).bound_low(trk_pt) &&
+          dtheta <= (1 + sf_h) * wdws_theta_.at(ibin).bound_high(trk_pt) &&
+          adphi > (1 - sf_l) * wdws_phi_.at(ibin).bound_low(trk_pt) &&
+          adphi <= (1 + sf_h) * wdws_phi_.at(ibin).bound_high(trk_pt) && dphi * trk_charge < 0 &&  // sign requirement
+          // rndm > 0.5
+          true)
+        matched.push_back(std::make_tuple(dtheta, adphi, std::distance(l1mus.begin(), l1muit)));
+    }
+
+    if (reject_trk)
+      matched.clear();  // quick fix - to be optimised to avoid the operations above
+
+    if (matched.empty())
+      out.at(std::distance(l1trks.begin(), l1trkit)) = -1;
+    else {
+      std::sort(matched.begin(), matched.end());  // closest in theta, then in phi
+      out.at(std::distance(l1trks.begin(), l1trkit)) = std::get<2>(matched.at(0));
+    }
+  }
+
+  // return out;
+
+  // now convert out to a unique set
+  auto unique_out = make_unique_coll(l1mus.size(), l1trks, out);
+
+  return unique_out;
+}
+
+std::vector<int> L1TkMuCorrDynamicWindows::make_unique_coll(const unsigned int& l1musSize,
+                                                            const L1TTTrackCollectionType& l1trks,
+                                                            const std::vector<int>& matches) {
+  std::vector<int> out(matches.size(), -1);
+
+  std::vector<std::vector<int>> macthed_to_emtf(l1musSize,
+                                                std::vector<int>(0));  // one vector of matched trk idx per EMTF
+
+  for (unsigned int itrack = 0; itrack < matches.size(); ++itrack) {
+    int iemtf = matches.at(itrack);
+    if (iemtf < 0)
+      continue;
+    macthed_to_emtf.at(iemtf).push_back(itrack);
+  }
+
+  std::function<bool(int, int, const L1TTTrackCollectionType&, int)> track_less_than_proto =
+      [](int idx1, int idx2, const L1TTTrackCollectionType& l1trkcoll, int nTrackParams) {
+        float pt1 = l1trkcoll.at(idx1).momentum().perp();
+        float pt2 = l1trkcoll.at(idx2).momentum().perp();
+        return (pt1 < pt2);
+      };
+
+  // // and binds to accept only 2 params
+  std::function<bool(int, int)> track_less_than =
+      std::bind(track_less_than_proto, std::placeholders::_1, std::placeholders::_2, l1trks, nTrkPars_);
+
+  for (unsigned int iemtf = 0; iemtf < macthed_to_emtf.size(); ++iemtf) {
+    std::vector<int>& thisv = macthed_to_emtf.at(iemtf);
+    if (thisv.empty())
+      continue;
+
+    std::sort(thisv.begin(), thisv.end(), track_less_than);
+
+    // copy to the output
+    int best_trk = thisv.back();
+    out.at(best_trk) = iemtf;
+  }
+
+  return out;
+}
+
+std::vector<double> L1TkMuCorrDynamicWindows::prepare_corr_bounds(const string& fname, const string& hname) {
+  // find the boundaries of the match windoww
+  TFile* fIn = TFile::Open(fname.c_str());
+  TH2* h_test = (TH2*)fIn->Get(hname.c_str());
+  if (h_test == nullptr) {
+    throw cms::Exception("L1TkMuCorrDynamicWindows")
+        << "Can't find histo " << hname << " in file " << fname << " to derive bounds.\n";
+  }
+
+  int nbds = h_test->GetNbinsY() + 1;
+  vector<double> bounds(nbds);
+  for (int ib = 0; ib < nbds; ++ib) {
+    bounds.at(ib) = h_test->GetYaxis()->GetBinLowEdge(ib + 1);
+  }
+  fIn->Close();
+  return bounds;
+}

--- a/L1Trigger/L1TTrackMatch/src/L1TkMuMantra.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkMuMantra.cc
@@ -5,7 +5,10 @@
 
 using namespace L1TkMuMantraDF;
 
-L1TkMuMantra::L1TkMuMantra(const std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, std::string name = "mantra")
+L1TkMuMantra::L1TkMuMantra(const std::vector<double>& bounds,
+                           TFile* fIn_theta,
+                           TFile* fIn_phi,
+                           std::string name = "mantra")
     : wdws_theta_(bounds.size() - 1, MuMatchWindow()), wdws_phi_(bounds.size() - 1, MuMatchWindow()) {
   name_ = name;
 

--- a/L1Trigger/L1TTrackMatch/src/L1TkMuMantra.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkMuMantra.cc
@@ -1,0 +1,215 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h"
+#include "TH2.h"
+
+using namespace L1TkMuMantraDF;
+
+L1TkMuMantra::L1TkMuMantra(std::vector<double>& bounds, TFile* fIn_theta, TFile* fIn_phi, std::string name = "mantra")
+    : wdws_theta_(bounds.size() - 1, MuMatchWindow()), wdws_phi_(bounds.size() - 1, MuMatchWindow()) {
+  name_ = name;
+
+  safety_factor_l_ = 0.0;
+  safety_factor_h_ = 0.0;
+
+  sort_type_ = kMaxPt;
+
+  // copy boundaries
+  nbins_ = bounds.size() - 1;
+  bounds_ = bounds;
+
+  // now load in memory the TF1 fits
+
+  for (int ib = 0; ib < nbins_; ++ib) {
+    std::string wdn;
+    std::string nml;
+    std::string nmc;
+    std::string nmh;
+    TF1* fl;
+    TF1* fc;
+    TF1* fh;
+
+    wdn = name_ + std::string("_wdw_theta_") + std::to_string(ib + 1);
+    nml = std::string("fit_low_") + std::to_string(ib + 1);
+    nmc = std::string("fit_cent_") + std::to_string(ib + 1);
+    nmh = std::string("fit_high_") + std::to_string(ib + 1);
+
+    fl = (TF1*)fIn_theta->Get(nml.c_str());
+    fc = (TF1*)fIn_theta->Get(nmc.c_str());
+    fh = (TF1*)fIn_theta->Get(nmh.c_str());
+    if (fl == nullptr || fc == nullptr || fh == nullptr) {
+      if (verbosity_ > 0) {
+        LogTrace("L1TkMuMantra") << "... fit theta low  : " << fl << std::endl;
+        LogTrace("L1TkMuMantra") << "... fit theta cent : " << fc << std::endl;
+        LogTrace("L1TkMuMantra") << "... fit theta high : " << fh << std::endl;
+      }
+      throw cms::Exception("L1TkMuMantra") << "TF1 named " << nml << " or " << nmc << " or " << nmh
+                                           << " not found in file " << fIn_theta->GetName() << ".\n";
+    }
+    wdws_theta_.at(ib).SetName(wdn);
+    wdws_theta_.at(ib).SetLower(fl);
+    wdws_theta_.at(ib).SetCentral(fc);
+    wdws_theta_.at(ib).SetUpper(fh);
+
+    wdn = name_ + std::string("_wdw_phi_") + std::to_string(ib + 1);
+    nml = std::string("fit_low_") + std::to_string(ib + 1);
+    nmc = std::string("fit_cent_") + std::to_string(ib + 1);
+    nmh = std::string("fit_high_") + std::to_string(ib + 1);
+    fl = (TF1*)fIn_phi->Get(nml.c_str());
+    fc = (TF1*)fIn_phi->Get(nmc.c_str());
+    fh = (TF1*)fIn_phi->Get(nmh.c_str());
+    if (fl == nullptr || fc == nullptr || fh == nullptr) {
+      if (verbosity_ > 0) {
+        LogTrace("L1TkMuMantra") << "... fit phi low  : " << fl << std::endl;
+        LogTrace("L1TkMuMantra") << "... fit phi cent : " << fc << std::endl;
+        LogTrace("L1TkMuMantra") << "... fit phi high : " << fh << std::endl;
+      }
+      throw cms::Exception("L1TkMuMantra") << "TF1 named " << nml << " or " << nmc << " or " << nmh
+                                           << " not found in file " << fIn_theta->GetName() << ".\n";
+    }
+    wdws_phi_.at(ib).SetName(wdn);
+    wdws_phi_.at(ib).SetLower(fl);
+    wdws_phi_.at(ib).SetCentral(fc);
+    wdws_phi_.at(ib).SetUpper(fh);
+  }
+}
+
+int L1TkMuMantra::findBin(double val) {
+  // FIXME: not the most efficient, nor the most elegant implementation for now
+  if (val < bounds_.at(0))
+    return 0;
+  if (val >= bounds_.back())
+    return (nbins_ - 1);  // i.e. bounds_size() -2
+
+  for (uint ib = 0; ib < bounds_.size() - 1; ++ib) {
+    if (val >= bounds_.at(ib) && val < bounds_.at(ib + 1))
+      return ib;
+  }
+
+  if (verbosity_ > 0)
+    LogTrace("L1TkMuMantra") << "Something strange happened at val " << val << std::endl;
+  return 0;
+}
+
+void L1TkMuMantra::test(double eta, double pt) {
+  int ibin = findBin(eta);
+
+  LogTrace("L1TkMuMantra") << " ---- eta : " << eta << " pt: " << pt << std::endl;
+  LogTrace("L1TkMuMantra") << " ---- bin " << ibin << std::endl;
+  LogTrace("L1TkMuMantra") << " ---- "
+                           << "- low_phi  : " << wdws_phi_.at(ibin).bound_low(pt)
+                           << "- cent_phi : " << wdws_phi_.at(ibin).bound_cent(pt)
+                           << "- high_phi : " << wdws_phi_.at(ibin).bound_high(pt) << std::endl;
+
+  LogTrace("L1TkMuMantra") << " ---- "
+                           << "- low_theta  : " << wdws_theta_.at(ibin).bound_low(pt)
+                           << "- cent_theta : " << wdws_theta_.at(ibin).bound_cent(pt)
+                           << "- high_theta : " << wdws_theta_.at(ibin).bound_high(pt) << std::endl;
+
+  return;
+}
+
+std::vector<int> L1TkMuMantra::find_match(const std::vector<track_df>& tracks, const std::vector<muon_df>& muons) {
+  std::vector<int> result(muons.size(), -1);  // init all TkMu to index -1
+  for (uint imu = 0; imu < muons.size(); ++imu) {
+    muon_df mu = muons.at(imu);
+    std::vector<std::pair<double, int>> matched_trks;  // sort_par, idx
+    for (uint itrk = 0; itrk < tracks.size(); ++itrk) {
+      // preselection of tracks
+      track_df trk = tracks.at(itrk);
+      if (trk.chi2 >= max_chi2)
+        continue;  // require trk.chi2 < max_chi2
+      if (trk.nstubs < min_nstubs)
+        continue;  // require trk.nstubs >= min_nstubs
+
+      // compute delta
+      // col_dphicharge = dataframe.loc[ : , 'trk_phi'].subtract(dataframe.loc[ : , phi_name]).multiply(dataframe.loc[ : , 'trk_charge']).apply(to_mpi_pi)
+      // col_dthetaendc = dataframe.loc[ : , theta_name].subtract(dataframe.loc[ : , 'trk_theta']).multiply(dataframe.loc[ : , etasign_name])
+
+      double dphi_charge = to_mpi_pi((trk.phi - mu.phi) * trk.charge);
+      // sign from theta, to avoid division by 0
+      double dtheta_endc = (mu.theta - trk.theta) * sign(mu.theta);
+      if (sign(mu.theta) != sign(trk.theta)) {
+        // crossing the barrel -> remove 180 deg to the theta of the neg candidate to avoid jumps at eta = 0
+        dtheta_endc -= TMath::Pi();
+      }
+
+      // lookup the values
+      int ibin = findBin(std::abs(trk.eta));
+
+      double phi_low = wdws_phi_.at(ibin).bound_low(trk.pt);
+      double phi_cent = wdws_phi_.at(ibin).bound_cent(trk.pt);
+      double phi_high = wdws_phi_.at(ibin).bound_high(trk.pt);
+      relax_windows(phi_low, phi_cent, phi_high);  // apply the safety factor
+      bool in_phi = (dphi_charge > phi_low && dphi_charge < phi_high);
+
+      double theta_low = wdws_theta_.at(ibin).bound_low(trk.pt);
+      double theta_cent = wdws_theta_.at(ibin).bound_cent(trk.pt);
+      double theta_high = wdws_theta_.at(ibin).bound_high(trk.pt);
+      relax_windows(theta_low, theta_cent, theta_high);  // apply the safety factor
+      bool in_theta = (dtheta_endc > theta_low && dtheta_endc < theta_high);
+
+      if (in_phi && in_theta) {
+        double sort_par = 99999;
+        if (sort_type_ == kMaxPt)
+          sort_par = trk.pt;
+        else if (sort_type_ == kMinDeltaPt) {
+          // trk.pt should always be > 0, but put this protection just in case
+          sort_par = (trk.pt > 0 ? std::abs(1. - (mu.pt / trk.pt)) : 0);
+        }
+        matched_trks.push_back(std::make_pair(sort_par, itrk));
+      }
+    }
+
+    // choose out of the matched tracks the best one
+    if (!matched_trks.empty()) {
+      sort(matched_trks.begin(), matched_trks.end());
+      int ibest = 99999;
+      if (sort_type_ == kMaxPt)
+        ibest = matched_trks.rbegin()->second;  // sorted low to high -> take last for highest pT (rbegin)
+      else if (sort_type_ == kMinDeltaPt)
+        ibest = matched_trks.begin()->second;  // sorted low to high -> take first for min pT distance (begin)
+      result.at(imu) = ibest;
+    }
+  }
+
+  return result;
+}
+
+void L1TkMuMantra::relax_windows(double& low, double cent, double& high) {
+  double delta_high = high - cent;
+  double delta_low = cent - low;
+
+  high = high + safety_factor_h_ * delta_high;
+  low = low - safety_factor_l_ * delta_low;
+
+  return;
+}
+
+void L1TkMuMantra::setArbitrationType(std::string type) {
+  if (verbosity_ > 0)
+    LogTrace("L1TkMuMantra") << "L1TkMuMantra : setting arbitration type to " << type << std::endl;
+  if (type == "MaxPt")
+    sort_type_ = kMaxPt;
+  else if (type == "MinDeltaPt")
+    sort_type_ = kMinDeltaPt;
+  else
+    throw cms::Exception("L1TkMuMantra") << "setArbitrationType : cannot understand the arbitration type passed.\n";
+}
+
+std::vector<double> L1TkMuMantra::prepare_corr_bounds(std::string fname, std::string hname) {
+  // find the boundaries of the match windoww
+  TFile* fIn = TFile::Open(fname.c_str());
+  TH2* h_test = (TH2*)fIn->Get(hname.c_str());
+  if (h_test == nullptr) {
+    throw cms::Exception("L1TkMuMantra") << "Can't find histo " << hname << " in file " << fname
+                                         << " to derive bounds.\n";
+  }
+
+  int nbds = h_test->GetNbinsY() + 1;
+  std::vector<double> bounds(nbds);
+  for (int ib = 0; ib < nbds; ++ib) {
+    bounds.at(ib) = h_test->GetYaxis()->GetBinLowEdge(ib + 1);
+  }
+  fIn->Close();
+  return bounds;
+}

--- a/L1Trigger/L1TTrackMatch/src/MuMatchWindow.cc
+++ b/L1Trigger/L1TTrackMatch/src/MuMatchWindow.cc
@@ -1,0 +1,40 @@
+#include "L1Trigger/L1TTrackMatch/interface/MuMatchWindow.h"
+
+MuMatchWindow::MuMatchWindow() { name_ = ""; }
+
+MuMatchWindow::MuMatchWindow(std::string name) { SetName(name); }
+
+MuMatchWindow::~MuMatchWindow() {}
+
+void MuMatchWindow::SetLower(std::string formula) {
+  TF1 f("tmp", formula.c_str(), 0, 1000);
+  SetLower(&f);
+}
+
+void MuMatchWindow::SetCentral(std::string formula) {
+  TF1 f("tmp", formula.c_str(), 0, 1000);
+  SetCentral(&f);
+}
+
+void MuMatchWindow::SetUpper(std::string formula) {
+  TF1 f("tmp", formula.c_str(), 0, 1000);
+  SetUpper(&f);
+}
+
+void MuMatchWindow::SetLower(TF1* formula) {
+  if (fLow_)
+    throw std::runtime_error("Cannot initialize twice fLow_");
+  fLow_ = std::shared_ptr<TF1>((TF1*)formula->Clone((name_ + std::string("low")).c_str()));
+}
+
+void MuMatchWindow::SetCentral(TF1* formula) {
+  if (fCent_)
+    throw std::runtime_error("Cannot initialize twice fCent_");
+  fCent_ = std::shared_ptr<TF1>((TF1*)formula->Clone((name_ + std::string("cent")).c_str()));
+}
+
+void MuMatchWindow::SetUpper(TF1* formula) {
+  if (fHigh_)
+    throw std::runtime_error("Cannot initialize twice fHigh_");
+  fHigh_ = std::shared_ptr<TF1>((TF1*)formula->Clone((name_ + std::string("high")).c_str()));
+}

--- a/L1Trigger/L1TTrackMatch/src/pTFrom2Stubs.cc
+++ b/L1Trigger/L1TTrackMatch/src/pTFrom2Stubs.cc
@@ -71,7 +71,7 @@ namespace pTFrom2Stubs {
   //====================
   float pTFrom2(std::vector<TTTrack<Ref_Phase2TrackerDigi_> >::const_iterator trk, const TrackerGeometry* tkGeometry) {
     float rinv = rInvFrom2(trk, tkGeometry);
-    return fabs(local_c_light * B_field / rinv);
+    return std::abs(local_c_light * B_field / rinv);
   }
   //====================
 }  // namespace pTFrom2Stubs

--- a/L1Trigger/L1TTrackMatch/src/pTFrom2Stubs.cc
+++ b/L1Trigger/L1TTrackMatch/src/pTFrom2Stubs.cc
@@ -1,0 +1,77 @@
+#include "L1Trigger/L1TTrackMatch/interface/pTFrom2Stubs.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "Geometry/CommonTopologies/interface/Topology.h"
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+static constexpr float local_c_light = 0.00299792;
+static constexpr float B_field = 3.8;
+
+namespace pTFrom2Stubs {
+
+  //====================
+  float rInvFrom2(std::vector<TTTrack<Ref_Phase2TrackerDigi_> >::const_iterator trk,
+                  const TrackerGeometry* tkGeometry) {
+    //vector of R, r and phi for each stub
+    std::vector<std::vector<float> > riPhiStubs(0);
+    //get stub reference
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+        vecStubRefs = trk->getStubRefs();
+
+    //loop over L1Track's stubs
+    int rsize = vecStubRefs.size();
+    for (int j = 0; j < rsize; ++j) {
+      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > stubRef =
+          vecStubRefs.at(j);
+      const TTStub<Ref_Phase2TrackerDigi_>* stub = &(*stubRef);
+      MeasurementPoint localPos = stub->clusterRef(0)->findAverageLocalCoordinates();
+
+      DetId detid = stub->clusterRef(0)->getDetId();
+
+      if (detid.det() != DetId::Detector::Tracker)
+        continue;
+      if (detid.subdetId() != StripSubdetector::TOB && detid.subdetId() != StripSubdetector::TID)
+        continue;
+      const GeomDet* geomDet = tkGeometry->idToDet(detid);
+      if (geomDet) {
+        const GeomDetUnit* gDetUnit = tkGeometry->idToDetUnit(detid);
+        GlobalPoint stubPosition = geomDet->surface().toGlobal(gDetUnit->topology().localPosition(localPos));
+
+        std::vector<float> tmp(0);
+        float Rad = sqrt(stubPosition.x() * stubPosition.x() + stubPosition.y() * stubPosition.y() + stubPosition.z() +
+                         stubPosition.z());
+        float r_i = sqrt(stubPosition.x() * stubPosition.x() + stubPosition.y() * stubPosition.y());
+        float phi_i = stubPosition.phi();
+
+        tmp.push_back(Rad);
+        tmp.push_back(r_i);
+        tmp.push_back(phi_i);
+
+        riPhiStubs.push_back(tmp);
+      }
+    }
+
+    std::sort(riPhiStubs.begin(), riPhiStubs.end());
+    //now calculate the curvature from first 2 stubs
+    float nr1 = (riPhiStubs[0])[1];
+    float nphi1 = (riPhiStubs[0])[2];
+
+    float nr2 = (riPhiStubs[1])[1];
+    float nphi2 = (riPhiStubs[1])[2];
+
+    float dPhi = reco::deltaPhi(nphi1, nphi2);
+
+    float ndist = sqrt(nr2 * nr2 + nr1 * nr1 - 2 * nr1 * nr2 * cos(dPhi));
+
+    float curvature = 2 * sin(dPhi) / ndist;
+    return curvature;
+  }
+  //====================
+  float pTFrom2(std::vector<TTTrack<Ref_Phase2TrackerDigi_> >::const_iterator trk, const TrackerGeometry* tkGeometry) {
+    float rinv = rInvFrom2(trk, tkGeometry);
+    return fabs(local_c_light * B_field / rinv);
+  }
+  //====================
+}  // namespace pTFrom2Stubs


### PR DESCRIPTION
supersedes #30204

#### PR description:

New Package for Phase2 L1TTrackMatch.  It contains producers for 
 - L1TkMuon
 - L1TkFastVertex
 - L1TkElectronTrackProducer
 - L1TkEmParticleProducer

```L1TkElectronTrackProducer``` is cloned and configured in different flavors to be a producer of L1 Electrons and  IsolatedElectrons
- L1TkElectronsCrystal has (barrel)
- L1TkElectronsEllipticMatchCrystal (barrel)
- L1TkElectronsLooseCrystal (barrel)
- L1TkIsoElectronsCrystal (barrel)
- L1TkElectronsHGC (endcap)
- L1TkElectronsEllipticMatchHGC (endcap)
- L1TkIsoElectronsHGC (endcap)
- L1TkElectronsLooseHGC (endcap)

```L1TkEmParticleProducer``` is cloned and configured in different flavors to be a producer of L1 Photons 
- L1TkPhotonsCrystal
- L1TkPhotonsHGC

```L1TkMuon``` depends on externals new datafiles in ```L1Trigger/L1TMuon/data``` which are pending PR.