### PR TITLE
Enable L1Tracks in L1T DQM (backport)

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -891,7 +891,8 @@ for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
         'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
         'keep *_TTClustersFromPhase2TrackerDigis_*_*',
         'keep *_TTStubsFromPhase2TrackerDigis_*_*',
-        'keep *_TrackerDTC_*_*'
+        'keep *_TrackerDTC_*_*',
+        'keep *_*_Level1TTTracks_*'
     ])
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017

--- a/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTStub.h
+++ b/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTStub.h
@@ -39,9 +39,14 @@ public:
   MonitorElement *Stub_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub per EC ring
 
   // Stub distribution
-  MonitorElement *Stub_Eta = nullptr;  // TTstub eta distribution
-  MonitorElement *Stub_Phi = nullptr;  // TTstub phi distribution
-  MonitorElement *Stub_R = nullptr;    // TTstub r distribution
+  MonitorElement *Stub_Eta = nullptr;         // TTstub eta distribution
+  MonitorElement *Stub_Phi = nullptr;         // TTstub phi distribution
+  MonitorElement *Stub_R = nullptr;           // TTstub r distribution
+  MonitorElement *Stub_bendFE = nullptr;      // TTstub trigger bend
+  MonitorElement *Stub_bendBE = nullptr;      // TTstub hardware bend
+  MonitorElement *Stub_rawBend = nullptr;     // TTstub raw bend
+  MonitorElement *Stub_bendOffset = nullptr;  // TTstub bend offset
+  MonitorElement *Stub_isPS = nullptr;        // is this stub a PS module?
 
   // STUB Displacement - offset
   MonitorElement *Stub_Barrel_W = nullptr;       // TTstub Pos-Corr Displacement (layer)

--- a/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTTrack.h
+++ b/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTTrack.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <bitset>
 
 class OuterTrackerMonitorTTTrack : public DQMEDAnalyzer {
 public:
@@ -24,34 +25,43 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   // Distributions of all tracks
-  MonitorElement *Track_NStubs = nullptr;      // Number of stubs per track
-  MonitorElement *Track_Eta_NStubs = nullptr;  // Number of stubs per track vs
-                                               // eta
+  MonitorElement *Track_All_N = nullptr;                 // Number of tracks per event
+  MonitorElement *Track_All_NStubs = nullptr;            // Number of stubs per track
+  MonitorElement *Track_All_NLayersMissed = nullptr;     // Number of layers missed per track
+  MonitorElement *Track_All_Eta_NStubs = nullptr;        // Number of stubs per track vs eta
+  MonitorElement *Track_All_Pt = nullptr;                // pT distrubtion for tracks
+  MonitorElement *Track_All_Eta = nullptr;               // eta distrubtion for tracks
+  MonitorElement *Track_All_Phi = nullptr;               // phi distrubtion for tracks
+  MonitorElement *Track_All_D0 = nullptr;                // d0 distrubtion for tracks
+  MonitorElement *Track_All_VtxZ = nullptr;              // z0 distrubtion for tracks
+  MonitorElement *Track_All_BendChi2 = nullptr;          // Bendchi2 distrubtion for tracks
+  MonitorElement *Track_All_Chi2 = nullptr;              // chi2 distrubtion for tracks
+  MonitorElement *Track_All_Chi2Red = nullptr;           // chi2/dof distrubtion for tracks
+  MonitorElement *Track_All_Chi2RZ = nullptr;            // chi2 r-phi distrubtion for tracks
+  MonitorElement *Track_All_Chi2RPhi = nullptr;          // chi2 r-z distrubtion for tracks
+  MonitorElement *Track_All_Chi2Red_NStubs = nullptr;    // chi2/dof vs number of stubs
+  MonitorElement *Track_All_Chi2Red_Eta = nullptr;       // chi2/dof vs eta of track
+  MonitorElement *Track_All_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
+  MonitorElement *Track_All_Eta_ECStubs = nullptr;       // eta vs number of stubs in end caps
+  MonitorElement *Track_All_Chi2_Probability = nullptr;  // chi2 probability
 
-  /// Low-quality TTTracks (All tracks)
-  MonitorElement *Track_LQ_N = nullptr;                 // Number of tracks per event
-  MonitorElement *Track_LQ_Pt = nullptr;                // pT distrubtion for tracks
-  MonitorElement *Track_LQ_Eta = nullptr;               // eta distrubtion for tracks
-  MonitorElement *Track_LQ_Phi = nullptr;               // phi distrubtion for tracks
-  MonitorElement *Track_LQ_D0 = nullptr;                // d0 distrubtion for tracks
-  MonitorElement *Track_LQ_VtxZ = nullptr;              // z0 distrubtion for tracks
-  MonitorElement *Track_LQ_Chi2 = nullptr;              // chi2 distrubtion for tracks
-  MonitorElement *Track_LQ_Chi2Red = nullptr;           // chi2/dof distrubtion for tracks
-  MonitorElement *Track_LQ_Chi2Red_NStubs = nullptr;    // chi2/dof vs number of stubs
-  MonitorElement *Track_LQ_Chi2Red_Eta = nullptr;       // chi2/dof vs eta of track
-  MonitorElement *Track_LQ_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
-  MonitorElement *Track_LQ_Eta_ECStubs = nullptr;       // eta vs number of stubs in end caps
-  MonitorElement *Track_LQ_Chi2_Probability = nullptr;  // chi2 probability
-
-  /// High-quality TTTracks (NStubs >=5, chi2/dof<10)
+  /// High-quality TTTracks; different depending on prompt vs displaced tracks
+  // Quality cuts: chi2/dof<10, bendchi2<2.2 (Prompt), default in config
+  // Quality cuts: chi2/dof<40, bendchi2<2.4 (Extended/Displaced tracks)  MonitorElement *Track_HQ_N = nullptr;                 // Number of tracks per event
   MonitorElement *Track_HQ_N = nullptr;                 // Number of tracks per event
+  MonitorElement *Track_HQ_NStubs = nullptr;            // Number of stubs per track
+  MonitorElement *Track_HQ_NLayersMissed = nullptr;     // Number of layers missed per track
+  MonitorElement *Track_HQ_Eta_NStubs = nullptr;        // Number of stubs per track vs eta
   MonitorElement *Track_HQ_Pt = nullptr;                // pT distrubtion for tracks
   MonitorElement *Track_HQ_Eta = nullptr;               // eta distrubtion for tracks
   MonitorElement *Track_HQ_Phi = nullptr;               // phi distrubtion for tracks
   MonitorElement *Track_HQ_D0 = nullptr;                // d0 distrubtion for tracks
   MonitorElement *Track_HQ_VtxZ = nullptr;              // z0 distrubtion for tracks
+  MonitorElement *Track_HQ_BendChi2 = nullptr;          // Bendchi2 distrubtion for tracks
   MonitorElement *Track_HQ_Chi2 = nullptr;              // chi2 distrubtion for tracks
   MonitorElement *Track_HQ_Chi2Red = nullptr;           // chi2/dof distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2RZ = nullptr;            // chi2 r-z distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2RPhi = nullptr;          // chi2 r-phi distrubtion for tracks
   MonitorElement *Track_HQ_Chi2Red_NStubs = nullptr;    // chi2/dof vs number of stubs
   MonitorElement *Track_HQ_Chi2Red_Eta = nullptr;       // chi2/dof vs eta of track
   MonitorElement *Track_HQ_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
@@ -64,6 +74,7 @@ private:
 
   unsigned int HQNStubs_;
   double HQChi2dof_;
+  double HQBendChi2_;
   std::string topFolderName_;
 };
 #endif

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -87,8 +87,8 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::Eve
       DetId detIdStub = theTrackerGeometry->idToDet((tempStubRef->clusterRef(0))->getDetId())->geographicalId();
 
       /// Get trigger displacement/offset
-      double displStub = tempStubRef->rawBend();
-      double offsetStub = tempStubRef->bendOffset();
+      double rawBend = tempStubRef->rawBend();
+      double bendOffset = tempStubRef->bendOffset();
 
       /// Define position stub by position inner cluster
       MeasurementPoint mp = (tempStubRef->clusterRef(0))->findAverageLocalCoordinates();
@@ -99,34 +99,39 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::Eve
       Stub_Phi->Fill(posStub.phi());
       Stub_R->Fill(posStub.perp());
       Stub_RZ->Fill(posStub.z(), posStub.perp());
+      Stub_bendFE->Fill(tempStubRef->bendFE());
+      Stub_bendBE->Fill(tempStubRef->bendBE());
+      Stub_rawBend->Fill(rawBend);
+      Stub_bendOffset->Fill(bendOffset);
+      Stub_isPS->Fill(tempStubRef->moduleTypePS());
 
       if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TOB)) {  // Phase 2 Outer Tracker Barrel
         Stub_Barrel->Fill(tTopo->layer(detIdStub));
         Stub_Barrel_XY->Fill(posStub.x(), posStub.y());
-        Stub_Barrel_W->Fill(tTopo->layer(detIdStub), displStub - offsetStub);
-        Stub_Barrel_O->Fill(tTopo->layer(detIdStub), offsetStub);
+        Stub_Barrel_W->Fill(tTopo->layer(detIdStub), rawBend - bendOffset);
+        Stub_Barrel_O->Fill(tTopo->layer(detIdStub), bendOffset);
       } else if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TID)) {  // Phase 2 Outer Tracker Endcap
         int disc = tTopo->layer(detIdStub);                                          // returns wheel
         int ring = tTopo->tidRing(detIdStub);
         Stub_Endcap_Disc->Fill(disc);
         Stub_Endcap_Ring->Fill(ring);
-        Stub_Endcap_Disc_W->Fill(disc, displStub - offsetStub);
-        Stub_Endcap_Ring_W->Fill(ring, displStub - offsetStub);
-        Stub_Endcap_Disc_O->Fill(disc, offsetStub);
-        Stub_Endcap_Ring_O->Fill(ring, offsetStub);
+        Stub_Endcap_Disc_W->Fill(disc, rawBend - bendOffset);
+        Stub_Endcap_Ring_W->Fill(ring, rawBend - bendOffset);
+        Stub_Endcap_Disc_O->Fill(disc, bendOffset);
+        Stub_Endcap_Ring_O->Fill(ring, bendOffset);
 
         if (posStub.z() > 0) {
           Stub_Endcap_Fw_XY->Fill(posStub.x(), posStub.y());
           Stub_Endcap_Disc_Fw->Fill(disc);
           Stub_Endcap_Ring_Fw[disc - 1]->Fill(ring);
-          Stub_Endcap_Ring_W_Fw[disc - 1]->Fill(ring, displStub - offsetStub);
-          Stub_Endcap_Ring_O_Fw[disc - 1]->Fill(ring, offsetStub);
+          Stub_Endcap_Ring_W_Fw[disc - 1]->Fill(ring, rawBend - bendOffset);
+          Stub_Endcap_Ring_O_Fw[disc - 1]->Fill(ring, bendOffset);
         } else {
           Stub_Endcap_Bw_XY->Fill(posStub.x(), posStub.y());
           Stub_Endcap_Disc_Bw->Fill(disc);
           Stub_Endcap_Ring_Bw[disc - 1]->Fill(ring);
-          Stub_Endcap_Ring_W_Bw[disc - 1]->Fill(ring, displStub - offsetStub);
-          Stub_Endcap_Ring_O_Bw[disc - 1]->Fill(ring, offsetStub);
+          Stub_Endcap_Ring_W_Bw[disc - 1]->Fill(ring, rawBend - bendOffset);
+          Stub_Endcap_Ring_O_Bw[disc - 1]->Fill(ring, bendOffset);
         }
       }
     }
@@ -227,6 +232,58 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
                           psTTStub_R.getParameter<double>("xmax"));
   Stub_R->setAxisTitle("R", 1);
   Stub_R->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub trigger bend
