### PR TITLE
Reduce boost dependency in CondCore/CondDB

### DIFF
--- a/CondCore/CondDB/BuildFile.xml
+++ b/CondCore/CondDB/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="CoralKernel"/>
 <use name="CoralBase"/>
 <use name="RelationalAccess"/>
+<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondCore/CondDB/plugins/RelationalAuthenticationService.cc
+++ b/CondCore/CondDB/plugins/RelationalAuthenticationService.cc
@@ -10,15 +10,14 @@
 #include "CoralKernel/Property.h"
 #include "CoralKernel/Context.h"
 //
-#include <memory>
 #include <cstdlib>
-#include <fstream>
-#include <sys/stat.h>
 #include <fcntl.h>
-#include <boost/filesystem.hpp>
-#include <boost/version.hpp>
+#include <fstream>
+#include <memory>
+#include <sys/stat.h>
+
 #include <boost/bind.hpp>
-//#include <iostream>
+
 #include "CoralBase/MessageStream.h"
 
 cond::RelationalAuthenticationService::RelationalAuthenticationService::RelationalAuthenticationService(

--- a/CondCore/CondDB/plugins/XMLAuthenticationService.cc
+++ b/CondCore/CondDB/plugins/XMLAuthenticationService.cc
@@ -17,15 +17,14 @@
 #include "xercesc/util/PlatformUtils.hpp"
 #include "XMLAuthenticationService.h"
 
-#include <memory>
 #include <cstdlib>
-#include <fstream>
-#include <sys/stat.h>
 #include <fcntl.h>
-#include <boost/filesystem.hpp>
-#include <boost/version.hpp>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sys/stat.h>
+
 #include <boost/bind.hpp>
-//#include <iostream>
 #include "CoralBase/MessageStream.h"
 
 constexpr char XML_AUTHENTICATION_FILE[] = "authentication.xml";
@@ -97,12 +96,12 @@ cond::XMLAuthenticationService::XMLAuthenticationService::~XMLAuthenticationServ
 }
 
 void cond::XMLAuthenticationService::XMLAuthenticationService::setAuthenticationPath(const std::string& inputPath) {
-  boost::filesystem::path boostAuthPath(inputPath);
-  if (boost::filesystem::is_directory(boostAuthPath)) {
-    boostAuthPath /= boost::filesystem::path(XML_AUTHENTICATION_FILE);
+  std::filesystem::path AuthPath(inputPath);
+  if (std::filesystem::is_directory(AuthPath)) {
+    AuthPath /= std::filesystem::path(XML_AUTHENTICATION_FILE);
   }
 
-  m_inputFileName = boostAuthPath.string();
+  m_inputFileName = AuthPath.string();
   reset();
 }
 
@@ -122,13 +121,9 @@ bool cond::XMLAuthenticationService::XMLAuthenticationService::processFile(const
     return false;
   }
 
-  // check the
-  boost::filesystem::path filePath(inputFileName);
-#if (BOOST_VERSION / 100000) >= 1 && ((BOOST_VERSION / 100) % 1000) >= 47
+  std::filesystem::path filePath(inputFileName);
   std::string name = filePath.filename().string();
-#else
-  std::string name = filePath.leaf();
-#endif
+
   /**
   if(name!=XML_AUTHENTICATION_FILE){
     cond::DecodingKey key;
@@ -380,17 +375,17 @@ std::set<std::string> cond::XMLAuthenticationService::XMLAuthenticationService::
   std::set<std::string> fileNames;
 
   // Try the file name as is...
-  boost::filesystem::path filePath(m_inputFileName);
-  if (boost::filesystem::exists(m_inputFileName)) {
-    if (boost::filesystem::is_directory(m_inputFileName)) {
+  std::filesystem::path filePath(m_inputFileName);
+  if (std::filesystem::exists(m_inputFileName)) {
+    if (std::filesystem::is_directory(m_inputFileName)) {
       //seal::MessageStream log( this, this->name(),seal::Msg::Verbose );
       log << coral::Error << "Provided path \"" << m_inputFileName << "\" is a directory."
           << coral::MessageStream::endmsg;
       return fileNames;
     }
-    boost::filesystem::path& fullPath = filePath.normalize();
+    std::filesystem::path fullPath = filePath.lexically_normal();
     fileNames.insert(fullPath.string());
-    if (filePath.is_complete())
+    if (filePath.is_absolute())
       return fileNames;
   }
 
@@ -403,12 +398,12 @@ std::set<std::string> cond::XMLAuthenticationService::XMLAuthenticationService::
 
   std::string searchPath(thePathVariable);
   //std::cout<<"searchPath "<<searchPath<<std::endl;
-  if (boost::filesystem::exists(searchPath)) {
-    if (!boost::filesystem::is_directory(searchPath)) {
+  if (std::filesystem::exists(searchPath)) {
+    if (!std::filesystem::is_directory(searchPath)) {
       log << coral::Debug << "Search path \"" << searchPath << "\" is not a directory." << coral::MessageStream::endmsg;
       return fileNames;
     }
-    boost::filesystem::path fullPath(searchPath);
+    std::filesystem::path fullPath(searchPath);
     fullPath /= filePath;
     fileNames.insert(fullPath.string());
   } else {

--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -15,8 +15,6 @@
 #include "CoralKernel/Context.h"
 #include "CoralKernel/IProperty.h"
 #include "CoralKernel/IPropertyManager.h"
-// externals
-#include <boost/filesystem/operations.hpp>
 
 namespace cond {
 

--- a/CondCore/CondDB/src/CredentialStore.cc
+++ b/CondCore/CondDB/src/CredentialStore.cc
@@ -24,9 +24,9 @@
 //
 #include "RelationalAccess/AuthenticationCredentials.h"
 //
-#include <sstream>
+#include <filesystem>
 #include <fstream>
-#include <boost/filesystem.hpp>
+#include <sstream>
 
 static const std::string serviceName = "CondAuthenticationService";
 
@@ -691,11 +691,11 @@ std::string cond::CredentialStore::setUpForService(const std::string& serviceNam
   if (authPath.empty()) {
     throwException("The authentication Path has not been provided.", "cond::CredentialStore::setUpForService");
   }
-  boost::filesystem::path fullPath(authPath);
-  if (!boost::filesystem::exists(authPath) || !boost::filesystem::is_directory(authPath)) {
+  std::filesystem::path fullPath(authPath);
+  if (!std::filesystem::exists(authPath) || !std::filesystem::is_directory(authPath)) {
     throwException("Authentication Path is invalid.", "cond::CredentialStore::setUpForService");
   }
-  boost::filesystem::path file(auth::DecodingKey::FILE_PATH);
+  std::filesystem::path file(auth::DecodingKey::FILE_PATH);
   fullPath /= file;
 
   m_key.init(fullPath.string(), auth::COND_KEY);


### PR DESCRIPTION
#### PR description:
Replaced boost filesystem for std filesystem.
The code should have the same behaviour.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 