### PR TITLE
drop type specs in RecoTracker/{DeDx,FinalTrackSelectors} 

### DIFF
--- a/RecoTracker/DeDx/python/dedxEstimatorsFromRefitter_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimatorsFromRefitter_cff.py
@@ -2,8 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TrackProducer.TrackRefitter_cfi import *
 
-RefitterForDeDx = TrackRefitter.clone()
-RefitterForDeDx.TrajectoryInEvent = True
+RefitterForDeDx = TrackRefitter.clone(
+    TrajectoryInEvent = True
+)
 
 from RecoTracker.DeDx.dedxEstimators_cff import *
 

--- a/RecoTracker/DeDx/python/dedxEstimators_Cosmics_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_Cosmics_cff.py
@@ -3,43 +3,31 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.DeDx.dedxEstimators_cff import *
 
-dedxHitInfoCTF                                     = dedxHitInfo.clone()
-dedxHitInfoCTF.tracks                              = cms.InputTag("ctfWithMaterialTracksP5")
+dedxHitInfoCTF     = dedxHitInfo.clone( tracks = "ctfWithMaterialTracksP5")
 
-dedxTruncated40CTF                                 = dedxTruncated40.clone()
-dedxTruncated40CTF.tracks                          = cms.InputTag("ctfWithMaterialTracksP5")
+dedxTruncated40CTF = dedxTruncated40.clone( tracks = "ctfWithMaterialTracksP5")
 
-dedxHarmonic2CTF                                   = dedxHarmonic2.clone()
-dedxHarmonic2CTF.tracks                            = cms.InputTag("ctfWithMaterialTracksP5")
+dedxHarmonic2CTF   = dedxHarmonic2.clone( tracks = "ctfWithMaterialTracksP5")
 
-dedxDiscrimASmiCTF                                      = dedxDiscrimASmi.clone()
-dedxDiscrimASmiCTF.tracks                               = cms.InputTag("ctfWithMaterialTracksP5")
+dedxDiscrimASmiCTF = dedxDiscrimASmi.clone( tracks = "ctfWithMaterialTracksP5")
 
 #TF
-dedxHitInfoCosmicTF                                = dedxHitInfo.clone()
-dedxHitInfoCosmicTF.tracks                         = cms.InputTag("cosmictrackfinderP5")
+dedxHitInfoCosmicTF     = dedxHitInfo.clone( tracks = "cosmictrackfinderP5")
 
-dedxTruncated40CosmicTF                            = dedxTruncated40.clone()
-dedxTruncated40CosmicTF.tracks                     = cms.InputTag("cosmictrackfinderP5")
+dedxTruncated40CosmicTF = dedxTruncated40.clone( tracks = "cosmictrackfinderP5")
 
-dedxHarmonic2CosmicTF                              = dedxHarmonic2.clone()
-dedxHarmonic2CosmicTF.tracks                       = cms.InputTag("cosmictrackfinderP5")
+dedxHarmonic2CosmicTF   = dedxHarmonic2.clone( tracks = "cosmictrackfinderP5")
 
-dedxDiscrimASmiCosmicTF                                 = dedxDiscrimASmi.clone()
-dedxDiscrimASmiCosmicTF.tracks                          = cms.InputTag("cosmictrackfinderP5")
+dedxDiscrimASmiCosmicTF = dedxDiscrimASmi.clone( tracks = "cosmictrackfinderP5")
 
 #CTF P5 LHC
-dedxHitInfoCTFP5LHC                                = dedxHitInfo.clone()
-dedxHitInfoCTFP5LHC.tracks                         = cms.InputTag("ctfWithMaterialTracksP5LHCNavigation")
+dedxHitInfoCTFP5LHC     = dedxHitInfo.clone( tracks = "ctfWithMaterialTracksP5LHCNavigation")
 
-dedxTruncated40CTFP5LHC                            = dedxTruncated40.clone()
-dedxTruncated40CTFP5LHC.tracks                     = cms.InputTag("ctfWithMaterialTracksP5LHCNavigation")
+dedxTruncated40CTFP5LHC = dedxTruncated40.clone( tracks = "ctfWithMaterialTracksP5LHCNavigation")
 
