### PR TITLE
Add all direct deps to BuildFile for CalibFormats/CaloObjects

### DIFF
--- a/CalibFormats/CaloObjects/BuildFile.xml
+++ b/CalibFormats/CaloObjects/BuildFile.xml
@@ -1,4 +1,6 @@
 <use name="DataFormats/DetId"/>
+<use name="DataFormats/Common"/>
+<use name="FWCore/MessageLogger"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.