### PR TITLE
drop type specs in RecoTracker/{SingleTrackPattern, SpecialSeedGenerators, TkSeedGenerator}

### DIFF
--- a/RecoTracker/SingleTrackPattern/python/CosmicTrackFinderP5_cff.py
+++ b/RecoTracker/SingleTrackPattern/python/CosmicTrackFinderP5_cff.py
@@ -1,13 +1,11 @@
 import FWCore.ParameterSet.Config as cms
-
-import copy
 from RecoTracker.SingleTrackPattern.CosmicCandidateFinder_cfi import *
 #cosmictrackfinderP5 = copy.deepcopy(cosmictrackfinder)
 #TEMPORARY FIX: actually it is not yet a candidateMaker
-cosmicCandidateFinderP5 = copy.deepcopy(cosmicCandidateFinder)
-cosmicCandidateFinderP5.GeometricStructure = 'STANDARD'
-cosmicCandidateFinderP5.cosmicSeeds = 'cosmicseedfinderP5'
-
+cosmicCandidateFinderP5 = cosmicCandidateFinder.clone(
+    GeometricStructure = 'STANDARD',
+    cosmicSeeds        = 'cosmicseedfinderP5'
+)
 from RecoTracker.TrackProducer.CosmicFinalFitWithMaterialP5_cff import *
 #import RecoTracker.TrackProducer.TrackRefitter_cfi 
 #cosmictrackfinderP5  = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone(

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
@@ -29,11 +29,11 @@ layerList = cms.vstring('TOB6+TOB5',
                         'TEC1_pos+TOB4'                                   
                         )
 from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import SeedFromConsecutiveHitsCreator as _SeedFromConsecutiveHitsCreator
