### PR TITLE
Concurrent ExternalLHEProducer (backport #28899)

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="boost"/>
 <library name="GeneratorInterfaceLHEProducer" file="LHEFilter.cc LHE2HepMCConverter.cc ExternalLHEProducer.cc ExternalLHEAsciiDumper.cc">
         <use name="FWCore/Framework"/>
+        <use name="FWCore/Concurrency"/>
         <use name="SimDataFormats/GeneratorProducts"/>
         <flags EDM_PLUGIN="1"/>
 </library>

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -23,12 +23,14 @@ Implementation:
 #include <vector>
 #include <string>
 #include <fstream>
+#include "boost/filesystem.hpp"
 #include <unistd.h>
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include "tbb/task_arena.h"
 
 
 #include "boost/bind.hpp"
@@ -43,6 +45,8 @@ Implementation:
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Concurrency/interface/FunctorTask.h"
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -69,7 +73,6 @@ class ExternalLHEProducer : public edm::one::EDProducer<edm::BeginRunProducer,
                                                         edm::EndRunProducer> {
 public:
   explicit ExternalLHEProducer(const edm::ParameterSet& iConfig);
-  ~ExternalLHEProducer() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
@@ -80,30 +83,31 @@ private:
   void endRunProduce(edm::Run&, edm::EventSetup const&) override;
   void preallocThreads(unsigned int) override;
 
-  int closeDescriptors(int preserve);
-  void executeScript();
-  std::unique_ptr<std::string> readOutput();
+  std::vector<std::string> makeArgs(uint32_t nEvents, unsigned int nThreads, std::uint32_t seed) const;
+  int closeDescriptors(int preserve) const;
+  void executeScript(std::vector<std::string> const& args, int id) const;
 
   void nextEvent();
   
   // ----------member data ---------------------------
   std::string scriptName_;
   std::string outputFile_;
-  std::vector<std::string> args_;
+  const std::vector<std::string> args_;
   uint32_t npars_;
   uint32_t nEvents_;
   bool storeXML_;
   unsigned int nThreads_{1};
   std::string outputContents_;
+  bool generateConcurrently_{false};
 
   // Used only if nPartonMapping is in the configuration
   std::map<unsigned, std::pair<unsigned, unsigned>> nPartonMapping_{};
 
   std::unique_ptr<lhef::LHEReader>	reader_;
-  std::shared_ptr<lhef::LHERunInfo>	runInfoLast;
-  std::shared_ptr<lhef::LHERunInfo>	runInfo;
-  std::shared_ptr<lhef::LHEEvent>	partonLevel;
-  boost::ptr_deque<LHERunInfoProduct>	runInfoProducts;
+  std::shared_ptr<lhef::LHERunInfo> runInfoLast_;
+  std::shared_ptr<lhef::LHERunInfo> runInfo_;
+  std::shared_ptr<lhef::LHEEvent> partonLevel_;
+  boost::ptr_deque<LHERunInfoProduct> runInfoProducts_;
   bool					wasMerged;
   
   class FileCloseSentry : private boost::noncopyable {
@@ -128,7 +132,8 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
   args_(iConfig.getParameter<std::vector<std::string> >("args")),
   npars_(iConfig.getParameter<uint32_t>("numberOfParameters")),
   nEvents_(iConfig.getUntrackedParameter<uint32_t>("nEvents")),
-  storeXML_(iConfig.getUntrackedParameter<bool>("storeXML"))
+  storeXML_(iConfig.getUntrackedParameter<bool>("storeXML")),
+  generateConcurrently_(iConfig.getUntrackedParameter<bool>("generateConcurrently"))
 {
   if (npars_ != args_.size())
     throw cms::Exception("ExternalLHEProducer") << "Problem with configuration: " << args_.size() << " script arguments given, expected " << npars_;
@@ -161,11 +166,6 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
 }
 
 
-ExternalLHEProducer::~ExternalLHEProducer()
-{
-}
-
-
 //
 // member functions
 //
@@ -182,31 +182,31 @@ void
 ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   nextEvent();
-  if (!partonLevel) {
+  if (!partonLevel_) {
     throw edm::Exception(edm::errors::EventGenerationFailure) << "No lhe event found in ExternalLHEProducer::produce().  "
     << "The likely cause is that the lhe file contains fewer events than were requested, which is possible "
     << "in case of phase space integration or uneweighting efficiency problems.";
   }
 
   std::unique_ptr<LHEEventProduct> product(
-	       new LHEEventProduct(*partonLevel->getHEPEUP(),
-				   partonLevel->originalXWGTUP())
+	       new LHEEventProduct(*partonLevel_->getHEPEUP(),
+				   partonLevel_->originalXWGTUP())
 	       );
-  if (partonLevel->getPDF()) {
-    product->setPDF(*partonLevel->getPDF());
+  if (partonLevel_->getPDF()) {
+    product->setPDF(*partonLevel_->getPDF());
   }
-  std::for_each(partonLevel->weights().begin(),
-                partonLevel->weights().end(),
+  std::for_each(partonLevel_->weights().begin(),
+                partonLevel_->weights().end(),
                 boost::bind(&LHEEventProduct::addWeight,
                             product.get(), _1));
-  product->setScales(partonLevel->scales());
+  product->setScales(partonLevel_->scales());
   if (nPartonMapping_.empty()) {
-    product->setNpLO(partonLevel->npLO());
-    product->setNpNLO(partonLevel->npNLO());
+    product->setNpLO(partonLevel_->npLO());
+    product->setNpNLO(partonLevel_->npNLO());
   }
   else {
     // overwrite npLO and npNLO values by user-specified mapping
-    unsigned processId(partonLevel->getHEPEUP()->IDPRUP);
+    unsigned processId(partonLevel_->getHEPEUP()->IDPRUP);
     unsigned order(0);
     unsigned np(0);
     try {
@@ -215,7 +215,7 @@ ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       np = procDef.second;
     }
     catch (std::out_of_range&) {
-      throw cms::Exception("ExternalLHEProducer") << "Unexpected IDPRUP encountered: " << partonLevel->getHEPEUP()->IDPRUP;
+      throw cms::Exception("ExternalLHEProducer") << "Unexpected IDPRUP encountered: " << partonLevel_->getHEPEUP()->IDPRUP;
     }
 
     switch (order) {
@@ -232,37 +232,37 @@ ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
   }
 
-  std::for_each(partonLevel->getComments().begin(),
-                partonLevel->getComments().end(),
+  std::for_each(partonLevel_->getComments().begin(),
+                partonLevel_->getComments().end(),
                 boost::bind(&LHEEventProduct::addComment,
                             product.get(), _1));
 
   iEvent.put(std::move(product));
 
-  if (runInfo) {
-    std::unique_ptr<LHERunInfoProduct> product(new LHERunInfoProduct(*runInfo->getHEPRUP()));
-    std::for_each(runInfo->getHeaders().begin(),
-                  runInfo->getHeaders().end(),
+  if (runInfo_) {
+    std::unique_ptr<LHERunInfoProduct> product(new LHERunInfoProduct(*runInfo_->getHEPRUP()));
+    std::for_each(runInfo_->getHeaders().begin(),
+                  runInfo_->getHeaders().end(),
                   boost::bind(&LHERunInfoProduct::addHeader,
                               product.get(), _1));
-    std::for_each(runInfo->getComments().begin(),
-                  runInfo->getComments().end(),
+    std::for_each(runInfo_->getComments().begin(),
+                  runInfo_->getComments().end(),
                   boost::bind(&LHERunInfoProduct::addComment,
                               product.get(), _1));
   
-    if (!runInfoProducts.empty()) {
-      runInfoProducts.front().mergeProduct(*product);
+    if (!runInfoProducts_.empty()) {
+      runInfoProducts_.front().mergeProduct(*product);
       if (!wasMerged) {
-        runInfoProducts.pop_front();
-        runInfoProducts.push_front(product.release());
+        runInfoProducts_.pop_front();
+        runInfoProducts_.push_front(product.release());
         wasMerged = true;
       }
     }
   
-    runInfo.reset();
+    runInfo_.reset();
   }
   
-  partonLevel.reset();
+  partonLevel_.reset();
   return; 
 }
 
@@ -273,11 +273,6 @@ ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& es)
 
   // pass the number of events as previous to last argument
   
-  std::ostringstream eventStream;
-  eventStream << nEvents_;
-  // args_.push_back(eventStream.str());
-  args_.insert(args_.begin() + 1, eventStream.str());
-
   // pass the random number generator seed as last argument
 
   edm::Service<edm::RandomNumberGenerator> rng;
@@ -288,26 +283,68 @@ ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& es)
       "which is not present in the configuration file.  You must add the service\n"
       "in the configuration file if you want to run ExternalLHEProducer";
   }
-  std::ostringstream randomStream;
-  randomStream << rng->mySeed(); 
-  // args_.push_back(randomStream.str());
-  args_.insert(args_.begin() + 2, randomStream.str());
 
-  // args_.emplace_back(std::to_string(nThreads_));
-  args_.insert(args_.begin() + 3, std::to_string(nThreads_));
+  std::vector<std::string> infiles;
+  auto const seed = rng->mySeed();
+  if (generateConcurrently_) {
+    infiles.resize(nThreads_);
+    auto const nEventsAve = nEvents_ / nThreads_;
+    unsigned int const overflow = nThreads_ - (nEvents_ % nThreads_);
+    std::exception_ptr except;
+    std::atomic<char> exceptSet{0};
 
-  for ( unsigned int iArg = 0; iArg < args_.size() ; iArg++ ) {
-    LogDebug("LHEInputArgs") << "arg [" << iArg << "] = " << args_[iArg];
+    tbb::this_task_arena::isolate([this, &except, &infiles, &exceptSet, nEventsAve, overflow, seed]() {
+      tbb::empty_task* waitTask = new (tbb::task::allocate_root()) tbb::empty_task;
+      waitTask->set_ref_count(1 + nThreads_);
+
+      for (unsigned int t = 0; t < nThreads_; ++t) {
+        uint32_t nEvents = nEventsAve;
+        if (nEvents_ % nThreads_ != 0 and t >= overflow) {
+          nEvents += 1;
+        }
+        auto task = edm::make_functor_task(tbb::task::allocate_root(),
+                                           [t, this, &infiles, seed, nEvents, &except, &exceptSet, waitTask]() {
+                                             try {
+                                               using namespace boost::filesystem;
+                                               using namespace std::string_literals;
+                                               auto out = path("thread"s + std::to_string(t)) / path(outputFile_);
+                                               infiles[t] = out.native();
+                                               executeScript(makeArgs(nEvents, 1, seed + t), t);
+                                             } catch (...) {
+                                               char expected = 0;
+                                               if (exceptSet.compare_exchange_strong(expected, 1)) {
+                                                 except = std::current_exception();
+                                                 exceptSet.store(2);
+                                               }
+                                             }
+                                             waitTask->decrement_ref_count();
+                                           });
+        tbb::task::spawn(*task);
+      }
+      waitTask->wait_for_all();
+      tbb::task::destroy(*waitTask);
+    });
+    if (exceptSet != 0) {
+      std::rethrow_exception(except);
+    }
+  } else {
+    infiles = std::vector<std::string>(1, outputFile_);
+    executeScript(makeArgs(nEvents_, nThreads_, seed), 0);
   }
 
-  executeScript();
-  
   //fill LHEXMLProduct (streaming read directly into compressed buffer to save memory)
   std::unique_ptr<LHEXMLStringProduct> p(new LHEXMLStringProduct);
 
   //store the XML file only if explictly requested
   if (storeXML_) {
-    std::ifstream instream(outputFile_);
+    std::string file;
+    if (generateConcurrently_) {
+      using namespace boost::filesystem;
+      file = (path("thread0") / path(outputFile_)).native();
+    } else {
+      file = outputFile_;
+    }
+    std::ifstream instream(file);
     if (!instream) {
       throw cms::Exception("OutputOpenError") << "Unable to open script output file " << outputFile_ << ".";
     }  
@@ -322,31 +359,30 @@ ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& es)
   // LHE C++ classes translation
   // (read back uncompressed file from disk in streaming mode again to save memory)
 
-  std::vector<std::string> infiles(1, outputFile_);
   unsigned int skip = 0;
   reader_ = std::make_unique<lhef::LHEReader>(infiles, skip);
 
   nextEvent();
-  if (runInfoLast) {
-    runInfo = runInfoLast;
+  if (runInfoLast_) {
+    runInfo_ = runInfoLast_;
   
-    std::unique_ptr<LHERunInfoProduct> product(new LHERunInfoProduct(*runInfo->getHEPRUP()));
-    std::for_each(runInfo->getHeaders().begin(),
-                  runInfo->getHeaders().end(),
+    std::unique_ptr<LHERunInfoProduct> product(new LHERunInfoProduct(*runInfo_->getHEPRUP()));
+    std::for_each(runInfo_->getHeaders().begin(),
+                  runInfo_->getHeaders().end(),
                   boost::bind(&LHERunInfoProduct::addHeader,
                               product.get(), _1));
-    std::for_each(runInfo->getComments().begin(),
-                  runInfo->getComments().end(),
+    std::for_each(runInfo_->getComments().begin(),
+                  runInfo_->getComments().end(),
                   boost::bind(&LHERunInfoProduct::addComment,
                               product.get(), _1));
   
     // keep a copy around in case of merging
-    runInfoProducts.push_back(new LHERunInfoProduct(*product));
+    runInfoProducts_.push_back(new LHERunInfoProduct(*product));
     wasMerged = false;
   
     run.put(std::move(product));
   
-    runInfo.reset();
+    runInfo_.reset();
   }
 
 }
@@ -356,29 +392,61 @@ void
 ExternalLHEProducer::endRunProduce(edm::Run& run, edm::EventSetup const& es)
 {
 
-  if (!runInfoProducts.empty()) {
-    std::unique_ptr<LHERunInfoProduct> product(runInfoProducts.pop_front().release());
+  if (!runInfoProducts_.empty()) {
+    std::unique_ptr<LHERunInfoProduct> product(runInfoProducts_.pop_front().release());
     run.put(std::move(product));
   }
   
   nextEvent();
-  if (partonLevel) {
+  if (partonLevel_) {
     throw edm::Exception(edm::errors::EventGenerationFailure) << "Error in ExternalLHEProducer::endRunProduce().  "
     << "Event loop is over, but there are still lhe events to process."
     << "This could happen if lhe file contains more events than requested.  This is never expected to happen.";
   }  
   
   reader_.reset();  
-  
-  if (unlink(outputFile_.c_str())) {
-    throw cms::Exception("OutputDeleteError") << "Unable to delete original script output file " << outputFile_ << " (errno=" << errno << ", " << strerror(errno) << ").";
-  }  
+  if (generateConcurrently_) {
+    for (unsigned int t = 0; t < nThreads_; ++t) {
+      using namespace boost::filesystem;
+      using namespace std::string_literals;
+      auto out = path("thread"s + std::to_string(t)) / path(outputFile_);
+      if (unlink(out.c_str())) {
+        throw cms::Exception("OutputDeleteError") << "Unable to delete original script output file " << out
+                                                  << " (errno=" << errno << ", " << strerror(errno) << ").";
+      }
+    }
+  } else {
+    if (unlink(outputFile_.c_str())) {
+      throw cms::Exception("OutputDeleteError") << "Unable to delete original script output file " << outputFile_
+                                                << " (errno=" << errno << ", " << strerror(errno) << ").";
+    }
+  }
+}
 
+std::vector<std::string> ExternalLHEProducer::makeArgs(uint32_t nEvents,
+                                                       unsigned int nThreads,
+                                                       std::uint32_t seed) const {
+  std::vector<std::string> args;
+  args.reserve(3 + args_.size());
+
+  args.push_back(args_.front());
+  args.push_back(std::to_string(nEvents));
+
+  args.push_back(std::to_string(seed));
+
+  args.push_back(std::to_string(nThreads));
+  std::copy(args_.begin() + 1, args_.end(), std::back_inserter(args));
+
+  for (unsigned int iArg = 0; iArg < args.size(); iArg++) {
+    LogDebug("LHEInputArgs") << "arg [" << iArg << "] = " << args[iArg];
+  }
+
+  return args;
 }
 
 // ------------ Close all the open file descriptors ------------
 int
-ExternalLHEProducer::closeDescriptors(int preserve)
+ExternalLHEProducer::closeDescriptors(int preserve) const
 {
   int maxfd = 1024;
   int fd;
@@ -417,14 +485,13 @@ ExternalLHEProducer::closeDescriptors(int preserve)
 
 // ------------ Execute the script associated with this producer ------------
 void 
-ExternalLHEProducer::executeScript()
+ExternalLHEProducer::executeScript(std::vector<std::string> const& args, int id) const
 {
 
   // Fork a script, wait until it finishes.
 
   int rc = 0, rc2 = 0;
   int filedes[2], fd_flags;
-  unsigned int argc;
 
   if (pipe(filedes)) {
     throw cms::Exception("Unable to create a new pipe");
@@ -438,12 +505,12 @@ ExternalLHEProducer::executeScript()
     throw cms::Exception("ExternalLHEProducer") << "Failed to set pipe file descriptor flags (errno=" << rc << ", " << strerror(rc) << ")";
   }
 
-  argc = 1 + args_.size();
+  unsigned int argc = 1 + args.size();
   // TODO: assert that we have a reasonable number of arguments
   char **argv = new char *[argc+1];
   argv[0] = strdup(scriptName_.c_str());
   for (unsigned int i=1; i<argc; i++) {
-    argv[i] = strdup(args_[i-1].c_str());
+    argv[i] = strdup(args[i-1].c_str());
   }
   argv[argc] = nullptr;
 
@@ -451,6 +518,14 @@ ExternalLHEProducer::executeScript()
   if (pid == 0) {
     // The child process
     if (!(rc = closeDescriptors(filedes[1]))) {
+      if (generateConcurrently_) {
+        using namespace boost::filesystem;
+        using namespace std::string_literals;
+        boost::system::error_code ec;
+        auto newDir = path("thread"s + std::to_string(id));
+        create_directory(newDir, ec);
+        current_path(newDir, ec);
+      }
       execvp(argv[0], argv); // If execv returns, we have an error.
       rc = errno;
     }
@@ -459,7 +534,7 @@ ExternalLHEProducer::executeScript()
   }
 
   // Free the arg vector ASAP
-  for (unsigned int i=0; i<args_.size()+1; i++) {
+  for (unsigned int i=0; i<args.size()+1; i++) {
     free(argv[i]);
   }
   delete [] argv;
@@ -500,34 +575,6 @@ ExternalLHEProducer::executeScript()
 
 }
 
-// ------------ Read the output script ------------
-#define BUFSIZE 4096
-std::unique_ptr<std::string> ExternalLHEProducer::readOutput()
-{
-  int fd;
-  ssize_t n;
-  char buf[BUFSIZE];
-
-  if ((fd = open(outputFile_.c_str(), O_RDONLY)) == -1) {
-    throw cms::Exception("OutputOpenError") << "Unable to open script output file " << outputFile_ << " (errno=" << errno << ", " << strerror(errno) << ").";
-  }
-
-  std::stringstream ss;
-  while ((n = read(fd, buf, BUFSIZE)) > 0 || (n == -1 && errno == EINTR)) {
-    if (n > 0)
-      ss.write(buf, n);
-  }
-  if (n == -1) {
-    throw cms::Exception("OutputOpenError") << "Unable to read from script output file " << outputFile_ << " (errno=" << errno << ", " << strerror(errno) << ").";
-  }
-
-  if (unlink(outputFile_.c_str())) {
-    throw cms::Exception("OutputDeleteError") << "Unable to delete original script output file " << outputFile_ << " (errno=" << errno << ", " << strerror(errno) << ").";
-  }
-
-  return std::unique_ptr<std::string>(new std::string(ss.str()));
-}
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void
 ExternalLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -543,6 +590,8 @@ ExternalLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<uint32_t>("numberOfParameters");
   desc.addUntracked<uint32_t>("nEvents");
   desc.addUntracked<bool>("storeXML", false);
+  desc.addUntracked<bool>("generateConcurrently", false)
+      ->setComment("If true, run the script concurrently in separate processes.");
 
   edm::ParameterSetDescription nPartonMappingDesc;
   nPartonMappingDesc.add<unsigned>("idprup");
@@ -556,18 +605,27 @@ ExternalLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 void ExternalLHEProducer::nextEvent()
 {
 
-  if (partonLevel)
+  if (partonLevel_)
     return;
 
   if(not reader_) { return;}
-  partonLevel = reader_->next();
-  if (!partonLevel)
+
+  partonLevel_ = reader_->next();
+  if (!partonLevel_) {
+    //see if we have another file to read;
+    bool newFileOpened;
+    do {
+      newFileOpened = false;
+      partonLevel_ = reader_->next(&newFileOpened);
+    } while (newFileOpened && !partonLevel_);
+  }
+  if (!partonLevel_)
     return;
 
-  std::shared_ptr<lhef::LHERunInfo> runInfoThis = partonLevel->getRunInfo();
-  if (runInfoThis != runInfoLast) {
-    runInfo = runInfoThis;
-    runInfoLast = runInfoThis;
+  std::shared_ptr<lhef::LHERunInfo> runInfoThis = partonLevel_->getRunInfo();
+  if (runInfoThis != runInfoLast_) {
+    runInfo_ = runInfoThis;
+    runInfoLast_ = runInfoThis;
   }
 }
 

--- a/GeneratorInterface/LHEInterface/test/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/test/BuildFile.xml
@@ -8,3 +8,8 @@
   <flags   TEST_RUNNER_ARGS=" /bin/bash GeneratorInterface/LHEInterface/test testMerging.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>
+<bin   name="testGeneratorInterfaceLHEInterface_TP" file="test_catch2_*.cc" >
+  <use   name="FWCore/TestProcessor"/>
+  <use   name="SimDataFormats/GeneratorProducts"/>
+  <use   name="catch2"/>
+</bin>

--- a/GeneratorInterface/LHEInterface/test/run_dummy_script.sh
+++ b/GeneratorInterface/LHEInterface/test/run_dummy_script.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo $0 $1
+SCRIPTPATH=`dirname $0`
+
+cp $SCRIPTPATH/ttbar.lhe dummy.lhe

--- a/GeneratorInterface/LHEInterface/test/test_catch2_ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/test/test_catch2_ExternalLHEProducer.cc
@@ -1,0 +1,94 @@
+#include "catch.hpp"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+
+static constexpr auto s_tag = "[ExternalLHEProducer]";
+
+TEST_CASE("Standard checks of ExternalLHEProducer", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    scriptName = cms.FileInPath("GeneratorInterface/LHEInterface/test/run_dummy_script.sh"),
+    outputFile = cms.string("dummy.lhe"),
+    numberOfParameters = cms.uint32(1),
+    args = cms.vstring('value'),
+    nEvents = cms.untracked.uint32(5),
+    storeXML = cms.untracked.bool(False),
+    generateConcurrently = cms.untracked.bool(False)
+ )
+process.moduleToTest(process.externalLHEProducer)
+process.RandomNumberGeneratorService = cms.Service('RandomNumberGeneratorService',
+     externalLHEProducer = cms.PSet(
+        initialSeed = cms.untracked.uint32(563)
+    )
+)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+  SECTION("base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("All events") {
+    edm::test::TestProcessor tester(config);
+
+    //there are 5 events in the input
+    {
+      auto event = tester.test();
+      auto const& prod = event.get<LHEEventProduct>();
+      REQUIRE(prod->hepeup().NUP == 12);
+    }
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("All events: generateConcurrently") {
+    edm::test::TestProcessor::Config config{baseConfig + "\nprocess.externalLHEProducer.generateConcurrently = True\n"};
+    edm::test::TestProcessor tester(config);
+
+    //there are 5 events in the input
+    {
+      auto event = tester.test();
+      auto const& prod = event.get<LHEEventProduct>();
+      REQUIRE(prod->hepeup().NUP == 12);
+    }
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  /* test not backported to 10_6_X
+  SECTION("Missing events") {
+    edm::test::TestProcessor tester(config);
+
+    //there are 5 events in the input
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_NOTHROW(tester.test());
+    REQUIRE_THROWS_AS(tester.testEndRun(), cms::Exception);
+  }*/
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_THROWS_AS(tester.testRunWithNoLuminosityBlocks(), cms::Exception);
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_THROWS_AS(tester.testLuminosityBlockWithNoEvents(), cms::Exception);
+  }
+}
+
+//Add additional TEST_CASEs to exercise the modules capabilities

--- a/GeneratorInterface/LHEInterface/test/test_catch2_main.cc
+++ b/GeneratorInterface/LHEInterface/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

**This PR is a backport of #28899 by @Dr15Jones.**

It adds the ability to use multiple TBB tasks to execute the script concurrently during the begin run phase.

#### PR validation:

This PR passes the additional unit tests brought by #28899. 
It is also validated on [`SMP-RunIISummer19UL17wmLHEGEN-00001`](https://cms-pdmv.cern.ch/mcm/requests?prepid=SMP-RunIISummer19UL17wmLHEGEN-00001&page=0&shown=127) for LHE/GEN-level physics results.

(A quick test for this PR)
```shell
cmsrel CMSSW_10_6_X_2020-06-30-2300
cd CMSSW_10_6_X_2020-06-30-2300/src/
cmsenv
git cms-merge-topic colizz:dev-106X-externalLHEProducer
curl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/B2G-RunIISummer19UL17wmLHEGEN-00001 --retry 2 --create-dirs -o Configuration/GenProduction/python/B2G-RunIISummer19UL17wmLHEGEN-00001-fragment.py 
scram b -j 8
cd ../..
cmsDriver.py Configuration/GenProduction/python/B2G-RunIISummer19UL17wmLHEGEN-00001-fragment.py --fileout file:B2G-RunIISummer19UL17wmLHEGEN-00001.root --mc --eventcontent RAWSIM,LHE --datatier GEN,LHE --conditions 106X_mc2017_realistic_v6 --beamspot Realistic25ns13TeVEarly2017Collision --step LHE,GEN --geometry DB:Extended --era Run2_2017 --python_filename B2G-RunIISummer19UL17wmLHEGEN-00001_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring --customise_commands='process.externalLHEProducer.generateConcurrently=cms.untracked.bool(True)' -n 200 --nThreads 2

cmsRun -e -j B2G-RunIISummer19UL17wmLHEGEN-00001_rt.xml B2G-RunIISummer19UL17wmLHEGEN-00001_1_cfg.py
```
