### PR TITLE
Reduce boost dependency in OnlineDB/EcalCondDB 

### DIFF
--- a/OnlineDB/EcalCondDB/interface/LMFUnique.h
+++ b/OnlineDB/EcalCondDB/interface/LMFUnique.h
@@ -5,10 +5,14 @@
  Giovanni.Organtini@roma1.infn.it 2010
  */
 
-#include <stdexcept>
+#include <algorithm>
+#include <cstring>
 #include <iostream>
+#include <list>
 #include <map>
-#include <boost/ptr_container/ptr_list.hpp>
+#include <memory>
+#include <stdexcept>
+
 #include "OnlineDB/EcalCondDB/interface/Tm.h"
 #include "OnlineDB/EcalCondDB/interface/IUniqueDBObject.h"
 #include "OnlineDB/Oracle/interface/Oracle.h"
@@ -70,7 +74,7 @@ public:
   inline void debug() { m_debug = 1; }
   inline void nodebug() { m_debug = 0; }
 
-  virtual boost::ptr_list<LMFUnique> fetchAll() const noexcept(false);
+  virtual std::list<std::unique_ptr<LMFUnique>> fetchAll() const noexcept(false);
 
   virtual bool operator<(const LMFUnique &r) { return (m_ID < r.m_ID); }
   virtual bool operator<=(const LMFUnique &r) { return (m_ID <= r.m_ID); }

--- a/OnlineDB/EcalCondDB/src/LMFColor.cc
+++ b/OnlineDB/EcalCondDB/src/LMFColor.cc
@@ -96,14 +96,19 @@ void LMFColor::getParameters(ResultSet *rset) {
   setString("lname", rset->getString(3));
 }
 
