### PR TITLE
fix stacked efficiency plots

### DIFF
--- a/Validation/RecoTrack/test/publicPlots/plot.py
+++ b/Validation/RecoTrack/test/publicPlots/plot.py
@@ -180,6 +180,7 @@ class PlotStack:
         self._legends = []
 
     def add(self, histo, legend):
+        histo.ResetBit(ROOT.TH1.kIsAverage)
         self._histos.append(histo)
         self._legends.append(legend)
 


### PR DESCRIPTION
#### PR description:

as reported in the conversation of https://github.com/cms-sw/cmssw/pull/28622
since 11_1_0_pre3 the efficiency plot in the DQM have the TH1::kIsAvarage bit set,
which prevents the efficiency histograms to be used in the proper way by the THStack
(by adding the different histograms the results is not the sum, but their average)
this PR fixes the handling of these plots in the TRK POG script

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
I'm going to make the backport to 111X for making the proper plots for the HLT TDR (for completeness and avoiding patch/private code)