### PR TITLE
Pile-Up ID training and WPs for 2017 UL samples

### DIFF
--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -70,7 +70,7 @@ public:
     std::vector<std::string> const& tmvaVariables() const { return tmvaVariables_; }
     std::vector<std::vector<std::string>> const& tmvaEtaVariables() const { return tmvaEtaVariables_; }
 
-    typedef float array_t[3][4][4];
+    typedef float array_t[3][5][4];
     array_t const& mvacut() const { return mvacut_; }
     array_t const& rmsCut() const { return rmsCut_; }
     array_t const& betaStarCut() const { return betaStarCut_; }
@@ -89,9 +89,9 @@ public:
     std::vector<std::string> tmvaVariables_;
     std::vector<std::vector<std::string>> tmvaEtaVariables_;
 
-    float mvacut_[3][4][4];       //Keep the array fixed
-    float rmsCut_[3][4][4];       //Keep the array fixed
-    float betaStarCut_[3][4][4];  //Keep the array fixed
+    float mvacut_[3][5][4];       //Keep the array fixed
+    float rmsCut_[3][5][4];       //Keep the array fixed
+    float betaStarCut_[3][5][4];  //Keep the array fixed
 
     std::map<std::string, std::string> tmvaNames_;
   };

--- a/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
@@ -10,19 +10,22 @@ full_81x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
     Pt1020_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
     Pt2030_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
-    Pt3050_Tight   = cms.vdouble( 0.86, -0.10, -0.05, -0.01),
+    Pt3040_Tight   = cms.vdouble( 0.86, -0.10, -0.05, -0.01),
+    Pt4050_Tight   = cms.vdouble( 0.86, -0.10, -0.05, -0.01),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
     Pt1020_Medium  = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
     Pt2030_Medium  = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
-    Pt3050_Medium  = cms.vdouble( 0.61, -0.35, -0.23, -0.17),
+    Pt3040_Medium  = cms.vdouble( 0.61, -0.35, -0.23, -0.17),
+    Pt4050_Medium  = cms.vdouble( 0.61, -0.35, -0.23, -0.17),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
     Pt1020_Loose   = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
     Pt2030_Loose   = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
-    Pt3050_Loose   = cms.vdouble(-0.89, -0.52, -0.38, -0.30)
+    Pt3040_Loose   = cms.vdouble(-0.89, -0.52, -0.38, -0.30),
+    Pt4050_Loose   = cms.vdouble(-0.89, -0.52, -0.38, -0.30)
 )
 
 ###########################################################
@@ -35,6 +38,34 @@ full_102x_chs_wp = full_81x_chs_wp.clone()
 ###########################################################
 full_94x_chs_wp = full_81x_chs_wp.clone()
 
+##########################################################
+## Working points for the 106X UL17 training
+###########################################################
+full_106x_UL17_chs_wp = cms.PSet(
+    # 4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
+    # 5 Pt Categories   0-10, 10-20, 20-30, 30-40, 40-50
+
+    #Tight Id
+    Pt010_Tight  = cms.vdouble( 0.77, 0.38, -0.31, -0.21),
+    Pt1020_Tight = cms.vdouble( 0.77, 0.38, -0.31, -0.21),
+    Pt2030_Tight = cms.vdouble( 0.90, 0.60, -0.12, -0.13),
+    Pt3040_Tight = cms.vdouble( 0.96, 0.82, 0.20, 0.09),
+    Pt4050_Tight = cms.vdouble( 0.98, 0.92, 0.47, 0.29),
+
+    #Medium Id
+    Pt010_Medium  = cms.vdouble( 0.26, -0.33, -0.54, -0.37),
+    Pt1020_Medium = cms.vdouble( 0.26, -0.33, -0.54, -0.37),
+    Pt2030_Medium = cms.vdouble( 0.68, -0.04, -0.43, -0.30),
+    Pt3040_Medium = cms.vdouble( 0.90, 0.36, -0.16, -0.09),
+    Pt4050_Medium = cms.vdouble( 0.96, 0.61, 0.14, 0.12),
+
+    #Loose Id
+    Pt010_Loose  = cms.vdouble(-0.95, -0.72, -0.68, -0.47),
+    Pt1020_Loose = cms.vdouble(-0.95, -0.72, -0.68, -0.47),
+    Pt2030_Loose = cms.vdouble(-0.88, -0.55, -0.60, -0.43),
+    Pt3040_Loose = cms.vdouble(-0.63, -0.18, -0.43, -0.24),
+    Pt4050_Loose = cms.vdouble(-0.19, 0.22, -0.13, -0.03)
+)
 
 ###########################################################
 ## Working points for the 80X training
