### PR TITLE
Fix modifiers in Phase2 L1T sequences and add Phase2 L1T objects to FEVTDEBUG EventContent

### DIFF
--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -12,6 +12,7 @@ _tttracks_l1tracktrigger = L1TrackTrigger.copy()
 _tttracks_l1tracktrigger = cms.Sequence(_tttracks_l1tracktrigger + L1PromptExtendedHybridTracksWithAssociators)
 
 from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
-phase2_trackerV14.toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
+(phase2_trigger & phase2_trackerV14).toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
 
 TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -153,3 +153,51 @@ def _appendME0Digis(obj):
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(L1TriggerFEVTDEBUG, func=_appendME0Digis)
+
+# adding phase2 trigger
+def _appendPhase2Digis(obj):
+    l1Phase2Digis = [
+        "keep *_simKBmtfDigis_*_*",
+        'keep *_hgcalVFEProducerhgcalConcentratorProducer__*',
+        'keep *_hgcalBackEndLayer1Producer__*',
+        'keep *_hgcalBackEndLayer2Producer__*',
+        'keep *_hgcalTowerMapProducer__*',
+        'keep *_hgcalTowerProducer__*',
+        'keep *_L1EGammaClusterEmuProducer__*',
+        'keep *_l1EGammaEEProducer__*',
+        'keep *_L1TkPrimaryVertex__*',
+        'keep *_L1TkElectronsCrystal__*',
+        'keep *_L1TkElectronsLooseCrystal__*',
+        'keep *_L1TkElectronsEllipticMatchCrystal__*',
+        'keep *_L1TkIsoElectronsCrystal__*',
+        'keep *_L1TkPhotonsCrystal__*',
+        'keep *_L1TkElectronsHGC__*',
+        'keep *_L1TkElectronsEllipticMatchHGC__*',
+        'keep *_L1TkIsoElectronsHGC__*',
+        'keep *_L1TkPhotonsHGC__*',
+        'keep *_L1TkMuons__*',
+        'keep *_pfClustersFromL1EGClusters__*',
+        'keep *_pfClustersFromCombinedCaloHCal__*',
+        'keep *_pfClustersFromCombinedCaloHF__*',
+        'keep *_pfClustersFromHGC3DClusters__*',
+        'keep *_pfTracksFromL1TracksBarrel__*',
+        'keep *_l1pfProducerBarrel__*',
+        'keep *_pfTracksFromL1TracksHGCal__*',
+        'keep *_l1pfProducerHGCal__*',
+        'keep *_l1pfProducerHGCalNoTK__*',
+        'keep *_l1pfProducerHF__*',
+        'keep *_l1pfCandidates__*',
+        'keep *_ak4PFL1Calo__*',
+        'keep *_ak4PFL1PF__*',
+        'keep *_ak4PFL1Puppi__*',
+        'keep *_ak4PFL1CaloCorrected__*',
+        'keep *_ak4PFL1PFCorrected__*',
+        'keep *_ak4PFL1PuppiCorrected__*',
+        'keep *_l1PFMetCalo__*',
+        'keep *_l1PFMetPF__*',
+        'keep *_l1PFMetPuppi__*',
+        ]
+    obj.outputCommands += l1Phase2Digis
+
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
+phase2_muon.toModify(L1TriggerFEVTDEBUG, func=_appendPhase2Digis)

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -63,12 +63,6 @@ from  L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *
 _phase2_siml1emulator = SimL1EmulatorTask.copy()
 _phase2_siml1emulator.add(hgcalTriggerPrimitivesTask)
 
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-#phase2_hgcal.toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator )
-
-from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
-(phase2_hgcal & ~phase2_hgcalV11).toReplaceWith( SimL1EmulatorTask, _phase2_siml1emulator )
-
 #%% # Barrel EGamma
 #%% # ########################################################################
 from L1Trigger.L1CaloTrigger.L1EGammaCrystalsEmulatorProducer_cfi import *
@@ -98,4 +92,5 @@ _phase2_siml1emulator.add( L1TkMuons )
 
 
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
-phase2_trigger.toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator)
+from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
+(phase2_trigger & phase2_trackerV14).toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator)

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -84,6 +84,14 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #
 stage2L1Trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis))
 
+#
+# Phase-2 Trigger
+#
+from L1Trigger.L1TMuonBarrel.simKBmtfStubs_cfi import *
+from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import *
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger 
+phase2_trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simKBmtfStubs, simKBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis))
+
 ## GEM TPs
 from L1Trigger.L1TGEM.simGEMDigis_cff import *
 _run3_SimL1TMuonTask = SimL1TMuonTask.copy()


### PR DESCRIPTION
#### PR description:

Based on #30491
Adding all Phase2 L1T products to FEVTDEBUG Event Content
Also add missing KBmtf in the Muon L1T sequence.
Synch of Modifiers between L1T sequences. We turn on the new Phase-2 L1T package only with `(phase2_trigger & phase2_trackerV14).t`

#### PR validation:

Workflow `23234.0` works (it was failing in #30491)
