### PR TITLE
Adding Online-Vs-Offline Track-level monitoring to DQM for BTV@HLT  

### DIFF
--- a/DQMOffline/Trigger/plugins/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/BTVHLTOfflineSource.cc
@@ -42,7 +42,6 @@
 #include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-
 #include "TMath.h"
 #include "TPRegexp.h"
 
@@ -54,15 +53,20 @@ public:
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  std::vector<const reco::Track*> getOfflineBTagTracks(float hltJetEta, float hltJetPhi, 
-  						       edm::Handle<edm::View<reco::BaseTagInfo> > offlineIPTagHandle, 
-						       std::vector<float>& offlineIP3D, std::vector<float>& offlineIP3DSig);
+  std::vector<const reco::Track*> getOfflineBTagTracks(float hltJetEta,
+                                                       float hltJetPhi,
+                                                       edm::Handle<edm::View<reco::BaseTagInfo>> offlineIPTagHandle,
+                                                       std::vector<float>& offlineIP3D,
+                                                       std::vector<float>& offlineIP3DSig);
 
-  typedef reco::TemplatedSecondaryVertexTagInfo<reco::CandIPTagInfo,reco::VertexCompositePtrCandidate> SVTagInfo;
+  typedef reco::TemplatedSecondaryVertexTagInfo<reco::CandIPTagInfo, reco::VertexCompositePtrCandidate> SVTagInfo;
 
   template <class Base>
-  std::vector<const reco::Track*> getOnlineBTagTracks(float hltJetEta, float hltJetPhi, edm::Handle <std::vector<Base> > jetSVTagsColl,
-						      std::vector<float>& onlineIP3D, std::vector<float>& onlineIP3DSig);
+  std::vector<const reco::Track*> getOnlineBTagTracks(float hltJetEta,
+                                                      float hltJetPhi,
+                                                      edm::Handle<std::vector<Base>> jetSVTagsColl,
+                                                      std::vector<float>& onlineIP3D,
+                                                      std::vector<float>& onlineIP3DSig);
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const& run, edm::EventSetup const& c) override;
 
@@ -72,7 +76,7 @@ private:
   std::string processname_;
   bool verbose_;
 
-  std::vector<std::pair<std::string, std::string> > custompathnamepairs_;
+  std::vector<std::pair<std::string, std::string>> custompathnamepairs_;
 
   edm::InputTag triggerSummaryLabel_;
   edm::InputTag triggerResultsLabel_;
@@ -85,23 +89,21 @@ private:
   edm::EDGetTokenT<reco::JetTagCollection> offlineDiscrTokenbb_;
   edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> offlineIPToken_;
 
-
-  edm::EDGetTokenT<std::vector<reco::Vertex> > hltFastPVToken_;
-  edm::EDGetTokenT<std::vector<reco::Vertex> > hltPFPVToken_;
-  edm::EDGetTokenT<std::vector<reco::Vertex> > hltCaloPVToken_;
-  edm::EDGetTokenT<std::vector<reco::Vertex> > offlinePVToken_;
+  edm::EDGetTokenT<std::vector<reco::Vertex>> hltFastPVToken_;
+  edm::EDGetTokenT<std::vector<reco::Vertex>> hltPFPVToken_;
+  edm::EDGetTokenT<std::vector<reco::Vertex>> hltCaloPVToken_;
+  edm::EDGetTokenT<std::vector<reco::Vertex>> offlinePVToken_;
 
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken;
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsFUToken;
   edm::EDGetTokenT<trigger::TriggerEvent> triggerSummaryToken;
   edm::EDGetTokenT<trigger::TriggerEvent> triggerSummaryFUToken;
 
-  edm::EDGetTokenT<std::vector<reco::ShallowTagInfo> > shallowTagInfosTokenCalo_;
-  edm::EDGetTokenT<std::vector<reco::ShallowTagInfo> > shallowTagInfosTokenPf_;
+  edm::EDGetTokenT<std::vector<reco::ShallowTagInfo>> shallowTagInfosTokenCalo_;
+  edm::EDGetTokenT<std::vector<reco::ShallowTagInfo>> shallowTagInfosTokenPf_;
 
-  edm::EDGetTokenT<std::vector<reco::SecondaryVertexTagInfo> > SVTagInfosTokenCalo_;
-  edm::EDGetTokenT<std::vector<SVTagInfo> > SVTagInfosTokenPf_;
-
+  edm::EDGetTokenT<std::vector<reco::SecondaryVertexTagInfo>> SVTagInfosTokenCalo_;
+  edm::EDGetTokenT<std::vector<SVTagInfo>> SVTagInfosTokenPf_;
 
   edm::EDGetTokenT<reco::JetTagCollection> caloTagsToken_;
   edm::EDGetTokenT<reco::JetTagCollection> pfTagsToken_;
