### PR TITLE
[Backport HGC trigger] Replace exception with warning for missing wafer in module mapping

### DIFF
--- a/L1Trigger/L1THGCal/plugins/BuildFile.xml
+++ b/L1Trigger/L1THGCal/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
   <use name="Geometry/HcalTowerAlgo"/>
   <use name="Geometry/CaloTopology"/>
   <use name="L1Trigger/L1THGCal"/>
+  <use name="tbb"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 


### PR DESCRIPTION
Backport of #30541

Original description:
> #### PR description:
> Replace exception, when a wafer is not found in the trigger module mapping, by a warning.
> 
> Mappings are now declared as `mutable` in order to cache the missing modules and avoid logging a warning multiple times for  the same wafer. But I'm not sure whether `mutable` members are authorized.
> 
> #### PR validation:
> Tested with D59 (`27834.0` workflow), which currently throws an exception.