### PR TITLE
Add all direct deps to BuildFile for RecoPixelVertexing/PixelTrackFitting

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTrackFitting/BuildFile.xml
@@ -25,6 +25,12 @@
 <use name="TrackingTools/TrajectoryParametrization"/>
 <use name="TrackingTools/TrajectoryState"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>
+<use name="DataFormats/BeamSpot"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/GeometryCommonDetAlgo"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="RecoTracker/TkSeedingLayers"/>
+<use name="TrackingTools/TrajectoryFiltering"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.