### PR TITLE
Add to GetterOfProducts support for ProcessBlock

### DIFF
--- a/FWCore/Framework/interface/WillGetIfMatch.h
+++ b/FWCore/Framework/interface/WillGetIfMatch.h
@@ -35,6 +35,8 @@ namespace edm {
           return module_->template consumes<T, edm::InLumi>(tag);
         } else if (transition == edm::InRun) {
           return module_->template consumes<T, edm::InRun>(tag);
+        } else if (transition == edm::InProcess) {
+          return module_->template consumes<T, edm::InProcess>(tag);
         }
       }
       return EDGetTokenT<T>{};

--- a/FWCore/Integration/test/testGetBy1_cfg.py
+++ b/FWCore/Integration/test/testGetBy1_cfg.py
@@ -45,7 +45,7 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.a1 = cms.EDAnalyzer("TestFindProduct",
   inputTags = cms.untracked.VInputTag( cms.InputTag("source") ),
-  expectedSum = cms.untracked.int32(110012),
+  expectedSum = cms.untracked.int32(530021),
   inputTagsNotFound = cms.untracked.VInputTag(
     cms.InputTag("source", processName=cms.InputTag.skipCurrentProcess()),
     cms.InputTag("intProducer", processName=cms.InputTag.skipCurrentProcess()),
@@ -65,7 +65,8 @@ process.a1 = cms.EDAnalyzer("TestFindProduct",
   ),
   inputTagsEndProcessBlock4 = cms.untracked.VInputTag(
     cms.InputTag("intProducerEndProcessBlock", "four"),
-  )
+  ),
+  testGetterOfProducts = cms.untracked.bool(True)
 )
 
 process.a2 = cms.EDAnalyzer("TestFindProduct",

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -1568,7 +1568,7 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e81
 ++++ finished: end job for module with label 'intProducer' id = 4
 ++++ starting: end job for module with label 'a1' id = 5
 Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
-TestFindProduct sum = 110012
+TestFindProduct sum = 530021
 ++++ finished: end job for module with label 'a1' id = 5
 Module type=TestFindProduct, Module label=a1, Parameter Set ID=73b313a2727141f62e12cd7cf1a5b8dc
 ++++ starting: end job for module with label 'a2' id = 6


### PR DESCRIPTION
#### PR description:

Improve GetterOfProducts so that it can be used to get products from a ProcessBlock. I also updated some comments.

#### PR validation:

An existing unit test which tests getting products from ProcessBlock was extended to cover the use of GetterOfProducts. This should have no effect on any existing RelVal tests or workflows as nothing is using ProcessBlock yet outside of Framework unit tests.
