### PR TITLE
Fix the MadGraph bug for multithreading (backport #30444)

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs_madgraphLO_multithread.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs_madgraphLO_multithread.sh
@@ -111,6 +111,25 @@ else
                                   math.sqrt(sum(x**2 for x in sum_xerru)),
                                   sum_axsec) 
 EOF
+
+        # fix another bug related to cross-section computing in multiththread mode, as identified in: https://bugs.launchpad.net/mg5amcnlo/+bug/1884085
+        patch process/madevent/bin/internal/madevent_interface.py << EOF
+=== modified file 'madgraph/interface/madevent_interface.py'
+--- madgraph/interface/madevent_interface.py	2020-06-08 15:08:17 +0000
++++ madgraph/interface/madevent_interface.py	2020-06-18 20:18:17 +0000
+@@ -6490,9 +6490,12 @@
+             os.chdir(self.me_dir)
+         else:
+             for line in open(pjoin(self.me_dir,'SubProcesses','subproc.mg')):
+-                os.mkdir(line.strip())
++                p = line.strip()
++                os.mkdir(p)
++                files.cp(pjoin(self.me_dir,'SubProcesses',p,'symfact.dat'),
++                         pjoin(p, 'symfact.dat'))
+             
+ 
+     def launch(self, nb_event, seed):
+EOF
     fi
     
     # fix another multi-thread related bug for MG 2.6.1 only

--- a/GeneratorInterface/LHEInterface/data/runcmsgrid_LO_support_multithread.patch
+++ b/GeneratorInterface/LHEInterface/data/runcmsgrid_LO_support_multithread.patch
@@ -1,9 +1,6 @@
 --- runcmsgrid.sh	2020-05-01 03:27:51.000000001 +0200
 +++ runcmsgrid.sh	2020-05-02 10:46:24.000000001 +0200
-@@ -43,6 +43,30 @@
- fi
- cd $LHEWORKDIR
- 
+@@ -48,1 +48,25 @@
 +# test if the current file system allow setting folder permission to read-only.
 +succ_setreadonly=true
 +mkdir testpermit
@@ -24,17 +21,12 @@
 +fi
 +
 +if fs listacl &>/dev/null; then
-+    fs sa -dir process/madevent -acl ${USER} all
++    fs sa -dir madevent -acl ${USER} all
 +else
-+    chmod +w process/madevent
++    chmod +w madevent
 +fi
- cd process
- 
  #make sure lhapdf points to local cmssw installation area
-@@ -56,6 +80,18 @@
- echo "nb_core = $ncpu" >> ./madevent/Cards/me5_configuration.txt
- #fi
- 
+@@ -59,3 +83,15 @@
 +function event_generate_per_thread () {
 +
 +# number of event to generate and seed in this thread
@@ -50,19 +42,10 @@
  #########################################
  # FORCE IT TO PRODUCE EXACTLY THE REQUIRED NUMBER OF EVENTS
  #########################################
-@@ -95,7 +131,7 @@
-   # run mg5_amc
-   echo "produced_lhe " $produced_lhe "nevt " $nevt "submitting_event " $submitting_event " remaining_event " $remaining_event
-   echo run.sh $submitting_event $run_random_seed
+@@ -98,1 +134,1 @@
 -  ./run.sh $submitting_event $run_random_seed
 +  ../process/run.sh $submitting_event $run_random_seed
-   
-   # compute number of events produced in the iteration
-   produced_lhe=$(($produced_lhe+`zgrep \<event events.lhe.gz | wc -l`))
-@@ -121,6 +157,56 @@
-     mv events_${run_counter}.lhe.gz events.lhe.gz
- fi
- 
+@@ -124,3 +160,53 @@
 +cd $LHEWORKDIR
 +
 +} ### end of function


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

**This PR is a backport from #30444**

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

The fix is on shell scripts, hence does not influence the CMSSW framework.
We tested the scripts on W+01234j and DY+01234j multi-jet processes to validate that the MG bug is solved.

(A quick test for this PR on [`SMP-MultiValidationUL17wmLHEGEN-00001`](https://cms-pdmv.cern.ch/mcm/requests?prepid=SMP-MultiValidationUL17wmLHEGEN-00001&page=0&shown=127))
```shell
cmsrel CMSSW_10_6_X_2020-06-26-2300
cd CMSSW_10_6_X_2020-06-26-2300/src/
cmsenv
git cms-merge-topic colizz:dev-mt-106X
curl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/SMP-MultiValidationUL17wmLHEGEN-00001 --retry 2 --create-dirs -o Configuration/GenProduction/python/SMP-MultiValidationUL17wmLHEGEN-00001-fragment.py 
scram b -j 8
cd ../..
cmsDriver.py Configuration/GenProduction/python/SMP-MultiValidationUL17wmLHEGEN-00001-fragment.py --fileout file:SMP-MultiValidationUL17wmLHEGEN-00001.root --mc --eventcontent RAWSIM,LHE --datatier GEN,LHE --conditions 106X_mc2017_realistic_v6 --beamspot Realistic25ns13TeVEarly2017Collision --step LHE,GEN --geometry DB:Extended --era Run2_2017 --python_filename SMP-MultiValidationUL17wmLHEGEN-00001_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 400 --nThreads 4

cmsRun -e -j SMP-MultiValidationUL17wmLHEGEN-00001_rt.xml SMP-MultiValidationUL17wmLHEGEN-00001_1_cfg.py
```