### PR TITLE
Add safety check to spot negative jet energy correction factors [11_1_X backport]

### DIFF
--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -61,6 +61,11 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX, const std::ve
     }
     result = tmp / mParameters.definitions().nBinVar();
   }
+  if (result <= 0) {
+    edm::LogWarning("SimpleJetCorrector")
+        << "Null or negative jet energy correction factor evaluated: " << result << ". Truncating to 10e-10.";
+    result = 10e-10;
+  }
   return result;
 }
 //------------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

Add a safety check when evaluating jet energy correction factors to spot cases where the functions yield unphysical negative corrections.
A warning is printed and the value is truncated to be small positive.
This should help spotting cases when calibration functions in the conditions are not fully positive defined (as they should).

#### PR validation:

runTheMatrix -l limited

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #29994.