### PR TITLE
[HGCal] Shrinking Layer Clustering internal data structures

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
@@ -65,9 +65,12 @@ public:
   // use this if you want to reuse the same cluster object but don't want to accumulate clusters (hardly useful?)
   void reset() override {
     clusters_v_.clear();
+    clusters_v_.shrink_to_fit();
     layerClustersPerLayer_.clear();
+    layerClustersPerLayer_.shrink_to_fit();
     for (auto &it : points_) {
       it.clear();
+      it.shrink_to_fit();
       std::vector<KDNode>().swap(it);
     }
     for (unsigned int i = 0; i < minpos_.size(); i++) {

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -72,6 +72,7 @@ public:
       cells.clear();
       cells.shrink_to_fit();
     }
+    density_.clear();
   }
 
   Density getDensity() override;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -63,12 +63,15 @@ public:
 
   void reset() override {
     clusters_v_.clear();
+    clusters_v_.shrink_to_fit();
     for (auto& cl : numberOfClustersPerLayer_) {
       cl = 0;
     }
 
-    for (auto& cells : cells_)
+    for (auto& cells : cells_) {
       cells.clear();
+      cells.shrink_to_fit();
+    }
   }
 
   Density getDensity() override;
@@ -173,6 +176,23 @@ private:
       sigmaNoise.clear();
       followers.clear();
       isSeed.clear();
+    }
+
+    void shrink_to_fit() {
+      detid.shrink_to_fit();
+      isSi.shrink_to_fit();
+      x.shrink_to_fit();
+      y.shrink_to_fit();
+      eta.shrink_to_fit();
+      phi.shrink_to_fit();
+      weight.shrink_to_fit();
+      rho.shrink_to_fit();
+      delta.shrink_to_fit();
+      nearestHigher.shrink_to_fit();
+      clusterIndex.shrink_to_fit();
+      sigmaNoise.shrink_to_fit();
+      followers.shrink_to_fit();
+      isSeed.shrink_to_fit();
     }
   };
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
@@ -133,8 +133,6 @@ void HGCalLayerClusterProducer::produce(edm::Event& evt, const edm::EventSetup& 
       clusters_sharing(new std::vector<reco::BasicCluster>);
   auto density = std::make_unique<Density>();
 
-  algo->reset();
-
   algo->getEventSetup(es);
 
   //make a map detid-rechit
@@ -246,6 +244,7 @@ void HGCalLayerClusterProducer::produce(edm::Event& evt, const edm::EventSetup& 
       clusterPtrsSharing.push_back(ptr);
     }
   }
+  algo->reset();
 }
 
 #endif


### PR DESCRIPTION
#### PR description:

The memory footprint of the `HGCalLayerClusterProducer` grows with increasing number of events. This is solved by  `shrink_to_fit()` after `clear()` when resetting these data structures.

