### PR TITLE
drop type specs in RecoTracker/{MkFit,MeasurementDet,IterativeTracking}

### DIFF
--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -10,9 +10,9 @@ from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 ###############################################
 
 # REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
-detachedQuadStepClusters = _cfg.clusterRemoverForIter("DetachedQuadStep")
+detachedQuadStepClusters = _cfg.clusterRemoverForIter('DetachedQuadStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(detachedQuadStepClusters, _cfg.clusterRemoverForIter("DetachedQuadStep", _eraName, _postfix))
+    _era.toReplaceWith(detachedQuadStepClusters, _cfg.clusterRemoverForIter('DetachedQuadStep', _eraName, _postfix))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerQuadruplets_cfi
@@ -24,16 +24,16 @@ detachedQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerQuadruplets_c
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 detachedQuadStepTrackingRegions = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
-    ptMin = 0.3,
+    ptMin            = 0.3,
     originHalfLength = 15.0,
-    originRadius = 1.5
+    originRadius     = 1.5
 ))
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toReplaceWith(detachedQuadStepTrackingRegions, _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(
-    ptMin = 0.45,
+    ptMin        = 0.45,
     originRadius = 0.9,
-    nSigmaZ = 5.0
+    nSigmaZ      = 5.0
 )))
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
@@ -41,8 +41,8 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(detachedQuadStepTrackingRegions, 
                 _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                    fixedError = 3.75,
-                    ptMin = 0.9,
+                    fixedError   = 3.75,
+                    ptMin        = 0.9,
                     originRadius = 1.5
                 )
                                                                       )
@@ -54,40 +54,40 @@ highBetaStar_2018.toModify(detachedQuadStepTrackingRegions,RegionPSet = dict(ptM
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 detachedQuadStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "detachedQuadStepSeedLayers",
-    trackingRegions = "detachedQuadStepTrackingRegions",
-    layerPairs = [0,1,2], # layer pairs (0,1), (1,2), (2,3),
-    maxElement = 50000000,
+    seedingLayers   = 'detachedQuadStepSeedLayers',
+    trackingRegions = 'detachedQuadStepTrackingRegions',
+    layerPairs      = [0,1,2], # layer pairs (0,1), (1,2), (2,3),
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
 from RecoPixelVertexing.PixelTriplets.pixelTripletLargeTipEDProducer_cfi import pixelTripletLargeTipEDProducer as _pixelTripletLargeTipEDProducer
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 detachedQuadStepHitQuadruplets = _caHitQuadrupletEDProducer.clone(
-    doublets = "detachedQuadStepHitDoublets",
+    doublets = 'detachedQuadStepHitDoublets',
     extraHitRPhitolerance = _pixelTripletLargeTipEDProducer.extraHitRPhitolerance,
     maxChi2 = dict(
         pt1    = 0.8, pt2    = 2,
         value1 = 500, value2 = 100,
     ),
     useBendingCorrection = True,
-    fitFastCircle = True,
+    fitFastCircle        = True,
     fitFastCircleChi2Cut = True,
-    CAThetaCut = 0.0011,
-    CAPhiCut = 0,
+    CAThetaCut           = 0.0011,
+    CAPhiCut             = 0,
 )
 highBetaStar_2018.toModify(detachedQuadStepHitQuadruplets,CAThetaCut = 0.0022,CAPhiCut = 0.1)
 
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cff import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
 detachedQuadStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(
-    seedingHitSets = "detachedQuadStepHitQuadruplets",
+    seedingHitSets     = 'detachedQuadStepHitQuadruplets',
     SeedComparitorPSet = dict(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
-        ComponentName = 'PixelClusterShapeSeedComparitor',
+        ComponentName  = 'PixelClusterShapeSeedComparitor',
         FilterAtHelixStage = cms.bool(False),
-        FilterPixelHits = cms.bool(True),
-        FilterStripHits = cms.bool(False),
+        FilterPixelHits    = cms.bool(True),
+        FilterStripHits    = cms.bool(False),
         ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
-        ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
+        ClusterShapeCacheSrc      = cms.InputTag('siPixelClusterShapeCache')
     ),
 )
 
@@ -95,14 +95,14 @@ detachedQuadStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProduc
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
 _fastSim_detachedQuadStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "detachedQuadStepTrackingRegions",
-    hitMasks = cms.InputTag("detachedQuadStepMasks"),
+    trackingRegions = 'detachedQuadStepTrackingRegions',
+    hitMasks        = cms.InputTag('detachedQuadStepMasks'),
     seedFinderSelector = dict( CAHitQuadrupletGeneratorFactory = _hitSetProducerToFactoryPSet(detachedQuadStepHitQuadruplets).clone(
-            SeedComparitorPSet = dict(ComponentName = "none")),
-                               layerList = detachedQuadStepSeedLayers.layerList.value(),
+            SeedComparitorPSet = dict(ComponentName = 'none')),
+                               layerList  = detachedQuadStepSeedLayers.layerList.value(),
                                #new parameters required for phase1 seeding
-                               BPix = dict(TTRHBuilder = 'WithoutRefit', HitProducer = 'TrackingRecHitProducer',),
-                               FPix = dict(TTRHBuilder = 'WithoutRefit', HitProducer = 'TrackingRecHitProducer',),
+                               BPix       = dict(TTRHBuilder = 'WithoutRefit', HitProducer = 'TrackingRecHitProducer',),
+                               FPix       = dict(TTRHBuilder = 'WithoutRefit', HitProducer = 'TrackingRecHitProducer',),
                                layerPairs = detachedQuadStepHitDoublets.layerPairs.value()
                                ))
 fastSim.toReplaceWith(detachedQuadStepSeeds,_fastSim_detachedQuadStepSeeds)
@@ -111,10 +111,10 @@ fastSim.toReplaceWith(detachedQuadStepSeeds,_fastSim_detachedQuadStepSeeds)
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff
 _detachedQuadStepTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.075,
+    minPt               = 0.075,
 )
 detachedQuadStepTrajectoryFilterBase = _detachedQuadStepTrajectoryFilterBase.clone(
-    maxCCCLostHits = 0,
+    maxCCCLostHits     = 0,
     minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 trackingPhase2PU140.toReplaceWith(detachedQuadStepTrajectoryFilterBase,
@@ -135,16 +135,15 @@ for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 detachedQuadStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = 'detachedQuadStepChi2Est',
-    nSigma = 3.0,
-    MaxChi2 = 9.0,
+    ComponentName    = 'detachedQuadStepChi2Est',
+    nSigma           = 3.0,
+    MaxChi2          = 9.0,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight'),
 )
 trackingPhase2PU140.toModify(detachedQuadStepChi2Est,
-    MaxChi2 = 12.0,
-    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone")
+    MaxChi2          = 12.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
-
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
@@ -155,19 +154,19 @@ detachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryB
     alwaysUseInvalidHits = True,
     estimator = 'detachedQuadStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7) 
+    maxPtForLooperReconstruction = cms.double(0.7)
 )
 trackingPhase2PU140.toModify(detachedQuadStepTrajectoryBuilder,
-    maxCand = 2,
+    maxCand              = 2,
     alwaysUseInvalidHits = False,
 )
 
 # MAKING OF TRACK CANDIDATES
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 detachedQuadStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
-    ComponentName = cms.string('detachedQuadStepTrajectoryCleanerBySharedHits'),
-    fractionShared = cms.double(0.13),
-    allowSharedFirstHit = cms.bool(True)
+    ComponentName       = 'detachedQuadStepTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.13,
+    allowSharedFirstHit = True
 )
 
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -183,50 +182,50 @@ detachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.
     useHitsSplitting = True
 )
 trackingPhase2PU140.toModify(detachedQuadStepTrackCandidates,
-    clustersToSkip = None,
-    phase2clustersToSkip = cms.InputTag("detachedQuadStepClusters")
+    clustersToSkip       = None,
+    phase2clustersToSkip = cms.InputTag('detachedQuadStepClusters')
 )
 
 #For FastSim phase1 tracking 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 _fastSim_detachedQuadStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    src = cms.InputTag("detachedQuadStepSeeds"),
+    src                      = 'detachedQuadStepSeeds',
     MinNumberOfCrossedLayers = 4,
-    hitMasks = cms.InputTag("detachedQuadStepMasks")
-    )
+    hitMasks                 = cms.InputTag('detachedQuadStepMasks')
+)
 fastSim.toReplaceWith(detachedQuadStepTrackCandidates,_fastSim_detachedQuadStepTrackCandidates)
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     AlgorithmName = 'detachedQuadStep',
-    src = 'detachedQuadStepTrackCandidates',
-    Fitter = 'FlexibleKFFittingSmoother',
+    src           = 'detachedQuadStepTrackCandidates',
+    Fitter        = 'FlexibleKFFittingSmoother',
 )
 fastSim.toModify(detachedQuadStepTracks,TTRHBuilder = 'WithoutRefit')
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 detachedQuadStep = TrackMVAClassifierDetached.clone(
-    mva = dict(GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1'),
-    src = 'detachedQuadStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1'),
+    src         = 'detachedQuadStepTracks',
     qualityCuts = [-0.5,0.0,0.5]
 )
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(detachedQuadStep, TrackLwtnnClassifier.clone(
-    src = 'detachedQuadStepTracks',
+    src         = 'detachedQuadStepTracks',
     qualityCuts = [-0.6, 0.05, 0.7]
 ))
 
 highBetaStar_2018.toModify(detachedQuadStep,qualityCuts = [-0.7,0.0,0.5])
 pp_on_AA_2018.toModify(detachedQuadStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorDetachedQuadStep_Phase1'),
+        mva         = dict(GBRForestLabel = 'HIMVASelectorDetachedQuadStep_Phase1'),
         qualityCuts = [-0.2, 0.2, 0.5],
 )
 
-fastSim.toModify(detachedQuadStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+fastSim.toModify(detachedQuadStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
@@ -316,15 +315,15 @@ detachedQuadStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cf
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 trackingPhase2PU140.toReplaceWith(detachedQuadStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-    TrackProducers = cms.VInputTag(cms.InputTag('detachedQuadStepTracks'),
-                                   cms.InputTag('detachedQuadStepTracks')),
-    hasSelector=cms.vint32(1,1),
-    shareFrac = cms.double(0.09),
-    indivShareFrac=cms.vdouble(0.09,0.09),
-    selectedTrackQuals = cms.VInputTag(cms.InputTag("detachedQuadStepSelector","detachedQuadStepVtx"),
-                                       cms.InputTag("detachedQuadStepSelector","detachedQuadStepTrk")),
+    TrackProducers     =['detachedQuadStepTracks',
+                         'detachedQuadStepTracks'],
+    hasSelector        =[1,1],
+    ShareFrac          = 0.09,
+    indivShareFrac     =[0.09,0.09],
+    selectedTrackQuals =['detachedQuadStepSelector:detachedQuadStepVtx',
+                         'detachedQuadStepSelector:detachedQuadStepTrk'],
     setsToMerge = cms.VPSet(cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )),
-    writeOnlyTrkQuals=cms.bool(True)
+    writeOnlyTrkQuals  =True
     )
 )
 

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -141,7 +141,7 @@ _detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Tra
 )
 detachedTripletStepTrajectoryFilterBase = _detachedTripletStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 0,
-    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(detachedTripletStepTrajectoryFilterBase, maxCCCLostHits = 2)
@@ -170,7 +170,7 @@ detachedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEst
     ComponentName = 'detachedTripletStepChi2Est',
     nSigma        = 3.0,
     MaxChi2       = 9.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight'),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
 )
 _tracker_apv_vfp30_2016.toModify(detachedTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -180,7 +180,7 @@ _tracker_apv_vfp30_2016.toModify(detachedTripletStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = dict(refToPSet_ = 'detachedTripletStepTrajectoryFilter'),
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryFilter')),
     maxCand = 3,
     alwaysUseInvalidHits = True,
     estimator = 'detachedTripletStepChi2Est',
@@ -200,7 +200,7 @@ detachedTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_c
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'detachedTripletStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryBuilder')),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
     )

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -14,29 +14,30 @@ from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 ###############################################
 
 # REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
-detachedTripletStepClusters = _cfg.clusterRemoverForIter("DetachedTripletStep")
+detachedTripletStepClusters = _cfg.clusterRemoverForIter('DetachedTripletStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(detachedTripletStepClusters, _cfg.clusterRemoverForIter("DetachedTripletStep", _eraName, _postfix))
+    _era.toReplaceWith(detachedTripletStepClusters, _cfg.clusterRemoverForIter('DetachedTripletStep', _eraName, _postfix))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
-detachedTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
-detachedTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('detachedTripletStepClusters')
-detachedTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('detachedTripletStepClusters')
+detachedTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    BPix = dict(skipClusters = cms.InputTag('detachedTripletStepClusters')),
+    FPix = dict(skipClusters = cms.InputTag('detachedTripletStepClusters'))
+)
 _phase1LayerList = [
         'BPix1+BPix2+BPix3',
         'BPix2+BPix3+BPix4',
-#        'BPix1+BPix3+BPix4', # has "hole", not tested
-#        'BPix1+BPix2+BPix4', # has "hole", not tested
+#        'BPix1+BPix3+BPix4', # has 'hole', not tested
+#        'BPix1+BPix2+BPix4', # has 'hole', not tested
         'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
 #        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', # mostly fake tracks, lots of seeds
-#        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',  # has "hole", not tested
+#        'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',  # has 'hole', not tested
         'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
 #        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg', # mostly fake tracks, lots of seeds
-#        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',  # has "hole", not tested
+#        'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',  # has 'hole', not tested
         'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
-#        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',  # has "hole", not tested
-#        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'  # has "hole", not tested
+#        'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',  # has 'hole', not tested
+#        'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'  # has 'hole', not tested
     ]
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(detachedTripletStepSeedLayers, layerList=_phase1LayerList)
@@ -44,9 +45,9 @@ trackingPhase1.toModify(detachedTripletStepSeedLayers, layerList=_phase1LayerLis
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 detachedTripletStepTrackingRegions = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
-    ptMin = 0.3,
+    ptMin            = 0.3,
     originHalfLength = 15.0,
-    originRadius = 1.5
+    originRadius     = 1.5
 ))
 trackingPhase1.toModify(detachedTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.25))
 
@@ -55,38 +56,36 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(detachedTripletStepTrackingRegions, 
                 _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                    fixedError = 2.5,
-                    ptMin = 0.9,
-                    originRadius = 1.5
+                    fixedError   = 2.5,
+                    ptMin        = 0.9,
+                    originRadius = 1.5)
                 )
-                                                                      )
 )
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(detachedTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.05))
 
-
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 detachedTripletStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "detachedTripletStepSeedLayers",
-    trackingRegions = "detachedTripletStepTrackingRegions",
-    maxElement = 50000000,
+    seedingLayers   = 'detachedTripletStepSeedLayers',
+    trackingRegions = 'detachedTripletStepTrackingRegions',
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletLargeTipEDProducer_cfi import pixelTripletLargeTipEDProducer as _pixelTripletLargeTipEDProducer
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 detachedTripletStepHitTriplets = _pixelTripletLargeTipEDProducer.clone(
-    doublets = "detachedTripletStepHitDoublets",
+    doublets = 'detachedTripletStepHitDoublets',
     produceSeedingHitSets = True,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cff import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
 detachedTripletStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(
-    seedingHitSets = "detachedTripletStepHitTriplets",
+    seedingHitSets = 'detachedTripletStepHitTriplets',
     SeedComparitorPSet = dict(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
-        ComponentName = 'PixelClusterShapeSeedComparitor',
+        ComponentName      = 'PixelClusterShapeSeedComparitor',
         FilterAtHelixStage = cms.bool(False),
-        FilterPixelHits = cms.bool(True),
-        FilterStripHits = cms.bool(False),
+        FilterPixelHits    = cms.bool(True),
+        FilterStripHits    = cms.bool(False),
         ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     ),
@@ -95,23 +94,23 @@ detachedTripletStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDPro
 from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
 trackingPhase1.toModify(detachedTripletStepHitDoublets, layerPairs = [0,1]) # layer pairs (0,1), (1,2)
 trackingPhase1.toReplaceWith(detachedTripletStepHitTriplets, _caHitTripletEDProducer.clone(
-    doublets = "detachedTripletStepHitDoublets",
+    doublets = 'detachedTripletStepHitDoublets',
     extraHitRPhitolerance = detachedTripletStepHitTriplets.extraHitRPhitolerance,
     maxChi2 = dict(
         pt1    = 0.8, pt2    = 2,
-        value1 = 300 , value2 = 10,
+        value1 = 300, value2 = 10,
     ),
     useBendingCorrection = True,
-    CAThetaCut = 0.001,
-    CAPhiCut = 0,
-    CAHardPtCut = 0.2,
+    CAThetaCut           = 0.001,
+    CAPhiCut             = 0,
+    CAHardPtCut          = 0.2,
 ))
 highBetaStar_2018.toModify(detachedTripletStepHitTriplets,CAThetaCut = 0.002,CAPhiCut = 0.1,CAHardPtCut = 0)
 
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 _fastSim_detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "detachedTripletStepTrackingRegions",
-    hitMasks = cms.InputTag("detachedTripletStepMasks"),
+    trackingRegions = 'detachedTripletStepTrackingRegions',
+    hitMasks        = cms.InputTag('detachedTripletStepMasks'),
     seedFinderSelector = dict( pixelTripletGeneratorFactory = _hitSetProducerToFactoryPSet(detachedTripletStepHitTriplets),
                                layerList = detachedTripletStepSeedLayers.layerList.value())
 )#new for phase1
@@ -138,11 +137,11 @@ _detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Tra
 #    maxLostHitsFraction = cms.double(1./10.),
 #    constantValueForLostHitsFractionFilter = cms.double(0.701),
     minimumNumberOfHits = 3,
-    minPt = 0.075,
+    minPt               = 0.075,
 )
 detachedTripletStepTrajectoryFilterBase = _detachedTripletStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 0,
-    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(detachedTripletStepTrajectoryFilterBase, maxCCCLostHits = 2)
@@ -168,23 +167,23 @@ detachedTripletStepTrajectoryFilter = cms.PSet(
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 detachedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('detachedTripletStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+    ComponentName = 'detachedTripletStepChi2Est',
+    nSigma        = 3.0,
+    MaxChi2       = 9.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight'),
 )
 _tracker_apv_vfp30_2016.toModify(detachedTripletStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutTiny")
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryFilter')),
+    trajectoryFilter = dict(refToPSet_ = 'detachedTripletStepTrajectoryFilter'),
     maxCand = 3,
     alwaysUseInvalidHits = True,
-    estimator = cms.string('detachedTripletStepChi2Est'),
+    estimator = 'detachedTripletStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
     )
@@ -196,41 +195,41 @@ trackingLowPU.toModify(detachedTripletStepTrajectoryBuilder,
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 detachedTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('detachedTripletStepSeeds'),
+    src = 'detachedTripletStepSeeds',
     clustersToSkip = cms.InputTag('detachedTripletStepClusters'),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryBuilder')),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'detachedTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
     )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 detachedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
-        ComponentName = cms.string('detachedTripletStepTrajectoryCleanerBySharedHits'),
-            fractionShared = cms.double(0.13),
-            allowSharedFirstHit = cms.bool(True)
-            )
+    ComponentName       = 'detachedTripletStepTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.13,
+    allowSharedFirstHit = True
+)
 detachedTripletStepTrackCandidates.TrajectoryCleaner = 'detachedTripletStepTrajectoryCleanerBySharedHits'
 trackingLowPU.toModify(detachedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 _fastSim_detachedTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    src = cms.InputTag("detachedTripletStepSeeds"),
+    src = 'detachedTripletStepSeeds',
     MinNumberOfCrossedLayers = 3,
-    hitMasks = cms.InputTag("detachedTripletStepMasks")
-    )
+    hitMasks = cms.InputTag('detachedTripletStepMasks')
+)
 fastSim.toReplaceWith(detachedTripletStepTrackCandidates,_fastSim_detachedTripletStepTrackCandidates)
 
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 detachedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    AlgorithmName = cms.string('detachedTripletStep'),
-    src = 'detachedTripletStepTrackCandidates',
-    Fitter = cms.string('FlexibleKFFittingSmoother')
-    )
+    AlgorithmName = 'detachedTripletStep',
+    src           = 'detachedTripletStepTrackCandidates',
+    Fitter        = 'FlexibleKFFittingSmoother'
+)
 fastSim.toModify(detachedTripletStepTracks,TTRHBuilder = 'WithoutRefit')
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
@@ -238,25 +237,27 @@ fastSim.toModify(detachedTripletStepTracks,TTRHBuilder = 'WithoutRefit')
 
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
-detachedTripletStepClassifier1 = TrackMVAClassifierDetached.clone()
-detachedTripletStepClassifier1.src = 'detachedTripletStepTracks'
-detachedTripletStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter3_13TeV'
-detachedTripletStepClassifier1.qualityCuts = [-0.5,0.0,0.5]
-fastSim.toModify(detachedTripletStepClassifier1,vertices = "firstStepPrimaryVerticesBeforeMixing")
+detachedTripletStepClassifier1 = TrackMVAClassifierDetached.clone(
+    src = 'detachedTripletStepTracks',
+    mva = dict(GBRForestLabel = 'MVASelectorIter3_13TeV'),
+    qualityCuts = [-0.5,0.0,0.5]
+)
+fastSim.toModify(detachedTripletStepClassifier1,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
-detachedTripletStepClassifier2 = TrackMVAClassifierPrompt.clone()
-detachedTripletStepClassifier2.src = 'detachedTripletStepTracks'
-detachedTripletStepClassifier2.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
-detachedTripletStepClassifier2.qualityCuts = [-0.2,0.0,0.4]
-fastSim.toModify(detachedTripletStepClassifier2,vertices = "firstStepPrimaryVerticesBeforeMixing")
+detachedTripletStepClassifier2 = TrackMVAClassifierPrompt.clone(
+    src = 'detachedTripletStepTracks',
+    mva = dict(GBRForestLabel = 'MVASelectorIter0_13TeV'),
+    qualityCuts = [-0.2,0.0,0.4]
+)
+fastSim.toModify(detachedTripletStepClassifier2,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
-detachedTripletStep = ClassifierMerger.clone()
-detachedTripletStep.inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
-
+detachedTripletStep = ClassifierMerger.clone(
+    inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
+)
 trackingPhase1.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1'),
-     qualityCuts = [-0.2,0.3,0.8]
+    mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1'),
+    qualityCuts = [-0.2,0.3,0.8]
 ))
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
@@ -265,7 +266,7 @@ trackdnn.toReplaceWith(detachedTripletStep, TrackLwtnnClassifier.clone(
      src = 'detachedTripletStepTracks',
      qualityCuts = [0.0, 0.4, 0.8],
 ))
