### PR TITLE
drop type specs in RecoTracker/{TkSeedingLayers,TrackProducer}

### DIFF
--- a/RecoTracker/TkSeedingLayers/python/MixedLayerPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/MixedLayerPairs_cfi.py
@@ -5,45 +5,42 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
-MixedLayerPairs = seedingLayersEDProducer.clone()
-MixedLayerPairs.layerList = cms.vstring('BPix1+BPix2', 
-        'BPix1+BPix3', 
-        'BPix2+BPix3', 
-        'BPix1+FPix1_pos', 
-        'BPix1+FPix1_neg', 
-        'BPix1+FPix2_pos', 
-        'BPix1+FPix2_neg', 
-        'BPix2+FPix1_pos', 
-        'BPix2+FPix1_neg', 
-        'BPix2+FPix2_pos', 
-        'BPix2+FPix2_neg', 
-        'FPix1_pos+FPix2_pos', 
-        'FPix1_neg+FPix2_neg', 
-        'FPix2_pos+TEC1_pos', 
-        'FPix2_pos+TEC2_pos', 
-        'TEC1_pos+TEC2_pos', 
-        'TEC2_pos+TEC3_pos', 
-        'FPix2_neg+TEC1_neg', 
-        'FPix2_neg+TEC2_neg', 
-        'TEC1_neg+TEC2_neg', 
-        'TEC2_neg+TEC3_neg'
+MixedLayerPairs = seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2', 
+                 'BPix1+BPix3', 
+                 'BPix2+BPix3', 
+                 'BPix1+FPix1_pos', 
+                 'BPix1+FPix1_neg', 
+                 'BPix1+FPix2_pos', 
+                 'BPix1+FPix2_neg', 
+                 'BPix2+FPix1_pos', 
+                 'BPix2+FPix1_neg', 
+                 'BPix2+FPix2_pos', 
+                 'BPix2+FPix2_neg', 
+                 'FPix1_pos+FPix2_pos', 
+                 'FPix1_neg+FPix2_neg', 
+                 'FPix2_pos+TEC1_pos', 
+                 'FPix2_pos+TEC2_pos', 
+                 'TEC1_pos+TEC2_pos', 
+                 'TEC2_pos+TEC3_pos', 
+                 'FPix2_neg+TEC1_neg', 
+                 'FPix2_neg+TEC2_neg', 
+                 'TEC1_neg+TEC2_neg', 
+                 'TEC2_neg+TEC3_neg'],
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(1),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    BPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    ),
+    FPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    )
 )
-MixedLayerPairs.TEC = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    minRing = cms.int32(1),
-    maxRing = cms.int32(1)
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-MixedLayerPairs.BPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-MixedLayerPairs.FPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-
-
-

--- a/RecoTracker/TkSeedingLayers/python/MixedLayerTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/MixedLayerTriplets_cfi.py
@@ -5,47 +5,44 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
-MixedLayerTriplets = seedingLayersEDProducer.clone()
-MixedLayerTriplets.layerList = cms.vstring('BPix1+BPix2+BPix3', 
-        'BPix1+BPix2+FPix1_pos', 
-        'BPix1+BPix2+FPix1_neg', 
-        'BPix1+FPix1_pos+FPix2_pos', 
-        'BPix1+FPix1_neg+FPix2_neg', 
-        'BPix1+BPix2+TIB1', 
-        'BPix1+BPix3+TIB1', 
-        'BPix2+BPix3+TIB1', 
-        'BPix1+FPix1_pos+TID1_pos', 
-        'BPix1+FPix1_neg+TID1_neg', 
-        'BPix1+FPix1_pos+TID2_pos', 
-        'BPix1+FPix1_neg+TID2_neg', 
-        'FPix1_pos+FPix2_pos+TEC1_pos', 
-        'FPix1_neg+FPix2_neg+TEC1_neg', 
-        'FPix1_pos+FPix2_pos+TEC2_pos', 
-        'FPix1_neg+FPix2_neg+TEC2_neg'
+MixedLayerTriplets = seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2+BPix3', 
+                 'BPix1+BPix2+FPix1_pos', 
+                 'BPix1+BPix2+FPix1_neg', 
+                 'BPix1+FPix1_pos+FPix2_pos', 
+                 'BPix1+FPix1_neg+FPix2_neg', 
+                 'BPix1+BPix2+TIB1', 
+                 'BPix1+BPix3+TIB1', 
+                 'BPix2+BPix3+TIB1', 
+                 'BPix1+FPix1_pos+TID1_pos', 
+                 'BPix1+FPix1_neg+TID1_neg', 
+                 'BPix1+FPix1_pos+TID2_pos', 
+                 'BPix1+FPix1_neg+TID2_neg', 
+                 'FPix1_pos+FPix2_pos+TEC1_pos', 
+                 'FPix1_neg+FPix2_neg+TEC1_neg', 
+                 'FPix1_pos+FPix2_pos+TEC2_pos', 
+                 'FPix1_neg+FPix2_neg+TEC2_neg'],
+    TEC = cms.PSet(
+	matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+	clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    FPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    ),
+    TID = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    BPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    ),
+    TIB = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    )
 )
