### PR TITLE
Add all direct deps to BuildFile for PhysicsTools/FWLite

### DIFF
--- a/PhysicsTools/FWLite/BuildFile.xml
+++ b/PhysicsTools/FWLite/BuildFile.xml
@@ -5,6 +5,10 @@
 <use name="DataFormats/FWLite"/>
 <use name="DataFormats/PatCandidates"/>
 <use name="PhysicsTools/SelectorUtils"/>
+<use name="DataFormats/Common"/>
+<use name="FWCore/FWLite"/>
+<use name="FWCore/Reflection"/>
+<use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.