### PR TITLE
Add all direct deps to BuildFile for DPGAnalysis/SiStripTools

### DIFF
--- a/DPGAnalysis/SiStripTools/BuildFile.xml
+++ b/DPGAnalysis/SiStripTools/BuildFile.xml
@@ -25,6 +25,7 @@
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="TrackingTools/TrajectoryState"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>
+<use name="DataFormats/Math"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.