@@ -46,19 +77,22 @@ full_80x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
     Pt1020_Tight   = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
     Pt2030_Tight   = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
-    Pt3050_Tight   = cms.vdouble( 0.62, -0.21, -0.07, -0.03),
+    Pt3040_Tight   = cms.vdouble( 0.62, -0.21, -0.07, -0.03),
+    Pt4050_Tight   = cms.vdouble( 0.62, -0.21, -0.07, -0.03),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.49, -0.53, -0.44, -0.42),
     Pt1020_Medium  = cms.vdouble(-0.49, -0.53, -0.44, -0.42),
     Pt2030_Medium  = cms.vdouble(-0.49, -0.53, -0.44, -0.42),
-    Pt3050_Medium  = cms.vdouble(-0.06, -0.42, -0.3 , -0.23),
+    Pt3040_Medium  = cms.vdouble(-0.06, -0.42, -0.3 , -0.23),
+    Pt4050_Medium  = cms.vdouble(-0.06, -0.42, -0.3 , -0.23),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.96, -0.64, -0.56, -0.54),
     Pt1020_Loose   = cms.vdouble(-0.96, -0.64, -0.56, -0.54),
     Pt2030_Loose   = cms.vdouble(-0.96, -0.64, -0.56, -0.54),
-    Pt3050_Loose   = cms.vdouble(-0.92, -0.56, -0.44, -0.39)
+    Pt3040_Loose   = cms.vdouble(-0.92, -0.56, -0.44, -0.39),
+    Pt4050_Loose   = cms.vdouble(-0.92, -0.56, -0.44, -0.39)
 )
 
 ###########################################################
@@ -71,19 +105,22 @@ full_76x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(0.09,-0.37,-0.24,-0.21),
     Pt1020_Tight   = cms.vdouble(0.09,-0.37,-0.24,-0.21),
     Pt2030_Tight   = cms.vdouble(0.09,-0.37,-0.24,-0.21),
-    Pt3050_Tight   = cms.vdouble(0.52,-0.19,-0.06,-0.03),
+    Pt3040_Tight   = cms.vdouble(0.52,-0.19,-0.06,-0.03),
+    Pt4050_Tight   = cms.vdouble(0.52,-0.19,-0.06,-0.03),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.58,-0.52,-0.40,-0.36),
     Pt1020_Medium  = cms.vdouble(-0.58,-0.52,-0.40,-0.36),
     Pt2030_Medium  = cms.vdouble(-0.58,-0.52,-0.40,-0.36),
-    Pt3050_Medium  = cms.vdouble(-0.20,-0.39,-0.24,-0.19),
+    Pt3040_Medium  = cms.vdouble(-0.20,-0.39,-0.24,-0.19),
+    Pt4050_Medium  = cms.vdouble(-0.20,-0.39,-0.24,-0.19),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
     Pt1020_Loose   = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
     Pt2030_Loose   = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
-    Pt3050_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31)
+    Pt3040_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31),
+    Pt4050_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31)
 )
 
 ###########################################################
@@ -96,19 +133,22 @@ full_74x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt1020_Tight   = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt2030_Tight   = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
-    Pt3050_Tight   = cms.vdouble(-0.5,-0.77,-0.80,-0.98),
+    Pt3040_Tight   = cms.vdouble(-0.5,-0.77,-0.80,-0.98),
+    Pt4050_Tight   = cms.vdouble(-0.5,-0.77,-0.80,-0.98),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt1020_Medium  = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt2030_Medium  = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
-    Pt3050_Medium  = cms.vdouble(-0.6,-0.85,-0.85,-0.99),
+    Pt3040_Medium  = cms.vdouble(-0.6,-0.85,-0.85,-0.99),
+    Pt4050_Medium  = cms.vdouble(-0.6,-0.85,-0.85,-0.99),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
     Pt1020_Loose   = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
     Pt2030_Loose   = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
