### PR TITLE
Add all direct deps to BuildFile for Fireworks/FWInterface

### DIFF
--- a/Fireworks/FWInterface/BuildFile.xml
+++ b/Fireworks/FWInterface/BuildFile.xml
@@ -17,6 +17,13 @@
 <use name="rootx11"/>
 <use name="boost_python"/>
 <use name="FWCore/PythonParameterSet"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/FWLite"/>
+<use name="FWCore/Common"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Utilities"/>
+<use name="Fireworks/TableWidget"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.