### PR TITLE
[NanoAOD] Don't handle column types redundantly anymore

### DIFF
--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -37,11 +37,11 @@ namespace nanoaod {
 
   class FlatTable {
   public:
-    enum ColumnType {
-      FloatColumn,
-      IntColumn,
-      UInt8Column,
-      BoolColumn
+    enum class ColumnType {
+      Float,
+      Int,
+      UInt8,
+      Bool
     };  // We could have other Float types with reduced mantissa, and similar
 
     FlatTable() : size_(0) {}
@@ -113,10 +113,10 @@ namespace nanoaod {
       if (values.size() != size())
         throw cms::Exception("LogicError", "Mismatched size for " + name);
       if constexpr (std::is_same<T, bool>()) {
-        columns_.emplace_back(name, docString, ColumnType::BoolColumn, uint8s_.size());
+        columns_.emplace_back(name, docString, ColumnType::Bool, uint8s_.size());
         uint8s_.insert(uint8s_.end(), values.begin(), values.end());
       } else if constexpr (std::is_same<T, float>()) {
-        columns_.emplace_back(name, docString, ColumnType::FloatColumn, floats_.size());
+        columns_.emplace_back(name, docString, ColumnType::Float, floats_.size());
         floats_.insert(floats_.end(), values.begin(), values.end());
         flatTableHelper::MaybeMantissaReduce<float>(mantissaBits).bulk(columnData<float>(columns_.size() - 1));
       } else {
@@ -134,10 +134,10 @@ namespace nanoaod {
       if (columnIndex(name) != -1)
         throw cms::Exception("LogicError", "Duplicated column: " + name);
       if constexpr (std::is_same<T, bool>()) {
-        columns_.emplace_back(name, docString, ColumnType::BoolColumn, uint8s_.size());
+        columns_.emplace_back(name, docString, ColumnType::Bool, uint8s_.size());
         uint8s_.push_back(value);
       } else if constexpr (std::is_same<T, float>()) {
-        columns_.emplace_back(name, docString, ColumnType::FloatColumn, floats_.size());
+        columns_.emplace_back(name, docString, ColumnType::Float, floats_.size());
         floats_.push_back(flatTableHelper::MaybeMantissaReduce<float>(mantissaBits).one(value));
       } else {
         ColumnType type = defaultColumnType<T>();
@@ -152,9 +152,9 @@ namespace nanoaod {
     template <typename T>
     static ColumnType defaultColumnType() {
       if constexpr (std::is_same<T, int>())
-        return ColumnType::IntColumn;
+        return ColumnType::Int;
       if constexpr (std::is_same<T, uint8_t>())
-        return ColumnType::UInt8Column;
+        return ColumnType::UInt8;
       throw cms::Exception("unsupported type");
     }
 

--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -18,7 +18,7 @@ namespace nanoaod {
       MaybeMantissaReduce(int mantissaBits) {}
       inline T one(const T &val) const { return val; }
       template <typename Span>
-      inline void bulk(Span &&data) const {}
+      inline void bulk(Span const &data) const {}
     };
     template <>
     struct MaybeMantissaReduce<float> {

--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/Math/interface/libminifloat.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/Range.h"
+#include "FWCore/Utilities/interface/Span.h"
 
 #include <cstdint>
 #include <vector>
@@ -17,8 +17,8 @@ namespace nanoaod {
     struct MaybeMantissaReduce {
       MaybeMantissaReduce(int mantissaBits) {}
       inline T one(const T &val) const { return val; }
-      template <typename Range>
-      inline void bulk(Range &&data) const {}
+      template <typename Span>
+      inline void bulk(Span &&data) const {}
     };
     template <>
     struct MaybeMantissaReduce<float> {
@@ -27,8 +27,8 @@ namespace nanoaod {
       inline float one(const float &val) const {
         return (bits_ > 0 ? MiniFloatConverter::reduceMantissaToNbitsRounding(val, bits_) : val);
       }
-      template <typename Range>
-      inline void bulk(Range &&data) const {
+      template <typename Span>
+      inline void bulk(Span &&data) const {
         if (bits_ > 0)
           MiniFloatConverter::reduceMantissaToNbitsRounding(bits_, data.begin(), data.end(), data.begin());
       }
@@ -69,14 +69,14 @@ namespace nanoaod {
     template <typename T>
     auto columnData(unsigned int column) const {
       auto begin = beginData<T>(column);
-      return edm::Range(begin, begin + size_);
+      return edm::Span(begin, begin + size_);
     }
 
     /// get a column by index (non-const)
     template <typename T>
     auto columnData(unsigned int column) {
       auto begin = beginData<T>(column);
-      return edm::Range(begin, begin + size_);
+      return edm::Span(begin, begin + size_);
     }
 
     /// get a column value for singleton (const)

--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -169,18 +169,24 @@ namespace nanoaod {
 
     template <typename T>
     auto const &bigVector() const {
-      return const_cast<FlatTable *>(this)->bigVector<T>();
+      return bigVectorImpl<T>(*this);
     }
     template <typename T>
     auto &bigVector() {
+      return bigVectorImpl<T>(*this);
+    }
+
+    template <typename T, class This>
+    static auto &bigVectorImpl(This &table) {
+      // helper function to avoid code duplication, for the two accessor functions that differ only in const-ness
       if constexpr (std::is_same<T, float>())
-        return floats_;
+        return table.floats_;
       else if constexpr (std::is_same<T, int>())
-        return ints_;
+        return table.ints_;
       else if constexpr (std::is_same<T, uint8_t>())
-        return uint8s_;
+        return table.uint8s_;
       else if constexpr (std::is_same<T, bool>())
-        return uint8s_;
+        return table.uint8s_;
       else
         static_assert(dependent_false<T>::value, "unsupported type");
     }

--- a/DataFormats/NanoAOD/src/FlatTable.cc
+++ b/DataFormats/NanoAOD/src/FlatTable.cc
@@ -25,6 +25,8 @@ void nanoaod::FlatTable::addExtension(const nanoaod::FlatTable& other) {
       case ColumnType::UInt8:
         addColumn<uint8_t>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i));
         break;
+      default:
+        throw cms::Exception("LogicError", "Unsupported type");
     }
   }
 }

--- a/DataFormats/NanoAOD/src/FlatTable.cc
+++ b/DataFormats/NanoAOD/src/FlatTable.cc
@@ -20,7 +20,7 @@ void nanoaod::FlatTable::addExtension(const nanoaod::FlatTable& other) {
         addColumn<int>(other.columnName(i), other.columnData<int>(i), other.columnDoc(i));
         break;
       case ColumnType::Bool:
-        addColumn<bool>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i));
+        addColumn<bool>(other.columnName(i), other.columnData<bool>(i), other.columnDoc(i));
         break;
       case ColumnType::UInt8:
         addColumn<uint8_t>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i));
@@ -38,7 +38,7 @@ double nanoaod::FlatTable::getAnyValue(unsigned int row, unsigned int column) co
     case ColumnType::Int:
       return *(beginData<int>(column) + row);
     case ColumnType::Bool:
-      return *(beginData<uint8_t>(column) + row);
+      return *(beginData<bool>(column) + row);
     case ColumnType::UInt8:
       return *(beginData<uint8_t>(column) + row);
   }

--- a/DataFormats/NanoAOD/src/FlatTable.cc
+++ b/DataFormats/NanoAOD/src/FlatTable.cc
@@ -14,14 +14,16 @@ void nanoaod::FlatTable::addExtension(const nanoaod::FlatTable& other) {
   for (unsigned int i = 0, n = other.nColumns(); i < n; ++i) {
     switch (other.columnType(i)) {
       case FloatColumn:
-        addColumn<float>(other.columnName(i), other.columnData<float>(i), other.columnDoc(i), other.columnType(i));
+        addColumn<float>(other.columnName(i), other.columnData<float>(i), other.columnDoc(i));
         break;
       case IntColumn:
-        addColumn<int>(other.columnName(i), other.columnData<int>(i), other.columnDoc(i), other.columnType(i));
+        addColumn<int>(other.columnName(i), other.columnData<int>(i), other.columnDoc(i));
         break;
-      case BoolColumn:  // as UInt8
+      case BoolColumn:
+        addColumn<bool>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i));
+        break;
       case UInt8Column:
-        addColumn<uint8_t>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i), other.columnType(i));
+        addColumn<uint8_t>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i));
         break;
     }
   }

--- a/DataFormats/NanoAOD/src/FlatTable.cc
+++ b/DataFormats/NanoAOD/src/FlatTable.cc
@@ -13,16 +13,16 @@ void nanoaod::FlatTable::addExtension(const nanoaod::FlatTable& other) {
     throw cms::Exception("LogicError", "Mismatch in adding extension");
   for (unsigned int i = 0, n = other.nColumns(); i < n; ++i) {
     switch (other.columnType(i)) {
-      case FloatColumn:
+      case ColumnType::Float:
         addColumn<float>(other.columnName(i), other.columnData<float>(i), other.columnDoc(i));
         break;
-      case IntColumn:
+      case ColumnType::Int:
         addColumn<int>(other.columnName(i), other.columnData<int>(i), other.columnDoc(i));
         break;
-      case BoolColumn:
+      case ColumnType::Bool:
         addColumn<bool>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i));
         break;
-      case UInt8Column:
+      case ColumnType::UInt8:
         addColumn<uint8_t>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i));
         break;
     }
