### PR TITLE
Add Phase2 L1T products to FEVTDEBUG EventContent

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -153,3 +153,51 @@ def _appendME0Digis(obj):
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(L1TriggerFEVTDEBUG, func=_appendME0Digis)
+
+# adding phase2 trigger
+def _appendPhase2Digis(obj):
+    l1Phase2Digis = [
+        "keep *_simKBmtfDigis_*_*",
+        'keep *_hgcalVFEProducerhgcalConcentratorProducer__*',
+        'keep *_hgcalBackEndLayer1Producer__*',
+        'keep *_hgcalBackEndLayer2Producer__*',
+        'keep *_hgcalTowerMapProducer__*',
+        'keep *_hgcalTowerProducer__*',
+        'keep *_L1EGammaClusterEmuProducer__*',
+        'keep *_l1EGammaEEProducer__*',
+        'keep *_L1TkPrimaryVertex__*',
+        'keep *_L1TkElectronsCrystal__*',
+        'keep *_L1TkElectronsLooseCrystal__*',
+        'keep *_L1TkElectronsEllipticMatchCrystal__*',
+        'keep *_L1TkIsoElectronsCrystal__*',
+        'keep *_L1TkPhotonsCrystal__*',
+        'keep *_L1TkElectronsHGC__*',
+        'keep *_L1TkElectronsEllipticMatchHGC__*',
+        'keep *_L1TkIsoElectronsHGC__*',
+        'keep *_L1TkPhotonsHGC__*',
+        'keep *_L1TkMuons__*',
+        'keep *_pfClustersFromL1EGClusters__*',
+        'keep *_pfClustersFromCombinedCaloHCal__*',
+        'keep *_pfClustersFromCombinedCaloHF__*',
+        'keep *_pfClustersFromHGC3DClusters__*',
+        'keep *_pfTracksFromL1TracksBarrel__*',
+        'keep *_l1pfProducerBarrel__*',
+        'keep *_pfTracksFromL1TracksHGCal__*',
+        'keep *_l1pfProducerHGCal__*',
+        'keep *_l1pfProducerHGCalNoTK__*',
+        'keep *_l1pfProducerHF__*',
+        'keep *_l1pfCandidates__*',
+        'keep *_ak4PFL1Calo__*',
+        'keep *_ak4PFL1PF__*',
+        'keep *_ak4PFL1Puppi__*',
+        'keep *_ak4PFL1CaloCorrected__*',
+        'keep *_ak4PFL1PFCorrected__*',
+        'keep *_ak4PFL1PuppiCorrected__*',
+        'keep *_l1PFMetCalo__*',
+        'keep *_l1PFMetPF__*',
+        'keep *_l1PFMetPuppi__*',
+        ]
+    obj.outputCommands += l1Phase2Digis
+
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
+phase2_muon.toModify(L1TriggerFEVTDEBUG, func=_appendPhase2Digis)

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -84,6 +84,14 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #
 stage2L1Trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis))
 
+#
+# Phase-2 Trigger
+#
+from L1Trigger.L1TMuonBarrel.simKBmtfStubs_cfi import *
+from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import *
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger 
+phase2_trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simKBmtfStubs, simKBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis))
+
 ## GEM TPs
 from L1Trigger.L1TGEM.simGEMDigis_cff import *
 _run3_SimL1TMuonTask = SimL1TMuonTask.copy()


### PR DESCRIPTION
PR 11_2_X 

Adding all Phase2 L1T products to FEVTDEBUG Event Content
Also add missing KBmtf in the Muon L1T sequence.

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
