### PR TITLE
Turnon L1T TrackTrigger, TrackMatch, PF, update TestOldDigiWorkflow, add objects in FEVTDEBUG (11_1_X backport)

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C8_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C8_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
+from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
 
-Phase2C8 = cms.ModifierChain(Phase2C4, phase2_hgcalV10)
+Phase2C8 = cms.ModifierChain(Phase2C4, phase2_hgcalV10, phase2_trackerV14)
 

--- a/Configuration/Eras/python/Modifier_phase2_trackerV14_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_trackerV14_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_trackerV14 =  cms.Modifier()
+

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3265,7 +3265,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       }
 
     # Adding Track trigger step in step2
-    upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:%s'%(hltversion),
+    upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',
                                       '-n':'10',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -672,6 +672,11 @@ class UpgradeWorkflow_TestOldDigi(UpgradeWorkflow):
             # handle separate PU input
             stepNamePU = step + 'PU' + self.suffix
             stepDict[stepNamePU][k] = merge([{'--filein': 'das:/RelValTTbar_14TeV/CMSSW_11_0_0_pre13-PU25ns_110X_mcRun4_realistic_v2_2026D49PU200-v2/GEN-SIM-DIGI-RAW'},stepDict[stepName][k]])
+            ## Use re-emulate the full L1 trigger when running on 11_0 DIGI. Ie. Replace L1Reco with L1TrackTrigger,L1. 
+            stepDict[stepName][k] = merge([{'-s': stepDict[stepName][k]['-s'].replace("L1Reco","L1TrackTrigger,L1")}, stepDict[stepName][k]])
+            stepDict[stepNamePU][k] = merge([{'-s': stepDict[stepNamePU][k]['-s'].replace("L1Reco","L1TrackTrigger,L1")}, stepDict[stepNamePU][k]])
+            stepDict[stepName][k] = merge([{'--customise_unsch': "L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC"}, stepDict[stepName][k]])
+            stepDict[stepNamePU][k] = merge([{'--customise_unsch': "L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC"}, stepDict[stepNamePU][k]])
         elif 'GenSim' in step or 'Digi' in step:
             # remove step
             stepDict[stepName][k] = None

--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.TrackTrigger.TrackTrigger_cff import *
 from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
-from L1Trigger.TrackerDTC.Producer_cff import *
+from L1Trigger.TrackerDTC.ProducerED_cff import *
+from L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff import * 
 
-#L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
 L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackerDTCProducer)
 
 # Customisation to enable TTTracks in geometry D41 and later (corresponding to phase2_trackerV14 or later). Includes the HGCAL L1 trigger

--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -7,4 +7,4 @@ from L1Trigger.TrackerDTC.Producer_cff import *
 #L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
 L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackerDTCProducer)
 
-TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)
+TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = True

--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -7,4 +7,12 @@ from L1Trigger.TrackerDTC.Producer_cff import *
 #L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
 L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackerDTCProducer)
 
+# Customisation to enable TTTracks in geometry D41 and later (corresponding to phase2_trackerV14 or later). Includes the HGCAL L1 trigger
+_tttracks_l1tracktrigger = L1TrackTrigger.copy()
+_tttracks_l1tracktrigger = cms.Sequence(_tttracks_l1tracktrigger + L1PromptExtendedHybridTracksWithAssociators)
+
+from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
+(phase2_trigger & phase2_trackerV14).toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
+
 TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = True

--- a/DataFormats/L1TrackTrigger/interface/TTDTC.h
+++ b/DataFormats/L1TrackTrigger/interface/TTDTC.h
@@ -25,23 +25,10 @@ public:
   // collection of optical links
   typedef std::vector<Stream> Streams;
 
-private:
-  // number of ATCA slots per shelf
-  static constexpr int numSlots_ = 12;
-
-public:
   TTDTC() {}
   TTDTC(int numRegions, int numOverlappingRegions, int numDTCsPerRegion);
   ~TTDTC() {}
 
