### PR TITLE
Update of the Tracker Online DQM client for Run3 conditions (backport of #30630)

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
-process = cms.Process("PIXELDQMLIVE", Run2_2018_pp_on_AA)
+from Configuration.Eras.Era_Run3 import Run3
+process = cms.Process("PIXELDQMLIVE", Run3)
 
 live=True
 unitTest = False

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3 import Run3
+from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("PIXELDQMLIVE", Run3)
 
 live=True

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
-process = cms.Process("SiStrpDQMLive", Run2_2018_pp_on_AA)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("SiStrpDQMLive", Run3)
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('siStripDigis',
@@ -266,6 +266,7 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
     process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)
 
     process.p = cms.Path(process.scalersRawToDigi*
+                         process.tcdsDigis*
                          process.APVPhases*
                          process.consecutiveHEs*
                          process.hltTriggerTypeFilter*
@@ -369,6 +370,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
 
     process.p = cms.Path(
         process.scalersRawToDigi*
+        process.tcdsDigis*
         process.APVPhases*
         process.consecutiveHEs*
         process.hltTriggerTypeFilter*
@@ -463,6 +465,7 @@ if (process.runType.getRunType() == process.runType.hpu_run):
     process.RecoForDQM_TrkReco       = cms.Sequence(process.offlineBeamSpot*process.MeasurementTrackerEvent*process.siPixelClusterShapeCache*process.recopixelvertexing*process.iterTracking_FirstStep)
 
     process.p = cms.Path(process.scalersRawToDigi*
+                         process.tcdsDigis*
                          process.APVPhases*
                          process.consecutiveHEs*
                          process.hltTriggerTypeFilter*
@@ -617,6 +620,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
     process.p = cms.Path(
         process.scalersRawToDigi*
+        process.tcdsDigis*
         process.APVPhases*
         process.consecutiveHEs*
         process.hltTriggerTypeFilter*


### PR DESCRIPTION
#### PR description:

Update of the Tracker Online DQM client in order to test Run3 configuration (i.e. transition from SCAL to TCDS)

#### PR validation:

Locally tested with MWGR#1 cosmic run (335507). The flag live need to be changed to "false" on the client under test:

cmsRun "client" dataset=/Cosmics/Commissioning2020-v1/RAW runNumber=335507


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of #30630 in order to use these changes during MWGR#4