-(trackdnn & fastSim).toModify(detachedTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+(trackdnn & fastSim).toModify(detachedTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 highBetaStar_2018.toModify(detachedTripletStep,qualityCuts = [-0.5,0.0,0.5])
 pp_on_AA_2018.toModify(detachedTripletStep, 
@@ -358,17 +359,13 @@ detachedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 trackingLowPU.toReplaceWith(detachedTripletStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-    TrackProducers = [
-        'detachedTripletStepTracks',
-        'detachedTripletStepTracks',
-    ],
-    hasSelector = [1,1],
-    selectedTrackQuals = [
-        cms.InputTag("detachedTripletStepSelector","detachedTripletStepVtx"),
-        cms.InputTag("detachedTripletStepSelector","detachedTripletStepTrk")
-    ],
-    setsToMerge = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )],
-    writeOnlyTrkQuals =True
+    TrackProducers     = ['detachedTripletStepTracks',
+                          'detachedTripletStepTracks'],
+    hasSelector        = [1,1],
+    selectedTrackQuals = ['detachedTripletStepSelector:detachedTripletStepVtx',
+                          'detachedTripletStepSelector:detachedTripletStepTrk'],
+    setsToMerge        = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )],
+    writeOnlyTrkQuals  = True
 ))
 
 DetachedTripletStepTask = cms.Task(detachedTripletStepClusters,

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -2,57 +2,57 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import seedClusterRemover
 initialStepSeedClusterMask = seedClusterRemover.clone(
-    trajectories = cms.InputTag("initialStepSeeds"),
+    trajectories = 'initialStepSeeds',
     oldClusterRemovalInfo = cms.InputTag("pixelLessStepClusters")
 )
 
 from RecoLocalTracker.SubCollectionProducers.seedClusterRemoverPhase2_cfi import seedClusterRemoverPhase2
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toReplaceWith(initialStepSeedClusterMask, seedClusterRemoverPhase2.clone(
-    trajectories = cms.InputTag("initialStepSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("highPtTripletStepClusters")
+    trajectories = 'initialStepSeeds',
+    oldClusterRemovalInfo = cms.InputTag('highPtTripletStepClusters')
     )
 )
 
 highPtTripletStepSeedClusterMask = seedClusterRemover.clone( # for Phase2PU140
-    trajectories = "highPtTripletStepSeeds",
-    oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
+    trajectories = 'highPtTripletStepSeeds',
+    oldClusterRemovalInfo = cms.InputTag('initialStepSeedClusterMask')
 )
 pixelPairStepSeedClusterMask = seedClusterRemover.clone(
-    trajectories = cms.InputTag("pixelPairStepSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
+    trajectories = 'pixelPairStepSeeds',
+    oldClusterRemovalInfo = cms.InputTag('initialStepSeedClusterMask')
 )
 
 trackingPhase2PU140.toReplaceWith(highPtTripletStepSeedClusterMask, seedClusterRemoverPhase2.clone(
-    trajectories = cms.InputTag("highPtTripletStepSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
+    trajectories = 'highPtTripletStepSeeds',
+    oldClusterRemovalInfo = cms.InputTag('initialStepSeedClusterMask')
     )
 )
 trackingPhase2PU140.toReplaceWith(pixelPairStepSeedClusterMask, seedClusterRemoverPhase2.clone(
-    trajectories = cms.InputTag("detachedQuadStepSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("highPtTripletStepSeedClusterMask")
+    trajectories = cms.InputTag('detachedQuadStepSeeds'),
+    oldClusterRemovalInfo = cms.InputTag('highPtTripletStepSeedClusterMask')
     )
 )
 
 # This is a pure guess to use detachedTripletStep for phase1 here instead of the pixelPair in Run2 configuration
 detachedTripletStepSeedClusterMask = seedClusterRemover.clone(
-    trajectories = cms.InputTag("lowPtTripletStepSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("initialStepSeedClusterMask")
+    trajectories = 'lowPtTripletStepSeeds',
+    oldClusterRemovalInfo = cms.InputTag('initialStepSeedClusterMask')
 )
 mixedTripletStepSeedClusterMask = seedClusterRemover.clone(
-    trajectories = cms.InputTag("mixedTripletStepSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("pixelPairStepSeedClusterMask")
+    trajectories = 'mixedTripletStepSeeds',
+    oldClusterRemovalInfo = cms.InputTag('pixelPairStepSeedClusterMask')
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(mixedTripletStepSeedClusterMask,
-    oldClusterRemovalInfo = "detachedTripletStepSeedClusterMask"
+    oldClusterRemovalInfo = 'detachedTripletStepSeedClusterMask'
 )
 pixelLessStepSeedClusterMask = seedClusterRemover.clone(
-    trajectories = cms.InputTag("pixelLessStepSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("mixedTripletStepSeedClusterMask")
+    trajectories = 'pixelLessStepSeeds',
+    oldClusterRemovalInfo = cms.InputTag('mixedTripletStepSeedClusterMask')
 )
 
-tripletElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+tripletElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring('BPix1+BPix2+BPix3', 
                             'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
                             'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg'),
@@ -89,9 +89,9 @@ trackingPhase2PU140.toModify(tripletElectronSeedLayers,
 
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 tripletElectronTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(
-    ptMin = 1.0,
+    ptMin        = 1.0,
     originRadius = 0.02,
-    nSigmaZ = 4.0
+    nSigmaZ      = 4.0
 ))
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
@@ -99,27 +99,29 @@ from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import g
 pp_on_AA_2018.toReplaceWith(tripletElectronTrackingRegions,
     _globalTrackingRegionWithVertices.clone(
         RegionPSet = dict(
-            fixedError = 0.5,
-            ptMin = 8.0,
-            originRadius = 0.02)))
+            fixedError   = 0.5,
+            ptMin        = 8.0,
+            originRadius = 0.02
+        )
+))
 
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 tripletElectronHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "tripletElectronSeedLayers",
-    trackingRegions = "tripletElectronTrackingRegions",
-    maxElement = 50000000,
+    seedingLayers   = 'tripletElectronSeedLayers',
+    trackingRegions = 'tripletElectronTrackingRegions',
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
 tripletElectronHitTriplets = _pixelTripletHLTEDProducer.clone(
-    doublets = "tripletElectronHitDoublets",
+    doublets   = 'tripletElectronHitDoublets',
     maxElement = 1000000,
     produceSeedingHitSets = True,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 tripletElectronSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "tripletElectronHitTriplets",
+    seedingHitSets = 'tripletElectronHitTriplets',
 )
 trackingPhase2PU140.toModify(tripletElectronHitTriplets,
     maxElement = 0,
@@ -127,16 +129,16 @@ trackingPhase2PU140.toModify(tripletElectronHitTriplets,
 
 from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import seedClusterRemover
 tripletElectronClusterMask = seedClusterRemover.clone(
-    trajectories = cms.InputTag("tripletElectronSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("pixelLessStepSeedClusterMask")
+    trajectories = 'tripletElectronSeeds',
+    oldClusterRemovalInfo = cms.InputTag('pixelLessStepSeedClusterMask')
 )
 trackingPhase2PU140.toReplaceWith(tripletElectronClusterMask, seedClusterRemoverPhase2.clone(
-    trajectories = cms.InputTag("tripletElectronSeeds"),
-    oldClusterRemovalInfo = cms.InputTag("pixelLessStepSeedClusterMask")
+    trajectories = 'tripletElectronSeeds',
+    oldClusterRemovalInfo = cms.InputTag('pixelLessStepSeedClusterMask')
     )
 )
 
-pixelPairElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+pixelPairElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
                             'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
                             'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
@@ -168,35 +170,35 @@ trackingPhase1.toModify(pixelPairElectronSeedLayers, layerList = _layerListForPh
 
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 pixelPairElectronTrackingRegions = _globalTrackingRegionWithVertices.clone(RegionPSet = dict(
-    ptMin = 1.0,
+    ptMin        = 1.0,
     originRadius = 0.015,
-    fixedError = 0.03,
+    fixedError   = 0.03,
 ))
 pp_on_AA_2018.toModify(pixelPairElectronTrackingRegions, RegionPSet = dict(ptMin = 8.0))
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 pixelPairElectronHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "pixelPairElectronSeedLayers",
-    trackingRegions = "pixelPairElectronTrackingRegions",
-    maxElement = 1000000,
+    seedingLayers         = 'pixelPairElectronSeedLayers',
+    trackingRegions       = 'pixelPairElectronTrackingRegions',
+    maxElement            = 1000000,
     produceSeedingHitSets = True,
-    maxElementTotal = 12000000,
+    maxElementTotal       = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 pixelPairElectronSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "pixelPairElectronHitDoublets",
+    seedingHitSets = 'pixelPairElectronHitDoublets',
 )
 
-stripPairElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+stripPairElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring('TIB1+TIB2', 'TIB1+TID1_pos', 'TIB1+TID1_neg', 'TID2_pos+TID3_pos', 'TID2_neg+TID3_neg',
                             'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos',
                             'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg'),
     TIB = cms.PSet(
     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
     skipClusters = cms.InputTag('tripletElectronClusterMask')
     ),
     TID = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
     skipClusters = cms.InputTag('tripletElectronClusterMask'),
     useRingSlector = cms.bool(True),
     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
@@ -204,7 +206,7 @@ stripPairElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     maxRing = cms.int32(2)
     ),
     TEC = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+    matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
     skipClusters = cms.InputTag('tripletElectronClusterMask'),
     useRingSlector = cms.bool(True),
     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
@@ -215,42 +217,42 @@ stripPairElectronSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
 
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 stripPairElectronTrackingRegions = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
-    ptMin = 1.0,
+    ptMin            = 1.0,
     originHalfLength = 12.0,
-    originRadius = 0.4,
+    originRadius     = 0.4,
 ))
 pp_on_AA_2018.toReplaceWith(stripPairElectronTrackingRegions,
     _globalTrackingRegionWithVertices.clone(
         RegionPSet = dict(
-            fixedError = 0.5,
-            ptMin = 8.0,
-            originRadius = 0.4)))
+            fixedError   = 0.5,
+            ptMin        = 8.0,
+            originRadius = 0.4
+        )
+))
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 stripPairElectronHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "stripPairElectronSeedLayers",
-    trackingRegions = "stripPairElectronTrackingRegions",
-    maxElement = 1000000,
+    seedingLayers         = 'stripPairElectronSeedLayers',
+    trackingRegions       = 'stripPairElectronTrackingRegions',
+    maxElement            = 1000000,
     produceSeedingHitSets = True,
-    maxElementTotal = 12000000,
+    maxElementTotal       = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 stripPairElectronSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "stripPairElectronHitDoublets",
+    seedingHitSets = 'stripPairElectronHitDoublets',
 )
 
 
 ###This seed collection is produced for electron reconstruction
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
 newCombinedSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone(
-    seedCollections = cms.VInputTag(
-      cms.InputTag('initialStepSeeds'),
-      cms.InputTag('pixelPairStepSeeds'),
-      cms.InputTag('mixedTripletStepSeeds'),
-      cms.InputTag('pixelLessStepSeeds'),
-      cms.InputTag('tripletElectronSeeds'),
-      cms.InputTag('pixelPairElectronSeeds'),
-      cms.InputTag('stripPairElectronSeeds')
-      )
+    seedCollections = ['initialStepSeeds',
+                       'pixelPairStepSeeds',
+                       'mixedTripletStepSeeds',
+                       'pixelLessStepSeeds',
+                       'tripletElectronSeeds',
+                       'pixelPairElectronSeeds',
+                       'stripPairElectronSeeds']
 )
 _seedCollections_Phase1 = [
     'initialStepSeeds',
@@ -267,11 +269,10 @@ _seedCollections_Phase1 = [
     'pixelPairStepSeeds'
 ]
 trackingPhase1.toModify(newCombinedSeeds, seedCollections = _seedCollections_Phase1)
-trackingPhase2PU140.toModify(newCombinedSeeds, seedCollections = [
-    'initialStepSeeds',
-    'highPtTripletStepSeeds',
-    'tripletElectronSeeds'
-])
+trackingPhase2PU140.toModify(newCombinedSeeds, 
+    seedCollections = ['initialStepSeeds',
+	               'highPtTripletStepSeeds',
+	               'tripletElectronSeeds'] )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from FastSimulation.Tracking.ElectronSeeds_cff import _newCombinedSeeds

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -180,7 +180,7 @@ highPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstim
 )
 trackingPhase2PU140.toModify(highPtTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
-    MaxChi2 = cms.double(20.0)
+    MaxChi2 = 20.0
 )
 
 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -8,9 +8,9 @@ from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 ### high-pT triplets ###
 
 # NEW CLUSTERS (remove previously used clusters)
-highPtTripletStepClusters = _cfg.clusterRemoverForIter("HighPtTripletStep")
+highPtTripletStepClusters = _cfg.clusterRemoverForIter('HighPtTripletStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(highPtTripletStepClusters, _cfg.clusterRemoverForIter("HighPtTripletStep", _eraName, _postfix))
+    _era.toReplaceWith(highPtTripletStepClusters, _cfg.clusterRemoverForIter('HighPtTripletStep', _eraName, _postfix))
 
 
 # SEEDING LAYERS
@@ -60,9 +60,9 @@ trackingPhase2PU140.toModify(highPtTripletStepSeedLayers,
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 highPtTripletStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(
-    ptMin = 0.55,
+    ptMin        = 0.55,
     originRadius = 0.02,
-    nSigmaZ = 4.0
+    nSigmaZ      = 4.0
 ))
 trackingPhase2PU140.toModify(highPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.7, originRadius = 0.02))
 
@@ -71,15 +71,15 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(highPtTripletStepTrackingRegions, 
                 _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                    fixedError = 0.2,
-                    ptMin = 0.7,
+                    fixedError   = 0.2,
+                    ptMin        = 0.7,
                     originRadius = 0.02
                 )
                                                                       )
 )
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(highPtTripletStepTrackingRegions,RegionPSet = dict(
-     ptMin = 0.05,
+     ptMin        = 0.05,
      originRadius = 0.2
 ))
 
@@ -87,10 +87,10 @@ highBetaStar_2018.toModify(highPtTripletStepTrackingRegions,RegionPSet = dict(
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 highPtTripletStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "highPtTripletStepSeedLayers",
-    trackingRegions = "highPtTripletStepTrackingRegions",
-    layerPairs = [0,1], # layer pairs (0,1), (1,2)
-    maxElement = 50000000,
+    seedingLayers   = 'highPtTripletStepSeedLayers',
+    trackingRegions = 'highPtTripletStepTrackingRegions',
+    layerPairs      = [0,1], # layer pairs (0,1), (1,2)
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
@@ -98,7 +98,7 @@ from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixel
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
 highPtTripletStepHitTriplets = _caHitTripletEDProducer.clone(
-    doublets = "highPtTripletStepHitDoublets",
+    doublets = 'highPtTripletStepHitDoublets',
     extraHitRPhitolerance = _pixelTripletHLTEDProducer.extraHitRPhitolerance,
     SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
     maxChi2 = dict(
@@ -106,9 +106,9 @@ highPtTripletStepHitTriplets = _caHitTripletEDProducer.clone(
         value1 = 100, value2 = 6,
     ),
     useBendingCorrection = True,
-    CAThetaCut = 0.004,
-    CAPhiCut = 0.07,
-    CAHardPtCut = 0.3,
+    CAThetaCut           = 0.004,
+    CAPhiCut             = 0.07,
+    CAHardPtCut          = 0.3,
 )
 
 trackingPhase2PU140.toModify(highPtTripletStepHitTriplets,CAThetaCut = 0.003,CAPhiCut = 0.06,CAHardPtCut = 0.5)
@@ -116,15 +116,15 @@ highBetaStar_2018.toModify(highPtTripletStepHitTriplets,CAThetaCut = 0.008,CAPhi
 
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 highPtTripletStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "highPtTripletStepHitTriplets",
+    seedingHitSets = 'highPtTripletStepHitTriplets',
 )
 
 #For FastSim phase1 tracking 
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
 _fastSim_highPtTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "highPtTripletStepTrackingRegions",
-    hitMasks = cms.InputTag("highPtTripletStepMasks"),
+    trackingRegions = 'highPtTripletStepTrackingRegions',
+    hitMasks        = cms.InputTag('highPtTripletStepMasks'),
     seedFinderSelector = dict( CAHitTripletGeneratorFactory = _hitSetProducerToFactoryPSet(highPtTripletStepHitTriplets),
                                layerList = highPtTripletStepSeedLayers.layerList.value(),
                                #new parameters required for phase1 seeding
@@ -133,17 +133,17 @@ _fastSim_highPtTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer
                                layerPairs = highPtTripletStepHitDoublets.layerPairs.value()
                                ))
 
-_fastSim_highPtTripletStepSeeds.seedFinderSelector.CAHitTripletGeneratorFactory.SeedComparitorPSet.ComponentName = "none"
+_fastSim_highPtTripletStepSeeds.seedFinderSelector.CAHitTripletGeneratorFactory.SeedComparitorPSet.ComponentName = 'none'
 fastSim.toReplaceWith(highPtTripletStepSeeds,_fastSim_highPtTripletStepSeeds)
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff
 _highPtTripletStepTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.2,
+    minPt               = 0.2,
 )
 highPtTripletStepTrajectoryFilterBase = _highPtTripletStepTrajectoryFilterBase.clone(
-    maxCCCLostHits = 0,
+    maxCCCLostHits     = 0,
     minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 trackingPhase2PU140.toReplaceWith(highPtTripletStepTrajectoryFilterBase, _highPtTripletStepTrajectoryFilterBase)
@@ -162,24 +162,24 @@ trackingPhase2PU140.toModify(highPtTripletStepTrajectoryFilter,
 
 
 highPtTripletStepTrajectoryFilterInOut = highPtTripletStepTrajectoryFilterBase.clone(
-    minPt = 0.4,
+    minPt               = 0.4,
     minimumNumberOfHits = 4,
-    seedExtension = 1,
+    seedExtension       = 1,
     strictSeedExtension = False, # allow inactive
-    pixelSeedExtension = False,
+    pixelSeedExtension  = False,
 )
 highBetaStar_2018.toModify(highPtTripletStepTrajectoryFilterInOut, minPt=0.05)
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 highPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
     ComponentName = 'highPtTripletStepChi2Est',
-    nSigma = 3.0,
-    MaxChi2 = 30.0,
+    nSigma        = 3.0,
+    MaxChi2       = 30.0,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
     pTChargeCutThreshold = 15.
 )
 trackingPhase2PU140.toModify(highPtTripletStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutNone"),
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
     MaxChi2 = cms.double(20.0)
 )
 
@@ -187,17 +187,17 @@ trackingPhase2PU140.toModify(highPtTripletStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi as _GroupedCkfTrajectoryBuilder_cfi
 highPtTripletStepTrajectoryBuilder = _GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = dict(refToPSet_ = 'highPtTripletStepTrajectoryFilter'),
+    trajectoryFilter     = dict(refToPSet_ = 'highPtTripletStepTrajectoryFilter'),
     alwaysUseInvalidHits = True,
-    maxCand = 3,
-    estimator = 'highPtTripletStepChi2Est',
+    maxCand              = 3,
+    estimator            = 'highPtTripletStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (with B=3.8T)
     maxPtForLooperReconstruction = cms.double(0.7)
 )
 trackingPhase2PU140.toModify(highPtTripletStepTrajectoryBuilder,
-    inOutTrajectoryFilter = dict(refToPSet_ = "highPtTripletStepTrajectoryFilterInOut"),
+    inOutTrajectoryFilter = dict(refToPSet_ = 'highPtTripletStepTrajectoryFilterInOut'),
     useSameTrajFilter = False,
     maxCand = 3,
 )
@@ -218,46 +218,46 @@ highPtTripletStepTrackCandidates = _CkfTrackCandidates_cfi.ckfTrackCandidates.cl
 # For Phase2PU140
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits as _trajectoryCleanerBySharedHits
 highPtTripletStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.clone(
-    ComponentName = 'highPtTripletStepTrajectoryCleanerBySharedHits',
-    fractionShared = 0.16,
+    ComponentName       = 'highPtTripletStepTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.16,
     allowSharedFirstHit = True
 )
 trackingPhase2PU140.toModify(highPtTripletStepTrackCandidates, 
-    TrajectoryCleaner = 'highPtTripletStepTrajectoryCleanerBySharedHits', 
-    clustersToSkip = None,
-    phase2clustersToSkip = cms.InputTag("highPtTripletStepClusters")
+    TrajectoryCleaner    = 'highPtTripletStepTrajectoryCleanerBySharedHits', 
+    clustersToSkip       = None,
+    phase2clustersToSkip = cms.InputTag('highPtTripletStepClusters')
 )
 
 #For FastSim phase1 tracking 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 _fastSim_highPtTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    src = cms.InputTag("highPtTripletStepSeeds"),
+    src                      = 'highPtTripletStepSeeds',
     MinNumberOfCrossedLayers = 3,
-    hitMasks = cms.InputTag("highPtTripletStepMasks")
-    )
+    hitMasks                 = cms.InputTag('highPtTripletStepMasks')
+)
 fastSim.toReplaceWith(highPtTripletStepTrackCandidates,_fastSim_highPtTripletStepTrackCandidates)
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'highPtTripletStepTrackCandidates',
+    src           = 'highPtTripletStepTrackCandidates',
     AlgorithmName = 'highPtTripletStep',
-    Fitter = 'FlexibleKFFittingSmoother',
+    Fitter        = 'FlexibleKFFittingSmoother',
 )
 fastSim.toModify(highPtTripletStepTracks,TTRHBuilder = 'WithoutRefit')
 
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 highPtTripletStep = TrackMVAClassifierPrompt.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1'),
-     src = 'highPtTripletStepTracks',
+     mva         = dict(GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1'),
+     src         = 'highPtTripletStepTracks',
      qualityCuts = [0.2,0.3,0.4]
 )
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(highPtTripletStep, TrackLwtnnClassifier.clone(
-    src = 'highPtTripletStepTracks',
+    src         = 'highPtTripletStepTracks',
     qualityCuts = [0.75, 0.775, 0.8],
 ))
 
@@ -267,7 +267,7 @@ pp_on_AA_2018.toModify(highPtTripletStep,
         qualityCuts = [-0.9, -0.3, 0.85],
 )
 
-fastSim.toModify(highPtTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+fastSim.toModify(highPtTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -15,9 +15,10 @@ trackerClusterCheckPreSplitting = _trackerClusterCheck.clone(
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
 import RecoTracker.TkSeedingLayers.PixelLayerQuadruplets_cfi
-initialStepSeedLayersPreSplitting = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
-initialStepSeedLayersPreSplitting.FPix.HitProducer = 'siPixelRecHitsPreSplitting'
-initialStepSeedLayersPreSplitting.BPix.HitProducer = 'siPixelRecHitsPreSplitting'
+initialStepSeedLayersPreSplitting = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    FPix = dict(HitProducer = 'siPixelRecHitsPreSplitting'),
+    BPix = dict(HitProducer = 'siPixelRecHitsPreSplitting')
+)
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(initialStepSeedLayersPreSplitting,
     layerList = RecoTracker.TkSeedingLayers.PixelLayerQuadruplets_cfi.PixelLayerQuadruplets.layerList.value()
@@ -26,26 +27,26 @@ trackingPhase1.toModify(initialStepSeedLayersPreSplitting,
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 initialStepTrackingRegionsPreSplitting = _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(
-    ptMin = 0.6,
+    ptMin        = 0.6,
     originRadius = 0.02,
-    nSigmaZ = 4.0
+    nSigmaZ      = 4.0
 ))
 trackingPhase1.toModify(initialStepTrackingRegionsPreSplitting, RegionPSet = dict(ptMin = 0.5))
 
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 initialStepHitDoubletsPreSplitting = _hitPairEDProducer.clone(
-    seedingLayers = "initialStepSeedLayersPreSplitting",
-    trackingRegions = "initialStepTrackingRegionsPreSplitting",
-    clusterCheck = "trackerClusterCheckPreSplitting",
-    maxElement = 50000000,
+    seedingLayers   = 'initialStepSeedLayersPreSplitting',
+    trackingRegions = 'initialStepTrackingRegionsPreSplitting',
+    clusterCheck    = 'trackerClusterCheckPreSplitting',
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
 initialStepHitTripletsPreSplitting = _pixelTripletHLTEDProducer.clone(
-    doublets = "initialStepHitDoubletsPreSplitting",
+    doublets              = 'initialStepHitDoubletsPreSplitting',
     produceSeedingHitSets = True,
     SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(
         clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting'
@@ -54,7 +55,7 @@ initialStepHitTripletsPreSplitting = _pixelTripletHLTEDProducer.clone(
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
 trackingPhase1.toModify(initialStepHitDoubletsPreSplitting, layerPairs = [0,1,2]) # layer pairs (0,1), (1,2), (2,3)
 initialStepHitQuadrupletsPreSplitting = _caHitQuadrupletEDProducer.clone(
-    doublets = "initialStepHitDoubletsPreSplitting",
+    doublets = 'initialStepHitDoubletsPreSplitting',
     extraHitRPhitolerance = initialStepHitTripletsPreSplitting.extraHitRPhitolerance,
     SeedComparitorPSet = initialStepHitTripletsPreSplitting.SeedComparitorPSet,
     maxChi2 = dict(
@@ -62,26 +63,26 @@ initialStepHitQuadrupletsPreSplitting = _caHitQuadrupletEDProducer.clone(
         value1 = 200, value2 = 50,
     ),
     useBendingCorrection = True,
-    fitFastCircle = True,
+    fitFastCircle        = True,
     fitFastCircleChi2Cut = True,
-    CAThetaCut = 0.0012,
-    CAPhiCut = 0.2,
+    CAThetaCut           = 0.0012,
+    CAPhiCut             = 0.2,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 initialStepSeedsPreSplitting = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "initialStepHitTripletsPreSplitting",
+    seedingHitSets = 'initialStepHitTripletsPreSplitting',
 )
-trackingPhase1.toModify(initialStepSeedsPreSplitting, seedingHitSets = "initialStepHitQuadrupletsPreSplitting")
+trackingPhase1.toModify(initialStepSeedsPreSplitting, seedingHitSets = 'initialStepHitQuadrupletsPreSplitting')
 
 
 # building
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 initialStepTrajectoryFilterBasePreSplitting = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 4,
-    minPt = 0.2,
-    maxCCCLostHits = 0,
-    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
-    )
+    minPt               = 0.2,
+    maxCCCLostHits      = 0,
+    minGoodStripCharge  = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+)
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(initialStepTrajectoryFilterBasePreSplitting, maxCCCLostHits = 2)
 import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
@@ -95,72 +96,75 @@ initialStepTrajectoryFilterPreSplitting = cms.PSet(
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 initialStepChi2EstPreSplitting = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('initialStepChi2EstPreSplitting'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(16.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
+    ComponentName = 'initialStepChi2EstPreSplitting',
+    nSigma        = 3.0,
+    MaxChi2       = 16.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
 )
 _tracker_apv_vfp30_2016.toModify(initialStepChi2EstPreSplitting,
-    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutTiny")
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilderPreSplitting = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilterPreSplitting')),
+    trajectoryFilter = dict(refToPSet_ = 'initialStepTrajectoryFilterPreSplitting'),
     alwaysUseInvalidHits = True,
-    maxCand = 3,
-    estimator = cms.string('initialStepChi2Est'),
-    )
+    maxCand   = 3,
+    estimator = 'initialStepChi2Est',
+)
 
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 initialStepTrackCandidatesPreSplitting = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('initialStepSeedsPreSplitting'),
+    src = 'initialStepSeedsPreSplitting',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryBuilderPreSplitting')),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'initialStepTrajectoryBuilderPreSplitting'),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
-    )
+)
 initialStepTrackCandidatesPreSplitting.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
 
 # fitting
 import RecoTracker.TrackProducer.TrackProducer_cfi
 initialStepTracksPreSplitting = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'initialStepTrackCandidatesPreSplitting',
-    AlgorithmName = cms.string('initialStep'),
-    Fitter = cms.string('FlexibleKFFittingSmoother'),
-    NavigationSchool ='',
+    src              = 'initialStepTrackCandidatesPreSplitting',
+    AlgorithmName    = 'initialStep',
+    Fitter           = 'FlexibleKFFittingSmoother',
+    NavigationSchool = '',
     MeasurementTrackerEvent = ''
-    )
+)
 initialStepTracksPreSplitting.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
 
 #vertices
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices as _offlinePrimaryVertices
-firstStepPrimaryVerticesPreSplitting = _offlinePrimaryVertices.clone()
-firstStepPrimaryVerticesPreSplitting.TrackLabel = cms.InputTag("initialStepTracksPreSplitting")
-firstStepPrimaryVerticesPreSplitting.vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
-
+firstStepPrimaryVerticesPreSplitting = _offlinePrimaryVertices.clone(
+    TrackLabel = 'initialStepTracksPreSplitting',
+    vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
+)
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(firstStepPrimaryVerticesPreSplitting, TkFilterParameters = dict(trackQuality = "any"))
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(firstStepPrimaryVerticesPreSplitting, TkFilterParameters = dict(trackQuality = 'any'))
 
 #Jet Core emulation to identify jet-tracks
 from RecoTracker.IterativeTracking.InitialStep_cff import initialStepTrackRefsForJets, caloTowerForTrk, ak4CaloJetsForTrk
 from RecoTracker.IterativeTracking.JetCoreRegionalStep_cff import jetsForCoreTracking
 initialStepTrackRefsForJetsPreSplitting = initialStepTrackRefsForJets.clone(
-    src = 'initialStepTracksPreSplitting')
+    src = 'initialStepTracksPreSplitting'
+)
 caloTowerForTrkPreSplitting = caloTowerForTrk.clone()
 ak4CaloJetsForTrkPreSplitting = ak4CaloJetsForTrk.clone(
-    src = 'caloTowerForTrkPreSplitting',
-    srcPVs = 'firstStepPrimaryVerticesPreSplitting')
+    src    = 'caloTowerForTrkPreSplitting',
+    srcPVs = 'firstStepPrimaryVerticesPreSplitting'
+)
 jetsForCoreTrackingPreSplitting = jetsForCoreTracking.clone(
-    src = 'ak4CaloJetsForTrkPreSplitting')
+    src    = 'ak4CaloJetsForTrkPreSplitting'
+)
 
 #Cluster Splitting
 from RecoLocalTracker.SubCollectionProducers.jetCoreClusterSplitter_cfi import jetCoreClusterSplitter
 siPixelClusters = jetCoreClusterSplitter.clone(
-    pixelClusters = cms.InputTag('siPixelClustersPreSplitting'),
+    pixelClusters = 'siPixelClustersPreSplitting',
     vertices      = 'firstStepPrimaryVerticesPreSplitting',
     cores         = 'jetsForCoreTrackingPreSplitting'
 )

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -99,7 +99,7 @@ initialStepChi2EstPreSplitting = RecoTracker.MeasurementDet.Chi2ChargeMeasuremen
     ComponentName = 'initialStepChi2EstPreSplitting',
     nSigma        = 3.0,
     MaxChi2       = 16.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
 )
 _tracker_apv_vfp30_2016.toModify(initialStepChi2EstPreSplitting,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -107,7 +107,7 @@ _tracker_apv_vfp30_2016.toModify(initialStepChi2EstPreSplitting,
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilderPreSplitting = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = dict(refToPSet_ = 'initialStepTrajectoryFilterPreSplitting'),
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilterPreSplitting')),
     alwaysUseInvalidHits = True,
     maxCand   = 3,
     estimator = 'initialStepChi2Est',
@@ -119,7 +119,7 @@ initialStepTrackCandidatesPreSplitting = RecoTracker.CkfPattern.CkfTrackCandidat
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'initialStepTrajectoryBuilderPreSplitting'),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryBuilderPreSplitting')),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
 )

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -26,15 +26,15 @@ trackingPhase2PU140.toModify(initialStepSeedLayers,
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 initialStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(
-    ptMin = 0.6,
+    ptMin        = 0.6,
     originRadius = 0.02,
-    nSigmaZ = 4.0
+    nSigmaZ      = 4.0
 ))
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase1.toModify(initialStepTrackingRegions, RegionPSet = dict(ptMin = 0.5))
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(initialStepTrackingRegions,RegionPSet = dict(
-     ptMin = 0.05,
+     ptMin        = 0.05,
      originRadius = 0.2
 ))
 trackingPhase2PU140.toModify(initialStepTrackingRegions, RegionPSet = dict(ptMin = 0.6,originRadius = 0.03))
