### PR TITLE
DQM: Use ProcessBlock in Harvesting

### DIFF
--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
@@ -98,9 +98,6 @@ SiPixelStatusHarvester::~SiPixelStatusHarvester() {}
 void SiPixelStatusHarvester::beginJob() {}
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusHarvester::endJob() {}
-
-//--------------------------------------------------------------------------------------------------
 void SiPixelStatusHarvester::bookHistograms(DQMStore::IBooker& iBooker,
                                             edm::Run const&,
                                             edm::EventSetup const& iSetup) {

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
@@ -43,7 +43,6 @@ public:
 
   // Operations
   void beginJob() override;
-  void endJob() override;
   void bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&, const edm::EventSetup&) final;
   void dqmEndRun(const edm::Run&, const edm::EventSetup&) final;
   void analyze(const edm::Event& iEvent, const edm::EventSetup&) final;

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -87,7 +87,6 @@ public:
 private:
   void beginJob() override;
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &, APVGain::APVGainHistograms &) const override;
-  void endJob() override;
   void checkBookAPVColls(const TrackerGeometry *bareTkGeomPtr, APVGain::APVGainHistograms &histograms) const;
 
   std::vector<std::string> dqm_tag_;

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -542,9 +542,6 @@ void SiStripGainsPCLWorker::checkBookAPVColls(const TrackerGeometry* bareTkGeomP
 }
 
 //********************************************************************************//
-void SiStripGainsPCLWorker::endJob() {}
-
-//********************************************************************************//
 void SiStripGainsPCLWorker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setUnknown();

