### PR TITLE
TrackletEventProcessor: properly initialise and check settings

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
@@ -25,7 +25,7 @@ namespace trklet {
 
     ~TrackletEventProcessor();
 
-    void init(const Settings* theSettings);
+    void init(Settings const& theSettings);
 
     void event(SLHCEvent& ev);
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -302,7 +302,7 @@ void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& i
   settings.setBfield(mMagneticFieldStrength);
 
   // initialize the tracklet event processing (this sets all the processing & memory modules, wiring, etc)
-  eventProcessor.init(&settings);
+  eventProcessor.init(settings);
 }
 
 //////////

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -14,10 +14,10 @@
 using namespace trklet;
 using namespace std;
 
-TrackletEventProcessor::TrackletEventProcessor() = default;
+TrackletEventProcessor::TrackletEventProcessor() : settings_(nullptr) {}
 
 TrackletEventProcessor::~TrackletEventProcessor() {
-  if (settings_->bookHistos()) {
+  if (settings_ && settings_->bookHistos()) {
     histbase_->close();
   }
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -22,8 +22,8 @@ TrackletEventProcessor::~TrackletEventProcessor() {
   }
 }
 
-void TrackletEventProcessor::init(const Settings* theSettings) {
-  settings_ = theSettings;
+void TrackletEventProcessor::init(Settings const& theSettings) {
+  settings_ = &theSettings;
 
   globals_ = make_unique<Globals>(*settings_);
 

--- a/L1Trigger/TrackFindingTracklet/test/fpga.cc
+++ b/L1Trigger/TrackFindingTracklet/test/fpga.cc
@@ -74,7 +74,7 @@ int main(const int argc, const char **argv) {
   // ---------------------------------------------------------
 
   TrackletEventProcessor eventProcessor;
-  eventProcessor.init(&settings);
+  eventProcessor.init(settings);
 
   if (argc < 3)
     edm::LogVerbatim("Tracklet") << "Need to specify the input ascii file and the number of events to run on!";


### PR DESCRIPTION
Initialise `settings` to `nullptr` in the constructor.
Check that `settings` is not `nullptr` before accessing it in the destructor.
Pass `settings` by reference to avoid the possibility of a null pointer.