### PR TITLE
Replace boost filesystem in DQMServices/FileIO

### DIFF
--- a/DQMServices/FileIO/plugins/BuildFile.xml
+++ b/DQMServices/FileIO/plugins/BuildFile.xml
@@ -4,9 +4,9 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="EventFilter/Utilities"/>
+<use name="stdcxx-fs"/>
 <use name="boost"/>
 <use name="boost_iostreams"/>
-<use name="boost_filesystem"/>
 <library file="*.cc" name="DQMServicesFileIOPlugins">
   <flags EDM_PLUGIN="1"/>
   <flags CXXFLAGS="-lboost_iostreams"/>

--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <fstream>
 #include <utility>
+#include <filesystem>
 #include <TString.h>
 #include <TSystem.h>
 
@@ -105,7 +106,7 @@ const std::string DQMFileSaverBase::filename(const FileParameters &fp, bool useL
   }
   buf[255] = 0;
 
-  namespace fs = boost::filesystem;
+  namespace fs = std::filesystem;
   fs::path path(fp.path_);
   fs::path file(buf);
 

--- a/DQMServices/FileIO/plugins/DQMFileSaverOnline.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverOnline.cc
@@ -23,7 +23,7 @@
 #include <vector>
 
 #include <openssl/md5.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/iostreams/device/mapped_file.hpp>
 
 using namespace dqm;

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -19,7 +19,7 @@
 
 #include <openssl/md5.h>
 #include <boost/property_tree/json_parser.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/format.hpp>
 
 #include <google/protobuf/io/coded_stream.h>
@@ -70,7 +70,7 @@ void DQMFileSaverPB::saveLumi(const FileParameters& fp) const {
     std::string runDir = str(boost::format("%s/run%06d") % fp.path_ % fp.run_);
     std::string baseName = str(boost::format("%s/run%06d_ls%04d_%s") % runDir % fp.run_ % fp.lumi_ % streamLabel_);
 
-    boost::filesystem::create_directories(runDir);
+    std::filesystem::create_directories(runDir);
 
     jsonFilePathName = baseName + ".jsn";
     openJsonFilePathName = jsonFilePathName + ".open";
@@ -113,7 +113,7 @@ boost::property_tree::ptree DQMFileSaverPB::fillJson(int run,
                                                      const std::string& mergeTypeStr,
                                                      evf::FastMonitoringService* fms) {
   namespace bpt = boost::property_tree;
-  namespace bfs = boost::filesystem;
+  namespace bfs = std::filesystem;
 
   bpt::ptree pt;
 


### PR DESCRIPTION
#### PR description:
Changed boost filesystem for standard template library filesystem.
The code should have the same behaviour in this case.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 