### PR TITLE
Backport to 11_1_X of "TTTrack bug fix for POCA" 

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -212,7 +212,7 @@ TTTrack<T>::TTTrack(double aRinv,
   double thePT = std::abs(MagConstant / aRinv * aBfield / 100.0);  // Rinv is in cm-1
   theMomentum_ = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
   theRInv_ = aRinv;
-  thePOCA_ = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
+  thePOCA_ = GlobalPoint(ad0 * sin(aphi0), -ad0 * cos(aphi0), az0);
   theD0_ = ad0;
   theZ0_ = az0;
   thePhi_ = aphi0;


### PR DESCRIPTION
This is identical to the PR https://github.com/cms-sw/cmssw/pull/30663 , except that it is a backport that should go into CMSSW 11.1.