### PR TITLE
Protection for extrapolation of laser corrections (reload PR #30254)

### DIFF
--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h
@@ -1,5 +1,6 @@
 //
 // Toyoko Orimoto (Caltech), 10 July 2007
+// Fabrice Couderc (Saclay), 16 March 2020 : add protection if t > t3 +deltat : t = t3 + deltat
 //
 
 #ifndef EcalLaserDbService_h
@@ -36,11 +37,14 @@ public:
   void setAPDPNData(const EcalLaserAPDPNRatios* fItem) { mAPDPNRatios_ = fItem; }
   void setLinearCorrectionsData(const EcalLinearCorrections* fItem) { mLinearCorrections_ = fItem; }
 
+  void setMaxExtrapolationTimeInSec(int deltaT) { maxExtrapolationTime_ = ((unsigned long long)deltaT) << 32; }
+
 private:
   const EcalLaserAlphas* mAlphas_;
   const EcalLaserAPDPNRatiosRef* mAPDPNRatiosRef_;
   const EcalLaserAPDPNRatios* mAPDPNRatios_;
   const EcalLinearCorrections* mLinearCorrections_;
+  unsigned long long maxExtrapolationTime_;
 
   typedef tbb::concurrent_unordered_set<uint32_t> ErrorMapT;
   mutable ErrorMapT channelsWithInvalidCorrection_;

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionService.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionService.cc
@@ -108,13 +108,10 @@ std::shared_ptr<EcalLaserDbService> EcalLaserCorrectionService::produce(const Ec
   return host;  // automatically converts to std::shared_ptr<EcalLaserDbService>
 }
 
-
-void  EcalLaserCorrectionService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void EcalLaserCorrectionService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<unsigned int>("maxExtrapolationTimeInSec", 0);
   descriptions.add("EcalLaserCorrectionService", desc);
 }
-
-
 
 DEFINE_FWK_EVENTSETUP_MODULE(EcalLaserCorrectionService);

--- a/CalibCalorimetry/EcalLaserCorrection/python/ecalLaserCorrectionService_cfi.py
+++ b/CalibCalorimetry/EcalLaserCorrection/python/ecalLaserCorrectionService_cfi.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-EcalLaserCorrectionService = cms.ESProducer("EcalLaserCorrectionService")
+EcalLaserCorrectionService = cms.ESProducer("EcalLaserCorrectionService", 
+                                        ### delta t is the safety margin before stopping
+                                        ### the laser correction extrapolation (this is in seconds)
+                                        maxExtrapolationTimeInSec = cms.uint32( 0 ) )
+
 
 

--- a/CalibCalorimetry/EcalLaserCorrection/src/EcalLaserDbService.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/src/EcalLaserDbService.cc
@@ -13,7 +13,11 @@
 using namespace std;
 
 EcalLaserDbService::EcalLaserDbService()
-    : mAlphas_(nullptr), mAPDPNRatiosRef_(nullptr), mAPDPNRatios_(nullptr), mLinearCorrections_(nullptr) {}
+    : mAlphas_(nullptr),
+      mAPDPNRatiosRef_(nullptr),
+      mAPDPNRatios_(nullptr),
+      mLinearCorrections_(nullptr),
+      maxExtrapolationTime_(0) {}
 
 const EcalLaserAlphas* EcalLaserDbService::getAlphas() const { return mAlphas_; }
 
@@ -192,6 +196,10 @@ float EcalLaserDbService::getLaserCorrection(DetId const& xid, edm::Timestamp co
     p_f = apdpnpair.p3;
   }
 
+  long long t_laser = t;
+  if (t > timestamp.t3.value() + maxExtrapolationTime_)
+    t_laser = ((long long)timestamp.t3.value()) + maxExtrapolationTime_;
+
   if (t >= linTimes.t1.value() && t < linTimes.t2.value()) {
     lt_i = linTimes.t1.value();
     lt_f = linTimes.t2.value();
@@ -217,7 +225,8 @@ float EcalLaserDbService::getLaserCorrection(DetId const& xid, edm::Timestamp co
 
   if (apdpnref != 0 && (t_i - t_f) != 0 && (lt_i - lt_f) != 0) {
     long long tt = t;  // never subtract two unsigned!
-    float interpolatedLaserResponse = p_i / apdpnref + float(tt - t_i) * (p_f - p_i) / (apdpnref * float(t_f - t_i));
+    float interpolatedLaserResponse =
+        p_i / apdpnref + float(t_laser - t_i) * (p_f - p_i) / (apdpnref * float(t_f - t_i));
     float interpolatedLinearResponse =
         lp_i / apdpnref + float(tt - lt_i) * (lp_f - lp_i) / (apdpnref * float(lt_f - lt_i));  // FIXED BY FC
 


### PR DESCRIPTION
reload of PR #30254 

#### PR description:
add extra parameter to protect for extrapolation of laser corrections.
 
if t > t3 + dt : t = t3+dt

#### PR validation:

addOnTests.py
runTheMatrix.py was not re-run, but was working perfectly for the last PR 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