+  edm::ParameterSet psTTStub_bend = conf_.getParameter<edm::ParameterSet>("TH1TTStub_bend");
+  HistoName = "Stub_bendFE";
+  Stub_bendFE = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTTStub_bend.getParameter<int32_t>("Nbinsx"),
+                               psTTStub_bend.getParameter<double>("xmin"),
+                               psTTStub_bend.getParameter<double>("xmax"));
+  Stub_bendFE->setAxisTitle("Trigger bend", 1);
+  Stub_bendFE->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub hardware bend
+  HistoName = "Stub_bendBE";
+  Stub_bendBE = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTTStub_bend.getParameter<int32_t>("Nbinsx"),
+                               psTTStub_bend.getParameter<double>("xmin"),
+                               psTTStub_bend.getParameter<double>("xmax"));
+  Stub_bendBE->setAxisTitle("Hardware bend", 1);
+  Stub_bendBE->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub raw bend
+  HistoName = "Stub_rawBend";
+  Stub_rawBend = iBooker.book1D(HistoName,
+                                HistoName,
+                                psTTStub_bend.getParameter<int32_t>("Nbinsx"),
+                                psTTStub_bend.getParameter<double>("xmin"),
+                                psTTStub_bend.getParameter<double>("xmax"));
+  Stub_rawBend->setAxisTitle("Raw bend", 1);
+  Stub_rawBend->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub bend offset
+  HistoName = "Stub_bendOffset";
+  Stub_bendOffset = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psTTStub_bend.getParameter<int32_t>("Nbinsx"),
+                                   psTTStub_bend.getParameter<double>("xmin"),
+                                   psTTStub_bend.getParameter<double>("xmax"));
+  Stub_bendOffset->setAxisTitle("Bend offset", 1);
+  Stub_bendOffset->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub, is PS?
+  edm::ParameterSet psTTStub_isPS = conf_.getParameter<edm::ParameterSet>("TH1TTStub_isPS");
+  HistoName = "Stub_isPS";
+  Stub_isPS = iBooker.book1D(HistoName,
+                             HistoName,
+                             psTTStub_isPS.getParameter<int32_t>("Nbinsx"),
+                             psTTStub_isPS.getParameter<double>("xmin"),
+                             psTTStub_isPS.getParameter<double>("xmax"));
+  Stub_isPS->setAxisTitle("Is PS?", 1);
+  Stub_isPS->setAxisTitle("# L1 Stubs ", 2);
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/NStubs");
   // TTStub barrel stack

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -42,6 +42,7 @@ OuterTrackerMonitorTTTrack::OuterTrackerMonitorTTTrack(const edm::ParameterSet &
       consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTTracksTag"));
   HQNStubs_ = conf_.getParameter<int>("HQNStubs");
   HQChi2dof_ = conf_.getParameter<double>("HQChi2dof");
+  HQBendChi2_ = conf_.getParameter<double>("HQBendChi2");
 }
 
 OuterTrackerMonitorTTTrack::~OuterTrackerMonitorTTTrack() {
@@ -58,8 +59,8 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::Ev
   iEvent.getByToken(ttTrackToken_, TTTrackHandle);
 
   /// Track Trigger Tracks
+  unsigned int numAllTracks = 0;
   unsigned int numHQTracks = 0;
-  unsigned int numLQTracks = 0;
 
   // Adding protection
   if (!TTTrackHandle.isValid())
@@ -74,81 +75,91 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::Ev
     int nBarrelStubs = 0;
     int nECStubs = 0;
 
-    double track_d0 = tempTrackPtr->d0();
-    double trackChi2 = tempTrackPtr->chi2();
-    double trackChi2R = tempTrackPtr->chi2Red();
+    float track_eta = tempTrackPtr->momentum().eta();
+    float track_d0 = tempTrackPtr->d0();
+    float track_bendchi2 = tempTrackPtr->stubPtConsistency();
+    float track_chi2 = tempTrackPtr->chi2();
+    float track_chi2dof = tempTrackPtr->chi2Red();
+    float track_chi2rz = tempTrackPtr->chi2Z();
+    float track_chi2rphi = tempTrackPtr->chi2XY();
+    int nLayersMissed = 0;
+    unsigned int hitPattern_ = (unsigned int)tempTrackPtr->hitPattern();
 
-    Track_NStubs->Fill(nStubs);
-    Track_Eta_NStubs->Fill(tempTrackPtr->eta(), nStubs);
+    int nbits = floor(log2(hitPattern_)) + 1;
+    int lay_i = 0;
+    bool seq = false;
+    for (int i = 0; i < nbits; i++) {
+      lay_i = ((1 << i) & hitPattern_) >> i;  //0 or 1 in ith bit (right to left)
+      if (lay_i && !seq)
+        seq = true;  //sequence starts when first 1 found
+      if (!lay_i && seq)
+        nLayersMissed++;
+    }
 
     std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
         theStubs = iterTTTrack.getStubRefs();
     for (auto istub : theStubs) {
-      bool inTIB = false;
-      bool inTOB = false;
-      bool inTEC = false;
-      bool inTID = false;
+      bool inBarrel = false;
+      bool inEC = false;
 
-      // Verify if stubs are in EC or barrel
-      DetId detId(istub->getDetId());
-      if (detId.det() == DetId::Detector::Tracker) {
-        if (detId.subdetId() == StripSubdetector::TIB)
-          inTIB = true;
-        else if (detId.subdetId() == StripSubdetector::TOB)
-          inTOB = true;
-        else if (detId.subdetId() == StripSubdetector::TEC)
-          inTEC = true;
-        else if (detId.subdetId() == StripSubdetector::TID)
-          inTID = true;
-      }
-      if (inTIB)
+      if (istub->getDetId().subdetId() == StripSubdetector::TOB)
+        inBarrel = true;
+      else if (istub->getDetId().subdetId() == StripSubdetector::TID)
+        inEC = true;
+      if (inBarrel)
         nBarrelStubs++;
-      else if (inTOB)
-        nBarrelStubs++;
-      else if (inTEC)
-        nECStubs++;
-      else if (inTID)
+      else if (inEC)
         nECStubs++;
     }  // end loop over stubs
 
-    // HQ tracks: >=5 stubs and chi2/dof < 1
-    if (nStubs >= HQNStubs_ && trackChi2R <= HQChi2dof_) {
+    // HQ tracks: bendchi2<2.2 and chi2/dof<10
+    if (nStubs >= HQNStubs_ && track_chi2dof <= HQChi2dof_ && track_bendchi2 <= HQBendChi2_) {
       numHQTracks++;
 
-      Track_HQ_Pt->Fill(tempTrackPtr->momentum().perp());  //4 for now for backwards compatibility
-      Track_HQ_Eta->Fill(tempTrackPtr->eta());
-      Track_HQ_Phi->Fill(tempTrackPtr->phi());
-      Track_HQ_VtxZ->Fill(tempTrackPtr->z0());
-      Track_HQ_Chi2->Fill(trackChi2);
-      Track_HQ_Chi2Red->Fill(trackChi2R);
+      Track_HQ_NStubs->Fill(nStubs);
+      Track_HQ_NLayersMissed->Fill(nLayersMissed);
+      Track_HQ_Eta_NStubs->Fill(track_eta, nStubs);
+      Track_HQ_Pt->Fill(tempTrackPtr->momentum().perp());
+      Track_HQ_Eta->Fill(track_eta);
+      Track_HQ_Phi->Fill(tempTrackPtr->momentum().phi());
       Track_HQ_D0->Fill(track_d0);
-      Track_HQ_Chi2Red_NStubs->Fill(nStubs, trackChi2R);
-      Track_HQ_Chi2Red_Eta->Fill(tempTrackPtr->eta(), trackChi2R);
-      Track_HQ_Eta_BarrelStubs->Fill(tempTrackPtr->eta(), nBarrelStubs);
-      Track_HQ_Eta_ECStubs->Fill(tempTrackPtr->eta(), nECStubs);
-      Track_HQ_Chi2_Probability->Fill(ChiSquaredProbability(trackChi2, nStubs));
+      Track_HQ_VtxZ->Fill(tempTrackPtr->z0());
+      Track_HQ_BendChi2->Fill(track_bendchi2);
+      Track_HQ_Chi2->Fill(track_chi2);
+      Track_HQ_Chi2RZ->Fill(track_chi2rz);
+      Track_HQ_Chi2RPhi->Fill(track_chi2rphi);
+      Track_HQ_Chi2Red->Fill(track_chi2dof);
+      Track_HQ_Chi2Red_NStubs->Fill(nStubs, track_chi2dof);
+      Track_HQ_Chi2Red_Eta->Fill(track_eta, track_chi2dof);
+      Track_HQ_Eta_BarrelStubs->Fill(track_eta, nBarrelStubs);
+      Track_HQ_Eta_ECStubs->Fill(track_eta, nECStubs);
+      Track_HQ_Chi2_Probability->Fill(ChiSquaredProbability(track_chi2, nStubs));
     }
 
-    // LQ: now defined as all tracks (including HQ tracks)
-    numLQTracks++;
-
-    Track_LQ_Pt->Fill(tempTrackPtr->momentum().perp());
-    Track_LQ_Eta->Fill(tempTrackPtr->eta());
-    Track_LQ_Phi->Fill(tempTrackPtr->phi());
-    Track_LQ_VtxZ->Fill(tempTrackPtr->z0());
-    Track_LQ_Chi2->Fill(trackChi2);
-    Track_LQ_Chi2Red->Fill(trackChi2R);
-    Track_LQ_D0->Fill(track_d0);
-    Track_LQ_Chi2Red_NStubs->Fill(nStubs, trackChi2R);
-    Track_LQ_Chi2Red_Eta->Fill(tempTrackPtr->eta(), trackChi2R);
-    Track_LQ_Eta_BarrelStubs->Fill(tempTrackPtr->eta(), nBarrelStubs);
-    Track_LQ_Eta_ECStubs->Fill(tempTrackPtr->eta(), nECStubs);
-    Track_LQ_Chi2_Probability->Fill(ChiSquaredProbability(trackChi2, nStubs));
-
+    // All tracks (including HQ tracks)
+    numAllTracks++;
+    Track_All_NStubs->Fill(nStubs);
+    Track_All_NLayersMissed->Fill(nLayersMissed);
+    Track_All_Eta_NStubs->Fill(track_eta, nStubs);
+    Track_All_Pt->Fill(tempTrackPtr->momentum().perp());
+    Track_All_Eta->Fill(track_eta);
+    Track_All_Phi->Fill(tempTrackPtr->momentum().phi());
+    Track_All_D0->Fill(track_d0);
+    Track_All_VtxZ->Fill(tempTrackPtr->z0());
+    Track_All_BendChi2->Fill(track_bendchi2);
+    Track_All_Chi2->Fill(track_chi2);
+    Track_All_Chi2RZ->Fill(track_chi2rz);
+    Track_All_Chi2RPhi->Fill(track_chi2rphi);
+    Track_All_Chi2Red->Fill(track_chi2dof);
+    Track_All_Chi2Red_NStubs->Fill(nStubs, track_chi2dof);
+    Track_All_Chi2Red_Eta->Fill(track_eta, track_chi2dof);
+    Track_All_Eta_BarrelStubs->Fill(track_eta, nBarrelStubs);
+    Track_All_Eta_ECStubs->Fill(track_eta, nECStubs);
+    Track_All_Chi2_Probability->Fill(ChiSquaredProbability(track_chi2, nStubs));
   }  // End of loop over TTTracks
 
   Track_HQ_N->Fill(numHQTracks);
-  Track_LQ_N->Fill(numLQTracks);
+  Track_All_N->Fill(numAllTracks);
 }  // end of method
 
 // ------------ method called once each job just before starting event loop
@@ -158,177 +169,44 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
                                                 edm::Run const &run,
                                                 edm::EventSetup const &es) {
   std::string HistoName;
-  iBooker.setCurrentFolder(topFolderName_ + "/Tracks/");
+
+  /// Low-quality tracks (All tracks, including HQ tracks)
+  iBooker.setCurrentFolder(topFolderName_ + "/Tracks/All");
+  // Nb of L1Tracks
+  HistoName = "Track_All_N";
+  edm::ParameterSet psTrack_N = conf_.getParameter<edm::ParameterSet>("TH1_NTracks");
+  Track_All_N = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTrack_N.getParameter<int32_t>("Nbinsx"),
+                               psTrack_N.getParameter<double>("xmin"),
+                               psTrack_N.getParameter<double>("xmax"));
+  Track_All_N->setAxisTitle("# L1 Tracks", 1);
+  Track_All_N->setAxisTitle("# Events", 2);
 
   // Number of stubs
   edm::ParameterSet psTrack_NStubs = conf_.getParameter<edm::ParameterSet>("TH1_NStubs");
-  HistoName = "Track_NStubs";
-  Track_NStubs = iBooker.book1D(HistoName,
-                                HistoName,
-                                psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
-                                psTrack_NStubs.getParameter<double>("xmin"),
-                                psTrack_NStubs.getParameter<double>("xmax"));
-  Track_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
-  Track_NStubs->setAxisTitle("# L1 Tracks", 2);
+  HistoName = "Track_All_NStubs";
+  Track_All_NStubs = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_NStubs.getParameter<double>("xmin"),
+                                    psTrack_NStubs.getParameter<double>("xmax"));
+  Track_All_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
+  Track_All_NStubs->setAxisTitle("# L1 Tracks", 2);
+
+  // Number of layers missed
+  HistoName = "Track_All_NLayersMissed";
+  Track_All_NLayersMissed = iBooker.book1D(HistoName,
+                                           HistoName,
+                                           psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+                                           psTrack_NStubs.getParameter<double>("xmin"),
+                                           psTrack_NStubs.getParameter<double>("xmax"));
+  Track_All_NLayersMissed->setAxisTitle("# Layers missed", 1);
+  Track_All_NLayersMissed->setAxisTitle("# L1 Tracks", 2);
 
   edm::ParameterSet psTrack_Eta_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Eta_NStubs");
