### PR TITLE
Move L1TrackTrigger step before L1 step

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3256,7 +3256,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       }
 
     # Adding Track trigger step in step2
-    upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:%s'%(hltversion),
+    upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',
                                       '-n':'10',

--- a/Validation/Geometry/test/runMaterialDumpAnalyser_PhaseII.sh
+++ b/Validation/Geometry/test/runMaterialDumpAnalyser_PhaseII.sh
@@ -59,7 +59,7 @@ fi
 # DIGI comes next
 if checkFile SingleMuPt10_step2_DIGI_L1_DIGI2RAW_HLT_PhaseII.root ; then
   cmsDriver.py step2   \
--s DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2  \
+-s DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2  \
 --conditions auto:phase2_realistic \
 -n -1  \
 --era Phase2C2  \


### PR DESCRIPTION
#### PR description:

Since the `L1` step will include both L1 particle flow and L1 track match, we need to run `L1TrackTrigger` *before* `L1`.
This PR makes  this fix, and propagate this also to `Validation/Geometry/test/runMaterialDumpAnalyser_PhaseII.sh` (found with from a simple query on LXR https://cmssdt.cern.ch/lxr/search?%21v=CMSSW_11_2_X_2020-06-28-2300&_filestring=&_string=%5C%2CL1TrackTrigger )

#### PR validation:

` runTheMatrix.py -l 21234.0,23234.0,20434.0,20034.0` works