### PR TITLE
cmsRun: By default use jemalloc for non-x86_64 archs too

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -33,10 +33,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <!-- jemalloc is mostly tested on x86_64 in upstream -->
-  <architecture name=".*_amd64_.*">
-    <use name="jemalloc"/>
-  </architecture>
+  <use name="jemalloc"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>

--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -76,10 +76,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <!-- jemalloc is mostly tested on x86_64 in upstream -->
-  <architecture name=".*_amd64_.*">
-    <use name="jemalloc"/>
-  </architecture>
+  <use name="jemalloc"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>


### PR DESCRIPTION
There are many relvals failing for aarch64 and ppc64le IBs, We think these crashes might be related to the usage of glibc for memory management. 

https://github.com/cms-sw/cmssw/pull/18405  suggest that we had issues with aarch64 and thatis why we disabled the usage of jemalloc. This PR proposses to try jemalloc for non-x86_64 IBs too.