### PR TITLE
Check valid pads and clusters in GEM trigger primitive producers

### DIFF
--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -37,10 +37,10 @@ bool GEMPadDigiCluster::isValid() const {
 }
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi) {
-  o << " bx: " << digi.bx() << " pads: ";
+  o << " bx: " << digi.bx() << " pads: [";
   for (auto p : digi.pads())
     o << " " << p;
-  o << std::endl;
+  o << "]";
   return o;
 }
 

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -227,6 +227,12 @@ public:
     return rawid;
   }
 
+  // subsystem
+  GEMSubDetId::Station subsystem() const;
+  bool isGE11() const;
+  bool isGE21() const;
+  bool isME0() const;
+
 private:
   constexpr void v12FromV11(const uint32_t& rawid) { id_ = v12Form(rawid); }
 

--- a/DataFormats/MuonDetId/src/GEMDetId.cc
+++ b/DataFormats/MuonDetId/src/GEMDetId.cc
@@ -4,6 +4,14 @@
 
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 
+GEMSubDetId::Station GEMDetId::subsystem() const { return GEMSubDetId::station(station()); }
+
+bool GEMDetId::isGE11() const { return subsystem() == GEMSubDetId::Station::GE11; }
+
+bool GEMDetId::isGE21() const { return subsystem() == GEMSubDetId::Station::GE21; }
+
+bool GEMDetId::isME0() const { return subsystem() == GEMSubDetId::Station::ME0; }
+
 std::ostream& operator<<(std::ostream& os, const GEMDetId& id) {
   os << " Re " << id.region() << " Ri " << id.ring() << " St " << id.station() << " La " << id.layer() << " Ch "
      << id.chamber() << " Ro " << id.roll() << " ";

--- a/Geometry/GEMGeometry/interface/GEMEtaPartition.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartition.h
@@ -79,7 +79,7 @@ public:
   int lastStripInPad(int pad) const;
 
   // subsystem
-  GEMSubDetId::Station station() const;
+  GEMSubDetId::Station subsystem() const;
   bool isME0() const;
   bool isGE11() const;
   bool isGE21() const;

--- a/Geometry/GEMGeometry/interface/GEMEtaPartition.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartition.h
@@ -78,6 +78,12 @@ public:
   /// returns last strip (INT number [0,nstrip-1]) for pad (an integer [0,npads-1])
   int lastStripInPad(int pad) const;
 
+  // subsystem
+  GEMSubDetId::Station station() const;
+  bool isME0() const;
+  bool isGE11() const;
+  bool isGE21() const;
+
 private:
   GEMDetId id_;
   GEMEtaPartitionSpecs* specs_;

--- a/Geometry/GEMGeometry/src/GEMEtaPartition.cc
+++ b/Geometry/GEMGeometry/src/GEMEtaPartition.cc
@@ -72,10 +72,10 @@ int GEMEtaPartition::lastStripInPad(int pad) const {
   return static_cast<int>(strip(lp));
 }
 
-GEMSubDetId::Station GEMEtaPartition::station() const { return GEMSubDetId::station(id().station()); }
+GEMSubDetId::Station GEMEtaPartition::subsystem() const { return id_.subsystem(); }
 
-bool GEMEtaPartition::isME0() const { return station() == GEMSubDetId::Station::ME0; }
+bool GEMEtaPartition::isGE11() const { return id_.isGE11(); }
 
-bool GEMEtaPartition::isGE11() const { return station() == GEMSubDetId::Station::GE11; }
+bool GEMEtaPartition::isGE21() const { return id_.isGE21(); }
 
-bool GEMEtaPartition::isGE21() const { return station() == GEMSubDetId::Station::GE21; }
+bool GEMEtaPartition::isME0() const { return id_.isME0(); }

--- a/Geometry/GEMGeometry/src/GEMEtaPartition.cc
+++ b/Geometry/GEMGeometry/src/GEMEtaPartition.cc
@@ -71,3 +71,20 @@ int GEMEtaPartition::lastStripInPad(int pad) const {
   LocalPoint lp = specificPadTopology().localPosition(p);
   return static_cast<int>(strip(lp));
 }
+
+GEMSubDetId::Station GEMEtaPartition::station() const
+{
+  return GEMSubDetId::station(id().station());
+}
+
+bool GEMEtaPartition::isME0() const {
+  return station() == GEMSubDetId::Station::ME0;
+}
+
+bool GEMEtaPartition::isGE11() const {
+  return station() == GEMSubDetId::Station::GE11;
+}
+
+bool GEMEtaPartition::isGE21() const {
+  return station() == GEMSubDetId::Station::GE21;
+}

--- a/Geometry/GEMGeometry/src/GEMEtaPartition.cc
+++ b/Geometry/GEMGeometry/src/GEMEtaPartition.cc
@@ -72,19 +72,10 @@ int GEMEtaPartition::lastStripInPad(int pad) const {
   return static_cast<int>(strip(lp));
 }
 
-GEMSubDetId::Station GEMEtaPartition::station() const
-{
-  return GEMSubDetId::station(id().station());
-}
+GEMSubDetId::Station GEMEtaPartition::station() const { return GEMSubDetId::station(id().station()); }
 
-bool GEMEtaPartition::isME0() const {
-  return station() == GEMSubDetId::Station::ME0;
-}
+bool GEMEtaPartition::isME0() const { return station() == GEMSubDetId::Station::ME0; }
 
-bool GEMEtaPartition::isGE11() const {
-  return station() == GEMSubDetId::Station::GE11;
-}
+bool GEMEtaPartition::isGE11() const { return station() == GEMSubDetId::Station::GE11; }
 
-bool GEMEtaPartition::isGE21() const {
-  return station() == GEMSubDetId::Station::GE21;
-}
+bool GEMEtaPartition::isGE21() const { return station() == GEMSubDetId::Station::GE21; }

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -59,7 +59,15 @@ std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_
       // now let's correlate the pads in two layers of this partition
       const auto& pads_range = (*det_range).second;
       for (auto p = pads_range.first; p != pads_range.second; ++p) {
+        // only consider valid pads
+        if (!p->isValid())
+          continue;
+
         for (auto co_p = co_pads_range.first; co_p != co_pads_range.second; ++co_p) {
+          // only consider valid pads
+          if (!co_p->isValid())
+            continue;
+
           // check the match in pad
           if ((unsigned)std::abs(p->pad() - co_p->pad()) > maxDeltaPad_)
             continue;
@@ -91,6 +99,10 @@ void GEMCoPadProcessor::declusterize(const GEMPadDigiClusterCollection* in_clust
     const GEMDetId& id = (*detUnitIt).first;
     const auto& range = (*detUnitIt).second;
     for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
+      // only consider valid clusters
+      if (!digiIt->isValid())
+        continue;
+
       for (const auto& p : digiIt->pads()) {
         out_pads.insertDigi(id, GEMPadDigi(p, digiIt->bx()));
       }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -189,7 +189,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
   for (const auto& part : geometry_->etaPartitions()) {
     // clusters are not build for ME0
     // -> ignore hits from station 0
-    if (part->id().station() == 0)
+    if (part->isME0())
       continue;
 
     GEMPadDigiClusters all_pad_clusters;
@@ -211,7 +211,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
           cl.push_back((*d).pad());
         } else {
           // put the current cluster in the proto collection
-          GEMPadDigiCluster pad_cluster(cl, startBX, GEMSubDetId::station(part->id().station()));
+          GEMPadDigiCluster pad_cluster(cl, startBX, part->subsystem());
 
           // check if the output cluster is valid
           checkValid(pad_cluster, part->id());
@@ -228,7 +228,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
 
     // put the last cluster in the proto collection
     if (pads.first != pads.second) {
-      GEMPadDigiCluster pad_cluster(cl, startBX, GEMSubDetId::station(part->id().station()));
+      GEMPadDigiCluster pad_cluster(cl, startBX, part->subsystem());
 
       // check if the output cluster is valid
       checkValid(pad_cluster, part->id());
@@ -249,9 +249,7 @@ void GEMPadDigiClusterProducer::sortClusters(const GEMPadDigiClusterContainer& p
 
   for (const auto& ch : geometry_->chambers()) {
     // check the station number
-    const int station = ch->id().station();
-    const bool isGE11 = (station == 1);
-    const unsigned nOH = isGE11 ? nOHGE11_ : nOHGE21_;
+    const unsigned nOH = ch->id().isGE11() ? nOHGE11_ : nOHGE21_;
     const unsigned nPartOH = ch->nEtaPartitions() / nOH;
 
     std::vector<std::vector<std::pair<GEMDetId, GEMPadDigiClusters> > > temp_clustersCH;
@@ -280,9 +278,7 @@ void GEMPadDigiClusterProducer::selectClusters(const GEMPadDigiClusterSortedCont
                                                GEMPadDigiClusterCollection& out_clusters) const {
   // loop over chambers
   for (const auto& ch : geometry_->chambers()) {
-    const int station = ch->id().station();
-    const bool isGE11 = (station == 1);
-    const unsigned maxClustersOH = isGE11 ? maxClustersOHGE11_ : maxClustersOHGE21_;
+    const unsigned maxClustersOH = ch->id().isGE11() ? maxClustersOHGE11_ : maxClustersOHGE21_;
 
     // loop over the optohybrids
     for (const auto& optohybrid : sorted_clusters.at(ch->id())) {

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -95,7 +95,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
   for (const auto& p : geometry_->etaPartitions()) {
     // when using the GE2/1 geometry with 16 eta partitions
     // ->ignore GE2/1
-    if (use16GE21_ and p->id().station() == 2)
+    if (use16GE21_ and p->isGE21())
       continue;
 
     // set of <pad, bx> pairs, sorted first by pad then by bx
@@ -108,10 +108,8 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
       unsigned pad_num = static_cast<int>(p->padOfStrip(d->strip()));
 
       // check that the input digi is valid
-      if ((GEMSubDetId::station(p->id().station()) == GEMSubDetId::Station::GE11 and
-           pad_num == GEMPadDigi::GE11InValid) or
-          (GEMSubDetId::station(p->id().station()) == GEMSubDetId::Station::GE21 and
-           pad_num == GEMPadDigi::GE21InValid)) {
+      if ((p->isGE11() and pad_num == GEMPadDigi::GE11InValid) or
+          (p->isGE21() and pad_num == GEMPadDigi::GE21InValid) or (p->isME0() and pad_num == GEMPadDigi::ME0InValid)) {
         edm::LogWarning("GEMPadDigiProducer") << "Invalid " << pad_num << " from  " << *d << " in " << p->id();
       }
       proto_pads.emplace(pad_num, d->bx());
@@ -119,7 +117,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(d.first, d.second, GEMSubDetId::station(p->id().station()));
+      GEMPadDigi pad_digi(d.first, d.second, p->subsystem());
       checkValid(pad_digi, p->id());
       out_pads.insertDigi(p->id(), pad_digi);
     }
@@ -130,7 +128,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
   for (const auto& p : geometry_->etaPartitions()) {
     // when using the GE2/1 geometry with 16 eta partitions
     // ->ignore GE1/1
-    if (p->id().station() == 1)
+    if (!p->isGE21())
       continue;
 
     // ignore eta partition with even numbers
@@ -160,7 +158,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(d.first, d.second);
+      GEMPadDigi pad_digi(d.first, d.second, p->subsystem());
       checkValid(pad_digi, p->id());
       out_pads.insertDigi(p->id(), pad_digi);
     }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -168,7 +168,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
 }
 
 void GEMPadDigiProducer::checkValid(const GEMPadDigi& pad, const GEMDetId& id) const {
-  // check if the cluster is valid
+  // check if the pad is valid
   // in principle, invalid pads can appear in the CMS raw data
   if (!pad.isValid()) {
     edm::LogWarning("GEMPadDigiProducer") << "Invalid " << pad << " in " << id;


### PR DESCRIPTION
#### PR description:

I added a few statements to ignore invalid pads and clusters in the GEM-CSC trigger. I also added checks (LogWarnings, not selections) in the GEM trigger primitive producers.

#### PR validation:

Tested with 23234.0 in 11_2_X.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A