### PR TITLE
add modifier for handling the pixel CPE for HLT phase2

### DIFF
--- a/Configuration/ProcessModifiers/python/phase2_PixelCPEGeneric4HLT_cff.py
+++ b/Configuration/ProcessModifiers/python/phase2_PixelCPEGeneric4HLT_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is to run the Pixel Generic CPE algorithm in Phase-2 workflows
+phase2_PixelCPEGeneric4HLT =  cms.Modifier()

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -18,3 +18,7 @@ phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRep
 # Turn off template reco for phase 2 (when not supported)
 from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
 phase2_PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')
+
+# Turn off template reco for phase 2 HLT
+from Configuration.ProcessModifiers.phase2_PixelCPEGeneric4HLT_cff import phase2_PixelCPEGeneric4HLT
+phase2_PixelCPEGeneric4HLT.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')


### PR DESCRIPTION
modifier to be used for HLT TDR, in order to make sure that we are using the generic CPE (w/ hardcoded CPE error in the seeding step, and generic error in the fitter when the track angle is available)

I'm going to make a new PR w/ the backport to 111X

@fwyzard