### PR TITLE
Add all direct deps to BuildFile for CondFormats/SiStripObjects

### DIFF
--- a/CondFormats/SiStripObjects/BuildFile.xml
+++ b/CondFormats/SiStripObjects/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="DataFormats/SiStripDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="DataFormats/DetId"/>
 <use name="clhep"/>
 <use name="boost"/>
 <use name="boost_serialization"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.