### PR TITLE
Add all direct deps to BuildFile for RecoPixelVertexing/PixelTriplets

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/BuildFile.xml
@@ -8,6 +8,24 @@
 <use name="RecoTracker/TkSeedingLayers"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <use name="RecoTracker/TkSeedGenerator"/>
+<use name="CommonTools/Utils"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/GeometrySurface"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/Math"/>
+<use name="DataFormats/SiPixelDetId"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="DataFormats/TrackerRecHit2D"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/Utilities"/>
+<use name="RecoPixelVertexing/PixelTrackFitting"/>
+<use name="RecoTracker/Record"/>
+<use name="RecoTracker/TkDetLayers"/>
+<use name="RecoTracker/TkMSParametrization"/>
+<use name="RecoTracker/TkTrackingRegions"/>
+<use name="RecoTracker/TransientTrackingRecHit"/>
+<use name="TrackingTools/DetLayers"/>
+<use name="TrackingTools/Records"/>
 <use name="vdt_headers"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.