@@ -42,26 +42,26 @@ trackingPhase2PU140.toModify(initialStepTrackingRegions, RegionPSet = dict(ptMin
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 initialStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "initialStepSeedLayers",
-    trackingRegions = "initialStepTrackingRegions",
-    maxElement = 50000000,
+    seedingLayers   = 'initialStepSeedLayers',
+    trackingRegions = 'initialStepTrackingRegions',
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
 initialStepHitTriplets = _pixelTripletHLTEDProducer.clone(
-    doublets = "initialStepHitDoublets",
+    doublets              = 'initialStepHitDoublets',
     produceSeedingHitSets = True,
     SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone()
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 initialStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "initialStepHitTriplets",
+    seedingHitSets = 'initialStepHitTriplets',
 )
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
 _initialStepCAHitQuadruplets = _caHitQuadrupletEDProducer.clone(
-    doublets = "initialStepHitDoublets",
+    doublets = 'initialStepHitDoublets',
     extraHitRPhitolerance = initialStepHitTriplets.extraHitRPhitolerance,
     SeedComparitorPSet = initialStepHitTriplets.SeedComparitorPSet,
     maxChi2 = dict(
@@ -69,14 +69,14 @@ _initialStepCAHitQuadruplets = _caHitQuadrupletEDProducer.clone(
         value1 = 200, value2 = 50,
     ),
     useBendingCorrection = True,
-    fitFastCircle = True,
+    fitFastCircle        = True,
     fitFastCircleChi2Cut = True,
-    CAThetaCut = 0.0012,
-    CAPhiCut = 0.2,
+    CAThetaCut           = 0.0012,
+    CAPhiCut             = 0.2,
 )
 highBetaStar_2018.toModify(_initialStepCAHitQuadruplets,
     CAThetaCut = 0.0024,
-    CAPhiCut = 0.4
+    CAPhiCut   = 0.4
 )
 initialStepHitQuadruplets = _initialStepCAHitQuadruplets.clone()
 
@@ -85,12 +85,12 @@ trackingPhase1.toModify(initialStepHitDoublets, layerPairs = [0,1,2]) # layer pa
 trackingPhase2PU140.toModify(initialStepHitDoublets, layerPairs = [0,1,2]) # layer pairs (0,1), (1,2), (2,3)
 trackingPhase2PU140.toModify(initialStepHitQuadruplets,
     CAThetaCut = 0.0010,
-    CAPhiCut = 0.175,
+    CAPhiCut   = 0.175,
 )
 
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cff import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
 _initialStepSeedsConsecutiveHitsTripletOnly = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(
-    seedingHitSets = "initialStepHitTriplets",
+    seedingHitSets     = 'initialStepHitTriplets',
     SeedComparitorPSet = dict(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
         ComponentName = 'PixelClusterShapeSeedComparitor',
         FilterAtHelixStage = cms.bool(False),
@@ -101,23 +101,23 @@ _initialStepSeedsConsecutiveHitsTripletOnly = _seedCreatorFromRegionConsecutiveH
     ),
 )
 trackingPhase1.toReplaceWith(initialStepSeeds, _initialStepSeedsConsecutiveHitsTripletOnly.clone(
-        seedingHitSets = "initialStepHitQuadruplets"
+        seedingHitSets = 'initialStepHitQuadruplets'
 ))
 trackingPhase2PU140.toReplaceWith(initialStepSeeds, _initialStepSeedsConsecutiveHitsTripletOnly.clone(
-        seedingHitSets = "initialStepHitQuadruplets"
+        seedingHitSets = 'initialStepHitQuadruplets'
 ))
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
 _fastSim_initialStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "initialStepTrackingRegions",
+    trackingRegions = 'initialStepTrackingRegions',
     seedFinderSelector = dict( pixelTripletGeneratorFactory = _hitSetProducerToFactoryPSet(initialStepHitTriplets),
                                layerList = initialStepSeedLayers.layerList.value())
 )
-_fastSim_initialStepSeeds.seedFinderSelector.pixelTripletGeneratorFactory.SeedComparitorPSet.ComponentName = "none"
+_fastSim_initialStepSeeds.seedFinderSelector.pixelTripletGeneratorFactory.SeedComparitorPSet.ComponentName = 'none'
 #new for phase1
 trackingPhase1.toModify(_fastSim_initialStepSeeds, seedFinderSelector = dict(
         pixelTripletGeneratorFactory = None,
-        CAHitQuadrupletGeneratorFactory = _hitSetProducerToFactoryPSet(initialStepHitQuadruplets).clone(SeedComparitorPSet = dict(ComponentName = "none")),
+        CAHitQuadrupletGeneratorFactory = _hitSetProducerToFactoryPSet(initialStepHitQuadruplets).clone(SeedComparitorPSet = dict(ComponentName = 'none')),
         #new parameters required for phase1 seeding
         BPix = dict(
             TTRHBuilder = 'WithoutRefit',
@@ -138,11 +138,11 @@ fastSim.toReplaceWith(initialStepSeeds,_fastSim_initialStepSeeds)
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 _initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.2,
+    minPt               = 0.2,
 )
 initialStepTrajectoryFilterBase = _initialStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 0,
-    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(initialStepTrajectoryFilterBase, maxCCCLostHits = 2)
@@ -155,9 +155,9 @@ highBetaStar_2018.toModify(initialStepTrajectoryFilterBase, minPt = 0.05)
 
 initialStepTrajectoryFilterInOut = initialStepTrajectoryFilterBase.clone(
     minimumNumberOfHits = 4,
-    seedExtension = 1,
+    seedExtension       = 1,
     strictSeedExtension = True, # don't allow inactive
-    pixelSeedExtension = True,
+    pixelSeedExtension  = True,
 )
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toReplaceWith(initialStepTrajectoryFilterBase, _initialStepTrajectoryFilterBase)
@@ -175,19 +175,18 @@ initialStepTrajectoryFilter = cms.PSet(
 
 trackingPhase2PU140.toReplaceWith(initialStepTrajectoryFilter, TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.2
-    )
-)
+    minPt               = 0.2
+))
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('initialStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(30.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
-    pTChargeCutThreshold = cms.double(15.)
+    ComponentName = 'initialStepChi2Est',
+    nSigma        = 3.0,
+    MaxChi2       = 30.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
+    pTChargeCutThreshold = 15.
 )
 _tracker_apv_vfp30_2016.toModify(initialStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutTiny")
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 trackingPhase2PU140.toModify(initialStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
@@ -196,13 +195,13 @@ trackingPhase2PU140.toModify(initialStepChi2Est,
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilter')),
+    trajectoryFilter = dict(refToPSet_ = 'initialStepTrajectoryFilter'),
     alwaysUseInvalidHits = True,
     maxCand = 3,
-    estimator = cms.string('initialStepChi2Est'),
+    estimator = 'initialStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
-    )
+)
 trackingLowPU.toModify(initialStepTrajectoryBuilder, maxCand = 5)
 trackingPhase1.toModify(initialStepTrajectoryBuilder,
     minNrOfHitsForRebuild = 1,
@@ -215,74 +214,76 @@ trackingPhase2PU140.toModify(initialStepTrajectoryBuilder,
 
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 initialStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('initialStepSeeds'),
+    src = 'initialStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryBuilder')),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'initialStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
-    )
+)
 
 from Configuration.ProcessModifiers.trackingMkFit_cff import trackingMkFit
 import RecoTracker.MkFit.mkFitInputConverter_cfi as mkFitInputConverter_cfi
 import RecoTracker.MkFit.mkFitProducer_cfi as mkFitProducer_cfi
 import RecoTracker.MkFit.mkFitOutputConverter_cfi as mkFitOutputConverter_cfi
 initialStepTrackCandidatesMkFitInput = mkFitInputConverter_cfi.mkFitInputConverter.clone(
-    seeds = "initialStepSeeds",
+    seeds = 'initialStepSeeds',
 )
 initialStepTrackCandidatesMkFit = mkFitProducer_cfi.mkFitProducer.clone(
-    hitsSeeds = "initialStepTrackCandidatesMkFitInput",
+    hitsSeeds = 'initialStepTrackCandidatesMkFitInput',
 )
 trackingMkFit.toReplaceWith(initialStepTrackCandidates, mkFitOutputConverter_cfi.mkFitOutputConverter.clone(
-    seeds = "initialStepSeeds",
-    hitsSeeds = "initialStepTrackCandidatesMkFitInput",
-    tracks = "initialStepTrackCandidatesMkFit",
+    seeds = 'initialStepSeeds',
+    hitsSeeds = 'initialStepTrackCandidatesMkFitInput',
+    tracks = 'initialStepTrackCandidatesMkFit',
 ))
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(initialStepTrackCandidates,
                       FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-        src = cms.InputTag("initialStepSeeds"),
+        src = 'initialStepSeeds',
         MinNumberOfCrossedLayers = 3
-    ))
+))
 
 
 # fitting
 import RecoTracker.TrackProducer.TrackProducer_cfi
 initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'initialStepTrackCandidates',
-    AlgorithmName = cms.string('initialStep'),
-    Fitter = cms.string('FlexibleKFFittingSmoother')
-    )
+    src           = 'initialStepTrackCandidates',
+    AlgorithmName = 'initialStep',
+    Fitter        = 'FlexibleKFFittingSmoother'
+)
 fastSim.toModify(initialStepTracks, TTRHBuilder = 'WithoutRefit')
 
 #vertices
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices as _offlinePrimaryVertices
-firstStepPrimaryVerticesUnsorted = _offlinePrimaryVertices.clone()
-firstStepPrimaryVerticesUnsorted.TrackLabel = cms.InputTag("initialStepTracks")
-firstStepPrimaryVerticesUnsorted.vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
-
+firstStepPrimaryVerticesUnsorted = _offlinePrimaryVertices.clone(
+    TrackLabel = 'initialStepTracks',
+    vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
+)
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(firstStepPrimaryVerticesUnsorted, TkFilterParameters = dict(trackQuality = "any"))
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(firstStepPrimaryVerticesUnsorted, TkFilterParameters = dict(trackQuality = 'any'))
 
 # we need a replacment for the firstStepPrimaryVerticesUnsorted
 # that includes tracker information of signal and pile up
 # after mixing there is no such thing as initialStepTracks,
 # so we replace the input collection for firstStepPrimaryVerticesUnsorted with generalTracks
 firstStepPrimaryVerticesBeforeMixing =  firstStepPrimaryVerticesUnsorted.clone()
-fastSim.toModify(firstStepPrimaryVerticesUnsorted, TrackLabel = "generalTracks")
+fastSim.toModify(firstStepPrimaryVerticesUnsorted, TrackLabel = 'generalTracks')
 
 
 from RecoJets.JetProducers.TracksForJets_cff import trackRefsForJets
-initialStepTrackRefsForJets = trackRefsForJets.clone(src = cms.InputTag('initialStepTracks'))
-fastSim.toModify(initialStepTrackRefsForJets, src = "generalTracks")
+initialStepTrackRefsForJets = trackRefsForJets.clone(
+    src = 'initialStepTracks'
+)
+fastSim.toModify(initialStepTrackRefsForJets, src = 'generalTracks')
 from RecoJets.JetProducers.caloJetsForTrk_cff import *
 from CommonTools.RecoAlgos.sortedPrimaryVertices_cfi import sortedPrimaryVertices as _sortedPrimaryVertices
 firstStepPrimaryVertices = _sortedPrimaryVertices.clone(
-    vertices = "firstStepPrimaryVerticesUnsorted",
-    particles = "initialStepTrackRefsForJets",
+    vertices  = 'firstStepPrimaryVerticesUnsorted',
+    particles = 'initialStepTrackRefsForJets',
 )
 
 
@@ -290,40 +291,43 @@ firstStepPrimaryVertices = _sortedPrimaryVertices.clone(
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 
-initialStepClassifier1 = TrackMVAClassifierPrompt.clone()
-initialStepClassifier1.src = 'initialStepTracks'
-initialStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
-initialStepClassifier1.qualityCuts = [-0.9,-0.8,-0.7]
-fastSim.toModify(initialStepClassifier1,vertices = "firstStepPrimaryVerticesBeforeMixing")
+initialStepClassifier1 = TrackMVAClassifierPrompt.clone(
+    src         = 'initialStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorIter0_13TeV'),
+    qualityCuts = [-0.9,-0.8,-0.7]
+)
+fastSim.toModify(initialStepClassifier1,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import detachedTripletStepClassifier1
 from RecoTracker.IterativeTracking.LowPtTripletStep_cff import lowPtTripletStep
-initialStepClassifier2 = detachedTripletStepClassifier1.clone()
-initialStepClassifier2.src = 'initialStepTracks'
-fastSim.toModify(initialStepClassifier2,vertices = "firstStepPrimaryVerticesBeforeMixing")
-initialStepClassifier3 = lowPtTripletStep.clone()
-initialStepClassifier3.src = 'initialStepTracks'
-fastSim.toModify(initialStepClassifier3,vertices = "firstStepPrimaryVerticesBeforeMixing")
+initialStepClassifier2 = detachedTripletStepClassifier1.clone(
+    src = 'initialStepTracks'
+)
+fastSim.toModify(initialStepClassifier2,vertices = 'firstStepPrimaryVerticesBeforeMixing')
+initialStepClassifier3 = lowPtTripletStep.clone(
+    src = 'initialStepTracks'
+)
+fastSim.toModify(initialStepClassifier3,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
-initialStep = ClassifierMerger.clone()
-initialStep.inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
-
+initialStep = ClassifierMerger.clone(
+    inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
+)
 trackingPhase1.toReplaceWith(initialStep, initialStepClassifier1.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
+     mva         = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
      qualityCuts = [-0.95,-0.85,-0.75]
 ))
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(initialStep, TrackLwtnnClassifier.clone(
-        src = 'initialStepTracks',
+        src         = 'initialStepTracks',
         qualityCuts = [0.0, 0.3, 0.6]
 ))
-(trackdnn & fastSim).toModify(initialStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+(trackdnn & fastSim).toModify(initialStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 pp_on_AA_2018.toModify(initialStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorInitialStep_Phase1'),
+        mva         = dict(GBRForestLabel = 'HIMVASelectorInitialStep_Phase1'),
         qualityCuts = [-0.9, -0.5, 0.2],
 )
 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -142,7 +142,7 @@ _initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryF
 )
 initialStepTrajectoryFilterBase = _initialStepTrajectoryFilterBase.clone(
     maxCCCLostHits = 0,
-    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(initialStepTrajectoryFilterBase, maxCCCLostHits = 2)
@@ -182,7 +182,7 @@ initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_c
     ComponentName = 'initialStepChi2Est',
     nSigma        = 3.0,
     MaxChi2       = 30.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
     pTChargeCutThreshold = 15.
 )
 _tracker_apv_vfp30_2016.toModify(initialStepChi2Est,
@@ -195,7 +195,7 @@ trackingPhase2PU140.toModify(initialStepChi2Est,
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = dict(refToPSet_ = 'initialStepTrajectoryFilter'),
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilter')),
     alwaysUseInvalidHits = True,
     maxCand = 3,
     estimator = 'initialStepChi2Est',
@@ -218,7 +218,7 @@ initialStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTr
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'initialStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryBuilder')),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
 )

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -6,10 +6,10 @@ from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 # This step runs over all clusters
 
 # run only if there are high pT jets
-jetsForCoreTracking = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4CaloJetsForTrk"), cut = cms.string("pt > 100 && abs(eta) < 2.5"))
+jetsForCoreTracking = cms.EDFilter('CandPtrSelector', src = cms.InputTag('ak4CaloJetsForTrk'), cut = cms.string('pt > 100 && abs(eta) < 2.5'))
 
 # care only at tracks from main PV
-firstStepGoodPrimaryVertices = cms.EDFilter("PrimaryVertexObjectFilter",
+firstStepGoodPrimaryVertices = cms.EDFilter('PrimaryVertexObjectFilter',
      filterParams = cms.PSet(
      	     minNdof = cms.double(25.0),
              maxZ = cms.double(15.0),
@@ -19,7 +19,7 @@ firstStepGoodPrimaryVertices = cms.EDFilter("PrimaryVertexObjectFilter",
 )
 
 # SEEDING LAYERS
-jetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+jetCoreRegionalStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
                             'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
                             'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
@@ -27,7 +27,7 @@ jetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
                             #'BPix2+TIB1','BPix2+TIB2',
                             'BPix3+TIB1','BPix3+TIB2'),
     TIB = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
     ),
     BPix = cms.PSet(
@@ -65,25 +65,25 @@ trackingPhase1.toModify(jetCoreRegionalStepSeedLayers, layerList = _layerListFor
 # TrackingRegion
 from RecoTauTag.HLTProducers.tauRegionalPixelSeedTrackingRegions_cfi import tauRegionalPixelSeedTrackingRegions as _tauRegionalPixelSeedTrackingRegions
 jetCoreRegionalStepTrackingRegions = _tauRegionalPixelSeedTrackingRegions.clone(RegionPSet=dict(
-    ptMin = 10,
+    ptMin          = 10,
     deltaPhiRegion = 0.20,
     deltaEtaRegion = 0.20,
-    JetSrc = "jetsForCoreTracking",
-    vertexSrc = "firstStepGoodPrimaryVertices",
-    howToUseMeasurementTracker = "Never"
+    JetSrc         = 'jetsForCoreTracking',
+    vertexSrc      = 'firstStepGoodPrimaryVertices',
+    howToUseMeasurementTracker = 'Never'
 ))
 
 # Seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 jetCoreRegionalStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "jetCoreRegionalStepSeedLayers",
-    trackingRegions = "jetCoreRegionalStepTrackingRegions",
+    seedingLayers         = 'jetCoreRegionalStepSeedLayers',
+    trackingRegions       = 'jetCoreRegionalStepTrackingRegions',
     produceSeedingHitSets = True,
-    maxElementTotal = 12000000,
+    maxElementTotal       = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 jetCoreRegionalStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "jetCoreRegionalStepHitDoublets",
+    seedingHitSets = 'jetCoreRegionalStepHitDoublets',
     forceKinematicWithRegionDirection = True
 )
 
@@ -91,8 +91,8 @@ jetCoreRegionalStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 jetCoreRegionalStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 4,
-    seedPairPenalty = 0,
-    minPt = 0.1
+    seedPairPenalty     = 0,
+    minPt               = 0.1
 )
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
@@ -102,9 +102,12 @@ for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
 
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
 jetCoreRegionalStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('jetCoreRegionalStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(30.0)
+    #ComponentName = cms.string('jetCoreRegionalStepChi2Est'),
+    #nSigma = cms.double(3.0),
+    #MaxChi2 = cms.double(30.0)
+    ComponentName = 'jetCoreRegionalStepChi2Est',
+    nSigma        = 3.0,
+    MaxChi2       = 30.0
 )
 
 # TRACK BUILDING
@@ -113,21 +116,21 @@ import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 CkfBaseTrajectoryFilter_block = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.CkfBaseTrajectoryFilter_block
 jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryFilter')),
+    trajectoryFilter = dict(refToPSet_ = 'jetCoreRegionalStepTrajectoryFilter'),
     #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
     maxCand = 50,
-    estimator = cms.string('jetCoreRegionalStepChi2Est'),
+    estimator = 'jetCoreRegionalStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
-    )
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 jetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('jetCoreRegionalStepSeeds'),
-    maxSeedsBeforeCleaning = cms.uint32(10000),
-    TrajectoryBuilderPSet = cms.PSet( refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryBuilder')),
-    NavigationSchool = cms.string('SimpleNavigationSchool'),
+    src                    = 'jetCoreRegionalStepSeeds',
+    maxSeedsBeforeCleaning = 10000,
+    TrajectoryBuilderPSet  = dict( refToPSet_ = 'jetCoreRegionalStepTrajectoryBuilder'),
+    NavigationSchool       = 'SimpleNavigationSchool',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     #numHitsForSeedCleaner = cms.int32(50),
     #onlyPixelHitsForSeedCleaner = cms.bool(True),
@@ -137,19 +140,19 @@ jetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_c
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 jetCoreRegionalStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    AlgorithmName = cms.string('jetCoreRegionalStep'),
-    src = 'jetCoreRegionalStepTrackCandidates',
-    Fitter = cms.string('FlexibleKFFittingSmoother')
-    )
+    AlgorithmName = 'jetCoreRegionalStep',
+    src           = 'jetCoreRegionalStepTrackCandidates',
+    Fitter        = 'FlexibleKFFittingSmoother'
+)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 _fastSim_jetCoreRegionalStepTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-    TrackProducers = (),
-    hasSelector=cms.vint32(),
-    selectedTrackQuals = cms.VInputTag(),
-    copyExtras = True
-    )
+    TrackProducers     = [],
+    hasSelector        = [],
+    selectedTrackQuals = [],
+    copyExtras         = True
+)
 fastSim.toReplaceWith(jetCoreRegionalStepTracks,_fastSim_jetCoreRegionalStepTracks)
 
 
@@ -176,18 +179,20 @@ from RecoTracker.IterativeTracking.InitialStep_cff import initialStepClassifier1
 
 
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
-jetCoreRegionalStep = TrackCutClassifier.clone()
-jetCoreRegionalStep.src='jetCoreRegionalStepTracks'
-jetCoreRegionalStep.mva.minPixelHits = [1,1,1]
-jetCoreRegionalStep.mva.maxChi2 = [9999.,9999.,9999.]
-jetCoreRegionalStep.mva.maxChi2n = [1.6,1.0,0.7]
-jetCoreRegionalStep.mva.minLayers = [3,5,5]
-jetCoreRegionalStep.mva.min3DLayers = [1,2,3]
-jetCoreRegionalStep.mva.maxLostLayers = [4,3,2]
-jetCoreRegionalStep.mva.maxDz = [0.5,0.35,0.2];
-jetCoreRegionalStep.mva.maxDr = [0.3,0.2,0.1];
-jetCoreRegionalStep.vertices = 'firstStepGoodPrimaryVertices'
-
+jetCoreRegionalStep = TrackCutClassifier.clone(
+    src = 'jetCoreRegionalStepTracks',
+    mva = dict(
+	minPixelHits  = [1,1,1],
+        maxChi2       = [9999.,9999.,9999.],
+        maxChi2n      = [1.6,1.0,0.7],
+        minLayers     = [3,5,5],
+        min3DLayers   = [1,2,3],
+        maxLostLayers = [4,3,2],
+        maxDz         = [0.5,0.35,0.2],
+        maxDr         = [0.3,0.2,0.1]
+	),
+    vertices = 'firstStepGoodPrimaryVertices'
+)
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 
 trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
@@ -199,11 +204,11 @@ trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(jetCoreRegionalStep, TrackLwtnnClassifier.clone(
-     src = 'jetCoreRegionalStepTracks',
+     src         = 'jetCoreRegionalStepTracks',
      qualityCuts = [0.6, 0.7, 0.8],
 ))
 
-fastSim.toModify(jetCoreRegionalStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+fastSim.toModify(jetCoreRegionalStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 # Final sequence
 JetCoreRegionalStepTask = cms.Task(jetsForCoreTracking,                 

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -102,9 +102,6 @@ for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
 
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
 jetCoreRegionalStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    #ComponentName = cms.string('jetCoreRegionalStepChi2Est'),
-    #nSigma = cms.double(3.0),
-    #MaxChi2 = cms.double(30.0)
     ComponentName = 'jetCoreRegionalStepChi2Est',
     nSigma        = 3.0,
     MaxChi2       = 30.0
@@ -116,7 +113,7 @@ import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 CkfBaseTrajectoryFilter_block = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.CkfBaseTrajectoryFilter_block
 jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = dict(refToPSet_ = 'jetCoreRegionalStepTrajectoryFilter'),
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryFilter')),
     #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
     maxCand = 50,
     estimator = 'jetCoreRegionalStepChi2Est',
@@ -129,7 +126,7 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 jetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src                    = 'jetCoreRegionalStepSeeds',
     maxSeedsBeforeCleaning = 10000,
-    TrajectoryBuilderPSet  = dict( refToPSet_ = 'jetCoreRegionalStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet  = cms.PSet( refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryBuilder')),
     NavigationSchool       = 'SimpleNavigationSchool',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     #numHitsForSeedCleaner = cms.int32(50),

--- a/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
@@ -58,7 +58,7 @@ lowPtBarrelTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEsti
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtBarrelTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = dict(refToPSet_ = 'lowPtBarrelTripletStepTrajectoryFilter'),
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('lowPtBarrelTripletStepTrajectoryFilter')),
     clustersToSkip = cms.InputTag('lowPtBarrelTripletStepClusters'),
     maxCand        = 3,
     #lostHitPenalty = cms.double(10.0), 
@@ -77,13 +77,13 @@ lowPtBarrelTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidate
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'lowPtBarrelTripletStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('lowPtBarrelTripletStepTrajectoryBuilder')),
     doSeedingRegionRebuilding = True,
     useHitsSplitting          = True,
-    TransientInitialStateEstimatorParameters = dict(
-        propagatorAlongTISE      = 'PropagatorWithMaterialForLoopers',
-        propagatorOppositeTISE   = 'PropagatorWithMaterialForLoopersOpposite',
-        numberMeasurementsForFit = 4
+    TransientInitialStateEstimatorParameters = cms.PSet(
+        propagatorAlongTISE      = cms.string('PropagatorWithMaterialForLoopers'),
+        propagatorOppositeTISE   = cms.string('PropagatorWithMaterialForLoopersOpposite'),
+        numberMeasurementsForFit = cms.int32(4)
     )
 )
 

--- a/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
@@ -3,36 +3,35 @@ import FWCore.ParameterSet.Config as cms
 # NEW CLUSTERS (remove previously used clusters)
 from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
 lowPtBarrelTripletStepClusters = trackClusterRemover.clone(
-    maxChi2               = cms.double(9.0),
-    trajectories          = cms.InputTag("lowPtForwardTripletStepTracks"),
-    pixelClusters         = cms.InputTag("siPixelClusters"),
-    stripClusters         = cms.InputTag("siStripClusters"),
-    oldClusterRemovalInfo = cms.InputTag("lowPtForwardTripletStepClusters"),
-    overrideTrkQuals      = cms.InputTag('lowPtForwardTripletStepSelector','lowPtForwardTripletStep'),
-    TrackQuality          = cms.string('highPurity'),
+    maxChi2               = 9.0,
+    trajectories          = 'lowPtForwardTripletStepTracks',
+    pixelClusters         = 'siPixelClusters',
+    stripClusters         = 'siStripClusters',
+    oldClusterRemovalInfo = 'lowPtForwardTripletStepClusters',
+    overrideTrkQuals      = 'lowPtForwardTripletStepSelector:lowPtForwardTripletStep',
+    TrackQuality          = 'highPurity'
 )
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
-lowPtBarrelTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
-lowPtBarrelTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtBarrelTripletStepClusters')
-lowPtBarrelTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtBarrelTripletStepClusters')
-lowPtBarrelTripletStepSeedLayers.layerList = cms.vstring('BPix1+BPix2+BPix3') 
-
+lowPtBarrelTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    BPix      = dict(skipClusters = cms.InputTag('lowPtBarrelTripletStepClusters')),
+    FPix      = dict(skipClusters = cms.InputTag('lowPtBarrelTripletStepClusters')),
+    layerList = ['BPix1+BPix2+BPix3'] 
+)
 
 # SEEDS
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
 lowPtBarrelTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
     RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