-dedxDiscrimASmiCTFP5LHC                                 = dedxDiscrimASmi.clone()
-dedxDiscrimASmiCTFP5LHC.tracks                          = cms.InputTag("ctfWithMaterialTracksP5LHCNavigation")
+dedxDiscrimASmiCTFP5LHC = dedxDiscrimASmi.clone( tracks = "ctfWithMaterialTracksP5LHCNavigation")
 
-dedxHarmonic2CTFP5LHC                              = dedxHarmonic2.clone()
-dedxHarmonic2CTFP5LHC.tracks                       = cms.InputTag("ctfWithMaterialTracksP5LHCNavigation")
+dedxHarmonic2CTFP5LHC   = dedxHarmonic2.clone( tracks = "ctfWithMaterialTracksP5LHCNavigation")
 
 doAlldEdXEstimatorsCTFTask      = cms.Task(dedxTruncated40CTF      , dedxHitInfoCTF      , dedxHarmonic2CTF)
 doAlldEdXEstimatorsCTF      = cms.Sequence(doAlldEdXEstimatorsCTFTask)

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -55,8 +55,8 @@ import FastSimulation.SimplifiedGeometryPropagator.FastTrackDeDxProducer_cfi
 fastSim.toReplaceWith(dedxHarmonic2,
     FastSimulation.SimplifiedGeometryPropagator.FastTrackDeDxProducer_cfi.FastTrackDeDxProducer.clone(
         ShapeTest = False,
-        simHit2RecHitMap = cms.InputTag("fastMatchedTrackerRecHits","simHit2RecHitMap"),
-        simHits = cms.InputTag("fastSimProducer","TrackerHits"),
+        simHit2RecHitMap = "fastMatchedTrackerRecHits:simHit2RecHitMap",
+        simHits = "fastSimProducer:TrackerHits",
     )
 )
 
@@ -69,26 +69,19 @@ dedxPixelAndStripHarmonic2T085 = dedxHarmonic2.clone(
         exponent  = -2.0, # Harmonic02
 )
 
-dedxTruncated40 = dedxHarmonic2.clone()
-dedxTruncated40.estimator =  cms.string('truncated')
+dedxTruncated40 = dedxHarmonic2.clone(estimator = 'truncated')
 
-dedxMedian  = dedxHarmonic2.clone()
-dedxMedian.estimator =  cms.string('median')
+dedxMedian = dedxHarmonic2.clone(estimator = 'median')
 
-dedxUnbinned = dedxHarmonic2.clone()
-dedxUnbinned.estimator =  cms.string('unbinnedFit')
+dedxUnbinned = dedxHarmonic2.clone(estimator = 'unbinnedFit')
 
-dedxDiscrimProd =  dedxHarmonic2.clone()
-dedxDiscrimProd.estimator = cms.string('productDiscrim')
+dedxDiscrimProd =  dedxHarmonic2.clone(estimator = 'productDiscrim')
 
-dedxDiscrimBTag         = dedxHarmonic2.clone()
-dedxDiscrimBTag.estimator = cms.string('btagDiscrim')
+dedxDiscrimBTag = dedxHarmonic2.clone(estimator = 'btagDiscrim')
 
-dedxDiscrimSmi         = dedxHarmonic2.clone()
-dedxDiscrimSmi.estimator = cms.string('smirnovDiscrim')
+dedxDiscrimSmi  = dedxHarmonic2.clone(estimator = 'smirnovDiscrim')
 
-dedxDiscrimASmi         = dedxHarmonic2.clone()
-dedxDiscrimASmi.estimator = cms.string('asmirnovDiscrim')
+dedxDiscrimASmi = dedxHarmonic2.clone(estimator = 'asmirnovDiscrim')
 
 doAlldEdXEstimatorsTask = cms.Task(dedxTruncated40 , dedxHarmonic2 , dedxPixelHarmonic2 , dedxPixelAndStripHarmonic2T085 , dedxHitInfo)
 doAlldEdXEstimators = cms.Sequence(doAlldEdXEstimatorsTask)

