### PR TITLE
Add all direct deps to BuildFile for RecoTracker/TkHitPairs

### DIFF
--- a/RecoTracker/TkHitPairs/BuildFile.xml
+++ b/RecoTracker/TkHitPairs/BuildFile.xml
@@ -11,6 +11,18 @@
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <use name="RecoTracker/TkMSParametrization"/>
 <use name="RecoTracker/TkSeedingLayers"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/Math"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="DataFormats/TrackingRecHit"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/Utilities"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="RecoTracker/TkTrackingRegions"/>
+<use name="RecoTracker/TransientTrackingRecHit"/>
+<use name="TrackingTools/Records"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.