### PR TITLE
Minimal cleanup of PFClusterValidation code

### DIFF
--- a/Validation/RecoParticleFlow/plugins/PFClusterValidation.cc
+++ b/Validation/RecoParticleFlow/plugins/PFClusterValidation.cc
@@ -1,34 +1,21 @@
-#include "Validation/RecoParticleFlow/plugins/PFClusterValidation.h"
-#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "Validation/RecoParticleFlow/plugins/PFClusterValidation.h"
 
 PFClusterValidation::PFClusterValidation(const edm::ParameterSet& conf) {
-  tok_evt_ = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared"));
+  hepMCTok_ = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared"));
 
-  PFClusterECALTok_ =
+  pfClusterECALTok_ =
       consumes<reco::PFClusterCollection>(conf.getUntrackedParameter<edm::InputTag>("pflowClusterECAL"));
-  PFClusterHCALTok_ =
+  pfClusterHCALTok_ =
       consumes<reco::PFClusterCollection>(conf.getUntrackedParameter<edm::InputTag>("pflowClusterHCAL"));
-  PFClusterHOTok_ = consumes<reco::PFClusterCollection>(conf.getUntrackedParameter<edm::InputTag>("pflowClusterHO"));
-  PFClusterHFTok_ = consumes<reco::PFClusterCollection>(
+  pfClusterHOTok_ = consumes<reco::PFClusterCollection>(conf.getUntrackedParameter<edm::InputTag>("pflowClusterHO"));
+  pfClusterHFTok_ = consumes<reco::PFClusterCollection>(
       conf.getUntrackedParameter<edm::InputTag>("pflowClusterHF"));  // cms.InputTag("particleFlowClusterECAL");
-
-  outputFile_ = conf.getUntrackedParameter<std::string>("outputFile", "myfile.root");
-  mc_ = conf.getUntrackedParameter<bool>("mc", true);
-
-  imc = 1;
-  if (!mc_)
-    imc = 0;
-
-  if (!outputFile_.empty()) {
-    edm::LogInfo("OutputInfo") << " Hcal RecHit Task histograms will be saved to '" << outputFile_.c_str() << "'";
-  } else {
-    edm::LogInfo("OutputInfo") << " Hcal RecHit Task histograms will NOT be saved";
-  }
 }
 
 PFClusterValidation::~PFClusterValidation() {}
@@ -36,9 +23,10 @@ PFClusterValidation::~PFClusterValidation() {}
 void PFClusterValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                          edm::Run const& irun,
                                          edm::EventSetup const& isetup) {
-  Char_t histo[100];
+  static const auto size = 100;
+  char histo[size];
   ibooker.setCurrentFolder("ParticleFlow/PFClusterV");
-  Double_t etaBinsOffset[83] = {
+  double etaBinsOffset[83] = {
       -5.191, -4.889, -4.716, -4.538, -4.363, -4.191, -4.013, -3.839, -3.664, -3.489, -3.314, -3.139, -2.964, -2.853,
       -2.65,  -2.5,   -2.322, -2.172, -2.043, -1.93,  -1.83,  -1.74,  -1.653, -1.566, -1.479, -1.392, -1.305, -1.218,
       -1.131, -1.044, -0.957, -0.879, -0.783, -0.696, -0.609, -0.522, -0.435, -0.348, -0.261, -0.174, -0.087, 0,
@@ -46,226 +34,200 @@ void PFClusterValidation::bookHistograms(DQMStore::IBooker& ibooker,
       1.305,  1.392,  1.479,  1.566,  1.653,  1.74,   1.83,   1.93,   2.043,  2.172,  2.322,  2.5,    2.65,   2.853,
       2.964,  3.139,  3.314,  3.489,  3.664,  3.839,  4.013,  4.191,  4.363,  4.538,  4.716,  4.889,  5.191};
 
-  //These the single pion scan histos
-  //-------------------------------------------------------------------------------------------
-  sprintf(histo, "emean_vs_eta_E");
-  emean_vs_eta_E = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
-  sprintf(histo, "emean_vs_eta_H");
-  emean_vs_eta_H = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
-  sprintf(histo, "emean_vs_eta_EH");
-  emean_vs_eta_EH = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  // These are the single pion scan histos
 
-  sprintf(histo, "emean_vs_eta_HF");
-  emean_vs_eta_HF = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
-  sprintf(histo, "emean_vs_eta_HO");
-  emean_vs_eta_HO = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  strncpy(histo, "emean_vs_eta_E", size);
+  emean_vs_eta_E_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  strncpy(histo, "emean_vs_eta_H", size);
+  emean_vs_eta_H_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  strncpy(histo, "emean_vs_eta_EH", size);
+  emean_vs_eta_EH_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
 
-  sprintf(histo, "emean_vs_eta_EHF");
-  emean_vs_eta_EHF = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
-  sprintf(histo, "emean_vs_eta_EHFO");
-  emean_vs_eta_EHFO = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  strncpy(histo, "emean_vs_eta_HF", size);
+  emean_vs_eta_HF_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  strncpy(histo, "emean_vs_eta_HO", size);
+  emean_vs_eta_HO_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
 
-  //1D histos
+  strncpy(histo, "emean_vs_eta_EHF", size);
+  emean_vs_eta_EHF_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  strncpy(histo, "emean_vs_eta_EHFO", size);
+  emean_vs_eta_EHFO_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
 
-  sprintf(histo, "Ratio_Esummed_ECAL_0");
-  Ratio_Esummed_ECAL_0 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HCAL_0");
-  Ratio_Esummed_HCAL_0 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HO_0");
-  Ratio_Esummed_HO_0 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_0");
-  Ratio_Esummed_ECAL_HCAL_0 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_HO_0");
-  Ratio_Esummed_ECAL_HCAL_HO_0 = ibooker.book1D(histo, histo, 50, 0., 5.);
+  // 1D histos
 
-  sprintf(histo, "Ratio_Esummed_ECAL_1");
-  Ratio_Esummed_ECAL_1 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HCAL_1");
-  Ratio_Esummed_HCAL_1 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HO_1");
-  Ratio_Esummed_HO_1 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_1");
-  Ratio_Esummed_ECAL_HCAL_1 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_HO_1");
-  Ratio_Esummed_ECAL_HCAL_HO_1 = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_0", size);
+  ratio_Esummed_ECAL_0_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HCAL_0", size);
+  ratio_Esummed_HCAL_0_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HO_0", size);
+  ratio_Esummed_HO_0_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_0", size);
+  ratio_Esummed_ECAL_HCAL_0_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_HO_0", size);
+  ratio_Esummed_ECAL_HCAL_HO_0_ = ibooker.book1D(histo, histo, 50, 0., 5.);
 
-  sprintf(histo, "Ratio_Esummed_ECAL_2");
-  Ratio_Esummed_ECAL_2 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HCAL_2");
-  Ratio_Esummed_HCAL_2 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HO_2");
-  Ratio_Esummed_HO_2 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_2");
-  Ratio_Esummed_ECAL_HCAL_2 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_HO_2");
-  Ratio_Esummed_ECAL_HCAL_HO_2 = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_1", size);
+  ratio_Esummed_ECAL_1_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HCAL_1", size);
+  ratio_Esummed_HCAL_1_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HO_1", size);
+  ratio_Esummed_HO_1_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_1", size);
+  ratio_Esummed_ECAL_HCAL_1_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_HO_1", size);
+  ratio_Esummed_ECAL_HCAL_HO_1_ = ibooker.book1D(histo, histo, 50, 0., 5.);
 
-  sprintf(histo, "Ratio_Esummed_ECAL_3");
-  Ratio_Esummed_ECAL_3 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HCAL_3");
-  Ratio_Esummed_HCAL_3 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HO_3");
-  Ratio_Esummed_HO_3 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_3");
-  Ratio_Esummed_ECAL_HCAL_3 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_HO_3");
-  Ratio_Esummed_ECAL_HCAL_HO_3 = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_2", size);
+  ratio_Esummed_ECAL_2_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HCAL_2", size);
+  ratio_Esummed_HCAL_2_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HO_2", size);
+  ratio_Esummed_HO_2_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_2", size);
+  ratio_Esummed_ECAL_HCAL_2_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_HO_2", size);
+  ratio_Esummed_ECAL_HCAL_HO_2_ = ibooker.book1D(histo, histo, 50, 0., 5.);
 
-  sprintf(histo, "Ratio_Esummed_ECAL_4");
-  Ratio_Esummed_ECAL_4 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HCAL_4");
-  Ratio_Esummed_HCAL_4 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HO_4");
-  Ratio_Esummed_HO_4 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_4");
-  Ratio_Esummed_ECAL_HCAL_4 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_ECAL_HCAL_HO_4");
-  Ratio_Esummed_ECAL_HCAL_HO_4 = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_3", size);
+  ratio_Esummed_ECAL_3_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HCAL_3", size);
+  ratio_Esummed_HCAL_3_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HO_3", size);
+  ratio_Esummed_HO_3_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_3", size);
+  ratio_Esummed_ECAL_HCAL_3_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_HO_3", size);
+  ratio_Esummed_ECAL_HCAL_HO_3_ = ibooker.book1D(histo, histo, 50, 0., 5.);
 
-  sprintf(histo, "Ratio_Esummed_HF_5");
-  Ratio_Esummed_HF_5 = ibooker.book1D(histo, histo, 50, 0., 5.);
-  sprintf(histo, "Ratio_Esummed_HF_6");
-  Ratio_Esummed_HF_6 = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_4", size);
+  ratio_Esummed_ECAL_4_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HCAL_4", size);
+  ratio_Esummed_HCAL_4_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HO_4", size);
+  ratio_Esummed_HO_4_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_4", size);
+  ratio_Esummed_ECAL_HCAL_4_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_ECAL_HCAL_HO_4", size);
+  ratio_Esummed_ECAL_HCAL_HO_4_ = ibooker.book1D(histo, histo, 50, 0., 5.);
 
-  sprintf(histo, "Egen_MC");
-  Egen_MC = ibooker.book1D(histo, histo, 50, 0, 50);
+  strncpy(histo, "Ratio_Esummed_HF_5", size);
+  ratio_Esummed_HF_5_ = ibooker.book1D(histo, histo, 50, 0., 5.);
+  strncpy(histo, "Ratio_Esummed_HF_6", size);
+  ratio_Esummed_HF_6_ = ibooker.book1D(histo, histo, 50, 0., 5.);
 
-  //-------------------------------------------------------------------------------------------
-
-}  // BOOKING HISTOS
-
-void PFClusterValidation::analyze(edm::Event const& event, edm::EventSetup const& c) {
-  if (imc != 0) {
-    edm::Handle<edm::HepMCProduct> evtMC;
-    event.getByToken(tok_evt_, evtMC);  // generator in late 310_preX
-    if (!evtMC.isValid()) {
-      edm::LogWarning("Module named pfclusterAnalyzer") << "no HepMCProduct found";
-    }
-
-    // MC particle with highest pt is taken as a direction reference
-    double maxPt = -99999.;
-    int npart = 0;
-    const HepMC::GenEvent* myGenEvent = evtMC->GetEvent();
-    for (HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin(); p != myGenEvent->particles_end();
-         ++p) {
-      double phip = (*p)->momentum().phi();
-      double etap = (*p)->momentum().eta();
-      double pt = (*p)->momentum().perp();
-      double energy = (*p)->momentum().e();
-      if (pt > maxPt) {
-        npart++;
-        maxPt = pt;
-        energy_MC = energy;
-        phi_MC = phip;
-        eta_MC = etap;
-      }
-    }
-  }
-  Egen_MC->Fill(energy_MC);
-
-  edm::Handle<reco::PFClusterCollection> pfClusterECAL;
-  event.getByToken(PFClusterECALTok_, pfClusterECAL);
-  //  reco::PFClusterCollection::const_iterator pf;
-
-  edm::Handle<reco::PFClusterCollection> pfClusterHCAL;
-  event.getByToken(PFClusterHCALTok_, pfClusterHCAL);
-
-  edm::Handle<reco::PFClusterCollection> pfClusterHO;
-  event.getByToken(PFClusterHOTok_, pfClusterHO);
-
-  edm::Handle<reco::PFClusterCollection> pfClusterHF;
-  event.getByToken(PFClusterHFTok_, pfClusterHF);
-
-  double Econe = 0.;
-  double Hcone = 0.;
-  double HFcone = 0.;
-  double HOcone = 0.;
-
-  // sum the energy in a dr cone for each subsystem
-  Econe = sumEnergy(pfClusterECAL);
-  Hcone = sumEnergy(pfClusterHCAL);
-  HOcone = sumEnergy(pfClusterHO);
-  HFcone = sumEnergy(pfClusterHF);
-
-  if (energy_MC > 0.) {
-    if (fabs(eta_MC) < 0.5) {
-      Ratio_Esummed_ECAL_0->Fill(Econe / energy_MC);
-      Ratio_Esummed_HCAL_0->Fill(Hcone / energy_MC);
-      Ratio_Esummed_HO_0->Fill(HOcone / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_0->Fill((Econe + Hcone) / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_HO_0->Fill((Econe + Hcone + HOcone) / energy_MC);
-    } else if (fabs(eta_MC) < 1.3 && fabs(eta_MC) > 0.5) {
-      Ratio_Esummed_ECAL_1->Fill(Econe / energy_MC);
-      Ratio_Esummed_HCAL_1->Fill(Hcone / energy_MC);
-      Ratio_Esummed_HO_1->Fill(HOcone / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_1->Fill((Econe + Hcone) / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_HO_1->Fill((Econe + Hcone + HOcone) / energy_MC);
-    } else if (fabs(eta_MC) < 2.1 && fabs(eta_MC) > 1.3) {
-      Ratio_Esummed_ECAL_2->Fill(Econe / energy_MC);
-      Ratio_Esummed_HCAL_2->Fill(Hcone / energy_MC);
-      Ratio_Esummed_HO_2->Fill(HOcone / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_2->Fill((Econe + Hcone) / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_HO_2->Fill((Econe + Hcone + HOcone) / energy_MC);
-    } else if (fabs(eta_MC) < 2.5 && fabs(eta_MC) > 2.1) {
-      Ratio_Esummed_ECAL_3->Fill(Econe / energy_MC);
-      Ratio_Esummed_HCAL_3->Fill(Hcone / energy_MC);
-      Ratio_Esummed_HO_3->Fill(HOcone / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_3->Fill((Econe + Hcone) / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_HO_3->Fill((Econe + Hcone + HOcone) / energy_MC);
-    } else if (2.5 < fabs(eta_MC) && fabs(eta_MC) < 3.0) {
-      Ratio_Esummed_ECAL_4->Fill(Econe / energy_MC);
-      Ratio_Esummed_HCAL_4->Fill(Hcone / energy_MC);
-      Ratio_Esummed_HO_4->Fill(HOcone / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_4->Fill((Econe + Hcone) / energy_MC);
-      Ratio_Esummed_ECAL_HCAL_HO_4->Fill((Econe + Hcone + HOcone) / energy_MC);
-    } else if (3.0 < fabs(eta_MC) && fabs(eta_MC) < 4.0) {
-      Ratio_Esummed_HF_5->Fill(HFcone / energy_MC);
-    } else if (4.0 < fabs(eta_MC) && fabs(eta_MC) < 5.0) {
-      Ratio_Esummed_HF_6->Fill(HFcone / energy_MC);
-    }
-  }
-
-  //These are the six single pion histos
-  emean_vs_eta_E->Fill(double(eta_MC), Econe);
-  emean_vs_eta_H->Fill(double(eta_MC), Hcone);
-  emean_vs_eta_EH->Fill(double(eta_MC), Econe + Hcone);
-
-  emean_vs_eta_HF->Fill(double(eta_MC), HFcone);
-  emean_vs_eta_HO->Fill(double(eta_MC), HOcone);
-  emean_vs_eta_EHF->Fill(double(eta_MC), Econe + Hcone + HFcone);
-  emean_vs_eta_EHFO->Fill(double(eta_MC), Econe + Hcone + HFcone + HOcone);
-
-}  //end for analyze
-
-double PFClusterValidation::dR(double eta1, double phi1, double eta2, double phi2) {
-  const double PI = 3.1415926535898;
-  double deltaphi = phi1 - phi2;
-  if (phi2 > phi1) {
-    deltaphi = phi2 - phi1;
-  }
-  if (deltaphi > PI) {
-    deltaphi = 2. * PI - deltaphi;
-  }
-  double deltaeta = eta2 - eta1;
-  double tmp = sqrt(deltaeta * deltaeta + deltaphi * deltaphi);
-  return tmp;
+  strncpy(histo, "Egen_MC", size);
+  egen_MC_ = ibooker.book1D(histo, histo, 50, 0, 50);
 }
 
-double PFClusterValidation::sumEnergy(edm::Handle<reco::PFClusterCollection> pfCluster1) {
-  reco::PFClusterCollection::const_iterator pf;
-  double sumenergy = 0.;
-  for (pf = pfCluster1->begin(); pf != pfCluster1->end(); ++pf) {
-    double eta = pf->eta();
-    double phi = pf->phi();
-    double en = pf->energy();
-    if (imc != 0) {
-      double r = dR(eta_MC, phi_MC, eta, phi);
-      if (r < partR) {
-        sumenergy += en;
-      }
+void PFClusterValidation::analyze(edm::Event const& event, edm::EventSetup const& c) {
+  double eta_MC = 0.;
+  double phi_MC = 0.;
+  double energy_MC = 0.;
+
+  edm::Handle<edm::HepMCProduct> hepMC;
+  event.getByToken(hepMCTok_, hepMC);
+  if (not hepMC.isValid()) {
+    edm::LogWarning("PFClusterValidation") << "HepMCProduct not found";
+    return;
+  }
+
+  // MC particle with highest pt is taken as a direction reference
+  double maxPt = -99999.;
+  const HepMC::GenEvent* myGenEvent = hepMC->GetEvent();
+  for (auto p = myGenEvent->particles_begin(); p != myGenEvent->particles_end(); ++p) {
+    double phip = (*p)->momentum().phi();
+    double etap = (*p)->momentum().eta();
+    double pt = (*p)->momentum().perp();
+    double energy = (*p)->momentum().e();
+    if (pt > maxPt) {
+      maxPt = pt;
+      energy_MC = energy;
+      phi_MC = phip;
+      eta_MC = etap;
     }
   }
-  return sumenergy;
+
+  egen_MC_->Fill(energy_MC);
+
+  edm::Handle<reco::PFClusterCollection> pfClusterECAL;
+  event.getByToken(pfClusterECALTok_, pfClusterECAL);
+
+  edm::Handle<reco::PFClusterCollection> pfClusterHCAL;
+  event.getByToken(pfClusterHCALTok_, pfClusterHCAL);
+
+  edm::Handle<reco::PFClusterCollection> pfClusterHO;
+  event.getByToken(pfClusterHOTok_, pfClusterHO);
+
+  edm::Handle<reco::PFClusterCollection> pfClusterHF;
+  event.getByToken(pfClusterHFTok_, pfClusterHF);
+
+  // sum the energy in a dR cone for each subsystem
+  double Econe = sumEnergy(pfClusterECAL, eta_MC, phi_MC);
+  double Hcone = sumEnergy(pfClusterHCAL, eta_MC, phi_MC);
+  double HOcone = sumEnergy(pfClusterHO, eta_MC, phi_MC);
+  double HFcone = sumEnergy(pfClusterHF, eta_MC, phi_MC);
+
+  if (energy_MC > 0.) {
+    if (std::abs(eta_MC) < 0.5) {
+      ratio_Esummed_ECAL_0_->Fill(Econe / energy_MC);
+      ratio_Esummed_HCAL_0_->Fill(Hcone / energy_MC);
+      ratio_Esummed_HO_0_->Fill(HOcone / energy_MC);
+      ratio_Esummed_ECAL_HCAL_0_->Fill((Econe + Hcone) / energy_MC);
+      ratio_Esummed_ECAL_HCAL_HO_0_->Fill((Econe + Hcone + HOcone) / energy_MC);
+    } else if (std::abs(eta_MC) < 1.3 && std::abs(eta_MC) > 0.5) {
+      ratio_Esummed_ECAL_1_->Fill(Econe / energy_MC);
+      ratio_Esummed_HCAL_1_->Fill(Hcone / energy_MC);
+      ratio_Esummed_HO_1_->Fill(HOcone / energy_MC);
+      ratio_Esummed_ECAL_HCAL_1_->Fill((Econe + Hcone) / energy_MC);
+      ratio_Esummed_ECAL_HCAL_HO_1_->Fill((Econe + Hcone + HOcone) / energy_MC);
+    } else if (std::abs(eta_MC) < 2.1 && std::abs(eta_MC) > 1.3) {
+      ratio_Esummed_ECAL_2_->Fill(Econe / energy_MC);
+      ratio_Esummed_HCAL_2_->Fill(Hcone / energy_MC);
+      ratio_Esummed_HO_2_->Fill(HOcone / energy_MC);
+      ratio_Esummed_ECAL_HCAL_2_->Fill((Econe + Hcone) / energy_MC);
+      ratio_Esummed_ECAL_HCAL_HO_2_->Fill((Econe + Hcone + HOcone) / energy_MC);
+    } else if (std::abs(eta_MC) < 2.5 && std::abs(eta_MC) > 2.1) {
+      ratio_Esummed_ECAL_3_->Fill(Econe / energy_MC);
+      ratio_Esummed_HCAL_3_->Fill(Hcone / energy_MC);
+      ratio_Esummed_HO_3_->Fill(HOcone / energy_MC);
+      ratio_Esummed_ECAL_HCAL_3_->Fill((Econe + Hcone) / energy_MC);
+      ratio_Esummed_ECAL_HCAL_HO_3_->Fill((Econe + Hcone + HOcone) / energy_MC);
+    } else if (2.5 < std::abs(eta_MC) && std::abs(eta_MC) < 3.0) {
+      ratio_Esummed_ECAL_4_->Fill(Econe / energy_MC);
+      ratio_Esummed_HCAL_4_->Fill(Hcone / energy_MC);
+      ratio_Esummed_HO_4_->Fill(HOcone / energy_MC);
+      ratio_Esummed_ECAL_HCAL_4_->Fill((Econe + Hcone) / energy_MC);
+      ratio_Esummed_ECAL_HCAL_HO_4_->Fill((Econe + Hcone + HOcone) / energy_MC);
+    } else if (3.0 < std::abs(eta_MC) && std::abs(eta_MC) < 4.0) {
+      ratio_Esummed_HF_5_->Fill(HFcone / energy_MC);
+    } else if (4.0 < std::abs(eta_MC) && std::abs(eta_MC) < 5.0) {
+      ratio_Esummed_HF_6_->Fill(HFcone / energy_MC);
+    }
+  }
+
+  emean_vs_eta_E_->Fill(eta_MC, Econe);
+  emean_vs_eta_H_->Fill(eta_MC, Hcone);
+  emean_vs_eta_EH_->Fill(eta_MC, Econe + Hcone);
+  emean_vs_eta_HF_->Fill(eta_MC, HFcone);
+  emean_vs_eta_HO_->Fill(eta_MC, HOcone);
+  emean_vs_eta_EHF_->Fill(eta_MC, Econe + Hcone + HFcone);
+  emean_vs_eta_EHFO_->Fill(eta_MC, Econe + Hcone + HFcone + HOcone);
+}
+
+double PFClusterValidation::sumEnergy(edm::Handle<reco::PFClusterCollection> const& pfClusters,
+                                      double eta,
+                                      double phi) {
+  if (not pfClusters.isValid())
+    return 0.;
+
+  double sum = 0.;
+  for (auto pf = pfClusters->begin(); pf != pfClusters->end(); ++pf) {
+    if (reco::deltaR2(eta, phi, pf->eta(), pf->phi()) < partR2) {
+      sum += pf->energy();
+    }
+  }
+
+  return sum;
 }
 
 DEFINE_FWK_MODULE(PFClusterValidation);

--- a/Validation/RecoParticleFlow/plugins/PFClusterValidation.cc
+++ b/Validation/RecoParticleFlow/plugins/PFClusterValidation.cc
@@ -23,35 +23,38 @@ PFClusterValidation::~PFClusterValidation() {}
 void PFClusterValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                          edm::Run const& irun,
                                          edm::EventSetup const& isetup) {
-  static const auto size = 100;
+  constexpr auto size = 100;
   char histo[size];
-  ibooker.setCurrentFolder("ParticleFlow/PFClusterV");
-  double etaBinsOffset[83] = {
+
+  constexpr double etaBinsOffset[] = {
       -5.191, -4.889, -4.716, -4.538, -4.363, -4.191, -4.013, -3.839, -3.664, -3.489, -3.314, -3.139, -2.964, -2.853,
       -2.65,  -2.5,   -2.322, -2.172, -2.043, -1.93,  -1.83,  -1.74,  -1.653, -1.566, -1.479, -1.392, -1.305, -1.218,
       -1.131, -1.044, -0.957, -0.879, -0.783, -0.696, -0.609, -0.522, -0.435, -0.348, -0.261, -0.174, -0.087, 0,
       0.087,  0.174,  0.261,  0.348,  0.435,  0.522,  0.609,  0.696,  0.783,  0.879,  0.957,  1.044,  1.131,  1.218,
       1.305,  1.392,  1.479,  1.566,  1.653,  1.74,   1.83,   1.93,   2.043,  2.172,  2.322,  2.5,    2.65,   2.853,
       2.964,  3.139,  3.314,  3.489,  3.664,  3.839,  4.013,  4.191,  4.363,  4.538,  4.716,  4.889,  5.191};
+  constexpr int etaBins = std::size(etaBinsOffset) - 1;
+
+  ibooker.setCurrentFolder("ParticleFlow/PFClusterV");
 
   // These are the single pion scan histos
 
   strncpy(histo, "emean_vs_eta_E", size);
-  emean_vs_eta_E_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  emean_vs_eta_E_ = ibooker.bookProfile(histo, histo, etaBins, etaBinsOffset, -100., 2000., " ");
   strncpy(histo, "emean_vs_eta_H", size);
-  emean_vs_eta_H_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  emean_vs_eta_H_ = ibooker.bookProfile(histo, histo, etaBins, etaBinsOffset, -100., 2000., " ");
   strncpy(histo, "emean_vs_eta_EH", size);
-  emean_vs_eta_EH_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  emean_vs_eta_EH_ = ibooker.bookProfile(histo, histo, etaBins, etaBinsOffset, -100., 2000., " ");
 
   strncpy(histo, "emean_vs_eta_HF", size);
-  emean_vs_eta_HF_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  emean_vs_eta_HF_ = ibooker.bookProfile(histo, histo, etaBins, etaBinsOffset, -100., 2000., " ");
   strncpy(histo, "emean_vs_eta_HO", size);
-  emean_vs_eta_HO_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  emean_vs_eta_HO_ = ibooker.bookProfile(histo, histo, etaBins, etaBinsOffset, -100., 2000., " ");
 
   strncpy(histo, "emean_vs_eta_EHF", size);
-  emean_vs_eta_EHF_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  emean_vs_eta_EHF_ = ibooker.bookProfile(histo, histo, etaBins, etaBinsOffset, -100., 2000., " ");
   strncpy(histo, "emean_vs_eta_EHFO", size);
-  emean_vs_eta_EHFO_ = ibooker.bookProfile(histo, histo, 82, etaBinsOffset, -100., 2000., " ");
+  emean_vs_eta_EHFO_ = ibooker.bookProfile(histo, histo, etaBins, etaBinsOffset, -100., 2000., " ");
 
   // 1D histos
 
@@ -162,10 +165,10 @@ void PFClusterValidation::analyze(edm::Event const& event, edm::EventSetup const
   event.getByToken(pfClusterHFTok_, pfClusterHF);
 
   // sum the energy in a dR cone for each subsystem
-  double Econe = sumEnergy(pfClusterECAL, eta_MC, phi_MC);
-  double Hcone = sumEnergy(pfClusterHCAL, eta_MC, phi_MC);
-  double HOcone = sumEnergy(pfClusterHO, eta_MC, phi_MC);
-  double HFcone = sumEnergy(pfClusterHF, eta_MC, phi_MC);
+  const double Econe = sumEnergy(pfClusterECAL, eta_MC, phi_MC);
+  const double Hcone = sumEnergy(pfClusterHCAL, eta_MC, phi_MC);
+  const double HOcone = sumEnergy(pfClusterHO, eta_MC, phi_MC);
+  const double HFcone = sumEnergy(pfClusterHF, eta_MC, phi_MC);
 
   if (energy_MC > 0.) {
     if (std::abs(eta_MC) < 0.5) {

--- a/Validation/RecoParticleFlow/plugins/PFClusterValidation.h
+++ b/Validation/RecoParticleFlow/plugins/PFClusterValidation.h
@@ -1,51 +1,42 @@
-#ifndef PFClusterValidation_h
-#define PFClusterValidation_h
+#ifndef Validation_RecoParticleFlow_plugins_PFClusterValidation_h
+#define Validation_RecoParticleFlow_plugins_PFClusterValidation_h
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
-#include "DataFormats/Math/interface/Vector3D.h"
-
-#include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-
-// including PFCluster
-#include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
-#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
-
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
-
-#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
-#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-#include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
-
-// end include PFCluster
-#include <vector>
-#include <utility>
-#include <iostream>
-#include <string>
 #include <algorithm>
 #include <cmath>
-#include "DQMServices/Core/interface/DQMStore.h"
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 class PFClusterValidation : public DQMEDAnalyzer {
 public:
@@ -55,73 +46,59 @@ public:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
 private:
-  double dR(double eta1, double phi1, double eta2, double phi2);
-  double sumEnergy(edm::Handle<reco::PFClusterCollection> pfCluster1);
-  std::string outputFile_;
-  //std::string mc_;
-  bool mc_;
+  static constexpr double partR2 = 0.3 * 0.3;  // dr cutoff (squared)
+  static double sumEnergy(edm::Handle<reco::PFClusterCollection> const& pfClusters, double eta, double phi);
 
-  typedef math::RhoEtaPhiVector Vector;
+  edm::EDGetTokenT<edm::HepMCProduct> hepMCTok_;
+  edm::EDGetTokenT<reco::PFClusterCollection> pfClusterECALTok_;
+  edm::EDGetTokenT<reco::PFClusterCollection> pfClusterHCALTok_;
+  edm::EDGetTokenT<reco::PFClusterCollection> pfClusterHOTok_;
+  edm::EDGetTokenT<reco::PFClusterCollection> pfClusterHFTok_;
 
-  edm::EDGetTokenT<edm::HepMCProduct> tok_evt_;
-  edm::EDGetTokenT<reco::PFClusterCollection> PFClusterECALTok_;
-  edm::EDGetTokenT<reco::PFClusterCollection> PFClusterHCALTok_;
-  edm::EDGetTokenT<reco::PFClusterCollection> PFClusterHOTok_;
-  edm::EDGetTokenT<reco::PFClusterCollection> PFClusterHFTok_;
+  MonitorElement* emean_vs_eta_E_;
+  MonitorElement* emean_vs_eta_H_;
+  MonitorElement* emean_vs_eta_EH_;
 
-  int imc;
+  MonitorElement* emean_vs_eta_HF_;
+  MonitorElement* emean_vs_eta_HO_;
+  MonitorElement* emean_vs_eta_EHF_;
+  MonitorElement* emean_vs_eta_EHFO_;
 
-  // this acts throught the entire class
-  // no reinitialization required
-  const double partR = 0.3;  // dr cutoff
-  double eta_MC, phi_MC, energy_MC = 9999.;
+  MonitorElement* ratio_Esummed_ECAL_0_;
+  MonitorElement* ratio_Esummed_HCAL_0_;
+  MonitorElement* ratio_Esummed_HO_0_;
 
-  //************Modules
+  MonitorElement* ratio_Esummed_ECAL_1_;
+  MonitorElement* ratio_Esummed_HCAL_1_;
+  MonitorElement* ratio_Esummed_HO_1_;
 
-  MonitorElement* emean_vs_eta_E;
-  MonitorElement* emean_vs_eta_H;
-  MonitorElement* emean_vs_eta_EH;
+  MonitorElement* ratio_Esummed_ECAL_2_;
+  MonitorElement* ratio_Esummed_HCAL_2_;
+  MonitorElement* ratio_Esummed_HO_2_;
 
-  MonitorElement* emean_vs_eta_HF;
-  MonitorElement* emean_vs_eta_HO;
-  MonitorElement* emean_vs_eta_EHF;
-  MonitorElement* emean_vs_eta_EHFO;
+  MonitorElement* ratio_Esummed_ECAL_3_;
+  MonitorElement* ratio_Esummed_HCAL_3_;
+  MonitorElement* ratio_Esummed_HO_3_;
 
-  MonitorElement* Ratio_Esummed_ECAL_0;
-  MonitorElement* Ratio_Esummed_HCAL_0;
-  MonitorElement* Ratio_Esummed_HO_0;
+  MonitorElement* ratio_Esummed_ECAL_4_;
+  MonitorElement* ratio_Esummed_HCAL_4_;
+  MonitorElement* ratio_Esummed_HO_4_;
 
-  MonitorElement* Ratio_Esummed_ECAL_1;
-  MonitorElement* Ratio_Esummed_HCAL_1;
-  MonitorElement* Ratio_Esummed_HO_1;
+  MonitorElement* ratio_Esummed_HF_5_;
+  MonitorElement* ratio_Esummed_HF_6_;
 
-  MonitorElement* Ratio_Esummed_ECAL_2;
-  MonitorElement* Ratio_Esummed_HCAL_2;
-  MonitorElement* Ratio_Esummed_HO_2;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_0_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_HO_0_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_1_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_HO_1_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_2_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_HO_2_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_3_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_HO_3_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_4_;
+  MonitorElement* ratio_Esummed_ECAL_HCAL_HO_4_;
 
-  MonitorElement* Ratio_Esummed_ECAL_3;
-  MonitorElement* Ratio_Esummed_HCAL_3;
-  MonitorElement* Ratio_Esummed_HO_3;
-
-  MonitorElement* Ratio_Esummed_ECAL_4;
-  MonitorElement* Ratio_Esummed_HCAL_4;
-  MonitorElement* Ratio_Esummed_HO_4;
-
-  MonitorElement* Ratio_Esummed_HF_5;
-  MonitorElement* Ratio_Esummed_HF_6;
-
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_0;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_HO_0;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_1;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_HO_1;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_2;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_HO_2;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_3;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_HO_3;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_4;
-  MonitorElement* Ratio_Esummed_ECAL_HCAL_HO_4;
-
-  MonitorElement* Egen_MC;
+  MonitorElement* egen_MC_;
 };
 
-#endif
+#endif  // Validation_RecoParticleFlow_plugins_PFClusterValidation_h


### PR DESCRIPTION
Minimal clean up of the PFClusterValidation module, addressing various issues:
  - unsafe assumptions that could potentially "leak" information across events;
  - use of common functions instead of private redefinitions;
  - adherence to CMS coding rules.