-CosmicSeedCreator = _SeedFromConsecutiveHitsCreator.clone()
-CosmicSeedCreator.ComponentName = cms.string('CosmicSeedCreator')
-# extra parameter specific to CosmicSeedCreator
-CosmicSeedCreator.maxseeds = cms.int32(10000)
- 
+CosmicSeedCreator = _SeedFromConsecutiveHitsCreator.clone(
+    ComponentName = 'CosmicSeedCreator',
+    # extra parameter specific to CosmicSeedCreator
+    maxseeds      = cms.int32(10000)
+)
 
 regionalCosmicTrackerSeeds = cms.EDProducer( "SeedGeneratorFromRegionHitsEDProducer",
    RegionFactoryPSet = cms.PSet(                                 

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
@@ -29,8 +29,9 @@ def makeSimpleCosmicSeedLayers(*layers):
     #print "SEEDING LAYER LIST = ", layerList
     return layerList
 
-layerInfo = RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi.layerInfo.clone()
-layerInfo.TEC.useSimpleRphiHitsCleaner = False
+layerInfo = RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi.layerInfo.clone(
+    TEC = dict(useSimpleRphiHitsCleaner = False)
+)
 layerList = makeSimpleCosmicSeedLayers('ALL'),
 
 simpleCosmicBONSeeds = cms.EDProducer("SimpleCosmicBONSeeder",

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -4,55 +4,51 @@ import FWCore.ParameterSet.Config as cms
 import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi 
 hitCollectorForCosmicDCSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('hitCollectorForCosmicDCSeeds'),
-    MaxChi2 = cms.double(100.0), ## was 30 ## TO BE TUNED
-    nSigma  = cms.double(4.),    ## was 3  ## TO BE TUNED 
-    MaxDisplacement = cms.double(100),
-    MaxSagitta = cms.double(-1.0),
-    MinimalTolerance = cms.double(0.5),
-    appendToDataLabel = cms.string(''),
+    ComponentName     = 'hitCollectorForCosmicDCSeeds',
+    MaxChi2           = 100.0, ## was 30 ## TO BE TUNED
+    nSigma            = 4.,    ## was 3  ## TO BE TUNED 
+    MaxDisplacement   = 100,
+    MaxSagitta        = -1.0,
+    MinimalTolerance  = 0.5,
+    appendToDataLabel = '',
 )
 cosmicDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
-    src = cms.InputTag("muonsFromCosmics"),
-    cut = cms.string("p > 3 && abs(eta)<1.6 && phi<0"),
-    hitCollector = cms.string('hitCollectorForCosmicDCSeeds'),
-    fromVertex = cms.bool(False),
-    maxEtaForTOB = cms.double(2.5),
-    minEtaForTEC = cms.double(0.0),
+    src          = 'muonsFromCosmics',
+    cut          = 'p > 3 && abs(eta)<1.6 && phi<0',
+    hitCollector = 'hitCollectorForCosmicDCSeeds',
+    fromVertex   = False,
+    maxEtaForTOB = 2.5,
+    minEtaForTEC = 0.0,
 )
 
 # Ckf pattern
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff
 Chi2MeasurementEstimatorForCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.Chi2MeasurementEstimatorForP5.clone(
-    ComponentName = cms.string('Chi2MeasurementEstimatorForCDC'),
+    ComponentName   = 'Chi2MeasurementEstimatorForCDC',
     MaxDisplacement = 500
 )
 
 ckfBaseTrajectoryFilterCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.ckfBaseTrajectoryFilterP5.clone(
-    maxLostHits = 10,
+    maxLostHits       = 10,
     maxConsecLostHits = 10
 )
 
 GroupedCkfTrajectoryBuilderCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.GroupedCkfTrajectoryBuilderP5.clone(
-    maxCand = 3,
+    maxCand   = 3,
     estimator = 'Chi2MeasurementEstimatorForCDC',
-    trajectoryFilter = cms.PSet(
-        refToPSet_ = cms.string('ckfBaseTrajectoryFilterCDC')
-    )
+    trajectoryFilter = dict(refToPSet_ = 'ckfBaseTrajectoryFilterCDC')
 )
 
 import RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff
 cosmicDCCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff.ckfTrackCandidatesP5.clone(
-    src = cms.InputTag( "cosmicDCSeeds" ),
-    TrajectoryBuilderPSet = cms.PSet(
-        refToPSet_ = cms.string('GroupedCkfTrajectoryBuilderCDC')
-    )
+    src = 'cosmicDCSeeds',
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'GroupedCkfTrajectoryBuilderCDC')
 )
 
 # Track producer
 import RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff
 cosmicDCTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWithMaterialTracksCosmics.clone(
-    src = cms.InputTag( "cosmicDCCkfTrackCandidates" ),
+    src = 'cosmicDCCkfTrackCandidates',
 )
 
 # Final Sequence

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -36,13 +36,13 @@ ckfBaseTrajectoryFilterCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP
 GroupedCkfTrajectoryBuilderCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.GroupedCkfTrajectoryBuilderP5.clone(
     maxCand   = 3,
     estimator = 'Chi2MeasurementEstimatorForCDC',
-    trajectoryFilter = dict(refToPSet_ = 'ckfBaseTrajectoryFilterCDC')
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('ckfBaseTrajectoryFilterCDC'))
 )
 
 import RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff
 cosmicDCCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff.ckfTrackCandidatesP5.clone(
     src = 'cosmicDCSeeds',
-    TrajectoryBuilderPSet = dict(refToPSet_ = 'GroupedCkfTrajectoryBuilderCDC')
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('GroupedCkfTrajectoryBuilderCDC'))
 )
 
 # Track producer

--- a/RecoTracker/SpecialSeedGenerators/python/outInSeedsFromStandaloneMuons_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/outInSeedsFromStandaloneMuons_cfi.py
@@ -2,15 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi 
 hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('hitCollectorForOutInMuonSeeds'),
-    MaxChi2 = cms.double(100.0), ## was 30 ## TO BE TUNED
-    nSigma  = cms.double(4.),    ## was 3  ## TO BE TUNED 
+    ComponentName = 'hitCollectorForOutInMuonSeeds',
+    MaxChi2       = 100.0, ## was 30 ## TO BE TUNED
+    nSigma        = 4.,    ## was 3  ## TO BE TUNED 
 )
 
