### PR TITLE
Run4-hgx254 Remove usage of magic numbers in the HGCal geometry code

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalTypes.h
+++ b/Geometry/HGCalCommonData/interface/HGCalTypes.h
@@ -68,6 +68,10 @@ public:
   static int32_t getUnpackedType(int id);
   static int32_t getUnpackedU(int id);
   static int32_t getUnpackedV(int id);
+  static int32_t packCellTypeUV(int type, int u, int v);
+  static int32_t getUnpackedCellType(int id);
+  static int32_t getUnpackedCellU(int id);
+  static int32_t getUnpackedCellV(int id);
 
 private:
   static constexpr int32_t facu_ = 1;
@@ -77,6 +81,9 @@ private:
   static constexpr int32_t signv_ = 100000;
   static constexpr int32_t maxuv_ = 100;
   static constexpr int32_t maxsign_ = 10;
+  static constexpr int32_t maxtype_ = 10;
+  static constexpr int32_t faccell_ = 100;
+  static constexpr int32_t faccelltype_ = 10000;
 };
 
 #endif

--- a/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.cc
@@ -17,6 +17,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeomTools.h"
 #include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferType.h"
 
 #include <cmath>
@@ -356,15 +357,15 @@ void DDHGCalEEAlgo::positionSensitive(const DDLogicalPart& glog,
                                 << (waferSize_ + waferSepar_);
 #endif
   for (int u = -N; u <= N; ++u) {
-    int iu = std::abs(u);
     for (int v = -N; v <= N; ++v) {
-      int iv = std::abs(v);
       int nr = 2 * v;
       int nc = -2 * u + v;
       double xpos = xyoff.first + nc * r;
       double ypos = xyoff.second + nr * dy;
       const auto& corner = HGCalGeomTools::waferCorner(xpos, ypos, r, R, rin, rout, false);
 #ifdef EDM_ML_DEBUG
+      int iu = std::abs(u);
+      int iv = std::abs(v);
       ++ntot;
       if (((corner.first <= 0) && std::abs(u) < 5 && std::abs(v) < 5) || (std::abs(u) < 2 && std::abs(v) < 2)) {
         edm::LogVerbatim("HGCalGeom") << "DDHGCalEEAlgo: " << glog.ddname() << " R " << rin << ":" << rout << "\n Z "
@@ -374,11 +375,7 @@ void DDHGCalEEAlgo::positionSensitive(const DDLogicalPart& glog,
 #endif
       if (corner.first > 0) {
         int type = waferType_->getType(xpos, ypos, zpos);
-        int copy = type * 1000000 + iv * 100 + iu;
-        if (u < 0)
-          copy += 10000;
-        if (v < 0)
-          copy += 100000;
+        int copy = HGCalTypes::packTypeUV(type, u, v);
 #ifdef EDM_ML_DEBUG
         if (iu > ium)
           ium = iu;

--- a/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.cc
@@ -17,6 +17,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeomTools.h"
 #include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferType.h"
 
 #include <cmath>
@@ -544,24 +545,20 @@ void DDHGCalHEAlgo::positionSensitive(const DDLogicalPart& glog,
                                 << xyoff.second << " WaferSize " << (waferSize_ + waferSepar_);
 #endif
   for (int u = -N; u <= N; ++u) {
-    int iu = std::abs(u);
     for (int v = -N; v <= N; ++v) {
-      int iv = std::abs(v);
       int nr = 2 * v;
       int nc = -2 * u + v;
       double xpos = xyoff.first + nc * r;
       double ypos = xyoff.second + nr * dy;
       std::pair<int, int> corner = HGCalGeomTools::waferCorner(xpos, ypos, r, R, rin, rout, false);
 #ifdef EDM_ML_DEBUG
+      int iu = std::abs(u);
+      int iv = std::abs(v);
       ++ntot;
 #endif
       if (corner.first > 0) {
         int type = waferType_->getType(xpos, ypos, zpos);
-        int copy = type * 1000000 + iv * 100 + iu;
-        if (u < 0)
-          copy += 10000;
-        if (v < 0)
-          copy += 100000;
+        int copy = HGCalTypes::packTypeUV(type, u, v);
 #ifdef EDM_ML_DEBUG
         if (iu > ium)
           ium = iu;

--- a/Geometry/HGCalCommonData/plugins/DDHGCalTBModule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalTBModule.cc
@@ -17,6 +17,7 @@
 #include "DetectorDescription/Core/interface/DDutils.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
@@ -299,11 +300,7 @@ void DDHGCalTBModule::positionSensitive(DDLogicalPart& glog, int type, double ri
           double rpos = std::sqrt(xpos * xpos + ypos * ypos);
           DDTranslation tran(xpos, ypos, 0.0);
           DDRotation rotation;
-          int copy = inr * 100 + inc;
-          if (nc < 0)
-            copy += 10000;
-          if (nr < 0)
-            copy += 100000;
+          int copy = HGCalTypes::packTypeUV(0, nc, nr);
           DDName name;
           if (type == 1) {
             name = (rpos < rMaxFine_) ? DDName(DDSplit(wafer_[0]).first, DDSplit(wafer_[0]).second)

--- a/Geometry/HGCalCommonData/plugins/DDHGCalTBModuleX.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalTBModuleX.cc
@@ -16,6 +16,7 @@
 #include "DetectorDescription/Core/interface/DDutils.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
@@ -350,11 +351,7 @@ void DDHGCalTBModuleX::positionSensitive(double zpos,
           double rpos = std::sqrt(xpos * xpos + ypos * ypos);
           DDTranslation tran(xpos, ypos, zpos);
           DDRotation rotation;
-          int copy = inr * 100 + inc;
-          if (nc < 0)
-            copy += 10000;
-          if (nr < 0)
-            copy += 100000;
+          int copy = HGCalTypes::packTypeUV(0, nc, nr);
           DDName name, nameX;
           if (type == 1) {
             nameX = DDName(DDSplit(covers_[0]).first, DDSplit(covers_[0]).second);

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWafer8.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWafer8.cc
@@ -9,6 +9,7 @@
 #include "DetectorDescription/Core/interface/DDutils.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 
 #include <string>
 #include <vector>
@@ -136,7 +137,7 @@ void DDHGCalWafer8::execute(DDCompactView& cpv) {
         else if (v == 0)
           cell = 6;
         DDTranslation tran(xp, yp, 0);
-        int copy = (cellType_ * 100 + v) * 100 + u;
+        int copy = HGCalTypes::packCellTypeUV(cellType_, u, v);
         cpv.position(DDName(cellNames_[cell]), glog, copy, tran, rot);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalWafer8: " << cellNames_[cell] << " number " << copy << " position in "

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -9,6 +9,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeomTools.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferMask.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferType.h"
@@ -993,12 +994,8 @@ std::pair<int, int> HGCalDDDConstants::rowColumnWafer(int wafer) const {
   int row(0), col(0);
   if (wafer < (int)(hgpar_->waferCopy_.size())) {
     int copy = hgpar_->waferCopy_[wafer];
-    col = copy % 100;
-    if ((copy / 10000) % 10 != 0)
-      col = -col;
-    row = (copy / 100) % 100;
-    if ((copy / 100000) % 10 != 0)
-      row = -row;
+    col = HGCalTypes::getUnpackedU(copy);
+    row = HGCalTypes::getUnpackedV(copy);;
   }
   return std::make_pair(row, col);
 }

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -995,7 +995,8 @@ std::pair<int, int> HGCalDDDConstants::rowColumnWafer(int wafer) const {
   if (wafer < (int)(hgpar_->waferCopy_.size())) {
     int copy = hgpar_->waferCopy_[wafer];
     col = HGCalTypes::getUnpackedU(copy);
-    row = HGCalTypes::getUnpackedV(copy);;
+    row = HGCalTypes::getUnpackedV(copy);
+    ;
   }
   return std::make_pair(row, col);
 }

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -13,6 +13,7 @@
 #include "DetectorDescription/Core/interface/DDutils.h"
 #include "DetectorDescription/DDCMS/interface/DDShapes.h"
 #include "DetectorDescription/RegressionTest/interface/DDErrorDetection.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferMask.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferType.h"
@@ -1418,11 +1419,7 @@ void HGCalGeomParameters::loadWaferHexagon(HGCalParameters& php) {
         }
         ++ntot;
         if (corner.first > 0) {
-          int copy = inr * 100 + inc;
-          if (nc < 0)
-            copy += 10000;
-          if (nr < 0)
-            copy += 100000;
+          int copy = HGCalTypes::packTypeUV(typel, nc, nr);
           if (inc > incm)
             incm = inc;
           if (inr > inrm)

--- a/Geometry/HGCalCommonData/src/HGCalTypes.cc
+++ b/Geometry/HGCalCommonData/src/HGCalTypes.cc
@@ -25,9 +25,7 @@ int32_t HGCalTypes::getUnpackedV(int copy) {
   return v;
 }
 
-int32_t HGCalTypes::packCellTypeUV(int type, int u, int v) {
-  return (type * faccelltype_ + v * faccell_ + u);
-}
+int32_t HGCalTypes::packCellTypeUV(int type, int u, int v) { return (type * faccelltype_ + v * faccell_ + u); }
 
 int32_t HGCalTypes::getUnpackedCellType(int copy) { return ((copy / faccelltype_) % faccell_); }
 

--- a/Geometry/HGCalCommonData/src/HGCalTypes.cc
+++ b/Geometry/HGCalCommonData/src/HGCalTypes.cc
@@ -11,7 +11,7 @@ int32_t HGCalTypes::packTypeUV(int type, int u, int v) {
   return copy;
 }
 
-int32_t HGCalTypes::getUnpackedType(int copy) { return (copy / factype_); }
+int32_t HGCalTypes::getUnpackedType(int copy) { return ((copy / factype_) % maxtype_); }
 
 int32_t HGCalTypes::getUnpackedU(int copy) {
   int32_t iu = (copy % maxuv_);
@@ -24,3 +24,13 @@ int32_t HGCalTypes::getUnpackedV(int copy) {
   int32_t v = (((copy / signv_) % maxsign_) > 0) ? -iv : iv;
   return v;
 }
+
+int32_t HGCalTypes::packCellTypeUV(int type, int u, int v) {
+  return (type * faccelltype_ + v * faccell_ + u);
+}
+
+int32_t HGCalTypes::getUnpackedCellType(int copy) { return ((copy / faccelltype_) % faccell_); }
+
+int32_t HGCalTypes::getUnpackedCellU(int copy) { return (copy % faccell_); }
+
+int32_t HGCalTypes::getUnpackedCellV(int copy) { return ((copy / faccell_) % faccell_); }

--- a/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
@@ -4,6 +4,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include "SimG4CMS/Calo/interface/HFNoseNumberingScheme.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include <iostream>
 
 //#define EDM_ML_DEBUG
@@ -21,15 +22,11 @@ uint32_t HFNoseNumberingScheme::getUnitID(
   wt = 1.0;
   int cellU(0), cellV(0), waferType(-1), waferU(0), waferV(0);
   if (cell >= 0) {
-    waferType = module / 1000000;
-    waferU = module % 100;
-    if ((module / 10000) % 10 > 0)
-      waferU = -waferU;
-    waferV = (module / 100) % 100;
-    if ((module / 100000) % 10 > 0)
-      waferV = -waferV;
-    cellU = cell % 100;
-    cellV = (cell / 100) % 100;
+    waferType = HGCalTypes::getUnpackedType(module);
+    waferU = HGCalTypes::getUnpackedU(module);
+    waferV = HGCalTypes::getUnpackedV(module);
+    cellU = HGCalTypes::getUnpackedCellU(cell);
+    cellV = HGCalTypes::getUnpackedCellV(cell);
   } else if (mode_ == HGCalGeometryMode::Hexagon8Full) {
     double xx = (pos.z() > 0) ? pos.x() : -pos.x();
     hgcons_.waferFromPosition(xx, pos.y(), layer, waferU, waferV, cellU, cellV, waferType, wt);

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -5,6 +5,7 @@
 #include "SimG4CMS/Calo/interface/HGCalNumberingScheme.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include <iostream>
 
 //#define EDM_ML_DEBUG
@@ -37,15 +38,11 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
   if ((mode_ == HGCalGeometryMode::Hexagon8Full) || (mode_ == HGCalGeometryMode::Hexagon8)) {
     int cellU(0), cellV(0), waferType(-1), waferU(0), waferV(0);
     if (cell >= 0) {
-      waferType = module / 1000000;
-      waferU = module % 100;
-      if ((module / 10000) % 10 > 0)
-        waferU = -waferU;
-      waferV = (module / 100) % 100;
-      if ((module / 100000) % 10 > 0)
-        waferV = -waferV;
-      cellU = cell % 100;
-      cellV = (cell / 100) % 100;
+      waferType = HGCalTypes::getUnpackedType(module);
+      waferU = HGCalTypes::getUnpackedU(module);
+      waferV = HGCalTypes::getUnpackedV(module);
+      cellU = HGCalTypes::getUnpackedCellU(cell);
+      cellV = HGCalTypes::getUnpackedCellV(cell);
     } else if (mode_ == HGCalGeometryMode::Hexagon8Full) {
       double xx = (pos.z() > 0) ? pos.x() : -pos.x();
       hgcons_.waferFromPosition(xx, pos.y(), layer, waferU, waferV, cellU, cellV, waferType, wt);


### PR DESCRIPTION
#### PR description:

Remove usage of magic numbers in the HGCal geometry code

#### PR validation:

Tested using runTheMatrix test workflows 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special