### PR TITLE
Hcal - QIEDelay in SIM

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/interface/HcalAmplifier.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalAmplifier.h
@@ -43,6 +43,7 @@ public:
 
 private:
   void pe2fC(CaloSamples& frame) const;
+  void applyQIEdelay(CaloSamples& frame, int delayQIE) const;
   void addPedestals(CaloSamples& frame, CLHEP::HepRandomEngine*) const;
   void makeNoise(HcalGenericDetId::HcalGenericSubdetector hcalSubDet,
                  const HcalCalibrationWidths& width,

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSimParameters.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSimParameters.h
@@ -40,7 +40,7 @@ public:
 
   int pixels(const DetId& detId) const;
   bool doSiPMSmearing() const { return theSiPMSmearing; }
-
+  int delayQIE() const { return delayQIE_; }
   double threshold_currentTDC() const { return threshold_currentTDC_; }
   double sipmTau() const { return theSiPMTau; }
   double sipmDarkCurrentuA(const DetId& detId) const;
@@ -61,6 +61,7 @@ private:
   HcalTimeSmearSettings theSmearSettings;
   double theSiPMTau;
   double threshold_currentTDC_;
+  int delayQIE_;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
@@ -70,6 +70,7 @@ void HcalAmplifier::applyQIEdelay(CaloSamples& cs, int delayQIE) const {
   int maxbin = cs.size();
   int precisebin = cs.preciseSize();
   CaloSamples data(detId, maxbin, precisebin);  // make a temporary copy
+  data = cs;
   data.setBlank();
   data.resetPrecise();
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
@@ -45,7 +45,9 @@ void HcalAmplifier::amplify(CaloSamples& frame, CLHEP::HepRandomEngine* engine) 
   pe2fC(frame);
 
   const HcalSimParameters& params = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(frame.id()));
-  if (params.delayQIE() > 0)
+  if (((frame.id().subdetId() == HcalGenericDetId::HcalGenBarrel) ||
+       (frame.id().subdetId() == HcalGenericDetId::HcalGenEndcap)) &&
+      params.delayQIE() > 0)
     applyQIEdelay(frame, params.delayQIE());
 
   // don't bother for blank signals

--- a/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
@@ -43,6 +43,11 @@ void HcalAmplifier::amplify(CaloSamples& frame, CLHEP::HepRandomEngine* engine) 
     theIonFeedbackSim->addThermalNoise(frame, engine);
   }
   pe2fC(frame);
+
+  const HcalSimParameters& params = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(frame.id()));
+  if (params.delayQIE() > 0)
+    applyQIEdelay(frame, params.delayQIE());
+
   // don't bother for blank signals
   if (theTimeSlewSim && frame.size() > 4 && frame[4] > 1.e-6) {
     theTimeSlewSim->delay(frame, engine, theTimeSlew);
@@ -58,6 +63,26 @@ void HcalAmplifier::amplify(CaloSamples& frame, CLHEP::HepRandomEngine* engine) 
 void HcalAmplifier::pe2fC(CaloSamples& frame) const {
   const CaloSimParameters& parameters = theParameterMap->simParameters(frame.id());
   frame *= parameters.photoelectronsToAnalog(frame.id());
+}
+
+void HcalAmplifier::applyQIEdelay(CaloSamples& cs, int delayQIE) const {
+  DetId detId(cs.id());
+  int maxbin = cs.size();
+  int precisebin = cs.preciseSize();
+  CaloSamples data(detId, maxbin, precisebin);  // make a temporary copy
+  data.setBlank();
+  data.resetPrecise();
+
+  for (int i = 0; i < precisebin; i++) {
+    if (i < 2 * delayQIE)
+      data.preciseAtMod(i) += 0.;
+    else
+      data.preciseAtMod(i) += cs.preciseAt(i - 2 * delayQIE);
+    int samplebin = (int)i * maxbin / precisebin;
+    data[samplebin] += data.preciseAt(i);
+  }
+
+  cs = data;  // update the sample
 }
 
 void HcalAmplifier::addPedestals(CaloSamples& frame, CLHEP::HepRandomEngine* engine) const {

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSimParameters.cc
@@ -47,7 +47,8 @@ HcalSimParameters::HcalSimParameters(const edm::ParameterSet& p)
       theSiPMSmearing(p.getParameter<bool>("doSiPMSmearing")),
       doTimeSmear_(p.getParameter<bool>("timeSmearing")),
       theSiPMTau(p.getParameter<double>("sipmTau")),
-      threshold_currentTDC_(p.getParameter<double>("threshold_currentTDC")) {
+      threshold_currentTDC_(p.getParameter<double>("threshold_currentTDC")),
+      delayQIE_(p.getParameter<int>("delayQIE")) {
   defaultTimeSmearing();
 
   edm::LogInfo("HcalSimParameters:") << " doSiPMsmearing    = " << theSiPMSmearing;

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -22,6 +22,7 @@ hcalSimParameters = cms.PSet(
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
         threshold_currentTDC = cms.double(-999.),
+        delayQIE = cms.int32(-999),
     ),
     hf2 = cms.PSet(
         readoutFrameSize = cms.int32(4),
@@ -35,6 +36,7 @@ hcalSimParameters = cms.PSet(
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
         threshold_currentTDC = cms.double(-999.),
+        delayQIE = cms.int32(-999),
     ),
     ho = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -53,6 +55,7 @@ hcalSimParameters = cms.PSet(
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(5.),
         threshold_currentTDC = cms.double(-999.),
+        delayQIE = cms.int32(-999),
     ),
     hb = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -71,6 +74,7 @@ hcalSimParameters = cms.PSet(
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
         threshold_currentTDC = cms.double(-999.),
+        delayQIE = cms.int32(-999),
     ),
     he = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -88,6 +92,7 @@ hcalSimParameters = cms.PSet(
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
         threshold_currentTDC = cms.double(-999.),
+        delayQIE = cms.int32(-999),
     ),
     zdc = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -101,6 +106,7 @@ hcalSimParameters = cms.PSet(
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
         threshold_currentTDC = cms.double(-999.),
+        delayQIE = cms.int32(-999),
     ),
 )
 


### PR DESCRIPTION
#### PR description:
Additional tech.method to perform time scan of the resulting simulated HBHE pulse shape (emulating real detector time scan by configurable delay in FE QIE chip) to adjust its parametrization eventually used for MAHI fit in Reconstruction. 

NB: not used by default.

study validation using this method: https://indico.cern.ch/event/936151/#110-mc-hbhe-signal-shape-time