### PR TITLE
CSJet update for fastjet-contrib 1.044

### DIFF
--- a/GeneratorInterface/RivetInterface/test/rivet_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/rivet_cfg.py
@@ -83,7 +83,7 @@ process.generator = cms.EDFilter("Pythia8GeneratorFilter",
 )
 
 process.load("GeneratorInterface.RivetInterface.rivetAnalyzer_cfi")
-process.rivetAnalyzer.AnalysisNames = cms.vstring('MC_GENERIC', 'CMS_2013_I1224539_DIJET', 'CMS_2014_I1305624')
+process.rivetAnalyzer.AnalysisNames = cms.vstring('MC_GENERIC', 'CMS_2014_I1305624')
 
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen*process.rivetAnalyzer)

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -114,7 +114,7 @@ void CSJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSet
         csRParam_);  // free parameter for the maximal allowed distance between particle i and ghost k
     subtractor.set_alpha(
         csAlpha_);  // free parameter for the distance measure (the exponent of particle pt). Note that in older versions of the package alpha was multiplied by two but in newer versions this is not the case anymore
-    subtractor.set_do_mass_subtraction(true);
+    subtractor.set_do_mass_subtraction();
     subtractor.set_remove_all_zero_pt_particles(true);
 
     std::vector<fastjet::PseudoJet> subtracted_particles = subtractor.do_subtraction(particles, ghosts);


### PR DESCRIPTION
#### PR description:

Update of fastjet-contrib required by new Rivet plugins, see https://github.com/cms-sw/cmsdist/pull/6028

Adapt for small change of `ConstituentSubtractor::set_do_mass_subtraction()`
```cpp
  void ConstituentSubtractor::set_do_mass_subtraction(bool do_mass_subtraction){
    _do_mass_subtraction=do_mass_subtraction;
  }
```
to
```cpp
  void ConstituentSubtractor::set_do_mass_subtraction(){
    _do_mass_subtraction=true;
    _masses_to_zero=false;
  }
```

Needs to be tested with https://github.com/cms-sw/cmsdist/pull/6028