### PR TITLE
Fix Service access from ES modules

### DIFF
--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -56,9 +56,10 @@ namespace edm::eventsetup {
     void prefetchAsyncImpl(WaitingTask* iWaitTask,
                            const EventSetupRecordImpl& iRecord,
                            const DataKey&,
-                           EventSetupImpl const* iEventSetupImpl) final {
+                           EventSetupImpl const* iEventSetupImpl,
+                           ServiceToken const& iToken) final {
       assert(iRecord.key() == RecordT::keyForClass());
-      callback_->prefetchAsync(iWaitTask, &iRecord, iEventSetupImpl);
+      callback_->prefetchAsync(iWaitTask, &iRecord, iEventSetupImpl, iToken);
     }
 
     void const* getAfterPrefetchImpl() const final { return smart_pointer_traits::getPointer(data_); }

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -31,6 +31,7 @@ namespace edm {
   class ActivityRegistry;
   class EventSetupImpl;
   class WaitingTask;
+  class ServiceToken;
 
   namespace eventsetup {
     struct ComponentDescription;
@@ -47,7 +48,8 @@ namespace edm {
       // ---------- const member functions ---------------------
       bool cacheIsValid() const { return cacheIsValid_.load(std::memory_order_acquire); }
 
-      void prefetchAsync(WaitingTask*, EventSetupRecordImpl const&, DataKey const&, EventSetupImpl const*) const;
+      void prefetchAsync(
+          WaitingTask*, EventSetupRecordImpl const&, DataKey const&, EventSetupImpl const*, ServiceToken const&) const;
 
       void doGet(EventSetupRecordImpl const&,
                  DataKey const&,
@@ -86,7 +88,8 @@ namespace edm {
       virtual void prefetchAsyncImpl(WaitingTask*,
                                      EventSetupRecordImpl const&,
                                      DataKey const& iKey,
-                                     EventSetupImpl const*) = 0;
+                                     EventSetupImpl const*,
+                                     ServiceToken const&) = 0;
 
       /** indicates that the Proxy should invalidate any cached information
           as that information has 'expired' (i.e. we have moved to a new IOV)

--- a/FWCore/Framework/interface/ESSourceDataProxyBase.h
+++ b/FWCore/Framework/interface/ESSourceDataProxyBase.h
@@ -57,7 +57,8 @@ namespace edm::eventsetup {
     void prefetchAsyncImpl(edm::WaitingTask* iTask,
                            edm::eventsetup::EventSetupRecordImpl const&,
                            edm::eventsetup::DataKey const& iKey,
-                           edm::EventSetupImpl const*) final;
+                           edm::EventSetupImpl const*,
+                           edm::ServiceToken const&) final;
 
     // ---------- member data --------------------------------
 

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -67,6 +67,7 @@ namespace edm {
   class ESInputTag;
   class EventSetupImpl;
   class WaitingTask;
+  class ServiceToken;
 
   namespace eventsetup {
     struct ComponentDescription;
@@ -89,7 +90,7 @@ namespace edm {
       bool doGet(ESProxyIndex iProxyIndex, EventSetupImpl const*, bool aGetTransiently = false) const;
 
       ///prefetch the data to setup for subsequent calls to getImplementation
-      void prefetchAsync(WaitingTask* iTask, ESProxyIndex iProxyIndex, EventSetupImpl const*) const;
+      void prefetchAsync(WaitingTask* iTask, ESProxyIndex iProxyIndex, EventSetupImpl const*, ServiceToken const&) const;
 
       /**returns true only if someone has already requested data for this key
           and the data was retrieved

--- a/FWCore/Framework/src/ESSourceDataProxyBase.cc
+++ b/FWCore/Framework/src/ESSourceDataProxyBase.cc
@@ -23,7 +23,8 @@
 void edm::eventsetup::ESSourceDataProxyBase::prefetchAsyncImpl(edm::WaitingTask* iTask,
                                                                edm::eventsetup::EventSetupRecordImpl const& iRecord,
                                                                edm::eventsetup::DataKey const& iKey,
-                                                               edm::EventSetupImpl const*) {
+                                                               edm::EventSetupImpl const*,
+                                                               edm::ServiceToken const&) {
   bool expected = false;
   auto doPrefetch = m_prefetching.compare_exchange_strong(expected, true);
   m_waitingList.add(iTask);

--- a/FWCore/Framework/src/EventSetupRecordImpl.cc
+++ b/FWCore/Framework/src/EventSetupRecordImpl.cc
@@ -302,7 +302,8 @@ namespace edm {
 
     void EventSetupRecordImpl::prefetchAsync(WaitingTask* iTask,
                                              ESProxyIndex iProxyIndex,
-                                             EventSetupImpl const* iEventSetupImpl) const {
+                                             EventSetupImpl const* iEventSetupImpl,
+                                             ServiceToken const& iToken) const {
       if UNLIKELY (iProxyIndex.value() == std::numeric_limits<int>::max()) {
         return;
       }
@@ -310,7 +311,7 @@ namespace edm {
       const DataProxy* proxy = proxies_[iProxyIndex.value()];
       if (nullptr != proxy) {
         auto const& key = keysForProxies_[iProxyIndex.value()];
-        proxy->prefetchAsync(iTask, *this, key, iEventSetupImpl);
+        proxy->prefetchAsync(iTask, *this, key, iEventSetupImpl, iToken);
       }
     }
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -214,7 +214,7 @@ namespace edm {
     //Need to be sure the ref count isn't set to 0 immediately
     iTask->increment_ref_count();
 
-    esPrefetchAsync(iTask, iEventSetup, iTransition);
+    esPrefetchAsync(iTask, iEventSetup, iTransition, token);
     for (auto const& item : items) {
       ProductResolverIndex productResolverIndex = item.productResolverIndex();
       bool skipCurrentProcess = item.skipCurrentProcess();
@@ -276,7 +276,10 @@ namespace edm {
     choiceHolder.doneWaiting(std::exception_ptr{});
   }
 
-  void Worker::esPrefetchAsync(WaitingTask* iTask, EventSetupImpl const& iImpl, Transition iTrans) {
+  void Worker::esPrefetchAsync(WaitingTask* iTask,
+                               EventSetupImpl const& iImpl,
+                               Transition iTrans,
+                               edm::ServiceToken const& iToken) {
     if (iTrans >= edm::Transition::NumberOfEventSetupTransitions) {
       return;
     }
@@ -294,34 +297,34 @@ namespace edm {
     // will work.
     if UNLIKELY (tbb::this_task_arena::max_concurrency() == 1) {
       //We spawn this first so that the other ES tasks are before it in the TBB queue
-      tbb::task::spawn(*make_functor_task(tbb::task::allocate_root(),
-                                          [this, task = edm::WaitingTaskHolder(iTask), iTrans, &iImpl]() mutable {
-                                            auto waitTask = edm::make_empty_waiting_task();
-                                            waitTask->set_ref_count(2);
-                                            auto waitTaskPtr = waitTask.get();
-                                            esTaskArena().execute([waitTaskPtr, this, iTrans, &iImpl]() {
-                                              auto const& recs = esRecordsToGetFrom(iTrans);
-                                              auto const& items = esItemsToGetFrom(iTrans);
-                                              waitTaskPtr->set_ref_count(2);
-                                              for (size_t i = 0; i != items.size(); ++i) {
-                                                if (recs[i] != ESRecordIndex{}) {
-                                                  auto rec = iImpl.findImpl(recs[i]);
-                                                  if (rec) {
-                                                    rec->prefetchAsync(waitTaskPtr, items[i], &iImpl);
-                                                  }
-                                                }
-                                              }
-                                              waitTaskPtr->decrement_ref_count();
-                                              waitTaskPtr->wait_for_all();
-                                            });
+      tbb::task::spawn(*make_functor_task(
+          tbb::task::allocate_root(), [this, task = edm::WaitingTaskHolder(iTask), iTrans, &iImpl, iToken]() mutable {
+            auto waitTask = edm::make_empty_waiting_task();
+            waitTask->set_ref_count(2);
+            auto waitTaskPtr = waitTask.get();
+            esTaskArena().execute([waitTaskPtr, this, iTrans, &iImpl, iToken]() {
+              auto const& recs = esRecordsToGetFrom(iTrans);
+              auto const& items = esItemsToGetFrom(iTrans);
+              waitTaskPtr->set_ref_count(2);
+              for (size_t i = 0; i != items.size(); ++i) {
+                if (recs[i] != ESRecordIndex{}) {
+                  auto rec = iImpl.findImpl(recs[i]);
+                  if (rec) {
+                    rec->prefetchAsync(waitTaskPtr, items[i], &iImpl, iToken);
+                  }
+                }
+              }
+              waitTaskPtr->decrement_ref_count();
+              waitTaskPtr->wait_for_all();
+            });
 
-                                            auto exPtr = waitTask->exceptionPtr();
-                                            if (exPtr) {
-                                              task.doneWaiting(*exPtr);
-                                            } else {
-                                              task.doneWaiting(std::exception_ptr{});
-                                            }
-                                          }));
+            auto exPtr = waitTask->exceptionPtr();
+            if (exPtr) {
+              task.doneWaiting(*exPtr);
+            } else {
+              task.doneWaiting(std::exception_ptr{});
+            }
+          }));
     } else {
       //We need iTask to run in the default arena since it is not an ES task
       auto task =
@@ -340,7 +343,7 @@ namespace edm {
           if (recs[i] != ESRecordIndex{}) {
             auto rec = iImpl.findImpl(recs[i]);
             if (rec) {
-              rec->prefetchAsync(task, items[i], &iImpl);
+              rec->prefetchAsync(task, items[i], &iImpl, iToken);
             }
           }
         }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -360,7 +360,7 @@ namespace edm {
     bool needsESPrefetching(Transition iTrans) const noexcept {
       return iTrans < edm::Transition::NumberOfEventSetupTransitions ? not esItemsToGetFrom(iTrans).empty() : false;
     }
-    void esPrefetchAsync(WaitingTask* iHolder, EventSetupImpl const&, Transition);
+    void esPrefetchAsync(WaitingTask* iHolder, EventSetupImpl const&, Transition, ServiceToken const&);
 
     void emitPostModuleEventPrefetchingSignal() {
       actReg_->postModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(), moduleCallingContext_);
@@ -1023,7 +1023,7 @@ namespace edm {
                 }
               }
             });
-        esPrefetchAsync(afterPrefetch, es, T::transition_);
+        esPrefetchAsync(afterPrefetch, es, T::transition_, serviceToken);
       } else {
         if (auto queue = this->serializeRunModule()) {
           queue.push(toDo);

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -103,7 +103,7 @@ namespace {
   void call(CALLBACK& iCallback) {
     auto waitTask = edm::make_empty_waiting_task();
     waitTask->set_ref_count(1);
-    iCallback.prefetchAsync(waitTask.get(), nullptr, nullptr);
+    iCallback.prefetchAsync(waitTask.get(), nullptr, nullptr, edm::ServiceToken{});
     waitTask->wait_for_all();
   }
 }  // namespace

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -756,7 +756,7 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl);
+          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl, edm::ServiceToken{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {
@@ -782,7 +782,7 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl);
+          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl, edm::ServiceToken{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -457,7 +457,8 @@ namespace {
       void prefetchAsyncImpl(edm::WaitingTask*,
                              EventSetupRecordImpl const&,
                              DataKey const&,
-                             edm::EventSetupImpl const*) override {}
+                             edm::EventSetupImpl const*,
+                             edm::ServiceToken const&) override {}
       void invalidateCache() override {}
       void const* getAfterPrefetchImpl() const override { return nullptr; }
     };

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -577,7 +577,7 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl);
+          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl, edm::ServiceToken{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -254,7 +254,7 @@ namespace {
       for (size_t i = 0; i != proxies.size(); ++i) {
         auto waitTask = edm::make_empty_waiting_task();
         waitTask->set_ref_count(2);
-        iRec.prefetchAsync(waitTask.get(), proxies[i], nullptr);
+        iRec.prefetchAsync(waitTask.get(), proxies[i], nullptr, edm::ServiceToken{});
         waitTask->decrement_ref_count();
         waitTask->wait_for_all();
         if (waitTask->exceptionPtr()) {

--- a/FWCore/Integration/test/WhatsItESProducer.cc
+++ b/FWCore/Integration/test/WhatsItESProducer.cc
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
 
 #include "FWCore/Integration/test/WhatsIt.h"
 #include "FWCore/Integration/test/Doodad.h"
@@ -33,6 +34,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
 
 //
 // class decleration
@@ -113,6 +116,10 @@ namespace edmtest {
 
   // ------------ method called to produce the data  ------------
   WhatsItESProducer::ReturnType WhatsItESProducer::produce(const GadgetRcd& iRecord) {
+    //This tests that the Service system is accessible from a ESProducer
+    edm::Service<edm::service::TriggerNamesService> tns;
+    tns->getProcessName();
+
     edm::ESHandle<Doodad> doodad = iRecord.getHandle(token_);
     auto pWhatsIt = std::make_unique<WhatsIt>();
     pWhatsIt->a = doodad->a;

--- a/FWCore/TestProcessor/interface/TestDataProxy.h
+++ b/FWCore/TestProcessor/interface/TestDataProxy.h
@@ -39,7 +39,8 @@ namespace edm {
       void prefetchAsyncImpl(WaitingTask*,
                              eventsetup::EventSetupRecordImpl const&,
                              eventsetup::DataKey const&,
-                             EventSetupImpl const*) final {
+                             EventSetupImpl const*,
+                             ServiceToken const&) final {
         return;
       }
 


### PR DESCRIPTION
#### PR description:

It was found that when using multiple threads an ES module might not be able to access a Service. This change properly propagates the Service access to any task that will run an ES module.

#### PR validation:

The code compiles and a simple test did not exhibit the problem after repeating the test 10 times. Previously it was failing around 1 out of 3 tries.