--- a/RecoTracker/DeDx/python/hltDeDxEstimatorProducer_cfi.py
+++ b/RecoTracker/DeDx/python/hltDeDxEstimatorProducer_cfi.py
@@ -3,5 +3,4 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.DeDx.dedxEstimators_cff import *
 
-DeDxEstimatorProducer = dedxHarmonic2.clone()
-DeDxEstimatorProducer.tracks=cms.InputTag("hltIter4Merged")
+DeDxEstimatorProducer = dedxHarmonic2.clone(tracks = "hltIter4Merged")

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -10,35 +10,39 @@ duplicateTrackCandidatesChi2Est = _Chi2MeasurementEstimator.clone(
     MaxChi2 = 100,
 )
 
-duplicateTrackCandidates = DuplicateTrackMerger.clone()
-duplicateTrackCandidates.source = cms.InputTag("preDuplicateMergingGeneralTracks")
-duplicateTrackCandidates.useInnermostState  = True
-duplicateTrackCandidates.ttrhBuilderName   = "WithAngleAndTemplate"
-duplicateTrackCandidates.chi2EstimatorName = "duplicateTrackCandidatesChi2Est"
-                                     
+duplicateTrackCandidates = DuplicateTrackMerger.clone(
+    source = "preDuplicateMergingGeneralTracks",
+    useInnermostState  = True,
+    ttrhBuilderName   = "WithAngleAndTemplate",
+    chi2EstimatorName = "duplicateTrackCandidatesChi2Est"
+)
+
 import RecoTracker.TrackProducer.TrackProducer_cfi
-mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone()
-mergedDuplicateTracks.src = cms.InputTag("duplicateTrackCandidates","candidates")
-mergedDuplicateTracks.Fitter='RKFittingSmoother' # no outlier rejection!
+mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = "duplicateTrackCandidates:candidates",
+    Fitter='RKFittingSmoother' # no outlier rejection!
+)
 
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
-duplicateTrackClassifier = TrackCutClassifier.clone()
-duplicateTrackClassifier.src='mergedDuplicateTracks'
-duplicateTrackClassifier.mva.minPixelHits = [0,0,0]
-duplicateTrackClassifier.mva.maxChi2 = [9999.,9999.,9999.]
-duplicateTrackClassifier.mva.maxChi2n = [10.,1.0,0.4]  # [9999.,9999.,9999.]
-duplicateTrackClassifier.mva.minLayers = [0,0,0]
-duplicateTrackClassifier.mva.min3DLayers = [0,0,0]
-duplicateTrackClassifier.mva.maxLostLayers = [99,99,99]
+duplicateTrackClassifier = TrackCutClassifier.clone(
+    src='mergedDuplicateTracks',
+    mva = dict(
+	minPixelHits = [0,0,0],
+	maxChi2 = [9999.,9999.,9999.],
+	maxChi2n = [10.,1.0,0.4],  # [9999.,9999.,9999.]
+	minLayers = [0,0,0],
+	min3DLayers = [0,0,0],
+	maxLostLayers = [99,99,99])
+)
 
