### PR TITLE
Add all direct deps to BuildFile for MuonAnalysis/MomentumScaleCalibration

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/BuildFile.xml
+++ b/MuonAnalysis/MomentumScaleCalibration/BuildFile.xml
@@ -8,6 +8,10 @@
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="CondFormats/RecoMuonObjects"/>
+<use name="DataFormats/HepMCCandidate"/>
+<use name="DataFormats/Math"/>
+<use name="DataFormats/MuonReco"/>
+<use name="FWCore/MessageLogger"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.