### PR TITLE
Remove boost binding in Fireworks

### DIFF
--- a/Fireworks/Calo/src/FWFromTEveCaloDataSelector.cc
+++ b/Fireworks/Calo/src/FWFromTEveCaloDataSelector.cc
@@ -11,9 +11,9 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <cassert>
+#include <functional>
 
 // user include files
 #include "Fireworks/Calo/src/FWFromTEveCaloDataSelector.h"
@@ -63,7 +63,8 @@ FWFromTEveCaloDataSelector::~FWFromTEveCaloDataSelector() {
 void FWFromTEveCaloDataSelector::doSelect() {
   assert(m_changeManager);
   FWChangeSentry sentry(*m_changeManager);
-  std::for_each(m_sliceSelectors.begin(), m_sliceSelectors.end(), boost::bind(&FWFromSliceSelector::clear, _1));
+  std::for_each(
+      m_sliceSelectors.begin(), m_sliceSelectors.end(), std::bind(&FWFromSliceSelector::clear, std::placeholders::_1));
   const TEveCaloData::vCellId_t& cellIds = m_data->GetCellsSelected();
   for (TEveCaloData::vCellId_t::const_iterator it = cellIds.begin(), itEnd = cellIds.end(); it != itEnd; ++it) {
     assert(it->fSlice < static_cast<int>(m_sliceSelectors.size()));

--- a/Fireworks/FWInterface/src/FWFFLooper.cc
+++ b/Fireworks/FWInterface/src/FWFFLooper.cc
@@ -1,5 +1,5 @@
+#include <functional>
 #include <iostream>
-#include "boost/bind.hpp"
 
 #include "Fireworks/FWInterface/interface/FWFFLooper.h"
 #include "Fireworks/FWInterface/src/FWFFNavigator.h"
@@ -168,7 +168,7 @@ FWFFLooper::FWFFLooper(edm::ParameterSet const& ps)
 
 void FWFFLooper::loadDefaultGeometryFile(void) {
   CmsShowTaskExecutor::TaskFunctor f;
-  f = boost::bind(&CmsShowMainBase::loadGeometry, this);
+  f = std::bind(&CmsShowMainBase::loadGeometry, this);
   startupTasks()->addTask(f);
 }
 
@@ -197,7 +197,7 @@ void FWFFLooper::startingNewLoop(unsigned int count) {
     // be responsible for returning the control to CMSSW.
     assert(m_Rint);
     CmsShowTaskExecutor::TaskFunctor f;
-    f = boost::bind(&TApplication::Terminate, m_Rint, 0);
+    f = std::bind(&TApplication::Terminate, m_Rint, 0);
     startupTasks()->addTask(f);
     // FIXME: do we really need to delay tasks like this?
     startupTasks()->startDoingTasks();
@@ -294,9 +294,9 @@ void FWFFLooper::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
     setupConfiguration();
     setupActions();
 
-    guiManager()->showEventFilterGUI_.connect(boost::bind(&FWFFLooper::showPathsGUI, this, _1));
+    guiManager()->showEventFilterGUI_.connect(std::bind(&FWFFLooper::showPathsGUI, this, std::placeholders::_1));
     guiManager()->setFilterButtonText("Show paths / CMSSW configuration editor");
-    guiManager()->filterButtonClicked_.connect(boost::bind(&FWGUIManager::showEventFilterGUI, guiManager()));
+    guiManager()->filterButtonClicked_.connect(std::bind(&FWGUIManager::showEventFilterGUI, guiManager()));
 
     m_firstTime = false;
     m_autoReload = false;

--- a/Fireworks/FWInterface/src/FWFFService.cc
+++ b/Fireworks/FWInterface/src/FWFFService.cc
@@ -1,5 +1,6 @@
+#include <functional>
 #include <iostream>
-#include "boost/bind.hpp"
+
 #include "Fireworks/FWInterface/interface/FWFFService.h"
 #include "Fireworks/FWInterface/src/FWFFNavigator.h"
 #include "Fireworks/FWInterface/src/FWFFMetadataManager.h"
@@ -144,7 +145,7 @@ FWFFService::FWFFService(edm::ParameterSet const& ps, edm::ActivityRegistry& ar)
   CmsShowTaskExecutor::TaskFunctor f;
 
   if (!geometryFilename.empty()) {
-    f = boost::bind(&CmsShowMainBase::loadGeometry, this);
+    f = std::bind(&CmsShowMainBase::loadGeometry, this);
     startupTasks()->addTask(f);
   }
 
@@ -177,7 +178,7 @@ void FWFFService::postBeginJob() {
   // be responsible for returning the control to CMSSW.
   assert(m_Rint);
   CmsShowTaskExecutor::TaskFunctor f;
-  f = boost::bind(&TApplication::Terminate, m_Rint, 0);
+  f = std::bind(&TApplication::Terminate, m_Rint, 0);
   startupTasks()->addTask(f);
   // FIXME: do we really need to delay tasks like this?
   startupTasks()->startDoingTasks();

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateDetailView.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateDetailView.cc
@@ -21,9 +21,6 @@
 #include "TGLabel.h"
 #include "TGLCameraOverlay.h"
 
-// boost includes
-#include "boost/bind.hpp"
-
 #include "Fireworks/ParticleFlow/plugins/FWPFCandidateDetailView.h"
 #include "Fireworks/Core/interface/fw3dlego_xbins.h"
 
@@ -45,6 +42,8 @@
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
+
+#include <functional>
 
 FWPFCandidateDetailView::FWPFCandidateDetailView()
     : m_range(1),
@@ -158,7 +157,8 @@ void FWPFCandidateDetailView::build(const FWModelId& id, const reco::PFCandidate
     m_sliderListener = new FWIntValueListener();
     TQObject::Connect(
         m_slider, "PositionChanged(Int_t)", "FWIntValueListenerBase", m_sliderListener, "setValue(Int_t)");
-    m_sliderListener->valueChanged_.connect(boost::bind(&FWPFCandidateDetailView::rangeChanged, this, _1));
+    m_sliderListener->valueChanged_.connect(
+        std::bind(&FWPFCandidateDetailView::rangeChanged, this, std::placeholders::_1));
     {
       CSGAction* action = new CSGAction(this, "Scale Et");
       TGCheckButton* b = new TGCheckButton(m_guiFrame, action->getName().c_str());

--- a/Fireworks/Tracks/plugins/FWTrackHitsDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackHitsDetailView.cc
@@ -35,8 +35,7 @@
 #include "Fireworks/Tracks/plugins/FWTrackHitsDetailView.h"
 #include "Fireworks/Tracks/interface/TrackUtils.h"
 
-// boost includes
-#include "boost/bind.hpp"
+#include <functional>
 
 FWTrackHitsDetailView::FWTrackHitsDetailView()
     : m_modules(nullptr),
@@ -61,7 +60,8 @@ void FWTrackHitsDetailView::build(const FWModelId& id, const reco::Track* track)
     m_sliderListener = new FWIntValueListener();
     TQObject::Connect(
         m_slider, "PositionChanged(Int_t)", "FWIntValueListenerBase", m_sliderListener, "setValue(Int_t)");
-    m_sliderListener->valueChanged_.connect(boost::bind(&FWTrackHitsDetailView::transparencyChanged, this, _1));
+    m_sliderListener->valueChanged_.connect(
+        std::bind(&FWTrackHitsDetailView::transparencyChanged, this, std::placeholders::_1));
   }
 
   {


### PR DESCRIPTION
#### PR description:
Finish replacing boost::bind for std::bind in fireworks.
The code should have the same behaviour and also similar performance. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 