### PR TITLE
TkAl: Add pool check to condor submission (11_1_X backport)

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
@@ -264,6 +264,15 @@ if not args.fireMerge:
         resources = '-q'+resources+' -m g_cmscaf'
     elif "htcondor" in resources:
         fire_htcondor = True
+        schedinfo = subprocess.check_output(["myschedd","show"])
+        if 'cafalca' in resources:
+            if not 'tzero' in schedinfo:
+                print("\nMPS fire: request to use CAF pool which has not been set up. Call `module load lxbatch/tzero` and try again")
+                exit(1)
+        else:
+            if not 'share' in schedinfo:
+                print("\nMPS fire: request to use standard pool when CAF pool is set up. Call `module load lxbatch/share` and try again")
+                exit(1)
     else:
         resources = '-q '+resources
 
@@ -322,6 +331,11 @@ else:
         resources = '-q cmscafalcamille'
     elif "htcondor" in resources:
         fire_htcondor = True
+        schedinfo = subprocess.check_output(["myschedd","show"])
+        if 'bigmem' in resources:
+            if not 'share' in schedinfo:
+                print("\nMPS fire: CAF pool is set up, but request to use high-memory machines which live in the standard pool. Call `module load lxbatch/share` and try again")
+                exit(1)
     else:
         resources = '-q '+resources
 

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -646,6 +646,12 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
 
     (options, args) = optParser.parse_args(argv)
 
+    schedinfo = subprocess.check_output(["myschedd","show"])
+    if not 'tzero' in schedinfo:
+        print("\nAll-In-One Tool: you need to call `module load lxbatch/tzero` before trying to submit jobs. Please do so and try again")
+        exit(1)
+
+
     if not options.restrictTo == None:
         options.restrictTo = options.restrictTo.split(",")
 

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -646,10 +646,11 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
 
     (options, args) = optParser.parse_args(argv)
 
-    schedinfo = subprocess.check_output(["myschedd","show"])
-    if not 'tzero' in schedinfo:
-        print("\nAll-In-One Tool: you need to call `module load lxbatch/tzero` before trying to submit jobs. Please do so and try again")
-        exit(1)
+    if not options.dryRun:
+        schedinfo = subprocess.check_output(["myschedd","show"])
+        if not 'tzero' in schedinfo:
+            print("\nAll-In-One Tool: you need to call `module load lxbatch/tzero` before trying to submit jobs. Please do so and try again")
+            exit(1)
 
 
     if not options.restrictTo == None:


### PR DESCRIPTION
#### PR description:
For the TkAl validation tool and millepede job submission this adds a check for which condor pool has been set up. If there is a mismatch between that and the requested resources the code exits and tells the user to set up the correct pool via `module load.` 

#### PR validation:

Tested job submission configurations - the change has the intended effect 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #30343. The backport is needed so that we can use this feature for studies on Run 3 samples (which were produced, and will be analysed in, CMSSW_11_1)