-    Pt3050_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99)
+    Pt3040_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99),
+    Pt4050_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99)
 )
 
 ###########################################################
@@ -121,25 +161,29 @@ full_53x_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt1020_Tight   = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt2030_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
-    Pt3050_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
+    Pt3040_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
+    Pt4050_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt2030_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
-    Pt3050_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
+    Pt3040_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
+    Pt4050_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt2030_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
-    Pt3050_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
+    Pt3040_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
+    Pt4050_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
 
     #MET
     Pt010_MET	   = cms.vdouble( 0.  ,-0.6,-0.4,-0.4),
     Pt1020_MET     = cms.vdouble( 0.3 ,-0.2,-0.4,-0.4),
     Pt2030_MET     = cms.vdouble( 0.  , 0. , 0. , 0. ),
-    Pt3050_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2)
+    Pt3040_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2),
+    Pt4050_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2)
     )
 
 full_53x_chs_wp  = cms.PSet(
@@ -149,19 +193,22 @@ full_53x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt1020_Tight   = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt2030_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
-    Pt3050_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
+    Pt3040_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
+    Pt4050_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt2030_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
-    Pt3050_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
+    Pt3040_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
+    Pt4050_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt2030_Loose   = cms.vdouble(-0.15,-0.26,-0.16,-0.16),
-    Pt3050_Loose   = cms.vdouble(-0.15,-0.26,-0.16,-0.16),
+    Pt3040_Loose   = cms.vdouble(-0.15,-0.26,-0.16,-0.16),
+    Pt4050_Loose   = cms.vdouble(-0.15,-0.26,-0.16,-0.16)
     )
 
 met_53x_wp  = cms.PSet(
@@ -170,26 +217,30 @@ met_53x_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(-2, -2, -2, -2, -2),
     Pt1020_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
     Pt2030_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
-    Pt3050_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt3040_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt4050_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
 
                     #Medium Id
     Pt010_Medium   = cms.vdouble(-2, -2, -2, -2, -2),
     Pt1020_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
     Pt2030_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
-    Pt3050_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt3040_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt4050_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
 
                     #Loose Id
     Pt010_Loose    = cms.vdouble(-2, -2, -2, -2, -2),
     Pt1020_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
     Pt2030_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
-    Pt3050_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt3040_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt4050_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
 
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
     #MET
     Pt010_MET      = cms.vdouble(-0.2 ,-0.3,-0.5,-0.5),
     Pt1020_MET     = cms.vdouble(-0.2 ,-0.2,-0.5,-0.3),
     Pt2030_MET     = cms.vdouble(-0.2 ,-0.2,-0.2, 0.1),
-    Pt3050_MET     = cms.vdouble(-0.2 ,-0.2, 0. , 0.2)
+    Pt3040_MET     = cms.vdouble(-0.2 ,-0.2, 0. , 0.2),
+    Pt4050_MET     = cms.vdouble(-0.2 ,-0.2, 0. , 0.2)
     )
 
 metfull_53x_wp  = cms.PSet(
@@ -197,7 +248,8 @@ metfull_53x_wp  = cms.PSet(
     Pt010_MET      = cms.vdouble(-0.2 ,-0.3,-0.5,-0.5),
     Pt1020_MET     = cms.vdouble(-0.2 ,-0.2,-0.5,-0.3),
     Pt2030_MET     = cms.vdouble( 0.  , 0. , 0. , 0. ),
-    Pt3050_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2)
+    Pt3040_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2),
+    Pt4050_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2)
     )
 
 
@@ -211,19 +263,22 @@ full_5x_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.47,-0.92,-0.92,-0.94),
     Pt1020_Tight   = cms.vdouble(-0.47,-0.92,-0.92,-0.94),
     Pt2030_Tight   = cms.vdouble(+0.32,-0.49,-0.61,-0.74),
