### PR TITLE
EMTF: Improve protection against corrupted LCT data

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/TrackTools.h
+++ b/L1Trigger/L1TMuonEndCap/interface/TrackTools.h
@@ -21,7 +21,11 @@ namespace emtf {
 
   // CSC max strip & max wire
 
-  void get_csc_max_strip_and_wire(int station, int ring, int& max_strip, int& max_wire);
+  std::pair<int, int> get_csc_max_strip_and_wire(int station, int ring);
+
+  // CSC max pattern & max quality
+
+  std::pair<int, int> get_csc_max_pattern_and_quality(int station, int ring);
 
   // ___________________________________________________________________________
   // coordinate ranges: phi[-180, 180] or [-pi, pi], theta[0, 90] or [0, pi/2]

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
@@ -138,23 +138,55 @@ void SectorProcessorLUT::read(bool pc_lut_data, int pc_lut_version) {
 }
 
 uint32_t SectorProcessorLUT::get_ph_init(int fw_endcap, int fw_sector, int pc_lut_id) const {
-  size_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
-  return ph_init_neighbor_.at(index);
+  const uint32_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
+  uint32_t entry = 0;
+
+  try {
+    entry = ph_init_neighbor_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
+                         << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id;
+  }
+  return entry;
 }
 
 uint32_t SectorProcessorLUT::get_ph_disp(int fw_endcap, int fw_sector, int pc_lut_id) const {
-  size_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
-  return ph_disp_neighbor_.at(index);
+  const uint32_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
+  uint32_t entry = 0;
+
+  try {
+    entry = ph_disp_neighbor_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
+                         << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id;
+  }
+  return entry;
 }
 
 uint32_t SectorProcessorLUT::get_th_init(int fw_endcap, int fw_sector, int pc_lut_id) const {
-  size_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
-  return th_init_neighbor_.at(index);
+  const uint32_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
+  uint32_t entry = 0;
+
+  try {
+    entry = th_init_neighbor_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
+                         << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id;
+  }
+  return entry;
 }
 
 uint32_t SectorProcessorLUT::get_th_disp(int fw_endcap, int fw_sector, int pc_lut_id) const {
-  size_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
-  return th_disp_neighbor_.at(index);
+  const uint32_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
+  uint32_t entry = 0;
+
+  try {
+    entry = th_disp_neighbor_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
+                         << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id;
+  }
+  return entry;
 }
 
 uint32_t SectorProcessorLUT::get_th_lut(int fw_endcap, int fw_sector, int pc_lut_id, int pc_wire_id) const {
@@ -167,8 +199,17 @@ uint32_t SectorProcessorLUT::get_th_lut(int fw_endcap, int fw_sector, int pc_lut
   if (pc_lut_id2 == 15)
     pc_lut_id2 -= 3;
 
-  size_t index = ((fw_endcap * 6 + fw_sector) * 61 + pc_lut_id2) * 128 + pc_wire_id;
-  return th_lut_neighbor_.at(index);
+  const uint32_t index = ((fw_endcap * 6 + fw_sector) * 61 + pc_lut_id2) * 128 + pc_wire_id;
+  uint32_t entry = 0;
+
+  try {
+    entry = th_lut_neighbor_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
+                         << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id
+                         << ", pc_wire_id: " << pc_wire_id;
+  }
+  return entry;
 }
 
 uint32_t SectorProcessorLUT::get_th_corr_lut(int fw_endcap, int fw_sector, int pc_lut_id, int pc_wire_strip_id) const {
@@ -188,25 +229,70 @@ uint32_t SectorProcessorLUT::get_th_corr_lut(int fw_endcap, int fw_sector, int p
   } else if (16 <= pc_lut_id2 && pc_lut_id2 < 19) {
     pc_lut_id2 -= 12;
   } else {
-    throw cms::Exception("L1TMuonEndCap") << "get_th_corr_lut(): out of range pc_lut_id: " << pc_lut_id;
+    edm::LogError("L1T") << "get_th_corr_lut(): out of range pc_lut_id: " << pc_lut_id;
   }
 
-  size_t index = ((fw_endcap * 6 + fw_sector) * 7 + pc_lut_id2) * 128 + pc_wire_strip_id;
-  return th_corr_lut_neighbor_.at(index);
+  const uint32_t index = ((fw_endcap * 6 + fw_sector) * 7 + pc_lut_id2) * 128 + pc_wire_strip_id;
+  uint32_t entry = 0;
+
+  try {
+    entry = th_corr_lut_neighbor_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
+                         << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id
+                         << ", pc_wire_strip_id: " << pc_wire_strip_id;
+  }
+  return entry;
 }
 
-uint32_t SectorProcessorLUT::get_ph_patt_corr(int pattern) const { return ph_patt_corr_.at(pattern); }
+uint32_t SectorProcessorLUT::get_ph_patt_corr(int pattern) const {
+  const uint32_t index = pattern;
+  uint32_t entry = 0;
 
-uint32_t SectorProcessorLUT::get_ph_patt_corr_sign(int pattern) const { return ph_patt_corr_sign_.at(pattern); }
+  try {
+    entry = ph_patt_corr_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. pattern: " << pattern;
+  }
+  return entry;
+}
+
+uint32_t SectorProcessorLUT::get_ph_patt_corr_sign(int pattern) const {
+  const uint32_t index = pattern;
+  uint32_t entry = 0;
+
+  try {
+    entry = ph_patt_corr_sign_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. pattern: " << pattern;
+  }
+  return entry;
+}
 
 uint32_t SectorProcessorLUT::get_ph_zone_offset(int pc_station, int pc_chamber) const {
-  size_t index = pc_station * 9 + pc_chamber;
-  return ph_zone_offset_.at(index);
+  const uint32_t index = pc_station * 9 + pc_chamber;
+  uint32_t entry = 0;
+
+  try {
+    entry = ph_zone_offset_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. pc_station: " << pc_station
+                         << ", pc_chamber: " << pc_chamber;
+  }
+  return entry;
 }
 
 uint32_t SectorProcessorLUT::get_ph_init_hard(int fw_station, int fw_cscid) const {
-  size_t index = fw_station * 16 + fw_cscid;
-  return ph_init_hard_.at(index);
+  const uint32_t index = fw_station * 16 + fw_cscid;
+  uint32_t entry = 0;
+
+  try {
+    entry = ph_init_hard_.at(index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_station: " << fw_station
+                         << ", fw_cscid: " << fw_cscid;
+  }
+  return entry;
 }
 
 uint32_t SectorProcessorLUT::get_cppf_lut_id(
@@ -227,9 +313,20 @@ uint32_t SectorProcessorLUT::get_cppf_ph_lut(int rpc_region,
                                              int rpc_roll,
                                              int halfstrip,
                                              bool is_neighbor) const {
-  size_t th_index = get_cppf_lut_id(rpc_region, rpc_sector, rpc_station, rpc_ring, rpc_subsector, rpc_roll);
-  size_t ph_index = (th_index * 64) + (halfstrip - 1);
-  uint32_t ph = cppf_ph_lut_.at(ph_index);
+  const uint32_t th_index = get_cppf_lut_id(rpc_region, rpc_sector, rpc_station, rpc_ring, rpc_subsector, rpc_roll);
+  const uint32_t ph_index = (th_index * 64) + (halfstrip - 1);
+  uint32_t ph = 0;
+
+  try {
+    ph = cppf_ph_lut_.at(ph_index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. rpc_region: " << rpc_region
+                         << ", rpc_sector: " << rpc_sector << ", rpc_station: " << rpc_station
+                         << ", rpc_ring: " << rpc_ring << ", rpc_subsector: " << rpc_subsector
+                         << ", rpc_roll: " << rpc_roll << ", halfstrip: " << halfstrip
+                         << ", is_neighbor: " << is_neighbor;
+  }
+
   if (!is_neighbor && rpc_subsector == 2)
     ph += 900;
   return ph;
@@ -237,8 +334,17 @@ uint32_t SectorProcessorLUT::get_cppf_ph_lut(int rpc_region,
 
 uint32_t SectorProcessorLUT::get_cppf_th_lut(
     int rpc_region, int rpc_sector, int rpc_station, int rpc_ring, int rpc_subsector, int rpc_roll) const {
-  size_t th_index = get_cppf_lut_id(rpc_region, rpc_sector, rpc_station, rpc_ring, rpc_subsector, rpc_roll);
-  uint32_t th = cppf_th_lut_.at(th_index);
+  const uint32_t th_index = get_cppf_lut_id(rpc_region, rpc_sector, rpc_station, rpc_ring, rpc_subsector, rpc_roll);
+  uint32_t th = 0;
+
+  try {
+    th = cppf_th_lut_.at(th_index);
+  } catch (...) {
+    edm::LogError("L1T") << "Could not retrieve entry from LUT. rpc_region: " << rpc_region
+                         << ", rpc_sector: " << rpc_sector << ", rpc_station: " << rpc_station
+                         << ", rpc_ring: " << rpc_ring << ", rpc_subsector: " << rpc_subsector
+                         << ", rpc_roll: " << rpc_roll;
+  }
   return th;
 }
 
@@ -348,8 +454,8 @@ void SectorProcessorLUT::read_cppf_file(const std::string& filename,
       uint32_t ph = buf5;
       uint32_t th = buf6;
 
-      size_t th_index = get_cppf_lut_id(rpc_region, rpc_sector, rpc_station, rpc_ring, rpc_subsector, rpc_roll);
-      size_t ph_index = (th_index * 64) + (halfstrip - 1);
+      const uint32_t th_index = get_cppf_lut_id(rpc_region, rpc_sector, rpc_station, rpc_ring, rpc_subsector, rpc_roll);
+      const uint32_t ph_index = (th_index * 64) + (halfstrip - 1);
 
       // std::cout << id << " " << rpc_region << " " << rpc_sector << " " << rpc_station << " " << rpc_ring << " "
       //    << rpc_subsector << " " << rpc_roll << " " << halfstrip << " " << th_index << " " << ph_index << std::endl;

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
@@ -141,9 +141,9 @@ uint32_t SectorProcessorLUT::get_ph_init(int fw_endcap, int fw_sector, int pc_lu
   const uint32_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
   uint32_t entry = 0;
 
-  try {
+  if (index < ph_init_neighbor_.size()) {
     entry = ph_init_neighbor_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
                          << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id;
   }
@@ -154,9 +154,9 @@ uint32_t SectorProcessorLUT::get_ph_disp(int fw_endcap, int fw_sector, int pc_lu
   const uint32_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
   uint32_t entry = 0;
 
-  try {
+  if (index < ph_disp_neighbor_.size()) {
     entry = ph_disp_neighbor_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
                          << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id;
   }
@@ -167,9 +167,9 @@ uint32_t SectorProcessorLUT::get_th_init(int fw_endcap, int fw_sector, int pc_lu
   const uint32_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
   uint32_t entry = 0;
 
-  try {
+  if (index < th_init_neighbor_.size()) {
     entry = th_init_neighbor_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
                          << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id;
   }
@@ -180,9 +180,9 @@ uint32_t SectorProcessorLUT::get_th_disp(int fw_endcap, int fw_sector, int pc_lu
   const uint32_t index = (fw_endcap * 6 + fw_sector) * 61 + pc_lut_id;
   uint32_t entry = 0;
 
-  try {
+  if (index < th_disp_neighbor_.size()) {
     entry = th_disp_neighbor_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
                          << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id;
   }
@@ -202,9 +202,9 @@ uint32_t SectorProcessorLUT::get_th_lut(int fw_endcap, int fw_sector, int pc_lut
   const uint32_t index = ((fw_endcap * 6 + fw_sector) * 61 + pc_lut_id2) * 128 + pc_wire_id;
   uint32_t entry = 0;
 
-  try {
+  if (index < th_lut_neighbor_.size()) {
     entry = th_lut_neighbor_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
                          << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id
                          << ", pc_wire_id: " << pc_wire_id;
@@ -235,9 +235,9 @@ uint32_t SectorProcessorLUT::get_th_corr_lut(int fw_endcap, int fw_sector, int p
   const uint32_t index = ((fw_endcap * 6 + fw_sector) * 7 + pc_lut_id2) * 128 + pc_wire_strip_id;
   uint32_t entry = 0;
 
-  try {
+  if (index < th_corr_lut_neighbor_.size()) {
     entry = th_corr_lut_neighbor_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_endcap: " << fw_endcap
                          << ", fw_sector: " << fw_sector << ", pc_lut_id: " << pc_lut_id
                          << ", pc_wire_strip_id: " << pc_wire_strip_id;
@@ -249,9 +249,9 @@ uint32_t SectorProcessorLUT::get_ph_patt_corr(int pattern) const {
   const uint32_t index = pattern;
   uint32_t entry = 0;
 
-  try {
+  if (index < ph_patt_corr_.size()) {
     entry = ph_patt_corr_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. pattern: " << pattern;
   }
   return entry;
@@ -261,9 +261,9 @@ uint32_t SectorProcessorLUT::get_ph_patt_corr_sign(int pattern) const {
   const uint32_t index = pattern;
   uint32_t entry = 0;
 
-  try {
+  if (index < ph_patt_corr_sign_.size()) {
     entry = ph_patt_corr_sign_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. pattern: " << pattern;
   }
   return entry;
@@ -273,9 +273,9 @@ uint32_t SectorProcessorLUT::get_ph_zone_offset(int pc_station, int pc_chamber) 
   const uint32_t index = pc_station * 9 + pc_chamber;
   uint32_t entry = 0;
 
-  try {
+  if (index < ph_zone_offset_.size()) {
     entry = ph_zone_offset_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. pc_station: " << pc_station
                          << ", pc_chamber: " << pc_chamber;
   }
@@ -286,9 +286,9 @@ uint32_t SectorProcessorLUT::get_ph_init_hard(int fw_station, int fw_cscid) cons
   const uint32_t index = fw_station * 16 + fw_cscid;
   uint32_t entry = 0;
 
-  try {
+  if (index < ph_init_hard_.size()) {
     entry = ph_init_hard_.at(index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. fw_station: " << fw_station
                          << ", fw_cscid: " << fw_cscid;
   }
@@ -317,9 +317,9 @@ uint32_t SectorProcessorLUT::get_cppf_ph_lut(int rpc_region,
   const uint32_t ph_index = (th_index * 64) + (halfstrip - 1);
   uint32_t ph = 0;
 
-  try {
+  if (ph_index < cppf_ph_lut_.size()) {
     ph = cppf_ph_lut_.at(ph_index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. rpc_region: " << rpc_region
                          << ", rpc_sector: " << rpc_sector << ", rpc_station: " << rpc_station
                          << ", rpc_ring: " << rpc_ring << ", rpc_subsector: " << rpc_subsector
@@ -337,9 +337,9 @@ uint32_t SectorProcessorLUT::get_cppf_th_lut(
   const uint32_t th_index = get_cppf_lut_id(rpc_region, rpc_sector, rpc_station, rpc_ring, rpc_subsector, rpc_roll);
   uint32_t th = 0;
 
-  try {
+  if (th_index < cppf_th_lut_.size()) {
     th = cppf_th_lut_.at(th_index);
-  } catch (...) {
+  } else {
     edm::LogError("L1T") << "Could not retrieve entry from LUT. rpc_region: " << rpc_region
                          << ", rpc_sector: " << rpc_sector << ", rpc_station: " << rpc_station
                          << ", rpc_ring: " << rpc_ring << ", rpc_subsector: " << rpc_subsector

--- a/L1Trigger/L1TMuonEndCap/src/TrackTools.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackTools.cc
@@ -138,9 +138,9 @@ namespace emtf {
   // | ME2/2, ME3/2, ME4/2        | 160        | 64         |
   // +----------------------------+------------+------------+
 
-  void get_csc_max_strip_and_wire(int station, int ring, int& max_strip, int& max_wire) {
-    max_strip = 0;                    // halfstrip
-    max_wire = 0;                     // wiregroup
+  std::pair<int, int> get_csc_max_strip_and_wire(int station, int ring) {
+    int max_strip = 0;                // halfstrip
+    int max_wire = 0;                 // wiregroup
     if (station == 1 && ring == 4) {  // ME1/1a
       max_strip = 96;
       max_wire = 48;
@@ -163,7 +163,13 @@ namespace emtf {
       max_strip = 160;
       max_wire = 64;
     }
-    return;
+    return std::make_pair(max_strip, max_wire);
+  }
+
+  std::pair<int, int> get_csc_max_pattern_and_quality(int station, int ring) {
+    int max_pattern = 11;
+    int max_quality = 16;
+    return std::make_pair(max_pattern, max_quality);
   }
 
 }  // namespace emtf


### PR DESCRIPTION
#### PR description:

Due to the [incident](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2170.html) from the recent MWGR, we found out that the EMTF emulator might crash if it receives CSC LCTs with unexpected parameters. This PR aims to **improve protection against such corrupted LCT data**.

The specific cause of the crash was the corrupted LCT pattern number. This pattern number is used to address a LUT to retrieve the phi coordinate correction value. The LUT expects a pattern number between 0 and 10. However, due to data corruption, the pattern number might exceed 10, and this line: `ph_patt_corr_.at(pattern);` would throw.

Changes made:
- To prevent this from happening in the future, all the functions involving a LUT in `L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc` now use "try-catch" blocks to catch errors due to `at()`.
- In `L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc`, the LCT parameters such as strip, wire, valid, pattern, and quality, are now checked against allowed values. If any of the LCT parameters are found to be corrupted, the LCT is rejected (i.e. it is not used in any subsequent steps in the track finder, including coordinate conversion). The warning messages have been expanded.
- The current logic that tries to patch the pattern number and the quality number has been removed.

#### PR validation:

Validated with:

- `runTheMatrix.py -l limited -i all -j10`. The only errors were coming from `DAS_ERROR`.
- Re-processing the raw data from the Run 336345 during MWGR, the EMTF emulator doesn't crash anymore.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

---
Notifications: @eyigitba 