@@ -216,12 +218,12 @@ BTVHLTOfflineSource::BTVHLTOfflineSource(const edm::ParameterSet& iConfig)
       offlineDiscrTokenb_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("offlineDiscrLabelb"))),
       offlineDiscrTokenbb_(
           consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("offlineDiscrLabelbb"))),
-      offlineIPToken_ (consumes<View<BaseTagInfo>>  (iConfig.getParameter<edm::InputTag>("offlineIPLabel"))),
+      offlineIPToken_(consumes<View<BaseTagInfo>>(iConfig.getParameter<edm::InputTag>("offlineIPLabel"))),
 
-      hltFastPVToken_(consumes<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("hltFastPVLabel"))),
-      hltPFPVToken_(consumes<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("hltPFPVLabel"))),
-      hltCaloPVToken_(consumes<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("hltCaloPVLabel"))),
-      offlinePVToken_(consumes<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("offlinePVLabel"))),
+      hltFastPVToken_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("hltFastPVLabel"))),
+      hltPFPVToken_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("hltPFPVLabel"))),
+      hltCaloPVToken_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("hltCaloPVLabel"))),
+      offlinePVToken_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("offlinePVLabel"))),
       triggerResultsToken(consumes<edm::TriggerResults>(triggerResultsLabel_)),
       triggerResultsFUToken(consumes<edm::TriggerResults>(
           edm::InputTag(triggerResultsLabel_.label(), triggerResultsLabel_.instance(), std::string("FU")))),
@@ -229,22 +231,20 @@ BTVHLTOfflineSource::BTVHLTOfflineSource(const edm::ParameterSet& iConfig)
       triggerSummaryFUToken(consumes<trigger::TriggerEvent>(
           edm::InputTag(triggerSummaryLabel_.label(), triggerSummaryLabel_.instance(), std::string("FU")))),
       shallowTagInfosTokenCalo_(
-          consumes<vector<reco::ShallowTagInfo> >(edm::InputTag("hltDeepCombinedSecondaryVertexBJetTagsInfosCalo"))),
+          consumes<vector<reco::ShallowTagInfo>>(edm::InputTag("hltDeepCombinedSecondaryVertexBJetTagsInfosCalo"))),
       shallowTagInfosTokenPf_(
-          consumes<vector<reco::ShallowTagInfo> >(edm::InputTag("hltDeepCombinedSecondaryVertexBJetTagsInfos"))),
-      SVTagInfosTokenCalo_(
-          consumes<std::vector<reco::SecondaryVertexTagInfo> >(edm::InputTag("hltInclusiveSecondaryVertexFinderTagInfos"))),
-      SVTagInfosTokenPf_(
-          consumes<std::vector<SVTagInfo> >(edm::InputTag("hltDeepSecondaryVertexTagInfosPF"))),
+          consumes<vector<reco::ShallowTagInfo>>(edm::InputTag("hltDeepCombinedSecondaryVertexBJetTagsInfos"))),
+      SVTagInfosTokenCalo_(consumes<std::vector<reco::SecondaryVertexTagInfo>>(
+          edm::InputTag("hltInclusiveSecondaryVertexFinderTagInfos"))),
+      SVTagInfosTokenPf_(consumes<std::vector<SVTagInfo>>(edm::InputTag("hltDeepSecondaryVertexTagInfosPF"))),
       caloTagsToken_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("onlineDiscrLabelCalo"))),
-      pfTagsToken_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("onlineDiscrLabelPF"))), 
+      pfTagsToken_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("onlineDiscrLabelPF"))),
       minDecayLength_(iConfig.getParameter<double>("minDecayLength")),
       maxDecayLength_(iConfig.getParameter<double>("maxDecayLength")),
       minJetDistance_(iConfig.getParameter<double>("minJetDistance")),
       maxJetDistance_(iConfig.getParameter<double>("maxJetDistance")),
