### PR TITLE
utilities for HGCAL end of life

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
@@ -104,6 +104,7 @@ public:
     iDesc.add<edm::ParameterSetDescription>("noises", descNestedNoises);
     edm::ParameterSetDescription descNestedNoiseMIP;
     descNestedNoiseMIP.add<bool>("scaleByDose", false);
+    descNestedNoiseMIP.add<double>("scaleByDoseFactor", 1.);
     iDesc.add<edm::ParameterSetDescription>("scaleByDose", descNestedNoiseMIP);
     descNestedNoiseMIP.add<std::string>("doseMap", "");
     iDesc.add<edm::ParameterSetDescription>("doseMap", descNestedNoiseMIP);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -98,6 +98,7 @@ public:
     edm::ParameterSetDescription descNestedNoiseMIP;
     descNestedNoiseMIP.add<bool>("scaleByDose", false);
     descNestedNoiseMIP.add<unsigned int>("scaleByDoseAlgo", 0);
+    descNestedNoiseMIP.add<double>("scaleByDoseFactor", 1.);
     descNestedNoiseMIP.add<std::string>("doseMap", "");
     descNestedNoiseMIP.add<double>("noise_MIP", 1. / 100.);
     iDesc.add<edm::ParameterSetDescription>("noiseMip", descNestedNoiseMIP);

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -235,29 +235,10 @@ def customise_aging_300(process):
     process=ageEcal(process,300,5.0e34)
     return process
 
-
-def getMeFiles( path ):
-    """ list files in a directory """
-    import os
-    command = 'ls -1 '+path
-    stream = os.popen(command)
-    return stream.readlines()
-
-def prepend(x) :
-    """ local files need the file: prefix"""
-    return 'file:'+x
-
 def customise_aging_1000(process):
     process=ageHcal(process,1000,5.0e34,"nominal")
     process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,1000,5.0e34)
-    # hard-coded hack here below; we need to get away from the instabilities of AAA
-    if hasattr(process,'mix'):
-        if hasattr(process.mix,'input'):
-            path = '/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/minbias_D49_1120pre1_20200616/GSD/*'
-            fileList=getMeFiles( path )
-            print('++ setting mix input files GF: %d files from directory %s'%(len(fileList), path ) )
-            process.mix.input.fileNames=map(prepend,fileList)
     return process
 
 def customise_aging_3000(process):
@@ -265,13 +246,6 @@ def customise_aging_3000(process):
     process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,3000,5.0e34)
     process=agedHGCal(process)
-    # hard-coded hack here below; we need to get away from the instabilities of AAA
-    if hasattr(process,'mix'):
-        if hasattr(process.mix,'input'):
-            path = '/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/minbias_D49_1120pre1_20200616/GSD/*'
-            fileList=getMeFiles( path )
-            print('++ setting mix input files GF: %d files from directory %s'%(len(fileList), path ) )
-            process.mix.input.fileNames=map(prepend,fileList)
     return process
 
 def customise_aging_3000_ultimate(process):

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -235,10 +235,29 @@ def customise_aging_300(process):
     process=ageEcal(process,300,5.0e34)
     return process
 
+
+def getMeFiles( path ):
+    """ list files in a directory """
+    import os
+    command = 'ls -1 '+path
+    stream = os.popen(command)
+    return stream.readlines()
+
+def prepend(x) :
+    """ local files need the file: prefix"""
+    return 'file:'+x
+
 def customise_aging_1000(process):
     process=ageHcal(process,1000,5.0e34,"nominal")
     process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,1000,5.0e34)
+    # hard-coded hack here below; we need to get away from the instabilities of AAA
+    if hasattr(process,'mix'):
+        if hasattr(process.mix,'input'):
+            path = '/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/minbias_D49_1120pre1_20200616/GSD/*'
+            fileList=getMeFiles( path )
+            print('++ setting mix input files GF: %d files from directory %s'%(len(fileList), path ) )
+            process.mix.input.fileNames=map(prepend,fileList)
     return process
 
 def customise_aging_3000(process):
@@ -246,6 +265,13 @@ def customise_aging_3000(process):
     process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,3000,5.0e34)
     process=agedHGCal(process)