-    Pt3050_Tight   = cms.vdouble(+0.32,-0.49,-0.61,-0.74),
+    Pt3040_Tight   = cms.vdouble(+0.32,-0.49,-0.61,-0.74),
+    Pt4050_Tight   = cms.vdouble(+0.32,-0.49,-0.61,-0.74),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.96,-0.95,-0.96),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.96,-0.95,-0.96),
     Pt2030_Medium  = cms.vdouble(-0.40,-0.74,-0.76,-0.81),
-    Pt3050_Medium  = cms.vdouble(-0.40,-0.74,-0.76,-0.81),
-
+    Pt3040_Medium  = cms.vdouble(-0.40,-0.74,-0.76,-0.81),
+    Pt4050_Medium  = cms.vdouble(-0.40,-0.74,-0.76,-0.81),
+    
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.97,-0.97,-0.97),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.97,-0.97,-0.97),
     Pt2030_Loose   = cms.vdouble(-0.80,-0.85,-0.84,-0.85),
-    Pt3050_Loose   = cms.vdouble(-0.80,-0.85,-0.84,-0.85)
+    Pt3040_Loose   = cms.vdouble(-0.80,-0.85,-0.84,-0.85),
+    Pt4050_Loose   = cms.vdouble(-0.80,-0.85,-0.84,-0.85)
 )
 
 simple_5x_wp = cms.PSet(
@@ -233,19 +288,22 @@ simple_5x_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.54,-0.93,-0.93,-0.94),
     Pt1020_Tight   = cms.vdouble(-0.54,-0.93,-0.93,-0.94),
     Pt2030_Tight   = cms.vdouble(+0.26,-0.54,-0.63,-0.74),
-    Pt3050_Tight   = cms.vdouble(+0.26,-0.54,-0.63,-0.74),
+    Pt3040_Tight   = cms.vdouble(+0.26,-0.54,-0.63,-0.74),
+    Pt4050_Tight   = cms.vdouble(+0.26,-0.54,-0.63,-0.74),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.85,-0.96,-0.95,-0.96),
     Pt1020_Medium  = cms.vdouble(-0.85,-0.96,-0.95,-0.96),
     Pt2030_Medium  = cms.vdouble(-0.40,-0.73,-0.74,-0.80),
-    Pt3050_Medium  = cms.vdouble(-0.40,-0.73,-0.74,-0.80),
+    Pt3040_Medium  = cms.vdouble(-0.40,-0.73,-0.74,-0.80),
+    Pt4050_Medium  = cms.vdouble(-0.40,-0.73,-0.74,-0.80),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.97,-0.96,-0.97),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.97,-0.96,-0.97),
     Pt2030_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84),
-    Pt3050_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84)
+    Pt3040_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84),
+    Pt4050_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84)
 
 )
 
@@ -259,19 +317,22 @@ full_5x_chs_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.59,-0.75,-0.78,-0.80),
     Pt1020_Tight   = cms.vdouble(-0.59,-0.75,-0.78,-0.80),
     Pt2030_Tight   = cms.vdouble(+0.41,-0.10,-0.20,-0.45),
-    Pt3050_Tight   = cms.vdouble(+0.41,-0.10,-0.20,-0.45),
+    Pt3040_Tight   = cms.vdouble(+0.41,-0.10,-0.20,-0.45),
+    Pt4050_Tight   = cms.vdouble(+0.41,-0.10,-0.20,-0.45),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.94,-0.91,-0.91,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.94,-0.91,-0.91,-0.92),
     Pt2030_Medium  = cms.vdouble(-0.58,-0.65,-0.57,-0.67),
-    Pt3050_Medium  = cms.vdouble(-0.58,-0.65,-0.57,-0.67),
+    Pt3040_Medium  = cms.vdouble(-0.58,-0.65,-0.57,-0.67),
+    Pt4050_Medium  = cms.vdouble(-0.58,-0.65,-0.57,-0.67),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.98,-0.95,-0.94,-0.94),
     Pt1020_Loose   = cms.vdouble(-0.98,-0.95,-0.94,-0.94),
     Pt2030_Loose   = cms.vdouble(-0.89,-0.77,-0.69,-0.75),
