### PR TITLE
Add all direct deps to BuildFile for PhysicsTools/IsolationUtils

### DIFF
--- a/PhysicsTools/IsolationUtils/BuildFile.xml
+++ b/PhysicsTools/IsolationUtils/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DataFormats/Math"/>
 <use name="FWCore/MessageLogger"/>
+<use name="DataFormats/Candidate"/>
 <use name="rootmath"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.