-generalTracks = DuplicateListMerger.clone()
-generalTracks.originalSource = cms.InputTag("preDuplicateMergingGeneralTracks")
-generalTracks.originalMVAVals = cms.InputTag("preDuplicateMergingGeneralTracks","MVAValues")
-generalTracks.mergedSource = cms.InputTag("mergedDuplicateTracks")
-generalTracks.mergedMVAVals = cms.InputTag("duplicateTrackClassifier","MVAValues")
-generalTracks.candidateSource = cms.InputTag("duplicateTrackCandidates","candidates")
-generalTracks.candidateComponents = cms.InputTag("duplicateTrackCandidates","candidateMap")
-
+generalTracks = DuplicateListMerger.clone(
+    originalSource      = "preDuplicateMergingGeneralTracks",
+    originalMVAVals     = "preDuplicateMergingGeneralTracks:MVAValues",
+    mergedSource        = "mergedDuplicateTracks",
+    mergedMVAVals       = "duplicateTrackClassifier:MVAValues",
+    candidateSource     = "duplicateTrackCandidates:candidates",
+    candidateComponents = "duplicateTrackCandidates:candidateMap"
+)
 
 generalTracksTask = cms.Task(
     duplicateTrackCandidates,
@@ -50,12 +54,11 @@ generalTracksSequence = cms.Sequence(generalTracksTask)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(generalTracksTask, 
-                      cms.Task(
-        duplicateTrackCandidates,
-        mergedDuplicateTracks,
-        duplicateTrackClassifier
-        )
+                      cms.Task(duplicateTrackCandidates,
+                               mergedDuplicateTracks,
+                               duplicateTrackClassifier)
 )
+
 def _fastSimGeneralTracks(process):
     from FastSimulation.Configuration.DigiAliases_cff import loadGeneralTracksAlias
     loadGeneralTracksAlias(process)
@@ -63,12 +66,11 @@ modifyMergeTrackCollections_fastSimGeneralTracks = fastSim.makeProcessModifier( 
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 conversionStepTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-    TrackProducers = cms.VInputTag(cms.InputTag('convStepTracks')),
-    hasSelector=cms.vint32(1),
-    selectedTrackQuals = cms.VInputTag(cms.InputTag("convStepSelector","convStep")
-                                       ),
+    TrackProducers     = ['convStepTracks'],
+    hasSelector        = [1],
+    selectedTrackQuals = ['convStepSelector:convStep'],
     setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(1), pQual=cms.bool(True) )
                              ),
     copyExtras = True,
-    makeReKeyedSeeds = cms.untracked.bool(False)
-    )
+    makeReKeyedSeeds = cms.untracked.bool(False),
+)

--- a/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
@@ -2,45 +2,42 @@ from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 
+testTrackClassifier1 = TrackMVAClassifierPrompt.clone(
+    src = 'initialStepTracks',
+    mva = dict(GBRForestLabel = 'MVASelectorIter0_13TeV'),
+    qualityCuts = [-0.9,-0.8,-0.7]
+)
 
-
-testTrackClassifier1 = TrackMVAClassifierPrompt.clone()
-testTrackClassifier1.src = 'initialStepTracks'
-testTrackClassifier1.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
-testTrackClassifier1.qualityCuts = [-0.9,-0.8,-0.7]
-
-
-testTrackClassifier2 = TrackCutClassifier.clone()
-testTrackClassifier2.src = 'initialStepTracks'
-testTrackClassifier2.mva.minPixelHits = [0,1,1]
-
+testTrackClassifier2 = TrackCutClassifier.clone(
+    src = 'initialStepTracks',
+    mva = dict(minPixelHits = [0,1,1])
+)
     
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
-testMergedClassifier = ClassifierMerger.clone()
-testMergedClassifier.inputClassifiers=['testTrackClassifier1','testTrackClassifier2']
+testMergedClassifier = ClassifierMerger.clone(
+    inputClassifiers=['testTrackClassifier1','testTrackClassifier2']
+)
 
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
-testTrackMerger = TrackCollectionMerger.clone()
-testTrackMerger.trackProducers = ['initialStepTracks']
-testTrackMerger.inputClassifiers =['testMergedClassifier']
-testTrackMerger.minQuality = 'tight'
+testTrackMerger = TrackCollectionMerger.clone(
+    trackProducers = ['initialStepTracks'],
+    inputClassifiers =['testMergedClassifier'],
+    minQuality = 'tight'
+)
 
