### PR TITLE
SimGeneral/Debugging: add MTD to the digi dump

### DIFF
--- a/SimGeneral/Debugging/test/SimDigiDumper.cc
+++ b/SimGeneral/Debugging/test/SimDigiDumper.cc
@@ -39,6 +39,8 @@ SimDigiDumper::SimDigiDumper(const edm::ParameterSet& iPSet) {
   MuCSCStripSrc_ = consumes<CSCStripDigiCollection>(iPSet.getParameter<edm::InputTag>("MuCSCStripSrc"));
   MuCSCWireSrc_ = consumes<CSCWireDigiCollection>(iPSet.getParameter<edm::InputTag>("MuCSCWireSrc"));
   MuRPCSrc_ = consumes<RPCDigiCollection>(iPSet.getParameter<edm::InputTag>("MuRPCSrc"));
+  BTLSrc_ = consumes<BTLDigiCollection>(iPSet.getParameter<edm::InputTag>("BTLSrc"));
+  ETLSrc_ = consumes<ETLDigiCollection>(iPSet.getParameter<edm::InputTag>("ETLSrc"));
 
   // TODO(proper responsible): update the cout, for sure not my
   // business.
@@ -144,6 +146,52 @@ void SimDigiDumper::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       for (unsigned int digis = 0; digis < EcalDigiES->size(); ++digis) {
         ESDataFrame esdf = (*ESdigis)[digis];
         std::cout << esdf << std::endl;
+      }
+    }
+  }
+
+  // BTL
+  bool isBTL = true;
+  edm::Handle<BTLDigiCollection> BTLDigi;
+  const BTLDigiCollection* BTLdigis = 0;
+  iEvent.getByToken(BTLSrc_, BTLDigi);
+  if (!BTLDigi.isValid()) {
+    std::cout << "Unable to find BTLDigi in event!" << std::endl;
+  } else {
+    BTLdigis = BTLDigi.product();
+    if (BTLDigi->size() == 0)
+      isBTL = false;
+    std::cout << "Barrel Timing Layer, digi multiplicity = " << BTLDigi->size() << std::endl;
+
+    if (isBTL) {
+      // loop over digis
+      for (unsigned int digis = 0; digis < BTLDigi->size(); ++digis) {
+        BTLDataFrame btldf = (*BTLdigis)[digis];
+        std::cout << btldf.id().rawId() << std::endl;
+        btldf.print();
+      }
+    }
+  }
+
+  // ETL
+  bool isETL = true;
+  edm::Handle<ETLDigiCollection> ETLDigi;
+  const ETLDigiCollection* ETLdigis = 0;
+  iEvent.getByToken(ETLSrc_, ETLDigi);
+  if (!ETLDigi.isValid()) {
+    std::cout << "Unable to find ETLDigi in event!" << std::endl;
+  } else {
+    ETLdigis = ETLDigi.product();
+    if (ETLDigi->size() == 0)
+      isETL = false;
+    std::cout << "Endcap Timing Layer, digi multiplicity = " << ETLDigi->size() << std::endl;
+
+    if (isETL) {
+      // loop over digis
+      for (unsigned int digis = 0; digis < ETLDigi->size(); ++digis) {
+        ETLDataFrame etldf = (*ETLdigis)[digis];
+        std::cout << etldf.id().rawId() << std::endl;
+        etldf.print();
       }
     }
   }

--- a/SimGeneral/Debugging/test/SimDigiDumper.h
+++ b/SimGeneral/Debugging/test/SimDigiDumper.h
@@ -26,6 +26,8 @@
 #include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
 // muon RPC info
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
+// BTL/ETL info
+#include "DataFormats/FTLDigi/interface/FTLDigiCollections.h"
 
 #include <vector>
 
@@ -42,6 +44,9 @@ private:
   edm::EDGetTokenT<EBDigiCollection> ECalEBSrc_;
   edm::EDGetTokenT<EEDigiCollection> ECalEESrc_;
   edm::EDGetTokenT<ESDigiCollection> ECalESSrc_;
+
+  edm::EDGetTokenT<BTLDigiCollection> BTLSrc_;
+  edm::EDGetTokenT<ETLDigiCollection> ETLSrc_;
 
   edm::EDGetTokenT<HBHEDigiCollection> HCalDigi_;
   edm::EDGetTokenT<HODigiCollection> HCalHODigi_;

