### PR TITLE
Add support of std::format()-like formatting to MessageLogger

### DIFF
--- a/FWCore/MessageLogger/BuildFile.xml
+++ b/FWCore/MessageLogger/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/Provenance"/>
 <use name="boost"/>
+<use name="fmt"/>
 <use name="tinyxml2"/>
 <use name="tbb"/>
 <export>

--- a/FWCore/MessageLogger/interface/ErrorObj.h
+++ b/FWCore/MessageLogger/interface/ErrorObj.h
@@ -78,6 +78,8 @@ namespace edm {
     ErrorObj& opltlt(const char s[]);
     inline ErrorObj& operator<<(std::ostream& (*f)(std::ostream&));
     inline ErrorObj& operator<<(std::ios_base& (*f)(std::ios_base&));
+    template <typename... Args>
+    inline ErrorObj& format(std::string_view fmt, Args const&... args);
 
     virtual ErrorObj& emitToken(const ELstring& txt);
 

--- a/FWCore/MessageLogger/interface/ErrorObj.icc
+++ b/FWCore/MessageLogger/interface/ErrorObj.icc
@@ -14,6 +14,8 @@
 
 #include <sstream>
 
+#include "fmt/ostream.h"
+
 namespace edm {
 
   // ----------------------------------------------------------------------
@@ -51,6 +53,14 @@ namespace edm {
 
   inline ErrorObj& ErrorObj::operator<<(std::ios_base& (*f)(std::ios_base&)) {
     f(myOs);
+    return *this;
+  }
+
+  template <typename... Args>
+  inline ErrorObj& ErrorObj::format(std::string_view fmt, Args const&... args) {
+    auto str = fmt::format(fmt, args...);
+    if (!str.empty())
+      emitToken(str);
     return *this;
   }
 

--- a/FWCore/MessageLogger/interface/MessageLogger.h
+++ b/FWCore/MessageLogger/interface/MessageLogger.h
@@ -165,6 +165,13 @@ namespace edm {
       return *this;
     }
 
+    template <typename... Args>
+    LogWarning& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
+      return *this;
+    }
+
     template <typename F>
     LogWarning& log(F&& iF) {
       if (ap.valid()) {
@@ -204,6 +211,13 @@ namespace edm {
       return *this;
     }
 
+    template <typename... Args>
+    LogError& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
+      return *this;
+    }
+
     template <typename F>
     LogError& log(F&& iF) {
       if (ap.valid()) {
@@ -235,6 +249,13 @@ namespace edm {
     }
     LogSystem& operator<<(std::ios_base& (*f)(std::ios_base&)) {
       ap << f;
+      return *this;
+    }
+
+    template <typename... Args>
+    LogSystem& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
       return *this;
     }
 
@@ -275,6 +296,13 @@ namespace edm {
     LogInfo& operator<<(std::ios_base& (*f)(std::ios_base&)) {
       if (ap.valid())
         ap << f;
+      return *this;
+    }
+
+    template <typename... Args>
+    LogInfo& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
       return *this;
     }
 
@@ -323,6 +351,13 @@ namespace edm {
       return *this;
     }
 
+    template <typename... Args>
+    LogVerbatim& format(std::string_view fmt, Args&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
+      return *this;
+    }
+
     template <typename F>
     LogVerbatim& log(F&& iF) {
       if (ap.valid()) {
@@ -368,6 +403,13 @@ namespace edm {
       return *this;
     }
 
+    template <typename... Args>
+    LogPrint& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
+      return *this;
+    }
+
     template <typename F>
     LogPrint& log(F&& iF) {
       if (ap.valid()) {
@@ -406,6 +448,13 @@ namespace edm {
     LogProblem& operator<<(std::ios_base& (*f)(std::ios_base&)) {
       if (ap.valid())
         ap << f;
+      return *this;
+    }
+
+    template <typename... Args>
+    LogProblem& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
       return *this;
     }
 
@@ -450,6 +499,13 @@ namespace edm {
       return *this;
     }
 
+    template <typename... Args>
+    LogImportant& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
+      return *this;
+    }
+
     template <typename F>
     LogImportant& log(F&& iF) {
       if (ap.valid()) {
@@ -485,6 +541,13 @@ namespace edm {
     }
     LogAbsolute& operator<<(std::ios_base& (*f)(std::ios_base&)) {
       ap << f;
+      return *this;
+    }
+
+    template <typename... Args>
+    LogAbsolute& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
       return *this;
     }
 
@@ -531,6 +594,13 @@ namespace edm {
     }
     // Change log 8:  The tests for ap.valid() being null
 
+    template <typename... Args>
+    LogDebug_& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
+      return *this;
+    }
+
     template <typename F>
     LogDebug_& log(F&& iF) {
       if (ap.valid()) {
@@ -568,6 +638,13 @@ namespace edm {
       return *this;
     }
     // Change log 8:  The tests for ap.valid() being null
+
+    template <typename... Args>
+    LogTrace_& format(std::string_view fmt, Args const&... args) {
+      if (ap.valid())
+        ap.format(fmt, args...);
+      return *this;
+    }
 
     template <typename F>
     LogTrace_& log(F&& iF) {
@@ -610,6 +687,13 @@ namespace edm {
         return *this;
       }
 
+      template <typename... Args>
+      LogWarningThatSuppressesLikeLogInfo& format(std::string_view fmt, Args const&... args) {
+        if (ap.valid())
+          ap.format(fmt, args...);
+        return *this;
+      }
+
       template <typename F>
       LogWarningThatSuppressesLikeLogInfo& log(F&& iF) {
         if (ap.valid()) {
@@ -637,6 +721,11 @@ namespace edm {
     }                                                                                     // Change log 12
     Suppress_LogDebug_& operator<<(std::ostream& (*)(std::ostream&)) { return *this; }    // Change log 12
     Suppress_LogDebug_& operator<<(std::ios_base& (*)(std::ios_base&)) { return *this; }  // Change log 12
+
+    template <typename... Args>
+    Suppress_LogDebug_& format(std::string_view fmt, Args const&... args) {
+      return *this;
+    }
 
     template <typename F>
     Suppress_LogDebug_& log(F&& iF) {

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -42,6 +42,13 @@ namespace edm {
       return *this;
     }
 
+    template <typename... Args>
+    MessageSender& format(std::string_view fmt, Args const&... args) {
+      if (valid())
+        errorobj_p->format(fmt, args...);
+      return *this;
+    }
+
     bool valid() { return errorobj_p != nullptr; }
 
   private:

--- a/FWCore/MessageService/test/UnitTestClient_C.cc
+++ b/FWCore/MessageService/test/UnitTestClient_C.cc
@@ -23,6 +23,14 @@ namespace edmtest {
     edm::LogWarning("cat_A") << "Test of spacing:"
                              << "The following should read a b c dd:"
                              << "a" << std::setfill('+') << "b" << std::hex << "c" << std::setw(2) << "dd";
+
+    edm::LogWarning("cat_A").format("Test of format hex: {0} in hex is {0:x}", i);
+    edm::LogWarning("cat_A")
+        .format("Test of format fill and width:")
+        .format("The following should read ++abcdefg $$$12: {:+>9} {:$>5}", "abcdefg", 12);
+    edm::LogWarning("cat_A").format("Test of format precision:Pi with precision 12 is {:.12g}", d);
+    edm::LogWarning("cat_A").format(
+        "Test of format spacing: The following should read a b cc: {} {:+>} {:>2}", "a", "b", "cc");
   }  // MessageLoggerClient::analyze()
 
 }  // namespace edmtest

--- a/FWCore/MessageService/test/unit_test_outputs/u10_warnings.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u10_warnings.log
@@ -10,3 +10,15 @@ Test of std::setprecision(p):Pi with precision 12 is3.14159265358
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of spacing:The following should read a b c dd:abcdd
 %MSG
+%MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
+Test of format hex: 145 in hex is 91
+%MSG
+%MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
+Test of format fill and width:The following should read ++abcdefg $$$12: ++abcdefg $$$12
+%MSG
+%MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
+Test of format precision:Pi with precision 12 is 3.14159265358
+%MSG
+%MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
+Test of format spacing: The following should read a b cc: a b cc
+%MSG

--- a/FWCore/MessageService/test/unit_test_outputs/u6_warnings.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u6_warnings.log
@@ -10,3 +10,15 @@ Test of std::setprecision(p):Pi with precision 12 is3.14159265358
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of spacing:The following should read a b c dd:abcdd
 %MSG
+%MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
+Test of format hex: 145 in hex is 91
+%MSG
+%MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
+Test of format fill and width:The following should read ++abcdefg $$$12: ++abcdefg $$$12
+%MSG
+%MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
+Test of format precision:Pi with precision 12 is 3.14159265358
+%MSG
+%MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
+Test of format spacing: The following should read a b cc: a b cc
+%MSG


### PR DESCRIPTION
#### PR description:

Following the discussion in https://github.com/cms-sw/cmssw/issues/30463 this PR adds support of message formatting via C++20's [string formatting language](https://en.cppreference.com/w/cpp/utility/format/formatter) to MessageLogger as `edm::LogInfo(category).format(...)` etc. In absence of support in any standard library implementation the [{fmt}](https://github.com/fmtlib/fmt) library is used (anyway the `std:format()` appears to be based on it; to be replaced with `std::format()` whenever we get there).

#### PR validation:

Framework unit tests run.
