### PR TITLE
Convert the CSCTriggerPrimitivesProducer to a "one" module

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -81,23 +81,24 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   produces<CSCCorrelatedLCTDigiCollection>("MPCSORTED");
   if (runME11ILT_ or runME21ILT_)
     produces<GEMCoPadDigiCollection>();
+
+  // temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
+  builder_ = std::make_unique<CSCTriggerPrimitivesBuilder>(config_);
 }
 
 CSCTriggerPrimitivesProducer::~CSCTriggerPrimitivesProducer() {}
 
-void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, const edm::EventSetup& setup) const {
-  // Remark: access builder using "streamCache(iID)"
-
+void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
   // get the csc geometry
   edm::ESHandle<CSCGeometry> h;
   setup.get<MuonGeometryRecord>().get(h);
-  streamCache(iID)->setCSCGeometry(&*h);
+  builder_->setCSCGeometry(&*h);
 
   // get the gem geometry if it's there
   edm::ESHandle<GEMGeometry> h_gem;
   setup.get<MuonGeometryRecord>().get(h_gem);
   if (h_gem.isValid()) {
-    streamCache(iID)->setGEMGeometry(&*h_gem);
+    builder_->setGEMGeometry(&*h_gem);
   } else {
     edm::LogInfo("CSCTriggerPrimitivesProducer|NoGEMGeometry")
         << "+++ Info: GEM geometry is unavailable. Running CSC-only trigger algorithm. +++\n";
@@ -119,7 +120,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
           << "+++ Cannot continue emulation without these parameters +++\n";
       return;
     }
-    streamCache(iID)->setConfigParameters(conf.product());
+    builder_->setConfigParameters(conf.product());
   }
 
   // Get the collections of comparator & wire digis from event.
@@ -172,21 +173,21 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
   // Fill output collections if valid input collections are available.
   if (wireDigis.isValid() && compDigis.isValid()) {
     const CSCBadChambers* temp = checkBadChambers_ ? pBadChambers.product() : new CSCBadChambers;
-    streamCache(iID)->build(temp,
-                            wireDigis.product(),
-                            compDigis.product(),
-                            gemPads,
-                            gemPadClusters,
-                            *oc_alct,
-                            *oc_alct_all,
-                            *oc_clct,
-                            *oc_clct_all,
-                            *oc_alctpretrigger,
-                            *oc_clctpretrigger,
-                            *oc_pretrig,
-                            *oc_lct,
-                            *oc_sorted_lct,
-                            *oc_gemcopad);
+    builder_->build(temp,
+                    wireDigis.product(),
+                    compDigis.product(),
+                    gemPads,
+                    gemPadClusters,
+                    *oc_alct,
+                    *oc_alct_all,
+                    *oc_clct,
+                    *oc_clct_all,
+                    *oc_alctpretrigger,
+                    *oc_clctpretrigger,
+                    *oc_pretrig,
+                    *oc_lct,
+                    *oc_sorted_lct,
+                    *oc_gemcopad);
     if (!checkBadChambers_)
       delete temp;
   }

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -30,7 +30,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -41,20 +41,20 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h"
 
-class CSCTriggerPrimitivesProducer : public edm::global::EDProducer<edm::StreamCache<CSCTriggerPrimitivesBuilder>> {
+// temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
+class CSCTriggerPrimitivesProducer : public edm::one::EDProducer<> {
 public:
   explicit CSCTriggerPrimitivesProducer(const edm::ParameterSet&);
   ~CSCTriggerPrimitivesProducer() override;
 
-  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   // master configuration
   edm::ParameterSet config_;
 
-  std::unique_ptr<CSCTriggerPrimitivesBuilder> beginStream(edm::StreamID) const override {
-    return std::unique_ptr<CSCTriggerPrimitivesBuilder>(new CSCTriggerPrimitivesBuilder(config_));
-  }
+  // temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
+  std::unique_ptr<CSCTriggerPrimitivesBuilder> builder_;
 
   // input tags for input collections
   edm::InputTag compDigiProducer_;


### PR DESCRIPTION
Uses a single CSCTriggerPrimitivesBuilder instead of one per stream, saving ~570 MB per stream in a TTbar Phase 2 workflow.