-    ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
-    RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
-    ptMin = 0.2,
-    originRadius = 0.03,
-    nSigmaZ = 4.0
+    ComponentName     = 'GlobalRegionProducerFromBeamSpot',
+    RegionPSet        = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+    ptMin             = 0.2,
+    originRadius      = 0.03,
+    nSigmaZ           = 4.0 )
     )
-    )
-    )
+)
 lowPtBarrelTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtBarrelTripletStepSeedLayers'
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
@@ -45,27 +44,25 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 lowPtBarrelTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     #maxLostHits = 3, # use LostHitFraction filter instead
     minimumNumberOfHits = 3,
-    minPt = 0.1
-    )
+    minPt               = 0.1
+)
 
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
 lowPtBarrelTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('lowPtBarrelTripletStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0) 
+    ComponentName = 'lowPtBarrelTripletStepChi2Est',
+    nSigma        = 3.0,
+    MaxChi2       = 9.0 
 )
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtBarrelTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('lowPtBarrelTripletStepTrajectoryFilter')),
+    trajectoryFilter = dict(refToPSet_ = 'lowPtBarrelTripletStepTrajectoryFilter'),
     clustersToSkip = cms.InputTag('lowPtBarrelTripletStepClusters'),
-    maxCand = 3,
-
+    maxCand        = 3,
     #lostHitPenalty = cms.double(10.0), 
-
-    estimator = cms.string('lowPtBarrelTripletStepChi2Est'),
+    estimator = 'lowPtBarrelTripletStepChi2Est',
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (with B=3.8T)
     maxPtForLooperReconstruction = cms.double(0.63) 
@@ -76,19 +73,17 @@ lowPtBarrelTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTraje
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtBarrelTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('lowPtBarrelTripletStepSeeds'),
-
+    src = 'lowPtBarrelTripletStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('lowPtBarrelTripletStepTrajectoryBuilder')),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'lowPtBarrelTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
-    useHitsSplitting = True,
-    TransientInitialStateEstimatorParameters = cms.PSet(
-        propagatorAlongTISE = cms.string('PropagatorWithMaterialForLoopers'),
-        propagatorOppositeTISE = cms.string('PropagatorWithMaterialForLoopersOpposite'),
-        numberMeasurementsForFit = cms.int32(4)
+    useHitsSplitting          = True,
+    TransientInitialStateEstimatorParameters = dict(
+        propagatorAlongTISE      = 'PropagatorWithMaterialForLoopers',
+        propagatorOppositeTISE   = 'PropagatorWithMaterialForLoopersOpposite',
+        numberMeasurementsForFit = 4
     )
 )
 
@@ -98,43 +93,41 @@ lowPtBarrelTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidate
 # TRACK FITTING
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
 lowPtBarrelTripletStepKFTrajectoryFitter = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
-    ComponentName = cms.string('lowPtBarrelTripletStepKFTrajectoryFitter'),
-    Propagator = cms.string('PropagatorWithMaterialForLoopers')
+    ComponentName = 'lowPtBarrelTripletStepKFTrajectoryFitter',
+    Propagator    = 'PropagatorWithMaterialForLoopers'
 )
 
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
 lowPtBarrelTripletStepKFTrajectorySmoother = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
-    ComponentName = cms.string('lowPtBarrelTripletStepKFTrajectorySmoother'),
-    Propagator = cms.string('PropagatorWithMaterialForLoopers'),
-    errorRescaling = cms.double(10.0)
+    ComponentName  = 'lowPtBarrelTripletStepKFTrajectorySmoother',
+    Propagator     = 'PropagatorWithMaterialForLoopers',
+    errorRescaling = 10.0
 )
 
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
 lowPtBarrelTripletStepKFFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
-    ComponentName = cms.string('lowPtBarrelTripletStepKFFittingSmoother'),
-    Fitter = cms.string('lowPtBarrelTripletStepKFTrajectoryFitter'),
-    Smoother = cms.string('lowPtBarrelTripletStepKFTrajectorySmoother'),
-    EstimateCut = cms.double(20.0),
-    LogPixelProbabilityCut = cms.double(-14.0),                               
-    MinNumberOfHits = cms.int32(3)
+    ComponentName          = 'lowPtBarrelTripletStepKFFittingSmoother',
+    Fitter                 = 'lowPtBarrelTripletStepKFTrajectoryFitter',
+    Smoother               = 'lowPtBarrelTripletStepKFTrajectorySmoother',
+    EstimateCut            = 20.0,
+    LogPixelProbabilityCut = -14.0,                               
+    MinNumberOfHits        = 3
 )
-
-
 
 import RecoTracker.TrackProducer.TrackProducer_cfi
 lowPtBarrelTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'lowPtBarrelTripletStepTrackCandidates',
-    AlgorithmName = cms.string('lowPtTripletStep'),
-    Fitter = cms.string('lowPtBarrelTripletStepKFFittingSmoother'),
+    src           = 'lowPtBarrelTripletStepTrackCandidates',
+    AlgorithmName = 'lowPtTripletStep',
+    Fitter        = 'lowPtBarrelTripletStepKFFittingSmoother',
     #Propagator = cms.string('PropagatorWithMaterialForLoopers'),
     #NavigationSchool = cms.string('') ### Is the outerHitPattern filled correctly for loopers???
-    )
+)
 
 
 # Final selection
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 lowPtBarrelTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
-    src='lowPtBarrelTripletStepTracks',
+    src = 'lowPtBarrelTripletStepTracks',
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'lowPtBarrelTripletStepLoose',
@@ -147,8 +140,8 @@ lowPtBarrelTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelec
             name = 'lowPtBarrelTripletStep',
             preFilterName = 'lowPtBarrelTripletStepTight',
             ),
-        ) #end of vpset
-    ) #end of clone
+    ) #end of vpset
+) #end of clone
 
 # Final sequence
 LowPtBarrelTripletStepTask = cms.Task(lowPtBarrelTripletStepClusters,

--- a/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
@@ -3,39 +3,37 @@ import FWCore.ParameterSet.Config as cms
 # NEW CLUSTERS (remove previously used clusters)
 from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
 lowPtForwardTripletStepClusters = trackClusterRemover.clone(
-    maxChi2          = cms.double(9.0),
-    trajectories     = cms.InputTag("initialStepTracks"),
-    pixelClusters    = cms.InputTag("siPixelClusters"),
-    stripClusters    = cms.InputTag("siStripClusters"),
-    overrideTrkQuals = cms.InputTag('initialStepSelector','initialStep'),
-    TrackQuality     = cms.string('highPurity'),
+    maxChi2          = 9.0,
+    trajectories     = 'initialStepTracks',
+    pixelClusters    = 'siPixelClusters',
+    stripClusters    = 'siStripClusters',
+    overrideTrkQuals = 'initialStepSelector:initialStep',
+    TrackQuality     = 'highPurity',
 )
-
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
-lowPtForwardTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
-lowPtForwardTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtForwardTripletStepClusters')
-lowPtForwardTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtForwardTripletStepClusters')
-lowPtForwardTripletStepSeedLayers.layerList = cms.vstring('BPix1+BPix2+FPix1_pos', 
-                                                    'BPix1+BPix2+FPix1_neg', 
-                                                    'BPix1+FPix1_pos+FPix2_pos', 
-                                                    'BPix1+FPix1_neg+FPix2_neg')
-
+lowPtForwardTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    BPix = dict(skipClusters = cms.InputTag('lowPtForwardTripletStepClusters')),
+    FPix = dict(skipClusters = cms.InputTag('lowPtForwardTripletStepClusters')),
+    layerList = ['BPix1+BPix2+FPix1_pos', 
+                 'BPix1+BPix2+FPix1_neg', 
+                 'BPix1+FPix1_pos+FPix2_pos', 
+                 'BPix1+FPix1_neg+FPix2_neg']
+)
 
 # SEEDS
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
 lowPtForwardTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
     RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
-    ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+    ComponentName     = 'GlobalRegionProducerFromBeamSpot',
     RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
-    ptMin = 0.2,
+    ptMin        = 0.2,
     originRadius = 0.03,
-    nSigmaZ = 4.0
+    nSigmaZ      = 4.0)
     )
-    )
-    )
+)
 lowPtForwardTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtForwardTripletStepSeedLayers'
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
@@ -48,42 +46,41 @@ import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 lowPtForwardTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     #maxLostHits = 1, ## use LostHitFraction filter instead
     minimumNumberOfHits = 3,
-    minPt = 0.1
-    )
+    minPt               = 0.1
+)
 
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
 lowPtForwardTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('lowPtForwardTripletStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0)
+    ComponentName = 'lowPtForwardTripletStepChi2Est',
+    nSigma        = 3.0,
+    MaxChi2       = 9.0
 )
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtForwardTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('lowPtForwardTripletStepTrajectoryFilter')),
-    clustersToSkip = cms.InputTag('lowPtForwardTripletStepClusters'),
-    maxCand = 3,
-    estimator = cms.string('lowPtForwardTripletStepChi2Est')
-    )
+    trajectoryFilter       = dict(refToPSet_ = 'lowPtForwardTripletStepTrajectoryFilter'),
+    clustersToSkip         = cms.InputTag('lowPtForwardTripletStepClusters'),
+    maxCand                = 3,
+    estimator              = 'lowPtForwardTripletStepChi2Est'
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtForwardTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('lowPtForwardTripletStepSeeds'),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('lowPtForwardTripletStepTrajectoryBuilder')),
+    src                       = 'lowPtForwardTripletStepSeeds',
+    TrajectoryBuilderPSet     = dict(refToPSet_ = 'lowPtForwardTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
-    useHitsSplitting = True
-    )
+    useHitsSplitting          = True
+)
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 lowPtForwardTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'lowPtForwardTripletStepTrackCandidates',
-    AlgorithmName = cms.string('lowPtTripletStep')
-    )
-
+    src           = 'lowPtForwardTripletStepTrackCandidates',
+    AlgorithmName = 'lowPtTripletStep'
+)
 
 # Final selection
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
@@ -60,7 +60,7 @@ lowPtForwardTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEst
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtForwardTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter       = dict(refToPSet_ = 'lowPtForwardTripletStepTrajectoryFilter'),
+    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('lowPtForwardTripletStepTrajectoryFilter')),
     clustersToSkip         = cms.InputTag('lowPtForwardTripletStepClusters'),
     maxCand                = 3,
     estimator              = 'lowPtForwardTripletStepChi2Est'
@@ -70,7 +70,7 @@ lowPtForwardTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTraj
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtForwardTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src                       = 'lowPtForwardTripletStepSeeds',
-    TrajectoryBuilderPSet     = dict(refToPSet_ = 'lowPtForwardTripletStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet     = cms.PSet(refToPSet_ = cms.string('lowPtForwardTripletStepTrajectoryBuilder')),
     doSeedingRegionRebuilding = True,
     useHitsSplitting          = True
 )

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -6,9 +6,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 
 # NEW CLUSTERS (remove previously used clusters)
-lowPtQuadStepClusters = _cfg.clusterRemoverForIter("LowPtQuadStep")
+lowPtQuadStepClusters = _cfg.clusterRemoverForIter('LowPtQuadStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(lowPtQuadStepClusters, _cfg.clusterRemoverForIter("LowPtQuadStep", _eraName, _postfix))
+    _era.toReplaceWith(lowPtQuadStepClusters, _cfg.clusterRemoverForIter('LowPtQuadStep', _eraName, _postfix))
 
 
 # SEEDING LAYERS
@@ -21,10 +21,10 @@ lowPtQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerQuadruplets_cfi.
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 lowPtQuadStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(
-    ptMin = 0.15,
+    ptMin        = 0.15,
     originRadius = 0.02,
-    nSigmaZ = 4.0
-))
+    nSigmaZ      = 4.0 )
+)
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(lowPtQuadStepTrackingRegions, RegionPSet = dict(ptMin = 0.35,originRadius = 0.025))
 
@@ -33,25 +33,24 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(lowPtQuadStepTrackingRegions, 
                 _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                    fixedError = 0.5,
-                    ptMin = 0.49,
-                    originRadius = 0.02
+                    fixedError   = 0.5,
+                    ptMin        = 0.49,
+                    originRadius = 0.02 )
                 )
-                                                            )
 )
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(lowPtQuadStepTrackingRegions,RegionPSet = dict(
-     ptMin = 0.05,
-     originRadius = 0.2,
-))
+     ptMin        = 0.05,
+     originRadius = 0.2, )
+)
 
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 lowPtQuadStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "lowPtQuadStepSeedLayers",
-    trackingRegions = "lowPtQuadStepTrackingRegions",
-    layerPairs = [0,1,2], # layer pairs (0,1), (1,2), (2,3)
-    maxElement = 50000000,
+    seedingLayers   = 'lowPtQuadStepSeedLayers',
+    trackingRegions = 'lowPtQuadStepTrackingRegions',
+    layerPairs      = [0,1,2], # layer pairs (0,1), (1,2), (2,3)
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
@@ -59,7 +58,7 @@ from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixel
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
 lowPtQuadStepHitQuadruplets = _caHitQuadrupletEDProducer.clone(
-    doublets = "lowPtQuadStepHitDoublets",
+    doublets = 'lowPtQuadStepHitDoublets',
     extraHitRPhitolerance = _pixelTripletHLTEDProducer.extraHitRPhitolerance,
     SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
     maxChi2 = dict(
@@ -67,45 +66,46 @@ lowPtQuadStepHitQuadruplets = _caHitQuadrupletEDProducer.clone(
         value1 = 1000, value2 = 150,
     ),
     useBendingCorrection = True,
-    fitFastCircle = True,
+    fitFastCircle        = True,
     fitFastCircleChi2Cut = True,
-    CAThetaCut = 0.0017,
-    CAPhiCut = 0.3,
+    CAThetaCut           = 0.0017,
+    CAPhiCut             = 0.3,
 )
 trackingPhase2PU140.toModify(lowPtQuadStepHitQuadruplets,CAThetaCut = 0.0015,CAPhiCut = 0.25)
 highBetaStar_2018.toModify(lowPtQuadStepHitQuadruplets,CAThetaCut = 0.0034,CAPhiCut = 0.6)
 
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 lowPtQuadStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "lowPtQuadStepHitQuadruplets",
+    seedingHitSets = 'lowPtQuadStepHitQuadruplets',
 )
 
 #For FastSim phase1 tracking
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
 _fastSim_lowPtQuadStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "lowPtQuadStepTrackingRegions",
-    hitMasks = cms.InputTag("lowPtQuadStepMasks"),
+    trackingRegions = 'lowPtQuadStepTrackingRegions',
+    hitMasks        = cms.InputTag('lowPtQuadStepMasks'),
     seedFinderSelector = dict( CAHitQuadrupletGeneratorFactory = _hitSetProducerToFactoryPSet(lowPtQuadStepHitQuadruplets).clone(
-            SeedComparitorPSet = dict(ComponentName = "none")),
+            SeedComparitorPSet = dict(ComponentName = 'none')),
                                layerList = lowPtQuadStepSeedLayers.layerList.value(),
                                #new parameters required for phase1 seeding
-                               BPix = dict(TTRHBuilder = 'WithoutRefit', HitProducer = 'TrackingRecHitProducer',),
-                               FPix = dict(TTRHBuilder = 'WithoutRefit', HitProducer = 'TrackingRecHitProducer',),
+                               BPix      = dict(TTRHBuilder = 'WithoutRefit', HitProducer = 'TrackingRecHitProducer',),
+                               FPix      = dict(TTRHBuilder = 'WithoutRefit', HitProducer = 'TrackingRecHitProducer',),
                                layerPairs = lowPtQuadStepHitDoublets.layerPairs.value()
-                               ))
+                               )
+)
 
-_fastSim_lowPtQuadStepSeeds.seedFinderSelector.CAHitQuadrupletGeneratorFactory.SeedComparitorPSet.ComponentName = "none"
+_fastSim_lowPtQuadStepSeeds.seedFinderSelector.CAHitQuadrupletGeneratorFactory.SeedComparitorPSet.ComponentName = 'none'
 fastSim.toReplaceWith(lowPtQuadStepSeeds,_fastSim_lowPtQuadStepSeeds)
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff
 _lowPtQuadStepTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.075,
+    minPt               = 0.075,
 )
 lowPtQuadStepTrajectoryFilterBase = _lowPtQuadStepTrajectoryFilterBase.clone(
-    maxCCCLostHits = 0,
+    maxCCCLostHits     = 0,
     minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 trackingPhase2PU140.toReplaceWith(lowPtQuadStepTrajectoryFilterBase, _lowPtQuadStepTrajectoryFilterBase)
@@ -124,13 +124,13 @@ trackingPhase2PU140.toModify(lowPtQuadStepTrajectoryFilter,
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 lowPtQuadStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = 'lowPtQuadStepChi2Est',
-    nSigma = 3.0,
-    MaxChi2 = 9.0,
+    ComponentName    = 'lowPtQuadStepChi2Est',
+    nSigma           = 3.0,
+    MaxChi2          = 9.0,
     clusterChargeCut = dict(refToPSet_ = ('SiStripClusterChargeCutTight')),
 )
 trackingPhase2PU140.toModify(lowPtQuadStepChi2Est,
-    MaxChi2 = 16.0,
+    MaxChi2          = 16.0,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 
@@ -138,16 +138,16 @@ trackingPhase2PU140.toModify(lowPtQuadStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = dict(refToPSet_ = 'lowPtQuadStepTrajectoryFilter'),
-    maxCand = 4,
-    estimator = cms.string('lowPtQuadStepChi2Est'),
+    trajectoryFilter       = dict(refToPSet_ = 'lowPtQuadStepTrajectoryFilter'),
+    maxCand                = 4,
+    estimator              = 'lowPtQuadStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (with B=3.8T)
     maxPtForLooperReconstruction = cms.double(0.7) 
 )
 trackingPhase2PU140.toModify(lowPtQuadStepTrajectoryBuilder,
-    minNrOfHitsForRebuild = 1,
+    minNrOfHitsForRebuild      = 1,
     keepOriginalIfRebuildFails = True,
 )
 
@@ -155,8 +155,8 @@ trackingPhase2PU140.toModify(lowPtQuadStepTrajectoryBuilder,
 # MAKING OF TRACK CANDIDATES
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits as _trajectoryCleanerBySharedHits
 lowPtQuadStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.clone(
-    ComponentName = 'lowPtQuadStepTrajectoryCleanerBySharedHits',
-    fractionShared = 0.16,
+    ComponentName       = 'lowPtQuadStepTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.16,
     allowSharedFirstHit = True
 )
 trackingPhase2PU140.toModify(lowPtQuadStepTrajectoryCleanerBySharedHits, fractionShared = 0.09)
@@ -165,34 +165,34 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'lowPtQuadStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
+    numHitsForSeedCleaner       = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'lowPtQuadStepTrajectoryBuilder'),
-    TrajectoryCleaner = 'lowPtQuadStepTrajectoryCleanerBySharedHits',
-    clustersToSkip = cms.InputTag('lowPtQuadStepClusters'),
-    doSeedingRegionRebuilding = True,
-    useHitsSplitting = True
+    TrajectoryBuilderPSet       = dict(refToPSet_ = 'lowPtQuadStepTrajectoryBuilder'),
+    TrajectoryCleaner           = 'lowPtQuadStepTrajectoryCleanerBySharedHits',
+    clustersToSkip              = cms.InputTag('lowPtQuadStepClusters'),
+    doSeedingRegionRebuilding   = True,
+    useHitsSplitting            = True
 )
 trackingPhase2PU140.toModify(lowPtQuadStepTrackCandidates,
-    clustersToSkip = None,
-    phase2clustersToSkip = cms.InputTag("lowPtQuadStepClusters")
+    clustersToSkip       = None,
+    phase2clustersToSkip = cms.InputTag('lowPtQuadStepClusters')
 )
 
 #For FastSim phase1 tracking
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 _fastSim_lowPtQuadStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    src = cms.InputTag("lowPtQuadStepSeeds"),
+    src                      = 'lowPtQuadStepSeeds',
     MinNumberOfCrossedLayers = 3,
-    hitMasks = cms.InputTag("lowPtQuadStepMasks")
-    )
+    hitMasks                 = cms.InputTag('lowPtQuadStepMasks')
+)
 fastSim.toReplaceWith(lowPtQuadStepTrackCandidates,_fastSim_lowPtQuadStepTrackCandidates)
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'lowPtQuadStepTrackCandidates',
+    src           = 'lowPtQuadStepTrackCandidates',
     AlgorithmName = 'lowPtQuadStep',
-    Fitter = 'FlexibleKFFittingSmoother',
+    Fitter        = 'FlexibleKFFittingSmoother',
 )
 fastSim.toModify(lowPtQuadStepTracks,TTRHBuilder = 'WithoutRefit')
 
@@ -200,25 +200,24 @@ fastSim.toModify(lowPtQuadStepTracks,TTRHBuilder = 'WithoutRefit')
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 lowPtQuadStep = TrackMVAClassifierPrompt.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1'),
-     src = 'lowPtQuadStepTracks',
+     mva         = dict(GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1'),
+     src         = 'lowPtQuadStepTracks',
      qualityCuts = [-0.7,-0.35,-0.15]
 )
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(lowPtQuadStep, TrackLwtnnClassifier.clone(
-    src = 'lowPtQuadStepTracks',
+    src         = 'lowPtQuadStepTracks',
     qualityCuts = [0.2, 0.425, 0.75]
 ))
 
 highBetaStar_2018.toModify(lowPtQuadStep,qualityCuts = [-0.9,-0.35,-0.15])
 pp_on_AA_2018.toModify(lowPtQuadStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorLowPtQuadStep_Phase1'),
+        mva         = dict(GBRForestLabel = 'HIMVASelectorLowPtQuadStep_Phase1'),
         qualityCuts = [-0.9, -0.4, 0.3],
 )
-
-fastSim.toModify(lowPtQuadStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+fastSim.toModify(lowPtQuadStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -164,7 +164,7 @@ _lowPtTripletStepStandardTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTra
 )
 lowPtTripletStepStandardTrajectoryFilter = _lowPtTripletStepStandardTrajectoryFilterBase.clone(
     maxCCCLostHits     = 0,
-    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
+    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(lowPtTripletStepStandardTrajectoryFilter, maxCCCLostHits = 1)
@@ -198,7 +198,7 @@ lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     ComponentName    = 'lowPtTripletStepChi2Est',
     nSigma           = 3.0,
     MaxChi2          = 9.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight'),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
 )
 _tracker_apv_vfp30_2016.toModify(lowPtTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -208,7 +208,7 @@ _tracker_apv_vfp30_2016.toModify(lowPtTripletStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter       = dict(refToPSet_ = 'lowPtTripletStepTrajectoryFilter'),
+    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryFilter')),
     maxCand                = 4,
     estimator              = 'lowPtTripletStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
@@ -230,7 +230,7 @@ lowPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner       = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet       = dict(refToPSet_ = 'lowPtTripletStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet       = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryBuilder')),
     clustersToSkip              = cms.InputTag('lowPtTripletStepClusters'),
     doSeedingRegionRebuilding   = True,
     useHitsSplitting            = True,

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -7,15 +7,16 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 
 # NEW CLUSTERS (remove previously used clusters)
-lowPtTripletStepClusters = _cfg.clusterRemoverForIter("LowPtTripletStep")
+lowPtTripletStepClusters = _cfg.clusterRemoverForIter('LowPtTripletStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(lowPtTripletStepClusters, _cfg.clusterRemoverForIter("LowPtTripletStep", _eraName, _postfix))
+    _era.toReplaceWith(lowPtTripletStepClusters, _cfg.clusterRemoverForIter('LowPtTripletStep', _eraName, _postfix))
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
-lowPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
-lowPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
-lowPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
+lowPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone(
+    BPix = dict(skipClusters = cms.InputTag('lowPtTripletStepClusters')),
+    FPix = dict(skipClusters = cms.InputTag('lowPtTripletStepClusters'))
+)
 _layerListForPhase1 = [
     'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
     'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
@@ -53,9 +54,9 @@ trackingPhase2PU140.toModify(lowPtTripletStepSeedLayers, layerList = _layerListF
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 lowPtTripletStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(
-    ptMin = 0.2,
+    ptMin        = 0.2,
     originRadius = 0.02,
-    nSigmaZ = 4.0
+    nSigmaZ      = 4.0
 ))
 trackingPhase1.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.2))
 trackingPhase2PU140.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.40))
