### PR TITLE
Move DQMServices/StreamerIO to std::filesystem

### DIFF
--- a/DQMServices/StreamerIO/plugins/BuildFile.xml
+++ b/DQMServices/StreamerIO/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="IOPool/Output"/>
 <use name="DQMServices/Core"/>
 <use name="DQMServices/Components"/>
+<use name="stdcxx-fs"/>
 <library file="*.cc" name="DQMServicesStreamerIOPlugins">
   <flags EDM_PLUGIN="1"/>
   <flags REM_CXXFLAGS="-Werror=unused-variable"/>

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
@@ -5,7 +5,7 @@
 #include <boost/regex.hpp>
 #include <boost/format.hpp>
 #include <boost/range.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <memory>
@@ -45,7 +45,7 @@ namespace dqmservices {
     if (boost::starts_with(datafn, "/"))
       return datafn;
 
-    boost::filesystem::path p(run_path);
+    std::filesystem::path p(run_path);
     p /= datafn;
     return p.string();
   }
@@ -183,10 +183,10 @@ namespace dqmservices {
     std::time_t mtime_now = 0;
 
     for (auto path : runPath_) {
-      if (!boost::filesystem::exists(path))
+      if (!std::filesystem::exists(path))
         continue;
 
-      mtime_now = mtime_now ^ boost::filesystem::last_write_time(path);
+      mtime_now = mtime_now ^ std::chrono::system_clock::to_time_t(std::filesystem::last_write_time(path));
     }
 
     return mtime_now;
@@ -217,13 +217,13 @@ namespace dqmservices {
     runPathMTime_ = mtime_now;
     runPathLastCollect_ = now;
 
-    using boost::filesystem::directory_entry;
-    using boost::filesystem::directory_iterator;
+    using std::filesystem::directory_entry;
+    using std::filesystem::directory_iterator;
 
     std::string fn_eor;
 
     for (auto runPath : runPath_) {
-      if (!boost::filesystem::exists(runPath)) {
+      if (!std::filesystem::exists(runPath)) {
         logFileAction("Directory does not exist: ", runPath);
 
         continue;

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
@@ -179,14 +179,16 @@ namespace dqmservices {
     mon_->outputUpdate(doc);
   }
 
-  std::time_t DQMFileIterator::mtimeHash() const {
-    std::time_t mtime_now = 0;
+  unsigned DQMFileIterator::mtimeHash() const {
+    unsigned mtime_now = 0;
 
     for (auto path : runPath_) {
       if (!std::filesystem::exists(path))
         continue;
 
-      mtime_now = mtime_now ^ std::chrono::system_clock::to_time_t(std::filesystem::last_write_time(path));
+      auto write_time = std::filesystem::last_write_time(path);
+      mtime_now =
+          mtime_now ^ std::chrono::duration_cast<std::chrono::microseconds>(write_time.time_since_epoch()).count();
     }
 
     return mtime_now;
@@ -205,7 +207,7 @@ namespace dqmservices {
     }
 
     // check if directory changed
-    std::time_t mtime_now = mtimeHash();
+    auto mtime_now = mtimeHash();
 
     if ((!ignoreTimers) && (last_ms < forceFileCheckTimeoutMillis_) && (mtime_now == runPathMTime_)) {
       // logFileAction("Directory hasn't changed.");

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.h
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.h
@@ -5,7 +5,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-#include "boost/filesystem.hpp"
+#include <filesystem>
 
 #include <map>
 #include <unordered_set>

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.h
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.h
@@ -111,13 +111,13 @@ namespace dqmservices {
 
     /* this should be different,
    * since time between hosts might be not in sync */
-    std::time_t runPathMTime_;
+    unsigned runPathMTime_;
     std::chrono::high_resolution_clock::time_point runPathLastCollect_;
 
     /* this is for missing lumi files */
     std::chrono::high_resolution_clock::time_point lastLumiLoad_;
 
-    std::time_t mtimeHash() const;
+    unsigned mtimeHash() const;
     void collect(bool ignoreTimers);
     void monUpdateLumi(const LumiEntry& lumi);
 

--- a/DQMServices/StreamerIO/plugins/DQMMonitoringService.h
+++ b/DQMServices/StreamerIO/plugins/DQMMonitoringService.h
@@ -12,7 +12,7 @@
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "boost/filesystem.hpp"
+#include <filesystem>
 
 #include <string>
 #include <vector>
@@ -22,7 +22,7 @@
 #include <chrono>
 #include <unordered_map>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
@@ -134,7 +134,7 @@ void DQMProtobufReader::beginLuminosityBlock(edm::LuminosityBlock& lb) {
   lb.put(std::move(json_product), "sourceJsonPath");
 
   if (flagLoadFiles_) {
-    if (!boost::filesystem::exists(path)) {
+    if (!std::filesystem::exists(path)) {
       fiterator_.logFileAction("Data file is missing ", path);
       fiterator_.logLumiState(currentLumi_, "error: data file missing");
       return;

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -10,7 +10,7 @@
 #include "FWCore/Utilities/interface/RegexMatch.h"
 #include "DQMStreamerReader.h"
 
-#include <cstdlib> 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <memory>

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -10,16 +10,17 @@
 #include "FWCore/Utilities/interface/RegexMatch.h"
 #include "DQMStreamerReader.h"
 
+#include <cstdlib> 
+#include <filesystem>
 #include <fstream>
 #include <memory>
+#include <queue>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/range.hpp>
 #include <boost/regex.hpp>
-#include <cstdlib>
-#include <queue>
+#include <boost/algorithm/string.hpp>
 
 #include <IOPool/Streamer/interface/DumpTools.h>
 
@@ -160,7 +161,7 @@ namespace dqmservices {
     DQMFileIterator::LumiEntry currentLumi = fiterator_.open();
     std::string p = currentLumi.get_data_path();
 
-    if (boost::filesystem::exists(p)) {
+    if (std::filesystem::exists(p)) {
       try {
         openFileImp_(currentLumi);
         return true;

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
@@ -10,7 +10,7 @@
 #include "DQMMonitoringService.h"
 #include "TriggerSelector.h"
 
-#include "boost/filesystem.hpp"
+#include <filesystem>
 
 #include <memory>
 #include <string>

--- a/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.cc
+++ b/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.cc
@@ -4,7 +4,7 @@
 #include "DQMServices/Components/interface/fillJson.h"
 
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
@@ -24,7 +24,7 @@ namespace dqmservices {
 
     std::string base = str(boost::format("run%06d_ls%04d_%s") % runNumber_ % sequence_ % streamLabel_);
 
-    boost::filesystem::path p(outputPath_);
+    std::filesystem::path p(outputPath_);
 
     currentFileName_ = (p / base).string() + ".root";
     currentJsonName_ = (p / base).string() + ".jsn";

--- a/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
+++ b/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
@@ -18,7 +18,7 @@
 #include <boost/regex.hpp>
 #include <boost/format.hpp>
 #include <boost/range.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace dqm {
@@ -176,8 +176,8 @@ namespace dqm {
   std::shared_ptr<dqm::rdm::Empty> RamdiskMonitor::globalBeginLuminosityBlock(edm::LuminosityBlock const &,
                                                                               edm::EventSetup const &eSetup) const {
     // search filesystem to find available lumi section files
-    using boost::filesystem::directory_entry;
-    using boost::filesystem::directory_iterator;
+    using std::filesystem::directory_entry;
+    using std::filesystem::directory_iterator;
 
     directory_iterator dend;
     for (directory_iterator di(runPath_); di != dend; ++di) {

--- a/DQMServices/StreamerIO/test/BuildFile.xml
+++ b/DQMServices/StreamerIO/test/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="IOPool/Streamer"/>
 <use name="EventFilter/Utilities"/>
 <use name="DQMServices/Components"/>
+<use name="stdcxx-fs"/>
 <library file="*.cc" name="DQMServicesStreamerIOTestPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest.cc
+++ b/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest.cc
@@ -4,8 +4,8 @@
 
 #include <zlib.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
+#include <filesystem>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -86,10 +86,10 @@ namespace dqmservices {
 
     currentFileBase_ = str(boost::format("run%06d_ls%04d_stream%s_local") % run % lumi % streamLabel_);
 
-    boost::filesystem::path p = outputPath_;
+    std::filesystem::path p = outputPath_;
     p /= str(boost::format("run%06d") % run);
 
-    boost::filesystem::create_directories(p);
+    std::filesystem::create_directories(p);
 
     currentFilePath_ = (p / currentFileBase_).string() + ".dat";
     currentJsonPath_ = (p / currentFileBase_).string() + ".jsn";
@@ -110,7 +110,7 @@ namespace dqmservices {
 
   void DQMStreamerOutputRepackerTest::closeFile() {
     edm::LogAbsolute("DQMStreamerOutputRepackerTest") << "Writing json: " << currentJsonPath_;
-    size_t fsize = boost::filesystem::file_size(currentFilePath_);
+    size_t fsize = std::filesystem::file_size(currentFilePath_);
 
     using namespace boost::property_tree;
     ptree pt;

--- a/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest.cc
+++ b/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest.cc
@@ -5,7 +5,6 @@
 #include <zlib.h>
 #include <boost/algorithm/string.hpp>
 #include <filesystem>
-#include <filesystem>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/DQMServices/StreamerIO/test/DQMStreamerWriteJsonAnalyzer.cc
+++ b/DQMServices/StreamerIO/test/DQMStreamerWriteJsonAnalyzer.cc
@@ -3,7 +3,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -21,7 +21,7 @@ namespace dqmservices {
     void writeJson() const;
     void writeEndJob() const;
 
-    boost::filesystem::path writePath_;
+    std::filesystem::path writePath_;
     unsigned int const eventsPerLumi_;
     unsigned int const runNumber_;
     std::string const streamName_;
@@ -37,10 +37,10 @@ namespace dqmservices {
         dataFileForEachLumi_(iPSet.getUntrackedParameter<std::vector<std::string>>("dataFileForEachLumi")),
         nEventsSeenSinceWrite_{0},
         fileIndex_{0} {
-    boost::filesystem::path path = iPSet.getUntrackedParameter<std::string>("pathToWriteJson");
+    std::filesystem::path path = iPSet.getUntrackedParameter<std::string>("pathToWriteJson");
     writePath_ /= str(boost::format("run%06d") % runNumber_);
 
-    boost::filesystem::create_directories(writePath_);
+    std::filesystem::create_directories(writePath_);
   }
 
   void DQMStreamerWriteJsonAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {


### PR DESCRIPTION
#### PR description:
This PR is a merge of #30661 and #30762.
#30661  was already merged with master, but it seems like it was reverted on:
https://github.com/cms-sw/cmssw/commit/cb7971c744513d6a6adf80d0eca7272d66b5c190 

#30762 is a fix to make #30661 work with gcc 9.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 