### PR TITLE
Add all direct deps to BuildFile for SimTracker/TrackHistory

### DIFF
--- a/SimTracker/TrackHistory/BuildFile.xml
+++ b/SimTracker/TrackHistory/BuildFile.xml
@@ -15,6 +15,22 @@
 <use name="SimTracker/TrackerHitAssociation"/>
 <use name="TrackingTools/TransientTrack"/>
 <use name="DataFormats/TrackerCommon"/>
+<use name="CommonTools/Utils"/>
+<use name="DataFormats/BeamSpot"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/DetId"/>
+<use name="DataFormats/MuonDetId"/>
+<use name="DataFormats/SiPixelDetId"/>
+<use name="DataFormats/SiStripDetId"/>
+<use name="DataFormats/TrackReco"/>
+<use name="DataFormats/TrackingRecHit"/>
+<use name="FWCore/MessageLogger"/>
+<use name="Geometry/Records"/>
+<use name="SimDataFormats/Associations"/>
+<use name="SimDataFormats/TrackingHit"/>
+<use name="TrackingTools/PatternTools"/>
+<use name="TrackingTools/Records"/>
+<use name="TrackingTools/TrajectoryState"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.