### PR TITLE
Add all direct deps to BuildFile for Calibration/HcalCalibAlgos

### DIFF
--- a/Calibration/HcalCalibAlgos/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/BuildFile.xml
@@ -13,6 +13,12 @@
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="Geometry/Records"/>
 <use name="CondTools/Hcal"/>
+<use name="Calibration/Tools"/>
+<use name="DataFormats/EcalRecHit"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="Geometry/CaloGeometry"/>
+<use name="Geometry/CaloTopology"/>
+<use name="Utilities/Xerces"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.