### PR TITLE
Add all direct deps to BuildFile for RecoEgamma/ElectronIdentification

### DIFF
--- a/RecoEgamma/ElectronIdentification/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/BuildFile.xml
@@ -4,6 +4,12 @@
 <use name="CommonTools/MVAUtils"/>
 <use name="RecoEgamma/EgammaTools"/>
 <use name="PhysicsTools/SelectorUtils"/>
+<use name="CommonTools/Utils"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/EgammaCandidates"/>
+<use name="DataFormats/GsfTrackReco"/>
+<use name="DataFormats/PatCandidates"/>
+<use name="DataFormats/VertexReco"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.