-MixedLayerTriplets.TEC = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    TTRHBuilder = cms.string('WithTrackAngle')
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-MixedLayerTriplets.FPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-MixedLayerTriplets.TID = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    TTRHBuilder = cms.string('WithTrackAngle')
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-MixedLayerTriplets.BPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-MixedLayerTriplets.TIB = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    TTRHBuilder = cms.string('WithTrackAngle')
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-
-
-

--- a/RecoTracker/TkSeedingLayers/python/PixelAndStripLayerPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelAndStripLayerPairs_cfi.py
@@ -5,58 +5,54 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
-PixelAndStripLayerPairs = seedingLayersEDProducer.clone()
-PixelAndStripLayerPairs.layerList = cms.vstring(
-        'BPix3+TIB1_pos',
-        'BPix2+TIB1_pos',
-        'BPix3+TIB2_pos',
-        'FPix1+TIB1_pos',
-#        'FPix1_pos+TID1_pos',
-#        'FPix2+TIB1_pos',
-        'FPix2_pos+TID1_pos',
-        'FPix2_pos+TID2_pos',
-        'FPix2_pos+TID3_pos',
-        'FPix2_pos+TEC1_pos',
-        'BPix3+TIB1_neg',
-        'BPix2+TIB1_neg',
-        'BPix3+TIB2_neg',
-        'FPix1+TIB1_neg',
-#        'FPix1_neg+TID1_neg',
-#        'FPix2+TIB1_neg',
-        'FPix2_neg+TID1_neg',
-        'FPix2_neg+TID2_neg',
-        'FPix2_neg+TID3_neg',
-        'FPix2_neg+TEC1_neg'
-)
-PixelAndStripLayerPairs.TIB = cms.PSet(
+PixelAndStripLayerPairs = seedingLayersEDProducer.clone(
+    layerList = ['BPix3+TIB1_pos',
+                 'BPix2+TIB1_pos',
+                 'BPix3+TIB2_pos',
+                 'FPix1+TIB1_pos',
+#                 'FPix1_pos+TID1_pos',
+#                 'FPix2+TIB1_pos',
+                 'FPix2_pos+TID1_pos',
+                 'FPix2_pos+TID2_pos',
+                 'FPix2_pos+TID3_pos',
+                 'FPix2_pos+TEC1_pos',
+                 'BPix3+TIB1_neg',
+                 'BPix2+TIB1_neg',
+                 'BPix3+TIB2_neg',
+                 'FPix1+TIB1_neg',
+#                 'FPix1_neg+TID1_neg',
+#                 'FPix2+TIB1_neg',
+                 'FPix2_neg+TID1_neg',
+                 'FPix2_neg+TID2_neg',
+                 'FPix2_neg+TID3_neg',
+                 'FPix2_neg+TEC1_neg'],
+    TIB = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-        TTRHBuilder = cms.string('WithTrackAngle')
-        ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TID = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(1),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(1),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    BPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    ),
+    FPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    ),
 )
-PixelAndStripLayerPairs.TID = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    minRing = cms.int32(1),
-    maxRing = cms.int32(1)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-PixelAndStripLayerPairs.TEC = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    minRing = cms.int32(1),
-    maxRing = cms.int32(1)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-PixelAndStripLayerPairs.BPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-PixelAndStripLayerPairs.FPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-
-
-

