### PR TITLE
Replace boost filesystem in EventFilter/Utilities

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
@@ -105,7 +105,7 @@ const std::string DQMFileSaverBase::filename(const FileParameters &fp, bool useL
   }
   buf[255] = 0;
 
-  namespace fs = boost::filesystem;
+  namespace fs = std::filesystem;
   fs::path path(fp.path_);
   fs::path file(buf);
 

--- a/EventFilter/Utilities/BuildFile.xml
+++ b/EventFilter/Utilities/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="DataFormats/TCDS"/>
 <use name="IOPool/Streamer"/>
 <use name="curl"/>
+<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -9,13 +9,14 @@
 #include "EventFilter/Utilities/interface/DirManager.h"
 
 //std headers
-#include <string>
-#include <sstream>
+#include <filesystem>
 #include <iomanip>
-#include <vector>
-#include <map>
 #include <list>
+#include <map>
 #include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
 
 //system headers
 #include <sys/stat.h>
@@ -26,7 +27,6 @@
 #include <cstdio>
 
 #include <tbb/concurrent_hash_map.h>
-#include <boost/filesystem.hpp>
 #include <boost/asio.hpp>
 
 class SystemBounds;
@@ -149,7 +149,7 @@ namespace evf {
                          std::string const& rawSourcePath,
                          int64_t& fileSizeFromJson,
                          bool& fileFound);
