### PR TITLE
Fix FE chip stub truncation in TTStubBuilder

### DIFF
--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -5,379 +5,26 @@
  * \author Andrew W. Rose
  * \author Nicola Pozzobon
  * \author Ivan Reid
- * \date 2013, Jul 18
+ * \author Ian Tomalin
+ * \date 2013 - 2020
  *
  */
 
 #include "L1Trigger/TrackTrigger/plugins/TTStubBuilder.h"
 
-/// Implement the producer
 template <>
-void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(tTopoToken);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-  edm::ESHandle<TrackerGeometry> tGeomHandle = iSetup.getHandle(tGeomToken);
-  const TrackerGeometry* const theTrackerGeom = tGeomHandle.product();
-
-  /// Prepare output
-  auto ttClusterDSVForOutput = std::make_unique<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>();
-  auto ttStubDSVForOutputTemp = std::make_unique<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>();
-  auto ttStubDSVForOutputAccepted = std::make_unique<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>();
-  auto ttStubDSVForOutputRejected = std::make_unique<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>();
-
-  static constexpr int CBCFailOffset = 500;
-  static constexpr int CICFailOffset = 1000;
-
-  /// Get the Clusters already stored away
-  edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> clusterHandle;
-  iEvent.getByToken(clustersToken, clusterHandle);
-
-  int nmod = -1;
-
-  // Loop over all the tracker elements
-
-  //  for (auto gd=theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++)
-  for (const auto& gd : theTrackerGeom->dets()) {
-    DetId detid = (*gd).geographicalId();
-    if (detid.subdetId() != StripSubdetector::TOB && detid.subdetId() != StripSubdetector::TID)
-      continue;  // only run on OT
-    if (!tTopo->isLower(detid))
-      continue;  // loop on the stacks: choose the lower arbitrarily
-    DetId lowerDetid = detid;
-    DetId upperDetid = tTopo->partnerDetId(detid);
-    DetId stackDetid = tTopo->stack(detid);
-    bool isPS = (theTrackerGeom->getDetectorType(stackDetid) == TrackerGeometry::ModuleType::Ph2PSP);
-
-    bool is10G_PS = false;
-
-    // Determine if this module is a 10G transmission scheme module
-    //
-    // sviret comment (221217): this info should be made available in conddb at some point
-    // not in TrackerTopology as some modules may switch between 10G and 5G transmission
-    // schemes during running period
-
-    if (detid.subdetId() == StripSubdetector::TOB) {
-      if (tTopo->layer(detid) == 1)
-        is10G_PS = true;
-    } else if (detid.subdetId() == StripSubdetector::TID) {
-      if (tTopo->tidRing(detid) <= high_rate_max_ring[tTopo->tidWheel(detid) - 1])
-        is10G_PS = true;
-    }
-
-    ++nmod;
-
-    unsigned int maxStubs;
-    std::vector<std::pair<unsigned int, double>> bendMap;
-
-    /// Go on only if both detectors have Clusters
-    if (clusterHandle->find(lowerDetid) == clusterHandle->end() ||
-        clusterHandle->find(upperDetid) == clusterHandle->end())
-      continue;
-
-    /// Get the DetSets of the Clusters
-    edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> lowerClusters = (*clusterHandle)[lowerDetid];
-    edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> upperClusters = (*clusterHandle)[upperDetid];
-
-    /// If there are Clusters in both sensors
-    /// you can try and make a Stub
-    /// This is ~redundant
-    if (lowerClusters.empty() || upperClusters.empty())
-      continue;
-
-    /// Create the vectors of objects to be passed to the FastFillers
-    std::vector<TTCluster<Ref_Phase2TrackerDigi_>> tempInner;
-    std::vector<TTCluster<Ref_Phase2TrackerDigi_>> tempOuter;
-    std::vector<TTStub<Ref_Phase2TrackerDigi_>> tempAccepted;
-    tempInner.clear();
-    tempOuter.clear();
-    tempAccepted.clear();
-
-    /// Get chip size information
-    int chipSize = 127;  /// SV 21/11/17: tracker topology method should be updated, currently provide wrong nums
-    if (isPS)
-      chipSize = 120;
-
-    /// Loop over pairs of Clusters
-    for (auto lowerClusterIter = lowerClusters.begin(); lowerClusterIter != lowerClusters.end(); ++lowerClusterIter) {
-      /// Temporary storage to allow only one stub per inner cluster
-      /// if requested in cfi
-      std::vector<TTStub<Ref_Phase2TrackerDigi_>> tempOutput;
-
-      for (auto upperClusterIter = upperClusters.begin(); upperClusterIter != upperClusters.end(); ++upperClusterIter) {
-        /// Build a temporary Stub
-        TTStub<Ref_Phase2TrackerDigi_> tempTTStub(stackDetid);
-        tempTTStub.addClusterRef(edmNew::makeRefTo(clusterHandle, lowerClusterIter));
-        tempTTStub.addClusterRef(edmNew::makeRefTo(clusterHandle, upperClusterIter));
-        tempTTStub.setModuleTypePS(isPS);
-
-        /// Check for compatibility
-        bool thisConfirmation = false;
-        int thisDisplacement = 999999;
-        int thisOffset = 0;
-        float thisHardBend = 0;
-
-        theStubFindingAlgoHandle->PatternHitCorrelation(
-            thisConfirmation, thisDisplacement, thisOffset, thisHardBend, tempTTStub);
-        // Removed real offset.  Ivan Reid 10/2019
-
-        /// If the Stub is above threshold
-        if (thisConfirmation) {
-          tempTTStub.setRawBend(thisDisplacement);
-          tempTTStub.setBendOffset(thisOffset);
-          tempTTStub.setBendBE(thisHardBend);
-          tempOutput.push_back(tempTTStub);
-        }  /// Stub accepted
-      }    /// End of loop over outer clusters
-
-      /// Here tempOutput stores all the stubs from this inner cluster
-      /// Check if there is need to store only one (if only one already, skip this step)
-      if (ForbidMultipleStubs && tempOutput.size() > 1) {
-        /// If so, sort the stubs by bend and keep only the first one (smallest bend)
-        std::sort(tempOutput.begin(), tempOutput.end(), TTStubBuilder<Ref_Phase2TrackerDigi_>::SortStubsBend);
-
-        /// Get to the second element (the switch above ensures there are min 2)
-        typename std::vector<TTStub<Ref_Phase2TrackerDigi_>>::iterator tempIter = tempOutput.begin();
-        ++tempIter;
-
-        /// tempIter points now to the second element
-
-        /// Delete all-but-the first one from tempOutput
-        tempOutput.erase(tempIter, tempOutput.end());
-      }
-
-      /// Here, tempOutput is either of size 1 (if entering the switch)
-      /// either of size N with all the valid combinations ...
-
-      /// Now loop over the accepted stubs (1 or N) for this inner cluster
-      for (unsigned int iTempStub = 0; iTempStub < tempOutput.size(); ++iTempStub) {
-        /// Get the stub
-        const TTStub<Ref_Phase2TrackerDigi_>& tempTTStub = tempOutput[iTempStub];
-
-        // A temporary stub, for FE problems
-        TTStub<Ref_Phase2TrackerDigi_> tempTTStub2(tempTTStub.getDetId());
-
-        tempTTStub2.addClusterRef((tempTTStub.clusterRef(0)));
-        tempTTStub2.addClusterRef((tempTTStub.clusterRef(1)));
-        tempTTStub2.setRawBend(2. * tempTTStub.rawBend());
-        tempTTStub2.setBendOffset(2. * tempTTStub.bendOffset());
-        tempTTStub2.setBendBE(tempTTStub.bendBE());
-        tempTTStub2.setModuleTypePS(tempTTStub.moduleTypePS());
-
-        /// Put in the output
-        if (!applyFE)  // No dynamic inefficiencies (DEFAULT)
-        {
-          /// This means that ALL stubs go into the output
-          tempInner.push_back(*(tempTTStub.clusterRef(0)));
-          tempOuter.push_back(*(tempTTStub.clusterRef(1)));
-          tempAccepted.push_back(tempTTStub);
-        } else {
-          bool FEreject = false;
-          /// This means that only some of them do
-          /// Put in the temporary output
-          MeasurementPoint mp0 = tempTTStub.clusterRef(0)->findAverageLocalCoordinates();
-          int seg = static_cast<int>(mp0.y());
-          if (isPS)
-            seg = seg / 16;
-          int chip = 1000 * nmod + 10 * int(tempTTStub.innerClusterPosition() / chipSize) +
-                     seg;                  /// Find out which MPA/CBC ASIC
-          int CIC_chip = 10 * nmod + seg;  /// Find out which CIC ASIC
-
-          // First look is the stub is passing trough the very front end (CBC/MPA)
-          (isPS) ? maxStubs = maxStubs_PS : maxStubs = maxStubs_2S;
-
-          if (isPS)  // MPA
-          {
-            if (moduleStubs_MPA.find(chip) == moduleStubs_MPA.end())  /// Already a stub for this ASIC?
-            {
-              /// No, so new entry
-              moduleStubs_MPA.emplace(chip, 1);
-            } else {
-              if (moduleStubs_MPA[chip] < int(maxStubs)) {
-                ++moduleStubs_MPA[chip];
-              } else {
-                FEreject = true;
-              }
-            }
-          } else  // CBC
-          {
-            if (moduleStubs_CBC.find(chip) == moduleStubs_CBC.end())  /// Already a stub for this ASIC?
-            {
-              /// No, so new entry
-              moduleStubs_CBC.emplace(chip, 1);
-            } else {
-              if (moduleStubs_CBC[chip] < int(maxStubs)) {
-                ++moduleStubs_CBC[chip];
-              } else {
-                FEreject = true;
-              }
-            }
-          }
-
-          // End of the MPA/CBC loop
-
-          // If the stub has been already thrown out, there is no reason to include it into the CIC stream
-          // We keep is in the stub final container tough, but flagged as reject by FE
-
-          if (FEreject) {
-            tempTTStub2.setRawBend(CBCFailOffset + 2. * tempTTStub.rawBend());
-            tempTTStub2.setBendOffset(CBCFailOffset + 2. * tempTTStub.bendOffset());
-
-            tempInner.push_back(*(tempTTStub2.clusterRef(0)));
-            tempOuter.push_back(*(tempTTStub2.clusterRef(1)));
-            tempAccepted.push_back(tempTTStub2);
-            continue;
-          }
-
-          maxStubs = isPS ? maxStubs_PS_CIC_5 : maxStubs_2S_CIC_5;
-
-          if (is10G_PS)
-            maxStubs = maxStubs_PS_CIC_10;
-
-          if (moduleStubs_CIC.find(CIC_chip) == moduleStubs_CIC.end())  /// Already a stub for this ASIC?
-          {
-            if (moduleStubs_MPA.find(chip) == moduleStubs_MPA.end())  /// Already a stub for this ASIC?
-            {
-              /// No, so new entry
-              moduleStubs_MPA.emplace(chip, 1);
-            } else {
-              if (moduleStubs_MPA[chip] < int(maxStubs)) {
-                ++moduleStubs_MPA[chip];
-              } else {
-                FEreject = true;
-              }
-            }
-          } else  // CBC
-          {
-            if (moduleStubs_CBC.find(chip) == moduleStubs_CBC.end())  /// Already a stub for this ASIC?
-            {
-              /// No, so new entry
-              moduleStubs_CBC.emplace(chip, 1);
-            } else {
-              if (moduleStubs_CBC[chip] < int(maxStubs)) {
-                ++moduleStubs_CBC[chip];
-              } else {
-                FEreject = true;
-              }
-            }
-          }
-
-          // End of the MPA/CBC loop
-
-          // If the stub has been already thrown out, there is no reason to include it into the CIC stream
-          // We keep is in the stub final container tough, but flagged as reject by FE
-
-          if (FEreject) {
-            tempTTStub2.setRawBend(CBCFailOffset + 2. * tempTTStub.rawBend());
-            tempTTStub2.setBendOffset(CBCFailOffset + 2. * tempTTStub.bendOffset());
-
-            tempInner.push_back(*(tempTTStub2.clusterRef(0)));
-            tempOuter.push_back(*(tempTTStub2.clusterRef(1)));
-            tempAccepted.push_back(tempTTStub2);
-            continue;
-          }
-
-          (isPS) ? maxStubs = maxStubs_PS_CIC_5 : maxStubs = maxStubs_2S_CIC_5;
-
-          if (is10G_PS)
-            maxStubs = maxStubs_PS_CIC_10;
-
-          if (moduleStubs_CIC.find(CIC_chip) == moduleStubs_CIC.end())  /// Already a stub for this ASIC?
-          {
-            bool CIC_reject = true;
-
-            if (moduleStubs_CIC[CIC_chip].size() < maxStubs) {
-              moduleStubs_CIC[CIC_chip].push_back(tempTTStub);  //We add the new stub
-              tempInner.push_back(*(tempTTStub.clusterRef(0)));
-              tempOuter.push_back(*(tempTTStub.clusterRef(1)));
-              tempAccepted.push_back(tempTTStub);  // The stub is added
-            } else {
-              moduleStubs_CIC[CIC_chip].push_back(tempTTStub);  //We add the new stub
-
-              /// Sort them by |bend| and pick up only the first N.
-              bendMap.clear();
-              bendMap.reserve(moduleStubs_CIC[CIC_chip].size());
-
-              for (unsigned int i = 0; i < moduleStubs_CIC[CIC_chip].size(); ++i) {
-                bendMap.emplace_back(i, moduleStubs_CIC[CIC_chip].at(i).bendFE());
-              }
-
-              std::sort(bendMap.begin(), bendMap.end(), TTStubBuilder<Ref_Phase2TrackerDigi_>::SortStubBendPairs);
-
-              // bendMap contains link over all the stubs included in moduleStubs_CIC[CIC_chip]
-
-              for (unsigned int i = 0; i < maxStubs; ++i) {
-                // The stub we have added is among the first ones, add it
-                if (bendMap[i].first == moduleStubs_CIC[CIC_chip].size() - 1) {
-                  CIC_reject = false;
-                }
-              }
-
-              if (CIC_reject)  // The stub added does not pass the cut
-              {
-                tempTTStub2.setRawBend(CICFailOffset + 2. * tempTTStub.rawBend());
-                tempTTStub2.setBendOffset(CICFailOffset + 2. * tempTTStub.bendOffset());
-
-                tempInner.push_back(*(tempTTStub2.clusterRef(0)));
-                tempOuter.push_back(*(tempTTStub2.clusterRef(1)));
-                tempAccepted.push_back(tempTTStub2);
-              } else {
-                tempInner.push_back(*(tempTTStub.clusterRef(0)));
-                tempOuter.push_back(*(tempTTStub.clusterRef(1)));
-                tempAccepted.push_back(tempTTStub);  // The stub is added
-              }
-            }
-          }
-        }  /// End of check on max number of stubs per module
-      }    /// End of nested loop
-    }      /// End of loop over pairs of Clusters
-
-    /// Create the FastFillers
-    if (!tempInner.empty()) {
-      typename edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>::FastFiller lowerOutputFiller(
-          *ttClusterDSVForOutput, lowerDetid);
-      for (unsigned int m = 0; m < tempInner.size(); m++) {
-        lowerOutputFiller.push_back(tempInner.at(m));
-      }
-      if (lowerOutputFiller.empty())
-        lowerOutputFiller.abort();
-    }
-
-    if (!tempOuter.empty()) {
-      typename edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>::FastFiller upperOutputFiller(
-          *ttClusterDSVForOutput, upperDetid);
-      for (unsigned int m = 0; m < tempOuter.size(); m++) {
-        upperOutputFiller.push_back(tempOuter.at(m));
-      }
-      if (upperOutputFiller.empty())
-        upperOutputFiller.abort();
-    }
-
-    if (!tempAccepted.empty()) {
-      typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::FastFiller tempAcceptedFiller(
-          *ttStubDSVForOutputTemp, stackDetid);
-      for (unsigned int m = 0; m < tempAccepted.size(); m++) {
-        tempAcceptedFiller.push_back(tempAccepted.at(m));
-      }
-      if (tempAcceptedFiller.empty())
-        tempAcceptedFiller.abort();
-    }
-
-  }  /// End of loop over detector elements
-
-  /// Put output in the event (1)
-  /// Get also the OrphanHandle of the accepted clusters
-  edm::OrphanHandle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> ttClusterAcceptedHandle =
-      iEvent.put(std::move(ttClusterDSVForOutput), "ClusterAccepted");
-
+void TTStubBuilder<Ref_Phase2TrackerDigi_>::updateStubs(
+    const edm::OrphanHandle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>& clusterHandle,
+    const edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>& inputEDstubs,
+    edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>& outputEDstubs) const {
   /// Now, correctly reset the output
   typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator stubDetIter;
 
-  for (stubDetIter = ttStubDSVForOutputTemp->begin(); stubDetIter != ttStubDSVForOutputTemp->end(); ++stubDetIter) {
+  for (stubDetIter = inputEDstubs.begin(); stubDetIter != inputEDstubs.end(); ++stubDetIter) {
     /// Get the DetId and prepare the FastFiller
     DetId thisStackedDetId = stubDetIter->id();
-    typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::FastFiller acceptedOutputFiller(
-        *ttStubDSVForOutputAccepted, thisStackedDetId);
+    typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::FastFiller outputFiller(outputEDstubs,
+                                                                                           thisStackedDetId);
 
     /// detid of the two components.
     ///This should be done via a TrackerTopology method that is not yet available.
@@ -385,11 +32,11 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
     DetId upperDetid = thisStackedDetId + 2;
 
     /// Get the DetSets of the clusters
-    edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> lowerClusters = (*ttClusterAcceptedHandle)[lowerDetid];
-    edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> upperClusters = (*ttClusterAcceptedHandle)[upperDetid];
+    edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> lowerClusters = (*clusterHandle)[lowerDetid];
+    edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> upperClusters = (*clusterHandle)[upperDetid];
 
     /// Get the DetSet of the stubs
-    edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>> theseStubs = (*ttStubDSVForOutputTemp)[thisStackedDetId];
+    edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>> theseStubs = inputEDstubs[thisStackedDetId];
 
     /// Prepare the new DetSet to replace the current one
     /// Loop over the stubs
@@ -410,14 +57,14 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
 
       for (clusterIter = lowerClusters.begin(); clusterIter != lowerClusters.end() && !lowerOK; ++clusterIter) {
         if (clusterIter->getHits() == lowerClusterToBeReplaced->getHits()) {
-          tempTTStub.addClusterRef(edmNew::makeRefTo(ttClusterAcceptedHandle, clusterIter));
+          tempTTStub.addClusterRef(edmNew::makeRefTo(clusterHandle, clusterIter));
           lowerOK = true;
         }
       }
 
       for (clusterIter = upperClusters.begin(); clusterIter != upperClusters.end() && !upperOK; ++clusterIter) {
         if (clusterIter->getHits() == upperClusterToBeReplaced->getHits()) {
-          tempTTStub.addClusterRef(edmNew::makeRefTo(ttClusterAcceptedHandle, clusterIter));
+          tempTTStub.addClusterRef(edmNew::makeRefTo(clusterHandle, clusterIter));
           upperOK = true;
         }
       }
@@ -432,18 +79,298 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
       tempTTStub.setBendBE(stubIter->bendBE());
       tempTTStub.setModuleTypePS(stubIter->moduleTypePS());
 
-      acceptedOutputFiller.push_back(tempTTStub);
+      outputFiller.push_back(tempTTStub);
 
     }  /// End of loop over stubs of this module
+  }    /// End of loop over stub DetSetVector
+}
 
