### PR TITLE
Jet ID for UL

### DIFF
--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -106,8 +106,8 @@ jetDQMAnalyzerAk4PFUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     #for PFJets: LOOSE,TIGHT
     JetIDQuality               = cms.string("LOOSE"),
     #options for Calo and JPT: PURE09,DQM09,CRAFT08
-    #for PFJets: FIRSTDATA or RUNIISTARTUP (suitable for RECO beyond 7_2_X) or WINTER16 (for 8_0_X onwards)
-    JetIDVersion               = cms.string("WINTER16"),
+    #for PFJets: RUN2ULPUPPI for 11_1_X onwards
+    JetIDVersion               = cms.string("RUN2ULCHS"),
     JetType = cms.string('pf'),#pf, calo or jpt
     JetCorrections = cms.InputTag("dqmAk4PFL1FastL2L3ResidualCorrector"),
     jetsrc = cms.InputTag("ak4PFJets"),
@@ -166,8 +166,8 @@ jetDQMAnalyzerAk8PFPUPPICleanedMiniAOD=jetDQMAnalyzerAk4PFCHSCleanedMiniAOD.clon
     jetsrc = cms.InputTag("slimmedJetsAK8"),
     #for PUPPI jets: TIGHT
     JetIDQuality               = cms.string("TIGHT"),
-    #for PUPPI jets: WINTER17PUPPI from 9_4_X onwards
-    JetIDVersion               = cms.string("WINTER17PUPPI"),
+    #for PUPPI jets: RUN2ULPUPPI from 11_1_X onwards
+    JetIDVersion               = cms.string("RUN2ULPUPPI"),
     fillsubstructure =cms.bool(True),
 )
 
@@ -176,8 +176,8 @@ jetDQMAnalyzerAk4PFCHSPuppiCleanedMiniAOD=jetDQMAnalyzerAk4PFCHSCleanedMiniAOD.c
     jetsrc = cms.InputTag("slimmedJetsPuppi"),
     #for PUPPI jets: TIGHT
     JetIDQuality               = cms.string("TIGHT"),
-    #for PUPPI jets: WINTER17PUPPI from 9_4_X onwards
-    JetIDVersion               = cms.string("WINTER17PUPPI"),
+    #for PUPPI jets: RUN2ULPUPPI from 11_1_X onwards
+    JetIDVersion               = cms.string("RUN2ULPUPPI"),
 )
 
 jetDQMAnalyzerIC5CaloHIUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -106,7 +106,7 @@ jetDQMAnalyzerAk4PFUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     #for PFJets: LOOSE,TIGHT
     JetIDQuality               = cms.string("LOOSE"),
     #options for Calo and JPT: PURE09,DQM09,CRAFT08
-    #for PFJets: RUN2ULPUPPI for 11_1_X onwards
+    #for PFJets: RUN2ULCHS for 11_1_X onwards
     JetIDVersion               = cms.string("RUN2ULCHS"),
     JetType = cms.string('pf'),#pf, calo or jpt
     JetCorrections = cms.InputTag("dqmAk4PFL1FastL2L3ResidualCorrector"),

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -161,6 +161,10 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
       pfjetidversion = PFJetIDSelectionFunctor::WINTER17;
     } else if (JetIDVersion_ == "WINTER17PUPPI") {
       pfjetidversion = PFJetIDSelectionFunctor::WINTER17PUPPI;
+    } else if (JetIDVersion_ == "RUN2ULCHS") {
+      pfjetidversion = PFJetIDSelectionFunctor::RUN2ULCHS;
+    } else if (JetIDVersion_ == "RUN2ULPUPPI") {
+      pfjetidversion = PFJetIDSelectionFunctor::RUN2ULPUPPI;
     } else {
       if (verbose_)
         std::cout << "no valid PF JetID version given" << std::endl;

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -2846,7 +2846,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       jetpassid = pfjetIDFunctor((*pfJets)[ijet]);
       if (jetCleaningFlag_) {
         Thiscleaned = jetpassid;
-        //JetIDWPU= (jetpassid && PileupJetIdentifier::passJetId( puidmvaflag, PileupJetIdentifier::kLoose ));
+        JetIDWPU = jetpassid;  // && PileupJetIdentifier::passJetId( puidmvaflag, PileupJetIdentifier::kLoose )
       }
       if (Thiscleaned && pass_uncorrected) {
         mPt_uncor = map_of_MEs[DirName + "/" + "Pt_uncor"];

--- a/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
+++ b/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 
 pfJetIDSelector = cms.PSet(
-        version = cms.string('RUNIIULCHS'),
+        version = cms.string('RUN2ULCHS'),
         quality = cms.string('TIGHT')
     )

--- a/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
+++ b/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 
 pfJetIDSelector = cms.PSet(
-        version = cms.string('WINTER17'),
+        version = cms.string('RUNIIULCHS'),
         quality = cms.string('TIGHT')
     )


### PR DESCRIPTION
#### PR description:

This adds the jet ID selector tuned on UL data for AK4 jets and updates DQM to use this definition to define "Cleaned" histograms.

Also, the JetID is now also applied to /DiJet/* histograms for RECO jets in DQM, which was previously only applied for MiniAOD jets in DQM.

Presentation of the CHS criteria for UL17+18: https://indico.cern.ch/event/928283/contributions/3917588/
Presentation of the PUPPI criteria for UL17: https://indico.cern.ch/event/937597/contributions/3940302/

This functor is not used in AOD/MiniAOD, but only in NanoAOD. Thus AOD/MiniAOD content are not expected to change but NanoAOD content can change.

The functor is used to define "Cleaned" DQM histograms, which are expected to change.

#### PR validation:

runTheMatrix.py -l limited

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Plan to backport to 10_6_X and integrate in UL-reMiniAOD.