### PR TITLE
Throw a separate exception if ESGetToken is uninitialized

### DIFF
--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -205,10 +205,12 @@ namespace edm {
     protected:
       template <template <typename> typename H, typename T, typename R>
       H<T> getHandleImpl(ESGetToken<T, R> const& iToken) const {
+        if UNLIKELY (not iToken.isInitialized()) {
+          std::rethrow_exception(makeInvalidTokenException(this->key(), DataKey::makeTypeTag<T>()));
+        }
         if UNLIKELY (iToken.transitionID() != transitionID()) {
           throwWrongTransitionID();
         }
-        assert(iToken.isInitialized());
         assert(getTokenIndices_);
         //need to check token has valid index
         if UNLIKELY (not iToken.hasValidIndex()) {

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -111,10 +111,9 @@ namespace edm {
 
       template <typename HolderT>
       bool get(char const* iName, HolderT& iHolder) const {
-        if
-          UNLIKELY(requireTokens_) {
-            throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iName);
-          }
+        if UNLIKELY (requireTokens_) {
+          throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iName);
+        }
         typename HolderT::value_type const* value = nullptr;
         ComponentDescription const* desc = nullptr;
         std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
@@ -136,10 +135,9 @@ namespace edm {
 
       template <typename HolderT>
       bool get(ESInputTag const& iTag, HolderT& iHolder) const {
-        if
-          UNLIKELY(requireTokens_) {
-            throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iTag.data().c_str());
-          }
+        if UNLIKELY (requireTokens_) {
+          throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iTag.data().c_str());
+        }
         typename HolderT::value_type const* value = nullptr;
         ComponentDescription const* desc = nullptr;
         std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
@@ -207,17 +205,20 @@ namespace edm {
     protected:
       template <template <typename> typename H, typename T, typename R>
       H<T> getHandleImpl(ESGetToken<T, R> const& iToken) const {
-        if
-          UNLIKELY(iToken.transitionID() != transitionID()) { throwWrongTransitionID(); }
+        if UNLIKELY (iToken.transitionID() != transitionID()) {
+          throwWrongTransitionID();
+        }
         assert(iToken.isInitialized());
         assert(getTokenIndices_);
         //need to check token has valid index
-        if
-          UNLIKELY(not iToken.hasValidIndex()) { return invalidTokenHandle<H>(iToken); }
+        if UNLIKELY (not iToken.hasValidIndex()) {
+          return invalidTokenHandle<H>(iToken);
+        }
 
         auto proxyIndex = getTokenIndices_[iToken.index().value()];
-        if
-          UNLIKELY(proxyIndex.value() == std::numeric_limits<int>::max()) { return noProxyHandle<H>(iToken); }
+        if UNLIKELY (proxyIndex.value() == std::numeric_limits<int>::max()) {
+          return noProxyHandle<H>(iToken);
+        }
 
         T const* value = nullptr;
         ComponentDescription const* desc = nullptr;
@@ -225,8 +226,9 @@ namespace edm {
 
         impl_->getImplementation(value, proxyIndex, H<T>::transientAccessOnly, desc, whyFailedFactory, eventSetupImpl_);
 
-        if
-          UNLIKELY(not value) { return H<T>(std::move(whyFailedFactory)); }
+        if UNLIKELY (not value) {
+          return H<T>(std::move(whyFailedFactory));
+        }
         return H<T>(value, desc);
       }
 

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -70,13 +70,24 @@ namespace edm {
       iException.addContext(ost.str());
     }
 
-    std::exception_ptr EventSetupRecord::makeInvalidTokenException(EventSetupRecordKey const& iRecordKey,
-                                                                   TypeTag const& iDataKey) {
+    std::exception_ptr EventSetupRecord::makeUninitializedTokenException(EventSetupRecordKey const& iRecordKey,
+                                                                         TypeTag const& iDataKey) {
       cms::Exception ex("InvalidESGetToken");
       ex << "Attempted to get data using an invalid token of type ESGetToken<" << iDataKey.name() << ","
          << iRecordKey.name()
          << ">.\n"
             "Please call consumes to properly initialize the token.";
+      return std::make_exception_ptr(ex);
+    }
+
+    std::exception_ptr EventSetupRecord::makeInvalidTokenException(EventSetupRecordKey const& iRecordKey,
+                                                                   TypeTag const& iDataKey,
+                                                                   unsigned int iTransitionID) {
+      cms::Exception ex("InvalidESGetToken");
+      ex << "Attempted to get data using an invalid token of type ESGetToken<" << iDataKey.name() << ","
+         << iRecordKey.name() << "> that had transition ID set (" << iTransitionID
+         << ") but not the index.\n"
+            "This should not happen, please contact core framework developers.";
       return std::make_exception_ptr(ex);
     }
 

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -588,6 +588,7 @@ namespace {
     }
 
     ESGetToken<edm::eventsetup::test::DummyData, edm::DefaultRecord> m_token;
+    ESGetToken<edm::eventsetup::test::DummyData, edm::DefaultRecord> m_tokenUninitialized;
   };
 
   class ConsumesProducer : public ESProducer {
@@ -763,6 +764,14 @@ void testEventsetup::getDataWithESGetTokenTest() {
                             true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data.value_);
+      bool uninitializedTokenThrewException = false;
+      try {
+        (void)eventSetup.getData(consumer.m_tokenUninitialized);
+      } catch (cms::Exception& ex) {
+        uninitializedTokenThrewException = true;
+        CPPUNIT_ASSERT(ex.category() == "InvalidESGetToken");
+      }
+      CPPUNIT_ASSERT(uninitializedTokenThrewException);
     }
 
     {


### PR DESCRIPTION
#### PR description:

In #30482 it was noticed that a `get()` with uninitialized `ESGetToken` throws an exception complaining on incorrect transition ID. This is confusing and inconsistent with `EDGetToken` and `EDPutToken`. This PR  changes `EventSetupRecord::getHandleImpl()` to first check if a token is initialized, and then check if the transition is correct.

In addition, `scram b code-format` lead to partial reformatting of `EventSetupRecord.h` (perhaps this file was missed in code formatting campaign after a clang version update or something), I included those changes in a separate commit.

#### PR validation:

Framework unit tests run.