### PR TITLE
Add all direct deps to BuildFile for EventFilter/GEMRawToDigi

### DIFF
--- a/EventFilter/GEMRawToDigi/BuildFile.xml
+++ b/EventFilter/GEMRawToDigi/BuildFile.xml
@@ -7,6 +7,9 @@
 <use name="FWCore/MessageLogger"/>
 <use name="Utilities/StorageFactory"/>
 <use name="FWCore/Sources"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/MuonData"/>
+<use name="DataFormats/MuonDetId"/>
 <use name="rootrflx"/>
 <use name="boost"/>
 <use name="root"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.