-    int grabNextJsonFileAndUnlock(boost::filesystem::path const& jsonSourcePath);
+    int grabNextJsonFileAndUnlock(std::filesystem::path const& jsonSourcePath);
 
     EvFDaqDirector::FileStatus contactFileBroker(unsigned int& serverHttpStatus,
                                                  bool& serverState,

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -10,7 +10,9 @@
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "boost/filesystem.hpp"
+#include <filesystem>
+
+#include <boost/thread.hpp>
 
 #include "EventFilter/Utilities/interface/MicroStateService.h"
 #include "EventFilter/Utilities/interface/FastMonitoringThread.h"
@@ -281,7 +283,7 @@ namespace evf {
     std::vector<ContainableAtomic<unsigned int>> eventCountForPathInit_;
     std::vector<bool> pathNamesReady_;
 
-    boost::filesystem::path workingDirectory_, runDirectory_;
+    std::filesystem::path workingDirectory_, runDirectory_;
 
     bool threadIDAvailable_ = false;
 

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -1,15 +1,15 @@
 #ifndef EventFilter_Utilities_FedRawDataInputSource_h
 #define EventFilter_Utilities_FedRawDataInputSource_h
 
-#include <memory>
-#include <cstdio>
-#include <mutex>
 #include <condition_variable>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <mutex>
 #include <thread>
+
 #include "tbb/concurrent_queue.h"
 #include "tbb/concurrent_vector.h"
-
-#include "boost/filesystem.hpp"
 
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"

--- a/EventFilter/Utilities/plugins/BuildFile.xml
+++ b/EventFilter/Utilities/plugins/BuildFile.xml
@@ -11,5 +11,6 @@
   <use name="CLHEP"/>
   <use name="boost"/>
   <use name="root"/>
+  <use name="stdcxx-fs"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -228,7 +228,7 @@ void RawEventFileWriterForBU::finishFileWrite(int ls) {
     rename(fileName_.c_str(), (destinationDir_ + fileName_.substr(fileName_.rfind("/"))).c_str());
     //create equivalent JSON file
     //TODO:fix this to use DaqDirector convention and better extension replace
-    boost::filesystem::path source(fileName_);
+    std::filesystem::path source(fileName_);
     std::string path = source.replace_extension(".jsn").string();
 
     fileMon_->snap(ls);

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -6,11 +6,12 @@
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-#include <sstream>
+#include <filesystem>
 #include <iomanip>
-#include <boost/filesystem.hpp>
-#include <boost/algorithm/string.hpp>
+#include <sstream>
+
 #include <zlib.h>
+#include <boost/algorithm/string.hpp>
 
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"
 #include "EventFilter/Utilities/interface/JsonMonitorable.h"
@@ -50,8 +51,8 @@ namespace evf {
   private:
     std::unique_ptr<Consumer> c_;
     std::string streamLabel_;
-    boost::filesystem::path openDatFilePath_;
-    boost::filesystem::path openDatChecksumFilePath_;
+    std::filesystem::path openDatFilePath_;
+    std::filesystem::path openDatChecksumFilePath_;
     jsoncollector::IntJ processed_;
     mutable jsoncollector::IntJ accepted_;
     jsoncollector::IntJ errorEvents_;
@@ -157,7 +158,7 @@ namespace evf {
       std::string content;
       jsoncollector::JSONSerializer::serialize(&outJsonDef_, content);
       jsoncollector::FileIO::writeStringToFile(outTmpJsonDefName, content);
-      boost::filesystem::rename(outTmpJsonDefName, outJsonDefName);
+      std::filesystem::rename(outTmpJsonDefName, outJsonDefName);
     }
     edm::Service<evf::EvFDaqDirector>()->unlockInitLock();
 
@@ -224,7 +225,7 @@ namespace evf {
           << " obtained:" << adler32c;
     } else {
       LogDebug("RecoEventOutputModuleForFU") << "Ini file checksum -: " << streamLabel_ << " " << adler32c;
-      boost::filesystem::rename(openIniFileName, edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_));
+      std::filesystem::rename(openIniFileName, edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_));
     }
   }
 
@@ -289,9 +290,8 @@ namespace evf {
       struct stat istat;
       stat(openDatFilePath_.string().c_str(), &istat);
       filesize = istat.st_size;
-      boost::filesystem::rename(
-          openDatFilePath_.string().c_str(),
-          edm::Service<evf::EvFDaqDirector>()->getDatFilePath(ls.luminosityBlock(), streamLabel_));
+      std::filesystem::rename(openDatFilePath_.string().c_str(),
+                              edm::Service<evf::EvFDaqDirector>()->getDatFilePath(ls.luminosityBlock(), streamLabel_));
     } else {
       filelist_ = "";
       fileAdler32_.value() = -1;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -240,11 +240,11 @@ namespace evf {
             throw cms::Exception("DaqDirector")
                 << " Error creating bu run dir -: " << hltdir << " mkdir error:" << strerror(errno) << "\n";
 
-          boost::filesystem::copy_file(hltSourceDirectory_ + "/HltConfig.py", tmphltdir + "/HltConfig.py");
+          std::filesystem::copy_file(hltSourceDirectory_ + "/HltConfig.py", tmphltdir + "/HltConfig.py");
 
-          boost::filesystem::copy_file(hltSourceDirectory_ + "/fffParameters.jsn", tmphltdir + "/fffParameters.jsn");
+          std::filesystem::copy_file(hltSourceDirectory_ + "/fffParameters.jsn", tmphltdir + "/fffParameters.jsn");
 
-          boost::filesystem::rename(tmphltdir, hltdir);
+          std::filesystem::rename(tmphltdir, hltdir);
         } else
           throw cms::Exception("DaqDirector") << " Error looking for HLT configuration -: " << hltSourceDirectory_;
       }
@@ -710,7 +710,7 @@ namespace evf {
   }
 
   int EvFDaqDirector::getNFilesFromEoLS(std::string BUEoLSFile) {
-    boost::filesystem::ifstream ij(BUEoLSFile);
+    std::ifstream ij(BUEoLSFile);
     Json::Value deserializeRoot;
     Json::Reader reader;
 
@@ -1097,7 +1097,7 @@ namespace evf {
     fileFound = true;
 
     //take only first three tokens delimited by "_" in the renamed raw file name
-    std::string jsonStem = boost::filesystem::path(rawSourcePath).stem().string();
+    std::string jsonStem = std::filesystem::path(rawSourcePath).stem().string();
     size_t pos = 0, n_tokens = 0;
     while (n_tokens++ < 3 && (pos = jsonStem.find("_", pos + 1)) != std::string::npos) {
     }
@@ -1177,7 +1177,7 @@ namespace evf {
 
     //should be ported to use fffnaming
     std::ostringstream fileNameWithPID;
-    fileNameWithPID << boost::filesystem::path(rawSourcePath).stem().string() << "_pid" << std::setfill('0')
+    fileNameWithPID << std::filesystem::path(rawSourcePath).stem().string() << "_pid" << std::setfill('0')
                     << std::setw(5) << pid_ << ".jsn";
 
     // assemble json destination path
@@ -1273,9 +1273,9 @@ namespace evf {
       } else {
         //json will normally not be bigger than buf_sz bytes
         try {
-          boost::filesystem::ifstream ij(jsonDestPath);
+          std::ifstream ij(jsonDestPath);
           ss << ij.rdbuf();
-        } catch (boost::filesystem::filesystem_error const& ex) {
+        } catch (std::filesystem::filesystem_error const& ex) {
           edm::LogError("EvFDaqDirector") << "grabNextJsonFile - BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
           return -1;
         }
@@ -1349,11 +1349,11 @@ namespace evf {
     return -1;
   }
 
-  int EvFDaqDirector::grabNextJsonFileAndUnlock(boost::filesystem::path const& jsonSourcePath) {
+  int EvFDaqDirector::grabNextJsonFileAndUnlock(std::filesystem::path const& jsonSourcePath) {
     std::string data;
     try {
       // assemble json destination path
-      boost::filesystem::path jsonDestPath(baseRunDir());
+      std::filesystem::path jsonDestPath(baseRunDir());
 
       //should be ported to use fffnaming
       std::ostringstream fileNameWithPID;
@@ -1363,20 +1363,20 @@ namespace evf {
 
       LogDebug("EvFDaqDirector") << "JSON rename -: " << jsonSourcePath << " to " << jsonDestPath;
       try {
-        boost::filesystem::copy(jsonSourcePath, jsonDestPath);
-      } catch (boost::filesystem::filesystem_error const& ex) {
+        std::filesystem::copy(jsonSourcePath, jsonDestPath);
+      } catch (std::filesystem::filesystem_error const& ex) {
         // Input dir gone?
         edm::LogError("EvFDaqDirector") << "grabNextFile BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
         //                                     << " Maybe the file is not yet visible by FU. Trying again in one second";
         sleep(1);
-        boost::filesystem::copy(jsonSourcePath, jsonDestPath);
+        std::filesystem::copy(jsonSourcePath, jsonDestPath);
       }
       unlockFULocal();
 
       try {
         //sometimes this fails but file gets deleted
-        boost::filesystem::remove(jsonSourcePath);
-      } catch (boost::filesystem::filesystem_error const& ex) {
+        std::filesystem::remove(jsonSourcePath);
+      } catch (std::filesystem::filesystem_error const& ex) {
         // Input dir gone?
         edm::LogError("EvFDaqDirector") << "grabNextFile BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
       } catch (std::exception const& ex) {
@@ -1384,7 +1384,7 @@ namespace evf {
         edm::LogError("EvFDaqDirector") << "grabNextFile std::exception CAUGHT -: " << ex.what();
       }
 
-      boost::filesystem::ifstream ij(jsonDestPath);
+      std::ifstream ij(jsonDestPath);
       Json::Value deserializeRoot;
       Json::Reader reader;
 
@@ -1418,7 +1418,7 @@ namespace evf {
               << " error reading number of events from BU JSON -: No input value " << data;
       }
       return boost::lexical_cast<int>(data);
-    } catch (boost::filesystem::filesystem_error const& ex) {
+    } catch (std::filesystem::filesystem_error const& ex) {
       // Input dir gone?
       unlockFULocal();
       edm::LogError("EvFDaqDirector") << "grabNextFile BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
@@ -1832,15 +1832,15 @@ namespace evf {
   void EvFDaqDirector::createRunOpendirMaybe() {
     // create open dir if not already there
 
-    boost::filesystem::path openPath = getRunOpenDirPath();
-    if (!boost::filesystem::is_directory(openPath)) {
+    std::filesystem::path openPath = getRunOpenDirPath();
+    if (!std::filesystem::is_directory(openPath)) {
       LogDebug("EvFDaqDirector") << "<open> FU dir not found. Creating... -:" << openPath.string();
-      boost::filesystem::create_directories(openPath);
+      std::filesystem::create_directories(openPath);
     }
   }
 
   int EvFDaqDirector::readLastLSEntry(std::string const& file) {
-    boost::filesystem::ifstream ij(file);
+    std::ifstream ij(file);
     Json::Value deserializeRoot;
     Json::Reader reader;
 

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -18,7 +18,7 @@
 #include "IOPool/Streamer/interface/EventMsgBuilder.h"
 
 #include <sys/stat.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/algorithm/string.hpp>
 
 namespace evf {
@@ -84,7 +84,7 @@ namespace evf {
       std::string content;
       jsoncollector::JSONSerializer::serialize(&outJsonDef_, content);
       jsoncollector::FileIO::writeStringToFile(outTmpJsonDefName, content);
-      boost::filesystem::rename(outTmpJsonDefName, outJsonDefName);
+      std::filesystem::rename(outTmpJsonDefName, outJsonDefName);
     }
     edm::Service<evf::EvFDaqDirector>()->unlockInitLock();
 
@@ -206,7 +206,7 @@ namespace evf {
                                               << " expected:" << preamble_adler32 << " obtained:" << adler32c;
     } else {
       LogDebug("EvFOutputModule") << "Ini file checksum -: " << streamLabel_ << " " << adler32c;
-      boost::filesystem::rename(openIniFileName, edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_));
+      std::filesystem::rename(openIniFileName, edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_));
     }
   }
 
@@ -252,12 +252,11 @@ namespace evf {
 
     if (jsonWriter_->processed_.value() != 0) {
       struct stat istat;
-      boost::filesystem::path openDatFilePath = lumiWriter->getFilePath();
+      std::filesystem::path openDatFilePath = lumiWriter->getFilePath();
       stat(openDatFilePath.string().c_str(), &istat);
       jsonWriter_->filesize_ = istat.st_size;
-      boost::filesystem::rename(
-          openDatFilePath.string().c_str(),
-          edm::Service<evf::EvFDaqDirector>()->getDatFilePath(iLB.luminosityBlock(), streamLabel_));
+      std::filesystem::rename(openDatFilePath.string().c_str(),
+                              edm::Service<evf::EvFDaqDirector>()->getDatFilePath(iLB.luminosityBlock(), streamLabel_));
       jsonWriter_->filelist_ = openDatFilePath.filename().string();
     } else {
       //remove empty file when no event processing has occurred

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -237,14 +237,14 @@ namespace evf {
     if (edm::Service<evf::EvFDaqDirector>().operator->() == nullptr) {
       throw cms::Exception("FastMonitoringService") << "EvFDaqDirector is not present";
     }
-    boost::filesystem::path runDirectory{edm::Service<evf::EvFDaqDirector>()->baseRunDir()};
+    std::filesystem::path runDirectory{edm::Service<evf::EvFDaqDirector>()->baseRunDir()};
     workingDirectory_ = runDirectory_ = runDirectory;
     workingDirectory_ /= "mon";
 
-    if (!boost::filesystem::is_directory(workingDirectory_)) {
+    if (!std::filesystem::is_directory(workingDirectory_)) {
       LogDebug("FastMonitoringService") << "<MON> DIR NOT FOUND! Trying to create -: " << workingDirectory_.string();
-      boost::filesystem::create_directories(workingDirectory_);
-      if (!boost::filesystem::is_directory(workingDirectory_))
+      std::filesystem::create_directories(workingDirectory_);
+      if (!std::filesystem::is_directory(workingDirectory_))
         edm::LogWarning("FastMonitoringService") << "Unable to create <MON> DIR -: " << workingDirectory_.string()
                                                  << ". No monitoring data will be written.";
     }
@@ -252,7 +252,7 @@ namespace evf {
     std::ostringstream fastFileName;
 
     fastFileName << fastName_ << "_pid" << std::setfill('0') << std::setw(5) << getpid() << ".fast";
-    boost::filesystem::path fast = workingDirectory_;
+    std::filesystem::path fast = workingDirectory_;
     fast /= fastFileName.str();
     fastPath_ = fast.string();
     if (filePerFwkStream_)
@@ -260,7 +260,7 @@ namespace evf {
         std::ostringstream fastFileNameTid;
         fastFileNameTid << fastName_ << "_pid" << std::setfill('0') << std::setw(5) << getpid() << "_tid" << i
                         << ".fast";
-        boost::filesystem::path fastTid = workingDirectory_;
+        std::filesystem::path fastTid = workingDirectory_;
         fastTid /= fastFileNameTid.str();
         fastPathList_.push_back(fastTid.string());
       }
@@ -515,14 +515,14 @@ namespace evf {
       std::stringstream slowFileNameStem;
       slowFileNameStem << slowName_ << "_ls" << std::setfill('0') << std::setw(4) << lumi << "_pid" << std::setfill('0')
                        << std::setw(5) << getpid();
-      boost::filesystem::path slow = workingDirectory_;
+      std::filesystem::path slow = workingDirectory_;
       slow /= slowFileNameStem.str();
       fmt_.jsonMonitor_->outputFullJSONs(slow.string(), ".jsn", lumi);
     } else {
       std::stringstream slowFileName;
       slowFileName << slowName_ << "_ls" << std::setfill('0') << std::setw(4) << lumi << "_pid" << std::setfill('0')
                    << std::setw(5) << getpid() << ".jsn";
-      boost::filesystem::path slow = workingDirectory_;
+      std::filesystem::path slow = workingDirectory_;
       slow /= slowFileName.str();
       fmt_.jsonMonitor_->outputFullJSON(slow.string(),
                                         lumi);  //full global and stream merge and JSON write for this lumi

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -977,7 +977,7 @@ void FedRawDataInputSource::readSupervisor() {
       if (useFileBroker_ || rawHeaderSize)
         rawFile = nextFile;
       else {
-        boost::filesystem::path rawFilePath(nextFile);
+        std::filesystem::path rawFilePath(nextFile);
         rawFile = rawFilePath.replace_extension(".raw").string();
       }
 
@@ -1386,20 +1386,20 @@ InputFile::~InputFile() {
     close(rawFd_);
 
   if (deleteFile_ && !fileName_.empty()) {
-    const boost::filesystem::path filePath(fileName_);
+    const std::filesystem::path filePath(fileName_);
     try {
       //sometimes this fails but file gets deleted
       LogDebug("FedRawDataInputSource:InputFile") << "Deleting input file -:" << fileName_;
-      boost::filesystem::remove(filePath);
+      std::filesystem::remove(filePath);
       return;
-    } catch (const boost::filesystem::filesystem_error& ex) {
+    } catch (const std::filesystem::filesystem_error& ex) {
       edm::LogError("FedRawDataInputSource:InputFile")
           << " - deleteFile BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what() << ". Trying again.";
     } catch (std::exception& ex) {
       edm::LogError("FedRawDataInputSource:InputFile")
           << " - deleteFile std::exception CAUGHT -: " << ex.what() << ". Trying again.";
     }
-    boost::filesystem::remove(filePath);
+    std::filesystem::remove(filePath);
   }
 }
 
@@ -1507,7 +1507,7 @@ long FedRawDataInputSource::initFileList() {
 
   if (!fileNames_.empty()) {
     //get run number from first file in the vector
-    boost::filesystem::path fileName = fileNames_[0];
+    std::filesystem::path fileName = fileNames_[0];
     std::string fileStem = fileName.stem().string();
     auto end = fileStem.find("_");
     if (fileStem.find("run") == 0) {
@@ -1536,7 +1536,7 @@ evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getFile(unsigned int& ls,
       nextFile = nextFile.substr(7);
     else if (nextFile.find("file:") == 0)
       nextFile = nextFile.substr(5);
-    boost::filesystem::path fileName = nextFile;
+    std::filesystem::path fileName = nextFile;
     std::string fileStem = fileName.stem().string();
     if (fileStem.find("ls"))
       fileStem = fileStem.substr(fileStem.find("ls") + 2);


### PR DESCRIPTION
#### PR description:
Changed boost filesystem for standard template library filesystem.
The code should have the same behaviour.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 