### PR TITLE
Add GEM trigger data to EMTF DAQ data format and unpacker

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTF/Counters.h
+++ b/DataFormats/L1TMuon/interface/EMTF/Counters.h
@@ -10,7 +10,9 @@ namespace l1t {
     public:
       explicit Counters(uint64_t dataword);
 
-      // rpc_counter not yet implemented in FW - AWB 31.01.16
+      // TODO: rpc_counter not yet implemented in FW - AWB 31.01.16
+      // TODO: gem_counter not yet implemented in FW - JS 01.07.20
+      // Autogenerate this class?
       Counters()
           : me1a_1(-99),
             me1a_2(-99),

--- a/DataFormats/L1TMuon/interface/EMTF/EventHeader.h
+++ b/DataFormats/L1TMuon/interface/EMTF/EventHeader.h
@@ -34,6 +34,8 @@ namespace l1t {
             me4(-99),
             cppf(-99),
             cppf_crc(-99),
+            gem(-99),
+            gem_crc(-99),
             format_errors(0),
             dataword(-99){};
 
@@ -62,6 +64,8 @@ namespace l1t {
       void set_me4(int bits) { me4 = bits; }
       void set_cppf(int bits) { cppf = bits; }
       void set_cppf_crc(int bits) { cppf_crc = bits; }
+      void set_gem(int bits) { gem = bits; }
+      void set_gem_crc(int bits) { gem_crc = bits; }
       void add_format_error() { format_errors += 1; }
       void set_dataword(uint64_t bits) { dataword = bits; }
 
@@ -88,6 +92,8 @@ namespace l1t {
       int ME4() const { return me4; }
       int CPPF() const { return cppf; }
       int CPPF_CRC() const { return cppf_crc; }
+      int GEM() const { return gem; }
+      int GEM_CRC() const { return gem_crc; }
       int Format_errors() const { return format_errors; }
       uint64_t Dataword() const { return dataword; }
 
@@ -115,6 +121,8 @@ namespace l1t {
       int me4;
       int cppf;
       int cppf_crc;
+      int gem;
+      int gem_crc;
       int format_errors;
       uint64_t dataword;
 

--- a/DataFormats/L1TMuon/interface/EMTF/GEM.h
+++ b/DataFormats/L1TMuon/interface/EMTF/GEM.h
@@ -1,0 +1,86 @@
+// Class for Gas-Electron Multiplier (GEM) EMTF Data Record
+
+#ifndef __l1t_emtf_GEM_h__
+#define __l1t_emtf_GEM_h__
+
+#include <vector>
+#include <cstdint>
+
+namespace l1t {
+  namespace emtf {
+    class GEM {
+    public:
+      explicit GEM(const uint64_t dataword);
+
+      GEM()
+          : pad(-99),
+            partition(-99),
+            cluster_size(-99),
+            cluster_id(-99),
+            link(-99),
+            gem_bxn(-99),
+            bc0(-99),
+            tbin(-99),
+            vp(-99),
+            format_errors(0),
+            dataword(-99){};
+
+      virtual ~GEM() = default;
+
+      inline void set_pad(const int bits) { pad = bits; }
+      inline void set_partition(const int bits) { partition = bits; }
+      inline void set_cluster_size(const int bits) { cluster_size = bits; }
+      inline void set_cluster_id(const int bits) { cluster_id = bits; }
+      inline void set_link(const int bits) { link = bits; }
+      inline void set_gem_bxn(const int bits) { gem_bxn = bits; }
+      inline void set_bc0(const int bits) { bc0 = bits; }
+      inline void set_tbin(const int bits) { tbin = bits; }
+      inline void set_vp(const int bits) { vp = bits; }
+      inline void add_format_error() { format_errors += 1; }
+      inline void set_dataword(const uint64_t bits) { dataword = bits; }
+
+      /// Returns the lowest pad (strip pair, i.e., local phi) of the cluster
+      inline int Pad() const { return pad; }
+      /// Returns the eta partition (local eta) of the cluster
+      inline int Partition() const { return partition; }
+      /// Returns the size (in pads) of the cluster
+      inline int ClusterSize() const { return cluster_size; }
+      /// Returns the the cluster ID within the link
+      inline int ClusterID() const { return cluster_id; }
+      /// Returns the input link of the cluster
+      inline int Link() const { return link; }
+      /// Returns the BX ID of the cluster
+      inline int GEM_BXN() const { return gem_bxn; }
+      /// Returns whether the cluster has BC0
+      inline int BC0() const { return bc0; }
+      /// Returns the time bin of the cluster
+      inline int TBIN() const { return tbin; }
+      /// Returns the valid flag? of the cluster
+      inline int VP() const { return vp; }
+      /// Returns the format errors associated with the cluster
+      inline int Format_errors() const { return format_errors; }
+      /// Returns the raw data word of the cluster
+      inline uint64_t Dataword() const { return dataword; }
+
+    private:
+      int pad;            ///< Pad (strip pair, i.e., local phi) of the GEM cluster
+      int partition;      ///< Partition (local eta) of the GEM cluster
+      int cluster_size;   ///< Size (in pads) of the GEM cluster
+      int cluster_id;     ///< Cluster number of the GEM cluster
+      int link;           ///< Input GEM link of the GEM cluster
+      int gem_bxn;        ///< BX ID of the GEM cluster
+      int bc0;            ///< BC0 valid for the GEM cluster
+      int tbin;           ///< Time bin of the GEM cluster
+      int vp;             ///< Valid status? of the GEM cluster
+      int format_errors;  ///< Number of format errors for the GEM cluster
+      uint64_t dataword;  ///< Raw EMTF DAQ word for the GEM cluster
+
+    };  // End of class GEM
+
+    // Define a vector of GEM
+    typedef std::vector<GEM> GEMCollection;
+
+  }  // End of namespace emtf
+}  // End of namespace l1t
+
+#endif /* define __l1t_emtf_GEM_h__ */

--- a/DataFormats/L1TMuon/interface/EMTFDaqOut.h
+++ b/DataFormats/L1TMuon/interface/EMTFDaqOut.h
@@ -11,6 +11,7 @@
 #include "EMTF/Counters.h"
 #include "EMTF/ME.h"
 #include "EMTF/RPC.h"
+#include "EMTF/GEM.h"
 #include "EMTF/SP.h"
 #include "EMTF/EventTrailer.h"
 #include "EMTF/MTF7Trailer.h"
@@ -32,6 +33,7 @@ namespace l1t {
           hasCounters(false),
           numME(0),
           numRPC(0),
+          numGEM(0),
           numSP(0),
           hasEventTrailer(false),
           hasMTF7Trailer(false),
@@ -78,6 +80,14 @@ namespace l1t {
       RPCCollection.push_back(bits);
       numRPC += 1;
     }
+    void set_GEMCollection(emtf::GEMCollection bits) {
+      GEMCollection = bits;
+      numGEM = GEMCollection.size();
+    }
+    void push_GEM(emtf::GEM bits) {
+      GEMCollection.push_back(bits);
+      numGEM += 1;
+    }
     void set_SPCollection(emtf::SPCollection bits) {
       SPCollection = bits;
       numSP = SPCollection.size();
@@ -108,6 +118,7 @@ namespace l1t {
     int NumSP() const { return numSP; }
     int NumRPC() const { return numRPC; }
     int NumME() const { return numME; }
+    int NumGEM() const { return numGEM; }
     bool HasAMC13Trailer() const { return hasAMC13Trailer; }
     bool HasMTF7Trailer() const { return hasMTF7Trailer; }
     bool HasEventTrailer() const { return hasEventTrailer; }
@@ -117,6 +128,7 @@ namespace l1t {
     emtf::Counters GetCounters() const { return Counters; }
     emtf::MECollection GetMECollection() const { return MECollection; }
     emtf::RPCCollection GetRPCCollection() const { return RPCCollection; }
+    emtf::GEMCollection GetGEMCollection() const { return GEMCollection; }
     emtf::SPCollection GetSPCollection() const { return SPCollection; }
     emtf::EventTrailer GetEventTrailer() const { return EventTrailer; }
     emtf::MTF7Trailer GetMTF7Trailer() const { return MTF7Trailer; }
@@ -127,6 +139,7 @@ namespace l1t {
     const emtf::Counters* PtrCounters() const { return &Counters; }
     const emtf::MECollection* PtrMECollection() const { return &MECollection; }
     const emtf::RPCCollection* PtrRPCCollection() const { return &RPCCollection; }
+    const emtf::GEMCollection* PtrGEMCollection() const { return &GEMCollection; }
     const emtf::SPCollection* PtrSPCollection() const { return &SPCollection; }
     const emtf::EventTrailer* PtrEventTrailer() const { return &EventTrailer; }
     const emtf::MTF7Trailer* PtrMTF7Trailer() const { return &MTF7Trailer; }
@@ -141,6 +154,7 @@ namespace l1t {
     bool hasCounters;
     int numME;
     int numRPC;
+    int numGEM;
     int numSP;
     bool hasEventTrailer;
     bool hasMTF7Trailer;
@@ -151,6 +165,7 @@ namespace l1t {
     emtf::Counters Counters;
     emtf::MECollection MECollection;
     emtf::RPCCollection RPCCollection;
+    emtf::GEMCollection GEMCollection;
     emtf::SPCollection SPCollection;
     emtf::EventTrailer EventTrailer;
     emtf::MTF7Trailer MTF7Trailer;

--- a/DataFormats/L1TMuon/interface/EMTFTrack.h
+++ b/DataFormats/L1TMuon/interface/EMTFTrack.h
@@ -13,6 +13,14 @@
 
 namespace l1t {
 
+  namespace emtf {
+    // Want a scoped enum, not necessarily a strongly-typed enum.
+    // This is because of all the casting that will be required throughout legacy code
+    // (usage will likely rely on implicit integer casting)
+    enum class EMTFCSCStation { ME1 = 0, ME2, ME3, ME4 };
+    enum class EMTFCSCSection { ME1sub1 = 0, ME1sub2, ME2, ME3, ME4 };
+  }  // namespace emtf
+
   struct EMTFPtLUT {
     uint64_t address;
     uint16_t mode;
@@ -41,6 +49,7 @@ namespace l1t {
           mode(-99),
           mode_CSC(0),
           mode_RPC(0),
+          mode_GEM(0),
           mode_neighbor(0),
           mode_inv(-99),
           rank(-99),
@@ -79,6 +88,7 @@ namespace l1t {
       numHits = 0;
       mode_CSC = 0;
       mode_RPC = 0;
+      mode_GEM = 0;
       mode_neighbor = 0;
     }
 
@@ -89,6 +99,8 @@ namespace l1t {
         mode_CSC |= (1 << (4 - hit.Station()));
       if (hit.Is_RPC())
         mode_RPC |= (1 << (4 - hit.Station()));
+      if (hit.Is_GEM())
+        mode_GEM |= (1 << (4 - hit.Station()));
       if (hit.Neighbor())
         mode_neighbor |= (1 << (4 - hit.Station()));
     }
@@ -146,6 +158,7 @@ namespace l1t {
     int Mode() const { return mode; }
     int Mode_CSC() const { return mode_CSC; }
     int Mode_RPC() const { return mode_RPC; }
+    int Mode_GEM() const { return mode_GEM; }
     int Mode_neighbor() const { return mode_neighbor; }
     int Mode_inv() const { return mode_inv; }
     int Rank() const { return rank; }
@@ -179,12 +192,13 @@ namespace l1t {
 
     EMTFPtLUT _PtLUT;
 
-    int endcap;         //    +/-1.  For ME+ and ME-.
-    int sector;         //  1 -  6.
-    int sector_idx;     //  0 - 11.  0 - 5 for ME+, 6 - 11 for ME-.
-    int mode;           //  0 - 15.
-    int mode_CSC;       //  0 - 15, CSC-only
-    int mode_RPC;       //  0 - 15, RPC-only
+    int endcap;      //    +/-1.  For ME+ and ME-.
+    int sector;      //  1 -  6.
+    int sector_idx;  //  0 - 11.  0 - 5 for ME+, 6 - 11 for ME-.
+    int mode;        //  0 - 15.
+    int mode_CSC;    //  0 - 15, CSC-only
+    int mode_RPC;    //  0 - 15, RPC-only
+    int mode_GEM;  //  0 - 15, GEM-only // TODO: verify if needed when including GEM, also start the good habit of documenting these
     int mode_neighbor;  // 0 - 15, only neighbor hits
     int mode_inv;       // 15 -  0.
     int rank;           //  0 - 127  (Range? - AWB 03.03.17)

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -41,6 +41,12 @@ namespace l1t {
     // Layer always filled as 1, as layer 2 is only used in the barrel
   }
 
+  GEMDetId EMTFHit::CreateGEMDetId() const {
+    return GEMDetId((endcap == 1) ? 1 : -1, ring, station, layer, chamber, roll);
+  }
+
+  ME0DetId EMTFHit::CreateME0DetId() const { return ME0DetId((endcap == 1) ? 1 : -1, layer, chamber, roll); }
+
   CPPFDigi EMTFHit::CreateCPPFDigi() const {
     if (!Is_RPC())
       return CPPFDigi();
@@ -88,5 +94,12 @@ namespace l1t {
   // RPCDigi EMTFHit::CreateRPCDigi() const {
   //   return RPCDigi( (strip_hi + strip_lo) / 2, bx + CSCConstants::LCT_CENTRAL_BX );
   // }
+
+  GEMPadDigiCluster EMTFHit::CreateGEMPadDigiCluster() const {
+    std::vector<uint16_t> pads;
+    for (int i = Pad_low(); i < Pad_hi(); ++i)
+      pads.emplace_back(static_cast<uint16_t>(i));
+    return GEMPadDigiCluster(pads, bx);
+  }
 
 }  // End namespace l1t

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -22,6 +22,8 @@
   <class name="l1t::emtf::MECollection"/>
   <class name="l1t::emtf::RPC"/>
   <class name="l1t::emtf::RPCCollection"/>
+  <class name="l1t::emtf::GEM"/>
+  <class name="l1t::emtf::GEMCollection"/>
   <class name="l1t::emtf::SP"/>
   <class name="l1t::emtf::SPCollection"/>
   <class name="l1t::emtf::EventTrailer"/>

--- a/EventFilter/L1TRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/L1TRawToDigi/plugins/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="DataFormats/L1TCalorimeter"/>
 <use name="DataFormats/TCDS"/>
 <use name="DataFormats/EcalDigi"/>
+<use name="DataFormats/GEMDigi"/>
 <use name="DataFormats/HcalDigi"/>
 <use name="DataFormats/L1CaloTrigger"/>
 <use name="L1Trigger/L1TCalorimeter"/>

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -1,0 +1,257 @@
+// Code to unpack the "GEM Data Record"
+
+#include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
+
+#include "EMTFCollections.h"
+#include "EMTFUnpackerTools.h"
+
+namespace l1t {
+  namespace stage2 {
+    namespace emtf {
+
+      class GEMBlockUnpacker : public Unpacker {
+      public:
+        virtual int checkFormat(const Block& block);
+        // virtual bool checkFormat() override; // Return "false" if block format does not match expected format
+        bool unpack(const Block& block, UnpackerCollections* coll) override;
+        // virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
+      };
+
+      // class GEMBlockPacker : public Packer {
+      // public:
+      // 	virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+      // };
+
+    }  // namespace emtf
+  }    // namespace stage2
+}  // namespace l1t
+
+namespace l1t {
+  namespace stage2 {
+    namespace emtf {
+
+      int GEMBlockUnpacker::checkFormat(const Block& block) {
+        auto payload = block.payload();
+        int errors = 0;
+
+        // Check the number of 16-bit words
+        if (payload.size() != 4) {
+          errors += 1;
+          edm::LogError("L1T|EMTF") << "Payload size in 'GEM Data Record' is different than expected";
+        }
+
+        // Check that each word is 16 bits
+        for (size_t i = 0; i < 4; ++i) {
+          if (GetHexBits(payload[i], 16, 31) != 0) {
+            errors += 1;
+            edm::LogError("L1T|EMTF") << "Payload[" << i << "] has more than 16 bits in 'GEM Data Record'";
+          }
+        }
+
+        uint16_t GEMa = payload[0];
+        uint16_t GEMb = payload[1];
+        uint16_t GEMc = payload[2];
+        uint16_t GEMd = payload[3];
+
+        // Check Format
+        if (GetHexBits(GEMa, 15, 15) != 1) {
+          errors += 1;
+          edm::LogError("L1T|EMTF") << "Format identifier bits in GEMa are incorrect";
+        }
+        if (GetHexBits(GEMb, 15, 15) != 1) {
+          errors += 1;
+          edm::LogError("L1T|EMTF") << "Format identifier bits in GEMb are incorrect";
+        }
+        if (GetHexBits(GEMc, 15, 15) != 1) {
+          errors += 1;
+          edm::LogError("L1T|EMTF") << "Format identifier bits in GEMc are incorrect";
+        }
+        if (GetHexBits(GEMd, 15, 15) != 0) {
+          errors += 1;
+          edm::LogError("L1T|EMTF") << "Format identifier bits in GEMd are incorrect";
+        }
+
+        return errors;
+      }
+
+      /**
+       * \brief Converts station, ring, sector, subsector, neighbor, and segment from the GEM output
+       * \param station
+       * \param ring
+       * \param sector
+       * \param subsector
+       * \param neighbor
+       * \param segment
+       * \param evt_sector
+       * \param frame
+       * \param word
+       * \param link is the "link index" field (0 - 6) in the EMTF DAQ document, not "link number" (1 - 7)
+      */
+      void convert_GEM_location(int& station,
+                                int& ring,
+                                int& sector,
+                                int& subsector,
+                                int& neighbor,
+                                int& layer,  // is this correct for the GEM case?
+                                const int evt_sector,
+                                const int cluster_id,  // used to differentiate between GEM layer 1/2
+                                const int link) {
+        station = -99;  // station is not encoded in the GEM frame
+        ring = 1;       // GEMs are only in GE1/1 and GE2/1
+        sector = -99;
+        subsector = -99;
+        neighbor = -99;
+        layer = -99;  // the GEM layer is 1 or 2, depending on the cluster ID
+
+        // Neighbor indicated by link == 6
+        sector = (link != 6 ? evt_sector : (evt_sector == 1 ? 6 : evt_sector - 1));
+        subsector = (link != 6 ? link : 0);  // TODO: verify subsector 0 in the neighbouring sector?
+        neighbor = (link == 6 ? 1 : 0);  // TODO: verify that 6 is for the neighbour, not 0 (as written in EMTFBlockRPC)
+        layer = (cluster_id % 8);        // + 1 if layer should be 1 or 2, otherwise layer is 0 or 1
+      }
+
+      /**
+       * \brief Unpack the GEM payload in the EMTF DAQ payload
+       *
+       * The GEM payload consists of up to 14 clusters per link (for the two GEM layers)
+       * 7 links (including neighbour).
+       * The EMTF firmware packs each cluster word into one 64-bit EMTF record, and
+       * that is what is unpacked here.
+       */
+      bool GEMBlockUnpacker::unpack(const Block& block, UnpackerCollections* coll) {
+        // std::cout << "Inside EMTFBlockGEM.cc: unpack" << std::endl;
+
+        // Get the payload for this block, made up of 16-bit words (0xffff)
+        // Format defined in MTF7Payload::getBlock() in src/Block.cc
+        // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
+        auto payload = block.payload();
+
+        // Check Format of Payload
+        l1t::emtf::GEM GEM_;
+        for (int err = 0; err < checkFormat(block); ++err) {
+          GEM_.add_format_error();
+        }
+
+        // Assign payload to 16-bit words
+        uint16_t GEMa = payload[0];
+        uint16_t GEMb = payload[1];
+        uint16_t GEMc = payload[2];
+        uint16_t GEMd = payload[3];
+
+        // res is a pointer to a collection of EMTFDaqOut class objects
+        // There is one EMTFDaqOut for each MTF7 (60 deg. sector) in the event
+        EMTFDaqOutCollection* res;
+        res = static_cast<EMTFCollections*>(coll)->getEMTFDaqOuts();
+        int iOut = res->size() - 1;
+
+        EMTFHitCollection* res_hit;
+        res_hit = static_cast<EMTFCollections*>(coll)->getEMTFHits();
+        EMTFHit Hit_;
+
+        // TODO: Verify this is correct for GEM
+        GEMPadDigiClusterCollection* res_GEM;
+        res_GEM = static_cast<EMTFCollections*>(coll)->getEMTFGEMPadClusters();
+
+        ////////////////////////////
+        // Unpack the GEM Data Record
+        ////////////////////////////
+
+        GEM_.set_pad(GetHexBits(GEMa, 0, 8));
+        GEM_.set_partition(GetHexBits(GEMa, 9, 11));
+        GEM_.set_cluster_size(GetHexBits(GEMa, 12, 14));
+
+        GEM_.set_cluster_id(GetHexBits(GEMb, 8, 11));
+        GEM_.set_link(GetHexBits(GEMb, 12, 14));
+
+        GEM_.set_gem_bxn(GetHexBits(GEMc, 0, 11));
+        GEM_.set_bc0(GetHexBits(GEMc, 14, 14));
+
+        GEM_.set_tbin(GetHexBits(GEMd, 0, 2));
+        GEM_.set_vp(GetHexBits(GEMd, 3, 3));
+
+        // GEM_.set_dataword(uint64_t dataword);
+
+        // Convert specially-encoded GEM quantities
+        // TODO: is the RPC or CSC method for this function better... - JS 06.07.20
+        int _station, _ring, _sector, _subsector, _neighbor, _layer;
+        convert_GEM_location(_station,
+                             _ring,
+                             _sector,
+                             _subsector,
+                             _neighbor,
+                             _layer,
+                             (res->at(iOut)).PtrEventHeader()->Sector(),
+                             GEM_.ClusterID(),
+                             GEM_.Link());
+
+        // Rotate by 20 deg to match GEM convention in CMSSW) // FIXME VERIFY
+        // int _sector_gem = (_subsector < 5) ? _sector : (_sector % 6) + 1; //
+        int _sector_gem = _sector;
+        // Rotate by 2 to match GEM convention in CMSSW (GEMDetId.h) // FIXME VERIFY
+        int _subsector_gem = ((_subsector + 1) % 6) + 1;
+        // Define chamber number) // FIXME VERIFY
+        int _chamber = (_sector_gem - 1) * 6 + _subsector_gem;
+        // Define CSC-like subsector) // FIXME WHY?? VERIFY
+        int _subsector_csc = (_station != 1) ? 0 : ((_chamber % 6 > 2) ? 1 : 2);
+
+        Hit_.set_station(_station);
+        Hit_.set_ring(_ring);
+        Hit_.set_sector(_sector);
+        Hit_.set_subsector(_subsector_csc);
+        Hit_.set_chamber(_chamber);
+        Hit_.set_neighbor(_neighbor);
+
+        // Fill the EMTFHit
+        ImportGEM(Hit_, GEM_, (res->at(iOut)).PtrEventHeader()->Endcap(), (res->at(iOut)).PtrEventHeader()->Sector());
+
+        // Set the stub number for this hit
+        // Each chamber can send up to 2 stubs per BX // FIXME is this true for GEM, are stubs relevant for GEMs?
+        // Also count stubs in corresponding CSC chamber; GEM hit counting is on top of LCT counting
+        Hit_.set_stub_num(0);
+        // See if matching hit is already in event record
+        bool exact_duplicate = false;
+        for (auto const& iHit : *res_hit) {
+          if (Hit_.BX() == iHit.BX() && Hit_.Endcap() == iHit.Endcap() && Hit_.Station() == iHit.Station() &&
+              Hit_.Chamber() == iHit.Chamber()) {
+            if ((iHit.Is_CSC() == 1 && iHit.Ring() == 2) ||
+                (iHit.Is_GEM() == 1)) {  // Copied from RPC, but GEM has no ring 2/3...
+              if (Hit_.Neighbor() == iHit.Neighbor()) {
+                Hit_.set_stub_num(Hit_.Stub_num() + 1);
+                if (iHit.Is_GEM() == 1 && iHit.Ring() == Hit_.Ring() && iHit.Roll() == Hit_.Roll() &&
+                    iHit.Pad() == Hit_.Pad()) {
+                  exact_duplicate = true;
+                }
+              }
+            }
+          }
+        }  // End loop: for (auto const & iHit : *res_hit)
+
+        if (exact_duplicate)
+          edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate GEM digis: BX " << Hit_.BX() << ", endcap "
+                                      << Hit_.Endcap() << ", station " << Hit_.Station() << ", neighbor "
+                                      << Hit_.Neighbor() << ", ring " << Hit_.Ring() << ", chamber " << Hit_.Chamber()
+                                      << ", roll " << Hit_.Roll() << ", pad " << Hit_.Pad() << std::endl;
+
+        (res->at(iOut)).push_GEM(GEM_);
+        if (!exact_duplicate)
+          res_hit->push_back(Hit_);
+
+        if (!exact_duplicate)
+          res_GEM->insertDigi(Hit_.GEM_DetId(), Hit_.CreateGEMPadDigiCluster());
+
+        // Finished with unpacking one GEM Data Record
+        return true;
+
+      }  // End bool GEMBlockUnpacker::unpack
+
+      // bool GEMBlockPacker::pack(const Block& block, UnpackerCollections *coll) {
+      // 	std::cout << "Inside GEMBlockPacker::pack" << std::endl;
+      // 	return true;
+      // } // End bool GEMBlockPacker::pack
+
+    }  // End namespace emtf
+  }    // End namespace stage2
+}  // End namespace l1t
+
+DEFINE_L1T_UNPACKER(l1t::stage2::emtf::GEMBlockUnpacker);
+// DEFINE_L1T_PACKER(l1t::stage2::emtf::GEMBlockPacker);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockHeaders.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockHeaders.cc
@@ -177,7 +177,7 @@ namespace l1t {
         uint16_t HD1b = payload[1];
         // uint16_t HD1c = payload[2];
         uint16_t HD1d = payload[3];
-        // uint16_t HD2a = payload[4];
+        uint16_t HD2a = payload[4];
         uint16_t HD2b = payload[5];
         uint16_t HD2c = payload[6];
         uint16_t HD2d = payload[7];
@@ -284,6 +284,8 @@ namespace l1t {
         EventHeader_.set_me4(GetHexBits(HD3d, 0, 10));
         EventHeader_.set_cppf(GetHexBits(HD3a, 11, 14, HD3b, 11, 13));
         EventHeader_.set_cppf_crc(GetHexBits(HD3c, 11, 14, HD3d, 11, 13));
+        EventHeader_.set_gem(GetHexBits(HD2a, 0, 6));
+        EventHeader_.set_gem_crc(GetHexBits(HD2a, 7, 11, HD3a, 9, 10));
         // EventHeader_.set_dataword(uint64_t bits)  { dataword = bits;  };
 
       write_Event:

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -93,9 +93,9 @@ namespace l1t {
           int arr[] = {_station, new_csc_ID, new_sector, -1, 0};
           std::vector<int> vec(arr, arr + 5);
           return vec;
-        } else if (_station == 5)
+        } else if (_station == 5) {
           new_sector = (_sector != 1) ? _sector - 1 : 6;  // Indicates neighbor chamber, don't return yet
-        else {
+        } else {
           int arr[] = {_station, _csc_ID, _sector, -99, -99};
           std::vector<int> vec(arr, arr + 5);
           return vec;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
@@ -20,7 +20,7 @@ namespace l1t {
         }
       }
       for (const auto& h : *EMTFHits_) {
-        if (has_LCT[h.Sector_idx()] || h.Is_RPC() == 0) {
+        if (has_LCT[h.Sector_idx()] || (h.Is_RPC() == 0 && h.Is_GEM() == 0)) {
           EMTFHits_ZS_->push_back(h);
         }
       }
@@ -30,6 +30,13 @@ namespace l1t {
           EMTFCPPFs_ZS_->push_back(c);
         }
       }
+      // TODO: Do we need something equivalent for GEMs - JS 03.07.20
+      // for (const auto& g : *EMTFGEMPadClusters_) {
+      //   int sect_idx = g.emtf_sector() - 1 + 6 * (g.gemId().region() == -1);
+      //   if (has_LCT[sect_idx]) {
+      //     EMTFGEMPadClusters_ZS_->push_back(g);
+      //   }
+      // }
 
       event_.put(std::move(regionalMuonCands_));
       event_.put(std::move(EMTFDaqOuts_));
@@ -37,6 +44,8 @@ namespace l1t {
       event_.put(std::move(EMTFTracks_));
       event_.put(std::move(EMTFLCTs_));
       event_.put(std::move(EMTFCPPFs_ZS_));
+      event_.put(std::move(EMTFGEMPadClusters_));
+      // event_.put(std::move(EMTFGEMPadClusters_ZS_));
     }
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
@@ -11,6 +11,7 @@
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 
 #include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
 
@@ -32,12 +33,13 @@ namespace l1t {
             EMTFTracks_(new EMTFTrackCollection()),
             EMTFLCTs_(new CSCCorrelatedLCTDigiCollection()),
             EMTFCPPFs_(new CPPFDigiCollection()),
-            EMTFCPPFs_ZS_(new CPPFDigiCollection()){};
+            EMTFCPPFs_ZS_(new CPPFDigiCollection()),
+            EMTFGEMPadClusters_(std::make_unique<GEMPadDigiClusterCollection>()),
+            EMTFGEMPadClusters_ZS_(std::make_unique<GEMPadDigiClusterCollection>()){};
 
       ~EMTFCollections() override;
 
       inline RegionalMuonCandBxCollection* getRegionalMuonCands() { return regionalMuonCands_.get(); }
-      // How does this work?  I haven't even defined a "get()" function for the EMTFDaqOutCollection. - AWB 28.01.16
       inline EMTFDaqOutCollection* getEMTFDaqOuts() { return EMTFDaqOuts_.get(); }
       inline EMTFHitCollection* getEMTFHits() { return EMTFHits_.get(); }
       inline EMTFHitCollection* getEMTFHits_ZS() { return EMTFHits_ZS_.get(); }
@@ -45,6 +47,8 @@ namespace l1t {
       inline CSCCorrelatedLCTDigiCollection* getEMTFLCTs() { return EMTFLCTs_.get(); }
       inline CPPFDigiCollection* getEMTFCPPFs() { return EMTFCPPFs_.get(); }
       inline CPPFDigiCollection* getEMTFCPPFs_ZS() { return EMTFCPPFs_ZS_.get(); }
+      inline GEMPadDigiClusterCollection* getEMTFGEMPadClusters() { return EMTFGEMPadClusters_.get(); }
+      inline GEMPadDigiClusterCollection* getEMTFGEMPadClusters_ZS() { return EMTFGEMPadClusters_ZS_.get(); }
 
     private:
       std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCands_;
@@ -55,6 +59,8 @@ namespace l1t {
       std::unique_ptr<CSCCorrelatedLCTDigiCollection> EMTFLCTs_;
       std::unique_ptr<CPPFDigiCollection> EMTFCPPFs_;
       std::unique_ptr<CPPFDigiCollection> EMTFCPPFs_ZS_;
+      std::unique_ptr<GEMPadDigiClusterCollection> EMTFGEMPadClusters_;
+      std::unique_ptr<GEMPadDigiClusterCollection> EMTFGEMPadClusters_ZS_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
@@ -41,6 +41,7 @@ namespace l1t {
       prod.produces<EMTFTrackCollection>();
       prod.produces<CSCCorrelatedLCTDigiCollection>();
       prod.produces<CPPFDigiCollection>();
+      prod.produces<GEMPadDigiClusterCollection>();
     }
 
     std::unique_ptr<UnpackerCollections> EMTFSetup::getCollections(edm::Event& e) {
@@ -61,21 +62,25 @@ namespace l1t {
           UnpackerFactory::get()->make("stage2::emtf::CountersBlockUnpacker");             // Unpack "Block of Counters"
       auto emtf_me_unp = UnpackerFactory::get()->make("stage2::emtf::MEBlockUnpacker");    // Unpack "ME Data Record"
       auto emtf_rpc_unp = UnpackerFactory::get()->make("stage2::emtf::RPCBlockUnpacker");  // Unpack "RPC Data Record"
+      auto emtf_gem_unp = UnpackerFactory::get()->make("stage2::emtf::GEMBlockUnpacker");  // Unpack "GEM Data Record"
+      // auto emtf_me0_unp = UnpackerFactory::get()->make("stage2::emtf::ME0BlockUnpacker"); // Unpack "ME0 Data Record"
       auto emtf_sp_unp =
           UnpackerFactory::get()->make("stage2::emtf::SPBlockUnpacker");  // Unpack "SP Output Data Record"
       auto emtf_trailers_unp =
           UnpackerFactory::get()->make("stage2::emtf::TrailersBlockUnpacker");  // Unpack "Event Record Trailer"
 
-      emtf_me_unp->setAlgoVersion(
-          fw);  // Currently only the CSC LCT unpacking needs the firmware version, can add others as needed - AWB 09.04.18
+      // Currently only the CSC LCT unpacking needs the firmware version, can add others as needed - AWB 09.04.18
+      emtf_me_unp->setAlgoVersion(fw);
 
       // Index of res is block->header().getID(), matching block_patterns_ in src/Block.cc
-      res[511] = emtf_headers_unp;
-      res[2] = emtf_counters_unp;
-      res[3] = emtf_me_unp;
-      res[4] = emtf_rpc_unp;
-      res[101] = emtf_sp_unp;
-      res[255] = emtf_trailers_unp;
+      res[l1t::mtf7::EvHd] = emtf_headers_unp;
+      res[l1t::mtf7::CnBlk] = emtf_counters_unp;
+      res[l1t::mtf7::ME] = emtf_me_unp;
+      res[l1t::mtf7::RPC] = emtf_rpc_unp;
+      res[l1t::mtf7::GEM] = emtf_gem_unp;
+      // res[l1t::mtf7::ME0]  = emtf_me0_unp;
+      res[l1t::mtf7::SPOut] = emtf_sp_unp;
+      res[l1t::mtf7::EvTr] = emtf_trailers_unp;
 
       return res;
     }  // End virtual UnpackerMap getUnpackers

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
@@ -7,7 +7,6 @@
 namespace l1t {
   namespace stage2 {
     EMTFTokens::EMTFTokens(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) {
-      // std::cout << "Inside EMTFTokens.cc: EMTFTokens" << std::endl;
       auto tag = cfg.getParameter<edm::InputTag>("InputLabel");
 
       regionalMuonCandToken_ = cc.consumes<RegionalMuonCandBxCollection>(tag);
@@ -16,6 +15,7 @@ namespace l1t {
       EMTFTrackToken_ = cc.consumes<EMTFTrackCollection>(tag);
       EMTFLCTToken_ = cc.consumes<CSCCorrelatedLCTDigiCollection>(tag);
       EMTFCPPFToken_ = cc.consumes<CPPFDigiCollection>(tag);
+      EMTFGEMPadClusterToken_ = cc.consumes<GEMPadDigiClusterCollection>(tag);
     }
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
@@ -7,6 +7,7 @@
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "EventFilter/L1TRawToDigi/interface/PackerTokens.h"
 
@@ -24,6 +25,9 @@ namespace l1t {
       inline const edm::EDGetTokenT<EMTFTrackCollection>& getEMTFTrackToken() const { return EMTFTrackToken_; }
       inline const edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>& getEMTFLCTToken() const { return EMTFLCTToken_; }
       inline const edm::EDGetTokenT<CPPFDigiCollection>& getEMTFCPPFToken() const { return EMTFCPPFToken_; }
+      inline const edm::EDGetTokenT<GEMPadDigiClusterCollection>& getEMTFGEMPadClusterToken() const {
+        return EMTFGEMPadClusterToken_;
+      }
 
     private:
       edm::EDGetTokenT<RegionalMuonCandBxCollection> regionalMuonCandToken_;
@@ -32,6 +36,7 @@ namespace l1t {
       edm::EDGetTokenT<EMTFTrackCollection> EMTFTrackToken_;
       edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> EMTFLCTToken_;
       edm::EDGetTokenT<CPPFDigiCollection> EMTFCPPFToken_;
+      edm::EDGetTokenT<GEMPadDigiClusterCollection> EMTFGEMPadClusterToken_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
@@ -18,7 +18,7 @@ namespace l1t {
         _hit.set_sync_err(_ME.SE());
         _hit.set_bx(_ME.TBIN() - 3);
         _hit.set_bc0(_ME.BC0());
-        _hit.set_subsystem(1);  // 1 for CSC
+        _hit.set_subsystem(l1tmu::TriggerPrimitive::kCSC);
         // _hit.set_layer();
 
         _hit.set_ring(L1TMuonEndCap::calc_ring(_hit.Station(), _hit.CSC_ID(), _hit.Strip()));
@@ -43,7 +43,7 @@ namespace l1t {
         _hit.set_bx(_RPC.TBIN() - 3);
         _hit.set_valid(_RPC.VP());
         _hit.set_bc0(_RPC.BC0());
-        _hit.set_subsystem(2);  // 2 for RPC
+        _hit.set_subsystem(l1tmu::TriggerPrimitive::kRPC);
 
         _hit.SetRPCDetId(_hit.CreateRPCDetId());
         // // Not yet implemented - AWB 15.03.17
@@ -59,6 +59,36 @@ namespace l1t {
         // EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockRPC.cc - AWB 02.05.17
 
       }  // End ImportRPC
+
+      void ImportGEM(EMTFHit& _hit, const l1t::emtf::GEM& _GEM, const int _endcap, const int _evt_sector) {
+        constexpr uint8_t GEM_MAX_CLUSTERS_PER_LAYER = 8;
+        _hit.set_endcap(_endcap == 1 ? 1 : -1);
+        _hit.set_sector_idx(_endcap == 1 ? _evt_sector - 1 : _evt_sector + 5);
+
+        _hit.set_pad(_GEM.Pad());
+        _hit.set_pad_hi(_GEM.Pad() + (_GEM.ClusterSize() - 1));
+        _hit.set_pad_low(_GEM.Pad());
+        _hit.set_partition(_GEM.Partition());
+        // TODO: verify layer naming is 0/1 and not 1/2
+        _hit.set_layer(_GEM.ClusterID() < GEM_MAX_CLUSTERS_PER_LAYER ? 0 : 1);
+        _hit.set_cluster_size(_GEM.ClusterSize());
+        _hit.set_cluster_id(_GEM.ClusterID());
+        // TODO: FIXME is this value known for GEM? - JS 13.07.20
+        _hit.set_bx(_GEM.TBIN() - 3);
+        _hit.set_valid(_GEM.VP());
+        _hit.set_bc0(_GEM.BC0());
+        _hit.set_subsystem(l1tmu::TriggerPrimitive::kGEM);
+
+        _hit.set_ring(1);  // GEM only on ring 1
+        // TODO: FIXME correct for GEM, should match CSC chamber, but GEM have 2 chambers (layers in a superchamber) per CSC chamber - JS 13.07.20
+        // _hit.set_chamber(L1TMuonEndCap::calc_chamber(_hit.Station(), _hit.Sector(), _hit.Subsector(), _hit.Ring(), _hit.GEM_ID()));
+        _hit.SetGEMDetId(_hit.CreateGEMDetId());
+        // _hit.SetGEMDigi(_hit.CreateGEMPadDigi());
+
+        // Station, Ring, Sector, Subsector, and Neighbor filled in
+        // EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockGEM.cc - JS 13.07.20
+
+      }  // End ImportGEM
 
       void ImportSP(EMTFTrack& _track, const l1t::emtf::SP _SP, const int _endcap, const int _evt_sector) {
         _track.set_endcap((_endcap == 1) ? 1 : -1);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.h
@@ -21,6 +21,7 @@ namespace l1t {
 
       void ImportME(EMTFHit& _hit, const l1t::emtf::ME _ME, const int _endcap, const int _evt_sector);
       void ImportRPC(EMTFHit& _hit, const l1t::emtf::RPC _RPC, const int _endcap, const int _evt_sector);
+      void ImportGEM(EMTFHit& _hit, const l1t::emtf::GEM& _GEM, const int _endcap, const int _evt_sector);
       void ImportSP(EMTFTrack& _track, const l1t::emtf::SP _SP, const int _endcap, const int _evt_sector);
 
       // Integer version of pow() - returns base^exp

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -9,17 +9,15 @@
 namespace l1t {
 
   const std::vector<unsigned int> MTF7Payload::block_patterns_ = {
-      // The "0b" prefix indicates binary; the block header id is stored in decimal.
-      // Bits are the left-most bit (D15) of every 16-bit word in the format document.
-      // Bottom-to-top in the document maps to left-to-right in each of the block_patterns_
-      0b000111111111,  // Event Record Header   : block->header().getID() = 511
-      // Left-most bits of 0xA and 0x9 are both 1 in binary
-      0b0010,      // Block of Counters     : block->header().getID() = 2
-      0b0011,      // ME Data Record        : block->header().getID() = 3
-      0b0100,      // RPC Data Record       : block->header().getID() = 4
-      0b01100101,  // SP Output Data Record : block->header().getID() = 101
-      0b11111111   // Event Record Trailer  : block->header().getID() = 255
-                   // Left-most bits of 0xF and 0xE are both 1 in binary
+      // from l1t::mtf7::mtf7_block_t enum definition
+      mtf7::EvHd,   // Event Record Header
+      mtf7::CnBlk,  // Block of Counters
+      mtf7::ME,     // ME Data Record
+      mtf7::RPC,    // RPC Data Record
+      mtf7::GEM,    // GEM Data Record
+      mtf7::ME0,    // ME0 Data Record
+      mtf7::SPOut,  // SP Output Data Record
+      mtf7::EvTr    // Event Record Trailer
   };
 
   uint32_t BlockHeader::raw() const {
@@ -132,8 +130,10 @@ namespace l1t {
     }
 
     // Check bits for EMTF Event Record Trailer, get firmware version
-    algo_ = 0;                        // Firmware version
-    for (int i = 4; i < 1590; i++) {  // Start after Counters block, up to 108 ME / 84 RPC / 3 SP blocks per BX, 8 BX
+    algo_ = 0;  // Firmware version
+
+    // Start after always present Counters block
+    for (unsigned i = DAQ_PAYLOAD_OFFSET; i < PAYLOAD_MAX_SIZE; i++) {
       if (((data16[4 * i + 0] >> 12) == 0xF) && ((data16[4 * i + 1] >> 12) == 0xF) &&
           ((data16[4 * i + 2] >> 12) == 0xF) && ((data16[4 * i + 3] >> 12) == 0xF) &&
           ((data16[4 * i + 4] >> 12) == 0xE) && ((data16[4 * i + 5] >> 12) == 0xE) &&


### PR DESCRIPTION
#### PR description:

This PR brings upcoming changes to the EMTF firmware for including the GEM trigger payload in the EMTF DAQ data.
The EMTF DAQ module firmware has been updated based on the specifications in DN-20-016, and is currently being integrated into the full EMTF firmware, but no data has yet been taken with the new format.

* Implementation for GE1/1 is fully included
* Implementations for GE2/1 and ME0 are yet to be implemented in FW as the protocol for transmission is not yet finalized

With the changes in this PR, there are no expected changes in current output, as the GEM payload is not in any RAW files and is not present in the MC due to the lack of an EMTF packer (future PR with @jiafulow).

Took the opportunity to reduce usage of magic numbers in places where GEM information was added.

#### PR validation:

As there is no EMTF packer, there is no way to currently emulate this new data stream until either data is taken with the new firmware, or the packer is developed.

Standard PR matrix tests were run on both `CMSSW_11_2_0` and `CMSSW_11_1_0`.
```
runTheMatrix.py -l limited -i all --ibeos
```
reported
```
36 34 30 23 16 4 1 1 1 tests passed, 1 1 3 0 0 0 0 0 0 failed
```
but the failed tests also failed in an unmodified release