-  // number of phi slices the outer tracker readout is organized in [default 9]
-  int numRegions() const { return numRegions_; }
-  // number of DTC boards used to readout a detector region [default 24]
-  int numDTCBoards() const { return numDTCsPerRegion_; }
-  // number of regions a reconstructable particle may cross [default 2]
-  int numDTCChannel() const { return numOverlappingRegions_; }
-  // number of DTC boards connected to one TFP [default 48]
-  int numTFPChannel() const { return numDTCsPerTFP_; }
   // all regions [default 0..8]
   const std::vector<int>& tfpRegions() const { return regions_; }
   // all TFP channel [default 0..47]
@@ -58,18 +45,6 @@ public:
   int nStubs() const;
   // total number of gaps
   int nGaps() const;
-  // converts dtc id into tk layout scheme
-  int tkLayoutId(int dtcId) const;
-  // converts tk layout id into dtc id
-  int dtcId(int tkLayoutId) const;
-  // converts TFP identifier (region[0-8], channel[0-47]) into dtcId [0-215]
-  int dtcId(int tfpRegion, int tfpChannel) const;
-  // checks if given dtcId is connected to PS or 2S sensormodules
-  bool psModlue(int dtcId) const;
-  // checks if given dtcId is connected to -z (false) or +z (true)
-  bool side(int dtcId) const;
-  // ATCA slot number [0-11] of given dtcId
-  int slot(int dtcId) const;
 
 private:
   // converts DTC identifier (region[0-8], board[0-23], channel[0-1]) into allStreams_ index [0-431]

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -153,3 +153,51 @@ def _appendME0Digis(obj):
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(L1TriggerFEVTDEBUG, func=_appendME0Digis)
+
+# adding phase2 trigger
+def _appendPhase2Digis(obj):
+    l1Phase2Digis = [
+        "keep *_simKBmtfDigis_*_*",
+        'keep *_hgcalVFEProducerhgcalConcentratorProducer__*',
+        'keep *_hgcalBackEndLayer1Producer__*',
+        'keep *_hgcalBackEndLayer2Producer__*',
+        'keep *_hgcalTowerMapProducer__*',
+        'keep *_hgcalTowerProducer__*',
+        'keep *_L1EGammaClusterEmuProducer__*',
+        'keep *_l1EGammaEEProducer__*',
+        'keep *_L1TkPrimaryVertex__*',
+        'keep *_L1TkElectronsCrystal__*',
+        'keep *_L1TkElectronsLooseCrystal__*',
+        'keep *_L1TkElectronsEllipticMatchCrystal__*',
+        'keep *_L1TkIsoElectronsCrystal__*',
+        'keep *_L1TkPhotonsCrystal__*',
+        'keep *_L1TkElectronsHGC__*',
+        'keep *_L1TkElectronsEllipticMatchHGC__*',
+        'keep *_L1TkIsoElectronsHGC__*',
+        'keep *_L1TkPhotonsHGC__*',
+        'keep *_L1TkMuons__*',
+        'keep *_pfClustersFromL1EGClusters__*',
+        'keep *_pfClustersFromCombinedCaloHCal__*',
+        'keep *_pfClustersFromCombinedCaloHF__*',
+        'keep *_pfClustersFromHGC3DClusters__*',
+        'keep *_pfTracksFromL1TracksBarrel__*',
+        'keep *_l1pfProducerBarrel__*',
+        'keep *_pfTracksFromL1TracksHGCal__*',
+        'keep *_l1pfProducerHGCal__*',
+        'keep *_l1pfProducerHGCalNoTK__*',
+        'keep *_l1pfProducerHF__*',
+        'keep *_l1pfCandidates__*',
+        'keep *_ak4PFL1Calo__*',
+        'keep *_ak4PFL1PF__*',
+        'keep *_ak4PFL1Puppi__*',
+        'keep *_ak4PFL1CaloCorrected__*',
+        'keep *_ak4PFL1PFCorrected__*',
+        'keep *_ak4PFL1PuppiCorrected__*',
+        'keep *_l1PFMetCalo__*',
+        'keep *_l1PFMetPF__*',
+        'keep *_l1PFMetPuppi__*',
+        ]
+    obj.outputCommands += l1Phase2Digis
+
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
+phase2_muon.toModify(L1TriggerFEVTDEBUG, func=_appendPhase2Digis)

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -132,6 +132,7 @@ _phase2_siml1emulator.add(l1PFJetsTask)
 l1PFMetsTask = cms.Task(l1PFMetCalo , l1PFMetPF , l1PFMetPuppi)
 _phase2_siml1emulator.add(l1PFMetsTask)
 
