### PR TITLE
Removed obsolete script from TB2006 analysis

### DIFF
--- a/Geometry/HcalTestBeamData/python/hcalDDDSimConstants_cff.py
+++ b/Geometry/HcalTestBeamData/python/hcalDDDSimConstants_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.HcalCommonData.hcalParameters_cfi             import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cfi        import *
-from Geometry.HcalCommonData.hcalDDDSimulationConstants_cfi import *
 from Geometry.HcalCommonData.caloSimulationParameters_cff   import *
 from Geometry.HcalTestBeamData.hcalTB02Parameters_cff       import *
 from Geometry.HcalTestBeamData.hcalTB06Parameters_cff       import *


### PR DESCRIPTION
#### PR description:
During recent HCAL scripts reorganization one python fragment become obsolete. As a result, TB2006 crash. This PR fixes the issue.

#### PR validation:
private

