### PR TITLE
Add all direct deps to BuildFile for FastSimDataFormats/CTPPSFastSim

### DIFF
--- a/FastSimDataFormats/CTPPSFastSim/BuildFile.xml
+++ b/FastSimDataFormats/CTPPSFastSim/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/Math"/>
+<use name="DataFormats/DetId"/>
 <use name="root"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.