@@ -66,43 +67,41 @@ from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import g
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(lowPtTripletStepTrackingRegions, 
                 _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
                     useFixedError = False,
-                    ptMin = 0.49,
-                    originRadius = 0.02
-                )
-                                                                      )
+                    ptMin         = 0.49,
+                    originRadius  = 0.02 )
+               )
 )
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(lowPtTripletStepTrackingRegions,RegionPSet = dict(
-     ptMin = 0.05,
-     originRadius = 0.2,
-))
-
+     ptMin        = 0.05,
+     originRadius = 0.2 )
+)
 
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 lowPtTripletStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "lowPtTripletStepSeedLayers",
-    trackingRegions = "lowPtTripletStepTrackingRegions",
-    maxElement = 50000000,
+    seedingLayers   = 'lowPtTripletStepSeedLayers',
+    trackingRegions = 'lowPtTripletStepTrackingRegions',
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
 lowPtTripletStepHitTriplets = _pixelTripletHLTEDProducer.clone(
-    doublets = "lowPtTripletStepHitDoublets",
+    doublets              = 'lowPtTripletStepHitDoublets',
     produceSeedingHitSets = True,
     SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone()
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 lowPtTripletStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "lowPtTripletStepHitTriplets",
+    seedingHitSets = 'lowPtTripletStepHitTriplets',
 )
 
 from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
 trackingPhase1.toModify(lowPtTripletStepHitDoublets, layerPairs = [0,1]) # layer pairs (0,1), (1,2)
 trackingPhase1.toReplaceWith(lowPtTripletStepHitTriplets, _caHitTripletEDProducer.clone(
-    doublets = "lowPtTripletStepHitDoublets",
+    doublets = 'lowPtTripletStepHitDoublets',
     extraHitRPhitolerance = lowPtTripletStepHitTriplets.extraHitRPhitolerance,
     SeedComparitorPSet = lowPtTripletStepHitTriplets.SeedComparitorPSet,
     maxChi2 = dict(
@@ -110,13 +109,13 @@ trackingPhase1.toReplaceWith(lowPtTripletStepHitTriplets, _caHitTripletEDProduce
         value1 = 70 , value2 = 8,
     ),
     useBendingCorrection = True,
-    CAThetaCut = 0.002,
-    CAPhiCut = 0.05,
-))
+    CAThetaCut           = 0.002,
+    CAPhiCut             = 0.05 )
+)
 
 trackingPhase2PU140.toModify(lowPtTripletStepHitDoublets, layerPairs = [0,1]) # layer pairs (0,1), (1,2)
 trackingPhase2PU140.toReplaceWith(lowPtTripletStepHitTriplets, _caHitTripletEDProducer.clone(
-    doublets = "lowPtTripletStepHitDoublets",
+    doublets = 'lowPtTripletStepHitDoublets',
     extraHitRPhitolerance = lowPtTripletStepHitTriplets.extraHitRPhitolerance,
     SeedComparitorPSet = lowPtTripletStepHitTriplets.SeedComparitorPSet,
     maxChi2 = dict(
@@ -124,25 +123,25 @@ trackingPhase2PU140.toReplaceWith(lowPtTripletStepHitTriplets, _caHitTripletEDPr
         value1 = 70 , value2 = 8,
     ),
     useBendingCorrection = True,
-    CAThetaCut = 0.002,
-    CAPhiCut = 0.05,
-))
+    CAThetaCut           = 0.002,
+    CAPhiCut             = 0.05 )
+)
 highBetaStar_2018.toModify(lowPtTripletStepHitTriplets,CAThetaCut = 0.004,CAPhiCut = 0.1)
  
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
-_fastSim_lowPtTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "lowPtTripletStepTrackingRegions",
-    hitMasks = cms.InputTag("lowPtTripletStepMasks"),
-)
-
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
-_fastSim_lowPtTripletStepSeeds.seedFinderSelector.pixelTripletGeneratorFactory = _hitSetProducerToFactoryPSet(lowPtTripletStepHitTriplets)
-_fastSim_lowPtTripletStepSeeds.seedFinderSelector.pixelTripletGeneratorFactory.SeedComparitorPSet.ComponentName = "none"
-_fastSim_lowPtTripletStepSeeds.seedFinderSelector.layerList = lowPtTripletStepSeedLayers.layerList.value()
+_fastSim_lowPtTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
+    trackingRegions = 'lowPtTripletStepTrackingRegions',
+    hitMasks        = cms.InputTag('lowPtTripletStepMasks'),
+    seedFinderSelector = dict(pixelTripletGeneratorFactory = _hitSetProducerToFactoryPSet(lowPtTripletStepHitTriplets).clone(
+                              SeedComparitorPSet = dict(ComponentName = 'none')),
+                              layerList = lowPtTripletStepSeedLayers.layerList.value()
+                         )
+)
 #new for phase1
 trackingPhase1.toModify(_fastSim_lowPtTripletStepSeeds, seedFinderSelector = dict(
         pixelTripletGeneratorFactory = None,
-        CAHitTripletGeneratorFactory = _hitSetProducerToFactoryPSet(lowPtTripletStepHitTriplets).clone(SeedComparitorPSet = dict(ComponentName = "none")),
+        CAHitTripletGeneratorFactory = _hitSetProducerToFactoryPSet(lowPtTripletStepHitTriplets).clone(SeedComparitorPSet = dict(ComponentName = 'none')),
         #new parameters required for phase1 seeding
         BPix = dict(
             TTRHBuilder = 'WithoutRefit',
@@ -161,11 +160,11 @@ fastSim.toReplaceWith(lowPtTripletStepSeeds,_fastSim_lowPtTripletStepSeeds)
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff as _TrajectoryFilter_cff
 _lowPtTripletStepStandardTrajectoryFilterBase = _TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.075,
+    minPt               = 0.075,
 )
 lowPtTripletStepStandardTrajectoryFilter = _lowPtTripletStepStandardTrajectoryFilterBase.clone(
-    maxCCCLostHits = 0,
-    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    maxCCCLostHits     = 0,
+    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(lowPtTripletStepStandardTrajectoryFilter, maxCCCLostHits = 1)
@@ -189,118 +188,117 @@ trackingPhase2PU140.toModify(lowPtTripletStepTrajectoryFilter,
 
 lowPtTripletStepTrajectoryFilterInOut = lowPtTripletStepStandardTrajectoryFilter.clone(
     minimumNumberOfHits = 4,
-    seedExtension = 1,
+    seedExtension       = 1,
     strictSeedExtension = False, # allow inactive
-    pixelSeedExtension = False,
+    pixelSeedExtension  = False,
 )
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 lowPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('lowPtTripletStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
+    ComponentName    = 'lowPtTripletStepChi2Est',
+    nSigma           = 3.0,
+    MaxChi2          = 9.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight'),
 )
 _tracker_apv_vfp30_2016.toModify(lowPtTripletStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutTiny")
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryFilter')),
-    maxCand = 4,
-    estimator = cms.string('lowPtTripletStepChi2Est'),
+    trajectoryFilter       = dict(refToPSet_ = 'lowPtTripletStepTrajectoryFilter'),
+    maxCand                = 4,
+    estimator              = 'lowPtTripletStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (with B=3.8T)
     maxPtForLooperReconstruction = cms.double(0.7) 
-    )
+)
 trackingLowPU.toModify(lowPtTripletStepTrajectoryBuilder, maxCand = 3)
 trackingPhase2PU140.toModify(lowPtTripletStepTrajectoryBuilder, 
-    inOutTrajectoryFilter = dict(refToPSet_ = "lowPtTripletStepTrajectoryFilterInOut"),
-    useSameTrajFilter = False,
-    maxCand = 3,
+    inOutTrajectoryFilter = dict(refToPSet_ = 'lowPtTripletStepTrajectoryFilterInOut'),
+    useSameTrajFilter     = False,
+    maxCand               = 3,
 )
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('lowPtTripletStepSeeds'),
+    src = 'lowPtTripletStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
+    numHitsForSeedCleaner       = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
-
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryBuilder')),
-    clustersToSkip = cms.InputTag('lowPtTripletStepClusters'),
-    doSeedingRegionRebuilding = True,
-    useHitsSplitting = True,
-    TrajectoryCleaner = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
+    TrajectoryBuilderPSet       = dict(refToPSet_ = 'lowPtTripletStepTrajectoryBuilder'),
+    clustersToSkip              = cms.InputTag('lowPtTripletStepClusters'),
+    doSeedingRegionRebuilding   = True,
+    useHitsSplitting            = True,
+    TrajectoryCleaner           = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
 )
 
 trackingPhase2PU140.toModify(lowPtTripletStepTrackCandidates,
     clustersToSkip = None,
-    phase2clustersToSkip = cms.InputTag("lowPtTripletStepClusters")
+    phase2clustersToSkip = cms.InputTag('lowPtTripletStepClusters')
 )
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(lowPtTripletStepTrackCandidates,
                       FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-        src = cms.InputTag("lowPtTripletStepSeeds"),
+        src = 'lowPtTripletStepSeeds',
         MinNumberOfCrossedLayers = 3,
-        hitMasks = cms.InputTag("lowPtTripletStepMasks"))
+        hitMasks = cms.InputTag('lowPtTripletStepMasks'))
 )
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'lowPtTripletStepTrackCandidates',
-    AlgorithmName = cms.string('lowPtTripletStep'),
-    Fitter = cms.string('FlexibleKFFittingSmoother')
-    )
+    src           = 'lowPtTripletStepTrackCandidates',
+    AlgorithmName = 'lowPtTripletStep',
+    Fitter        = 'FlexibleKFFittingSmoother'
+)
 fastSim.toModify(lowPtTripletStepTracks, TTRHBuilder = 'WithoutRefit')
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
-        ComponentName = cms.string('lowPtTripletStepTrajectoryCleanerBySharedHits'),
-            fractionShared = cms.double(0.16),
-            allowSharedFirstHit = cms.bool(True)
-            )
+    ComponentName       = 'lowPtTripletStepTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.16,
+    allowSharedFirstHit = True
+)
 trackingLowPU.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 trackingPhase2PU140.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.09)
 
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
-lowPtTripletStep =  TrackMVAClassifierPrompt.clone()
-lowPtTripletStep.src = 'lowPtTripletStepTracks'
-lowPtTripletStep.mva.GBRForestLabel = 'MVASelectorIter1_13TeV'
-lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
-
+lowPtTripletStep =  TrackMVAClassifierPrompt.clone(
+    src         = 'lowPtTripletStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorIter1_13TeV'),
+    qualityCuts = [-0.6,-0.3,-0.1]
+)
 trackingPhase1.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
+     mva         = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
      qualityCuts = [-0.4,0.0,0.3],
 ))
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(lowPtTripletStep, TrackLwtnnClassifier.clone(
-    src = 'lowPtTripletStepTracks',
+    src         = 'lowPtTripletStepTracks',
     qualityCuts = [0.2, 0.5, 0.8]
 ))
 
 highBetaStar_2018.toModify(lowPtTripletStep,qualityCuts = [-0.7,-0.3,-0.1])
 pp_on_AA_2018.toModify(lowPtTripletStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorLowPtTripletStep_Phase1'),
+        mva         = dict(GBRForestLabel = 'HIMVASelectorLowPtTripletStep_Phase1'),
         qualityCuts = [-0.8, -0.4, 0.5],
 )
-fastSim.toModify(lowPtTripletStep, vertices = "firstStepPrimaryVerticesBeforeMixing")
+fastSim.toModify(lowPtTripletStep, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 # For LowPU and Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 lowPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
     src = 'lowPtTripletStepTracks',
-    useAnyMVA = cms.bool(False),
+    useAnyMVA      = cms.bool(False),
     GBRForestLabel = cms.string('MVASelectorIter1'),
     trackSelectors= [
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
@@ -317,7 +315,7 @@ lowPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cf
     ] #end of vpset
 ) #end of clone
 trackingPhase2PU140.toModify(lowPtTripletStepSelector,
-    useAnyMVA = None,
+    useAnyMVA      = None,
     GBRForestLabel = None,
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -11,26 +11,26 @@ from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 ###############################################################
 
 #here just for backward compatibility
-chargeCut2069Clusters =  cms.EDProducer("ClusterChargeMasker",
-    oldClusterRemovalInfo = cms.InputTag(""), # to be set below
-    pixelClusters = cms.InputTag("siPixelClusters"),
-    stripClusters = cms.InputTag("siStripClusters"),
+chargeCut2069Clusters =  cms.EDProducer('ClusterChargeMasker',
+    oldClusterRemovalInfo = cms.InputTag(''), # to be set below
+    pixelClusters = cms.InputTag('siPixelClusters'),
+    stripClusters = cms.InputTag('siStripClusters'),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 
-mixedTripletStepClusters = _cfg.clusterRemoverForIter("MixedTripletStep")
+mixedTripletStepClusters = _cfg.clusterRemoverForIter('MixedTripletStep')
 chargeCut2069Clusters.oldClusterRemovalInfo = mixedTripletStepClusters.oldClusterRemovalInfo.value()
-mixedTripletStepClusters.oldClusterRemovalInfo = "chargeCut2069Clusters"
+mixedTripletStepClusters.oldClusterRemovalInfo = 'chargeCut2069Clusters'
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(mixedTripletStepClusters, _cfg.clusterRemoverForIter("MixedTripletStep", _eraName, _postfix))
+    _era.toReplaceWith(mixedTripletStepClusters, _cfg.clusterRemoverForIter('MixedTripletStep', _eraName, _postfix))
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(chargeCut2069Clusters, oldClusterRemovalInfo = mixedTripletStepClusters.oldClusterRemovalInfo.value())
-trackingPhase1.toModify(mixedTripletStepClusters, oldClusterRemovalInfo="chargeCut2069Clusters")
+trackingPhase1.toModify(mixedTripletStepClusters, oldClusterRemovalInfo='chargeCut2069Clusters')
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import detachedTripletStepSeedLayers
-mixedTripletStepSeedLayersA = cms.EDProducer("SeedingLayersEDProducer",
+mixedTripletStepSeedLayersA = cms.EDProducer('SeedingLayersEDProducer',
      layerList = cms.vstring('BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'),
 #    layerList = cms.vstring('BPix1+BPix2+BPix3', 
 #        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
@@ -47,7 +47,7 @@ mixedTripletStepSeedLayersA = cms.EDProducer("SeedingLayersEDProducer",
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
     TEC = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
         minRing = cms.int32(1),
@@ -82,13 +82,13 @@ highBetaStar_2018.toModify(mixedTripletStepSeedLayersA,
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 _mixedTripletStepTrackingRegionsCommon = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
-    ptMin = 0.4,
+    ptMin            = 0.4,
     originHalfLength = 15.0,
-    originRadius = 1.5
+    originRadius     = 1.5
 ))
 trackingLowPU.toModify(_mixedTripletStepTrackingRegionsCommon, RegionPSet = dict(originHalfLength = 10.0))
 highBetaStar_2018.toModify(_mixedTripletStepTrackingRegionsCommon,RegionPSet = dict(
-     ptMin = 0.05,
+     ptMin        = 0.05,
      originRadius = 0.2
 ))
 
@@ -99,15 +99,15 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 _mixedTripletStepTrackingRegionsCommon_pp_on_HI = _globalTrackingRegionWithVertices.clone(
                 RegionPSet=dict(
-                    fixedError = 3.75,
-                    ptMin = 0.4,
-                    originRadius = 1.5,
+                    fixedError             = 3.75,
+                    ptMin                  = 0.4,
+                    originRadius           = 1.5,
                     originRScaling4BigEvts = True,
-                    ptMinScaling4BigEvts= True,
-                    minOriginR = 0.,
-                    maxPtMin = 0.7,
-                    scalingStartNPix = 20000,
-                    scalingEndNPix = 35000
+                    ptMinScaling4BigEvts   = True,
+                    minOriginR             = 0.,
+                    maxPtMin               = 0.7,
+                    scalingStartNPix       = 20000,
+                    scalingEndNPix         = 35000
                 )
 )
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(mixedTripletStepTrackingRegionsA,_mixedTripletStepTrackingRegionsCommon_pp_on_HI)
@@ -116,25 +116,25 @@ _mixedTripletStepTrackingRegionsCommon_pp_on_HI = _globalTrackingRegionWithVerti
 # seeding
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import ClusterShapeHitFilterESProducer as _ClusterShapeHitFilterESProducer
 mixedTripletStepClusterShapeHitFilter  = _ClusterShapeHitFilterESProducer.clone(
-    ComponentName = 'mixedTripletStepClusterShapeHitFilter',
+    ComponentName    = 'mixedTripletStepClusterShapeHitFilter',
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
 )
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 mixedTripletStepHitDoubletsA = _hitPairEDProducer.clone(
-    seedingLayers = "mixedTripletStepSeedLayersA",
-    trackingRegions = "mixedTripletStepTrackingRegionsA",
-    maxElement = 50000000,
+    seedingLayers   = 'mixedTripletStepSeedLayersA',
+    trackingRegions = 'mixedTripletStepTrackingRegionsA',
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletLargeTipEDProducer_cfi import pixelTripletLargeTipEDProducer as _pixelTripletLargeTipEDProducer
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 mixedTripletStepHitTripletsA = _pixelTripletLargeTipEDProducer.clone(
-    doublets = "mixedTripletStepHitDoubletsA",
+    doublets              = 'mixedTripletStepHitDoubletsA',
     produceSeedingHitSets = True,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cff import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
 _mixedTripletStepSeedsACommon = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(
-    seedingHitSets = "mixedTripletStepHitTripletsA",
+    seedingHitSets     = 'mixedTripletStepHitTripletsA',
     SeedComparitorPSet = dict(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
         ComponentName = 'PixelClusterShapeSeedComparitor',
         FilterAtHelixStage = cms.bool(False),
@@ -152,8 +152,8 @@ mixedTripletStepSeedsA = _mixedTripletStepSeedsACommon.clone()
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
 _fastSim_mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "mixedTripletStepTrackingRegionsA",
-    hitMasks = cms.InputTag("mixedTripletStepMasks"),
+    trackingRegions = 'mixedTripletStepTrackingRegionsA',
+    hitMasks        = cms.InputTag('mixedTripletStepMasks'),
     seedFinderSelector = dict(pixelTripletGeneratorFactory = _hitSetProducerToFactoryPSet(mixedTripletStepHitTripletsA),
                               layerList = mixedTripletStepSeedLayersA.layerList.value())
 )
@@ -161,7 +161,7 @@ fastSim.toReplaceWith(mixedTripletStepSeedsA,_fastSim_mixedTripletStepSeedsA)
 
 
 # SEEDING LAYERS
-mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
+mixedTripletStepSeedLayersB = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring('BPix2+BPix3+TIB1'),
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
@@ -169,7 +169,7 @@ mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
     TIB = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     )
@@ -185,23 +185,22 @@ mixedTripletStepTrackingRegionsB = _mixedTripletStepTrackingRegionsCommon.clone(
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(mixedTripletStepTrackingRegionsB, 
                 _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet=dict(
                     fixedError = 2.5,
-                    ptMin = 0.6,
+                    ptMin      = 0.6,)
                 )
-           )
 )
 highBetaStar_2018.toReplaceWith(mixedTripletStepTrackingRegionsB, _mixedTripletStepTrackingRegionsCommon.clone())
 
 # seeding
 mixedTripletStepHitDoubletsB = mixedTripletStepHitDoubletsA.clone(
-    seedingLayers = "mixedTripletStepSeedLayersB",
-    trackingRegions = "mixedTripletStepTrackingRegionsB",
+    seedingLayers   = 'mixedTripletStepSeedLayersB',
+    trackingRegions = 'mixedTripletStepTrackingRegionsB',
 )
-mixedTripletStepHitTripletsB = mixedTripletStepHitTripletsA.clone(doublets = "mixedTripletStepHitDoubletsB")
-mixedTripletStepSeedsB = _mixedTripletStepSeedsACommon.clone(seedingHitSets = "mixedTripletStepHitTripletsB")
+mixedTripletStepHitTripletsB = mixedTripletStepHitTripletsA.clone(doublets = 'mixedTripletStepHitDoubletsB')
+mixedTripletStepSeedsB = _mixedTripletStepSeedsACommon.clone(seedingHitSets = 'mixedTripletStepHitTripletsB')
 #fastsim
 _fastSim_mixedTripletStepSeedsB = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "mixedTripletStepTrackingRegionsB",
-    hitMasks = cms.InputTag("mixedTripletStepMasks"),
+    trackingRegions = 'mixedTripletStepTrackingRegionsB',
+    hitMasks        = cms.InputTag('mixedTripletStepMasks'),
     seedFinderSelector = dict(pixelTripletGeneratorFactory = _hitSetProducerToFactoryPSet(mixedTripletStepHitTripletsB),
                               layerList = mixedTripletStepSeedLayersB.layerList.value())
 )
@@ -209,18 +208,16 @@ fastSim.toReplaceWith(mixedTripletStepSeedsB,_fastSim_mixedTripletStepSeedsB)
 
 
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
-mixedTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
-mixedTripletStepSeeds.seedCollections = cms.VInputTag(
-        cms.InputTag('mixedTripletStepSeedsA'),
-        cms.InputTag('mixedTripletStepSeedsB'),
-        )
-
+mixedTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone(
+    seedCollections = ['mixedTripletStepSeedsA',
+                       'mixedTripletStepSeedsB']
+)
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 _mixedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
 #    maxLostHits = 0,
     minimumNumberOfHits = 3,
-    minPt = 0.1
+    minPt               = 0.1
 )
 highBetaStar_2018.toModify(_mixedTripletStepTrajectoryFilterBase,minPt = 0.05)
 
@@ -240,8 +237,8 @@ import TrackingTools.MaterialEffects.MaterialPropagator_cfi
 mixedTripletStepPropagator = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone(
 #mixedTripletStepPropagator = TrackingTools.MaterialEffects.MaterialPropagatorParabolicMf_cff.MaterialPropagatorParabolicMF.clone(
     ComponentName = 'mixedTripletStepPropagator',
-    ptMin = 0.1
-    )
+    ptMin         = 0.1
+)
 for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
     e.toModify(mixedTripletStepPropagator, ptMin=0.4)
 highBetaStar_2018.toModify(mixedTripletStepPropagator,ptMin = 0.05)
@@ -250,18 +247,18 @@ import TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi
 mixedTripletStepPropagatorOpposite = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone(
 #mixedTripletStepPropagatorOpposite = TrackingTools.MaterialEffects.MaterialPropagatorParabolicMf_cff.OppositeMaterialPropagatorParabolicMF.clone(
     ComponentName = 'mixedTripletStepPropagatorOpposite',
-    ptMin = 0.1
-    )
+    ptMin         = 0.1
+)
 for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
     e.toModify(mixedTripletStepPropagatorOpposite, ptMin=0.4)
 highBetaStar_2018.toModify(mixedTripletStepPropagatorOpposite,ptMin = 0.05)
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('mixedTripletStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(16.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+    ComponentName    = 'mixedTripletStepChi2Est',
+    nSigma           = 3.0,
+    MaxChi2          = 16.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
 )
 trackingLowPU.toModify(mixedTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -271,88 +268,90 @@ trackingLowPU.toModify(mixedTripletStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 mixedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('mixedTripletStepTrajectoryFilter')),
-    propagatorAlong = cms.string('mixedTripletStepPropagator'),
-    propagatorOpposite = cms.string('mixedTripletStepPropagatorOpposite'),
-    maxCand = 2,
-    estimator = cms.string('mixedTripletStepChi2Est'),
+    trajectoryFilter       = dict(refToPSet_ = 'mixedTripletStepTrajectoryFilter'),
+    propagatorAlong        = 'mixedTripletStepPropagator',
+    propagatorOpposite     = 'mixedTripletStepPropagatorOpposite',
+    maxCand                = 2,
+    estimator              = 'mixedTripletStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
-    )
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 mixedTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('mixedTripletStepSeeds'),
+    src            = 'mixedTripletStepSeeds',
     clustersToSkip = cms.InputTag('mixedTripletStepClusters'),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
+    numHitsForSeedCleaner     = cms.int32(50),
     #onlyPixelHitsForSeedCleaner = cms.bool(True),
 
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('mixedTripletStepTrajectoryBuilder')),
+    TrajectoryBuilderPSet     = dict(refToPSet_ = 'mixedTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
-    useHitsSplitting = True,
-    TrajectoryCleaner = 'mixedTripletStepTrajectoryCleanerBySharedHits'
+    useHitsSplitting          = True,
+    TrajectoryCleaner         = 'mixedTripletStepTrajectoryCleanerBySharedHits'
 )
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(mixedTripletStepTrackCandidates,
                       FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-        src = cms.InputTag("mixedTripletStepSeeds"),
+        src = 'mixedTripletStepSeeds',
         MinNumberOfCrossedLayers = 3,
-        hitMasks = cms.InputTag("mixedTripletStepMasks"),
+        hitMasks = cms.InputTag('mixedTripletStepMasks'),
         )
 )
 
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 mixedTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
-        ComponentName = cms.string('mixedTripletStepTrajectoryCleanerBySharedHits'),
-            fractionShared = cms.double(0.11),
-            allowSharedFirstHit = cms.bool(True)
-            )
+        ComponentName       = 'mixedTripletStepTrajectoryCleanerBySharedHits',
+        fractionShared      = 0.11,
+        allowSharedFirstHit = True
+)
 trackingLowPU.toModify(mixedTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 mixedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    AlgorithmName = cms.string('mixedTripletStep'),
-    src = 'mixedTripletStepTrackCandidates',
-    Fitter = cms.string('FlexibleKFFittingSmoother')
+    AlgorithmName = 'mixedTripletStep',
+    src           = 'mixedTripletStepTrackCandidates',
+    Fitter        = 'FlexibleKFFittingSmoother'
 )
 fastSim.toModify(mixedTripletStepTracks, TTRHBuilder = 'WithoutRefit')
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
-mixedTripletStepClassifier1 = TrackMVAClassifierDetached.clone()
-mixedTripletStepClassifier1.src = 'mixedTripletStepTracks'
-mixedTripletStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter4_13TeV'
-mixedTripletStepClassifier1.qualityCuts = [-0.5,0.0,0.5]
-fastSim.toModify(mixedTripletStepClassifier1, vertices = "firstStepPrimaryVerticesBeforeMixing")
+mixedTripletStepClassifier1 = TrackMVAClassifierDetached.clone(
+     src         = 'mixedTripletStepTracks',
+     mva         = dict(GBRForestLabel = 'MVASelectorIter4_13TeV'),
+     qualityCuts = [-0.5,0.0,0.5]
+)
+fastSim.toModify(mixedTripletStepClassifier1, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
-mixedTripletStepClassifier2 = TrackMVAClassifierPrompt.clone()
-mixedTripletStepClassifier2.src = 'mixedTripletStepTracks'
-mixedTripletStepClassifier2.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
-mixedTripletStepClassifier2.qualityCuts = [-0.2,-0.2,-0.2]
-fastSim.toModify(mixedTripletStepClassifier2,vertices = "firstStepPrimaryVerticesBeforeMixing")
+mixedTripletStepClassifier2 = TrackMVAClassifierPrompt.clone(
+    src         = 'mixedTripletStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorIter0_13TeV'),
+    qualityCuts = [-0.2,-0.2,-0.2]
+)
+fastSim.toModify(mixedTripletStepClassifier2,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
-mixedTripletStep = ClassifierMerger.clone()
-mixedTripletStep.inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
-
+mixedTripletStep = ClassifierMerger.clone(
+    inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
+)
 trackingPhase1.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
-	mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1'),
-	qualityCuts = [-0.5,0.0,0.5]
+    mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1'),
+    qualityCuts = [-0.5,0.0,0.5]
 ))
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(mixedTripletStep, TrackLwtnnClassifier.clone(
-     src = 'mixedTripletStepTracks',
-     qualityCuts = [-0.8, -0.35, 0.1]
+    src = 'mixedTripletStepTracks',
+    qualityCuts = [-0.8, -0.35, 0.1]
 ))
-(trackdnn & fastSim).toModify(mixedTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+(trackdnn & fastSim).toModify(mixedTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 highBetaStar_2018.toModify(mixedTripletStep,qualityCuts = [-0.7,0.0,0.5])
 pp_on_AA_2018.toModify(mixedTripletStep, qualityCuts = [-0.5,0.0,0.9])
@@ -360,8 +359,8 @@ pp_on_AA_2018.toModify(mixedTripletStep, qualityCuts = [-0.5,0.0,0.9])
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 mixedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
-    src = 'mixedTripletStepTracks',
-    useAnyMVA = cms.bool(False),
+    src            = 'mixedTripletStepTracks',
+    useAnyMVA      = cms.bool(False),
     GBRForestLabel = cms.string('MVASelectorIter4'),
     trackSelectors = [
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
@@ -447,13 +446,13 @@ mixedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cf
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 _trackListMergerBase = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-    TrackProducers = ['mixedTripletStepTracks',
-                      'mixedTripletStepTracks'],
-    hasSelector = [1,1],
-    selectedTrackQuals = [cms.InputTag("mixedTripletStepSelector","mixedTripletStepVtx"),
-                          cms.InputTag("mixedTripletStepSelector","mixedTripletStepTrk")],
-    setsToMerge = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )],
-    writeOnlyTrkQuals = True
+    TrackProducers     = ['mixedTripletStepTracks',
+                          'mixedTripletStepTracks'],
+    hasSelector        = [1,1],
+    selectedTrackQuals = ['mixedTripletStepSelector:mixedTripletStepVtx',
+                          'mixedTripletStepSelector:mixedTripletStepTrk'],
+    setsToMerge        = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )],
+    writeOnlyTrkQuals  = True
 )
 trackingLowPU.toReplaceWith(mixedTripletStep, _trackListMergerBase)
 
@@ -483,7 +482,7 @@ trackingLowPU.toReplaceWith(MixedTripletStepTask, _MixedTripletStepTask_LowPU)
 #fastsim
 import FastSimulation.Tracking.FastTrackerRecHitMaskProducer_cfi
 mixedTripletStepMasks = FastSimulation.Tracking.FastTrackerRecHitMaskProducer_cfi.maskProducerFromClusterRemover(mixedTripletStepClusters)
