### PR TITLE
Reduce boost dependency in FWCore/MessageService 

### DIFF
--- a/FWCore/MessageService/BuildFile.xml
+++ b/FWCore/MessageService/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
-<use name="boost"/>
 <use name="tbb"/>
 <export>
   <lib name="1"/>

--- a/FWCore/MessageService/interface/MessageServicePresence.h
+++ b/FWCore/MessageService/interface/MessageServicePresence.h
@@ -4,9 +4,8 @@
 #include "FWCore/Utilities/interface/Presence.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
-#include "boost/thread/thread.hpp"
-
 #include <memory>
+#include <thread>
 
 namespace edm {
   namespace service {
@@ -29,7 +28,7 @@ namespace edm {
 
       // --- data:
       edm::propagate_const<std::shared_ptr<ThreadQueue>> m_queue;
-      boost::thread m_scribeThread;
+      std::thread m_scribeThread;
 
     };  // MessageServicePresence
 

--- a/FWCore/MessageService/src/MessageServicePresence.cc
+++ b/FWCore/MessageService/src/MessageServicePresence.cc
@@ -52,7 +52,7 @@ namespace edm {
                           // start a new thread, run rMLS(m_queue)
                           // ChangeLog 2
                           ))
-    // Note that m_scribeThread, which is a boost::thread, has a single-argument ctor -
+    // Note that m_scribeThread, which is a std::thread, has a single-argument ctor -
     // just the function to be run.  But we need to do something first, namely,
     // ensure that the MessageLoggerQ is in a valid state - and that requires
     // a statement.  So we bundle that statement in parenthesis, separated by


### PR DESCRIPTION
#### PR description:
Replaced boost thread for std thread. 
I believe in this case there is no need to use boost threading.  

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 