### PR TITLE
Add all direct deps to BuildFile for Fireworks/Core

### DIFF
--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -17,6 +17,11 @@
 <use name="FWCore/Utilities"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <use name="Fireworks/TableWidget"/>
+<use name="DataFormats/BeamSpot"/>
+<use name="DataFormats/Provenance"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/Reflection"/>
 <use name="boost"/>
 <use name="boost_program_options"/>
 <use name="boost_regex"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.