### PR TITLE
Add all direct deps to BuildFile for PhysicsTools/MVAComputer

### DIFF
--- a/PhysicsTools/MVAComputer/BuildFile.xml
+++ b/PhysicsTools/MVAComputer/BuildFile.xml
@@ -3,6 +3,8 @@
 <use name="FWCore/Utilities"/>
 <use name="CondCore/ESSources"/>
 <use name="CondFormats/PhysicsToolsObjects"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/PluginManager"/>
 <use name="rootcore"/>
 <use name="boost"/>
 <use name="zlib"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.