+template <typename T, typename U>
+inline T &unique_static_cast(U &i) {
+  return *(static_cast<T *>(i.get()));
+}
+
 bool LMFColor::isValid() {
-  boost::ptr_list<LMFUnique> listOfValidColors = fetchAll();
-  boost::ptr_list<LMFUnique>::const_iterator i = listOfValidColors.begin();
-  boost::ptr_list<LMFUnique>::const_iterator e = listOfValidColors.end();
+  auto listOfValidColors = fetchAll();
+  auto i = listOfValidColors.begin();
+  auto e = listOfValidColors.end();
   bool ret = false;
   while (i != e) {
-    const LMFColor *c = static_cast<const LMFColor *>(&(*i));
-    if (c->getShortName() == getShortName()) {
+    const LMFColor &c = unique_static_cast<const LMFColor>(*i);
+    if (c.getShortName() == getShortName()) {
       ret = true;
       i = e;
     }

--- a/OnlineDB/EcalCondDB/src/LMFDefFabric.cc
+++ b/OnlineDB/EcalCondDB/src/LMFDefFabric.cc
@@ -144,6 +144,11 @@ LMFRunTag LMFDefFabric::getRunTagFromID(int id) const {
 
 int LMFDefFabric::getRunTagID(std::string tag, int version) const { return getRunTag(tag, version).getID(); }
 
+template <typename T, typename U>
+inline T &unique_static_cast(U &i) {
+  return *(static_cast<T *>(i.get()));
+}
+
 void LMFDefFabric::initialize() noexcept(false) {
   _lmfColors.clear();
   _lmfTrigTypes.clear();
@@ -152,15 +157,13 @@ void LMFDefFabric::initialize() noexcept(false) {
   _lmfSeqVersions.clear();
   _lmfCorrVersions.clear();
   if ((m_env != nullptr) && (m_conn != nullptr)) {
-    boost::ptr_list<LMFUnique> listOfObjects;
-    boost::ptr_list<LMFUnique>::const_iterator i;
-    boost::ptr_list<LMFUnique>::const_iterator e;
-    listOfObjects = LMFColor(m_env, m_conn).fetchAll();
-    i = listOfObjects.begin();
-    e = listOfObjects.end();
+    auto listOfObjects = LMFColor(m_env, m_conn).fetchAll();
+    auto i = listOfObjects.begin();
+    auto e = listOfObjects.end();
+
     while (i != e) {
-      const LMFColor *c = static_cast<const LMFColor *>(&(*i));
-      _lmfColors.push_back(*c);
+      const LMFColor &c = unique_static_cast<const LMFColor>(*i);
+      _lmfColors.push_back(c);
       i++;
     }
     listOfObjects.clear();
@@ -168,8 +171,8 @@ void LMFDefFabric::initialize() noexcept(false) {
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      const LMFTrigType *c = static_cast<const LMFTrigType *>(&(*i));
-      _lmfTrigTypes.push_back(*c);
+      const LMFTrigType &c = unique_static_cast<const LMFTrigType>(*i);
+      _lmfTrigTypes.push_back(c);
       i++;
     }
     listOfObjects.clear();
@@ -177,8 +180,8 @@ void LMFDefFabric::initialize() noexcept(false) {
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      const LMFRunTag *c = static_cast<const LMFRunTag *>(&(*i));
-      _lmfRunTags.push_back(*c);
+      const LMFRunTag &c = unique_static_cast<const LMFRunTag>(*i);
+      _lmfRunTags.push_back(c);
       i++;
     }
     listOfObjects.clear();
@@ -186,8 +189,8 @@ void LMFDefFabric::initialize() noexcept(false) {
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      const LMFPrimVers *c = static_cast<const LMFPrimVers *>(&(*i));
-      _lmfPrimVersions.push_back(*c);
+      const LMFPrimVers &c = unique_static_cast<const LMFPrimVers>(*i);
+      _lmfPrimVersions.push_back(c);
       i++;
     }
     listOfObjects.clear();
@@ -195,8 +198,8 @@ void LMFDefFabric::initialize() noexcept(false) {
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      const LMFCorrVers *c = static_cast<const LMFCorrVers *>(&(*i));
-      _lmfCorrVersions.push_back(*c);
+      const LMFCorrVers &c = unique_static_cast<const LMFCorrVers>(*i);
+      _lmfCorrVersions.push_back(c);
       i++;
     }
     listOfObjects.clear();
@@ -204,8 +207,8 @@ void LMFDefFabric::initialize() noexcept(false) {
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      const LMFSeqVers *c = static_cast<const LMFSeqVers *>(&(*i));
-      _lmfSeqVersions.push_back(*c);
+      const LMFSeqVers &c = unique_static_cast<const LMFSeqVers>(*i);
+      _lmfSeqVersions.push_back(c);
       i++;
     }
     listOfObjects.clear();

--- a/OnlineDB/EcalCondDB/src/LMFUnique.cc
+++ b/OnlineDB/EcalCondDB/src/LMFUnique.cc
@@ -58,11 +58,11 @@ void LMFUnique::attach(std::string name, LMFUnique* u) {
   }
 }
 
-boost::ptr_list<LMFUnique> LMFUnique::fetchAll() const noexcept(false) {
+std::list<std::unique_ptr<LMFUnique>> LMFUnique::fetchAll() const noexcept(false) {
   /*
     Returns a list of pointers to DB objects
    */
-  boost::ptr_list<LMFUnique> l;
+  std::list<std::unique_ptr<LMFUnique>> l;
   this->checkConnection();
 
   try {
@@ -84,8 +84,8 @@ boost::ptr_list<LMFUnique> LMFUnique::fetchAll() const noexcept(false) {
             o->dump();
           }
           try {
-            l.push_back(o);
-          } catch (boost::bad_pointer& e) {
+            l.emplace_back(o);
+          } catch (std::exception& e) {
             throw(std::runtime_error(m_className + "::fetchAll:  " + e.what()));
           }
         }

--- a/OnlineDB/EcalCondDB/test/TestLMF2010-write.cpp
+++ b/OnlineDB/EcalCondDB/test/TestLMF2010-write.cpp
@@ -117,13 +117,10 @@ public:
       cout << "Does not exists" << endl;
     }
     // we can just get the tags from the DB
-    boost::ptr_list<LMFUnique> listOfTags = lmfruntag.fetchAll();
-    boost::ptr_list<LMFUnique>::iterator itag = listOfTags.begin();
-    boost::ptr_list<LMFUnique>::iterator etag = listOfTags.end();
+    auto listOfTags = lmfruntag.fetchAll();
     cout << "Found " << listOfTags.size() << " tags" << endl;
-    while (itag != etag) {
-      itag->dump();
-      itag++;
+    for (auto &tag : listOfTags) {
+      tag->dump();
     }
     // we can also get the tags from the fabric
     lmfruntag = fabric.getRunTag("gen", 3);


### PR DESCRIPTION
#### PR description:
Changed boost::ptr_list for std::list<std::unique_ptr<>>.
The code should have the same behaviour and also similar performance. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 