### PR TITLE
Backport DeepMET into CMSSW_10_6_X (original: #29764)

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -163,13 +163,13 @@ namespace pat {
        Raw=0, Type1=1, Type01=2, TypeXY=3, Type1XY=4, Type01XY=5,
        Type1Smear=6, Type01Smear=7, Type1SmearXY=8, 
        Type01SmearXY=9, RawCalo=10, RawChs=11, RawTrk=12, 
-	   RawDeepResponseTune=13, RawDeepResolutionTune=14, METCorrectionLevelSize=15
+       RawDeepResponseTune=13, RawDeepResolutionTune=14, METCorrectionLevelSize=15
       };
       enum METCorrectionType {
        None=0, T1=1, T0=2, TXY=3, TXYForRaw=4,
        TXYForT01=5, TXYForT1Smear=6, TXYForT01Smear=7,
        Smear=8, Calo=9, Chs=10, Trk=11, 
-	   DeepResponseTune=12, DeepResolutionTune=13, METCorrectionTypeSize=14
+       DeepResponseTune=12, DeepResolutionTune=13, METCorrectionTypeSize=14
       };
 
       struct Vector2 { 

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -162,12 +162,14 @@ namespace pat {
       enum METCorrectionLevel {
        Raw=0, Type1=1, Type01=2, TypeXY=3, Type1XY=4, Type01XY=5,
        Type1Smear=6, Type01Smear=7, Type1SmearXY=8, 
-       Type01SmearXY=9, RawCalo=10, RawChs=11, RawTrk=12, METCorrectionLevelSize=13
+       Type01SmearXY=9, RawCalo=10, RawChs=11, RawTrk=12, 
+	   RawDeepResponseTune=13, RawDeepResolutionTune=14, METCorrectionLevelSize=15
       };
       enum METCorrectionType {
        None=0, T1=1, T0=2, TXY=3, TXYForRaw=4,
        TXYForT01=5, TXYForT1Smear=6, TXYForT01Smear=7,
-       Smear=8, Calo=9, Chs=10, Trk=11, METCorrectionTypeSize=12
+       Smear=8, Calo=9, Chs=10, Trk=11, 
+	   DeepResponseTune=12, DeepResolutionTune=13, METCorrectionTypeSize=14
       };
 
       struct Vector2 { 

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -4,7 +4,6 @@
 #ifndef DataFormats_PatCandidates_MET_h
 #define DataFormats_PatCandidates_MET_h
 
-
 /**
   \class    pat::MET MET.h "DataFormats/PatCandidates/interface/MET.h"
   \brief    Analysis-level MET class
@@ -30,256 +29,321 @@
 // Define typedefs for convenience
 namespace pat {
   class MET;
-  typedef std::vector<MET>              METCollection; 
-  typedef edm::Ref<METCollection>       METRef; 
-  typedef edm::RefVector<METCollection> METRefVector; 
-}
-
+  typedef std::vector<MET> METCollection;
+  typedef edm::Ref<METCollection> METRef;
+  typedef edm::RefVector<METCollection> METRefVector;
+}  // namespace pat
 
 // Class definition
 namespace pat {
 
-
   class MET : public PATObject<reco::MET> {
+  public:
+    /// default constructor
+    MET();
+    /// constructor from reco::MET
+    MET(const reco::MET& aMET);
+    /// constructor from a RefToBase to reco::MET (to be superseded by Ptr counterpart)
+    MET(const edm::RefToBase<reco::MET>& aMETRef);
+    /// constructor from a Ptr to a reco::MET
+    MET(const edm::Ptr<reco::MET>& aMETRef);
+    /// copy constructor
+    MET(MET const&);
+    /// constructor for corrected METs (keeping specific informations from src MET)
+    MET(const reco::MET& corMET, const MET& srcMET);
+    /// destructor
+    ~MET() override;
 
+    MET& operator=(MET const&);
+
+    /// required reimplementation of the Candidate's clone method
+    MET* clone() const override { return new MET(*this); }
+
+    // ---- methods for generated MET link ----
+    /// return the associated GenMET
+    const reco::GenMET* genMET() const;
+    /// set the associated GenMET
+    void setGenMET(const reco::GenMET& gm);
+
+    // ----- MET significance functions ----
+    // set the MET Significance
+    void setMETSignificance(const double& metSig);
+    // get the MET significance
+    double metSignificance() const;
+    // set the MET sumPtUnclustered for MET Significance
+    void setMETSumPtUnclustered(const double& sumPtUnclustered);
+    // get the MET sumPtUnclustered
+    double metSumPtUnclustered() const;
+
+    // ---- methods for uncorrected MET ----
+    // Methods not yet defined
+    //float uncorrectedPt() const;
+    //float uncorrectedPhi() const;
+    //float uncorrectedSumEt() const;
+
+    // ---- methods to know what the pat::MET was constructed from ----
+    /// True if this pat::MET was made from a reco::CaloMET
+    bool isCaloMET() const { return !caloMET_.empty(); }
+    /// True if this pat::MET was made from a reco::pfMET
+    bool isPFMET() const { return !pfMET_.empty(); }
+    /// True if this pat::MET was NOT made from a reco::CaloMET nor a reco::pfMET
+    bool isRecoMET() const { return (caloMET_.empty() && pfMET_.empty()); }
+
+    // ---- methods for CaloMET specific stuff ----
+    /// Returns the maximum energy deposited in ECAL towers
+    double maxEtInEmTowers() const { return caloSpecific().MaxEtInEmTowers; }
+    /// Returns the maximum energy deposited in HCAL towers
+    double maxEtInHadTowers() const { return caloSpecific().MaxEtInHadTowers; }
+    /// Returns the event hadronic energy fraction
+    double etFractionHadronic() const { return caloSpecific().EtFractionHadronic; }
+    /// Returns the event electromagnetic energy fraction
+    double emEtFraction() const { return caloSpecific().EtFractionEm; }
+    /// Returns the event hadronic energy in HB
+    double hadEtInHB() const { return caloSpecific().HadEtInHB; }
+    /// Returns the event hadronic energy in HO
+    double hadEtInHO() const { return caloSpecific().HadEtInHO; }
+    /// Returns the event hadronic energy in HE
+    double hadEtInHE() const { return caloSpecific().HadEtInHE; }
+    /// Returns the event hadronic energy in HF
+    double hadEtInHF() const { return caloSpecific().HadEtInHF; }
+    /// Returns the event electromagnetic energy in EB
+    double emEtInEB() const { return caloSpecific().EmEtInEB; }
+    /// Returns the event electromagnetic energy in EE
+    double emEtInEE() const { return caloSpecific().EmEtInEE; }
+    /// Returns the event electromagnetic energy extracted from HF
+    double emEtInHF() const { return caloSpecific().EmEtInHF; }
+    /// Returns the event MET Significance
+    double caloMetSignificance() const { return caloSpecific().METSignificance; }
+    /// Returns the event SET in HF+
+    double CaloSETInpHF() const { return caloSpecific().CaloSETInpHF; }
+    /// Returns the event SET in HF-
+    double CaloSETInmHF() const { return caloSpecific().CaloSETInmHF; }
+    /// Returns the event MET in HF+
+    double CaloMETInpHF() const { return caloSpecific().CaloMETInpHF; }
+    /// Returns the event MET in HF-
+    double CaloMETInmHF() const { return caloSpecific().CaloMETInmHF; }
+    /// Returns the event MET-phi in HF+
+    double CaloMETPhiInpHF() const { return caloSpecific().CaloMETPhiInpHF; }
+    /// Returns the event MET-phi in HF-
+    double CaloMETPhiInmHF() const { return caloSpecific().CaloMETPhiInmHF; }
+    /// accessor for the CaloMET-specific structure
+    const SpecificCaloMETData& caloSpecific() const {
+      if (!isCaloMET())
+        throw cms::Exception("pat::MET") << "This pat::MET has not been made from a reco::CaloMET\n";
+      return caloMET_[0];
+    }
+
+    // ---- methods for PFMET specific stuff ----
+    double NeutralEMFraction() const { return pfSpecific().NeutralEMFraction; }
+    double NeutralHadEtFraction() const { return pfSpecific().NeutralHadFraction; }
+    double ChargedEMEtFraction() const { return pfSpecific().ChargedEMFraction; }
+    double ChargedHadEtFraction() const { return pfSpecific().ChargedHadFraction; }
+    double MuonEtFraction() const { return pfSpecific().MuonFraction; }
+    double Type6EtFraction() const { return pfSpecific().Type6Fraction; }
+    double Type7EtFraction() const { return pfSpecific().Type7Fraction; }
+    /// accessor for the pfMET-specific structure
+    const SpecificPFMETData& pfSpecific() const {
+      if (!isPFMET())
+        throw cms::Exception("pat::MET") << "This pat::MET has not been made from a reco::PFMET\n";
+      return pfMET_[0];
+    }
+
+    // ---- members for MET corrections ----
+    enum METUncertainty {
+      JetResUp = 0,
+      JetResDown = 1,
+      JetEnUp = 2,
+      JetEnDown = 3,
+      MuonEnUp = 4,
+      MuonEnDown = 5,
+      ElectronEnUp = 6,
+      ElectronEnDown = 7,
+      TauEnUp = 8,
+      TauEnDown = 9,
+      UnclusteredEnUp = 10,
+      UnclusteredEnDown = 11,
+      PhotonEnUp = 12,
+      PhotonEnDown = 13,
+      NoShift = 14,
+      METUncertaintySize = 15,
+      JetResUpSmear = 16,
+      JetResDownSmear = 17,
+      METFullUncertaintySize = 18
+    };
+    enum METCorrectionLevel {
+      Raw = 0,
+      Type1 = 1,
+      Type01 = 2,
+      TypeXY = 3,
+      Type1XY = 4,
+      Type01XY = 5,
+      Type1Smear = 6,
+      Type01Smear = 7,
+      Type1SmearXY = 8,
+      Type01SmearXY = 9,
+      RawCalo = 10,
+      RawChs = 11,
+      RawTrk = 12,
+      RawDeepResponseTune = 13,
+      RawDeepResolutionTune = 14,
+      METCorrectionLevelSize = 15
+    };
+    enum METCorrectionType {
+      None = 0,
+      T1 = 1,
+      T0 = 2,
+      TXY = 3,
+      TXYForRaw = 4,
+      TXYForT01 = 5,
+      TXYForT1Smear = 6,
+      TXYForT01Smear = 7,
+      Smear = 8,
+      Calo = 9,
+      Chs = 10,
+      Trk = 11,
+      DeepResponseTune = 12,
+      DeepResolutionTune = 13,
+      METCorrectionTypeSize = 14
+    };
+
+    struct Vector2 {
+      double px, py;
+      double pt() const { return hypotf(px, py); }
+      double phi() const { return std::atan2(py, px); }
+    };
+
+    Vector2 shiftedP2(METUncertainty shift, METCorrectionLevel level = Type1) const;
+    Vector shiftedP3(METUncertainty shift, METCorrectionLevel level = Type1) const;
+    LorentzVector shiftedP4(METUncertainty shift, METCorrectionLevel level = Type1) const;
+    double shiftedPx(METUncertainty shift, METCorrectionLevel level = Type1) const {
+      return shiftedP2(shift, level).px;
+    };
+    double shiftedPy(METUncertainty shift, METCorrectionLevel level = Type1) const {
+      return shiftedP2(shift, level).py;
+    };
+    double shiftedPt(METUncertainty shift, METCorrectionLevel level = Type1) const {
+      return shiftedP2(shift, level).pt();
+    };
+    double shiftedPhi(METUncertainty shift, METCorrectionLevel level = Type1) const {
+      return shiftedP2(shift, level).phi();
+    };
+    double shiftedSumEt(METUncertainty shift, METCorrectionLevel level = Type1) const;
+
+    Vector2 corP2(METCorrectionLevel level = Type1) const;
+    Vector corP3(METCorrectionLevel level = Type1) const;
+    LorentzVector corP4(METCorrectionLevel level = Type1) const;
+    double corPx(METCorrectionLevel level = Type1) const { return corP2(level).px; };
+    double corPy(METCorrectionLevel level = Type1) const { return corP2(level).py; };
+    double corPt(METCorrectionLevel level = Type1) const { return corP2(level).pt(); };
+    double corPhi(METCorrectionLevel level = Type1) const { return corP2(level).phi(); };
+    double corSumEt(METCorrectionLevel level = Type1) const;
+
+    Vector2 uncorP2() const;
+    Vector uncorP3() const;
+    LorentzVector uncorP4() const;
+    double uncorPx() const { return uncorP2().px; };
+    double uncorPy() const { return uncorP2().py; };
+    double uncorPt() const { return uncorP2().pt(); };
+    double uncorPhi() const { return uncorP2().phi(); };
+    double uncorSumEt() const;
+
+    void setUncShift(double px, double py, double sumEt, METUncertainty shift, bool isSmeared = false);
+    void setCorShift(double px, double py, double sumEt, METCorrectionType level);
+
+    // specific method to fill and retrieve the caloMET quickly from miniAODs,
+    //should be used by JetMET experts only for the beginning
+    //of the runII, will be discarded later once we are sure
+    //everything is fine
+    Vector2 caloMETP2() const;
+    double caloMETPt() const;
+    double caloMETPhi() const;
+    double caloMETSumEt() const;
+
+    //Functions for backward compatibility with 74X samples.
+    // allow access to 74X samples, transparent and not used in 75
+    Vector2 shiftedP2_74x(METUncertainty shift, METCorrectionLevel level) const;
+    Vector shiftedP3_74x(METUncertainty shift, METCorrectionLevel level) const;
+    LorentzVector shiftedP4_74x(METUncertainty shift, METCorrectionLevel level) const;
+    double shiftedSumEt_74x(METUncertainty shift, METCorrectionLevel level) const;
+
+    /// this below should be private but Reflex doesn't like it
+    class PackedMETUncertainty {
+      // defined as C++ class so that I can change the packing without having to touch the code elsewhere
+      // the compiler should anyway inline everything whenever possible
     public:
-
-      /// default constructor
-      MET();
-      /// constructor from reco::MET
-      MET(const reco::MET & aMET);
-      /// constructor from a RefToBase to reco::MET (to be superseded by Ptr counterpart)
-      MET(const edm::RefToBase<reco::MET> & aMETRef);
-      /// constructor from a Ptr to a reco::MET
-      MET(const edm::Ptr<reco::MET> & aMETRef);
-      /// copy constructor
-      MET( MET const&);
-      /// constructor for corrected METs (keeping specific informations from src MET)
-      MET(const reco::MET & corMET, const MET& srcMET );
-      /// destructor
-      ~MET() override;
-
-      MET& operator=(MET const&);
-
-      /// required reimplementation of the Candidate's clone method
-      MET * clone() const override { return new MET(*this); }
-
-      // ---- methods for generated MET link ----
-      /// return the associated GenMET
-      const reco::GenMET * genMET() const;
-      /// set the associated GenMET
-      void setGenMET(const reco::GenMET & gm);
-
-      // ----- MET significance functions ----
-      // set the MET Significance
-      void setMETSignificance(const double& metSig);
-      // get the MET significance
-      double metSignificance() const;
-      // set the MET sumPtUnclustered for MET Significance
-      void setMETSumPtUnclustered(const double& sumPtUnclustered);
-      // get the MET sumPtUnclustered
-      double metSumPtUnclustered() const;
-
-      // ---- methods for uncorrected MET ----
-      // Methods not yet defined
-      //float uncorrectedPt() const;
-      //float uncorrectedPhi() const;
-      //float uncorrectedSumEt() const;
-
-      // ---- methods to know what the pat::MET was constructed from ----
-      /// True if this pat::MET was made from a reco::CaloMET
-      bool isCaloMET() const { return !caloMET_.empty(); }
-      /// True if this pat::MET was made from a reco::pfMET
-      bool isPFMET() const { return !pfMET_.empty(); }
-      /// True if this pat::MET was NOT made from a reco::CaloMET nor a reco::pfMET
-      bool isRecoMET() const { return  ( caloMET_.empty() && pfMET_.empty() ); }
-
-      // ---- methods for CaloMET specific stuff ----
-      /// Returns the maximum energy deposited in ECAL towers
-      double maxEtInEmTowers() const {return caloSpecific().MaxEtInEmTowers;}
-      /// Returns the maximum energy deposited in HCAL towers
-      double maxEtInHadTowers() const {return caloSpecific().MaxEtInHadTowers;}
-      /// Returns the event hadronic energy fraction
-      double etFractionHadronic () const {return caloSpecific().EtFractionHadronic;}
-      /// Returns the event electromagnetic energy fraction
-      double emEtFraction() const {return caloSpecific().EtFractionEm;}
-      /// Returns the event hadronic energy in HB
-      double hadEtInHB() const {return caloSpecific().HadEtInHB;}
-      /// Returns the event hadronic energy in HO
-      double hadEtInHO() const {return caloSpecific().HadEtInHO;}
-      /// Returns the event hadronic energy in HE
-      double hadEtInHE() const {return caloSpecific().HadEtInHE;}
-      /// Returns the event hadronic energy in HF
-      double hadEtInHF() const {return caloSpecific().HadEtInHF;}
-      /// Returns the event electromagnetic energy in EB
-      double emEtInEB() const {return caloSpecific().EmEtInEB;}
-      /// Returns the event electromagnetic energy in EE
-      double emEtInEE() const {return caloSpecific().EmEtInEE;}
-      /// Returns the event electromagnetic energy extracted from HF
-      double emEtInHF() const {return caloSpecific().EmEtInHF;}
-      /// Returns the event MET Significance
-      double caloMetSignificance() const {return caloSpecific().METSignificance;}
-      /// Returns the event SET in HF+
-      double CaloSETInpHF() const {return caloSpecific().CaloSETInpHF;}
-      /// Returns the event SET in HF-
-      double CaloSETInmHF() const {return caloSpecific().CaloSETInmHF;}
-      /// Returns the event MET in HF+
-      double CaloMETInpHF() const {return caloSpecific().CaloMETInpHF;}
-      /// Returns the event MET in HF-
-      double CaloMETInmHF() const {return caloSpecific().CaloMETInmHF;}
-      /// Returns the event MET-phi in HF+
-      double CaloMETPhiInpHF() const {return caloSpecific().CaloMETPhiInpHF;}
-      /// Returns the event MET-phi in HF-
-      double CaloMETPhiInmHF() const {return caloSpecific().CaloMETPhiInmHF;}
-      /// accessor for the CaloMET-specific structure
-      const SpecificCaloMETData & caloSpecific() const {
-          if (!isCaloMET()) throw cms::Exception("pat::MET") << "This pat::MET has not been made from a reco::CaloMET\n";
-          return caloMET_[0];
+      PackedMETUncertainty() : dpx_(0), dpy_(0), dsumEt_(0) {
+        pack();
+        unpack();
       }
-
-      // ---- methods for PFMET specific stuff ----
-      double NeutralEMFraction() const { return pfSpecific().NeutralEMFraction; }
-      double NeutralHadEtFraction() const { return pfSpecific().NeutralHadFraction; }
-      double ChargedEMEtFraction() const { return pfSpecific().ChargedEMFraction; }
-      double ChargedHadEtFraction() const { return pfSpecific().ChargedHadFraction; }
-      double MuonEtFraction() const { return pfSpecific().MuonFraction; }
-      double Type6EtFraction() const { return pfSpecific().Type6Fraction; }
-      double Type7EtFraction() const { return pfSpecific().Type7Fraction; }
-      /// accessor for the pfMET-specific structure
-      const SpecificPFMETData & pfSpecific() const {
-          if (!isPFMET()) throw cms::Exception("pat::MET") << "This pat::MET has not been made from a reco::PFMET\n";
-          return pfMET_[0];
+      PackedMETUncertainty(float dpx, float dpy, float dsumEt) : dpx_(dpx), dpy_(dpy), dsumEt_(dsumEt) {
+        pack();
+        unpack();
       }
-
-      // ---- members for MET corrections ----
-      enum METUncertainty {
-       JetResUp=0, JetResDown=1, JetEnUp=2, JetEnDown=3,
-       MuonEnUp=4, MuonEnDown=5, ElectronEnUp=6, ElectronEnDown=7,
-       TauEnUp=8, TauEnDown=9, UnclusteredEnUp=10, UnclusteredEnDown=11,
-       PhotonEnUp=12, PhotonEnDown=13, NoShift=14, METUncertaintySize=15,
-       JetResUpSmear=16, JetResDownSmear=17, METFullUncertaintySize=18
-      };
-      enum METCorrectionLevel {
-       Raw=0, Type1=1, Type01=2, TypeXY=3, Type1XY=4, Type01XY=5,
-       Type1Smear=6, Type01Smear=7, Type1SmearXY=8, 
-       Type01SmearXY=9, RawCalo=10, RawChs=11, RawTrk=12, 
-       RawDeepResponseTune=13, RawDeepResolutionTune=14, METCorrectionLevelSize=15
-      };
-      enum METCorrectionType {
-       None=0, T1=1, T0=2, TXY=3, TXYForRaw=4,
-       TXYForT01=5, TXYForT1Smear=6, TXYForT01Smear=7,
-       Smear=8, Calo=9, Chs=10, Trk=11, 
-       DeepResponseTune=12, DeepResolutionTune=13, METCorrectionTypeSize=14
-      };
-
-      struct Vector2 { 
-        double px, py; 
-        double pt() const { return hypotf(px,py); }  
-        double phi() const { return std::atan2(py,px); }
-      };
-
-      Vector2 shiftedP2(METUncertainty shift, METCorrectionLevel level=Type1)  const ;
-      Vector shiftedP3(METUncertainty shift, METCorrectionLevel level=Type1)  const ;
-      LorentzVector shiftedP4(METUncertainty shift, METCorrectionLevel level=Type1)  const ;
-      double shiftedPx(METUncertainty shift, METCorrectionLevel level=Type1)  const { return shiftedP2(shift,level).px; };
-      double shiftedPy(METUncertainty shift, METCorrectionLevel level=Type1)  const { return shiftedP2(shift,level).py; };
-      double shiftedPt(METUncertainty shift, METCorrectionLevel level=Type1)  const { return shiftedP2(shift,level).pt(); };
-      double shiftedPhi(METUncertainty shift, METCorrectionLevel level=Type1) const { return shiftedP2(shift,level).phi(); };
-      double shiftedSumEt(METUncertainty shift, METCorrectionLevel level=Type1) const ;
-
-      Vector2 corP2(METCorrectionLevel level=Type1)  const ;
-      Vector corP3(METCorrectionLevel level=Type1)  const ;
-      LorentzVector corP4(METCorrectionLevel level=Type1)  const ;
-      double corPx(METCorrectionLevel level=Type1)  const { return corP2(level).px; };
-      double corPy(METCorrectionLevel level=Type1)  const { return corP2(level).py; };
-      double corPt(METCorrectionLevel level=Type1)  const { return corP2(level).pt(); };
-      double corPhi(METCorrectionLevel level=Type1) const { return corP2(level).phi(); };
-      double corSumEt(METCorrectionLevel level=Type1) const ;
-
-      Vector2 uncorP2() const;
-      Vector uncorP3()  const ;
-      LorentzVector uncorP4()  const ;
-      double uncorPx() const { return uncorP2().px; };
-      double uncorPy() const { return uncorP2().py; };
-      double uncorPt() const { return uncorP2().pt(); };
-      double uncorPhi() const { return uncorP2().phi(); };
-      double uncorSumEt() const;
-
-      void setUncShift(double px, double py, double sumEt, METUncertainty shift, bool isSmeared=false);
-      void setCorShift(double px, double py, double sumEt, METCorrectionType level);
-
-      // specific method to fill and retrieve the caloMET quickly from miniAODs, 
-      //should be used by JetMET experts only for the beginning
-      //of the runII, will be discarded later once we are sure
-      //everything is fine
-      Vector2 caloMETP2() const;
-      double caloMETPt() const;
-      double caloMETPhi() const;
-      double caloMETSumEt() const;
-
-      //Functions for backward compatibility with 74X samples.
-      // allow access to 74X samples, transparent and not used in 75
-      Vector2 shiftedP2_74x(METUncertainty shift, METCorrectionLevel level) const ;
-      Vector shiftedP3_74x(METUncertainty shift, METCorrectionLevel level) const ;
-      LorentzVector shiftedP4_74x(METUncertainty shift, METCorrectionLevel level) const ;
-      double shiftedSumEt_74x(METUncertainty shift, METCorrectionLevel level) const ;
-	
-
-      /// this below should be private but Reflex doesn't like it
-      class PackedMETUncertainty {
-        // defined as C++ class so that I can change the packing without having to touch the code elsewhere
-        // the compiler should anyway inline everything whenever possible
-        public:
-            PackedMETUncertainty() : dpx_(0), dpy_(0), dsumEt_(0) {pack(); unpack();}
-            PackedMETUncertainty(float dpx, float dpy, float dsumEt) : dpx_(dpx), dpy_(dpy), dsumEt_(dsumEt) {pack();unpack();}
-            double dpx() const { if(!unpacked_) unpack(); return dpx_; }
-            double dpy() const { if(!unpacked_) unpack(); return dpy_; }
-            double dsumEt() const { if(!unpacked_) unpack(); return dsumEt_; }
-            void set(float dpx, float dpy, float dsumEt) { dpx_ = dpx; dpy_ = dpy; dsumEt_ = dsumEt; pack(); unpack();}
-	    void add(float dpx, float dpy, float dsumEt) { dpx_ += dpx; dpy_ += dpy; dsumEt_ += dsumEt; }
-            void  unpack() const ;
-            void  pack();
-
-        protected:
-            mutable float dpx_, dpy_, dsumEt_;
-            mutable bool unpacked_;
-            uint16_t packedDpx_,packedDpy_,packedDSumEt_;
-      };
-    private:
-
-      // ---- GenMET holder ----
-      std::vector<reco::GenMET> genMET_;
-      // ---- holder for CaloMET specific info ---
-      std::vector<SpecificCaloMETData> caloMET_;
-      // ---- holder for pfMET specific info ---
-      std::vector<SpecificPFMETData> pfMET_;
-
-      // MET significance
-      double metSig_;
-      // MET sumPtUnclustered for MET Significance
-      double sumPtUnclustered_;
-
-      const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
-   
-      std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> > corMap_;
-      void initCorMap();
-
-    
+      double dpx() const {
+        if (!unpacked_)
+          unpack();
+        return dpx_;
+      }
+      double dpy() const {
+        if (!unpacked_)
+          unpack();
+        return dpy_;
+      }
+      double dsumEt() const {
+        if (!unpacked_)
+          unpack();
+        return dsumEt_;
+      }
+      void set(float dpx, float dpy, float dsumEt) {
+        dpx_ = dpx;
+        dpy_ = dpy;
+        dsumEt_ = dsumEt;
+        pack();
+        unpack();
+      }
+      void add(float dpx, float dpy, float dsumEt) {
+        dpx_ += dpx;
+        dpy_ += dpy;
+        dsumEt_ += dsumEt;
+      }
+      void unpack() const;
+      void pack();
 
     protected:
+      mutable float dpx_, dpy_, dsumEt_;
+      mutable bool unpacked_;
+      uint16_t packedDpx_, packedDpy_, packedDSumEt_;
+    };
 
-      // ---- non-public correction utilities ----
-      //kept for 74X backward-compatibility, not initialized and used in 75X
-      std::vector<PackedMETUncertainty> uncertaintiesRaw_, uncertaintiesType1_, uncertaintiesType1p2_;
-      
-      std::vector<PackedMETUncertainty> uncertainties_;
-      std::vector<PackedMETUncertainty> corrections_;
-      
-      PackedMETUncertainty caloPackedMet_;
+  private:
+    // ---- GenMET holder ----
+    std::vector<reco::GenMET> genMET_;
+    // ---- holder for CaloMET specific info ---
+    std::vector<SpecificCaloMETData> caloMET_;
+    // ---- holder for pfMET specific info ---
+    std::vector<SpecificPFMETData> pfMET_;
 
+    // MET significance
+    double metSig_;
+    // MET sumPtUnclustered for MET Significance
+    double sumPtUnclustered_;
+
+    const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
+
+    std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> > corMap_;
+    void initCorMap();
+
+  protected:
+    // ---- non-public correction utilities ----
+    //kept for 74X backward-compatibility, not initialized and used in 75X
+    std::vector<PackedMETUncertainty> uncertaintiesRaw_, uncertaintiesType1_, uncertaintiesType1p2_;
+
+    std::vector<PackedMETUncertainty> uncertainties_;
+    std::vector<PackedMETUncertainty> corrections_;
+
+    PackedMETUncertainty caloPackedMet_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -203,6 +203,16 @@ MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpRawTrk;
   tmpRawTrk.push_back(MET::Trk);
   corMap_[MET::RawTrk] = tmpRawTrk;
+
+  //specific deep response tune case
+  std::vector<MET::METCorrectionType> tmpDeepResponse;
+  tmpDeepResponse.push_back(MET::DeepResponseTune);
+  corMap_[MET::RawDeepResponseTune] = tmpDeepResponse;
+
+  //specific deep resolution tune case
+  std::vector<MET::METCorrectionType> tmpDeepResolution;
+  tmpDeepResolution.push_back(MET::DeepResolutionTune);
+  corMap_[MET::RawDeepResolutionTune] = tmpDeepResolution;
 }
 
 const MET::PackedMETUncertainty

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -3,143 +3,133 @@
 
 #include "DataFormats/PatCandidates/interface/MET.h"
 
-
 using namespace pat;
 
-
 /// default constructor
-MET::MET() {
+MET::MET() { initCorMap(); }
+
+/// constructor from reco::MET
+MET::MET(const reco::MET &aMET) : PATObject<reco::MET>(aMET) {
+  const reco::CaloMET *calo = dynamic_cast<const reco::CaloMET *>(&aMET);
+  if (calo != nullptr)
+    caloMET_.push_back(calo->getSpecific());
+  const reco::PFMET *pf = dynamic_cast<const reco::PFMET *>(&aMET);
+  if (pf != nullptr)
+    pfMET_.push_back(pf->getSpecific());
+  const pat::MET *pm = dynamic_cast<const pat::MET *>(&aMET);
+  if (pm != nullptr)
+    this->operator=(*pm);
+
+  metSig_ = 0.;
+  sumPtUnclustered_ = 0.;
   initCorMap();
 }
 
-
-/// constructor from reco::MET
-MET::MET(const reco::MET & aMET) : PATObject<reco::MET>(aMET) {
-    const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(&aMET);
-    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
-    const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(&aMET);
-    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
-    const pat::MET * pm = dynamic_cast<const pat::MET *>(&aMET);
-    if (pm != nullptr) this->operator=(*pm);
-
-    metSig_ =0.;
-    sumPtUnclustered_ = 0.;
-    initCorMap();
-}
-
-
 /// constructor from ref to reco::MET
-MET::MET(const edm::RefToBase<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
-    const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
-    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
-    const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
-    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
-    const pat::MET * pm = dynamic_cast<const pat::MET *>(aMETRef.get());
-    if (pm != nullptr) this->operator=(*pm);
+MET::MET(const edm::RefToBase<reco::MET> &aMETRef) : PATObject<reco::MET>(aMETRef) {
+  const reco::CaloMET *calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
+  if (calo != nullptr)
+    caloMET_.push_back(calo->getSpecific());
+  const reco::PFMET *pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
+  if (pf != nullptr)
+    pfMET_.push_back(pf->getSpecific());
+  const pat::MET *pm = dynamic_cast<const pat::MET *>(aMETRef.get());
+  if (pm != nullptr)
+    this->operator=(*pm);
 
-    metSig_ =0.;
-    sumPtUnclustered_ = 0.;
-    initCorMap();
+  metSig_ = 0.;
+  sumPtUnclustered_ = 0.;
+  initCorMap();
 }
 
 /// constructor from ref to reco::MET
-MET::MET(const edm::Ptr<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
-    const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
-    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
-    const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
-    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
-    const pat::MET * pm = dynamic_cast<const pat::MET *>(aMETRef.get());
-    if (pm != nullptr) this->operator=(*pm);
+MET::MET(const edm::Ptr<reco::MET> &aMETRef) : PATObject<reco::MET>(aMETRef) {
+  const reco::CaloMET *calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
+  if (calo != nullptr)
+    caloMET_.push_back(calo->getSpecific());
+  const reco::PFMET *pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
+  if (pf != nullptr)
+    pfMET_.push_back(pf->getSpecific());
+  const pat::MET *pm = dynamic_cast<const pat::MET *>(aMETRef.get());
+  if (pm != nullptr)
+    this->operator=(*pm);
 
-    metSig_ =0.;
-    sumPtUnclustered_ = 0.;
-    initCorMap();
+  metSig_ = 0.;
+  sumPtUnclustered_ = 0.;
+  initCorMap();
 }
 
 /// copy constructor
-MET::MET(MET const& iOther):
-PATObject<reco::MET>(iOther),
-genMET_(iOther.genMET_),
-caloMET_(iOther.caloMET_),
-pfMET_(iOther.pfMET_),
-metSig_(iOther.metSig_),
-sumPtUnclustered_(iOther.sumPtUnclustered_),
-uncertaintiesRaw_(iOther.uncertaintiesRaw_), //74X reading compatibility
-uncertaintiesType1_(iOther.uncertaintiesType1_), //74X compatibility
-uncertaintiesType1p2_(iOther.uncertaintiesType1p2_), //74X compatibility
-uncertainties_(iOther.uncertainties_),
-corrections_(iOther.corrections_),
-caloPackedMet_(iOther.caloPackedMet_) {
-
+MET::MET(MET const &iOther)
+    : PATObject<reco::MET>(iOther),
+      genMET_(iOther.genMET_),
+      caloMET_(iOther.caloMET_),
+      pfMET_(iOther.pfMET_),
+      metSig_(iOther.metSig_),
+      sumPtUnclustered_(iOther.sumPtUnclustered_),
+      uncertaintiesRaw_(iOther.uncertaintiesRaw_),          //74X reading compatibility
+      uncertaintiesType1_(iOther.uncertaintiesType1_),      //74X compatibility
+      uncertaintiesType1p2_(iOther.uncertaintiesType1p2_),  //74X compatibility
+      uncertainties_(iOther.uncertainties_),
+      corrections_(iOther.corrections_),
+      caloPackedMet_(iOther.caloPackedMet_) {
   initCorMap();
 }
 
-/// constructor for corrected mets, keeping track of srcMET informations, 
+/// constructor for corrected mets, keeping track of srcMET informations,
 // old uncertainties discarded on purpose to avoid confusion
-MET::MET(const reco::MET & corMET, const MET& srcMET ):
-PATObject<reco::MET>(corMET),
-genMET_(srcMET.genMET_),
-caloMET_(srcMET.caloMET_),
-pfMET_(srcMET.pfMET_),
-metSig_(srcMET.metSig_),
-sumPtUnclustered_(srcMET.sumPtUnclustered_),
-caloPackedMet_(srcMET.caloPackedMet_) {
-
+MET::MET(const reco::MET &corMET, const MET &srcMET)
+    : PATObject<reco::MET>(corMET),
+      genMET_(srcMET.genMET_),
+      caloMET_(srcMET.caloMET_),
+      pfMET_(srcMET.pfMET_),
+      metSig_(srcMET.metSig_),
+      sumPtUnclustered_(srcMET.sumPtUnclustered_),
+      caloPackedMet_(srcMET.caloPackedMet_) {
   setSignificanceMatrix(srcMET.getSignificanceMatrix());
 
   initCorMap();
 }
 
 /// destructor
-MET::~MET() {
+MET::~MET() {}
 
-}
+MET &MET::operator=(MET const &iOther) {
+  PATObject<reco::MET>::operator=(iOther);
+  genMET_ = iOther.genMET_;
+  caloMET_ = iOther.caloMET_;
+  pfMET_ = iOther.pfMET_;
+  uncertaintiesRaw_ = iOther.uncertaintiesRaw_;  //74X compatibility
+  uncertaintiesType1_ = iOther.uncertaintiesType1_;
+  uncertaintiesType1p2_ = iOther.uncertaintiesType1p2_;
+  uncertainties_ = iOther.uncertainties_;
+  corrections_ = iOther.corrections_;
+  metSig_ = iOther.metSig_;
+  sumPtUnclustered_ = iOther.sumPtUnclustered_;
+  caloPackedMet_ = iOther.caloPackedMet_;
 
-MET& MET::operator=(MET const& iOther) {
-   PATObject<reco::MET>::operator=(iOther);
-   genMET_ = iOther.genMET_;
-   caloMET_ =iOther.caloMET_;
-   pfMET_ =iOther.pfMET_;
-   uncertaintiesRaw_ = iOther.uncertaintiesRaw_; //74X compatibility
-   uncertaintiesType1_ = iOther.uncertaintiesType1_;
-   uncertaintiesType1p2_ = iOther.uncertaintiesType1p2_;
-   uncertainties_ = iOther.uncertainties_;
-   corrections_ = iOther.corrections_;
-   metSig_ = iOther.metSig_;
-   sumPtUnclustered_ = iOther.sumPtUnclustered_;
-   caloPackedMet_ = iOther.caloPackedMet_;
-
-   return *this;
+  return *this;
 }
 
 /// return the generated MET from neutrinos
-const reco::GenMET * MET::genMET() const {
-  return (!genMET_.empty() ? &genMET_.front() : nullptr );
-}
+const reco::GenMET *MET::genMET() const { return (!genMET_.empty() ? &genMET_.front() : nullptr); }
 
 /// method to set the generated MET
-void MET::setGenMET(const reco::GenMET & gm) {
+void MET::setGenMET(const reco::GenMET &gm) {
   genMET_.clear();
   genMET_.push_back(gm);
 }
 
-
 //Method to set the MET significance
-void MET::setMETSignificance(const double& metSig) {
-  metSig_ = metSig;
-}
+void MET::setMETSignificance(const double &metSig) { metSig_ = metSig; }
 
-double MET::metSignificance() const {
-  return metSig_;
-}
+double MET::metSignificance() const { return metSig_; }
 
 void MET::setMETSumPtUnclustered(const double &sumPtUnclustered) { sumPtUnclustered_ = sumPtUnclustered; }
 
 double MET::metSumPtUnclustered() const { return sumPtUnclustered_; }
 
-void
-MET::initCorMap() {
-
+void MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpRaw;
   std::vector<MET::METCorrectionType> tmpType1;
   std::vector<MET::METCorrectionType> tmpType01;
@@ -150,9 +140,9 @@ MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpType01Smear;
   std::vector<MET::METCorrectionType> tmpType1SmearXY;
   std::vector<MET::METCorrectionType> tmpType01SmearXY;
-  
+
   tmpRaw.push_back(MET::None);
-  
+
   tmpType1.push_back(MET::T1);
   tmpType01.push_back(MET::T1);
   tmpType1XY.push_back(MET::T1);
@@ -166,7 +156,7 @@ MET::initCorMap() {
   tmpType01XY.push_back(MET::T0);
   tmpType01Smear.push_back(MET::T0);
   tmpType01SmearXY.push_back(MET::T0);
-  
+
   tmpType1Smear.push_back(MET::Smear);
   tmpType01Smear.push_back(MET::Smear);
   tmpType1SmearXY.push_back(MET::Smear);
@@ -188,7 +178,7 @@ MET::initCorMap() {
   corMap_[MET::Type01Smear] = tmpType01Smear;
   corMap_[MET::Type1SmearXY] = tmpType1SmearXY;
   corMap_[MET::Type01SmearXY] = tmpType01SmearXY;
-  
+
   //specific calo case
   std::vector<MET::METCorrectionType> tmpRawCalo;
   tmpRawCalo.push_back(MET::Calo);
@@ -215,267 +205,246 @@ MET::initCorMap() {
   corMap_[MET::RawDeepResolutionTune] = tmpDeepResolution;
 }
 
-const MET::PackedMETUncertainty
-MET::findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const {
-
+const MET::PackedMETUncertainty MET::findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const {
   //find corrections shifts =============================
   std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> >::const_iterator itCor_ = corMap_.find(cor);
-  if(itCor_==corMap_.end() ) throw cms::Exception("Unsupported", "Specified MET correction scheme does not exist");
+  if (itCor_ == corMap_.end())
+    throw cms::Exception("Unsupported", "Specified MET correction scheme does not exist");
 
-  bool isSmeared=false;
+  bool isSmeared = false;
   MET::PackedMETUncertainty totShift;
-  unsigned int scor=itCor_->second.size();
-  for(unsigned int i=0; i<scor;i++) {
-    totShift.add( corrections_[ itCor_->second[i] ].dpx(),
-  		  corrections_[ itCor_->second[i] ].dpy(),
-  		  corrections_[ itCor_->second[i] ].dsumEt() );
+  unsigned int scor = itCor_->second.size();
+  for (unsigned int i = 0; i < scor; i++) {
+    totShift.add(corrections_[itCor_->second[i]].dpx(),
+                 corrections_[itCor_->second[i]].dpy(),
+                 corrections_[itCor_->second[i]].dsumEt());
 
-    if(itCor_->first>=MET::Type1Smear)
-      isSmeared=true;
+    if (itCor_->first >= MET::Type1Smear)
+      isSmeared = true;
   }
-
-  
 
   //find uncertainty shift =============================
 
   if (uncertainties_.empty())
-      return totShift;
+    return totShift;
 
-  if(shift>=MET::METUncertaintySize) throw cms::Exception("Unsupported", "MET uncertainty does not exist");
-  if(isSmeared && shift<=MET::JetResDown) shift = (MET::METUncertainty)(MET::METUncertaintySize+shift+1);
-							  
-  totShift.add( uncertainties_[ shift ].dpx(),
-  		uncertainties_[ shift ].dpy(),
-  		uncertainties_[ shift ].dsumEt() );
+  if (shift >= MET::METUncertaintySize)
+    throw cms::Exception("Unsupported", "MET uncertainty does not exist");
+  if (isSmeared && shift <= MET::JetResDown)
+    shift = (MET::METUncertainty)(MET::METUncertaintySize + shift + 1);
+
+  totShift.add(uncertainties_[shift].dpx(), uncertainties_[shift].dpy(), uncertainties_[shift].dsumEt());
 
   return totShift;
 }
 
-
-MET::Vector2 MET::shiftedP2(MET::METUncertainty shift, MET::METCorrectionLevel cor)  const {
-  
+MET::Vector2 MET::shiftedP2(MET::METUncertainty shift, MET::METCorrectionLevel cor) const {
   Vector2 vo;
 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
-    if(cor!=MET::METCorrectionLevel::RawCalo) {
+  if (!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
+    if (cor != MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP2_74x(shift, cor);
     } else {
-      Vector2 ret{ caloPackedMet_.dpx(), caloPackedMet_.dpy() };
+      Vector2 ret{caloPackedMet_.dpx(), caloPackedMet_.dpy()};
       vo = ret;
     }
-  }
-  else {
-    const MET::PackedMETUncertainty& v = findMETTotalShift(cor,shift);
-    Vector2 ret{ (px() + v.dpx()), (py() + v.dpy()) };
+  } else {
+    const MET::PackedMETUncertainty &v = findMETTotalShift(cor, shift);
+    Vector2 ret{(px() + v.dpx()), (py() + v.dpy())};
     //return ret;
     vo = ret;
   }
   return vo;
 }
-MET::Vector MET::shiftedP3(MET::METUncertainty shift, MET::METCorrectionLevel cor)  const {
-
+MET::Vector MET::shiftedP3(MET::METUncertainty shift, MET::METCorrectionLevel cor) const {
   Vector vo;
 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
-    if(cor!=MET::METCorrectionLevel::RawCalo) {
+  if (!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
+    if (cor != MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP3_74x(shift, cor);
     } else {
       Vector tmp(caloPackedMet_.dpx(), caloPackedMet_.dpy(), 0);
       vo = tmp;
     }
-  }
-  else {
-    const MET::PackedMETUncertainty& v = findMETTotalShift(cor,shift);
+  } else {
+    const MET::PackedMETUncertainty &v = findMETTotalShift(cor, shift);
     //return Vector(px() + v.dpx(), py() + v.dpy(), 0);
     Vector tmp(px() + v.dpx(), py() + v.dpy(), 0);
     vo = tmp;
   }
   return vo;
 }
-MET::LorentzVector MET::shiftedP4(METUncertainty shift, MET::METCorrectionLevel cor)  const {
-
+MET::LorentzVector MET::shiftedP4(METUncertainty shift, MET::METCorrectionLevel cor) const {
   LorentzVector vo;
 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
-    if(cor!=MET::METCorrectionLevel::RawCalo) {
+  if (!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
+    if (cor != MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP4_74x(shift, cor);
     } else {
       double x = caloPackedMet_.dpx(), y = caloPackedMet_.dpy();
-      LorentzVector tmp(x, y, 0, std::hypot(x,y));
-      vo =  tmp;
+      LorentzVector tmp(x, y, 0, std::hypot(x, y));
+      vo = tmp;
     }
-  }
-  else {
-    const MET::PackedMETUncertainty& v = findMETTotalShift(cor,shift);
+  } else {
+    const MET::PackedMETUncertainty &v = findMETTotalShift(cor, shift);
     double x = px() + v.dpx(), y = py() + v.dpy();
     //return LorentzVector(x, y, 0, std::hypot(x,y));
-    LorentzVector tmp(x, y, 0, std::hypot(x,y));
-    vo =  tmp;
+    LorentzVector tmp(x, y, 0, std::hypot(x, y));
+    vo = tmp;
   }
   return vo;
 }
 double MET::shiftedSumEt(MET::METUncertainty shift, MET::METCorrectionLevel cor) const {
-
   double sumEto;
 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
-    if(cor!=MET::METCorrectionLevel::RawCalo) {
+  if (!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
+    if (cor != MET::METCorrectionLevel::RawCalo) {
       sumEto = shiftedSumEt_74x(shift, cor);
     } else {
       sumEto = caloPackedMet_.dsumEt();
     }
-  }
-  else {
-    const MET::PackedMETUncertainty& v = findMETTotalShift(cor,shift);
+  } else {
+    const MET::PackedMETUncertainty &v = findMETTotalShift(cor, shift);
     //return sumEt() + v.dsumEt();
     sumEto = sumEt() + v.dsumEt();
   }
   return sumEto;
 }
 
-MET::Vector2 MET::corP2(MET::METCorrectionLevel cor)  const {
-  return shiftedP2(MET::NoShift, cor );
-}
-MET::Vector MET::corP3(MET::METCorrectionLevel cor)  const {
-  return shiftedP3(MET::NoShift, cor );
-}
-MET::LorentzVector MET::corP4(MET::METCorrectionLevel cor)  const {
-  return shiftedP4(MET::NoShift, cor );
-}
-double MET::corSumEt(MET::METCorrectionLevel cor) const {
-  return shiftedSumEt(MET::NoShift, cor );
-}
+MET::Vector2 MET::corP2(MET::METCorrectionLevel cor) const { return shiftedP2(MET::NoShift, cor); }
+MET::Vector MET::corP3(MET::METCorrectionLevel cor) const { return shiftedP3(MET::NoShift, cor); }
+MET::LorentzVector MET::corP4(MET::METCorrectionLevel cor) const { return shiftedP4(MET::NoShift, cor); }
+double MET::corSumEt(MET::METCorrectionLevel cor) const { return shiftedSumEt(MET::NoShift, cor); }
 
-MET::Vector2 MET::uncorP2()  const {
-  return shiftedP2(MET::NoShift, MET::Raw );
-}
-MET::Vector MET::uncorP3()  const {
-  return shiftedP3(MET::NoShift, MET::Raw );
-}
-MET::LorentzVector MET::uncorP4()  const {
-  return shiftedP4(MET::NoShift, MET::Raw );
-}
-double MET::uncorSumEt() const {
-  return shiftedSumEt(MET::NoShift, MET::Raw );
-}
-
+MET::Vector2 MET::uncorP2() const { return shiftedP2(MET::NoShift, MET::Raw); }
+MET::Vector MET::uncorP3() const { return shiftedP3(MET::NoShift, MET::Raw); }
+MET::LorentzVector MET::uncorP4() const { return shiftedP4(MET::NoShift, MET::Raw); }
+double MET::uncorSumEt() const { return shiftedSumEt(MET::NoShift, MET::Raw); }
 
 void MET::setUncShift(double px, double py, double sumEt, METUncertainty shift, bool isSmeared) {
-  if (uncertainties_.empty()) { 
+  if (uncertainties_.empty()) {
     uncertainties_.resize(METUncertainty::METFullUncertaintySize);
   }
 
-  if(isSmeared && shift<=MET::JetResDown) {
+  if (isSmeared && shift <= MET::JetResDown) {
     //changing reference to only get the uncertainty shift and not the smeared one
     // which is performed independently
-    shift = (MET::METUncertainty)(METUncertainty::METUncertaintySize+shift+1);
-    const PackedMETUncertainty& ref = uncertainties_[METUncertainty::NoShift];
-    uncertainties_[shift].set(px + ref.dpx() - this->px(), py + ref.dpy() - this->py(), sumEt + ref.dsumEt() - this->sumEt() );
-  }
-  else
+    shift = (MET::METUncertainty)(METUncertainty::METUncertaintySize + shift + 1);
+    const PackedMETUncertainty &ref = uncertainties_[METUncertainty::NoShift];
+    uncertainties_[shift].set(
+        px + ref.dpx() - this->px(), py + ref.dpy() - this->py(), sumEt + ref.dsumEt() - this->sumEt());
+  } else
     uncertainties_[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
-  
 }
 
 void MET::setCorShift(double px, double py, double sumEt, MET::METCorrectionType level) {
   if (corrections_.empty()) {
     corrections_.resize(MET::METCorrectionType::METCorrectionTypeSize);
   }
-  
+
   corrections_[level].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
 }
 
-
 MET::Vector2 MET::caloMETP2() const {
-  return shiftedP2(MET::METUncertainty::NoShift, MET::METCorrectionLevel::RawCalo );
+  return shiftedP2(MET::METUncertainty::NoShift, MET::METCorrectionLevel::RawCalo);
 }
 
-double MET::caloMETPt() const {
-  return caloMETP2().pt();
-}
+double MET::caloMETPt() const { return caloMETP2().pt(); }
 
-double MET::caloMETPhi() const {
-  return caloMETP2().phi();
-}
+double MET::caloMETPhi() const { return caloMETP2().phi(); }
 
-double MET::caloMETSumEt() const {
-  return shiftedSumEt(MET::NoShift, MET::RawCalo );
-}
+double MET::caloMETSumEt() const { return shiftedSumEt(MET::NoShift, MET::RawCalo); }
 
 // functions to access to 74X samples ========================================================
-MET::Vector2 MET::shiftedP2_74x(MET::METUncertainty shift, MET::METCorrectionLevel level)  const {
-  if (level != Type1 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples \n");
-    const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ :  uncertaintiesRaw_);
-    if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
-    if (v.size() == 1) {
-        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)\n");
-        return Vector2{ (px() + v.front().dpx()), (py() + v.front().dpy()) };
-    }
-    Vector2 ret{ (px() + v[shift].dpx()), (py() + v[shift].dpy()) };
-    return ret;
+MET::Vector2 MET::shiftedP2_74x(MET::METUncertainty shift, MET::METCorrectionLevel level) const {
+  if (level != Type1 && level != Raw)
+    throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples \n");
+  const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
+  if (v.empty())
+    throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
+  if (v.size() == 1) {
+    if (shift != MET::METUncertainty::NoShift)
+      throw cms::Exception(
+          "Unsupported",
+          "MET uncertainties not available for the specified correction type (only central value available)\n");
+    return Vector2{(px() + v.front().dpx()), (py() + v.front().dpy())};
+  }
+  Vector2 ret{(px() + v[shift].dpx()), (py() + v[shift].dpy())};
+  return ret;
 }
 
-MET::Vector MET::shiftedP3_74x(MET::METUncertainty shift, MET::METCorrectionLevel level)  const {
-  if (level != Type1 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples \n");
-    const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ :  uncertaintiesRaw_);
-    if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
-    if (v.size() == 1) {
-        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)\n");
-        return Vector(px() + v.front().dpx(), py() + v.front().dpy(), 0);
-    }
-    return Vector(px() + v[shift].dpx(), py() + v[shift].dpy(), 0);
+MET::Vector MET::shiftedP3_74x(MET::METUncertainty shift, MET::METCorrectionLevel level) const {
+  if (level != Type1 && level != Raw)
+    throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples \n");
+  const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
+  if (v.empty())
+    throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
+  if (v.size() == 1) {
+    if (shift != MET::METUncertainty::NoShift)
+      throw cms::Exception(
+          "Unsupported",
+          "MET uncertainties not available for the specified correction type (only central value available)\n");
+    return Vector(px() + v.front().dpx(), py() + v.front().dpy(), 0);
+  }
+  return Vector(px() + v[shift].dpx(), py() + v[shift].dpy(), 0);
 }
 
-MET::LorentzVector MET::shiftedP4_74x(METUncertainty shift, MET::METCorrectionLevel level)  const {
-  if (level != Type1 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples\n");
-    const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
-    if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
-    if (v.size() == 1) {
-        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)\n");
-        double x = px() + v.front().dpx(), y = py() + v.front().dpy();
-        return LorentzVector(x, y, 0, std::hypot(x,y));
-    }
-    double x = px() + v[shift].dpx(), y = py() + v[shift].dpy();
-    return LorentzVector(x, y, 0, std::hypot(x,y));
+MET::LorentzVector MET::shiftedP4_74x(METUncertainty shift, MET::METCorrectionLevel level) const {
+  if (level != Type1 && level != Raw)
+    throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples\n");
+  const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
+  if (v.empty())
+    throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
+  if (v.size() == 1) {
+    if (shift != MET::METUncertainty::NoShift)
+      throw cms::Exception(
+          "Unsupported",
+          "MET uncertainties not available for the specified correction type (only central value available)\n");
+    double x = px() + v.front().dpx(), y = py() + v.front().dpy();
+    return LorentzVector(x, y, 0, std::hypot(x, y));
+  }
+  double x = px() + v[shift].dpx(), y = py() + v[shift].dpy();
+  return LorentzVector(x, y, 0, std::hypot(x, y));
 }
 
 double MET::shiftedSumEt_74x(MET::METUncertainty shift, MET::METCorrectionLevel level) const {
-  if (level != Type1 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples\n");
-    const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
-    if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
-    if (v.size() == 1) {
-        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)\n");
-        return sumEt() + v.front().dsumEt();
-    }
-    return sumEt() + v[shift].dsumEt();
+  if (level != Type1 && level != Raw)
+    throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples\n");
+  const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
+  if (v.empty())
+    throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
+  if (v.size() == 1) {
+    if (shift != MET::METUncertainty::NoShift)
+      throw cms::Exception(
+          "Unsupported",
+          "MET uncertainties not available for the specified correction type (only central value available)\n");
+    return sumEt() + v.front().dsumEt();
+  }
+  return sumEt() + v[shift].dsumEt();
 }
-
-
-
 
 #include "DataFormats/Math/interface/libminifloat.h"
 
 void MET::PackedMETUncertainty::pack() {
-  packedDpx_  =  MiniFloatConverter::float32to16(dpx_);
-  packedDpy_  =  MiniFloatConverter::float32to16(dpy_);
-  packedDSumEt_  =  MiniFloatConverter::float32to16(dsumEt_);
+  packedDpx_ = MiniFloatConverter::float32to16(dpx_);
+  packedDpy_ = MiniFloatConverter::float32to16(dpy_);
+  packedDSumEt_ = MiniFloatConverter::float32to16(dsumEt_);
 }
-void  MET::PackedMETUncertainty::unpack() const {
-  unpacked_=true;
-  dpx_=MiniFloatConverter::float16to32(packedDpx_);
-  dpy_=MiniFloatConverter::float16to32(packedDpy_);
-  dsumEt_=MiniFloatConverter::float16to32(packedDSumEt_);
+void MET::PackedMETUncertainty::unpack() const {
+  unpacked_ = true;
+  dpx_ = MiniFloatConverter::float16to32(packedDpx_);
+  dpy_ = MiniFloatConverter::float16to32(packedDpy_);
+  dsumEt_ = MiniFloatConverter::float16to32(packedDSumEt_);
 }
-

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -3,7 +3,6 @@
   \brief    Slimmer of PAT METs 
 */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -15,21 +14,34 @@
 #include "DataFormats/PatCandidates/interface/MET.h"
 
 namespace pat {
-  
+
   class PATMETSlimmer : public edm::global::EDProducer<> {
   public:
-    explicit PATMETSlimmer(const edm::ParameterSet & iConfig);
-    ~PATMETSlimmer() override { }
-    
-    void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
-    
+    explicit PATMETSlimmer(const edm::ParameterSet &iConfig);
+    ~PATMETSlimmer() override {}
+
+    void produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
+
   private:
     class OneMETShift {
     public:
-      OneMETShift() : shift(pat::MET::NoShift), level(pat::MET::None), t0FromMiniAOD(false), corShift(false), uncShift(false), isSmeared(false) {}
-      OneMETShift(pat::MET::METUncertainty shift_, pat::MET::METCorrectionType level_, const edm::InputTag & baseTag, edm::ConsumesCollector && cc,
-                  bool t0FromMiniAOD_, bool corShift_, bool uncShift_, bool isSmeared_=false) ;
+      OneMETShift()
+          : shift(pat::MET::NoShift),
+            level(pat::MET::None),
+            t0FromMiniAOD(false),
+            corShift(false),
+            uncShift(false),
+            isSmeared(false) {}
+      OneMETShift(pat::MET::METUncertainty shift_,
+                  pat::MET::METCorrectionType level_,
+                  const edm::InputTag &baseTag,
+                  edm::ConsumesCollector &&cc,
+                  bool t0FromMiniAOD_,
+                  bool corShift_,
+                  bool uncShift_,
+                  bool isSmeared_ = false);
       void readAndSet(const edm::Event &ev, pat::MET &met) const;
+
     private:
       const pat::MET::METUncertainty shift;
       const pat::MET::METCorrectionType level;
@@ -38,150 +50,213 @@ namespace pat {
       const bool corShift;
       const bool uncShift;
       const bool isSmeared;
-      
     };
-    void maybeReadShifts(const edm::ParameterSet &basePSet, const std::string &name, pat::MET::METCorrectionType level, bool readFromMiniAOD=false) ;
-    
+    void maybeReadShifts(const edm::ParameterSet &basePSet,
+                         const std::string &name,
+                         pat::MET::METCorrectionType level,
+                         bool readFromMiniAOD = false);
+
     const edm::EDGetTokenT<pat::METCollection> src_;
     std::vector<OneMETShift> shifts_;
-    
+
     const bool onMiniAOD_;
   };
-  
-} // namespace
 
-pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet & iConfig) :
-  src_(consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  onMiniAOD_(iConfig.existsAs<bool>("runningOnMiniAOD") ?  iConfig.getParameter<bool>("runningOnMiniAOD") : false)
-{
-  maybeReadShifts( iConfig, "rawVariation", pat::MET::None );
-  maybeReadShifts( iConfig, "t1Uncertainties", pat::MET::T1 );
-  maybeReadShifts( iConfig, "t01Variation", pat::MET::T0, onMiniAOD_ );
-  maybeReadShifts( iConfig, "t1SmearedVarsAndUncs", pat::MET::Smear );
-  
-  maybeReadShifts( iConfig, "tXYUncForRaw", pat::MET::TXYForRaw );
-  maybeReadShifts( iConfig, "tXYUncForT1", pat::MET::TXY );
-  maybeReadShifts( iConfig, "tXYUncForT01", pat::MET::TXYForT01 ); 
-  maybeReadShifts( iConfig, "tXYUncForT1Smear", pat::MET::TXYForT1Smear );
-  maybeReadShifts( iConfig, "tXYUncForT01Smear", pat::MET::TXYForT01Smear );
-  maybeReadShifts( iConfig, "caloMET", pat::MET::Calo );
-  maybeReadShifts( iConfig, "chsMET", pat::MET::Chs );
-  maybeReadShifts( iConfig, "trkMET", pat::MET::Trk );
+}  // namespace pat
+
+pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet &iConfig)
+    : src_(consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      onMiniAOD_(iConfig.existsAs<bool>("runningOnMiniAOD") ? iConfig.getParameter<bool>("runningOnMiniAOD") : false) {
+  maybeReadShifts(iConfig, "rawVariation", pat::MET::None);
+  maybeReadShifts(iConfig, "t1Uncertainties", pat::MET::T1);
+  maybeReadShifts(iConfig, "t01Variation", pat::MET::T0, onMiniAOD_);
+  maybeReadShifts(iConfig, "t1SmearedVarsAndUncs", pat::MET::Smear);
+
+  maybeReadShifts(iConfig, "tXYUncForRaw", pat::MET::TXYForRaw);
+  maybeReadShifts(iConfig, "tXYUncForT1", pat::MET::TXY);
+  maybeReadShifts(iConfig, "tXYUncForT01", pat::MET::TXYForT01);
+  maybeReadShifts(iConfig, "tXYUncForT1Smear", pat::MET::TXYForT1Smear);
+  maybeReadShifts(iConfig, "tXYUncForT01Smear", pat::MET::TXYForT01Smear);
+  maybeReadShifts(iConfig, "caloMET", pat::MET::Calo);
+  maybeReadShifts(iConfig, "chsMET", pat::MET::Chs);
+  maybeReadShifts(iConfig, "trkMET", pat::MET::Trk);
   if (iConfig.getParameter<bool>("addDeepMETs")) {
     maybeReadShifts(iConfig, "deepMETResolutionTune", pat::MET::DeepResolutionTune);
     maybeReadShifts(iConfig, "deepMETResponseTune", pat::MET::DeepResponseTune);
   }
 
-  produces<std::vector<pat::MET> >();
+  produces<std::vector<pat::MET>>();
 }
 
-void pat::PATMETSlimmer::maybeReadShifts(const edm::ParameterSet &basePSet, const std::string &name, pat::MET::METCorrectionType level, bool readFromMiniAOD) {
- 
-    if (basePSet.existsAs<edm::ParameterSet>(name)) {
-        throw cms::Exception("Unsupported", "Reading PSets not supported, for now just use input tag");
-    } else if (basePSet.existsAs<edm::InputTag>(name) ) {
-        const edm::InputTag & baseTag = basePSet.getParameter<edm::InputTag>(name);
+void pat::PATMETSlimmer::maybeReadShifts(const edm::ParameterSet &basePSet,
+                                         const std::string &name,
+                                         pat::MET::METCorrectionType level,
+                                         bool readFromMiniAOD) {
+  if (basePSet.existsAs<edm::ParameterSet>(name)) {
+    throw cms::Exception("Unsupported", "Reading PSets not supported, for now just use input tag");
+  } else if (basePSet.existsAs<edm::InputTag>(name)) {
+    const edm::InputTag &baseTag = basePSet.getParameter<edm::InputTag>(name);
 
-	if(level==pat::MET::T1) {
-	  shifts_.push_back(OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false, false));
-	  shifts_.push_back(OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetResUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::MuonEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::MuonEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::ElectronEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::ElectronEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::PhotonEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::PhotonEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::TauEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::TauEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::UnclusteredEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::UnclusteredEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	}
-	else if(level==pat::MET::Smear) {
-	  shifts_.push_back(OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetResUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true, true));
-	}
-	else {
-	  shifts_.push_back(OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false));
-	}
+    if (level == pat::MET::T1) {
+      shifts_.push_back(
+          OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false, false));
+      shifts_.push_back(
+          OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetResUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::MuonEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::MuonEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::ElectronEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::ElectronEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::PhotonEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::PhotonEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::TauEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::TauEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::UnclusteredEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::UnclusteredEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+    } else if (level == pat::MET::Smear) {
+      shifts_.push_back(
+          OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetResUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true, true));
+    } else {
+      shifts_.push_back(
+          OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false));
     }
-
+  }
 }
 
-pat::PATMETSlimmer::OneMETShift::OneMETShift(pat::MET::METUncertainty shift_, pat::MET::METCorrectionType level_, const edm::InputTag & baseTag,
-					     edm::ConsumesCollector && cc, bool t0FromMiniAOD_, bool corShift_, bool uncShift_, bool isSmeared) :
-  shift(shift_), level(level_), t0FromMiniAOD(t0FromMiniAOD_), corShift(corShift_), uncShift(uncShift_), isSmeared(isSmeared)
-{
-
-    std::string baseTagStr = baseTag.encode();
-    char buff[1024];
-    switch (shift) {
-        case pat::MET::NoShift  : snprintf(buff, 1023, baseTagStr.c_str(), "");   break;
-        case pat::MET::JetEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetEnUp");   break;
-        case pat::MET::JetEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetEnDown"); break;
-        case pat::MET::JetResUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetResUp");   break;
-        case pat::MET::JetResDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetResDown"); break;
-        case pat::MET::MuonEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnUp");   break;
-        case pat::MET::MuonEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnDown"); break;
-        case pat::MET::ElectronEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnUp");   break;
-        case pat::MET::ElectronEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnDown"); break;
-        case pat::MET::PhotonEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "PhotonEnUp");   break;
-        case pat::MET::PhotonEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "PhotonEnDown"); break;
-        case pat::MET::TauEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "TauEnUp");   break;
-        case pat::MET::TauEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "TauEnDown"); break;
-        case pat::MET::UnclusteredEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "UnclusteredEnUp");   break;
-        case pat::MET::UnclusteredEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "UnclusteredEnDown"); break;
-        default: throw cms::Exception("LogicError", "OneMETShift constructor called with bogus shift");
-    }
-    token = cc.consumes<pat::METCollection>(edm::InputTag(buff));
-
+pat::PATMETSlimmer::OneMETShift::OneMETShift(pat::MET::METUncertainty shift_,
+                                             pat::MET::METCorrectionType level_,
+                                             const edm::InputTag &baseTag,
+                                             edm::ConsumesCollector &&cc,
+                                             bool t0FromMiniAOD_,
+                                             bool corShift_,
+                                             bool uncShift_,
+                                             bool isSmeared)
+    : shift(shift_),
+      level(level_),
+      t0FromMiniAOD(t0FromMiniAOD_),
+      corShift(corShift_),
+      uncShift(uncShift_),
+      isSmeared(isSmeared) {
+  std::string baseTagStr = baseTag.encode();
+  char buff[1024];
+  switch (shift) {
+    case pat::MET::NoShift:
+      snprintf(buff, 1023, baseTagStr.c_str(), "");
+      break;
+    case pat::MET::JetEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "JetEnUp");
+      break;
+    case pat::MET::JetEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "JetEnDown");
+      break;
+    case pat::MET::JetResUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "JetResUp");
+      break;
+    case pat::MET::JetResDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "JetResDown");
+      break;
+    case pat::MET::MuonEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnUp");
+      break;
+    case pat::MET::MuonEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnDown");
+      break;
+    case pat::MET::ElectronEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnUp");
+      break;
+    case pat::MET::ElectronEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnDown");
+      break;
+    case pat::MET::PhotonEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "PhotonEnUp");
+      break;
+    case pat::MET::PhotonEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "PhotonEnDown");
+      break;
+    case pat::MET::TauEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "TauEnUp");
+      break;
+    case pat::MET::TauEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "TauEnDown");
+      break;
+    case pat::MET::UnclusteredEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "UnclusteredEnUp");
+      break;
+    case pat::MET::UnclusteredEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "UnclusteredEnDown");
+      break;
+    default:
+      throw cms::Exception("LogicError", "OneMETShift constructor called with bogus shift");
+  }
+  token = cc.consumes<pat::METCollection>(edm::InputTag(buff));
 }
 
