### PR TITLE
[Clang tidy] Apply checks for db-hlt

### DIFF
--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
@@ -15,8 +15,10 @@
 ///
 ///////////////////////////////////////////////////////////////////////
 
-#include <string>
+#include <memory>
+
 #include <map>
+        #include <string>
 //#include <vector>
 #include <sstream>
 #include <fstream>
@@ -84,7 +86,7 @@ AlCaRecoTriggerBitsRcdRead::AlCaRecoTriggerBitsRcdRead(const edm::ParameterSet &
       break;
   }
   if (!fileName.empty()) {
-    output_.reset(new std::ofstream(fileName.c_str()));
+    output_ = std::make_unique<std::ofstream>(fileName.c_str());
     if (!output_->good()) {
       edm::LogError("IOproblem") << "Could not open output file " << fileName << ".";
       output_.reset();

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
@@ -18,7 +18,7 @@
 #include <memory>
 
 #include <map>
-        #include <string>
+#include <string>
 //#include <vector>
 #include <sstream>
 #include <fstream>


### PR DESCRIPTION
Apply new clang checks, redone. Apologies for the inconvenience. See #30508 for more info.