### PR TITLE
Add all direct deps to BuildFile for Alignment/CocoaFit

### DIFF
--- a/Alignment/CocoaFit/BuildFile.xml
+++ b/Alignment/CocoaFit/BuildFile.xml
@@ -11,6 +11,10 @@
 <use name="CondFormats/Alignment"/>
 <use name="CondFormats/AlignmentRecord"/>
 <use name="CondCore/DBOutputService"/>
+<use name="CondCore/CondDB"/>
+<use name="DataFormats/GeometryCommonDetAlgo"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="Geometry/Records"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
for all packages that still should be made into cxx modules (well, current list of them). Additions made by looking for packages directly included in interface or src.