### PR TITLE
Backport ExternalGeneratorFilter and core functions it depends on to 10_6_X

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2289,6 +2289,14 @@ class ConfigBuilder(object):
         from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
         self.process = customiseEarlyDelete(self.process)
 
+        imports = cms.specialImportRegistry.getSpecialImports()
+        if len(imports) > 0:
+            #need to inject this at the top
+            index = self.pythonCfgCode.find("import FWCore.ParameterSet.Config")
+            #now find the end of line
+            index = self.pythonCfgCode.find("\n",index)
+            self.pythonCfgCode = self.pythonCfgCode[:index]+ "\n" + "\n".join(imports)+"\n" +self.pythonCfgCode[index:]
+
 
         # make the .io file
 

--- a/DataFormats/Common/interface/RandomNumberGeneratorState.h
+++ b/DataFormats/Common/interface/RandomNumberGeneratorState.h
@@ -1,0 +1,26 @@
+#ifndef DataFormats_Common_RandomNumberGeneratorState_h
+#define DataFormats_Common_RandomNumberGeneratorState_h
+
+/*----------------------------------------------------------------------
+  
+RandomNumberGeneratorState is used to communicate with an external process
+----------------------------------------------------------------------*/
+
+#include <vector>
+namespace edm {
+  struct RandomNumberGeneratorState {
+    RandomNumberGeneratorState() = default;
+    RandomNumberGeneratorState(std::vector<unsigned long> iState, long iSeed)
+        : state_(std::move(iState)), seed_{iSeed} {}
+
+    RandomNumberGeneratorState(RandomNumberGeneratorState const&) = default;
+    RandomNumberGeneratorState(RandomNumberGeneratorState&&) = default;
+
+    RandomNumberGeneratorState& operator=(RandomNumberGeneratorState const&) = default;
+    RandomNumberGeneratorState& operator=(RandomNumberGeneratorState&&) = default;
+
+    std::vector<unsigned long> state_;
+    long seed_;
+  };
+}  // namespace edm
+#endif

--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -31,6 +31,7 @@
 #include "DataFormats/Common/interface/SecondaryEventIDAndFileInfo.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
 
 #include <vector>
 

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -185,5 +185,8 @@
 
  <class name="edm::RefProd<std::vector<int> >"/>
  <class name="edm::RefToBaseProd<int>"/>
+ <class name="edm::RandomNumberGeneratorState" ClassVersion="3">
+  <version ClassVersion="3" checksum="2237762164"/>
+ </class>
 
 </lcgdict>

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -30,6 +30,7 @@
 #include "DataFormats/Common/interface/Holder.h"
 #include "DataFormats/Common/interface/RefToBaseProd.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -5,6 +5,7 @@
  <class name="edmtest::IntProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="4286676158"/>
  </class>
+ <class name="std::pair<edmtest::IntProduct, edm::RandomNumberGeneratorState>"/>
  <class name="edmtest::UInt64Product" ClassVersion="11">
   <version ClassVersion="11" checksum="3240540910"/>
   <version ClassVersion="10" checksum="380152127"/>

--- a/FWCore/Integration/bin/BuildFile.xml
+++ b/FWCore/Integration/bin/BuildFile.xml
@@ -1,0 +1,6 @@
+<bin   name="cmsTestInterProcess" file="interprocess.cc">
+  <use   name="boost"/>
+  <use   name="boost_program_options"/>
+  <use   name="FWCore/TestProcessor"/>
+  <use   name="FWCore/SharedMemory"/>
+</bin>

--- a/FWCore/Integration/bin/BuildFile.xml
+++ b/FWCore/Integration/bin/BuildFile.xml
@@ -4,3 +4,12 @@
   <use   name="FWCore/TestProcessor"/>
   <use   name="FWCore/SharedMemory"/>
 </bin>
+
+<bin   name="cmsTestInterProcessRandom" file="interprocess_random.cc">
+  <use   name="boost"/>
+  <use   name="boost_program_options"/>
+  <use   name="FWCore/TestProcessor"/>
+  <use   name="FWCore/SharedMemory"/>
+  <use   name="FWCore/Services"/>
+  <use   name="FWCore/Utilities"/>
+</bin>

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -1,0 +1,223 @@
+#include "boost/program_options.hpp"
+
+#include <atomic>
+#include <csignal>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
+static char const* const kMemoryNameOpt = "memory-name";
+static char const* const kMemoryNameCommandOpt = "memory-name,m";
+static char const* const kUniqueIDOpt = "unique-id";
+static char const* const kUniqueIDCommandOpt = "unique-id,i";
+static char const* const kHelpOpt = "help";
+static char const* const kHelpCommandOpt = "help,h";
+
+//NOTE: Can use TestProcessor as the harness for the worker
+
+using namespace edm::shared_memory;
+class Harness {
+public:
+  Harness(std::string const& iConfig) : tester_(edm::test::TestProcessor::Config{iConfig}) {}
+
+  edmtest::ThingCollection getBeginRunValue(unsigned int iRun) {
+    auto run = tester_.testBeginRun(iRun);
+    return *run.get<edmtest::ThingCollection>("beginRun");
+  }
+
+  edmtest::ThingCollection getBeginLumiValue(unsigned int iLumi) {
+    auto lumi = tester_.testBeginLuminosityBlock(iLumi);
+    return *lumi.get<edmtest::ThingCollection>("beginLumi");
+  }
+
+  edmtest::ThingCollection getEventValue() {
+    auto event = tester_.test();
+    return *event.get<edmtest::ThingCollection>();
+  }
+
+  edmtest::ThingCollection getEndLumiValue() {
+    auto lumi = tester_.testEndLuminosityBlock();
+    return *lumi.get<edmtest::ThingCollection>("endLumi");
+  }
+
+  edmtest::ThingCollection getEndRunValue() {
+    auto run = tester_.testEndRun();
+    return *run.get<edmtest::ThingCollection>("endRun");
+  }
+
+private:
+  edm::test::TestProcessor tester_;
+};
+
+int main(int argc, char* argv[]) {
+  std::string descString(argv[0]);
+  descString += " [--";
+  descString += kMemoryNameOpt;
+  descString += "] memory_name";
+  boost::program_options::options_description desc(descString);
+
+  desc.add_options()(kHelpCommandOpt, "produce help message")(
+      kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
+      kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
+
+  boost::program_options::positional_options_description p;
+  p.add(kMemoryNameOpt, 1);
+  p.add(kUniqueIDOpt, 2);
+
+  boost::program_options::options_description all_options("All Options");
+  all_options.add(desc);
+
+  boost::program_options::variables_map vm;
+  try {
+    store(boost::program_options::command_line_parser(argc, argv).options(all_options).positional(p).run(), vm);
+    notify(vm);
+  } catch (boost::program_options::error const& iException) {
+    std::cout << argv[0] << ": Error while trying to process command line arguments:\n"
+              << iException.what() << "\nFor usage and an options list, please do 'cmsRun --help'.";
+    return 1;
+  }
+
+  if (vm.count(kHelpOpt)) {
+    std::cout << desc << std::endl;
+    return 0;
+  }
+
+  if (!vm.count(kMemoryNameOpt)) {
+    std::cout << " no argument given" << std::endl;
+    return 1;
+  }
+
+  if (!vm.count(kUniqueIDOpt)) {
+    std::cout << " no second argument given" << std::endl;
+    return 1;
+  }
+
+  WorkerMonitorThread monitorThread;
+
+  monitorThread.startThread();
+
+  try {
+    std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
+    std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
+    {
+      //using namespace boost::interprocess;
+      //auto controlNameUnique = unique_name(memoryName, uniqueID);
+
+      //This class is holding the lock
+      WorkerChannel communicationChannel(memoryName, uniqueID);
+
+      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferIndex()};
+      int counter = 0;
+
+      //The lock must be released if there is a catastrophic signal
+      auto lockPtr = communicationChannel.accessLock();
+      monitorThread.setAction([lockPtr]() {
+        if (lockPtr) {
+          std::cerr << "SIGNAL CAUGHT: unlock\n";
+          lockPtr->unlock();
+        }
+      });
+
+      using TCSerializer = ROOTSerializer<edmtest::ThingCollection, WriteBuffer>;
+      TCSerializer serializer(sm_buffer);
+      TCSerializer br_serializer(sm_buffer);
+      TCSerializer bl_serializer(sm_buffer);
+      TCSerializer el_serializer(sm_buffer);
+      TCSerializer er_serializer(sm_buffer);
+
+      std::cerr << uniqueID << " process: initializing " << std::endl;
+      int nlines;
+      std::cin >> nlines;
+
+      std::string configuration;
+      for (int i = 0; i < nlines; ++i) {
+        std::string c;
+        std::getline(std::cin, c);
+        std::cerr << c << "\n";
+        configuration += c + "\n";
+      }
+
+      Harness harness(configuration);
+
+      //Either ROOT or the Framework are overriding the signal handlers
+      monitorThread.setupSignalHandling();
+
+      std::cerr << uniqueID << " process: done initializing" << std::endl;
+      communicationChannel.workerSetupDone();
+
+      std::cerr << uniqueID << " process: waiting " << counter << std::endl;
+      communicationChannel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+        ++counter;
+        switch (iTransition) {
+          case edm::Transition::BeginRun: {
+            std::cerr << uniqueID << " process: start beginRun " << std::endl;
+            auto value = harness.getBeginRunValue(iTransitionID);
+
+            br_serializer.serialize(value);
+            std::cerr << uniqueID << " process: end beginRun " << value.size() << std::endl;
+
+            break;
+          }
+          case edm::Transition::BeginLuminosityBlock: {
+            std::cerr << uniqueID << " process: start beginLumi " << std::endl;
+            auto value = harness.getBeginLumiValue(iTransitionID);
+
+            bl_serializer.serialize(value);
+            std::cerr << uniqueID << " process: end beginLumi " << value.size() << std::endl;
+
+            break;
+          }
+          case edm::Transition::Event: {
+            std::cerr << uniqueID << " process: integrating " << counter << std::endl;
+            auto value = harness.getEventValue();
+
+            std::cerr << uniqueID << " process: integrated " << counter << std::endl;
+
+            serializer.serialize(value);
+            std::cerr << uniqueID << " process: " << value.size() << " " << counter << std::endl;
+            //usleep(10000000);
+            break;
+          }
+          case edm::Transition::EndLuminosityBlock: {
+            std::cerr << uniqueID << " process: start endLumi " << std::endl;
+            auto value = harness.getEndLumiValue();
+
+            el_serializer.serialize(value);
+            std::cerr << uniqueID << " process: end endLumi " << value.size() << std::endl;
+
+            break;
+          }
+          case edm::Transition::EndRun: {
+            std::cerr << uniqueID << " process: start endRun " << std::endl;
+            auto value = harness.getEndRunValue();
+
+            er_serializer.serialize(value);
+            std::cerr << uniqueID << " process: end endRun " << value.size() << std::endl;
+
+            break;
+          }
+          default: {
+            assert(false);
+          }
+        }
+        std::cerr << uniqueID << " process: notifying and waiting" << counter << std::endl;
+      });
+    }
+  } catch (std::exception const& iExcept) {
+    std::cerr << "caught exception \n" << iExcept.what() << "\n";
+    return 1;
+  } catch (...) {
+    std::cerr << "caught unknown exception";
+    return 1;
+  }
+  return 0;
+}

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
       //This class is holding the lock
       WorkerChannel communicationChannel(memoryName, uniqueID);
 
-      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferIndex()};
+      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferInfo()};
       int counter = 0;
 
       //The lock must be released if there is a catastrophic signal

--- a/FWCore/Integration/bin/interprocess_random.cc
+++ b/FWCore/Integration/bin/interprocess_random.cc
@@ -1,0 +1,199 @@
+#include "boost/program_options.hpp"
+
+#include <atomic>
+#include <csignal>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
+
+#include "FWCore/Services/interface/ExternalRandomNumberGeneratorService.h"
+
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
+static char const* const kMemoryNameOpt = "memory-name";
+static char const* const kMemoryNameCommandOpt = "memory-name,m";
+static char const* const kUniqueIDOpt = "unique-id";
+static char const* const kUniqueIDCommandOpt = "unique-id,i";
+static char const* const kHelpOpt = "help";
+static char const* const kHelpCommandOpt = "help,h";
+
+//NOTE: Can use TestProcessor as the harness for the worker
+
+using SentType = std::pair<edmtest::IntProduct, edm::RandomNumberGeneratorState>;
+
+using namespace edm::shared_memory;
+class Harness {
+public:
+  Harness(std::string const& iConfig, edm::ServiceToken iToken)
+      : tester_(edm::test::TestProcessor::Config{iConfig}, iToken) {}
+
+  edmtest::IntProduct getBeginLumiValue(unsigned int iLumi) {
+    auto lumi = tester_.testBeginLuminosityBlock(iLumi);
+    return *lumi.get<edmtest::IntProduct>("lumi");
+  }
+
+  edmtest::IntProduct getEventValue() {
+    auto event = tester_.test();
+    return *event.get<edmtest::IntProduct>();
+  }
+
+private:
+  edm::test::TestProcessor tester_;
+};
+
+int main(int argc, char* argv[]) {
+  std::string descString(argv[0]);
+  descString += " [--";
+  descString += kMemoryNameOpt;
+  descString += "] memory_name";
+  boost::program_options::options_description desc(descString);
+
+  desc.add_options()(kHelpCommandOpt, "produce help message")(
+      kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
+      kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
+
+  boost::program_options::positional_options_description p;
+  p.add(kMemoryNameOpt, 1);
+  p.add(kUniqueIDOpt, 2);
+
+  boost::program_options::options_description all_options("All Options");
+  all_options.add(desc);
+
+  boost::program_options::variables_map vm;
+  try {
+    store(boost::program_options::command_line_parser(argc, argv).options(all_options).positional(p).run(), vm);
+    notify(vm);
+  } catch (boost::program_options::error const& iException) {
+    std::cout << argv[0] << ": Error while trying to process command line arguments:\n"
+              << iException.what() << "\nFor usage and an options list, please do 'cmsRun --help'.";
+    return 1;
+  }
+
+  if (vm.count(kHelpOpt)) {
+    std::cout << desc << std::endl;
+    return 0;
+  }
+
+  if (!vm.count(kMemoryNameOpt)) {
+    std::cout << " no argument given" << std::endl;
+    return 1;
+  }
+
+  if (!vm.count(kUniqueIDOpt)) {
+    std::cout << " no second argument given" << std::endl;
+    return 1;
+  }
+
+  WorkerMonitorThread monitorThread;
+
+  monitorThread.startThread();
+
+  try {
+    std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
+    std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
+    {
+      //This class is holding the lock
+      WorkerChannel communicationChannel(memoryName, uniqueID);
+
+      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferIndex()};
+      ReadBuffer sm_readbuffer{std::string("Rand") + memoryName, communicationChannel.toWorkerBufferIndex()};
+      int counter = 0;
+
+      //The lock must be released if there is a catastrophic signal
+      auto lockPtr = communicationChannel.accessLock();
+      monitorThread.setAction([lockPtr]() {
+        if (lockPtr) {
+          std::cerr << "SIGNAL CAUGHT: unlock\n";
+          lockPtr->unlock();
+        }
+      });
+
+      using TCSerializer = ROOTSerializer<SentType, WriteBuffer>;
+      TCSerializer serializer(sm_buffer);
+      TCSerializer bl_serializer(sm_buffer);
+
+      using TCDeserializer = ROOTDeserializer<edm::RandomNumberGeneratorState, ReadBuffer>;
+      TCDeserializer random_deserializer(sm_readbuffer);
+
+      std::cerr << uniqueID << " process: initializing " << std::endl;
+      int nlines;
+      std::cin >> nlines;
+
+      std::string configuration;
+      for (int i = 0; i < nlines; ++i) {
+        std::string c;
+        std::getline(std::cin, c);
+        std::cerr << c << "\n";
+        configuration += c + "\n";
+      }
+
+      edm::ExternalRandomNumberGeneratorService* randomService = new edm::ExternalRandomNumberGeneratorService;
+      auto serviceToken =
+          edm::ServiceRegistry::createContaining(std::unique_ptr<edm::RandomNumberGenerator>(randomService));
+
+      Harness harness(configuration, serviceToken);
+
+      //Either ROOT or the Framework are overriding the signal handlers
+      monitorThread.setupSignalHandling();
+
+      std::cerr << uniqueID << " process: done initializing" << std::endl;
+      communicationChannel.workerSetupDone();
+
+      std::cerr << uniqueID << " process: waiting " << counter << std::endl;
+      communicationChannel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+        ++counter;
+        switch (iTransition) {
+          case edm::Transition::BeginLuminosityBlock: {
+            std::cerr << uniqueID << " process: start beginLumi " << std::endl;
+            auto randState = random_deserializer.deserialize();
+            std::cerr << " state " << randState.seed_ << std::endl;
+            randomService->setState(randState.state_, randState.seed_);
+            SentType toSend;
+            toSend.first = harness.getBeginLumiValue(iTransitionID);
+            toSend.second.state_ = randomService->getState();
+            toSend.second.seed_ = randomService->mySeed();
+            bl_serializer.serialize(toSend);
+            std::cerr << uniqueID << " process: end beginLumi " << toSend.first.value << std::endl;
+
+            break;
+          }
+          case edm::Transition::Event: {
+            std::cerr << uniqueID << " process: begin event " << counter << std::endl;
+            auto randState = random_deserializer.deserialize();
+            randomService->setState(randState.state_, randState.seed_);
+            SentType toSend;
+            toSend.first = harness.getEventValue();
+            toSend.second.state_ = randomService->getState();
+            toSend.second.seed_ = randomService->mySeed();
+            std::cerr << uniqueID << " process: end event " << counter << std::endl;
+
+            serializer.serialize(toSend);
+            std::cerr << uniqueID << " process: " << toSend.first.value << " " << counter << std::endl;
+            //usleep(10000000);
+            break;
+          }
+          default: {
+            assert(false);
+          }
+        }
+        std::cerr << uniqueID << " process: notifying and waiting" << counter << std::endl;
+      });
+    }
+  } catch (std::exception const& iExcept) {
+    std::cerr << "caught exception \n" << iExcept.what() << "\n";
+    return 1;
+  } catch (...) {
+    std::cerr << "caught unknown exception";
+    return 1;
+  }
+  return 0;
+}

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -322,5 +322,29 @@
     <use   name="FWCore/SharedMemory"/>
     <use   name="boost"/>
   </library>
+  <library   file="RandomIntProducer.cc" name="RandomIntProducer">
+    <flags   EDM_PLUGIN="1"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/Utilities"/>
+    <use   name="DataFormats/TestObjects"/>
+    <use   name="clhep"/>
+  </library>
+  <library   file="TestInterProcessRandomProd.cc" name="TestInterProcessRandomProd">
+    <flags   EDM_PLUGIN="1"/>
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/Sources"/>
+    <use   name="FWCore/SharedMemory"/>
+    <use   name="boost"/>
+    <use   name="clhep"/>
+  </library>
+  <bin   file="RandomIntProducer_t.cpp">
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/TestProcessor"/>
+    <use   name="DataFormats/Provenance"/>
+    <use   name="catch2"/>
+  </bin>
   <test name="TestFWCoreIntegrationInterProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TestInterProcessProd_cfg.py"/>
 </environment>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -314,4 +314,13 @@
     <use   name="FWCore/Sources"/>
     <use   name="DataFormats/TestObjects"/>
   </library>
+  <library   file="TestInterProcessProd.cc" name="TestInterProcessProd">
+    <flags   EDM_PLUGIN="1"/>
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/Sources"/>
+    <use   name="FWCore/SharedMemory"/>
+    <use   name="boost"/>
+  </library>
+  <test name="TestFWCoreIntegrationInterProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TestInterProcessProd_cfg.py"/>
 </environment>

--- a/FWCore/Integration/test/RandomIntProducer.cc
+++ b/FWCore/Integration/test/RandomIntProducer.cc
@@ -1,0 +1,45 @@
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+
+#include "CLHEP/Random/RandFlat.h"
+
+namespace edmtest {
+  class RandomIntProducer : public edm::one::EDProducer<edm::BeginLuminosityBlockProducer> {
+  public:
+    RandomIntProducer(edm::ParameterSet const& iPSet);
+
+    void produce(edm::Event&, edm::EventSetup const&) final;
+
+    void beginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) final;
+
+  private:
+    edm::EDPutTokenT<IntProduct> const evToken_;
+    edm::EDPutTokenT<IntProduct> const lumiToken_;
+  };
+  RandomIntProducer::RandomIntProducer(edm::ParameterSet const&)
+      : evToken_{produces<IntProduct>()},
+        lumiToken_{produces<IntProduct, edm::Transition::BeginLuminosityBlock>("lumi")} {}
+
+  void RandomIntProducer::produce(edm::Event& iEvent, edm::EventSetup const&) {
+    edm::Service<edm::RandomNumberGenerator> gen;
+    iEvent.emplace(evToken_, CLHEP::RandFlat::shootInt(&gen->getEngine(iEvent.streamID()), 10));
+  }
+
+  void RandomIntProducer::beginLuminosityBlockProduce(edm::LuminosityBlock& iLumi, edm::EventSetup const&) {
+    edm::Service<edm::RandomNumberGenerator> gen;
+    iLumi.emplace(lumiToken_, CLHEP::RandFlat::shootInt(&gen->getEngine(iLumi.index()), 10));
+  }
+
+}  // namespace edmtest
+
+using namespace edmtest;
+DEFINE_FWK_MODULE(RandomIntProducer);