-testTrackClassifier3 = TrackMVAClassifierDetached.clone()
-testTrackClassifier3.src = 'detachedTripletStepTracks'
-testTrackClassifier3.mva.GBRForestLabel = 'MVASelectorIter3_13TeV'
-testTrackClassifier3.qualityCuts = [-0.5,0.0,0.5]
-
+testTrackClassifier3 = TrackMVAClassifierDetached.clone(
+    src = 'detachedTripletStepTracks',
+    mva = dict(GBRForestLabel = 'MVASelectorIter3_13TeV'),
+    qualityCuts = [-0.5,0.0,0.5]
+)
 
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
-testTrackMerger2 = TrackCollectionMerger.clone()
-testTrackMerger2.trackProducers = ['initialStepTracks','detachedTripletStepTracks']
-testTrackMerger2.inputClassifiers =['testMergedClassifier','testTrackClassifier3']
-testTrackMerger2.minQuality = 'tight'
-
-
-
-
+testTrackMerger2 = TrackCollectionMerger.clone(
+    trackProducers = ['initialStepTracks','detachedTripletStepTracks'],
+    inputClassifiers =['testMergedClassifier','testTrackClassifier3'],
+    minQuality = 'tight'
+)
 
 testTrackCloning = cms.Sequence(testTrackClassifier1*testTrackClassifier2*testTrackClassifier3*
                                 testMergedClassifier*testTrackMerger*testTrackMerger2)

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -3,25 +3,26 @@ from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
-earlyGeneralTracks =  TrackCollectionMerger.clone()
-earlyGeneralTracks.trackProducers = ['initialStepTracks',
-                                     'jetCoreRegionalStepTracks',
-                                     'lowPtTripletStepTracks',
-                                     'pixelPairStepTracks',
-                                     'detachedTripletStepTracks',
-                                     'mixedTripletStepTracks',
-                                     'pixelLessStepTracks',
-                                     'tobTecStepTracks'
-                                     ]
-earlyGeneralTracks.inputClassifiers =["initialStep",
-                                      "jetCoreRegionalStep",
-                                      "lowPtTripletStep",
-                                      "pixelPairStep",
-                                      "detachedTripletStep",
-                                      "mixedTripletStep",
-                                      "pixelLessStep",
-                                      "tobTecStep"
-                                      ]
+earlyGeneralTracks =  TrackCollectionMerger.clone(
+    trackProducers = ['initialStepTracks',
+                      'jetCoreRegionalStepTracks',
+                      'lowPtTripletStepTracks',
+                      'pixelPairStepTracks',
+                      'detachedTripletStepTracks',
+                      'mixedTripletStepTracks',
+                      'pixelLessStepTracks',
+                      'tobTecStepTracks'
+                      ],
+    inputClassifiers =['initialStep',
+                       'jetCoreRegionalStep',
+                       'lowPtTripletStep',
+                       'pixelPairStep',
+                       'detachedTripletStep',
+                       'mixedTripletStep',
+                       'pixelLessStep',
+                       'tobTecStep'
+                       ]
+)
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toModify(earlyGeneralTracks,
     trackProducers = [
@@ -34,13 +35,13 @@ trackingLowPU.toModify(earlyGeneralTracks,
         'tobTecStepTracks'
     ],
     inputClassifiers = [
-        "initialStepSelector",
-        "lowPtTripletStepSelector",
-        "pixelPairStepSelector",
-        "detachedTripletStep",
-        "mixedTripletStep",
-        "pixelLessStepSelector",
-        "tobTecStep"
+        'initialStepSelector',
+        'lowPtTripletStepSelector',
+        'pixelPairStepSelector',
+        'detachedTripletStep',
+        'mixedTripletStep',
+        'pixelLessStepSelector',
+        'tobTecStep'
     ]
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
@@ -59,17 +60,17 @@ _forPhase1 = dict(
         'tobTecStepTracks'
     ],
     inputClassifiers = [
-        "initialStep",
-        "highPtTripletStep",
-        "jetCoreRegionalStep",
-        "lowPtQuadStep",
-        "lowPtTripletStep",
-        "detachedQuadStep",
-        "detachedTripletStep",
-        "pixelPairStep",
-        "mixedTripletStep",
-        "pixelLessStep",
-        "tobTecStep"
+        'initialStep',
+        'highPtTripletStep',
+        'jetCoreRegionalStep',
+        'lowPtQuadStep',
+        'lowPtTripletStep',
+        'detachedQuadStep',
+        'detachedTripletStep',
+        'pixelPairStep',
+        'mixedTripletStep',
+        'pixelLessStep',
+        'tobTecStep'
     ],
 )
 trackingPhase1.toModify(earlyGeneralTracks, **_forPhase1)
@@ -87,15 +88,15 @@ trackingPhase2PU140.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
                     ],
     hasSelector = [1,1,1,1,1,1],
     indivShareFrac = [1.0,0.16,0.095,0.09,0.09,0.09],
