### PR TITLE
Remove boost::ptr_map dependency in DQM/EcalCommon

### DIFF
--- a/DQM/EcalCommon/interface/MESet.h
+++ b/DQM/EcalCommon/interface/MESet.h
@@ -11,9 +11,9 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <string>
+#include <map>
+#include <memory>
 #include <vector>
-
-#include "boost/ptr_container/ptr_map.hpp"
 
 namespace ecaldqm {
   /*
@@ -338,15 +338,33 @@ namespace ecaldqm {
 
 }  // namespace ecaldqm
 
-namespace boost {
-  template <>
-  inline ecaldqm::MESet *new_clone<ecaldqm::MESet>(ecaldqm::MESet const &);
-  template <>
-  void delete_clone<ecaldqm::MESet>(ecaldqm::MESet const *);
-}  // namespace boost
-
 namespace ecaldqm {
-  typedef boost::ptr_map<std::string, MESet> MESetCollection;
-}
+
+  class MESetCollection {
+    using MESetColletionType = std::map<std::string, std::unique_ptr<MESet>>;
+
+  public:
+    using iterator = MESetColletionType::iterator;
+    using const_iterator = MESetColletionType::const_iterator;
+
+    void insert(const std::string &key, MESet *ptr) { _MESetColletion.emplace(key, ptr); }
+    void insert(const std::string &&key, MESet *ptr) { _MESetColletion.emplace(key, ptr); }
+
+    void erase(const std::string &key) { _MESetColletion.erase(key); }
+
+    auto begin() { return _MESetColletion.begin(); }
+    auto end() const { return _MESetColletion.end(); }
+
+    const_iterator find(const std::string &key) const { return _MESetColletion.find(key); }
+    iterator find(const std::string &key) { return _MESetColletion.find(key); }
+
+    //return a reference, but this collection still has the ownership
+    MESet &at(const std::string &key) { return *(_MESetColletion.at(key).get()); }
+
+  private:
+    MESetColletionType _MESetColletion;
+  };
+
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/plugins/EcalMEFormatter.cc
+++ b/DQM/EcalCommon/plugins/EcalMEFormatter.cc
@@ -36,20 +36,20 @@ void EcalMEFormatter::dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &_igetter
 void EcalMEFormatter::format_(DQMStore::IGetter &_igetter, bool _checkLumi) {
   std::string failedPath;
 
-  for (ecaldqm::MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr) {
-    if (_checkLumi && !mItr->second->getLumiFlag())
+  for (auto &mItr : MEs_) {
+    if (_checkLumi && !mItr.second->getLumiFlag())
       continue;
-    mItr->second->clear();
-    if (!mItr->second->retrieve(_igetter, &failedPath)) {
+    mItr.second->clear();
+    if (!mItr.second->retrieve(_igetter, &failedPath)) {
       if (verbosity_ > 0)
-        edm::LogWarning("EcalDQM") << "Could not find ME " << mItr->first << "@" << failedPath;
+        edm::LogWarning("EcalDQM") << "Could not find ME " << mItr.first << "@" << failedPath;
       continue;
     }
     if (verbosity_ > 1)
-      edm::LogInfo("EcalDQM") << "Retrieved " << mItr->first << " from DQMStore";
+      edm::LogInfo("EcalDQM") << "Retrieved " << mItr.first << " from DQMStore";
 
-    if (dynamic_cast<ecaldqm::MESetDet2D *>(mItr->second))
-      formatDet2D_(*mItr->second);
+    if (dynamic_cast<ecaldqm::MESetDet2D *>(mItr.second.get()))
+      formatDet2D_(*mItr.second);
   }
 }
 

--- a/DQM/EcalCommon/src/MESet.cc
+++ b/DQM/EcalCommon/src/MESet.cc
@@ -487,14 +487,3 @@ namespace ecaldqm {
     return true;
   }
 }  // namespace ecaldqm
-
-namespace boost {
-  template <>
-  inline ecaldqm::MESet *new_clone<ecaldqm::MESet>(ecaldqm::MESet const &_s) {
-    return _s.clone();
-  }
-  template <>
-  void delete_clone<ecaldqm::MESet>(ecaldqm::MESet const *_s) {
-    checked_delete(_s);
-  }
-}  // namespace boost

--- a/DQM/EcalMonitorClient/src/DQWorkerClient.cc
+++ b/DQM/EcalMonitorClient/src/DQWorkerClient.cc
@@ -36,8 +36,8 @@ namespace ecaldqm {
     // Flags the Client ME to run as lumibased:
     // In offline mode will save the ME client at the end of the LS
     // See: EcalDQMonitorClient::dqmEndLuminosityBlock
-    for (MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr) {
-      if (mItr->second->getLumiFlag()) {
+    for (auto& mItr : MEs_) {
+      if (mItr.second->getLumiFlag()) {
         hasLumiPlots_ = true;
         break;
       }
@@ -111,15 +111,15 @@ namespace ecaldqm {
   }
 
   void DQWorkerClient::resetMEs() {
-    for (MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr) {
-      MESet* meset(mItr->second);
+    for (auto& mItr : MEs_) {
+      MESet* meset(mItr.second.get());
 
       // Protects Trend-type Client MEs from being reset at the end of the LS
       // See: EcalDQMonitorClient::runWorkers
       if (meset->getBinType() == ecaldqm::binning::kTrend)
         continue;
 
-      if (qualitySummaries_.find(mItr->first) != qualitySummaries_.end()) {
+      if (qualitySummaries_.find(mItr.first) != qualitySummaries_.end()) {
         MESetMulti* multi(dynamic_cast<MESetMulti*>(meset));
         if (multi) {
           for (unsigned iS(0); iS < multi->getMultiplicity(); ++iS) {


### PR DESCRIPTION
#### PR description:
Removed boost::ptr_map dependency.
The code should have the same behaviour and also similar performance. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 