-mixedTripletStepMasks.oldHitRemovalInfo = cms.InputTag("pixelPairStepMasks")
+mixedTripletStepMasks.oldHitRemovalInfo = cms.InputTag('pixelPairStepMasks')
 
 fastSim.toReplaceWith(MixedTripletStepTask,
                       cms.Task(mixedTripletStepMasks

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -258,7 +258,7 @@ mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstima
     ComponentName    = 'mixedTripletStepChi2Est',
     nSigma           = 3.0,
     MaxChi2          = 16.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 trackingLowPU.toModify(mixedTripletStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -268,7 +268,7 @@ trackingLowPU.toModify(mixedTripletStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 mixedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter       = dict(refToPSet_ = 'mixedTripletStepTrajectoryFilter'),
+    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('mixedTripletStepTrajectoryFilter')),
     propagatorAlong        = 'mixedTripletStepPropagator',
     propagatorOpposite     = 'mixedTripletStepPropagatorOpposite',
     maxCand                = 2,
@@ -286,7 +286,7 @@ mixedTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.
     numHitsForSeedCleaner     = cms.int32(50),
     #onlyPixelHitsForSeedCleaner = cms.bool(True),
 
-    TrajectoryBuilderPSet     = dict(refToPSet_ = 'mixedTripletStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet     = cms.PSet(refToPSet_ = cms.string('mixedTripletStepTrajectoryBuilder')),
     doSeedingRegionRebuilding = True,
     useHitsSplitting          = True,
     TrajectoryCleaner         = 'mixedTripletStepTrajectoryCleanerBySharedHits'

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -71,8 +71,8 @@ muonSeededTrajectoryBuilderForInOut = RecoTracker.CkfPattern.GroupedCkfTrajector
     lostHitPenalty   = 1.0,   
     maxCand          = 5,
     estimator        = 'muonSeededMeasurementEstimatorForInOut',
-    trajectoryFilter = dict(refToPSet_ = 'muonSeededTrajectoryFilterForInOut'),
-    inOutTrajectoryFilter      = dict(refToPSet_ = 'muonSeededTrajectoryFilterForInOut'), # not sure if it is used
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForInOut')),
+    inOutTrajectoryFilter      = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForInOut')), # not sure if it is used
     minNrOfHitsForRebuild      = 2,
     requireSeedHitsInRebuild   = True, 
     keepOriginalIfRebuildFails = True, 
@@ -82,8 +82,8 @@ muonSeededTrajectoryBuilderForOutIn = RecoTracker.CkfPattern.GroupedCkfTrajector
     lostHitPenalty   = 1.0,   
     maxCand          = 3,
     estimator        = 'muonSeededMeasurementEstimatorForOutIn',
-    trajectoryFilter = dict(refToPSet_ = 'muonSeededTrajectoryFilterForOutIn'),
-    inOutTrajectoryFilter      = dict(refToPSet_ = 'muonSeededTrajectoryFilterForOutIn'), # not sure if it is used
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutIn')),
+    inOutTrajectoryFilter      = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutIn')), # not sure if it is used
     minNrOfHitsForRebuild      = 5,
     requireSeedHitsInRebuild   = True, 
     keepOriginalIfRebuildFails = False, 
@@ -101,13 +101,13 @@ muonSeededFittingSmootherWithOutliersRejectionAndRK = TrackingTools.TrackFitters
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 muonSeededTrackCandidatesInOut = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'muonSeededSeedsInOut',
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'muonSeededTrajectoryBuilderForInOut'),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryBuilderForInOut')),
     TrajectoryCleaner     = 'muonSeededTrajectoryCleanerBySharedHits',
     RedundantSeedCleaner  = 'none', 
 )
 muonSeededTrackCandidatesOutIn = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'muonSeededSeedsOutIn',
-    TrajectoryBuilderPSet       = dict(refToPSet_ = 'muonSeededTrajectoryBuilderForOutIn'),
+    TrajectoryBuilderPSet       = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryBuilderForOutIn')),
     TrajectoryCleaner           = 'muonSeededTrajectoryCleanerBySharedHits',
     numHitsForSeedCleaner       = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(False),

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -7,10 +7,10 @@ from RecoMuon.MuonIdentification.earlyMuons_cfi import earlyMuons
 import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 import RecoTracker.SpecialSeedGenerators.inOutSeedsFromTrackerMuons_cfi
 muonSeededSeedsOutIn = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
-    src = "earlyMuons",
+    src = 'earlyMuons',
 )
 muonSeededSeedsInOut = RecoTracker.SpecialSeedGenerators.inOutSeedsFromTrackerMuons_cfi.inOutSeedsFromTrackerMuons.clone(
-    src = "earlyMuons",
+    src = 'earlyMuons',
 )
 ### This is also needed for seeding
 from RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi import hitCollectorForOutInMuonSeeds
@@ -21,133 +21,136 @@ _tracker_apv_vfp30_2016.toModify(hitCollectorForOutInMuonSeeds, MinPtForHitRecov
 ###---------- Trajectory Cleaner, deciding how overlapping track candidates are arbitrated  ----------------
 import TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi 
 muonSeededTrajectoryCleanerBySharedHits = TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi.trajectoryCleanerBySharedHits.clone(
-    ComponentName = cms.string('muonSeededTrajectoryCleanerBySharedHits'),
-    fractionShared = cms.double(0.1),
-    ValidHitBonus = cms.double(1000.0),
-    MissingHitPenalty = cms.double(1.0),
-    ComponentType = cms.string('TrajectoryCleanerBySharedHits'),
-    allowSharedFirstHit = cms.bool(True)
+    ComponentName       = 'muonSeededTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.1,
+    ValidHitBonus       = 1000.0,
+    MissingHitPenalty   = 1.0,
+    ComponentType       = 'TrajectoryCleanerBySharedHits',
+    allowSharedFirstHit = True
 )
 
 ###------------- MeasurementEstimator, defining the searcgh window for pattern recongnition ----------------
 
 from TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi import Chi2MeasurementEstimator as _Chi2MeasurementEstimator
 _muonSeededMeasurementEstimatorForInOutBase = _Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('muonSeededMeasurementEstimatorForInOut'),
-    MaxChi2 = cms.double(80.0), ## was 30 ## TO BE TUNED
-    nSigma  = cms.double(4.),    ## was 3  ## TO BE TUNED 
+    ComponentName = 'muonSeededMeasurementEstimatorForInOut',
+    MaxChi2       = 80.0, ## was 30 ## TO BE TUNED
+    nSigma        = 4.,    ## was 3  ## TO BE TUNED 
 )
 muonSeededMeasurementEstimatorForInOut = _muonSeededMeasurementEstimatorForInOutBase.clone(
-    MaxSagitta = cms.double(-1.)
+    MaxSagitta = -1.
 )
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(muonSeededMeasurementEstimatorForInOut, MaxChi2 = 400.0, MaxSagitta = 2)
 
 _muonSeededMeasurementEstimatorForOutInBase = _Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('muonSeededMeasurementEstimatorForOutIn'),
-    MaxChi2 = cms.double(30.0), ## was 30 ## TO BE TUNED
-    nSigma  = cms.double(3.),    ## was 3  ## TO BE TUNED
+    ComponentName = 'muonSeededMeasurementEstimatorForOutIn',
+    MaxChi2       = 30.0, ## was 30 ## TO BE TUNED
+    nSigma        = 3.,    ## was 3  ## TO BE TUNED
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016 as _tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(_muonSeededMeasurementEstimatorForOutInBase, MinPtForHitRecoveryInGluedDet=1e9)
 muonSeededMeasurementEstimatorForOutIn = _muonSeededMeasurementEstimatorForOutInBase.clone(
-    MaxSagitta = cms.double(-1.) 
+    MaxSagitta = -1. 
 )
 
 ###------------- TrajectoryFilter, defining selections on the trajectories while building them ----------------
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-muonSeededTrajectoryFilterForInOut = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone()
-muonSeededTrajectoryFilterForInOut.constantValueForLostHitsFractionFilter = 10 ## allow more lost hits
-muonSeededTrajectoryFilterForInOut.minimumNumberOfHits = 3 ## allow more lost hits
-
-muonSeededTrajectoryFilterForOutIn = muonSeededTrajectoryFilterForInOut.clone()
-muonSeededTrajectoryFilterForOutIn.constantValueForLostHitsFractionFilter = 10 ## allow more lost hits
-muonSeededTrajectoryFilterForOutIn.minimumNumberOfHits = 5 ## allow more lost hits
-
+muonSeededTrajectoryFilterForInOut = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    constantValueForLostHitsFractionFilter = 10, ## allow more lost hits
+    minimumNumberOfHits                    = 3 ## allow more lost hits
+)
+muonSeededTrajectoryFilterForOutIn = muonSeededTrajectoryFilterForInOut.clone(
+    constantValueForLostHitsFractionFilter = 10, ## allow more lost hits
+    minimumNumberOfHits = 5 ## allow more lost hits
+)
 ###------------- TrajectoryBuilders ----------------
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 muonSeededTrajectoryBuilderForInOut = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    foundHitBonus = cms.double(1000.0),  
-    lostHitPenalty = cms.double(1.0),   
-    maxCand   = cms.int32(5),
-    estimator = cms.string('muonSeededMeasurementEstimatorForInOut'),
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForInOut')),
-    inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForInOut')), # not sure if it is used
-    minNrOfHitsForRebuild    = cms.int32(2),
-    requireSeedHitsInRebuild = cms.bool(True), 
-    keepOriginalIfRebuildFails = cms.bool(True), 
+    foundHitBonus    = 1000.0,  
+    lostHitPenalty   = 1.0,   
+    maxCand          = 5,
+    estimator        = 'muonSeededMeasurementEstimatorForInOut',
+    trajectoryFilter = dict(refToPSet_ = 'muonSeededTrajectoryFilterForInOut'),
+    inOutTrajectoryFilter      = dict(refToPSet_ = 'muonSeededTrajectoryFilterForInOut'), # not sure if it is used
+    minNrOfHitsForRebuild      = 2,
+    requireSeedHitsInRebuild   = True, 
+    keepOriginalIfRebuildFails = True, 
 )
 muonSeededTrajectoryBuilderForOutIn = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    foundHitBonus = cms.double(1000.0),  
-    lostHitPenalty = cms.double(1.0),   
-    maxCand   = cms.int32(3),
-    estimator = cms.string('muonSeededMeasurementEstimatorForOutIn'),
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutIn')),
-    inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutIn')), # not sure if it is used
-    minNrOfHitsForRebuild    = cms.int32(5),
-    requireSeedHitsInRebuild = cms.bool(True), 
-    keepOriginalIfRebuildFails = cms.bool(False), 
+    foundHitBonus    = 1000.0,  
+    lostHitPenalty   = 1.0,   
+    maxCand          = 3,
+    estimator        = 'muonSeededMeasurementEstimatorForOutIn',
+    trajectoryFilter = dict(refToPSet_ = 'muonSeededTrajectoryFilterForOutIn'),
+    inOutTrajectoryFilter      = dict(refToPSet_ = 'muonSeededTrajectoryFilterForOutIn'), # not sure if it is used
+    minNrOfHitsForRebuild      = 5,
+    requireSeedHitsInRebuild   = True, 
+    keepOriginalIfRebuildFails = False, 
 )
 
 ###-------------  Fitter-Smoother -------------------
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff
 muonSeededFittingSmootherWithOutliersRejectionAndRK = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFittingSmootherWithOutliersRejectionAndRK.clone(
-    ComponentName = cms.string("muonSeededFittingSmootherWithOutliersRejectionAndRK"),
-    BreakTrajWith2ConsecutiveMissing = cms.bool(False), 
-    EstimateCut = cms.double(50.), ## was 20.
+    ComponentName = 'muonSeededFittingSmootherWithOutliersRejectionAndRK',
+    BreakTrajWith2ConsecutiveMissing = False, 
+    EstimateCut   = 50., ## was 20.
 )
 
 ######## TRACK CANDIDATE MAKERS
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 muonSeededTrackCandidatesInOut = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag("muonSeededSeedsInOut"),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string("muonSeededTrajectoryBuilderForInOut")),
-    TrajectoryCleaner = cms.string('muonSeededTrajectoryCleanerBySharedHits'),
-    RedundantSeedCleaner = cms.string("none"), 
+    src = 'muonSeededSeedsInOut',
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'muonSeededTrajectoryBuilderForInOut'),
+    TrajectoryCleaner     = 'muonSeededTrajectoryCleanerBySharedHits',
+    RedundantSeedCleaner  = 'none', 
 )
 muonSeededTrackCandidatesOutIn = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag("muonSeededSeedsOutIn"),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string("muonSeededTrajectoryBuilderForOutIn")),
-    TrajectoryCleaner = cms.string('muonSeededTrajectoryCleanerBySharedHits'),
-    numHitsForSeedCleaner = cms.int32(50),
+    src = 'muonSeededSeedsOutIn',
+    TrajectoryBuilderPSet       = dict(refToPSet_ = 'muonSeededTrajectoryBuilderForOutIn'),
+    TrajectoryCleaner           = 'muonSeededTrajectoryCleanerBySharedHits',
+    numHitsForSeedCleaner       = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(False),
 )
 
 ######## TRACK PRODUCERS 
 import RecoTracker.TrackProducer.TrackProducer_cfi
 muonSeededTracksOutIn = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = cms.InputTag("muonSeededTrackCandidatesOutIn"),
-    AlgorithmName = cms.string('muonSeededStepOutIn'),
-    Fitter = cms.string("muonSeededFittingSmootherWithOutliersRejectionAndRK"),
+    src           = 'muonSeededTrackCandidatesOutIn',
+    AlgorithmName = 'muonSeededStepOutIn',
+    Fitter        = 'muonSeededFittingSmootherWithOutliersRejectionAndRK',
 )
 muonSeededTracksInOut = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = cms.InputTag("muonSeededTrackCandidatesInOut"),
-    AlgorithmName = cms.string('muonSeededStepInOut'),
-    Fitter = cms.string("muonSeededFittingSmootherWithOutliersRejectionAndRK"),
+    src           = 'muonSeededTrackCandidatesInOut',
+    AlgorithmName = 'muonSeededStepInOut',
+    Fitter        = 'muonSeededFittingSmootherWithOutliersRejectionAndRK',
 )
-
 
 # Final Classifier
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
-muonSeededTracksInOutClassifier = TrackCutClassifier.clone()
-muonSeededTracksInOutClassifier.src='muonSeededTracksInOut'
-muonSeededTracksInOutClassifier.mva.minPixelHits = [0,0,0]
-muonSeededTracksInOutClassifier.mva.maxChi2 = [9999.,9999.,9999.]
-muonSeededTracksInOutClassifier.mva.maxChi2n = [10.0,1.0,0.4]
-muonSeededTracksInOutClassifier.mva.minLayers = [3,5,5]
-muonSeededTracksInOutClassifier.mva.min3DLayers = [1,2,2]
-muonSeededTracksInOutClassifier.mva.maxLostLayers = [4,3,2]
+muonSeededTracksInOutClassifier = TrackCutClassifier.clone(
+    src = 'muonSeededTracksInOut',
+    mva = dict(
+	minPixelHits  = [0,0,0],
+        maxChi2       = [9999.,9999.,9999.],
+        maxChi2n      = [10.0,1.0,0.4],
+        minLayers     = [3,5,5],
+        min3DLayers   = [1,2,2],
+        maxLostLayers = [4,3,2]
+    )
+)
 
-
-muonSeededTracksOutInClassifier = TrackCutClassifier.clone()
-muonSeededTracksOutInClassifier.src='muonSeededTracksOutIn'
-muonSeededTracksOutInClassifier.mva.minPixelHits = [0,0,0]
-muonSeededTracksOutInClassifier.mva.maxChi2 = [9999.,9999.,9999.]
-muonSeededTracksOutInClassifier.mva.maxChi2n = [10.0,1.0,0.4]
-muonSeededTracksOutInClassifier.mva.minLayers = [3,5,5]
-muonSeededTracksOutInClassifier.mva.min3DLayers = [1,2,2]
-muonSeededTracksOutInClassifier.mva.maxLostLayers = [4,3,2]
-
+muonSeededTracksOutInClassifier = TrackCutClassifier.clone(
+    src = 'muonSeededTracksOutIn',
+    mva = dict(
+	minPixelHits  = [0,0,0],
+        maxChi2       = [9999.,9999.,9999.],
+        maxChi2n      = [10.0,1.0,0.4],
+        minLayers     = [3,5,5],
+        min3DLayers   = [1,2,2],
+        maxLostLayers = [4,3,2]
+    )
+)
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
@@ -155,35 +158,35 @@ muonSeededTracksInOutSelector = RecoTracker.FinalTrackSelectors.multiTrackSelect
     src='muonSeededTracksInOut',
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-            name = 'muonSeededTracksInOutLoose',
-            applyAdaptedPVCuts = cms.bool(False),
-            chi2n_par = 10.0,
-            minNumberLayers = 3,
-            min_nhits = 5,
-            maxNumberLostLayers = 4,
-            minNumber3DLayers = 0,
+            name                  = 'muonSeededTracksInOutLoose',
+            applyAdaptedPVCuts    = False,
+            chi2n_par             = 10.0,
+            minNumberLayers       = 3,
+            min_nhits             = 5,
+            maxNumberLostLayers   = 4,
+            minNumber3DLayers     = 0,
             minHitsToBypassChecks = 7
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
-            name = 'muonSeededTracksInOutTight',
-            preFilterName = 'muonSeededTracksInOutLoose',
-            applyAdaptedPVCuts = cms.bool(False),
-            chi2n_par = 1.0,
-            minNumberLayers = 5,
-            min_nhits = 6,
-            maxNumberLostLayers = 3,
-            minNumber3DLayers = 2,
+            name                  = 'muonSeededTracksInOutTight',
+            preFilterName         = 'muonSeededTracksInOutLoose',
+            applyAdaptedPVCuts    = False,
+            chi2n_par             = 1.0,
+            minNumberLayers       = 5,
+            min_nhits             = 6,
+            maxNumberLostLayers   = 3,
+            minNumber3DLayers     = 2,
             minHitsToBypassChecks = 10
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
-            name = 'muonSeededTracksInOutHighPurity',
-            preFilterName = 'muonSeededTracksInOutTight',
-            applyAdaptedPVCuts = cms.bool(False),
-            chi2n_par = 0.4,
-            minNumberLayers = 5,
-            min_nhits = 7,
-            maxNumberLostLayers = 2,
-            minNumber3DLayers = 2,
+            name                  = 'muonSeededTracksInOutHighPurity',
+            preFilterName         = 'muonSeededTracksInOutTight',
+            applyAdaptedPVCuts    = False,
+            chi2n_par             = 0.4,
+            minNumberLayers       = 5,
+            min_nhits             = 7,
+            maxNumberLostLayers   = 2,
+            minNumber3DLayers     = 2,
             minHitsToBypassChecks = 20
             ),
         ) #end of vpset
@@ -192,35 +195,35 @@ muonSeededTracksOutInSelector = RecoTracker.FinalTrackSelectors.multiTrackSelect
     src='muonSeededTracksOutIn',
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-            name = 'muonSeededTracksOutInLoose',
-            applyAdaptedPVCuts = cms.bool(False),
-            chi2n_par = 10.0,
-            minNumberLayers = 3,
-            min_nhits = 5,
-            maxNumberLostLayers = 4,
-            minNumber3DLayers = 0,
+            name                  = 'muonSeededTracksOutInLoose',
+            applyAdaptedPVCuts    = False,
+            chi2n_par             = 10.0,
+            minNumberLayers       = 3,
+            min_nhits             = 5,
+            maxNumberLostLayers   = 4,
+            minNumber3DLayers     = 0,
             minHitsToBypassChecks = 7
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
-            name = 'muonSeededTracksOutInTight',
-            preFilterName = 'muonSeededTracksOutInLoose',
-            applyAdaptedPVCuts = cms.bool(False),
-            chi2n_par = 1.0,
-            minNumberLayers = 5,
-            min_nhits = 6,
-            maxNumberLostLayers = 3,
-            minNumber3DLayers = 2,
+            name                  = 'muonSeededTracksOutInTight',
+            preFilterName         = 'muonSeededTracksOutInLoose',
+            applyAdaptedPVCuts    = False,
+            chi2n_par             = 1.0,
+            minNumberLayers       = 5,
+            min_nhits             = 6,
+            maxNumberLostLayers   = 3,
+            minNumber3DLayers     = 2,
             minHitsToBypassChecks = 10
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
-            name = 'muonSeededTracksOutInHighPurity',
-            preFilterName = 'muonSeededTracksOutInTight',
-            applyAdaptedPVCuts = cms.bool(False),
-            chi2n_par = 0.4,
-            minNumberLayers = 5,
-            min_nhits = 7,
-            maxNumberLostLayers = 2,
-            minNumber3DLayers = 2,
+            name                  = 'muonSeededTracksOutInHighPurity',
+            preFilterName         = 'muonSeededTracksOutInTight',
+            applyAdaptedPVCuts    = False,
+            chi2n_par             = 0.4,
+            minNumberLayers       = 5,
+            min_nhits             = 7,
+            maxNumberLostLayers   = 2,
+            minNumber3DLayers     = 2,
             minHitsToBypassChecks = 20
             ),
         ) #end of vpset
@@ -274,10 +277,10 @@ muonSeededStep = cms.Sequence(muonSeededStepTask)
    
     
 ##### MODULES FOR DEBUGGING ###############3
-muonSeededSeedsInOutAsTracks = cms.EDProducer("FakeTrackProducerFromSeed", src = cms.InputTag("muonSeededSeedsInOut"))
-muonSeededSeedsOutInAsTracks = cms.EDProducer("FakeTrackProducerFromSeed", src = cms.InputTag("muonSeededSeedsOutIn"))
-muonSeededTrackCandidatesInOutAsTracks = cms.EDProducer("FakeTrackProducerFromCandidate", src = cms.InputTag("muonSeededTrackCandidatesInOut"))
-muonSeededTrackCandidatesOutInAsTracks = cms.EDProducer("FakeTrackProducerFromCandidate", src = cms.InputTag("muonSeededTrackCandidatesOutIn"))
+muonSeededSeedsInOutAsTracks = cms.EDProducer('FakeTrackProducerFromSeed', src = cms.InputTag('muonSeededSeedsInOut'))
+muonSeededSeedsOutInAsTracks = cms.EDProducer('FakeTrackProducerFromSeed', src = cms.InputTag('muonSeededSeedsOutIn'))
+muonSeededTrackCandidatesInOutAsTracks = cms.EDProducer('FakeTrackProducerFromCandidate', src = cms.InputTag('muonSeededTrackCandidatesInOut'))
+muonSeededTrackCandidatesOutInAsTracks = cms.EDProducer('FakeTrackProducerFromCandidate', src = cms.InputTag('muonSeededTrackCandidatesOutIn'))
 muonSeededStepDebugInOutTask = cms.Task(
     muonSeededSeedsInOutAsTracks , muonSeededTrackCandidatesInOutAsTracks
 )

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -10,15 +10,15 @@ from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 # Large impact parameter tracking using TIB/TID/TEC stereo layer seeding #
 ##########################################################################
 
-pixelLessStepClusters = _cfg.clusterRemoverForIter("PixelLessStep")
+pixelLessStepClusters = _cfg.clusterRemoverForIter('PixelLessStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(pixelLessStepClusters, _cfg.clusterRemoverForIter("PixelLessStep", _eraName, _postfix))
+    _era.toReplaceWith(pixelLessStepClusters, _cfg.clusterRemoverForIter('PixelLessStep', _eraName, _postfix))
 
 
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
-pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+pixelLessStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring(
     #TIB
     'TIB1+TIB2+MTIB3','TIB1+TIB2+MTIB4',
@@ -47,16 +47,16 @@ pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     ),
     TIB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
          skipClusters   = cms.InputTag('pixelLessStepClusters')
     ),
     MTIB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
          skipClusters   = cms.InputTag('pixelLessStepClusters'),
-         rphiRecHits    = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
+         rphiRecHits    = cms.InputTag('siStripMatchedRecHits','rphiRecHit')
     ),
     TID = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         skipClusters = cms.InputTag('pixelLessStepClusters'),
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
@@ -64,7 +64,7 @@ pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(2)
     ),
     MTID = cms.PSet(
-        rphiRecHits    = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        rphiRecHits    = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
         skipClusters = cms.InputTag('pixelLessStepClusters'),
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
@@ -72,7 +72,7 @@ pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(3)
     ),
     TEC = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         skipClusters = cms.InputTag('pixelLessStepClusters'),
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
@@ -80,7 +80,7 @@ pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         maxRing = cms.int32(2)
     ),
     MTEC = cms.PSet(
-        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        rphiRecHits = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
         skipClusters = cms.InputTag('pixelLessStepClusters'),
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
@@ -108,14 +108,14 @@ trackingLowPU.toModify(pixelLessStepSeedLayers,
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 pixelLessStepTrackingRegions = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
-    ptMin = 0.4,
+    ptMin            = 0.4,
     originHalfLength = 12.0,
-    originRadius = 1.0
+    originRadius     = 1.0
 ))
 trackingLowPU.toModify(pixelLessStepTrackingRegions, RegionPSet = dict(
-    ptMin = 0.7,
+    ptMin            = 0.7,
     originHalfLength = 10.0,
-    originRadius = 2.0,
+    originRadius     = 2.0,
 ))
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
@@ -123,48 +123,48 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.IterativeTracking.MixedTripletStep_cff import _mixedTripletStepTrackingRegionsCommon_pp_on_HI
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(pixelLessStepTrackingRegions, 
                 _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet=dict(
-                    ptMinScaling4BigEvts= False,
-                    fixedError = 3.0,
-                    ptMin = 2.0,
-                    originRadius = 1.0
-                )                                                                      )
+                    ptMinScaling4BigEvts = False,
+                    fixedError           = 3.0,
+                    ptMin                = 2.0,
+                    originRadius         = 1.0 )
+                )
 )
 
 
 # seeding
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import ClusterShapeHitFilterESProducer as _ClusterShapeHitFilterESProducer
 pixelLessStepClusterShapeHitFilter = _ClusterShapeHitFilterESProducer.clone(
-    ComponentName = 'pixelLessStepClusterShapeHitFilter',
-    doStripShapeCut = cms.bool(False),
+    ComponentName    = 'pixelLessStepClusterShapeHitFilter',
+    doStripShapeCut  = cms.bool(False),
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
 )
 
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 pixelLessStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "pixelLessStepSeedLayers",
-    trackingRegions = "pixelLessStepTrackingRegions",
-    maxElement = 50000000,
+    seedingLayers   = 'pixelLessStepSeedLayers',
+    trackingRegions = 'pixelLessStepTrackingRegions',
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoTracker.TkSeedGenerator.multiHitFromChi2EDProducer_cfi import multiHitFromChi2EDProducer as _multiHitFromChi2EDProducer
 pixelLessStepHitTriplets = _multiHitFromChi2EDProducer.clone(
-    doublets = "pixelLessStepHitDoublets",
+    doublets = 'pixelLessStepHitDoublets',
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cff import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
 from RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi import StripSubClusterShapeSeedFilter as _StripSubClusterShapeSeedFilter
 pixelLessStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(
-    seedingHitSets = "pixelLessStepHitTriplets",
+    seedingHitSets = 'pixelLessStepHitTriplets',
     SeedComparitorPSet = dict(
         ComponentName = 'CombinedSeedComparitor',
-        mode = cms.string("and"),
+        mode = cms.string('and'),
         comparitors = cms.VPSet(
             cms.PSet(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
-                ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+                ComponentName      = cms.string('PixelClusterShapeSeedComparitor'),
                 FilterAtHelixStage = cms.bool(True),
-                FilterPixelHits = cms.bool(False),
-                FilterStripHits = cms.bool(True),
+                FilterPixelHits    = cms.bool(False),
+                FilterStripHits    = cms.bool(True),
                 ClusterShapeHitFilterName = cms.string('pixelLessStepClusterShapeHitFilter'),
-                ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+                ClusterShapeCacheSrc      = cms.InputTag('siPixelClusterShapeCache') # not really needed here since FilterPixelHits=False
             ), 
             _StripSubClusterShapeSeedFilter.clone()
         )
@@ -172,35 +172,35 @@ pixelLessStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.
 )
 trackingLowPU.toModify(pixelLessStepHitDoublets, produceSeedingHitSets=True, produceIntermediateHitDoublets=False)
 trackingLowPU.toModify(pixelLessStepSeeds,
-    seedingHitSets = "pixelLessStepHitDoublets",
+    seedingHitSets = 'pixelLessStepHitDoublets',
     SeedComparitorPSet = dict(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
-        ComponentName = 'PixelClusterShapeSeedComparitor',
-        FilterAtHelixStage = cms.bool(True),
-        FilterPixelHits = cms.bool(False),
-        FilterStripHits = cms.bool(True),
-        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
-        ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+        ComponentName      = 'PixelClusterShapeSeedComparitor',
+        FilterAtHelixStage = True,
+        FilterPixelHits    = False,
+        FilterStripHits    = True,
+        ClusterShapeHitFilterName = 'ClusterShapeHitFilter',
+        ClusterShapeCacheSrc      = 'siPixelClusterShapeCache' # not really needed here since FilterPixelHits=False
     )
 )
 #fastsim
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
-_fastSim_pixelLessStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "pixelLessStepTrackingRegions",
-    hitMasks = cms.InputTag("pixelLessStepMasks"),
-)
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
-_fastSim_pixelLessStepSeeds.seedFinderSelector.MultiHitGeneratorFactory = _hitSetProducerToFactoryPSet(pixelLessStepHitTriplets)
-_fastSim_pixelLessStepSeeds.seedFinderSelector.MultiHitGeneratorFactory.refitHits = False
-_fastSim_pixelLessStepSeeds.seedFinderSelector.layerList = pixelLessStepSeedLayers.layerList.value()
+_fastSim_pixelLessStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
+    trackingRegions = 'pixelLessStepTrackingRegions',
+    hitMasks        = cms.InputTag('pixelLessStepMasks'),
+    seedFinderSelector = dict( MultiHitGeneratorFactory = _hitSetProducerToFactoryPSet(pixelLessStepHitTriplets).clone(
+                              refitHits = False),
+                              layerList = pixelLessStepSeedLayers.layerList.value()
+))
 fastSim.toReplaceWith(pixelLessStepSeeds,_fastSim_pixelLessStepSeeds)
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 _pixelLessStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
-    maxLostHits = 0,
+    maxLostHits         = 0,
     minimumNumberOfHits = 4,
