### PR TITLE
Fix out-of-bound issue in call to LUT in GEM-CSC trigger [11_1_X]

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -200,6 +200,8 @@ protected:
 
   /** Chamber id (trigger-type labels). */
   unsigned gemId;
+  int maxPads() const;
+  int maxRolls() const;
 
   const GEMGeometry* gem_g;
   bool gemGeometryAvailable;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -175,7 +175,6 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
     valid = true;
   } else if (clct.isValid() and gem2.isValid() and not alct.isValid()) {
-
     assert(gem2.roll() >= GEMDetId::minRollId);
     assert(gem2.roll() <= maxRolls());
 
@@ -185,7 +184,7 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     bx = gem2.bx(1) + CSCConstants::LCT_CENTRAL_BX;
     keyStrip = clct.getKeyStrip();
     // choose the corresponding wire-group in the middle of the partition
-    keyWG = mymap2.at(gem2.roll() -1 );
+    keyWG = mymap2.at(gem2.roll() - 1);
     bend = clct.getBend();
     thisLCT.setCLCT(clct);
     thisLCT.setGEM1(gem2.first());
@@ -275,13 +274,9 @@ void CSCGEMMotherboard::setupGeometry() {
   generator_->setGEMGeometry(gem_g);
 }
 
-int CSCGEMMotherboard::maxPads() const {
-  return gem_g->superChamber(gemId)->chamber(1)->etaPartition(1)->npads();
-}
+int CSCGEMMotherboard::maxPads() const { return gem_g->superChamber(gemId)->chamber(1)->etaPartition(1)->npads(); }
 
-int CSCGEMMotherboard::maxRolls() const {
-  return gem_g->superChamber(gemId)->chamber(1)->nEtaPartitions();
-}
+int CSCGEMMotherboard::maxRolls() const { return gem_g->superChamber(gemId)->chamber(1)->nEtaPartitions(); }
 
 void CSCGEMMotherboard::printGEMTriggerPads(int bx_start, int bx_stop, enum CSCPart part) {
   LogTrace("CSCGEMMotherboard") << "------------------------------------------------------------------------"

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -144,20 +144,26 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
         p = CSCPart::ME1A;
     }
 
+    assert(gem2.pad(1) >= 0);
+    assert(gem2.pad(2) >= 0);
+    assert(gem2.pad(1) < maxPads());
+    assert(gem2.pad(2) < maxPads());
+
     const auto& mymap1 = getLUT()->get_gem_pad_to_csc_hs(theParity, p);
     // GEM pad number is counting from 1
     // keyStrip from mymap:  for ME1b 0-127 and for ME1a 0-95
     // keyStrip for CLCT: for ME1b 0-127 and for ME1a 128-223
-    keyStrip = mymap1[gem2.pad(2) - 1];
-    if (p == CSCPart::ME1A and keyStrip <= CSCConstants::MAX_HALF_STRIP_ME1B)
+    keyStrip = mymap1.at(gem2.pad(2));
+    if (p == CSCPart::ME1A and keyStrip <= CSCConstants::MAX_HALF_STRIP_ME1B) {
       keyStrip += CSCConstants::MAX_HALF_STRIP_ME1B + 1;
+    }
     keyWG = alct.getKeyWG();
 
     if ((not doesWiregroupCrossStrip(keyWG, keyStrip)) and p == CSCPart::ME1B and keyWG <= 15) {
       //try ME1A as strip and WG do not cross
       p = CSCPart::ME1A;
       const auto& mymap2 = getLUT()->get_gem_pad_to_csc_hs(theParity, p);
-      keyStrip = mymap2[gem2.pad(2) - 1] + CSCConstants::MAX_HALF_STRIP_ME1B + 1;
+      keyStrip = mymap2.at(gem2.pad(2)) + CSCConstants::MAX_HALF_STRIP_ME1B + 1;
     }
 
     pattern = promoteALCTGEMpattern_ ? 10 : 0;
@@ -169,13 +175,17 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
     valid = true;
   } else if (clct.isValid() and gem2.isValid() and not alct.isValid()) {
+
+    assert(gem2.roll() >= GEMDetId::minRollId);
+    assert(gem2.roll() <= maxRolls());
+
     const auto& mymap2 = getLUT()->get_gem_roll_to_csc_wg(theParity);
     pattern = encodePattern(clct.getPattern());
     quality = promoteCLCTGEMquality_ ? 15 : 11;
     bx = gem2.bx(1) + CSCConstants::LCT_CENTRAL_BX;
     keyStrip = clct.getKeyStrip();
     // choose the corresponding wire-group in the middle of the partition
-    keyWG = mymap2[gem2.roll() - 1];
+    keyWG = mymap2.at(gem2.roll() -1 );
     bend = clct.getBend();
     thisLCT.setCLCT(clct);
     thisLCT.setGEM1(gem2.first());
@@ -221,7 +231,7 @@ bool CSCGEMMotherboard::isPadInOverlap(int roll) const {
     // overlap region are WGs 10-15
     if ((i < 10) or (i > 15))
       continue;
-    if ((mymap[i].first <= roll) and (roll <= mymap[i].second))
+    if ((mymap.at(i).first <= roll) and (roll <= mymap.at(i).second))
       return true;
   }
   return false;
@@ -240,8 +250,8 @@ int CSCGEMMotherboard::getRoll(const GEMPadDigiId& p) const { return GEMDetId(p.
 int CSCGEMMotherboard::getRoll(const GEMCoPadDigiId& p) const { return p.second.roll(); }
 
 std::pair<int, int> CSCGEMMotherboard::getRolls(const CSCALCTDigi& alct) const {
-  return std::make_pair((getLUT()->get_csc_wg_to_gem_roll(theParity))[alct.getKeyWG()].first,
-                        (getLUT()->get_csc_wg_to_gem_roll(theParity))[alct.getKeyWG()].second);
+  const auto& mymap(getLUT()->get_csc_wg_to_gem_roll(theParity));
+  return std::make_pair(mymap.at(alct.getKeyWG()).first, mymap.at(alct.getKeyWG()).second);
 }
 
 float CSCGEMMotherboard::getPad(const GEMPadDigi& p) const { return p.pad(); }
@@ -257,12 +267,20 @@ float CSCGEMMotherboard::getPad(const CSCCLCTDigi& clct, enum CSCPart part) cons
   //ME1A part, convert halfstrip from 128-223 to 0-95
   if (part == CSCPart::ME1A and keyStrip > CSCConstants::MAX_HALF_STRIP_ME1B)
     keyStrip = keyStrip - CSCConstants::MAX_HALF_STRIP_ME1B - 1;
-  return 0.5 * (mymap[keyStrip].first + mymap[keyStrip].second);
+  return 0.5 * (mymap.at(keyStrip).first + mymap.at(keyStrip).second);
 }
 
 void CSCGEMMotherboard::setupGeometry() {
   CSCUpgradeMotherboard::setupGeometry();
   generator_->setGEMGeometry(gem_g);
+}
+
+int CSCGEMMotherboard::maxPads() const {
+  return gem_g->superChamber(gemId)->chamber(1)->etaPartition(1)->npads();
+}
+
+int CSCGEMMotherboard::maxRolls() const {
+  return gem_g->superChamber(gemId)->chamber(1)->nEtaPartitions();
 }
 
 void CSCGEMMotherboard::printGEMTriggerPads(int bx_start, int bx_stop, enum CSCPart part) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -144,6 +144,8 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
         p = CSCPart::ME1A;
     }
 
+    // min pad number is always 0
+    // max pad number is 191 or 383, depending on the station
     assert(gem2.pad(1) >= 0);
     assert(gem2.pad(2) >= 0);
     assert(gem2.pad(1) < maxPads());
@@ -175,6 +177,8 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
     valid = true;
   } else if (clct.isValid() and gem2.isValid() and not alct.isValid()) {
+    // min roll number is always 1
+    // max roll number is 8 or 16, depending on the station
     assert(gem2.roll() >= GEMDetId::minRollId);
     assert(gem2.roll() <= maxRolls());
 

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -27,6 +27,8 @@ GEMCoPadProcessor::GEMCoPadProcessor() : theRegion(1), theStation(1), theChamber
 void GEMCoPadProcessor::clear() { gemCoPadV.clear(); }
 
 std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_pads) {
+  clear();  
+    
   // Build coincidences
   for (auto det_range = in_pads->begin(); det_range != in_pads->end(); ++det_range) {
     const GEMDetId& id = (*det_range).first;


### PR DESCRIPTION
#### PR description:

* This PR should fix a bug reported in the GEM-CSC trigger in CMSSW_11_0_X samples, when a pad number goes out of bounds in the `[]` operator. I also replaced `[]` with `at()` and added a few assert statements. The bug was introduced when the pad numbering in GE1/1 was changed from 1->192 to 0->191, and in GE2/1 from 1->384 to 0->383. Messages like the one below must not appear any more
```
%MSG-w L1T:  L1TMuonEndCapTrackProducer:simEmtfDigis 19-Jun-2020 08:46:45 CEST  Run: 1 Event: 41297689
EMTF CSC format error in station 1, ring 1: tp_data.keywire = 561 (max = 47)
%MSG
```

* Clear copad vector in the copad processor for each new event. As explained here (https://github.com/cms-sw/cmssw/pull/30169#issuecomment-646297979) there should be a reduction in the number of coincidence GEM pads in the comparisons.

#### PR validation:

Tested on a few thousand events in `/Mu_FlatPt2to100-pythia8-gun/PhaseIITDRSpring19DR-PU200_106X_upgrade2023_realistic_v3-v2/GEN-SIM-DIGI-RAW`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/30564. Partial backport of https://github.com/cms-sw/cmssw/pull/30169 (https://github.com/cms-sw/cmssw/pull/30169/commits/50a2b7fca312e60c5002cceb1ad31b9a5f5b186e) needed for HLT TDR reprocessing.

FYI @eyigitba @tahuang1991 @rekovic 