### PR TITLE
Fix TSGFromPropagation

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.cc
@@ -32,7 +32,7 @@ TSGFromPropagation::TSGFromPropagation(const edm::ParameterSet& iConfig, edm::Co
 TSGFromPropagation::TSGFromPropagation(const edm::ParameterSet& iConfig,
                                        edm::ConsumesCollector& iC,
                                        const MuonServiceProxy* service)
-    : theService(service), theTSTransformer(nullptr), theSigmaZ(0), theConfig(iConfig) {
+    : theService(service), theSigmaZ(0), theConfig(iConfig) {
   theCategory = "Muon|RecoMuon|TSGFromPropagation";
   theMeasTrackerName = iConfig.getParameter<std::string>("MeasurementTrackerName");
   theMeasurementTrackerEventTag = iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent");

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.cc
@@ -32,14 +32,30 @@ TSGFromPropagation::TSGFromPropagation(const edm::ParameterSet& iConfig, edm::Co
 TSGFromPropagation::TSGFromPropagation(const edm::ParameterSet& iConfig,
                                        edm::ConsumesCollector& iC,
                                        const MuonServiceProxy* service)
-    : theService(service), theSigmaZ(0), theConfig(iConfig) {
-  theCategory = "Muon|RecoMuon|TSGFromPropagation";
-  theMeasTrackerName = iConfig.getParameter<std::string>("MeasurementTrackerName");
-  theMeasurementTrackerEventTag = iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent");
-  theBeamSpotInputTag = theConfig.getParameter<edm::InputTag>("beamSpot");
-  theBeamSpotToken = iC.consumes<reco::BeamSpot>(theBeamSpotInputTag);
-  theMeasurementTrackerEventToken = iC.consumes<MeasurementTrackerEvent>(theMeasurementTrackerEventTag);
-}
+    : theCategory("Muon|RecoMuon|TSGFromPropagation"),
+      theMeasTrackerName(iConfig.getParameter<std::string>("MeasurementTrackerName")),
+      theService(service),
+      theMaxChi2(iConfig.getParameter<double>("MaxChi2")),
+      theFixedErrorRescaling(iConfig.getParameter<double>("ErrorRescaling")),
+      theUseVertexStateFlag(iConfig.getParameter<bool>("UseVertexState")),
+      theUpdateStateFlag(iConfig.getParameter<bool>("UpdateState")),
+      theResetMethod([]() {
+        auto resetMethod = iConfig.getParameter<std::string>("ResetMethod");
+        if (resetMethod != "discrete" && resetMethod != "fixed" && resetMethod != "matrix") {
+          edm::LogError("TSGFromPropagation") << "Wrong error rescaling method: " << resetMethod << "\n"
+                                              << "Possible choices are: discrete, fixed, matrix.\n"
+                                              << "Use discrete method" << std::endl;
+          resetMethod = "discrete";
+        }
+        return resetMethod;
+      }()),
+      theSelectStateFlag(iConfig.getParameter<bool>("SelectState")),
+      thePropagatorName(iConfig.getParameter<std::string>("Propagator")),
+      theSigmaZ(iConfig.getParameter<double>("SigmaZ")),
+      theErrorMatrixPset(iConfig.getParameter<edm::ParameterSet>("errorMatrixPset")),
+      theBeamSpotToken(iC.consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+      theMeasurementTrackerEventToken(
+          iC.consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent"))) {}
 
 TSGFromPropagation::~TSGFromPropagation() { LogTrace(theCategory) << " TSGFromPropagation dtor called "; }
 
@@ -131,20 +147,7 @@ void TSGFromPropagation::trackerSeeds(const TrackCand& staMuon,
 }
 
 void TSGFromPropagation::init(const MuonServiceProxy* service) {
-  theMaxChi2 = theConfig.getParameter<double>("MaxChi2");
-
-  theFixedErrorRescaling = theConfig.getParameter<double>("ErrorRescaling");
-
   theFlexErrorRescaling = 1.0;
-
-  theResetMethod = theConfig.getParameter<std::string>("ResetMethod");
-
-  if (theResetMethod != "discrete" && theResetMethod != "fixed" && theResetMethod != "matrix") {
-    edm::LogError("TSGFromPropagation") << "Wrong error rescaling method: " << theResetMethod << "\n"
-                                        << "Possible choices are: discrete, fixed, matrix.\n"
-                                        << "Use discrete method" << std::endl;
-    theResetMethod = "discrete";
-  }
 
   theEstimator = std::make_unique<Chi2MeasurementEstimator>(theMaxChi2);
 
@@ -152,28 +155,12 @@ void TSGFromPropagation::init(const MuonServiceProxy* service) {
 
   theCacheId_TG = 0;
 
-  thePropagatorName = theConfig.getParameter<std::string>("Propagator");
-
   theService = service;
-
-  theUseVertexStateFlag = theConfig.getParameter<bool>("UseVertexState");
-
-  theUpdateStateFlag = theConfig.getParameter<bool>("UpdateState");
-
-  theSelectStateFlag = theConfig.getParameter<bool>("SelectState");
 
   theUpdator = std::make_unique<KFUpdator>();
 
-  theSigmaZ = theConfig.getParameter<double>("SigmaZ");
-
-  //theBeamSpotInputTag = theConfig.getParameter<edm::InputTag>("beamSpot");
-
-  edm::ParameterSet errorMatrixPset = theConfig.getParameter<edm::ParameterSet>("errorMatrixPset");
-  if (theResetMethod == "matrix" && !errorMatrixPset.empty()) {
-    theAdjustAtIp = errorMatrixPset.getParameter<bool>("atIP");
-    theErrorMatrixAdjuster = std::make_unique<MuonErrorMatrix>(errorMatrixPset);
-  } else {
-    theAdjustAtIp = false;
+  if (theResetMethod == "matrix" && !theErrorMatrixPset.empty()) {
+    theErrorMatrixAdjuster = std::make_unique<MuonErrorMatrix>(theErrorMatrixPset);
   }
 
   theService->eventSetup().get<TrackerRecoGeometryRecord>().get(theTracker);

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
@@ -108,13 +108,12 @@ private:
   unsigned long long theCacheId_MT;
   unsigned long long theCacheId_TG;
 
-  std::string theCategory;
+  const std::string theCategory;
 
   edm::ESHandle<GeometricSearchTracker> theTracker;
 
-  std::string theMeasTrackerName;
+  const std::string theMeasTrackerName;
   edm::ESHandle<MeasurementTracker> theMeasTracker;
-  edm::InputTag theMeasurementTrackerEventTag;
   edm::Handle<MeasurementTrackerEvent> theMeasTrackerEvent;
 
   std::unique_ptr<const DirectTrackerNavigation> theNavigation;
@@ -125,34 +124,31 @@ private:
 
   std::unique_ptr<const Chi2MeasurementEstimator> theEstimator;
 
-  double theMaxChi2;
+  const double theMaxChi2;
 
   double theFlexErrorRescaling;
 
-  double theFixedErrorRescaling;
+  const double theFixedErrorRescaling;
 
-  bool theUseVertexStateFlag;
+  const bool theUseVertexStateFlag;
 
-  bool theUpdateStateFlag;
+  const bool theUpdateStateFlag;
 
-  std::string theResetMethod;
+  const std::string theResetMethod;
 
-  bool theSelectStateFlag;
+  const bool theSelectStateFlag;
 
-  std::string thePropagatorName;
+  const std::string thePropagatorName;
 
   std::unique_ptr<MuonErrorMatrix> theErrorMatrixAdjuster;
 
-  bool theAdjustAtIp;
+  const double theSigmaZ;
 
-  double theSigmaZ;
-
-  edm::ParameterSet theConfig;
+  const edm::ParameterSet theErrorMatrixPset;
 
   edm::Handle<reco::BeamSpot> beamSpot;
-  edm::InputTag theBeamSpotInputTag;
-  edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;
-  edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventToken;
+  const edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;
+  const edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventToken;
 };
 
 #endif

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
@@ -125,8 +125,6 @@ private:
 
   std::unique_ptr<const Chi2MeasurementEstimator> theEstimator;
 
-  TrajectoryStateTransform* theTSTransformer;
-
   double theMaxChi2;
 
   double theFlexErrorRescaling;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
@@ -134,7 +134,8 @@ private:
 
   const bool theUpdateStateFlag;
 
-  const std::string theResetMethod;
+  enum class ResetMethod { discrete, fixed, matrix };
+  const ResetMethod theResetMethod;
 
   const bool theSelectStateFlag;
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
@@ -20,6 +20,8 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+#include <memory>
+
 class Chi2MeasurementEstimator;
 class Propagator;
 class MeasurementTracker;
@@ -55,9 +57,9 @@ private:
 
   TrajectoryStateOnSurface outerTkState(const TrackCand&) const;
 
-  const TrajectoryStateUpdator* updator() const { return theUpdator; }
+  const TrajectoryStateUpdator* updator() const { return theUpdator.get(); }
 
-  const Chi2MeasurementEstimator* estimator() const { return theEstimator; }
+  const Chi2MeasurementEstimator* estimator() const { return theEstimator.get(); }
 
   edm::ESHandle<Propagator> propagator() const { return theService->propagator(thePropagatorName); }
 
@@ -115,13 +117,13 @@ private:
   edm::InputTag theMeasurementTrackerEventTag;
   edm::Handle<MeasurementTrackerEvent> theMeasTrackerEvent;
 
-  const DirectTrackerNavigation* theNavigation;
+  std::unique_ptr<const DirectTrackerNavigation> theNavigation;
 
   const MuonServiceProxy* theService;
 
-  const TrajectoryStateUpdator* theUpdator;
+  std::unique_ptr<const TrajectoryStateUpdator> theUpdator;
 
-  const Chi2MeasurementEstimator* theEstimator;
+  std::unique_ptr<const Chi2MeasurementEstimator> theEstimator;
 
   TrajectoryStateTransform* theTSTransformer;
 
@@ -141,7 +143,7 @@ private:
 
   std::string thePropagatorName;
 
-  MuonErrorMatrix* theErrorMatrixAdjuster;
+  std::unique_ptr<MuonErrorMatrix> theErrorMatrixAdjuster;
 
   bool theAdjustAtIp;
 


### PR DESCRIPTION
#### PR description:

TSGFromPropagation was causing a crash when cmsRun was terminated early. This was caused by a pointer being assigned in the init function, not the constructor. This was why the class was inspected. The following changes were made
- all owning pointers were changed to std::unique_ptr
- parameters are not read and assigned in the constructor instead of `init`
- immutable member data are now declared `const`
- unused/unnecessary member variables were removed
- theResetMethod was changed from a `std::string` to an enum.

The latter changed uncovered a bug where two of the string comparisons used with `theResetMethod` were typos: They should have been `"discrete"` but were instead `"discreate"`.

#### PR validation:

The code compiles.