### PR TITLE
Use --customise instead of --customise_unsc in TestOldDigi workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -677,8 +677,8 @@ class UpgradeWorkflow_TestOldDigi(UpgradeWorkflow):
             ## Use re-emulate the full L1 trigger when running on 11_0 DIGI. Ie. Replace L1Reco with L1TrackTrigger,L1. 
             stepDict[stepName][k] = merge([{'-s': stepDict[stepName][k]['-s'].replace("L1Reco","L1TrackTrigger,L1")}, stepDict[stepName][k]])
             stepDict[stepNamePU][k] = merge([{'-s': stepDict[stepNamePU][k]['-s'].replace("L1Reco","L1TrackTrigger,L1")}, stepDict[stepNamePU][k]])
-            stepDict[stepName][k] = merge([{'--customise_unsch': "L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC"}, stepDict[stepName][k]])
-            stepDict[stepNamePU][k] = merge([{'--customise_unsch': "L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC"}, stepDict[stepNamePU][k]])
+            stepDict[stepName][k] = merge([{'--customise': "L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC"}, stepDict[stepName][k]])
+            stepDict[stepNamePU][k] = merge([{'--customise': "L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC"}, stepDict[stepNamePU][k]])
         elif 'GenSim' in step or 'Digi' in step:
             # remove step
             stepDict[stepName][k] = None


### PR DESCRIPTION
#### PR description:

Use `--customise` instead of `--customise_unsc` in TestOldDigi workflow

#### PR validation:

From python dump of `23234.1001` step1:

Without PR
```
process.L1TrackTrigger_step = cms.Path(cms.Task(process.TTClusterAssociatorFromPixelDigis, process.TTClustersFromPhase2TrackerDigis, process.TTStubAssociatorFromPixelDigis, process.TTStubsFromPhase2TrackerDigis, process.TTTrackAssociatorFromPixelDigis, process.TTTrackAssociatorFromPixelDigisExtended, process.TTTracksFromExtendedTrackletEmulation, process.TTTracksFromTrackletEmulation, process.TrackerDTCProducer, process.offlineBeamSpot))
```

With PR
```
process.L1TrackTrigger_step = cms.Path(cms.Task(process.TTClustersFromPhase2TrackerDigis, process.TTStubsFromPhase2TrackerDigis, process.TTTracksFromExtendedTrackletEmulation, process.TTTracksFromTrackletEmulation, process.TrackerDTCProducer, process.offlineBeamSpot))
```
