### PR TITLE
remove ROOTCLING ifdefs that are no longer needed (were never?) 

### DIFF
--- a/DPGAnalysis/SiStripTools/interface/Multiplicities.h
+++ b/DPGAnalysis/SiStripTools/interface/Multiplicities.h
@@ -1,13 +1,11 @@
 #ifndef DPGAnalysis_SiStripTools_Multiplicities_H
 #define DPGAnalysis_SiStripTools_Multiplicities_H
 
-#ifndef __ROOTCLING__
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
-#endif
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
@@ -33,10 +31,8 @@ namespace edm {
 class ClusterSummarySingleMultiplicity {
 public:
   ClusterSummarySingleMultiplicity();
-#ifndef __ROOTCLING__
   ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
   ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
-#endif
 
   void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   int mult() const;
@@ -45,19 +41,15 @@ private:
   ClusterSummary::CMSTracker m_subdetenum;
   ClusterSummary::VariablePlacement m_varenum;
   int m_mult;
-#ifndef __ROOTCLING__
   edm::EDGetTokenT<ClusterSummary> m_collection;
-#endif
 };
 
 template <class T>
 class SingleMultiplicity {
 public:
   SingleMultiplicity();
-#ifndef __ROOTCLING__
   SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
   SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
-#endif
 
   void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   int mult() const;
@@ -68,9 +60,7 @@ private:
   bool m_useQuality;
   std::string m_qualityLabel;
   int m_mult;
-#ifndef __ROOTCLING__
   edm::EDGetTokenT<T> m_collection;
-#endif
 };
 
 template <class T>
@@ -78,15 +68,11 @@ SingleMultiplicity<T>::SingleMultiplicity()
     : m_modthr(-1),
       m_useQuality(false),
       m_qualityLabel(),
-      m_mult(0)
-#ifndef __ROOTCLING__
-      ,
+      m_mult(0),
       m_collection()
-#endif
 {
 }
 
-#ifndef __ROOTCLING__
 template <class T>
 SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
     : m_modthr(iConfig.getUntrackedParameter<int>("moduleThreshold")),
@@ -101,9 +87,7 @@ SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig, edm:
       m_qualityLabel(iConfig.getUntrackedParameter<std::string>("qualityLabel", "")),
       m_mult(0),
       m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName"))) {}
-#endif
 
-#ifndef __ROOTCLING__
 template <class T>
 void SingleMultiplicity<T>::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   m_mult = 0;
@@ -125,7 +109,6 @@ void SingleMultiplicity<T>::getEvent(const edm::Event& iEvent, const edm::EventS
     }
   }
 }
-#endif
 
 template <class T>
 int SingleMultiplicity<T>::mult() const {
@@ -136,10 +119,8 @@ template <class T1, class T2>
 class MultiplicityPair {
 public:
   MultiplicityPair();
-#ifndef __ROOTCLING__
   MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
   MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
-#endif
 
   void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   int mult1() const;
@@ -153,7 +134,6 @@ private:
 template <class T1, class T2>
 MultiplicityPair<T1, T2>::MultiplicityPair() : m_multiplicity1(), m_multiplicity2() {}
 
-#ifndef __ROOTCLING__
 template <class T1, class T2>
 MultiplicityPair<T1, T2>::MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
     : m_multiplicity1(iConfig.getParameter<edm::ParameterSet>("firstMultiplicityConfig"), iC),
@@ -162,7 +142,6 @@ template <class T1, class T2>
 MultiplicityPair<T1, T2>::MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
     : m_multiplicity1(iConfig.getParameter<edm::ParameterSet>("firstMultiplicityConfig"), iC),
       m_multiplicity2(iConfig.getParameter<edm::ParameterSet>("secondMultiplicityConfig"), iC) {}
-#endif
 
 template <class T1, class T2>
 void MultiplicityPair<T1, T2>::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/DPGAnalysis/SiStripTools/interface/Multiplicities.h
+++ b/DPGAnalysis/SiStripTools/interface/Multiplicities.h
@@ -65,13 +65,7 @@ private:
 
 template <class T>
 SingleMultiplicity<T>::SingleMultiplicity()
-    : m_modthr(-1),
-      m_useQuality(false),
-      m_qualityLabel(),
-      m_mult(0),
-      m_collection()
-{
-}
+    : m_modthr(-1), m_useQuality(false), m_qualityLabel(), m_mult(0), m_collection() {}
 
 template <class T>
 SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)

--- a/DataFormats/CaloTowers/interface/CaloTower.h
+++ b/DataFormats/CaloTowers/interface/CaloTower.h
@@ -79,11 +79,7 @@ public:
   // setters
   void addConstituent(DetId id) { constituents_.push_back(id); }
   void addConstituents(const std::vector<DetId>& ids);
-#ifdef __ROOTCLING__
-  void setConstituents(const std::vector<DetId>& ids) { constituents_ = ids; }
-#else
   void setConstituents(std::vector<DetId>&& ids) { constituents_ = std::move(ids); }
-#endif
   void setEcalTime(int t) { ecalTime_ = t; };
   void setHcalTime(int t) { hcalTime_ = t; };
   void setHcalSubdet(int lastHB, int lastHE, int lastHF, int lastHO) {

--- a/FWCore/MessageLogger/interface/ELseverityLevel.h
+++ b/FWCore/MessageLogger/interface/ELseverityLevel.h
@@ -49,7 +49,6 @@ namespace edm {
 
   class ELseverityLevel;
 
-#ifndef __ROOTCLING__
   // ----------------------------------------------------------------------
   // Synonym for type of ELseverityLevel-generating function:
   // ----------------------------------------------------------------------
@@ -85,7 +84,6 @@ namespace edm {
     const ELstring getVarName() const;
 
   };  // ELslProxy<ELslGen>
-#endif
 
   // ----------------------------------------------------------------------
 
@@ -152,7 +150,6 @@ namespace edm {
 
   };  // ELseverityLevel
 
-#ifndef __ROOTCLING__
   // ----------------------------------------------------------------------
   // Declare the globally available severity objects,
   // one generator function and one proxy per non-default ELsev_:
@@ -181,16 +178,6 @@ namespace edm {
 
   extern ELslGen ELhighestSeverityGen;
   extern ELslProxy<ELhighestSeverityGen> const ELhighestSeverity;
-#else
-  ELseverityLevel const ELzeroSeverity;
-  ELseverityLevel const ELdebug;
-  ELseverityLevel const ELinfo;
-  ELseverityLevel const ELwarning;
-  ELseverityLevel const ELerror;
-  ELseverityLevel const ELunspecified;
-  ELseverityLevel const ELsevere;
-  ELseverityLevel const ELhighestSeverity;
-#endif
 
   // ----------------------------------------------------------------------
   // Comparators:
@@ -209,11 +196,9 @@ namespace edm {
 
 // ----------------------------------------------------------------------
 
-#ifndef __ROOTCLING__
 #define ELSEVERITYLEVEL_ICC
 #include "FWCore/MessageLogger/interface/ELseverityLevel.icc"
 #undef ELSEVERITYLEVEL_ICC
-#endif
 
 // ----------------------------------------------------------------------
 


### PR DESCRIPTION
given that cling understands c++ - changes block modules build. There is one more case in DataFormats/Common that changes class definition so we are still looking at that one.

