### PR TITLE
Stream case with ProcessBlock and no GlobalCache

### DIFF
--- a/FWCore/Framework/interface/stream/callAbilities.h
+++ b/FWCore/Framework/interface/stream/callAbilities.h
@@ -67,7 +67,7 @@ namespace edm {
     //********************************
     // CallInputProcessBlock
     //********************************
-    template <typename T, bool>
+    template <typename T, bool, bool>
     struct CallInputProcessBlockImpl {
       static void accessInputProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache* iGC) {
         // This is not fully implemented yet and will never be called
@@ -76,12 +76,26 @@ namespace edm {
     };
 
     template <typename T>
-    struct CallInputProcessBlockImpl<T, false> {
+    struct CallInputProcessBlockImpl<T, true, false> {
+      static void accessInputProcessBlock(edm::ProcessBlock const& processBlock, typename T::GlobalCache*) {
+        // This is not fully implemented yet and will never be called
+        T::accessInputProcessBlock(processBlock);
+      }
+    };
+
+    template <typename T>
+    struct CallInputProcessBlockImpl<T, false, true> {
       static void accessInputProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
     };
 
     template <typename T>
-    using CallInputProcessBlock = CallInputProcessBlockImpl<T, T::HasAbility::kInputProcessBlockCache>;
+    struct CallInputProcessBlockImpl<T, false, false> {
+      static void accessInputProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
+    };
+
+    template <typename T>
+    using CallInputProcessBlock =
+        CallInputProcessBlockImpl<T, T::HasAbility::kInputProcessBlockCache, T::HasAbility::kGlobalCache>;
 
     //********************************
     // CallGlobalRun
@@ -246,7 +260,7 @@ namespace edm {
     //********************************
     // CallWatchProcessBlock
     //********************************
-    template <typename T, bool>
+    template <typename T, bool, bool>
     struct CallWatchProcessBlockImpl {
       static void beginProcessBlock(edm::ProcessBlock const& iProcessBlock, typename T::GlobalCache* iGC) {
         T::beginProcessBlock(iProcessBlock, iGC);
@@ -258,18 +272,36 @@ namespace edm {
     };
 
     template <typename T>
-    struct CallWatchProcessBlockImpl<T, false> {
+    struct CallWatchProcessBlockImpl<T, true, false> {
+      static void beginProcessBlock(edm::ProcessBlock const& processBlock, typename T::GlobalCache*) {
+        T::beginProcessBlock(processBlock);
+      }
+
+      static void endProcessBlock(edm::ProcessBlock const& processBlock, typename T::GlobalCache*) {
+        T::endProcessBlock(processBlock);
+      }
+    };
+
+    template <typename T>
+    struct CallWatchProcessBlockImpl<T, false, true> {
       static void beginProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
       static void endProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
     };
 
     template <typename T>
-    using CallWatchProcessBlock = CallWatchProcessBlockImpl<T, T::HasAbility::kWatchProcessBlock>;
+    struct CallWatchProcessBlockImpl<T, false, false> {
+      static void beginProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
+      static void endProcessBlock(edm::ProcessBlock const&, typename T::GlobalCache*) {}
+    };
+
+    template <typename T>
+    using CallWatchProcessBlock =
+        CallWatchProcessBlockImpl<T, T::HasAbility::kWatchProcessBlock, T::HasAbility::kGlobalCache>;
 
     //********************************
     // CallBeginProcessBlockProduce
     //********************************
-    template <typename T, bool>
+    template <typename T, bool, bool>
     struct CallBeginProcessBlockProduceImpl {
       static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache* globalCache) {
         T::beginProcessBlockProduce(processBlock, globalCache);
@@ -277,17 +309,30 @@ namespace edm {
     };
 
     template <typename T>
-    struct CallBeginProcessBlockProduceImpl<T, false> {
+    struct CallBeginProcessBlockProduceImpl<T, true, false> {
+      static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache*) {
+        T::beginProcessBlockProduce(processBlock);
+      }
+    };
+
+    template <typename T>
+    struct CallBeginProcessBlockProduceImpl<T, false, true> {
       static void produce(edm::ProcessBlock&, typename T::GlobalCache*) {}
     };
 
     template <typename T>
-    using CallBeginProcessBlockProduce = CallBeginProcessBlockProduceImpl<T, T::HasAbility::kBeginProcessBlockProducer>;
+    struct CallBeginProcessBlockProduceImpl<T, false, false> {
+      static void produce(edm::ProcessBlock&, typename T::GlobalCache*) {}
+    };
+
+    template <typename T>
+    using CallBeginProcessBlockProduce =
+        CallBeginProcessBlockProduceImpl<T, T::HasAbility::kBeginProcessBlockProducer, T::HasAbility::kGlobalCache>;
 
     //********************************
     // CallEndProcessBlockProduce
     //********************************
-    template <typename T, bool>
+    template <typename T, bool, bool>
     struct CallEndProcessBlockProduceImpl {
       static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache* globalCache) {
         T::endProcessBlockProduce(processBlock, globalCache);
@@ -295,12 +340,25 @@ namespace edm {
     };
 
     template <typename T>
-    struct CallEndProcessBlockProduceImpl<T, false> {
+    struct CallEndProcessBlockProduceImpl<T, true, false> {
+      static void produce(edm::ProcessBlock& processBlock, typename T::GlobalCache*) {
+        T::endProcessBlockProduce(processBlock);
+      }
+    };
+
+    template <typename T>
+    struct CallEndProcessBlockProduceImpl<T, false, true> {
       static void produce(edm::ProcessBlock&, typename T::GlobalCache*) {}
     };
 
     template <typename T>
-    using CallEndProcessBlockProduce = CallEndProcessBlockProduceImpl<T, T::HasAbility::kEndProcessBlockProducer>;
+    struct CallEndProcessBlockProduceImpl<T, false, false> {
+      static void produce(edm::ProcessBlock&, typename T::GlobalCache*) {}
+    };
+
+    template <typename T>
+    using CallEndProcessBlockProduce =
+        CallEndProcessBlockProduceImpl<T, T::HasAbility::kEndProcessBlockProducer, T::HasAbility::kGlobalCache>;
 
     //********************************
     // CallBeginRunProduce

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -462,8 +462,6 @@ namespace edmtest {
         : public edm::stream::EDProducer<edm::WatchProcessBlock, edm::GlobalCache<TestGlobalCache>> {
     public:
       explicit ProcessBlockIntProducer(edm::ParameterSet const& pset, TestGlobalCache const* testGlobalCache) {
-        produces<unsigned int>();
-
         {
           auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
           if (not tag.label().empty()) {
@@ -498,10 +496,6 @@ namespace edmtest {
                 << "expected " << valueToGet << " but got " << processBlock.get(testGlobalCache->getTokenBegin_);
           }
         }
-      }
-
-      static std::shared_ptr<UnsafeCache> accessInputProcessBlock(edm::ProcessBlock const&, TestGlobalCache*) {
-        return std::make_shared<UnsafeCache>();
       }
 
       void produce(edm::Event&, edm::EventSetup const&) override {
@@ -560,7 +554,6 @@ namespace edmtest {
     public:
       explicit TestBeginProcessBlockProducer(edm::ParameterSet const& pset, TestGlobalCache const* testGlobalCache) {
         testGlobalCache->token_ = produces<unsigned int, edm::Transition::BeginProcessBlock>("begin");
-        produces<unsigned int>();
 
         auto tag = pset.getParameter<edm::InputTag>("consumesBeginProcessBlock");
         if (not tag.label().empty()) {
@@ -624,7 +617,6 @@ namespace edmtest {
     public:
       explicit TestEndProcessBlockProducer(edm::ParameterSet const& pset, TestGlobalCache const* testGlobalCache) {
         testGlobalCache->token_ = produces<unsigned int, edm::Transition::EndProcessBlock>("end");
-        produces<unsigned int>();
 
         auto tag = pset.getParameter<edm::InputTag>("consumesEndProcessBlock");
         if (not tag.label().empty()) {
@@ -675,6 +667,35 @@ namespace edmtest {
                                               << " but it was supposed to be " << testGlobalCache->trans_;
         }
       }
+    };
+
+    class ProcessBlockIntProducerNoGlobalCache : public edm::stream::EDProducer<edm::WatchProcessBlock> {
+    public:
+      explicit ProcessBlockIntProducerNoGlobalCache(edm::ParameterSet const&) {}
+
+      static void beginProcessBlock(edm::ProcessBlock const&) {}
+
+      void produce(edm::Event&, edm::EventSetup const&) override {}
+
+      static void endProcessBlock(edm::ProcessBlock const&) {}
+    };
+
+    class TestBeginProcessBlockProducerNoGlobalCache : public edm::stream::EDProducer<edm::BeginProcessBlockProducer> {
+    public:
+      explicit TestBeginProcessBlockProducerNoGlobalCache(edm::ParameterSet const&) {}
+
+      static void beginProcessBlockProduce(edm::ProcessBlock&) {}
+
+      void produce(edm::Event&, edm::EventSetup const&) override {}
+    };
+
+    class TestEndProcessBlockProducerNoGlobalCache : public edm::stream::EDProducer<edm::EndProcessBlockProducer> {
+    public:
+      explicit TestEndProcessBlockProducerNoGlobalCache(edm::ParameterSet const&) {}
+
+      void produce(edm::Event&, edm::EventSetup const&) override {}
+
+      static void endProcessBlockProduce(edm::ProcessBlock&) {}
     };
 
     class TestBeginRunProducer : public edm::stream::EDProducer<edm::RunCache<bool>, edm::BeginRunProducer> {
@@ -989,6 +1010,9 @@ DEFINE_FWK_MODULE(edmtest::stream::LumiSummaryIntProducer);
 DEFINE_FWK_MODULE(edmtest::stream::ProcessBlockIntProducer);
 DEFINE_FWK_MODULE(edmtest::stream::TestBeginProcessBlockProducer);
 DEFINE_FWK_MODULE(edmtest::stream::TestEndProcessBlockProducer);
+DEFINE_FWK_MODULE(edmtest::stream::ProcessBlockIntProducerNoGlobalCache);
+DEFINE_FWK_MODULE(edmtest::stream::TestBeginProcessBlockProducerNoGlobalCache);
+DEFINE_FWK_MODULE(edmtest::stream::TestEndProcessBlockProducerNoGlobalCache);
 DEFINE_FWK_MODULE(edmtest::stream::TestBeginRunProducer);
 DEFINE_FWK_MODULE(edmtest::stream::TestEndRunProducer);
 DEFINE_FWK_MODULE(edmtest::stream::TestBeginLumiBlockProducer);

--- a/FWCore/Framework/test/test_stream_modules_cfg.py
+++ b/FWCore/Framework/test/test_stream_modules_cfg.py
@@ -79,6 +79,10 @@ process.TestEndProcessBlockProdRead = cms.EDProducer("edmtest::stream::TestEndPr
     consumesEndProcessBlock = cms.InputTag("TestEndProcessBlockProd", "end")
 )
 
+process.ProcessBlockIntProdNoGlobalCache = cms.EDProducer("edmtest::stream::ProcessBlockIntProducerNoGlobalCache")
+process.TestBeginProcessBlockProdNoGlobalCache = cms.EDProducer("edmtest::stream::TestBeginProcessBlockProducerNoGlobalCache")
+process.TestEndProcessBlockProdNoGlobalCache = cms.EDProducer("edmtest::stream::TestEndProcessBlockProducerNoGlobalCache")
+
 process.TestBeginRunProd = cms.EDProducer("edmtest::stream::TestBeginRunProducer",
     transitions = cms.int32(int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvt)
@@ -227,6 +231,9 @@ process.p = cms.Path(process.GlobIntProd +
                      process.TestBeginProcessBlockProd +
                      process.TestEndProcessBlockProdRead +
                      process.TestEndProcessBlockProd +
+                     process.ProcessBlockIntProdNoGlobalCache +
+                     process.TestBeginProcessBlockProdNoGlobalCache +
+                     process.TestEndProcessBlockProdNoGlobalCache +
                      process.TestBeginRunProd +
                      process.TestEndRunProd +
                      process.TestBeginLumiBlockProd +


### PR DESCRIPTION
#### PR description:

Improves the interface in the case of a stream module
with ProcessBlock extensions but without the GlobalCache
extension. The GlobalCache pointer argument is no longer
required (or allowed). Previously, it would just always
be set to nullptr.

#### PR validation:

This includes additions to an existing Framework unit test to cover this improvement. Note that outside of Framework unit tests there is nothing that uses this code yet so nothing in the RelVals should be affected.