-      dRTrackMatch_(iConfig.getParameter<double>("dRTrackMatch"))
-{
-  std::vector<edm::ParameterSet> paths = iConfig.getParameter<std::vector<edm::ParameterSet> >("pathPairs");
+      dRTrackMatch_(iConfig.getParameter<double>("dRTrackMatch")) {
+  std::vector<edm::ParameterSet> paths = iConfig.getParameter<std::vector<edm::ParameterSet>>("pathPairs");
   for (const auto& path : paths) {
     custompathnamepairs_.push_back(
         make_pair(path.getParameter<std::string>("pathname"), path.getParameter<std::string>("pathtype")));
@@ -307,8 +307,8 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
   Handle<reco::JetTagCollection> offlineJetTagHandlerbb;
   iEvent.getByToken(offlineDiscrTokenbb_, offlineJetTagHandlerbb);
 
-  Handle<View<BaseTagInfo> > offlineIPTagHandle;
-  iEvent.getByToken (offlineIPToken_, offlineIPTagHandle);
+  Handle<View<BaseTagInfo>> offlineIPTagHandle;
+  iEvent.getByToken(offlineIPToken_, offlineIPTagHandle);
 
   Handle<reco::VertexCollection> offlineVertexHandler;
   iEvent.getByToken(offlinePVToken_, offlineVertexHandler);
@@ -320,20 +320,19 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
   if (!triggerResults.isValid())
     return;
 
-  edm::Handle <std::vector<SVTagInfo> > jetSVTagsCollPF;
-  edm::Handle <std::vector<reco::SecondaryVertexTagInfo> > jetSVTagsCollCalo;
-    
-  for (auto& v : hltPathsAll_) {
+  edm::Handle<std::vector<SVTagInfo>> jetSVTagsCollPF;
+  edm::Handle<std::vector<reco::SecondaryVertexTagInfo>> jetSVTagsCollCalo;
 
+  for (auto& v : hltPathsAll_) {
     unsigned index = triggerNames.triggerIndex(v.getPath());
     if (!(index < triggerNames.size())) {
       continue;
     }
 
-    if(v.getTriggerType() == "PF"){
-      iEvent.getByToken (SVTagInfosTokenPf_, jetSVTagsCollPF);
-    }else{
-      iEvent.getByToken (SVTagInfosTokenCalo_, jetSVTagsCollCalo);
+    if (v.getTriggerType() == "PF") {
+      iEvent.getByToken(SVTagInfosTokenPf_, jetSVTagsCollPF);
+    } else {
+      iEvent.getByToken(SVTagInfosTokenCalo_, jetSVTagsCollCalo);
     }
 
     // PF and Calo btagging
@@ -354,7 +353,7 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
           float DR = reco::deltaR(iterOffb.first->eta(), iterOffb.first->phi(), iter->first->eta(), iter->first->phi());
           if (DR < 0.3) {
             float Discr_offline = iterOffb.second;
-	    
+
             // offline probb and probbb must be added (if probbb isn't specified, it'll just use probb)
             if (offlineJetTagHandlerbb.isValid()) {
               for (auto const& iterOffbb : *offlineJetTagHandlerbb) {
@@ -383,77 +382,89 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
             if (Discr_online > turnon_threshold_tight_)
               v.Discr_turnon_tight.numerator->Fill(Discr_offline);
 
-
-	    
             break;
           }
         }
-      }///offline
-      
-      
-      bool pfSVTagCollValid   = (v.getTriggerType() == "PF" && jetSVTagsCollPF.isValid());
+      }  ///offline
+
+      bool pfSVTagCollValid = (v.getTriggerType() == "PF" && jetSVTagsCollPF.isValid());
       bool caloSVTagCollValid = (v.getTriggerType() == "Calo" && jetSVTagsCollCalo.isValid());
-      if (offlineIPTagHandle.isValid() && ( pfSVTagCollValid || caloSVTagCollValid) ){
-	std::vector<float> offlineIP3D;  std::vector<float> offlineIP3DSig; 
-	std::vector<const reco::Track*> offlineTracks = getOfflineBTagTracks(iter->first->eta(), iter->first->phi(), offlineIPTagHandle, offlineIP3D, offlineIP3DSig);
-	std::vector<const reco::Track*> onlineTracks;  std::vector<float> onlineIP3D;  std::vector<float> onlineIP3DSig; 
-	if(pfSVTagCollValid)    onlineTracks = getOnlineBTagTracks<SVTagInfo>(iter->first->eta(), iter->first->phi(), jetSVTagsCollPF, onlineIP3D, onlineIP3DSig);
-	if(caloSVTagCollValid)  onlineTracks = getOnlineBTagTracks<reco::SecondaryVertexTagInfo>(iter->first->eta(), iter->first->phi(), jetSVTagsCollCalo, onlineIP3D, onlineIP3DSig);
+      if (offlineIPTagHandle.isValid() && (pfSVTagCollValid || caloSVTagCollValid)) {
+        std::vector<float> offlineIP3D;
+        std::vector<float> offlineIP3DSig;
+        std::vector<const reco::Track*> offlineTracks = getOfflineBTagTracks(
+            iter->first->eta(), iter->first->phi(), offlineIPTagHandle, offlineIP3D, offlineIP3DSig);
+        std::vector<const reco::Track*> onlineTracks;
+        std::vector<float> onlineIP3D;
+        std::vector<float> onlineIP3DSig;
+        if (pfSVTagCollValid)
+          onlineTracks = getOnlineBTagTracks<SVTagInfo>(
+              iter->first->eta(), iter->first->phi(), jetSVTagsCollPF, onlineIP3D, onlineIP3DSig);
+        if (caloSVTagCollValid)
+          onlineTracks = getOnlineBTagTracks<reco::SecondaryVertexTagInfo>(
+              iter->first->eta(), iter->first->phi(), jetSVTagsCollCalo, onlineIP3D, onlineIP3DSig);
 
-	for(unsigned int iOffTrk = 0; iOffTrk < offlineTracks.size(); ++iOffTrk){
-	  const reco::Track* offTrk = offlineTracks.at(iOffTrk);
-	  bool hasMatch = false;
-	  float offTrkEta = offTrk->eta();
-	  float offTrkPhi = offTrk->phi();
+        for (unsigned int iOffTrk = 0; iOffTrk < offlineTracks.size(); ++iOffTrk) {
+          const reco::Track* offTrk = offlineTracks.at(iOffTrk);
+          bool hasMatch = false;
+          float offTrkEta = offTrk->eta();
+          float offTrkPhi = offTrk->phi();
 
-	  for(const reco::Track* onTrk : onlineTracks){	  
-	    float DR = reco::deltaR(offTrkEta, offTrkPhi, onTrk->eta(), onTrk->phi());
-	    if (DR < dRTrackMatch_) {
-	      hasMatch = true;
-	    }
-	  }
+          for (const reco::Track* onTrk : onlineTracks) {
+            float DR = reco::deltaR(offTrkEta, offTrkPhi, onTrk->eta(), onTrk->phi());
+            if (DR < dRTrackMatch_) {
+              hasMatch = true;
+            }
+          }
 
-	  float offTrkPt = offTrk->pt();
-	  v.OnlineTrkEff_Pt.denominator->Fill(offTrkPt);
-	  if(hasMatch) v.OnlineTrkEff_Pt.numerator->Fill(offTrkPt);
+          float offTrkPt = offTrk->pt();
+          v.OnlineTrkEff_Pt.denominator->Fill(offTrkPt);
+          if (hasMatch)
+            v.OnlineTrkEff_Pt.numerator->Fill(offTrkPt);
 
-	  v.OnlineTrkEff_Eta.denominator->Fill(offTrkEta);
-	  if(hasMatch) v.OnlineTrkEff_Eta.numerator->Fill(offTrkEta);
+          v.OnlineTrkEff_Eta.denominator->Fill(offTrkEta);
+          if (hasMatch)
+            v.OnlineTrkEff_Eta.numerator->Fill(offTrkEta);
 
-	  v.OnlineTrkEff_3d_ip_distance.denominator->Fill(offlineIP3D.at(iOffTrk));
-	  if(hasMatch) v.OnlineTrkEff_3d_ip_distance.numerator->Fill(offlineIP3D.at(iOffTrk));
+          v.OnlineTrkEff_3d_ip_distance.denominator->Fill(offlineIP3D.at(iOffTrk));
+          if (hasMatch)
+            v.OnlineTrkEff_3d_ip_distance.numerator->Fill(offlineIP3D.at(iOffTrk));
 
-	  v.OnlineTrkEff_3d_ip_sig.denominator->Fill(offlineIP3DSig.at(iOffTrk));
-	  if(hasMatch) v.OnlineTrkEff_3d_ip_sig.numerator->Fill(offlineIP3DSig.at(iOffTrk));
-	}
-	
-	for(unsigned int iOnTrk = 0; iOnTrk < onlineTracks.size(); ++iOnTrk){
-	  const reco::Track* onTrk = onlineTracks.at(iOnTrk);
-	  bool hasMatch = false;
-	  float onTrkEta = onTrk->eta();
-	  float onTrkPhi = onTrk->phi();
+          v.OnlineTrkEff_3d_ip_sig.denominator->Fill(offlineIP3DSig.at(iOffTrk));
+          if (hasMatch)
+            v.OnlineTrkEff_3d_ip_sig.numerator->Fill(offlineIP3DSig.at(iOffTrk));
+        }
 
-	  for(const reco::Track* offTrk : offlineTracks){	  
-	    float DR = reco::deltaR(onTrkEta, onTrkPhi, offTrk->eta(), offTrk->phi());
-	    if (DR < dRTrackMatch_) {
-	      hasMatch = true;
-	    }
-	  }
+        for (unsigned int iOnTrk = 0; iOnTrk < onlineTracks.size(); ++iOnTrk) {
+          const reco::Track* onTrk = onlineTracks.at(iOnTrk);
+          bool hasMatch = false;
+          float onTrkEta = onTrk->eta();
+          float onTrkPhi = onTrk->phi();
 
-	  float onTrkPt = onTrk->pt();
-	  v.OnlineTrkFake_Pt.denominator->Fill(onTrkPt);
-	  if(!hasMatch) v.OnlineTrkFake_Pt.numerator->Fill(onTrkPt);
+          for (const reco::Track* offTrk : offlineTracks) {
+            float DR = reco::deltaR(onTrkEta, onTrkPhi, offTrk->eta(), offTrk->phi());
+            if (DR < dRTrackMatch_) {
+              hasMatch = true;
+            }
+          }
 
-	  v.OnlineTrkFake_Eta.denominator->Fill(onTrkEta);
-	  if(!hasMatch) v.OnlineTrkFake_Eta.numerator->Fill(onTrkEta);
-	  
-	  v.OnlineTrkFake_3d_ip_distance.denominator->Fill(onlineIP3D.at(iOnTrk));
-	  if(!hasMatch) v.OnlineTrkFake_3d_ip_distance.numerator->Fill(onlineIP3D.at(iOnTrk));
+          float onTrkPt = onTrk->pt();
+          v.OnlineTrkFake_Pt.denominator->Fill(onTrkPt);
+          if (!hasMatch)
+            v.OnlineTrkFake_Pt.numerator->Fill(onTrkPt);
 
-	  v.OnlineTrkFake_3d_ip_sig.denominator->Fill(onlineIP3DSig.at(iOnTrk));
-	  if(!hasMatch) v.OnlineTrkFake_3d_ip_sig.numerator->Fill(onlineIP3DSig.at(iOnTrk));
-	}
+          v.OnlineTrkFake_Eta.denominator->Fill(onTrkEta);
+          if (!hasMatch)
+            v.OnlineTrkFake_Eta.numerator->Fill(onTrkEta);
 
+          v.OnlineTrkFake_3d_ip_distance.denominator->Fill(onlineIP3D.at(iOnTrk));
+          if (!hasMatch)
+            v.OnlineTrkFake_3d_ip_distance.numerator->Fill(onlineIP3D.at(iOnTrk));
+
+          v.OnlineTrkFake_3d_ip_sig.denominator->Fill(onlineIP3DSig.at(iOnTrk));
+          if (!hasMatch)
+            v.OnlineTrkFake_3d_ip_sig.numerator->Fill(onlineIP3DSig.at(iOnTrk));
+        }
       }
 
       if (v.getTriggerType() == "PF") {
@@ -467,8 +478,8 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
           v.PVz_HLTMinusRECO->Fill(VertexHandler->begin()->z() - offlineVertexHandler->begin()->z());
         }
       }
-    }// caloTagsValid
-    
+    }  // caloTagsValid
+
     // specific to Calo b-tagging
     if (caloTags.isValid() && v.getTriggerType() == "Calo" && !caloTags->empty()) {
       iEvent.getByToken(hltCaloPVToken_, VertexHandler);
@@ -483,13 +494,11 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
     // additional plots from tag info collections
     /////////////////////////////////////////////
 
-    edm::Handle<std::vector<reco::ShallowTagInfo> > shallowTagInfosCalo;
+    edm::Handle<std::vector<reco::ShallowTagInfo>> shallowTagInfosCalo;
     iEvent.getByToken(shallowTagInfosTokenCalo_, shallowTagInfosCalo);
 
-    edm::Handle<std::vector<reco::ShallowTagInfo> > shallowTagInfosPf;
+    edm::Handle<std::vector<reco::ShallowTagInfo>> shallowTagInfosPf;
     iEvent.getByToken(shallowTagInfosTokenPf_, shallowTagInfosPf);
-
-	
 
     //    edm::Handle<std::vector<reco::TemplatedSecondaryVertexTagInfo<reco::IPTagInfo<edm::RefVector<std::vector<reco::Track>, reco::Track, edm::refhelper::FindUsingAdvance<std::vector<reco::Track>, reco::Track> >, reco::JTATagInfo>, reco::Vertex> > > caloTagInfos;
     //    iEvent.getByToken(caloTagInfosToken_, caloTagInfos);
@@ -531,7 +540,6 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
           v.n_vtx_trks->Fill(tagVar);
         }
 
-      
         // // track N total/pixel hits
         // for (const auto & tagVar : tagVars.getList(reco::btau::trackNPixelHits, false)) {
         //   v.n_pixel_hits->Fill(tagVar);}
@@ -539,7 +547,7 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
         //   v.n_total_hits->Fill(tagVar);}
       }
     }
-        
+
     // ... otherwise from usual tag infos.
     // else
     // if (   (v.getTriggerType() == "PF"   && pfTagInfos.isValid())
@@ -575,30 +583,33 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
     //     }
     //   }
     // }
-  }  
+  }
 }
 
