### PR TITLE
Add all direct deps to BuildFile for PhysicsTools/SelectorUtils

### DIFF
--- a/PhysicsTools/SelectorUtils/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/BuildFile.xml
@@ -26,5 +26,11 @@
   <use name="FWCore/Common"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
+<use name="DataFormats/RecoCandidate"/>
+<use name="DataFormats/TrackReco"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/ParameterSetReader"/>
+<use name="FWCore/PluginManager"/>
   <use name="openssl"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.