--- a/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
+++ b/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
@@ -9,6 +9,9 @@ SiPixelPhase1SummaryOnline = DQMEDHarvester("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(True),
     RunOnEndJob = cms.bool(True),
+    # schedule this module to run *after* the QTests.
+    inputGeneration = cms.untracked.string('DQMGenerationQTest'),
+    outputGeneration = cms.untracked.string('DQMGenerationSummary'),
     SummaryMaps = cms.VPSet(
         cms.PSet(
             MapName = cms.string("Digi"),
@@ -39,6 +42,9 @@ SiPixelPhase1SummaryOffline = DQMEDHarvester("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(False),
     RunOnEndJob = cms.bool(True),
+    # schedule this module to run *after* the QTests.
+    inputGeneration = cms.untracked.string('DQMGenerationQTest'),
+    outputGeneration = cms.untracked.string('DQMGenerationSummary'),
     SummaryMaps = cms.VPSet(
         cms.PSet(
             MapName = cms.string("Digi"),
@@ -69,6 +75,9 @@ SiPixelPhase1SummaryCosmics = DQMEDHarvester("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(False),
     RunOnEndJob = cms.bool(True),
+    # schedule this module to run *after* the QTests.
+    inputGeneration = cms.untracked.string('DQMGenerationQTest'),
+    outputGeneration = cms.untracked.string('DQMGenerationSummary'),
     SummaryMaps = cms.VPSet(
         cms.PSet(
             MapName = cms.string("Digi"),

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -46,7 +46,8 @@
 using namespace std;
 using namespace edm;
 
-SiPixelPhase1Summary::SiPixelPhase1Summary(const edm::ParameterSet& iConfig) : conf_(iConfig), firstLumi(true) {
+SiPixelPhase1Summary::SiPixelPhase1Summary(const edm::ParameterSet& iConfig)
+    : DQMEDHarvester(iConfig), conf_(iConfig), firstLumi(true) {
   LogInfo("PixelDQM") << "SiPixelPhase1Summary::SiPixelPhase1Summary: Got DQM BackEnd interface" << endl;
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   runOnEndLumi_ = conf_.getParameter<bool>("RunOnEndLumi");

--- a/DQMOffline/CalibTracker/src/StatisticsFilter.cc
+++ b/DQMOffline/CalibTracker/src/StatisticsFilter.cc
@@ -48,7 +48,6 @@ public:
 private:
   void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
 
@@ -120,9 +119,6 @@ bool StatisticsFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 // ------------ method called once each job just before starting event loop  ------------
 void StatisticsFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void StatisticsFilter::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(StatisticsFilter);

--- a/DQMOffline/Trigger/interface/DQMOfflineHLTEventInfoClient.h
+++ b/DQMOffline/Trigger/interface/DQMOfflineHLTEventInfoClient.h
@@ -41,9 +41,6 @@ protected:
   /// EndRun
   void endRun(const edm::Run& r, const edm::EventSetup& c) override;
 
-  /// Endjob
-  void endJob() override;
-
 private:
   void initialize();
   edm::ParameterSet parameters_;

--- a/DQMOffline/Trigger/interface/HLTInclusiveVBFClient.h
+++ b/DQMOffline/Trigger/interface/HLTInclusiveVBFClient.h
@@ -54,8 +54,6 @@ public:
   explicit HLTInclusiveVBFClient(const edm::ParameterSet&);
   ~HLTInclusiveVBFClient() override;
 
-  void beginJob() override;
-  void endJob() override;
   void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
   void endRun(const edm::Run& run, const edm::EventSetup& c) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;

--- a/DQMOffline/Trigger/plugins/DQMOfflineHLTEventInfoClient.cc
+++ b/DQMOffline/Trigger/plugins/DQMOfflineHLTEventInfoClient.cc
@@ -58,9 +58,6 @@ protected:
   /// EndRun
   void endRun(const edm::Run& r, const edm::EventSetup& c);
 
-  /// Endjob
-  void endJob();
-
 private:
 
   void initialize();
@@ -252,5 +249,3 @@ void DQMOfflineHLTEventInfoClient::endRun(const Run& r, const EventSetup& contex
   CertificationSummaryMap_->setBinContent(1, 6, tauValue);       //Tau
 }
 
-//--------------------------------------------------------
-void DQMOfflineHLTEventInfoClient::endJob() {}

--- a/DQMOffline/Trigger/plugins/DQMOfflineHLTEventInfoClient.cc
+++ b/DQMOffline/Trigger/plugins/DQMOfflineHLTEventInfoClient.cc
@@ -248,4 +248,3 @@ void DQMOfflineHLTEventInfoClient::endRun(const Run& r, const EventSetup& contex
   CertificationSummaryMap_->setBinContent(1, 5, 1);              //BJet
   CertificationSummaryMap_->setBinContent(1, 6, tauValue);       //Tau
 }
-

--- a/DQMOffline/Trigger/plugins/HLTInclusiveVBFClient.cc
+++ b/DQMOffline/Trigger/plugins/HLTInclusiveVBFClient.cc
@@ -37,8 +37,6 @@ HLTInclusiveVBFClient::HLTInclusiveVBFClient(const edm::ParameterSet& iConfig) :
 
 HLTInclusiveVBFClient::~HLTInclusiveVBFClient() = default;
 
-void HLTInclusiveVBFClient::beginJob() {}
-
 void HLTInclusiveVBFClient::beginRun(const edm::Run& r, const edm::EventSetup& context) {}
 
 void HLTInclusiveVBFClient::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {}
@@ -48,8 +46,6 @@ void HLTInclusiveVBFClient::endLuminosityBlock(const edm::LuminosityBlock& lumiS
 }
 
 void HLTInclusiveVBFClient::endRun(const edm::Run& r, const edm::EventSetup& context) {}
-
-void HLTInclusiveVBFClient::endJob() {}
 
 void HLTInclusiveVBFClient::runClient_() {
   if (!dbe_)

--- a/DQMOffline/Trigger/plugins/HLTOverallSummary.cc
+++ b/DQMOffline/Trigger/plugins/HLTOverallSummary.cc
@@ -56,9 +56,7 @@ public:
   explicit HLTOverallSummary(const edm::ParameterSet& pset);
   ~HLTOverallSummary() override;
 
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void endRun(const edm::Run&, const edm::EventSetup&) override;
 
@@ -101,12 +99,6 @@ void HLTOverallSummary::analyze(const edm::Event& iEvent, const edm::EventSetup&
   if (verbose_)
     LogInfo("HLTMuonVal") << ">>> Analyze (HLTOverallSummary) <<<" << std::endl;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void HLTOverallSummary::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void HLTOverallSummary::endJob() {}
 
 // ------------ method called just before starting a new run  ------------
 void HLTOverallSummary::beginRun(const edm::Run& run, const edm::EventSetup& c) {

--- a/DQMServices/Components/plugins/DQMDaqInfo.cc
+++ b/DQMServices/Components/plugins/DQMDaqInfo.cc
@@ -137,6 +137,4 @@ void DQMDaqInfo::beginJob() {
   NumberOfFeds[L1T] = L1TRange.second - L1TRange.first + 1;
 }
 
-void DQMDaqInfo::endJob() {}
-
 void DQMDaqInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {}

--- a/DQMServices/Components/plugins/DQMDaqInfo.h
+++ b/DQMServices/Components/plugins/DQMDaqInfo.h
@@ -53,7 +53,6 @@ private:
   void beginJob() override;
   void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   DQMStore* dbe_;
 

--- a/DQMServices/Components/plugins/DQMFileSaver.cc
+++ b/DQMServices/Components/plugins/DQMFileSaver.cc
@@ -25,7 +25,7 @@ namespace saverDetails {
 // - This includes ALCAHARVEST. TODO: check if the data written there is needed for the PCL.
 // This module is not used in online. This module is (hopefully?) not used at HLT.
 // Online and HLT use modules in DQMServices/FileIO.
-class DQMFileSaver : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+class DQMFileSaver : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::WatchProcessBlock> {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;
@@ -35,7 +35,7 @@ protected:
   void beginRun(edm::Run const &, edm::EventSetup const &) override{};
   void analyze(const edm::Event &e, const edm::EventSetup &) override;
   void endRun(const edm::Run &, const edm::EventSetup &) override;
-  void endJob() override;
+  void endProcessBlock(const edm::ProcessBlock &) override;
 
 private:
   void saveForOffline(const std::string &workflow, int run, int lumi);
@@ -147,10 +147,8 @@ DQMFileSaver::DQMFileSaver(const edm::ParameterSet &ps)
       dbe_(&*edm::Service<DQMStore>()),
       nrun_(0),
       irun_(0) {
-  // Note: this is insufficient, we also need to enforce running *after* all
-  // DQMEDAnalyzers (a.k.a. EDProducers) in endJob.
-  // This is not supported in edm currently.
   consumesMany<DQMToken, edm::InRun>();
+  consumesMany<DQMToken, edm::InProcess>();
   workflow_ = ps.getUntrackedParameter<std::string>("workflow", workflow_);
   if (workflow_.empty() || workflow_[0] != '/' || *workflow_.rbegin() == '/' ||
       std::count(workflow_.begin(), workflow_.end(), '/') != 3 ||
@@ -208,7 +206,7 @@ void DQMFileSaver::endRun(const edm::Run &iRun, const edm::EventSetup &) {
   }
 }
 
-void DQMFileSaver::endJob() {
+void DQMFileSaver::endProcessBlock(const edm::ProcessBlock &) {
   if (saveAtJobEnd_) {
     if (forceRunNumber_ > 0)
       saveForOffline(workflow_, forceRunNumber_, 0);

--- a/DQMServices/Components/plugins/DQMLumiMonitor.cc
+++ b/DQMServices/Components/plugins/DQMLumiMonitor.cc
@@ -142,7 +142,6 @@ void DQMLumiMonitor::endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, e
 
 void DQMLumiMonitor::endRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
 
-void DQMLumiMonitor::endJob() {}
 // Define this as a plug-in
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(DQMLumiMonitor);

--- a/DQMServices/Components/plugins/DQMLumiMonitor.h
+++ b/DQMServices/Components/plugins/DQMLumiMonitor.h
@@ -40,7 +40,6 @@ protected:
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
   void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup) override;
   void endRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
-  void endJob() override;
 
 private:
   void bookHistograms();

--- a/DQMServices/Components/plugins/DQMMessageLoggerClient.cc
+++ b/DQMServices/Components/plugins/DQMMessageLoggerClient.cc
@@ -170,6 +170,3 @@ void DQMMessageLoggerClient::fillHistograms() {
 
 void DQMMessageLoggerClient::endRun(const Run& r, const EventSetup& es) { fillHistograms(); }
 
-void DQMMessageLoggerClient::endJob() {
-  //LogTrace(metname)<<"[DQMMessageLoggerClient] EndJob";
-}

--- a/DQMServices/Components/plugins/DQMMessageLoggerClient.cc
+++ b/DQMServices/Components/plugins/DQMMessageLoggerClient.cc
@@ -169,4 +169,3 @@ void DQMMessageLoggerClient::fillHistograms() {
 }
 
 void DQMMessageLoggerClient::endRun(const Run& r, const EventSetup& es) { fillHistograms(); }
-

--- a/DQMServices/Components/plugins/DQMMessageLoggerClient.h
+++ b/DQMServices/Components/plugins/DQMMessageLoggerClient.h
@@ -29,7 +29,6 @@ protected:
 
   // Save the histos
   void endRun(const edm::Run &, const edm::EventSetup &) override;
-  void endJob() override;
 
 private:
   void fillHistograms();

--- a/DQMServices/Components/plugins/EDMtoMEConverter.h
+++ b/DQMServices/Components/plugins/EDMtoMEConverter.h
@@ -60,8 +60,6 @@ public:
   explicit EDMtoMEConverter(const edm::ParameterSet&);
   ~EDMtoMEConverter() override;
 
-  void beginJob() final{};
-  void endJob() final{};
   void beginRun(const edm::Run&, const edm::EventSetup&) final{};
   void endRun(const edm::Run&, const edm::EventSetup&) final{};
   void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final{};

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -83,8 +83,6 @@ MEtoEDMConverter::~MEtoEDMConverter() = default;
 
 void MEtoEDMConverter::beginJob() {}
 
-void MEtoEDMConverter::endJob() {}
-
 std::shared_ptr<meedm::Void> MEtoEDMConverter::globalBeginRun(edm::Run const& iRun,
                                                               const edm::EventSetup& iSetup) const {
   return std::shared_ptr<meedm::Void>();

--- a/DQMServices/Components/plugins/MEtoEDMConverter.h
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.h
@@ -68,7 +68,6 @@ public:
   explicit MEtoEDMConverter(const edm::ParameterSet&);
   ~MEtoEDMConverter() override;
   void beginJob() override;
-  void endJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
   std::shared_ptr<meedm::Void> globalBeginRun(edm::Run const&, const edm::EventSetup&) const override;
   void globalEndRun(edm::Run const&, const edm::EventSetup&) override;

--- a/DQMServices/Demo/test/TestHarvester.cc
+++ b/DQMServices/Demo/test/TestHarvester.cc
@@ -73,13 +73,6 @@ public:
     out->Fill(whathappened);
   }
 
-  void endJob() override {
-    edm::Service<DQMStore> store;
-    whathappened += "endJob() ";
-    store->setCurrentFolder(folder_);
-    MonitorElement *out = store->bookString("harvestingsummary", "missing");
-    out->Fill(whathappened);
-  }
   void endLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &) override {
     whathappened += "endLumi(" + std::to_string(lumi.run()) + "," + std::to_string(lumi.luminosityBlock()) + ") ";
   }

--- a/DQMServices/Demo/test/runtests.sh
+++ b/DQMServices/Demo/test/runtests.sh
@@ -125,7 +125,9 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py numberEventsInRun=300 numberEventsIn
 # 10. Try running some harvesting modules and check if their output makes it out.
 # Note that we pass the files out-of order here; the DQMIO input should sort them.
 cmsRun $LOCAL_TEST_DIR/run_harvesters_cfg.py inputFiles=part1.root inputFiles=part3.root inputFiles=part2.root legacyoutput=True
-[ 2 = $(rootlist DQM_V0001_R000000001__Harvesting__DQMTests__DQMIO.root | grep  -c '<harvestingsummary>s=beginRun(1) endLumi(1,1) endLumi(1,2) endLumi(1,3) endRun(1) endJob() </harvestingsummary>') ]
+[ 1 = $(rootlist DQM_V0001_R000000001__Harvesting__DQMTests__DQMIO.root | grep  -c '<harvestingsummary>s=beginRun(1) endLumi(1,1) endLumi(1,2) endLumi(1,3) endRun(1) endJob() </harvestingsummary>') ]
+# The legacy harvester can only do per-run harvesting.
+[ 2 = $(rootlist DQM_V0001_R000000001__Harvesting__DQMTests__DQMIO.root | grep  -c '<runsummary>s=beginRun(1) endLumi(1,1) endLumi(1,2) endLumi(1,3) endRun(1) </runsummary>') ]
 
 # 11. Try MEtoEDM and EDMtoME.
 cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=metoedm.root numberEventsInRun=100 numberEventsInLuminosityBlock=20 nEvents=100 metoedmoutput=True

--- a/Validation/RecoTau/plugins/DQMHistNormalizer.cc
+++ b/Validation/RecoTau/plugins/DQMHistNormalizer.cc
@@ -35,7 +35,6 @@ public:
   explicit DQMHistNormalizer(const edm::ParameterSet&);
   ~DQMHistNormalizer() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override {}
   void endRun(const edm::Run& r, const edm::EventSetup& c) override;
 
 private:

--- a/Validation/RecoTau/plugins/DQMHistPlotter.h
+++ b/Validation/RecoTau/plugins/DQMHistPlotter.h
@@ -157,7 +157,6 @@ public:
   explicit TauDQMHistPlotter(const edm::ParameterSet&);
   ~TauDQMHistPlotter() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override {}
   void endRun(const edm::Run& r, const edm::EventSetup& c) override;
 
 private:


### PR DESCRIPTION
#### PR description:

This PR aims to use the new ProcessBlock feature in DQM HARVESTING to fix issue #28354.

See also my recent talk about how this works: https://indico.cern.ch/event/934933/contributions/3928462/attachments/2072544/3479621/dqm-cmssw.pdf (Page 50).

Caveats:

- ~It does not work for now. Either the dependencies are not correctly set up at all or at least `process.Tracer = cms.Service("Tracer", dumpPathsAndConsumes = cms.untracked.bool(True))` does not correctly display them.~ Fixed with #30737.
- This only covers DQM HARVESTING. ALCAHARVEST most likely has the same hidden dependency problem. For the DQM parts of the AlCa setup this PR will do something, but I don't know which modules actually write the conditions payload at `endJob` and if their assumptions remain within the guarantees of edm.
- I don't know if there are any hidden dependencies left. They are hidden, after all. But at least the most obvious (between any harvesting module and the `DQMFileSaver` should be covered and more depdendencies can be added it if turns out to be required. (Update: One more dependency around QTests in `SiPixelPhase1Summary` found and fixed here. There might be more like these, and they might show up randomly now and then.)
- I did not change how HARVESTING/QTests work. The interesting case here is harvesting/qtest/harvesting sequences, where as of today, we do the first harvesting and the qtests in `endRun` and then the second harvesting in `endJob` (now `endProcessBlock`). That was the only way to do it without `ProcessBlock`s. Now we *could* do it all in `endProcessBlock` (a.k.a. `dqmEndJob`) using token dependencies and two separate harvesting modules, but I did not perform this transform. In practice, the only use case for such a setup is `SiStripMonitorClient`, and I am happy that it works as is and don't want to break and debug it another time.
- I have no idea how to actually set up process blocks for multi-run harvesting for now. I just replaced `endJob` with `endProcessBlock` for now, which should cover all existing cases. With `ProcessBlocks`, it should be possible again to harvest multiple runs independently in one job (or even multi-run harvest multiple groups of runs), but there is no need or support for that right now.
- `endJob` harvesting is now no longer supported in legacy modules. It was not really used anyways. I removed a bunch of empty `endJob` methods to avoid confusion. Some modules still have `endJob` harvesting code, but it is not used in production; it can still work in stand-alone setups that do not rely on `DQMFileSaver`.

#### PR validation:

Dependencies are displayed by the tracer, and the PR tests seem ok. This may break some stand-alone workflows (esp. Validation) if they use legacy modules, use end-job harvesting, and use `DQMFileSaver`. (Not sure if that combination exists anywhere).

@wddgit @makortel FYI.