### PR TITLE
Add all direct deps to BuildFile for EgammaAnalysis/ElectronTools

### DIFF
--- a/EgammaAnalysis/ElectronTools/BuildFile.xml
+++ b/EgammaAnalysis/ElectronTools/BuildFile.xml
@@ -12,6 +12,16 @@
 <use name="DataFormats/TrackReco"/>
 <use name="TrackingTools/IPTools"/>
 <use name="RecoEgamma/EgammaTools"/>
+<use name="DataFormats/EcalDetId"/>
+<use name="DataFormats/EcalRecHit"/>
+<use name="DataFormats/GsfTrackReco"/>
+<use name="DataFormats/Math"/>
+<use name="DataFormats/MuonReco"/>
+<use name="DataFormats/ParticleFlowCandidate"/>
+<use name="DataFormats/RecoCandidate"/>
+<use name="DataFormats/VertexReco"/>
+<use name="Geometry/CaloGeometry"/>
+<use name="TrackingTools/TransientTrack"/>
 <use name="clhep"/>
 <use name="root"/>
 <use name="rootcore"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.