-void 
-pat::PATMETSlimmer::produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
-    using namespace edm;
-    using namespace std;
+void pat::PATMETSlimmer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  using namespace edm;
+  using namespace std;
 
-    Handle<pat::METCollection>  src;
-    iEvent.getByToken(src_, src);
-    if (src->size() != 1) throw cms::Exception("CorruptData", "More than one MET in the collection");
+  Handle<pat::METCollection> src;
+  iEvent.getByToken(src_, src);
+  if (src->size() != 1)
+    throw cms::Exception("CorruptData", "More than one MET in the collection");
 
-    auto out = std::make_unique<std::vector<pat::MET>>(1, src->front());
-    pat::MET & met = out->back();
+  auto out = std::make_unique<std::vector<pat::MET>>(1, src->front());
+  pat::MET &met = out->back();
 
-    for (const OneMETShift &shift : shifts_) {
-        shift.readAndSet(iEvent, met);
-    }
+  for (const OneMETShift &shift : shifts_) {
+    shift.readAndSet(iEvent, met);
+  }
 
-    iEvent.put(std::move(out));
-
+  iEvent.put(std::move(out));
 }
 
 void
 
 pat::PATMETSlimmer::OneMETShift::readAndSet(const edm::Event &ev, pat::MET &met) const {
-    edm::Handle<pat::METCollection>  src;
-    ev.getByToken(token, src);
+  edm::Handle<pat::METCollection> src;
+  ev.getByToken(token, src);
 
-    if (src->size() != 1) throw cms::Exception("CorruptData", "More than one MET in the shifted collection");
-    const pat::MET &met2 = src->front();
+  if (src->size() != 1)
+    throw cms::Exception("CorruptData", "More than one MET in the shifted collection");
+  const pat::MET &met2 = src->front();
 
-
-    if(t0FromMiniAOD) {
-      if(uncShift) met.setUncShift(met2.shiftedPx( shift, pat::MET::Type01), met2.shiftedPy(shift, pat::MET::Type01), 
-				   met2.shiftedSumEt(shift, pat::MET::Type01), shift, isSmeared);
-      if(corShift) met.setCorShift(met2.corPx(pat::MET::Type01), met2.corPy(pat::MET::Type01), 
-				   met2.corSumEt(pat::MET::Type01), level);
-    }
-    else {
-      if(uncShift) met.setUncShift(met2.px(), met2.py(), met2.sumEt(), shift, isSmeared);
-      if(corShift) met.setCorShift(met2.px(), met2.py(), met2.sumEt(), level);
-    }
-
+  if (t0FromMiniAOD) {
+    if (uncShift)
+      met.setUncShift(met2.shiftedPx(shift, pat::MET::Type01),
+                      met2.shiftedPy(shift, pat::MET::Type01),
+                      met2.shiftedSumEt(shift, pat::MET::Type01),
+                      shift,
+                      isSmeared);
+    if (corShift)
+      met.setCorShift(
+          met2.corPx(pat::MET::Type01), met2.corPy(pat::MET::Type01), met2.corSumEt(pat::MET::Type01), level);
+  } else {
+    if (uncShift)
+      met.setUncShift(met2.px(), met2.py(), met2.sumEt(), shift, isSmeared);
+    if (corShift)
+      met.setCorShift(met2.px(), met2.py(), met2.sumEt(), level);
+  }
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -67,6 +67,10 @@ pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet & iConfig) :
   maybeReadShifts( iConfig, "caloMET", pat::MET::Calo );
   maybeReadShifts( iConfig, "chsMET", pat::MET::Chs );
   maybeReadShifts( iConfig, "trkMET", pat::MET::Trk );