--- a/FWCore/Integration/test/RandomIntProducer_t.cpp
+++ b/FWCore/Integration/test/RandomIntProducer_t.cpp
@@ -1,0 +1,109 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+
+static constexpr auto s_tag = "[RandomIntProducer]";
+
+TEST_CASE("Direct", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+process = TestProcess()
+process.test = cms.EDProducer('RandomIntProducer')
+process.add_(cms.Service("RandomNumberGeneratorService",
+                         test = cms.PSet(initialSeed = cms.untracked.uint32(12345))
+))
+process.moduleToTest(process.test)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION("Base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("transitions") {
+    edm::test::TestProcessor tester(config);
+    {
+      auto lumi = tester.testBeginLuminosityBlock(1).get<edmtest::IntProduct>("lumi");
+      REQUIRE(lumi->value == 1);
+    }
+    {
+      auto event = tester.test().get<edmtest::IntProduct>();
+      REQUIRE(event->value == 6);
+    }
+    {
+      auto event = tester.test().get<edmtest::IntProduct>();
+      REQUIRE(event->value == 4);
+    }
+    {
+      auto lumi = tester.testBeginLuminosityBlock(2).get<edmtest::IntProduct>("lumi");
+      REQUIRE(lumi->value == 1);
+    }
+  }
+}
+
+TEST_CASE("External", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class RandomIntExternalProcessProducer(cms.EDProducer):
+  def __init__(self, prod):
+      self.__dict__['_prod'] = prod
+      super(cms.EDProducer,self).__init__('TestInterProcessRandomProd')
+  def __setattr__(self, name, value):
+      setattr(self._prod, name, value)
+  def __getattr__(self, name):
+      if name =='_prod':
+          return self.__dict__['_prod']
+      return getattr(self._prod, name)
+  def clone(self, **params):
+      returnValue = RandomIntExternalProcessProducer.__new__(type(self))
+      returnValue.__init__(self._prod.clone())
+      return returnValue
+  def insertInto(self, parameterSet, myname):
+      newpset = parameterSet.newPSet()
+      newpset.addString(True, "@module_label", self.moduleLabel_(myname))
+      newpset.addString(True, "@module_type", self.type_())
+      newpset.addString(True, "@module_edm_type", cms.EDProducer.__name__)
+      newpset.addString(True, "@external_type", self._prod.type_())
+      newpset.addString(False,"@python_config", self._prod.dumpPython())
+      self._prod.insertContentsInto(newpset)
+      parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
+
+process = TestProcess()
+_generator = cms.EDProducer('RandomIntProducer')
+process.test = RandomIntExternalProcessProducer(_generator)
+process.add_(cms.Service("RandomNumberGeneratorService",
+                         test = cms.PSet(initialSeed = cms.untracked.uint32(12345))
+))
+process.moduleToTest(process.test)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION("Base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("transitions") {
+    edm::test::TestProcessor tester(config);
+    {
+      auto lumi = tester.testBeginLuminosityBlock(1).get<edmtest::IntProduct>("lumi");
+      REQUIRE(lumi->value == 1);
+    }
+    {
+      auto event = tester.test().get<edmtest::IntProduct>();
+      REQUIRE(event->value == 6);
+    }
+    {
+      auto event = tester.test().get<edmtest::IntProduct>();
+      REQUIRE(event->value == 4);
+    }
+    {
+      auto lumi = tester.testBeginLuminosityBlock(2).get<edmtest::IntProduct>("lumi");
+      REQUIRE(lumi->value == 1);
+    }
+  }
+}

--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -1,0 +1,297 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+
+#include <stdio.h>
+#include <iostream>
+
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+
+using namespace edm::shared_memory;
+namespace testinter {
+
+  struct StreamCache {
+    StreamCache(const std::string& iConfig, int id)
+        : id_{id},
+          channel_("testProd", id_),
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferIndex()},
+          deserializer_{readBuffer_},
+          br_deserializer_{readBuffer_},
+          er_deserializer_{readBuffer_},
+          bl_deserializer_{readBuffer_},
+          el_deserializer_(readBuffer_) {
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel_.setupWorker([&]() {
+        using namespace std::string_literals;
+        std::cout << id_ << " starting external process" << std::endl;
+        pipe_ = popen(("cmsTestInterProcess "s + channel_.sharedMemoryName() + " " + channel_.uniqueID()).c_str(), "w");
+
+        if (NULL == pipe_) {
+          abort();
+        }
+
+        {
+          auto nlines = std::to_string(std::count(iConfig.begin(), iConfig.end(), '\n'));
+          auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
+          assert(result = nlines.size());
+          result = fwrite(iConfig.data(), sizeof(char), iConfig.size(), pipe_);
+          assert(result == iConfig.size());
+          fflush(pipe_);
+        }
+      });
+    }
+
+    template <typename SERIAL>
+    auto doTransition(SERIAL& iDeserializer, edm::Transition iTrans, unsigned long long iTransitionID)
+        -> decltype(iDeserializer.deserialize()) {
+      decltype(iDeserializer.deserialize()) value;
+      if (not channel_.doTransition(
+              [&value, this]() {
+                value = deserializer_.deserialize();
+                std::cout << id_ << " from shared memory " << value.size() << std::endl;
+              },
+              iTrans,
+              iTransitionID)) {
+        std::cout << id_ << " FAILED waiting for external process" << std::endl;
+        externalFailed_ = true;
+        throw cms::Exception("ExternalFailed");
+      }
+      return value;
+    }
+    edmtest::ThingCollection produce(unsigned long long iTransitionID) {
+      return doTransition(deserializer_, edm::Transition::Event, iTransitionID);
+    }
+
+    edmtest::ThingCollection beginRunProduce(unsigned long long iTransitionID) {
+      return doTransition(br_deserializer_, edm::Transition::BeginRun, iTransitionID);
+    }
+
+    edmtest::ThingCollection endRunProduce(unsigned long long iTransitionID) {
+      if (not externalFailed_) {
+        return doTransition(er_deserializer_, edm::Transition::EndRun, iTransitionID);
+      }
+      return edmtest::ThingCollection();
+    }
+
+    edmtest::ThingCollection beginLumiProduce(unsigned long long iTransitionID) {
+      return doTransition(bl_deserializer_, edm::Transition::BeginLuminosityBlock, iTransitionID);
+    }
+
+    edmtest::ThingCollection endLumiProduce(unsigned long long iTransitionID) {
+      if (not externalFailed_) {
+        return doTransition(el_deserializer_, edm::Transition::EndLuminosityBlock, iTransitionID);
+      }
+      return edmtest::ThingCollection();
+    }
+
+    ~StreamCache() {
+      channel_.stopWorker();
+      pclose(pipe_);
+    }
+
+  private:
+    std::string unique_name(std::string iBase) {
+      auto pid = getpid();
+      iBase += std::to_string(pid);
+      iBase += "_";
+      iBase += std::to_string(id_);
+
+      return iBase;
+    }
+
+    int id_;
+    FILE* pipe_;
+    ControllerChannel channel_;
+    ReadBuffer readBuffer_;
+
+    using TCDeserializer = ROOTDeserializer<edmtest::ThingCollection, ReadBuffer>;
+    TCDeserializer deserializer_;
+    TCDeserializer br_deserializer_;
+    TCDeserializer er_deserializer_;
+    TCDeserializer bl_deserializer_;
+    TCDeserializer el_deserializer_;
+    bool externalFailed_ = false;
+  };
+
+  struct RunCache {
+    //Only stream 0 sets this at stream end Run and it is read at global end run
+    // the framework guarantees those calls can not happen simultaneously
+    CMS_THREAD_SAFE mutable edmtest::ThingCollection thingCollection_;
+  };
+  struct LumiCache {
+    //Only stream 0 sets this at stream end Lumi and it is read at global end Lumi
+    // the framework guarantees those calls can not happen simultaneously
+    CMS_THREAD_SAFE mutable edmtest::ThingCollection thingCollection_;
+  };
+}  // namespace testinter
+
+class TestInterProcessProd : public edm::global::EDProducer<edm::StreamCache<testinter::StreamCache>,
+                                                            edm::RunCache<testinter::RunCache>,
+                                                            edm::BeginRunProducer,
+                                                            edm::EndRunProducer,
+                                                            edm::LuminosityBlockCache<testinter::LumiCache>,
+                                                            edm::BeginLuminosityBlockProducer,
+                                                            edm::EndLuminosityBlockProducer> {
+public:
+  TestInterProcessProd(edm::ParameterSet const&);
+
+  std::unique_ptr<testinter::StreamCache> beginStream(edm::StreamID) const final;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
+
+  void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const final;
+  std::shared_ptr<testinter::RunCache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const final;
+  void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final;
+  void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final;
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const final {}
+  void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const final;
+
+  void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
+  std::shared_ptr<testinter::LumiCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                   edm::EventSetup const&) const final;
+  void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final {}
+  void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
+
+private:
+  edm::EDPutTokenT<edmtest::ThingCollection> const token_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const brToken_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const erToken_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const blToken_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const elToken_;
+
+  std::string config_;
+
+  //This is set at beginStream and used for globalBeginRun
+  //The framework guarantees that non of those can happen concurrently
+  CMS_THREAD_SAFE mutable testinter::StreamCache* stream0Cache_ = nullptr;
+  //A stream which has finished processing the last lumi is used for the
+  // call to globalBeginLuminosityBlockProduce
+  mutable std::atomic<testinter::StreamCache*> availableForBeginLumi_;
+  //Streams all see the lumis in the same order, we want to be sure to pick a stream cache
+  // to use at globalBeginLumi which just finished the most recent lumi and not a previous one
+  mutable std::atomic<unsigned int> lastLumiIndex_ = 0;
+};
+
+TestInterProcessProd::TestInterProcessProd(edm::ParameterSet const& iPSet)
+    : token_{produces<edmtest::ThingCollection>()},
+      brToken_{produces<edmtest::ThingCollection, edm::Transition::BeginRun>("beginRun")},
+      erToken_{produces<edmtest::ThingCollection, edm::Transition::EndRun>("endRun")},
+      blToken_{produces<edmtest::ThingCollection, edm::Transition::BeginLuminosityBlock>("beginLumi")},
+      elToken_{produces<edmtest::ThingCollection, edm::Transition::EndLuminosityBlock>("endLumi")},
+      config_{iPSet.getUntrackedParameter<std::string>("@python_config")} {}
+
+std::unique_ptr<testinter::StreamCache> TestInterProcessProd::beginStream(edm::StreamID iID) const {
+  auto const label = moduleDescription().moduleLabel();
+
+  using namespace std::string_literals;
+
+  std::string config = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+)_";
+  config += "process."s + label + "=" + config_ + "\n";
+  config += "process.moduleToTest(process."s + label + ")\n";
+  config += R"_(
+process.add_(cms.Service("InitRootHandlers", UnloadRootSigHandler=cms.untracked.bool(True)))
+  )_";
+
+  auto cache = std::make_unique<testinter::StreamCache>(config, iID.value());
+  if (iID.value() == 0) {
+    stream0Cache_ = cache.get();
+
+    availableForBeginLumi_ = stream0Cache_;
+  }
+
+  return cache;
+}
+
+void TestInterProcessProd::produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const {
+  auto value = streamCache(iID)->produce(iEvent.id().event());
+  iEvent.emplace(token_, value);
+}
+
+void TestInterProcessProd::globalBeginRunProduce(edm::Run& iRun, edm::EventSetup const&) const {
+  auto v = stream0Cache_->beginRunProduce(iRun.run());
+  iRun.emplace(brToken_, v);
+}
+std::shared_ptr<testinter::RunCache> TestInterProcessProd::globalBeginRun(edm::Run const&,
+                                                                          edm::EventSetup const&) const {
+  return std::make_shared<testinter::RunCache>();
+}
+
+void TestInterProcessProd::streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const {
+  if (iID.value() != 0) {
+    (void)streamCache(iID)->beginRunProduce(iRun.run());
+  }
+}
+void TestInterProcessProd::streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const {
+  if (iID.value() == 0) {
+    runCache(iRun.index())->thingCollection_ = streamCache(iID)->endRunProduce(iRun.run());
+  } else {
+    (void)streamCache(iID)->endRunProduce(iRun.run());
+  }
+}
+void TestInterProcessProd::globalEndRunProduce(edm::Run& iRun, edm::EventSetup const&) const {
+  iRun.emplace(erToken_, std::move(runCache(iRun.index())->thingCollection_));
+}
+
+void TestInterProcessProd::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                             edm::EventSetup const&) const {
+  while (not availableForBeginLumi_.load()) {
+  }
+
+  auto v = availableForBeginLumi_.load()->beginLumiProduce(iLuminosityBlock.run());
+  iLuminosityBlock.emplace(blToken_, v);
+
+  lastLumiIndex_.store(iLuminosityBlock.index());
+}
+
+std::shared_ptr<testinter::LumiCache> TestInterProcessProd::globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                                       edm::EventSetup const&) const {
+  return std::make_shared<testinter::LumiCache>();
+}
+
+void TestInterProcessProd::streamBeginLuminosityBlock(edm::StreamID iID,
+                                                      edm::LuminosityBlock const& iLuminosityBlock,
+                                                      edm::EventSetup const&) const {
+  auto cache = streamCache(iID);
+  if (cache != availableForBeginLumi_.load()) {
+    (void)cache->beginLumiProduce(iLuminosityBlock.run());
+  } else {
+    availableForBeginLumi_ = nullptr;
+  }
+}
+
+void TestInterProcessProd::streamEndLuminosityBlock(edm::StreamID iID,
+                                                    edm::LuminosityBlock const& iLuminosityBlock,
+                                                    edm::EventSetup const&) const {
+  if (iID.value() == 0) {
+    luminosityBlockCache(iLuminosityBlock.index())->thingCollection_ =
+        streamCache(iID)->endLumiProduce(iLuminosityBlock.run());
+  } else {
+    (void)streamCache(iID)->endLumiProduce(iLuminosityBlock.run());
+  }
+
+  if (lastLumiIndex_ == iLuminosityBlock.index()) {
+    testinter::StreamCache* expected = nullptr;
+
+    availableForBeginLumi_.compare_exchange_strong(expected, streamCache(iID));
+  }
+}
+
+void TestInterProcessProd::globalEndLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                           edm::EventSetup const&) const {
+  iLuminosityBlock.emplace(elToken_, std::move(luminosityBlockCache(iLuminosityBlock.index())->thingCollection_));
+}
+
+DEFINE_FWK_MODULE(TestInterProcessProd);

--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -21,7 +21,7 @@ namespace testinter {
     StreamCache(const std::string& iConfig, int id)
         : id_{id},
           channel_("testProd", id_),
-          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferIndex()},
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferInfo()},
           deserializer_{readBuffer_},
           br_deserializer_{readBuffer_},
           er_deserializer_{readBuffer_},

--- a/FWCore/Integration/test/TestInterProcessRandomProd.cc
+++ b/FWCore/Integration/test/TestInterProcessRandomProd.cc
@@ -1,0 +1,256 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include <stdio.h>
+#include <iostream>
+
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/engineIDulong.h"
+#include "CLHEP/Random/RanecuEngine.h"
+
+using namespace edm::shared_memory;
+namespace testinter {
+
+  using ReturnedType = std::pair<edmtest::IntProduct, edm::RandomNumberGeneratorState>;
+
+  struct StreamCache {
+    StreamCache(const std::string& iConfig, int id)
+        : id_{id},
+          channel_("testProd", id_),
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferIndex()},
+          writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferIndex()},
+          deserializer_{readBuffer_},
+          bl_deserializer_{readBuffer_},
+          randSerializer_{writeBuffer_} {
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel_.setupWorker([&]() {
+        using namespace std::string_literals;
+        std::cout << id_ << " starting external process" << std::endl;
+        pipe_ = popen(("cmsTestInterProcessRandom "s + channel_.sharedMemoryName() + " " + channel_.uniqueID()).c_str(),
+                      "w");
+
+        if (NULL == pipe_) {
+          abort();
+        }
+
+        {
+          auto nlines = std::to_string(std::count(iConfig.begin(), iConfig.end(), '\n'));
+          auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
+          assert(result = nlines.size());
+          result = fwrite(iConfig.data(), sizeof(char), iConfig.size(), pipe_);
+          assert(result == iConfig.size());
+          fflush(pipe_);
+        }
+      });
+    }
+
+    template <typename SERIAL>
+    auto doTransition(SERIAL& iDeserializer, edm::Transition iTrans, unsigned long long iTransitionID)
+        -> decltype(iDeserializer.deserialize()) {
+      decltype(iDeserializer.deserialize()) value;
+      if (not channel_.doTransition(
+              [&value, this]() {
+                value = deserializer_.deserialize();
+                std::cout << id_ << " from shared memory " << value.first.value << std::endl;
+              },
+              iTrans,
+              iTransitionID)) {
+        std::cout << id_ << " FAILED waiting for external process" << std::endl;
+        externalFailed_ = true;
+        throw cms::Exception("ExternalFailed");
+      }
+      return value;
+    }
+    edmtest::IntProduct produce(unsigned long long iTransitionID, edm::StreamID iStream) {
+      edm::Service<edm::RandomNumberGenerator> gen;
+      auto& engine = gen->getEngine(iStream);
+      edm::RandomNumberGeneratorState state{engine.put(), engine.getSeed()};
+      randSerializer_.serialize(state);
+      auto v = doTransition(deserializer_, edm::Transition::Event, iTransitionID);
+      if (v.second.state_[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+        engine.setSeed(v.second.seed_, 0);
+      }
+      engine.get(v.second.state_);
+      return v.first;
+    }
+
+    ReturnedType beginLumiProduce(edm::RandomNumberGeneratorState const& iState,
+                                  unsigned long long iTransitionID,
+                                  edm::LuminosityBlockIndex iLumi) {
+      edm::Service<edm::RandomNumberGenerator> gen;
+      //NOTE: root serialize requires a `void*` not a `void const*` even though it doesn't modify the object
+      randSerializer_.serialize(const_cast<edm::RandomNumberGeneratorState&>(iState));
+      return doTransition(bl_deserializer_, edm::Transition::BeginLuminosityBlock, iTransitionID);
+    }
+
+    ~StreamCache() {
+      channel_.stopWorker();
+      pclose(pipe_);
+    }
+
+  private:
+    std::string unique_name(std::string iBase) {
+      auto pid = getpid();
+      iBase += std::to_string(pid);
+      iBase += "_";
+      iBase += std::to_string(id_);
+
+      return iBase;
+    }
+
+    int id_;
+    FILE* pipe_;
+    ControllerChannel channel_;
+    ReadBuffer readBuffer_;
+    WriteBuffer writeBuffer_;
+
+    using TCDeserializer = ROOTDeserializer<ReturnedType, ReadBuffer>;
+    TCDeserializer deserializer_;
+    TCDeserializer bl_deserializer_;
+    using TCSerializer = ROOTSerializer<edm::RandomNumberGeneratorState, WriteBuffer>;
+    TCSerializer randSerializer_;
+
+    bool externalFailed_ = false;
+  };
+
+}  // namespace testinter
+
+class TestInterProcessRandomProd
+    : public edm::global::EDProducer<edm::StreamCache<testinter::StreamCache>,
+                                     edm::LuminosityBlockCache<edm::RandomNumberGeneratorState>,
+                                     edm::BeginLuminosityBlockProducer> {
+public:
+  TestInterProcessRandomProd(edm::ParameterSet const&);
+
+  std::unique_ptr<testinter::StreamCache> beginStream(edm::StreamID) const final;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
+
+  void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final {}
+  void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final {}
+
+  std::shared_ptr<edm::RandomNumberGeneratorState> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                              edm::EventSetup const&) const final;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final {}
+
+  void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
+  void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+
+private:
+  edm::EDPutTokenT<edmtest::IntProduct> const token_;
+  edm::EDPutTokenT<edmtest::IntProduct> const blToken_;
+
+  std::string config_;
+
+  //This is set at beginStream and used for globalBeginRun
+  //The framework guarantees that non of those can happen concurrently
+  CMS_THREAD_SAFE mutable testinter::StreamCache* stream0Cache_ = nullptr;
+  //A stream which has finished processing the last lumi is used for the
+  // call to globalBeginLuminosityBlockProduce
+  mutable std::atomic<testinter::StreamCache*> availableForBeginLumi_;
+  //Streams all see the lumis in the same order, we want to be sure to pick a stream cache
+  // to use at globalBeginLumi which just finished the most recent lumi and not a previous one
+  mutable std::atomic<unsigned int> lastLumiIndex_ = 0;
+};
+
+TestInterProcessRandomProd::TestInterProcessRandomProd(edm::ParameterSet const& iPSet)
+    : token_{produces<edmtest::IntProduct>()},
+      blToken_{produces<edmtest::IntProduct, edm::Transition::BeginLuminosityBlock>("lumi")},
+      config_{iPSet.getUntrackedParameter<std::string>("@python_config")} {}
+
+std::unique_ptr<testinter::StreamCache> TestInterProcessRandomProd::beginStream(edm::StreamID iID) const {
+  auto const label = moduleDescription().moduleLabel();
+
+  using namespace std::string_literals;
+
+  std::string config = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+)_";
+  config += "process."s + label + "=" + config_ + "\n";
+  config += "process.moduleToTest(process."s + label + ")\n";
+  config += R"_(
+process.add_(cms.Service("InitRootHandlers", UnloadRootSigHandler=cms.untracked.bool(True)))
+  )_";
+
+  auto cache = std::make_unique<testinter::StreamCache>(config, iID.value());
+  if (iID.value() == 0) {
+    stream0Cache_ = cache.get();
+
+    availableForBeginLumi_ = stream0Cache_;
+  }
+
+  return cache;
+}
+
+void TestInterProcessRandomProd::produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const {
+  auto value = streamCache(iID)->produce(iEvent.id().event(), iID);
+  iEvent.emplace(token_, value);
+}
+
+std::shared_ptr<edm::RandomNumberGeneratorState> TestInterProcessRandomProd::globalBeginLuminosityBlock(
+    edm::LuminosityBlock const& iLumi, edm::EventSetup const&) const {
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iLumi.index());
+  return std::make_shared<edm::RandomNumberGeneratorState>(engine.put(), engine.getSeed());
+}
+
+void TestInterProcessRandomProd::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                                   edm::EventSetup const&) const {
+  while (not availableForBeginLumi_.load()) {
+  }
+
+  auto v = availableForBeginLumi_.load()->beginLumiProduce(
+      *luminosityBlockCache(iLuminosityBlock.index()), iLuminosityBlock.luminosityBlock(), iLuminosityBlock.index());
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iLuminosityBlock.index());
+  if (v.second.state_[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+    engine.setSeed(v.second.seed_, 0);
+  }
+  engine.get(v.second.state_);
+
+  iLuminosityBlock.emplace(blToken_, v.first);
+
+  lastLumiIndex_.store(iLuminosityBlock.index());
+}
+
+void TestInterProcessRandomProd::streamBeginLuminosityBlock(edm::StreamID iID,
+                                                            edm::LuminosityBlock const& iLuminosityBlock,
+                                                            edm::EventSetup const&) const {
+  auto cache = streamCache(iID);
+  if (cache != availableForBeginLumi_.load()) {
+    (void)cache->beginLumiProduce(
+        *luminosityBlockCache(iLuminosityBlock.index()), iLuminosityBlock.luminosityBlock(), iLuminosityBlock.index());
+  } else {
+    availableForBeginLumi_ = nullptr;
+  }
+}
+
+void TestInterProcessRandomProd::streamEndLuminosityBlock(edm::StreamID iID,
+                                                          edm::LuminosityBlock const& iLuminosityBlock,
+                                                          edm::EventSetup const&) const {
+  if (lastLumiIndex_ == iLuminosityBlock.index()) {
+    testinter::StreamCache* expected = nullptr;
+
+    availableForBeginLumi_.compare_exchange_strong(expected, streamCache(iID));
+  }
+}
+
+DEFINE_FWK_MODULE(TestInterProcessRandomProd);

