### PR TITLE
Fix Unknown parameter name ClusterShapeCacheSrc specified while calling Modifier

### DIFF
--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -175,11 +175,11 @@ trackingLowPU.toModify(pixelLessStepSeeds,
     seedingHitSets = 'pixelLessStepHitDoublets',
     SeedComparitorPSet = dict(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
         ComponentName      = 'PixelClusterShapeSeedComparitor',
-        FilterAtHelixStage = True,
-        FilterPixelHits    = False,
-        FilterStripHits    = True,
-        ClusterShapeHitFilterName = 'ClusterShapeHitFilter',
-        ClusterShapeCacheSrc      = 'siPixelClusterShapeCache' # not really needed here since FilterPixelHits=False
+        FilterAtHelixStage = cms.bool(True),
+        FilterPixelHits    = cms.bool(False),
+        FilterStripHits    = cms.bool(True),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc      = cms.InputTag('siPixelClusterShapeCache') # not really needed here since FilterPixelHits=False
     )
 )
 #fastsim


### PR DESCRIPTION
#### PR description:

To Fix the failing workflows issue : [PR#30766](https://github.com/cms-sw/cmssw/issues/30766).
`      raise KeyError("Unknown parameter name "+key+" specified while calling Modifier")
KeyError: 'Unknown parameter name ClusterShapeCacheSrc specified while calling Modifier'`

The reference PR is [PR#30671](https://github.com/cms-sw/cmssw/pull/30671) : drop type specs in RecoTracker/{MkFit,MeasurementDet,IterativeTracking}
 