### PR TITLE
Move RecoLuminosity/LumiProducer to std::filesystem

### DIFF
--- a/RecoLuminosity/LumiProducer/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="CoralBase"/>
 <use name="RelationalAccess"/>
 <use name="FWCore/Utilities"/>
+<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="FWCore/Framework"/>
+<use name="stdcxx-fs"/>
 <library file="Module.cc" name="LumiServicesPlugins">
   <use name="RecoLuminosity/LumiProducer"/>
   <flags EDM_PLUGIN="1"/>

--- a/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
@@ -47,9 +47,9 @@ Description: A essource/esproducer for lumi values from DIP via runtime logger D
 #include <vector>
 #include <cstring>
 #include <iterator>
+#include <filesystem>
+
 #include <boost/tokenizer.hpp>
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
 
 namespace edm {
   class EventSetup;

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
@@ -56,14 +56,14 @@ Description: A essource/esproducer for lumi correction factor and run parameters
 #include <vector>
 #include <cstring>
 #include <iterator>
+#include <filesystem>
+
 #include <boost/tokenizer.hpp>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include "Utilities/Xerces/interface/Xerces.h"
 #include <xercesc/util/XMLString.hpp>
-#include <boost/filesystem.hpp>
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
+
 std::string LumiCorrectionSource::x2s(const XMLCh* toTranscode) const {
   std::string tmp(xercesc::XMLString::transcode(toTranscode));
   return tmp;
@@ -148,19 +148,19 @@ std::string LumiCorrectionSource::translateFrontierConnect(const std::string& co
     if (servlet == "cms_conditions_data")
       servlet = "";
     if (m_siteconfpath.length() == 0) {
-      std::string url = (boost::filesystem::path("SITECONF") / boost::filesystem::path("local") /
-                         boost::filesystem::path("JobConfig") / boost::filesystem::path("site-local-config.xml"))
+      std::string url = (std::filesystem::path("SITECONF") / std::filesystem::path("local") /
+                         std::filesystem::path("JobConfig") / std::filesystem::path("site-local-config.xml"))
                             .string();
       char* tmp = std::getenv("CMS_PATH");
       if (tmp) {
-        m_siteconfpath = (boost::filesystem::path(tmp) / boost::filesystem::path(url)).string();
+        m_siteconfpath = (std::filesystem::path(tmp) / std::filesystem::path(url)).string();
       }
     } else {
-      if (!boost::filesystem::exists(boost::filesystem::path(m_siteconfpath))) {
+      if (!std::filesystem::exists(std::filesystem::path(m_siteconfpath))) {
         throw cms::Exception("Non existing path ") << m_siteconfpath;
       }
       m_siteconfpath =
-          (boost::filesystem::path(m_siteconfpath) / boost::filesystem::path("site-local-config.xml")).string();
+          (std::filesystem::path(m_siteconfpath) / std::filesystem::path("site-local-config.xml")).string();
     }
     result = fproto + servletTranslation(servlet) + connectStr.substr(endservlet);
   }
@@ -195,9 +195,9 @@ LumiCorrectionSource::LumiCorrectionSource(const edm::ParameterSet& iConfig)
   } else {
     m_connectStr = connectStr;
     std::string authpath = iConfig.getUntrackedParameter<std::string>("authpath", "");
-    boost::filesystem::path boostAuthPath(authpath);
-    if (boost::filesystem::is_directory(boostAuthPath)) {
-      boostAuthPath /= boost::filesystem::path("authentication.xml");
+    std::filesystem::path boostAuthPath(authpath);
+    if (std::filesystem::is_directory(boostAuthPath)) {
+      boostAuthPath /= std::filesystem::path("authentication.xml");
     }
     m_authfilename = boostAuthPath.string();
   }

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
@@ -61,14 +61,13 @@ from the configuration file, the DB is not implemented yet)
 #include <vector>
 #include <cstring>
 #include <iterator>
+#include <filesystem>
+
 #include <boost/tokenizer.hpp>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include "Utilities/Xerces/interface/Xerces.h"
 #include <xercesc/util/XMLString.hpp>
-
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
 
 namespace edm {
   class EventSetup;
@@ -255,19 +254,19 @@ LumiProducer::LumiProducer::LumiProducer(const edm::ParameterSet& iConfig)
 
       std::string siteconfpath = iConfig.getUntrackedParameter<std::string>("siteconfpath", "");
       if (siteconfpath.length() == 0) {
-        std::string url = (boost::filesystem::path("SITECONF") / boost::filesystem::path("local") /
-                           boost::filesystem::path("JobConfig") / boost::filesystem::path("site-local-config.xml"))
+        std::string url = (std::filesystem::path("SITECONF") / std::filesystem::path("local") /
+                           std::filesystem::path("JobConfig") / std::filesystem::path("site-local-config.xml"))
                               .string();
         char* tmp = std::getenv("CMS_PATH");
         if (tmp) {
-          m_siteconfpath = (boost::filesystem::path(tmp) / boost::filesystem::path(url)).string();
+          m_siteconfpath = (std::filesystem::path(tmp) / std::filesystem::path(url)).string();
         }
       } else {
-        if (!boost::filesystem::exists(boost::filesystem::path(siteconfpath))) {
+        if (!std::filesystem::exists(std::filesystem::path(siteconfpath))) {
           throw cms::Exception("Non existing path ") << siteconfpath;
         }
         m_siteconfpath =
-            (boost::filesystem::path(siteconfpath) / boost::filesystem::path("site-local-config.xml")).string();
+            (std::filesystem::path(siteconfpath) / std::filesystem::path("site-local-config.xml")).string();
       }
       //std::cout<<"servlet : "<<servlet<<std::endl;
       m_connectStr = fproto + servletTranslation(servlet) + connectStr.substr(endservlet);

--- a/RecoLuminosity/LumiProducer/src/DBConfig.cc
+++ b/RecoLuminosity/LumiProducer/src/DBConfig.cc
@@ -4,18 +4,20 @@
 #include "CoralKernel/Context.h"
 #include "CoralKernel/IProperty.h"
 #include "CoralKernel/IPropertyManager.h"
-#include <boost/filesystem/operations.hpp>
+
+#include <filesystem>
+
 namespace lumi {
   const std::string defaultAuthFileName = "authentication.xml";
 }
 lumi::DBConfig::DBConfig(coral::ConnectionService& svc) : m_svc(&svc) {}
 lumi::DBConfig::~DBConfig() {}
 void lumi::DBConfig::setAuthentication(const std::string& authPath) {
-  boost::filesystem::path boostAuthPath(authPath);
-  if (boost::filesystem::is_directory(boostAuthPath)) {
-    boostAuthPath /= boost::filesystem::path(lumi::defaultAuthFileName);
+  std::filesystem::path filesystemAuthPath(authPath);
+  if (std::filesystem::is_directory(filesystemAuthPath)) {
+    filesystemAuthPath /= std::filesystem::path(lumi::defaultAuthFileName);
   }
-  std::string authFileName = boostAuthPath.string();
+  std::string authFileName = filesystemAuthPath.string();
   coral::Context::instance().PropertyManager().property("AuthenticationFile")->set(authFileName);
   coral::Context::instance().loadComponent("CORAL/Services/XMLAuthenticationService");
 }


### PR DESCRIPTION
#### PR description:
Replaced boost::filesystem for std::filesystem.
- std::filesystem and boost::filesystem are very similar in functionality. We should use std::filesystem where possible, since it is from c++17 standard.
#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 