### PR TITLE
Add all direct deps to BuildFile for TrackingTools/TransientTrackingRecHit

### DIFF
--- a/TrackingTools/TransientTrackingRecHit/BuildFile.xml
+++ b/TrackingTools/TransientTrackingRecHit/BuildFile.xml
@@ -11,6 +11,7 @@
 <use name="DataFormats/GeometryCommonDetAlgo"/>
 <use name="TrackingTools/DetLayers"/>
 <use name="TrackingTools/TrajectoryState"/>
+<use name="DataFormats/CLHEP"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.