### PR TITLE
Add all direct deps to BuildFile for PhysicsTools/Utilities

### DIFF
--- a/PhysicsTools/Utilities/BuildFile.xml
+++ b/PhysicsTools/Utilities/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Common"/>
 <use name="SimDataFormats/PileupSummaryInfo"/>
+<use name="PhysicsTools/SelectorUtils"/>
 <use name="roofit"/>
 <use name="rootcore"/>
 <use name="root"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.