--- a/FWCore/Integration/test/TestInterProcessRandomProd.cc
+++ b/FWCore/Integration/test/TestInterProcessRandomProd.cc
@@ -32,8 +32,8 @@ namespace testinter {
     StreamCache(const std::string& iConfig, int id)
         : id_{id},
           channel_("testProd", id_),
-          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferIndex()},
-          writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferIndex()},
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferInfo()},
+          writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferInfo()},
           deserializer_{readBuffer_},
           bl_deserializer_{readBuffer_},
           randSerializer_{writeBuffer_} {

--- a/FWCore/Integration/test/ThingAlgorithm.cc
+++ b/FWCore/Integration/test/ThingAlgorithm.cc
@@ -5,7 +5,11 @@ namespace edmtest {
   void ThingAlgorithm::run(ThingCollection& thingCollection) const {
     thingCollection.reserve(nThings_);
     auto offset = offset_.fetch_add(offsetDelta_);
-    for (int i = 0; i < nThings_; ++i) {
+    int nItems = nThings_;
+    if (grow_) {
+      nItems *= offset;
+    }
+    for (int i = 0; i < nItems; ++i) {
       Thing tc;
       tc.a = i + offset;
       thingCollection.push_back(tc);

--- a/FWCore/Integration/test/ThingAlgorithm.h
+++ b/FWCore/Integration/test/ThingAlgorithm.h
@@ -10,8 +10,8 @@
 namespace edmtest {
   class ThingAlgorithm {
   public:
-    ThingAlgorithm(long iOffsetDelta = 0, int nThings = 20)
-        : offset_(0), offsetDelta_(iOffsetDelta), nThings_(nThings) {}
+    ThingAlgorithm(long iOffsetDelta = 0, int nThings = 20, bool grow = false)
+        : offset_(0), offsetDelta_(iOffsetDelta), nThings_(nThings), grow_(grow) {}
 
     /// Runs the algorithm and returns a list of Things
     /// The user declares the vector and calls this method.
@@ -21,6 +21,7 @@ namespace edmtest {
     mutable std::atomic<long> offset_;
     const long offsetDelta_;
     const int nThings_;
+    const bool grow_;
   };
 
 }  // namespace edmtest

--- a/FWCore/Integration/test/ThingProducer.cc
+++ b/FWCore/Integration/test/ThingProducer.cc
@@ -6,9 +6,9 @@
 
 namespace edmtest {
   ThingProducer::ThingProducer(edm::ParameterSet const& iConfig)
-      : alg_(iConfig.getParameter<int>(
-                 "offsetDelta"),  //this really should be tracked, but I want backwards compatibility
-             iConfig.getParameter<int>("nThings")),
+      : alg_(iConfig.getParameter<int>("offsetDelta"),
+             iConfig.getParameter<int>("nThings"),
+             iConfig.getParameter<bool>("grow")),
         noPut_(iConfig.getUntrackedParameter<bool>("noPut"))  // used for testing with missing products
   {
     evToken_ = produces<ThingCollection>();
@@ -101,7 +101,9 @@ namespace edmtest {
             "How much extra to increment the value used when creating Things for a new container. E.g. the last value "
             "used to create Thing from the previous event is incremented by 'offsetDelta' to compute the value to use "
             "of the first Thing created in the next Event.");
-    desc.add<int>("nThings", 20)->setComment("How many Things to put in each collection");
+    desc.add<int>("nThings", 20)->setComment("How many Things to put in each collection.");
+    desc.add<bool>("grow", false)
+        ->setComment("If true, multiply 'nThings' by the value of offset for each run of the algorithm.");
     desc.addUntracked<bool>("noPut", false)
         ->setComment("If true, data is not put into the Principal. This is used to test missing products.");
     descriptions.add("thingProd", desc);

--- a/FWCore/Integration/test/test_TestInterProcessProd_cfg.py
+++ b/FWCore/Integration/test/test_TestInterProcessProd_cfg.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+
+class ThingExternalProcessProducer(cms.EDProducer):
+    def __init__(self, prod):
+        self.__dict__['_prod'] = prod
+        super(cms.EDProducer,self).__init__('TestInterProcessProd')
+    def __setattr__(self, name, value):
+        setattr(self._prod, name, value)
+    def __getattr__(self, name):
+        if name =='_prod':
+            return self.__dict__['_prod']
+        return getattr(self._prod, name)
+    def clone(self, **params):
+        returnValue = ThingExternalProcessProducerProducer.__new__(type(self))
+        returnValue.__init__(self._prod.clone())
+        return returnValue
+    def insertInto(self, parameterSet, myname):
+        newpset = parameterSet.newPSet()
+        newpset.addString(True, "@module_label", self.moduleLabel_(myname))
+        newpset.addString(True, "@module_type", self.type_())
+        newpset.addString(True, "@module_edm_type", cms.EDProducer.__name__)
+        newpset.addString(True, "@external_type", self._prod.type_())
+        newpset.addString(False,"@python_config", self._prod.dumpPython())
+        self._prod.insertContentsInto(newpset)
+        parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
+
+
+_generator = cms.EDProducer("ThingProducer", nThings = cms.int32(100), grow=cms.bool(True), offsetDelta = cms.int32(1))
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+)
+
+process.thing = ThingExternalProcessProducer(_generator)
+
+process.p = cms.Path(process.thing)
+
+process.getter = cms.EDAnalyzer("edmtest::ThingAnalyzer")
+
+process.o = cms.EndPath(process.getter)
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+)

--- a/FWCore/Services/BuildFile.xml
+++ b/FWCore/Services/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/Provenance"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Streamer"/>
+<use   name="SimDataFormats/RandomEngine"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>
@@ -12,6 +13,7 @@
 <use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="roothistmatrix"/>
+<use   name="clhep"/>
 <use   name="xerces-c"/>
 <export>
   <lib   name="1"/>

--- a/FWCore/Services/interface/ExternalRandomNumberGeneratorService.h
+++ b/FWCore/Services/interface/ExternalRandomNumberGeneratorService.h
@@ -1,0 +1,61 @@
+#ifndef FWCore_Services_ExternalRandomNumberGeneratorService_h
+#define FWCore_Services_ExternalRandomNumberGeneratorService_h
+
+/** \class edm::ExternalRandomNumberGenerator
+
+  Description: Interface for obtaining random number engines.
+
+  Usage:
+*/
+
+#include <cstdint>
+#include <iosfwd>
+#include <memory>
+#include <vector>
+
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+namespace edm {
+
+  class ExternalRandomNumberGeneratorService : public RandomNumberGenerator {
+  public:
+    ExternalRandomNumberGeneratorService();
+
+    void setState(std::vector<unsigned long> const&, long seed);
+    std::vector<unsigned long> getState() const;
+
+    CLHEP::HepRandomEngine& getEngine(StreamID const&) final;
+    CLHEP::HepRandomEngine& getEngine(LuminosityBlockIndex const&) final;
+    std::unique_ptr<CLHEP::HepRandomEngine> cloneEngine(LuminosityBlockIndex const&) final;
+    std::uint32_t mySeed() const final;
+
+    // The following functions should not be used by general users.  They
+    // should only be called by Framework code designed to work with the
+    // service while it is saving the engine states or restoring them.
+    // The first two are called by the EventProcessor at special times.
+    // The next two are called by a dedicated producer module (RandomEngineStateProducer).
+
+    void preBeginLumi(LuminosityBlock const& lumi) final;
+    void postEventRead(Event const& event) final;
+
+    void setLumiCache(LuminosityBlockIndex, std::vector<RandomEngineState> const& iStates) final;
+    void setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) final;
+
+    std::vector<RandomEngineState> const& getEventCache(StreamID const&) const final;
+    std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const final;
+
+    void consumes(ConsumesCollector&& iC) const final;
+
+    /// For debugging purposes only.
+    void print(std::ostream& os) const final;
+
+  private:
+    ExternalRandomNumberGeneratorService(ExternalRandomNumberGeneratorService const&) = delete;
+    ExternalRandomNumberGeneratorService const& operator=(ExternalRandomNumberGeneratorService const&) = delete;
+
+    std::unique_ptr<CLHEP::HepRandomEngine> createFromState(std::vector<unsigned long> const&, long seed) const;
+
+    std::unique_ptr<CLHEP::HepRandomEngine> engine_;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/Services/src/ExternalRandomNumberGeneratorService.cc
+++ b/FWCore/Services/src/ExternalRandomNumberGeneratorService.cc
@@ -1,0 +1,91 @@
+#include "FWCore/Services/interface/ExternalRandomNumberGeneratorService.h"
+
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "CLHEP/Random/engineIDulong.h"
+#include "CLHEP/Random/JamesRandom.h"
+#include "CLHEP/Random/RanecuEngine.h"
+#include "CLHEP/Random/MixMaxRng.h"
+
+#include "SimDataFormats/RandomEngine/interface/RandomEngineState.h"
+
+using namespace edm;
+
+namespace {
+  const std::vector<RandomEngineState> s_dummyStates;
+}
+
+ExternalRandomNumberGeneratorService::ExternalRandomNumberGeneratorService() {}
+
+void ExternalRandomNumberGeneratorService::setState(std::vector<unsigned long> const& iState, long iSeed) {
+  if (not engine_) {
+    engine_ = createFromState(iState, iSeed);
+  } else {
+    engine_->get(iState);
+  }
+}
+
+std::vector<unsigned long> ExternalRandomNumberGeneratorService::getState() const { return engine_->put(); }
+
+CLHEP::HepRandomEngine& ExternalRandomNumberGeneratorService::getEngine(StreamID const&) { return *engine_; }
+CLHEP::HepRandomEngine& ExternalRandomNumberGeneratorService::getEngine(LuminosityBlockIndex const&) {
+  return *engine_;
+}
+
+std::unique_ptr<CLHEP::HepRandomEngine> ExternalRandomNumberGeneratorService::cloneEngine(LuminosityBlockIndex const&) {
+  std::vector<unsigned long> stateL = engine_->put();
+
+  long seedL = engine_->getSeed();
+  return createFromState(stateL, seedL);
+}
+
+std::unique_ptr<CLHEP::HepRandomEngine> ExternalRandomNumberGeneratorService::createFromState(
+    std::vector<unsigned long> const& stateL, long seedL) const {
+  std::unique_ptr<CLHEP::HepRandomEngine> newEngine;
+  if (stateL[0] == CLHEP::engineIDulong<CLHEP::HepJamesRandom>()) {
+    newEngine = std::make_unique<CLHEP::HepJamesRandom>(seedL);
+  } else if (stateL[0] == CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+    newEngine = std::make_unique<CLHEP::RanecuEngine>();
+  } else if (stateL[0] == CLHEP::engineIDulong<CLHEP::MixMaxRng>()) {
+    newEngine = std::make_unique<CLHEP::MixMaxRng>(seedL);
+    //} else if (stateL[0] == CLHEP::engineIDulong<TRandomAdaptor>()) {
+    //  newEngine = std::make_unique<TRandomAdaptor>(seedL);
+  } else {
+    // Sanity check, it should not be possible for this to happen.
+    throw Exception(errors::Unknown)
+        << "The ExternalRandomNumberGeneratorService is trying to clone unknown engine type\n";
+  }
+  if (stateL[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+    newEngine->setSeed(seedL, 0);
+  }
+  newEngine->get(stateL);
+  return newEngine;
+}
+
+std::uint32_t ExternalRandomNumberGeneratorService::mySeed() const { return 0; }
+
+void ExternalRandomNumberGeneratorService::preBeginLumi(LuminosityBlock const&) {}
+
+void ExternalRandomNumberGeneratorService::postEventRead(Event const&) {}
+
+void ExternalRandomNumberGeneratorService::setLumiCache(LuminosityBlockIndex,
+                                                        std::vector<RandomEngineState> const& iStates) {}
+void ExternalRandomNumberGeneratorService::setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) {}
+
+std::vector<RandomEngineState> const& ExternalRandomNumberGeneratorService::getEventCache(StreamID const&) const {
+  return s_dummyStates;
+}
+
+std::vector<RandomEngineState> const& ExternalRandomNumberGeneratorService::getLumiCache(
+    LuminosityBlockIndex const&) const {
+  return s_dummyStates;
+}
+
+void ExternalRandomNumberGeneratorService::consumes(ConsumesCollector&& iC) const {}
+
+/// For debugging purposes only.
+void ExternalRandomNumberGeneratorService::print(std::ostream& os) const {}

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -13,3 +13,8 @@
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Services/test test_mallocopts.sh test_sitelocalconfig.sh test_resource.sh test_zombiekiller.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>
+<bin    file="test_catch2_*.cc" name="testFWCoreServicesCatch2">
+  <use name="catch2"/>
+  <use name="clhep"/>
+  <use name="FWCore/Services"/>
+</bin>

--- a/FWCore/Services/test/test_catch2_ExternalRandomNumberGeneratorService.cc
+++ b/FWCore/Services/test/test_catch2_ExternalRandomNumberGeneratorService.cc
@@ -1,0 +1,59 @@
+#include "FWCore/Services/interface/ExternalRandomNumberGeneratorService.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "CLHEP/Random/JamesRandom.h"
+#include "CLHEP/Random/RanecuEngine.h"
+#include "CLHEP/Random/MixMaxRng.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+namespace {
+  void test(CLHEP::HepRandomEngine& iRand, CLHEP::HepRandomEngine& iEngine) {
+    REQUIRE(iRand.flat() == iEngine.flat());
+    REQUIRE(iRand.flat() == iEngine.flat());
+    REQUIRE(iRand.flat() == iEngine.flat());
+    REQUIRE(iRand.flat() == iEngine.flat());
+  }
+}  // namespace
+
+TEST_CASE("Test ExternalRandomNumberGeneratorService", "[externalrandomnumbergeneratorservice]") {
+  SECTION("JamesRandom") {
+    edm::ExternalRandomNumberGeneratorService service;
+    CLHEP::HepJamesRandom rand(12345);
+
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+
+    //advance the one to see how it works
+    rand.flat();
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+  }
+
+  SECTION("RanecuEngine") {
+    edm::ExternalRandomNumberGeneratorService service;
+    CLHEP::RanecuEngine rand(12345);
+
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+
+    //advance the one to see how it works
+    rand.flat();
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+  }
+
+  SECTION("MixMaxRng") {
+    edm::ExternalRandomNumberGeneratorService service;
+    CLHEP::MixMaxRng rand(12345);
+
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+
+    //advance the one to see how it works
+    rand.flat();
+    service.setState(rand.put(), rand.getSeed());
+    test(rand, service.getEngine(edm::StreamID::invalidStreamID()));
+  }
+}

--- a/FWCore/SharedMemory/BuildFile.xml
+++ b/FWCore/SharedMemory/BuildFile.xml
@@ -1,0 +1,5 @@
+<use   name="boost"/>
+<use   name="rootcore"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/FWCore/SharedMemory/Readme.md
+++ b/FWCore/SharedMemory/Readme.md
@@ -1,0 +1,21 @@
+# FWCore/SharedMemory Documentation
+
+## Introduction
+This package contains code to assist in having two processes communicate via shared memory. The primary idea is to have one of the processes be cmsRun (with a module working as the Controller) and then having the other process do work on behalf of the module as its Worker. One module can have several Workers, for example one Worker per Stream. Although the various classes in the package are capable of working independently, when used together they handle most of the needs for interprocess communication.
+
+The shared memory control is being handled by boost's interprocess package.
+
+## Classes
+The following are short descriptions for each class available in the package. All classes are in the edm::shared_memory namespace.
+
+### ROOTSerializer and ROOTDeserializer
+These classes do not directly use shared memory. They are wrappers around ROOT's mechanism for using dictionaries to serialize and deserialize C++ objects. These classes are used in conjunction with other classes which control the memory buffer into which the object is serialized and from which it is deserialized.
+
+### ReadBuffer and WriteBuffer
+A pair of ReadBuffer and WriteBuffer use the same shared memory area to communicate. They are capable of dynamically creating new buffers internally if there is a need to grow the buffer.
+
+### ControllerChannel and WorkerChannel
+These classes handle synchonizing communication between the Controller and Worker processes. They handle initialization of the Worker and then processing of the various framework transitions. These classes also work with the ReadBuffer and WriteBuffer objects to synchronize communication and handling the index used when the buffers change.
+
+### WorkerMonitorThread
+This class does not directly use shared memory. It is designed to use a helper thread and a signal handler to monitor the Worker process for a unix signal that will terminate the process. In the advent of such a signal, a user callable routine will be called. This is used to unlock the scoped lock being held by the WorkerChannel which will allow the Controller process to time out on its wait using that lock.

--- a/FWCore/SharedMemory/interface/BufferInfo.h
+++ b/FWCore/SharedMemory/interface/BufferInfo.h
@@ -1,0 +1,33 @@
+#ifndef FWCore_SharedMemory_BufferInfo_h
+#define FWCore_SharedMemory_BufferInfo_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     BufferInfo
+//
+/**\class BufferInfo BufferInfo.h " FWCore/SharedMemory/interface/BufferInfo.h"
+
+ Description: Information needed to manage the buffer
+
+ Usage:
+    This is an internal detail of the system.
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  struct BufferInfo {
+    int identifier_;
+    char index_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -1,0 +1,134 @@
+#ifndef FWCore_SharedMemory_ControllerChannel_h
+#define FWCore_SharedMemory_ControllerChannel_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ControllerChannel
+//
+/**\class ControllerChannel ControllerChannel.h " FWCore/SharedMemory/interface/ControllerChannel.h"
+
+ Description: Primary communication channel for the Controller process
+
+ Usage:
+    Works in conjunction with the WorkerChannel
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <string>
+#include <iostream>
+#include "boost/interprocess/managed_shared_memory.hpp"
+#include "boost/interprocess/sync/named_mutex.hpp"
+#include "boost/interprocess/sync/named_condition.hpp"
+#include "boost/interprocess/sync/scoped_lock.hpp"
+
+// user include files
+#include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class ControllerChannel {
+  public:
+    /** iName is used as the base for the shared memory name. The full name uses iID as well as getpid() to create the value sharedMemoryName().
+     iID allows multiple ControllChannels to use the same base name iName.
+     */
+    ControllerChannel(std::string const& iName, int iID);
+    ~ControllerChannel();
+    ControllerChannel(const ControllerChannel&) = delete;
+    const ControllerChannel& operator=(const ControllerChannel&) = delete;
+    ControllerChannel(ControllerChannel&&) = delete;
+    const ControllerChannel& operator=(ControllerChannel&&) = delete;
+
+    // ---------- member functions ---------------------------
+
+    /** setupWorker must be called only once and done before any calls to doTransition. The functor iF should setup values associated
+     with shared memory use, such as manipulating the value from toWorkerBufferIndex(). The call to setupWorker proper synchronizes
+     the Controller and Worker processes.
+     */
+    template <typename F>
+    void setupWorker(F&& iF) {
+      using namespace boost::interprocess;
+      scoped_lock<named_mutex> lock(mutex_);
+      iF();
+      using namespace boost::posix_time;
+      //std::cout << id_ << " waiting for external process" << std::endl;
+
+      if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(60))) {
+        //std::cout << id_ << " FAILED waiting for external process" << std::endl;
+        throw cms::Exception("ExternalFailed");
+      } else {
+        //std::cout << id_ << " done waiting for external process" << std::endl;
+      }
+    }
+
+    template <typename F>
+    bool doTransition(F&& iF, edm::Transition iTrans, unsigned long long iTransitionID) {
+      using namespace boost::interprocess;
+
+      //std::cout << id_ << " taking from lock" << std::endl;
+      scoped_lock<named_mutex> lock(mutex_);
+
+      if (not wait(lock, iTrans, iTransitionID)) {
+        return false;
+      }
+      //std::cout <<id_<<"running doTranstion command"<<std::endl;
+      iF();
+      return true;
+    }
+
+    ///This can be used with WriteBuffer to keep Controller and Worker in sync
+    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    ///This can be used with ReadBuffer to keep Controller and Worker in sync
+    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
+
+    void stopWorker() {
+      //std::cout <<"stopWorker"<<std::endl;
+      using namespace boost::interprocess;
+      scoped_lock<named_mutex> lock(mutex_);
+      *stop_ = true;
+      //std::cout <<"stopWorker sending notification"<<std::endl;
+      cndFromMain_.notify_all();
+    }
+
+    // ---------- const member functions ---------------------------
+    std::string const& sharedMemoryName() const { return smName_; }
+    std::string uniqueID() const { return uniqueName(""); }
+
+    //should only be called after calling `doTransition`
+    bool shouldKeepEvent() const { return *keepEvent_; }
+
+  private:
+    static char* bufferIndex(const char* iWhich, boost::interprocess::managed_shared_memory& mem);
+
+    std::string uniqueName(std::string iBase) const;
+
+    bool wait(boost::interprocess::scoped_lock<boost::interprocess::named_mutex>& lock,
+              edm::Transition iTrans,
+              unsigned long long iTransID);
+
+    // ---------- member data --------------------------------
+    int id_;
+    std::string smName_;
+    boost::interprocess::managed_shared_memory managed_sm_;
+    char* toWorkerBufferIndex_;
+    char* fromWorkerBufferIndex_;
+
+    boost::interprocess::named_mutex mutex_;
+    boost::interprocess::named_condition cndFromMain_;
+
+    boost::interprocess::named_condition cndToMain_;
+
+    edm::Transition* transitionType_;
+    unsigned long long* transitionID_;
+    bool* stop_;
+    bool* keepEvent_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -29,6 +29,7 @@
 // user include files
 #include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/SharedMemory/interface/BufferInfo.h"
 
 // forward declarations
 
@@ -48,7 +49,7 @@ namespace edm::shared_memory {
     // ---------- member functions ---------------------------
 
     /** setupWorker must be called only once and done before any calls to doTransition. The functor iF should setup values associated
-     with shared memory use, such as manipulating the value from toWorkerBufferIndex(). The call to setupWorker proper synchronizes
+     with shared memory use, such as manipulating the value from toWorkerBufferInfo(). The call to setupWorker proper synchronizes
      the Controller and Worker processes.
      */
     template <typename F>
@@ -83,9 +84,9 @@ namespace edm::shared_memory {
     }
 
     ///This can be used with WriteBuffer to keep Controller and Worker in sync
-    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    BufferInfo* toWorkerBufferInfo() { return toWorkerBufferInfo_; }
     ///This can be used with ReadBuffer to keep Controller and Worker in sync
-    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
+    BufferInfo* fromWorkerBufferInfo() { return fromWorkerBufferInfo_; }
 
     void stopWorker() {
       //std::cout <<"stopWorker"<<std::endl;
@@ -104,7 +105,7 @@ namespace edm::shared_memory {
     bool shouldKeepEvent() const { return *keepEvent_; }
 
   private:
-    static char* bufferIndex(const char* iWhich, boost::interprocess::managed_shared_memory& mem);
+    static BufferInfo* bufferInfo(const char* iWhich, boost::interprocess::managed_shared_memory& mem);
 
     std::string uniqueName(std::string iBase) const;
 
@@ -116,8 +117,8 @@ namespace edm::shared_memory {
     int id_;
     std::string smName_;
     boost::interprocess::managed_shared_memory managed_sm_;
-    char* toWorkerBufferIndex_;
-    char* fromWorkerBufferIndex_;
+    BufferInfo* toWorkerBufferInfo_;
+    BufferInfo* fromWorkerBufferInfo_;
 
     boost::interprocess::named_mutex mutex_;
     boost::interprocess::named_condition cndFromMain_;

--- a/FWCore/SharedMemory/interface/ROOTDeserializer.h
+++ b/FWCore/SharedMemory/interface/ROOTDeserializer.h
@@ -1,0 +1,64 @@
+#ifndef FWCore_SharedMemory_ROOTDeserializer_h
+#define FWCore_SharedMemory_ROOTDeserializer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ROOTDeserializer
+//
+/**\class ROOTDeserializer ROOTDeserializer.h " FWCore/SharedMemory/interface/ROOTDeserializer.h"
+
+ Description: Use ROOT dictionaries to deserialize object from a buffer
+
+ Usage:
+    Used in conjunction with ROOTSerializer.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  22/01/2020
+//
+
+// system include files
+#include "TClass.h"
+#include "TBufferFile.h"
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  template <typename T, typename READBUFFER>
+  class ROOTDeserializer {
+  public:
+    ROOTDeserializer(READBUFFER& iBuffer)
+        : buffer_{iBuffer}, class_{TClass::GetClass(typeid(T))}, bufferFile_(TBuffer::kRead) {}
+
+    ROOTDeserializer(const ROOTDeserializer&) = delete;
+    const ROOTDeserializer& operator=(const ROOTDeserializer&) = delete;
+    ROOTDeserializer(ROOTDeserializer&&) = delete;
+    const ROOTDeserializer& operator=(ROOTDeserializer&&) = delete;
+
+    // ---------- const member functions ---------------------
+
+    // ---------- member functions ---------------------------
+    T deserialize() {
+      T value;
+      if (buffer_.mustGetBufferAgain()) {
+        auto buff = buffer_.buffer();
+        bufferFile_.SetBuffer(buff.first, buff.second, kFALSE);
+      }
+
+      class_->ReadBuffer(bufferFile_, &value);
+      bufferFile_.Reset();
+      return value;
+    }
+
+  private:
+    // ---------- member data --------------------------------
+    READBUFFER& buffer_;
+    TClass* const class_;
+    TBufferFile bufferFile_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ROOTDeserializer.h
+++ b/FWCore/SharedMemory/interface/ROOTDeserializer.h
@@ -43,9 +43,10 @@ namespace edm::shared_memory {
     // ---------- member functions ---------------------------
     T deserialize() {
       T value;
-      if (buffer_.mustGetBufferAgain()) {
+      if (previousBufferIdentifier_ != buffer_.bufferIdentifier()) {
         auto buff = buffer_.buffer();
         bufferFile_.SetBuffer(buff.first, buff.second, kFALSE);
+        previousBufferIdentifier_ = buffer_.bufferIdentifier();
       }
 
       class_->ReadBuffer(bufferFile_, &value);
@@ -58,6 +59,7 @@ namespace edm::shared_memory {
     READBUFFER& buffer_;
     TClass* const class_;
     TBufferFile bufferFile_;
+    int previousBufferIdentifier_ = 0;
   };
 }  // namespace edm::shared_memory
 

--- a/FWCore/SharedMemory/interface/ROOTSerializer.h
+++ b/FWCore/SharedMemory/interface/ROOTSerializer.h
@@ -1,0 +1,59 @@
+#ifndef FWCore_SharedMemory_ROOTSerializer_h
+#define FWCore_SharedMemory_ROOTSerializer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ROOTSerializer
+//
+/**\class ROOTSerializer ROOTSerializer.h " FWCore/SharedMemory/interface/ROOTSerializer.h"
+
+ Description: Use ROOT dictionaries to serialize object to a buffer
+
+ Usage:
+    This is used in conjuction with ROOTDeserializer.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  22/01/2020
+//
+
+// system include files
+#include "TClass.h"
+#include "TBufferFile.h"
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  template <typename T, typename WRITEBUFFER>
+  class ROOTSerializer {
+  public:
+    ROOTSerializer(WRITEBUFFER& iBuffer)
+        : buffer_(iBuffer), class_{TClass::GetClass(typeid(T))}, bufferFile_{TBuffer::kWrite} {}
+
+    ROOTSerializer(const ROOTSerializer&) = delete;
+    const ROOTSerializer& operator=(const ROOTSerializer&) = delete;
+    ROOTSerializer(ROOTSerializer&&) = delete;
+    const ROOTSerializer& operator=(ROOTSerializer&&) = delete;
+
+    // ---------- const member functions ---------------------
+
+    // ---------- member functions ---------------------------
+    void serialize(T& iValue) {
+      bufferFile_.Reset();
+      class_->WriteBuffer(bufferFile_, &iValue);
+
+      buffer_.copyToBuffer(bufferFile_.Buffer(), bufferFile_.Length());
+    }
+
+  private:
+    // ---------- member data --------------------------------
+    WRITEBUFFER& buffer_;
+    TClass* const class_;
+    TBufferFile bufferFile_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ReadBuffer.h
+++ b/FWCore/SharedMemory/interface/ReadBuffer.h
@@ -1,0 +1,73 @@
+#ifndef FWCore_SharedMemory_ReadBuffer_h
+#define FWCore_SharedMemory_ReadBuffer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ReadBuffer
+//
+/**\class ReadBuffer ReadBuffer.h " FWCore/SharedMemory/interface/ReadBuffer.h"
+
+ Description: Manages a shared memory buffer used for reading
+
+ Usage:
+      Handles reading from a dynamically allocatable shared memory buffer.
+This works in conjunction with WriteBuffer.
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <array>
+#include <memory>
+#include <string>
+#include "boost/interprocess/managed_shared_memory.hpp"
+
+// user include files
+#include "FWCore/SharedMemory/interface/buffer_names.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class ReadBuffer {
+  public:
+    /** iUniqueName : must be unique for all processes running on a system.
+        iBufferIndex : is a pointer to a shared_memory address where the same address needs to be shared by ReadBuffer and WriteBuffer.
+    */
+    ReadBuffer(std::string const& iUniqueName, char* iBufferIndex)
+        : buffer_{nullptr, 0}, bufferIndex_{iBufferIndex}, bufferOldIndex_{3} {
+      *bufferIndex_ = 0;
+      bufferNames_[0] = iUniqueName + buffer_names::kBuffer0;
+      bufferNames_[1] = iUniqueName + buffer_names::kBuffer1;
+    }
+    ReadBuffer(const ReadBuffer&) = delete;
+    const ReadBuffer& operator=(const ReadBuffer&) = delete;
+    ReadBuffer(ReadBuffer&&) = delete;
+    const ReadBuffer& operator=(ReadBuffer&&) = delete;
+
+    // ---------- const member functions ---------------------
+    bool mustGetBufferAgain() const { return *bufferIndex_ != bufferOldIndex_; }
+
+    // ---------- member functions ---------------------------
+    std::pair<char*, std::size_t> buffer() {
+      if (mustGetBufferAgain()) {
+        using namespace boost::interprocess;
+        sm_ = std::make_unique<managed_shared_memory>(open_only, bufferNames_[*bufferIndex_].c_str());
+        buffer_ = sm_->find<char>(buffer_names::kBuffer);
+        bufferOldIndex_ = *bufferIndex_;
+      }
+      return buffer_;
+    }
+
+  private:
+    // ---------- member data --------------------------------
+    std::pair<char*, std::size_t> buffer_;
+    char* bufferIndex_;
+    char bufferOldIndex_;
+    std::array<std::string, 2> bufferNames_;
+    std::unique_ptr<boost::interprocess::managed_shared_memory> sm_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/WorkerChannel.h
+++ b/FWCore/SharedMemory/interface/WorkerChannel.h
@@ -1,0 +1,105 @@
+#ifndef FWCore_SharedMemory_WorkerChannel_h
+#define FWCore_SharedMemory_WorkerChannel_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WorkerChannel
+//
+/**\class WorkerChannel WorkerChannel.h " FWCore/SharedMemory/interface/WorkerChannel.h"
+
+ Description:  Primary communication channel for the Worker process
+
+ Usage:
+    Used in conjunction with the ControllerChannel
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <string>
+#include "boost/interprocess/managed_shared_memory.hpp"
+#include "boost/interprocess/sync/named_mutex.hpp"
+#include "boost/interprocess/sync/named_condition.hpp"
+#include "boost/interprocess/sync/scoped_lock.hpp"
+
+// user include files
+#include "FWCore/Utilities/interface/Transition.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class WorkerChannel {
+  public:
+    /** iName must match the value from ControllerChannel::sharedMemoryName()
+     iUniqueName must match the value from ControllerChannel::uniqueID()     
+     */
+    WorkerChannel(std::string const& iName, const std::string& iUniqueID);
+    WorkerChannel(const WorkerChannel&) = delete;
+    const WorkerChannel& operator=(const WorkerChannel&) = delete;
+    WorkerChannel(WorkerChannel&&) = delete;
+    const WorkerChannel& operator=(WorkerChannel&&) = delete;
+
+    // ---------- member functions ---------------------------
+    /// the lock is made accessible so that the WorkerMonitorThread can be used to unlock it in the event of a unix signal
+    boost::interprocess::scoped_lock<boost::interprocess::named_mutex>* accessLock() { return &lock_; }
+
+    ///This can be used with ReadBuffer to keep Controller and Worker in sync
+    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    ///This can be used with WriteBuffer to keep Controller and Worker in sync
+    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
+
+    ///Matches the ControllerChannel::setupWorker call
+    void workerSetupDone() {
+      //The controller is waiting for the worker to be setup
+      notifyController();
+    }
+
+    /**Matches the ControllerChannel::doTransition calls.
+     iF is a function that takes as arguments a edm::Transition and unsigned long long
+     */
+    template <typename F>
+    void handleTransitions(F&& iF) {
+      while (true) {
+        waitForController();
+        if (stopRequested()) {
+          break;
+        }
+
+        iF(transition(), transitionID());
+        notifyController();
+      }
+    }
+
+    ///call this from the `handleTransitions` functor
+    void shouldKeepEvent(bool iChoice) { *keepEvent_ = iChoice; }
+
+    ///These are here for expert use
+    void notifyController() { cndToController_.notify_all(); }
+    void waitForController() { cndFromController_.wait(lock_); }
+
+    // ---------- const member functions ---------------------------
+    edm::Transition transition() const noexcept { return *transitionType_; }
+    unsigned long long transitionID() const noexcept { return *transitionID_; }
+    bool stopRequested() const noexcept { return *stop_; }
+
+  private:
+    // ---------- member data --------------------------------
+    boost::interprocess::managed_shared_memory managed_shm_;
+
+    boost::interprocess::named_mutex mutex_;
+    boost::interprocess::named_condition cndFromController_;
+    bool* stop_;
+    edm::Transition* transitionType_;
+    unsigned long long* transitionID_;
+    char* toWorkerBufferIndex_;
+    char* fromWorkerBufferIndex_;
+    boost::interprocess::named_condition cndToController_;
+    bool* keepEvent_;
+    boost::interprocess::scoped_lock<boost::interprocess::named_mutex> lock_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/WorkerChannel.h
+++ b/FWCore/SharedMemory/interface/WorkerChannel.h
@@ -27,6 +27,7 @@
 
 // user include files
 #include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/SharedMemory/interface/BufferInfo.h"
 
 // forward declarations
 
@@ -47,9 +48,9 @@ namespace edm::shared_memory {
     boost::interprocess::scoped_lock<boost::interprocess::named_mutex>* accessLock() { return &lock_; }
 
     ///This can be used with ReadBuffer to keep Controller and Worker in sync
-    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    BufferInfo* toWorkerBufferInfo() { return toWorkerBufferInfo_; }
     ///This can be used with WriteBuffer to keep Controller and Worker in sync
-    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
+    BufferInfo* fromWorkerBufferInfo() { return fromWorkerBufferInfo_; }
 
     ///Matches the ControllerChannel::setupWorker call
     void workerSetupDone() {
@@ -94,8 +95,8 @@ namespace edm::shared_memory {
     bool* stop_;
     edm::Transition* transitionType_;
     unsigned long long* transitionID_;
-    char* toWorkerBufferIndex_;
-    char* fromWorkerBufferIndex_;
+    BufferInfo* toWorkerBufferInfo_;
+    BufferInfo* fromWorkerBufferInfo_;
     boost::interprocess::named_condition cndToController_;
     bool* keepEvent_;
     boost::interprocess::scoped_lock<boost::interprocess::named_mutex> lock_;

--- a/FWCore/SharedMemory/interface/WorkerMonitorThread.h
+++ b/FWCore/SharedMemory/interface/WorkerMonitorThread.h
@@ -1,0 +1,77 @@
+#ifndef FWCore_SharedMemory_WorkerMonitorThread_h
+#define FWCore_SharedMemory_WorkerMonitorThread_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WorkerMonitorThread
+//
+/**\class WorkerMonitorThread WorkerMonitorThread.h " FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
+ Description: Manages a thread that monitors the worker process for unix signals
+
+ Usage:
+      Allows a user settable action to happen in the case of a unix signal occuring.
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <atomic>
+#include <csignal>
+#include <functional>
+#include <thread>
+
+// user include files
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class WorkerMonitorThread {
+  public:
+    WorkerMonitorThread() {}
+    ~WorkerMonitorThread() {
+      if (not stopRequested_.load()) {
+        stop();
+      }
+    }
+    WorkerMonitorThread(const WorkerMonitorThread&) = delete;
+    const WorkerMonitorThread& operator=(const WorkerMonitorThread&) = delete;
+    WorkerMonitorThread(WorkerMonitorThread&&) = delete;
+    const WorkerMonitorThread& operator=(WorkerMonitorThread&&) = delete;
+
+    // ---------- const member functions ---------------------
+
+    // ---------- member functions ---------------------------
+    void setAction(std::function<void()> iFunc) {
+      action_ = std::move(iFunc);
+      actionSet_.store(true);
+    }
+
+    void startThread();
+
+    ///Sets the unix signal handler which communicates with the thread.
+    void setupSignalHandling();
+
+    void stop();
+
+  private:
+    static void sig_handler(int sig, siginfo_t*, void*);
+    void run();
+    // ---------- member data --------------------------------
+    std::atomic<bool> stopRequested_ = false;
+    std::atomic<bool> helperReady_ = false;
+    std::atomic<bool> actionSet_ = false;
+    CMS_THREAD_GUARD(actionSet_) std::function<void()> action_;
+
+    static std::atomic<int> s_pipeReadEnd;
+    static std::atomic<int> s_pipeWriteEnd;
+    static std::atomic<bool> s_helperThreadDone;
+
+    std::thread helperThread_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/WriteBuffer.h
+++ b/FWCore/SharedMemory/interface/WriteBuffer.h
@@ -1,0 +1,75 @@
+#ifndef FWCore_SharedMemory_WriteBuffer_h
+#define FWCore_SharedMemory_WriteBuffer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WriteBuffer
+//
+/**\class WriteBuffer WriteBuffer.h " FWCore/SharedMemory/interface/WriteBuffer.h"
+
+ Description: Manages a shared memory buffer used for writing
+
+ Usage:
+    Handles writing to a shared memory buffer. The buffer size grows automatically when necessary.
+ This works in conjunction with ReadBuffer.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <array>
+#include <memory>
+#include <string>
+#include <cassert>
+#include <algorithm>
+#include "boost/interprocess/managed_shared_memory.hpp"
+
+// user include files
+#include "FWCore/SharedMemory/interface/buffer_names.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class WriteBuffer {
+  public:
+    /** iUniqueName : must be unique for all processes running on a system.
+        iBufferIndex : is a pointer to a shared_memory address where the same address needs to be shared by ReadBuffer and WriteBuffer.
+    */
+
+    WriteBuffer(std::string const& iUniqueName, char* iBufferIndex)
+        : bufferSize_{0}, buffer_{nullptr}, bufferIndex_{iBufferIndex} {
+      bufferNames_[0] = iUniqueName + buffer_names::kBuffer0;
+      bufferNames_[1] = iUniqueName + buffer_names::kBuffer1;
+      assert(bufferIndex_);
+    }
+    WriteBuffer(const WriteBuffer&) = delete;
+    const WriteBuffer& operator=(const WriteBuffer&) = delete;
+    WriteBuffer(WriteBuffer&&) = delete;
+    const WriteBuffer& operator=(WriteBuffer&&) = delete;
+
+    ~WriteBuffer();
+
+    // ---------- member functions ---------------------------
+    void copyToBuffer(const char* iStart, std::size_t iLength) {
+      if (iLength > bufferSize_) {
+        growBuffer(iLength);
+      }
+      std::copy(iStart, iStart + iLength, buffer_);
+    }
+
+  private:
+    void growBuffer(std::size_t iLength);
+
+    // ---------- member data --------------------------------
+    std::size_t bufferSize_;
+    char* buffer_;
+    char* bufferIndex_;
+    std::array<std::string, 2> bufferNames_;
+    std::unique_ptr<boost::interprocess::managed_shared_memory> sm_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/WriteBuffer.h
+++ b/FWCore/SharedMemory/interface/WriteBuffer.h
@@ -29,6 +29,7 @@
 
 // user include files
 #include "FWCore/SharedMemory/interface/buffer_names.h"
+#include "FWCore/SharedMemory/interface/BufferInfo.h"
 
 // forward declarations
 
@@ -36,14 +37,14 @@ namespace edm::shared_memory {
   class WriteBuffer {
   public:
     /** iUniqueName : must be unique for all processes running on a system.
-        iBufferIndex : is a pointer to a shared_memory address where the same address needs to be shared by ReadBuffer and WriteBuffer.
+        iBufferInfo : is a pointer to a shared_memory address where the same address needs to be shared by ReadBuffer and WriteBuffer.
     */
 
-    WriteBuffer(std::string const& iUniqueName, char* iBufferIndex)
-        : bufferSize_{0}, buffer_{nullptr}, bufferIndex_{iBufferIndex} {
+    WriteBuffer(std::string const& iUniqueName, BufferInfo* iBufferInfo)
+        : bufferSize_{0}, buffer_{nullptr}, bufferInfo_{iBufferInfo} {
       bufferNames_[0] = iUniqueName + buffer_names::kBuffer0;
       bufferNames_[1] = iUniqueName + buffer_names::kBuffer1;
-      assert(bufferIndex_);
+      assert(bufferInfo_);
     }
     WriteBuffer(const WriteBuffer&) = delete;
     const WriteBuffer& operator=(const WriteBuffer&) = delete;
@@ -66,7 +67,7 @@ namespace edm::shared_memory {
     // ---------- member data --------------------------------
     std::size_t bufferSize_;
     char* buffer_;
-    char* bufferIndex_;
+    BufferInfo* bufferInfo_;
     std::array<std::string, 2> bufferNames_;
     std::unique_ptr<boost::interprocess::managed_shared_memory> sm_;
   };

--- a/FWCore/SharedMemory/interface/buffer_names.h
+++ b/FWCore/SharedMemory/interface/buffer_names.h
@@ -1,0 +1,35 @@
+#ifndef FWCore_SharedMemory_buffer_names_h
+#define FWCore_SharedMemory_buffer_names_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     buffer_names
+//
+/**
+
+ Description: Shared memory names used for the ReadBuffer and WriteBuffer
+
+ Usage:
+      Internal details of ReadBuffer and WriteBuffer
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  namespace buffer_names {
+    constexpr char const* const kBuffer = "buffer";
+    constexpr char const* const kBuffer0 = "buffer0";
+    constexpr char const* const kBuffer1 = "buffer1";
+  }  // namespace buffer_names
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/channel_names.h
+++ b/FWCore/SharedMemory/interface/channel_names.h
@@ -1,0 +1,41 @@
+#ifndef FWCore_SharedMemory_channel_names_h
+#define FWCore_SharedMemory_channel_names_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     channel_names
+//
+/**
+
+ Description: Shared memory names used for the ControllerChannel and WorkerChannel
+
+ Usage:
+      Internal details of ControllerChannel and WorkerChannel
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  namespace channel_names {
+    constexpr char const* const kToWorkerBufferIndex = "bufferIndexToWorker";
+    constexpr char const* const kFromWorkerBufferIndex = "bufferIndexFromWorker";
+    constexpr char const* const kMutex = "mtx";
+    constexpr char const* const kConditionFromMain = "cndFromMain";
+    constexpr char const* const kConditionToMain = "cndToMain";
+    constexpr char const* const kStop = "stop";
+    constexpr char const* const kKeepEvent = "keepEvent";
+    constexpr char const* const kTransitionType = "transitionType";
+    constexpr char const* const kTransitionID = "transitionID";
+  };  // namespace channel_names
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/channel_names.h
+++ b/FWCore/SharedMemory/interface/channel_names.h
@@ -26,8 +26,8 @@
 
 namespace edm::shared_memory {
   namespace channel_names {
-    constexpr char const* const kToWorkerBufferIndex = "bufferIndexToWorker";
-    constexpr char const* const kFromWorkerBufferIndex = "bufferIndexFromWorker";
+    constexpr char const* const kToWorkerBufferInfo = "bufferInfoToWorker";
+    constexpr char const* const kFromWorkerBufferInfo = "bufferInfoFromWorker";
     constexpr char const* const kMutex = "mtx";
     constexpr char const* const kConditionFromMain = "cndFromMain";
     constexpr char const* const kConditionToMain = "cndToMain";

--- a/FWCore/SharedMemory/src/ControllerChannel.cc
+++ b/FWCore/SharedMemory/src/ControllerChannel.cc
@@ -1,0 +1,110 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ControllerChannel
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <cassert>
+
+// user include files
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/channel_names.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm::shared_memory;
+using namespace boost::interprocess;
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+
+ControllerChannel::ControllerChannel(std::string const& iName, int id)
+    : id_{id},
+      smName_{uniqueName(iName)},
+      managed_sm_{open_or_create, smName_.c_str(), 1024},
+      toWorkerBufferIndex_{bufferIndex(channel_names::kToWorkerBufferIndex, managed_sm_)},
+      fromWorkerBufferIndex_{bufferIndex(channel_names::kFromWorkerBufferIndex, managed_sm_)},
+      mutex_{open_or_create, uniqueName(channel_names::kMutex).c_str()},
+      cndFromMain_{open_or_create, uniqueName(channel_names::kConditionFromMain).c_str()},
+      cndToMain_{open_or_create, uniqueName(channel_names::kConditionToMain).c_str()} {
+  managed_sm_.destroy<bool>(channel_names::kStop);
+  stop_ = managed_sm_.construct<bool>(channel_names::kStop)(false);
+  assert(stop_);
+  keepEvent_ = managed_sm_.construct<bool>(channel_names::kKeepEvent)(true);
+  assert(keepEvent_);
+
+  managed_sm_.destroy<edm::Transition>(channel_names::kTransitionType);
+  transitionType_ =
+      managed_sm_.construct<edm::Transition>(channel_names::kTransitionType)(edm::Transition::NumberOfTransitions);
+  assert(transitionType_);
+
+  managed_sm_.destroy<unsigned long long>(channel_names::kTransitionID);
+  transitionID_ = managed_sm_.construct<unsigned long long>(channel_names::kTransitionID)(0);
+  assert(transitionID_);
+}
+
+ControllerChannel::~ControllerChannel() {
+  managed_sm_.destroy<bool>(channel_names::kKeepEvent);
+  managed_sm_.destroy<bool>(channel_names::kStop);
+  managed_sm_.destroy<unsigned int>(channel_names::kTransitionType);
+  managed_sm_.destroy<unsigned long long>(channel_names::kTransitionID);
+  managed_sm_.destroy<char>(channel_names::kToWorkerBufferIndex);
+  managed_sm_.destroy<char>(channel_names::kFromWorkerBufferIndex);
+
+  named_mutex::remove(uniqueName(channel_names::kMutex).c_str());
+  named_condition::remove(uniqueName(channel_names::kConditionFromMain).c_str());
+  named_condition::remove(uniqueName(channel_names::kConditionToMain).c_str());
+}
+
+//
+// member functions
+//
+std::string ControllerChannel::uniqueName(std::string iBase) const {
+  auto pid = getpid();
+  iBase += std::to_string(pid);
+  iBase += "_";
+  iBase += std::to_string(id_);
+
+  return iBase;
+}
+
+bool ControllerChannel::wait(scoped_lock<named_mutex>& lock, edm::Transition iTrans, unsigned long long iTransID) {
+  *transitionType_ = iTrans;
+  *transitionID_ = iTransID;
+  //std::cout << id_ << " notifying" << std::endl;
+  cndFromMain_.notify_all();
+
+  //std::cout << id_ << " waiting" << std::endl;
+  using namespace boost::posix_time;
+  if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(60))) {
+    //std::cout << id_ << " waiting FAILED" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//
+char* ControllerChannel::bufferIndex(const char* iWhich, managed_shared_memory& mem) {
+  mem.destroy<char>(iWhich);
+  char* v = mem.construct<char>(iWhich)();
+  return v;
+}

--- a/FWCore/SharedMemory/src/ControllerChannel.cc
+++ b/FWCore/SharedMemory/src/ControllerChannel.cc
@@ -35,8 +35,8 @@ ControllerChannel::ControllerChannel(std::string const& iName, int id)
     : id_{id},
       smName_{uniqueName(iName)},
       managed_sm_{open_or_create, smName_.c_str(), 1024},
-      toWorkerBufferIndex_{bufferIndex(channel_names::kToWorkerBufferIndex, managed_sm_)},
-      fromWorkerBufferIndex_{bufferIndex(channel_names::kFromWorkerBufferIndex, managed_sm_)},
+      toWorkerBufferInfo_{bufferInfo(channel_names::kToWorkerBufferInfo, managed_sm_)},
+      fromWorkerBufferInfo_{bufferInfo(channel_names::kFromWorkerBufferInfo, managed_sm_)},
       mutex_{open_or_create, uniqueName(channel_names::kMutex).c_str()},
       cndFromMain_{open_or_create, uniqueName(channel_names::kConditionFromMain).c_str()},
       cndToMain_{open_or_create, uniqueName(channel_names::kConditionToMain).c_str()} {
@@ -61,8 +61,8 @@ ControllerChannel::~ControllerChannel() {
   managed_sm_.destroy<bool>(channel_names::kStop);
   managed_sm_.destroy<unsigned int>(channel_names::kTransitionType);
   managed_sm_.destroy<unsigned long long>(channel_names::kTransitionID);
-  managed_sm_.destroy<char>(channel_names::kToWorkerBufferIndex);
-  managed_sm_.destroy<char>(channel_names::kFromWorkerBufferIndex);
+  managed_sm_.destroy<BufferInfo>(channel_names::kToWorkerBufferInfo);
+  managed_sm_.destroy<BufferInfo>(channel_names::kFromWorkerBufferInfo);
 
   named_mutex::remove(uniqueName(channel_names::kMutex).c_str());
   named_condition::remove(uniqueName(channel_names::kConditionFromMain).c_str());
@@ -103,8 +103,8 @@ bool ControllerChannel::wait(scoped_lock<named_mutex>& lock, edm::Transition iTr
 //
 // static member functions
 //
-char* ControllerChannel::bufferIndex(const char* iWhich, managed_shared_memory& mem) {
-  mem.destroy<char>(iWhich);
-  char* v = mem.construct<char>(iWhich)();
+BufferInfo* ControllerChannel::bufferInfo(const char* iWhich, managed_shared_memory& mem) {
+  mem.destroy<BufferInfo>(iWhich);
+  BufferInfo* v = mem.construct<BufferInfo>(iWhich)();
   return v;
 }

--- a/FWCore/SharedMemory/src/WorkerChannel.cc
+++ b/FWCore/SharedMemory/src/WorkerChannel.cc
@@ -1,0 +1,69 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WorkerChannel
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <cassert>
+
+// user include files
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/SharedMemory/interface/channel_names.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm::shared_memory;
+using namespace boost::interprocess;
+
+namespace {
+  std::string unique_name(std::string iBase, std::string_view ID) {
+    iBase.append(ID);
+    return iBase;
+  }
+}  // namespace
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+
+WorkerChannel::WorkerChannel(std::string const& iName, const std::string& iUniqueID)
+    : managed_shm_{open_only, iName.c_str()},
+      mutex_{open_or_create, unique_name(channel_names::kMutex, iUniqueID).c_str()},
+      cndFromController_{open_or_create, unique_name(channel_names::kConditionFromMain, iUniqueID).c_str()},
+      stop_{managed_shm_.find<bool>(channel_names::kStop).first},
+      transitionType_{managed_shm_.find<edm::Transition>(channel_names::kTransitionType).first},
+      transitionID_{managed_shm_.find<unsigned long long>(channel_names::kTransitionID).first},
+      toWorkerBufferIndex_{managed_shm_.find<char>(channel_names::kToWorkerBufferIndex).first},
+      fromWorkerBufferIndex_{managed_shm_.find<char>(channel_names::kFromWorkerBufferIndex).first},
+      cndToController_{open_or_create, unique_name(channel_names::kConditionToMain, iUniqueID).c_str()},
+      keepEvent_{managed_shm_.find<bool>(channel_names::kKeepEvent).first},
+      lock_{mutex_} {
+  assert(stop_);
+  assert(transitionType_);
+  assert(transitionID_);
+  assert(toWorkerBufferIndex_);
+  assert(fromWorkerBufferIndex_);
+}
+
+//
+// member functions
+//
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//

--- a/FWCore/SharedMemory/src/WorkerChannel.cc
+++ b/FWCore/SharedMemory/src/WorkerChannel.cc
@@ -44,16 +44,16 @@ WorkerChannel::WorkerChannel(std::string const& iName, const std::string& iUniqu
       stop_{managed_shm_.find<bool>(channel_names::kStop).first},
       transitionType_{managed_shm_.find<edm::Transition>(channel_names::kTransitionType).first},
       transitionID_{managed_shm_.find<unsigned long long>(channel_names::kTransitionID).first},
-      toWorkerBufferIndex_{managed_shm_.find<char>(channel_names::kToWorkerBufferIndex).first},
-      fromWorkerBufferIndex_{managed_shm_.find<char>(channel_names::kFromWorkerBufferIndex).first},
+      toWorkerBufferInfo_{managed_shm_.find<BufferInfo>(channel_names::kToWorkerBufferInfo).first},
+      fromWorkerBufferInfo_{managed_shm_.find<BufferInfo>(channel_names::kFromWorkerBufferInfo).first},
       cndToController_{open_or_create, unique_name(channel_names::kConditionToMain, iUniqueID).c_str()},
       keepEvent_{managed_shm_.find<bool>(channel_names::kKeepEvent).first},
       lock_{mutex_} {
   assert(stop_);
   assert(transitionType_);
   assert(transitionID_);
-  assert(toWorkerBufferIndex_);
-  assert(fromWorkerBufferIndex_);
+  assert(toWorkerBufferInfo_);
+  assert(fromWorkerBufferInfo_);
 }
 
 //

--- a/FWCore/SharedMemory/src/WorkerMonitorThread.cc
+++ b/FWCore/SharedMemory/src/WorkerMonitorThread.cc
@@ -1,0 +1,133 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WorkerMonitorThread
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <cerrno>
+#include <csignal>
+#include <iostream>
+#include <unistd.h>
+
+// user include files
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm::shared_memory;
+
+//
+// static data member definitions
+//
+std::atomic<bool> WorkerMonitorThread::s_helperThreadDone = false;
+std::atomic<int> WorkerMonitorThread::s_pipeReadEnd = 0;
+std::atomic<int> WorkerMonitorThread::s_pipeWriteEnd = 0;
+
+//
+// constructors and destructor
+//
+
+//
+// member functions
+//
+void WorkerMonitorThread::run() {
+  //std::cerr << "Started cleanup thread\n";
+  sigset_t ensemble;
+
+  sigemptyset(&ensemble);
+  sigaddset(&ensemble, SIGABRT);
+  sigaddset(&ensemble, SIGILL);
+  sigaddset(&ensemble, SIGBUS);
+  sigaddset(&ensemble, SIGSEGV);
+  sigaddset(&ensemble, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &ensemble, nullptr);
+
+  //std::cerr << "Start loop\n";
+  helperReady_ = true;
+  while (true) {
+    int signal = -1;
+    auto res = read(s_pipeReadEnd.load(), &signal, sizeof(signal) / sizeof(char));
+    if (res == -1) {
+      if (errno == EINTR) {
+        continue;
+      }
+      abort();
+    }
+    if (signal != 0) {
+      if (actionSet_) {
+        action_();
+      }
+      std::cerr << "Worker: SIGNAL CAUGHT " << signal << "\n";
+      s_helperThreadDone = true;
+      break;
+    } /* else {
+      std::cerr << "SIGNAL woke\n";
+    } */
+  }
+  //std::cerr << "Ending cleanup thread\n";
+}
+
+void WorkerMonitorThread::startThread() {
+  {
+    //Setup watchdog thread for crashing signals
+
+    int pipeEnds[2] = {0, 0};
+    auto ret = pipe(pipeEnds);
+    if (ret != 0) {
+      abort();
+    }
+    s_pipeReadEnd.store(pipeEnds[0]);
+    s_pipeWriteEnd.store(pipeEnds[1]);
+    //Need to use signal handler since signals generated
+    // from within a program are thread specific which can
+    // only be handed by a signal handler
+    setupSignalHandling();
+
+    std::thread t(&WorkerMonitorThread::run, this);
+    t.detach();
+    helperThread_ = std::move(t);
+  }
+  while (helperReady_.load() == false) {
+  }
+}
+
+void WorkerMonitorThread::setupSignalHandling() {
+  struct sigaction act;
+  act.sa_sigaction = sig_handler;
+  act.sa_flags = SA_SIGINFO;
+  sigemptyset(&act.sa_mask);
+  sigaction(SIGABRT, &act, nullptr);
+  sigaction(SIGILL, &act, nullptr);
+  sigaction(SIGBUS, &act, nullptr);
+  sigaction(SIGSEGV, &act, nullptr);
+  sigaction(SIGTERM, &act, nullptr);
+}
+
+void WorkerMonitorThread::stop() {
+  stopRequested_ = true;
+  int sig = 0;
+  write(s_pipeWriteEnd.load(), &sig, sizeof(int) / sizeof(char));
+}
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//
+void WorkerMonitorThread::sig_handler(int sig, siginfo_t*, void*) {
+  write(s_pipeWriteEnd.load(), &sig, sizeof(int) / sizeof(char));
+  while (not s_helperThreadDone) {
+  };
+  signal(sig, SIG_DFL);
+  raise(sig);
+}

--- a/FWCore/SharedMemory/src/WriteBuffer.cc
+++ b/FWCore/SharedMemory/src/WriteBuffer.cc
@@ -1,0 +1,63 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WriteBuffer
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+
+// user include files
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm::shared_memory;
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+
+WriteBuffer::~WriteBuffer() {
+  if (sm_) {
+    sm_->destroy<char>(buffer_names::kBuffer);
+    sm_.reset();
+    boost::interprocess::shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
+  }
+}
+//
+// member functions
+//
+void WriteBuffer::growBuffer(std::size_t iLength) {
+  int newBuffer = (*bufferIndex_ + 1) % 2;
+  if (sm_) {
+    sm_->destroy<char>(buffer_names::kBuffer);
+    sm_.reset();
+    boost::interprocess::shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
+  }
+  sm_ = std::make_unique<boost::interprocess::managed_shared_memory>(
+      boost::interprocess::open_or_create, bufferNames_[newBuffer].c_str(), iLength + 1024);
+  assert(sm_.get());
+  bufferSize_ = iLength;
+  *bufferIndex_ = newBuffer;
+  buffer_ = sm_->construct<char>(buffer_names::kBuffer)[iLength](0);
+  assert(buffer_);
+}
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//

--- a/FWCore/SharedMemory/src/WriteBuffer.cc
+++ b/FWCore/SharedMemory/src/WriteBuffer.cc
@@ -32,24 +32,25 @@ WriteBuffer::~WriteBuffer() {
   if (sm_) {
     sm_->destroy<char>(buffer_names::kBuffer);
     sm_.reset();
-    boost::interprocess::shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
+    boost::interprocess::shared_memory_object::remove(bufferNames_[bufferInfo_->index_].c_str());
   }
 }
 //
 // member functions
 //
 void WriteBuffer::growBuffer(std::size_t iLength) {
-  int newBuffer = (*bufferIndex_ + 1) % 2;
+  int newBuffer = (bufferInfo_->index_ + 1) % 2;
   if (sm_) {
     sm_->destroy<char>(buffer_names::kBuffer);
     sm_.reset();
-    boost::interprocess::shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
+    boost::interprocess::shared_memory_object::remove(bufferNames_[bufferInfo_->index_].c_str());
   }
   sm_ = std::make_unique<boost::interprocess::managed_shared_memory>(
       boost::interprocess::open_or_create, bufferNames_[newBuffer].c_str(), iLength + 1024);
   assert(sm_.get());
   bufferSize_ = iLength;
-  *bufferIndex_ = newBuffer;
+  bufferInfo_->index_ = newBuffer;
+  bufferInfo_->identifier_ = bufferInfo_->identifier_ + 1;
   buffer_ = sm_->construct<char>(buffer_names::kBuffer)[iLength](0);
   assert(buffer_);
 }

--- a/FWCore/SharedMemory/test/BuildFile.xml
+++ b/FWCore/SharedMemory/test/BuildFile.xml
@@ -1,0 +1,17 @@
+<bin file="test_catch2_*.cc" name="testFWCoreSharedMemoryCatch2">
+  <use name="catch2"/>
+  <use   name="FWCore/SharedMemory"/>
+<use   name="DataFormats/TestObjects"/>
+</bin>
+<bin file="test_channels.cc" name="testFWCoreSharedMemoryChannels">
+  <use name="FWCore/SharedMemory"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+
+<bin file="test_monitorthread.cc" name="testFWCoreSharedMemoryMonitorThread">
+  <use name="FWCore/SharedMemory"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+<test name="testFWCoreSharedMemoryMonitorThreadSignals" command="test_monitor_thread_signals.sh">
+  <flags   PRE_TEST="testFWCoreSharedMemoryMonitorThread"/>
+</test>

--- a/FWCore/SharedMemory/test/test_catch2_buffer.cc
+++ b/FWCore/SharedMemory/test/test_catch2_buffer.cc
@@ -1,0 +1,71 @@
+#include "catch.hpp"
+#include <stdio.h>
+#include <string>
+#include <algorithm>
+
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+
+using namespace edm::shared_memory;
+
+TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
+  char bufferIndex = 0;
+
+  std::string const uniqueName = "BufferTest" + std::to_string(getpid());
+
+  WriteBuffer writeBuffer(uniqueName, &bufferIndex);
+
+  ReadBuffer readBuffer(uniqueName, &bufferIndex);
+
+  SECTION("First") {
+    std::array<char, 4> dummy = {{'t', 'e', 's', 't'}};
+
+    writeBuffer.copyToBuffer(dummy.data(), dummy.size());
+
+    REQUIRE(readBuffer.mustGetBufferAgain());
+    {
+      auto b = readBuffer.buffer();
+      REQUIRE(b.second == dummy.size());
+      REQUIRE(std::equal(b.first, b.first + b.second, dummy.cbegin(), dummy.cend()));
+    }
+
+    SECTION("Smaller") {
+      dummy[0] = 'm';
+
+      writeBuffer.copyToBuffer(dummy.data(), dummy.size() - 1);
+
+      REQUIRE(not readBuffer.mustGetBufferAgain());
+      {
+        auto b = readBuffer.buffer();
+        //the second argument is the buffer capacity, not the last length sent
+        REQUIRE(b.second == dummy.size());
+        REQUIRE(std::equal(b.first, b.first + b.second - 1, dummy.cbegin(), dummy.cbegin() + dummy.size() - 1));
+      }
+
+      SECTION("Larger") {
+        std::array<char, 6> dummy = {{'l', 'a', 'r', 'g', 'e', 'r'}};
+        writeBuffer.copyToBuffer(dummy.data(), dummy.size());
+
+        REQUIRE(readBuffer.mustGetBufferAgain());
+        {
+          auto b = readBuffer.buffer();
+          REQUIRE(b.second == dummy.size());
+          REQUIRE(std::equal(b.first, b.first + b.second, dummy.cbegin(), dummy.cend()));
+        }
+
+        SECTION("Largest") {
+          //this should go back to buffer0
+          std::array<char, 7> dummy = {{'l', 'a', 'r', 'g', 'e', 's', 't'}};
+          writeBuffer.copyToBuffer(dummy.data(), dummy.size());
+
+          REQUIRE(readBuffer.mustGetBufferAgain());
+          {
+            auto b = readBuffer.buffer();
+            REQUIRE(b.second == dummy.size());
+            REQUIRE(std::equal(b.first, b.first + b.second, dummy.cbegin(), dummy.cend()));
+          }
+        }
+      }
+    }
+  }
+}

--- a/FWCore/SharedMemory/test/test_catch2_buffer.cc
+++ b/FWCore/SharedMemory/test/test_catch2_buffer.cc
@@ -9,20 +9,20 @@
 using namespace edm::shared_memory;
 
 TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
-  char bufferIndex = 0;
+  BufferInfo bufferInfo = {0, 0};
 
   std::string const uniqueName = "BufferTest" + std::to_string(getpid());
 
-  WriteBuffer writeBuffer(uniqueName, &bufferIndex);
+  WriteBuffer writeBuffer(uniqueName, &bufferInfo);
 
-  ReadBuffer readBuffer(uniqueName, &bufferIndex);
+  ReadBuffer readBuffer(uniqueName, &bufferInfo);
 
   SECTION("First") {
     std::array<char, 4> dummy = {{'t', 'e', 's', 't'}};
 
     writeBuffer.copyToBuffer(dummy.data(), dummy.size());
 
-    REQUIRE(readBuffer.mustGetBufferAgain());
+    REQUIRE(readBuffer.bufferIdentifier() == 1);
     {
       auto b = readBuffer.buffer();
       REQUIRE(b.second == dummy.size());
@@ -34,7 +34,7 @@ TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
 
       writeBuffer.copyToBuffer(dummy.data(), dummy.size() - 1);
 
-      REQUIRE(not readBuffer.mustGetBufferAgain());
+      REQUIRE(readBuffer.bufferIdentifier() == 1);
       {
         auto b = readBuffer.buffer();
         //the second argument is the buffer capacity, not the last length sent
@@ -46,7 +46,7 @@ TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
         std::array<char, 6> dummy = {{'l', 'a', 'r', 'g', 'e', 'r'}};
         writeBuffer.copyToBuffer(dummy.data(), dummy.size());
 
-        REQUIRE(readBuffer.mustGetBufferAgain());
+        REQUIRE(readBuffer.bufferIdentifier() == 2);
         {
           auto b = readBuffer.buffer();
           REQUIRE(b.second == dummy.size());
@@ -58,7 +58,7 @@ TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
           std::array<char, 7> dummy = {{'l', 'a', 'r', 'g', 'e', 's', 't'}};
           writeBuffer.copyToBuffer(dummy.data(), dummy.size());
 
-          REQUIRE(readBuffer.mustGetBufferAgain());
+          REQUIRE(readBuffer.bufferIdentifier() == 3);
           {
             auto b = readBuffer.buffer();
             REQUIRE(b.second == dummy.size());

--- a/FWCore/SharedMemory/test/test_catch2_main.cc
+++ b/FWCore/SharedMemory/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/FWCore/SharedMemory/test/test_catch2_serialize.cc
+++ b/FWCore/SharedMemory/test/test_catch2_serialize.cc
@@ -1,0 +1,129 @@
+#include "catch.hpp"
+#include <utility>
+#include <algorithm>
+#include <iterator>
+
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+
+#include "DataFormats/TestObjects/interface/Thing.h"
+
+namespace {
+  struct ReadWriteTestBuffer {
+    std::pair<char*, std::size_t> buffer() { return std::pair(&buffer_.front(), size()); }
+
+    bool mustGetBufferAgain() { return resized_; }
+
+    void copyToBuffer(char* iStart, std::size_t iLength) {
+      buffer_.clear();
+      if (iLength > buffer_.capacity()) {
+        buffer_.reserve(iLength);
+        resized_ = true;
+      } else {
+        resized_ = false;
+      }
+      std::copy(iStart, iStart + iLength, std::back_insert_iterator(buffer_));
+    }
+
+    std::size_t size() const { return buffer_.size(); }
+
+    std::vector<char> buffer_;
+    bool resized_ = true;
+  };
+
+  bool compare(std::vector<edmtest::Thing> const& iLHS, std::vector<edmtest::Thing> const& iRHS) {
+    if (iLHS.size() != iRHS.size()) {
+      return false;
+    }
+
+    for (size_t i = 0; i < iLHS.size(); ++i) {
+      if (iLHS[i].a != iRHS[i].a) {
+        return false;
+      }
+    }
+    return true;
+  }
+}  // namespace
+using namespace edm::shared_memory;
+TEST_CASE("test De/ROOTSerializer", "[ROOTSerializer]") {
+  SECTION("Process edmtest::Thing") {
+    ReadWriteTestBuffer buffer;
+
+    ROOTSerializer<edmtest::Thing, ReadWriteTestBuffer> serializer(buffer);
+    ROOTDeserializer<edmtest::Thing, ReadWriteTestBuffer> deserializer(buffer);
+
+    edmtest::Thing t;
+    t.a = 42;
+
+    serializer.serialize(t);
+    REQUIRE(buffer.mustGetBufferAgain() == true);
+
+    auto newT = deserializer.deserialize();
+
+    REQUIRE(t.a == newT.a);
+    SECTION("Reuse buffer") {
+      t.a = 12;
+      serializer.serialize(t);
+      REQUIRE(buffer.mustGetBufferAgain() == false);
+
+      auto newT = deserializer.deserialize();
+
+      REQUIRE(t.a == newT.a);
+    }
+  }
+
+  SECTION("Process std::vector<edmtest::Thing>") {
+    ReadWriteTestBuffer buffer;
+
+    ROOTSerializer<std::vector<edmtest::Thing>, ReadWriteTestBuffer> serializer(buffer);
+    ROOTDeserializer<std::vector<edmtest::Thing>, ReadWriteTestBuffer> deserializer(buffer);
+
+    std::vector<edmtest::Thing> t;
+    t.reserve(4);
+    for (int i = 0; i < 4; ++i) {
+      edmtest::Thing temp;
+      temp.a = i;
+      t.push_back(temp);
+    }
+
+    serializer.serialize(t);
+    REQUIRE(buffer.mustGetBufferAgain() == true);
+
+    auto newT = deserializer.deserialize();
+
+    REQUIRE(compare(t, newT));
+    SECTION("Reuse edtest::Thing buffer") {
+      for (auto& v : t) {
+        v.a += 1;
+      }
+      serializer.serialize(t);
+      REQUIRE(buffer.mustGetBufferAgain() == false);
+
+      auto newT = deserializer.deserialize();
+
+      REQUIRE(compare(t, newT));
+    }
+
+    SECTION("Grow") {
+      t.emplace_back();
+      serializer.serialize(t);
+      REQUIRE(buffer.mustGetBufferAgain() == true);
+
+      auto newT = deserializer.deserialize();
+
+      REQUIRE(compare(t, newT));
+    }
+
+    SECTION("Shrink") {
+      t.pop_back();
+      t.pop_back();
+
+      serializer.serialize(t);
+      REQUIRE(buffer.mustGetBufferAgain() == false);
+
+      auto newT = deserializer.deserialize();
+
+      REQUIRE(compare(t, newT));
+    }
+  }
+}

--- a/FWCore/SharedMemory/test/test_channels.cc
+++ b/FWCore/SharedMemory/test/test_channels.cc
@@ -1,0 +1,186 @@
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <cassert>
+namespace {
+  int controller(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    ControllerChannel channel("TestChannel", 0);
+
+    //Pipe has to close AFTER we tell the worker to stop
+    auto closePipe = [](FILE* iFile) { pclose(iFile); };
+    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
+
+    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
+    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
+
+    {
+      std::string command(argv[0]);
+      command += " ";
+      command += channel.sharedMemoryName();
+      command += " ";
+      command += channel.uniqueID();
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel.setupWorker([&]() {
+        pipe.reset(popen(command.c_str(), "w"));
+
+        if (not pipe) {
+          throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
+        }
+      });
+    }
+    {
+      *channel.toWorkerBufferIndex() = 0;
+      auto result = channel.doTransition(
+          [&]() {
+            if (*channel.fromWorkerBufferIndex() != 1) {
+              throw cms::Exception("BadValue")
+                  << "wrong value of fromWorkerBufferIndex " << *channel.fromWorkerBufferIndex();
+            }
+            if (not channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told not to keep event";
+            }
+          },
+          edm::Transition::Event,
+          2);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+    {
+      *channel.toWorkerBufferIndex() = 1;
+      auto result = channel.doTransition(
+          [&]() {
+            if (*channel.fromWorkerBufferIndex() != 0) {
+              throw cms::Exception("BadValue")
+                  << "wrong value of fromWorkerBufferIndex " << *channel.fromWorkerBufferIndex();
+            }
+            if (channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told to keep event";
+            }
+          },
+          edm::Transition::Event,
+          3);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    {
+      auto result = channel.doTransition([&]() {}, edm::Transition::EndLuminosityBlock, 1);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    //std::cout <<"controller going to stop"<<std::endl;
+    return 0;
+  }
+
+  int worker(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    assert(argc == 3);
+    WorkerChannel channel(argv[1], argv[2]);
+
+    //std::cerr<<"worker setup\n";
+    channel.workerSetupDone();
+
+    int transitionCount = 0;
+    channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+      switch (transitionCount) {
+        case 0: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 2ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (*channel.toWorkerBufferIndex() != 0) {
+            throw cms::Exception("BadValue") << "wrong toWorkerBufferIndex received " << *channel.toWorkerBufferIndex();
+          }
+          *channel.fromWorkerBufferIndex() = 1;
+          channel.shouldKeepEvent(true);
+          break;
+        }
+
+        case 1: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 3ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (*channel.toWorkerBufferIndex() != 1) {
+            throw cms::Exception("BadValue") << "wrong toWorkerBufferIndex received " << *channel.toWorkerBufferIndex();
+          }
+          *channel.fromWorkerBufferIndex() = 0;
+          channel.shouldKeepEvent(false);
+          break;
+        }
+
+        case 2: {
+          if (iTransition != edm::Transition::EndLuminosityBlock) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 1ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+          break;
+        }
+        default: {
+          throw cms::Exception("MissingStop") << "stopRequested not set";
+        }
+      }
+      ++transitionCount;
+    });
+    if (transitionCount != 3) {
+      throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
+    }
+    return 0;
+  }
+  const char* jobType(bool isWorker) {
+    if (isWorker) {
+      return "Worker";
+    }
+    return "Controller";
+  }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  bool isWorker = true;
+  int retValue = 0;
+  try {
+    if (argc > 1) {
+      retValue = worker(argc, argv);
+    } else {
+      isWorker = false;
+      retValue = controller(argc, argv);
+    }
+  } catch (std::exception const& iException) {
+    std::cerr << "Caught exception\n" << iException.what() << "\n";
+    if (isWorker) {
+      std::cerr << "in worker\n";
+    } else {
+      std::cerr << "in controller\n";
+    }
+    return 1;
+  }
+  if (0 == retValue) {
+    std::cout << jobType(isWorker) << " success" << std::endl;
+  } else {
+    std::cout << jobType(isWorker) << " failed" << std::endl;
+  }
+  return 0;
+}

--- a/FWCore/SharedMemory/test/test_channels.cc
+++ b/FWCore/SharedMemory/test/test_channels.cc
@@ -38,12 +38,16 @@ namespace {
       });
     }
     {
-      *channel.toWorkerBufferIndex() = 0;
+      *channel.toWorkerBufferInfo() = {0, 0};
       auto result = channel.doTransition(
           [&]() {
-            if (*channel.fromWorkerBufferIndex() != 1) {
+            if (channel.fromWorkerBufferInfo()->index_ != 1) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
               throw cms::Exception("BadValue")
-                  << "wrong value of fromWorkerBufferIndex " << *channel.fromWorkerBufferIndex();
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
             }
             if (not channel.shouldKeepEvent()) {
               throw cms::Exception("BadValue") << "told not to keep event";
@@ -56,12 +60,16 @@ namespace {
       }
     }
     {
-      *channel.toWorkerBufferIndex() = 1;
+      *channel.toWorkerBufferInfo() = {1, 1};
       auto result = channel.doTransition(
           [&]() {
-            if (*channel.fromWorkerBufferIndex() != 0) {
+            if (channel.fromWorkerBufferInfo()->index_ != 0) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
               throw cms::Exception("BadValue")
-                  << "wrong value of fromWorkerBufferIndex " << *channel.fromWorkerBufferIndex();
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
             }
             if (channel.shouldKeepEvent()) {
               throw cms::Exception("BadValue") << "told to keep event";
@@ -105,10 +113,15 @@ namespace {
             throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
           }
 
-          if (*channel.toWorkerBufferIndex() != 0) {
-            throw cms::Exception("BadValue") << "wrong toWorkerBufferIndex received " << *channel.toWorkerBufferIndex();
+          if (channel.toWorkerBufferInfo()->index_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
           }
-          *channel.fromWorkerBufferIndex() = 1;
+          if (channel.toWorkerBufferInfo()->identifier_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {1, 1};
           channel.shouldKeepEvent(true);
           break;
         }
@@ -121,10 +134,15 @@ namespace {
             throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
           }
 
-          if (*channel.toWorkerBufferIndex() != 1) {
-            throw cms::Exception("BadValue") << "wrong toWorkerBufferIndex received " << *channel.toWorkerBufferIndex();
+          if (channel.toWorkerBufferInfo()->index_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
           }
-          *channel.fromWorkerBufferIndex() = 0;
+          if (channel.toWorkerBufferInfo()->identifier_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {2, 0};
           channel.shouldKeepEvent(false);
           break;
         }

--- a/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
+++ b/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+dir=${PWD}
+cd ${LOCALTOP}
+
+#need to find a test program which we do not put on the PATH
+${CMSSW_BASE}/test/${SCRAM_ARCH}/testFWCoreSharedMemoryMonitorThread 6 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
+
+retValue=$?
+if [ "$retValue" != "134" ]; then
+  echo "Wrong return value " $retValue
+  exit $retValue
+else
+  grep -q 'Action run' testFWCoreSharedMemoryMonitorThread.log || die 'Action not run' $?
+  grep -q 'Worker: SIGNAL CAUGHT 6' testFWCoreSharedMemoryMonitorThread.log || die 'Signal not reported' $?
+fi
+
+
+${CMSSW_BASE}/test/${SCRAM_ARCH}/testFWCoreSharedMemoryMonitorThread 11 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
+
+retValue=$?
+if [ "$retValue" != "139" ]; then
+  echo "Wrong return value " $retValue
+  exit $retValue
+else
+  grep -q 'Action run' testFWCoreSharedMemoryMonitorThread.log || die 'Action not run' $?
+  grep -q 'Worker: SIGNAL CAUGHT 11' testFWCoreSharedMemoryMonitorThread.log || die 'Signal not reported' $?
+fi
+

--- a/FWCore/SharedMemory/test/test_monitorthread.cc
+++ b/FWCore/SharedMemory/test/test_monitorthread.cc
@@ -1,0 +1,19 @@
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+#include <iostream>
+#include <unistd.h>
+#include <cstdlib>
+#include <cstring>
+
+int main(int argc, char** argv) {
+  edm::shared_memory::WorkerMonitorThread monitor;
+
+  monitor.startThread();
+
+  monitor.setAction([&]() { std::cerr << "Action run\n"; });
+  if (argc > 1) {
+    char* end;
+    int sig = std::strtol(argv[1], &end, 10);
+    raise(sig);
+  }
+  return 0;
+}

--- a/FWCore/TestProcessor/Readme.md
+++ b/FWCore/TestProcessor/Readme.md
@@ -111,6 +111,20 @@ The return value of `test()` is an `edm::test::Event`. The `Event` class gives a
   
 The `edm::test::Event` also has the method `modulePassed()` which is only useful when testing an `EDFilter`. In that case, the method returns `true` if the module passed the Event and `false` otherwise.
 
+### Run and LuminosityBlock product testing
+It is possible to also test Run and LuminosityBlock products created by the module. This can be accomplished by calling
+* `testBeginRun(edm::RunNumber_t)`
+* `testEndRun()`
+* `testBeginLuminosityBlock(edm::LuminosityBlockNumber_t)`
+* `testEndLuminosityBlock()`
+
+Like `test()` one can pass an unlimited number of arguments of type  `std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>` in order to control EventSetup data passed to the module (`EDPutToken` are not supported at this time). Each of the above `test` functions also return either `edm::test::Run` or `edm::test::LuminosityBlock` which has the same interface as `edm::test::Event` except they do not have the method `modulePassed()` because filtering does not occur on those transitions. 
+
+The `test` methods all make sure all the needed transitions occur in the necessary order. For example, calling `test()` and then `testEndRun()` will cause _streamEndLuminosityBlock_ and _globalEndLuminosityBlock_ to occur.
+
+When calling `testBeginRun(edm:RunNumber_t)` or `testBeginLuminosityBlock(edm::LuminosityBlockNumber_t)` one is required to pass in a Run or LuminosityBlock number which is different from the number previously used by any earlier calls to a `test` function. 
+
+
 ### Full Example 
 
 ```cpp

--- a/FWCore/TestProcessor/interface/LuminosityBlock.h
+++ b/FWCore/TestProcessor/interface/LuminosityBlock.h
@@ -1,0 +1,73 @@
+#ifndef FWCore_TestProcessor_LuminosityBlock_h
+#define FWCore_TestProcessor_LuminosityBlock_h
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     LuminosityBlock
+//
+/**\class LuminosityBlock LuminosityBlock.h "LuminosityBlock.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 30 Apr 2018 18:51:27 GMT
+//
+
+// system include files
+#include <string>
+
+// user include files
+#include "FWCore/TestProcessor/interface/TestHandle.h"
+#include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+// forward declarations
+
+namespace edm {
+
+  namespace test {
+
+    class LuminosityBlock {
+    public:
+      LuminosityBlock(std::shared_ptr<LuminosityBlockPrincipal const> iPrincipal,
+                      std::string iModuleLabel,
+                      std::string iProcessName);
+
+      // ---------- const member functions ---------------------
+      template <typename T>
+      TestHandle<T> get() const {
+        static const std::string s_null;
+        return get<T>(s_null);
+      }
+
+      template <typename T>
+      TestHandle<T> get(std::string const& iInstanceLabel) const {
+        auto h = principal_->getByLabel(
+            edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), label_, iInstanceLabel, processName_, nullptr, nullptr, nullptr);
+        if (h.failedToGet()) {
+          return TestHandle<T>(std::move(h.whyFailedFactory()));
+        }
+        void const* basicWrapper = h.wrapper();
+        assert(basicWrapper);
+        Wrapper<T> const* wrapper = static_cast<Wrapper<T> const*>(basicWrapper);
+        return TestHandle<T>(wrapper->product());
+      }
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+
+    private:
+      // ---------- member data --------------------------------
+      std::shared_ptr<LuminosityBlockPrincipal const> principal_;
+      std::string label_;
+      std::string processName_;
+    };
+  }  // namespace test
+}  // namespace edm
+
+#endif

--- a/FWCore/TestProcessor/interface/Run.h
+++ b/FWCore/TestProcessor/interface/Run.h
@@ -1,0 +1,72 @@
+#ifndef FWCore_TestProcessor_Run_h
+#define FWCore_TestProcessor_Run_h
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     Run
+//
+/**\class Run Run.h "Run.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 30 Apr 2018 18:51:27 GMT
+//
+
+// system include files
+#include <string>
+
+// user include files
+#include "FWCore/TestProcessor/interface/TestHandle.h"
+#include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+// forward declarations
+
+namespace edm {
+
+  namespace test {
+
+    class Run {
+    public:
+      Run(std::shared_ptr<RunPrincipal const> iPrincipal, std::string iModuleLabel, std::string iProcessName);
+
+      // ---------- const member functions ---------------------
+      template <typename T>
+      TestHandle<T> get() const {
+        static const std::string s_null;
+        return get<T>(s_null);
+      }
+
+      template <typename T>
+      TestHandle<T> get(std::string const& iInstanceLabel) const {
+        auto h = principal_->getByLabel(
+            edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), label_, iInstanceLabel, processName_, nullptr, nullptr, nullptr);
+        if (h.failedToGet()) {
+          return TestHandle<T>(std::move(h.whyFailedFactory()));
+        }
+        void const* basicWrapper = h.wrapper();
+        assert(basicWrapper);
+        Wrapper<T> const* wrapper = static_cast<Wrapper<T> const*>(basicWrapper);
+        return TestHandle<T>(wrapper->product());
+      }
+
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+
+    private:
+      // ---------- member data --------------------------------
+      std::shared_ptr<RunPrincipal const> principal_;
+      std::string label_;
+      std::string processName_;
+    };
+  }  // namespace test
+}  // namespace edm
+
+#endif

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -155,7 +155,7 @@ namespace edm {
     public:
       using Config = TestProcessorConfig;
 
-      TestProcessor(Config const& iConfig);
+      TestProcessor(Config const& iConfig, ServiceToken iToken = ServiceToken());
       ~TestProcessor() noexcept(false);
 
       /** Run the test. The function arguments are the data products to be added to the

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -42,6 +42,8 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 
 #include "FWCore/TestProcessor/interface/Event.h"
+#include "FWCore/TestProcessor/interface/LuminosityBlock.h"
+#include "FWCore/TestProcessor/interface/Run.h"
 #include "FWCore/TestProcessor/interface/TestDataProxy.h"
 #include "FWCore/TestProcessor/interface/ESPutTokenT.h"
 #include "FWCore/TestProcessor/interface/ESProduceEntry.h"
@@ -164,6 +166,24 @@ namespace edm {
         return testImpl(std::forward<T>(iArgs)...);
       }
 
+      template <typename... T>
+      edm::test::LuminosityBlock testBeginLuminosityBlock(edm::LuminosityBlockNumber_t iNum, T&&... iArgs) {
+        return testBeginLuminosityBlockImpl(iNum, std::forward<T>(iArgs)...);
+      }
+      template <typename... T>
+      edm::test::LuminosityBlock testEndLuminosityBlock(T&&... iArgs) {
+        return testEndLuminosityBlockImpl(std::forward<T>(iArgs)...);
+      }
+
+      template <typename... T>
+      edm::test::Run testBeginRun(edm::RunNumber_t iNum, T&&... iArgs) {
+        return testBeginRunImpl(iNum, std::forward<T>(iArgs)...);
+      }
+      template <typename... T>
+      edm::test::Run testEndRun(T&&... iArgs) {
+        return testEndRunImpl(std::forward<T>(iArgs)...);
+      }
+
       /** Run only beginJob and endJob. Once this is used, you should not attempt to run any further tests.
 This simulates a problem happening early in the job which causes processing not to proceed.
    */
@@ -224,6 +244,40 @@ This simulates a problem happening early in the job which causes processing not 
 
       edm::test::Event testImpl();
 
+      template <typename T, typename... U>
+      edm::test::LuminosityBlock testBeginLuminosityBlockImpl(
+          edm::LuminosityBlockNumber_t iNum,
+          std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>>&& iPut,
+          U&&... iArgs) {
+        put(std::move(iPut));
+        return testBeginLuminosityBlockImpl(iNum, std::forward<U>(iArgs)...);
+      }
+      edm::test::LuminosityBlock testBeginLuminosityBlockImpl(edm::LuminosityBlockNumber_t);
+
+      template <typename T, typename... U>
+      edm::test::LuminosityBlock testEndLuminosityBlockImpl(
+          std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>>&& iPut, U&&... iArgs) {
+        put(std::move(iPut));
+        return testEndLuminosityBlockImpl(std::forward<U>(iArgs)...);
+      }
+      edm::test::LuminosityBlock testEndLuminosityBlockImpl();
+
+      template <typename T, typename... U>
+      edm::test::Run testBeginRunImpl(edm::RunNumber_t iNum,
+                                      std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>>&& iPut,
+                                      U&&... iArgs) {
+        put(std::move(iPut));
+        return testBeginRunImpl(iNum, std::forward<U>(iArgs)...);
+      }
+      edm::test::Run testBeginRunImpl(edm::RunNumber_t);
+      template <typename T, typename... U>
+      edm::test::LuminosityBlock testEndRunImpl(std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>>&& iPut,
+                                                U&&... iArgs) {
+        put(std::move(iPut));
+        return testEndRunImpl(std::forward<U>(iArgs)...);
+      }
+      edm::test::Run testEndRunImpl();
+
       void setupProcessing();
       void teardownProcessing();
 
@@ -231,8 +285,8 @@ This simulates a problem happening early in the job which causes processing not 
       void beginRun();
       void beginLuminosityBlock();
       void event();
-      void endLuminosityBlock();
-      void endRun();
+      std::shared_ptr<LuminosityBlockPrincipal> endLuminosityBlock();
+      std::shared_ptr<RunPrincipal> endRun();
       void endJob();
 
       // ---------- member data --------------------------------
@@ -268,8 +322,6 @@ This simulates a problem happening early in the job which causes processing not 
       bool beginJobCalled_ = false;
       bool beginRunCalled_ = false;
       bool beginLumiCalled_ = false;
-      bool newRun_ = true;
-      bool newLumi_ = true;
     };
   }  // namespace test
 }  // namespace edm

--- a/FWCore/TestProcessor/src/LuminosityBlock.cc
+++ b/FWCore/TestProcessor/src/LuminosityBlock.cc
@@ -1,0 +1,50 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     LuminosityBlock
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 30 Apr 2018 18:51:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/TestProcessor/interface/LuminosityBlock.h"
+
+namespace edm {
+  namespace test {
+
+    //
+    // constants, enums and typedefs
+    //
+
+    //
+    // static data member definitions
+    //
+
+    //
+    // constructors and destructor
+    //
+    LuminosityBlock::LuminosityBlock(std::shared_ptr<LuminosityBlockPrincipal const> iPrincipal,
+                                     std::string iModuleLabel,
+                                     std::string iProcessName)
+        : principal_{std::move(iPrincipal)}, label_{std::move(iModuleLabel)}, processName_{std::move(iProcessName)} {}
+
+    //
+    // member functions
+    //
+
+    //
+    // const member functions
+    //
+
+    //
+    // static member functions
+    //
+
+  }  // namespace test
+}  // namespace edm

--- a/FWCore/TestProcessor/src/Run.cc
+++ b/FWCore/TestProcessor/src/Run.cc
@@ -1,0 +1,48 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     Run
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 30 Apr 2018 18:51:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/TestProcessor/interface/Run.h"
+
+namespace edm {
+  namespace test {
+
+    //
+    // constants, enums and typedefs
+    //
+
+    //
+    // static data member definitions
+    //
+
+    //
+    // constructors and destructor
+    //
+    Run::Run(std::shared_ptr<RunPrincipal const> iPrincipal, std::string iModuleLabel, std::string iProcessName)
+        : principal_{std::move(iPrincipal)}, label_{std::move(iModuleLabel)}, processName_{std::move(iProcessName)} {}
+
+    //
+    // member functions
+    //
+
+    //
+    // const member functions
+    //
+
+    //
+    // static member functions
+    //
+
+  }  // namespace test
+}  // namespace edm

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -81,7 +81,7 @@ namespace edm {
     //
     // constructors and destructor
     //
-    TestProcessor::TestProcessor(Config const& iConfig)
+    TestProcessor::TestProcessor(Config const& iConfig, ServiceToken iToken)
         : espController_(std::make_unique<eventsetup::EventSetupsController>()),
           historyAppender_(std::make_unique<HistoryAppender>()),
           moduleRegistry_(std::make_shared<ModuleRegistry>()) {
@@ -102,8 +102,7 @@ namespace edm {
 
       //initialize the services
       auto& serviceSets = procDesc->getServicesPSets();
-      ServiceToken token =
-          items.initServices(serviceSets, *psetPtr, ServiceToken(), serviceregistry::kOverlapIsError, true);
+      ServiceToken token = items.initServices(serviceSets, *psetPtr, iToken, serviceregistry::kOverlapIsError, true);
       serviceToken_ = items.addCPRandTNS(*psetPtr, token);
 
       //make the services available

--- a/FWCore/Utilities/interface/RandomNumberGenerator.h
+++ b/FWCore/Utilities/interface/RandomNumberGenerator.h
@@ -193,6 +193,9 @@ namespace edm {
     virtual void preBeginLumi(LuminosityBlock const& lumi) = 0;
     virtual void postEventRead(Event const& event) = 0;
 
+    virtual void setLumiCache(LuminosityBlockIndex, std::vector<RandomEngineState> const& iStates) = 0;
+    virtual void setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) = 0;
+
     virtual std::vector<RandomEngineState> const& getEventCache(StreamID const&) const = 0;
     virtual std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const = 0;
 

--- a/GeneratorInterface/Core/bin/BuildFile.xml
+++ b/GeneratorInterface/Core/bin/BuildFile.xml
@@ -1,0 +1,9 @@
+<bin   name="cmsExternalGenerator" file="externalGenerator.cc">
+  <use   name="boost"/>
+  <use   name="boost_program_options"/>
+  <use   name="FWCore/TestProcessor"/>
+  <use   name="FWCore/SharedMemory"/>
+  <use   name="FWCore/Services"/>
+  <use   name="FWCore/Utilities"/>
+  <use   name="SimDataFormats/GeneratorProducts"/>
+</bin>

--- a/GeneratorInterface/Core/plugins/BuildFile.xml
+++ b/GeneratorInterface/Core/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="GeneratorInterface/Core"/>
+<use   name="FWCore/SharedMemory"/>
 
 <library   name="GeneratorInterfaceCore_plugins" file="*.cc" >
   <flags   EDM_PLUGIN="1"/>

--- a/GeneratorInterface/Core/plugins/CompareGeneratorResultsAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/CompareGeneratorResultsAnalyzer.cc
@@ -1,0 +1,361 @@
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
+#include <sstream>
+#include <iostream>
+
+namespace cgra {
+  struct DummyCache {};
+};  // namespace cgra
+
+class CompareGeneratorResultsAnalyzer
+    : public edm::global::EDAnalyzer<edm::RunCache<cgra::DummyCache>, edm::LuminosityBlockCache<cgra::DummyCache>> {
+public:
+  CompareGeneratorResultsAnalyzer(edm::ParameterSet const&);
+
+  std::shared_ptr<cgra::DummyCache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override;
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const override;
+
+  std::shared_ptr<cgra::DummyCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                               edm::EventSetup const&) const override;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+
+  void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+
+private:
+  std::string mod1_;
+  std::string mod2_;
+
+  edm::EDGetTokenT<GenEventInfoProduct> evToken1_;
+  edm::EDGetTokenT<GenEventInfoProduct> evToken2_;
+
+  edm::EDGetTokenT<edm::HepMCProduct> hepMCToken1_;
+  edm::EDGetTokenT<edm::HepMCProduct> hepMCToken2_;
+
+  edm::EDGetTokenT<GenLumiInfoHeader> lumiHeaderToken1_;
+  edm::EDGetTokenT<GenLumiInfoHeader> lumiHeaderToken2_;
+
+  edm::EDGetTokenT<GenLumiInfoProduct> lumiProductToken1_;
+  edm::EDGetTokenT<GenLumiInfoProduct> lumiProductToken2_;
+
+  edm::EDGetTokenT<GenRunInfoProduct> runProductToken1_;
+  edm::EDGetTokenT<GenRunInfoProduct> runProductToken2_;
+
+  bool allowXSecDifferences_;
+};
+
+CompareGeneratorResultsAnalyzer::CompareGeneratorResultsAnalyzer(edm::ParameterSet const& iPSet)
+    : mod1_{iPSet.getUntrackedParameter<std::string>("module1")},
+      mod2_{iPSet.getUntrackedParameter<std::string>("module2")},
+      evToken1_{consumes<GenEventInfoProduct>(mod1_)},
+      evToken2_{consumes<GenEventInfoProduct>(mod2_)},
+      hepMCToken1_{consumes<edm::HepMCProduct>(edm::InputTag(mod1_, "unsmeared"))},
+      hepMCToken2_{consumes<edm::HepMCProduct>(edm::InputTag(mod2_, "unsmeared"))},
+      lumiHeaderToken1_{consumes<GenLumiInfoHeader, edm::InLumi>(mod1_)},
+      lumiHeaderToken2_{consumes<GenLumiInfoHeader, edm::InLumi>(mod2_)},
+      lumiProductToken1_{consumes<GenLumiInfoProduct, edm::InLumi>(mod1_)},
+      lumiProductToken2_{consumes<GenLumiInfoProduct, edm::InLumi>(mod2_)},
+      runProductToken1_{consumes<GenRunInfoProduct, edm::InRun>(mod1_)},
+      runProductToken2_{consumes<GenRunInfoProduct, edm::InRun>(mod2_)},
+      allowXSecDifferences_{iPSet.getUntrackedParameter<bool>("allowXSecDifferences", false)} {}
+
+std::shared_ptr<cgra::DummyCache> CompareGeneratorResultsAnalyzer::globalBeginRun(edm::Run const&,
+                                                                                  edm::EventSetup const&) const {
+  return std::shared_ptr<cgra::DummyCache>();
+}
+
+void CompareGeneratorResultsAnalyzer::globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const {
+  auto const& prod1 = iRun.get(runProductToken1_);
+  auto const& prod2 = iRun.get(runProductToken2_);
+
+  if (not prod1.isProductEqual(prod2)) {
+    throw cms::Exception("ComparisonFailure") << "The GenRunInfoProducts are different";
+  }
+}
+
+std::shared_ptr<cgra::DummyCache> CompareGeneratorResultsAnalyzer::globalBeginLuminosityBlock(
+    edm::LuminosityBlock const& iLumi, edm::EventSetup const&) const {
+  auto const& prod1 = iLumi.get(lumiHeaderToken1_);
+  auto const& prod2 = iLumi.get(lumiHeaderToken2_);
+
+  if (prod1.randomConfigIndex() != prod2.randomConfigIndex()) {
+    throw cms::Exception("ComparisonFailure") << "The GenLumiInfoHeaders have different randomConfigIndex "
+                                              << prod1.randomConfigIndex() << " " << prod2.randomConfigIndex();
+  }
+
+  if (prod1.configDescription() != prod2.configDescription()) {
+    throw cms::Exception("ComparisonFailure") << "The GenLumiInfoHeaders have different configDescription "
+                                              << prod1.configDescription() << " " << prod2.configDescription();
+  }
+
+  if (prod1.lheHeaders().size() != prod2.lheHeaders().size()) {
+    throw cms::Exception("ComparisonFailure") << "The GenLumiInfoHeaders have different lheHeaders "
+                                              << prod1.lheHeaders().size() << " " << prod2.lheHeaders().size();
+  }
+
+  if (prod1.weightNames().size() != prod2.weightNames().size()) {
+    throw cms::Exception("ComparisonFailure") << "The GenLumiInfoHeaders have different weightNames "
+                                              << prod1.weightNames().size() << " " << prod2.weightNames().size();
+  }
+
+  return std::shared_ptr<cgra::DummyCache>();
+}
+
+namespace {
+  void compare(size_t iIndex,
+               GenLumiInfoProduct::ProcessInfo const& p1,
+               GenLumiInfoProduct::ProcessInfo const& p2,
+               bool allowXSecDifferences) {
+    if (p1.process() != p2.process()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] process " << p1.process() << " " << p2.process();
+    }
+
+    if (p1.nPassPos() != p2.nPassPos()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] nPassPos " << p1.nPassPos() << " " << p2.nPassPos();
+    }
+
+    if (p1.nPassNeg() != p2.nPassNeg()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] nPassNeg " << p1.nPassNeg() << " " << p2.nPassNeg();
+    }
+
+    if (p1.nTotalPos() != p2.nTotalPos()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] nTotalPos " << p1.nTotalPos() << " " << p2.nTotalPos();
+    }
+
+    if (p1.nTotalNeg() != p2.nTotalNeg()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] nTotalNeg " << p1.nTotalNeg() << " " << p2.nTotalNeg();
+    }
+
+    if (p1.lheXSec().error() != p2.lheXSec().error()) {
+      if (allowXSecDifferences) {
+        edm::LogWarning("ComparisonFailure")
+            << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] lheXSec.error "
+            << p1.lheXSec().error() << " " << p2.lheXSec().error();
+      } else {
+        throw cms::Exception("ComparisonFailure")
+            << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] lheXSec.error "
+            << p1.lheXSec().error() << " " << p2.lheXSec().error();
+      }
+    }
+
+    if (p1.lheXSec().value() != p2.lheXSec().value()) {
+      if (allowXSecDifferences) {
+        //throw cms::Exception("ComparisonFailure")
+        edm::LogWarning("ComparisonFailure")
+            << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] lheXSec.value "
+            << p1.lheXSec().value() << " " << p2.lheXSec().value();
+      } else {
+        throw cms::Exception("ComparisonFailure")
+            << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] lheXSec.value "
+            << p1.lheXSec().value() << " " << p2.lheXSec().value();
+      }
+    }
+
+    if (p1.tried().n() != p2.tried().n()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] tried.n " << p1.tried().n() << " " << p2.tried().n();
+    }
+
+    if (p1.tried().sum() != p2.tried().sum()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] tried.sum " << p1.tried().sum() << " " << p2.tried().sum();
+    }
+
+    if (p1.tried().sum2() != p2.tried().sum2()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] tried.sum2 " << p1.tried().sum2() << " " << p2.tried().sum2();
+    }
+
+    if (p1.selected().n() != p2.selected().n()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] selected.n " << p1.selected().n() << " " << p2.selected().n();
+    }
+
+    if (p1.selected().sum() != p2.selected().sum()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] selected.sum "
+          << p1.selected().sum() << " " << p2.selected().sum();
+    }
+
+    if (p1.selected().sum2() != p2.selected().sum2()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] selected.sum2 "
+          << p1.selected().sum2() << " " << p2.selected().sum2();
+    }
+
+    if (p1.killed().n() != p2.killed().n()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] killed.n " << p1.killed().n() << " " << p2.killed().n();
+    }
+
+    if (p1.killed().sum() != p2.killed().sum()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] killed sum " << p1.killed().sum() << " " << p2.killed().sum();
+    }
+
+    if (p1.killed().sum2() != p2.killed().sum2()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] killed.sum2 " << p1.killed().sum2() << " " << p2.killed().sum2();
+    }
+
+    if (p1.accepted().n() != p2.accepted().n()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex
+                                                << "] accepted.n " << p1.accepted().n() << " " << p2.accepted().n();
+    }
+
+    if (p1.accepted().sum() != p2.accepted().sum()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] accepted.sum "
+          << p1.accepted().sum() << " " << p2.accepted().sum();
+    }
+
+    if (p1.accepted().sum2() != p2.accepted().sum2()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] accepted.sum2 "
+          << p1.accepted().sum2() << " " << p2.accepted().sum2();
+    }
+
+    if (p1.acceptedBr().n() != p2.acceptedBr().n()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] acceptedBr.n "
+          << p1.acceptedBr().n() << " " << p2.acceptedBr().n();
+    }
+
+    if (p1.acceptedBr().sum() != p2.acceptedBr().sum()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] acceptedZBr.sum "
+          << p1.acceptedBr().sum() << " " << p2.acceptedBr().sum();
+    }
+
+    if (p1.acceptedBr().sum2() != p2.acceptedBr().sum2()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoProducts have different getProcessInfos()[" << iIndex << "] acceptedBr.sum2 "
+          << p1.acceptedBr().sum2() << " " << p2.acceptedBr().sum2();
+    }
+  }
+}  // namespace
+
+void CompareGeneratorResultsAnalyzer::globalEndLuminosityBlock(edm::LuminosityBlock const& iLumi,
+                                                               edm::EventSetup const&) const {
+  auto const& prod1 = iLumi.get(lumiProductToken1_);
+  auto const& prod2 = iLumi.get(lumiProductToken2_);
+
+  if (not prod1.isProductEqual(prod2)) {
+    if (prod1.getHEPIDWTUP() != prod1.getHEPIDWTUP()) {
+      throw cms::Exception("ComparisonFailure") << "The GenLumiInfoProducts have different getHEPIDWTUP "
+                                                << prod1.getHEPIDWTUP() << " " << prod2.getHEPIDWTUP();
+    }
+
+    if (prod1.getProcessInfos().size() != prod2.getProcessInfos().size()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenLumiInfoHeaders have different getProcessInfos " << prod1.getProcessInfos().size() << " "
+          << prod2.getProcessInfos().size();
+    }
+
+    for (size_t i = 0; i < prod1.getProcessInfos().size(); ++i) {
+      compare(i, prod1.getProcessInfos()[i], prod2.getProcessInfos()[i], allowXSecDifferences_);
+    }
+
+    if (not allowXSecDifferences_) {
+      throw cms::Exception("ComparisionFailure") << "The GenLumiInfoProducts are different";
+    }
+  }
+}
+
+namespace {
+  void compare(GenEventInfoProduct const& prod1, GenEventInfoProduct const& prod2) {
+    if (prod1.weights().size() != prod2.weights().size()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different weights "
+                                                << prod1.weights().size() << " " << prod2.weights().size();
+    }
+
+    if (prod1.binningValues().size() != prod2.binningValues().size()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different binningValues "
+                                                << prod1.binningValues().size() << " " << prod2.binningValues().size();
+    }
+
+    if (prod1.DJRValues().size() != prod2.DJRValues().size()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different DJRValues "
+                                                << prod1.DJRValues().size() << " " << prod2.DJRValues().size();
+    }
+
+    if (prod1.signalProcessID() != prod2.signalProcessID()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different signalProcessID "
+                                                << prod1.signalProcessID() << " " << prod2.signalProcessID();
+    }
+
+    if (prod1.qScale() != prod2.qScale()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenEventInfoProducts have different qScale " << prod1.qScale() << " " << prod2.qScale();
+    }
+
+    if (prod1.alphaQCD() != prod2.alphaQCD()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenEventInfoProducts have different alphaQCD " << prod1.alphaQCD() << " " << prod2.alphaQCD();
+    }
+
+    if (prod1.alphaQED() != prod2.alphaQED()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenEventInfoProducts have different alphaQED " << prod1.alphaQED() << " " << prod2.alphaQED();
+    }
+
+    if (prod1.nMEPartons() != prod2.nMEPartons()) {
+      throw cms::Exception("ComparisonFailure")
+          << "The GenEventInfoProducts have different nMEPartons " << prod1.nMEPartons() << " " << prod2.nMEPartons();
+    }
+
+    if (prod1.nMEPartonsFiltered() != prod2.nMEPartonsFiltered()) {
+      throw cms::Exception("ComparisonFailure") << "The GenEventInfoProducts have different nMEPartonsFiltered "
+                                                << prod1.nMEPartonsFiltered() << " " << prod2.nMEPartonsFiltered();
+    }
+  }
+
+  void compare(HepMC::GenEvent const& prod1, HepMC::GenEvent const& prod2) {
+    if (prod1.signal_process_id() != prod2.signal_process_id()) {
+      throw cms::Exception("ComparisonFailure") << "The HepMCProducts have different signal_process_id "
+                                                << prod1.signal_process_id() << " " << prod2.signal_process_id();
+    }
+
+    if (prod1.vertices_size() != prod2.vertices_size()) {
+      throw cms::Exception("ComparisonFailure") << "The HepMCProducts have different vertices_size() "
+                                                << prod1.vertices_size() << " " << prod2.vertices_size();
+    }
+
+    if (prod1.particles_size() != prod2.particles_size()) {
+      throw cms::Exception("ComparisonFailure") << "The HepMCProducts have different particles_size() "
+                                                << prod1.particles_size() << " " << prod2.particles_size();
+    }
+  }
+}  // namespace
+
+void CompareGeneratorResultsAnalyzer::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
+  auto const& prod1 = iEvent.get(evToken1_);
+  auto const& prod2 = iEvent.get(evToken2_);
+
+  compare(prod1, prod2);
+
+  auto const& hepmc1 = iEvent.get(hepMCToken1_);
+  auto const& hepmc2 = iEvent.get(hepMCToken2_);
+
+  compare(hepmc1.getHepMCData(), hepmc2.getHepMCData());
+}
+
+DEFINE_FWK_MODULE(CompareGeneratorResultsAnalyzer);

--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -1,0 +1,349 @@
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h"
+
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/engineIDulong.h"
+#include "CLHEP/Random/RanecuEngine.h"
+
+#include <cstdio>
+#include <iostream>
+
+using namespace edm::shared_memory;
+namespace externalgen {
+
+  struct StreamCache {
+    StreamCache(const std::string& iConfig, int id, bool verbose)
+        : id_{id},
+          channel_("extGen", id_),
+          readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferInfo()},
+          writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferInfo()},
+          deserializer_{readBuffer_},
+          er_deserializer_{readBuffer_},
+          bl_deserializer_{readBuffer_},
+          el_deserializer_(readBuffer_),
+          randSerializer_(writeBuffer_) {
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel_.setupWorker([&]() {
+        using namespace std::string_literals;
+        edm::LogSystem("ExternalProcess") << id_ << " starting external process \n";
+        std::string verboseCommand;
+        if (verbose) {
+          verboseCommand = "--verbose ";
+        }
+        pipe_ =
+            popen(("cmsExternalGenerator "s + verboseCommand + channel_.sharedMemoryName() + " " + channel_.uniqueID())
+                      .c_str(),
+                  "w");
+
+        if (nullptr == pipe_) {
+          abort();
+        }
+
+        {
+          auto nlines = std::to_string(std::count(iConfig.begin(), iConfig.end(), '\n'));
+          auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
+          assert(result = nlines.size());
+          result = fwrite(iConfig.data(), sizeof(char), iConfig.size(), pipe_);
+          assert(result == iConfig.size());
+          fflush(pipe_);
+        }
+      });
+    }
+
+    template <typename SERIAL>
+    auto doTransition(SERIAL& iDeserializer, edm::Transition iTrans, unsigned long long iTransitionID)
+        -> decltype(iDeserializer.deserialize()) {
+      decltype(iDeserializer.deserialize()) value;
+      if (not channel_.doTransition(
+              [&value, &iDeserializer]() { value = iDeserializer.deserialize(); }, iTrans, iTransitionID)) {
+        externalFailed_ = true;
+        throw cms::Exception("ExternalFailed") << "failed waiting for external process";
+      }
+      return value;
+    }
+    ExternalGeneratorEventInfo produce(edm::StreamID iStream, unsigned long long iTransitionID) {
+      edm::Service<edm::RandomNumberGenerator> gen;
+      auto& engine = gen->getEngine(iStream);
+      edm::RandomNumberGeneratorState state{engine.put(), engine.getSeed()};
+      randSerializer_.serialize(state);
+
+      return doTransition(deserializer_, edm::Transition::Event, iTransitionID);
+    }
+
+    std::optional<GenRunInfoProduct> endRunProduce(unsigned long long iTransitionID) {
+      if (not externalFailed_) {
+        return doTransition(er_deserializer_, edm::Transition::EndRun, iTransitionID);
+      }
+      return {};
+    }
+
+    ExternalGeneratorLumiInfo beginLumiProduce(unsigned long long iTransitionID,
+                                               edm::RandomNumberGeneratorState const& iState) {
+      //NOTE: root serialize requires a `void*` not a `void const*` even though it doesn't modify the object
+      randSerializer_.serialize(const_cast<edm::RandomNumberGeneratorState&>(iState));
+      return doTransition(bl_deserializer_, edm::Transition::BeginLuminosityBlock, iTransitionID);
+    }
+
+    std::optional<GenLumiInfoProduct> endLumiProduce(unsigned long long iTransitionID) {
+      if (not externalFailed_) {
+        return doTransition(el_deserializer_, edm::Transition::EndLuminosityBlock, iTransitionID);
+      }
+      return {};
+    }
+
+    ~StreamCache() {
+      channel_.stopWorker();
+      pclose(pipe_);
+    }
+
+  private:
+    std::string unique_name(std::string iBase) {
+      auto pid = getpid();
+      iBase += std::to_string(pid);
+      iBase += "_";
+      iBase += std::to_string(id_);
+
+      return iBase;
+    }
+
+    int id_;
+    FILE* pipe_;
+    ControllerChannel channel_;
+    ReadBuffer readBuffer_;
+    WriteBuffer writeBuffer_;
+
+    template <typename T>
+    using Deserializer = ROOTDeserializer<T, ReadBuffer>;
+    Deserializer<ExternalGeneratorEventInfo> deserializer_;
+    Deserializer<GenRunInfoProduct> er_deserializer_;
+    Deserializer<ExternalGeneratorLumiInfo> bl_deserializer_;
+    Deserializer<GenLumiInfoProduct> el_deserializer_;
+    ROOTSerializer<edm::RandomNumberGeneratorState, WriteBuffer> randSerializer_;
+
+    bool externalFailed_ = false;
+  };
+
+  struct RunCache {
+    //Only stream 0 sets this at stream end Run and it is read at global end run
+    // the framework guarantees those calls can not happen simultaneously
+    CMS_THREAD_SAFE mutable GenRunInfoProduct runInfo_;
+  };
+  struct LumiCache {
+    LumiCache(std::vector<unsigned long> iState, long iSeed) : randomState_(std::move(iState), iSeed) {}
+    //Only stream 0 sets this at stream end Lumi and it is read at global end Lumi
+    // the framework guarantees those calls can not happen simultaneously
+    CMS_THREAD_SAFE mutable edm::RandomNumberGeneratorState randomState_;
+  };
+}  // namespace externalgen
+
+class ExternalGeneratorFilter : public edm::global::EDFilter<edm::StreamCache<externalgen::StreamCache>,
+                                                             edm::RunCache<externalgen::RunCache>,
+                                                             edm::EndRunProducer,
+                                                             edm::LuminosityBlockCache<externalgen::LumiCache>,
+                                                             edm::LuminosityBlockSummaryCache<GenLumiInfoProduct>,
+                                                             edm::BeginLuminosityBlockProducer,
+                                                             edm::EndLuminosityBlockProducer> {
+public:
+  ExternalGeneratorFilter(edm::ParameterSet const&);
+
+  std::unique_ptr<externalgen::StreamCache> beginStream(edm::StreamID) const final;
+  bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
+
+  std::shared_ptr<externalgen::RunCache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const final;
+  void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final;
+  void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final;
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const final {}
+  void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const final;
+
+  void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
+  std::shared_ptr<externalgen::LumiCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                     edm::EventSetup const&) const final;
+  std::shared_ptr<GenLumiInfoProduct> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                                        edm::EventSetup const&) const final;
+  void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void streamEndLuminosityBlockSummary(edm::StreamID,
+                                       edm::LuminosityBlock const&,
+                                       edm::EventSetup const&,
+                                       GenLumiInfoProduct*) const final;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final {}
+  void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                       edm::EventSetup const&,
+                                       GenLumiInfoProduct*) const final {}
+  void globalEndLuminosityBlockProduce(edm::LuminosityBlock&,
+                                       edm::EventSetup const&,
+                                       GenLumiInfoProduct const*) const final;
+
+private:
+  edm::EDPutTokenT<edm::HepMCProduct> const hepMCToken_;
+  edm::EDPutTokenT<GenEventInfoProduct> const genEventToken_;
+  edm::EDPutTokenT<GenRunInfoProduct> const runInfoToken_;
+  edm::EDPutTokenT<GenLumiInfoHeader> const lumiHeaderToken_;
+  edm::EDPutTokenT<GenLumiInfoProduct> const lumiInfoToken_;
+
+  std::string const config_;
+  bool const verbose_;
+
+  //This is set at beginStream and used for globalBeginRun
+  //The framework guarantees that non of those can happen concurrently
+  CMS_THREAD_SAFE mutable externalgen::StreamCache* stream0Cache_ = nullptr;
+  //A stream which has finished processing the last lumi is used for the
+  // call to globalBeginLuminosityBlockProduce
+  mutable std::atomic<externalgen::StreamCache*> availableForBeginLumi_;
+  //Streams all see the lumis in the same order, we want to be sure to pick a stream cache
+  // to use at globalBeginLumi which just finished the most recent lumi and not a previous one
+  mutable std::atomic<unsigned int> lastLumiIndex_ = 0;
+};
+
+ExternalGeneratorFilter::ExternalGeneratorFilter(edm::ParameterSet const& iPSet)
+    : hepMCToken_{produces<edm::HepMCProduct>("unsmeared")},
+      genEventToken_{produces<GenEventInfoProduct>()},
+      runInfoToken_{produces<GenRunInfoProduct, edm::Transition::EndRun>()},
+      lumiHeaderToken_{produces<GenLumiInfoHeader, edm::Transition::BeginLuminosityBlock>()},
+      lumiInfoToken_{produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>()},
+      config_{iPSet.getUntrackedParameter<std::string>("@python_config")},
+      verbose_{iPSet.getUntrackedParameter<bool>("_external_process_verbose_")} {}
+
+std::unique_ptr<externalgen::StreamCache> ExternalGeneratorFilter::beginStream(edm::StreamID iID) const {
+  auto const label = moduleDescription().moduleLabel();
+
+  using namespace std::string_literals;
+
+  std::string config = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+)_";
+  config += "process."s + label + "=" + config_ + "\n";
+  config += "process.moduleToTest(process."s + label + ")\n";
+  config += R"_(
+process.add_(cms.Service("InitRootHandlers", UnloadRootSigHandler=cms.untracked.bool(True)))
+  )_";
+
+  auto cache = std::make_unique<externalgen::StreamCache>(config, iID.value(), verbose_);
+  if (iID.value() == 0) {
+    stream0Cache_ = cache.get();
+
+    availableForBeginLumi_ = stream0Cache_;
+  }
+
+  return cache;
+}
+
+bool ExternalGeneratorFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const {
+  auto value = streamCache(iID)->produce(iID, iEvent.id().event());
+
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iID);
+  //if (value.randomState_.state_[0] != CLHEP::engineIDulong<CLHEP::RanecuEngine>()) {
+  //  engine.setSeed(value.randomState_.seed_, 0);
+  //}
+  engine.get(value.randomState_.state_);
+
+  iEvent.emplace(hepMCToken_, std::move(value.hepmc_));
+  iEvent.emplace(genEventToken_, std::move(value.eventInfo_));
+  return value.keepEvent_;
+}
+
+std::shared_ptr<externalgen::RunCache> ExternalGeneratorFilter::globalBeginRun(edm::Run const&,
+                                                                               edm::EventSetup const&) const {
+  return std::make_shared<externalgen::RunCache>();
+}
+
+void ExternalGeneratorFilter::streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const {}
+void ExternalGeneratorFilter::streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const {
+  if (iID.value() == 0) {
+    runCache(iRun.index())->runInfo_ = *streamCache(iID)->endRunProduce(iRun.run());
+  } else {
+    (void)streamCache(iID)->endRunProduce(iRun.run());
+  }
+}
+void ExternalGeneratorFilter::globalEndRunProduce(edm::Run& iRun, edm::EventSetup const&) const {
+  iRun.emplace(runInfoToken_, std::move(runCache(iRun.index())->runInfo_));
+}
+
+void ExternalGeneratorFilter::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                                edm::EventSetup const&) const {
+  while (not availableForBeginLumi_.load()) {
+  }
+
+  auto v = availableForBeginLumi_.load()->beginLumiProduce(
+      iLuminosityBlock.luminosityBlock(), luminosityBlockCache(iLuminosityBlock.index())->randomState_);
+
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iLuminosityBlock.index());
+  engine.get(v.randomState_.state_);
+
+  iLuminosityBlock.emplace(lumiHeaderToken_, std::move(v.header_));
+
+  lastLumiIndex_.store(iLuminosityBlock.index());
+}
+
+std::shared_ptr<externalgen::LumiCache> ExternalGeneratorFilter::globalBeginLuminosityBlock(
+    edm::LuminosityBlock const& iLumi, edm::EventSetup const&) const {
+  edm::Service<edm::RandomNumberGenerator> gen;
+  auto& engine = gen->getEngine(iLumi.index());
+  auto s = engine.put();
+  return std::make_shared<externalgen::LumiCache>(s, engine.getSeed());
+}
+
+std::shared_ptr<GenLumiInfoProduct> ExternalGeneratorFilter::globalBeginLuminosityBlockSummary(
+    edm::LuminosityBlock const&, edm::EventSetup const&) const {
+  return std::make_shared<GenLumiInfoProduct>();
+}
+
+void ExternalGeneratorFilter::streamBeginLuminosityBlock(edm::StreamID iID,
+                                                         edm::LuminosityBlock const& iLuminosityBlock,
+                                                         edm::EventSetup const&) const {
+  auto cache = streamCache(iID);
+  if (cache != availableForBeginLumi_.load()) {
+    (void)cache->beginLumiProduce(iLuminosityBlock.run(), luminosityBlockCache(iLuminosityBlock.index())->randomState_);
+  } else {
+    availableForBeginLumi_ = nullptr;
+  }
+}
+
+void ExternalGeneratorFilter::streamEndLuminosityBlock(edm::StreamID iID,
+                                                       edm::LuminosityBlock const& iLuminosityBlock,
+                                                       edm::EventSetup const&) const {}
+
+void ExternalGeneratorFilter::streamEndLuminosityBlockSummary(edm::StreamID iID,
+                                                              edm::LuminosityBlock const& iLuminosityBlock,
+                                                              edm::EventSetup const&,
+                                                              GenLumiInfoProduct* iProduct) const {
+  iProduct->mergeProduct(*streamCache(iID)->endLumiProduce(iLuminosityBlock.run()));
+
+  if (lastLumiIndex_ == iLuminosityBlock.index()) {
+    externalgen::StreamCache* expected = nullptr;
+
+    availableForBeginLumi_.compare_exchange_strong(expected, streamCache(iID));
+  }
+}
+
+void ExternalGeneratorFilter::globalEndLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                              edm::EventSetup const&,
+                                                              GenLumiInfoProduct const* iProduct) const {
+  iLuminosityBlock.emplace(lumiInfoToken_, std::move(*iProduct));
+}
+
+DEFINE_FWK_MODULE(ExternalGeneratorFilter);

--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+class ExternalGeneratorFilter(cms.EDFilter):
+    def __init__(self, prod, _external_process_verbose_ = cms.untracked.bool(False)):
+        self.__dict__['_external_process_verbose_']=_external_process_verbose_
+        self.__dict__['_prod'] = prod
+        super(cms.EDFilter,self).__init__('ExternalGeneratorFilter')
+    def __setattr__(self, name, value):
+        if name =='_external_process_verbose_':
+            return self.__dict__['_external_process_verbose_']
+        setattr(self._prod, name, value)
+    def __getattr__(self, name):
+        if name =='_prod':
+            return self.__dict__['_prod']
+        if name == '_external_process_verbose_':
+            return self.__dict__['_external_process_verbose_']
+        return getattr(self._prod, name)
+    def clone(self, **params):
+        returnValue = ExternalGeneratorFilter.__new__(type(self))
+        returnValue.__init__(self._prod.clone())
+        return returnValue
+    def insertInto(self, parameterSet, myname):
+        newpset = parameterSet.newPSet()
+        newpset.addString(True, "@module_label", self.moduleLabel_(myname))
+        newpset.addString(True, "@module_type", self.type_())
+        newpset.addString(True, "@module_edm_type", cms.EDFilter.__name__)
+        newpset.addString(True, "@external_type", self._prod.type_())
+        newpset.addString(False,"@python_config", self._prod.dumpPython())
+        newpset.addBool(False,"_external_process_verbose_", self._external_process_verbose_.value())
+        self._prod.insertContentsInto(newpset)
+        parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
+    def dumpPython(self, options=cms.PrintOptions()):
+        cms.specialImportRegistry.registerUse(self)
+        result = "%s(" % self.__class__.__name__ # not including cms. since the deriving classes are not in cms "namespace"
+        options.indent()
+        result += "\n"+options.indentation() + self._prod.dumpPython(options)
+        result +=options.indentation()+",\n"
+        result += options.indentation() + self._external_process_verbose_.dumpPython(options)
+        options.unindent()
+        result += "\n)\n"
+        return result
+
+cms.specialImportRegistry.registerSpecialImportForType(ExternalGeneratorFilter, "from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter")

--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -15,6 +15,8 @@ class ExternalGeneratorFilter(cms.EDFilter):
         if name == '_external_process_verbose_':
             return self.__dict__['_external_process_verbose_']
         return getattr(self._prod, name)
+    def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): self.__dict__.update(d)
     def clone(self, **params):
         returnValue = ExternalGeneratorFilter.__new__(type(self))
         returnValue.__init__(self._prod.clone())

--- a/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
@@ -17,3 +17,7 @@
   <use name="FWCore/TestProcessor"/>
   <use name="catch2"/>
 </bin>
+
+<test name="TestGeneratorInterfacePythia8InterfaceCompareIdentical" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_identical_generators_cfg.py"/>
+<test name="TestGeneratorInterfacePythia8InterfaceCompareExternal" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_external_generators_cfg.py"/>
+<test name="TestGeneratorInterfacePythia8InterfaceCompareExternalStreams" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py"/>

--- a/GeneratorInterface/Pythia8Interface/test/compare_external_generators_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/compare_external_generators_cfg.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+process.source =cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+)
+
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.gen1 = process.RandomNumberGeneratorService.generator.clone()
+process.RandomNumberGeneratorService.gen2 = process.RandomNumberGeneratorService.generator.clone()
+process.gen1 = cms.EDFilter("Pythia8GeneratorFilter",
+                            comEnergy = cms.double(7000.),
+                            PythiaParameters = cms.PSet(
+                                pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                                                'PhaseSpace:pTHatMin = 20.'),
+                                parameterSets = cms.vstring('pythia8_example02')
+                            )
+                        )
+
+_pythia8 = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter
+process.gen2 = ExternalGeneratorFilter(_pythia8)
+
+process.compare = cms.EDAnalyzer("CompareGeneratorResultsAnalyzer", module1 = cms.untracked.string("gen1"), module2 =cms.untracked.string("gen2"))
+
+process.p = cms.Path(process.gen1+process.gen2+process.compare)

--- a/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+process.source =cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+)
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(2),
+    numberOfThreads = cms.untracked.uint32(2),
+)
+
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.gen1 = process.RandomNumberGeneratorService.generator.clone()
+process.RandomNumberGeneratorService.gen2 = process.RandomNumberGeneratorService.generator.clone()
+process.gen1 = cms.EDFilter("Pythia8GeneratorFilter",
+                            comEnergy = cms.double(7000.),
+                            PythiaParameters = cms.PSet(
+                                pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                                                'PhaseSpace:pTHatMin = 20.'),
+                                parameterSets = cms.vstring('pythia8_example02')
+                            )
+                        )
+
+_pythia8 = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter
+process.gen2 = ExternalGeneratorFilter(_pythia8)
+
+process.sleeper = cms.EDProducer("timestudy::SleepingProducer", ivalue = cms.int32(1), consumes = cms.VInputTag(), eventTimes=cms.vdouble(1.))
+
+process.compare = cms.EDAnalyzer("CompareGeneratorResultsAnalyzer", 
+                                 module1 = cms.untracked.string("gen1"), 
+                                 module2 =cms.untracked.string("gen2"),
+                                 allowXSecDifferences = cms.untracked.bool(True))
+
+process.p = cms.Path(process.sleeper+process.gen1+process.gen2+process.compare)

--- a/GeneratorInterface/Pythia8Interface/test/compare_identical_generators_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/compare_identical_generators_cfg.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+process.source =cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+)
+
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.gen1 = process.RandomNumberGeneratorService.generator.clone()
+process.RandomNumberGeneratorService.gen2 = process.RandomNumberGeneratorService.generator.clone()
+process.gen1 = cms.EDFilter("Pythia8GeneratorFilter",
+                            comEnergy = cms.double(7000.),
+                            PythiaParameters = cms.PSet(
+                                pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                                                'PhaseSpace:pTHatMin = 20.'),
+                                parameterSets = cms.vstring('pythia8_example02')
+                            )
+                        )
+process.gen2 = cms.EDFilter("Pythia8GeneratorFilter",
+                            comEnergy = cms.double(7000.),
+                            PythiaParameters = cms.PSet(
+                                pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                                                'PhaseSpace:pTHatMin = 20.'),
+                                parameterSets = cms.vstring('pythia8_example02')
+                            )
+                        )
+process.compare = cms.EDAnalyzer("CompareGeneratorResultsAnalyzer", module1 = cms.untracked.string("gen1"), module2 =cms.untracked.string("gen2"))
+
+process.p = cms.Path(process.gen1+process.gen2+process.compare)

--- a/GeneratorInterface/Pythia8Interface/test/test_catch2_External_Pythia8GeneratorFilter.cc
+++ b/GeneratorInterface/Pythia8Interface/test/test_catch2_External_Pythia8GeneratorFilter.cc
@@ -1,0 +1,57 @@
+#include "catch.hpp"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+static constexpr auto s_tag = "[External Pythia8GeneratorFilter]";
+
+TEST_CASE("Standard checks of ExternalGeneratorFilter with Pythia8GeneratorFilter", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.toTest = process.RandomNumberGeneratorService.generator.clone()
+from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter
+_pythia8 = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+process.toTest = ExternalGeneratorFilter(_pythia8)
+
+process.add_(cms.Service('Tracer'))
+
+process.moduleToTest(process.toTest)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+  SECTION("base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+}
+
+//Add additional TEST_CASEs to exercise the modules capabilities

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -491,6 +491,19 @@ namespace edm {
     }
 
     void
+    RandomNumberGeneratorService::setLumiCache(LuminosityBlockIndex iLumi, std::vector<RandomEngineState> const& iStates) {
+      lumiCache_[iLumi] = iStates;
+      // Copy from cache to engine the state for a particular luminosityBlockIndex
+      restoreFromCache(lumiCache_[iLumi], lumiEngines_[iLumi]);
+    }
+    void
+    RandomNumberGeneratorService::setEventCache(StreamID iStream, std::vector<RandomEngineState> const& iStates) {
+      eventCache_[iStream] = iStates;
+      // copy from event cache to engines
+      restoreFromCache(eventCache_[iStream], streamEngines_[iStream]);
+    }
+
+    void
     RandomNumberGeneratorService::preModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
       preModuleStreamCheck(sc, mcc);
     }

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -87,6 +87,8 @@ namespace edm {
 
       void preBeginLumi(LuminosityBlock const& lumi) override;
       void postEventRead(Event const& event) override;
+      void setLumiCache(LuminosityBlockIndex, std::vector<RandomEngineState> const& iStates) override;
+      void setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) override;
 
       /// These next 12 functions are only used to check that random numbers are not
       /// being generated in these methods when enable checking is configured on.

--- a/SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h
@@ -1,0 +1,21 @@
+#ifndef SimDataFormats_GeneratorProducts_ExternalGeneratorEventInfo_h
+#define SimDataFormats_GeneratorProducts_ExternalGeneratorEventInfo_h
+
+/** \class ExternalGeneratorEventInfo
+ *
+ * This class is an internal detail of the ExternalGeneratorFilter. It is the type
+ *  used to transfer from the external process to ExternalGeneratorFilter the 
+ *  event information.
+ */
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
+
+struct ExternalGeneratorEventInfo {
+  edm::HepMCProduct hepmc_;
+  GenEventInfoProduct eventInfo_;
+  edm::RandomNumberGeneratorState randomState_;
+  bool keepEvent_;
+};
+
+#endif

--- a/SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h
@@ -1,0 +1,18 @@
+#ifndef SimDataFormats_GeneratorProducts_ExternalGeneratorLumiInfo_h
+#define SimDataFormats_GeneratorProducts_ExternalGeneratorLumiInfo_h
+
+/** \class ExternalGeneratorLumiInfo
+ *
+ * This class is an internal detail of the ExternalGeneratorFilter. It is the type
+ *  used to transfer from the external process to ExternalGeneratorFilter the 
+ *  begin LuminosityBlock information.
+ */
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "DataFormats/Common/interface/RandomNumberGeneratorState.h"
+
+struct ExternalGeneratorLumiInfo {
+  GenLumiInfoHeader header_;
+  edm::RandomNumberGeneratorState randomState_;
+};
+
+#endif

--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
@@ -2,6 +2,7 @@
 #define SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h
 
 #include <vector>
+#include <cmath>
 
 /** \class GenLumiInfoProduct
  *
@@ -68,12 +69,13 @@ class GenLumiInfoProduct {
     double sum() const { return sum_; }
     double sum2() const{ return sum2_; }
 
-    void add(const FinalStat& other)
-    {
-      n_ += other.n();
-      sum_ += other.sum();
-      sum2_ += other.sum2();
+    void add(const FinalStat& other) {
+      if (other.n() != 0 and other.sum_ != -1. and other.sum2() != -1.) {
+        n_ += other.n();
+        sum_ += other.sum();
+        sum2_ += other.sum2();
       }
+    }
 
     bool operator == (const FinalStat &other) const
     { return n_ == other.n_ && sum_ == other.sum_ && sum2_ == other.sum2_; }
@@ -92,21 +94,22 @@ class GenLumiInfoProduct {
 
     // accessors
     int process() const {return process_;}
-    XSec lheXSec() const {return lheXSec_;}
+    XSec const &lheXSec() const {return lheXSec_;}
 
     unsigned int nPassPos() const {return nPassPos_;}
     unsigned int nPassNeg() const {return nPassNeg_;}
     unsigned int nTotalPos() const {return nTotalPos_;}
     unsigned int nTotalNeg() const {return nTotalNeg_;}
 
-    FinalStat tried() const {return tried_;}
-    FinalStat selected() const {return selected_;}
-    FinalStat killed() const {return killed_;}
-    FinalStat accepted() const {return accepted_;}
-    FinalStat acceptedBr() const {return acceptedBr_;}
+    FinalStat const &tried() const {return tried_;}
+    FinalStat const &selected() const {return selected_;}
+    FinalStat const &killed() const {return killed_;}
+    FinalStat const &accepted() const {return accepted_;}
+    FinalStat const &acceptedBr() const {return acceptedBr_;}
 
     // setters
     void addOthers(const ProcessInfo& other){
+      mergeXSec(other.lheXSec(), other.selected().sum());
       nPassPos_ += other.nPassPos();
       nPassNeg_ += other.nPassNeg();
       nTotalPos_ += other.nTotalPos();
@@ -130,6 +133,21 @@ class GenLumiInfoProduct {
     void setAcceptedBr(unsigned int n, double sum, double sum2) { acceptedBr_ = FinalStat(n,sum,sum2); }
 	  
   private:
+    void mergeXSec(XSec const &iXSec, double iWeight) {
+      if (iWeight <= 0.) {
+        return;
+      }
+      if (lheXSec_.value() <= 0.) {
+        lheXSec_ = iXSec;
+      } else {
+        bool useWeights = (lheXSec_.error() <= 0. || iXSec.error() <= 0.);
+        double wgt1 = useWeights ? selected().sum() : 1. / (lheXSec_.error() * lheXSec_.error());
+        double wgt2 = useWeights ? iWeight : 1. / (iXSec.error() * iXSec.error());
+        double xsec = (wgt1 * lheXSec_.value() + wgt2 * iXSec.value()) / (wgt1 + wgt2);
+        double err = useWeights ? 0. : 1.0 / std::sqrt(wgt1 + wgt2);
+        lheXSec_ = XSec(xsec, err);
+      }
+    }
     int             process_;
     XSec            lheXSec_;
     unsigned int    nPassPos_;

--- a/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
@@ -71,7 +71,7 @@ const bool operator ==(const GenLumiInfoProduct& lhs, const GenLumiInfoProduct& 
 
   bool condition= (lhs.getHEPIDWTUP() == rhs.getHEPIDWTUP()) &&
     (lhssize == rhssize);
-  unsigned int passCounts=-999;
+  unsigned int passCounts=0;
   if(condition)
     {
       for(unsigned int i=0; i<lhssize; i++){

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -17,6 +17,9 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h"
+
 #include <HepMC/GenRanges.h>
 
 //needed for backward compatibility between HepMC 2.06.xx and 2.05.yy

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -235,4 +235,11 @@
    ]]>
  </ioread>        
 
+<class name="ExternalGeneratorLumiInfo" ClassVersion="3">
+  <version ClassVersion="3" checksum="2760887354"/>
+</class>
+<class name="ExternalGeneratorEventInfo" ClassVersion="3">
+  <version ClassVersion="3" checksum="2860722409"/>
+</class>
+
 </lcgdict>


### PR DESCRIPTION
#### PR description:

This PR is a backport of `ExternalGeneratorFilter` module and the core implementations it depends on. It includes a collection of eight orginal PRs authored by @Dr15Jones.

- Commit 1-3: [backport #28721 & #28759]: enable `TestProcessor` to support Run and Lumi product testing and to support external services. (commit cherry picking)
- Commit 4: [backport #28792]: create `FWCore/SharedMemory` infrastructure to allow cmsRun to control an external process. Depends on commit 1-3.
- Commit 5: [backport #28729]: add ability to set RandomEngineStates in Service.
- Commit 6: [backport #29384]: test inter process random state transfers. Depends on commit 5.
- Commit 7: [backport #29445]: **the main PR** that adds `ExternalGeneratorFilter` module to run `GeneratorFilter` in an external process controlled by cmsRun. Depends on commit 4, 5, 6.
- Commit 8: [backport #30346]: allow `ExternalGeneratorFilter` to be pickled. Depends on commit 7.
- Commit 9 (newly added): [backport #29611]: extend `ConfigBuilder` to properly handle special import handling. (commit cherry picking)

For compatibility purposes, small additional changes are made compared to original commits. Please see the details in each commit below.

#### PR validation:

This PR passes the new unit tests that are introduced in the original backported PRs.
It is also tested on [`BPH-RunIIFall18GS-00222`](https://cms-pdmv.cern.ch/mcm/requests?page=0&prepid=BPH-RunIIFall18GS-00222) requested by Jordan. More validation to come.

(a quick test for this PR)
```shell
cmsrel CMSSW_10_6_X_2020-07-07-2300
cd CMSSW_10_6_X_2020-07-07-2300/src/
cmsenv
git cms-merge-topic colizz:dev-106X-externalGeneratorFilter
curl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BPH-RunIIFall18GS-00222 --retry 2 --create-dirs -o Configuration/GenProduction/python/BPH-RunIIFall18GS-00222-fragment.py 
scram b -j 8
cd ../..
cmsDriver.py Configuration/GenProduction/python/BPH-RunIIFall18GS-00222-fragment.py --fileout file:BPH-RunIIFall18GS-00222.root --mc --eventcontent RAWSIM --datatier GEN-SIM --conditions 102X_upgrade2018_realistic_v11 --beamspot Realistic25ns13TeVEarly2018Collision --step GEN,SIM --nThreads 8 --geometry DB:Extended --era Run2_2018 --python_filename BPH-RunIIFall18GS-00222_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring --customise_commands='from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter; process.generator = ExternalGeneratorFilter(process.generator)' -n 1000

cmsRun -e -j BPH-RunIIFall18GS-00222_rt.xml BPH-RunIIFall18GS-00222_1_cfg.py
```