### PR TITLE
Add all direct deps to BuildFile for RecoParticleFlow/Benchmark

### DIFF
--- a/RecoParticleFlow/Benchmark/BuildFile.xml
+++ b/RecoParticleFlow/Benchmark/BuildFile.xml
@@ -8,6 +8,9 @@
 <use name="FWCore/Utilities"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="RecoParticleFlow/PFTracking"/>
+<use name="CommonTools/UtilAlgos"/>
+<use name="DataFormats/METReco"/>
+<use name="DataFormats/TrackReco"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.