### PR TITLE
Force the definition of the USEHYBRID preprocessor symbol

### DIFF
--- a/L1Trigger/TrackFindingTracklet/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/BuildFile.xml
@@ -38,6 +38,7 @@
 <use name="TrackingTools/TrajectoryParametrization"/>
 <use name="TrackingTools/TrajectoryState"/>
 <use name="TrackingTools/TransientTrack"/>
+<flags CXXFLAGS="-DUSEHYBRID"/>
 
 <export>
   <lib   name="1"/>

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -28,7 +28,9 @@ namespace trklet {
     Settings() {
       //Comment out to run tracklet-only algorithm
 #ifdef CMSSW_GIT_HASH
-#define USEHYBRID
+#ifndef USEHYBRID
+#error USEHYBRID is not defined
+#endif
 #endif
     }
 

--- a/L1Trigger/TrackFindingTracklet/plugins/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/plugins/BuildFile.xml
@@ -10,4 +10,5 @@
   <use name="SimDataFormats/GeneratorProducts"/>
   <use name="SimGeneral/HepPDTRecord"/>
   <flags EDM_PLUGIN="1"/>
+  <flags CXXFLAGS="-DUSEHYBRID"/>
 </library>

--- a/L1Trigger/TrackFindingTracklet/test/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/test/BuildFile.xml
@@ -2,6 +2,7 @@
   <library   file="*.cc" name="TrackFindingTrackletTests">
     <flags   EDM_PLUGIN="1"/>
     <flags   SKIP_FILES="fpga.cc"/>
+    <flags   CXXFLAGS="-DUSEHYBRID"/>
     <use   name="clhep"/>
     <use   name="root"/>
     <use   name="heppdt"/>


### PR DESCRIPTION
#### PR description:

Force the definition of the `USEHYBRID` preprocessor symbol in all the L1Trigger/TrackFindingTracklet BuildFiles. 

#### PR validation:

The code now seems to be running fine on a Power8 machine, where before it was crashing before the first event.
