### PR TITLE
Reduce boost dependency in EventFilter/Utilities

### DIFF
--- a/EventFilter/Utilities/interface/MicroStateServiceClassic.h
+++ b/EventFilter/Utilities/interface/MicroStateServiceClassic.h
@@ -10,8 +10,7 @@
 
 #include "EventFilter/Utilities/interface/MicroStateService.h"
 
-#include "boost/thread/thread.hpp"
-
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -48,7 +47,7 @@ namespace evf {
     const std::string input;
     const std::string fwkovh;
     const std::string *microstate2_;
-    boost::mutex lock_;
+    std::mutex lock_;
   };
 
 }  // namespace evf

--- a/EventFilter/Utilities/src/MicroStateServiceClassic.cc
+++ b/EventFilter/Utilities/src/MicroStateServiceClassic.cc
@@ -21,58 +21,58 @@ namespace evf {
   MicroStateServiceClassic::~MicroStateServiceClassic() {}
 
   void MicroStateServiceClassic::postBeginJob() {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate1_ = "BJD";
   }
 
   void MicroStateServiceClassic::postEndJob() {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate1_ = "EJ";
     microstate2_ = &done;
   }
 
   void MicroStateServiceClassic::preEventProcessing(const edm::EventID& iID, const edm::Timestamp& iTime) {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate1_ = "PRO";
   }
 
   void MicroStateServiceClassic::postEventProcessing(const edm::Event& e, const edm::EventSetup&) {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate2_ = &input;
   }
 
   void MicroStateServiceClassic::preSourceEvent(edm::StreamID) {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate2_ = &input;
   }
 
   void MicroStateServiceClassic::postSourceEvent(edm::StreamID) {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate2_ = &fwkovh;
   }
 
   void MicroStateServiceClassic::preModule(const edm::ModuleDescription& desc) {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate2_ = &(desc.moduleLabel());
   }
 
   void MicroStateServiceClassic::postModule(const edm::ModuleDescription& desc) {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate2_ = &fwkovh;
   }
 
   std::string MicroStateServiceClassic::getMicroState1() {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     return microstate1_;
   }
 
   std::string const& MicroStateServiceClassic::getMicroState2() {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     return *microstate2_;
   }
 
   void MicroStateServiceClassic::setMicroState(MicroStateService::Microstate m) {
-    boost::mutex::scoped_lock sl(lock_);
+    std::scoped_lock sl(lock_);
     microstate2_ = &(reservedMicroStateNames[m].moduleLabel());
   }
 


### PR DESCRIPTION
#### PR description:
Replaced boost mutex for std mutex.
The code should have the same behaviour and also similar performance. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 