-outInSeedsFromStandaloneMuons = cms.EDProducer("OutsideInMuonSeeder",
+outInSeedsFromStandaloneMuons = cms.EDProducer('OutsideInMuonSeeder',
     ## Input collection of muons, and selection. outerTrack.isNonnull is implicit.
-    src = cms.InputTag("muons"),
-    cut = cms.string("pt > 10 && outerTrack.hitPattern.muonStationsWithValidHits >= 2"),
+    src = cms.InputTag('muons'),
+    cut = cms.string('pt > 10 && outerTrack.hitPattern.muonStationsWithValidHits >= 2'),
     layersToTry = cms.int32(3), # try up to 3 layers where at least one seed is found
     hitsToTry = cms.int32(3),   # use at most 3 hits from the same layer
     ## Use as state the muon updated ad vertex (True) or the innermost state of the standalone track (False)

--- a/RecoTracker/TkNavigation/python/BeamHaloNavigationSchoolESProducer_cfi.py
+++ b/RecoTracker/TkNavigation/python/BeamHaloNavigationSchoolESProducer_cfi.py
@@ -1,8 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkNavigation.NavigationSchoolESProducer_cfi import *
-beamHaloNavigationSchoolESProducer = navigationSchoolESProducer.clone()
-beamHaloNavigationSchoolESProducer.ComponentName       = cms.string('BeamHaloNavigationSchool')
-beamHaloNavigationSchoolESProducer.SimpleMagneticField = cms.string('')
-
-
+beamHaloNavigationSchoolESProducer = navigationSchoolESProducer.clone(
+    ComponentName       = 'BeamHaloNavigationSchool',
+    SimpleMagneticField = '',
+)

--- a/RecoTracker/TkSeedGenerator/python/GlobalMixedSeeds_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalMixedSeeds_cff.py
@@ -19,9 +19,9 @@ from RecoTracker.TkSeedingLayers.MixedLayerPairs_cfi import *
 
 import RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi
 globalMixedSeeds = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi.seedGeneratorFromRegionHitsEDProducer.clone(
-    OrderedHitsFactoryPSet = cms.PSet(
-       ComponentName = cms.string('StandardHitPairGenerator'),
-       SeedingLayers = cms.InputTag('MixedLayerPairs'),
-       maxElement = cms.uint32(1000000)
+    OrderedHitsFactoryPSet = dict(
+       ComponentName = 'StandardHitPairGenerator',
+       SeedingLayers = 'MixedLayerPairs',
+       maxElement    = 1000000
     )
 )

--- a/RecoTracker/TkSeedGenerator/python/GlobalPixelLessSeeds_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalPixelLessSeeds_cff.py
@@ -19,10 +19,7 @@ globalPixelLessSeeds = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsED
         maxElement    = 100000
     ),
     ## whatever happens to the beam spot
-    #RegionFactoryPSet = cms.PSet( RegionPSet.clone(originHalfLength = 40)),
     RegionFactoryPSet = dict(RegionPSet = dict(originHalfLength = 40)),
-#globalPixelLessSeeds.RegionFactoryPSet.RegionPSet.originHalfLength = 40
     ## safe against APV-induced noise
     ClusterCheckPSet = dict(MaxNumberOfCosmicClusters = 5000)
-#globalPixelLessSeeds.ClusterCheckPSet.MaxNumberOfCosmicClusters    = 5000
 )

--- a/RecoTracker/TkSeedGenerator/python/GlobalPixelLessSeeds_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalPixelLessSeeds_cff.py
@@ -13,13 +13,16 @@ from RecoTracker.TkSeedingLayers.PixelLessLayerPairs4PixelLessTracking_cfi impor
 
 import RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi
 globalPixelLessSeeds = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi.seedGeneratorFromRegionHitsEDProducer.clone(
-    OrderedHitsFactoryPSet = cms.PSet(
-        ComponentName = cms.string('StandardHitPairGenerator'),
-        SeedingLayers = cms.InputTag('pixelLessLayerPairs4PixelLessTracking'),
-        maxElement = cms.uint32(100000)
-        )
-    )
-## whatever happens to the beam spot
-globalPixelLessSeeds.RegionFactoryPSet.RegionPSet.originHalfLength = 40
-## safe against APV-induced noise
-globalPixelLessSeeds.ClusterCheckPSet.MaxNumberOfCosmicClusters    = 5000
+    OrderedHitsFactoryPSet = dict(
+        ComponentName = 'StandardHitPairGenerator',
+        SeedingLayers = 'pixelLessLayerPairs4PixelLessTracking',
+        maxElement    = 100000
+    ),
+    ## whatever happens to the beam spot
+    #RegionFactoryPSet = cms.PSet( RegionPSet.clone(originHalfLength = 40)),
+    RegionFactoryPSet = dict(RegionPSet = dict(originHalfLength = 40)),
+#globalPixelLessSeeds.RegionFactoryPSet.RegionPSet.originHalfLength = 40
+    ## safe against APV-induced noise
+    ClusterCheckPSet = dict(MaxNumberOfCosmicClusters = 5000)
+#globalPixelLessSeeds.ClusterCheckPSet.MaxNumberOfCosmicClusters    = 5000
+)

