### PR TITLE
Add all direct deps to BuildFile for SimTracker/TrackTriggerAssociation

### DIFF
--- a/SimTracker/TrackTriggerAssociation/BuildFile.xml
+++ b/SimTracker/TrackTriggerAssociation/BuildFile.xml
@@ -12,6 +12,8 @@
 <use name="rootrflx"/>
 <use name="DataFormats/L1TrackTrigger"/>
 <use name="DataFormats/Phase2TrackerDigi"/>
+<use name="DataFormats/GeometryCommonDetAlgo"/>
+<use name="SimDataFormats/TrackerDigiSimLink"/>
 <export>
   <flags SEALPLUGIN="1"/>
   <lib name="1"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.