-    minPt = 0.1
-    )
+    minPt               = 0.1
+)
 pixelLessStepTrajectoryFilter = _pixelLessStepTrajectoryFilterBase.clone(
     seedPairPenalty = 1,
 )
@@ -210,10 +210,10 @@ for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('pixelLessStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(16.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+    ComponentName    = 'pixelLessStepChi2Est',
+    nSigma           = 3.0,
+    MaxChi2          = 16.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
 )
 trackingLowPU.toModify(pixelLessStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -223,87 +223,89 @@ trackingLowPU.toModify(pixelLessStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 pixelLessStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryFilter')),
-    minNrOfHitsForRebuild = 4,
-    maxCand = 2,
-    alwaysUseInvalidHits = False,
-    estimator = cms.string('pixelLessStepChi2Est'),
+    trajectoryFilter       = dict(refToPSet_ = 'pixelLessStepTrajectoryFilter'),
+    minNrOfHitsForRebuild  = 4,
+    maxCand                = 2,
+    alwaysUseInvalidHits   = False,
+    estimator              = 'pixelLessStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7)
-    )
+    maxPtForLooperReconstruction   = cms.double(0.7)
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 pixelLessStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('pixelLessStepSeeds'),
-    clustersToSkip = cms.InputTag('pixelLessStepClusters'),
+    src                   = 'pixelLessStepSeeds',
+    clustersToSkip        = cms.InputTag('pixelLessStepClusters'),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     #onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryBuilder')),
-    TrajectoryCleaner = 'pixelLessStepTrajectoryCleanerBySharedHits'
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'pixelLessStepTrajectoryBuilder'),
+    TrajectoryCleaner     = 'pixelLessStepTrajectoryCleanerBySharedHits'
 )
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(pixelLessStepTrackCandidates,
                       FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-        src = cms.InputTag("pixelLessStepSeeds"),
+        src = 'pixelLessStepSeeds',
         MinNumberOfCrossedLayers = 6, # ?
-        hitMasks = cms.InputTag("pixelLessStepMasks")
+        hitMasks = cms.InputTag('pixelLessStepMasks')
         )
 )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 pixelLessStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
-    ComponentName = cms.string('pixelLessStepTrajectoryCleanerBySharedHits'),
-    fractionShared = cms.double(0.11),
-    allowSharedFirstHit = cms.bool(True)
-    )
+    ComponentName       = 'pixelLessStepTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.11,
+    allowSharedFirstHit = True
+)
 trackingLowPU.toModify(pixelLessStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 pixelLessStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'pixelLessStepTrackCandidates',
-    AlgorithmName = cms.string('pixelLessStep'),
-    Fitter = cms.string('FlexibleKFFittingSmoother')
-    )
+    src           = 'pixelLessStepTrackCandidates',
+    AlgorithmName = 'pixelLessStep',
+    Fitter        = 'FlexibleKFFittingSmoother'
+)
 fastSim.toModify(pixelLessStepTracks, TTRHBuilder = 'WithoutRefit')
 
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
-pixelLessStepClassifier1 = TrackMVAClassifierPrompt.clone()
-pixelLessStepClassifier1.src = 'pixelLessStepTracks'
-pixelLessStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter5_13TeV'
-pixelLessStepClassifier1.qualityCuts = [-0.4,0.0,0.4]
-fastSim.toModify(pixelLessStepClassifier1, vertices = "firstStepPrimaryVerticesBeforeMixing" )
+pixelLessStepClassifier1 = TrackMVAClassifierPrompt.clone(
+    src         = 'pixelLessStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorIter5_13TeV'),
+    qualityCuts = [-0.4,0.0,0.4]
+)
+fastSim.toModify(pixelLessStepClassifier1, vertices = 'firstStepPrimaryVerticesBeforeMixing' )
 
-pixelLessStepClassifier2 = TrackMVAClassifierPrompt.clone()
-pixelLessStepClassifier2.src = 'pixelLessStepTracks'
-pixelLessStepClassifier2.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
-pixelLessStepClassifier2.qualityCuts = [-0.0,0.0,0.0]
-fastSim.toModify(pixelLessStepClassifier2, vertices = "firstStepPrimaryVerticesBeforeMixing" )
+pixelLessStepClassifier2 = TrackMVAClassifierPrompt.clone(
+    src         = 'pixelLessStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorIter0_13TeV'),
+    qualityCuts = [-0.0,0.0,0.0]
+)
+fastSim.toModify(pixelLessStepClassifier2, vertices = 'firstStepPrimaryVerticesBeforeMixing' )
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
-pixelLessStep = ClassifierMerger.clone()
-pixelLessStep.inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassifier2']
-
+pixelLessStep = ClassifierMerger.clone(
+    inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassifier2']
+)
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 
 trackingPhase1.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
-	mva = dict(GBRForestLabel = 'MVASelectorPixelLessStep_Phase1'),
-	qualityCuts = [-0.4,0.0,0.4]
+    mva         = dict(GBRForestLabel = 'MVASelectorPixelLessStep_Phase1'),
+    qualityCuts = [-0.4,0.0,0.4]
 ))
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(pixelLessStep, TrackLwtnnClassifier.clone(
-     src = 'pixelLessStepTracks',
-     qualityCuts = [-0.6, -0.05, 0.5]
+    src         = 'pixelLessStepTracks',
+    qualityCuts = [-0.6, -0.05, 0.5]
 ))
-(trackdnn & fastSim).toModify(pixelLessStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+(trackdnn & fastSim).toModify(pixelLessStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 pp_on_AA_2018.toModify(pixelLessStep, qualityCuts = [-0.4,0.0,0.8])
 
@@ -311,9 +313,9 @@ pp_on_AA_2018.toModify(pixelLessStep, qualityCuts = [-0.4,0.0,0.8])
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 pixelLessStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
     src='pixelLessStepTracks',
-    useAnyMVA = cms.bool(False),
+    useAnyMVA      = cms.bool(False),
     GBRForestLabel = cms.string('MVASelectorIter5'),
-    trackSelectors= cms.VPSet(
+    trackSelectors = cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'pixelLessStepLoose',
             chi2n_par = 0.5,
@@ -353,7 +355,7 @@ pixelLessStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.m
             dz_par2 = ( 0.9, 4.0 )
         ),
     ),
-    vertices = cms.InputTag("pixelVertices")#end of vpset
+    vertices = 'pixelVertices'#end of vpset
 ) #end of clone
 
 PixelLessStepTask = cms.Task(pixelLessStepClusters,

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -213,7 +213,7 @@ pixelLessStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     ComponentName    = 'pixelLessStepChi2Est',
     nSigma           = 3.0,
     MaxChi2          = 16.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 trackingLowPU.toModify(pixelLessStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -223,7 +223,7 @@ trackingLowPU.toModify(pixelLessStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 pixelLessStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter       = dict(refToPSet_ = 'pixelLessStepTrajectoryFilter'),
+    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryFilter')),
     minNrOfHitsForRebuild  = 4,
     maxCand                = 2,
     alwaysUseInvalidHits   = False,
@@ -240,7 +240,7 @@ pixelLessStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckf
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     #onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'pixelLessStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryBuilder')),
     TrajectoryCleaner     = 'pixelLessStepTrajectoryCleanerBySharedHits'
 )
 import FastSimulation.Tracking.TrackCandidateProducer_cfi

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -7,13 +7,13 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 
 # NEW CLUSTERS (remove previously used clusters)
-pixelPairStepClusters = _cfg.clusterRemoverForIter("PixelPairStep")
+pixelPairStepClusters = _cfg.clusterRemoverForIter('PixelPairStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(pixelPairStepClusters, _cfg.clusterRemoverForIter("PixelPairStep", _eraName, _postfix))
+    _era.toReplaceWith(pixelPairStepClusters, _cfg.clusterRemoverForIter('PixelPairStep', _eraName, _postfix))
 
 
 # SEEDING LAYERS
-pixelPairStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+pixelPairStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
         'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
         'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
@@ -67,9 +67,9 @@ trackingPhase2PU140.toModify(pixelPairStepSeedLayers,
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
 pixelPairStepTrackingRegions = _globalTrackingRegionWithVertices.clone(RegionPSet = dict(
-    ptMin = 0.6,
+    ptMin        = 0.6,
     originRadius = 0.015,
-    fixedError = 0.03,
+    fixedError   = 0.03,
     useMultipleScattering = True,
 ))
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
@@ -82,28 +82,28 @@ trackingPhase1.toModify(pixelPairStepTrackingRegions, RegionPSet=_region_Phase1)
 trackingPhase2PU140.toModify(pixelPairStepTrackingRegions, RegionPSet=_region_Phase1)
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(pixelPairStepTrackingRegions,RegionPSet = dict(
-     ptMin = 0.05,
+     ptMin        = 0.05,
      originRadius = 0.2,
-     fixedError = 4.
+     fixedError   = 4.
 ))
-fastSim.toModify(pixelPairStepTrackingRegions, RegionPSet=dict(VertexCollection = "firstStepPrimaryVerticesBeforeMixing"))
+fastSim.toModify(pixelPairStepTrackingRegions, RegionPSet=dict(VertexCollection = 'firstStepPrimaryVerticesBeforeMixing'))
 
 # SEEDS
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 pixelPairStepHitDoublets = _hitPairEDProducer.clone(
-    seedingLayers = "pixelPairStepSeedLayers",
-    trackingRegions = "pixelPairStepTrackingRegions",
+    seedingLayers         = 'pixelPairStepSeedLayers',
+    trackingRegions       = 'pixelPairStepTrackingRegions',
     produceSeedingHitSets = True,
-    maxElementTotal = 12000000,
+    maxElementTotal       = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 pixelPairStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "pixelPairStepHitDoublets",
+    seedingHitSets = 'pixelPairStepHitDoublets',
     SeedComparitorPSet = dict(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
-        ComponentName = 'PixelClusterShapeSeedComparitor',
+        ComponentName      = 'PixelClusterShapeSeedComparitor',
         FilterAtHelixStage = cms.bool(True),
-        FilterPixelHits = cms.bool(True),
-        FilterStripHits = cms.bool(False),
+        FilterPixelHits    = cms.bool(True),
+        FilterStripHits    = cms.bool(False),
         ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache'),
     )
@@ -117,8 +117,8 @@ pixelPairStepSeedsA = pixelPairStepSeeds.clone()
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 fastSim.toReplaceWith(pixelPairStepSeeds,
                       FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-        trackingRegions = "pixelPairStepTrackingRegions",
-        hitMasks = cms.InputTag("pixelPairStepMasks"),
+        trackingRegions    = 'pixelPairStepTrackingRegions',
+        hitMasks           = cms.InputTag('pixelPairStepMasks'),
         seedFinderSelector = dict(layerList = pixelPairStepSeedLayers.layerList.value())
         )
 )
@@ -130,73 +130,73 @@ pixelPairStepTrackingRegionsSeedLayersB = _pixelInactiveAreaTrackingRegionsAndSe
 # Commented ones are already included in the global seeds (A), but are
 # included below for completenees
 #
-#        "BPix1+BPix2",
-#        "BPix1+BPix3",
-        "BPix1+BPix4",
-#        "BPix2+BPix3",
-        "BPix2+BPix4",
-        "BPix3+BPix4",
-#        "BPix1+FPix1_pos"    , "BPix1+FPix1_neg",
-        "BPix1+FPix2_pos"    , "BPix1+FPix2_neg",
-        "BPix1+FPix3_pos"    , "BPix1+FPix3_neg",
-#        "BPix2+FPix1_pos"    , "BPix2+FPix1_neg",
-        "BPix2+FPix2_pos"    , "BPix2+FPix2_neg",
-        "BPix3+FPix1_pos"    , "BPix3+FPix1_neg",
-        "FPix1_pos+FPix2_pos", "FPix1_neg+FPix2_neg",
-        "FPix1_pos+FPix3_pos", "FPix1_neg+FPix3_neg",
-        "FPix2_pos+FPix3_pos", "FPix2_neg+FPix3_neg",
+#        'BPix1+BPix2',
+#        'BPix1+BPix3',
+        'BPix1+BPix4',
+#        'BPix2+BPix3',
+        'BPix2+BPix4',
+        'BPix3+BPix4',
+#        'BPix1+FPix1_pos'    , 'BPix1+FPix1_neg',
+        'BPix1+FPix2_pos'    , 'BPix1+FPix2_neg',
+        'BPix1+FPix3_pos'    , 'BPix1+FPix3_neg',
+#        'BPix2+FPix1_pos'    , 'BPix2+FPix1_neg',
+        'BPix2+FPix2_pos'    , 'BPix2+FPix2_neg',
+        'BPix3+FPix1_pos'    , 'BPix3+FPix1_neg',
+        'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+        'FPix1_pos+FPix3_pos', 'FPix1_neg+FPix3_neg',
+        'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg',
     ],
     BPix = dict(
-        TTRHBuilder = cms.string('WithTrackAngle'),
-        HitProducer = cms.string('siPixelRecHits'),
+        TTRHBuilder  = cms.string('WithTrackAngle'),
+        HitProducer  = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')
     ),
     FPix = dict(
-        TTRHBuilder = cms.string('WithTrackAngle'),
-        HitProducer = cms.string('siPixelRecHits'),
+        TTRHBuilder  = cms.string('WithTrackAngle'),
+        HitProducer  = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')
     ),
     RegionPSet = dict(
-        ptMin = 0.6,
-        originRadius = 0.015,
-        operationMode = "VerticesFixed",
-        zErrorVertex = 0.03,
-        maxNVertices = 5,
+        ptMin         = 0.6,
+        originRadius  = 0.015,
+        operationMode = 'VerticesFixed',
+        zErrorVertex  = 0.03,
+        maxNVertices  = 5,
     ),
     ignoreSingleFPixPanelModules = True,
 )
 highBetaStar_2018.toModify(pixelPairStepTrackingRegionsSeedLayersB,RegionPSet = dict(
-     ptMin = 0.05,
+     ptMin        = 0.05,
      originRadius = 0.2,
 ))
 #include commented lines from above in pp_on_XY eras; global seeds (A) are not used in this era b/c timing
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 (pp_on_XeXe_2017 | pp_on_AA_2018).toModify(pixelPairStepTrackingRegionsSeedLayersB, layerList = [
-      "BPix1+BPix2", "BPix1+BPix3", "BPix1+BPix4", "BPix2+BPix3", "BPix2+BPix4","BPix3+BPix4",
-      "BPix1+FPix1_pos"    , "BPix1+FPix1_neg",
-      "BPix1+FPix2_pos"    , "BPix1+FPix2_neg",
-      "BPix1+FPix3_pos"    , "BPix1+FPix3_neg",
-      "BPix2+FPix1_pos"    , "BPix2+FPix1_neg",
-      "BPix2+FPix2_pos"    , "BPix2+FPix2_neg",
-      "BPix3+FPix1_pos"    , "BPix3+FPix1_neg",
-      "FPix1_pos+FPix2_pos", "FPix1_neg+FPix2_neg",
-      "FPix1_pos+FPix3_pos", "FPix1_neg+FPix3_neg",
-      "FPix2_pos+FPix3_pos", "FPix2_neg+FPix3_neg" 
+      'BPix1+BPix2', 'BPix1+BPix3', 'BPix1+BPix4', 'BPix2+BPix3', 'BPix2+BPix4','BPix3+BPix4',
+      'BPix1+FPix1_pos'    , 'BPix1+FPix1_neg',
+      'BPix1+FPix2_pos'    , 'BPix1+FPix2_neg',
+      'BPix1+FPix3_pos'    , 'BPix1+FPix3_neg',
+      'BPix2+FPix1_pos'    , 'BPix2+FPix1_neg',
+      'BPix2+FPix2_pos'    , 'BPix2+FPix2_neg',
+      'BPix3+FPix1_pos'    , 'BPix3+FPix1_neg',
+      'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+      'FPix1_pos+FPix3_pos', 'FPix1_neg+FPix3_neg',
+      'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg' 
    ])
 
 pixelPairStepHitDoubletsB = pixelPairStepHitDoublets.clone(
-    seedingLayers = "",
-    trackingRegions = "",
-    trackingRegionsSeedingLayers = "pixelPairStepTrackingRegionsSeedLayersB",
+    seedingLayers   = '',
+    trackingRegions = '',
+    trackingRegionsSeedingLayers = 'pixelPairStepTrackingRegionsSeedLayersB',
 )
-pixelPairStepSeedsB = pixelPairStepSeedsA.clone(seedingHitSets = "pixelPairStepHitDoubletsB")
+pixelPairStepSeedsB = pixelPairStepSeedsA.clone(seedingHitSets = 'pixelPairStepHitDoubletsB')
 
 
 # Merge
 from RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi import globalCombinedSeeds as _globalCombinedSeeds
 _pixelPairStepSeedsMerged = _globalCombinedSeeds.clone(
-    seedCollections = ["pixelPairStepSeedsA", "pixelPairStepSeedsB"],
+    seedCollections = ['pixelPairStepSeedsA', 'pixelPairStepSeedsB'],
 )
 (trackingPhase1 & ~fastSim).toReplaceWith(pixelPairStepSeeds, _pixelPairStepSeedsMerged)
 
@@ -207,11 +207,11 @@ _pixelPairStepSeedsMerged = _globalCombinedSeeds.clone(
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 _pixelPairStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
-    minPt = 0.1,
+    minPt               = 0.1,
 )
 pixelPairStepTrajectoryFilterBase = _pixelPairStepTrajectoryFilterBase.clone(
-    seedPairPenalty =0,
-    maxCCCLostHits = 0,
+    seedPairPenalty = 0,
+    maxCCCLostHits  = 0,
     minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
@@ -243,43 +243,43 @@ trackingPhase2PU140.toModify(pixelPairStepTrajectoryFilter,
 
 pixelPairStepTrajectoryFilterInOut = pixelPairStepTrajectoryFilterBase.clone(
     minimumNumberOfHits = 4,
-    seedExtension = 1,
+    seedExtension       = 1,
     strictSeedExtension = False, # allow inactive
-    pixelSeedExtension = False,
+    pixelSeedExtension  = False,
 )
 
 
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('pixelPairStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
-    pTChargeCutThreshold = cms.double(15.)
+    ComponentName    = 'pixelPairStepChi2Est',
+    nSigma           = 3.0,
+    MaxChi2          = 9.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
+    pTChargeCutThreshold = 15.
 )
 _tracker_apv_vfp30_2016.toModify(pixelPairStepChi2Est,
-    clusterChargeCut = dict(refToPSet_ = "SiStripClusterChargeCutTiny")
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
 )
 trackingLowPU.toModify(pixelPairStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny'),
 )
-highBetaStar_2018.toModify(pixelPairStepChi2Est,MaxChi2 = cms.double(30))
+highBetaStar_2018.toModify(pixelPairStepChi2Est,MaxChi2 = 30)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('pixelPairStepTrajectoryFilter')),
-    maxCand = 3,
-    estimator = cms.string('pixelPairStepChi2Est'),
+    trajectoryFilter       = dict(refToPSet_ = 'pixelPairStepTrajectoryFilter'),
+    maxCand                = 3,
+    estimator              = 'pixelPairStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
-    )
+)
 trackingLowPU.toModify(pixelPairStepTrajectoryBuilder, maxCand = 2)
 _seedExtension = dict(
-    inOutTrajectoryFilter = dict(refToPSet_ = "pixelPairStepTrajectoryFilterInOut"),
-    useSameTrajFilter = False,
+    inOutTrajectoryFilter = dict(refToPSet_ = 'pixelPairStepTrajectoryFilterInOut'),
+    useSameTrajFilter     = False,
 )
 trackingPhase1.toModify(pixelPairStepTrajectoryBuilder, **_seedExtension)
 trackingPhase2PU140.toModify(pixelPairStepTrajectoryBuilder, **_seedExtension)
@@ -290,32 +290,32 @@ trackingPhase2PU140.toModify(pixelPairStepTrajectoryBuilder, **_seedExtension)
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 pixelPairStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('pixelPairStepSeeds'),
-    clustersToSkip = cms.InputTag('pixelPairStepClusters'),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelPairStepTrajectoryBuilder')),
+    src = 'pixelPairStepSeeds',
+    clustersToSkip        = cms.InputTag('pixelPairStepClusters'),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'pixelPairStepTrajectoryBuilder'),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
 
 )
 trackingPhase2PU140.toModify(pixelPairStepTrackCandidates,
-    clustersToSkip = None,
-    phase2clustersToSkip = cms.InputTag("pixelPairStepClusters"),
-    TrajectoryCleaner = "pixelPairStepTrajectoryCleanerBySharedHits"
+    clustersToSkip       = None,
+    phase2clustersToSkip = cms.InputTag('pixelPairStepClusters'),
+    TrajectoryCleaner    = 'pixelPairStepTrajectoryCleanerBySharedHits'
 )
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(pixelPairStepTrackCandidates,
                       FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-        src = cms.InputTag("pixelPairStepSeeds"),
+        src = 'pixelPairStepSeeds',
         MinNumberOfCrossedLayers = 2, # ?
-        hitMasks = cms.InputTag("pixelPairStepMasks")
+        hitMasks = cms.InputTag('pixelPairStepMasks')
         )
 )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits as _trajectoryCleanerBySharedHits
 pixelPairStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.clone(
-    ComponentName = 'pixelPairStepTrajectoryCleanerBySharedHits',
-    fractionShared = 0.095,
+    ComponentName       = 'pixelPairStepTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.095,
     allowSharedFirstHit = True
 )
 trackingPhase2PU140.toModify(pixelPairStepTrajectoryCleanerBySharedHits, fractionShared = 0.09)
@@ -323,40 +323,40 @@ trackingPhase2PU140.toModify(pixelPairStepTrajectoryCleanerBySharedHits, fractio
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    AlgorithmName = cms.string('pixelPairStep'),
-    src = 'pixelPairStepTrackCandidates',
-    Fitter = cms.string('FlexibleKFFittingSmoother')
-    )
+    AlgorithmName = 'pixelPairStep',
+    src           = 'pixelPairStepTrackCandidates',
+    Fitter        = 'FlexibleKFFittingSmoother'
+)
 fastSim.toModify(pixelPairStepTracks, TTRHBuilder = 'WithoutRefit')
 
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
-pixelPairStep =  TrackMVAClassifierPrompt.clone()
-pixelPairStep.src = 'pixelPairStepTracks'
-pixelPairStep.mva.GBRForestLabel = 'MVASelectorIter2_13TeV'
-pixelPairStep.qualityCuts = [-0.2,0.0,0.3]
-
+pixelPairStep =  TrackMVAClassifierPrompt.clone(
+    src         = 'pixelPairStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorIter2_13TeV'),
+    qualityCuts = [-0.2,0.0,0.3]
+)
 trackingPhase1.toModify(pixelPairStep, mva=dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1'))
 
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(pixelPairStep, TrackLwtnnClassifier.clone(
-    src='pixelPairStepTracks',
-    qualityCuts=[-0.6, -0.1, 0.4]
+    src         = 'pixelPairStepTracks',
+    qualityCuts = [-0.6, -0.1, 0.4]
 ))
 
 highBetaStar_2018.toModify(pixelPairStep,qualityCuts = [-0.95,0.0,0.3])
 pp_on_AA_2018.toModify(pixelPairStep, qualityCuts = [-0.2, 0.0, 0.98])
-fastSim.toModify(pixelPairStep, vertices = "firstStepPrimaryVerticesBeforeMixing")
+fastSim.toModify(pixelPairStep, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 # For LowPU and Phase2PU140
 import RecoTracker.IterativeTracking.LowPtTripletStep_cff
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 pixelPairStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
-    src='pixelPairStepTracks',
-    useAnyMVA = cms.bool(True),
+    src            = 'pixelPairStepTracks',
+    useAnyMVA      = cms.bool(True),
     GBRForestLabel = cms.string('MVASelectorIter2'),
-    trackSelectors= cms.VPSet(
+    trackSelectors = cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'pixelPairStepLoose',
         ), #end of pset
@@ -369,12 +369,12 @@ pixelPairStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.m
             preFilterName = 'pixelPairStepTight',
         ),
     ),
-    vertices = cms.InputTag("pixelVertices")#end of vpset
+    vertices = 'pixelVertices' #end of vpset
 ) #end of clone
 trackingPhase2PU140.toModify(pixelPairStepSelector,
-    useAnyMVA = None,
+    useAnyMVA      = None,
     GBRForestLabel = None,
-    trackSelectors= cms.VPSet(
+    trackSelectors = cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'pixelPairStepLoose',
             chi2n_par = 0.7,
@@ -416,7 +416,7 @@ trackingPhase2PU140.toModify(pixelPairStepSelector,
             dz_par2 = ( 0.35, 4.0 )
             ),
         ), #end of vpset
-    vertices = "firstStepPrimaryVertices"
+    vertices = 'firstStepPrimaryVertices'
 ) #end of clone
 
 

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -255,7 +255,7 @@ pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     ComponentName    = 'pixelPairStepChi2Est',
     nSigma           = 3.0,
     MaxChi2          = 9.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
     pTChargeCutThreshold = 15.
 )
 _tracker_apv_vfp30_2016.toModify(pixelPairStepChi2Est,
@@ -270,7 +270,7 @@ highBetaStar_2018.toModify(pixelPairStepChi2Est,MaxChi2 = 30)
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter       = dict(refToPSet_ = 'pixelPairStepTrajectoryFilter'),
+    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('pixelPairStepTrajectoryFilter')),
     maxCand                = 3,
     estimator              = 'pixelPairStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
