### PR TITLE
Add all direct deps to BuildFile for Alignment/LaserAlignment

### DIFF
--- a/Alignment/LaserAlignment/BuildFile.xml
+++ b/Alignment/LaserAlignment/BuildFile.xml
@@ -2,6 +2,9 @@
 <use name="FWCore/Utilities"/>
 <use name="Alignment/CommonAlignment"/>
 <use name="Alignment/TrackerAlignment"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/TrackingRecHit"/>
+<use name="TrackingTools/TrajectoryState"/>
 <use name="clhepheader"/>
 <use name="rootcore"/>
 <use name="rootminuit"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.