### PR TITLE
TCDS multi-fed support in DAQ and unpacker

### DIFF
--- a/DataFormats/TCDS/interface/TCDSRecord.h
+++ b/DataFormats/TCDS/interface/TCDSRecord.h
@@ -99,6 +99,9 @@ public:
   // The BST message as received from the LHC
   const BSTRecord& getBST() const { return bst_; }
 
+  // Source FED ID
+  uint16_t getSourceID() const { return sourceid_; }
+
   // List of active paritions, currently not implemented
   typedef std::bitset<96> ActivePartitions;
   ActivePartitions getActivePartitions() const { return activePartitions_; }
@@ -146,6 +149,7 @@ private:
   uint16_t triggerTypeFlags_;
   uint16_t inputs_;
   uint16_t bxid_;
+  uint16_t sourceid_;
 
   ActivePartitions activePartitions_;
   L1aHistory l1aHistory_;

--- a/DataFormats/TCDS/src/TCDSRecord.cc
+++ b/DataFormats/TCDS/src/TCDSRecord.cc
@@ -42,6 +42,7 @@ TCDSRecord::TCDSRecord(const unsigned char* rawData) {
   triggerTypeFlags_ = tcdsRaw->header.triggerTypeFlags;
   inputs_ = tcdsRaw->header.inputs;
   bxid_ = tcdsRaw->header.bxid;
+  sourceid_ = fedHeader.sourceID();
 
   activePartitions_ = ActivePartitions(tcdsRaw->header.activePartitions0);
   activePartitions_ |= ActivePartitions(tcdsRaw->header.activePartitions1) << 32;

--- a/DataFormats/TCDS/src/classes_def.xml
+++ b/DataFormats/TCDS/src/classes_def.xml
@@ -8,8 +8,9 @@
     <version ClassVersion="4" checksum="3132515293"/>
   </class>
 
-  <class name="TCDSRecord" ClassVersion="3">
-    <version ClassVersion="3" checksum="850266115"/>
+  <class name="TCDSRecord" ClassVersion="4">
+    <version ClassVersion="4" checksum="850266115"/>
+    <version ClassVersion="3" checksum="1408516613"/>
   </class>
 
   <class name="edm::RefProd<TCDSRecord>"/>

--- a/DataFormats/TCDS/src/classes_def.xml
+++ b/DataFormats/TCDS/src/classes_def.xml
@@ -8,8 +8,8 @@
     <version ClassVersion="4" checksum="3132515293"/>
   </class>
 
-  <class name="TCDSRecord" ClassVersion="3">
-    <version ClassVersion="3" checksum="1408516613"/>
+  <class name="TCDSRecord" ClassVersion="4">
+    <version ClassVersion="4" checksum="850266115"/>
   </class>
 
   <class name="edm::RefProd<TCDSRecord>"/>

--- a/DataFormats/TCDS/src/classes_def.xml
+++ b/DataFormats/TCDS/src/classes_def.xml
@@ -8,8 +8,8 @@
     <version ClassVersion="4" checksum="3132515293"/>
   </class>
 
-  <class name="TCDSRecord" ClassVersion="4">
-    <version ClassVersion="4" checksum="850266115"/>
+  <class name="TCDSRecord" ClassVersion="3">
+    <version ClassVersion="3" checksum="850266115"/>
   </class>
 
   <class name="edm::RefProd<TCDSRecord>"/>

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -92,6 +92,7 @@ private:
   const bool alwaysStartFromFirstLS_;
   const bool verifyChecksum_;
   const bool useL1EventID_;
+  const std::vector<unsigned int> testTCDSFEDRange_;
   std::vector<std::string> fileNames_;
   bool useFileBroker_;
   //std::vector<std::string> fileNamesSorted_;

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -120,6 +120,9 @@ private:
   unsigned int eventsThisLumi_;
   unsigned long eventsThisRun_ = 0;
 
+  uint16_t MINTCDSuTCAFEDID_ = FEDNumbering::MINTCDSuTCAFEDID;
+  uint16_t MAXTCDSuTCAFEDID_ = FEDNumbering::MAXTCDSuTCAFEDID;
+
   /*
    *
    * Multithreaded file reader

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -20,6 +20,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "IOPool/Streamer/interface/FRDEventMessage.h"
 
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
 
 class FEDRawDataCollection;

--- a/EventFilter/Utilities/plugins/DaqFakeReader.cc
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.cc
@@ -41,7 +41,8 @@ DaqFakeReader::DaqFakeReader(const edm::ParameterSet& pset)
                                                              : 0xffffffff) {
   // mean = pset.getParameter<float>("mean");
   if (tcdsFEDID_ < FEDNumbering::MINTCDSuTCAFEDID)
-      throw cms::Exception("DaqFakeReader::DaqFakeReader") << " TCDS FED ID lower than " << FEDNumbering::MINTCDSuTCAFEDID;
+    throw cms::Exception("DaqFakeReader::DaqFakeReader")
+        << " TCDS FED ID lower than " << FEDNumbering::MINTCDSuTCAFEDID;
   produces<FEDRawDataCollection>();
 }
 
@@ -120,7 +121,6 @@ void DaqFakeReader::fillFEDs(
   }
 }
 
-
 void DaqFakeReader::fillTCDSFED(EventID& eID, FEDRawDataCollection& data, uint32_t ls, timeval* now) {
   uint32_t fedId = tcdsFEDID_;
   FEDRawData& feddata = data.FEDData(fedId);
@@ -133,7 +133,7 @@ void DaqFakeReader::fillTCDSFED(EventID& eID, FEDRawDataCollection& data, uint32
   FEDHeader::set(feddata.data(),
                  1,            // Trigger type
                  eID.event(),  // LV1_id (24 bits)
-                 bxid,            // BX_id
+                 bxid,         // BX_id
                  fedId);       // source_id
 
   tcds::Raw_v1* tcds = reinterpret_cast<tcds::Raw_v1*>(feddata.data() + FEDHeader::length);
@@ -159,7 +159,6 @@ void DaqFakeReader::fillTCDSFED(EventID& eID, FEDRawDataCollection& data, uint32
                   0,   // Evt_stat
                   0);  // TTS bits
 }
-
 
 void DaqFakeReader::beginLuminosityBlock(LuminosityBlock const& iL, EventSetup const& iE) {
   std::cout << "DaqFakeReader begin Lumi " << iL.luminosityBlock() << std::endl;

--- a/EventFilter/Utilities/plugins/DaqFakeReader.h
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.h
@@ -39,6 +39,7 @@ private:
   //
   void fillFEDs(const int, const int, edm::EventID& eID, FEDRawDataCollection& data, float meansize, float width);
   void fillGTPFED(edm::EventID& eID, FEDRawDataCollection& data, timeval* now);
+  void fillTCDSFED(edm::EventID& eID, FEDRawDataCollection& data, uint32_t ls, timeval* now);
   virtual void beginLuminosityBlock(edm::LuminosityBlock const& iL, edm::EventSetup const& iE);
 
 private:
@@ -51,6 +52,7 @@ private:
   unsigned int meansize;  // in bytes
   unsigned int width;
   unsigned int injected_errors_per_million_events;
+  unsigned int tcdsFEDID_;
   unsigned int modulo_error_events;
   unsigned int fakeLs_ = 0;
 };

--- a/EventFilter/Utilities/plugins/DaqFakeReader.h
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.h
@@ -38,7 +38,6 @@ private:
   // private member functions
   //
   void fillFEDs(const int, const int, edm::EventID& eID, FEDRawDataCollection& data, float meansize, float width);
-  void fillGTPFED(edm::EventID& eID, FEDRawDataCollection& data, timeval* now);
   void fillTCDSFED(edm::EventID& eID, FEDRawDataCollection& data, uint32_t ls, timeval* now);
   virtual void beginLuminosityBlock(edm::LuminosityBlock const& iL, edm::EventSetup const& iE);
 

--- a/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
+++ b/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
@@ -71,9 +71,15 @@ void TcdsRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   TCDSRecord tcdsRecord;
   if (rawdata.isValid()) {
-    const FEDRawData& tcdsData = rawdata->FEDData(FEDNumbering::MINTCDSuTCAFEDID);
-    if (tcdsData.size() > 0) {
-      tcdsRecord = TCDSRecord(tcdsData.data());
+    uint16_t selectedId = 0;
+    for (uint16_t fedId = FEDNumbering::MINTCDSuTCAFEDID; fedId <= FEDNumbering::MINTCDSuTCAFEDID; fedId++) {
+      const FEDRawData& tcdsData = rawdata->FEDData(fedId);
+      if (tcdsData.size() > 0) {
+        if (selectedId)
+          throw cms::Exception("TcdsRawToDigi::produce") << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedId;
+        tcdsRecord = TCDSRecord(tcdsData.data());
+        selectedId = fedId;
+      }
     }
   }
   iEvent.put(std::make_unique<TCDSRecord>(tcdsRecord), "tcdsRecord");

--- a/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
+++ b/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
@@ -76,7 +76,8 @@ void TcdsRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       const FEDRawData& tcdsData = rawdata->FEDData(fedId);
       if (tcdsData.size() > 0) {
         if (selectedId)
-          throw cms::Exception("TcdsRawToDigi::produce") << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedId;
+          throw cms::Exception("TcdsRawToDigi::produce")
+              << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedId;
         tcdsRecord = TCDSRecord(tcdsData.data());
         selectedId = fedId;
       }

--- a/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
+++ b/EventFilter/Utilities/plugins/TcdsRawToDigi.cc
@@ -72,7 +72,7 @@ void TcdsRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   TCDSRecord tcdsRecord;
   if (rawdata.isValid()) {
     uint16_t selectedId = 0;
-    for (uint16_t fedId = FEDNumbering::MINTCDSuTCAFEDID; fedId <= FEDNumbering::MINTCDSuTCAFEDID; fedId++) {
+    for (uint16_t fedId = FEDNumbering::MINTCDSuTCAFEDID; fedId <= FEDNumbering::MAXTCDSuTCAFEDID; fedId++) {
       const FEDRawData& tcdsData = rawdata->FEDData(fedId);
       if (tcdsData.size() > 0) {
         if (selectedId)

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -617,7 +617,9 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
     aux.setProcessHistoryID(processHistoryID_);
     makeEvent(eventPrincipal, aux);
   } else if (tcds_pointer_ == nullptr) {
-    assert(GTPEventID_);
+    if (!GTPEventID_) {
+      throw cms::Exception("FedRawDataInputSource::read") << "No TCDS or GTP FED in event with FEDHeader EID -: " << L1EventID_;
+    }
     eventID_ = edm::EventID(eventRunNumber_, currentLumiSection_, GTPEventID_);
     edm::EventAuxiliary aux(eventID_, processGUID(), tstamp, true, edm::EventAuxiliary::PhysicsTrigger);
     aux.setProcessHistoryID(processHistoryID_);

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -61,7 +61,8 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm:
       alwaysStartFromFirstLS_(pset.getUntrackedParameter<bool>("alwaysStartFromFirstLS", false)),
       verifyChecksum_(pset.getUntrackedParameter<bool>("verifyChecksum", true)),
       useL1EventID_(pset.getUntrackedParameter<bool>("useL1EventID", false)),
-      testTCDSFEDRange_(pset.getUntrackedParameter<std::vector<unsigned int>>("testTCDSFEDRange", std::vector<unsigned int>())),
+      testTCDSFEDRange_(
+          pset.getUntrackedParameter<std::vector<unsigned int>>("testTCDSFEDRange", std::vector<unsigned int>())),
       fileNames_(pset.getUntrackedParameter<std::vector<std::string>>("fileNames", std::vector<std::string>())),
       fileListMode_(pset.getUntrackedParameter<bool>("fileListMode", false)),
       fileListLoopMode_(pset.getUntrackedParameter<bool>("fileListLoopMode", false)),
@@ -618,7 +619,8 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
     makeEvent(eventPrincipal, aux);
   } else if (tcds_pointer_ == nullptr) {
     if (!GTPEventID_) {
-      throw cms::Exception("FedRawDataInputSource::read") << "No TCDS or GTP FED in event with FEDHeader EID -: " << L1EventID_;
+      throw cms::Exception("FedRawDataInputSource::read")
+          << "No TCDS or GTP FED in event with FEDHeader EID -: " << L1EventID_;
     }
     eventID_ = edm::EventID(eventRunNumber_, currentLumiSection_, GTPEventID_);
     edm::EventAuxiliary aux(eventID_, processGUID(), tstamp, true, edm::EventAuxiliary::PhysicsTrigger);
@@ -704,25 +706,26 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
     const uint16_t fedId = fedHeader.sourceID();
     if (fedId > FEDNumbering::MAXFEDID) {
       throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection") << "Out of range FED ID : " << fedId;
-    }
-    else if (UNLIKELY(testTCDSFEDRange_.size())) {
-      if (testTCDSFEDRange_.size()!=2) {
-        throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection") << "Invalid TCDS Test FED range parameter";
+    } else if (UNLIKELY(testTCDSFEDRange_.size())) {
+      if (testTCDSFEDRange_.size() != 2) {
+        throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
+            << "Invalid TCDS Test FED range parameter";
       }
       if (fedId >= testTCDSFEDRange_[0] && fedId <= testTCDSFEDRange_[1]) {
         if (!selectedTCDSFed) {
           selectedTCDSFed = fedId;
           tcds_pointer_ = event + eventSize;
-        }
-        else throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection") << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
+        } else
+          throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
+              << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
       }
-    }
-    else if (fedId >= FEDNumbering::MINTCDSuTCAFEDID && fedId <= FEDNumbering::MAXTCDSuTCAFEDID) {
+    } else if (fedId >= FEDNumbering::MINTCDSuTCAFEDID && fedId <= FEDNumbering::MAXTCDSuTCAFEDID) {
       if (!selectedTCDSFed) {
         selectedTCDSFed = fedId;
         tcds_pointer_ = event + eventSize;
-      }
-        else throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection") << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
+      } else
+        throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
+            << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
     }
     if (fedId == FEDNumbering::MINTriggerGTPFEDID) {
       if (evf::evtn::evm_board_sense(event + eventSize, fedSize))
@@ -1536,7 +1539,7 @@ long FedRawDataInputSource::initFileList() {
     else if (fileStem.find("file:") == 0)
       fileStem = fileStem.substr(5);
     auto end = fileStem.find('_');
-    
+
     if (fileStem.find("run") == 0) {
       std::string runStr = fileStem.substr(3, end - 3);
       try {

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -78,6 +78,15 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm:
   edm::LogInfo("FedRawDataInputSource") << "Construction. read-ahead chunk size -: " << std::endl
                                         << (eventChunkSize_ / 1048576) << " MB on host " << thishost;
 
+  if (testTCDSFEDRange_.size()) {
+    if (testTCDSFEDRange_.size() != 2) {
+      throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
+          << "Invalid TCDS Test FED range parameter";
+    }
+    MINTCDSuTCAFEDID_ = testTCDSFEDRange_[0];
+    MAXTCDSuTCAFEDID_ = testTCDSFEDRange_[1];
+  }
+
   long autoRunNumber = -1;
   if (fileListMode_) {
     autoRunNumber = initFileList();
@@ -706,20 +715,7 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
     const uint16_t fedId = fedHeader.sourceID();
     if (fedId > FEDNumbering::MAXFEDID) {
       throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection") << "Out of range FED ID : " << fedId;
-    } else if (UNLIKELY(testTCDSFEDRange_.size())) {
-      if (testTCDSFEDRange_.size() != 2) {
-        throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
-            << "Invalid TCDS Test FED range parameter";
-      }
-      if (fedId >= testTCDSFEDRange_[0] && fedId <= testTCDSFEDRange_[1]) {
-        if (!selectedTCDSFed) {
-          selectedTCDSFed = fedId;
-          tcds_pointer_ = event + eventSize;
-        } else
-          throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
-              << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
-      }
-    } else if (fedId >= FEDNumbering::MINTCDSuTCAFEDID && fedId <= FEDNumbering::MAXTCDSuTCAFEDID) {
+    } else if (fedId >= MINTCDSuTCAFEDID_ && fedId <= MAXTCDSuTCAFEDID_) {
       if (!selectedTCDSFed) {
         selectedTCDSFed = fedId;
         tcds_pointer_ = event + eventSize;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -16,7 +16,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/fstream.hpp>
 
-#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -77,7 +77,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm:
   edm::LogInfo("FedRawDataInputSource") << "Construction. read-ahead chunk size -: " << std::endl
                                         << (eventChunkSize_ / 1048576) << " MB on host " << thishost;
 
-  if (testTCDSFEDRange_.size()) {
+  if (!testTCDSFEDRange_.empty()) {
     if (testTCDSFEDRange_.size() != 2) {
       throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection")
           << "Invalid TCDS Test FED range parameter";

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -218,7 +218,7 @@ void FedRawDataInputSource::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.addUntracked<bool>("useL1EventID", false)
       ->setComment("Use L1 event ID from FED header if true or from TCDS FED if false");
   desc.addUntracked<std::vector<unsigned int>>("testTCDSFEDRange", std::vector<unsigned int>())
-      ->setComment("Range to search for TCDS FED ID in test setup");
+      ->setComment("[min, max] range to search for TCDS FED ID in test setup");
   desc.addUntracked<bool>("fileListMode", false)
       ->setComment("Use fileNames parameter to directly specify raw files to open");
   desc.addUntracked<std::vector<std::string>>("fileNames", std::vector<std::string>())

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -1531,7 +1531,12 @@ long FedRawDataInputSource::initFileList() {
     //get run number from first file in the vector
     std::filesystem::path fileName = fileNames_[0];
     std::string fileStem = fileName.stem().string();
+    if (fileStem.find("file://") == 0)
+      fileStem = fileStem.substr(7);
+    else if (fileStem.find("file:") == 0)
+      fileStem = fileStem.substr(5);
     auto end = fileStem.find('_');
+    
     if (fileStem.find("run") == 0) {
       std::string runStr = fileStem.substr(3, end - 3);
       try {

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -123,7 +123,7 @@ process.a = cms.EDAnalyzer("ExceptionGenerator",
 process.s = cms.EDProducer("DaqFakeReader",
                            meanSize = cms.untracked.uint32(options.fedMeanSize),
                            width = cms.untracked.uint32(int(math.ceil(options.fedMeanSize/2.))),
-                           #tcdsFEDID = cms.untracked.uint32(1024),
+                           tcdsFEDID = cms.untracked.uint32(1024),
                            injectErrPpm = cms.untracked.uint32(0)
                            )
 

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -123,6 +123,7 @@ process.a = cms.EDAnalyzer("ExceptionGenerator",
 process.s = cms.EDProducer("DaqFakeReader",
                            meanSize = cms.untracked.uint32(options.fedMeanSize),
                            width = cms.untracked.uint32(int(math.ceil(options.fedMeanSize/2.))),
+                           #tcdsFEDID = cms.untracked.uint32(1024),
                            injectErrPpm = cms.untracked.uint32(0)
                            )
 

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -84,7 +84,7 @@ except Exception as ex:
 process.source = cms.Source("FedRawDataInputSource",
     getLSFromFilename = cms.untracked.bool(True),
     verifyChecksum = cms.untracked.bool(True),
-    useL1EventID = cms.untracked.bool(True),
+    useL1EventID = cms.untracked.bool(False),
     eventChunkSize = cms.untracked.uint32(8),
     eventChunkBlock = cms.untracked.uint32(8),
     numBuffers = cms.untracked.uint32(2),
@@ -120,7 +120,12 @@ process.b = cms.EDAnalyzer("ExceptionGenerator",
     defaultAction = cms.untracked.int32(0),
     defaultQualifier = cms.untracked.int32(5))
 
-process.p1 = cms.Path(process.a*process.filter1)
+
+process.tcdsRawToDigi = cms.EDProducer("TcdsRawToDigi",
+    InputLabel = cms.InputTag("rawDataCollector")
+)
+
+process.p1 = cms.Path(process.a*process.tcdsRawToDigi*process.filter1)
 process.p2 = cms.Path(process.b*process.filter2)
 
 process.streamA = cms.OutputModule("EvFOutputModule",

--- a/EventFilter/Utilities/test/unittest_FU.py
+++ b/EventFilter/Utilities/test/unittest_FU.py
@@ -86,7 +86,7 @@ ram_dir_path=options.buBaseDir+"/run"+str(options.runNumber).zfill(6)+"/"
 process.source = cms.Source("FedRawDataInputSource",
     getLSFromFilename = cms.untracked.bool(True),
     verifyChecksum = cms.untracked.bool(True),
-    useL1EventID = cms.untracked.bool(True),
+    useL1EventID = cms.untracked.bool(False),
     eventChunkSize = cms.untracked.uint32(8),
     eventChunkBlock = cms.untracked.uint32(8),
     numBuffers = cms.untracked.uint32(2),
@@ -130,7 +130,11 @@ process.b = cms.EDAnalyzer("ExceptionGenerator",
     defaultAction = cms.untracked.int32(0),
     defaultQualifier = cms.untracked.int32(5))
 
-process.p1 = cms.Path(process.a*process.filter1)
+process.tcdsRawToDigi = cms.EDProducer("TcdsRawToDigi",
+    InputLabel = cms.InputTag("rawDataCollector")
+)
+
+process.p1 = cms.Path(process.a*process.tcdsRawToDigi*process.filter1)
 process.p2 = cms.Path(process.b*process.filter2)
 
 process.streamA = cms.OutputModule("EvFOutputModule",


### PR DESCRIPTION
#### PR description:

- FedRawDataInputSource and unpacker will look for TCDS FED ID in the Min-Max range for TCDS (this adds support for MiniDAQ and other setup with TCDS ID which is not 1024).
- test range parameter added to the Input source to allow other FED ID values in daq3val
- FRDStreamSource and TCDS unpacker (TCDSRawToDigi) also gains this functionality
- update to DataFormat/TCDS adding FED ID number to the record.
- fakeBU can generate TCDS FED payload, GTP FED generator removed. Test scrips now rely on TCDS FED, and include unpacker

#### PR validation:

Tested with new "fakeBU" FED ID generator (incorporated in automated unit test for this module), manually with sample of raw event (file) and in test HLT-like cluster.
