### PR TITLE
Include full Phase-2 L1Trigger in TestOldDigi workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -672,6 +672,11 @@ class UpgradeWorkflow_TestOldDigi(UpgradeWorkflow):
             # handle separate PU input
             stepNamePU = step + 'PU' + self.suffix
             stepDict[stepNamePU][k] = merge([{'--filein': 'das:/RelValTTbar_14TeV/CMSSW_11_0_0_pre13-PU25ns_110X_mcRun4_realistic_v2_2026D49PU200-v2/GEN-SIM-DIGI-RAW'},stepDict[stepName][k]])
+            ## Use re-emulate the full L1 trigger when running on 11_0 DIGI. Ie. Replace L1Reco with L1TrackTrigger,L1. 
+            stepDict[stepName][k] = merge([{'-s': stepDict[stepName][k]['-s'].replace("L1Reco","L1TrackTrigger,L1")}, stepDict[stepName][k]])
+            stepDict[stepNamePU][k] = merge([{'-s': stepDict[stepNamePU][k]['-s'].replace("L1Reco","L1TrackTrigger,L1")}, stepDict[stepNamePU][k]])
+            stepDict[stepName][k] = merge([{'--customise_unsch': "L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC"}, stepDict[stepName][k]])
+            stepDict[stepNamePU][k] = merge([{'--customise_unsch': "L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC"}, stepDict[stepNamePU][k]])
         elif 'GenSim' in step or 'Digi' in step:
             # remove step
             stepDict[stepName][k] = None

--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -14,4 +14,4 @@ _tttracks_l1tracktrigger = cms.Sequence(_tttracks_l1tracktrigger + L1PromptExten
 from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
 phase2_trackerV14.toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
 
-TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)
+TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = True

--- a/L1Trigger/Configuration/python/customisePhase2TTNoMC.py
+++ b/L1Trigger/Configuration/python/customisePhase2TTNoMC.py
@@ -1,0 +1,4 @@
+def customisePhase2TTNoMC(process):
+    process.L1TrackTrigger.replace(process.L1PromptExtendedHybridTracksWithAssociators, process.L1PromptExtendedHybridTracks)
+    process.L1TrackTrigger.remove(process.TrackTriggerAssociatorClustersStubs)
+    return process


### PR DESCRIPTION
#### PR description:

This PR updates the TestOldDigi workflows (23234.1001, 23434.1001) used to run  re-reco on the 11_0 digis. The PR replaces `L1Reco` step with `L1TrackTrigger,L1` steps which run the full Phase-2 L1Trigger. In order to be compatible with 11_0 digis, we need also to set `readMoreMcTruth = False` in two L1TT modules using a customzation function
 
#### PR validation:

The new matrix changes only the TestOldDigi workflows as expected.

cc: @kpedro88 @rekovic 