### PR TITLE
Add all direct deps to BuildFile for RecoMuon/MuonIdentification

### DIFF
--- a/RecoMuon/MuonIdentification/BuildFile.xml
+++ b/RecoMuon/MuonIdentification/BuildFile.xml
@@ -28,6 +28,23 @@
 <use name="RecoMuon/TrackingTools"/>
 <use name="DataFormats/CSCRecHit"/>
 <use name="PhysicsTools/SelectorUtils"/>
+<use name="DataFormats/CSCDigi"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/DTDigi"/>
+<use name="DataFormats/DTRecHit"/>
+<use name="DataFormats/EcalDetId"/>
+<use name="DataFormats/PatCandidates"/>
+<use name="DataFormats/TrackingRecHit"/>
+<use name="FWCore/PluginManager"/>
+<use name="MagneticField/Engine"/>
+<use name="MagneticField/Records"/>
+<use name="RecoMuon/DetLayers"/>
+<use name="RecoMuon/MeasurementDet"/>
+<use name="RecoTracker/Record"/>
+<use name="SimDataFormats/Track"/>
+<use name="SimDataFormats/TrackingHit"/>
+<use name="TrackingTools/TrackAssociator"/>
+<use name="TrackingTools/TransientTrack"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.