--- a/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromPairsWithVertices_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromPairsWithVertices_cff.py
@@ -15,13 +15,13 @@ from RecoTracker.TkSeedingLayers.MixedLayerPairs_cfi import *
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import *
 import RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi
 globalSeedsFromPairsWithVertices = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi.seedGeneratorFromRegionHitsEDProducer.clone(
-    OrderedHitsFactoryPSet = cms.PSet(
-      ComponentName = cms.string('StandardHitPairGenerator'),
-      SeedingLayers = cms.InputTag('MixedLayerPairs'),
-      maxElement = cms.uint32(1000000)
+    OrderedHitsFactoryPSet = dict(
+      ComponentName = 'StandardHitPairGenerator',
+      SeedingLayers = 'MixedLayerPairs',
+      maxElement    = 1000000
     ),
-    RegionFactoryPSet = cms.PSet(
-      RegionPSet = globalTrackingRegionWithVertices.RegionPSet.clone(),
-      ComponentName = cms.string('GlobalTrackingRegionWithVerticesProducer')
+    RegionFactoryPSet = dict(
+      RegionPSet    = globalTrackingRegionWithVertices.RegionPSet.clone(),
+      ComponentName = 'GlobalTrackingRegionWithVerticesProducer'
     )
 )    

--- a/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromTriplets_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromTriplets_cff.py
@@ -15,9 +15,9 @@ from RecoPixelVertexing.PixelTriplets.PixelTripletHLTGenerator_cfi import *
 
 import RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi
 globalSeedsFromTriplets = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi.seedGeneratorFromRegionHitsEDProducer.clone(
-    OrderedHitsFactoryPSet = cms.PSet(
-      ComponentName = cms.string('StandardHitTripletGenerator'),
-      SeedingLayers = cms.InputTag('PixelLayerTriplets'),
+    OrderedHitsFactoryPSet = dict(
+      ComponentName = 'StandardHitTripletGenerator',
+      SeedingLayers = 'PixelLayerTriplets',
       GeneratorPSet = cms.PSet(PixelTripletHLTGenerator.clone(maxElement = cms.uint32(1000000)))
 # this one uses an exact helix extrapolation and can deal correctly with
 # arbitrarily large D0 and generally exhibits a smaller fake rate:

--- a/RecoTracker/TkSeedGenerator/python/GlobalTobTecSeeds_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalTobTecSeeds_cff.py
@@ -13,7 +13,7 @@ from RecoTracker.TkSeedingLayers.TobTecLayerPairs_cfi import *
 import RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi
 globalTobTecSeeds = RecoTracker.TkSeedGenerator.SeedGeneratorFromRegionHitsEDProducer_cfi.seedGeneratorFromRegionHitsEDProducer.clone(
     OrderedHitsFactoryPSet = cms.PSet(
-      ComponentName = cms.string('StandardHitPairGenerator'),
-      SeedingLayers = cms.InputTag('TobTecLayerPairs')
+      ComponentName = 'StandardHitPairGenerator',
+      SeedingLayers = 'TobTecLayerPairs'
     )
 )


### PR DESCRIPTION
#### PR description: Update the safer syntax for existing parameter

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#29979](https://github.com/cms-sw/cmssw/pull/29979), [PR#30147](https://github.com/cms-sw/cmssw/pull/30147), [PR#30270](https://github.com/cms-sw/cmssw/pull/30270) , [PR#30271](https://github.com/cms-sw/cmssw/pull/30271), [PR#30353](https://github.com/cms-sw/cmssw/pull/30353), [PR#30556](https://github.com/cms-sw/cmssw/pull/30556),[PR#30671](https://github.com/cms-sw/cmssw/pull/30556))

In this PR, 11 files updated. 
- RecoTracker/{SingleTrackPattern}  1 file 
- RecoTracker/{SpecialSeedGenerators} 4 files 
- RecoTracker/{TkNavigation} 1 file 
- RecoTracker/{TkSeedGenerator} 5 files 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).