@@ -33,13 +33,13 @@ double nanoaod::FlatTable::getAnyValue(unsigned int row, unsigned int column) co
   if (column >= nColumns())
     throw cms::Exception("LogicError", "Invalid column");
   switch (columnType(column)) {
-    case FloatColumn:
+    case ColumnType::Float:
       return *(beginData<float>(column) + row);
-    case IntColumn:
+    case ColumnType::Int:
       return *(beginData<int>(column) + row);
-    case BoolColumn:
+    case ColumnType::Bool:
       return *(beginData<uint8_t>(column) + row);
-    case UInt8Column:
+    case ColumnType::UInt8:
       return *(beginData<uint8_t>(column) + row);
   }
   throw cms::Exception("LogicError", "Unsupported type");

--- a/FWCore/Utilities/interface/Range.h
+++ b/FWCore/Utilities/interface/Range.h
@@ -1,8 +1,6 @@
 #ifndef FWCore_Utilities_Range_h
 #define FWCore_Utilities_Range_h
 
-#include <cstddef>
-
 namespace edm {
   /*
       *class which implements begin() and end() to use range-based loop with
@@ -18,12 +16,6 @@ namespace edm {
     T end() const { return end_; }
 
     bool empty() const { return begin_ == end_; }
-    auto size() const { return end_ - begin_; }
-
-    auto const& operator[](std::size_t idx) const { return *(begin_ + idx); }
-
-    auto const& front() const { return *begin_; }
-    auto const& back() const { return *(end_ - 1); }
 
   private:
     const T begin_;

--- a/FWCore/Utilities/interface/Range.h
+++ b/FWCore/Utilities/interface/Range.h
@@ -1,6 +1,8 @@
 #ifndef FWCore_Utilities_Range_h
 #define FWCore_Utilities_Range_h
 
+#include <cstddef>
+
 namespace edm {
   /*
       *class which implements begin() and end() to use range-based loop with

--- a/FWCore/Utilities/interface/Range.h
+++ b/FWCore/Utilities/interface/Range.h
@@ -16,6 +16,12 @@ namespace edm {
     T end() const { return end_; }
 
     bool empty() const { return begin_ == end_; }
+    auto size() const { return end_ - begin_; }
+
+    auto const& operator[](std::size_t idx) const { return *(begin_ + idx); }
+
+    auto const& front() const { return *begin_; }
+    auto const& back() const { return *(end_ - 1); }
 
   private:
     const T begin_;

--- a/FWCore/Utilities/interface/Span.h
+++ b/FWCore/Utilities/interface/Span.h
@@ -1,0 +1,37 @@
+#ifndef FWCore_Utilities_Span_h
+#define FWCore_Utilities_Span_h
+
+#include <cstddef>
+
+namespace edm {
+  /*
+      *An edm::Span wraps begin() and end() iterators to a contiguous sequence
+      of objects with the first element of the sequence at position zero,
+      In other words the iterators should refer to random-access containers.
+
+      To be replaced with std::Span in C++20.
+      */
+
+  template <class T>
+  class Span {
+  public:
+    Span(T begin, T end) : begin_(begin), end_(end) {}
+
+    T begin() const { return begin_; }
+    T end() const { return end_; }
+
+    bool empty() const { return begin_ == end_; }
+    auto size() const { return end_ - begin_; }
+
+    auto const& operator[](std::size_t idx) const { return *(begin_ + idx); }
+
+    auto const& front() const { return *begin_; }
+    auto const& back() const { return *(end_ - 1); }
+
+  private:
+    const T begin_;
+    const T end_;
+  };
+};  // namespace edm
+
+#endif

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -129,20 +129,15 @@ public:
         const auto &varPSet = extvarsPSet.getParameter<edm::ParameterSet>(vname);
         const std::string &type = varPSet.getParameter<std::string>("type");
         if (type == "int")
-          extvars_.push_back(
-              std::make_unique<IntExtVar>(vname, varPSet, this->consumesCollector()));
+          extvars_.push_back(std::make_unique<IntExtVar>(vname, varPSet, this->consumesCollector()));
         else if (type == "float")
-          extvars_.push_back(std::make_unique<FloatExtVar>(
-              vname, varPSet, this->consumesCollector()));
+          extvars_.push_back(std::make_unique<FloatExtVar>(vname, varPSet, this->consumesCollector()));
         else if (type == "double")
-          extvars_.push_back(std::make_unique<DoubleExtVar>(
-              vname, varPSet, this->consumesCollector()));
+          extvars_.push_back(std::make_unique<DoubleExtVar>(vname, varPSet, this->consumesCollector()));
         else if (type == "uint8")
-          extvars_.push_back(std::make_unique<UInt8ExtVar>(
-              vname, varPSet, this->consumesCollector()));
+          extvars_.push_back(std::make_unique<UInt8ExtVar>(vname, varPSet, this->consumesCollector()));
         else if (type == "bool")