-  HistoName = "Track_Eta_NStubs";
-  Track_Eta_NStubs = iBooker.book2D(HistoName,
-                                    HistoName,
-                                    psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-                                    psTrack_Eta_NStubs.getParameter<double>("xmin"),
-                                    psTrack_Eta_NStubs.getParameter<double>("xmax"),
-                                    psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-                                    psTrack_Eta_NStubs.getParameter<double>("ymin"),
-                                    psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_Eta_NStubs->setAxisTitle("#eta", 1);
-  Track_Eta_NStubs->setAxisTitle("# L1 Stubs", 2);
-
-  /// Low-quality tracks (All tracks, including HQ tracks)
-  iBooker.setCurrentFolder(topFolderName_ + "/Tracks/LQ");
-  // Nb of L1Tracks
-  HistoName = "Track_LQ_N";
-  edm::ParameterSet psTrack_N = conf_.getParameter<edm::ParameterSet>("TH1_NTracks");
-  Track_LQ_N = iBooker.book1D(HistoName,
-                              HistoName,
-                              psTrack_N.getParameter<int32_t>("Nbinsx"),
-                              psTrack_N.getParameter<double>("xmin"),
-                              psTrack_N.getParameter<double>("xmax"));
-  Track_LQ_N->setAxisTitle("# L1 Tracks", 1);
-  Track_LQ_N->setAxisTitle("# Events", 2);
-
-  // Pt of the tracks
-  edm::ParameterSet psTrack_Pt = conf_.getParameter<edm::ParameterSet>("TH1_Track_Pt");
-  HistoName = "Track_LQ_Pt";
-  Track_LQ_Pt = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTrack_Pt.getParameter<int32_t>("Nbinsx"),
-                               psTrack_Pt.getParameter<double>("xmin"),
-                               psTrack_Pt.getParameter<double>("xmax"));
-  Track_LQ_Pt->setAxisTitle("p_{T} [GeV]", 1);
-  Track_LQ_Pt->setAxisTitle("# L1 Tracks", 2);
-
-  // Phi
-  edm::ParameterSet psTrack_Phi = conf_.getParameter<edm::ParameterSet>("TH1_Track_Phi");
-  HistoName = "Track_LQ_Phi";
-  Track_LQ_Phi = iBooker.book1D(HistoName,
-                                HistoName,
-                                psTrack_Phi.getParameter<int32_t>("Nbinsx"),
-                                psTrack_Phi.getParameter<double>("xmin"),
-                                psTrack_Phi.getParameter<double>("xmax"));
-  Track_LQ_Phi->setAxisTitle("#phi", 1);
-  Track_LQ_Phi->setAxisTitle("# L1 Tracks", 2);
-
-  // D0
-  edm::ParameterSet psTrack_D0 = conf_.getParameter<edm::ParameterSet>("TH1_Track_D0");
-  HistoName = "Track_LQ_D0";
-  Track_LQ_D0 = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTrack_D0.getParameter<int32_t>("Nbinsx"),
-                               psTrack_D0.getParameter<double>("xmin"),
-                               psTrack_D0.getParameter<double>("xmax"));
-  Track_LQ_D0->setAxisTitle("Track D0", 1);
-  Track_LQ_D0->setAxisTitle("# L1 Tracks", 2);
-
-  // Eta
-  edm::ParameterSet psTrack_Eta = conf_.getParameter<edm::ParameterSet>("TH1_Track_Eta");
-  HistoName = "Track_LQ_Eta";
-  Track_LQ_Eta = iBooker.book1D(HistoName,
-                                HistoName,
-                                psTrack_Eta.getParameter<int32_t>("Nbinsx"),
-                                psTrack_Eta.getParameter<double>("xmin"),
-                                psTrack_Eta.getParameter<double>("xmax"));
-  Track_LQ_Eta->setAxisTitle("#eta", 1);
-  Track_LQ_Eta->setAxisTitle("# L1 Tracks", 2);
-
-  // VtxZ
-  edm::ParameterSet psTrack_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1_Track_VtxZ");
-  HistoName = "Track_LQ_VtxZ";
-  Track_LQ_VtxZ = iBooker.book1D(HistoName,
-                                 HistoName,
-                                 psTrack_VtxZ.getParameter<int32_t>("Nbinsx"),
-                                 psTrack_VtxZ.getParameter<double>("xmin"),
-                                 psTrack_VtxZ.getParameter<double>("xmax"));
-  Track_LQ_VtxZ->setAxisTitle("L1 Track vertex position z [cm]", 1);
-  Track_LQ_VtxZ->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2
-  edm::ParameterSet psTrack_Chi2 = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
-  HistoName = "Track_LQ_Chi2";
-  Track_LQ_Chi2 = iBooker.book1D(HistoName,
-                                 HistoName,
-                                 psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
-                                 psTrack_Chi2.getParameter<double>("xmin"),
-                                 psTrack_Chi2.getParameter<double>("xmax"));
-  Track_LQ_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
-  Track_LQ_Chi2->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2Red
-  edm::ParameterSet psTrack_Chi2Red = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
-  HistoName = "Track_LQ_Chi2Red";
-  Track_LQ_Chi2Red = iBooker.book1D(HistoName,
-                                    HistoName,
-                                    psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
-                                    psTrack_Chi2Red.getParameter<double>("xmin"),
-                                    psTrack_Chi2Red.getParameter<double>("xmax"));
-  Track_LQ_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
-  Track_LQ_Chi2Red->setAxisTitle("# L1 Tracks", 2);
-
-  // Chi2 prob
-  edm::ParameterSet psTrack_Chi2_Probability = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2_Probability");
-  HistoName = "Track_LQ_Chi2_Probability";
-  Track_LQ_Chi2_Probability = iBooker.book1D(HistoName,
-                                             HistoName,
-                                             psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
-                                             psTrack_Chi2_Probability.getParameter<double>("xmin"),
-                                             psTrack_Chi2_Probability.getParameter<double>("xmax"));
-  Track_LQ_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
-  Track_LQ_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
-
-  // Reduced chi2 vs #stubs
-  edm::ParameterSet psTrack_Chi2Red_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_NStubs");
-  HistoName = "Track_LQ_Chi2Red_NStubs";
-  Track_LQ_Chi2Red_NStubs = iBooker.book2D(HistoName,
-                                           HistoName,
-                                           psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsx"),
-                                           psTrack_Chi2Red_NStubs.getParameter<double>("xmin"),
-                                           psTrack_Chi2Red_NStubs.getParameter<double>("xmax"),
-                                           psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsy"),
-                                           psTrack_Chi2Red_NStubs.getParameter<double>("ymin"),
-                                           psTrack_Chi2Red_NStubs.getParameter<double>("ymax"));
-  Track_LQ_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
-  Track_LQ_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
-
-  // chi2/dof vs eta
-  edm::ParameterSet psTrack_Chi2R_Eta = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_Eta");
-  HistoName = "Track_LQ_Chi2Red_Eta";
-  Track_LQ_Chi2Red_Eta = iBooker.book2D(HistoName,
-                                        HistoName,
-                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
-                                        psTrack_Chi2R_Eta.getParameter<double>("xmin"),
-                                        psTrack_Chi2R_Eta.getParameter<double>("xmax"),
-                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
-                                        psTrack_Chi2R_Eta.getParameter<double>("ymin"),
-                                        psTrack_Chi2R_Eta.getParameter<double>("ymax"));
-  Track_LQ_Chi2Red_Eta->setAxisTitle("#eta", 1);
-  Track_LQ_Chi2Red_Eta->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
-
-  // Eta vs #stubs in barrel
-  HistoName = "Track_LQ_Eta_BarrelStubs";
-  Track_LQ_Eta_BarrelStubs = iBooker.book2D(HistoName,
-                                            HistoName,
-                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-                                            psTrack_Eta_NStubs.getParameter<double>("xmin"),
-                                            psTrack_Eta_NStubs.getParameter<double>("xmax"),
-                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-                                            psTrack_Eta_NStubs.getParameter<double>("ymin"),
-                                            psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_LQ_Eta_BarrelStubs->setAxisTitle("#eta", 1);
-  Track_LQ_Eta_BarrelStubs->setAxisTitle("# L1 Barrel Stubs", 2);
-
-  // Eta vs #stubs in EC
-  HistoName = "Track_LQ_Eta_ECStubs";
-  Track_LQ_Eta_ECStubs = iBooker.book2D(HistoName,
+  HistoName = "Track_All_Eta_NStubs";
+  Track_All_Eta_NStubs = iBooker.book2D(HistoName,
                                         HistoName,
                                         psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
                                         psTrack_Eta_NStubs.getParameter<double>("xmin"),
@@ -336,8 +214,181 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
                                         psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
                                         psTrack_Eta_NStubs.getParameter<double>("ymin"),
                                         psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_LQ_Eta_ECStubs->setAxisTitle("#eta", 1);
-  Track_LQ_Eta_ECStubs->setAxisTitle("# L1 EC Stubs", 2);
+  Track_All_Eta_NStubs->setAxisTitle("#eta", 1);
+  Track_All_Eta_NStubs->setAxisTitle("# L1 Stubs", 2);
+
+  // Pt of the tracks
+  edm::ParameterSet psTrack_Pt = conf_.getParameter<edm::ParameterSet>("TH1_Track_Pt");
+  HistoName = "Track_All_Pt";
+  Track_All_Pt = iBooker.book1D(HistoName,
+                                HistoName,
+                                psTrack_Pt.getParameter<int32_t>("Nbinsx"),
+                                psTrack_Pt.getParameter<double>("xmin"),
+                                psTrack_Pt.getParameter<double>("xmax"));
+  Track_All_Pt->setAxisTitle("p_{T} [GeV]", 1);
+  Track_All_Pt->setAxisTitle("# L1 Tracks", 2);
+
+  // Phi
+  edm::ParameterSet psTrack_Phi = conf_.getParameter<edm::ParameterSet>("TH1_Track_Phi");
+  HistoName = "Track_All_Phi";
+  Track_All_Phi = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrack_Phi.getParameter<int32_t>("Nbinsx"),
+                                 psTrack_Phi.getParameter<double>("xmin"),
+                                 psTrack_Phi.getParameter<double>("xmax"));
+  Track_All_Phi->setAxisTitle("#phi", 1);
+  Track_All_Phi->setAxisTitle("# L1 Tracks", 2);
+
+  // D0
+  edm::ParameterSet psTrack_D0 = conf_.getParameter<edm::ParameterSet>("TH1_Track_D0");
+  HistoName = "Track_All_D0";
+  Track_All_D0 = iBooker.book1D(HistoName,
+                                HistoName,
+                                psTrack_D0.getParameter<int32_t>("Nbinsx"),
+                                psTrack_D0.getParameter<double>("xmin"),
+                                psTrack_D0.getParameter<double>("xmax"));
+  Track_All_D0->setAxisTitle("Track D0", 1);
+  Track_All_D0->setAxisTitle("# L1 Tracks", 2);
+
+  // Eta
+  edm::ParameterSet psTrack_Eta = conf_.getParameter<edm::ParameterSet>("TH1_Track_Eta");
+  HistoName = "Track_All_Eta";
+  Track_All_Eta = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrack_Eta.getParameter<int32_t>("Nbinsx"),
+                                 psTrack_Eta.getParameter<double>("xmin"),
+                                 psTrack_Eta.getParameter<double>("xmax"));
+  Track_All_Eta->setAxisTitle("#eta", 1);
+  Track_All_Eta->setAxisTitle("# L1 Tracks", 2);
+
+  // VtxZ
+  edm::ParameterSet psTrack_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1_Track_VtxZ");
+  HistoName = "Track_All_VtxZ";
+  Track_All_VtxZ = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrack_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                  psTrack_VtxZ.getParameter<double>("xmin"),
+                                  psTrack_VtxZ.getParameter<double>("xmax"));
+  Track_All_VtxZ->setAxisTitle("L1 Track vertex position z [cm]", 1);
+  Track_All_VtxZ->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2
+  edm::ParameterSet psTrack_Chi2 = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
+  HistoName = "Track_All_Chi2";
+  Track_All_Chi2 = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                  psTrack_Chi2.getParameter<double>("xmin"),
+                                  psTrack_Chi2.getParameter<double>("xmax"));
+  Track_All_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
+  Track_All_Chi2->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2 r-z
+  HistoName = "Track_All_Chi2RZ";
+  Track_All_Chi2RZ = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_Chi2.getParameter<double>("xmin"),
+                                    psTrack_Chi2.getParameter<double>("xmax"));
+  Track_All_Chi2RZ->setAxisTitle("L1 Track #chi^{2} r-z", 1);
+  Track_All_Chi2RZ->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2 r-phi
+  HistoName = "Track_All_Chi2RPhi";
+  Track_All_Chi2RPhi = iBooker.book1D(HistoName,
+                                      HistoName,
+                                      psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                      psTrack_Chi2.getParameter<double>("xmin"),
+                                      psTrack_Chi2.getParameter<double>("xmax"));
+  Track_All_Chi2RPhi->setAxisTitle("L1 Track #chi^{2}", 1);
+  Track_All_Chi2RPhi->setAxisTitle("# L1 Tracks", 2);
+
+  // Bendchi2
+  edm::ParameterSet psTrack_Chi2R = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
+  HistoName = "Track_All_BendChi2";
+  Track_All_BendChi2 = iBooker.book1D(HistoName,
+                                      HistoName,
+                                      psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
+                                      psTrack_Chi2R.getParameter<double>("xmin"),
+                                      psTrack_Chi2R.getParameter<double>("xmax"));
+  Track_All_BendChi2->setAxisTitle("L1 Track Bend #chi^{2}", 1);
+  Track_All_BendChi2->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2Red
+  edm::ParameterSet psTrack_Chi2Red = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
+  HistoName = "Track_All_Chi2Red";
+  Track_All_Chi2Red = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
+                                     psTrack_Chi2R.getParameter<double>("xmin"),
+                                     psTrack_Chi2R.getParameter<double>("xmax"));
+  Track_All_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
+  Track_All_Chi2Red->setAxisTitle("# L1 Tracks", 2);
+
+  // Chi2 prob
+  edm::ParameterSet psTrack_Chi2_Probability = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2_Probability");
+  HistoName = "Track_All_Chi2_Probability";
+  Track_All_Chi2_Probability = iBooker.book1D(HistoName,
+                                              HistoName,
+                                              psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
+                                              psTrack_Chi2_Probability.getParameter<double>("xmin"),
+                                              psTrack_Chi2_Probability.getParameter<double>("xmax"));
+  Track_All_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
+  Track_All_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
+
+  // Reduced chi2 vs #stubs
+  edm::ParameterSet psTrack_Chi2R_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_NStubs");
+  HistoName = "Track_All_Chi2Red_NStubs";
+  Track_All_Chi2Red_NStubs = iBooker.book2D(HistoName,
+                                            HistoName,
+                                            psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsx"),
+                                            psTrack_Chi2R_NStubs.getParameter<double>("xmin"),
+                                            psTrack_Chi2R_NStubs.getParameter<double>("xmax"),
+                                            psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsy"),
+                                            psTrack_Chi2R_NStubs.getParameter<double>("ymin"),
+                                            psTrack_Chi2R_NStubs.getParameter<double>("ymax"));
+  Track_All_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
+  Track_All_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
+
+  // chi2/dof vs eta
+  edm::ParameterSet psTrack_Chi2R_Eta = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_Eta");
+  HistoName = "Track_All_Chi2Red_Eta";
+  Track_All_Chi2Red_Eta = iBooker.book2D(HistoName,
+                                         HistoName,
+                                         psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
+                                         psTrack_Chi2R_Eta.getParameter<double>("xmin"),
+                                         psTrack_Chi2R_Eta.getParameter<double>("xmax"),
+                                         psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
+                                         psTrack_Chi2R_Eta.getParameter<double>("ymin"),
+                                         psTrack_Chi2R_Eta.getParameter<double>("ymax"));
+  Track_All_Chi2Red_Eta->setAxisTitle("#eta", 1);
+  Track_All_Chi2Red_Eta->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
+
+  // Eta vs #stubs in barrel
+  HistoName = "Track_All_Eta_BarrelStubs";
+  Track_All_Eta_BarrelStubs = iBooker.book2D(HistoName,
+                                             HistoName,
+                                             psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                             psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                             psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                             psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                             psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                             psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_All_Eta_BarrelStubs->setAxisTitle("#eta", 1);
+  Track_All_Eta_BarrelStubs->setAxisTitle("# L1 Barrel Stubs", 2);
+
+  // Eta vs #stubs in EC
+  HistoName = "Track_LQ_Eta_ECStubs";
+  Track_All_Eta_ECStubs = iBooker.book2D(HistoName,
+                                         HistoName,
+                                         psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                         psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                         psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                         psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                         psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                         psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_All_Eta_ECStubs->setAxisTitle("#eta", 1);
+  Track_All_Eta_ECStubs->setAxisTitle("# L1 EC Stubs", 2);
 
   /// High-quality tracks (Now defined as >=5 stubs and chi2/dof < 10)
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/HQ");
@@ -350,6 +401,39 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
                               psTrack_N.getParameter<double>("xmax"));
   Track_HQ_N->setAxisTitle("# L1 Tracks", 1);
   Track_HQ_N->setAxisTitle("# Events", 2);
+
+  // Number of stubs
+  HistoName = "Track_HQ_NStubs";
+  Track_HQ_NStubs = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+                                   psTrack_NStubs.getParameter<double>("xmin"),
+                                   psTrack_NStubs.getParameter<double>("xmax"));
+  Track_HQ_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
+  Track_HQ_NStubs->setAxisTitle("# L1 Tracks", 2);
+
+  // Number of layers missed
+  HistoName = "Track_HQ_NLayersMissed";
+  Track_HQ_NLayersMissed = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+                                          psTrack_NStubs.getParameter<double>("xmin"),
+                                          psTrack_NStubs.getParameter<double>("xmax"));
+  Track_HQ_NLayersMissed->setAxisTitle("# Layers missed", 1);
+  Track_HQ_NLayersMissed->setAxisTitle("# L1 Tracks", 2);
+
+  // Track eta vs #stubs
+  HistoName = "Track_HQ_Eta_NStubs";
+  Track_HQ_Eta_NStubs = iBooker.book2D(HistoName,
+                                       HistoName,
+                                       psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                       psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                       psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                       psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                       psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                       psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Eta_NStubs->setAxisTitle("#eta", 1);
+  Track_HQ_Eta_NStubs->setAxisTitle("# L1 Stubs", 2);
 
   // Pt of the tracks
   HistoName = "Track_HQ_Pt";
@@ -411,13 +495,42 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   Track_HQ_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
   Track_HQ_Chi2->setAxisTitle("# L1 Tracks", 2);
 
+  // Bendchi2
+  HistoName = "Track_HQ_BendChi2";
+  Track_HQ_BendChi2 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
+                                     psTrack_Chi2R.getParameter<double>("xmin"),
+                                     psTrack_Chi2R.getParameter<double>("xmax"));
+  Track_HQ_BendChi2->setAxisTitle("L1 Track Bend #chi^{2}", 1);
+  Track_HQ_BendChi2->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2 r-z
+  HistoName = "Track_HQ_Chi2RZ";
+  Track_HQ_Chi2RZ = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                   psTrack_Chi2.getParameter<double>("xmin"),
+                                   psTrack_Chi2.getParameter<double>("xmax"));
+  Track_HQ_Chi2RZ->setAxisTitle("L1 Track #chi^{2} r-z", 1);
+  Track_HQ_Chi2RZ->setAxisTitle("# L1 Tracks", 2);
+
+  HistoName = "Track_HQ_Chi2RPhi";
+  Track_HQ_Chi2RPhi = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                     psTrack_Chi2.getParameter<double>("xmin"),
+                                     psTrack_Chi2.getParameter<double>("xmax"));
+  Track_HQ_Chi2RPhi->setAxisTitle("L1 Track #chi^{2} r-phi", 1);
+  Track_HQ_Chi2RPhi->setAxisTitle("# L1 Tracks", 2);
+
   // chi2Red
   HistoName = "Track_HQ_Chi2Red";
   Track_HQ_Chi2Red = iBooker.book1D(HistoName,
                                     HistoName,
-                                    psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
-                                    psTrack_Chi2Red.getParameter<double>("xmin"),
-                                    psTrack_Chi2Red.getParameter<double>("xmax"));
+                                    psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_Chi2R.getParameter<double>("xmin"),
+                                    psTrack_Chi2R.getParameter<double>("xmax"));
   Track_HQ_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
   Track_HQ_Chi2Red->setAxisTitle("# L1 Tracks", 2);
 