+  if (iConfig.getParameter<bool>("addDeepMETs")) {
+    maybeReadShifts(iConfig, "deepMETResolutionTune", pat::MET::DeepResolutionTune);
+    maybeReadShifts(iConfig, "deepMETResponseTune", pat::MET::DeepResponseTune);
+  }
 
   produces<std::vector<pat::MET> >();
 }

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -20,8 +20,6 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedMETs_*_*',
         'keep *_slimmedMETsNoHF_*_*',
         'keep *_slimmedMETsPuppi_*_*',
-        'keep *_slimmedMETsDeep_*_*',
-        'keep *_slimmedMETsDeepResp_*_*',
         'keep *_slimmedSecondaryVertices_*_*',
         'keep *_slimmedLambdaVertices_*_*',
         'keep *_slimmedKshortVertices_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -20,6 +20,8 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedMETs_*_*',
         'keep *_slimmedMETsNoHF_*_*',
         'keep *_slimmedMETsPuppi_*_*',
+        'keep *_slimmedMETsDeep_*_*',
+        'keep *_slimmedMETsDeepResp_*_*',
         'keep *_slimmedSecondaryVertices_*_*',
         'keep *_slimmedLambdaVertices_*_*',
         'keep *_slimmedKshortVertices_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -178,6 +178,8 @@ def miniAOD_customizeCommon(process):
 
     process.load('PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi')
     task.add(process.slimmedMETs)
