### PR TITLE
Add all direct deps to BuildFile for RecoEgamma/PhotonIdentification

### DIFF
--- a/RecoEgamma/PhotonIdentification/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/BuildFile.xml
@@ -8,6 +8,21 @@
 <use name="Geometry/CaloGeometry"/>
 <use name="RecoEgamma/EgammaIsolationAlgos"/>
 <use name="PhysicsTools/SelectorUtils"/>
+<use name="CommonTools/Utils"/>
+<use name="CondFormats/DataRecord"/>
+<use name="CondFormats/EcalObjects"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/DetId"/>
+<use name="DataFormats/EcalDetId"/>
+<use name="DataFormats/EcalRecHit"/>
+<use name="DataFormats/EgammaCandidates"/>
+<use name="DataFormats/TrackReco"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
+<use name="Geometry/CaloEventSetup"/>
+<use name="Geometry/CaloTopology"/>
+<use name="Geometry/Records"/>
+<use name="RecoLocalCalo/EcalRecAlgos"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.