### PR TITLE
ETLDetId modified for future v5 ETL geometry

### DIFF
--- a/DataFormats/ForwardDetId/interface/ETLDetId.h
+++ b/DataFormats/ForwardDetId/interface/ETLDetId.h
@@ -14,10 +14,10 @@
 
 class ETLDetId : public MTDDetId {
 public:
-  static const uint32_t kETLmoduleOffset = 7;
-  static const uint32_t kETLmoduleMask = 0x1FF;
-  static const uint32_t kETLmodTypeOffset = 5;
-  static const uint32_t kETLmodTypeMask = 0x3;
+  static const uint32_t kETLmoduleOffset = 5;    //7
+  static const uint32_t kETLmoduleMask = 0x7FF;  //0x1FF
+  static const uint32_t kETLmodTypeOffset = 3;   //5
+  static const uint32_t kETLmodTypeMask = 0x3;   //0x3
 
   static constexpr int kETLv1maxRing = 11;
   static constexpr int kETLv1maxModule = 176;
@@ -31,8 +31,14 @@ public:
   static const uint32_t kETLsectorMask = 0x3;
 
   static constexpr int kETLv4maxRing = 16;
-  static constexpr int kETLv4maxModule = 248;
+  static constexpr int kETLv4maxSector = 4;
+  static constexpr int kETLv4maxModule = 517;  //248
   static constexpr int kETLv4nDisc = 2;
+
+  static constexpr int kETLv5maxRing = 14;
+  static constexpr int kETLv5maxSector = 2;
+  static constexpr int kETLv5maxModule = 517;
+  static constexpr int kETLv5nDisc = kETLv4nDisc;
 
   static constexpr uint32_t kSoff = 4;
 
@@ -95,6 +101,8 @@ public:
   inline int nDisc() const {
     return (((((id_ >> kRodRingOffset) & kRodRingMask) - 1) >> kETLnDiscOffset) & kETLnDiscMask) + 1;
   }
+
+  uint32_t newForm(const uint32_t& rawid);
 };
 
 std::ostream& operator<<(std::ostream&, const ETLDetId&);

--- a/DataFormats/ForwardDetId/src/ETLDetId.cc
+++ b/DataFormats/ForwardDetId/src/ETLDetId.cc
@@ -11,3 +11,13 @@ std::ostream& operator<<(std::ostream& os, const ETLDetId& id) {
      << " Module type : " << id.modType() << std::endl;
   return os;
 }
+
+uint32_t ETLDetId::newForm(const uint32_t& rawid) {
+  uint32_t rawid_new = 0;
+  rawid_new |= (MTDType::ETL & ETLDetId::kMTDsubdMask) << ETLDetId::kMTDsubdOffset |
+               (mtdSide() & ETLDetId::kZsideMask) << ETLDetId::kZsideOffset |
+               (mtdRR() & ETLDetId::kRodRingMask) << ETLDetId::kRodRingOffset |
+               (module() & ETLDetId::kETLmoduleMask) << (ETLDetId::kETLmoduleOffset - 2) |
+               (modType() & ETLDetId::kETLmodTypeMask) << (kETLmodTypeOffset - 2);
+  return rawid_new;
+}

--- a/DataFormats/ForwardDetId/src/classes_def.xml
+++ b/DataFormats/ForwardDetId/src/classes_def.xml
@@ -30,8 +30,15 @@
   <class name="BTLDetId" ClassVersion="3">
    <version ClassVersion="3" checksum="1515591716"/>
   </class>
-  <class name="ETLDetId" ClassVersion="3">
+  <class name="ETLDetId" ClassVersion="4">
+   <version ClassVersion="4" checksum="1644731879"/>
    <version ClassVersion="3" checksum="1644731879"/>
+   <ioread sourceClass = "ETLDetId" version="[-3]" targetClass="ETLDetId" source="" target="">
+    <![CDATA[
+       ETLDetId tmp(newObj->newForm(newObj->rawId()));
+        *newObj=tmp;
+    ]]>
+   </ioread>
   </class>
   <class name="HFNoseDetId" ClassVersion="0">
    <version ClassVersion="0" checksum="1469396081"/>


### PR DESCRIPTION
#### PR description:

The future ETL v5 (to be implemented in a following PR) introduces D-shaped sectors, instead of the quarters used in ETL v4. The new, D-shaped sectors comprise more than 512 modules, which is the maximum number of modules that can be accommodated using the bits presently allocated in ETLDetId. ETLDetId.h has been modified to fix this issue, by adding 2 bits. The new ETLDetId is backward compatible with the older versions, thanks to a dedicated compatibility code implemented in ETLDetId.cc.

Both ETL versions and the backward compatibility issue were presented at the last MTD DPG meeting (https://indico.cern.ch/event/919571/contributions/3864046/attachments/2039610/3415525/MTD_DPG_20200515.pdf )

#### PR validation:

- The dump geometries for scenario D50 using the old ETLDetId format and the new one described above have been compared: the logical volumes paths are the same, while the rawID differ only for the positions of the 2 bits related to the sensor modules, as expected.
- relVal 23234.0 has been run too
