### PR TITLE
[Clang tidy] Apply checks for dqm-geometry

### DIFF
--- a/Validation/Geometry/src/MaterialBudgetHcal.cc
+++ b/Validation/Geometry/src/MaterialBudgetHcal.cc
@@ -16,6 +16,8 @@
 #include "G4Track.hh"
 
 #include <iostream>
+#include <memory>
+
 
 MaterialBudgetHcal::MaterialBudgetHcal(const edm::ParameterSet& p) {
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MaterialBudgetHcal");
@@ -25,11 +27,11 @@ MaterialBudgetHcal::MaterialBudgetHcal(const edm::ParameterSet& p) {
   edm::LogVerbatim("MaterialBudget") << "MaterialBudgetHcal initialized with rMax " << rMax_ << " mm and zMax " << zMax_
                                      << " mm doHcal is set to " << doHcal;
   if (doHcal) {
-    theHistoHcal_.reset(new MaterialBudgetHcalHistos(m_p));
+    theHistoHcal_ = std::make_unique<MaterialBudgetHcalHistos>(m_p);
     theHistoCastor_.reset(nullptr);
   } else {
     theHistoHcal_.reset(nullptr);
-    theHistoCastor_.reset(new MaterialBudgetCastorHistos(m_p));
+    theHistoCastor_ = std::make_unique<MaterialBudgetCastorHistos>(m_p);
   }
 }
 

--- a/Validation/Geometry/src/MaterialBudgetHcal.cc
+++ b/Validation/Geometry/src/MaterialBudgetHcal.cc
@@ -18,7 +18,6 @@
 #include <iostream>
 #include <memory>
 
-
 MaterialBudgetHcal::MaterialBudgetHcal(const edm::ParameterSet& p) {
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MaterialBudgetHcal");
   rMax_ = m_p.getUntrackedParameter<double>("RMax", 4.5) * CLHEP::m;


### PR DESCRIPTION
Apply new clang checks, redone. Apologies for the inconvenience. See #30508 for more info.