### PR TITLE
Migrate from boost::format to {fmt} library

### DIFF
--- a/HLTrigger/JSONMonitoring/plugins/BuildFile.xml
+++ b/HLTrigger/JSONMonitoring/plugins/BuildFile.xml
@@ -1,9 +1,10 @@
 <library file="*.cc" name="HLTriggerJSONMonitoringPlugins">
+  <use name="fmt"/>
+  <use name="EventFilter/Utilities"/>
   <use name="FWCore/PrescaleService"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
   <use name="HLTrigger/HLTcore"/>
-  <use name="EventFilter/Utilities"/>
   <use name="L1Trigger/L1TGlobal"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -7,30 +7,30 @@
 #include <atomic>
 #include <fstream>
 
-#include <boost/format.hpp>
+#include <fmt/printf.h>
 
+#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
+#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
+#include "EventFilter/Utilities/interface/FastMonitor.h"
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/JSONSerializer.h"
+#include "EventFilter/Utilities/interface/JsonMonitorable.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "EventFilter/Utilities/interface/JsonMonitorable.h"
-#include "EventFilter/Utilities/interface/FastMonitor.h"
-#include "EventFilter/Utilities/interface/JSONSerializer.h"
-#include "EventFilter/Utilities/interface/FastMonitoringService.h"
-#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
-#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
-#include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
-#include "CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h"
-#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
-#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 
 struct L1TriggerJSONMonitoringData {
   // special values for prescale index checks
@@ -204,11 +204,11 @@ std::shared_ptr<L1TriggerJSONMonitoringData::run> L1TriggerJSONMonitoring::globa
   }
 
   // write the per-run .jsd file
-  rundata->jsdFileName = (boost::format("run%06d_ls0000_streamL1Rates_pid%05d.jsd") % run.run() % getpid()).str();
+  rundata->jsdFileName = fmt::sprintf("run%06d_ls0000_streamL1Rates_pid%05d.jsd", run.run(), getpid());
   writeJsdFile(*rundata);
 
   // write the per-run .ini file
-  // iniFileName = (boost::format("run%06d_ls0000_streamL1Rates_pid%05d.ini") % run.run() % getpid()).str();
+  //iniFileName = fmt::sprintf("run%06d_ls0000_streamL1Rates_pid%05d.ini", run.run(), getpid());
   writeIniFile(*rundata, run.run(), triggerNames);
 
   return rundata;
@@ -403,14 +403,14 @@ void L1TriggerJSONMonitoring::globalEndLuminosityBlockSummary(edm::LuminosityBlo
     */
     jsndata[jsoncollector::DataPoint::DATA].append(lumidata->prescaleIndex);
 
-    auto jsndataFileName = boost::format("run%06d_ls%04d_streamL1Rates_pid%05d.jsndata") % run % ls % getpid();
+    auto jsndataFileName = fmt::sprintf("run%06d_ls%04d_streamL1Rates_pid%05d.jsndata", run, ls, getpid());
 
     std::string result = writer.write(jsndata);
-    std::ofstream jsndataFile(rundata.baseRunDir + "/" + jsndataFileName.str());
+    std::ofstream jsndataFile(rundata.baseRunDir + "/" + jsndataFileName);
     jsndataFile << result;
     jsndataFile.close();
 
-    jsndataFileList = jsndataFileName.str();
+    jsndataFileList = jsndataFileName;
     jsndataSize = result.size();
     jsndataAdler32 = cms::Adler32(result.c_str(), result.size());
   }
@@ -438,8 +438,8 @@ void L1TriggerJSONMonitoring::globalEndLuminosityBlockSummary(edm::LuminosityBlo
   jsn[jsoncollector::DataPoint::DATA].append(rundata.streamMergeType);
   jsn[jsoncollector::DataPoint::DATA].append(jsnHLTErrorEvents);
 
-  auto jsnFileName = boost::format("run%06d_ls%04d_streamL1Rates_pid%05d.jsn") % run % ls % getpid();
-  std::ofstream jsnFile(rundata.baseRunDir + "/" + jsnFileName.str());
+  auto jsnFileName = fmt::sprintf("run%06d_ls%04d_streamL1Rates_pid%05d.jsn", run, ls, getpid());
+  std::ofstream jsnFile(rundata.baseRunDir + "/" + jsnFileName);
   jsnFile << writer.write(jsn);
   jsnFile.close();
 }
@@ -480,7 +480,7 @@ void L1TriggerJSONMonitoring::writeIniFile(L1TriggerJSONMonitoringData::run cons
   */
   content["Event-Type"] = eventTypes;
 
-  std::string iniFileName = (boost::format("run%06d_ls0000_streamL1Rates_pid%05d.ini") % run % getpid()).str();
+  std::string iniFileName = fmt::sprintf("run%06d_ls0000_streamL1Rates_pid%05d.ini", run, getpid());
   std::ofstream file(rundata.baseRunDir + "/" + iniFileName);
   Json::StyledWriter writer;
   file << writer.write(content);

--- a/HLTrigger/Timer/plugins/BuildFile.xml
+++ b/HLTrigger/Timer/plugins/BuildFile.xml
@@ -1,5 +1,5 @@
 <library file="*.cc" name="HLTriggerTimerPlugins">
-  <use name="boost_regex"/>
+  <use name="fmt"/>
   <use name="json"/>
   <use name="DQMServices/Core"/>
   <use name="DataFormats/Luminosity"/>

--- a/HLTrigger/Timer/plugins/ThroughputService.cc
+++ b/HLTrigger/Timer/plugins/ThroughputService.cc
@@ -3,8 +3,8 @@
 #include <chrono>
 #include <ctime>
 
-// boost headers
-#include <boost/format.hpp>
+// {fmt} headers
+#include <fmt/printf.h>
 
 // CMSSW headers
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -55,9 +55,8 @@ void ThroughputService::preallocate(edm::service::SystemBounds const& bounds) {
   auto concurrent_threads = bounds.maxNumberOfThreads();
 
   if (m_enable_dqm and m_dqm_bynproc)
-    m_dqm_path += (boost::format("/Running on %s with %d streams on %d threads") % processor_model %
-                   concurrent_streams % concurrent_threads)
-                      .str();
+    m_dqm_path += fmt::sprintf(
+        "/Running on %s with %d streams on %d threads", processor_model, concurrent_streams, concurrent_threads);
 }
 
 void ThroughputService::preGlobalBeginRun(edm::GlobalContext const& gc) {
@@ -70,7 +69,7 @@ void ThroughputService::preGlobalBeginRun(edm::GlobalContext const& gc) {
   }
 
   if (m_enable_dqm) {
-    std::string y_axis_title = (boost::format("events / %g s") % m_time_resolution).str();
+    std::string y_axis_title = fmt::sprintf("events / %g s", m_time_resolution);
     unsigned int bins = std::round(m_time_range / m_time_resolution);
     double range = bins * m_time_resolution;
 


### PR DESCRIPTION
#### PR description:

Migrate from `boost::format` to the `{fmt}` library.

#### PR validation:

None.