-    selectedTrackQuals = cms.VInputTag(cms.InputTag("initialStepSelector","initialStep"),
-                                       cms.InputTag("highPtTripletStepSelector","highPtTripletStep"),
-                                       cms.InputTag("lowPtQuadStepSelector","lowPtQuadStep"),
-                                       cms.InputTag("lowPtTripletStepSelector","lowPtTripletStep"),
-                                       cms.InputTag("detachedQuadStep"),
-                                       cms.InputTag("pixelPairStepSelector","pixelPairStep"),
-                                       ),
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5), pQual=cms.bool(True) )
-                             ),
+    selectedTrackQuals = ['initialStepSelector:initialStep',
+                          'highPtTripletStepSelector:highPtTripletStep',
+                          'lowPtQuadStepSelector:lowPtQuadStep',
+                          'lowPtTripletStepSelector:lowPtTripletStep',
+                          'detachedQuadStep',
+                          'pixelPairStepSelector:pixelPairStep',
+                          ],
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5), pQual=cms.bool(True) ) 
+	),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
     )

--- a/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
@@ -56,25 +56,25 @@ looseMTS = cms.PSet(
 tightMTS=looseMTS.clone(
     preFilterName='TrkLoose',
 #   second param is actually an int
-    d0_par1 = cms.vdouble(0.3, 4.0),
-    dz_par1 = cms.vdouble(0.35,4.0),
-    d0_par2 = cms.vdouble(0.4, 4.0),
-    dz_par2 = cms.vdouble(0.4, 4.0),
-    chi2n_par = cms.double(0.7),
-    chi2n_no1Dmod_par = cms.double(9999),
-    name= cms.string('TrkTight'),
-    minNumberLayers = cms.uint32(3),
-    minNumber3DLayers = cms.uint32(3),
-    maxNumberLostLayers = cms.uint32(2),
-    qualityBit = cms.string('tight'), ## set to '' or comment out if you dont want to set the bit
-    keepAllTracks= cms.bool(True)
-    )
+    d0_par1 = [0.3, 4.0],
+    dz_par1 = [0.35,4.0],
+    d0_par2 = [0.4, 4.0],
+    dz_par2 = [0.4, 4.0],
+    chi2n_par = 0.7,
+    chi2n_no1Dmod_par = 9999,
+    name = 'TrkTight',
+    minNumberLayers = 3,
+    minNumber3DLayers = 3,
+    maxNumberLostLayers = 2,
+    qualityBit = 'tight', ## set to '' or comment out if you dont want to set the bit
+    keepAllTracks= True
+)
 
 highpurityMTS= tightMTS.clone(
-    name= cms.string('TrkHighPurity'),                           
-    preFilterName='TrkTight',
-    res_par=cms.vdouble(0.003,0.001),
-    qualityBit = cms.string('highPurity') ## set to '' or comment out if you dont want to set the bit
+    name = 'TrkHighPurity',                           
+    preFilterName = 'TrkTight',
+    res_par = [0.003,0.001],
+    qualityBit = 'highPurity' ## set to '' or comment out if you dont want to set the bit
 )
 
 #typical configuration is six selectors... something like this to