-    if (acceptedOutputFiller.empty())
-      acceptedOutputFiller.abort();
+/// Implement the producer
+template <>
+void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  //Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(tTopoToken);
+  const TrackerTopology* const tTopo = tTopoHandle.product();
+  edm::ESHandle<TrackerGeometry> tGeomHandle = iSetup.getHandle(tGeomToken);
+  const TrackerGeometry* const theTrackerGeom = tGeomHandle.product();
 
-  }  /// End of loop over stub DetSetVector
+  /// -- Prepare output
+  /// TTClusters associated to TTStubs
+  auto ttClusterDSVForOutputAcc = std::make_unique<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>();
+  auto ttClusterDSVForOutputRej = std::make_unique<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>();
+  /// TTStubs with Refs to clusters pointing to collection of clusters in entire tracker.
+  auto ttStubDSVForOutputAccTemp = std::make_unique<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>();
+  auto ttStubDSVForOutputRejTemp = std::make_unique<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>();
+  /// TTStubs with Refs to clusters pointing to collection of clusters associated to stubs.
+  auto ttStubDSVForOutputAcc = std::make_unique<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>();
+  auto ttStubDSVForOutputRej = std::make_unique<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>();
+
+  /// Read the Clusters from the entire tracker.
+  edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> clusterHandle;
+  iEvent.getByToken(clustersToken, clusterHandle);
+
+  int nmod = -1;
+
+  // Loop over all the tracker elements
+
+  for (const auto& gd : theTrackerGeom->dets()) {
+    DetId detid = (*gd).geographicalId();
+    if (detid.subdetId() != StripSubdetector::TOB && detid.subdetId() != StripSubdetector::TID)
+      continue;  // only run on OT
+    if (!tTopo->isLower(detid))
+      continue;  // loop on the stacks: choose the lower sensor
+    DetId lowerDetid = detid;
+    DetId upperDetid = tTopo->partnerDetId(detid);
+    DetId stackDetid = tTopo->stack(detid);
+    bool isPS = (theTrackerGeom->getDetectorType(stackDetid) == TrackerGeometry::ModuleType::Ph2PSP);
+
+    bool is10G_PS = false;
+
+    // Determine if this module is a 10G transmission scheme module
+    //
+    // TO FIX: take this info from Tracker -> DTC cabling map.
+
+    if (detid.subdetId() == StripSubdetector::TOB) {
+      if (tTopo->layer(detid) <= high_rate_max_layer)
+        is10G_PS = true;
+    } else if (detid.subdetId() == StripSubdetector::TID) {
+      if (tTopo->tidRing(detid) <= high_rate_max_ring[tTopo->tidWheel(detid) - 1])
+        is10G_PS = true;
+    }
+
+    ++nmod;
+
+    unsigned int maxStubs;
+    std::vector<std::pair<unsigned int, double>> bendMap;
+
+    /// Go on only if both detectors have Clusters
+    if (clusterHandle->find(lowerDetid) == clusterHandle->end() ||
+        clusterHandle->find(upperDetid) == clusterHandle->end())
+      continue;
+
+    /// Get the DetSets of the Clusters
+    edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> lowerClusters = (*clusterHandle)[lowerDetid];
+    edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> upperClusters = (*clusterHandle)[upperDetid];
+
+    /// If there are Clusters in both sensors, you can try and make a Stub
+    /// This is ~redundant
+    if (lowerClusters.empty() || upperClusters.empty())
+      continue;
+
+    /// Create the vectors of objects to be passed to the FastFillers
+    std::vector<TTCluster<Ref_Phase2TrackerDigi_>> tempClusLowerAcc;
+    std::vector<TTCluster<Ref_Phase2TrackerDigi_>> tempClusLowerRej;
+    std::vector<TTCluster<Ref_Phase2TrackerDigi_>> tempClusUpperAcc;
+    std::vector<TTCluster<Ref_Phase2TrackerDigi_>> tempClusUpperRej;
+    std::vector<TTStub<Ref_Phase2TrackerDigi_>> tempStubAcc;
+    std::vector<TTStub<Ref_Phase2TrackerDigi_>> tempStubRej;
+    tempClusLowerAcc.clear();
+    tempClusLowerRej.clear();
+    tempClusUpperAcc.clear();
+    tempClusUpperRej.clear();
+    tempStubAcc.clear();
+    tempStubRej.clear();
+
+    /// Get chip size information
+    /// FIX ME: Should take this from TrackerTopology, but it was buggy in 2017 (SV)
+    const int chipSize = isPS ? 120 : 127;
+    // No. of macro pixels along local y in each half of 2S module.
+    constexpr int numMacroPixels = 16;
+
+    /// Loop over pairs of Clusters
+    for (auto lowerClusterIter = lowerClusters.begin(); lowerClusterIter != lowerClusters.end(); ++lowerClusterIter) {
+      /// Temporary storage to allow only one stub per inner cluster, if requested in cfi
+      std::vector<TTStub<Ref_Phase2TrackerDigi_>> tempOutput;
+
+      for (auto upperClusterIter = upperClusters.begin(); upperClusterIter != upperClusters.end(); ++upperClusterIter) {
+        /// Build a temporary Stub
+        TTStub<Ref_Phase2TrackerDigi_> tempTTStub(stackDetid);
+        tempTTStub.addClusterRef(edmNew::makeRefTo(clusterHandle, lowerClusterIter));
+        tempTTStub.addClusterRef(edmNew::makeRefTo(clusterHandle, upperClusterIter));
+        tempTTStub.setModuleTypePS(isPS);
+
+        /// Check for compatibility of cluster pair
+        bool thisConfirmation = false;
+        int thisDisplacement = 999999;
+        int thisOffset = 0;
+        float thisHardBend = 0;
+
+        theStubFindingAlgoHandle->PatternHitCorrelation(
+            thisConfirmation, thisDisplacement, thisOffset, thisHardBend, tempTTStub);
+        // Removed real offset.  Ivan Reid 10/2019
+
+        /// If the Stub is above threshold
+        if (thisConfirmation) {
+          tempTTStub.setRawBend(thisDisplacement);
+          tempTTStub.setBendOffset(thisOffset);
+          tempTTStub.setBendBE(thisHardBend);
+          tempOutput.push_back(tempTTStub);
+        }  /// Stub accepted
+      }    /// End of loop over upper clusters
+
+      /// Here tempOutput stores all the stubs from this lower cluster
+      /// Check if there is need to store only one (if only one already, skip this step)
+      if (ForbidMultipleStubs && tempOutput.size() > 1) {
+        /// If so, sort the stubs by bend and keep only the first one (smallest bend)
+        std::sort(tempOutput.begin(), tempOutput.end(), TTStubBuilder<Ref_Phase2TrackerDigi_>::SortStubsBend);
+
+        /// Get to the second element (the switch above ensures there are min 2)
+        typename std::vector<TTStub<Ref_Phase2TrackerDigi_>>::iterator tempIter = tempOutput.begin();
+        ++tempIter;
+
+        /// tempIter points now to the second element
+
+        /// Delete all-but-the first one from tempOutput
+        tempOutput.erase(tempIter, tempOutput.end());
+      }
+
+      /// Here, tempOutput is either of size 1 (if ForbidMultupleStubs = true),
+      /// or of size N with all the valid combinations ...
+
+      /// Now loop over the accepted stubs (1 or N) for this lower cluster
+
+      for (auto& tempTTStub : tempOutput) {
+        /// Put in the output
+        if (not applyFE)  // No dynamic inefficiencies
+        {
+          /// This means that ALL stubs go into the output
+          tempClusLowerAcc.push_back(*(tempTTStub.clusterRef(0)));
+          tempClusUpperAcc.push_back(*(tempTTStub.clusterRef(1)));
+          tempStubAcc.push_back(tempTTStub);
+        } else {
+          bool FEreject = false;
+
+          /// This means that only some stubs go to the output
+          MeasurementPoint mp0 = tempTTStub.clusterRef(0)->findAverageLocalCoordinates();
+          int seg = static_cast<int>(mp0.y());  // Identifies which half of module
+          if (isPS)
+            seg = seg / numMacroPixels;
+          /// Find out which MPA/CBC ASIC
+          int chip = 1000 * nmod + 10 * int(tempTTStub.innerClusterPosition() / chipSize) + seg;
+          /// Find out which CIC ASIC
+          int CIC_chip = 10 * nmod + seg;
+
+          // First look is the stub is passing trough the very front end (CBC/MPA)
+          maxStubs = isPS ? maxStubs_PS : maxStubs_2S;
+
+          if (isPS)  // MPA
+          {
+            if (moduleStubs_MPA[chip] < int(maxStubs)) {
+              moduleStubs_MPA[chip]++;
+            } else {
+              FEreject = true;
+            }
+          } else  // CBC
+          {
+            if (moduleStubs_CBC[chip] < int(maxStubs)) {
+              moduleStubs_CBC[chip]++;
+            } else {
+              FEreject = true;
+            }
+          }
+
+          // End of the MPA/CBC loop
+
+          // If the stub has been already thrown out, there is no reason to include it into the CIC stream
+          // We put it in the rejected container, flagged with offset to indicate reason.
+
+          if (FEreject) {
+            tempTTStub.setRawBend(CBCFailOffset + 2. * tempTTStub.rawBend());
+            tempTTStub.setBendOffset(CBCFailOffset + 2. * tempTTStub.bendOffset());
+            tempClusLowerRej.push_back(*(tempTTStub.clusterRef(0)));
+            tempClusUpperRej.push_back(*(tempTTStub.clusterRef(1)));
+            tempStubRej.push_back(tempTTStub);
+            continue;
+          }
+
+          maxStubs = isPS ? maxStubs_PS_CIC_5 : maxStubs_2S_CIC_5;
+
+          if (is10G_PS)
+            maxStubs = maxStubs_PS_CIC_10;
+
+          bool CIC_reject = true;
+
+          moduleStubs_CIC[CIC_chip].push_back(tempTTStub);  //We temporarily add the new stub
+
+          if (moduleStubs_CIC[CIC_chip].size() <= maxStubs) {
+            tempClusLowerAcc.push_back(*(tempTTStub.clusterRef(0)));
+            tempClusUpperAcc.push_back(*(tempTTStub.clusterRef(1)));
+            tempStubAcc.push_back(tempTTStub);  // The stub is kept
+
+          } else {
+            /// TO FIX: The maxStub stubs with lowest |bend| are retained. This algo considers all stubs
+            /// since the last multiple of 8 events, (i.e. in 1-8 events), whereas true CIC chip considers
+            /// all stubs in current block of 8 events (i.e. always in 8 events). So may be optimistic.
+
+            /// Sort stubs by |bend|.
+            bendMap.clear();
+            bendMap.reserve(moduleStubs_CIC[CIC_chip].size());
+
+            for (unsigned int i = 0; i < moduleStubs_CIC[CIC_chip].size(); ++i) {
+              bendMap.emplace_back(i, moduleStubs_CIC[CIC_chip].at(i).bendFE());
+            }
+
+            std::sort(bendMap.begin(), bendMap.end(), TTStubBuilder<Ref_Phase2TrackerDigi_>::SortStubBendPairs);
+
+            // bendMap contains link over all the stubs included in moduleStubs_CIC[CIC_chip]
+
+            for (unsigned int i = 0; i < maxStubs; ++i) {
+              // The stub we have just added is amongst those with smallest |bend| so keep it.
+              if (bendMap[i].first == moduleStubs_CIC[CIC_chip].size() - 1) {
+                CIC_reject = false;
+              }
+            }
+
+            if (CIC_reject)  // The stub added does not pass the cut
+            {
+              tempTTStub.setRawBend(CICFailOffset + 2. * tempTTStub.rawBend());
+              tempTTStub.setBendOffset(CICFailOffset + 2. * tempTTStub.bendOffset());
+              tempClusLowerRej.push_back(*(tempTTStub.clusterRef(0)));
+              tempClusUpperRej.push_back(*(tempTTStub.clusterRef(1)));
+              tempStubRej.push_back(tempTTStub);
+            } else {
+              tempClusLowerAcc.push_back(*(tempTTStub.clusterRef(0)));
+              tempClusUpperAcc.push_back(*(tempTTStub.clusterRef(1)));
+              tempStubAcc.push_back(tempTTStub);  // The stub is added
+            }
+          }
+        }  /// End of check on max number of stubs per module
+      }    /// End of nested loop
+    }      /// End of loop over pairs of Clusters
+
+    /// Fill output collections
+    if (not tempClusLowerAcc.empty())
+      this->fill(*ttClusterDSVForOutputAcc, lowerDetid, tempClusLowerAcc);
+    if (not tempClusLowerRej.empty())
+      this->fill(*ttClusterDSVForOutputRej, lowerDetid, tempClusLowerRej);
+    if (not tempClusUpperAcc.empty())
+      this->fill(*ttClusterDSVForOutputAcc, upperDetid, tempClusUpperAcc);
+    if (not tempClusUpperRej.empty())
+      this->fill(*ttClusterDSVForOutputRej, upperDetid, tempClusUpperRej);
+    if (not tempStubAcc.empty())
+      this->fill(*ttStubDSVForOutputAccTemp, stackDetid, tempStubAcc);
+    if (not tempStubRej.empty())
+      this->fill(*ttStubDSVForOutputRejTemp, stackDetid, tempStubRej);
+
+  }  /// End of loop over detector elements
+
+  // Store the subset of clusters associated to stubs.
+
+  edm::OrphanHandle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> ttClusterAccHandle =
+      iEvent.put(std::move(ttClusterDSVForOutputAcc), "ClusterAccepted");
+  edm::OrphanHandle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> ttClusterRejHandle =
+      iEvent.put(std::move(ttClusterDSVForOutputRej), "ClusterRejected");
+
+  /// The TTStubs created above contain Refs to the ClusterInclusive collection (all clusters in Tracker).
+  /// Replace them with new TTStubs with Refs to ClusterAccepted collection (only clusters in Stubs),
+  /// so big ClusterInclusive collection can be dropped.
+
+  this->updateStubs(ttClusterAccHandle, *ttStubDSVForOutputAccTemp, *ttStubDSVForOutputAcc);
+  this->updateStubs(ttClusterRejHandle, *ttStubDSVForOutputRejTemp, *ttStubDSVForOutputRej);
 
   /// Put output in the event (2)