--- a/RecoTracker/TkSeedingLayers/python/PixelLayerPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLayerPairs_cfi.py
@@ -2,29 +2,26 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
-PixelLayerPairs = seedingLayersEDProducer.clone()
-PixelLayerPairs.layerList = cms.vstring('BPix1+BPix2', 
-        'BPix1+BPix3', 
-        'BPix2+BPix3', 
-        'BPix1+FPix1_pos', 
-        'BPix1+FPix1_neg', 
-        'BPix1+FPix2_pos', 
-        'BPix1+FPix2_neg', 
-        'BPix2+FPix1_pos', 
-        'BPix2+FPix1_neg', 
-        'BPix2+FPix2_pos', 
-        'BPix2+FPix2_neg', 
-        'FPix1_pos+FPix2_pos', 
-        'FPix1_neg+FPix2_neg'
+PixelLayerPairs = seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2', 
+                 'BPix1+BPix3', 
+                 'BPix2+BPix3', 
+                 'BPix1+FPix1_pos', 
+                 'BPix1+FPix1_neg', 
+                 'BPix1+FPix2_pos', 
+                 'BPix1+FPix2_neg', 
+                 'BPix2+FPix1_pos', 
+                 'BPix2+FPix1_neg', 
+                 'BPix2+FPix2_pos', 
+                 'BPix2+FPix2_neg', 
+                 'FPix1_pos+FPix2_pos', 
+                 'FPix1_neg+FPix2_neg'],
+    BPix = cms.PSet(
+	TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    ),
+    FPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    ),
 )
-PixelLayerPairs.BPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-PixelLayerPairs.FPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-
-
-

--- a/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
@@ -2,22 +2,21 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
-PixelLayerTriplets = seedingLayersEDProducer.clone()
-PixelLayerTriplets.layerList = cms.vstring('BPix1+BPix2+BPix3', 
-    'BPix1+BPix2+FPix1_pos', 
-    'BPix1+BPix2+FPix1_neg', 
-    'BPix1+FPix1_pos+FPix2_pos', 
-    'BPix1+FPix1_neg+FPix2_neg'
+PixelLayerTriplets = seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2+BPix3', 
+                 'BPix1+BPix2+FPix1_pos', 
+                 'BPix1+BPix2+FPix1_neg', 
+                 'BPix1+FPix1_pos+FPix2_pos', 
+                 'BPix1+FPix1_neg+FPix2_neg'],
+    BPix = cms.PSet(
+	TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    ),    
+    FPix = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+    )
 )
