### PR TITLE
 [TEST-only] Disable new phase-2 L1 code (111X) 

### DIFF
--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -13,6 +13,6 @@ _tttracks_l1tracktrigger = cms.Sequence(_tttracks_l1tracktrigger + L1PromptExten
 
 from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
-(phase2_trigger & phase2_trackerV14).toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
+#(phase2_trigger & phase2_trackerV14).toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
 
 TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = True

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -163,4 +163,4 @@ _phase2_siml1emulator.add( L1TkMuons )
 
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
 from Configuration.Eras.Modifier_phase2_trackerV14_cff import phase2_trackerV14
-(phase2_trigger & phase2_trackerV14).toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator)
+#(phase2_trigger & phase2_trackerV14).toReplaceWith( SimL1EmulatorTask , _phase2_siml1emulator)


### PR DESCRIPTION
For test only. Disable new phase-2 L1 code to check the comparison of the short matrix. 
CMSSW_11_1_X version of #30545