### PR TITLE
Reduce boost dependency in L1Trigger/TrackFindingTMTT

### DIFF
--- a/L1Trigger/TrackFindingTMTT/BuildFile.xml
+++ b/L1Trigger/TrackFindingTMTT/BuildFile.xml
@@ -18,7 +18,6 @@
 <use name="SimTracker/TrackTriggerAssociation"/>
 <use name="DataFormats/JetReco"/>
 <use name="L1Trigger/TrackTrigger"/>
-<use name="boost"/>
 <use name="roothistmatrix"/>
 <export>
     <lib name="1"/>

--- a/L1Trigger/TrackFindingTMTT/interface/HTbase.h
+++ b/L1Trigger/TrackFindingTMTT/interface/HTbase.h
@@ -1,20 +1,36 @@
+
 #ifndef L1Trigger_TrackFindingTMTT_HTbase_h
 #define L1Trigger_TrackFindingTMTT_HTbase_h
 
 #include "L1Trigger/TrackFindingTMTT/interface/HTcell.h"
 #include "L1Trigger/TrackFindingTMTT/interface/L1track2D.h"
 
-#include <boost/numeric/ublas/matrix.hpp>
-
 #include <vector>
 #include <list>
 #include <utility>
 #include <memory>
 
-using boost::numeric::ublas::matrix;
+namespace tmtt {
+  template <typename T>
+  class matrix {
+  public:
+    //for a mxn matrix - row major
+    matrix(unsigned int m, unsigned int n) : _n{n}, _m{m} { _matrix.resize(m * n); }
+    const T& operator()(unsigned int i, unsigned int j) const { return _matrix.at(i * _n + j); }
+    T& operator()(unsigned int i, unsigned int j) {
+      if (i >= _m || j >= _n)
+        throw std::out_of_range("matrix access out of bounds");
+
+      return _matrix[i * _n + j];
+    }
+
+  private:
+    std::vector<T> _matrix;
+    unsigned int _n, _m;
+  };
+}  // namespace tmtt
 
 //=== Base class for Hough Transform array for a single (eta,phi) sector.
-
 namespace tmtt {
 
   class Settings;

--- a/L1Trigger/TrackFindingTMTT/interface/Histos.h
+++ b/L1Trigger/TrackFindingTMTT/interface/Histos.h
@@ -7,9 +7,6 @@
 #include "L1Trigger/TrackFindingTMTT/interface/L1track3D.h"
 #include "L1Trigger/TrackFindingTMTT/interface/TrackerModule.h"
 
-#include <boost/numeric/ublas/matrix.hpp>
-using boost::numeric::ublas::matrix;
-
 #include <vector>
 #include <map>
 #include <list>

--- a/L1Trigger/TrackFindingTMTT/interface/MiniHTstage.h
+++ b/L1Trigger/TrackFindingTMTT/interface/MiniHTstage.h
@@ -4,7 +4,6 @@
 #include "L1Trigger/TrackFindingTMTT/interface/HTrphi.h"
 #include "L1Trigger/TrackFindingTMTT/interface/MuxHToutputs.h"
 
-using boost::numeric::ublas::matrix;
 #include <memory>
 
 namespace tmtt {

--- a/L1Trigger/TrackFindingTMTT/interface/MuxHToutputs.h
+++ b/L1Trigger/TrackFindingTMTT/interface/MuxHToutputs.h
@@ -3,11 +3,8 @@
 
 #include "L1Trigger/TrackFindingTMTT/interface/HTrphi.h"
 
-#include "boost/numeric/ublas/matrix.hpp"
 #include <vector>
 #include <memory>
-
-using boost::numeric::ublas::matrix;
 
 //==================================================================================================
 /**

--- a/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
+++ b/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
@@ -15,8 +15,6 @@
 #include "FWCore/MessageService/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include <boost/numeric/ublas/matrix.hpp>
-
 #include <iostream>
 #include <vector>
 #include <list>
@@ -25,7 +23,6 @@
 #include <mutex>
 
 using namespace std;
-using boost::numeric::ublas::matrix;
 
 namespace tmtt {
 

--- a/L1Trigger/TrackFindingTMTT/src/Histos.cc
+++ b/L1Trigger/TrackFindingTMTT/src/Histos.cc
@@ -636,7 +636,6 @@ namespace tmtt {
     //=== Count stubs per event assigned to track candidates in the Tracker
 
     unsigned int nStubsOnTracks = 0;
-    matrix nStubsOnTracksInSec(numPhiSectors_, numEtaRegions_, 0);
     vector<unsigned int> nStubsOnTracksInNonant(numPhiNonants, 0);
 
     for (const L1track3D& t : tracks) {


### PR DESCRIPTION
#### PR description:
Replaced boost::numeric::ublas::matrix for a wrapped std::vector.
Since the boost::matrix here is used basically as an fixed indexed storage, a std::vector replacement should not impact performance significantly.


#### PR validation:
Passed on basic runTheMatrix test.

I've made a few benchmarks to measure performance differences. And in theory, it should not be significant in this use case.
https://gist.github.com/camolezi/fdffbe34f149552e8601964a7cc87e73

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 