### PR TITLE
Convert the CSCTriggerPrimitivesProducer to a "one" module

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -30,7 +30,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -45,20 +45,20 @@
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "CondFormats/DataRecord/interface/CSCDBL1TPParametersRcd.h"
 
-class CSCTriggerPrimitivesProducer : public edm::global::EDProducer<edm::StreamCache<CSCTriggerPrimitivesBuilder>> {
+// temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
+class CSCTriggerPrimitivesProducer : public edm::one::EDProducer<> {
 public:
   explicit CSCTriggerPrimitivesProducer(const edm::ParameterSet&);
   ~CSCTriggerPrimitivesProducer() override;
 
-  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   // master configuration
   edm::ParameterSet config_;
 
-  std::unique_ptr<CSCTriggerPrimitivesBuilder> beginStream(edm::StreamID) const override {
-    return std::unique_ptr<CSCTriggerPrimitivesBuilder>(new CSCTriggerPrimitivesBuilder(config_));
-  }
+  // temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
+  std::unique_ptr<CSCTriggerPrimitivesBuilder> builder_;
 
   // input tags for input collections
   edm::InputTag compDigiProducer_;


### PR DESCRIPTION
Uses a single CSCTriggerPrimitivesBuilder instead of one per stream, saving ~570 MB per stream in a TTbar Phase 2 workflow.
