### PR TITLE
Add all direct deps to BuildFile for AnalysisDataFormats/SUSYBSMObjects

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/BuildFile.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/BuildFile.xml
@@ -2,6 +2,9 @@
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/CSCRecHit"/>
 <use name="DataFormats/DTRecHit"/>
+<use name="DataFormats/EcalRecHit"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/TrackReco"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.