-    Pt3050_Loose   = cms.vdouble(-0.89,-0.77,-0.69,-0.57)
+    Pt3040_Loose   = cms.vdouble(-0.89,-0.77,-0.69,-0.57),
+    Pt4050_Loose   = cms.vdouble(-0.89,-0.77,-0.69,-0.57)
 )
 
 simple_5x_chs_wp = cms.PSet(
@@ -281,19 +342,22 @@ simple_5x_chs_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.60,-0.74,-0.78,-0.81),
     Pt1020_Tight   = cms.vdouble(-0.60,-0.74,-0.78,-0.81),
     Pt2030_Tight   = cms.vdouble(-0.47,-0.06,-0.23,-0.47),
-    Pt3050_Tight   = cms.vdouble(-0.47,-0.06,-0.23,-0.47),
+    Pt3040_Tight   = cms.vdouble(-0.47,-0.06,-0.23,-0.47),
+    Pt4050_Tight   = cms.vdouble(-0.47,-0.06,-0.23,-0.47),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.95,-0.94,-0.92,-0.91),
     Pt1020_Medium  = cms.vdouble(-0.95,-0.94,-0.92,-0.91),
     Pt2030_Medium  = cms.vdouble(-0.59,-0.65,-0.56,-0.68),
-    Pt3050_Medium  = cms.vdouble(-0.59,-0.65,-0.56,-0.68),
+    Pt3040_Medium  = cms.vdouble(-0.59,-0.65,-0.56,-0.68),
+    Pt4050_Medium  = cms.vdouble(-0.59,-0.65,-0.56,-0.68),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.98,-0.96,-0.94,-0.94),
     Pt1020_Loose   = cms.vdouble(-0.98,-0.96,-0.94,-0.94),
     Pt2030_Loose   = cms.vdouble(-0.89,-0.75,-0.72,-0.75),
-    Pt3050_Loose   = cms.vdouble(-0.89,-0.75,-0.72,-0.75)
+    Pt3040_Loose   = cms.vdouble(-0.89,-0.75,-0.72,-0.75),
+    Pt4050_Loose   = cms.vdouble(-0.89,-0.75,-0.72,-0.75)
 )
 
 
@@ -307,19 +371,22 @@ PuJetIdOptMVA_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.5,-0.2,-0.83,-0.7),
     Pt1020_Tight   = cms.vdouble(-0.5,-0.2,-0.83,-0.7),
     Pt2030_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
-    Pt3050_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
+    Pt3040_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
+    Pt4050_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.73,-0.89,-0.89,-0.83),
     Pt1020_Medium  = cms.vdouble(-0.73,-0.89,-0.89,-0.83),
     Pt2030_Medium  = cms.vdouble(0.1,  -0.4, -0.4, -0.45),
-    Pt3050_Medium  = cms.vdouble(0.1,  -0.4, -0.4, -0.45),
+    Pt3040_Medium  = cms.vdouble(0.1,  -0.4, -0.4, -0.45),
+    Pt4050_Medium  = cms.vdouble(0.1,  -0.4, -0.4, -0.45),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.9,-0.9, -0.9,-0.9),
     Pt1020_Loose   = cms.vdouble(-0.9,-0.9, -0.9,-0.9),
     Pt2030_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6),
-    Pt3050_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6)
+    Pt3040_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6),
+    Pt4050_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6)
 )
 
 PuJetIdMinMVA_wp = cms.PSet(
@@ -329,19 +396,22 @@ PuJetIdMinMVA_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.5,-0.2,-0.83,-0.7),
     Pt1020_Tight   = cms.vdouble(-0.5,-0.2,-0.83,-0.7),
     Pt2030_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
-    Pt3050_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
+    Pt3040_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
+    Pt4050_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.73,-0.89,-0.89,-0.83),
     Pt1020_Medium  = cms.vdouble(-0.73,-0.89,-0.89,-0.83),
     Pt2030_Medium  = cms.vdouble(0.1,  -0.4, -0.5, -0.45),