+    process.slimmedMETs.addDeepMETs = True
+
     addToProcessAndTask('slimmedMETsNoHF', process.slimmedMETs.clone(), process, task)
     process.slimmedMETsNoHF.src = cms.InputTag("patMETsNoHF")
     process.slimmedMETsNoHF.rawVariation =  cms.InputTag("patPFMetNoHF")

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -504,26 +504,25 @@ def miniAOD_customizeCommon(process):
 
     process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
 
-
-    addToProcessAndTask('slimmedMETsDeep', process.deepMETProducer.clone(), process, task)
-    addToProcessAndTask('slimmedMETsDeepResp', process.deepMETProducer.clone(), process, task)
-    process.slimmedMETsDeepResp.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
+    addToProcessAndTask('deepMETsResolutionTune', process.deepMETProducer.clone(), process, task)
+    addToProcessAndTask('deepMETsResponseTune', process.deepMETProducer.clone(), process, task)
+    process.deepMETsResponseTune.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
 
     from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
     phase2_common.toModify(
-        process.slimmedMETsDeep,
+        process.deepMETsResolutionTune,
         max_n_pf=12500,
         graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb"
     )
     phase2_common.toModify(
-        process.slimmedMETsDeepResp,
+        process.deepMETsResponseTune,
         max_n_pf=12500,
         graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb"
     )
 
     from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
     run2_jme_2016.toModify(
-        process.slimmedMETsDeepResp,
+        process.deepMETsResponseTune,
         graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"
     )
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -178,7 +178,6 @@ def miniAOD_customizeCommon(process):
 
     process.load('PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi')
     task.add(process.slimmedMETs)
