### PR TITLE
[11.1.X] add onlineMetaDataDigis unpacker for Strip online client

### DIFF
--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -267,6 +267,7 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
 
     process.p = cms.Path(process.scalersRawToDigi*
                          process.tcdsDigis*
+                         process.onlineMetaDataDigis*
                          process.APVPhases*
                          process.consecutiveHEs*
                          process.hltTriggerTypeFilter*
@@ -371,6 +372,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.p = cms.Path(
         process.scalersRawToDigi*
         process.tcdsDigis*
+        process.onlineMetaDataDigis*
         process.APVPhases*
         process.consecutiveHEs*
         process.hltTriggerTypeFilter*
@@ -466,6 +468,7 @@ if (process.runType.getRunType() == process.runType.hpu_run):
 
     process.p = cms.Path(process.scalersRawToDigi*
                          process.tcdsDigis*
+                         process.onlineMetaDataDigis*
                          process.APVPhases*
                          process.consecutiveHEs*
                          process.hltTriggerTypeFilter*
@@ -621,6 +624,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.p = cms.Path(
         process.scalersRawToDigi*
         process.tcdsDigis*
+        process.onlineMetaDataDigis*
         process.APVPhases*
         process.consecutiveHEs*
         process.hltTriggerTypeFilter*


### PR DESCRIPTION
backport of #30677

#### PR description:

Title says it all, adds the `onlineMetaDataDigis` unpacker for Strip online client, to fix a crash seen in the DQM playback system.

#### PR validation:

~None so far~.
```
 ./src/DQM/Integration/test/runtest.sh sistrip_dqm_sourceclient-live_cfg.py
```
runs to completion.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of #30677
