### PR TITLE
Clean up unused boost dependencies on RecoTracker/CkfPattern

### DIFF
--- a/RecoTracker/CkfPattern/BuildFile.xml
+++ b/RecoTracker/CkfPattern/BuildFile.xml
@@ -19,5 +19,4 @@
 <use name="TrackingTools/TrajectoryCleaning"/>
 <use name="TrackingTools/TrajectoryFiltering"/>
 <use name="TrackingTools/TrackFitters"/>
-<use name="boost"/>
 <use name="root"/>

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -26,7 +26,6 @@ class TrajectoryFilter;
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 
 #include <map>
-#include <boost/unordered_map.hpp>
 
 class TransientTrackingRecHitBuilder;
 class TrajectoryFilter;

--- a/RecoTracker/CkfPattern/src/IntermediateTrajectoryCleaner.cc
+++ b/RecoTracker/CkfPattern/src/IntermediateTrajectoryCleaner.cc
@@ -1,5 +1,4 @@
 #include "RecoTracker/CkfPattern/interface/IntermediateTrajectoryCleaner.h"
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 


### PR DESCRIPTION
#### PR description:
Clean up unused boost dependencies.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 