### PR TITLE
Add all direct deps to BuildFile for RecoTracker/TkTrackingRegions

### DIFF
--- a/RecoTracker/TkTrackingRegions/BuildFile.xml
+++ b/RecoTracker/TkTrackingRegions/BuildFile.xml
@@ -13,6 +13,20 @@
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <use name="TrackingTools/MeasurementDet"/>
 <use name="TrackingTools/KalmanUpdators"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/GeometrySurface"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/Math"/>
+<use name="DataFormats/TrackerRecHit2D"/>
+<use name="DataFormats/TrackingRecHit"/>
+<use name="FWCore/Utilities"/>
+<use name="Geometry/Records"/>
+<use name="MagneticField/Engine"/>
+<use name="MagneticField/Records"/>
+<use name="TrackingTools/DetLayers"/>
+<use name="TrackingTools/GeomPropagators"/>
+<use name="TrackingTools/TrajectoryParametrization"/>
+<use name="TrackingTools/TrajectoryState"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.