### PR TITLE
Add all direct deps to BuildFile for CondFormats/SiPixelObjects

### DIFF
--- a/CondFormats/SiPixelObjects/BuildFile.xml
+++ b/CondFormats/SiPixelObjects/BuildFile.xml
@@ -8,6 +8,15 @@
 <use name="CondFormats/SiStripObjects"/>
 <use name="root"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
+<use name="CondFormats/External"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/ParameterSet"/>
+<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
+<use name="Geometry/Records"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.