### PR TITLE
removed unnessecary argument of EventSetup from getPredictions function

### DIFF
--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -90,9 +90,7 @@ namespace deep_tau {
     static void globalEndJob(const DeepTauCache* cache) {}
 
   private:
-    virtual tensorflow::Tensor getPredictions(edm::Event& event,
-                                              const edm::EventSetup& es,
-                                              edm::Handle<TauCollection> taus) = 0;
+    virtual tensorflow::Tensor getPredictions(edm::Event& event, edm::Handle<TauCollection> taus) = 0;
     virtual void createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus);
 
   protected:

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -74,9 +74,7 @@ public:
   }
 
 private:
-  tensorflow::Tensor getPredictions(edm::Event& event,
-                                    const edm::EventSetup& es,
-                                    edm::Handle<TauCollection> taus) override {
+  tensorflow::Tensor getPredictions(edm::Event& event, edm::Handle<TauCollection> taus) override {
     edm::Handle<pat::PackedCandidateCollection> pfcands;
     event.getByToken(pfcandToken_, pfcands);
 

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -965,9 +965,7 @@ private:
   }
 
 private:
-  tensorflow::Tensor getPredictions(edm::Event& event,
-                                    const edm::EventSetup& es,
-                                    edm::Handle<TauCollection> taus) override {
+  tensorflow::Tensor getPredictions(edm::Event& event, edm::Handle<TauCollection> taus) override {
     edm::Handle<pat::ElectronCollection> electrons;
     event.getByToken(electrons_token_, electrons);
 

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -94,7 +94,7 @@ namespace deep_tau {
     edm::Handle<TauCollection> taus;
     event.getByToken(tausToken_, taus);
 
-    const tensorflow::Tensor& pred = getPredictions(event, es, taus);
+    const tensorflow::Tensor& pred = getPredictions(event, taus);
     createOutputs(event, pred, taus);
   }
 


### PR DESCRIPTION
#### PR description:

removed the argument of EventSetup from getPredictions function in DeepTauBase module and the other 2 modules that call the function.

#### PR validation:

the code compiles