### PR TITLE
Allow pixel template ID = 0 to ensure backwards compatibility

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -184,7 +184,7 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
   // First, interpolate the template needed to analyze this cluster
   // check to see of the track direction is in the physical range of the loaded template
 
-  if (id > 0) {  //if id == 0 bypass interpolation (used in calibration)
+  if (id >= 0) {  //if id < 0 bypass interpolation (used in calibration)
     if (!templ.interpolate(id, cotalpha, cotbeta, locBz, locBx)) {
       if (theVerboseLevel > 2) {
         LOGDEBUG("SiPixelTemplateReco") << "input cluster direction cot(alpha) = " << cotalpha

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -113,7 +113,7 @@ int SiPixelTemplateReco2D::PixelTempReco2D(int id,
 
   // Extract some relevant info from the 2D template
 
-  if (id > 0) {  // if id==0, bypass interpolation (used in calibration)
+  if (id >= 0) {  // if id < 0, bypass interpolation (used in calibration)
     if (!templ2D.interpolate(id, cotalpha, cotbeta, locBz, locBx))
       return 4;
   }


### PR DESCRIPTION
This PR is very small bugfix. [PR #28945](https://github.com/cms-sw/cmssw/pull/28945) introduced a very small backwards compatabibility issue that was pointed out in [this ](https://hypernews.cern.ch/HyperNews/CMS/get/pixelOfflineSW/1543.html )hypernews thread. A config to reproduce the crash is [here](http://musich.web.cern.ch/musich/display/reproduce_crash_cfg.py)

The issue is that there was one pixel template that was used for 0T conditions in 2017 that had a template ID of 0. The PR #28945 synced with standalone calibration code that used ID = 0 to signify a special calibration template and bypass some of the regular functionality. So this meant this specific template would no longer be used correctly. This PR makes the very small change of requiring these calibration templates to have a negative ID instead of 0. There should be no changes in anything except for things with GT's containing this specific payload (SiPixelTemplateDBObject_phase1_0T_mc_v2). 

@mmusich @tvami @pmaksim1 @slava77 @perrotta 
