### PR TITLE
fakeEmtfParams name update - Backport to CMSSW_11_1_X

### DIFF
--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonEndCapForestOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonEndCapForestOnline_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from L1Trigger.L1TMuonEndCap.fakeEmtfParams_cff import *
+from L1Trigger.L1TMuonEndCap.fakeEmtfParams_empty_cff import *
 
 L1TMuonEndCapForestOnlineProd = cms.ESProducer("L1TMuonEndCapForestOnlineProd",
     onlineAuthentication = cms.string('.'),


### PR DESCRIPTION
#### PR description:

Backport of [PR#30633](https://github.com/cms-sw/cmssw/pull/30633) to CMSSW_11_1_X

The backport is needed as [PR#29767](https://github.com/cms-sw/cmssw/pull/29767) updates the `fakeEmtfParams_cff` module name, breaking the L1 O2O.
