### PR TITLE
Fix for Conddb function to identify current run

### DIFF
--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -158,7 +158,7 @@ namespace cond {
       RunInfoProxy getRunInfo(cond::Time_t start, cond::Time_t end);
 
       // get the ongoing run
-      cond::RunInfo_t getCurrentRun();
+      cond::RunInfo_t getLastRun();
 
       // runinfo write access
       RunInfoEditor editRunInfo();

--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -13,7 +13,7 @@
 //
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/functional/hash.hpp>
+#include <functional>
 //
 #include "CondCore/CondDB/interface/Time.h"
 
@@ -123,7 +123,7 @@ namespace cond {
     std::size_t hashvalue() const {
       // Derived from CondDB v1 TagMetadata implementation.
       // Unique Keys constructed with Record and Labels - allowing for multiple references of the same Tag in a GT
-      boost::hash<std::string> hasher;
+      std::hash<std::string> hasher;
       std::string key = recordName();
       if (!recordLabel().empty())
         key = key + "_" + recordLabel();
@@ -137,8 +137,15 @@ namespace cond {
   };
 
   struct RunInfo_t {
+    RunInfo_t() : run(0), start(), end() {}
     RunInfo_t(const std::tuple<long long unsigned int, boost::posix_time::ptime, boost::posix_time::ptime>& data)
         : run(std::get<0>(data)), start(std::get<1>(data)), end(std::get<2>(data)) {}
+    bool isOnGoing() {
+      if (run == 0)
+        return false;
+      auto now = boost::posix_time::second_clock::universal_time();
+      return (start < now) && (end == start);
+    }
     Time_t run;
     boost::posix_time::ptime start;
     boost::posix_time::ptime end;

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -219,7 +219,7 @@ namespace cond {
       virtual bool exists() = 0;
       virtual void create() = 0;
       virtual bool select(cond::Time_t runNumber, boost::posix_time::ptime& start, boost::posix_time::ptime& end) = 0;
-      virtual cond::Time_t getLastInserted() = 0;
+      virtual cond::Time_t getLastInserted(boost::posix_time::ptime& start, boost::posix_time::ptime& end) = 0;
       virtual bool getInclusiveRunRange(
           cond::Time_t lower,
           cond::Time_t upper,

--- a/CondCore/CondDB/src/RunInfoEditor.cc
+++ b/CondCore/CondDB/src/RunInfoEditor.cc
@@ -40,7 +40,8 @@ namespace cond {
     cond::Time_t RunInfoEditor::getLastInserted() {
       if (m_data.get()) {
         checkTransaction("RunInfoEditor::getLastInserted");
-        return m_session->runInfoSchema().runInfoTable().getLastInserted();
+        boost::posix_time::ptime start, end;
+        return m_session->runInfoSchema().runInfoTable().getLastInserted(start, end);
       }
       return cond::time::MIN_VAL;
     }

--- a/CondCore/CondDB/src/RunInfoProxy.cc
+++ b/CondCore/CondDB/src/RunInfoProxy.cc
@@ -73,7 +73,10 @@ namespace cond {
       checkTransaction("RunInfoProxy::load(Time_t,Time_t)");
 
       std::string dummy;
-      m_session->runInfoSchema().runInfoTable().getInclusiveRunRange(low, up, m_data->runList);
+      if (!m_session->runInfoSchema().runInfoTable().getInclusiveRunRange(low, up, m_data->runList)) {
+        throwException("No runs have been found in the range (" + std::to_string(low) + "," + std::to_string(up) + ")",
+                       "RunInfoProxy::load(Time_t,Time_t)");
+      }
     }
 
     void RunInfoProxy::load(const boost::posix_time::ptime& low, const boost::posix_time::ptime& up) {
@@ -86,7 +89,11 @@ namespace cond {
       checkTransaction("RunInfoProxy::load(const boost::posix_time::ptime&,const boost::posix_time::ptime&)");
 
       std::string dummy;
-      m_session->runInfoSchema().runInfoTable().getInclusiveTimeRange(low, up, m_data->runList);
+      if (!m_session->runInfoSchema().runInfoTable().getInclusiveTimeRange(low, up, m_data->runList)) {
+        throwException("No runs have been found in the interval (" + boost::posix_time::to_simple_string(low) + "," +
+                           boost::posix_time::to_simple_string(up) + ")",
+                       "RunInfoProxy::load(boost::posix_time::ptime&,const boost::posix_time::ptime&)");
+      }
     }
 
     void RunInfoProxy::reset() {

--- a/CondCore/CondDB/src/RunInfoSchema.cc
+++ b/CondCore/CondDB/src/RunInfoSchema.cc
@@ -33,7 +33,7 @@ namespace cond {
       return ret;
     }
 
-    cond::Time_t RUN_INFO::Table::getLastInserted() {
+    cond::Time_t RUN_INFO::Table::getLastInserted(boost::posix_time::ptime& start, boost::posix_time::ptime& end) {
       cond::Time_t run = cond::time::MIN_VAL;
       Query<MAX_RUN_NUMBER> q0(m_schema);
       try {
@@ -46,6 +46,7 @@ namespace cond {
         if (message.find("Attempt to access data of NULL attribute") != 0)
           throw;
       }
+      select(run, start, end);
       return run;
     }
 
@@ -92,12 +93,6 @@ namespace cond {
       }
       return runData.size() > prevSize;
     }
-
-    //bool RUN_INFO::Table::getRunForTime( const boost::posix_time::ptime& time,
-    //					 cond::Time_t& runNumber, boost::posix_time::ptime& start, boost::posix_time::ptime& end ){
-    //      Query< RUN_NUMBER, START_TIME, END_TIME > q(m_schema);
-    //      q.addCondition< START_TIME >( upper,"<=" );
-    //    }
 
     void RUN_INFO::Table::insertOne(cond::Time_t runNumber,
                                     const boost::posix_time::ptime& start,

--- a/CondCore/CondDB/src/RunInfoSchema.h
+++ b/CondCore/CondDB/src/RunInfoSchema.h
@@ -43,7 +43,7 @@ namespace cond {
         bool exists() override;
         void create() override;
         bool select(cond::Time_t runNumber, boost::posix_time::ptime& start, boost::posix_time::ptime& end) override;
-        cond::Time_t getLastInserted() override;
+        cond::Time_t getLastInserted(boost::posix_time::ptime& start, boost::posix_time::ptime& end) override;
         bool getInclusiveRunRange(
             cond::Time_t lower,
             cond::Time_t upper,

--- a/CondCore/CondDB/src/Session.cc
+++ b/CondCore/CondDB/src/Session.cc
@@ -198,13 +198,13 @@ namespace cond {
       return proxy;
     }
 
-    cond::RunInfo_t Session::getCurrentRun() {
+    cond::RunInfo_t Session::getLastRun() {
       if (!m_session->transaction.get())
         throwException("The transaction is not active.", "Session::getRunInfo");
-      RunInfoProxy proxy(m_session);
-      boost::posix_time::ptime now = boost::posix_time::second_clock::local_time();
-      proxy.load(now, now);
-      return proxy.get(now);
+      m_session->openRunInfoDb();
+      cond::RunInfo_t ret;
+      ret.run = m_session->runInfoSchema().runInfoTable().getLastInserted(ret.start, ret.end);
+      return ret;
     }
 
     RunInfoEditor Session::editRunInfo() {

--- a/CondCore/CondDB/src/SessionImpl.h
+++ b/CondCore/CondDB/src/SessionImpl.h
@@ -33,7 +33,7 @@ namespace cond {
       bool gtDbExists = false;
       bool gtDbOpen = false;
       bool runInfoDbExists = false;
-      bool runInfoDbOpen = true;
+      bool runInfoDbOpen = false;
       size_t clients = 0;
     };
 

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -1,6 +1,4 @@
 <use name="CondCore/CondDB"/>
-<use name="CondFormats/Common"/>
-<use name="DataFormats/StdDictionaries"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <library file="" name="testCondDBDict"/>
@@ -32,6 +30,9 @@
 </bin>
 
 <bin file="testRunInfo.cpp" name="testRunInfo">
+</bin>
+
+<bin file="testRunInfo2.cpp" name="testRunInfo2">
 </bin>
 
 <bin file="testGroupSelection.cpp" name="testGroupSelection">

--- a/CondCore/CondDB/test/testRunInfo2.cpp
+++ b/CondCore/CondDB/test/testRunInfo2.cpp
@@ -1,0 +1,56 @@
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+//
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+//
+#include <fstream>
+#include <iomanip>
+#include <cstdlib>
+#include <iostream>
+
+using namespace cond::persistency;
+
+int run(const std::string& connectionString) {
+  try {
+    //*************
+    std::cout << "> Connecting with db in " << connectionString << std::endl;
+    ConnectionPool connPool;
+    connPool.setMessageVerbosity(coral::Debug);
+    connPool.configure();
+    Session session = connPool.createSession(connectionString);
+    session.transaction().start();
+    cond::RunInfo_t r = session.getLastRun();
+    std::cout << "Last run: " << r.run << " start:" << r.start << std::endl;
+    if (r.isOnGoing())
+      std::cout << "Run is ongoing" << std::endl;
+    else
+      std::cout << "Run was ending on " << r.end << std::endl;
+    session.transaction().commit();
+  } catch (cond::Exception& e) {
+    std::cout << "ERROR: " << e.what() << std::endl;
+    return 1;
+  }
+  //std::cout << "## RunInfo test successfully completed." << std::endl;
+  return 0;
+}
+
+int main(int argc, char** argv) {
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
+  static const edm::ServiceRegistry::Operate operate(services);
+  int ret = 0;
+  std::string connectionString0("frontier://FrontierProd/CMS_CONDITIONS");
+  //std::string connectionString0("frontier://FrontierProd/CMS_CONDITIONS");
+  //std::string connectionString0("oracle://cms_orcoff_prep/CMS_CONDITIONS");
+  ret = run(connectionString0);
+  return ret;
+}

--- a/CondCore/DBOutputService/src/OnlineDBOutputService.cc
+++ b/CondCore/DBOutputService/src/OnlineDBOutputService.cc
@@ -6,19 +6,19 @@
 cond::service::OnlineDBOutputService::OnlineDBOutputService(const edm::ParameterSet& iConfig,
                                                             edm::ActivityRegistry& iAR)
     : PoolDBOutputService(iConfig, iAR),
+      m_runNumber(iConfig.getUntrackedParameter<unsigned long long>("runNumber", 0)),
       m_latencyInLumisections(iConfig.getUntrackedParameter<unsigned int>("latency", 1)),
       m_lastLumiUrl(iConfig.getUntrackedParameter<std::string>("lastLumiUrl", "")),
       m_preLoadConnectionString(iConfig.getUntrackedParameter<std::string>("preLoadConnectionString", "")),
       m_debug(iConfig.getUntrackedParameter<bool>("debugLogging", false)) {
   if (!m_lastLumiUrl.empty()) {
     startTransaction();
-    m_runNumber = PoolDBOutputService::session().getCurrentRun().run;
+    auto lastRun = PoolDBOutputService::session().getLastRun();
+    if (lastRun.isOnGoing()) {
+      m_runNumber = lastRun.run;
+    }
   } else {
     m_lastLumiFile = iConfig.getUntrackedParameter<std::string>("lastLumiFile", "");
-    //if( m_lastLumiFile.size() == 0 ){
-    //  m_runNumber = iConfig.getUntrackedParameter<unsigned long long>("runNumber",100000);
-    //  m_startRunTime = std::chrono::steady_clock::now();
-    //}
   }
 }
 

--- a/CondCore/Utilities/test/testPngHistograms.cpp
+++ b/CondCore/Utilities/test/testPngHistograms.cpp
@@ -9,10 +9,6 @@
 
 int main(int argc, char** argv) {
   Py_Initialize();
-  if (argc < 3) {
-    std::cout << "Not enough arguments given." << std::endl;
-    return 0;
-  }
 
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
@@ -24,11 +20,10 @@ int main(int argc, char** argv) {
   edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
   edm::ServiceRegistry::Operate operate(servToken);
 
-  std::string connectionString("oracle://cms_orcon_adg/CMS_CONDITIONS");
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
 
-  std::string tag = std::string(argv[1]);
-  std::string runTimeType = cond::time::timeTypeName(cond::runnumber);
-  cond::Time_t since = boost::lexical_cast<unsigned long long>(argv[2]);
+  std::string tag = std::string("BasicPayload_v10.0");
+  cond::Time_t since = boost::lexical_cast<unsigned long long>("901");
 
   std::cout << "## PNG Histo" << std::endl;
 


### PR DESCRIPTION
#### PR description:

This fix replaces a function "getCurrentRun" in the CondDB API ( Session object ) with a more general getLastRun function.
The single client of this function has been adapted to the new semantics.

PR validation:

A unit test has been added. The rest of the CondDB unit and integration test are successfully running

This PR is a backport of https://github.com/cms-sw/cmssw/pull/30739
The back-port is required to operate on the HLT workflow