-    process.slimmedMETs.addDeepMETs = True
 
     addToProcessAndTask('slimmedMETsNoHF', process.slimmedMETs.clone(), process, task)
     process.slimmedMETsNoHF.src = cms.InputTag("patMETsNoHF")
@@ -506,8 +505,8 @@ def miniAOD_customizeCommon(process):
 
     process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
 
-    addToProcessAndTask('deepMETsResolutionTune', process.deepMETProducer.clone(), process, task)
-    addToProcessAndTask('deepMETsResponseTune', process.deepMETProducer.clone(), process, task)
+    process.deepMETsResolutionTune = process.deepMETProducer.clone()
+    process.deepMETsResponseTune = process.deepMETProducer.clone()
     process.deepMETsResponseTune.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
 
     from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
@@ -515,6 +514,10 @@ def miniAOD_customizeCommon(process):
         process.deepMETsResponseTune,
         graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"
     )
+
+    run2_miniAOD_devel.toModify(task, func=lambda t: t.add(process.deepMETsResolutionTune, process.deepMETsResponseTune))
+    run2_miniAOD_devel.toModify(process.slimmedMETs, addDeepMETs = True)
+
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)
     process.load("TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff")
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -512,19 +512,19 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
     phase2_common.toModify(
         process.slimmedMETsDeep,
-        max_n_pf=cms.uint32(12500),
-        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb")
+        max_n_pf=12500,
+        graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb"
     )
     phase2_common.toModify(
         process.slimmedMETsDeepResp,
-        max_n_pf=cms.uint32(12500),
-        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb")
+        max_n_pf=12500,
+        graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb"
     )
 
     from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
     run2_jme_2016.toModify(
         process.slimmedMETsDeepResp,
-        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb")
+        graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"
     )
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)
     process.load("TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff")

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -510,18 +510,6 @@ def miniAOD_customizeCommon(process):
     addToProcessAndTask('deepMETsResponseTune', process.deepMETProducer.clone(), process, task)
     process.deepMETsResponseTune.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
 