@@ -435,12 +548,12 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   HistoName = "Track_HQ_Chi2Red_NStubs";
   Track_HQ_Chi2Red_NStubs = iBooker.book2D(HistoName,
                                            HistoName,
-                                           psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsx"),
-                                           psTrack_Chi2Red_NStubs.getParameter<double>("xmin"),
-                                           psTrack_Chi2Red_NStubs.getParameter<double>("xmax"),
-                                           psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsy"),
-                                           psTrack_Chi2Red_NStubs.getParameter<double>("ymin"),
-                                           psTrack_Chi2Red_NStubs.getParameter<double>("ymax"));
+                                           psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsx"),
+                                           psTrack_Chi2R_NStubs.getParameter<double>("xmin"),
+                                           psTrack_Chi2R_NStubs.getParameter<double>("xmax"),
+                                           psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsy"),
+                                           psTrack_Chi2R_NStubs.getParameter<double>("ymin"),
+                                           psTrack_Chi2R_NStubs.getParameter<double>("ymax"));
   Track_HQ_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
   Track_HQ_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
 

--- a/DQM/SiOuterTracker/python/OuterTrackerMonitorTTCluster_cfi.py
+++ b/DQM/SiOuterTracker/python/OuterTrackerMonitorTTCluster_cfi.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-import math
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 OuterTrackerMonitorTTCluster = DQMEDAnalyzer('OuterTrackerMonitorTTCluster',
@@ -38,8 +37,8 @@ OuterTrackerMonitorTTCluster = DQMEDAnalyzer('OuterTrackerMonitorTTCluster',
 # Cluster phi distribution
     TH1TTCluster_Phi = cms.PSet(
         Nbinsx = cms.int32(60),
-        xmax = cms.double(math.pi),
-        xmin = cms.double(-math.pi)
+        xmax = cms.double(3.5),
+        xmin = cms.double(-3.5)
         ),
 
 # Cluster R distribution

--- a/DQM/SiOuterTracker/python/OuterTrackerMonitorTTStub_cfi.py
+++ b/DQM/SiOuterTracker/python/OuterTrackerMonitorTTStub_cfi.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-import math
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 OuterTrackerMonitorTTStub = DQMEDAnalyzer('OuterTrackerMonitorTTStub',
@@ -37,8 +36,8 @@ OuterTrackerMonitorTTStub = DQMEDAnalyzer('OuterTrackerMonitorTTStub',
 #TTStub phi distribution
     TH1TTStub_Phi = cms.PSet(
         Nbinsx = cms.int32(60),
-        xmin = cms.double(-math.pi),
-        xmax = cms.double(math.pi)
+        xmin = cms.double(-3.5),
+        xmax = cms.double(3.5)
         ),
 
 #TTStub R distribution
@@ -46,6 +45,20 @@ OuterTrackerMonitorTTStub = DQMEDAnalyzer('OuterTrackerMonitorTTStub',
         Nbinsx = cms.int32(45),
         xmin = cms.double(0),
         xmax = cms.double(120)
+        ),
+
+#TTStub bend distribution
+    TH1TTStub_bend = cms.PSet(
+        Nbinsx = cms.int32(60),
+        xmin = cms.double(-8.5),
+        xmax = cms.double(8.5)
+        ),
+
+#TTStub, isPS?
+    TH1TTStub_isPS = cms.PSet(
+        Nbinsx = cms.int32(2),
+        xmin = cms.double(0.0),
+        xmax = cms.double(2.0)
         ),
 
 #TTStub Barrel Layers

--- a/DQM/SiOuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
+++ b/DQM/SiOuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
@@ -4,22 +4,23 @@ import math
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 OuterTrackerMonitorTTTrack = DQMEDAnalyzer('OuterTrackerMonitorTTTrack',
     TopFolderName  = cms.string('SiOuterTracker'),
-    TTTracksTag    = cms.InputTag("TTTracksFromTracklet", "Level1TTTracks"), #tracks (currently from tracklet)
-    HQNStubs       = cms.int32(5),  #cut for "high quality" tracks
+    TTTracksTag    = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"), #tracks (currently from tracklet)
+    HQNStubs       = cms.int32(4),  #cut for "high quality" tracks
     HQChi2dof      = cms.double(10.0), #cut for "high quality" tracks
+    HQBendChi2     = cms.double(2.2), #cut for "high quality" tracks
 
 # Number of stubs per track
     TH1_NStubs = cms.PSet(
-        Nbinsx = cms.int32(11),
-        xmax = cms.double(10.5),
-        xmin = cms.double(-0.5)
+        Nbinsx = cms.int32(8),
+        xmax = cms.double(8),
+        xmin = cms.double(0)
         ),
 
 # Number of TTTracks
     TH1_NTracks = cms.PSet(
         Nbinsx = cms.int32(100),
-        xmax = cms.double(99.5),
-        xmin = cms.double(-0.5)
+        xmax = cms.double(399),
+        xmin = cms.double(0)
         ),
 
 #Pt of the track
@@ -32,15 +33,15 @@ OuterTrackerMonitorTTTrack = DQMEDAnalyzer('OuterTrackerMonitorTTTrack',
 #Phi of the track
     TH1_Track_Phi = cms.PSet(
         Nbinsx = cms.int32(60),
-        xmax = cms.double(math.pi),
-        xmin = cms.double(-math.pi)
+        xmax = cms.double(3.5),
+        xmin = cms.double(-3.5)
         ),
 
 #D0 of the track
     TH1_Track_D0 = cms.PSet(
         Nbinsx = cms.int32(50),
-        xmax = cms.double(25),
-        xmin = cms.double(-25)
+        xmax = cms.double(5.0),
+        xmin = cms.double(-5.0)
         ),
 
 #Eta of the track
@@ -52,9 +53,9 @@ OuterTrackerMonitorTTTrack = DQMEDAnalyzer('OuterTrackerMonitorTTTrack',
 
 #VtxZ of the track
     TH1_Track_VtxZ = cms.PSet(
-        Nbinsx = cms.int32(51),
-        xmax = cms.double(25),
-        xmin = cms.double(-25)
+        Nbinsx = cms.int32(41),
+        xmax = cms.double(20),
+        xmin = cms.double(-20)
         ),
 
 #Chi2 of the track
@@ -80,9 +81,9 @@ OuterTrackerMonitorTTTrack = DQMEDAnalyzer('OuterTrackerMonitorTTTrack',
 
 #Chi2R of the track vs Nb of stubs
     TH2_Track_Chi2R_NStubs = cms.PSet(
-        Nbinsx = cms.int32(11),
-        xmax = cms.double(10.5),
-        xmin = cms.double(-0.5),
+        Nbinsx = cms.int32(5),
+        xmax = cms.double(8),
+        xmin = cms.double(3),
         Nbinsy = cms.int32(15),
         ymax = cms.double(10),
         ymin = cms.double(0)
@@ -103,8 +104,8 @@ OuterTrackerMonitorTTTrack = DQMEDAnalyzer('OuterTrackerMonitorTTTrack',
         Nbinsx = cms.int32(15),
         xmax = cms.double(3.0),
         xmin = cms.double(-3.0),
-        Nbinsy = cms.int32(11),
-        ymax = cms.double(10.5),
-        ymin = cms.double(-0.5)
+        Nbinsy = cms.int32(5),
+        ymax = cms.double(8),
+        ymin = cms.double(3)
         ),
 )

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMCHarvester.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMCHarvester.cc
@@ -295,17 +295,15 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt1->SetStats(false);
 
       int testNumEntries1 = resPt1a->GetEntries();
-      // if (resPt1a->GetEntries() > 0 && resPt2a->GetEntries() > 0 && resPt3a->GetEntries() > 0 &&
-      //     resPt4a->GetEntries() > 0 && resPt5a->GetEntries() > 0 && resPt6a->GetEntries() > 0) {
       if (testNumEntries1 > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1a->Fit(fit2, "Q", "R");
-        resPt2a->Fit(fit2, "Q", "R");
-        resPt3a->Fit(fit2, "Q", "R");
-        resPt4a->Fit(fit2, "Q", "R");
-        resPt5a->Fit(fit2, "Q", "R");
-        resPt6a->Fit(fit2, "Q", "R");
+        resPt1a->Fit(fit2, "R");
+        resPt2a->Fit(fit2, "R");
+        resPt3a->Fit(fit2, "R");
+        resPt4a->Fit(fit2, "R");
+        resPt5a->Fit(fit2, "R");
+        resPt6a->Fit(fit2, "R");
         sigma_pt1.push_back(resPt1a->GetFunction("fit2")->GetParameter(2));
         sigma_pt1.push_back(resPt2a->GetFunction("fit2")->GetParameter(2));
         sigma_pt1.push_back(resPt3a->GetFunction("fit2")->GetParameter(2));
@@ -360,16 +358,14 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       int testNumEntries2 = resPt1b->GetEntries();
       if (testNumEntries2 > 0) {
-      // if (resPt1b->GetEntries() > 0 && resPt2b->GetEntries() > 0 && resPt3b->GetEntries() > 0 &&
-      //     resPt4b->GetEntries() > 0 && resPt5b->GetEntries() > 0 && resPt6b->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1b->Fit(fit2, "Q", "R");
-        resPt2b->Fit(fit2, "Q", "R");
-        resPt3b->Fit(fit2, "Q", "R");
-        resPt4b->Fit(fit2, "Q", "R");
-        resPt5b->Fit(fit2, "Q", "R");
-        resPt6b->Fit(fit2, "Q", "R");
+        resPt1b->Fit(fit2, "R");
+        resPt2b->Fit(fit2, "R");
+        resPt3b->Fit(fit2, "R");
+        resPt4b->Fit(fit2, "R");
+        resPt5b->Fit(fit2, "R");
+        resPt6b->Fit(fit2, "R");
         sigma_pt2.push_back(resPt1b->GetFunction("fit2")->GetParameter(2));
         sigma_pt2.push_back(resPt2b->GetFunction("fit2")->GetParameter(2));
         sigma_pt2.push_back(resPt3b->GetFunction("fit2")->GetParameter(2));
@@ -423,17 +419,15 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt3->SetStats(false);
 
       int testNumEntries3 = resPt1c->GetEntries();
-      // if (resPt1c->GetEntries() > 0 && resPt2c->GetEntries() > 0 && resPt3c->GetEntries() > 0 &&
-      //     resPt4c->GetEntries() > 0 && resPt5c->GetEntries() > 0 && resPt6c->GetEntries() > 0) {
       if (testNumEntries3 > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1c->Fit(fit2, "Q", "R");
-        resPt2c->Fit(fit2, "Q", "R");
-        resPt3c->Fit(fit2, "Q", "R");
-        resPt4c->Fit(fit2, "Q", "R");
-        resPt5c->Fit(fit2, "Q", "R");
-        resPt6c->Fit(fit2, "Q", "R");
+        resPt1c->Fit(fit2, "R");
+        resPt2c->Fit(fit2, "R");
+        resPt3c->Fit(fit2, "R");
+        resPt4c->Fit(fit2, "R");
+        resPt5c->Fit(fit2, "R");
+        resPt6c->Fit(fit2, "R");
         sigma_pt3.push_back(resPt1c->GetFunction("fit2")->GetParameter(2));
         sigma_pt3.push_back(resPt2c->GetFunction("fit2")->GetParameter(2));
         sigma_pt3.push_back(resPt3c->GetFunction("fit2")->GetParameter(2));
@@ -487,16 +481,14 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       int testNumEntries4 = resEta1->GetEntries();
       if (testNumEntries4 > 0) {
-      // if (resEta1->GetEntries() > 0 && resEta2->GetEntries() > 0 && resEta3->GetEntries() > 0 &&
-      //     resEta4->GetEntries() > 0 && resEta5->GetEntries() > 0 && resEta6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resEta1->Fit(fit, "Q", "R");
-        resEta2->Fit(fit, "Q", "R");
-        resEta3->Fit(fit, "Q", "R");
-        resEta4->Fit(fit, "Q", "R");
-        resEta5->Fit(fit, "Q", "R");
-        resEta6->Fit(fit, "Q", "R");
+        resEta1->Fit(fit, "R");
+        resEta2->Fit(fit, "R");
+        resEta3->Fit(fit, "R");
+        resEta4->Fit(fit, "R");
+        resEta5->Fit(fit, "R");
+        resEta6->Fit(fit, "R");
         sigma_eta.push_back(resEta1->GetFunction("fit")->GetParameter(2));
         sigma_eta.push_back(resEta2->GetFunction("fit")->GetParameter(2));
         sigma_eta.push_back(resEta3->GetFunction("fit")->GetParameter(2));
@@ -550,16 +542,14 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       int testNumEntries5 = resPhi1->GetEntries();
       if (testNumEntries5 > 0) {
-      // if (resPhi1->GetEntries() > 0 && resPhi2->GetEntries() > 0 && resPhi3->GetEntries() > 0 &&
-      //     resPhi4->GetEntries() > 0 && resPhi5->GetEntries() > 0 && resPhi6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPhi1->Fit(fit, "Q", "R");
-        resPhi2->Fit(fit, "Q", "R");
-        resPhi3->Fit(fit, "Q", "R");
-        resPhi4->Fit(fit, "Q", "R");
-        resPhi5->Fit(fit, "Q", "R");
-        resPhi6->Fit(fit, "Q", "R");
+        resPhi1->Fit(fit, "R");
+        resPhi2->Fit(fit, "R");
+        resPhi3->Fit(fit, "R");
+        resPhi4->Fit(fit, "R");
+        resPhi5->Fit(fit, "R");
+        resPhi6->Fit(fit, "R");
         sigma_phi.push_back(resPhi1->GetFunction("fit")->GetParameter(2));
         sigma_phi.push_back(resPhi2->GetFunction("fit")->GetParameter(2));
         sigma_phi.push_back(resPhi3->GetFunction("fit")->GetParameter(2));
@@ -613,16 +603,14 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       int testNumEntries6 = resVtxZ_1->GetEntries();
       if (testNumEntries6 > 0) {
-      // if (resVtxZ_1->GetEntries() > 0 && resVtxZ_2->GetEntries() > 0 && resVtxZ_3->GetEntries() > 0 &&
-      //     resVtxZ_4->GetEntries() > 0 && resVtxZ_5->GetEntries() > 0 && resVtxZ_6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resVtxZ_1->Fit(fit3, "Q", "R");
-        resVtxZ_2->Fit(fit3, "Q", "R");
-        resVtxZ_3->Fit(fit3, "Q", "R");
-        resVtxZ_4->Fit(fit3, "Q", "R");
-        resVtxZ_5->Fit(fit3, "Q", "R");
-        resVtxZ_6->Fit(fit3, "Q", "R");
+        resVtxZ_1->Fit(fit3, "R");
+        resVtxZ_2->Fit(fit3, "R");
+        resVtxZ_3->Fit(fit3, "R");
+        resVtxZ_4->Fit(fit3, "R");
+        resVtxZ_5->Fit(fit3, "R");
+        resVtxZ_6->Fit(fit3, "R");
         sigma_VtxZ.push_back(resVtxZ_1->GetFunction("fit3")->GetParameter(2));
         sigma_VtxZ.push_back(resVtxZ_2->GetFunction("fit3")->GetParameter(2));
         sigma_VtxZ.push_back(resVtxZ_3->GetFunction("fit3")->GetParameter(2));
@@ -676,16 +664,14 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       int testNumEntries7 = resd0_1->GetEntries();
       if (testNumEntries7 > 0) {
-      // if (resd0_1->GetEntries() > 0 && resd0_2->GetEntries() > 0 && resd0_3->GetEntries() > 0 &&
-      //     resd0_4->GetEntries() > 0 && resd0_5->GetEntries() > 0 && resd0_6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resd0_1->Fit(fit, "Q", "R");
-        resd0_2->Fit(fit, "Q", "R");
-        resd0_3->Fit(fit, "Q", "R");
-        resd0_4->Fit(fit, "Q", "R");
-        resd0_5->Fit(fit, "Q", "R");
-        resd0_6->Fit(fit, "Q", "R");
+        resd0_1->Fit(fit, "R");
+        resd0_2->Fit(fit, "R");
+        resd0_3->Fit(fit, "R");
+        resd0_4->Fit(fit, "R");
+        resd0_5->Fit(fit, "R");
+        resd0_6->Fit(fit, "R");
         sigma_d0.push_back(resd0_1->GetFunction("fit")->GetParameter(2));
         sigma_d0.push_back(resd0_2->GetFunction("fit")->GetParameter(2));
         sigma_d0.push_back(resd0_3->GetFunction("fit")->GetParameter(2));

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMCHarvester.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMCHarvester.cc
@@ -1,4 +1,5 @@
 #include "OuterTrackerMCHarvester.h"
+#include "TFitResult.h"
 
 OuterTrackerMCHarvester::OuterTrackerMCHarvester(const edm::ParameterSet &iConfig) {}
 
@@ -294,30 +295,33 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt1->SetMinimum(0.0);
       resPt1->SetStats(false);
 
-      //int testNumEntries1 = resPt1a->GetEntries();
       if (resPt1a->GetEntries() > 0 && resPt2a->GetEntries() > 0 && resPt3a->GetEntries() > 0 &&
           resPt4a->GetEntries() > 0 && resPt5a->GetEntries() > 0 && resPt6a->GetEntries() > 0) {
-        //if (testNumEntries1 > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1a->Fit(fit2, "Q", "R");
-        resPt2a->Fit(fit2, "Q", "R");
-        resPt3a->Fit(fit2, "Q", "R");
-        resPt4a->Fit(fit2, "Q", "R");
-        resPt5a->Fit(fit2, "Q", "R");
-        resPt6a->Fit(fit2, "Q", "R");
-        sigma_pt1.push_back(resPt1a->GetFunction("fit2")->GetParameter(2));
-        sigma_pt1.push_back(resPt2a->GetFunction("fit2")->GetParameter(2));
-        sigma_pt1.push_back(resPt3a->GetFunction("fit2")->GetParameter(2));
-        sigma_pt1.push_back(resPt4a->GetFunction("fit2")->GetParameter(2));
-        sigma_pt1.push_back(resPt5a->GetFunction("fit2")->GetParameter(2));
-        sigma_pt1.push_back(resPt6a->GetFunction("fit2")->GetParameter(2));
-        error_pt1.push_back(resPt1a->GetFunction("fit2")->GetParError(2));
-        error_pt1.push_back(resPt2a->GetFunction("fit2")->GetParError(2));
-        error_pt1.push_back(resPt3a->GetFunction("fit2")->GetParError(2));
-        error_pt1.push_back(resPt4a->GetFunction("fit2")->GetParError(2));
-        error_pt1.push_back(resPt5a->GetFunction("fit2")->GetParError(2));
-        error_pt1.push_back(resPt6a->GetFunction("fit2")->GetParError(2));
+        TFitResultPtr r_pt1a = resPt1a->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt2a = resPt2a->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt3a = resPt3a->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt4a = resPt4a->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt5a = resPt5a->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt6a = resPt6a->Fit(fit2, "Q", "RS");
+
+        //Check fit status before extracting parameters
+        Int_t fs_pt1a = r_pt1a; Int_t fs_pt2a = r_pt2a; Int_t fs_pt3a = r_pt3a;
+        Int_t fs_pt4a = r_pt4a; Int_t fs_pt5a = r_pt5a; Int_t fs_pt6a = r_pt6a;
+
+        if (fs_pt1a==0) {sigma_pt1.push_back(r_pt1a->Parameter(2)); error_pt1.push_back(r_pt1a->ParError(2));}
+        else {sigma_pt1.push_back(-1); error_pt1.push_back(-1);}
+        if (fs_pt2a==0) {sigma_pt1.push_back(r_pt2a->Parameter(2)); error_pt1.push_back(r_pt2a->ParError(2));}
+        else {sigma_pt1.push_back(-1); error_pt1.push_back(-1);}
+        if (fs_pt3a==0) {sigma_pt1.push_back(r_pt3a->Parameter(2)); error_pt1.push_back(r_pt3a->ParError(2));}
+        else {sigma_pt1.push_back(-1); error_pt1.push_back(-1);}
+        if (fs_pt4a==0) {sigma_pt1.push_back(r_pt4a->Parameter(2)); error_pt1.push_back(r_pt4a->ParError(2));}
+        else {sigma_pt1.push_back(-1); error_pt1.push_back(-1);}
+        if (fs_pt5a==0) {sigma_pt1.push_back(r_pt5a->Parameter(2)); error_pt1.push_back(r_pt5a->ParError(2));}
+        else {sigma_pt1.push_back(-1); error_pt1.push_back(-1);}
+        if (fs_pt6a==0) {sigma_pt1.push_back(r_pt6a->Parameter(2)); error_pt1.push_back(r_pt6a->ParError(2));}
+        else {sigma_pt1.push_back(-1); error_pt1.push_back(-1);}
 
         // Fill the new histogram to create resolution plot
         for (int i = 0; i < 6; i++) {
@@ -358,30 +362,33 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt2->SetMinimum(0.0);
       resPt2->SetStats(false);
 
-      //int testNumEntries2 = resPt1b->GetEntries();
-      // if (testNumEntries2 > 0) {
       if (resPt1b->GetEntries() > 0 && resPt2b->GetEntries() > 0 && resPt3b->GetEntries() > 0 &&
           resPt4b->GetEntries() > 0 && resPt5b->GetEntries() > 0 && resPt6b->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1b->Fit(fit2, "Q", "R");
-        resPt2b->Fit(fit2, "Q", "R");
-        resPt3b->Fit(fit2, "Q", "R");
-        resPt4b->Fit(fit2, "Q", "R");
-        resPt5b->Fit(fit2, "Q", "R");
-        resPt6b->Fit(fit2, "Q", "R");
-        sigma_pt2.push_back(resPt1b->GetFunction("fit2")->GetParameter(2));
-        sigma_pt2.push_back(resPt2b->GetFunction("fit2")->GetParameter(2));
-        sigma_pt2.push_back(resPt3b->GetFunction("fit2")->GetParameter(2));
-        sigma_pt2.push_back(resPt4b->GetFunction("fit2")->GetParameter(2));
-        sigma_pt2.push_back(resPt5b->GetFunction("fit2")->GetParameter(2));
-        sigma_pt2.push_back(resPt6b->GetFunction("fit2")->GetParameter(2));
-        error_pt2.push_back(resPt1b->GetFunction("fit2")->GetParError(2));
-        error_pt2.push_back(resPt2b->GetFunction("fit2")->GetParError(2));
-        error_pt2.push_back(resPt3b->GetFunction("fit2")->GetParError(2));
-        error_pt2.push_back(resPt4b->GetFunction("fit2")->GetParError(2));
-        error_pt2.push_back(resPt5b->GetFunction("fit2")->GetParError(2));
-        error_pt2.push_back(resPt6b->GetFunction("fit2")->GetParError(2));
+        TFitResultPtr r_pt1b = resPt1b->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt2b = resPt2b->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt3b = resPt3b->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt4b = resPt4b->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt5b = resPt5b->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt6b = resPt6b->Fit(fit2, "Q", "RS");
+
+        //Check fit status before extracting parameters
+        Int_t fs_pt1b = r_pt1b; Int_t fs_pt2b = r_pt2b; Int_t fs_pt3b = r_pt3b;
+        Int_t fs_pt4b = r_pt4b; Int_t fs_pt5b = r_pt5b; Int_t fs_pt6b = r_pt6b;
+
+        if (fs_pt1b==0) {sigma_pt2.push_back(r_pt1b->Parameter(2)); error_pt2.push_back(r_pt1b->ParError(2));}
+        else {sigma_pt2.push_back(-1); error_pt2.push_back(-1);}
+        if (fs_pt2b==0) {sigma_pt2.push_back(r_pt2b->Parameter(2)); error_pt2.push_back(r_pt2b->ParError(2));}
+        else {sigma_pt2.push_back(-1); error_pt2.push_back(-1);}
+        if (fs_pt3b==0) {sigma_pt2.push_back(r_pt3b->Parameter(2)); error_pt2.push_back(r_pt3b->ParError(2));}
+        else {sigma_pt2.push_back(-1); error_pt2.push_back(-1);}
+        if (fs_pt4b==0) {sigma_pt2.push_back(r_pt4b->Parameter(2)); error_pt2.push_back(r_pt4b->ParError(2));}
+        else {sigma_pt2.push_back(-1); error_pt2.push_back(-1);}
+        if (fs_pt5b==0) {sigma_pt2.push_back(r_pt5b->Parameter(2)); error_pt2.push_back(r_pt5b->ParError(2));}
+        else {sigma_pt2.push_back(-1); error_pt2.push_back(-1);}
+        if (fs_pt6b==0) {sigma_pt2.push_back(r_pt6b->Parameter(2)); error_pt2.push_back(r_pt6b->ParError(2));}
+        else {sigma_pt2.push_back(-1); error_pt2.push_back(-1);}
 
         // Fill the new histogram to create resolution plot
         for (int i = 0; i < 6; i++) {
@@ -422,30 +429,33 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt3->SetMinimum(0.0);
       resPt3->SetStats(false);
 
-      //int testNumEntries3 = resPt1c->GetEntries();
       if (resPt1c->GetEntries() > 0 && resPt2c->GetEntries() > 0 && resPt3c->GetEntries() > 0 &&
           resPt4c->GetEntries() > 0 && resPt5c->GetEntries() > 0 && resPt6c->GetEntries() > 0) {
-        //        if (testNumEntries3 > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1c->Fit(fit2, "Q", "R");
-        resPt2c->Fit(fit2, "Q", "R");
-        resPt3c->Fit(fit2, "Q", "R");
-        resPt4c->Fit(fit2, "Q", "R");
-        resPt5c->Fit(fit2, "Q", "R");
-        resPt6c->Fit(fit2, "Q", "R");
-        sigma_pt3.push_back(resPt1c->GetFunction("fit2")->GetParameter(2));
-        sigma_pt3.push_back(resPt2c->GetFunction("fit2")->GetParameter(2));
-        sigma_pt3.push_back(resPt3c->GetFunction("fit2")->GetParameter(2));
-        sigma_pt3.push_back(resPt4c->GetFunction("fit2")->GetParameter(2));
-        sigma_pt3.push_back(resPt5c->GetFunction("fit2")->GetParameter(2));
-        sigma_pt3.push_back(resPt6c->GetFunction("fit2")->GetParameter(2));
-        error_pt3.push_back(resPt1c->GetFunction("fit2")->GetParError(2));
-        error_pt3.push_back(resPt2c->GetFunction("fit2")->GetParError(2));
-        error_pt3.push_back(resPt3c->GetFunction("fit2")->GetParError(2));
-        error_pt3.push_back(resPt4c->GetFunction("fit2")->GetParError(2));
-        error_pt3.push_back(resPt5c->GetFunction("fit2")->GetParError(2));
-        error_pt3.push_back(resPt6c->GetFunction("fit2")->GetParError(2));
+        TFitResultPtr r_pt1c = resPt1c->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt2c = resPt2c->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt3c = resPt3c->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt4c = resPt4c->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt5c = resPt5c->Fit(fit2, "Q", "RS");
+        TFitResultPtr r_pt6c = resPt6c->Fit(fit2, "Q", "RS");
+
+        //Check fit status before extracting parameters
+        Int_t fs_pt1c = r_pt1c; Int_t fs_pt2c = r_pt2c; Int_t fs_pt3c = r_pt3c;
+        Int_t fs_pt4c = r_pt4c; Int_t fs_pt5c = r_pt5c; Int_t fs_pt6c = r_pt6c;
+
+        if (fs_pt1c==0) {sigma_pt3.push_back(r_pt1c->Parameter(2)); error_pt3.push_back(r_pt1c->ParError(2));}
+        else {sigma_pt3.push_back(-1); error_pt3.push_back(-1);}
+        if (fs_pt2c==0) {sigma_pt3.push_back(r_pt2c->Parameter(2)); error_pt3.push_back(r_pt2c->ParError(2));}
+        else {sigma_pt3.push_back(-1); error_pt3.push_back(-1);}
+        if (fs_pt3c==0) {sigma_pt3.push_back(r_pt3c->Parameter(2)); error_pt3.push_back(r_pt3c->ParError(2));}
+        else {sigma_pt3.push_back(-1); error_pt3.push_back(-1);}
+        if (fs_pt4c==0) {sigma_pt3.push_back(r_pt4c->Parameter(2)); error_pt3.push_back(r_pt4c->ParError(2));}
+        else {sigma_pt3.push_back(-1); error_pt3.push_back(-1);}
+        if (fs_pt5c==0) {sigma_pt3.push_back(r_pt5c->Parameter(2)); error_pt3.push_back(r_pt5c->ParError(2));}
+        else {sigma_pt3.push_back(-1); error_pt3.push_back(-1);}
+        if (fs_pt6c==0) {sigma_pt3.push_back(r_pt6c->Parameter(2)); error_pt3.push_back(r_pt6c->ParError(2));}
+        else {sigma_pt3.push_back(-1); error_pt3.push_back(-1);}
 
         // Fill the new histogram to create resolution plot
         for (int i = 0; i < 6; i++) {
@@ -485,29 +495,33 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resEta->SetMinimum(0.0);
       resEta->SetStats(false);
 
-      //int testNumEntries4 = resEta1->GetEntries();
       if (resEta1->GetEntries() > 0 && resEta2->GetEntries() > 0 && resEta3->GetEntries() > 0 &&
           resEta4->GetEntries() > 0 && resEta5->GetEntries() > 0 && resEta6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resEta1->Fit(fit, "Q", "R");
-        resEta2->Fit(fit, "Q", "R");
-        resEta3->Fit(fit, "Q", "R");
-        resEta4->Fit(fit, "Q", "R");
-        resEta5->Fit(fit, "Q", "R");
-        resEta6->Fit(fit, "Q", "R");
-        sigma_eta.push_back(resEta1->GetFunction("fit")->GetParameter(2));
-        sigma_eta.push_back(resEta2->GetFunction("fit")->GetParameter(2));
-        sigma_eta.push_back(resEta3->GetFunction("fit")->GetParameter(2));
-        sigma_eta.push_back(resEta4->GetFunction("fit")->GetParameter(2));
-        sigma_eta.push_back(resEta5->GetFunction("fit")->GetParameter(2));
-        sigma_eta.push_back(resEta6->GetFunction("fit")->GetParameter(2));
-        error_eta.push_back(resEta1->GetFunction("fit")->GetParError(2));
-        error_eta.push_back(resEta2->GetFunction("fit")->GetParError(2));
-        error_eta.push_back(resEta3->GetFunction("fit")->GetParError(2));
-        error_eta.push_back(resEta4->GetFunction("fit")->GetParError(2));
-        error_eta.push_back(resEta5->GetFunction("fit")->GetParError(2));
-        error_eta.push_back(resEta6->GetFunction("fit")->GetParError(2));
+        TFitResultPtr r_eta1 = resEta1->Fit(fit, "Q", "RS");
+        TFitResultPtr r_eta2 = resEta2->Fit(fit, "Q", "RS");
+        TFitResultPtr r_eta3 = resEta3->Fit(fit, "Q", "RS");
+        TFitResultPtr r_eta4 = resEta4->Fit(fit, "Q", "RS");
+        TFitResultPtr r_eta5 = resEta5->Fit(fit, "Q", "RS");
+        TFitResultPtr r_eta6 = resEta6->Fit(fit, "Q", "RS");
+
+        //Check fit status before extracting parameters
+        Int_t fs_eta1 = r_eta1; Int_t fs_eta2 = r_eta2; Int_t fs_eta3 = r_eta3;
+        Int_t fs_eta4 = r_eta4; Int_t fs_eta5 = r_eta5; Int_t fs_eta6 = r_eta6;
+
+        if (fs_eta1==0) {sigma_eta.push_back(r_eta1->Parameter(2)); error_eta.push_back(r_eta1->ParError(2));}
+        else {sigma_eta.push_back(-1); error_eta.push_back(-1);}
+        if (fs_eta2==0) {sigma_eta.push_back(r_eta2->Parameter(2)); error_eta.push_back(r_eta2->ParError(2));}
+        else {sigma_eta.push_back(-1); error_eta.push_back(-1);}
+        if (fs_eta3==0) {sigma_eta.push_back(r_eta3->Parameter(2)); error_eta.push_back(r_eta3->ParError(2));}
+        else {sigma_eta.push_back(-1); error_eta.push_back(-1);}
+        if (fs_eta4==0) {sigma_eta.push_back(r_eta4->Parameter(2)); error_eta.push_back(r_eta4->ParError(2));}
+        else {sigma_eta.push_back(-1); error_eta.push_back(-1);}
+        if (fs_eta5==0) {sigma_eta.push_back(r_eta5->Parameter(2)); error_eta.push_back(r_eta5->ParError(2));}
+        else {sigma_eta.push_back(-1); error_eta.push_back(-1);}
+        if (fs_eta6==0) {sigma_eta.push_back(r_eta6->Parameter(2)); error_eta.push_back(r_eta6->ParError(2));}
+        else {sigma_eta.push_back(-1); error_eta.push_back(-1);}
 
         // Fill the new histogram to create resolution plot
         for (int i = 0; i < 6; i++) {
@@ -547,29 +561,33 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPhi->SetMinimum(0.0);
       resPhi->SetStats(false);
 
-      //int testNumEntries5 = resPhi1->GetEntries();
       if (resPhi1->GetEntries() > 0 && resPhi2->GetEntries() > 0 && resPhi3->GetEntries() > 0 &&
           resPhi4->GetEntries() > 0 && resPhi5->GetEntries() > 0 && resPhi6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPhi1->Fit(fit, "Q", "R");
-        resPhi2->Fit(fit, "Q", "R");
-        resPhi3->Fit(fit, "Q", "R");
-        resPhi4->Fit(fit, "Q", "R");
-        resPhi5->Fit(fit, "Q", "R");
-        resPhi6->Fit(fit, "Q", "R");
-        sigma_phi.push_back(resPhi1->GetFunction("fit")->GetParameter(2));
-        sigma_phi.push_back(resPhi2->GetFunction("fit")->GetParameter(2));
-        sigma_phi.push_back(resPhi3->GetFunction("fit")->GetParameter(2));
-        sigma_phi.push_back(resPhi4->GetFunction("fit")->GetParameter(2));
-        sigma_phi.push_back(resPhi5->GetFunction("fit")->GetParameter(2));
-        sigma_phi.push_back(resPhi6->GetFunction("fit")->GetParameter(2));
-        error_phi.push_back(resPhi1->GetFunction("fit")->GetParError(2));
-        error_phi.push_back(resPhi2->GetFunction("fit")->GetParError(2));
-        error_phi.push_back(resPhi3->GetFunction("fit")->GetParError(2));
-        error_phi.push_back(resPhi4->GetFunction("fit")->GetParError(2));
-        error_phi.push_back(resPhi5->GetFunction("fit")->GetParError(2));
-        error_phi.push_back(resPhi6->GetFunction("fit")->GetParError(2));
+        TFitResultPtr r_phi1 = resPhi1->Fit(fit, "Q", "RS");
+        TFitResultPtr r_phi2 = resPhi2->Fit(fit, "Q", "RS");
+        TFitResultPtr r_phi3 = resPhi3->Fit(fit, "Q", "RS");
+        TFitResultPtr r_phi4 = resPhi4->Fit(fit, "Q", "RS");
+        TFitResultPtr r_phi5 = resPhi5->Fit(fit, "Q", "RS");
+        TFitResultPtr r_phi6 = resPhi6->Fit(fit, "Q", "RS");
+
+        //Check fit status before extracting parameters
+        Int_t fs_phi1 = r_phi1; Int_t fs_phi2 = r_phi2; Int_t fs_phi3 = r_phi3;
+        Int_t fs_phi4 = r_phi4; Int_t fs_phi5 = r_phi5; Int_t fs_phi6 = r_phi6;
+
+        if (fs_phi1==0) {sigma_phi.push_back(r_phi1->Parameter(2)); error_phi.push_back(r_phi1->ParError(2));}
+        else {sigma_phi.push_back(-1); error_phi.push_back(-1);}
+        if (fs_phi2==0) {sigma_phi.push_back(r_phi2->Parameter(2)); error_phi.push_back(r_phi2->ParError(2));}
+        else {sigma_phi.push_back(-1); error_phi.push_back(-1);}
+        if (fs_phi3==0) {sigma_phi.push_back(r_phi3->Parameter(2)); error_phi.push_back(r_phi3->ParError(2));}
+        else {sigma_phi.push_back(-1); error_phi.push_back(-1);}
+        if (fs_phi4==0) {sigma_phi.push_back(r_phi4->Parameter(2)); error_phi.push_back(r_phi4->ParError(2));}
+        else {sigma_phi.push_back(-1); error_phi.push_back(-1);}
+        if (fs_phi5==0) {sigma_phi.push_back(r_phi5->Parameter(2)); error_phi.push_back(r_phi5->ParError(2));}
+        else {sigma_phi.push_back(-1); error_phi.push_back(-1);}
+        if (fs_phi6==0) {sigma_phi.push_back(r_phi6->Parameter(2)); error_phi.push_back(r_phi6->ParError(2));}
+        else {sigma_phi.push_back(-1); error_phi.push_back(-1);}
 
         // Fill the new histogram to create resolution plot
         for (int i = 0; i < 6; i++) {
@@ -609,29 +627,33 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resVtxZ->SetMinimum(0.0);
       resVtxZ->SetStats(false);
 
-      //int testNumEntries6 = resVtxZ_1->GetEntries();
       if (resVtxZ_1->GetEntries() > 0 && resVtxZ_2->GetEntries() > 0 && resVtxZ_3->GetEntries() > 0 &&
           resVtxZ_4->GetEntries() > 0 && resVtxZ_5->GetEntries() > 0 && resVtxZ_6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resVtxZ_1->Fit(fit3, "Q", "R");
-        resVtxZ_2->Fit(fit3, "Q", "R");
-        resVtxZ_3->Fit(fit3, "Q", "R");
-        resVtxZ_4->Fit(fit3, "Q", "R");
-        resVtxZ_5->Fit(fit3, "Q", "R");
-        resVtxZ_6->Fit(fit3, "Q", "R");
-        sigma_VtxZ.push_back(resVtxZ_1->GetFunction("fit3")->GetParameter(2));
-        sigma_VtxZ.push_back(resVtxZ_2->GetFunction("fit3")->GetParameter(2));
-        sigma_VtxZ.push_back(resVtxZ_3->GetFunction("fit3")->GetParameter(2));
-        sigma_VtxZ.push_back(resVtxZ_4->GetFunction("fit3")->GetParameter(2));
-        sigma_VtxZ.push_back(resVtxZ_5->GetFunction("fit3")->GetParameter(2));
-        sigma_VtxZ.push_back(resVtxZ_6->GetFunction("fit3")->GetParameter(2));
-        error_VtxZ.push_back(resVtxZ_1->GetFunction("fit3")->GetParError(2));
-        error_VtxZ.push_back(resVtxZ_2->GetFunction("fit3")->GetParError(2));
-        error_VtxZ.push_back(resVtxZ_3->GetFunction("fit3")->GetParError(2));
-        error_VtxZ.push_back(resVtxZ_4->GetFunction("fit3")->GetParError(2));
-        error_VtxZ.push_back(resVtxZ_5->GetFunction("fit3")->GetParError(2));
-        error_VtxZ.push_back(resVtxZ_6->GetFunction("fit3")->GetParError(2));
+        TFitResultPtr r_vtxz1 = resVtxZ_1->Fit(fit3, "Q", "RS");
+        TFitResultPtr r_vtxz2 = resVtxZ_2->Fit(fit3, "Q", "RS");
+        TFitResultPtr r_vtxz3 = resVtxZ_3->Fit(fit3, "Q", "RS");
+        TFitResultPtr r_vtxz4 = resVtxZ_4->Fit(fit3, "Q", "RS");
+        TFitResultPtr r_vtxz5 = resVtxZ_5->Fit(fit3, "Q", "RS");
+        TFitResultPtr r_vtxz6 = resVtxZ_6->Fit(fit3, "Q", "RS");
+
+        //Check fit status before extracting parameters
+        Int_t fs_vtxz1 = r_vtxz1; Int_t fs_vtxz2 = r_vtxz2; Int_t fs_vtxz3 = r_vtxz3;
+        Int_t fs_vtxz4 = r_vtxz4; Int_t fs_vtxz5 = r_vtxz5; Int_t fs_vtxz6 = r_vtxz6;
+
+        if (fs_vtxz1==0) {sigma_VtxZ.push_back(r_vtxz1->Parameter(2)); error_VtxZ.push_back(r_vtxz1->ParError(2));}
+        else {sigma_VtxZ.push_back(-1); error_VtxZ.push_back(-1);}
+        if (fs_vtxz2==0) {sigma_VtxZ.push_back(r_vtxz2->Parameter(2)); error_VtxZ.push_back(r_vtxz2->ParError(2));}
+        else {sigma_VtxZ.push_back(-1); error_VtxZ.push_back(-1);}
+        if (fs_vtxz3==0) {sigma_VtxZ.push_back(r_vtxz3->Parameter(2)); error_VtxZ.push_back(r_vtxz3->ParError(2));}
+        else {sigma_VtxZ.push_back(-1); error_VtxZ.push_back(-1);}
+        if (fs_vtxz4==0) {sigma_VtxZ.push_back(r_vtxz4->Parameter(2)); error_VtxZ.push_back(r_vtxz4->ParError(2));}
+        else {sigma_VtxZ.push_back(-1); error_VtxZ.push_back(-1);}
+        if (fs_vtxz5==0) {sigma_VtxZ.push_back(r_vtxz5->Parameter(2)); error_VtxZ.push_back(r_vtxz5->ParError(2));}
+        else {sigma_VtxZ.push_back(-1); error_VtxZ.push_back(-1);}
+        if (fs_vtxz6==0) {sigma_VtxZ.push_back(r_vtxz6->Parameter(2)); error_VtxZ.push_back(r_vtxz6->ParError(2));}
+        else {sigma_VtxZ.push_back(-1); error_VtxZ.push_back(-1);}
 
         // Fill the new histogram to create resolution plot
         for (int i = 0; i < 6; i++) {
@@ -671,29 +693,33 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resd0->SetMinimum(0.0);
       resd0->SetStats(false);
 
-      //int testNumEntries7 = resd0_1->GetEntries();
       if (resd0_1->GetEntries() > 0 && resd0_2->GetEntries() > 0 && resd0_3->GetEntries() > 0 &&
           resd0_4->GetEntries() > 0 && resd0_5->GetEntries() > 0 && resd0_6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resd0_1->Fit(fit, "Q", "R");
-        resd0_2->Fit(fit, "Q", "R");
-        resd0_3->Fit(fit, "Q", "R");
-        resd0_4->Fit(fit, "Q", "R");
-        resd0_5->Fit(fit, "Q", "R");
-        resd0_6->Fit(fit, "Q", "R");
-        sigma_d0.push_back(resd0_1->GetFunction("fit")->GetParameter(2));
-        sigma_d0.push_back(resd0_2->GetFunction("fit")->GetParameter(2));
-        sigma_d0.push_back(resd0_3->GetFunction("fit")->GetParameter(2));
-        sigma_d0.push_back(resd0_4->GetFunction("fit")->GetParameter(2));
-        sigma_d0.push_back(resd0_5->GetFunction("fit")->GetParameter(2));
-        sigma_d0.push_back(resd0_6->GetFunction("fit")->GetParameter(2));
-        error_d0.push_back(resd0_1->GetFunction("fit")->GetParError(2));
-        error_d0.push_back(resd0_2->GetFunction("fit")->GetParError(2));
-        error_d0.push_back(resd0_3->GetFunction("fit")->GetParError(2));
-        error_d0.push_back(resd0_4->GetFunction("fit")->GetParError(2));
-        error_d0.push_back(resd0_5->GetFunction("fit")->GetParError(2));
-        error_d0.push_back(resd0_6->GetFunction("fit")->GetParError(2));
+        TFitResultPtr r_d01 = resd0_1->Fit(fit, "Q", "RS");
+        TFitResultPtr r_d02 = resd0_2->Fit(fit, "Q", "RS");
+        TFitResultPtr r_d03 = resd0_3->Fit(fit, "Q", "RS");
+        TFitResultPtr r_d04 = resd0_4->Fit(fit, "Q", "RS");
+        TFitResultPtr r_d05 = resd0_5->Fit(fit, "Q", "RS");
+        TFitResultPtr r_d06 = resd0_6->Fit(fit, "Q", "RS");
+
+        //Check fit status before extracting parameters
+        Int_t fs_d01 = r_d01; Int_t fs_d02 = r_d02; Int_t fs_d03 = r_d03;
+        Int_t fs_d04 = r_d04; Int_t fs_d05 = r_d05; Int_t fs_d06 = r_d06;
+
+        if (fs_d01==0) {sigma_d0.push_back(r_d01->Parameter(2)); error_d0.push_back(r_d01->ParError(2));}
+        else {sigma_d0.push_back(-1); error_d0.push_back(-1);}
+        if (fs_d02==0) {sigma_d0.push_back(r_d02->Parameter(2)); error_d0.push_back(r_d02->ParError(2));}
+        else {sigma_d0.push_back(-1); error_d0.push_back(-1);}
+        if (fs_d03==0) {sigma_d0.push_back(r_d03->Parameter(2)); error_d0.push_back(r_d03->ParError(2));}
+        else {sigma_d0.push_back(-1); error_d0.push_back(-1);}
+        if (fs_d04==0) {sigma_d0.push_back(r_d04->Parameter(2)); error_d0.push_back(r_d04->ParError(2));}
+        else {sigma_d0.push_back(-1); error_d0.push_back(-1);}
+        if (fs_d05==0) {sigma_d0.push_back(r_d05->Parameter(2)); error_d0.push_back(r_d05->ParError(2));}
+        else {sigma_d0.push_back(-1); error_d0.push_back(-1);}
+        if (fs_d06==0) {sigma_d0.push_back(r_d06->Parameter(2)); error_d0.push_back(r_d06->ParError(2));}
+        else {sigma_d0.push_back(-1); error_d0.push_back(-1);}
 
         // Fill the new histogram to create resolution plot
         for (int i = 0; i < 6; i++) {

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMCHarvester.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMCHarvester.cc
@@ -294,10 +294,10 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt1->SetMinimum(0.0);
       resPt1->SetStats(false);
 
-      //int testNumEntries1 = resPt1a->GetEntries();
-      if (resPt1a->GetEntries() > 0 && resPt2a->GetEntries() > 0 && resPt3a->GetEntries() > 0 &&
-          resPt4a->GetEntries() > 0 && resPt5a->GetEntries() > 0 && resPt6a->GetEntries() > 0) {
-        //if (testNumEntries1 > 0) {
+      int testNumEntries1 = resPt1a->GetEntries();
+      // if (resPt1a->GetEntries() > 0 && resPt2a->GetEntries() > 0 && resPt3a->GetEntries() > 0 &&
+      //     resPt4a->GetEntries() > 0 && resPt5a->GetEntries() > 0 && resPt6a->GetEntries() > 0) {
+      if (testNumEntries1 > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
         resPt1a->Fit(fit2, "Q", "R");
@@ -358,10 +358,10 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt2->SetMinimum(0.0);
       resPt2->SetStats(false);
 
-      //int testNumEntries2 = resPt1b->GetEntries();
-      // if (testNumEntries2 > 0) {
-      if (resPt1b->GetEntries() > 0 && resPt2b->GetEntries() > 0 && resPt3b->GetEntries() > 0 &&
-          resPt4b->GetEntries() > 0 && resPt5b->GetEntries() > 0 && resPt6b->GetEntries() > 0) {
+      int testNumEntries2 = resPt1b->GetEntries();
+      if (testNumEntries2 > 0) {
+      // if (resPt1b->GetEntries() > 0 && resPt2b->GetEntries() > 0 && resPt3b->GetEntries() > 0 &&
+      //     resPt4b->GetEntries() > 0 && resPt5b->GetEntries() > 0 && resPt6b->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
         resPt1b->Fit(fit2, "Q", "R");
@@ -422,10 +422,10 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt3->SetMinimum(0.0);
       resPt3->SetStats(false);
 
-      //int testNumEntries3 = resPt1c->GetEntries();
-      if (resPt1c->GetEntries() > 0 && resPt2c->GetEntries() > 0 && resPt3c->GetEntries() > 0 &&
-          resPt4c->GetEntries() > 0 && resPt5c->GetEntries() > 0 && resPt6c->GetEntries() > 0) {
-        //        if (testNumEntries3 > 0) {
+      int testNumEntries3 = resPt1c->GetEntries();
+      // if (resPt1c->GetEntries() > 0 && resPt2c->GetEntries() > 0 && resPt3c->GetEntries() > 0 &&
+      //     resPt4c->GetEntries() > 0 && resPt5c->GetEntries() > 0 && resPt6c->GetEntries() > 0) {
+      if (testNumEntries3 > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
         resPt1c->Fit(fit2, "Q", "R");
@@ -485,9 +485,10 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resEta->SetMinimum(0.0);
       resEta->SetStats(false);
 
-      //int testNumEntries4 = resEta1->GetEntries();
-      if (resEta1->GetEntries() > 0 && resEta2->GetEntries() > 0 && resEta3->GetEntries() > 0 &&
-          resEta4->GetEntries() > 0 && resEta5->GetEntries() > 0 && resEta6->GetEntries() > 0) {
+      int testNumEntries4 = resEta1->GetEntries();
+      if (testNumEntries4 > 0) {
+      // if (resEta1->GetEntries() > 0 && resEta2->GetEntries() > 0 && resEta3->GetEntries() > 0 &&
+      //     resEta4->GetEntries() > 0 && resEta5->GetEntries() > 0 && resEta6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
         resEta1->Fit(fit, "Q", "R");
@@ -547,9 +548,10 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPhi->SetMinimum(0.0);
       resPhi->SetStats(false);
 
-      //int testNumEntries5 = resPhi1->GetEntries();
-      if (resPhi1->GetEntries() > 0 && resPhi2->GetEntries() > 0 && resPhi3->GetEntries() > 0 &&
-          resPhi4->GetEntries() > 0 && resPhi5->GetEntries() > 0 && resPhi6->GetEntries() > 0) {
+      int testNumEntries5 = resPhi1->GetEntries();
+      if (testNumEntries5 > 0) {
+      // if (resPhi1->GetEntries() > 0 && resPhi2->GetEntries() > 0 && resPhi3->GetEntries() > 0 &&
+      //     resPhi4->GetEntries() > 0 && resPhi5->GetEntries() > 0 && resPhi6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
         resPhi1->Fit(fit, "Q", "R");
@@ -609,9 +611,10 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resVtxZ->SetMinimum(0.0);
       resVtxZ->SetStats(false);
 
-      //int testNumEntries6 = resVtxZ_1->GetEntries();
-      if (resVtxZ_1->GetEntries() > 0 && resVtxZ_2->GetEntries() > 0 && resVtxZ_3->GetEntries() > 0 &&
-          resVtxZ_4->GetEntries() > 0 && resVtxZ_5->GetEntries() > 0 && resVtxZ_6->GetEntries() > 0) {
+      int testNumEntries6 = resVtxZ_1->GetEntries();
+      if (testNumEntries6 > 0) {
+      // if (resVtxZ_1->GetEntries() > 0 && resVtxZ_2->GetEntries() > 0 && resVtxZ_3->GetEntries() > 0 &&
+      //     resVtxZ_4->GetEntries() > 0 && resVtxZ_5->GetEntries() > 0 && resVtxZ_6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
         resVtxZ_1->Fit(fit3, "Q", "R");
@@ -671,9 +674,10 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resd0->SetMinimum(0.0);
       resd0->SetStats(false);
 
-      //int testNumEntries7 = resd0_1->GetEntries();
-      if (resd0_1->GetEntries() > 0 && resd0_2->GetEntries() > 0 && resd0_3->GetEntries() > 0 &&
-          resd0_4->GetEntries() > 0 && resd0_5->GetEntries() > 0 && resd0_6->GetEntries() > 0) {
+      int testNumEntries7 = resd0_1->GetEntries();
+      if (testNumEntries7 > 0) {
+      // if (resd0_1->GetEntries() > 0 && resd0_2->GetEntries() > 0 && resd0_3->GetEntries() > 0 &&
+      //     resd0_4->GetEntries() > 0 && resd0_5->GetEntries() > 0 && resd0_6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
         resd0_1->Fit(fit, "Q", "R");

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMCHarvester.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMCHarvester.cc
@@ -294,16 +294,18 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt1->SetMinimum(0.0);
       resPt1->SetStats(false);
 
-      int testNumEntries1 = resPt1a->GetEntries();
-      if (testNumEntries1 > 0) {
+      //int testNumEntries1 = resPt1a->GetEntries();
+      if (resPt1a->GetEntries() > 0 && resPt2a->GetEntries() > 0 && resPt3a->GetEntries() > 0 &&
+          resPt4a->GetEntries() > 0 && resPt5a->GetEntries() > 0 && resPt6a->GetEntries() > 0) {
+        //if (testNumEntries1 > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1a->Fit(fit2, "R");
-        resPt2a->Fit(fit2, "R");
-        resPt3a->Fit(fit2, "R");
-        resPt4a->Fit(fit2, "R");
-        resPt5a->Fit(fit2, "R");
-        resPt6a->Fit(fit2, "R");
+        resPt1a->Fit(fit2, "Q", "R");
+        resPt2a->Fit(fit2, "Q", "R");
+        resPt3a->Fit(fit2, "Q", "R");
+        resPt4a->Fit(fit2, "Q", "R");
+        resPt5a->Fit(fit2, "Q", "R");
+        resPt6a->Fit(fit2, "Q", "R");
         sigma_pt1.push_back(resPt1a->GetFunction("fit2")->GetParameter(2));
         sigma_pt1.push_back(resPt2a->GetFunction("fit2")->GetParameter(2));
         sigma_pt1.push_back(resPt3a->GetFunction("fit2")->GetParameter(2));
@@ -356,16 +358,18 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt2->SetMinimum(0.0);
       resPt2->SetStats(false);
 
-      int testNumEntries2 = resPt1b->GetEntries();
-      if (testNumEntries2 > 0) {
+      //int testNumEntries2 = resPt1b->GetEntries();
+      // if (testNumEntries2 > 0) {
+      if (resPt1b->GetEntries() > 0 && resPt2b->GetEntries() > 0 && resPt3b->GetEntries() > 0 &&
+          resPt4b->GetEntries() > 0 && resPt5b->GetEntries() > 0 && resPt6b->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1b->Fit(fit2, "R");
-        resPt2b->Fit(fit2, "R");
-        resPt3b->Fit(fit2, "R");
-        resPt4b->Fit(fit2, "R");
-        resPt5b->Fit(fit2, "R");
-        resPt6b->Fit(fit2, "R");
+        resPt1b->Fit(fit2, "Q", "R");
+        resPt2b->Fit(fit2, "Q", "R");
+        resPt3b->Fit(fit2, "Q", "R");
+        resPt4b->Fit(fit2, "Q", "R");
+        resPt5b->Fit(fit2, "Q", "R");
+        resPt6b->Fit(fit2, "Q", "R");
         sigma_pt2.push_back(resPt1b->GetFunction("fit2")->GetParameter(2));
         sigma_pt2.push_back(resPt2b->GetFunction("fit2")->GetParameter(2));
         sigma_pt2.push_back(resPt3b->GetFunction("fit2")->GetParameter(2));
@@ -418,16 +422,18 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPt3->SetMinimum(0.0);
       resPt3->SetStats(false);
 
-      int testNumEntries3 = resPt1c->GetEntries();
-      if (testNumEntries3 > 0) {
+      //int testNumEntries3 = resPt1c->GetEntries();
+      if (resPt1c->GetEntries() > 0 && resPt2c->GetEntries() > 0 && resPt3c->GetEntries() > 0 &&
+          resPt4c->GetEntries() > 0 && resPt5c->GetEntries() > 0 && resPt6c->GetEntries() > 0) {
+        //        if (testNumEntries3 > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPt1c->Fit(fit2, "R");
-        resPt2c->Fit(fit2, "R");
-        resPt3c->Fit(fit2, "R");
-        resPt4c->Fit(fit2, "R");
-        resPt5c->Fit(fit2, "R");
-        resPt6c->Fit(fit2, "R");
+        resPt1c->Fit(fit2, "Q", "R");
+        resPt2c->Fit(fit2, "Q", "R");
+        resPt3c->Fit(fit2, "Q", "R");
+        resPt4c->Fit(fit2, "Q", "R");
+        resPt5c->Fit(fit2, "Q", "R");
+        resPt6c->Fit(fit2, "Q", "R");
         sigma_pt3.push_back(resPt1c->GetFunction("fit2")->GetParameter(2));
         sigma_pt3.push_back(resPt2c->GetFunction("fit2")->GetParameter(2));
         sigma_pt3.push_back(resPt3c->GetFunction("fit2")->GetParameter(2));
@@ -479,16 +485,17 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resEta->SetMinimum(0.0);
       resEta->SetStats(false);
 
-      int testNumEntries4 = resEta1->GetEntries();
-      if (testNumEntries4 > 0) {
+      //int testNumEntries4 = resEta1->GetEntries();
+      if (resEta1->GetEntries() > 0 && resEta2->GetEntries() > 0 && resEta3->GetEntries() > 0 &&
+          resEta4->GetEntries() > 0 && resEta5->GetEntries() > 0 && resEta6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resEta1->Fit(fit, "R");
-        resEta2->Fit(fit, "R");
-        resEta3->Fit(fit, "R");
-        resEta4->Fit(fit, "R");
-        resEta5->Fit(fit, "R");
-        resEta6->Fit(fit, "R");
+        resEta1->Fit(fit, "Q", "R");
+        resEta2->Fit(fit, "Q", "R");
+        resEta3->Fit(fit, "Q", "R");
+        resEta4->Fit(fit, "Q", "R");
+        resEta5->Fit(fit, "Q", "R");
+        resEta6->Fit(fit, "Q", "R");
         sigma_eta.push_back(resEta1->GetFunction("fit")->GetParameter(2));
         sigma_eta.push_back(resEta2->GetFunction("fit")->GetParameter(2));
         sigma_eta.push_back(resEta3->GetFunction("fit")->GetParameter(2));
@@ -540,16 +547,17 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resPhi->SetMinimum(0.0);
       resPhi->SetStats(false);
 
-      int testNumEntries5 = resPhi1->GetEntries();
-      if (testNumEntries5 > 0) {
+      //int testNumEntries5 = resPhi1->GetEntries();
+      if (resPhi1->GetEntries() > 0 && resPhi2->GetEntries() > 0 && resPhi3->GetEntries() > 0 &&
+          resPhi4->GetEntries() > 0 && resPhi5->GetEntries() > 0 && resPhi6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resPhi1->Fit(fit, "R");
-        resPhi2->Fit(fit, "R");
-        resPhi3->Fit(fit, "R");
-        resPhi4->Fit(fit, "R");
-        resPhi5->Fit(fit, "R");
-        resPhi6->Fit(fit, "R");
+        resPhi1->Fit(fit, "Q", "R");
+        resPhi2->Fit(fit, "Q", "R");
+        resPhi3->Fit(fit, "Q", "R");
+        resPhi4->Fit(fit, "Q", "R");
+        resPhi5->Fit(fit, "Q", "R");
+        resPhi6->Fit(fit, "Q", "R");
         sigma_phi.push_back(resPhi1->GetFunction("fit")->GetParameter(2));
         sigma_phi.push_back(resPhi2->GetFunction("fit")->GetParameter(2));
         sigma_phi.push_back(resPhi3->GetFunction("fit")->GetParameter(2));
@@ -601,16 +609,17 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resVtxZ->SetMinimum(0.0);
       resVtxZ->SetStats(false);
 
-      int testNumEntries6 = resVtxZ_1->GetEntries();
-      if (testNumEntries6 > 0) {
+      //int testNumEntries6 = resVtxZ_1->GetEntries();
+      if (resVtxZ_1->GetEntries() > 0 && resVtxZ_2->GetEntries() > 0 && resVtxZ_3->GetEntries() > 0 &&
+          resVtxZ_4->GetEntries() > 0 && resVtxZ_5->GetEntries() > 0 && resVtxZ_6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resVtxZ_1->Fit(fit3, "R");
-        resVtxZ_2->Fit(fit3, "R");
-        resVtxZ_3->Fit(fit3, "R");
-        resVtxZ_4->Fit(fit3, "R");
-        resVtxZ_5->Fit(fit3, "R");
-        resVtxZ_6->Fit(fit3, "R");
+        resVtxZ_1->Fit(fit3, "Q", "R");
+        resVtxZ_2->Fit(fit3, "Q", "R");
+        resVtxZ_3->Fit(fit3, "Q", "R");
+        resVtxZ_4->Fit(fit3, "Q", "R");
+        resVtxZ_5->Fit(fit3, "Q", "R");
+        resVtxZ_6->Fit(fit3, "Q", "R");
         sigma_VtxZ.push_back(resVtxZ_1->GetFunction("fit3")->GetParameter(2));
         sigma_VtxZ.push_back(resVtxZ_2->GetFunction("fit3")->GetParameter(2));
         sigma_VtxZ.push_back(resVtxZ_3->GetFunction("fit3")->GetParameter(2));
@@ -662,16 +671,17 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
       resd0->SetMinimum(0.0);
       resd0->SetStats(false);
 
-      int testNumEntries7 = resd0_1->GetEntries();
-      if (testNumEntries7 > 0) {
+      //int testNumEntries7 = resd0_1->GetEntries();
+      if (resd0_1->GetEntries() > 0 && resd0_2->GetEntries() > 0 && resd0_3->GetEntries() > 0 &&
+          resd0_4->GetEntries() > 0 && resd0_5->GetEntries() > 0 && resd0_6->GetEntries() > 0) {
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
-        resd0_1->Fit(fit, "R");
-        resd0_2->Fit(fit, "R");
-        resd0_3->Fit(fit, "R");
-        resd0_4->Fit(fit, "R");
-        resd0_5->Fit(fit, "R");
-        resd0_6->Fit(fit, "R");
+        resd0_1->Fit(fit, "Q", "R");
+        resd0_2->Fit(fit, "Q", "R");
+        resd0_3->Fit(fit, "Q", "R");
+        resd0_4->Fit(fit, "Q", "R");
+        resd0_5->Fit(fit, "Q", "R");
+        resd0_6->Fit(fit, "Q", "R");
         sigma_d0.push_back(resd0_1->GetFunction("fit")->GetParameter(2));
         sigma_d0.push_back(resd0_2->GetFunction("fit")->GetParameter(2));
         sigma_d0.push_back(resd0_3->GetFunction("fit")->GetParameter(2));

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.h
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.h
@@ -33,10 +33,6 @@ public:
   MonitorElement *trackParts_Phi = nullptr;
   MonitorElement *trackParts_Pt = nullptr;
 
-  // Plots for correctly matched tracks
-  MonitorElement *Track_MatchedChi2 = nullptr;     // Chi2 for only tracks correctly matched to truth level
-  MonitorElement *Track_MatchedChi2Red = nullptr;  // Chi2/dof for only tracks correctly matched to truth level
-
   // pT and eta for efficiency plots
   MonitorElement *tp_pt = nullptr;             // denominator
   MonitorElement *tp_pt_zoom = nullptr;        // denominator
@@ -109,17 +105,13 @@ private:
       ttStubMCTruthToken_;  // MC truth association map for stubs
   edm::EDGetTokenT<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>
       ttTrackMCTruthToken_;  // MC truth association map for tracks
-  int L1Tk_nPar;
   int L1Tk_minNStub;
-  double L1Tk_maxChi2;
   double L1Tk_maxChi2dof;
   int TP_minNStub;
   int TP_minNLayersStub;
   double TP_minPt;
-  double TP_maxPt;
   double TP_maxEta;
   double TP_maxVtxZ;
-  int TP_select_eventid;
   std::string topFolderName_;
 };
 #endif

--- a/Validation/SiOuterTrackerV/python/OuterTrackerMonitorTrackingParticles_cfi.py
+++ b/Validation/SiOuterTrackerV/python/OuterTrackerMonitorTrackingParticles_cfi.py
@@ -8,17 +8,13 @@ OuterTrackerMonitorTrackingParticles = DQMEDAnalyzer('OuterTrackerMonitorTrackin
     MCTruthStubInputTag = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"), #truth stub associator
     MCTruthTrackInputTag = cms.InputTag("TTTrackAssociatorFromPixelDigis", "Level1TTTracks"), #truth track associator
     MCTruthClusterInputTag = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"), #truth cluster associator
-    L1Tk_nPar = cms.int32(4),           # use 4 or 5-parameter L1 track fit ??
     L1Tk_minNStub = cms.int32(4),       # L1 tracks with >= 4 stubs
-    L1Tk_maxChi2 = cms.double(400.0),   # L1 tracks with Chi2 <= X
-    L1Tk_maxChi2dof = cms.double(100.0),# L1 tracks with Chi2 <= X
+    L1Tk_maxChi2dof = cms.double(25.0),# L1 tracks with Chi2 <= X
     TP_minNStub = cms.int32(4),      # require TP to have >= X number of stubs associated with it
     TP_minNLayersStub = cms.int32(4),   # require TP to have >= X number of layers hit with stubs
     TP_minPt = cms.double(2.0),      # only save TPs with pt > X GeV
-    TP_maxPt = cms.double(1000.0),   # only save TPs with pt < X GeV
     TP_maxEta = cms.double(2.4),     # only save TPs with |eta| < X
-    TP_maxVtxZ = cms.double(30.0),     # only save TPs with |z0| < X cm
-    TP_select_eventid = cms.int32(0),# if zero, only look at TPs from primary interaction, else, include TPs from pileup
+    TP_maxVtxZ = cms.double(15.0),     # only save TPs with |z0| < X cm
 
 # tracking particles vs eta
     TH1TrackParts_Eta = cms.PSet(
@@ -38,20 +34,6 @@ OuterTrackerMonitorTrackingParticles = DQMEDAnalyzer('OuterTrackerMonitorTrackin
     TH1TrackParts_Pt = cms.PSet(
         Nbinsx = cms.int32(45),
         xmax = cms.double(100),
-        xmin = cms.double(0)
-        ),
-
-#Chi2 of the track
-    TH1_Track_Chi2 = cms.PSet(
-        Nbinsx = cms.int32(100),
-        xmax = cms.double(50),
-        xmin = cms.double(0)
-        ),
-
-#Chi2R of the track
-    TH1_Track_Chi2R = cms.PSet(
-        Nbinsx = cms.int32(100),
-        xmax = cms.double(10),
         xmin = cms.double(0)
         ),
 


### PR DESCRIPTION
#### PR description:
Backport of #30460

Updating Level-1 Trigger DQM (TTClusters, TTStubs, and TTTracks).
Clusters:
-cluster phi range extended
Stubs:
-stub phi range extended
-5 new distributions added (trigger bend, hardware bend, raw bend, bend offset, and PS module) -> very useful in finding bugs when the TTStub class is updated
Tracks:
-Modified the track input so it will automatically run on the newly merged Hybrid Tracks
-Updated the general track directory to by high-quality ("HQ") tracks and all produced tracks
-Updated the definition of HQ track -> reflects the track quality cuts optimized for Level-1 track MET
-Added nLayersMissed distribution, determined by the L1T group to be very important in separating real from fake tracks
-Added bend chi2 distribution, determined by the L1T group to be very important in separating real from fake tracks
-Added two Chi2 distributions, Chi2 r-phi and Chi2 r-z

Validation package:
-Removed the matched tracks chi2 and chi2dof distributions (they are not very helpful for validation)
-Cleaned up some of the code, removing pieces that are no longer necessary due to the cleaned up TTTrack class (L1Tk_nPar, L1Tk_maxChi2, TP_maxPt, and TP_select_eventid)
**Note** DQM/SiOuterTracker/Track plots are empty, since the running of the L1T tracks are not yet included in CMSSW_11_1_X (at least when I tested it)

#### PR validation:

Ran standalone to make sure output was as expected.
Ran runTheMatrix for 23234.0 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of #30460
Requested.
