### PR TITLE
TrackletEventProcessor Pointer Fixes

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
@@ -25,6 +25,11 @@ namespace trklet {
 
     ~TrackletEventProcessor();
 
+    TrackletEventProcessor(const TrackletEventProcessor&) = delete;
+    TrackletEventProcessor(const TrackletEventProcessor&&) = delete;
+    TrackletEventProcessor& operator=(const TrackletEventProcessor&) = delete;
+    TrackletEventProcessor& operator=(const TrackletEventProcessor&&) = delete;
+
     void init(const Settings* theSettings);
 
     void event(SLHCEvent& ev);
@@ -40,7 +45,7 @@ namespace trklet {
 
     std::vector<std::unique_ptr<Sector> > sectors_;
 
-    HistBase* histbase_{};
+    HistBase* histbase_{nullptr};
 
     int eventnum_ = {0};
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -17,8 +17,10 @@ using namespace std;
 TrackletEventProcessor::TrackletEventProcessor() = default;
 
 TrackletEventProcessor::~TrackletEventProcessor() {
-  if (settings_->bookHistos()) {
-    histbase_->close();
+  if (settings_ && settings_->bookHistos()) {
+    if (histbase_) {
+      histbase_->close();
+    }
   }
 }
 


### PR DESCRIPTION
#### PR description:
This is a  drive by PR to fix improper usage of points. Specifically if you run on zero events, the TrackletEventProcessor is never initiated and therefore the null pointer settings_ is dereferenced when the job exists. 

At the same time, I did the minimum in best practices fixes to by 
1) ensuring all pointers are always initialised to nullptr
2) disabling of copy, move and assignment operators 