### PR TITLE
Reduce boost dependency in DQM/PixelLumi

### DIFF
--- a/DQM/PixelLumi/plugins/BrilClient.cc
+++ b/DQM/PixelLumi/plugins/BrilClient.cc
@@ -1,9 +1,9 @@
 #include "BrilClient.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <filesystem>
 #include <iostream>
 #include <vector>
 
@@ -38,7 +38,7 @@ void BrilClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker_,
   //
 
   ptree json;
-  if (!boost::filesystem::exists(*filePath_)) {
+  if (!std::filesystem::exists(*filePath_)) {
     edm::LogWarning("BrilClient") << "BrilClient"
                                   << " File missing: " << *filePath_ << std::endl;
 

--- a/DQM/PixelLumi/plugins/BuildFile.xml
+++ b/DQM/PixelLumi/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
+<use name="stdcxx-fs"/>
 <library name="DQMPLumDQMPlugins" file="*.cc">
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:
Replaced boost filesystem for standard library filesystem.
The code should have the same behaviour.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 