### PR TITLE
Add all direct deps to BuildFile for TrackingTools/GsfTracking

### DIFF
--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -26,3 +26,11 @@
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/GeometryCommonDetAlgo"/>
+<use name="DataFormats/Math"/>
+<use name="DataFormats/TrackReco"/>
+<use name="DataFormats/TrackerRecHit2D"/>
+<use name="DataFormats/TrackingRecHit"/>
+<use name="RecoTracker/TransientTrackingRecHit"/>
+<use name="TrackingTools/DetLayers"/>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.