-std::vector<const reco::Track*> BTVHLTOfflineSource::getOfflineBTagTracks(float hltJetEta, float hltJetPhi, 
-									  Handle<View<BaseTagInfo> > offlineIPTagHandle,
-									  std::vector<float>& offlineIP3D, std::vector<float>& offlineIP3DSig){
+std::vector<const reco::Track*> BTVHLTOfflineSource::getOfflineBTagTracks(float hltJetEta,
+                                                                          float hltJetPhi,
+                                                                          Handle<View<BaseTagInfo>> offlineIPTagHandle,
+                                                                          std::vector<float>& offlineIP3D,
+                                                                          std::vector<float>& offlineIP3DSig) {
   std::vector<const reco::Track*> offlineTracks;
-
 
   for (auto const& iterOffIP : *offlineIPTagHandle) {
     float DR = reco::deltaR(iterOffIP.jet()->eta(), iterOffIP.jet()->phi(), hltJetEta, hltJetPhi);
 
-    if (DR > 0.3) continue;
-           	    
-    const reco::IPTagInfo<vector<reco::CandidatePtr>, reco::JetTagInfo>* tagInfo = dynamic_cast<const reco::IPTagInfo<vector<reco::CandidatePtr>, reco::JetTagInfo>*>(&iterOffIP);
-      
+    if (DR > 0.3)
+      continue;
+
+    const reco::IPTagInfo<vector<reco::CandidatePtr>, reco::JetTagInfo>* tagInfo =
+        dynamic_cast<const reco::IPTagInfo<vector<reco::CandidatePtr>, reco::JetTagInfo>*>(&iterOffIP);
+
     if (!tagInfo) {
       throw cms::Exception("Configuration")
-      	<< "BTagPerformanceAnalyzer: Extended TagInfo not of type TrackIPTagInfo. " << std::endl;
+          << "BTagPerformanceAnalyzer: Extended TagInfo not of type TrackIPTagInfo. " << std::endl;
     }
 
     const GlobalPoint pv(tagInfo->primaryVertex()->position().x(),
-			 tagInfo->primaryVertex()->position().y(),
-			 tagInfo->primaryVertex()->position().z());
+                         tagInfo->primaryVertex()->position().y(),
+                         tagInfo->primaryVertex()->position().z());
 
     const std::vector<reco::btag::TrackIPData>& ip = tagInfo->impactParameterData();
 
@@ -610,42 +621,44 @@ std::vector<const reco::Track*> BTVHLTOfflineSource::getOfflineBTagTracks(float 
       double decayLength = (ip[sortedIndices[n]].closestToJetAxis - pv).mag();
       double jetDistance = ip[sortedIndices[n]].distanceToJetAxis.value();
       if (decayLength > minDecayLength_ && decayLength < maxDecayLength_ && fabs(jetDistance) >= minJetDistance_ &&
-	  fabs(jetDistance) < maxJetDistance_) {
-	selectedIndices.push_back(sortedIndices[n]);
-	selectedTracks.push_back(sortedTracks[n]);
+          fabs(jetDistance) < maxJetDistance_) {
+        selectedIndices.push_back(sortedIndices[n]);
+        selectedTracks.push_back(sortedTracks[n]);
       }
     }
 
     for (unsigned int n = 0; n != selectedIndices.size(); ++n) {
       const reco::Track* track = reco::btag::toTrack(selectedTracks[n]);
-      offlineTracks .push_back(track);
-      offlineIP3D   .push_back(ip[n].ip3d.value());
+      offlineTracks.push_back(track);
+      offlineIP3D.push_back(ip[n].ip3d.value());
       offlineIP3DSig.push_back(ip[n].ip3d.significance());
     }
-
   }
   return offlineTracks;
 }
 
