### PR TITLE
Remove boost mutex in GeneratorInterface

### DIFF
--- a/GeneratorInterface/Herwig7Interface/src/Proxy.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Proxy.cc
@@ -1,12 +1,11 @@
 #include <map>
-
-#include <boost/thread.hpp>
+#include <mutex>
 
 #include "GeneratorInterface/Herwig7Interface/interface/Proxy.h"
 
 using namespace ThePEG;
 
-static boost::mutex mutex;
+static std::mutex mutex;
 
 typedef std::map<ProxyBase::ProxyID, std::weak_ptr<ProxyBase> > ProxyMap;
 
@@ -27,7 +26,7 @@ static ProxyMap *getProxyMapInstance() {
 ProxyBase::ProxyBase(ProxyID id) : id(id) {}
 
 ProxyBase::~ProxyBase() {
-  boost::mutex::scoped_lock scoped_lock(mutex);
+  std::scoped_lock scoped_lock(mutex);
 
   ProxyMap *map = getProxyMapInstance();
   if (map)
@@ -37,7 +36,7 @@ ProxyBase::~ProxyBase() {
 std::shared_ptr<ProxyBase> ProxyBase::create(ctor_t ctor) {
   static ProxyBase::ProxyID nextProxyID = 0;
 
-  boost::mutex::scoped_lock scoped_lock(mutex);
+  std::scoped_lock scoped_lock(mutex);
 
   std::shared_ptr<ProxyBase> proxy(ctor(++nextProxyID));
 
@@ -49,7 +48,7 @@ std::shared_ptr<ProxyBase> ProxyBase::create(ctor_t ctor) {
 }
 
 std::shared_ptr<ProxyBase> ProxyBase::find(ProxyID id) {
-  boost::mutex::scoped_lock scoped_lock(mutex);
+  std::scoped_lock scoped_lock(mutex);
 
   ProxyMap *map = getProxyMapInstance();
   if (!map)

--- a/GeneratorInterface/LHEInterface/src/LHEProxy.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEProxy.cc
@@ -1,12 +1,11 @@
 #include <map>
-
-#include <boost/thread.hpp>
+#include <mutex>
 
 #include "GeneratorInterface/LHEInterface/interface/LHEProxy.h"
 
 using namespace lhef;
 
-static boost::mutex mutex;
+static std::mutex mutex;
 
 typedef std::map<LHEProxy::ProxyID, std::weak_ptr<LHEProxy> > ProxyMap;
 
@@ -27,7 +26,7 @@ static ProxyMap *getProxyMapInstance() {
 LHEProxy::LHEProxy(ProxyID id) : id(id) {}
 
 LHEProxy::~LHEProxy() {
-  boost::mutex::scoped_lock scoped_lock(mutex);
+  std::scoped_lock scoped_lock(mutex);
 
   ProxyMap *map = getProxyMapInstance();
   if (map)
@@ -37,7 +36,7 @@ LHEProxy::~LHEProxy() {
 std::shared_ptr<LHEProxy> LHEProxy::create() {
   static LHEProxy::ProxyID nextProxyID = 0;
 
-  boost::mutex::scoped_lock scoped_lock(mutex);
+  std::scoped_lock scoped_lock(mutex);
 
   std::shared_ptr<LHEProxy> proxy(new LHEProxy(++nextProxyID));
 
@@ -49,7 +48,7 @@ std::shared_ptr<LHEProxy> LHEProxy::create() {
 }
 
 std::shared_ptr<LHEProxy> LHEProxy::find(ProxyID id) {
-  boost::mutex::scoped_lock scoped_lock(mutex);
+  std::scoped_lock scoped_lock(mutex);
 
   ProxyMap *map = getProxyMapInstance();
   if (!map)


### PR DESCRIPTION
#### PR description:
Replaced boost mutex for std mutex.
The code should have the same behaviour and also similar performance. 

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 