### PR TITLE
Modify MkFitInputWrapper and to take moved-in parameters by value

### DIFF
--- a/RecoTracker/MkFit/interface/MkFitInputWrapper.h
+++ b/RecoTracker/MkFit/interface/MkFitInputWrapper.h
@@ -17,10 +17,10 @@ namespace mkfit {
 class MkFitInputWrapper {
 public:
   MkFitInputWrapper();
-  MkFitInputWrapper(MkFitHitIndexMap&& hitIndexMap,
-                    std::vector<mkfit::HitVec>&& hits,
-                    mkfit::TrackVec&& seeds,
-                    mkfit::LayerNumberConverter&& lnc);
+  MkFitInputWrapper(MkFitHitIndexMap hitIndexMap,
+                    std::vector<mkfit::HitVec> hits,
+                    mkfit::TrackVec seeds,
+                    mkfit::LayerNumberConverter const& lnc);
   ~MkFitInputWrapper();
 
   MkFitInputWrapper(MkFitInputWrapper const&) = delete;

--- a/RecoTracker/MkFit/plugins/MkFitInputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitInputConverter.cc
@@ -123,7 +123,7 @@ void MkFitInputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const e
   // Then import seeds
   auto mkFitSeeds = convertSeeds(iEvent.get(seedToken_), hitIndexMap, ttrhBuilder, iSetup.getData(mfToken_));
 
-  iEvent.emplace(putToken_, std::move(hitIndexMap), std::move(mkFitHits), std::move(mkFitSeeds), std::move(lnc));
+  iEvent.emplace(putToken_, std::move(hitIndexMap), std::move(mkFitHits), std::move(mkFitSeeds), lnc);
 }
 
 bool MkFitInputConverter::passCCC(const SiStripRecHit2D& hit, const DetId hitId) const {

--- a/RecoTracker/MkFit/src/MkFitInputWrapper.cc
+++ b/RecoTracker/MkFit/src/MkFitInputWrapper.cc
@@ -7,14 +7,14 @@
 
 MkFitInputWrapper::MkFitInputWrapper() = default;
 
-MkFitInputWrapper::MkFitInputWrapper(MkFitHitIndexMap&& hitIndexMap,
-                                     std::vector<mkfit::HitVec>&& hits,
-                                     mkfit::TrackVec&& seeds,
-                                     mkfit::LayerNumberConverter&& lnc)
+MkFitInputWrapper::MkFitInputWrapper(MkFitHitIndexMap hitIndexMap,
+                                     std::vector<mkfit::HitVec> hits,
+                                     mkfit::TrackVec seeds,
+                                     mkfit::LayerNumberConverter const& lnc)
     : hitIndexMap_{std::move(hitIndexMap)},
       hits_{std::move(hits)},
       seeds_{std::make_unique<mkfit::TrackVec>(std::move(seeds))},
-      lnc_{std::make_unique<mkfit::LayerNumberConverter>(std::move(lnc))} {}
+      lnc_{std::make_unique<mkfit::LayerNumberConverter>(lnc)} {}
 
 MkFitInputWrapper::~MkFitInputWrapper() = default;
 


### PR DESCRIPTION
#### PR description:

This PR changes `MkFitInputWrapper` constructor to take parameters benefiting from move by value, and others by const reference as recommended in the code rules (4.20). The change was prompted by clang-tidy noticing that `mkfit::LayerNumberConverter` does not benefit from move in https://github.com/cms-sw/cmssw/pull/30508.

#### PR validation:

Workflow 11634.7 runs.