### PR TITLE
PR 11_2_X L1T TrackTrigger Hybrid Extended ONE Producer.

### DIFF
--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -9,7 +9,7 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 //
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -129,7 +129,7 @@ public:
   }
 };
 
-class L1FPGATrackProducer : public edm::stream::EDProducer<> {
+class L1FPGATrackProducer : public edm::one::EDProducer<edm::one::WatchRuns> {
 public:
   /// Constructor/destructor
   explicit L1FPGATrackProducer(const edm::ParameterSet& iConfig);
@@ -193,6 +193,7 @@ private:
   /// ///////////////// ///
   /// MANDATORY METHODS ///
   void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 };
 
@@ -289,6 +290,10 @@ L1FPGATrackProducer::~L1FPGATrackProducer() {
     asciiEventOut_.close();
   }
 }
+
+///////END RUN
+//
+void L1FPGATrackProducer::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
 ////////////
 // BEGIN JOB


### PR DESCRIPTION
#### PR description:

Turn the `L1FPGATrackProducer` from `edm::stream` to `edm::one` Producer to fix multiple memory consumption at beginRun when running on multiple streams.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