--- a/SimGeneral/Debugging/test/runSimDigiDumper_cfg.py
+++ b/SimGeneral/Debugging/test/runSimDigiDumper_cfg.py
@@ -16,14 +16,16 @@ process.prod = cms.EDAnalyzer("SimDigiDumper",
     MuCSCStripSrc = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi"),
     MuDTSrc = cms.InputTag("simMuonDTDigis"),
     HCalDigi = cms.InputTag("simHcalDigis"),
-    ZdcDigi = cms.InputTag("simHcalUnsuppressedDigis"),                        
+    ZdcDigi = cms.InputTag("simHcalUnsuppressedDigis"),
     MuCSCWireSrc = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi"),
     ECalEESrc = cms.InputTag("simEcalDigis","eeDigis"),
     SiStripSrc = cms.InputTag("simSiStripDigis","ZeroSuppressed"),
     SiPxlSrc = cms.InputTag("simSiPixelDigis"),
     ECalEBSrc = cms.InputTag("simEcalDigis","ebDigis"),
     ECalESSrc = cms.InputTag("simEcalPreshowerDigis"),
-    MuRPCSrc = cms.InputTag("simMuonRPCDigis")
+    MuRPCSrc = cms.InputTag("simMuonRPCDigis"),
+    BTLSrc = cms.InputTag("mix","FTLBarrel"),
+    ETLSrc = cms.InputTag("mix","FTLEndcap"),
 )
 
 process.p1 = cms.Path(process.prod)


### PR DESCRIPTION
#### PR description:

Simple update of the ```SimDigiDumper``` class, to be used for visual inspection of DIGI collections content, where the MTD digi collections (BTL and ETL) are added and printed, if present.

#### PR validation:

Used in debugging #30340 , here is the dump for a digi in test wf. 23234.0 :

```
Barrel Timing Layer, digi multiplicity = 539
1652623911
[0] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 12 Row: 0 Column: 13 Raw Flag=0x3 Raw Data=0x3ffffc0c
[1] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 11 Row: 0 Column: 13 Raw Flag=0x3 Raw Data=0x3ffffc0b
1652626726
[0] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 43 Row: 2 Column: 12 Raw Flag=0x3 Raw Data=0x3ffffc2b
[1] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 45 Row: 2 Column: 12 Raw Flag=0x3 Raw Data=0x3ffffc2d
1652630315
[0] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 4 Row: 1 Column: 14 Raw Flag=0x3 Raw Data=0x3ffffc04
[1] THR: 1 Mode: 0 ToA2: 978 ToA: 948 Data: 5 Row: 1 Column: 14 Raw Flag=0x2 Raw Data=0x3d2ed005
1652632077
[0] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 10 Row: 1 Column: 4 Raw Flag=0x3 Raw Data=0x3ffffc0a
[1] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 10 Row: 1 Column: 4 Raw Flag=0x3 Raw Data=0x3ffffc0a
1652632080
[0] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 6 Row: 1 Column: 5 Raw Flag=0x3 Raw Data=0x3ffffc06
[1] THR: 1 Mode: 1 ToA2: 1023 ToA: 1023 Data: 6 Row: 1 Column: 5 Raw Flag=0x3 Raw Data=0x3ffffc06
1652635414
[0] THR: 1 Mode: 0 ToA2: 890 ToA: 853 Data: 8 Row: 1 Column: 7 Raw Flag=0x2 Raw Data=0x37ad5408
[1] THR: 1 Mode: 0 ToA2: 891 ToA: 847 Data: 8 Row: 1 Column: 7 Raw Flag=0x2 Raw Data=0x37bd3c08
(...)
Endcap Timing Layer, digi multiplicity = 206
1661011072
[0] (row,col) : (10,1) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x2500000
[1] (row,col) : (10,1) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x2500000
[2] (row,col) : (10,1) THR: 1 Mode: 0 ToA: 1027 Data: 10 Raw=0x8254030a
[3] (row,col) : (10,1) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x2500000
[4] (row,col) : (10,1) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x2500000
1661011584
[0] (row,col) : (45,18) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x25680000
[1] (row,col) : (45,18) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x25680000
[2] (row,col) : (45,18) THR: 1 Mode: 0 ToA: 896 Data: 12 Raw=0xa56b800c
[3] (row,col) : (45,18) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x25680000
[4] (row,col) : (45,18) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x25680000
1661011712
[0] (row,col) : (39,17) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x23380000
[1] (row,col) : (39,17) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x23380000
[2] (row,col) : (39,17) THR: 1 Mode: 0 ToA: 885 Data: 9 Raw=0xa33b7509
[3] (row,col) : (39,17) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x23380000
[4] (row,col) : (39,17) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x23380000
1661011712
[0] (row,col) : (6,19) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x26300000
[1] (row,col) : (6,19) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x26300000
[2] (row,col) : (6,19) THR: 1 Mode: 0 ToA: 927 Data: 28 Raw=0xa6339f1c
[3] (row,col) : (6,19) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x26300000
[4] (row,col) : (6,19) THR: 0 Mode: 0 ToA: 0 Data: 0 Raw=0x26300000
(...)
```

It does not affect any production workflow or unit test.