-    Pt3050_Medium  = cms.vdouble(0.1,  -0.4, -0.5, -0.45),
+    Pt3040_Medium  = cms.vdouble(0.1,  -0.4, -0.5, -0.45),
+    Pt4050_Medium  = cms.vdouble(0.1,  -0.4, -0.5, -0.45),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.9,-0.9, -0.94,-0.9),
     Pt1020_Loose   = cms.vdouble(-0.9,-0.9, -0.94,-0.9),
     Pt2030_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6),
-    Pt3050_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6)
+    Pt3040_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6),
+    Pt4050_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6)
 )
 
 EmptyJetIdParams = cms.PSet(
@@ -351,19 +421,22 @@ EmptyJetIdParams = cms.PSet(
     Pt010_Tight    = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt1020_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt2030_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
-    Pt3050_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt3040_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt4050_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt1020_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt2030_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
-    Pt3050_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt3040_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt4050_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt1020_Loose   = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt2030_Loose   = cms.vdouble(-999.,-999.,-999.,-999.),
-    Pt3050_Loose   = cms.vdouble(-999.,-999.,-999.,-999.)
+    Pt3040_Loose   = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt4050_Loose   = cms.vdouble(-999.,-999.,-999.,-999.)
 )
 
 
@@ -374,38 +447,44 @@ PuJetIdCutBased_wp = cms.PSet(
     Pt010_BetaStarTight    = cms.vdouble( 0.15, 0.15, 999., 999.),
     Pt1020_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
     Pt2030_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
-    Pt3050_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
-
+    Pt3040_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
+    Pt4050_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
+    
     #Medium Id => Daniele
     Pt010_BetaStarMedium   = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt1020_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt2030_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
-    Pt3050_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
+    Pt3040_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
+    Pt4050_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
 
     #Loose Id
     Pt010_BetaStarLoose    = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt1020_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt2030_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
-    Pt3050_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
+    Pt3040_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
+    Pt4050_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
 
     #RMS variable
     #Tight Id
     Pt010_RMSTight         = cms.vdouble( 0.06, 0.07, 0.04, 0.05),
     Pt1020_RMSTight        = cms.vdouble( 0.06, 0.07, 0.04, 0.05),
     Pt2030_RMSTight        = cms.vdouble( 0.05, 0.07, 0.03, 0.045),
-    Pt3050_RMSTight        = cms.vdouble( 0.05, 0.06, 0.03, 0.04),
-
+    Pt3040_RMSTight        = cms.vdouble( 0.05, 0.06, 0.03, 0.04),
+    Pt4050_RMSTight        = cms.vdouble( 0.05, 0.06, 0.03, 0.04),
+    
     #Medium Id => Daniele
     Pt010_RMSMedium        = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt1020_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt2030_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
-    Pt3050_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
+    Pt3040_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
+    Pt4050_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
 
     #Loose Id
     Pt010_RMSLoose         = cms.vdouble( 0.06, 0.05, 0.05, 0.07),
     Pt1020_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.07),
     Pt2030_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.055),
-    Pt3050_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.055)
+    Pt3040_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.055),
+    Pt4050_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.055)
     )
 
 
@@ -416,18 +495,21 @@ JetIdParams = cms.PSet(
     Pt010_Tight    = cms.vdouble( 0.5,0.6,0.6,0.9),
     Pt1020_Tight   = cms.vdouble(-0.2,0.2,0.2,0.6),
     Pt2030_Tight   = cms.vdouble( 0.3,0.4,0.7,0.8),
-    Pt3050_Tight   = cms.vdouble( 0.5,0.4,0.8,0.9),
+    Pt3040_Tight   = cms.vdouble( 0.5,0.4,0.8,0.9),
+    Pt4050_Tight   = cms.vdouble( 0.5,0.4,0.8,0.9),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble( 0.2,0.4,0.2,0.6),
     Pt1020_Medium  = cms.vdouble(-0.3,0. ,0. ,0.5),
     Pt2030_Medium  = cms.vdouble( 0.2,0.2,0.5,0.7),
-    Pt3050_Medium  = cms.vdouble( 0.3,0.2,0.7,0.8),
+    Pt3040_Medium  = cms.vdouble( 0.3,0.2,0.7,0.8),
+    Pt4050_Medium  = cms.vdouble( 0.3,0.2,0.7,0.8),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble( 0. , 0. , 0. ,0.2),
     Pt1020_Loose   = cms.vdouble(-0.4,-0.4,-0.4,0.4),
     Pt2030_Loose   = cms.vdouble( 0. , 0. , 0.2,0.6),
-    Pt3050_Loose   = cms.vdouble( 0. , 0. , 0.6,0.2)
+    Pt3040_Loose   = cms.vdouble( 0. , 0. , 0.6,0.2),
+    Pt4050_Loose   = cms.vdouble( 0. , 0. , 0.6,0.2)
 )
 

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -150,6 +150,18 @@ full_94x_chs.trainings[2].tmvaVariables = trainingVariables_94X_Eta0To3
 full_94x_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta3p0To5p0_chs_BDT.weights.xml.gz"
 full_94x_chs.trainings[3].tmvaVariables = trainingVariables_94X_Eta3To5
 
