### PR TITLE
Update global tags to use V5 JEC for 2017 data/MC and Run 3 MC and add V7b JR for 2018 data/MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '111X_dataRun2_v3',
+    'run1_data'         :   '112X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '111X_dataRun2_v3',
+    'run2_data'         :   '112X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '111X_dataRun2_HEfail_v3',
+    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '111X_dataRun2_relval_v3',
+    'run2_data_relval'  :   '112X_dataRun2_relval_v1',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
@@ -49,11 +49,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '111X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '111X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    :  '112X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '111X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'      :  '112X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '111X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak' :  '112X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '111X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '112X_dataRun2_v1',
+    'run1_data'         :   '112X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '112X_dataRun2_v1',
+    'run2_data'         :   '112X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v1',
+    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '112X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '112X_dataRun2_relval_v2',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
@@ -57,15 +57,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '111X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '111X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '111X_upgrade2018_realistic_HEfail_v1',
+    'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '111X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '112X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '111X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak' :   '112X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '112X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -67,17 +67,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '111X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '112X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '112X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v2',
+    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' :  '112X_mcRun3_2021_realistic_HI_v2',
+    'phase1_2021_realistic_hi' :  '112X_mcRun3_2021_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v3', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v2', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v3', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

This PR updates the JEC for 2017 to the V5 version recently derived for the 2017 legacy reprocessing. In addition, the same JEC are used for Run 3 MC scenarios.

In addition, the jet resolution corrections for 2018 data and MC have been updated to match those used in the 102X series. See the [HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4309/2/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1/1.html) for details.

The GT differences are as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_v3/112X_dataRun2_v2

**Offline data (HE failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_HEfail_v3/112X_dataRun2_HEfail_v2

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_relval_v3/112X_dataRun2_relval_v2

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mc2017_realistic_v2/112X_mc2017_realistic_v2

**2017 realistic (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mc2017cosmics_realistic_deco_v1/112X_mc2017cosmics_realistic_deco_v2

**2017 realistic (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mc2017cosmics_realistic_peak_v1/112X_mc2017cosmics_realistic_peak_v2

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_realistic_v1/112X_upgrade2018_realistic_v1

**2018 realistic (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_realistic_HEfail_v1/112X_upgrade2018_realistic_HEfail_v1

**2018 realistic (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018cosmics_realistic_deco_v1/112X_upgrade2018cosmics_realistic_deco_v1

**2018 realistic (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018cosmics_realistic_peak_v1/112X_upgrade2018cosmics_realistic_peak_v1

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_design_v2/112X_mcRun3_2021_design_v3

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v2/112X_mcRun3_2021_realistic_v3

**2021 realistic (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v2/112X_mcRun3_2021cosmics_realistic_deco_v3

**2021 realistic heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v2/112X_mcRun3_2021_realistic_HI_v3

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2023_realistic_v2/112X_mcRun3_2023_realistic_v3

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2024_realistic_v2/112X_mcRun3_2024_realistic_v3

The cosmic GTs are updated purely to minimize the tag difference between the pp collision and cosmic GTs. Differences in the PR comparison tests are expected only for 2017 data, 2017 MC and Run 3 scenarios.

#### PR validation:

See the threads in the [AlCaDB HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4309.html) and the [Jet Energy Scale HN](https://hypernews.cern.ch/HyperNews/CMS/get/jes/1004.html) for more details.

In addition, a technical test was performed:

`runTheMatrix.py -l limited,12024.0,7.23,159.0,12834.0,7.21 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but the 2017-specific portion (76260a5) will be backported to 10_6_X for use in the UL. There is no need to backport the portion that is specific to Run 3 (6c82887).