-          extvars_.push_back(
-              std::make_unique<BoolExtVar>(vname, varPSet, this->consumesCollector()));
+          extvars_.push_back(std::make_unique<BoolExtVar>(vname, varPSet, this->consumesCollector()));
         else
           throw cms::Exception("Configuration", "unsupported type " + type + " for variable " + vname);
       }

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -93,10 +93,16 @@ protected:
     void fill(std::vector<const T *> selobjs, nanoaod::FlatTable &out) const override {
       std::vector<ValType> vals(selobjs.size());
       for (unsigned int i = 0, n = vals.size(); i < n; ++i) {
-        if (this->precision_ == -2) {
-          vals[i] = MiniFloatConverter::reduceMantissaToNbitsRounding(func_(*selobjs[i]), precisionFunc_(*selobjs[i]));
-        } else
+        if constexpr (std::is_same<ValType, float>()) {
+          if (this->precision_ == -2) {
+            vals[i] =
+                MiniFloatConverter::reduceMantissaToNbitsRounding(func_(*selobjs[i]), precisionFunc_(*selobjs[i]));
+          } else {
+            vals[i] = func_(*selobjs[i]);
+          }
+        } else {
           vals[i] = func_(*selobjs[i]);
+        }
       }
       out.template addColumn<ValType>(this->name_, vals, this->doc_, this->precision_);
     }

--- a/PhysicsTools/NanoAOD/plugins/BTagSFProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/BTagSFProducer.cc
@@ -227,10 +227,7 @@ void BTagSFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
         EventWt *= SF;
       }
 
-      out->addColumnValue<float>(discShortNames_[iDisc],
-                                 EventWt,
-                                 "b-tag event weight for " + discShortNames_[iDisc],
-                                 nanoaod::FlatTable::FloatColumn);
+      out->addColumnValue<float>(discShortNames_[iDisc], EventWt, "b-tag event weight for " + discShortNames_[iDisc]);
     }
   }
 

--- a/PhysicsTools/NanoAOD/plugins/CandMCMatchTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/CandMCMatchTableProducer.cc
@@ -138,12 +138,8 @@ public:
       };
     }
 
-    tab->addColumn<int>(
-        branchName_ + "Idx", key, "Index into genParticle list for " + doc_, nanoaod::FlatTable::IntColumn);
-    tab->addColumn<uint8_t>(branchName_ + "Flav",
-                            flav,
-                            "Flavour of genParticle for " + doc_ + ": " + flavDoc_,
-                            nanoaod::FlatTable::UInt8Column);
+    tab->addColumn<int>(branchName_ + "Idx", key, "Index into genParticle list for " + doc_);
+    tab->addColumn<uint8_t>(branchName_ + "Flav", flav, "Flavour of genParticle for " + doc_ + ": " + flavDoc_);
 
     iEvent.put(std::move(tab));
   }

--- a/PhysicsTools/NanoAOD/plugins/EnergyRingsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/EnergyRingsTableProducer.cc
@@ -89,108 +89,39 @@ void EnergyRingsTableProducer::produce(edm::Event& iEvent, const edm::EventSetup
     numdaughterspt03.push_back(numDaughtersPt03);
   }                                                                            //end of jet loop
   auto tab = std::make_unique<nanoaod::FlatTable>(ncand, name_, false, true);  //extension to Jet collection set to true
-  tab->addColumn<int>(
-      "numDaughtersPt03", numdaughterspt03, "number of jet daughters with pT>0.3 GeV", nanoaod::FlatTable::IntColumn);
+  tab->addColumn<int>("numDaughtersPt03", numdaughterspt03, "number of jet daughters with pT>0.3 GeV");
 
