### PR TITLE
HCAL:  more Validation wfs cleaning

### DIFF
--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -184,8 +184,6 @@ globalValidationHCAL = cms.Sequence(
       hcalSimHitsValidationSequence
     + hcaldigisValidationSequence
     + hcalSimHitStudy
-    + hcalRecHitsValidationSequence
-    + calotowersValidationSequence
 )
 
 globalValidationHCALOnly = cms.Sequence(

--- a/Validation/Configuration/python/noiseSimValid_cff.py
+++ b/Validation/Configuration/python/noiseSimValid_cff.py
@@ -8,13 +8,11 @@ from Validation.EcalDigis.ecalDigisValidationSequence_cff import *
 from Validation.EcalRecHits.ecalRecHitsValidationSequence_cff import *
 from Validation.HcalHits.HcalSimHitStudy_cfi import *
 from Validation.HcalDigis.hcalDigisValidationSequence_cff import *
-from Validation.HcalRecHits.hcalRecHitsValidationSequence_cff import *
-from Validation.CaloTowers.calotowersValidationSequence_cff import *
 from Validation.MuonHits.muonHitsValidation_cfi import *
 from Validation.MuonDTDigis.dtDigiValidation_cfi import *
 from Validation.MuonCSCDigis.cscDigiValidation_cfi import *
 from Validation.MuonRPCDigis.validationMuonRPCDigis_cfi import *
 
-noiseSimValid = cms.Sequence(trackerHitsValidation+trackerDigisValidation+trackerRecHitsValidation+ecalSimHitsValidationSequence+ecalDigisValidationSequence+ecalRecHitsValidationSequence+hcalSimHitStudy+hcalDigisValidationSequence+hcalRecHitsValidationSequence+calotowersValidationSequence+validSimHit+muondtdigianalyzer+cscDigiValidation+validationMuonRPCDigis)
+noiseSimValid = cms.Sequence(trackerHitsValidation+trackerDigisValidation+trackerRecHitsValidation+ecalSimHitsValidationSequence+ecalDigisValidationSequence+ecalRecHitsValidationSequence+hcalSimHitStudy+hcalDigisValidationSequence+validSimHit+muondtdigianalyzer+cscDigiValidation+validationMuonRPCDigis)
 
 

--- a/Validation/RecoHI/python/globalValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/globalValidationHeavyIons_cff.py
@@ -44,8 +44,7 @@ globalValidationHI = cms.Sequence(
 
     + hcalSimHitStudy
     #+ hcalDigisValidationSequence  # simHcalDigis not in RAWDEBUG
-    + hcalRecHitsValidationSequence
-    + calotowersValidationSequence
+    # hcalRecHits and calotowers come from DQMOffline/Hcal 
     
     + hiTrackValidation         # validation of 'hiGeneralTracks'
     + hiJetValidation           # validation of pileup jet finders


### PR DESCRIPTION
#### PR description:

(1) CaloTowersD and HcalRecHitsD (from DQMOffline/Hcal) are used by HCAL in RelVals.

(2) CaloTowersV and HcalRecHitsV (from Validation/CaloTowers and Validation/HcalRecHits respectively)
 is a legacy stuff = redundant for RelVals, now used solely in HCAL private MC tests.

Previously in https://github.com/cms-sw/cmssw/pull/28594  
modules  (2) were removed from globalValidation sequence.
More cleaning is done with this PR in globalValidationHCAL sequence,
used in particular for Phase2 (2026) RelVals.  

#### PR validation:

runTheMatrix.py -l limited   OK

In wf 23234.0 (Phase2)  now remain only necessary histo directories in the DQM harvested file.    