-  iEvent.put(std::move(ttStubDSVForOutputAccepted), "StubAccepted");
-  iEvent.put(std::move(ttStubDSVForOutputRejected), "StubRejected");
+  iEvent.put(std::move(ttStubDSVForOutputAcc), "StubAccepted");
+  iEvent.put(std::move(ttStubDSVForOutputRej), "StubRejected");
 
   ++ievt;
   if (ievt % 8 == 0)

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -19,10 +19,8 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::updateStubs(
     const edm::OrphanHandle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>& clusterHandle,
     const edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>& inputEDstubs,
     edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>& outputEDstubs) const {
-
   /// Loop over tracker modules
   for (const auto& module : inputEDstubs) {
-
     /// Get the DetId and prepare the FastFiller
     DetId thisStackedDetId = module.id();
     typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::FastFiller outputFiller(outputEDstubs,

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
@@ -9,7 +9,8 @@
 * \author Andrew W. Rose
 * \author Nicola Pozzobon
 * \author Ivan Reid
-* \date 2013, Jul 18
+* \author Ian Tomalin
+* \date 2013 - 2020
 *
 */
 
@@ -49,10 +50,13 @@ public:
   /// Destructor;
   ~TTStubBuilder() override;
 
+  // TTStub bendOffset has this added to it, if stub truncated by FE, to indicate reason.
+  enum FEreject { CBCFailOffset = 500, CICFailOffset = 1000 };
+
 private:
   /// Data members
-  edm::ESHandle<TTStubAlgorithm<T> > theStubFindingAlgoHandle;
-  edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<T> > > clustersToken;
+  edm::ESHandle<TTStubAlgorithm<T>> theStubFindingAlgoHandle;
+  edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<T>>> clustersToken;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken;
   edm::ESGetToken<TTStubAlgorithm<T>, TTStubAlgorithmRecord> ttStubToken;
@@ -69,35 +73,43 @@ private:
                                 const std::pair<unsigned int, double>& right);
   static bool SortStubsBend(const TTStub<T>& left, const TTStub<T>& right);
 
-  // FE stub extraction limits (only for experts, not used by default)
+  /// Fill output cluster & stub collections.
+  template <typename TT>
+  void fill(edmNew::DetSetVector<TT>& outputEP, const DetId& detId, const std::vector<TT>& inputVec) const {
+    /// Create the FastFiller
+    typename edmNew::DetSetVector<TT>::FastFiller outputFiller(outputEP, detId);
+    outputFiller.resize(inputVec.size());
+    std::copy(inputVec.begin(), inputVec.end(), outputFiller.begin());
+  }
 
-  bool applyFE;  // Turn ON (true) or OFF (false) the dynamic FE inefficiency accounting
-                 // OFF is by default, ON is for experts only
+  /// Update output stubs with Refs to cluster collection that is associated to stubs.
+  void updateStubs(const edm::OrphanHandle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>& clusterHandle,
+                   const edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>& inputEDstubs,
+                   edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>& outputEDstubs) const;
 
+  /// FE truncation
+
+  bool applyFE;  // Turn ON (true) or OFF (false) the dynamic FE stub truncation.
+
+  // Tuncation cut-offs
   unsigned int maxStubs_2S;         // CBC chip limit (in stubs/chip/BX)
   unsigned int maxStubs_PS;         // MPA chip limit (in stubs/chip/2BX)
   unsigned int maxStubs_2S_CIC_5;   // 2S 5G chip limit (in stubs/CIC/8BX)
   unsigned int maxStubs_PS_CIC_5;   // PS 5G chip limit (in stubs/CIC/8BX)
   unsigned int maxStubs_PS_CIC_10;  // PS 10G chip limit (in stubs/CIC/8BX)
 
-  unsigned int tedd1_maxring;  // PS 10G outermost ring in TEDD1 (default is 3)
-  unsigned int tedd2_maxring;  // PS 10G outermost ring in TEDD2 (default is 0)
+  // Which modules read by 10Gb/s links instead of 5Gb/s
+  // (Unlike TkLayout, CMSSW starts ring count at 1 for the innermost physically present ring in each disk)
+  // sviret comment (221217): this info should be made available in conddb at some point
+  // (not in TrackerTopology, as modules may switch between 10G & 5G transmission schems during running?)
+  unsigned int high_rate_max_ring[5];  //Outermost ring with 10Gb/s link vs disk.
+  unsigned int high_rate_max_layer;    // Outermost barrel layer with 10Gb/s link.
 
+  /// Temporary storage for stubs over several events for truncation use.
   int ievt;
-
-  /// Temporary storage for stubs before max check
-
-  std::unordered_map<int, std::vector<TTStub<Ref_Phase2TrackerDigi_> > > moduleStubs_CIC;
+  std::unordered_map<int, std::vector<TTStub<Ref_Phase2TrackerDigi_>>> moduleStubs_CIC;
   std::unordered_map<int, int> moduleStubs_MPA;
   std::unordered_map<int, int> moduleStubs_CBC;
-
-  // Which disk rings are in 10G transmission scheme module
-  //
-  // sviret comment (221217): this info should be made available in conddb at some point
-  // not in TrackerTopology as some modules may switch between 10G and 5G transmission
-  // schemes during running period
-
-  unsigned int high_rate_max_ring[5];
 
 };  /// Close class
 
@@ -111,7 +123,7 @@ private:
 /// Constructors
 template <typename T>
 TTStubBuilder<T>::TTStubBuilder(const edm::ParameterSet& iConfig) {
-  clustersToken = consumes<edmNew::DetSetVector<TTCluster<T> > >(iConfig.getParameter<edm::InputTag>("TTClusters"));
+  clustersToken = consumes<edmNew::DetSetVector<TTCluster<T>>>(iConfig.getParameter<edm::InputTag>("TTClusters"));
   tTopoToken = esConsumes<TrackerTopology, TrackerTopologyRcd>();
   tGeomToken = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   ttStubToken = esConsumes<TTStubAlgorithm<T>, TTStubAlgorithmRecord, edm::Transition::BeginRun>();
@@ -122,17 +134,20 @@ TTStubBuilder<T>::TTStubBuilder(const edm::ParameterSet& iConfig) {
   maxStubs_2S_CIC_5 = iConfig.getParameter<uint32_t>("SS5GCIClimit");
   maxStubs_PS_CIC_5 = iConfig.getParameter<uint32_t>("PS5GCIClimit");
   maxStubs_PS_CIC_10 = iConfig.getParameter<uint32_t>("PS10GCIClimit");
-  tedd1_maxring = iConfig.getParameter<uint32_t>("TEDD1Max10GRing");
-  tedd2_maxring = iConfig.getParameter<uint32_t>("TEDD2Max10GRing");
-  produces<edmNew::DetSetVector<TTCluster<T> > >("ClusterAccepted");
-  produces<edmNew::DetSetVector<TTStub<T> > >("StubAccepted");
-  produces<edmNew::DetSetVector<TTStub<T> > >("StubRejected");
+  unsigned int tedd1_max10Gring = iConfig.getParameter<uint32_t>("TEDD1Max10GRing");
+  unsigned int tedd2_max10Gring = iConfig.getParameter<uint32_t>("TEDD2Max10GRing");
+  high_rate_max_layer = iConfig.getParameter<uint32_t>("BarrelMax10GLay");
+  // Stubs passing & failing FE chip cuts, plus associated clusters.
+  produces<edmNew::DetSetVector<TTCluster<T>>>("ClusterAccepted");
+  produces<edmNew::DetSetVector<TTCluster<T>>>("ClusterRejected");
+  produces<edmNew::DetSetVector<TTStub<T>>>("StubAccepted");
+  produces<edmNew::DetSetVector<TTStub<T>>>("StubRejected");
 
-  high_rate_max_ring[0] = tedd1_maxring;
-  high_rate_max_ring[1] = tedd1_maxring;
-  high_rate_max_ring[2] = tedd2_maxring;
-  high_rate_max_ring[3] = tedd2_maxring;
-  high_rate_max_ring[4] = tedd2_maxring;
+  high_rate_max_ring[0] = tedd1_max10Gring;
+  high_rate_max_ring[1] = tedd1_max10Gring;
+  high_rate_max_ring[2] = tedd2_max10Gring;
+  high_rate_max_ring[3] = tedd2_max10Gring;
+  high_rate_max_ring[4] = tedd2_max10Gring;
 }
 
 /// Destructor

--- a/L1Trigger/TrackTrigger/python/TTStub_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStub_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 TTStubsFromPhase2TrackerDigis = cms.EDProducer("TTStubBuilder_Phase2TrackerDigi_",
     TTClusters = cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
     OnlyOnePerInputCluster = cms.bool(True), 
-    # Warning: results if FEineffs=True depend on order events processed in, so in
-    # multithreaded job can change if same job run twice.                                               
+    # Warning: results if FEineffs=True depend on order events processed in,
+    # so in multithreaded job can change if same job run twice.         
     FEineffs      = cms.bool(False), # Turn ON (true) or OFF (false) dynamic FE stub truncation
     CBClimit      = cms.uint32(3),   # CBC chip limit (in stubs/chip/BX)
     MPAlimit      = cms.uint32(5),   # MPA chip limit (in stubs/chip/2BX)

--- a/L1Trigger/TrackTrigger/python/TTStub_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStub_cfi.py
@@ -4,7 +4,7 @@ TTStubsFromPhase2TrackerDigis = cms.EDProducer("TTStubBuilder_Phase2TrackerDigi_
     TTClusters = cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
     OnlyOnePerInputCluster = cms.bool(True), 
     # Warning: results if FEineffs=True depend on order events processed in,
-    # so in multithreaded job can change if same job run twice.         
+    # so in multithreaded job can change if same job run twice.
     FEineffs      = cms.bool(False), # Turn ON (true) or OFF (false) dynamic FE stub truncation
     CBClimit      = cms.uint32(3),   # CBC chip limit (in stubs/chip/BX)
     MPAlimit      = cms.uint32(5),   # MPA chip limit (in stubs/chip/2BX)

--- a/L1Trigger/TrackTrigger/python/TTStub_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStub_cfi.py
@@ -3,14 +3,17 @@ import FWCore.ParameterSet.Config as cms
 TTStubsFromPhase2TrackerDigis = cms.EDProducer("TTStubBuilder_Phase2TrackerDigi_",
     TTClusters = cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
     OnlyOnePerInputCluster = cms.bool(True), 
-    FEineffs      = cms.bool(False), # Turn ON (true) or OFF (false) the dynamic FE inefficiency accounting
+    FEineffs      = cms.bool(True), # Turn ON (true) or OFF (false) the dynamic FE inefficiency accounting
     CBClimit      = cms.uint32(3),   # CBC chip limit (in stubs/chip/BX)
     MPAlimit      = cms.uint32(5),   # MPA chip limit (in stubs/chip/2BX)
+    # N.B. CIC chip uses FEC5 mode for PS modules & FEC12 mode for 2S modules.
     SS5GCIClimit  = cms.uint32(16),  # 2S 5G chip limit (in stubs/CIC/8BX)
-    PS5GCIClimit  = cms.uint32(17),  # PS 5G chip limit (in stubs/CIC/8BX)
+    PS5GCIClimit  = cms.uint32(16),  # PS 5G chip limit (in stubs/CIC/8BX)
     PS10GCIClimit = cms.uint32(35),  # PS 10G chip limit (in stubs/CIC/8BX)
-    TEDD1Max10GRing = cms.uint32(3), # How many rings are PS10G in TEDD1 disks (1/2)? 
-    TEDD2Max10GRing = cms.uint32(0)  # How many rings are PS10G in TEDD2 disks (3/4/5)? 
+    # N.B. CMSSW defines inner ring present in any given wheel as number 1.
+    TEDD1Max10GRing = cms.uint32(7), # No. of PS10G rings in TEDD1 disks (1/2)
+    TEDD2Max10GRing = cms.uint32(3), # No. of PS10G rings in TEDD2 disks (3/4/5) 
+    BarrelMax10GLay = cms.uint32(2)  # No. of PS10G layers in barrel                                               
 )
 
 

--- a/L1Trigger/TrackTrigger/python/TTStub_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStub_cfi.py
@@ -3,7 +3,9 @@ import FWCore.ParameterSet.Config as cms
 TTStubsFromPhase2TrackerDigis = cms.EDProducer("TTStubBuilder_Phase2TrackerDigi_",
     TTClusters = cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
     OnlyOnePerInputCluster = cms.bool(True), 
-    FEineffs      = cms.bool(True), # Turn ON (true) or OFF (false) the dynamic FE inefficiency accounting
+    # Warning: results if FEineffs=True depend on order events processed in, so in
+    # multithreaded job can change if same job run twice.                                               
+    FEineffs      = cms.bool(False), # Turn ON (true) or OFF (false) dynamic FE stub truncation
     CBClimit      = cms.uint32(3),   # CBC chip limit (in stubs/chip/BX)
     MPAlimit      = cms.uint32(5),   # MPA chip limit (in stubs/chip/2BX)
     # N.B. CIC chip uses FEC5 mode for PS modules & FEC12 mode for 2S modules.

--- a/SimTracker/TrackTriggerAssociation/python/TTClusterAssociation_cfi.py
+++ b/SimTracker/TrackTriggerAssociation/python/TTClusterAssociation_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 TTClusterAssociatorFromPixelDigis = cms.EDProducer("TTClusterAssociator_Phase2TrackerDigi_",
     TTClusters = cms.VInputTag( cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
                                 cms.InputTag("TTStubsFromPhase2TrackerDigis", "ClusterAccepted"),
+                                cms.InputTag("TTStubsFromPhase2TrackerDigis", "ClusterRejected"),
     ),
     digiSimLinks = cms.InputTag( "mix","Tracker" ), 
     trackingParts= cms.InputTag( "mix","MergedTrackTruth" )

--- a/SimTracker/TrackTriggerAssociation/python/TTStubAssociation_cfi.py
+++ b/SimTracker/TrackTriggerAssociation/python/TTStubAssociation_cfi.py
@@ -5,10 +5,10 @@ TTStubAssociatorFromPixelDigis = cms.EDProducer("TTStubAssociator_Phase2TrackerD
                              cms.InputTag("TTStubsFromPhase2TrackerDigis", "StubRejected"),
     ),
     TTClusterTruth = cms.VInputTag( cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
-                                    cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterInclusive"),
+                                    cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterRejected"),
     ) # NOTE: the two vectors of input tags must be of the same size and in the correct order
       # as the producer would run on a specific pair and return a big error message
       # if the vectors are uncorrectly dimensioned
-      # so "StubAccepted" needs the "ClusterAccepted" MC truth, and "StubRejected" the "ClusterInclusive" MC truth
+      # so "StubAccepted" needs the "ClusterAccepted" MC truth, and "StubRejected" the "ClusterRejected" MC truth
 )
 


### PR DESCRIPTION
This fixes several issues with simulation of truncation of stubs in the front-end tracker chips in the TTStubBuilder. (N.B. Until this PR, truncation has always been disabled by default, so these issues had no effect on official MC production).

1. It eliminates a bug that was introduced in CMSSW 11.0
2. It updates the list of which tracker modules have 10Gb/s vs 5Gb/s opto-link readout.
3. It moves truncated stubs to the "StubRejected" collection (in case needed for debugging), whereas previously they were left in the "StubAccepted" collection, meaning they could incorrectly be used for L1 tracking.
4. It adds a new collection "ClusterRejected" of clusters associated to the "StubRejected" stubs.
5. It cleans up and shortens the code.
6. Python cfg keeps FE stub truncation disabled by default.

N.B. At some point in the future, we should update further to take opto-link speed from DB.

PR validation:
Have created stubs in multithreaded job and run L1 tracking on them.