+####################################################################################################################
+trainingVariables_106X_Eta0To3 = list(trainingVariables_102X_Eta0To3)
+trainingVariables_106X_Eta3To5 = list(trainingVariables_102X_Eta3To5)
+full_106x_UL17_chs = full_81x_chs.clone(JetIdParams = full_106x_UL17_chs_wp)
+full_106x_UL17_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta0p0To2p5_chs_BDT.weights.xml.gz"
+full_106x_UL17_chs.trainings[0].tmvaVariables = trainingVariables_106X_Eta0To3
+full_106x_UL17_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta2p5To2p75_chs_BDT.weights.xml.gz"
+full_106x_UL17_chs.trainings[1].tmvaVariables = trainingVariables_106X_Eta0To3
+full_106x_UL17_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta2p75To3p0_chs_BDT.weights.xml.gz"
+full_106x_UL17_chs.trainings[2].tmvaVariables = trainingVariables_106X_Eta0To3
+full_106x_UL17_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta3p0To5p0_chs_BDT.weights.xml.gz"
+full_106x_UL17_chs.trainings[3].tmvaVariables = trainingVariables_106X_Eta3To5
 
 ####################################################################################################################
 full_80x_chs = cms.PSet(

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -13,8 +13,9 @@ _chsalgos_80x = cms.VPSet(full_80x_chs,cutbased)
 _chsalgos_81x = cms.VPSet(full_81x_chs,cutbased)
 _chsalgos_94x = cms.VPSet(full_94x_chs,cutbased)
 _chsalgos_102x = cms.VPSet(full_102x_chs,cutbased)
+_chsalgos_106X_UL17 = cms.VPSet(full_106x_UL17_chs,cutbased)
 
-_stdalgos    = _chsalgos_102x
+_stdalgos    = _chsalgos_106X_UL17
 
 # Calculate+store variables and run MVAs
 pileupJetId = cms.EDProducer('PileupJetIdProducer',

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -84,8 +84,8 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
           mvacut_[i0][2][i2] = pt2030[i2];
         for (int i2 = 0; i2 < 4; i2++)
           mvacut_[i0][3][i2] = pt3040[i2];
-	for (int i2 = 0; i2 < 4; i2++)
-	  mvacut_[i0][4][i2] = pt4050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][4][i2] = pt4050[i2];
       }
       if (cutBased_ && i1 == 0) {
         for (int i2 = 0; i2 < 4; i2++)
@@ -96,8 +96,8 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
           betaStarCut_[i0][2][i2] = pt2030[i2];
         for (int i2 = 0; i2 < 4; i2++)
           betaStarCut_[i0][3][i2] = pt3040[i2];
-	for (int i2 = 0; i2 < 4; i2++)
-	  betaStarCut_[i0][4][i2] = pt4050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][4][i2] = pt4050[i2];
       }
       if (cutBased_ && i1 == 1) {
         for (int i2 = 0; i2 < 4; i2++)
@@ -108,8 +108,8 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
           rmsCut_[i0][2][i2] = pt2030[i2];
         for (int i2 = 0; i2 < 4; i2++)
           rmsCut_[i0][3][i2] = pt3040[i2];
-	for (int i2 = 0; i2 < 4; i2++)
-	  rmsCut_[i0][4][i2] = pt4050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][4][i2] = pt4050[i2];
       }
     }
   }

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -73,7 +73,8 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
       std::vector<double> pt010 = jetConfig.getParameter<std::vector<double> >(("Pt010_" + lFullCutType).c_str());
       std::vector<double> pt1020 = jetConfig.getParameter<std::vector<double> >(("Pt1020_" + lFullCutType).c_str());
       std::vector<double> pt2030 = jetConfig.getParameter<std::vector<double> >(("Pt2030_" + lFullCutType).c_str());
