### PR TITLE
Add all direct deps to BuildFile for FastSimDataFormats/External

### DIFF
--- a/FastSimDataFormats/External/BuildFile.xml
+++ b/FastSimDataFormats/External/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/DetId"/>
+<use name="DataFormats/GeometryVector"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.