### PR TITLE
Add all direct deps to BuildFile for CalibTracker/SiPixelQuality

### DIFF
--- a/CalibTracker/SiPixelQuality/BuildFile.xml
+++ b/CalibTracker/SiPixelQuality/BuildFile.xml
@@ -1,6 +1,9 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/SiPixelDetId"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Provenance"/>
+<use name="FWCore/MessageLogger"/>
 <use name="clhep"/>
 <use name="root"/>
 <export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.