### PR TITLE
Backport to 111X of ESGetToken update in L1T O2O producer 

### DIFF
--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -47,6 +47,7 @@ private:
 protected:
   l1t::OMDSReader m_omdsReader;
   bool m_forceGeneration;
+  edm::ESConsumesCollectorT<TRcd> m_setWhatProduced(const edm::ParameterSet&);
 
   // Called from produce methods.
   // bool is true if the object data should be made.
@@ -67,9 +68,9 @@ L1ConfigOnlineProdBaseExt<TRcd, TData>::L1ConfigOnlineProdBaseExt(const edm::Par
       m_copyFromCondDB(false) {
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this)
-    .setConsumes(keyList_token)
-    .setConsumes(key_token);
+  // setWhatProduced(this)
+  //   .setConsumes(keyList_token)
+  //   .setConsumes(key_token);
 
   //now do what ever other initialization is needed
 
@@ -88,6 +89,15 @@ L1ConfigOnlineProdBaseExt<TRcd, TData>::L1ConfigOnlineProdBaseExt(const edm::Par
                          iConfig.getParameter<std::string>("onlineAuthentication"));
   }
 }
+
+template<class TRcd, class TData>
+edm::ESConsumesCollectorT<TRcd> L1ConfigOnlineProdBaseExt<TRcd, TData>::m_setWhatProduced(const edm::ParameterSet& iConfig){
+  auto collector = setWhatProduced(this);
+  collector.setConsumes(keyList_token);
+  collector.setConsumes(key_token);
+  return collector; 
+}
+
 
 template <class TRcd, class TData>
 L1ConfigOnlineProdBaseExt<TRcd, TData>::~L1ConfigOnlineProdBaseExt() {

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -169,9 +169,8 @@ bool L1ConfigOnlineProdBaseExt<TRcd, TData>::getObjectKey(const TRcd& record, st
   // If L1TriggerKeyExt is invalid, then all configuration objects are
   // already in ORCON.
   // edm::ESHandle<L1TriggerKeyExt> key_token;
-  L1TriggerKeyExt key;
   try {
-    key = keyRcd.get(key_token);
+    keyRcd.get(key_token);
   } catch (l1t::DataAlreadyPresentException& ex) {
     objectKey = std::string();
     return false;
@@ -181,7 +180,7 @@ bool L1ConfigOnlineProdBaseExt<TRcd, TData>::getObjectKey(const TRcd& record, st
   std::string recordName = edm::typelookup::className<TRcd>();
   std::string dataType = edm::typelookup::className<TData>();
 
-  objectKey = key.get(recordName, dataType);
+  objectKey = keyRcd.get(key_token).get(recordName, dataType);
 
   /*    edm::LogVerbatim( "L1-O2O" ) */
   /*      << "L1ConfigOnlineProdBase record " << recordName */

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -43,7 +43,6 @@ private:
   edm::ESGetToken<L1TriggerKeyListExt, L1TriggerKeyListExtRcd> keyList_token;
   edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> key_token;
 
-
 protected:
   l1t::OMDSReader m_omdsReader;
   bool m_forceGeneration;
@@ -90,14 +89,14 @@ L1ConfigOnlineProdBaseExt<TRcd, TData>::L1ConfigOnlineProdBaseExt(const edm::Par
   }
 }
 
-template<class TRcd, class TData>
-edm::ESConsumesCollectorT<TRcd> L1ConfigOnlineProdBaseExt<TRcd, TData>::m_setWhatProduced(const edm::ParameterSet& iConfig){
+template <class TRcd, class TData>
+edm::ESConsumesCollectorT<TRcd> L1ConfigOnlineProdBaseExt<TRcd, TData>::m_setWhatProduced(
+    const edm::ParameterSet& iConfig) {
   auto collector = setWhatProduced(this);
   collector.setConsumes(keyList_token);
   collector.setConsumes(key_token);
-  return collector; 
+  return collector;
 }
-
 
 template <class TRcd, class TData>
 L1ConfigOnlineProdBaseExt<TRcd, TData>::~L1ConfigOnlineProdBaseExt() {
@@ -121,7 +120,7 @@ std::unique_ptr<const TData> L1ConfigOnlineProdBaseExt<TRcd, TData>::produce(con
       ///	   iRecord.template getRecord< L1TriggerKeyListRcd >() ;
       ///	 edm::ESHandle< L1TriggerKeyList > keyList ;
 
-      auto const keyList = keyListRcd.get(keyList_token);
+      auto const& keyList = keyListRcd.get(keyList_token);
 
       // Find payload token
       std::string recordName = edm::typelookup::className<TRcd>();

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -46,7 +46,7 @@ private:
 protected:
   l1t::OMDSReader m_omdsReader;
   bool m_forceGeneration;
-  edm::ESConsumesCollectorT<TRcd> m_setWhatProduced(const edm::ParameterSet&);
+  edm::ESConsumesCollectorT<TRcd> wrappedSetWhatProduced(const edm::ParameterSet&);
 
   // Called from produce methods.
   // bool is true if the object data should be made.
@@ -90,7 +90,7 @@ L1ConfigOnlineProdBaseExt<TRcd, TData>::L1ConfigOnlineProdBaseExt(const edm::Par
 }
 
 template <class TRcd, class TData>
-edm::ESConsumesCollectorT<TRcd> L1ConfigOnlineProdBaseExt<TRcd, TData>::m_setWhatProduced(
+edm::ESConsumesCollectorT<TRcd> L1ConfigOnlineProdBaseExt<TRcd, TData>::wrappedSetWhatProduced(
     const edm::ParameterSet& iConfig) {
   auto collector = setWhatProduced(this);
   collector.setConsumes(keyList_token);

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -9,7 +9,6 @@
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
@@ -41,6 +40,9 @@ public:
 
 private:
   // ----------member data ---------------------------
+  edm::ESGetToken<L1TriggerKeyListExt, L1TriggerKeyListExtRcd> keyList_token;
+  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> key_token;
+
 
 protected:
   l1t::OMDSReader m_omdsReader;
@@ -65,7 +67,9 @@ L1ConfigOnlineProdBaseExt<TRcd, TData>::L1ConfigOnlineProdBaseExt(const edm::Par
       m_copyFromCondDB(false) {
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this);
+  setWhatProduced(this)
+    .setConsumes(keyList_token)
+    .setConsumes(key_token);
 
   //now do what ever other initialization is needed
 
@@ -104,16 +108,15 @@ std::unique_ptr<const TData> L1ConfigOnlineProdBaseExt<TRcd, TData>::produce(con
           ///	 // Get L1TriggerKeyList from EventSetup
           ///	 const L1TriggerKeyListRcd& keyListRcd =
           iRecord.template getRecord<L1TriggerKeyListExtRcd>();
-      edm::ESHandle<L1TriggerKeyListExt> keyList;
       ///	   iRecord.template getRecord< L1TriggerKeyListRcd >() ;
       ///	 edm::ESHandle< L1TriggerKeyList > keyList ;
 
-      keyListRcd.get(keyList);
+      auto const keyList = keyListRcd.get(keyList_token);
 
       // Find payload token
       std::string recordName = edm::typelookup::className<TRcd>();
       std::string dataType = edm::typelookup::className<TData>();
-      std::string payloadToken = keyList->token(recordName, dataType, key);
+      std::string payloadToken = keyList.token(recordName, dataType, key);
 
       edm::LogVerbatim("L1-O2O") << "Copying payload for " << recordName << "@" << dataType << " obj key " << key
                                  << " from CondDB.";
@@ -156,9 +159,10 @@ bool L1ConfigOnlineProdBaseExt<TRcd, TData>::getObjectKey(const TRcd& record, st
 
   // If L1TriggerKeyExt is invalid, then all configuration objects are
   // already in ORCON.
-  edm::ESHandle<L1TriggerKeyExt> key;
+  // edm::ESHandle<L1TriggerKeyExt> key_token;
+  L1TriggerKeyExt key;
   try {
-    keyRcd.get(key);
+    key = keyRcd.get(key_token);
   } catch (l1t::DataAlreadyPresentException& ex) {
     objectKey = std::string();
     return false;
@@ -168,7 +172,7 @@ bool L1ConfigOnlineProdBaseExt<TRcd, TData>::getObjectKey(const TRcd& record, st
   std::string recordName = edm::typelookup::className<TRcd>();
   std::string dataType = edm::typelookup::className<TData>();
 
-  objectKey = key->get(recordName, dataType);
+  objectKey = key.get(recordName, dataType);
 
   /*    edm::LogVerbatim( "L1-O2O" ) */
   /*      << "L1ConfigOnlineProdBase record " << recordName */

--- a/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
@@ -7,6 +7,7 @@
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"

--- a/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
@@ -7,7 +7,6 @@
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
@@ -29,6 +28,8 @@ public:
 
 private:
   // ----------member data ---------------------------
+  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> L1TriggerKeyExt_token;
+
 protected:
   l1t::OMDSReader m_omdsReader;
 };

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
@@ -15,7 +15,6 @@ L1CondDBPayloadWriterExt::L1CondDBPayloadWriterExt(const edm::ParameterSet& iCon
       m_newL1TriggerKeyListExt(iConfig.getParameter<bool>("newL1TriggerKeyListExt")) {
   //now do what ever initialization is needed
   key_token = esConsumes<L1TriggerKeyExt, L1TriggerKeyExtRcd>();      
-      std::cout << "*************** HERE WE DIVE ***************************" << std::endl;
 
 }
 
@@ -49,7 +48,6 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
   
   try {
     // Get L1TriggerKeyExt
-    std::cout << "*************** HERE WE JIBE ***************************" << std::endl;
     key = iSetup.get<L1TriggerKeyExtRcd>().get(key_token);
     if (!m_overwriteKeys) {
       triggerKeyOK = oldKeyList.token(key.tscKey()).empty();
@@ -59,15 +57,10 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
     edm::LogVerbatim("L1-O2O") << ex.what();
   }
 
-  std::cout << "*************** HERE WE ARRIVE ***************************" << std::endl;
-
   if (triggerKeyOK && m_writeL1TriggerKeyExt) {
     edm::LogVerbatim("L1-O2O") << "Object key for L1TriggerKeyExtRcd@L1TriggerKeyExt: " << key.tscKey();
     token = m_writer.writePayload(iSetup, "L1TriggerKeyExtRcd@L1TriggerKeyExt");
   }
-
-  std::cout << "*************** HERE WE STRIVE ***************************" << std::endl;
-
 
   // If L1TriggerKeyExt is invalid, then all configuration data is already in DB
   bool throwException = false;
@@ -80,8 +73,6 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
         throw cond::Exception("L1CondDBPayloadWriter: TSC key " + key.tscKey() + " already in L1TriggerKeyListExt");
       }
     }
-
-    std::cout << "*************** HERE WE DRIVE ***************************" << std::endl;
 
     if (m_writeConfigData) {
       // Loop over record@type in L1TriggerKeyExt
@@ -135,8 +126,6 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
       }
     }
   }
-
-   std::cout << "*************** HERE WE DIE ***************************" << std::endl;
 
 
   if (keyList) {

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
@@ -14,8 +14,7 @@ L1CondDBPayloadWriterExt::L1CondDBPayloadWriterExt(const edm::ParameterSet& iCon
       m_logTransactions(iConfig.getParameter<bool>("logTransactions")),
       m_newL1TriggerKeyListExt(iConfig.getParameter<bool>("newL1TriggerKeyListExt")) {
   //now do what ever initialization is needed
-  key_token = esConsumes<L1TriggerKeyExt, L1TriggerKeyExtRcd>();      
-
+  key_token = esConsumes<L1TriggerKeyExt, L1TriggerKeyExtRcd>();
 }
 
 L1CondDBPayloadWriterExt::~L1CondDBPayloadWriterExt() {

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
@@ -44,7 +44,6 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
   // L1TriggerKeyListExt.  writePayload() will not catch this situation in
   // the case of dummy configurations.
   bool triggerKeyOK = true;
-  
   try {
     // Get L1TriggerKeyExt
     key = iSetup.get<L1TriggerKeyExtRcd>().get(key_token);

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
@@ -14,6 +14,9 @@ L1CondDBPayloadWriterExt::L1CondDBPayloadWriterExt(const edm::ParameterSet& iCon
       m_logTransactions(iConfig.getParameter<bool>("logTransactions")),
       m_newL1TriggerKeyListExt(iConfig.getParameter<bool>("newL1TriggerKeyListExt")) {
   //now do what ever initialization is needed
+  key_token = esConsumes<L1TriggerKeyExt, L1TriggerKeyExtRcd>();      
+      std::cout << "*************** HERE WE DIVE ***************************" << std::endl;
+
 }
 
 L1CondDBPayloadWriterExt::~L1CondDBPayloadWriterExt() {
@@ -38,28 +41,33 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
 
   // Write L1TriggerKeyExt to ORCON with no IOV
   std::string token;
-  ESHandle<L1TriggerKeyExt> key;
-
+  L1TriggerKeyExt key;
   // Before calling writePayload(), check if TSC key is already in
   // L1TriggerKeyListExt.  writePayload() will not catch this situation in
   // the case of dummy configurations.
   bool triggerKeyOK = true;
+  
   try {
     // Get L1TriggerKeyExt
-    iSetup.get<L1TriggerKeyExtRcd>().get(key);
-
+    std::cout << "*************** HERE WE JIBE ***************************" << std::endl;
+    key = iSetup.get<L1TriggerKeyExtRcd>().get(key_token);
     if (!m_overwriteKeys) {
-      triggerKeyOK = oldKeyList.token(key->tscKey()).empty();
+      triggerKeyOK = oldKeyList.token(key.tscKey()).empty();
     }
   } catch (l1t::DataAlreadyPresentException& ex) {
     triggerKeyOK = false;
     edm::LogVerbatim("L1-O2O") << ex.what();
   }
 
+  std::cout << "*************** HERE WE ARRIVE ***************************" << std::endl;
+
   if (triggerKeyOK && m_writeL1TriggerKeyExt) {
-    edm::LogVerbatim("L1-O2O") << "Object key for L1TriggerKeyExtRcd@L1TriggerKeyExt: " << key->tscKey();
+    edm::LogVerbatim("L1-O2O") << "Object key for L1TriggerKeyExtRcd@L1TriggerKeyExt: " << key.tscKey();
     token = m_writer.writePayload(iSetup, "L1TriggerKeyExtRcd@L1TriggerKeyExt");
   }
+
+  std::cout << "*************** HERE WE STRIVE ***************************" << std::endl;
+
 
   // If L1TriggerKeyExt is invalid, then all configuration data is already in DB
   bool throwException = false;
@@ -68,15 +76,17 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
     // Record token in L1TriggerKeyListExt
     if (m_writeL1TriggerKeyExt) {
       keyList = new L1TriggerKeyListExt(oldKeyList);
-      if (!(keyList->addKey(key->tscKey(), token, m_overwriteKeys))) {
-        throw cond::Exception("L1CondDBPayloadWriter: TSC key " + key->tscKey() + " already in L1TriggerKeyListExt");
+      if (!(keyList->addKey(key.tscKey(), token, m_overwriteKeys))) {
+        throw cond::Exception("L1CondDBPayloadWriter: TSC key " + key.tscKey() + " already in L1TriggerKeyListExt");
       }
     }
 
+    std::cout << "*************** HERE WE DRIVE ***************************" << std::endl;
+
     if (m_writeConfigData) {
       // Loop over record@type in L1TriggerKeyExt
-      L1TriggerKeyExt::RecordToKey::const_iterator it = key->recordToKeyMap().begin();
-      L1TriggerKeyExt::RecordToKey::const_iterator end = key->recordToKeyMap().end();
+      L1TriggerKeyExt::RecordToKey::const_iterator it = key.recordToKeyMap().begin();
+      L1TriggerKeyExt::RecordToKey::const_iterator end = key.recordToKeyMap().end();
 
       for (; it != end; ++it) {
         // Do nothing if object key is null.
@@ -125,6 +135,9 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
       }
     }
   }
+
+   std::cout << "*************** HERE WE DIE ***************************" << std::endl;
+
 
   if (keyList) {
     // Write L1TriggerKeyListExt to ORCON

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
@@ -125,7 +125,6 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
     }
   }
 
-
   if (keyList) {
     // Write L1TriggerKeyListExt to ORCON
     m_writer.writeKeyList(keyList, 0, m_logTransactions);

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.h
@@ -10,7 +10,12 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
 #include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
+
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
 
 class L1CondDBPayloadWriterExt : public edm::EDAnalyzer {
 public:
@@ -25,6 +30,9 @@ private:
   // ----------member data ---------------------------
   l1t::DataWriterExt m_writer;
   // std::string m_tag ; // tag is known by PoolDBOutputService
+
+  // token to access object key
+  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> key_token;
 
   // set to false to write config data without valid TSC key
   bool m_writeL1TriggerKeyExt;

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
@@ -7,15 +7,14 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 L1TriggerKeyOnlineProdExt::L1TriggerKeyOnlineProdExt(const edm::ParameterSet& iConfig)  {
-  //  : m_subsystemLabels(iConfig.getParameter<std::vector<std::string> >("subsystemLabels")) {
   //the following line is needed to tell the framework what
   // data is being produced
   auto cc = setWhatProduced(this);
-  //TODO HERE understand how to have multiple tokens per each subsystem
   
-  //now do what ever other initialization is needed
   for(auto const& label : iConfig.getParameter<std::vector<std::string> >("subsystemLabels"))  {
     m_subsystemTokens.emplace_back(cc.consumesFrom<L1TriggerKeyExt, L1TriggerKeyExtRcd>(edm::ESInputTag{"",label}));
+  
+  //now do what ever other initialization is needed
   }
 
   cc.setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"","SubsystemKeysOnly"});

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
@@ -6,18 +6,18 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 
-L1TriggerKeyOnlineProdExt::L1TriggerKeyOnlineProdExt(const edm::ParameterSet& iConfig)  {
+L1TriggerKeyOnlineProdExt::L1TriggerKeyOnlineProdExt(const edm::ParameterSet& iConfig) {
   //the following line is needed to tell the framework what
   // data is being produced
   auto cc = setWhatProduced(this);
-  
-  for(auto const& label : iConfig.getParameter<std::vector<std::string> >("subsystemLabels"))  {
-    m_subsystemTokens.emplace_back(cc.consumesFrom<L1TriggerKeyExt, L1TriggerKeyExtRcd>(edm::ESInputTag{"",label}));
-  
-  //now do what ever other initialization is needed
+
+  for (auto const& label : iConfig.getParameter<std::vector<std::string> >("subsystemLabels")) {
+    m_subsystemTokens.emplace_back(cc.consumesFrom<L1TriggerKeyExt, L1TriggerKeyExtRcd>(edm::ESInputTag{"", label}));
+
+    //now do what ever other initialization is needed
   }
 
-  cc.setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"","SubsystemKeysOnly"});
+  cc.setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"", "SubsystemKeysOnly"});
 }
 
 L1TriggerKeyOnlineProdExt::~L1TriggerKeyOnlineProdExt() {
@@ -42,7 +42,7 @@ L1TriggerKeyOnlineProdExt::ReturnType L1TriggerKeyOnlineProdExt::produce(const L
   auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(subsystemKeys);
 
   // Collate object keys
-  for(auto const& token: m_subsystemTokens) {
+  for (auto const& token : m_subsystemTokens) {
     pL1TriggerKey->add(iRecord.get(token).recordToKeyMap());
   }
 

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
@@ -6,13 +6,19 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 
-L1TriggerKeyOnlineProdExt::L1TriggerKeyOnlineProdExt(const edm::ParameterSet& iConfig)
-    : m_subsystemLabels(iConfig.getParameter<std::vector<std::string> >("subsystemLabels")) {
+L1TriggerKeyOnlineProdExt::L1TriggerKeyOnlineProdExt(const edm::ParameterSet& iConfig)  {
+  //  : m_subsystemLabels(iConfig.getParameter<std::vector<std::string> >("subsystemLabels")) {
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this);
-
+  auto cc = setWhatProduced(this);
+  //TODO HERE understand how to have multiple tokens per each subsystem
+  
   //now do what ever other initialization is needed
+  for(auto const& label : iConfig.getParameter<std::vector<std::string> >("subsystemLabels"))  {
+    m_subsystemTokens.emplace_back(cc.consumesFrom<L1TriggerKeyExt, L1TriggerKeyExtRcd>(edm::ESInputTag{"",label}));
+  }
+
+  cc.setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"","SubsystemKeysOnly"});
 }
 
 L1TriggerKeyOnlineProdExt::~L1TriggerKeyOnlineProdExt() {
@@ -27,27 +33,18 @@ L1TriggerKeyOnlineProdExt::~L1TriggerKeyOnlineProdExt() {
 // ------------ method called to produce the data  ------------
 L1TriggerKeyOnlineProdExt::ReturnType L1TriggerKeyOnlineProdExt::produce(const L1TriggerKeyExtRcd& iRecord) {
   // Start with "SubsystemKeysOnly"
-  edm::ESHandle<L1TriggerKeyExt> subsystemKeys;
+  L1TriggerKeyExt subsystemKeys;
   try {
-    iRecord.get("SubsystemKeysOnly", subsystemKeys);
+    subsystemKeys = iRecord.get(L1TriggerKeyExt_token);
   } catch (l1t::DataAlreadyPresentException& ex) {
     throw ex;
   }
 
-  auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(*subsystemKeys);
+  auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(subsystemKeys);
 
   // Collate object keys
-  std::vector<std::string>::const_iterator itr = m_subsystemLabels.begin();
-  std::vector<std::string>::const_iterator end = m_subsystemLabels.end();
-  for (; itr != end; ++itr) {
-    edm::ESHandle<L1TriggerKeyExt> objectKeys;
-    try {
-      iRecord.get(*itr, objectKeys);
-    } catch (l1t::DataAlreadyPresentException& ex) {
-      throw ex;
-    }
-
-    pL1TriggerKey->add(objectKeys->recordToKeyMap());
+  for(auto const& token: m_subsystemTokens) {
+    pL1TriggerKey->add(iRecord.get(token).recordToKeyMap());
   }
 
   return pL1TriggerKey;

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
@@ -23,6 +24,8 @@ public:
 
 private:
   // ----------member data ---------------------------
+  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> L1TriggerKeyExt_token;
+  std::vector<edm::ESGetToken< L1TriggerKeyExt, L1TriggerKeyExtRcd>> m_subsystemTokens;
   std::vector<std::string> m_subsystemLabels;
 };
 

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h
@@ -25,7 +25,7 @@ public:
 private:
   // ----------member data ---------------------------
   edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> L1TriggerKeyExt_token;
-  std::vector<edm::ESGetToken< L1TriggerKeyExt, L1TriggerKeyExtRcd>> m_subsystemTokens;
+  std::vector<edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd>> m_subsystemTokens;
   std::vector<std::string> m_subsystemLabels;
 };
 

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -18,6 +18,12 @@ L1ObjectKeysOnlineProdBaseExt::L1ObjectKeysOnlineProdBaseExt(const edm::Paramete
   //now do what ever other initialization is needed
 }
 
+// edm::ESConsumesCollectorT<L1TriggerKeyExtRcd> L1ObjectKeysOnlineProdBaseExt::m_setWhatProduced(const edm::ParameterSet& iConfig) {
+//   edm::ESConsumesCollectorT<L1TriggerKeyExtRcd> collector = setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"));
+//   collector.setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"","SubsystemKeysOnly"});
+//   return collector;
+// }
+
 L1ObjectKeysOnlineProdBaseExt::~L1ObjectKeysOnlineProdBaseExt() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
@@ -42,6 +48,7 @@ L1ObjectKeysOnlineProdBaseExt::ReturnType L1ObjectKeysOnlineProdBaseExt::produce
 
   return pL1TriggerKey;
 }
+
 
 //define this as a plug-in
 //DEFINE_FWK_EVENTSETUP_MODULE(L1ObjectKeysOnlineProdBaseExt);

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -18,12 +18,6 @@ L1ObjectKeysOnlineProdBaseExt::L1ObjectKeysOnlineProdBaseExt(const edm::Paramete
   //now do what ever other initialization is needed
 }
 
-// edm::ESConsumesCollectorT<L1TriggerKeyExtRcd> L1ObjectKeysOnlineProdBaseExt::m_setWhatProduced(const edm::ParameterSet& iConfig) {
-//   edm::ESConsumesCollectorT<L1TriggerKeyExtRcd> collector = setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"));
-//   collector.setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"","SubsystemKeysOnly"});
-//   return collector;
-// }
-
 L1ObjectKeysOnlineProdBaseExt::~L1ObjectKeysOnlineProdBaseExt() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -12,7 +12,8 @@ L1ObjectKeysOnlineProdBaseExt::L1ObjectKeysOnlineProdBaseExt(const edm::Paramete
 
   // The subsystemLabel is used by L1TriggerKeyOnlineProdExt to identify the
   // L1TriggerKeysExt to concatenate.
-  setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"));
+  setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"))
+    .setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"","SubsystemKeysOnly"});
 
   //now do what ever other initialization is needed
 }
@@ -26,15 +27,15 @@ L1ObjectKeysOnlineProdBaseExt::~L1ObjectKeysOnlineProdBaseExt() {
 L1ObjectKeysOnlineProdBaseExt::ReturnType L1ObjectKeysOnlineProdBaseExt::produce(const L1TriggerKeyExtRcd& iRecord) {
   // Get L1TriggerKeyExt with label "SubsystemKeysOnly".  Re-throw exception if
   // not present.
-  edm::ESHandle<L1TriggerKeyExt> subsystemKeys;
+  L1TriggerKeyExt subsystemKeys;
   try {
-    iRecord.get("SubsystemKeysOnly", subsystemKeys);
+    subsystemKeys = iRecord.get(L1TriggerKeyExt_token);
   } catch (l1t::DataAlreadyPresentException& ex) {
     throw ex;
   }
 
   // Copy L1TriggerKeyExt to new object.
-  auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(*subsystemKeys);
+  auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(subsystemKeys);
 
   // Get object keys.
   fillObjectKeys(pL1TriggerKey.get());

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -13,7 +13,7 @@ L1ObjectKeysOnlineProdBaseExt::L1ObjectKeysOnlineProdBaseExt(const edm::Paramete
   // The subsystemLabel is used by L1TriggerKeyOnlineProdExt to identify the
   // L1TriggerKeysExt to concatenate.
   setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"))
-    .setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"","SubsystemKeysOnly"});
+      .setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"", "SubsystemKeysOnly"});
 
   //now do what ever other initialization is needed
 }
@@ -48,7 +48,6 @@ L1ObjectKeysOnlineProdBaseExt::ReturnType L1ObjectKeysOnlineProdBaseExt::produce
 
   return pL1TriggerKey;
 }
-
 
 //define this as a plug-in
 //DEFINE_FWK_EVENTSETUP_MODULE(L1ObjectKeysOnlineProdBaseExt);

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -21,6 +21,8 @@ class L1TCaloParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TCaloParamsO2
 private:
   unsigned int exclusiveLayer;  // 0 - process calol1 and calol2, 1 - only calol1, 2 - only calol2
   bool transactionSafe;
+  edm::ESGetToken<l1t::CaloParams,L1TCaloParamsRcd> baseSettings_token;
+
 
   bool readCaloLayer1OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper,
                                     std::map<std::string, l1t::Parameter>& conf,
@@ -210,6 +212,8 @@ bool L1TCaloParamsOnlineProd::readCaloLayer2OnlineSettings(l1t::CaloParamsHelper
 
 L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd, l1t::CaloParams>(iConfig) {
+  m_setWhatProduced(iConfig)
+    .setConsumes(baseSettings_token);
   exclusiveLayer = iConfig.getParameter<uint32_t>("exclusiveLayer");
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
@@ -217,8 +221,7 @@ L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfi
 std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::string& objectKey,
                                                                           const L1TCaloParamsO2ORcd& record) {
   const L1TCaloParamsRcd& baseRcd = record.template getRecord<L1TCaloParamsRcd>();
-  edm::ESHandle<l1t::CaloParams> baseSettings; // this needs to be a token 
-  baseRcd.get(baseSettings);
+  auto const baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TCaloParamsOnlineProd") << "Key is empty";
@@ -226,7 +229,7 @@ std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const 
       throw std::runtime_error("SummaryForFunctionManager: Calo  | Faulty  | Empty objectKey");
     else {
       edm::LogError("L1-O2O: L1TCaloParamsOnlineProd") << "returning unmodified prototype of l1t::CaloParams";
-      return std::make_unique<const l1t::CaloParams>(*(baseSettings.product()));
+      return std::make_unique<const l1t::CaloParams>(baseSettings);
     }
   }
 
@@ -283,7 +286,7 @@ std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const 
       throw std::runtime_error(std::string("SummaryForFunctionManager: Calo  | Faulty  | ") + e.what());
     else {
       edm::LogError("L1-O2O: L1TCaloParamsOnlineProd") << "returning unmodified prototype of l1t::CaloParams";
-      return std::make_unique<const l1t::CaloParams>(*(baseSettings.product()));
+      return std::make_unique<const l1t::CaloParams>(baseSettings);
     }
   }
 
@@ -305,7 +308,7 @@ std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const 
     output.close();
   }
 
-  l1t::CaloParamsHelperO2O m_params_helper(*(baseSettings.product()));
+  l1t::CaloParamsHelperO2O m_params_helper(baseSettings);
 
   if (exclusiveLayer == 0 || exclusiveLayer == 1) {
     try {
@@ -329,7 +332,7 @@ std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const 
         throw std::runtime_error(std::string("SummaryForFunctionManager: Calo  | Faulty  | ") + e.what());
       else {
         edm::LogError("L1-O2O: L1TCaloParamsOnlineProd") << "returning unmodified prototype of l1t::CaloParams";
-        return std::make_unique<const l1t::CaloParams>(*(baseSettings.product()));
+        return std::make_unique<const l1t::CaloParams>(baseSettings);
       }
     }
   }
@@ -363,7 +366,7 @@ std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const 
         throw std::runtime_error(std::string("SummaryForFunctionManager: Calo  | Faulty  | ") + e.what());
       else {
         edm::LogError("L1-O2O: L1TCaloParamsOnlineProd") << "returning unmodified prototype of l1t::CaloParams";
-        return std::make_unique<const l1t::CaloParams>(*(baseSettings.product()));
+        return std::make_unique<const l1t::CaloParams>(baseSettings);
       }
     }
   }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -211,7 +211,7 @@ bool L1TCaloParamsOnlineProd::readCaloLayer2OnlineSettings(l1t::CaloParamsHelper
 
 L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd, l1t::CaloParams>(iConfig) {
-  m_setWhatProduced(iConfig).setConsumes(baseSettings_token);
+  wrappedSetWhatProduced(iConfig).setConsumes(baseSettings_token);
   exclusiveLayer = iConfig.getParameter<uint32_t>("exclusiveLayer");
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -21,8 +21,7 @@ class L1TCaloParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TCaloParamsO2
 private:
   unsigned int exclusiveLayer;  // 0 - process calol1 and calol2, 1 - only calol1, 2 - only calol2
   bool transactionSafe;
-  edm::ESGetToken<l1t::CaloParams,L1TCaloParamsRcd> baseSettings_token;
-
+  edm::ESGetToken<l1t::CaloParams, L1TCaloParamsRcd> baseSettings_token;
 
   bool readCaloLayer1OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper,
                                     std::map<std::string, l1t::Parameter>& conf,
@@ -212,8 +211,7 @@ bool L1TCaloParamsOnlineProd::readCaloLayer2OnlineSettings(l1t::CaloParamsHelper
 
 L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd, l1t::CaloParams>(iConfig) {
-  m_setWhatProduced(iConfig)
-    .setConsumes(baseSettings_token);
+  m_setWhatProduced(iConfig).setConsumes(baseSettings_token);
   exclusiveLayer = iConfig.getParameter<uint32_t>("exclusiveLayer");
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
@@ -221,7 +219,7 @@ L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfi
 std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::string& objectKey,
                                                                           const L1TCaloParamsO2ORcd& record) {
   const L1TCaloParamsRcd& baseRcd = record.template getRecord<L1TCaloParamsRcd>();
-  auto const baseSettings = baseRcd.get(baseSettings_token);
+  auto const& baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TCaloParamsOnlineProd") << "Key is empty";

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -217,7 +217,7 @@ L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfi
 std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::string& objectKey,
                                                                           const L1TCaloParamsO2ORcd& record) {
   const L1TCaloParamsRcd& baseRcd = record.template getRecord<L1TCaloParamsRcd>();
-  edm::ESHandle<l1t::CaloParams> baseSettings;
+  edm::ESHandle<l1t::CaloParams> baseSettings; // this needs to be a token 
   baseRcd.get(baseSettings);
 
   if (objectKey.empty()) {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -40,6 +40,7 @@ public:
 
 L1TGlobalPrescalesVetosOnlineProd::L1TGlobalPrescalesVetosOnlineProd(const edm::ParameterSet &iConfig)
     : L1ConfigOnlineProdBaseExt<L1TGlobalPrescalesVetosO2ORcd, L1TGlobalPrescalesVetos>(iConfig) {
+  m_setWhatProduced(iConfig);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -40,7 +40,7 @@ public:
 
 L1TGlobalPrescalesVetosOnlineProd::L1TGlobalPrescalesVetosOnlineProd(const edm::ParameterSet &iConfig)
     : L1ConfigOnlineProdBaseExt<L1TGlobalPrescalesVetosO2ORcd, L1TGlobalPrescalesVetos>(iConfig) {
-  m_setWhatProduced(iConfig);
+  wrappedSetWhatProduced(iConfig);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -16,6 +16,7 @@ using namespace XERCES_CPP_NAMESPACE;
 class L1TMuonBarrelParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams> {
 private:
   bool transactionSafe;
+  edm::ESGetToken<L1TMuonBarrelParams,L1TMuonBarrelParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonBarrelParams> newObject(const std::string& objectKey,
@@ -27,14 +28,15 @@ public:
 
 L1TMuonBarrelParamsOnlineProd::L1TMuonBarrelParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams>(iConfig) {
+  m_setWhatProduced(iConfig)
+    .setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
 std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(
     const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) {
   const L1TMuonBarrelParamsRcd& baseRcd = record.template getRecord<L1TMuonBarrelParamsRcd>();
-  edm::ESHandle<L1TMuonBarrelParams> baseSettings;
-  baseRcd.get(baseSettings);
+  auto const baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TMuonBarrelParamsOnlineProd") << "Key is empty, returning empty L1TMuonBarrelParams";
@@ -42,7 +44,7 @@ std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObj
       throw std::runtime_error("SummaryForFunctionManager: BMTF  | Faulty  | Empty objectKey");
     else {
       edm::LogError("L1-O2O: L1TMuonBarrelParamsOnlineProd") << "returning unmodified prototype of L1TMuonBarrelParams";
-      return std::make_unique<const L1TMuonBarrelParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonBarrelParams>(baseSettings);
     }
   }
 
@@ -79,7 +81,7 @@ std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObj
       throw std::runtime_error(std::string("SummaryForFunctionManager: BMTF  | Faulty  | ") + e.what());
     else {
       edm::LogError("L1-O2O: L1TMuonBarrelParamsOnlineProd") << "returning unmodified prototype of L1TMuonBarrelParams";
-      return std::make_unique<const L1TMuonBarrelParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonBarrelParams>(baseSettings);
     }
   }
 
@@ -131,11 +133,11 @@ std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObj
       throw std::runtime_error(std::string("SummaryForFunctionManager: BMTF  | Faulty  | ") + e.what());
     else {
       edm::LogError("L1-O2O: L1TMuonBarrelParamsOnlineProd") << "returning unmodified prototype of L1TMuonBarrelParams";
-      return std::make_unique<const L1TMuonBarrelParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonBarrelParams>(baseSettings);
     }
   }
 
-  L1TMuonBarrelParamsHelper m_params_helper(*(baseSettings.product()));
+  L1TMuonBarrelParamsHelper m_params_helper(baseSettings);
   try {
     m_params_helper.configFromDB(parsedXMLs);
   } catch (std::runtime_error& e) {
@@ -144,7 +146,7 @@ std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObj
       throw std::runtime_error(std::string("SummaryForFunctionManager: BMTF  | Faulty  | ") + e.what());
     else {
       edm::LogError("L1-O2O: L1TMuonBarrelParamsOnlineProd") << "returning unmodified prototype of L1TMuonBarrelParams";
-      return std::make_unique<const L1TMuonBarrelParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonBarrelParams>(baseSettings);
     }
   }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -16,7 +16,7 @@ using namespace XERCES_CPP_NAMESPACE;
 class L1TMuonBarrelParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams> {
 private:
   bool transactionSafe;
-  edm::ESGetToken<L1TMuonBarrelParams,L1TMuonBarrelParamsRcd> baseSettings_token;
+  edm::ESGetToken<L1TMuonBarrelParams, L1TMuonBarrelParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonBarrelParams> newObject(const std::string& objectKey,
@@ -28,15 +28,14 @@ public:
 
 L1TMuonBarrelParamsOnlineProd::L1TMuonBarrelParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams>(iConfig) {
-  m_setWhatProduced(iConfig)
-    .setConsumes(baseSettings_token);
+  m_setWhatProduced(iConfig).setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
 std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(
     const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) {
   const L1TMuonBarrelParamsRcd& baseRcd = record.template getRecord<L1TMuonBarrelParamsRcd>();
-  auto const baseSettings = baseRcd.get(baseSettings_token);
+  auto const& baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TMuonBarrelParamsOnlineProd") << "Key is empty, returning empty L1TMuonBarrelParams";

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -28,7 +28,7 @@ public:
 
 L1TMuonBarrelParamsOnlineProd::L1TMuonBarrelParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams>(iConfig) {
-  m_setWhatProduced(iConfig).setConsumes(baseSettings_token);
+  wrappedSetWhatProduced(iConfig).setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProd.cc
@@ -21,6 +21,7 @@ public:
 
 L1TMuonEndCapForestOnlineProd::L1TMuonEndCapForestOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonEndCapForestO2ORcd, L1TMuonEndCapForest>(iConfig) {
+  m_setWhatProduced(iConfig);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProd.cc
@@ -21,7 +21,7 @@ public:
 
 L1TMuonEndCapForestOnlineProd::L1TMuonEndCapForestOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonEndCapForestO2ORcd, L1TMuonEndCapForest>(iConfig) {
-  m_setWhatProduced(iConfig);
+  wrappedSetWhatProduced(iConfig);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProxy.cc
@@ -9,6 +9,9 @@
 #include "CondFormats/DataRecord/interface/L1TMuonEndCapForestO2ORcd.h"
 
 class L1TMuonEndCapForestOnlineProxy : public edm::ESProducer {
+private:
+	 edm::ESGetToken<L1TMuonEndCapForest,L1TMuonEndCapForestRcd> baseSettings_token;
+
 public:
   std::unique_ptr<L1TMuonEndCapForest> produce(const L1TMuonEndCapForestO2ORcd& record);
 
@@ -17,15 +20,15 @@ public:
 };
 
 L1TMuonEndCapForestOnlineProxy::L1TMuonEndCapForestOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {
-  setWhatProduced(this);
+  setWhatProduced(this)
+  	.setConsumes(baseSettings_token);
 }
 
 std::unique_ptr<L1TMuonEndCapForest> L1TMuonEndCapForestOnlineProxy::produce(const L1TMuonEndCapForestO2ORcd& record) {
   const L1TMuonEndCapForestRcd& baseRcd = record.template getRecord<L1TMuonEndCapForestRcd>();
-  edm::ESHandle<L1TMuonEndCapForest> baseSettings;
-  baseRcd.get(baseSettings);
+  auto const baseSettings = baseRcd.get(baseSettings_token);
 
-  return std::make_unique<L1TMuonEndCapForest>(*(baseSettings.product()));
+  return std::make_unique<L1TMuonEndCapForest>(baseSettings);
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProxy.cc
@@ -10,7 +10,7 @@
 
 class L1TMuonEndCapForestOnlineProxy : public edm::ESProducer {
 private:
-	 edm::ESGetToken<L1TMuonEndCapForest,L1TMuonEndCapForestRcd> baseSettings_token;
+  edm::ESGetToken<L1TMuonEndCapForest, L1TMuonEndCapForestRcd> baseSettings_token;
 
 public:
   std::unique_ptr<L1TMuonEndCapForest> produce(const L1TMuonEndCapForestO2ORcd& record);
@@ -20,13 +20,12 @@ public:
 };
 
 L1TMuonEndCapForestOnlineProxy::L1TMuonEndCapForestOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {
-  setWhatProduced(this)
-  	.setConsumes(baseSettings_token);
+  setWhatProduced(this).setConsumes(baseSettings_token);
 }
 
 std::unique_ptr<L1TMuonEndCapForest> L1TMuonEndCapForestOnlineProxy::produce(const L1TMuonEndCapForestO2ORcd& record) {
   const L1TMuonEndCapForestRcd& baseRcd = record.template getRecord<L1TMuonEndCapForestRcd>();
-  auto const baseSettings = baseRcd.get(baseSettings_token);
+  auto const& baseSettings = baseRcd.get(baseSettings_token);
 
   return std::make_unique<L1TMuonEndCapForest>(baseSettings);
 }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
@@ -15,6 +15,7 @@
 class L1TMuonEndCapParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams> {
 private:
   bool transactionSafe;
+  edm::ESGetToken<L1TMuonEndCapParams,L1TMuonEndCapParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonEndCapParams> newObject(const std::string& objectKey,
@@ -26,14 +27,15 @@ public:
 
 L1TMuonEndCapParamsOnlineProd::L1TMuonEndCapParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams>(iConfig) {
+  m_setWhatProduced(iConfig)
+    .setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
 std::unique_ptr<const L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(
     const std::string& objectKey, const L1TMuonEndCapParamsO2ORcd& record) {
   const L1TMuonEndCapParamsRcd& baseRcd = record.template getRecord<L1TMuonEndCapParamsRcd>();
-  edm::ESHandle<L1TMuonEndCapParams> baseSettings;
-  baseRcd.get(baseSettings);
+  auto const baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TMuonEndCapParamsOnlineProd") << "Key is empty";
@@ -41,7 +43,7 @@ std::unique_ptr<const L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObj
       throw std::runtime_error("SummaryForFunctionManager: EMTF  | Faulty  | Empty objectKey");
     else {
       edm::LogError("L1-O2O: L1TMuonEndCapParamsOnlineProd") << "returning unmodified prototype of L1TMuonEndCapParams";
-      return std::make_unique<const L1TMuonEndCapParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonEndCapParams>(baseSettings);
     }
   }
 
@@ -70,7 +72,7 @@ std::unique_ptr<const L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObj
       throw std::runtime_error("SummaryForFunctionManager: EMTF  | Faulty  | Broken key");
     else {
       edm::LogError("L1-O2O: L1TMuonEndCapParamsOnlineProd") << "returning unmodified prototype of L1TMuonEndCapParams";
-      return std::make_unique<const L1TMuonEndCapParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonEndCapParams>(baseSettings);
     }
   }
 
@@ -103,7 +105,7 @@ std::unique_ptr<const L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObj
       throw std::runtime_error("SummaryForFunctionManager: EMTF  | Faulty  | Cannot parse XMLs");
     else {
       edm::LogError("L1-O2O: L1TMuonEndCapParamsOnlineProd") << "returning unmodified prototype of L1TMuonEndCapParams";
-      return std::make_unique<const L1TMuonEndCapParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonEndCapParams>(baseSettings);
     }
   }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
@@ -15,7 +15,7 @@
 class L1TMuonEndCapParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams> {
 private:
   bool transactionSafe;
-  edm::ESGetToken<L1TMuonEndCapParams,L1TMuonEndCapParamsRcd> baseSettings_token;
+  edm::ESGetToken<L1TMuonEndCapParams, L1TMuonEndCapParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonEndCapParams> newObject(const std::string& objectKey,
@@ -27,15 +27,14 @@ public:
 
 L1TMuonEndCapParamsOnlineProd::L1TMuonEndCapParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams>(iConfig) {
-  m_setWhatProduced(iConfig)
-    .setConsumes(baseSettings_token);
+  m_setWhatProduced(iConfig).setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
 std::unique_ptr<const L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(
     const std::string& objectKey, const L1TMuonEndCapParamsO2ORcd& record) {
   const L1TMuonEndCapParamsRcd& baseRcd = record.template getRecord<L1TMuonEndCapParamsRcd>();
-  auto const baseSettings = baseRcd.get(baseSettings_token);
+  auto const& baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TMuonEndCapParamsOnlineProd") << "Key is empty";

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
@@ -38,7 +38,7 @@ std::unique_ptr<const L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObj
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TMuonEndCapParamsOnlineProd") << "Key is empty";
     if (transactionSafe)
-      throw std::runtime_error("SummaryForFunctionManager: BMTF  | Faulty  | Empty objectKey");
+      throw std::runtime_error("SummaryForFunctionManager: EMTF  | Faulty  | Empty objectKey");
     else {
       edm::LogError("L1-O2O: L1TMuonEndCapParamsOnlineProd") << "returning unmodified prototype of L1TMuonEndCapParams";
       return std::make_unique<const L1TMuonEndCapParams>(*(baseSettings.product()));

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
@@ -27,7 +27,7 @@ public:
 
 L1TMuonEndCapParamsOnlineProd::L1TMuonEndCapParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams>(iConfig) {
-  m_setWhatProduced(iConfig).setConsumes(baseSettings_token);
+  wrappedSetWhatProduced(iConfig).setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -27,7 +27,7 @@ public:
 
 L1TMuonGlobalParamsOnlineProd::L1TMuonGlobalParamsOnlineProd(const edm::ParameterSet &iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams>(iConfig) {
-  setWhatProduced(this,&L1TMuonGlobalParamsOnlineProd::newObject)
+  m_setWhatProduced(iConfig)
     .setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
@@ -35,7 +35,7 @@ L1TMuonGlobalParamsOnlineProd::L1TMuonGlobalParamsOnlineProd(const edm::Paramete
 std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(
     const std::string &objectKey, const L1TMuonGlobalParamsO2ORcd &record) {
   const L1TMuonGlobalParamsRcd &baseRcd = record.template getRecord<L1TMuonGlobalParamsRcd>();
-  const L1TMuonGlobalParams &baseSettings = baseRcd.get(baseSettings_token);
+  auto const baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TMuonGlobalParamsOnlineProd") << "Key is empty";

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -15,6 +15,7 @@
 class L1TMuonGlobalParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams> {
 private:
   bool transactionSafe;
+  edm::ESGetToken<L1TMuonGlobalParams,L1TMuonGlobalParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonGlobalParams> newObject(const std::string &objectKey,
@@ -26,14 +27,15 @@ public:
 
 L1TMuonGlobalParamsOnlineProd::L1TMuonGlobalParamsOnlineProd(const edm::ParameterSet &iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams>(iConfig) {
+  setWhatProduced(this,&L1TMuonGlobalParamsOnlineProd::newObject)
+    .setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
 std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(
     const std::string &objectKey, const L1TMuonGlobalParamsO2ORcd &record) {
   const L1TMuonGlobalParamsRcd &baseRcd = record.template getRecord<L1TMuonGlobalParamsRcd>();
-  edm::ESHandle<L1TMuonGlobalParams> baseSettings;
-  baseRcd.get(baseSettings);
+  const L1TMuonGlobalParams &baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TMuonGlobalParamsOnlineProd") << "Key is empty";
@@ -41,7 +43,7 @@ std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObj
       throw std::runtime_error("SummaryForFunctionManager: uGMT  | Faulty  | Empty objectKey");
     else {
       edm::LogError("L1-O2O: L1TMuonGlobalParams") << "returning unmodified prototype of L1TMuonGlobalParams";
-      return std::make_unique<const L1TMuonGlobalParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonGlobalParams>(baseSettings);
     }
   }
 
@@ -81,7 +83,7 @@ std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObj
       throw std::runtime_error("SummaryForFunctionManager: uGMT  | Faulty  | Broken key");
     else {
       edm::LogError("L1-O2O: L1TMuonGlobalParamsOnlineProd") << "returning unmodified prototype of L1TMuonGlobalParams";
-      return std::make_unique<const L1TMuonGlobalParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonGlobalParams>(baseSettings);
     }
   }
 
@@ -127,11 +129,11 @@ std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObj
       throw std::runtime_error("SummaryForFunctionManager: uGMT  | Faulty  | Cannot parse XMLs");
     else {
       edm::LogError("L1-O2O: L1TMuonGlobalParamsOnlineProd") << "returning unmodified prototype of L1TMuonGlobalParams";
-      return std::make_unique<const L1TMuonGlobalParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonGlobalParams>(baseSettings);
     }
   }
 
-  L1TMuonGlobalParamsHelper m_params_helper(*(baseSettings.product()));
+  L1TMuonGlobalParamsHelper m_params_helper(baseSettings);
   try {
     m_params_helper.loadFromOnline(trgSys);
   } catch (std::runtime_error &e) {
@@ -140,7 +142,7 @@ std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObj
       throw std::runtime_error("SummaryForFunctionManager: uGMT  | Faulty  | Cannot run helper");
     else {
       edm::LogError("L1-O2O: L1TMuonGlobalParamsOnlineProd") << "returning unmodified prototype of L1TMuonGlobalParams";
-      return std::make_unique<const L1TMuonGlobalParams>(*(baseSettings.product()));
+      return std::make_unique<const L1TMuonGlobalParams>(baseSettings);
     }
   }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -27,7 +27,7 @@ public:
 
 L1TMuonGlobalParamsOnlineProd::L1TMuonGlobalParamsOnlineProd(const edm::ParameterSet &iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams>(iConfig) {
-  m_setWhatProduced(iConfig).setConsumes(baseSettings_token);
+  wrappedSetWhatProduced(iConfig).setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -15,7 +15,7 @@
 class L1TMuonGlobalParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams> {
 private:
   bool transactionSafe;
-  edm::ESGetToken<L1TMuonGlobalParams,L1TMuonGlobalParamsRcd> baseSettings_token;
+  edm::ESGetToken<L1TMuonGlobalParams, L1TMuonGlobalParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonGlobalParams> newObject(const std::string &objectKey,
@@ -27,15 +27,14 @@ public:
 
 L1TMuonGlobalParamsOnlineProd::L1TMuonGlobalParamsOnlineProd(const edm::ParameterSet &iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams>(iConfig) {
-  m_setWhatProduced(iConfig)
-    .setConsumes(baseSettings_token);
+  m_setWhatProduced(iConfig).setConsumes(baseSettings_token);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
 std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(
     const std::string &objectKey, const L1TMuonGlobalParamsO2ORcd &record) {
   const L1TMuonGlobalParamsRcd &baseRcd = record.template getRecord<L1TMuonGlobalParamsRcd>();
-  auto const baseSettings = baseRcd.get(baseSettings_token);
+  auto const &baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
     edm::LogError("L1-O2O: L1TMuonGlobalParamsOnlineProd") << "Key is empty";

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProd.cc
@@ -22,6 +22,7 @@ public:
 
 L1TMuonOverlapParamsOnlineProd::L1TMuonOverlapParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonOverlapParamsO2ORcd, L1TMuonOverlapParams>(iConfig) {
+  m_setWhatProduced(iConfig);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProd.cc
@@ -22,7 +22,7 @@ public:
 
 L1TMuonOverlapParamsOnlineProd::L1TMuonOverlapParamsOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonOverlapParamsO2ORcd, L1TMuonOverlapParams>(iConfig) {
-  m_setWhatProduced(iConfig);
+  wrappedSetWhatProduced(iConfig);
   transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
@@ -20,7 +20,7 @@ public:
 
 L1TMuonOverlapParamsOnlineProxy::L1TMuonOverlapParamsOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {
   setWhatProduced(this)
-  	.setConsumes(baseSettings_token);
+    .setConsumes(baseSettings_token);
 }
 
 std::unique_ptr<L1TMuonOverlapParams> L1TMuonOverlapParamsOnlineProxy::produce(

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
@@ -10,7 +10,8 @@
 
 class L1TMuonOverlapParamsOnlineProxy : public edm::ESProducer {
 private:
-	edm::ESGetToken<L1TMuonOverlapParams,L1TMuonOverlapParamsRcd> baseSettings_token;
+  edm::ESGetToken<L1TMuonOverlapParams, L1TMuonOverlapParamsRcd> baseSettings_token;
+
 public:
   std::unique_ptr<L1TMuonOverlapParams> produce(const L1TMuonOverlapParamsO2ORcd& record);
 
@@ -19,14 +20,13 @@ public:
 };
 
 L1TMuonOverlapParamsOnlineProxy::L1TMuonOverlapParamsOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {
-  setWhatProduced(this)
-    .setConsumes(baseSettings_token);
+  setWhatProduced(this).setConsumes(baseSettings_token);
 }
 
 std::unique_ptr<L1TMuonOverlapParams> L1TMuonOverlapParamsOnlineProxy::produce(
     const L1TMuonOverlapParamsO2ORcd& record) {
   const L1TMuonOverlapParamsRcd& baseRcd = record.template getRecord<L1TMuonOverlapParamsRcd>();
-  auto const baseSettings = baseRcd.get(baseSettings_token);
+  auto const& baseSettings = baseRcd.get(baseSettings_token);
 
   return std::make_unique<L1TMuonOverlapParams>(baseSettings);
 }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
@@ -3,13 +3,14 @@
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsO2ORcd.h"
 
 class L1TMuonOverlapParamsOnlineProxy : public edm::ESProducer {
 private:
+	edm::ESGetToken<L1TMuonOverlapParams,L1TMuonOverlapParamsRcd> baseSettings_token;
 public:
   std::unique_ptr<L1TMuonOverlapParams> produce(const L1TMuonOverlapParamsO2ORcd& record);
 
@@ -18,16 +19,16 @@ public:
 };
 
 L1TMuonOverlapParamsOnlineProxy::L1TMuonOverlapParamsOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {
-  setWhatProduced(this);
+  setWhatProduced(this)
+  	.setConsumes(baseSettings_token);
 }
 
 std::unique_ptr<L1TMuonOverlapParams> L1TMuonOverlapParamsOnlineProxy::produce(
     const L1TMuonOverlapParamsO2ORcd& record) {
   const L1TMuonOverlapParamsRcd& baseRcd = record.template getRecord<L1TMuonOverlapParamsRcd>();
-  edm::ESHandle<L1TMuonOverlapParams> baseSettings;
-  baseRcd.get(baseSettings);
+  auto const baseSettings = baseRcd.get(baseSettings_token);
 
-  return std::make_unique<L1TMuonOverlapParams>(*(baseSettings.product()));
+  return std::make_unique<L1TMuonOverlapParams>(baseSettings);
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
@@ -28,7 +28,9 @@ public:
 };
 
 L1TUtmTriggerMenuOnlineProd::L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet& iConfig)
-    : L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuO2ORcd, L1TUtmTriggerMenu>(iConfig) {}
+    : L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuO2ORcd, L1TUtmTriggerMenu>(iConfig) {
+  m_setWhatProduced(iConfig);
+    }
 
 std::unique_ptr<const L1TUtmTriggerMenu> L1TUtmTriggerMenuOnlineProd::newObject(const std::string& objectKey,
                                                                                 const L1TUtmTriggerMenuO2ORcd& record) {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
@@ -29,7 +29,7 @@ public:
 
 L1TUtmTriggerMenuOnlineProd::L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuO2ORcd, L1TUtmTriggerMenu>(iConfig) {
-  m_setWhatProduced(iConfig);
+  wrappedSetWhatProduced(iConfig);
 }
 
 std::unique_ptr<const L1TUtmTriggerMenu> L1TUtmTriggerMenuOnlineProd::newObject(const std::string& objectKey,

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
@@ -30,7 +30,7 @@ public:
 L1TUtmTriggerMenuOnlineProd::L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuO2ORcd, L1TUtmTriggerMenu>(iConfig) {
   m_setWhatProduced(iConfig);
-    }
+}
 
 std::unique_ptr<const L1TUtmTriggerMenu> L1TUtmTriggerMenuOnlineProd::newObject(const std::string& objectKey,
                                                                                 const L1TUtmTriggerMenuO2ORcd& record) {


### PR DESCRIPTION

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of [PR#30155](https://github.com/cms-sw/cmssw/pull/30155) to  CMSSW_11_1_X

This PR updates L1T O2O producers to use ESGetToken.

The backport is needed as since CMSSW_11_0_X, which incorporates [PR#28223](https://github.com/cms-sw/cmssw/pull/28223) ESProducers need to use ESGetToken to access data from EventSetup.