-    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-    phase2_common.toModify(
-        process.deepMETsResolutionTune,
-        max_n_pf=12500,
-        graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb"
-    )
-    phase2_common.toModify(
-        process.deepMETsResponseTune,
-        max_n_pf=12500,
-        graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb"
-    )
-
     from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
     run2_jme_2016.toModify(
         process.deepMETsResponseTune,

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -502,6 +502,30 @@ def miniAOD_customizeCommon(process):
     process.slimmedMETsPuppi.tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxyPuppi")
     del process.slimmedMETsPuppi.caloMET
 
+    process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
+
+
+    addToProcessAndTask('slimmedMETsDeep', process.deepMETProducer.clone(), process, task)
+    addToProcessAndTask('slimmedMETsDeepResp', process.deepMETProducer.clone(), process, task)
+    process.slimmedMETsDeepResp.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
+
+    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+    phase2_common.toModify(
+        process.slimmedMETsDeep,
+        max_n_pf=cms.uint32(12500),
+        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb")
+    )
+    phase2_common.toModify(
+        process.slimmedMETsDeepResp,
+        max_n_pf=cms.uint32(12500),
+        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb")
+    )
+
+    from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
+    run2_jme_2016.toModify(
+        process.slimmedMETsDeepResp,
+        graph_path=cms.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb")
+    )
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)
     process.load("TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff")
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
@@ -19,6 +19,8 @@ slimmedMETs = cms.EDProducer("PATMETSlimmer",
    #adding CHS and Track MET for the Jet/MET studies
    chsMET = cms.InputTag("patCHSMet"),
    trkMET = cms.InputTag("patTrkMet"),
+   deepMETResolutionTune = cms.InputTag("deepMETsResolutionTune"),
+   deepMETResponseTune = cms.InputTag("deepMETsResponseTune"),
 
    #switch to read the type0 correction from the existing slimmedMET
    #when running on top of miniAOD (type0 cannot be redone at the miniAOD level

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
@@ -19,6 +19,9 @@ slimmedMETs = cms.EDProducer("PATMETSlimmer",
    #adding CHS and Track MET for the Jet/MET studies
    chsMET = cms.InputTag("patCHSMet"),
    trkMET = cms.InputTag("patTrkMet"),
+
+   #adding DeepMET variants
+   addDeepMETs = cms.bool(False),
    deepMETResolutionTune = cms.InputTag("deepMETsResolutionTune"),
    deepMETResponseTune = cms.InputTag("deepMETsResponseTune"),
 

--- a/RecoMET/METPUSubtraction/plugins/BuildFile.xml
+++ b/RecoMET/METPUSubtraction/plugins/BuildFile.xml
@@ -1,22 +1,23 @@
 <export>
 </export>
-<library   name="RecoMETMETPUSubtraction_plugins" file="*.cc">
-  <use   name="FWCore/Framework"/>
-  <use   name="FWCore/MessageLogger"/>
-  <use   name="FWCore/ParameterSet"/>
-  <use   name="FWCore/Utilities"/>
-  <use   name="CommonTools/Utils"/>
-  <use   name="DataFormats/Candidate"/>
-  <use   name="DataFormats/JetReco"/>
-  <use   name="DataFormats/METReco"/>
-  <use   name="DataFormats/MuonReco"/>
-  <use   name="DataFormats/ParticleFlowCandidate"/>
-  <use   name="DataFormats/PatCandidates"/>
-  <use   name="DataFormats/TauReco"/>
-  <use   name="DataFormats/VertexReco"/>
-  <use   name="JetMETCorrections/Objects"/>
-  <use   name="RecoMET/METPUSubtraction"/>
-  <use   name="RecoJets/JetProducers"/> 
-  <use   name="root"/>
-  <use   name="roottmva"/>
+<library name="RecoMETMETPUSubtraction_plugins" file="*.cc">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <use name="CommonTools/Utils"/>
+  <use name="DataFormats/Candidate"/>
+  <use name="DataFormats/JetReco"/>
+  <use name="DataFormats/METReco"/>
+  <use name="DataFormats/MuonReco"/>
+  <use name="DataFormats/ParticleFlowCandidate"/>
+  <use name="DataFormats/PatCandidates"/>
+  <use name="DataFormats/TauReco"/>
+  <use name="DataFormats/VertexReco"/>
+  <use name="JetMETCorrections/Objects"/>
+  <use name="RecoMET/METPUSubtraction"/>
+  <use name="RecoJets/JetProducers"/>
+  <use name="PhysicsTools/TensorFlow"/>
+  <use name="root"/>
+  <use name="roottmva"/>
 </library>

--- a/RecoMET/METPUSubtraction/plugins/BuildFile.xml
+++ b/RecoMET/METPUSubtraction/plugins/BuildFile.xml
@@ -1,23 +1,23 @@
 <export>
 </export>
-<library name="RecoMETMETPUSubtraction_plugins" file="*.cc">
-  <use name="FWCore/Framework"/>
-  <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/Utilities"/>
-  <use name="CommonTools/Utils"/>
-  <use name="DataFormats/Candidate"/>
-  <use name="DataFormats/JetReco"/>
-  <use name="DataFormats/METReco"/>
-  <use name="DataFormats/MuonReco"/>
-  <use name="DataFormats/ParticleFlowCandidate"/>
-  <use name="DataFormats/PatCandidates"/>
-  <use name="DataFormats/TauReco"/>
-  <use name="DataFormats/VertexReco"/>
-  <use name="JetMETCorrections/Objects"/>
-  <use name="RecoMET/METPUSubtraction"/>
-  <use name="RecoJets/JetProducers"/>
-  <use name="PhysicsTools/TensorFlow"/>
-  <use name="root"/>
-  <use name="roottmva"/>
+<library   name="RecoMETMETPUSubtraction_plugins" file="*.cc">
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/MessageLogger"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="FWCore/Utilities"/>
+  <use   name="CommonTools/Utils"/>
+  <use   name="DataFormats/Candidate"/>
+  <use   name="DataFormats/JetReco"/>
+  <use   name="DataFormats/METReco"/>
+  <use   name="DataFormats/MuonReco"/>
+  <use   name="DataFormats/ParticleFlowCandidate"/>
+  <use   name="DataFormats/PatCandidates"/>
+  <use   name="DataFormats/TauReco"/>
+  <use   name="DataFormats/VertexReco"/>
+  <use   name="JetMETCorrections/Objects"/>
+  <use   name="RecoMET/METPUSubtraction"/>
+  <use   name="RecoJets/JetProducers"/>
+  <use   name="PhysicsTools/TensorFlow"/>
+  <use   name="root"/>
+  <use   name="roottmva"/>
 </library>

--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -1,0 +1,163 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+
+struct DeepMETCache {
+  std::atomic<tensorflow::GraphDef*> graph_def;
+};
+
+class DeepMETProducer : public edm::stream::EDProducer<edm::GlobalCache<DeepMETCache> > {
+public:
+  explicit DeepMETProducer(const edm::ParameterSet&, const DeepMETCache*);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  // static methods for handling the global cache
+  static std::unique_ptr<DeepMETCache> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(DeepMETCache*);
+private:
+  const edm::EDGetTokenT<std::vector<pat::PackedCandidate> > pf_token_;
+  float norm_;
+  bool ignore_leptons_;
+  unsigned int max_n_pf_;
+
+  tensorflow::Session* session_;
+
+  std::unordered_map<int, int32_t> charge_embedding_;
+  std::unordered_map<int, int32_t> pdg_id_embedding_;
+};
+
+
+namespace {
+  float divide_and_rm_outlier(float val, float norm) {
+    float ret_val = val/norm;
+    if (ret_val > 1e6 || ret_val < -1e6)
+      return 0.;
+    return ret_val;
+  }
+}
+
+DeepMETProducer::DeepMETProducer(const edm::ParameterSet& cfg, const DeepMETCache* cache) :
+  pf_token_(consumes<std::vector<pat::PackedCandidate> >(cfg.getParameter<edm::InputTag>("pf_src"))),
+  norm_(cfg.getParameter<double>("norm_factor")), 
+  ignore_leptons_(cfg.getParameter<bool>("ignore_leptons")),
+  max_n_pf_(cfg.getParameter<unsigned int>("max_n_pf")) {
+    session_ = tensorflow::createSession(cache->graph_def);
+    produces<pat::METCollection>();
+    charge_embedding_ = {{-1, 0}, {0, 1}, {1, 2}};
+    pdg_id_embedding_ = {{-211, 0}, {-13, 1}, {-11, 2}, {0, 3}, {1, 4}, {2, 5}, {11, 6}, {13, 7}, {22, 8}, {130, 9}, {211, 10}};;
+}
+
+void DeepMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+  edm::Handle<std::vector<pat::PackedCandidate> > pf_h;
+  event.getByToken(pf_token_, pf_h);
+
+  // PF keys [b'PF_dxy', b'PF_dz', b'PF_eta', b'PF_mass', b'PF_pt', b'PF_puppiWeight', b'PF_px', b'PF_py']
+  tensorflow::TensorShape shape({1, max_n_pf_, 8});
+  tensorflow::TensorShape cat_shape({1, max_n_pf_, 1});
+  tensorflow::Tensor input(tensorflow::DT_FLOAT, shape);
+  tensorflow::Tensor input_cat0(tensorflow::DT_FLOAT, cat_shape);
+  tensorflow::Tensor input_cat1(tensorflow::DT_FLOAT, cat_shape);
+  tensorflow::Tensor input_cat2(tensorflow::DT_FLOAT, cat_shape);
+
+  tensorflow::TensorShape out_shape({1, 2});
+  tensorflow::Tensor output(tensorflow::DT_FLOAT, out_shape);
+
+  tensorflow::NamedTensorList input_list = {{"input", input}, {"input_cat0", input_cat0}, {"input_cat1", input_cat1}, {"input_cat2", input_cat2}};
+
+  // Set all inputs to zero
+  input.flat<float>().setZero();
+  input_cat0.flat<float>().setZero();
+  input_cat1.flat<float>().setZero();
+  input_cat2.flat<float>().setZero();
+
+  size_t i_pf = 0;
+  float px_leptons = 0.;
+  float py_leptons = 0.;
+  for (const auto& pf : *pf_h) {
+
+    if (ignore_leptons_) {
+      int pdg_id = std::abs(pf.pdgId());
+      if (pdg_id == 11 || pdg_id == 13) {
+        px_leptons += pf.px();
+        py_leptons += pf.py();
+        continue;
+      }
+    } 
+
+    // fill the tensor
+    float* ptr = &input.tensor<float, 3>()(0, i_pf, 0);
+    *ptr = pf.dxy();
+    *(++ptr) = pf.dz();
+    *(++ptr) = pf.eta();
+    *(++ptr) = pf.mass();
+    *(++ptr) = divide_and_rm_outlier(pf.pt(), norm_);
+    *(++ptr) = pf.puppiWeight();
+    *(++ptr) = divide_and_rm_outlier(pf.px(), norm_);
+    *(++ptr) = divide_and_rm_outlier(pf.py(), norm_);
+    input_cat0.tensor<float, 3>()(0, i_pf, 0) = charge_embedding_[pf.charge()];
+    input_cat1.tensor<float, 3>()(0, i_pf, 0) = pdg_id_embedding_[pf.pdgId()];
+    input_cat2.tensor<float, 3>()(0, i_pf, 0) = pf.fromPV();
+
+    ++i_pf;
+    if (i_pf > max_n_pf_)
+    {
+      break; // output a warning?
+    }
+  }
+
+  std::vector<tensorflow::Tensor> outputs;
+  std::vector<std::string> output_names = {"output/BiasAdd"};
+
+  // run the inference and return met
+  tensorflow::run(session_, input_list, output_names, &outputs);
+
+  // The DNN directly estimates the missing px and py, not the recoil
+  float px = outputs[0].tensor<float, 2>()(0, 0) * norm_;
+  float py = outputs[0].tensor<float, 2>()(0, 1) * norm_;
+
+  px -= px_leptons;
+  py -= py_leptons;
+
+  auto pf_mets = std::make_unique<pat::METCollection>();
+  reco::LeafCandidate::LorentzVector p4(px, py, 0., std::sqrt(px*px + py*py));
+  const reco::Candidate::Point vtx(0.0, 0.0, 0.0);
+  pf_mets->emplace_back(reco::MET(p4, vtx));
+  event.put(std::move(pf_mets));
+}
+
+std::unique_ptr<DeepMETCache> DeepMETProducer::initializeGlobalCache(const edm::ParameterSet& params) {
+  // this method is supposed to create, initialize and return a DeepMETCache instance
+  std::unique_ptr<DeepMETCache> cache = std::make_unique<DeepMETCache>();
+
+  // load the graph def and save it
+  std::string graphPath = params.getParameter<std::string>("graph_path");
+  if (!graphPath.empty()) {
+    graphPath = edm::FileInPath(graphPath).fullPath();
+    cache->graph_def = tensorflow::loadGraphDef(graphPath);
+  }
+
+  return cache;
+}
+
+void DeepMETProducer::globalEndJob(DeepMETCache* cache) {
+  delete cache->graph_def;
+}
+
+void DeepMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("pf_src", edm::InputTag("packedPFCandidates"));
+  desc.add<bool>("ignore_leptons", false);
+  desc.add<double>("norm_factor", 50.);
+  desc.add<unsigned int>("max_n_pf", 4500);
+  desc.add<std::string>("graph_path", "RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_2018.pb");
+  descriptions.add("deepMETProducer", desc);
+}
+
+DEFINE_FWK_MODULE(DeepMETProducer);

