### PR TITLE
Add all direct deps to BuildFile for CalibCalorimetry/EcalLaserAnalyzer

### DIFF
--- a/CalibCalorimetry/EcalLaserAnalyzer/BuildFile.xml
+++ b/CalibCalorimetry/EcalLaserAnalyzer/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="root"/>
+<use name="FWCore/MessageLogger"/>
 <use name="rootgraphics"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.