### PR TITLE
Drop 'drop*' as not necessary for MicroEventContent (MiniAOD)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 MicroEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring(
-        'drop *',
         'keep *_slimmedPhotons_*_*',
         'keep *_slimmedOOTPhotons_*_*',
         'keep *_slimmedElectrons_*_*',


### PR DESCRIPTION
#### PR description:
It is unclear the benefit to have
`'drop *',`
in the definition of MicroEventContent. This drop will happen anyways in e.g.
https://github.com/cms-sw/cmssw/blob/master/Configuration/EventContent/python/EventContent_cff.py#L783-L788

With this drop in the definition of MicroEventContent, it will make a bit more longer cmsDriver if we would like to add MiniAOD together with anything, e.g. RECO + MiniAOD together for TDR study.

#### PR validation:
`cmsDriver.py step1 --conditions auto:phase2_realistic_T15 -n 2 --era Phase2C9 --eventcontent RECOSIM,MINIAODSIM,DQM --runUnscheduled --filein  /store/relval/CMSSW_11_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v2/10000/01054EE2-1B51-C449-91A2-5202A60D16A3.root -s RAW2DIGI,L1TrackTrigger,L1,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC --geometry Extended2026D49 --fileout file:step1_WithValidation.root --customise_command "process.RECOSIMoutput.outputCommands.append('keep *_*_*_HLT'); process.RECOSIMoutput.outputCommands.append('keep *_*_*_SIM'); process.RECOSIMoutput.outputCommands.extend(process.L1TriggerFEVTDEBUG.outputCommands); process.RECOSIMoutput.outputCommands.extend(process.MicroEventContentMC.outputCommands)" --no_exec --python RECO_WithValidation.py`

Without: Only MINIAOD content will be written as RECOSIM
With this PR: MINIAOD content is added together with RECOSIM and L1T

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
The backport will need for 11_1 (if we decide to use for HLTTDR production)