@@ -292,7 +292,7 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 pixelPairStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'pixelPairStepSeeds',
     clustersToSkip        = cms.InputTag('pixelPairStepClusters'),
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'pixelPairStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelPairStepTrajectoryBuilder')),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -220,7 +220,7 @@ tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cf
     ComponentName    = 'tobTecStepChi2Est',
     nSigma           = 3.0,
     MaxChi2          = 16.0,
-    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 trackingLowPU.toModify(tobTecStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -230,8 +230,8 @@ trackingLowPU.toModify(tobTecStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter       = dict(refToPSet_ = 'tobTecStepTrajectoryFilter'),
-    inOutTrajectoryFilter  = dict(refToPSet_ = 'tobTecStepInOutTrajectoryFilter'),
+    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryFilter')),
+    inOutTrajectoryFilter  = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter')),
     useSameTrajFilter      = False,
     minNrOfHitsForRebuild  = 4,
     alwaysUseInvalidHits   = False,
@@ -261,7 +261,7 @@ tobTecStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTra
     numHitsForSeedCleaner       = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
 
-    TrajectoryBuilderPSet       = dict(refToPSet_ = 'tobTecStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet       = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryBuilder')),
     doSeedingRegionRebuilding   = True,
     useHitsSplitting            = True,
     cleanTrajectoryAfterInOut   = True,

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -9,13 +9,13 @@ from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 # Very large impact parameter tracking using TOB + TEC ring 5 seeding #
 #######################################################################
 
-tobTecStepClusters = _cfg.clusterRemoverForIter("TobTecStep")
+tobTecStepClusters = _cfg.clusterRemoverForIter('TobTecStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
-    _era.toReplaceWith(tobTecStepClusters, _cfg.clusterRemoverForIter("TobTecStep", _eraName, _postfix))
+    _era.toReplaceWith(tobTecStepClusters, _cfg.clusterRemoverForIter('TobTecStep', _eraName, _postfix))
 
 # TRIPLET SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
-tobTecStepSeedLayersTripl = cms.EDProducer("SeedingLayersEDProducer",
+tobTecStepSeedLayersTripl = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring(
     #TOB
     'TOB1+TOB2+MTOB3','TOB1+TOB2+MTOB4',
@@ -24,16 +24,16 @@ tobTecStepSeedLayersTripl = cms.EDProducer("SeedingLayersEDProducer",
     ),
     TOB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
          skipClusters   = cms.InputTag('tobTecStepClusters')
     ),
     MTOB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
          skipClusters   = cms.InputTag('tobTecStepClusters'),
-         rphiRecHits    = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
+         rphiRecHits    = cms.InputTag('siStripMatchedRecHits','rphiRecHit')
     ),
     MTEC = cms.PSet(
-        rphiRecHits    = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        rphiRecHits    = cms.InputTag('siStripMatchedRecHits','rphiRecHit'),
         skipClusters = cms.InputTag('tobTecStepClusters'),
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
@@ -45,9 +45,9 @@ tobTecStepSeedLayersTripl = cms.EDProducer("SeedingLayersEDProducer",
 # Triplet TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 tobTecStepTrackingRegionsTripl = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
-    ptMin = 0.55,
+    ptMin            = 0.55,
     originHalfLength = 20.0,
-    originRadius = 3.5
+    originRadius     = 3.5
 ))
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
@@ -55,69 +55,70 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.IterativeTracking.MixedTripletStep_cff import _mixedTripletStepTrackingRegionsCommon_pp_on_HI
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(tobTecStepTrackingRegionsTripl, 
                 _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet=dict(
-                    ptMinScaling4BigEvts= False,
-                    fixedError = 5.0,
-                    ptMin = 2.0,
-                    originRadius = 3.5
+                    ptMinScaling4BigEvts = False,
+                    fixedError           = 5.0,
+                    ptMin                = 2.0,
+                    originRadius         = 3.5
                 )                                                                      )
 )
 
 # Triplet seeding
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import ClusterShapeHitFilterESProducer as _ClusterShapeHitFilterESProducer
 tobTecStepClusterShapeHitFilter = _ClusterShapeHitFilterESProducer.clone(
-    ComponentName = 'tobTecStepClusterShapeHitFilter',
-    doStripShapeCut = cms.bool(False),
+    ComponentName    = 'tobTecStepClusterShapeHitFilter',
+    doStripShapeCut  = cms.bool(False),
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
 )
 
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 tobTecStepHitDoubletsTripl = _hitPairEDProducer.clone(
-    seedingLayers = "tobTecStepSeedLayersTripl",
-    trackingRegions = "tobTecStepTrackingRegionsTripl",
-    maxElement = 50000000,
+    seedingLayers   = 'tobTecStepSeedLayersTripl',
+    trackingRegions = 'tobTecStepTrackingRegionsTripl',
+    maxElement      = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoTracker.TkSeedGenerator.multiHitFromChi2EDProducer_cfi import multiHitFromChi2EDProducer as _multiHitFromChi2EDProducer
 tobTecStepHitTripletsTripl = _multiHitFromChi2EDProducer.clone(
-    doublets = "tobTecStepHitDoubletsTripl",
+    doublets      = 'tobTecStepHitDoubletsTripl',
     extraPhiKDBox = 0.01,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
 from RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi import StripSubClusterShapeSeedFilter as _StripSubClusterShapeSeedFilter
 _tobTecStepSeedComparitorPSet = dict(
     ComponentName = 'CombinedSeedComparitor',
-    mode = cms.string("and"),
-    comparitors = cms.VPSet(
+    mode          = cms.string('and'),
+    comparitors   = cms.VPSet(
         cms.PSet(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
-            ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+            ComponentName      = cms.string('PixelClusterShapeSeedComparitor'),
             FilterAtHelixStage = cms.bool(True),
-            FilterPixelHits = cms.bool(False),
-            FilterStripHits = cms.bool(True),
+            FilterPixelHits    = cms.bool(False),
+            FilterStripHits    = cms.bool(True),
             ClusterShapeHitFilterName = cms.string('tobTecStepClusterShapeHitFilter'),
-            ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+            ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache') # not really needed here since FilterPixelHits=False
         ),
         _StripSubClusterShapeSeedFilter.clone()
     )
 )
 tobTecStepSeedsTripl = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(#empirically better than 'SeedFromConsecutiveHitsTripletOnlyCreator'
-    seedingHitSets = "tobTecStepHitTripletsTripl",
+    seedingHitSets     = 'tobTecStepHitTripletsTripl',
     SeedComparitorPSet = _tobTecStepSeedComparitorPSet,
 )
 #fastsim
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
-_fastSim_tobTecStepSeedsTripl = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    trackingRegions = "tobTecStepTrackingRegionsTripl",
-    hitMasks = cms.InputTag("tobTecStepMasks"),
-)
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
-_fastSim_tobTecStepSeedsTripl.seedFinderSelector.MultiHitGeneratorFactory = _hitSetProducerToFactoryPSet(tobTecStepHitTripletsTripl)
-_fastSim_tobTecStepSeedsTripl.seedFinderSelector.MultiHitGeneratorFactory.SeedComparitorPSet=cms.PSet(  ComponentName = cms.string( "none" ) )
-_fastSim_tobTecStepSeedsTripl.seedFinderSelector.MultiHitGeneratorFactory.refitHits = False
-_fastSim_tobTecStepSeedsTripl.seedFinderSelector.layerList = tobTecStepSeedLayersTripl.layerList.value()
+_fastSim_tobTecStepSeedsTripl = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
+    trackingRegions = 'tobTecStepTrackingRegionsTripl',
+    hitMasks        = cms.InputTag('tobTecStepMasks'),
+    seedFinderSelector = dict(MultiHitGeneratorFactory = _hitSetProducerToFactoryPSet(tobTecStepHitTripletsTripl).clone(
+                              SeedComparitorPSet = cms.PSet(ComponentName = cms.string('none')), 
+                              refitHits          = False),
+                              layerList = tobTecStepSeedLayersTripl.layerList.value()
+                              )
+)
 fastSim.toReplaceWith(tobTecStepSeedsTripl,_fastSim_tobTecStepSeedsTripl)
 
 # PAIR SEEDING LAYERS
-tobTecStepSeedLayersPair = cms.EDProducer("SeedingLayersEDProducer",
+tobTecStepSeedLayersPair = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring('TOB1+TEC1_pos','TOB1+TEC1_neg', 
                             'TEC1_pos+TEC2_pos','TEC1_neg+TEC2_neg', 
                             'TEC2_pos+TEC3_pos','TEC2_neg+TEC3_neg', 
@@ -127,11 +128,11 @@ tobTecStepSeedLayersPair = cms.EDProducer("SeedingLayersEDProducer",
                             'TEC6_pos+TEC7_pos','TEC6_neg+TEC7_neg'),
     TOB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
-         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
          skipClusters   = cms.InputTag('tobTecStepClusters')
     ),
     TEC = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         skipClusters = cms.InputTag('tobTecStepClusters'),
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
@@ -141,39 +142,39 @@ tobTecStepSeedLayersPair = cms.EDProducer("SeedingLayersEDProducer",
 )
 # Pair TrackingRegion
 tobTecStepTrackingRegionsPair = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
-    ptMin = 0.6,
+    ptMin            = 0.6,
     originHalfLength = 30.0,
-    originRadius = 6.0,
+    originRadius     = 6.0,
 ))
 
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(tobTecStepTrackingRegionsPair, 
-                _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet=dict(
-                    ptMinScaling4BigEvts= False,
-                    fixedError = 7.5,
-                    ptMin = 2.0,
-                    originRadius = 6.0
+                _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet = dict(
+                    ptMinScaling4BigEvts = False,
+                    fixedError           = 7.5,
+                    ptMin                = 2.0,
+                    originRadius         = 6.0
                 )                                                                      )
 )
 
 
 # Pair seeds
 tobTecStepHitDoubletsPair = _hitPairEDProducer.clone(
-    seedingLayers = "tobTecStepSeedLayersPair",
-    trackingRegions = "tobTecStepTrackingRegionsPair",
+    seedingLayers         = 'tobTecStepSeedLayersPair',
+    trackingRegions       = 'tobTecStepTrackingRegionsPair',
     produceSeedingHitSets = True,
-    maxElementTotal = 12000000,
+    maxElementTotal       = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 tobTecStepSeedsPair = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "tobTecStepHitDoubletsPair",
+    seedingHitSets     = 'tobTecStepHitDoubletsPair',
     SeedComparitorPSet = _tobTecStepSeedComparitorPSet,
 )
 #fastsim
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 fastSim.toReplaceWith(tobTecStepSeedsPair,
                       FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-        trackingRegions = "tobTecStepTrackingRegionsPair",
-        hitMasks = cms.InputTag("tobTecStepMasks"),
+        trackingRegions = 'tobTecStepTrackingRegionsPair',
+        hitMasks        = cms.InputTag('tobTecStepMasks'),
         seedFinderSelector = dict(layerList = tobTecStepSeedLayersPair.layerList.value())
         )
 )
@@ -181,25 +182,25 @@ fastSim.toReplaceWith(tobTecStepSeedsPair,
 
 # Combined seeds
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
-tobTecStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
-tobTecStepSeeds.seedCollections = cms.VInputTag(cms.InputTag('tobTecStepSeedsTripl'),cms.InputTag('tobTecStepSeedsPair'))
-
+tobTecStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone(
+    seedCollections = ['tobTecStepSeedsTripl', 'tobTecStepSeedsPair']
+)
 # LowPU
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toModify(tobTecStepHitDoubletsPair, seedingLayers = 'tobTecStepSeedLayers')
 trackingLowPU.toReplaceWith(tobTecStepSeeds, _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
-    seedingHitSets = "tobTecStepHitDoubletsPair",
+    seedingHitSets = 'tobTecStepHitDoubletsPair',
 ))
 
 
 # QUALITY CUTS DURING TRACK BUILDING (for inwardss and outwards track building steps)
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 _tobTecStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
-    maxLostHits = 0,
+    maxLostHits         = 0,
     minimumNumberOfHits = 5,
-    minPt = 0.1,
-    minHitsMinPt = 3
-    )
+    minPt               = 0.1,
+    minHitsMinPt        = 3
+)
 tobTecStepTrajectoryFilter = _tobTecStepTrajectoryFilterBase.clone(
     seedPairPenalty = 1,
 )
@@ -216,10 +217,10 @@ tobTecStepInOutTrajectoryFilter = tobTecStepTrajectoryFilter.clone(
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 tobTecStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('tobTecStepChi2Est'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(16.0),
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+    ComponentName    = 'tobTecStepChi2Est',
+    nSigma           = 3.0,
+    MaxChi2          = 16.0,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTight')
 )
 trackingLowPU.toModify(tobTecStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
@@ -229,21 +230,21 @@ trackingLowPU.toModify(tobTecStepChi2Est,
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryFilter')),
-    inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter')),
-    useSameTrajFilter = False,
-    minNrOfHitsForRebuild = 4,
-    alwaysUseInvalidHits = False,
-    maxCand = 2,
-    estimator = cms.string('tobTecStepChi2Est'),
+    trajectoryFilter       = dict(refToPSet_ = 'tobTecStepTrajectoryFilter'),
+    inOutTrajectoryFilter  = dict(refToPSet_ = 'tobTecStepInOutTrajectoryFilter'),
+    useSameTrajFilter      = False,
+    minNrOfHitsForRebuild  = 4,
+    alwaysUseInvalidHits   = False,
+    maxCand                = 2,
+    estimator              = 'tobTecStepChi2Est',
     #startSeedHitsInRebuild = True
     maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7)
-    )
+    maxPtForLooperReconstruction   = cms.double(0.7)
+)
 # Important note for LowPU: in RunI_TobTecStep the
 # inOutTrajectoryFilter parameter is spelled as
 # inOutTrajectoryFilterName, and I suspect it has no effect there. I
-# chose to "fix" the behaviour here, so the era is not fully
+# chose to 'fix' the behaviour here, so the era is not fully
 # equivalent to the customize. To restore the customize behaviour,
 # uncomment the following lines
 #trackingLowPU.toModify(tobTecStepTrajectoryBuilder,
@@ -254,115 +255,117 @@ tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 tobTecStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag('tobTecStepSeeds'),
-    clustersToSkip = cms.InputTag('tobTecStepClusters'),
+    src = 'tobTecStepSeeds',
+    clustersToSkip              = cms.InputTag('tobTecStepClusters'),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
+    numHitsForSeedCleaner       = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
 
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryBuilder')),
-    doSeedingRegionRebuilding = True,
-    useHitsSplitting = True,
-    cleanTrajectoryAfterInOut = True,
+    TrajectoryBuilderPSet       = dict(refToPSet_ = 'tobTecStepTrajectoryBuilder'),
+    doSeedingRegionRebuilding   = True,
+    useHitsSplitting            = True,
+    cleanTrajectoryAfterInOut   = True,
     TrajectoryCleaner = 'tobTecStepTrajectoryCleanerBySharedHits'
 )
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(tobTecStepTrackCandidates,
                       FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
         MinNumberOfCrossedLayers = 3,
-        src = cms.InputTag("tobTecStepSeeds"),
-        hitMasks = cms.InputTag("tobTecStepMasks")
+        src      = 'tobTecStepSeeds',
+        hitMasks = cms.InputTag('tobTecStepMasks')
         )
-                      )
+)
 
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 tobTecStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
-    ComponentName = cms.string('tobTecStepTrajectoryCleanerBySharedHits'),
-    fractionShared = cms.double(0.09),
-    allowSharedFirstHit = cms.bool(True)
-    )
+    ComponentName       = 'tobTecStepTrajectoryCleanerBySharedHits',
+    fractionShared      = 0.09,
+    allowSharedFirstHit = True
+)
 trackingLowPU.toModify(tobTecStepTrajectoryCleanerBySharedHits, fractionShared = 0.19)
 
 # TRACK FITTING AND SMOOTHING OPTIONS
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff
 tobTecStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.KFFittingSmootherWithOutliersRejectionAndRK.clone(
-    ComponentName = 'tobTecStepFitterSmoother',
-    EstimateCut = 30,
+    ComponentName   = 'tobTecStepFitterSmoother',
+    EstimateCut     = 30,
     MinNumberOfHits = 7,
-    Fitter = cms.string('tobTecStepRKFitter'),
-    Smoother = cms.string('tobTecStepRKSmoother')
-    )
+    Fitter          = 'tobTecStepRKFitter',
+    Smoother        = 'tobTecStepRKSmoother'
+)
 trackingLowPU.toModify(tobTecStepFitterSmoother, MinNumberOfHits = 8)
 
 tobTecStepFitterSmootherForLoopers = tobTecStepFitterSmoother.clone(
     ComponentName = 'tobTecStepFitterSmootherForLoopers',
-    Fitter = cms.string('tobTecStepRKFitterForLoopers'),
-    Smoother = cms.string('tobTecStepRKSmootherForLoopers')
+    Fitter        = 'tobTecStepRKFitterForLoopers',
+    Smoother      = 'tobTecStepRKSmootherForLoopers'
 )
 
 # Also necessary to specify minimum number of hits after final track fit
 tobTecStepRKTrajectoryFitter = TrackingTools.TrackFitters.RungeKuttaFitters_cff.RKTrajectoryFitter.clone(
-    ComponentName = cms.string('tobTecStepRKFitter'),
-    minHits = 7
+    ComponentName = 'tobTecStepRKFitter',
+    minHits       = 7
 )
 trackingLowPU.toModify(tobTecStepRKTrajectoryFitter, minHits = 8)
 
 tobTecStepRKTrajectoryFitterForLoopers = tobTecStepRKTrajectoryFitter.clone(
-    ComponentName = cms.string('tobTecStepRKFitterForLoopers'),
-    Propagator = cms.string('PropagatorWithMaterialForLoopers'),
+    ComponentName = 'tobTecStepRKFitterForLoopers',
+    Propagator    = 'PropagatorWithMaterialForLoopers',
 )
 
 tobTecStepRKTrajectorySmoother = TrackingTools.TrackFitters.RungeKuttaFitters_cff.RKTrajectorySmoother.clone(
-    ComponentName = cms.string('tobTecStepRKSmoother'),
+    ComponentName  = 'tobTecStepRKSmoother',
     errorRescaling = 10.0,
-    minHits = 7
+    minHits        = 7
 )
 trackingLowPU.toModify(tobTecStepRKTrajectorySmoother, minHits = 8)
 
 tobTecStepRKTrajectorySmootherForLoopers = tobTecStepRKTrajectorySmoother.clone(
-    ComponentName = cms.string('tobTecStepRKSmootherForLoopers'),
-    Propagator = cms.string('PropagatorWithMaterialForLoopers'),
+    ComponentName = 'tobTecStepRKSmootherForLoopers',
+    Propagator    = 'PropagatorWithMaterialForLoopers',
 )
 
 import TrackingTools.TrackFitters.FlexibleKFFittingSmoother_cfi
 tobTecFlexibleKFFittingSmoother = TrackingTools.TrackFitters.FlexibleKFFittingSmoother_cfi.FlexibleKFFittingSmoother.clone(
-    ComponentName = cms.string('tobTecFlexibleKFFittingSmoother'),
-    standardFitter = cms.string('tobTecStepFitterSmoother'),
-    looperFitter = cms.string('tobTecStepFitterSmootherForLoopers'),
+    ComponentName  = 'tobTecFlexibleKFFittingSmoother',
+    standardFitter = 'tobTecStepFitterSmoother',
+    looperFitter   = 'tobTecStepFitterSmootherForLoopers',
 )
 
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
 tobTecStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = 'tobTecStepTrackCandidates',
-    AlgorithmName = cms.string('tobTecStep'),
+    src           = 'tobTecStepTrackCandidates',
+    AlgorithmName = 'tobTecStep',
     #Fitter = 'tobTecStepFitterSmoother',
-    Fitter = 'tobTecFlexibleKFFittingSmoother',
-    )
+    Fitter        = 'tobTecFlexibleKFFittingSmoother',
+)
 fastSim.toModify(tobTecStepTracks, TTRHBuilder = 'WithoutRefit')
 
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
-tobTecStepClassifier1 = TrackMVAClassifierDetached.clone()
-tobTecStepClassifier1.src = 'tobTecStepTracks'
-tobTecStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter6_13TeV'
-tobTecStepClassifier1.qualityCuts = [-0.6,-0.45,-0.3]
-fastSim.toModify(tobTecStepClassifier1, vertices = "firstStepPrimaryVerticesBeforeMixing")
+tobTecStepClassifier1 = TrackMVAClassifierDetached.clone(
+    src         = 'tobTecStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorIter6_13TeV'),
+    qualityCuts = [-0.6,-0.45,-0.3]
+)
+fastSim.toModify(tobTecStepClassifier1, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
-tobTecStepClassifier2 = TrackMVAClassifierPrompt.clone()
-tobTecStepClassifier2.src = 'tobTecStepTracks'
-tobTecStepClassifier2.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
-tobTecStepClassifier2.qualityCuts = [0.0,0.0,0.0]
-fastSim.toModify(tobTecStepClassifier2,vertices = "firstStepPrimaryVerticesBeforeMixing")
+tobTecStepClassifier2 = TrackMVAClassifierPrompt.clone(
+    src         = 'tobTecStepTracks',
+    mva         = dict(GBRForestLabel = 'MVASelectorIter0_13TeV'),
+    qualityCuts = [0.0,0.0,0.0]
+)
+fastSim.toModify(tobTecStepClassifier2,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
-tobTecStep = ClassifierMerger.clone()
-tobTecStep.inputClassifiers=['tobTecStepClassifier1','tobTecStepClassifier2']
-
+tobTecStep = ClassifierMerger.clone(
+    inputClassifiers = ['tobTecStepClassifier1','tobTecStepClassifier2']
+)
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
      mva = dict(GBRForestLabel = 'MVASelectorTobTecStep_Phase1'),
@@ -372,17 +375,17 @@ trackingPhase1.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackdnn.toReplaceWith(tobTecStep, TrackLwtnnClassifier.clone(
-     src = 'tobTecStepTracks',
+     src         = 'tobTecStepTracks',
      qualityCuts = [-0.4, -0.25, -0.1]
 ))
-(trackdnn & fastSim).toModify(tobTecStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+(trackdnn & fastSim).toModify(tobTecStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 pp_on_AA_2018.toModify(tobTecStep, qualityCuts = [-0.6,-0.3,0.7])
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 trackingLowPU.toReplaceWith(tobTecStep, RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
-    src = 'tobTecStepTracks',
-    useAnyMVA = cms.bool(False),
+    src            = 'tobTecStepTracks',
+    useAnyMVA      = cms.bool(False),
     GBRForestLabel = cms.string('MVASelectorIter6'),
     trackSelectors = [
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
@@ -449,7 +452,7 @@ TobTecStep = cms.Sequence(TobTecStepTask)
 ### Following are specific for LowPU, they're collected here to
 ### not to interfere too much with the default configuration
 # SEEDING LAYERS
-tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+tobTecStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
     layerList = cms.vstring('TOB1+TOB2', 
         'TOB1+TEC1_pos', 'TOB1+TEC1_neg', 
         'TEC1_pos+TEC2_pos', 'TEC2_pos+TEC3_pos', 
@@ -459,12 +462,12 @@ tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         'TEC3_neg+TEC4_neg', 'TEC4_neg+TEC5_neg', 
         'TEC5_neg+TEC6_neg', 'TEC6_neg+TEC7_neg'),
     TOB = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         skipClusters = cms.InputTag('tobTecStepClusters'),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTiny'))
     ),
     TEC = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         skipClusters = cms.InputTag('tobTecStepClusters'),
         #    untracked bool useSimpleRphiHitsCleaner = false
         useRingSlector = cms.bool(True),

--- a/RecoTracker/MeasurementDet/python/Chi2ChargeMeasurementEstimator_cfi.py
+++ b/RecoTracker/MeasurementDet/python/Chi2ChargeMeasurementEstimator_cfi.py
@@ -5,7 +5,7 @@ from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
 from RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorDefault_cfi import Chi2ChargeMeasurementEstimatorDefault
 Chi2ChargeMeasurementEstimator = Chi2ChargeMeasurementEstimatorDefault.clone(
-    clusterChargeCut = dict(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
 )
 _tracker_apv_vfp30_2016.toModify(Chi2ChargeMeasurementEstimator, MinPtForHitRecoveryInGluedDet=0.9)
 

--- a/RecoTracker/MeasurementDet/python/Chi2ChargeMeasurementEstimator_cfi.py
+++ b/RecoTracker/MeasurementDet/python/Chi2ChargeMeasurementEstimator_cfi.py
@@ -4,8 +4,9 @@ from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_v
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
 from RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorDefault_cfi import Chi2ChargeMeasurementEstimatorDefault
-Chi2ChargeMeasurementEstimator = Chi2ChargeMeasurementEstimatorDefault.clone()
-Chi2ChargeMeasurementEstimator.clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+Chi2ChargeMeasurementEstimator = Chi2ChargeMeasurementEstimatorDefault.clone(
+    clusterChargeCut = dict(refToPSet_ = cms.string('SiStripClusterChargeCutTight'))
+)
 _tracker_apv_vfp30_2016.toModify(Chi2ChargeMeasurementEstimator, MinPtForHitRecoveryInGluedDet=0.9)
 
 

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
@@ -5,4 +5,4 @@ from RecoTracker.MeasurementDet._MeasurementTrackerESProducer_default_cfi import
 MeasurementTracker = _MeasurementTrackerESProducer_default.clone()
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(MeasurementTracker, Phase2StripCPE = cms.string('Phase2StripCPE'))
+trackingPhase2PU140.toModify(MeasurementTracker, Phase2StripCPE = 'Phase2StripCPE')

--- a/RecoTracker/MkFit/python/mkFitInputConverter_cfi.py
+++ b/RecoTracker/MkFit/python/mkFitInputConverter_cfi.py
@@ -4,6 +4,6 @@ from RecoTracker.MkFit.mkFitInputConverterDefault_cfi import mkFitInputConverter
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
 mkFitInputConverter = _mkFitInputConverterDefault.clone(
-    minGoodStripCharge = dict(
+    minGoodStripCharge = cms.PSet(
         refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )

--- a/RecoTracker/MkFit/python/mkFitInputConverter_cfi.py
+++ b/RecoTracker/MkFit/python/mkFitInputConverter_cfi.py
@@ -4,7 +4,6 @@ from RecoTracker.MkFit.mkFitInputConverterDefault_cfi import mkFitInputConverter
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
 mkFitInputConverter = _mkFitInputConverterDefault.clone(
-    minGoodStripCharge = cms.PSet(
-        refToPSet_ = cms.string('SiStripClusterChargeCutLoose')
-    )
+    minGoodStripCharge = dict(
+        refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )


### PR DESCRIPTION
#### PR description: Update the safer syntax for existing parameter

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#29979](https://github.com/cms-sw/cmssw/pull/29979), [PR#30147](https://github.com/cms-sw/cmssw/pull/30147), [PR#30270](https://github.com/cms-sw/cmssw/pull/30270) , [PR#30271](https://github.com/cms-sw/cmssw/pull/30271), [PR#30353](https://github.com/cms-sw/cmssw/pull/30353), [PR#30556](https://github.com/cms-sw/cmssw/pull/30556))

In this PR, 19 files updated. 
- RecoTracker/{MkFit}  1 file 
- RecoTracker/{MeasurementDet} 2 files 
- RecoTracker/{IterativeTracking} 16 files 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).