-PixelLayerTriplets.BPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)    
-PixelLayerTriplets.FPix = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    HitProducer = cms.string('siPixelRecHits'),
-)
-
 _layersForPhase1 = [
     'BPix1+BPix2+BPix3',
     'BPix2+BPix3+BPix4',
@@ -53,4 +52,3 @@ _layersForPhase2 = [ 'BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
 ]
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(PixelLayerTriplets, layerList=_layersForPhase2)
-

--- a/RecoTracker/TkSeedingLayers/python/PixelLessLayerPairs4PixelLessTracking_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLessLayerPairs4PixelLessTracking_cfi.py
@@ -5,8 +5,8 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
-pixelLessLayerPairs4PixelLessTracking = seedingLayersEDProducer.clone()
-pixelLessLayerPairs4PixelLessTracking.layerList = cms.vstring(
+pixelLessLayerPairs4PixelLessTracking = seedingLayersEDProducer.clone(
+    layerList = [
         'TIB1+TIB2','TIB1+TIB3','TIB2+TIB3',
         'TIB1+TID1_pos', 'TIB1+TID1_neg',
         'TIB2+TID1_pos', 'TIB2+TID1_neg',
@@ -20,76 +20,72 @@ pixelLessLayerPairs4PixelLessTracking.layerList = cms.vstring(
         'TID2_neg+TID3_neg', 
         'TID3_neg+TEC2_neg', 
         'TEC1_neg+TEC2_neg',
-        'TEC2_neg+TEC3_neg'
+        'TEC2_neg+TEC3_neg'],
+    TID1 = cms.PSet(
+        useSimpleRphiHitsCleaner = cms.bool(False),
+        minRing = cms.int32(1),
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+        stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        maxRing = cms.int32(3),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TID2 = cms.PSet(
+        useSimpleRphiHitsCleaner = cms.bool(False),
+        minRing = cms.int32(1),
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+        stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        maxRing = cms.int32(3),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TID3 = cms.PSet(
+        useSimpleRphiHitsCleaner = cms.bool(False),        
+        minRing = cms.int32(1),
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+        stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        maxRing = cms.int32(2),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TEC = cms.PSet(
+        useSimpleRphiHitsCleaner = cms.bool(False),        
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+        stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(2),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TIB1 = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+        stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+        useSimpleRphiHitsCleaner = cms.bool(False),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TIB2 = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+        stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+        useSimpleRphiHitsCleaner = cms.bool(False),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TIB3 = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
+        stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
+        useSimpleRphiHitsCleaner = cms.bool(False),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    )
 )
-pixelLessLayerPairs4PixelLessTracking.TID1 = cms.PSet(
-    useSimpleRphiHitsCleaner = cms.bool(False),
-    minRing = cms.int32(1),
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
-    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    maxRing = cms.int32(3)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-pixelLessLayerPairs4PixelLessTracking.TID2 = cms.PSet(
-    useSimpleRphiHitsCleaner = cms.bool(False),
-    minRing = cms.int32(1),
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
-    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    maxRing = cms.int32(3)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-pixelLessLayerPairs4PixelLessTracking.TID3 = cms.PSet(
-    useSimpleRphiHitsCleaner = cms.bool(False),        
-    minRing = cms.int32(1),
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
-    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    maxRing = cms.int32(2)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-
-pixelLessLayerPairs4PixelLessTracking.TEC = cms.PSet(
-    useSimpleRphiHitsCleaner = cms.bool(False),        
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
-    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    minRing = cms.int32(1),
-    maxRing = cms.int32(2)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-pixelLessLayerPairs4PixelLessTracking.TIB1 = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
-    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
-    useSimpleRphiHitsCleaner = cms.bool(False)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-pixelLessLayerPairs4PixelLessTracking.TIB2 = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
-    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
-    useSimpleRphiHitsCleaner = cms.bool(False)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-pixelLessLayerPairs4PixelLessTracking.TIB3 = cms.PSet(
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHitUnmatched"),
-    stereoRecHits = cms.InputTag("siStripMatchedRecHits","stereoRecHitUnmatched"),
-    useSimpleRphiHitsCleaner = cms.bool(False)
-   ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-
-
-

--- a/RecoTracker/TkSeedingLayers/python/PixelLessLayerPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLessLayerPairs_cfi.py
@@ -2,55 +2,52 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
-PixelLessLayerPairs = seedingLayersEDProducer.clone()
-PixelLessLayerPairs.layerList = cms.vstring('TIB1+TIB2', 
-        'TIB1+TID1_pos', 
-#        'TIB1+TID2_pos', 
-        'TIB1+TID1_neg', 
-#        'TIB1+TID2_neg', 
-        'TID1_pos+TID2_pos', 
-        'TID2_pos+TID3_pos', 
-        'TID3_pos+TEC1_pos', 
-        'TEC1_pos+TEC2_pos', 
-        'TEC2_pos+TEC3_pos', 
-        'TEC3_pos+TEC4_pos',
-        'TEC3_pos+TEC5_pos', 
-        'TEC4_pos+TEC5_pos',                             
-        'TID1_neg+TID2_neg', 
-        'TID2_neg+TID3_neg', 
-        'TID3_neg+TEC1_neg', 
-        'TEC1_neg+TEC2_neg', 
-        'TEC2_neg+TEC3_neg',
-        'TEC3_neg+TEC4_neg',
-        'TEC3_neg+TEC5_neg',
-        'TEC4_neg+TEC5_neg'
-)
+PixelLessLayerPairs = seedingLayersEDProducer.clone(
+    layerList = ['TIB1+TIB2', 
+                 'TIB1+TID1_pos', 
+#                 'TIB1+TID2_pos', 
+                 'TIB1+TID1_neg', 
+#                 'TIB1+TID2_neg', 
+                 'TID1_pos+TID2_pos', 
+                 'TID2_pos+TID3_pos', 
+                 'TID3_pos+TEC1_pos', 
+                 'TEC1_pos+TEC2_pos', 
+                 'TEC2_pos+TEC3_pos', 
+                 'TEC3_pos+TEC4_pos',
+                 'TEC3_pos+TEC5_pos', 
+                 'TEC4_pos+TEC5_pos',                             
+                 'TID1_neg+TID2_neg', 
+                 'TID2_neg+TID3_neg', 
+                 'TID3_neg+TEC1_neg', 
+                 'TEC1_neg+TEC2_neg', 
+                 'TEC2_neg+TEC3_neg',
+                 'TEC3_neg+TEC4_neg',
+                 'TEC3_neg+TEC5_neg',
+                 'TEC4_neg+TEC5_neg'],
 
 # WARNING: in the old implemenation, all the 3 rings of  TID were used.
 # we need a different configuaration of rings for TID disks. Is it feasible 
 # in the current framework?? 
 
-PixelLessLayerPairs.TIB = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    TTRHBuilder = cms.string('WithTrackAngle')
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    TIB = cms.PSet(
+	matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TID = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(2),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        minRing = cms.int32(1),
+        maxRing = cms.int32(2),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    )
 )
-PixelLessLayerPairs.TID = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    minRing = cms.int32(1),
-    maxRing = cms.int32(2)
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-PixelLessLayerPairs.TEC = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    minRing = cms.int32(1),
-    maxRing = cms.int32(2)
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-
-
-

--- a/RecoTracker/TkSeedingLayers/python/TTRHBuilderWithoutAngle4MixedPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/TTRHBuilderWithoutAngle4MixedPairs_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 import RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi 
-myTTRHBuilderWithoutAngle4MixedPairs = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone()
-myTTRHBuilderWithoutAngle4MixedPairs.StripCPE = 'Fake'
-myTTRHBuilderWithoutAngle4MixedPairs.ComponentName = 'TTRHBuilderWithoutAngle4MixedPairs'
-
+myTTRHBuilderWithoutAngle4MixedPairs = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone(
+    StripCPE      = 'Fake',
+    ComponentName = 'TTRHBuilderWithoutAngle4MixedPairs'
+)

--- a/RecoTracker/TkSeedingLayers/python/TTRHBuilderWithoutAngle4MixedTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/TTRHBuilderWithoutAngle4MixedTriplets_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 import RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi 
-myTTRHBuilderWithoutAngle4MixedTriplets = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone()
-myTTRHBuilderWithoutAngle4MixedTriplets.StripCPE = 'Fake'
-myTTRHBuilderWithoutAngle4MixedTriplets.ComponentName = 'TTRHBuilderWithoutAngle4MixedTriplets'
-
+myTTRHBuilderWithoutAngle4MixedTriplets = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone(
+    StripCPE      = 'Fake',
+    ComponentName = 'TTRHBuilderWithoutAngle4MixedTriplets'
+)

--- a/RecoTracker/TkSeedingLayers/python/TTRHBuilderWithoutAngle4PixelPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/TTRHBuilderWithoutAngle4PixelPairs_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 import RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi 
-myTTRHBuilderWithoutAngle4PixelPairs = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone()
-myTTRHBuilderWithoutAngle4PixelPairs.StripCPE = 'Fake'
-myTTRHBuilderWithoutAngle4PixelPairs.ComponentName = 'TTRHBuilderWithoutAngle4PixelPairs'
-
+myTTRHBuilderWithoutAngle4PixelPairs = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone(
+    StripCPE      = 'Fake',
+    ComponentName = 'TTRHBuilderWithoutAngle4PixelPairs'
+)

--- a/RecoTracker/TkSeedingLayers/python/TTRHBuilderWithoutAngle4PixelTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/TTRHBuilderWithoutAngle4PixelTriplets_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 import RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi 
-myTTRHBuilderWithoutAngle4PixelTriplets = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone()
-myTTRHBuilderWithoutAngle4PixelTriplets.StripCPE = 'Fake'
-myTTRHBuilderWithoutAngle4PixelTriplets.ComponentName = 'TTRHBuilderWithoutAngle4PixelTriplets'
-
+myTTRHBuilderWithoutAngle4PixelTriplets = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone(
+    StripCPE      = 'Fake',
+    ComponentName = 'TTRHBuilderWithoutAngle4PixelTriplets'
+)

--- a/RecoTracker/TkSeedingLayers/python/TobTecLayerPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/TobTecLayerPairs_cfi.py
@@ -2,51 +2,49 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
 
-TobTecLayerPairs = seedingLayersEDProducer.clone()
+TobTecLayerPairs = seedingLayersEDProducer.clone(
 
 # Don't bother with TEC8 and 9, as tracking requires 2 hits outside
 # the seeding pairs.
-TobTecLayerPairs.layerList = cms.vstring('TOB1+TOB2', 
-        'TOB1+TEC1_pos', 
-#        'TOB1+TEC2_pos', 
-        'TOB1+TEC1_neg', 
-#        'TOB1+TEC2_neg', 
-        'TEC1_pos+TEC2_pos', 
-#        'TEC1_pos+TEC3_pos', 
-        'TEC2_pos+TEC3_pos', 
-#        'TEC2_pos+TEC4_pos', 
-        'TEC3_pos+TEC4_pos', 
-#        'TEC3_pos+TEC5_pos', 
-        'TEC4_pos+TEC5_pos', 
-#        'TEC4_pos+TEC6_pos', 
-        'TEC5_pos+TEC6_pos', 
-#        'TEC5_pos+TEC7_pos', 
-        'TEC6_pos+TEC7_pos', 
-        'TEC1_neg+TEC2_neg', 
-#        'TEC1_neg+TEC3_neg', 
-        'TEC2_neg+TEC3_neg', 
-#        'TEC2_neg+TEC4_neg', 
-        'TEC3_neg+TEC4_neg', 
-#        'TEC3_neg+TEC5_neg', 
-        'TEC4_neg+TEC5_neg', 
-#        'TEC4_neg+TEC6_neg', 
-        'TEC5_neg+TEC6_neg', 
-#        'TEC5_neg+TEC7_neg', 
-        'TEC6_neg+TEC7_neg'
-)
-TobTecLayerPairs.TOB = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    TTRHBuilder = cms.string('WithTrackAngle')
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
-TobTecLayerPairs.TEC = cms.PSet(
-    matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-    useRingSlector = cms.bool(True),
-    TTRHBuilder = cms.string('WithTrackAngle'),
-    minRing = cms.int32(5),
-    maxRing = cms.int32(5)
-    ,clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-)
+    layerList = ['TOB1+TOB2', 
+                 'TOB1+TEC1_pos', 
+#                 'TOB1+TEC2_pos', 
+                 'TOB1+TEC1_neg', 
+#                 'TOB1+TEC2_neg', 
+                 'TEC1_pos+TEC2_pos', 
+#                 'TEC1_pos+TEC3_pos', 
+                 'TEC2_pos+TEC3_pos', 
+#                 'TEC2_pos+TEC4_pos', 
+                 'TEC3_pos+TEC4_pos', 
+#                 'TEC3_pos+TEC5_pos', 
+                 'TEC4_pos+TEC5_pos', 
+#                 'TEC4_pos+TEC6_pos', 
+                 'TEC5_pos+TEC6_pos', 
+#                 'TEC5_pos+TEC7_pos', 
+                 'TEC6_pos+TEC7_pos', 
+                 'TEC1_neg+TEC2_neg', 
+#                 'TEC1_neg+TEC3_neg', 
+                 'TEC2_neg+TEC3_neg', 
+#                 'TEC2_neg+TEC4_neg', 
+                 'TEC3_neg+TEC4_neg', 
+#                 'TEC3_neg+TEC5_neg', 
+                 'TEC4_neg+TEC5_neg', 
+#                 'TEC4_neg+TEC6_neg', 
+                 'TEC5_neg+TEC6_neg', 
+#                 'TEC5_neg+TEC7_neg', 
+                 'TEC6_neg+TEC7_neg'],
 
-
-
+    TOB = cms.PSet(
+	matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TEC = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        minRing = cms.int32(5),
+        maxRing = cms.int32(5),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    )
+)

--- a/RecoTracker/TrackProducer/python/CTFCombinedSeeds_cff.py
+++ b/RecoTracker/TrackProducer/python/CTFCombinedSeeds_cff.py
@@ -16,6 +16,6 @@ from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi impo
 
 import RecoTracker.TrackProducer.TrackProducer_cfi
 # TrackProducer
-ctfCombinedSeeds = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone()
-ctfCombinedSeeds.src = 'ckfTrackCandidatesCombinedSeeds'
-
+ctfCombinedSeeds = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'ckfTrackCandidatesCombinedSeeds'
+)

--- a/RecoTracker/TrackProducer/python/CTFFinalFitWithMaterialBHM_cff.py
+++ b/RecoTracker/TrackProducer/python/CTFFinalFitWithMaterialBHM_cff.py
@@ -5,33 +5,37 @@ from TrackingTools.GeomPropagators.BeamHaloPropagator_cff import *
 from TrackingTools.TrackFitters.KFTrajectoryFitter_cfi import *
 # KFTrajectoryFitterESProducer
 #include "TrackingTools/TrackFitters/data/KFTrajectoryFitterESProducer.cfi"
-KFTrajectoryFitterBeamHalo = copy.deepcopy(KFTrajectoryFitter)
+KFTrajectoryFitterBeamHalo = KFTrajectoryFitter.clone(
+    ComponentName = 'KFFitterBH',
+    Propagator    = 'BeamHaloPropagatorAlong'
+)
 from TrackingTools.TrackFitters.KFTrajectorySmoother_cfi import *
 # KFTrajectorySmootherESProducer
 #include "TrackingTools/TrackFitters/data/KFTrajectorySmootherESProducer.cfi"
-KFTrajectorySmootherBeamHalo = copy.deepcopy(KFTrajectorySmoother)
+KFTrajectorySmootherBeamHalo = KFTrajectorySmoother.clone(
+    ComponentName = 'KFSmootherBH',
+    Propagator    = 'BeamHaloPropagatorAlong'
+)
 from TrackingTools.TrackFitters.KFFittingSmoother_cfi import *
 # KFFittingSmootherESProducer
 #include "TrackingTools/TrackFitters/data/KFFittingSmootherESProducer.cfi"
-KFFittingSmootherBeamHalo = copy.deepcopy(KFFittingSmoother)
+KFFittingSmootherBeamHalo = KFFittingSmoother.clone(
+    ComponentName = 'KFFittingSmootherBH',
+    Fitter        = 'KFFitterBH',
+    Smoother      = 'KFSmootherBH'
+)
 # generate the final tracks ######################
 #get the dependencies
 from RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff import *
 from RecoTracker.TrackProducer.TrackProducer_cfi import *
 #clone the track producer
-beamhaloTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone()
-KFTrajectoryFitterBeamHalo.ComponentName = 'KFFitterBH'
-KFTrajectoryFitterBeamHalo.Propagator = 'BeamHaloPropagatorAlong'
-KFTrajectorySmootherBeamHalo.ComponentName = 'KFSmootherBH'
-KFTrajectorySmootherBeamHalo.Propagator = 'BeamHaloPropagatorAlong'
-KFFittingSmootherBeamHalo.ComponentName = 'KFFittingSmootherBH'
-KFFittingSmootherBeamHalo.Fitter = 'KFFitterBH'
-KFFittingSmootherBeamHalo.Smoother = 'KFSmootherBH'
-beamhaloTracks.src = 'beamhaloTrackCandidates'
-beamhaloTracks.Fitter = 'KFFittingSmootherBH'
-beamhaloTracks.Propagator = 'BeamHaloPropagatorAlong'
-beamhaloTracks.TTRHBuilder = 'WithTrackAngle'
-beamhaloTracks.NavigationSchool = 'BeamHaloNavigationSchool'
-beamhaloTracks.AlgorithmName = 'beamhalo'
-beamhaloTracks.alias = 'beamhaloTracks'
-beamhaloTracks.GeometricInnerState = True
+beamhaloTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src                 = 'beamhaloTrackCandidates',
+    Fitter              = 'KFFittingSmootherBH',
+    Propagator          = 'BeamHaloPropagatorAlong',
+    TTRHBuilder         = 'WithTrackAngle',
+    NavigationSchool    = 'BeamHaloNavigationSchool',
+    AlgorithmName       = 'beamhalo',
+    alias               = 'beamhaloTracks',
+    GeometricInnerState = True
+)


### PR DESCRIPTION
#### PR description: Update the safer syntax for existing parameter

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#30353](https://github.com/cms-sw/cmssw/pull/30353), [PR#30556](https://github.com/cms-sw/cmssw/pull/30556), [PR#30671](https://github.com/cms-sw/cmssw/pull/30671))

In this PR, 14 files updated. 
- RecoTracker/{TkSeedingLayers}  12 files 
- RecoTracker/{TrackProducer} 2 files 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).