### PR TITLE
Move to std::filesystem on Calibration/EcalCalibAlgos

### DIFF
--- a/Calibration/EcalCalibAlgos/BuildFile.xml
+++ b/Calibration/EcalCalibAlgos/BuildFile.xml
@@ -22,6 +22,7 @@
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="DQMServices/Core"/>
 <use name="CondCore/DBOutputService"/>
+<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration.cc
@@ -29,8 +29,6 @@
 
 #include "FWCore/Framework/interface/Run.h"
 
-#include "boost/filesystem/operations.hpp"
-
 using namespace std;
 #include <fstream>
 #include <iostream>

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.cc
@@ -13,8 +13,8 @@
 #include "TH1F.h"
 #include "TFile.h"
 
+#include <filesystem>
 #include <fstream>
-#include "boost/filesystem/operations.hpp"
 
 using namespace std;
 
@@ -51,7 +51,7 @@ void PhiSymmetryCalibration_step2::setUp(const edm::EventSetup& se) {
   /// if a miscalibration was applied, load it, if not put it to 1
   if (have_initial_miscalib_) {
     EcalCondHeader h;
-    namespace fs = boost::filesystem;
+    namespace fs = std::filesystem;
     fs::path p(initialmiscalibfile_.c_str());
     if (!fs::exists(p))
       edm::LogError("PhiSym") << "File not found: " << initialmiscalibfile_ << endl;
@@ -74,7 +74,7 @@ void PhiSymmetryCalibration_step2::setUp(const edm::EventSetup& se) {
   // if not put them to one
   if (reiteration_) {
     EcalCondHeader h;
-    namespace fs = boost::filesystem;
+    namespace fs = std::filesystem;
     fs::path p(oldcalibfile_.c_str());
     if (!fs::exists(p))
       edm::LogError("PhiSym") << "File not found: " << oldcalibfile_ << endl;

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.cc
@@ -13,8 +13,8 @@
 #include "TH1F.h"
 #include "TFile.h"
 
+#include <filesystem>
 #include <fstream>
-#include "boost/filesystem/operations.hpp"
 
 using namespace std;
 
@@ -63,7 +63,7 @@ void PhiSymmetryCalibration_step2_SM::setUp(const edm::EventSetup& se) {
   /// if a miscalibration was applied, load it, if not put it to 1
   if (have_initial_miscalib_) {
     EcalCondHeader h;
-    namespace fs = boost::filesystem;
+    namespace fs = std::filesystem;
     fs::path p(initialmiscalibfile_.c_str());
     if (!fs::exists(p))
       edm::LogError("PhiSym") << "File not found: " << initialmiscalibfile_ << endl;
@@ -85,7 +85,7 @@ void PhiSymmetryCalibration_step2_SM::setUp(const edm::EventSetup& se) {
   // if not put them to one
   if (reiteration_) {
     EcalCondHeader h;
-    namespace fs = boost::filesystem;
+    namespace fs = std::filesystem;
     fs::path p(oldcalibfile_.c_str());
     if (!fs::exists(p))
       edm::LogError("PhiSym") << "File not found: " << oldcalibfile_ << endl;


### PR DESCRIPTION
#### PR description:
Boost and std filesystem have similar functionality. When possible we should use std::filesystem to avoid unnecessary dependencies.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 