+# --> add modules
 #%% # Barrel EGamma
 #%% # ########################################################################
 from L1Trigger.L1CaloTrigger.L1EGammaCrystalsEmulatorProducer_cfi import *

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -132,7 +132,34 @@ _phase2_siml1emulator.add(l1PFJetsTask)
 l1PFMetsTask = cms.Task(l1PFMetCalo , l1PFMetPF , l1PFMetPuppi)
 _phase2_siml1emulator.add(l1PFMetsTask)
 
-# --> add modules
+#%% # Barrel EGamma
+#%% # ########################################################################
+from L1Trigger.L1CaloTrigger.L1EGammaCrystalsEmulatorProducer_cfi import *
+_phase2_siml1emulator.add(L1EGammaClusterEmuProducer)
+
+from L1Trigger.L1CaloTrigger.l1EGammaEEProducer_cfi import *
+_phase2_siml1emulator.add(l1EGammaEEProducer)
+
+# Tk + StandaloneObj, including L1TkPrimaryVertex
+# ########################################################################
+from L1Trigger.L1TTrackMatch.L1TkObjectProducers_cff import *
+
+_phase2_siml1emulator.add(L1TkPrimaryVertex)
+
+_phase2_siml1emulator.add(L1TkElectronsCrystal)
+_phase2_siml1emulator.add(L1TkElectronsLooseCrystal)
+_phase2_siml1emulator.add(L1TkElectronsEllipticMatchCrystal)
+_phase2_siml1emulator.add(L1TkIsoElectronsCrystal)
+_phase2_siml1emulator.add(L1TkPhotonsCrystal)
+
+_phase2_siml1emulator.add(L1TkElectronsHGC)
+_phase2_siml1emulator.add(L1TkElectronsEllipticMatchHGC)
+_phase2_siml1emulator.add(L1TkIsoElectronsHGC)
+_phase2_siml1emulator.add(L1TkPhotonsHGC)
+
+_phase2_siml1emulator.add( L1TkMuons )
+
+
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
 from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
 (phase2_trigger & phase2_trackerV14).toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator)

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -58,10 +58,81 @@ from L1Trigger.L1TGlobal.GlobalParameters_cff import *
 # soon to be removed when availble in GTs
 from L1Trigger.L1TTwinMux.fakeTwinMuxParams_cff import *
 
-# Customisation for the phase2_hgcal era. Includes the HGCAL L1 trigger
-from  L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *
 _phase2_siml1emulator = SimL1EmulatorTask.copy()
