### PR TITLE
Removed boost::filesystem in GeneratorInterface/EvtGenInterface

### DIFF
--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -47,9 +47,6 @@
 #include <cstdlib>
 #include <cstdio>
 
-#include "boost/filesystem.hpp"
-#include "boost/filesystem/path.hpp"
-
 using namespace gen;
 using namespace edm;
 
@@ -366,10 +363,7 @@ void EvtGenInterface::init() {
 
   if (fPSet->exists("user_decay_embedded")) {
     std::vector<std::string> user_decay_lines = fPSet->getParameter<std::vector<std::string> >("user_decay_embedded");
-    auto tmp_dir = boost::filesystem::temp_directory_path();
-    tmp_dir += "/%%%%-%%%%-%%%%-%%%%";
-    auto tmp_path = boost::filesystem::unique_path(tmp_dir);
-    std::string user_decay_tmp = std::string(tmp_path.c_str());
+    std::string user_decay_tmp = std::tmpnam(nullptr);
     FILE* tmpf = std::fopen(user_decay_tmp.c_str(), "w");
     if (!tmpf) {
       edm::LogError("EvtGenInterface::~EvtGenInterface")


### PR DESCRIPTION
#### PR description:
 Boost here is only used to create a temporary file.
I think a std::tmpnam should be enough in this case.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 