--- a/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
@@ -2,48 +2,42 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
-preDuplicateMergingGeneralTracks = TrackCollectionMerger.clone()
-preDuplicateMergingGeneralTracks.trackProducers = [
-    "earlyGeneralTracks", 
-    "muonSeededTracksInOut",
-    "muonSeededTracksOutIn",
-    ]
-preDuplicateMergingGeneralTracks.inputClassifiers =[
-   "earlyGeneralTracks", 
-   "muonSeededTracksInOutClassifier",
-   "muonSeededTracksOutInClassifier"
-   ]
-
-preDuplicateMergingGeneralTracks.foundHitBonus  = 100.0
-preDuplicateMergingGeneralTracks.lostHitPenalty =   1.0
-
+preDuplicateMergingGeneralTracks = TrackCollectionMerger.clone(
+    trackProducers   = ["earlyGeneralTracks", 
+                        "muonSeededTracksInOut",
+                        "muonSeededTracksOutIn"],
+    inputClassifiers = ["earlyGeneralTracks", 
+                       "muonSeededTracksInOutClassifier",
+                       "muonSeededTracksOutInClassifier"],
+    foundHitBonus    = 100.0,
+    lostHitPenalty   = 1.0
+)
 
 # For Phase2PU140
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger as _trackListMerger
 trackingPhase2PU140.toReplaceWith(preDuplicateMergingGeneralTracks, _trackListMerger.clone(
-    TrackProducers = cms.VInputTag(
-        cms.InputTag("earlyGeneralTracks"),
-        cms.InputTag("muonSeededTracksInOut"),
-        cms.InputTag("muonSeededTracksOutIn"),
-    ),
-    hasSelector = cms.vint32(0,1,1),
-    selectedTrackQuals = cms.VInputTag(
-        cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity"), # not used but needed
-        cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity"),
-        cms.InputTag("muonSeededTracksOutInSelector","muonSeededTracksOutInHighPurity"),
-    ),
+    TrackProducers     = ["earlyGeneralTracks", 
+                          "muonSeededTracksInOut", 
+                          "muonSeededTracksOutIn"],
+    hasSelector        = [0,1,1],
+    selectedTrackQuals = ["muonSeededTracksInOutSelector:muonSeededTracksInOutHighPurity", # not used but needed
+                          "muonSeededTracksInOutSelector:muonSeededTracksInOutHighPurity",
+                          "muonSeededTracksOutInSelector:muonSeededTracksOutInHighPurity"],
+#    mvaValueTags       = ["earlyGeneralTracks:MVAVals",
+#                          "muonSeededTracksInOutSelector:MVAVals",
+#                          "muonSeededTracksOutInSelector:MVAVals"],
     mvaValueTags = cms.VInputTag(
         cms.InputTag("earlyGeneralTracks","MVAVals"),
         cms.InputTag("muonSeededTracksInOutSelector","MVAVals"),
         cms.InputTag("muonSeededTracksOutInSelector","MVAVals"),
     ),
+    #setsToMerge      = dict(pQual = False, tLists = [0, 1, 2]),
     setsToMerge = cms.VPSet(cms.PSet(pQual = cms.bool(False), tLists = cms.vint32(0, 1, 2))),
-    FoundHitBonus  = 100.0,
-    LostHitPenalty =   1.0,
-    indivShareFrac = cms.vdouble(1.0, 0.16, 0.095, 0.09, 0.095,0.095, 0.095, 0.08),
-    copyExtras = True,
+    FoundHitBonus    = 100.0,
+    LostHitPenalty   = 1.0,
+    indivShareFrac   = [1.0, 0.16, 0.095, 0.09, 0.095,0.095, 0.095, 0.08],
+    copyExtras       = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
     )
 )
-


### PR DESCRIPTION
#### PR description: Update the safer syntax for existing parameter
Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#29979](https://github.com/cms-sw/cmssw/pull/29979), [PR#30147](https://github.com/cms-sw/cmssw/pull/30147), [PR#30270](https://github.com/cms-sw/cmssw/pull/30270) , [PR#30271](https://github.com/cms-sw/cmssw/pull/30271), [PR#30353](https://github.com/cms-sw/cmssw/pull/30353))

In this PR, 9 files updated. 
- RecoTracker/{DeDx} 4 files 
- RecoTracker/{FinalTrackSelectors} 5 files


#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).