--- a/RecoMET/METPUSubtraction/test/testDeepMET_cfg.py
+++ b/RecoMET/METPUSubtraction/test/testDeepMET_cfg.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+from RecoMET.METPUSubtraction.deepMETProducer_cfi import deepMETProducer
+
+process = cms.Process('DeepMET')
+
+process.task = cms.Task()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load(
+    'Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input=cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+                            secondaryFileNames=cms.untracked.vstring(),
+                            fileNames=cms.untracked.vstring(
+                                # '/store/relval/CMSSW_11_0_0_pre7/RelValTTbar_13/MINIAODSIM/PUpmx25ns_110X_mc2017_realistic_v1_rsb-v1/10000/A745F01B-D6C3-A843-97B7-2B12C7C0DD4E.root'),
+                                '/store/mc/RunIIAutumn18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/270000/9E5D0032-E9FB-6646-B1AB-67EA8B95FCCD.root'),
+                            skipEvents=cms.untracked.uint32(0)
+                            )
+
+process.deepMETProducer = deepMETProducer.clone()
+
+process.sequence = cms.Sequence(process.deepMETProducer)
+process.p = cms.Path(process.sequence)
+process.output = cms.OutputModule("PoolOutputModule",
+                                  outputCommands=cms.untracked.vstring(
+                                      'keep *'),
+                                  fileName=cms.untracked.string(
+                                      "DeepMETTest.root")
+                                  )
+process.outpath  = cms.EndPath(process.output)


### PR DESCRIPTION
#### PR description:

Backport DeepMET into CMSSW_10_6_X, in order to get it included in the next ReMiniAOD campaign. The cmsdist in CMSSW_10_6_X also needs to be updated, please test it together with

https://github.com/cms-sw/cmsdist/pull/6054

The massive changes in `DataFormats/PatCandidates/interface/MET.h`, `DataFormats/PatCandidates/src/MET.cc` and `PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc` are from code-format checks and most of these are unrelated to DeepMET updates.

#### PR validation:

tested with `runTheMatrix.py -l limited -i all --ibeos`, failed one test from `Flag_trkPOG_logErrorTooManyClusters`, which seems irrelevant to our updates. No clue where the problem comes from yet.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport: https://github.com/cms-sw/cmssw/pull/29764/

@steggema @intrepid42 
