### PR TITLE
Migrate to std::filesystem 

### DIFF
--- a/DataFormats/OnlineMetaData/test/BuildFile.xml
+++ b/DataFormats/OnlineMetaData/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="cppunit"/>
 <use name="DataFormats/FEDRawData"/>
 <use name="DataFormats/OnlineMetaData"/>
+<use name="stdcxx-fs"/>
 <bin name="testDataFormatsOnlineMetaData" file="testRunner.cpp,onlineMetaDataRecord_t.cpp">
 </bin>

--- a/DataFormats/OnlineMetaData/test/onlineMetaDataRecord_t.cpp
+++ b/DataFormats/OnlineMetaData/test/onlineMetaDataRecord_t.cpp
@@ -7,12 +7,11 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string.h>
 #include <vector>
-
-#include <boost/filesystem.hpp>
 
 class TestOnlineMetaDataRecord : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestOnlineMetaDataRecord);
@@ -46,7 +45,7 @@ const unsigned char* TestOnlineMetaDataRecord::readPayload(const std::string& du
   const std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
   const std::string CMSSW_RELEASE_BASE(std::getenv("CMSSW_RELEASE_BASE"));
   const std::string dumpFilePath = "/src/DataFormats/OnlineMetaData/test/" + dumpFileName;
-  const std::string fullPath = boost::filesystem::exists((CMSSW_BASE + dumpFilePath).c_str())
+  const std::string fullPath = std::filesystem::exists((CMSSW_BASE + dumpFilePath).c_str())
                                    ? CMSSW_BASE + dumpFilePath
                                    : CMSSW_RELEASE_BASE + dumpFilePath;
 

--- a/IORawData/CaloPatterns/BuildFile.xml
+++ b/IORawData/CaloPatterns/BuildFile.xml
@@ -6,6 +6,6 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/HcalObjects"/>
 <use name="root"/>
-<use name="boost_filesystem"/>
+<use name="stdcxx-fs"/>
 <use name="CalibCalorimetry/HcalAlgos"/>
 <flags EDM_PLUGIN="1"/>

--- a/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
@@ -4,9 +4,9 @@
 #include "HtrXmlPatternWriter.h"
 #include "TFile.h"
 #include "TH1.h"
-#include <iostream>
+#include <filesystem>
 #include <fstream>
-#include "boost/filesystem/operations.hpp"
+#include <iostream>
 
 HtrXmlPatternTool::HtrXmlPatternTool(HtrXmlPatternToolParameters* params) {
   m_params = params;
@@ -107,7 +107,7 @@ void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID, HODigiCollection::con
     std::cerr << "Bad (crate): (" << HEID.readoutVMECrateId() << ")" << std::endl;
 }
 
-void HtrXmlPatternTool::prepareDirs() { boost::filesystem::create_directory(m_params->m_output_directory); }
+void HtrXmlPatternTool::prepareDirs() { std::filesystem::create_directory(m_params->m_output_directory); }
 
 void HtrXmlPatternTool::writeXML() {
   std::cout << "Writing XML..." << std::endl;

--- a/L1TriggerConfig/L1GtConfigProducers/BuildFile.xml
+++ b/L1TriggerConfig/L1GtConfigProducers/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="HLTrigger/HLTcore"/>
 <use name="Utilities/Xerces"/>
 <use name="xerces-c"/>
+<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriter.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriter.cc
@@ -16,11 +16,9 @@
 #include "L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlWriter.h"
 
 // system include files
+#include <filesystem>
 #include <iostream>
 #include <sys/stat.h>
-
-// user include files
-#include "boost/filesystem.hpp"
 
 //   base class
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -102,7 +100,7 @@ void L1GtVhdlWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& ev
   channelVector.push_back("-- ca10: free");
 
   // check, weather output directory exists and create it on the fly if not
-  if (boost::filesystem::is_directory(outputDir_)) {
+  if (std::filesystem::is_directory(outputDir_)) {
     std::cout << std::endl << "Ok - Output directory exists!" << std::endl;
   } else {
     if (!mkdir(outputDir_.c_str(), 0666))


### PR DESCRIPTION
#### PR description:
Boost and std filesystem have similar functionality. When possible we should use std::filesystem to avoid unnecessary dependencies.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 