### PR TITLE
TTTrack bug fix for POCA 

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -212,7 +212,7 @@ TTTrack<T>::TTTrack(double aRinv,
   double thePT = std::abs(MagConstant / aRinv * aBfield / 100.0);  // Rinv is in cm-1
   theMomentum_ = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
   theRInv_ = aRinv;
-  thePOCA_ = GlobalPoint(ad0 * sin(aphi0), - ad0 * cos(aphi0), az0);
+  thePOCA_ = GlobalPoint(ad0 * sin(aphi0), -ad0 * cos(aphi0), az0);
   theD0_ = ad0;
   theZ0_ = az0;
   thePhi_ = aphi0;

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -212,7 +212,7 @@ TTTrack<T>::TTTrack(double aRinv,
   double thePT = std::abs(MagConstant / aRinv * aBfield / 100.0);  // Rinv is in cm-1
   theMomentum_ = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
   theRInv_ = aRinv;
-  thePOCA_ = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
+  thePOCA_ = GlobalPoint(ad0 * sin(aphi0), - ad0 * cos(aphi0), az0);
   theD0_ = ad0;
   theZ0_ = az0;
   thePhi_ = aphi0;


### PR DESCRIPTION
There was a bug in the variable "thePOCA", which represents the point of closest approach of the helix to the line x=y=0. This will affect anyone who uses the function TTTrack::POCA().

However, people using other TTTrack functions, such as those giving access to the helix parameters, will be unaffected.

I'd suggest back-porting this fix to CMSSW 11.1, if possible, as although I suspect few people use TTTrack::POCA(), the bug will confuse anyone who does.