### PR TITLE
Fix bug introduced in the L1T PF code cleanup for release integration (11.1.x)

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCaloProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCaloProducer.cc
@@ -268,12 +268,12 @@ void L1TPFCaloProducer::readPhase2BarrelCaloTowers_(edm::Event &event, const edm
         continue;
       if (debug_ && (t.hcalTowerEt() > 0 || t.ecalTowerEt() > 0)) {
         edm::LogWarning("L1TPFCaloProducer")
-            << "adding phase2 L1 CaloTower eta " << t.towerEta() << "   phi " << t.towerIPhi() << "   ieta "
+            << "adding phase2 L1 CaloTower eta " << t.towerEta() << "   phi " << t.towerPhi() << "   ieta "
             << t.towerIEta() << "   iphi " << t.towerIPhi() << "   ecal " << t.ecalTowerEt() << "    hcal "
             << t.hcalTowerEt() << "\n";
       }
-      hcalClusterer_.add(t.hcalTowerEt(), t.towerEta(), t.towerIPhi());
-      ecalClusterer_.add(t.ecalTowerEt(), t.towerEta(), t.towerIPhi());
+      hcalClusterer_.add(t.hcalTowerEt(), t.towerEta(), t.towerPhi());
+      ecalClusterer_.add(t.ecalTowerEt(), t.towerEta(), t.towerPhi());
     }
   }
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
@@ -34,8 +34,8 @@ l1tpf_calo::Phase1GridBase::Phase1GridBase(
         continue;
       ieta_[icell] = ie;
       iphi_[icell] = iph;
-      float etaLo = (absie < nEta_ ? towerEtas_[absie-1] : towerEtas_[absie-2]);
-      float etaHi = (absie < nEta_ ? towerEtas_[absie] : towerEtas_[absie-1]);
+      float etaLo = (absie < nEta_ ? towerEtas_[absie - 1] : towerEtas_[absie - 2]);
+      float etaHi = (absie < nEta_ ? towerEtas_[absie] : towerEtas_[absie - 1]);
       eta_[icell] = (ie > 0 ? 0.5 : -0.5) * (etaLo + etaHi);
       etaWidth_[icell] = (etaHi - etaLo);
       phiWidth_[icell] = 2 * M_PI / nPhi_;

--- a/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
@@ -34,8 +34,10 @@ l1tpf_calo::Phase1GridBase::Phase1GridBase(
         continue;
       ieta_[icell] = ie;
       iphi_[icell] = iph;
-      eta_[icell] = (ie > 0 ? 0.5 : -0.5) * (towerEtas_[absie - 1] + towerEtas_[absie]);
-      etaWidth_[icell] = (towerEtas_[absie] - towerEtas_[absie - 1]);
+      float etaLo = (absie < nEta_ ? towerEtas_[absie-1] : towerEtas_[absie-2]);
+      float etaHi = (absie < nEta_ ? towerEtas_[absie] : towerEtas_[absie-1]);
+      eta_[icell] = (ie > 0 ? 0.5 : -0.5) * (etaLo + etaHi);
+      etaWidth_[icell] = (etaHi - etaLo);
       phiWidth_[icell] = 2 * M_PI / nPhi_;
       if (absie >= ietaVeryCoarse_)
         phiWidth_[icell] *= 4;


### PR DESCRIPTION
#### PR description:

Fix bug introduced in the code cleanup for release integration that was resulting garbage clusters in the barrel.
see https://hypernews.cern.ch/HyperNews/CMS/get/L1TriggerUpgrades/384/1.html

Backport #30736 .

#### PR validation:

Validation plots by @gpetruc from #30736.

Plots of jet response and resolution in the barrel (ttbar, PU 200):

   * [in the old trigger branch before cleanup (good reference)](https://gpetrucc.web.cern.ch/gpetrucc/drop/plots/l1stage2/11_1_X/from110X/110X_v0.4/val/TTbar_PU200/?match=jet_eta_00_13)
   * [in the current 11_1_0_patch2 (broken)](https://gpetrucc.web.cern.ch/gpetrucc/drop/plots/l1stage2/11_1_X/from110X/110X_v1/val/TTbar_PU200/?match=jet_eta_00_13)
   * [in 11_1_0_patch2 + this fix (recovered old behaviour)](https://gpetrucc.web.cern.ch/gpetrucc/drop/plots/l1stage2/11_1_X/from110X/110X_v1.1/val/TTbar_PU200/?match=jet_eta_00_13)

@rekovic @gpetruc FYI