### PR TITLE
Reduce boost dependency in RecoTracker/TkSeedingLayers

### DIFF
--- a/RecoTracker/TkSeedingLayers/BuildFile.xml
+++ b/RecoTracker/TkSeedingLayers/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="boost"/>
 <use name="clhep"/>
 <use name="root"/>
 <use name="DataFormats/SiPixelDetId"/>


### PR DESCRIPTION
#### PR description:
Changed boost::ptr_vector for std::vector<std::unique_ptr<>>
The code should have the same behavior and also similar performance. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 