-_phase2_siml1emulator.add(hgcalTriggerPrimitivesTask)
 
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator )
+# ########################################################################
+# ########################################################################
+#
+# Phase-2 
+#
+# ########################################################################
+# ########################################################################
+
+# ########################################################################
+# Phase-2 Trigger Primitives
+# ########################################################################
+
+# HGCAL TP 
+# ########################################################################
+from  L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *
+_phase2_siml1emulator.add(hgcalTriggerPrimitivesTask)
+ 
+# ########################################################################
+# Phase 2 L1T
+# ########################################################################
+
+# Barrel and EndCap EGamma
+# ########################################################################
+
+from L1Trigger.L1CaloTrigger.L1EGammaCrystalsEmulatorProducer_cfi import *
+_phase2_siml1emulator.add(L1EGammaClusterEmuProducer)
+
+from L1Trigger.L1CaloTrigger.l1EGammaEEProducer_cfi import *
+_phase2_siml1emulator.add(l1EGammaEEProducer)
+
+# ########################################################################
+# Phase-2 L1T - TrackTrigger dependent modules
+# ########################################################################
+
+# Tk + StandaloneObj, including L1TkPrimaryVertex
+# ########################################################################
+from L1Trigger.L1TTrackMatch.L1TkObjectProducers_cff import *
+
+_phase2_siml1emulator.add(L1TkPrimaryVertex)
+
+_phase2_siml1emulator.add(L1TkElectronsCrystal)
+_phase2_siml1emulator.add(L1TkElectronsLooseCrystal)
+_phase2_siml1emulator.add(L1TkElectronsEllipticMatchCrystal)
+_phase2_siml1emulator.add(L1TkIsoElectronsCrystal)
+_phase2_siml1emulator.add(L1TkPhotonsCrystal)
+
+_phase2_siml1emulator.add(L1TkElectronsHGC)
+_phase2_siml1emulator.add(L1TkElectronsEllipticMatchHGC)
+_phase2_siml1emulator.add(L1TkIsoElectronsHGC)
+_phase2_siml1emulator.add(L1TkPhotonsHGC)
+
+_phase2_siml1emulator.add( L1TkMuons )
+
+# PF Candidates
+# ########################################################################
+from L1Trigger.Phase2L1ParticleFlow.l1ParticleFlow_cff import *
+_phase2_siml1emulator.add(l1ParticleFlowTask)
+
+# PF JetMET
+# ########################################################################
+from L1Trigger.Phase2L1ParticleFlow.l1pfJetMet_cff import *
+# Describe here l1PFJets Task
+# ###############################
+l1PFJetsTask = cms.Task(
+  ak4PFL1Calo , ak4PFL1PF , ak4PFL1Puppi ,
+  ak4PFL1CaloCorrected , ak4PFL1PFCorrected , ak4PFL1PuppiCorrected)
+_phase2_siml1emulator.add(l1PFJetsTask)
+# Describe here l1PFMets Task
+# ###############################
+l1PFMetsTask = cms.Task(l1PFMetCalo , l1PFMetPF , l1PFMetPuppi)
+_phase2_siml1emulator.add(l1PFMetsTask)
+
+# --> add modules
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
+from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
+(phase2_trigger & phase2_trackerV14).toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator)

--- a/L1Trigger/Configuration/python/customisePhase2TTNoMC.py
+++ b/L1Trigger/Configuration/python/customisePhase2TTNoMC.py
@@ -1,0 +1,4 @@
+def customisePhase2TTNoMC(process):
+    process.L1TrackTrigger.replace(process.L1PromptExtendedHybridTracksWithAssociators, process.L1PromptExtendedHybridTracks)
+    process.L1TrackTrigger.remove(process.TrackTriggerAssociatorClustersStubs)
+    return process

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -84,6 +84,14 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #
 stage2L1Trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis))
 
+#
+# Phase-2 Trigger
+#
+from L1Trigger.L1TMuonBarrel.simKBmtfStubs_cfi import *
+from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import *
+from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger 
+phase2_trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simKBmtfStubs, simKBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis))
+
 ## GEM TPs
 from L1Trigger.L1TGEM.simGEMDigis_cff import *
 _run3_SimL1TMuonTask = SimL1TMuonTask.copy()

--- a/Validation/Geometry/test/runMaterialDumpAnalyser_PhaseII.sh
+++ b/Validation/Geometry/test/runMaterialDumpAnalyser_PhaseII.sh
@@ -59,7 +59,7 @@ fi
 # DIGI comes next
 if checkFile SingleMuPt10_step2_DIGI_L1_DIGI2RAW_HLT_PhaseII.root ; then
   cmsDriver.py step2   \
--s DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2  \
+-s DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2  \
 --conditions auto:phase2_realistic \
 -n -1  \
 --era Phase2C2  \


### PR DESCRIPTION
This PR solves the conflict between #30520 #30519 #30517.
This backports to 11_1_X:
- Update of TestOldDigi workflow (#30484)
- Add Phase2 L1T objects to FEVTDEBUG EventContent (#30498)
- Turn on L1 track trigger in Phase2C8 and later (#30479)
- Turn on the ParticleFlow and TrackMatch (#30482, #30363)

Require the L1T PF package #30523