### PR TITLE
Turn on L1 track trigger in Phase2C8 and later

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C8_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C8_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
+from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
 
-Phase2C8 = cms.ModifierChain(Phase2C4, phase2_hgcalV10)
+Phase2C8 = cms.ModifierChain(Phase2C4, phase2_hgcalV10, phase2_trackerV14)
 

--- a/Configuration/Eras/python/Modifier_phase2_trackerV14_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_trackerV14_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_trackerV14 =  cms.Modifier()
+

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -60,7 +60,7 @@ class Eras (object):
                            'run3_HB', 'run3_common', 'run3_RPC',
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017',
                            'run2_CSC_2018',
-                           'phase2_common', 'phase2_tracker',
+                           'phase2_common', 'phase2_tracker', 'phase2_trackerV14',
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing', 'phase2_hgcalV9', 'phase2_hfnose', 'phase2_hgcalV10', 'phase2_hgcalV11', 'phase2_hgcalV12',
                            'phase2_timing_layer', 'phase2_hcal', 'phase2_ecal',
                            'phase2_trigger',

--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -3,8 +3,15 @@ import FWCore.ParameterSet.Config as cms
 from L1Trigger.TrackTrigger.TrackTrigger_cff import *
 from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
 from L1Trigger.TrackerDTC.ProducerED_cff import *
+from L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff import * 
 
-#L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
 L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackerDTCProducer)
+
+# Customisation to enable TTTracks in geometry D41 and later (corresponding to phase2_trackerV14 or later). Includes the HGCAL L1 trigger
+_tttracks_l1tracktrigger = L1TrackTrigger.copy()
+_tttracks_l1tracktrigger = cms.Sequence(_tttracks_l1tracktrigger + L1PromptExtendedHybridTracksWithAssociators)
+
+from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
+phase2_trackerV14.toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
 
 TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)


### PR DESCRIPTION
#### PR description:

This PR turn on the L1 track trigger adding the modifier phase2_trackerV14 added to Phase2C8.
In this way we do *not* turn on L1 track trigger in D35.

#### PR validation:

The configuration made with cmsDriver looks ok. Local `runTheMatrix` tests are ok for `20034.0,20434.0,21234.0,23234.0`

@rekovic 
@kpedro88 