-  tab->addColumn<float>("EmFractionEnergyRing0",
-                        EmFractionEnergyRings[0],
-                        "Em energy fraction in ring in dR 0-0.05",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("EmFractionEnergyRing1",
-                        EmFractionEnergyRings[1],
-                        "Em energy fraction in ring in dR 0.05-0.1",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("EmFractionEnergyRing2",
-                        EmFractionEnergyRings[2],
-                        "Em energy fraction in ring in dR 0.1-0.2",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("EmFractionEnergyRing3",
-                        EmFractionEnergyRings[3],
-                        "Em energy fraction in ring in dR 0.2-0.3",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("EmFractionEnergyRing4",
-                        EmFractionEnergyRings[4],
-                        "Em energy fraction in ring in dR 0.3-0.4",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("EmFractionEnergyRing5",
-                        EmFractionEnergyRings[5],
-                        "Em energy fraction in ring in dR 0.4 overflow",
-                        nanoaod::FlatTable::FloatColumn);
+  tab->addColumn<float>("EmFractionEnergyRing0", EmFractionEnergyRings[0], "Em energy fraction in ring in dR 0-0.05");
+  tab->addColumn<float>("EmFractionEnergyRing1", EmFractionEnergyRings[1], "Em energy fraction in ring in dR 0.05-0.1");
+  tab->addColumn<float>("EmFractionEnergyRing2", EmFractionEnergyRings[2], "Em energy fraction in ring in dR 0.1-0.2");
+  tab->addColumn<float>("EmFractionEnergyRing3", EmFractionEnergyRings[3], "Em energy fraction in ring in dR 0.2-0.3");
+  tab->addColumn<float>("EmFractionEnergyRing4", EmFractionEnergyRings[4], "Em energy fraction in ring in dR 0.3-0.4");
+  tab->addColumn<float>(
+      "EmFractionEnergyRing5", EmFractionEnergyRings[5], "Em energy fraction in ring in dR 0.4 overflow");
 
-  tab->addColumn<float>("ChFractionEnergyRing0",
-                        ChFractionEnergyRings[0],
-                        "Ch energy fraction in ring in dR 0-0.05",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("ChFractionEnergyRing1",
-                        ChFractionEnergyRings[1],
-                        "Ch energy fraction in ring in dR 0.05-0.1",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("ChFractionEnergyRing2",
-                        ChFractionEnergyRings[2],
-                        "Ch energy fraction in ring in dR 0.1-0.2",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("ChFractionEnergyRing3",
-                        ChFractionEnergyRings[3],
-                        "Ch energy fraction in ring in dR 0.2-0.3",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("ChFractionEnergyRing4",
-                        ChFractionEnergyRings[4],
-                        "Ch energy fraction in ring in dR 0.3-0.4",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("ChFractionEnergyRing5",
-                        ChFractionEnergyRings[5],
-                        "Ch energy fraction in ring in dR 0.4 overflow",
-                        nanoaod::FlatTable::FloatColumn);
+  tab->addColumn<float>("ChFractionEnergyRing0", ChFractionEnergyRings[0], "Ch energy fraction in ring in dR 0-0.05");
+  tab->addColumn<float>("ChFractionEnergyRing1", ChFractionEnergyRings[1], "Ch energy fraction in ring in dR 0.05-0.1");
+  tab->addColumn<float>("ChFractionEnergyRing2", ChFractionEnergyRings[2], "Ch energy fraction in ring in dR 0.1-0.2");
+  tab->addColumn<float>("ChFractionEnergyRing3", ChFractionEnergyRings[3], "Ch energy fraction in ring in dR 0.2-0.3");
+  tab->addColumn<float>("ChFractionEnergyRing4", ChFractionEnergyRings[4], "Ch energy fraction in ring in dR 0.3-0.4");
+  tab->addColumn<float>(
+      "ChFractionEnergyRing5", ChFractionEnergyRings[5], "Ch energy fraction in ring in dR 0.4 overflow");
 
-  tab->addColumn<float>("MuFractionEnergyRing0",
-                        MuFractionEnergyRings[0],
-                        "Mu energy fraction in ring in dR 0-0.05",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("MuFractionEnergyRing1",
-                        MuFractionEnergyRings[1],
-                        "Mu energy fraction in ring in dR 0.05-0.1",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("MuFractionEnergyRing2",
-                        MuFractionEnergyRings[2],
-                        "Mu energy fraction in ring in dR 0.1-0.2",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("MuFractionEnergyRing3",
-                        MuFractionEnergyRings[3],
-                        "Mu energy fraction in ring in dR 0.2-0.3",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("MuFractionEnergyRing4",
-                        MuFractionEnergyRings[4],
-                        "Mu energy fraction in ring in dR 0.3-0.4",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("MuFractionEnergyRing5",
-                        MuFractionEnergyRings[5],
-                        "Mu energy fraction in ring in dR 0.4 overflow",
-                        nanoaod::FlatTable::FloatColumn);
+  tab->addColumn<float>("MuFractionEnergyRing0", MuFractionEnergyRings[0], "Mu energy fraction in ring in dR 0-0.05");
+  tab->addColumn<float>("MuFractionEnergyRing1", MuFractionEnergyRings[1], "Mu energy fraction in ring in dR 0.05-0.1");
+  tab->addColumn<float>("MuFractionEnergyRing2", MuFractionEnergyRings[2], "Mu energy fraction in ring in dR 0.1-0.2");
+  tab->addColumn<float>("MuFractionEnergyRing3", MuFractionEnergyRings[3], "Mu energy fraction in ring in dR 0.2-0.3");
+  tab->addColumn<float>("MuFractionEnergyRing4", MuFractionEnergyRings[4], "Mu energy fraction in ring in dR 0.3-0.4");
+  tab->addColumn<float>(
+      "MuFractionEnergyRing5", MuFractionEnergyRings[5], "Mu energy fraction in ring in dR 0.4 overflow");
 
-  tab->addColumn<float>("NeFractionEnergyRing0",
-                        NeFractionEnergyRings[0],
-                        "Ne energy fraction in ring in dR 0-0.05",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("NeFractionEnergyRing1",
-                        NeFractionEnergyRings[1],
-                        "Ne energy fraction in ring in dR 0.05-0.1",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("NeFractionEnergyRing2",
-                        NeFractionEnergyRings[2],
-                        "Ne energy fraction in ring in dR 0.1-0.2",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("NeFractionEnergyRing3",
-                        NeFractionEnergyRings[3],
-                        "Ne energy fraction in ring in dR 0.2-0.3",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("NeFractionEnergyRing4",
-                        NeFractionEnergyRings[4],
-                        "Ne energy fraction in ring in dR 0.3-0.4",
-                        nanoaod::FlatTable::FloatColumn);
-  tab->addColumn<float>("NeFractionEnergyRing5",
-                        NeFractionEnergyRings[5],
-                        "Ne energy fraction in ring in dR 0.4 overflow",
-                        nanoaod::FlatTable::FloatColumn);
+  tab->addColumn<float>("NeFractionEnergyRing0", NeFractionEnergyRings[0], "Ne energy fraction in ring in dR 0-0.05");
+  tab->addColumn<float>("NeFractionEnergyRing1", NeFractionEnergyRings[1], "Ne energy fraction in ring in dR 0.05-0.1");
+  tab->addColumn<float>("NeFractionEnergyRing2", NeFractionEnergyRings[2], "Ne energy fraction in ring in dR 0.1-0.2");
+  tab->addColumn<float>("NeFractionEnergyRing3", NeFractionEnergyRings[3], "Ne energy fraction in ring in dR 0.2-0.3");
+  tab->addColumn<float>("NeFractionEnergyRing4", NeFractionEnergyRings[4], "Ne energy fraction in ring in dR 0.3-0.4");
+  tab->addColumn<float>(
+      "NeFractionEnergyRing5", NeFractionEnergyRings[5], "Ne energy fraction in ring in dR 0.4 overflow");
 
   iEvent.put(std::move(tab));
 }

--- a/PhysicsTools/NanoAOD/plugins/GenJetFlavourTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenJetFlavourTableProducer.cc
@@ -87,9 +87,8 @@ void GenJetFlavourTableProducer::produce(edm::Event& iEvent, const edm::EventSet
   }
 
   auto tab = std::make_unique<nanoaod::FlatTable>(ncand, name_, false, true);
-  tab->addColumn<int>("partonFlavour", partonFlavour, "flavour from parton matching", nanoaod::FlatTable::IntColumn);
-  tab->addColumn<uint8_t>(
-      "hadronFlavour", hadronFlavour, "flavour from hadron ghost clustering", nanoaod::FlatTable::UInt8Column);
+  tab->addColumn<int>("partonFlavour", partonFlavour, "flavour from parton matching");
+  tab->addColumn<uint8_t>("hadronFlavour", hadronFlavour, "flavour from hadron ghost clustering");
 
   iEvent.put(std::move(tab));
 }

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -288,7 +288,7 @@ public:
     // table for gen info, always available
     auto out = std::make_unique<nanoaod::FlatTable>(1, "genWeight", true);
     out->setDoc("generator weight");
-    out->addColumnValue<float>("", weight, "generator weight", nanoaod::FlatTable::FloatColumn);
+    out->addColumnValue<float>("", weight, "generator weight");
     iEvent.put(std::move(out));
 
     std::string model_label = streamCache(id)->countermap.getLabel();
@@ -399,31 +399,23 @@ public:
                             vectorSize > 1 ? "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
                                              "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 "
                                            : "dummy PS weight (1.0) ",
-                            nanoaod::FlatTable::FloatColumn,
                             lheWeightPrecision_);
 
     outScale.reset(new nanoaod::FlatTable(wScale.size(), "LHEScaleWeight", false));
-    outScale->addColumn<float>(
-        "", wScale, weightChoice->scaleWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
+    outScale->addColumn<float>("", wScale, weightChoice->scaleWeightsDoc, lheWeightPrecision_);
 
     outPdf.reset(new nanoaod::FlatTable(wPDF.size(), "LHEPdfWeight", false));
-    outPdf->addColumn<float>(
-        "", wPDF, weightChoice->pdfWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
+    outPdf->addColumn<float>("", wPDF, weightChoice->pdfWeightsDoc, lheWeightPrecision_);
 
     outRwgt.reset(new nanoaod::FlatTable(wRwgt.size(), "LHEReweightingWeight", false));
-    outRwgt->addColumn<float>(
-        "", wRwgt, weightChoice->rwgtWeightDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
+    outRwgt->addColumn<float>("", wRwgt, weightChoice->rwgtWeightDoc, lheWeightPrecision_);
 
     outNamed.reset(new nanoaod::FlatTable(1, "LHEWeight", true));
-    outNamed->addColumnValue<float>("originalXWGTUP",
-                                    lheProd.originalXWGTUP(),
-                                    "Nominal event weight in the LHE file",
-                                    nanoaod::FlatTable::FloatColumn);
+    outNamed->addColumnValue<float>("originalXWGTUP", lheProd.originalXWGTUP(), "Nominal event weight in the LHE file");
     for (unsigned int i = 0, n = wNamed.size(); i < n; ++i) {
       outNamed->addColumnValue<float>(namedWeightLabels_[i],
                                       wNamed[i],
                                       "LHE weight for id " + namedWeightIDs_[i] + ", relative to nominal",
-                                      nanoaod::FlatTable::FloatColumn,
                                       lheWeightPrecision_);
     }
 
@@ -460,12 +452,10 @@ public:
       wPS.push_back(1.0);
 
     outScale.reset(new nanoaod::FlatTable(wScale.size(), "LHEScaleWeight", false));
-    outScale->addColumn<float>(
-        "", wScale, weightChoice->scaleWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
+    outScale->addColumn<float>("", wScale, weightChoice->scaleWeightsDoc, lheWeightPrecision_);
 
     outPdf.reset(new nanoaod::FlatTable(wPDF.size(), "LHEPdfWeight", false));
-    outPdf->addColumn<float>(
-        "", wPDF, weightChoice->pdfWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
+    outPdf->addColumn<float>("", wPDF, weightChoice->pdfWeightsDoc, lheWeightPrecision_);
 
     outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
     outPS->addColumn<float>("",
@@ -473,14 +463,12 @@ public:
                             wPS.size() > 1 ? "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
                                              "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 "
                                            : "dummy PS weight (1.0) ",
-                            nanoaod::FlatTable::FloatColumn,
                             lheWeightPrecision_);
 
     outNamed.reset(new nanoaod::FlatTable(1, "LHEWeight", true));
-    outNamed->addColumnValue<float>(
-        "originalXWGTUP", originalXWGTUP, "Nominal event weight in the LHE file", nanoaod::FlatTable::FloatColumn);
+    outNamed->addColumnValue<float>("originalXWGTUP", originalXWGTUP, "Nominal event weight in the LHE file");
     /*for (unsigned int i = 0, n = wNamed.size(); i < n; ++i) {
-      outNamed->addColumnValue<float>(namedWeightLabels_[i], wNamed[i], "LHE weight for id "+namedWeightIDs_[i]+", relative to nominal", nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
+      outNamed->addColumnValue<float>(namedWeightLabels_[i], wNamed[i], "LHE weight for id "+namedWeightIDs_[i]+", relative to nominal", lheWeightPrecision_);
       }*/
 
     counter->incLHE(genWeight, wScale, wPDF, std::vector<double>(), std::vector<double>(), wPS);
@@ -506,7 +494,6 @@ public:
                             vectorSize > 1 ? "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
                                              "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 "
                                            : "dummy PS weight (1.0) ",
-                            nanoaod::FlatTable::FloatColumn,
                             lheWeightPrecision_);
 
     counter->incGenOnly(genWeight);

--- a/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
@@ -18,22 +18,17 @@ public:
       if (type == "int")
         vars_.push_back(std::make_unique<IntVar>(vname, varPSet, consumesCollector()));
       else if (type == "float")
-        vars_.push_back(
-            std::make_unique<FloatVar>(vname, varPSet, consumesCollector()));
+        vars_.push_back(std::make_unique<FloatVar>(vname, varPSet, consumesCollector()));
       else if (type == "double")
-        vars_.push_back(
-            std::make_unique<DoubleVar>(vname, varPSet, consumesCollector()));
+        vars_.push_back(std::make_unique<DoubleVar>(vname, varPSet, consumesCollector()));
       else if (type == "bool")
         vars_.push_back(std::make_unique<BoolVar>(vname, varPSet, consumesCollector()));
       else if (type == "candidatescalarsum")
-        vars_.push_back(std::make_unique<CandidateScalarSumVar>(
-            vname, varPSet, consumesCollector()));
+        vars_.push_back(std::make_unique<CandidateScalarSumVar>(vname, varPSet, consumesCollector()));
       else if (type == "candidatesize")
-        vars_.push_back(
-            std::make_unique<CandidateSizeVar>(vname, varPSet, consumesCollector()));
+        vars_.push_back(std::make_unique<CandidateSizeVar>(vname, varPSet, consumesCollector()));
       else if (type == "candidatesummass")
-        vars_.push_back(std::make_unique<CandidateSumMassVar>(
-            vname, varPSet, consumesCollector()));
+        vars_.push_back(std::make_unique<CandidateSumMassVar>(vname, varPSet, consumesCollector()));
       else
         throw cms::Exception("Configuration", "unsupported type " + type + " for variable " + vname);
     }

--- a/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
@@ -131,38 +131,30 @@ public:
       lheVpt = std::hypot(pup[v.first][0] + pup[v.second][0], pup[v.first][1] + pup[v.second][1]);
     }
 
-    out.addColumnValue<uint8_t>(
-        "Njets", lheNj, "Number of jets (partons) at LHE step", nanoaod::FlatTable::UInt8Column);
-    out.addColumnValue<uint8_t>("Nb", lheNb, "Number of b partons at LHE step", nanoaod::FlatTable::UInt8Column);
-    out.addColumnValue<uint8_t>("Nc", lheNc, "Number of c partons at LHE step", nanoaod::FlatTable::UInt8Column);
-    out.addColumnValue<uint8_t>(
-        "Nuds", lheNuds, "Number of u,d,s partons at LHE step", nanoaod::FlatTable::UInt8Column);
-    out.addColumnValue<uint8_t>(
-        "Nglu", lheNglu, "Number of gluon partons at LHE step", nanoaod::FlatTable::UInt8Column);
-    out.addColumnValue<float>("HT", lheHT, "HT, scalar sum of parton pTs at LHE step", nanoaod::FlatTable::FloatColumn);
+    out.addColumnValue<uint8_t>("Njets", lheNj, "Number of jets (partons) at LHE step");
+    out.addColumnValue<uint8_t>("Nb", lheNb, "Number of b partons at LHE step");
+    out.addColumnValue<uint8_t>("Nc", lheNc, "Number of c partons at LHE step");
+    out.addColumnValue<uint8_t>("Nuds", lheNuds, "Number of u,d,s partons at LHE step");
+    out.addColumnValue<uint8_t>("Nglu", lheNglu, "Number of gluon partons at LHE step");
+    out.addColumnValue<float>("HT", lheHT, "HT, scalar sum of parton pTs at LHE step");
     out.addColumnValue<float>("HTIncoming",
                               lheHTIncoming,
                               "HT, scalar sum of parton pTs at LHE step, restricted to partons",
                               nanoaod::FlatTable::FloatColumn);
-    out.addColumnValue<float>("Vpt", lheVpt, "pT of the W or Z boson at LHE step", nanoaod::FlatTable::FloatColumn);
-    out.addColumnValue<uint8_t>("NpNLO", lheProd.npNLO(), "number of partons at NLO", nanoaod::FlatTable::UInt8Column);
-    out.addColumnValue<uint8_t>("NpLO", lheProd.npLO(), "number of partons at LO", nanoaod::FlatTable::UInt8Column);
-    out.addColumnValue<float>("AlphaS", alphaS, "Per-event alphaS", nanoaod::FlatTable::FloatColumn);
+    out.addColumnValue<float>("Vpt", lheVpt, "pT of the W or Z boson at LHE step");
+    out.addColumnValue<uint8_t>("NpNLO", lheProd.npNLO(), "number of partons at NLO");
+    out.addColumnValue<uint8_t>("NpLO", lheProd.npLO(), "number of partons at LO");
+    out.addColumnValue<float>("AlphaS", alphaS, "Per-event alphaS");
 
     auto outPart = std::make_unique<nanoaod::FlatTable>(vals_pt.size(), "LHEPart", false);
-    outPart->addColumn<float>("pt", vals_pt, "Pt of LHE particles", nanoaod::FlatTable::FloatColumn, this->precision_);
-    outPart->addColumn<float>(
-        "eta", vals_eta, "Pseodorapidity of LHE particles", nanoaod::FlatTable::FloatColumn, this->precision_);
-    outPart->addColumn<float>(
-        "phi", vals_phi, "Phi of LHE particles", nanoaod::FlatTable::FloatColumn, this->precision_);
-    outPart->addColumn<float>(
-        "mass", vals_mass, "Mass of LHE particles", nanoaod::FlatTable::FloatColumn, this->precision_);
-    outPart->addColumn<float>(
-        "incomingpz", vals_pz, "Pz of incoming LHE particles", nanoaod::FlatTable::FloatColumn, this->precision_);
-    outPart->addColumn<int>("pdgId", vals_pid, "PDG ID of LHE particles", nanoaod::FlatTable::IntColumn);
-    outPart->addColumn<int>(
-        "status", vals_status, "LHE particle status; -1:incoming, 1:outgoing", nanoaod::FlatTable::IntColumn);
-    outPart->addColumn<int>("spin", vals_spin, "Spin of LHE particles", nanoaod::FlatTable::IntColumn);
+    outPart->addColumn<float>("pt", vals_pt, "Pt of LHE particles", this->precision_);
+    outPart->addColumn<float>("eta", vals_eta, "Pseodorapidity of LHE particles", this->precision_);
+    outPart->addColumn<float>("phi", vals_phi, "Phi of LHE particles", this->precision_);
+    outPart->addColumn<float>("mass", vals_mass, "Mass of LHE particles", this->precision_);
+    outPart->addColumn<float>("incomingpz", vals_pz, "Pz of incoming LHE particles", this->precision_);
+    outPart->addColumn<int>("pdgId", vals_pid, "PDG ID of LHE particles");
+    outPart->addColumn<int>("status", vals_status, "LHE particle status; -1:incoming, 1:outgoing");
+    outPart->addColumn<int>("spin", vals_spin, "Spin of LHE particles");
 
     return outPart;
   }

--- a/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
@@ -137,10 +137,8 @@ public:
     out.addColumnValue<uint8_t>("Nuds", lheNuds, "Number of u,d,s partons at LHE step");
     out.addColumnValue<uint8_t>("Nglu", lheNglu, "Number of gluon partons at LHE step");
     out.addColumnValue<float>("HT", lheHT, "HT, scalar sum of parton pTs at LHE step");
-    out.addColumnValue<float>("HTIncoming",
-                              lheHTIncoming,
-                              "HT, scalar sum of parton pTs at LHE step, restricted to partons",
-                              nanoaod::FlatTable::FloatColumn);
+    out.addColumnValue<float>(
+        "HTIncoming", lheHTIncoming, "HT, scalar sum of parton pTs at LHE step, restricted to partons");
     out.addColumnValue<float>("Vpt", lheVpt, "pT of the W or Z boson at LHE step");
     out.addColumnValue<uint8_t>("NpNLO", lheProd.npNLO(), "number of partons at NLO");
     out.addColumnValue<uint8_t>("NpLO", lheProd.npLO(), "number of partons at LO");

--- a/PhysicsTools/NanoAOD/plugins/MuonIDTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/MuonIDTableProducer.cc
@@ -70,22 +70,19 @@ void MuonIDTableProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::
   }
 
   auto tab = std::make_unique<nanoaod::FlatTable>(ncand, name_, false, true);
-  tab->addColumn<uint8_t>("tightId", tight, "POG Tight muon ID", nanoaod::FlatTable::BoolColumn);
+  tab->addColumn<bool>("tightId", tight, "POG Tight muon ID");
   tab->addColumn<uint8_t>(
       "highPtId",
       highPt,
-      "POG highPt muon ID (1 = tracker high pT, 2 = global high pT, which includes tracker high pT)",
-      nanoaod::FlatTable::UInt8Column);
-  tab->addColumn<uint8_t>(
+      "POG highPt muon ID (1 = tracker high pT, 2 = global high pT, which includes tracker high pT)");
+  tab->addColumn<bool>(
       "softId",
       soft,
-      "POG Soft muon ID (using the relaxed cuts in the data Run 2016 B-F periods, and standard cuts elsewhere)",
-      nanoaod::FlatTable::BoolColumn);
-  tab->addColumn<uint8_t>(
+      "POG Soft muon ID (using the relaxed cuts in the data Run 2016 B-F periods, and standard cuts elsewhere)");
+  tab->addColumn<bool>(
       "mediumId",
       medium,
-      "POG Medium muon ID (using the relaxed cuts in the data Run 2016 B-F periods, and standard cuts elsewhere)",
-      nanoaod::FlatTable::BoolColumn);
+      "POG Medium muon ID (using the relaxed cuts in the data Run 2016 B-F periods, and standard cuts elsewhere)");
 
   iEvent.put(std::move(tab));
 }

--- a/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
@@ -77,18 +77,15 @@ public:
     out.addColumnValue<float>("nTrueInt",
                               nt,
                               "the true mean number of the poisson distribution for this event from which the number "
-                              "of interactions each bunch crossing has been sampled",
-                              nanoaod::FlatTable::FloatColumn);
+                              "of interactions each bunch crossing has been sampled");
     out.addColumnValue<int>(
         "nPU",
         npu,
-        "the number of pileup interactions that have been added to the event in the current bunch crossing",
-        nanoaod::FlatTable::IntColumn);
-    out.addColumnValue<int>("sumEOOT", eoot, "number of early out of time pileup", nanoaod::FlatTable::IntColumn);
-    out.addColumnValue<int>("sumLOOT", loot, "number of late out of time pileup", nanoaod::FlatTable::IntColumn);
-    out.addColumnValue<float>("pudensity", pudensity, "PU vertices / mm", nanoaod::FlatTable::FloatColumn);
-    out.addColumnValue<float>(
-        "gpudensity", gpudensity, "Generator-level PU vertices / mm", nanoaod::FlatTable::FloatColumn);
+        "the number of pileup interactions that have been added to the event in the current bunch crossing");
+    out.addColumnValue<int>("sumEOOT", eoot, "number of early out of time pileup");
+    out.addColumnValue<int>("sumLOOT", loot, "number of late out of time pileup");
+    out.addColumnValue<float>("pudensity", pudensity, "PU vertices / mm");
+    out.addColumnValue<float>("gpudensity", gpudensity, "Generator-level PU vertices / mm");
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/NanoAOD/plugins/NanoAODBaseCrossCleaner.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODBaseCrossCleaner.cc
@@ -104,11 +104,11 @@ void NanoAODBaseCrossCleaner::produce(edm::Event& iEvent, const edm::EventSetup&
 
   objectSelection(*jetsIn, *muonsIn, *electronsIn, *tausIn, *photonsIn, jets, muons, eles, taus, photons);
 
-  muonsTable->addColumn<uint8_t>(name_, muons, doc_, nanoaod::FlatTable::UInt8Column);
-  jetsTable->addColumn<uint8_t>(name_, jets, doc_, nanoaod::FlatTable::UInt8Column);
-  electronsTable->addColumn<uint8_t>(name_, eles, doc_, nanoaod::FlatTable::UInt8Column);
-  tausTable->addColumn<uint8_t>(name_, taus, doc_, nanoaod::FlatTable::UInt8Column);
-  photonsTable->addColumn<uint8_t>(name_, photons, doc_, nanoaod::FlatTable::UInt8Column);
+  muonsTable->addColumn<uint8_t>(name_, muons, doc_);
+  jetsTable->addColumn<uint8_t>(name_, jets, doc_);
+  electronsTable->addColumn<uint8_t>(name_, eles, doc_);
+  tausTable->addColumn<uint8_t>(name_, taus, doc_);
+  photonsTable->addColumn<uint8_t>(name_, photons, doc_);
 
   iEvent.put(std::move(jetsTable), "jets");
   iEvent.put(std::move(muonsTable), "muons");

--- a/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
@@ -94,8 +94,10 @@ private:
           vfill<uint8_t>(table, icol, rowsel);
           break;
         case FlatTable::ColumnType::Bool:
-          vfill<uint8_t>(table, icol, rowsel);
+          vfill<bool>(table, icol, rowsel);
           break;
+        default:
+          throw cms::Exception("LogicError", "Unsupported type");
       }
     }
 

--- a/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
@@ -84,16 +84,16 @@ private:
       if (icol == -1)
         return;  // columns may be missing (e.g. mc-only)
       switch (table.columnType(icol)) {
-        case FlatTable::FloatColumn:
+        case FlatTable::ColumnType::Float:
           vfill<float>(table, icol, rowsel);
           break;
-        case FlatTable::IntColumn:
+        case FlatTable::ColumnType::Int:
           vfill<int>(table, icol, rowsel);
           break;
-        case FlatTable::UInt8Column:
+        case FlatTable::ColumnType::UInt8:
           vfill<uint8_t>(table, icol, rowsel);
           break;
-        case FlatTable::BoolColumn:
+        case FlatTable::ColumnType::Bool:
           vfill<uint8_t>(table, icol, rowsel);
           break;
       }

--- a/PhysicsTools/NanoAOD/plugins/NativeArrayTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/NativeArrayTableProducer.cc
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-template <typename TIn, typename TCol, nanoaod::FlatTable::ColumnType CT>
+template <typename TIn, typename TCol>
 class NativeArrayTableProducer : public edm::stream::EDProducer<> {
 public:
   NativeArrayTableProducer(edm::ParameterSet const& params)
@@ -23,7 +23,7 @@ public:
     const auto& in = *src;
     auto out = std::make_unique<nanoaod::FlatTable>(in.size(), name_, false, false);
     out->setDoc(doc_);
-    (*out).template addColumn<TCol>(this->name_, in, this->doc_, CT);
+    (*out).template addColumn<TCol>(this->name_, in, this->doc_);
     iEvent.put(std::move(out));
   }
 
@@ -33,10 +33,10 @@ protected:
   const edm::EDGetTokenT<TIn> src_;
 };
 
-typedef NativeArrayTableProducer<std::vector<float>, float, nanoaod::FlatTable::FloatColumn> FloatArrayTableProducer;
-typedef NativeArrayTableProducer<std::vector<double>, float, nanoaod::FlatTable::FloatColumn> DoubleArrayTableProducer;
-typedef NativeArrayTableProducer<std::vector<int>, int, nanoaod::FlatTable::IntColumn> IntArrayTableProducer;
-typedef NativeArrayTableProducer<std::vector<bool>, uint8_t, nanoaod::FlatTable::UInt8Column> BoolArrayTableProducer;
+typedef NativeArrayTableProducer<std::vector<float>, float> FloatArrayTableProducer;
+typedef NativeArrayTableProducer<std::vector<double>, float> DoubleArrayTableProducer;
+typedef NativeArrayTableProducer<std::vector<int>, int> IntArrayTableProducer;
+typedef NativeArrayTableProducer<std::vector<bool>, bool> BoolArrayTableProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(FloatArrayTableProducer);

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
@@ -25,6 +25,8 @@ void TableOutputBranches::defineBranchesFromFirstEvent(const nanoaod::FlatTable 
       case nanoaod::FlatTable::ColumnType::Bool:
         m_uint8Branches.emplace_back(var, tab.columnDoc(i), "O");
         break;
+      default:
+        throw cms::Exception("LogicError", "Unsupported type");
     }
   }
 }

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
@@ -13,16 +13,16 @@ void TableOutputBranches::defineBranchesFromFirstEvent(const nanoaod::FlatTable 
   for (size_t i = 0; i < tab.nColumns(); i++) {
     const std::string &var = tab.columnName(i);
     switch (tab.columnType(i)) {
-      case (nanoaod::FlatTable::FloatColumn):
+      case nanoaod::FlatTable::ColumnType::Float:
         m_floatBranches.emplace_back(var, tab.columnDoc(i), "F");
         break;
-      case (nanoaod::FlatTable::IntColumn):
+      case nanoaod::FlatTable::ColumnType::Int:
         m_intBranches.emplace_back(var, tab.columnDoc(i), "I");
         break;
-      case (nanoaod::FlatTable::UInt8Column):
+      case nanoaod::FlatTable::ColumnType::UInt8:
         m_uint8Branches.emplace_back(var, tab.columnDoc(i), "b");
         break;
-      case (nanoaod::FlatTable::BoolColumn):
+      case nanoaod::FlatTable::ColumnType::Bool:
         m_uint8Branches.emplace_back(var, tab.columnDoc(i), "O");
         break;
     }

--- a/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
@@ -282,18 +282,16 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
   }
 
   auto tab = std::make_unique<nanoaod::FlatTable>(nobj, name_, false, false);
-  tab->addColumn<int>("id", id, idDoc_, nanoaod::FlatTable::IntColumn);
-  tab->addColumn<float>("pt", pt, "pt", nanoaod::FlatTable::FloatColumn, 12);
-  tab->addColumn<float>("eta", eta, "eta", nanoaod::FlatTable::FloatColumn, 12);
-  tab->addColumn<float>("phi", phi, "phi", nanoaod::FlatTable::FloatColumn, 12);
-  tab->addColumn<float>("l1pt", l1pt, "pt of associated L1 seed", nanoaod::FlatTable::FloatColumn, 8);
-  tab->addColumn<int>("l1iso", l1iso, "iso of associated L1 seed", nanoaod::FlatTable::IntColumn);
-  tab->addColumn<int>("l1charge", l1charge, "charge of associated L1 seed", nanoaod::FlatTable::IntColumn);
-  tab->addColumn<float>("l1pt_2", l1pt_2, "pt of associated secondary L1 seed", nanoaod::FlatTable::FloatColumn, 8);
-  tab->addColumn<float>(
-      "l2pt", l2pt, "pt of associated 'L2' seed (i.e. HLT before tracking/PF)", nanoaod::FlatTable::FloatColumn, 10);
-  tab->addColumn<int>(
-      "filterBits", bits, "extra bits of associated information: " + bitsDoc_, nanoaod::FlatTable::IntColumn);
+  tab->addColumn<int>("id", id, idDoc_);
+  tab->addColumn<float>("pt", pt, "pt", 12);
+  tab->addColumn<float>("eta", eta, "eta", 12);
+  tab->addColumn<float>("phi", phi, "phi", 12);
+  tab->addColumn<float>("l1pt", l1pt, "pt of associated L1 seed", 8);
+  tab->addColumn<int>("l1iso", l1iso, "iso of associated L1 seed");
+  tab->addColumn<int>("l1charge", l1charge, "charge of associated L1 seed");
+  tab->addColumn<float>("l1pt_2", l1pt_2, "pt of associated secondary L1 seed", 8);
+  tab->addColumn<float>("l2pt", l2pt, "pt of associated 'L2' seed (i.e. HLT before tracking/PF)", 10);
+  tab->addColumn<int>("filterBits", bits, "extra bits of associated information: " + bitsDoc_);
   iEvent.put(std::move(tab));
 }
 

--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -117,39 +117,27 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.getByToken(pvs_, pvsIn);
   iEvent.getByToken(pvsScore_, pvsScoreIn);
   auto pvTable = std::make_unique<nanoaod::FlatTable>(1, pvName_, true);
-  pvTable->addColumnValue<float>(
-      "ndof", (*pvsIn)[0].ndof(), "main primary vertex number of degree of freedom", nanoaod::FlatTable::FloatColumn, 8);
-  pvTable->addColumnValue<float>(
-      "x", (*pvsIn)[0].position().x(), "main primary vertex position x coordinate", nanoaod::FlatTable::FloatColumn, 10);
-  pvTable->addColumnValue<float>(
-      "y", (*pvsIn)[0].position().y(), "main primary vertex position y coordinate", nanoaod::FlatTable::FloatColumn, 10);
-  pvTable->addColumnValue<float>(
-      "z", (*pvsIn)[0].position().z(), "main primary vertex position z coordinate", nanoaod::FlatTable::FloatColumn, 16);
-  pvTable->addColumnValue<float>(
-      "chi2", (*pvsIn)[0].normalizedChi2(), "main primary vertex reduced chi2", nanoaod::FlatTable::FloatColumn, 8);
+  pvTable->addColumnValue<float>("ndof", (*pvsIn)[0].ndof(), "main primary vertex number of degree of freedom", 8);
+  pvTable->addColumnValue<float>("x", (*pvsIn)[0].position().x(), "main primary vertex position x coordinate", 10);
+  pvTable->addColumnValue<float>("y", (*pvsIn)[0].position().y(), "main primary vertex position y coordinate", 10);
+  pvTable->addColumnValue<float>("z", (*pvsIn)[0].position().z(), "main primary vertex position z coordinate", 16);
+  pvTable->addColumnValue<float>("chi2", (*pvsIn)[0].normalizedChi2(), "main primary vertex reduced chi2", 8);
   int goodPVs = 0;
   for (const auto& pv : *pvsIn)
     if (goodPvCut_(pv))
       goodPVs++;
+  pvTable->addColumnValue<int>("npvs", pvsIn->size(), "total number of reconstructed primary vertices");
   pvTable->addColumnValue<int>(
-      "npvs", (*pvsIn).size(), "total number of reconstructed primary vertices", nanoaod::FlatTable::IntColumn);
-  pvTable->addColumnValue<int>("npvsGood",
-                               goodPVs,
-                               "number of good reconstructed primary vertices. selection:" + goodPvCutString_,
-                               nanoaod::FlatTable::IntColumn);
-  pvTable->addColumnValue<float>("score",
-                                 (*pvsScoreIn).get(pvsIn.id(), 0),
-                                 "main primary vertex score, i.e. sum pt2 of clustered objects",
-                                 nanoaod::FlatTable::FloatColumn,
-                                 8);
+      "npvsGood", goodPVs, "number of good reconstructed primary vertices. selection:" + goodPvCutString_);
+  pvTable->addColumnValue<float>(
+      "score", pvsScoreIn->get(pvsIn.id(), 0), "main primary vertex score, i.e. sum pt2 of clustered objects", 8);
 
   auto otherPVsTable =
       std::make_unique<nanoaod::FlatTable>((*pvsIn).size() > 4 ? 3 : (*pvsIn).size() - 1, "Other" + pvName_, false);
   std::vector<float> pvsz;
   for (size_t i = 1; i < (*pvsIn).size() && i < 4; i++)
     pvsz.push_back((*pvsIn)[i - 1].position().z());
-  otherPVsTable->addColumn<float>(
-      "z", pvsz, "Z position of other primary vertices, excluding the main PV", nanoaod::FlatTable::FloatColumn, 8);
+  otherPVsTable->addColumn<float>("z", pvsz, "Z position of other primary vertices, excluding the main PV", 8);
 
   edm::Handle<edm::View<reco::VertexCompositePtrCandidate>> svsIn;
   iEvent.getByToken(svs_, svsIn);
@@ -183,12 +171,11 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   auto svsTable = std::make_unique<nanoaod::FlatTable>(selCandSv->size(), svName_, false);
   // For SV we fill from here only stuff that cannot be created with the SimpleFlatTableProducer
-  svsTable->addColumn<float>("dlen", dlen, "decay length in cm", nanoaod::FlatTable::FloatColumn, 10);
-  svsTable->addColumn<float>("dlenSig", dlenSig, "decay length significance", nanoaod::FlatTable::FloatColumn, 10);
-  svsTable->addColumn<float>("dxy", dxy, "2D decay length in cm", nanoaod::FlatTable::FloatColumn, 10);
-  svsTable->addColumn<float>("dxySig", dxySig, "2D decay length significance", nanoaod::FlatTable::FloatColumn, 10);
-  svsTable->addColumn<float>(
-      "pAngle", pAngle, "pointing angle, i.e. acos(p_SV * (SV - PV)) ", nanoaod::FlatTable::FloatColumn, 10);
+  svsTable->addColumn<float>("dlen", dlen, "decay length in cm", 10);
+  svsTable->addColumn<float>("dlenSig", dlenSig, "decay length significance", 10);
+  svsTable->addColumn<float>("dxy", dxy, "2D decay length in cm", 10);
+  svsTable->addColumn<float>("dxySig", dxySig, "2D decay length significance", 10);
+  svsTable->addColumn<float>("pAngle", pAngle, "pointing angle, i.e. acos(p_SV * (SV - PV)) ", 10);
 
   iEvent.put(std::move(pvTable), "pv");
   iEvent.put(std::move(otherPVsTable), "otherPVs");


### PR DESCRIPTION
#### PR description:

This is just a re-opening of https://github.com/cms-nanoAOD/cmssw/pull/401 from September 2019, but this time to upstream CMSSW instead of cmssw-nanoAOD. Back in the day I was interested in storing columns of so far not supported basic types in NanoAOD (like `uint16_t`), and made some developments which are I think the first steps towards this. Since https://github.com/cms-sw/cmssw/pull/30273 set the precedent that technical NanoAOD developments are acceptable outside cmssw-nanoAOD, I reopen the PR here almost a year later. Original description in the following.

----------

Hi NanoAOD devs!

I hope this is the right cmssw fork and branch for this PR.

Yesterday I wanted to introduce some new column types in my private nanoAOD productions (int16_t for example, to save a bit of space) and use them in the flat table producers. However, I realized that there are many parts of the NanoAOD code which have to be tweaked if you want to do this, as the way how column types are handled is not completely trivial.

One source of complication is that when you add a column to a flat table with addColumn(), you have to pass the type as a template argument as well as an enum value in the function parameters. After working a bit with the code, I understood that this is redundant, because the check_type function makes sure you always use the right enum value with the right template parameter. Therefore, we could just drop this enum parameter and deduce it from the template argument. In this situation, we would also not need check_type anymore.

The only tricky part are bool columns, which should actually be represented by a uint8_t vector. So far, the logic to take care of this had to be implemented in the plugins that made use of the FlatTable class, but I think I found a way to have this logic directly in the FlatTable class so one can just use addColumn<bool> to create bool columns and they will be internally stored in the uint8_t vector.

What do you think? This simplifies the type handling already quite a bit, and I think it's the good path towards a FlatTable class that will support all basic types that you can also store in TTrees.

I tested this with the local matrix tests so far, can the nano-bot tests still be done here? That would be very cool!

Thanks for considering this and cheers,
Jonas

#### PR validation:

* CMSSW compiles
* local matrix tests pass
* bot tests in cms-nanoAOD pass (see https://github.com/cms-nanoAOD/cmssw/pull/401)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport  intended.