+    # hard-coded hack here below; we need to get away from the instabilities of AAA
+    if hasattr(process,'mix'):
+        if hasattr(process.mix,'input'):
+            path = '/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/minbias_D49_1120pre1_20200616/GSD/*'
+            fileList=getMeFiles( path )
+            print('++ setting mix input files GF: %d files from directory %s'%(len(fileList), path ) )
+            process.mix.input.fileNames=map(prepend,fileList)
     return process
 
 def customise_aging_3000_ultimate(process):

--- a/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
+++ b/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
@@ -71,7 +71,7 @@ HGCSiNoiseMapAnalyzer::HGCSiNoiseMapAnalyzer(const edm::ParameterSet &iConfig) {
   //configure the dose map
   std::string doseMapURL(iConfig.getParameter<std::string>("doseMap"));
   unsigned int doseMapAlgo(iConfig.getParameter<unsigned int>("doseMapAlgo"));
-  double scaleByDoseFactor = myCfg_.getParameter<edm::ParameterSet>("noise_fC").getParameter<double>("scaleByDoseFactor");
+  double scaleByDoseFactor = iConfig.getParameter<edm::ParameterSet>("noise_fC").getParameter<double>("scaleByDoseFactor");
   std::vector<double> ileakParam(
       iConfig.getParameter<edm::ParameterSet>("ileakParam").template getParameter<std::vector<double>>("ileakParam"));
   std::vector<double> cceParamFine(

--- a/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
+++ b/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
@@ -71,6 +71,7 @@ HGCSiNoiseMapAnalyzer::HGCSiNoiseMapAnalyzer(const edm::ParameterSet &iConfig) {
   //configure the dose map
   std::string doseMapURL(iConfig.getParameter<std::string>("doseMap"));
   unsigned int doseMapAlgo(iConfig.getParameter<unsigned int>("doseMapAlgo"));
+  double scaleByDoseFactor = myCfg_.getParameter<edm::ParameterSet>("noise_fC").getParameter<double>("scaleByDoseFactor");
   std::vector<double> ileakParam(
       iConfig.getParameter<edm::ParameterSet>("ileakParam").template getParameter<std::vector<double>>("ileakParam"));
   std::vector<double> cceParamFine(
@@ -82,11 +83,15 @@ HGCSiNoiseMapAnalyzer::HGCSiNoiseMapAnalyzer(const edm::ParameterSet &iConfig) {
 
   noiseMaps_[DetId::HGCalEE] = std::unique_ptr<HGCalSiNoiseMap>(new HGCalSiNoiseMap);
   noiseMaps_[DetId::HGCalEE]->setDoseMap(doseMapURL, doseMapAlgo);
+  noiseMaps_[DetId::HGCalEE]->setDoseMap(doseMapURL, doseMapAlgo);
+  noiseMaps_[DetId::HGCalEE]->setFluenceScaleFactor(scaleByDoseFactor);
+
   noiseMaps_[DetId::HGCalEE]->setIleakParam(ileakParam);
   noiseMaps_[DetId::HGCalEE]->setCceParam(cceParamFine, cceParamThin, cceParamThick);
 
   noiseMaps_[DetId::HGCalHSi] = std::unique_ptr<HGCalSiNoiseMap>(new HGCalSiNoiseMap);
   noiseMaps_[DetId::HGCalHSi]->setDoseMap(doseMapURL, doseMapAlgo);
+  noiseMaps_[DetId::HGCalHSi]->setFluenceScaleFactor(scaleByDoseFactor);
   noiseMaps_[DetId::HGCalHSi]->setIleakParam(ileakParam);
   noiseMaps_[DetId::HGCalHSi]->setCceParam(cceParamFine, cceParamThin, cceParamThick);
 

--- a/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
+++ b/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
@@ -71,7 +71,8 @@ HGCSiNoiseMapAnalyzer::HGCSiNoiseMapAnalyzer(const edm::ParameterSet &iConfig) {
   //configure the dose map
   std::string doseMapURL(iConfig.getParameter<std::string>("doseMap"));
   unsigned int doseMapAlgo(iConfig.getParameter<unsigned int>("doseMapAlgo"));
-  double scaleByDoseFactor = iConfig.getParameter<edm::ParameterSet>("noise_fC").getParameter<double>("scaleByDoseFactor");
+  double scaleByDoseFactor =
+      iConfig.getParameter<edm::ParameterSet>("noise_fC").getParameter<double>("scaleByDoseFactor");
   std::vector<double> ileakParam(
       iConfig.getParameter<edm::ParameterSet>("ileakParam").template getParameter<std::vector<double>>("ileakParam"));
   std::vector<double> cceParamFine(

--- a/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
+++ b/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
@@ -84,7 +84,6 @@ HGCSiNoiseMapAnalyzer::HGCSiNoiseMapAnalyzer(const edm::ParameterSet &iConfig) {
 
   noiseMaps_[DetId::HGCalEE] = std::unique_ptr<HGCalSiNoiseMap>(new HGCalSiNoiseMap);
   noiseMaps_[DetId::HGCalEE]->setDoseMap(doseMapURL, doseMapAlgo);
-  noiseMaps_[DetId::HGCalEE]->setDoseMap(doseMapURL, doseMapAlgo);
   noiseMaps_[DetId::HGCalEE]->setFluenceScaleFactor(scaleByDoseFactor);
 
   noiseMaps_[DetId::HGCalEE]->setIleakParam(ileakParam);

--- a/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
+++ b/SimCalorimetry/HGCalSimAlgos/test/HGCSiNoiseMapAnalyzer.cc
@@ -71,8 +71,7 @@ HGCSiNoiseMapAnalyzer::HGCSiNoiseMapAnalyzer(const edm::ParameterSet &iConfig) {
   //configure the dose map
   std::string doseMapURL(iConfig.getParameter<std::string>("doseMap"));
   unsigned int doseMapAlgo(iConfig.getParameter<unsigned int>("doseMapAlgo"));
-  double scaleByDoseFactor =
-      iConfig.getParameter<edm::ParameterSet>("noise_fC").getParameter<double>("scaleByDoseFactor");
+  double scaleByDoseFactor(iConfig.getParameter<double>("scaleByDoseFactor"));
   std::vector<double> ileakParam(
       iConfig.getParameter<edm::ParameterSet>("ileakParam").template getParameter<std::vector<double>>("ileakParam"));
   std::vector<double> cceParamFine(

--- a/SimCalorimetry/HGCalSimAlgos/test/hgcsiNoiseMapTester_cfg.py
+++ b/SimCalorimetry/HGCalSimAlgos/test/hgcsiNoiseMapTester_cfg.py
@@ -11,15 +11,16 @@ options.parseArguments()
 process = cms.Process("demo",eras.Phase2C8)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.load('Configuration.Geometry.GeometryExtended2026D41Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 process.source = cms.Source("EmptySource")
 
-from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCAL_ileakParam_toUse, HGCAL_cceParams_toUse
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import * #HGCAL_ileakParam_toUse, HGCAL_cceParams_toUse
 process.plotter_eol = cms.EDAnalyzer("HGCSiNoiseMapAnalyzer",
+                                     scaleByDoseFactor  = cms.double(1.),
                                      doseMap            = cms.string( options.doseMap ),
                                      doseMapAlgo        = cms.uint32(0),
                                      ileakParam         = HGCAL_ileakParam_toUse,

--- a/SimCalorimetry/HGCalSimAlgos/test/hgcsiNoiseMapTester_cfg.py
+++ b/SimCalorimetry/HGCalSimAlgos/test/hgcsiNoiseMapTester_cfg.py
@@ -18,7 +18,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 process.source = cms.Source("EmptySource")
 
-from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import * #HGCAL_ileakParam_toUse, HGCAL_cceParams_toUse
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCAL_ileakParam_toUse, HGCAL_cceParams_toUse
 process.plotter_eol = cms.EDAnalyzer("HGCSiNoiseMapAnalyzer",
                                      scaleByDoseFactor  = cms.double(1.),
                                      doseMap            = cms.string( options.doseMap ),

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -137,6 +137,9 @@ protected:
   //determines if the dose map should be used instead
   bool scaleByDose_;
 
+  //multiplicative fator to scale fluence map
+  double scaleByDoseFactor_;
+
   //path to dose map
   std::string doseMapFile_;
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -33,12 +33,12 @@ cceParamFine_ttu800  = [1.5e+15, 3.35246e-17,  0.251679]      #120
 cceParamThin_ttu800  = [1.5e+15, -1.62096e-16, 0.293828]      #200
 cceParamThick_ttu800 = [6e+14,   -5.95259e-16, 0.183929]      #300
 #  line+log tdr 600V EPI
-cceParamFine_epi600  = [3.5e+15, -9.73872e-19, 0.263812]      #100
+cceParamFine_epi600  = [3.5e+15, -9.73872e-19, 0.263812]      #120
 cceParamThin_epi600  = [1.5e+15, -3.09878e-16, 0.211207]      #200
 cceParamThick_epi600 = [6e+14,   -7.96539e-16, 0.251751]      #300
 
 HGCAL_cceParams_toUse = cms.PSet(
-    cceParamFine  = cms.vdouble(cceParamFine_tdr600),
+    cceParamFine  = cms.vdouble(cceParamFine_epi600),
     cceParamThin  = cms.vdouble(cceParamThin_tdr600),
     cceParamThick = cms.vdouble(cceParamThick_tdr600)
     )

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -221,8 +221,8 @@ def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
 def HGCal_setEndOfLifeNoise_4000(process):
     HGCAL_cceParams_toUse = cms.PSet(
         cceParamFine  = cms.vdouble(cceParamFine_epi800),
-        cceParamThin  = cms.vdouble(cceParamThin_ttu800),
-        cceParamThick = cms.vdouble(cceParamThick_ttu800)
+        cceParamThin  = cms.vdouble(cceParamThin_tdr800),
+        cceParamThick = cms.vdouble(cceParamThick_tdr800)
     )
     process.HGCAL_ileakParam_toUse    = cms.PSet(
         ileakParam = cms.vdouble(ileakParam_800V)

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -32,10 +32,13 @@ cceParamThick_ttu600 = [6e+14,   -8.01557e-16, 0.157375]      #300
 cceParamFine_ttu800  = [1.5e+15, 3.35246e-17,  0.251679]      #120
 cceParamThin_ttu800  = [1.5e+15, -1.62096e-16, 0.293828]      #200
 cceParamThick_ttu800 = [6e+14,   -5.95259e-16, 0.183929]      #300
+# scaling the ddfz curve to match Timo's 800V measuremetn at 3.5E15
+cceParamFine_epi800 = [3.5e+15, -1.4285714e-17, 0.263812]     #120
 #  line+log tdr 600V EPI
-cceParamFine_epi600  = [3.5e+15, -9.73872e-19, 0.263812]      #120
+cceParamFine_epi600  = [3.5e+15, -3.428571e-17, 0.263812]     #120 - scaling the ddfz curve to match Timo's 600V measurement at 3.5E15 
 cceParamThin_epi600  = [1.5e+15, -3.09878e-16, 0.211207]      #200
 cceParamThick_epi600 = [6e+14,   -7.96539e-16, 0.251751]      #300
+
 
 HGCAL_cceParams_toUse = cms.PSet(
     cceParamFine  = cms.vdouble(cceParamFine_epi600),
@@ -216,10 +219,16 @@ def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     return process
 
 def HGCal_setEndOfLifeNoise_4000(process):
+    HGCAL_cceParams_toUse = cms.PSet(
+        cceParamFine  = cms.vdouble(cceParamFine_epi800),
+        cceParamThin  = cms.vdouble(cceParamThin_ttu800),
+        cceParamThick = cms.vdouble(cceParamThick_ttu800)
+    )
     process.HGCAL_ileakParam_toUse    = cms.PSet(
-    ileakParam = cms.vdouble(ileakParam_800V)
+        ileakParam = cms.vdouble(ileakParam_800V)
     )
     return HGCal_setEndOfLifeNoise(process,byDoseFactor=1.333)
+
 
 def HGCal_ignoreFluence(process):
     """include all effects except fluence impact on leakage current and CCE"""

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -219,7 +219,7 @@ def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     return process
 
 def HGCal_setEndOfLifeNoise_4000(process):
-    HGCAL_cceParams_toUse = cms.PSet(
+    process.HGCAL_cceParams_toUse = cms.PSet(
         cceParamFine  = cms.vdouble(cceParamFine_epi800),
         cceParamThin  = cms.vdouble(cceParamThin_tdr800),
         cceParamThick = cms.vdouble(cceParamThick_tdr800)
@@ -229,6 +229,16 @@ def HGCal_setEndOfLifeNoise_4000(process):
     )
     return HGCal_setEndOfLifeNoise(process,byDoseFactor=1.333)
 
+def HGCal_setEndOfLifeNoise_1500(process):
+    process.HGCAL_cceParams_toUse = cms.PSet(
+        cceParamFine  = cms.vdouble(cceParamFine_epi600),
+        cceParamThin  = cms.vdouble(cceParamThin_tdr600),
+        cceParamThick = cms.vdouble(cceParamThick_tdr600)
+    )
+    process.HGCAL_ileakParam_toUse    = cms.PSet(
+        ileakParam = cms.vdouble(ileakParam_600V)
+    )
+    return HGCal_setEndOfLifeNoise(process,byDoseFactor=0.5)
 
 def HGCal_ignoreFluence(process):
     """include all effects except fluence impact on leakage current and CCE"""

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -216,6 +216,9 @@ def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     return process
 
 def HGCal_setEndOfLifeNoise_4000(process):
+    process.HGCAL_ileakParam_toUse    = cms.PSet(
+    ileakParam = cms.vdouble(ileakParam_800V)
+    )
     return HGCal_setEndOfLifeNoise(process,byDoseFactor=1.333)
 
 def HGCal_ignoreFluence(process):

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -46,6 +46,7 @@ HGCAL_cceParams_toUse = cms.PSet(
 HGCAL_noise_fC = cms.PSet(
     scaleByDose = cms.bool(False),
     scaleByDoseAlgo = cms.uint32(0),
+    scaleByDoseFactor = cms.double(1),
     doseMap = cms.string(""),
     values = cms.vdouble( [x*fC_per_ele for x in nonAgedNoises] ), #100,200,300 um
     )
@@ -53,6 +54,7 @@ HGCAL_noise_fC = cms.PSet(
 HGCAL_noise_heback = cms.PSet(
     scaleByDose = cms.bool(False),
     scaleByDoseAlgo = cms.uint32(0),
+    scaleByDoseFactor = cms.double(1),
     doseMap = cms.string(""), #empty dose map at begin-of-life
     noise_MIP = cms.double(1./100.)
     )
@@ -206,12 +208,15 @@ for _m in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigiti
 #function to set noise to aged HGCal
 endOfLifeCCEs = [0.5, 0.5, 0.7]
 endOfLifeNoises = [2400.0,2250.0,1750.0]
-def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0):
+def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     """includes all effects from radiation and gain choice"""
     # byDoseAlgo is used as a collection of bits to toggle: FLUENCE, CCE, NOISE, PULSEPERGAIN, CACHEDOP (from lsb to Msb)
-    process=HGCal_setRealisticNoiseSi(process,byDose=byDose,byDoseAlgo=byDoseAlgo)
-    process=HGCal_setRealisticNoiseSci(process,byDose=byDose,byDoseAlgo=byDoseAlgo)
+    process=HGCal_setRealisticNoiseSi(process,byDose=byDose,byDoseAlgo=byDoseAlgo,byDoseFactor=byDoseFactor)
+    process=HGCal_setRealisticNoiseSci(process,byDose=byDose,byDoseAlgo=byDoseAlgo,byDoseFactor=byDoseFactor)
     return process
+
+def HGCal_setEndOfLifeNoise_4000(process):
+    return HGCal_setEndOfLifeNoise(process,byDoseFactor=1.333)
 
 def HGCal_ignoreFluence(process):
     """include all effects except fluence impact on leakage current and CCE"""
@@ -256,10 +261,11 @@ def HGCal_useCaching(process):
 
 doseMap = cms.string("SimCalorimetry/HGCalSimProducers/data/doseParams_3000fb_fluka-3.7.20.txt")
 
-def HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap):
+def HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap,byDoseFactor=1):
     process.HGCAL_noise_fC = cms.PSet(
         scaleByDose = cms.bool(byDose),
         scaleByDoseAlgo = cms.uint32(byDoseAlgo),
+        scaleByDoseFactor = cms.double(byDoseFactor),
         doseMap = byDoseMap,
         values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #100,200,300 um
         )
@@ -271,10 +277,11 @@ def HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap
         )
     return process
 
-def HGCal_setRealisticNoiseSci(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap):
+def HGCal_setRealisticNoiseSci(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap,byDoseFactor=1):
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(byDose),
         scaleByDoseAlgo = cms.uint32(byDoseAlgo),
+        scaleByDoseFactor = cms.double(byDoseFactor),
         doseMap = byDoseMap,
         noise_MIP = cms.double(1./5.) #uses noise map
         )
@@ -284,12 +291,14 @@ def HGCal_disableNoise(process):
     process.HGCAL_noise_fC = cms.PSet(
         scaleByDose = cms.bool(False),
         scaleByDoseAlgo = cms.uint32(0),
+        scaleByDoseFactor = cms.double(1),
         doseMap = cms.string(""),
         values = cms.vdouble(0,0,0), #100,200,300 um
     )
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(False),
         scaleByDoseAlgo = cms.uint32(0),
+        scaleByDoseFactor = cms.double(1),
         doseMap = cms.string(""),
         noise_MIP = cms.double(0.) #zero noise
         )

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -190,7 +190,6 @@ void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& 
 
 template <class DFr>
 void HGCDigitizerBase<DFr>::updateOutput(std::unique_ptr<HGCDigitizerBase::DColl>& coll, const DFr& rawDataFrame) {
-
   // 9th is the sample of hte intime amplitudes
   int itIdx(9);
   if (rawDataFrame.size() <= itIdx + 2)
@@ -201,16 +200,15 @@ void HGCDigitizerBase<DFr>::updateOutput(std::unique_ptr<HGCDigitizerBase::DColl
 
   // if in time amplitude is above threshold
   // , then don't push back the dataframe
-  if ( (! rawDataFrame[itIdx].threshold() ) ) {
+  if ((!rawDataFrame[itIdx].threshold())) {
     return;
-    }
+  }
 
   for (int it = 0; it < 5; it++) {
     dataFrame.setSample(it, rawDataFrame[itIdx - 2 + it]);
   }
 
   coll->push_back(dataFrame);
-
 }
 
 // cause the compiler to generate the appropriate code

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -188,22 +188,46 @@ void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& 
 
 template <class DFr>
 void HGCDigitizerBase<DFr>::updateOutput(std::unique_ptr<HGCDigitizerBase::DColl>& coll, const DFr& rawDataFrame) {
+
+  // 9th is the sample of hte intime amplitudes
   int itIdx(9);
   if (rawDataFrame.size() <= itIdx + 2)
     return;
 
   DFr dataFrame(rawDataFrame.id());
   dataFrame.resize(5);
-  bool putInEvent(false);
+
+  // if neither:
+  //      in time amplitude is above threshold
+  //      bx-1  amplitude above threshold
+  // , then don't push back the dataframe
+  if ( (! rawDataFrame[itIdx].threshold() ) ) {
+    return;
+    }
+
   for (int it = 0; it < 5; it++) {
     dataFrame.setSample(it, rawDataFrame[itIdx - 2 + it]);
-    if (it == 2)
-      putInEvent = rawDataFrame[itIdx - 2 + it].threshold();
   }
 
-  if (putInEvent) {
-    coll->push_back(dataFrame);
-  }
+  coll->push_back(dataFrame);
+
+// how it was
+//
+//  DFr dataFrame(rawDataFrame.id());
+//  dataFrame.resize(5);
+//  bool putInEvent(false);
+//  for (int it = 0; it < 5; it++) {
+//    dataFrame.setSample(it, rawDataFrame[itIdx - 2 + it]);
+//    if (it == 2)
+//      putInEvent = rawDataFrame[itIdx - 2 + it].threshold();
+//  }
+//
+//  if (putInEvent) {
+//    coll->push_back(dataFrame);
+//  }
+//
+
+
 }
 
 // cause the compiler to generate the appropriate code

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -36,8 +36,10 @@ HGCDigitizerBase<DFr>::HGCDigitizerBase(const edm::ParameterSet& ps)
     scaleByDose_ = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<bool>("scaleByDose");
     int scaleByDoseAlgo =
         myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<uint32_t>("scaleByDoseAlgo");
+    scaleByDoseFactor_ = myCfg_.getParameter<edm::ParameterSet>("noise_fC").getParameter<double>("scaleByDoseFactor");
     doseMapFile_ = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<std::string>("doseMap");
     scal_.setDoseMap(doseMapFile_, scaleByDoseAlgo);
+    scal_.setFluenceScaleFactor(scaleByDoseFactor_);
   } else {
     noise_fC_.resize(1, 1.f);
   }
@@ -197,9 +199,7 @@ void HGCDigitizerBase<DFr>::updateOutput(std::unique_ptr<HGCDigitizerBase::DColl
   DFr dataFrame(rawDataFrame.id());
   dataFrame.resize(5);
 
-  // if neither:
-  //      in time amplitude is above threshold
-  //      bx-1  amplitude above threshold
+  // if in time amplitude is above threshold
   // , then don't push back the dataframe
   if ( (! rawDataFrame[itIdx].threshold() ) ) {
     return;
@@ -210,23 +210,6 @@ void HGCDigitizerBase<DFr>::updateOutput(std::unique_ptr<HGCDigitizerBase::DColl
   }
 
   coll->push_back(dataFrame);
-
-// how it was
-//
-//  DFr dataFrame(rawDataFrame.id());
-//  dataFrame.resize(5);
-//  bool putInEvent(false);
-//  for (int it = 0; it < 5; it++) {
-//    dataFrame.setSample(it, rawDataFrame[itIdx - 2 + it]);
-//    if (it == 2)
-//      putInEvent = rawDataFrame[itIdx - 2 + it].threshold();
-//  }
-//
-//  if (putInEvent) {
-//    coll->push_back(dataFrame);
-//  }
-//
-
 
 }
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -20,6 +20,7 @@ HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet& ps) : HGCDigitiz
   sipmMapFile_ = cfg.getParameter<std::string>("sipmMap");
   scaleByDose_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<bool>("scaleByDose");
   unsigned int scaleByDoseAlgo = cfg.getParameter<edm::ParameterSet>("noise").getParameter<uint32_t>("scaleByDoseAlgo");
+  scaleByDoseFactor_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<double>("scaleByDoseFactor");
   doseMapFile_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<std::string>("doseMap");
   noise_MIP_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<double>("noise_MIP");
   thresholdFollowsMIP_ = cfg.getParameter<bool>("thresholdFollowsMIP");
@@ -31,6 +32,7 @@ HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet& ps) : HGCDigitiz
   sdPixels_ = cfg.getParameter<double>("sdPixels");
 
   scal_.setDoseMap(doseMapFile_, scaleByDoseAlgo);
+  scal_.setFluenceScaleFactor(scaleByDoseFactor_);
   scal_.setSipmMap(sipmMapFile_);
 }
 


### PR DESCRIPTION
#### PR description:

Only technical changes:
 - avoid looping over in-time and out-of-time HGCAL digis if a data farme wont' be kept
- add utilities and customise functions we've used to validate the HGCAL noise model and occupancies toggling on-and-off noise, out-of-time
- implement interface to actually use the existing capability of scaling the fluence map to model HGCAL ageing at an arbitrary integrated luminosity

#### PR validation:

We've reported on occupancy and spectra on slides 17-22 of this [talk at the HGCAL mini-workshop last week](https://indico.cern.ch/event/933714/contributions/3924245/attachments/2072440/)

Not a backport.

@pfs @rovere 
