### PR TITLE
retain only RAW data collections in DQM/Integration unit test setup

### DIFF
--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -109,7 +109,20 @@ eventRange = cms.untracked.VEventRange(eventsToProcess)
 
 print("Got %d files." % len(readFiles))
 
-source = cms.Source ("PoolSource", fileNames = readFiles, secondaryFileNames = secFiles, eventsToProcess = eventRange)
+source = cms.Source ("PoolSource",
+                     fileNames = readFiles,
+                     secondaryFileNames = secFiles,
+                     eventsToProcess = eventRange,
+                     ### As we are testing with FEVT, we don't want any unpacked collection
+                     ### This makes the tests slightly more realistic (live production uses streamer files
+                     inputCommands = cms.untracked.vstring(
+                       'drop *',
+                       'keep FEDRawDataCollection_rawDataCollector_*_*',
+                       'keep GlobalObjectMapRecord_hltGtStage2ObjectMap_*_*',
+                       'keep edmTriggerResults_TriggerResults_*_*'
+                     ),
+                     dropDescendantsOfDroppedBranches = cms.untracked.bool(True)
+                   )
 maxEvents = cms.untracked.PSet(
   input = cms.untracked.int32(-1)
 )


### PR DESCRIPTION
#### PR description:

As discussed with core DQM team, this change makes the DQM/Integration test setup for online clients slightly more realistic as it drops all the RECO level unpacked collections from the input `FEVT` data-tier, making it more similar to the input streamer files which are used in live production mode. 

#### PR validation:

```bash
$ scramv1 b runtests > & log.log & 
$ more log.log | grep 'client succeeded'
---> test TestDQMOnlineClient-scal_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-dt4ml_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-info_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-hcal_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-hlt_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-sistrip_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-hcalreco_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-l1tstage2_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-csc_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-castor_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-mutracking_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-beampixel_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-dt_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-beam_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-es_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-pixel_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-pixellumi_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-ctpps_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-ecal_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-gem_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-rpc_dqm_sourceclient succeeded
---> test TestDQMOnlineClient-fed_dqm_sourceclient succeeded

```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport - no backport is intended for the moment, though it can done if needed.
