### PR TITLE
 Remove boost dependency from GeneratorInterface/LHEInterface

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="FWCore/Utilities"/>
 <use name="GeneratorInterface/LHEInterface"/>
 <use name="GeneratorInterface/Core"/>
-<use name="boost"/>
 <use name="stdcxx-fs"/>
 <library name="GeneratorInterfaceLHEProducer" file="LHEFilter.cc LHE2HepMCConverter.cc ExternalLHEProducer.cc ExternalLHEAsciiDumper.cc">
   <use name="FWCore/Framework"/>

--- a/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="GeneratorInterface/LHEInterface"/>
 <use name="GeneratorInterface/Core"/>
 <use name="boost"/>
+<use name="stdcxx-fs"/>
 <library name="GeneratorInterfaceLHEProducer" file="LHEFilter.cc LHE2HepMCConverter.cc ExternalLHEProducer.cc ExternalLHEAsciiDumper.cc">
   <use name="FWCore/Framework"/>
   <use name="FWCore/Concurrency"/>

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -108,9 +108,12 @@ private:
   class FileCloseSentry{
   public:
     explicit FileCloseSentry(int fd) : fd_(fd){};
-    
+
     ~FileCloseSentry() { close(fd_); }
-    
+
+    //Make this noncopyable
+    FileCloseSentry(const FileCloseSentry&) = delete;
+    FileCloseSentry& operator=(const FileCloseSentry&) = delete;
   private:
     int fd_;
   };


### PR DESCRIPTION
#### PR description:
- C++17 std::filesystem is very similar to boost::filesystem. There is no reason to use boost::filesystem in this case, when std::filesystem could be used
- We can delete the copy constructor and copy assignment operator instead of using boost::noncopyable
- In this case we don't need boost::ptr_deque. Its possible to use std::deque< std::unique_ptr > without a loss in readability
#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 