### PR TITLE
Add all direct deps to BuildFile for CondCore/Utilities

### DIFF
--- a/CondCore/Utilities/BuildFile.xml
+++ b/CondCore/Utilities/BuildFile.xml
@@ -32,6 +32,10 @@
 <use name="CondFormats/PCLConfig"/>
 <use name="CondFormats/SiPhase2TrackerObjects"/>
 <use name="CondFormats/PPSObjects"/>
+<use name="CondFormats/External"/>
+<use name="CondFormats/Serialization"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
 <use name="rootgraphics"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.