### PR TITLE
Add all direct deps to BuildFile for AnalysisDataFormats/TrackInfo

### DIFF
--- a/AnalysisDataFormats/TrackInfo/BuildFile.xml
+++ b/AnalysisDataFormats/TrackInfo/BuildFile.xml
@@ -6,6 +6,9 @@
 <use name="DataFormats/TrajectoryState"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
 <use name="FWCore/MessageLogger"/>
+<use name="DataFormats/BeamSpot"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/Math"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.