### PR TITLE
Added an option to not fail var parsing if var is provided but not registered

### DIFF
--- a/FWCore/ParameterSet/python/VarParsing.py
+++ b/FWCore/ParameterSet/python/VarParsing.py
@@ -163,10 +163,12 @@ class VarParsing (object):
         self._tagOrder.append (tag)
 
 
-    def parseArguments (self):
+    def parseArguments (self, raise_if_not_registered=True):
         """Parses command line arguments.  Parsing starts just after
         the name of the configuration script.  Parsing will fail if
-        there is not 'xxxx.py'"""
+        there is not 'xxxx.py'
+        If raise_if_not_registered is False, variables that are
+        provided but not registered will be ignored without an error."""
         self._currentlyParsing = True
         foundPy      = False
         printStatus  = False
@@ -200,9 +202,12 @@ class VarParsing (object):
                 else:
                     # just a name and value
                     if name not in self._register:
-                        print("Error:  '%s' not registered." \
-                              % name)
-                        raise RuntimeError("Unknown variable")
+                        if raise_if_not_registered:
+                            print("Error:  '%s' not registered." \
+                                % name)
+                            raise RuntimeError("Unknown variable")
+                        else:
+                            continue
                     if VarParsing.multiplicity.singleton == \
                            self._register[name]:
                         # singleton


### PR DESCRIPTION
#### PR description:

In Online DQM clients we would like to register and process only certain variables and leave others to be handled by other modules/dependencies. This is currently impossible because if we register only one variable but more are provided, an `Unknown variable` error or raised.

There are two workarounds to this issue known to me:
* Registering all variables everywhere
* Parsing `sys.argv` ourselves

Both workarounds are not ideal.

This PR adds a flag to `VarParsing.parseArguments()` method: `raise_if_not_registered`. The default value is `True` which ensures that all current usages behave the same. Passing `False` will ignore variables that are passed but not registered.

#### PR validation:

PR was validated locally.