-      std::vector<double> pt3050 = jetConfig.getParameter<std::vector<double> >(("Pt3050_" + lFullCutType).c_str());
+      std::vector<double> pt3040 = jetConfig.getParameter<std::vector<double> >(("Pt3040_" + lFullCutType).c_str());
+      std::vector<double> pt4050 = jetConfig.getParameter<std::vector<double> >(("Pt4050_" + lFullCutType).c_str());
       if (!cutBased_) {
         for (int i2 = 0; i2 < 4; i2++)
           mvacut_[i0][0][i2] = pt010[i2];
@@ -82,7 +83,9 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
         for (int i2 = 0; i2 < 4; i2++)
           mvacut_[i0][2][i2] = pt2030[i2];
         for (int i2 = 0; i2 < 4; i2++)
-          mvacut_[i0][3][i2] = pt3050[i2];
+          mvacut_[i0][3][i2] = pt3040[i2];
+	for (int i2 = 0; i2 < 4; i2++)
+	  mvacut_[i0][4][i2] = pt4050[i2];
       }
       if (cutBased_ && i1 == 0) {
         for (int i2 = 0; i2 < 4; i2++)
@@ -92,7 +95,9 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
         for (int i2 = 0; i2 < 4; i2++)
           betaStarCut_[i0][2][i2] = pt2030[i2];
         for (int i2 = 0; i2 < 4; i2++)
-          betaStarCut_[i0][3][i2] = pt3050[i2];
+          betaStarCut_[i0][3][i2] = pt3040[i2];
+	for (int i2 = 0; i2 < 4; i2++)
+	  betaStarCut_[i0][4][i2] = pt4050[i2];
       }
       if (cutBased_ && i1 == 1) {
         for (int i2 = 0; i2 < 4; i2++)
@@ -102,7 +107,9 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
         for (int i2 = 0; i2 < 4; i2++)
           rmsCut_[i0][2][i2] = pt2030[i2];
         for (int i2 = 0; i2 < 4; i2++)
-          rmsCut_[i0][3][i2] = pt3050[i2];
+          rmsCut_[i0][3][i2] = pt3040[i2];
+	for (int i2 = 0; i2 < 4; i2++)
+	  rmsCut_[i0][4][i2] = pt4050[i2];
       }
     }
   }
@@ -192,8 +199,10 @@ std::pair<int, int> PileupJetIdAlgo::getJetIdKey(float jetPt, float jetEta) {
     ptId = 1;
   if (jetPt >= 20 && jetPt < 30)
     ptId = 2;
-  if (jetPt >= 30)
+  if (jetPt >= 30 && jetPt < 40)
     ptId = 3;
+  if (jetPt >= 40)
+    ptId = 4;
 
   int etaId = 0;
   if (std::abs(jetEta) >= 2.5 && std::abs(jetEta) < 2.75)


### PR DESCRIPTION
#### PR description:

- With this PR new training files and working points for UL 2017 samples are added. New pt bins are introduced and the code changed accordingly. (Studies shown here [PU ID, UL17 slides](https://indico.cern.ch/event/916566/#44-ul17-pu-jet-id-update))
- There is also a PR for the new weights for PUJetID [PR#11](https://github.com/cms-data/RecoJets-JetProducers/pull/11)

#### PR validation:

Passed code-checks and code-format tests.
Passed runTheMatrix test workflows

FYI: @alefisico @camclean @singh-ramanpreet 