-template<class Base>
-std::vector<const reco::Track*> BTVHLTOfflineSource::getOnlineBTagTracks(float hltJetEta, float hltJetPhi, edm::Handle <std::vector<Base> > jetSVTagsColl, std::vector<float>& onlineIP3D, std::vector<float>& onlineIP3DSig){
+template <class Base>
+std::vector<const reco::Track*> BTVHLTOfflineSource::getOnlineBTagTracks(float hltJetEta,
+                                                                         float hltJetPhi,
+                                                                         edm::Handle<std::vector<Base>> jetSVTagsColl,
+                                                                         std::vector<float>& onlineIP3D,
+                                                                         std::vector<float>& onlineIP3DSig) {
   std::vector<const reco::Track*> onlineTracks;
 
-  for(auto iterTI = jetSVTagsColl->begin(); iterTI != jetSVTagsColl->end(); ++iterTI) {
-
+  for (auto iterTI = jetSVTagsColl->begin(); iterTI != jetSVTagsColl->end(); ++iterTI) {
     float DR = reco::deltaR(iterTI->jet()->eta(), iterTI->jet()->phi(), hltJetEta, hltJetPhi);
-    if (DR > 0.3) continue;
+    if (DR > 0.3)
+      continue;
 
-    const auto & ipInfo = *(iterTI->trackIPTagInfoRef().get());
+    const auto& ipInfo = *(iterTI->trackIPTagInfoRef().get());
     const std::vector<reco::btag::TrackIPData>& ip = ipInfo.impactParameterData();
 
-
     unsigned int trackSize = ipInfo.selectedTracks().size();
-    for (unsigned int itt=0; itt < trackSize; ++itt){
-      const auto ptrackRef = (ipInfo.selectedTracks()[itt]); //TrackRef or 
-      const reco::Track * ptrackPtr = reco::btag::toTrack(ptrackRef);
-      onlineTracks .push_back(ptrackPtr);
-      onlineIP3D   .push_back(ip[itt].ip3d.value());
+    for (unsigned int itt = 0; itt < trackSize; ++itt) {
+      const auto ptrackRef = (ipInfo.selectedTracks()[itt]);  //TrackRef or
+      const reco::Track* ptrackPtr = reco::btag::toTrack(ptrackRef);
+      onlineTracks.push_back(ptrackPtr);
+      onlineIP3D.push_back(ip[itt].ip3d.value());
       onlineIP3DSig.push_back(ip[itt].ip3d.significance());
     }
   }

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
@@ -18,9 +18,16 @@ BTVHLTOfflineSource = DQMEDAnalyzer("BTVHLTOfflineSource",
     hltPFPVLabel            = cms.InputTag("hltVerticesPFSelector"),
     hltCaloPVLabel          = cms.InputTag("hltVerticesL3"),
     offlinePVLabel          = cms.InputTag("offlinePrimaryVertices"),
+    offlineIPLabel          = cms.InputTag("pfImpactParameterTagInfos"),
     turnon_threshold_loose  = cms.double(0.2),
     turnon_threshold_medium = cms.double(0.5),
     turnon_threshold_tight  = cms.double(0.8),
+    minDecayLength          = cms.double(-9999.0),
+    maxDecayLength          = cms.double(5.0),
+    minJetDistance          = cms.double(0.0),
+    maxJetDistance          = cms.double(0.07),
+    dRTrackMatch            = cms.double(0.01),
+
 
     pathPairs = cms.VPSet(
 

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
@@ -190,9 +190,45 @@ BTVEfficiency_TurnOnCurves = DQMEDHarvester("DQMGenericClient",
     ),
 )
 
+
+BTVEfficiency_OnlineTrackEff = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring(
+        "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5*",
+        "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5*",
+        "HLT/BTV/HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94*",
+    ),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "OnlineTrkEff_Pt   'Relative Online Track Eff vs Pt;Pt;relative efficiency'   OnlineTrkEff_Pt_numerator   OnlineTrkEff_Pt_denominator",
+        "OnlineTrkEff_Eta  'Relative Online Track Eff vs Eta;Eta;relative efficiency' OnlineTrkEff_Eta_numerator   OnlineTrkEff_Eta_denominator",
+        "OnlineTrkEff_3d_ip_distance  'Relative Online Track Eff vs IP3D;IP3D;relative efficiency' OnlineTrkEff_3d_ip_distance_numerator   OnlineTrkEff_3d_ip_distance_denominator",
+        "OnlineTrkEff_3d_ip_sig  'Relative Online Track Eff vs IP3D signifance;IP3D significance;relative efficiency' OnlineTrkEff_3d_ip_sig_numerator   OnlineTrkEff_3d_ip_sig_denominator",
+    ),
+)
+
+BTVEfficiency_OnlineTrackFake = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring(
+        "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5*",
+        "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5*",
+        "HLT/BTV/HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94*",
+    ),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "OnlineTrkFake_Pt   'Relative Online Fake Rate vs Pt;Pt;relative fake rate'   OnlineTrkFake_Pt_numerator   OnlineTrkFake_Pt_denominator",
+        "OnlineTrkFake_Eta  'Relative Online Fake Rate vs Eta;Eta;relative fake rate' OnlineTrkFake_Eta_numerator   OnlineTrkFake_Eta_denominator",
+        "OnlineTrkFake_3d_ip_distance  'Relative Online Fake Rate vs IP3D;IP3D;relative fake rate' OnlineTrkFake_3d_ip_distance_numerator   OnlineTrkFake_3d_ip_distance_denominator",
+        "OnlineTrkFake_3d_ip_sig  'Relative Online Fake Rate vs IP3D signifance;IP3D significance;relative fake rate' OnlineTrkFake_3d_ip_sig_numerator   OnlineTrkFake_3d_ip_sig_denominator",
+    ),
+)
+
+
 btaggingClient = cms.Sequence(
 
     BTVEfficiency_TurnOnCurves
+  + BTVEfficiency_OnlineTrackEff
+  + BTVEfficiency_OnlineTrackFake
   + BTVEfficiency_BTagMu_DiJet
   + BTVEfficiency_BTagMu_Jet
   + BTVEfficiency_BTagDiMu_Jet

--- a/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
@@ -744,13 +744,7 @@ HLTDebugFEVT  = cms.PSet(
         'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*',
         'keep *_hltScoutingPrimaryVertexPacker_*_*',
         'keep *_hltScoutingTrackPacker_*_*',
-        'keep edmTriggerResults_*_*_*',
-        'keep *_hltImpactParameterTagInfos_*_*', 
-        'keep *_hltDeepBLifetimeTagInfosPF_*_*', 
-        'keep *_hltDeepSecondaryVertexTagInfosPF_*_*', 
-        'keep *_hltInclusiveSecondaryVertexFinderTagInfos_*_*',
-        'keep *_hltMergedTracksForBTag_*_*',
-        'keep *_hltFastPixelBLifetimeL3Associator_*_*', 
+        'keep edmTriggerResults_*_*_*'
     ) )
 )
 

