### PR TITLE
11_2_X L1T  FEVTDEBUG EventContent for Phase2 era (keep TTStubs and TTClusters)

### DIFF
--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -9,6 +9,7 @@
  <class name="std::bitset<7>"/>
  <class name="std::bitset<15>"/>
  <class name="std::bitset<25>"/>
+ <class name="std::bitset<64>"/>
  <class name="std::bitset<96>"/>
  <class name="std::deque<int>"/>
  <class name="std::forward_iterator_tag"/>

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -196,6 +196,8 @@ def _appendPhase2Digis(obj):
         'keep *_l1PFMetCalo_*_*',
         'keep *_l1PFMetPF_*_*',
         'keep *_l1PFMetPuppi_*_*',
+        'keep *_TTStubsFromPhase2TrackerDigis_*_*',
+        'keep *_TTClustersFromPhase2TrackerDigis_*_*',
         'keep *_TTTracksFromExtendedTrackletEmulation_*_*',
         'keep *_TTTracksFromTrackletEmulation_*_*',
         ]


### PR DESCRIPTION
#### PR description:

Expand FEVTDEBUG EventContet for Phase2 era to keep TTStubs and TTClusters. 

These are needed for proper debugging and validation and L1TrackerTrigger tracks and needed for HLT TDR reprocessing.

#### Additional comments for HLT TDR reprocessing:
When re-processing HLT TDR we should drop the original TTStubs and TTCluster collections found in the input DIGI file and produced in the original HLT process.

```
'drop *_TTStubsFromPhase2TrackerDigis_*_HLT',
'drop *_TTClustersFromPhase2TrackerDigis_*_HLT',
```

Could be done via customization:
```
--customise_command process.FEVTDEBUGHLToutput.outputCommands.append('drop *_TTStubsFromPhase2TrackerDigis_*_HLT', 'drop *_TTClustersFromPhase2TrackerDigis_*_HLT')
```


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->
