### PR TITLE
Add all direct deps to BuildFile for CondFormats/HLTObjects

### DIFF
--- a/CondFormats/HLTObjects/BuildFile.xml
+++ b/CondFormats/HLTObjects/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/HLTReco"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
+<use name="CondFormats/External"/>
 <use name="boost_serialization"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.