### PR TITLE
Disabled the TED and TRE tables by default.

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -159,6 +159,7 @@ namespace trklet {
 
     unsigned int writememsect() const { return writememsect_; }
 
+    bool enableTripletTables() const { return enableTripletTables_; }
     bool writeTripletTables() const { return writeTripletTables_; }
 
     bool writeoutReal() const { return writeoutReal_; }
@@ -227,6 +228,9 @@ namespace trklet {
     std::string skimfile() const { return skimfile_; }
     void setSkimfile(std::string skimfile) { skimfile_ = skimfile; }
 
+    unsigned int nbitstrackletindex() const { return nbitstrackletindex_; }
+    void setNbitstrackletindex(unsigned int nbitstrackletindex) { nbitstrackletindex_ = nbitstrackletindex; }
+
     double dphisectorHG() const {
       return 2 * M_PI / N_SECTOR +
              2 * std::max(std::abs(asin(0.5 * rinvmax() * rmean(0)) - asin(0.5 * rinvmax() * rcrit_)),
@@ -271,7 +275,7 @@ namespace trklet {
     unsigned int NLONGVMBITS() const { return NLONGVMBITS_; }
     unsigned int NLONGVMBINS() const { return (1 << NLONGVMBITS_); }
 
-    unsigned int ntrackletmax() const { return ntrackletmax_; }
+    unsigned int ntrackletmax() const { return ((1 << nbitstrackletindex_) - 1); }
 
     //Bits used to store track parameter in tracklet
     int nbitsrinv() const { return nbitsrinv_; }
@@ -418,7 +422,7 @@ namespace trklet {
 
     double ptcutte_{1.8};  //Minimum pt in TE
 
-    unsigned int ntrackletmax_{127};  //maximum number of tracklets that can be stored
+    unsigned int nbitstrackletindex_{7};  //Bits used to store the tracklet index
 
     //Bits used to store track parameter in tracklet
     int nbitsrinv_{14};
@@ -646,6 +650,12 @@ namespace trklet {
 
     unsigned int writememsect_{3};  //writemem only for this sector (note that the files will have _4 extension)
 
+    //FIXME: The TED and TRE tables are currently under development. They use
+    //substantial memory during processing, and their effects on efficiency are
+    //not fully understood
+    bool enableTripletTables_{false};  //Enable the application of the TED and
+                                       //TRE tables; when this flag is false,
+                                       //the tables will not be read from disk
     bool writeTripletTables_{false};  //Train and write the TED and TRE tables. N.B.: the tables
                                       //cannot be applied while they are being trained, i.e.,
                                       //this flag effectively turns off the cuts in

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -656,10 +656,10 @@ namespace trklet {
     bool enableTripletTables_{false};  //Enable the application of the TED and
                                        //TRE tables; when this flag is false,
                                        //the tables will not be read from disk
-    bool writeTripletTables_{false};  //Train and write the TED and TRE tables. N.B.: the tables
-                                      //cannot be applied while they are being trained, i.e.,
-                                      //this flag effectively turns off the cuts in
-                                      //TrackletEngineDisplaced and TripletEngine
+    bool writeTripletTables_{false};   //Train and write the TED and TRE tables. N.B.: the tables
+                                       //cannot be applied while they are being trained, i.e.,
+                                       //this flag effectively turns off the cuts in
+                                       //TrackletEngineDisplaced and TripletEngine
 
     bool writeoutReal_{false};
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -650,9 +650,6 @@ namespace trklet {
 
     unsigned int writememsect_{3};  //writemem only for this sector (note that the files will have _4 extension)
 
-    //FIXME: The TED and TRE tables are currently under development. They use
-    //substantial memory during processing, and their effects on efficiency are
-    //not fully understood
     bool enableTripletTables_{false};  //Enable the application of the TED and
                                        //TRE tables; when this flag is false,
                                        //the tables will not be read from disk

--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -489,7 +489,7 @@ namespace trklet {
     bool isOverlap() const { return overlap_; }
     int isDisk() const { return disk_; }
 
-    void setTrackletIndex(int index);
+    void setTrackletIndex(unsigned int index);
 
     int trackletIndex() const { return trackletIndex_; }
 
@@ -497,7 +497,7 @@ namespace trklet {
 
     int TCIndex() const { return TCIndex_; }
 
-    int TCID() const { return TCIndex_ * (1 << 7) + trackletIndex_; }
+    int TCID() const { return TCIndex_ * (1 << settings_.nbitstrackletindex()) + trackletIndex_; }
 
     int getISeed() const;
     int getITC() const;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEngineDisplaced.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEngineDisplaced.h
@@ -30,7 +30,7 @@ namespace trklet {
 
     void readTables();
 
-    const short memNameToIndex(const std::string &name);
+    const short memNameToIndex(const std::string& name);
 
   private:
     int layer1_;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEngineDisplaced.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEngineDisplaced.h
@@ -30,6 +30,8 @@ namespace trklet {
 
     void readTables();
 
+    const short memNameToIndex(const std::string &name);
+
   private:
     int layer1_;
     int layer2_;
@@ -41,7 +43,7 @@ namespace trklet {
 
     std::vector<StubPairsMemory*> stubpairs_;
 
-    std::vector<std::set<std::string> > table_;
+    std::vector<std::set<short> > table_;
 
     int firstphibits_;
     int secondphibits_;

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -261,6 +261,11 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   if (extended_) {
     settings.setTableTEDFile(tableTEDFile.fullPath());
     settings.setTableTREFile(tableTREFile.fullPath());
+
+    //FIXME: The TED and TRE tables are currently disabled by default, so we
+    //need to allow for the additional tracklets that will eventually be
+    //removed by these tables, once they are finalized
+    settings.setNbitstrackletindex(10);
   }
 
   eventnum = 0;

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -826,7 +826,7 @@ std::vector<Tracklet*> FitTrack::orderedMatches(vector<FullMatchMemory*>& fullma
 
   int bestIndex = -1;
   do {
-    int bestTCID = (1 << 16);
+    int bestTCID = -1;
     bestIndex = -1;
     for (unsigned int i = 0; i < fullmatch.size(); i++) {
       if (indexArray[i] >= fullmatch[i]->nMatches()) {
@@ -834,7 +834,7 @@ std::vector<Tracklet*> FitTrack::orderedMatches(vector<FullMatchMemory*>& fullma
         continue;
       }
       int TCID = fullmatch[i]->getTracklet(indexArray[i])->TCID();
-      if (TCID < bestTCID) {
+      if (TCID < bestTCID || bestTCID < 0) {
         bestTCID = TCID;
         bestIndex = i;
       }

--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -501,7 +501,7 @@ std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > MatchCalculator:
   int bestIndex = -1;
   do {
     int bestSector = 100;
-    int bestTCID = (1 << 16);
+    int bestTCID = -1;
     bestIndex = -1;
     for (unsigned int i = 0; i < candmatch.size(); i++) {
       if (indexArray[i] >= candmatch[i]->nMatches()) {
@@ -523,7 +523,7 @@ std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > MatchCalculator:
         bestIndex = i;
       }
       if (dSector == bestSector) {
-        if (TCID < bestTCID) {
+        if (TCID < bestTCID || bestTCID < 0) {
           bestTCID = TCID;
           bestIndex = i;
         }

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -272,7 +272,7 @@ std::string Tracklet::trackletprojstr(int layer) const {
   if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
     throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
   }
-  tmp.set(trackletIndex_, 7, true, __LINE__, __FILE__);
+  tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
   FPGAWord tcid;
   if (settings_.extended()) {
     tcid.set(TCIndex_, 8, true, __LINE__, __FILE__);
@@ -292,7 +292,7 @@ std::string Tracklet::trackletprojstrD(int disk) const {
   if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
     throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
   }
-  tmp.set(trackletIndex_, 7, true, __LINE__, __FILE__);
+  tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
   FPGAWord tcid;
   if (settings_.extended()) {
     tcid.set(TCIndex_, 8, true, __LINE__, __FILE__);
@@ -377,7 +377,7 @@ std::string Tracklet::fullmatchstr(int layer) {
   if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
     throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
   }
-  tmp.set(trackletIndex_, 7, true, __LINE__, __FILE__);
+  tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
   FPGAWord tcid;
   if (settings_.extended()) {
     tcid.set(TCIndex_, 8, true, __LINE__, __FILE__);
@@ -396,7 +396,7 @@ std::string Tracklet::fullmatchdiskstr(int disk) {
   if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
     throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
   }
-  tmp.set(trackletIndex_, 7, true, __LINE__, __FILE__);
+  tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
   FPGAWord tcid;
   if (settings_.extended()) {
     tcid.set(TCIndex_, 8, true, __LINE__, __FILE__);
@@ -839,9 +839,9 @@ int Tracklet::disk2() const {
   return innerStub_->disk() - 1;
 }
 
-void Tracklet::setTrackletIndex(int index) {
+void Tracklet::setTrackletIndex(unsigned int index) {
   trackletIndex_ = index;
-  assert(index < 128);
+  assert(index <= settings_.ntrackletmax());
 }
 
 int Tracklet::getISeed() const {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
@@ -171,7 +171,8 @@ void TrackletEngineDisplaced::execute() {
             index = (index << firstbend.nbits()) + firstbend.value();
             index = (index << secondbend.nbits()) + secondbend.value();
 
-            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || table_.at(index).empty())) {
+            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                (index >= table_.size() || table_.at(index).empty())) {
               if (settings_.debugTracklet()) {
                 edm::LogVerbatim("Tracklet") << "Stub pair rejected because of stub pt cut bends : "
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
@@ -183,7 +184,8 @@ void TrackletEngineDisplaced::execute() {
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) || (index < table_.size() && table_.at(index).count(isp))) {
+              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) ||
+                  (index < table_.size() && table_.at(index).count(isp))) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -249,7 +251,8 @@ void TrackletEngineDisplaced::execute() {
             index = (index << firstbend.nbits()) + firstbend.value();
             index = (index << secondbend.nbits()) + secondbend.value();
 
-            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || table_.at(index).empty())) {
+            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                (index >= table_.size() || table_.at(index).empty())) {
               if (settings_.debugTracklet()) {
                 edm::LogVerbatim("Tracklet") << "Stub pair rejected because of stub pt cut bends : "
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
@@ -261,7 +264,8 @@ void TrackletEngineDisplaced::execute() {
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) || (index < table_.size() && table_.at(index).count(isp))) {
+              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) ||
+                  (index < table_.size() && table_.at(index).count(isp))) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -327,7 +331,8 @@ void TrackletEngineDisplaced::execute() {
             index = (index << firstbend.nbits()) + firstbend.value();
             index = (index << secondbend.nbits()) + secondbend.value();
 
-            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || table_.at(index).empty())) {
+            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                (index >= table_.size() || table_.at(index).empty())) {
               if (settings_.debugTracklet()) {
                 edm::LogVerbatim("Tracklet") << "Stub pair rejected because of stub pt cut bends : "
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
@@ -340,7 +345,8 @@ void TrackletEngineDisplaced::execute() {
               edm::LogVerbatim("Tracklet") << "Adding disk-disk pair in " << getName();
 
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) || (index < table_.size() && table_.at(index).count(isp))) {
+              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) ||
+                  (index < table_.size() && table_.at(index).count(isp))) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -406,7 +412,7 @@ void TrackletEngineDisplaced::readTables() {
   fin.close();
 }
 
-const short TrackletEngineDisplaced::memNameToIndex(const string &name) {
+const short TrackletEngineDisplaced::memNameToIndex(const string& name) {
   for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp)
     if (stubpairs_.at(isp)->getName() == name)
       return isp;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
@@ -56,8 +56,6 @@ TrackletEngineDisplaced::TrackletEngineDisplaced(string name,
 
   firstphibits_ = settings_.nfinephi(0, iSeed_);
   secondphibits_ = settings_.nfinephi(1, iSeed_);
-
-  readTables();
 }
 
 TrackletEngineDisplaced::~TrackletEngineDisplaced() { table_.clear(); }
@@ -99,6 +97,9 @@ void TrackletEngineDisplaced::addInput(MemoryBase* memory, string input) {
 void TrackletEngineDisplaced::execute() {
   if (!settings_.useSeed(iSeed_))
     return;
+
+  if (table_.empty() && (settings_.enableTripletTables() && !settings_.writeTripletTables()))
+    readTables();
 
   unsigned int countall = 0;
   unsigned int countpass = 0;
@@ -170,23 +171,19 @@ void TrackletEngineDisplaced::execute() {
             index = (index << firstbend.nbits()) + firstbend.value();
             index = (index << secondbend.nbits()) + secondbend.value();
 
-            if (index >= table_.size())
-              table_.resize(index + 1);
-
-            if (table_.at(index).empty()) {
+            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || table_.at(index).empty())) {
               if (settings_.debugTracklet()) {
                 edm::LogVerbatim("Tracklet") << "Stub pair rejected because of stub pt cut bends : "
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
                                              << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule());
               }
-              if (!settings_.writeTripletTables())
-                continue;
+              continue;
             }
 
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName())) {
+              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) || (index < table_.size() && table_.at(index).count(isp))) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -252,21 +249,19 @@ void TrackletEngineDisplaced::execute() {
             index = (index << firstbend.nbits()) + firstbend.value();
             index = (index << secondbend.nbits()) + secondbend.value();
 
-            if (index >= table_.size())
-              table_.resize(index + 1);
-
-            if (table_.at(index).empty()) {
+            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || table_.at(index).empty())) {
               if (settings_.debugTracklet()) {
                 edm::LogVerbatim("Tracklet") << "Stub pair rejected because of stub pt cut bends : "
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
                                              << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule());
               }
+              continue;
             }
 
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName()) || true) {
+              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) || (index < table_.size() && table_.at(index).count(isp))) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -332,22 +327,20 @@ void TrackletEngineDisplaced::execute() {
             index = (index << firstbend.nbits()) + firstbend.value();
             index = (index << secondbend.nbits()) + secondbend.value();
 
-            if (index >= table_.size())
-              table_.resize(index + 1);
-
-            if (table_.at(index).empty()) {
+            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || table_.at(index).empty())) {
               if (settings_.debugTracklet()) {
                 edm::LogVerbatim("Tracklet") << "Stub pair rejected because of stub pt cut bends : "
                                              << benddecode(firstvmstub.bend().value(), firstvmstub.isPSmodule()) << " "
                                              << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule());
               }
+              continue;
             }
 
             if (settings_.debugTracklet())
               edm::LogVerbatim("Tracklet") << "Adding disk-disk pair in " << getName();
 
             for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if (settings_.writeTripletTables() || table_.at(index).count(stubpairs_.at(isp)->getName()) || true) {
+              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) || (index < table_.size() && table_.at(index).count(isp))) {
                 if (settings_.writeMonitorData("Seeds")) {
                   ofstream fout("seeds.txt", ofstream::app);
                   fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << iSeed_ << endl;
@@ -408,7 +401,14 @@ void TrackletEngineDisplaced::readTables() {
     table_.resize(table_.size() + 1);
 
     while (iss >> word)
-      table_[table_.size() - 1].insert(word);
+      table_[table_.size() - 1].insert(memNameToIndex(word));
   }
   fin.close();
+}
+
+const short TrackletEngineDisplaced::memNameToIndex(const string &name) {
+  for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp)
+    if (stubpairs_.at(isp)->getName() == name)
+      return isp;
+  return -1;
 }

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
@@ -202,7 +202,8 @@ void TripletEngine::execute() {
               index = (index << secondbend.nbits()) + secondbend.value();
               index = (index << thirdbend.nbits()) + thirdbend.value();
 
-              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || !table_[index])) {
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                  (index >= table_.size() || !table_[index])) {
                 if (settings_.debugTracklet()) {
                   edm::LogVerbatim("Tracklet")
                       << "Stub pair rejected because of stub pt cut bends : "
@@ -284,7 +285,8 @@ void TripletEngine::execute() {
               index = (index << secondbend.nbits()) + secondbend.value();
               index = (index << thirdbend.nbits()) + thirdbend.value();
 
-              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || !table_[index])) {
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                  (index >= table_.size() || !table_[index])) {
                 if (settings_.debugTracklet()) {
                   edm::LogVerbatim("Tracklet")
                       << "Stub triplet rejected because of stub pt cut bends : "
@@ -367,7 +369,8 @@ void TripletEngine::execute() {
               index = (index << secondbend.nbits()) + secondbend.value();
               index = (index << thirdbend.nbits()) + thirdbend.value();
 
-              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || !table_[index])) {
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                  (index >= table_.size() || !table_[index])) {
                 if (settings_.debugTracklet()) {
                   edm::LogVerbatim("Tracklet")
                       << "Stub pair rejected because of stub pt cut bends : "

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
@@ -65,7 +65,8 @@ TripletEngine::TripletEngine(string name, Settings const &settings, Globals *glo
     secondphibits_ = settings_.nfinephi(1, iSeed_);
     thirdphibits_ = settings_.nfinephi(2, iSeed_);
   }
-  readTables();
+  if (settings_.enableTripletTables() && !settings_.writeTripletTables())
+    readTables();
 }
 
 TripletEngine::~TripletEngine() {
@@ -201,29 +202,28 @@ void TripletEngine::execute() {
               index = (index << secondbend.nbits()) + secondbend.value();
               index = (index << thirdbend.nbits()) + thirdbend.value();
 
-              if (index >= table_.size())
-                table_.resize(index + 1, false);
-
-              if (!table_[index]) {
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || !table_[index])) {
                 if (settings_.debugTracklet()) {
                   edm::LogVerbatim("Tracklet")
                       << "Stub pair rejected because of stub pt cut bends : "
                       << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule()) << " "
                       << benddecode(thirdvmstub.bend().value(), thirdvmstub.isPSmodule());
                 }
-                if (!settings_.writeTripletTables())
-                  continue;
+                continue;
               }
-              if (settings_.writeTripletTables())
+              if (settings_.writeTripletTables()) {
+                if (index >= table_.size())
+                  table_.resize(index + 1, false);
                 table_[index] = true;
 
-              const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
-              const string &tedName = stubpairs_.at(i)->getTEDName(j);
-              if (!tmpSPTable_.count(tedName))
-                tmpSPTable_[tedName];
-              if (spIndex >= tmpSPTable_.at(tedName).size())
-                tmpSPTable_.at(tedName).resize(spIndex + 1);
-              tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+                const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
+                const string &tedName = stubpairs_.at(i)->getTEDName(j);
+                if (!tmpSPTable_.count(tedName))
+                  tmpSPTable_[tedName];
+                if (spIndex >= tmpSPTable_.at(tedName).size())
+                  tmpSPTable_.at(tedName).resize(spIndex + 1);
+                tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+              }
 
               if (settings_.debugTracklet())
                 edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
@@ -284,27 +284,28 @@ void TripletEngine::execute() {
               index = (index << secondbend.nbits()) + secondbend.value();
               index = (index << thirdbend.nbits()) + thirdbend.value();
 
-              if (index >= table_.size())
-                table_.resize(index + 1, false);
-
-              if (!table_[index]) {
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || !table_[index])) {
                 if (settings_.debugTracklet()) {
                   edm::LogVerbatim("Tracklet")
                       << "Stub triplet rejected because of stub pt cut bends : "
                       << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule()) << " "
                       << benddecode(thirdvmstub.bend().value(), thirdvmstub.isPSmodule());
                 }
+                continue;
               }
-              if (settings_.writeTripletTables())
+              if (settings_.writeTripletTables()) {
+                if (index >= table_.size())
+                  table_.resize(index + 1, false);
                 table_[index] = true;
 
-              const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
-              const string &tedName = stubpairs_.at(i)->getTEDName(j);
-              if (!tmpSPTable_.count(tedName))
-                tmpSPTable_[tedName];
-              if (spIndex >= tmpSPTable_.at(tedName).size())
-                tmpSPTable_.at(tedName).resize(spIndex + 1);
-              tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+                const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
+                const string &tedName = stubpairs_.at(i)->getTEDName(j);
+                if (!tmpSPTable_.count(tedName))
+                  tmpSPTable_[tedName];
+                if (spIndex >= tmpSPTable_.at(tedName).size())
+                  tmpSPTable_.at(tedName).resize(spIndex + 1);
+                tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+              }
 
               if (settings_.debugTracklet())
                 edm::LogVerbatim("Tracklet") << "Adding layer-disk pair in " << getName();
@@ -366,27 +367,28 @@ void TripletEngine::execute() {
               index = (index << secondbend.nbits()) + secondbend.value();
               index = (index << thirdbend.nbits()) + thirdbend.value();
 
-              if (index >= table_.size())
-                table_.resize(index + 1, false);
-
-              if (!table_[index]) {
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) && (index >= table_.size() || !table_[index])) {
                 if (settings_.debugTracklet()) {
                   edm::LogVerbatim("Tracklet")
                       << "Stub pair rejected because of stub pt cut bends : "
                       << benddecode(secondvmstub.bend().value(), secondvmstub.isPSmodule()) << " "
                       << benddecode(thirdvmstub.bend().value(), thirdvmstub.isPSmodule());
                 }
+                continue;
               }
-              if (settings_.writeTripletTables())
+              if (settings_.writeTripletTables()) {
+                if (index >= table_.size())
+                  table_.resize(index + 1, false);
                 table_[index] = true;
 
-              const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
-              const string &tedName = stubpairs_.at(i)->getTEDName(j);
-              if (!tmpSPTable_.count(tedName))
-                tmpSPTable_[tedName];
-              if (spIndex >= tmpSPTable_.at(tedName).size())
-                tmpSPTable_.at(tedName).resize(spIndex + 1);
-              tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+                const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
+                const string &tedName = stubpairs_.at(i)->getTEDName(j);
+                if (!tmpSPTable_.count(tedName))
+                  tmpSPTable_[tedName];
+                if (spIndex >= tmpSPTable_.at(tedName).size())
+                  tmpSPTable_.at(tedName).resize(spIndex + 1);
+                tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+              }
 
               if (settings_.debugTracklet())
                 edm::LogVerbatim("Tracklet") << "Adding layer-disk pair in " << getName();


### PR DESCRIPTION
#### PR description:

Addresses issues #30742 and #30744. After discussion with @skinnari and @tomalin, we decided that the tables in the TrackletEngineDisplaced and TripletEngine can be disabled by default. These tables are meant to reduce the occupancy for downstream modules while minimally impacting the ultimate tracking efficiency. This will be necessary for the eventual FPGA design, but given the problems with these tables in terms of memory usage and the effect on tracking efficiency, we think disabling them in the emulation is the best solution for now.

I also increased the maximum number of tracklets in the case of the extended algorithm. This is a temporary change that is necessary to handle the additional tracklets that will eventually be removed by the now-disabled tables.

Finally, there are a few other minor changes meant to reduce the memory usage of these tables. Several other changes are foreseen in the near future. But since the tables are disabled by default now, this is somewhat moot for the time being.

#### PR validation:

I ran the L1TrackNtupleMaker analyzer over 100 ttbar events with 200 PU. With the baseline, non-extended algorithm, the results are exactly identical, as expected. With the extended algorithm, I see approximately half the memory usage in `top`, and the memory usage does not appear to grow over time as seen before.

I also ran over a sample of displaced muons with no PU with the extended algorithm. With the tables disabled, as is now the default, we see good efficiency for tracks with d<sub>0</sub> up to ~5 cm.