### PR TITLE
 BeamSpotOnline in DQM beamspot clients

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.h
@@ -68,6 +68,7 @@ private:
   const double dzMin_;
   const double dzMax_;
   std::string monitorName_;
+  std::string recordName_;                  // output BeamSpotOnline Record name
   edm::EDGetTokenT<reco::BeamSpot> bsSrc_;  // beam spot
   edm::EDGetTokenT<reco::TrackCollection> tracksLabel_;
   edm::EDGetTokenT<reco::VertexCollection> pvSrc_;  // primary vertex

--- a/DQM/BeamMonitor/plugins/BuildFile.xml
+++ b/DQM/BeamMonitor/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="RecoVertex/BeamSpotProducer"/>
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/TrackerRecHit2D"/>
+<use name="CondCore/DBOutputService"/>
 <library file="BeamMonitor.cc" name="BeamMonitor">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DQM/BeamMonitor/python/BeamMonitor_Cosmics_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_Cosmics_cff.py
@@ -10,6 +10,7 @@ dqmBeamMonitor = DQMEDAnalyzer("BeamMonitor",
                               resetEveryNLumi = cms.untracked.int32(20),
                               resetPVEveryNLumi = cms.untracked.int32(2),
                               Debug = cms.untracked.bool(False),
+                              recordName = cms.untracked.string('BeamSpotOnlineHLTObjectsRcd'),
                               BeamFitter = cms.PSet(
         			Debug = cms.untracked.bool(False),
         			TrackCollection = cms.untracked.InputTag('ctfWithMaterialTracksP5'), ## ctfWithMaterialTracksP5 for CRAFT

--- a/DQM/BeamMonitor/python/BeamMonitor_MC_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_MC_cff.py
@@ -11,6 +11,7 @@ dqmBeamMonitor = cms.DQMEDAnalyzer("BeamMonitor",
                               fitPVEveryNLumi = cms.untracked.int32(1),
                               resetPVEveryNLumi = cms.untracked.int32(2),
                               Debug = cms.untracked.bool(False),
+                              recordName = cms.untracked.string('BeamSpotOnlineHLTObjectsRcd'),
                               BeamFitter = cms.PSet(
         			Debug = cms.untracked.bool(False),
         			TrackCollection = cms.untracked.InputTag('generalTracks'), ## ctfWithMaterialTracksP5 for CRAFT

--- a/DQM/BeamMonitor/python/BeamMonitor_PixelLess_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_PixelLess_cff.py
@@ -9,6 +9,7 @@ dqmBeamMonitor_pixelless = DQMEDAnalyzer("BeamMonitor",
                               fitPVEveryNLumi = cms.untracked.int32(1),
                               resetPVEveryNLumi = cms.untracked.int32(2),
                               Debug = cms.untracked.bool(False),
+                              recordName = cms.untracked.string('BeamSpotOnlineHLTObjectsRcd'),
                               BeamFitter = cms.PSet(
         			Debug = cms.untracked.bool(False),
         			TrackCollection = cms.untracked.InputTag('ctfPixelLess'),

--- a/DQM/BeamMonitor/python/BeamMonitor_Pixel_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_Pixel_cff.py
@@ -12,6 +12,7 @@ dqmBeamMonitor = DQMEDAnalyzer("BeamMonitor",
                               resetPVEveryNLumi = cms.untracked.int32(5),
                               Debug = cms.untracked.bool(False),
                               OnlineMode = cms.untracked.bool(True),
+                              recordName = cms.untracked.string('BeamSpotOnlineHLTObjectsRcd'),
                               BeamFitter = cms.PSet(
                                 Debug = cms.untracked.bool(False),
                                 TrackCollection = cms.untracked.InputTag('pixelTracks'),

--- a/DQM/BeamMonitor/python/BeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_cff.py
@@ -12,6 +12,7 @@ dqmBeamMonitor = DQMEDAnalyzer("BeamMonitor",
                               resetPVEveryNLumi = cms.untracked.int32(5),
                               Debug = cms.untracked.bool(False),
                               OnlineMode = cms.untracked.bool(True),
+                              recordName = cms.untracked.string('BeamSpotOnlineHLTObjectsRcd'),
                               BeamFitter = cms.PSet(
                                 Debug = cms.untracked.bool(False),
                                 TrackCollection = cms.untracked.InputTag('generalTracks'),

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,24 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('runNumber',
+                 1, #default value, int limit -3
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number")
+options.register('transDelay',
+                 0, #default value, int limit -3
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "delay in seconds for the commit of the db transaction")
+options.parseArguments()
+
+# Define here the BeamSpotOnline record name,
+# it will be used both in BeamMonitor setup and in payload creation/upload
+BSOnlineRecordName = 'BeamSpotOnlineLegacyObjectsRcd'
+
 #from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 #process = cms.Process("BeamMonitor", Run2_2018) FIXME
 import sys
@@ -281,6 +299,7 @@ process.siStripDigis.ProductLabel        = rawDataInputTag
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
 process.dqmBeamMonitor.OnlineMode = True
+process.dqmBeamMonitor.recordName = BSOnlineRecordName
 
 process.dqmBeamMonitor.resetEveryNLumi   = 5 # was 10 for HI
 process.dqmBeamMonitor.resetPVEveryNLumi = 5 # was 10 for HI
@@ -332,6 +351,34 @@ if (process.runType.getRunType() == process.runType.hi_run):
     )
 
 process.dqmBeamMonitor.hltResults = cms.InputTag("TriggerResults","","HLT")
+
+#---------
+# Upload BeamSpotOnlineObject (LegacyRcd) to CondDB
+process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
+
+    DBParameters = cms.PSet(
+                            messageLevel = cms.untracked.int32(0),
+                            authenticationPath = cms.untracked.string('/build/gg')
+                           ),
+
+    ## Produce a (local) SQLITE FILE ...
+    #connect = cms.string('sqlite_file:BeamSpotOnlineLegacy.db'),
+    #preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineLegacy.db'),
+    ## ... or upload to CondDB
+    connect = cms.string('oracle://cms_orcoff_prep/CMS_CONDITIONS'),
+    preLoadConnectionString = cms.untracked.string('frontier://FrontierPrep/CMS_CONDITIONS'),
+
+    runNumber = cms.untracked.uint64(options.runNumber),
+    lastLumiFile = cms.untracked.string('last_lumi.txt'),
+    writeTransactionDelay = cms.untracked.uint32(options.transDelay),
+    autoCommit = cms.untracked.bool(True),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string(BSOnlineRecordName),
+        tag = cms.string('BSOnlineLegacy_tag'),
+        timetype = cms.untracked.string('Lumi'),
+        onlyAppendUpdatePolicy = cms.untracked.bool(True)
+    ))
+)
 
 #---------
 # Final path

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -364,10 +364,7 @@ process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
                             authenticationPath = cms.untracked.string('')
                            ),
 
-    ## Produce a (local) SQLITE FILE ...
-    #connect = cms.string('sqlite_file:BeamSpotOnlineLegacy.db'),
-    #preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineLegacy.db'),
-    ## ... or upload to CondDB
+    # Upload to CondDB
     connect = cms.string('oracle://cms_orcoff_prep/CMS_CONDITIONS'),
     preLoadConnectionString = cms.untracked.string('frontier://FrontierPrep/CMS_CONDITIONS'),
 
@@ -382,6 +379,11 @@ process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
         onlyAppendUpdatePolicy = cms.untracked.bool(True)
     ))
 )
+
+# If not live: produce a (local) SQLITE FILE
+if not live:
+    process.OnlineDBOutputService.connect = cms.string('sqlite_file:BeamSpotOnlineLegacy.db')
+    process.OnlineDBOutputService.preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineLegacy.db')
 
 #---------
 # Final path

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -358,7 +358,7 @@ process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
 
     DBParameters = cms.PSet(
                             messageLevel = cms.untracked.int32(0),
-                            authenticationPath = cms.untracked.string('/build/gg')
+                            authenticationPath = cms.untracked.string('')
                            ),
 
     ## Produce a (local) SQLITE FILE ...
@@ -369,7 +369,7 @@ process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
     preLoadConnectionString = cms.untracked.string('frontier://FrontierPrep/CMS_CONDITIONS'),
 
     runNumber = cms.untracked.uint64(options.runNumber),
-    lastLumiFile = cms.untracked.string('last_lumi.txt'),
+    lastLumiFile = cms.untracked.string(''),
     writeTransactionDelay = cms.untracked.uint32(options.transDelay),
     autoCommit = cms.untracked.bool(True),
     toPut = cms.VPSet(cms.PSet(

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -1,25 +1,6 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-import FWCore.ParameterSet.VarParsing as VarParsing
-options = VarParsing.VarParsing()
-options.register('runNumber',
-                 1, #default value, int limit -3
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "Run number")
-options.register('transDelay',
-                 0, #default value, int limit -3
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "delay in seconds for the commit of the db transaction")
-options.register('unitTest',
-                 False, #default value
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.bool,
-                 "load or not the unitTest inputsource module")
-options.parseArguments()
-
 # Define here the BeamSpotOnline record name,
 # it will be used both in BeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineLegacyObjectsRcd'
@@ -41,18 +22,23 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 # switch
 live = True # FIXME
-unitTest = options.unitTest
-if unitTest:
+unitTest = False
+
+if 'unitTest=True' in sys.argv:
     live=False
+    unitTest=True
 
 #---------------
 # Input sources
 if unitTest:
     process.load("DQM.Integration.config.unittestinputsource_cfi")
+    from DQM.Integration.config.unittestinputsource_cfi import options
 elif live:
     process.load("DQM.Integration.config.inputsource_cfi")
+    from DQM.Integration.config.inputsource_cfi import options
 else:
     process.load("DQM.Integration.config.fileinputsource_cfi")
+    from DQM.Integration.config.fileinputsource_cfi import options
 
 #--------------------------
 # HLT Filter

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -28,6 +28,12 @@ if 'unitTest=True' in sys.argv:
     live=False
     unitTest=True
 
+# Switch to veto the upload of the BeamSpot conditions to the DB
+# when False it performs the upload
+noDB = True
+if 'noDB=False' in sys.argv:
+    noDB=False
+
 #---------------
 # Input sources
 if unitTest:
@@ -366,8 +372,8 @@ process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
     ))
 )
 
-# If not live: produce a (local) SQLITE FILE
-if not live:
+# If not live or noDB: produce a (local) SQLITE file
+if not live or noDB:
     process.OnlineDBOutputService.connect = cms.string('sqlite_file:BeamSpotOnlineLegacy.db')
     process.OnlineDBOutputService.preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineLegacy.db')
 

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -13,6 +13,11 @@ options.register('transDelay',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "delay in seconds for the commit of the db transaction")
+options.register('unitTest',
+                 False, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "load or not the unitTest inputsource module")
 options.parseArguments()
 
 # Define here the BeamSpotOnline record name,
@@ -36,11 +41,9 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 # switch
 live = True # FIXME
-unitTest = False
-
-if 'unitTest=True' in sys.argv:
+unitTest = options.unitTest
+if unitTest:
     live=False
-    unitTest=True
 
 #---------------
 # Input sources

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -162,7 +162,7 @@ if (process.runType.getRunType() == process.runType.pp_run or
 
         DBParameters = cms.PSet(
                                 messageLevel = cms.untracked.int32(0),
-                                authenticationPath = cms.untracked.string('/build/gg')
+                                authenticationPath = cms.untracked.string('')
                                ),
 
         ## Produce a (local) SQLITE FILE ...
@@ -173,7 +173,7 @@ if (process.runType.getRunType() == process.runType.pp_run or
         preLoadConnectionString = cms.untracked.string('frontier://FrontierPrep/CMS_CONDITIONS'),
 
         runNumber = cms.untracked.uint64(options.runNumber),
-        lastLumiFile = cms.untracked.string('last_lumi.txt'),
+        lastLumiFile = cms.untracked.string(''),
         writeTransactionDelay = cms.untracked.uint32(options.transDelay),
         autoCommit = cms.untracked.bool(True),
         toPut = cms.VPSet(cms.PSet(

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -29,6 +29,12 @@ unitTest=False
 if 'unitTest=True' in sys.argv:
   unitTest=True
 
+# Switch to veto the upload of the BeamSpot conditions to the DB
+# when False it performs the upload
+noDB = True
+if 'noDB=False' in sys.argv:
+  noDB=False
+
 # Common part for PP and H.I Running
 #-----------------------------
 if unitTest:
@@ -170,8 +176,8 @@ if (process.runType.getRunType() == process.runType.pp_run or
         ))
     )
 
-    # If not live: produce a (local) SQLITE FILE
-    if unitTest:
+    # If not live or noDB: produce a (local) SQLITE file
+    if unitTest or noDB:
       process.OnlineDBOutputService.connect = cms.string('sqlite_file:BeamSpotOnlineHLT.db')
       process.OnlineDBOutputService.preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineHLT.db')
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -13,6 +13,11 @@ options.register('transDelay',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "delay in seconds for the commit of the db transaction")
+options.register('unitTest',
+                 False, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "load or not the unitTest inputsource module")
 options.parseArguments()
 
 # Define once the BeamSpotOnline record name,
@@ -39,9 +44,7 @@ process = cms.Process("BeamMonitor", Run2_2018_pp_on_AA)
 #    destinations = cms.untracked.vstring('cerr'),
 #)
 
-unitTest=False
-if 'unitTest=True' in sys.argv:
-  unitTest=True
+unitTest = options.unitTest
 
 # Common part for PP and H.I Running
 #-----------------------------

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -168,10 +168,7 @@ if (process.runType.getRunType() == process.runType.pp_run or
                                 authenticationPath = cms.untracked.string('')
                                ),
 
-        ## Produce a (local) SQLITE FILE ...
-        #connect = cms.string('sqlite_file:BeamSpotOnlineHLT.db'),
-        #preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineHLT.db'),
-        ## ... or upload to CondDB
+        # Upload to CondDB
         connect = cms.string('oracle://cms_orcoff_prep/CMS_CONDITIONS'),
         preLoadConnectionString = cms.untracked.string('frontier://FrontierPrep/CMS_CONDITIONS'),
 
@@ -186,6 +183,11 @@ if (process.runType.getRunType() == process.runType.pp_run or
             onlyAppendUpdatePolicy = cms.untracked.bool(True)
         ))
     )
+
+    # If not live: produce a (local) SQLITE FILE
+    if unitTest:
+      process.OnlineDBOutputService.connect = cms.string('sqlite_file:BeamSpotOnlineHLT.db')
+      process.OnlineDBOutputService.preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineHLT.db')
 
     process.p = cms.Path( process.hltTriggerTypeFilter
                         * process.dqmcommon

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -1,25 +1,6 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-import FWCore.ParameterSet.VarParsing as VarParsing
-options = VarParsing.VarParsing()
-options.register('runNumber',
-                 1, #default value, int limit -3
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "Run number")
-options.register('transDelay',
-                 0, #default value, int limit -3
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "delay in seconds for the commit of the db transaction")
-options.register('unitTest',
-                 False, #default value
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.bool,
-                 "load or not the unitTest inputsource module")
-options.parseArguments()
-
 # Define once the BeamSpotOnline record name,
 # will be used both in BeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineHLTObjectsRcd'
@@ -44,21 +25,26 @@ process = cms.Process("BeamMonitor", Run2_2018_pp_on_AA)
 #    destinations = cms.untracked.vstring('cerr'),
 #)
 
-unitTest = options.unitTest
+unitTest=False
+if 'unitTest=True' in sys.argv:
+  unitTest=True
 
 # Common part for PP and H.I Running
 #-----------------------------
 if unitTest:
   process.load("DQM.Integration.config.unittestinputsource_cfi")
+  from DQM.Integration.config.unittestinputsource_cfi import options
 else:
   # for live online DQM in P5
   process.load("DQM.Integration.config.inputsource_cfi")
+  from DQM.Integration.config.inputsource_cfi import options
 
   # new stream label
   process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
 
 # for testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")
+#from DQM.Integration.config.fileinputsource_cfi import options
 
 #--------------------------
 # HLT Filter

--- a/DQM/Integration/python/config/fileinputsource_cfi.py
+++ b/DQM/Integration/python/config/fileinputsource_cfi.py
@@ -58,6 +58,12 @@ options.register('transDelay',
                  VarParsing.VarParsing.varType.int,
                  "delay in seconds for the commit of the db transaction")
 
+options.register('noDB',
+                 True, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't upload the BeamSpot conditions to the DB")
+
 options.parseArguments()
 
 try:

--- a/DQM/Integration/python/config/fileinputsource_cfi.py
+++ b/DQM/Integration/python/config/fileinputsource_cfi.py
@@ -52,6 +52,12 @@ options.register('dataset',
                  VarParsing.VarParsing.varType.string,
                  "Dataset name like '/ExpressPhysicsPA/PARun2016D-Express-v1/FEVT', or 'auto' to guess it with a DAS query. A dataset_cfi.py that defines 'readFiles' and 'secFiles' (like a DAS Python snippet) will override this, to avoid DAS queries.")
 
+options.register('transDelay',
+                 0, #default value, int limit -3
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "delay in seconds for the commit of the db transaction")
+
 options.parseArguments()
 
 try:

--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -33,6 +33,12 @@ options.register('skipFirstLumis',
                  VarParsing.VarParsing.varType.bool,
                  "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
 
+options.register('transDelay',
+                 0, #default value, int limit -3
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "delay in seconds for the commit of the db transaction")
+
 # Parameters for runType
 
 options.register ('runkey',

--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -39,6 +39,12 @@ options.register('transDelay',
                  VarParsing.VarParsing.varType.int,
                  "delay in seconds for the commit of the db transaction")
 
+options.register('noDB',
+                 True, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't upload the BeamSpot conditions to the DB")
+
 # Parameters for runType
 
 options.register ('runkey',

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -74,6 +74,12 @@ options.register('unitTest',
                  VarParsing.VarParsing.varType.bool,
                  "Required to avoid the error.")
 
+options.register('noDB',
+                 True, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't upload the BeamSpot conditions to the DB")
+
 options.parseArguments()
 
 print("Querying DAS for files...")

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -60,6 +60,12 @@ options.register('eventsPerLumi',
                  VarParsing.VarParsing.varType.int,
                  "This number of last events in each lumisection will be processed.")
 
+options.register('transDelay',
+                 0, #default value, int limit -3
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "delay in seconds for the commit of the db transaction")
+
 # This is used only by the online clients themselves. 
 # We need to register it here because otherwise an error occurs saying that there is an unidentified option.
 options.register('unitTest',


### PR DESCRIPTION
#### PR description:
This PR introduces changes in the DQM code related to BeamSpot.
- The BeamSpot fit results are now also stored in a `BeamSpotOnlineObjects` (introduced in #29662 ) and saved in a payload using the service `cond::service::OnlineDBOutputService`.
- The ` DQM/BeamMonitor/python/*py` configuration files are updated to include the default value of the BeamSpot Online record name for the upload to CondDB.
- Both beamspot python clients `DQM/Integration/python/clients/beam*_dqm_sourceclient-live_cfg.py` are updated to handle the upload of the payload to the database always using `OnlineDBOutputService`
- No changes in the actual fitting of the beamspot are introduced.
- Nothing is removed/deleted from the `BeamMonitor.cc` plugin, only the changes described above are added

There are two still open questions for which I might need help from DQM and DB experts:
1. **For DQM experts:**
Is it ok to have `options = VarParsing.VarParsing()` under `DQM/Integration/python/clients`? I only see usage of this in `DQM/Integration/python/config`, so I was wondering if it is correct or it might cause problems. The options are needed to properly setup the `OnlineDBOutputService`.

2. **For DB experts:**
I'm not sure how to properly configure these lines in `OnlineDBOutputService`:
  - `authenticationPath`
  - `lastLumiFile`
  - `connect` and `preLoadConnectionString`


#### Backporting:
Once this PR is completed and merged, it will need a backport to CMSSW_11_1