--- a/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
@@ -744,7 +744,13 @@ HLTDebugFEVT  = cms.PSet(
         'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*',
         'keep *_hltScoutingPrimaryVertexPacker_*_*',
         'keep *_hltScoutingTrackPacker_*_*',
-        'keep edmTriggerResults_*_*_*'
+        'keep edmTriggerResults_*_*_*',
+        'keep *_hltImpactParameterTagInfos_*_*', 
+        'keep *_hltDeepBLifetimeTagInfosPF_*_*', 
+        'keep *_hltDeepSecondaryVertexTagInfosPF_*_*', 
+        'keep *_hltInclusiveSecondaryVertexFinderTagInfos_*_*',
+        'keep *_hltMergedTracksForBTag_*_*',
+        'keep *_hltFastPixelBLifetimeL3Associator_*_*', 
     ) )
 )
 


### PR DESCRIPTION

#### PR description:

Adding Relative Online-Offline Track Efficiencies and Fake rates to the BTVHLTOffline DQM Monitoring

This commit:
  - Adds 16 histograms in BTVHLTOfflineSource:  2 (efficiencies and fake rates) x 4 variables (pt / eta / ip3d / ip3dSig) x 2 (numerator / denominator)
  - Adds logic to retrieve online and offline tracks and fill numerator/denominator hists
  - Adds Harvesting configuration to make the ratios

To the products needed in the step2 input I add the following output lines to HLTDebugFEVT
in HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
(This change in NOT included in this commit)
+        'keep *_hltImpactParameterTagInfos_*_*',
+        'keep *_hltDeepBLifetimeTagInfosPF_*_*',
+        'keep *_hltDeepSecondaryVertexTagInfosPF_*_*',
+        'keep *_hltInclusiveSecondaryVertexFinderTagInfos_*_*',
+        'keep *_hltMergedTracksForBTag_*_*',
+        'keep *_hltFastPixelBLifetimeL3Associator_*_*',


#### PR validation:

Standard runTheMaxtrix and look at the DQM plots produced

