### PR TITLE
Add all direct deps to BuildFile for AnalysisDataFormats/TopObjects

### DIFF
--- a/AnalysisDataFormats/TopObjects/BuildFile.xml
+++ b/AnalysisDataFormats/TopObjects/BuildFile.xml
@@ -3,6 +3,10 @@
 <use name="DataFormats/PatCandidates"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="CommonTools/CandUtils"/>
+<use name="CommonTools/Utils"/>
+<use name="DataFormats/Candidate"/>
+<use name="DataFormats/Math"/>
+<use name="FWCore/MessageLogger"/>
 <use name="root"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.