### PR TITLE
[Clang tidy] Apply checks for daq-reconstruction

### DIFF
--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -1,6 +1,8 @@
-#include <zlib.h>
 #include <iostream>
+#include <memory>
+#include <zlib.h>
 
+        
 #include "IOPool/Streamer/interface/FRDEventMessage.h"
 #include "IOPool/Streamer/interface/FRDFileHeader.h"
 
@@ -91,7 +93,7 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id,
     if (fin_.gcount() != totalSize - FRDHeaderVersionSize[detectedFRDversion_]) {
       throw cms::Exception("FRDStreamSource::setRunAndEventInfo") << "premature end of file " << *itFileName_;
     }
-    frdEventMsg.reset(new FRDEventMsgView(&buffer_[0]));
+    frdEventMsg = std::make_unique<FRDEventMsgView>(&buffer_[0]);
   }
 
   if (verifyChecksum_ && frdEventMsg->version() >= 5) {

--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -2,7 +2,6 @@
 #include <memory>
 #include <zlib.h>
 
-        
 #include "IOPool/Streamer/interface/FRDEventMessage.h"
 #include "IOPool/Streamer/interface/FRDFileHeader.h"
 

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -217,7 +217,7 @@ void RawEventFileWriterForBU::finishFileWrite(int ls) {
     write(outfd_, (char*)&frdFileHeader, sizeof(FRDFileHeader_v1));
     closefd();
     //move raw file from open to run directory
-    rename(fileName_.c_str(), (destinationDir_ + fileName_.substr(fileName_.rfind("/"))).c_str());
+    rename(fileName_.c_str(), (destinationDir_ + fileName_.substr(fileName_.rfind('/'))).c_str());
 
     edm::LogInfo("RawEventFileWriterForBU")
         << "Wrote RAW input file: " << fileName_ << " with perFileEventCount = " << perFileEventCount_.value()
@@ -225,7 +225,7 @@ void RawEventFileWriterForBU::finishFileWrite(int ls) {
   } else {
     closefd();
     //move raw file from open to run directory
-    rename(fileName_.c_str(), (destinationDir_ + fileName_.substr(fileName_.rfind("/"))).c_str());
+    rename(fileName_.c_str(), (destinationDir_ + fileName_.substr(fileName_.rfind('/'))).c_str());
     //create equivalent JSON file
     //TODO:fix this to use DaqDirector convention and better extension replace
     std::filesystem::path source(fileName_);
@@ -236,7 +236,7 @@ void RawEventFileWriterForBU::finishFileWrite(int ls) {
     fileMon_->discardCollected(ls);
 
     //move the json file from open
-    rename(path.c_str(), (destinationDir_ + path.substr(path.rfind("/"))).c_str());
+    rename(path.c_str(), (destinationDir_ + path.substr(path.rfind('/'))).c_str());
 
     edm::LogInfo("RawEventFileWriterForBU")
         << "Wrote JSON input file: " << path << " with perFileEventCount = " << perFileEventCount_.value()

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -1099,7 +1099,7 @@ namespace evf {
     //take only first three tokens delimited by "_" in the renamed raw file name
     std::string jsonStem = std::filesystem::path(rawSourcePath).stem().string();
     size_t pos = 0, n_tokens = 0;
-    while (n_tokens++ < 3 && (pos = jsonStem.find("_", pos + 1)) != std::string::npos) {
+    while (n_tokens++ < 3 && (pos = jsonStem.find('_', pos + 1)) != std::string::npos) {
     }
     std::string reducedJsonStem = jsonStem.substr(0, pos);
 
@@ -1531,7 +1531,7 @@ namespace evf {
         std::string fileInfo;
         std::map<std::string, std::string> serverMap;
         while (std::getline(response_stream, fileInfo) && fileInfo != "\r") {
-          auto pos = fileInfo.find("=");
+          auto pos = fileInfo.find('=');
           if (pos == std::string::npos)
             continue;
           auto stitle = fileInfo.substr(0, pos);
@@ -1984,7 +1984,7 @@ namespace evf {
     edm::ParameterSet const& topPset = edm::getParameterSet(pc.parameterSetID());
     if (topPset.existsAs<edm::ParameterSet>(mergeTypePset_, true)) {
       const edm::ParameterSet& tsPset(topPset.getParameterSet(mergeTypePset_));
-      for (std::string pname : tsPset.getParameterNames()) {
+      for (const std::string& pname : tsPset.getParameterNames()) {
         std::string streamType = tsPset.getParameter<std::string>(pname);
         tbb::concurrent_hash_map<std::string, std::string>::accessor ac;
         mergeTypeMap_.insert(ac, pname);

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -117,7 +117,7 @@ namespace evf {
     if (streamLabel_.find(testPrefix) == 0)
       streamLabel_ = std::string("stream") + streamLabel_.substr(testPrefix.size());
 
-    if (streamLabel_.find("_") != std::string::npos) {
+    if (streamLabel_.find('_') != std::string::npos) {
       throw cms::Exception("EvFOutputModule") << "Underscore character is reserved can not be used for stream names in "
                                                  "FFF, but was detected in stream name -: "
                                               << streamLabel_;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -220,7 +220,7 @@ edm::RawInputSource::Next FedRawDataInputSource::checkNext() {
     //this thread opens new files and dispatches reading to worker readers
     //threadInit_.store(false,std::memory_order_release);
     std::unique_lock<std::mutex> lk(startupLock_);
-    readSupervisorThread_.reset(new std::thread(&FedRawDataInputSource::readSupervisor, this));
+    readSupervisorThread_ = std::make_unique<std::thread>(&FedRawDataInputSource::readSupervisor, this);
     startedSupervisorThread_ = true;
     startupCv_.wait(lk);
   }
@@ -486,7 +486,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
       }
     }
 
-    event_.reset(new FRDEventMsgView(dataPosition));
+    event_ = std::make_unique<FRDEventMsgView>(dataPosition);
     if (event_->size() > eventChunkSize_) {
       throw cms::Exception("FedRawDataInputSource::getNextEvent")
           << " event id:" << event_->event() << " lumi:" << event_->lumi() << " run:" << event_->run()
@@ -504,7 +504,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
       readNextChunkIntoBuffer(currentFile_.get());
       //recalculate chunk position
       dataPosition = currentFile_->chunks_[0]->buf_ + currentFile_->chunkPosition_;
-      event_.reset(new FRDEventMsgView(dataPosition));
+      event_ = std::make_unique<FRDEventMsgView>(dataPosition);
     }
     currentFile_->bufferPosition_ += event_->size();
     currentFile_->chunkPosition_ += event_->size();
@@ -531,7 +531,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
     //read header, copy it to a single chunk if necessary
     bool chunkEnd = currentFile_->advance(dataPosition, FRDHeaderVersionSize[detectedFRDversion_]);
 
-    event_.reset(new FRDEventMsgView(dataPosition));
+    event_ = std::make_unique<FRDEventMsgView>(dataPosition);
     if (event_->size() > eventChunkSize_) {
       throw cms::Exception("FedRawDataInputSource::getNextEvent")
           << " event id:" << event_->event() << " lumi:" << event_->lumi() << " run:" << event_->run()
@@ -560,7 +560,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
         assert(chunkEnd);
         chunkIsFree_ = true;
         //header is moved
-        event_.reset(new FRDEventMsgView(dataPosition));
+        event_ = std::make_unique<FRDEventMsgView>(dataPosition);
       } else {
         //everything is in a single chunk, only move pointers forward
         chunkEnd = currentFile_->advance(dataPosition, msgSize);
@@ -1498,10 +1498,10 @@ std::pair<bool, unsigned int> FedRawDataInputSource::getEventReport(unsigned int
 
 long FedRawDataInputSource::initFileList() {
   std::sort(fileNames_.begin(), fileNames_.end(), [](std::string a, std::string b) {
-    if (a.rfind("/") != std::string::npos)
-      a = a.substr(a.rfind("/"));
-    if (b.rfind("/") != std::string::npos)
-      b = b.substr(b.rfind("/"));
+    if (a.rfind('/') != std::string::npos)
+      a = a.substr(a.rfind('/'));
+    if (b.rfind('/') != std::string::npos)
+      b = b.substr(b.rfind('/'));
     return b > a;
   });
 
@@ -1509,7 +1509,7 @@ long FedRawDataInputSource::initFileList() {
     //get run number from first file in the vector
     std::filesystem::path fileName = fileNames_[0];
     std::string fileStem = fileName.stem().string();
-    auto end = fileStem.find("_");
+    auto end = fileStem.find('_');
     if (fileStem.find("run") == 0) {
       std::string runStr = fileStem.substr(3, end - 3);
       try {
@@ -1540,8 +1540,8 @@ evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getFile(unsigned int& ls,
     std::string fileStem = fileName.stem().string();
     if (fileStem.find("ls"))
       fileStem = fileStem.substr(fileStem.find("ls") + 2);
-    if (fileStem.find("_"))
-      fileStem = fileStem.substr(0, fileStem.find("_"));
+    if (fileStem.find('_'))
+      fileStem = fileStem.substr(0, fileStem.find('_'));
 
     if (!fileListLoopMode_)
       ls = boost::lexical_cast<unsigned int>(fileStem);


### PR DESCRIPTION
Apply new clang checks, redone. Apologies for the inconvenience. See #30508 for more info.