### PR TITLE
Use dxy sign of GSF track instead of IPTools for pat::Electron

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -1201,29 +1201,23 @@ void PATElectronProducer::embedHighLevel(pat::Electron& anElectron,
                                          reco::BeamSpot& beamspot,
                                          bool beamspotIsValid) {
   // Correct to PV
-
   // PV2D
-  std::pair<bool, Measurement1D> result =
-      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
-  double d0_corr = result.second.value();
-  double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  anElectron.setDB(d0_corr, d0_err, pat::Electron::PV2D);
+  anElectron.setDB(track->dxy(primaryVertex.position()),
+                   track->dxyError(primaryVertex.position(), primaryVertex.covariance()),
+                   pat::Electron::PV2D);
 
   // PV3D
-  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
-  d0_corr = result.second.value();
-  d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
+  std::pair<bool,Measurement1D> result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
+  double d0_corr = result.second.value();
+  double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   anElectron.setDB(d0_corr, d0_err, pat::Electron::PV3D);
 
   // Correct to beam spot
+  // BS2D
+  anElectron.setDB(track->dxy(beamspot), track->dxyError(beamspot), pat::Electron::BS2D);
+
   // make a fake vertex out of beam spot
   reco::Vertex vBeamspot(beamspot.position(), beamspot.covariance3D());
-
-  // BS2D
-  result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
-  d0_corr = result.second.value();
-  d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  anElectron.setDB(d0_corr, d0_err, pat::Electron::BS2D);
 
   // BS3D
   result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
@@ -1232,8 +1226,7 @@ void PATElectronProducer::embedHighLevel(pat::Electron& anElectron,
   anElectron.setDB(d0_corr, d0_err, pat::Electron::BS3D);
 
   // PVDZ
-  anElectron.setDB(
-      track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ);
+  anElectron.setDB(track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -1207,7 +1207,8 @@ void PATElectronProducer::embedHighLevel(pat::Electron& anElectron,
                    pat::Electron::PV2D);
 
   // PV3D
-  std::pair<bool,Measurement1D> result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
+  std::pair<bool, Measurement1D> result =
+      IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   anElectron.setDB(d0_corr, d0_err, pat::Electron::PV3D);
@@ -1226,7 +1227,8 @@ void PATElectronProducer::embedHighLevel(pat::Electron& anElectron,
   anElectron.setDB(d0_corr, d0_err, pat::Electron::BS3D);
 
   // PVDZ
-  anElectron.setDB(track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ);
+  anElectron.setDB(
+      track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
#### PR description:

Propagate the dxy sign fix for muons (#28753) to electrons as well.

#### PR validation:

Made nAODs from a bb4l AOD samples (~6k events) before and after the code change, verified that only dxy sign changed.

A backport to 106X ala #29537 can be made if needed.
