### PR TITLE
MTD Geometry: updated GeometricTimingDet to remove the residual dependency on DDSolidShape

### DIFF
--- a/Geometry/MTDNumberingBuilder/interface/GeometricTimingDet.h
+++ b/Geometry/MTDNumberingBuilder/interface/GeometricTimingDet.h
@@ -2,7 +2,7 @@
 #define Geometry_MTDNumberingBuilder_GeometricTimingDet_H
 
 #include "CondFormats/GeometryObjects/interface/PGeometricTimingDet.h"
-#include "DetectorDescription/Core/interface/DDSolidShapes.h"
+#include "DetectorDescription/DDCMS/interface/DDSolidShapes.h"
 #include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "DataFormats/GeometrySurface/interface/Bounds.h"
 #include "DataFormats/DetId/interface/DetId.h"
@@ -99,7 +99,8 @@ public:
   double phi() const { return phi_; }
   double rho() const { return rho_; }
 
-  DDSolidShape const& shape() const { return shape_; }
+  LegacySolidShape shape() const { return cms::dd::value(cms::LegacySolidShapeMap, shape_); }
+  cms::DDSolidShape shape_dd4hep() const { return shape_; }
   GeometricTimingEnumType type() const { return type_; }
   std::string const& name() const { return ddname_; }
   // internal representaion
@@ -169,7 +170,7 @@ private:
   double phi_;
   double rho_;
   RotationMatrix rot_;
-  DDSolidShape shape_;
+  cms::DDSolidShape shape_;
   nav_type ddd_;
   std::string ddname_;
   GeometricTimingEnumType type_;

--- a/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
+++ b/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
@@ -74,7 +74,7 @@ GeometricTimingDet::GeometricTimingDet(DDFilteredView* fv, GeometricTimingEnumTy
       phi_(trans_.Phi()),
       rho_(trans_.Rho()),
       rot_(fv->rotation()),
-      shape_(fv->shape()),
+      shape_(cms::dd::name_from_value(cms::LegacySolidShapeMap, fv->shape())),
       ddname_(fv->name()),
       type_(type),
       params_(fv->parameters()),
@@ -95,7 +95,7 @@ using namespace geant_units::operators;
 GeometricTimingDet::GeometricTimingDet(cms::DDFilteredView* fv, GeometricTimingEnumType type)
     : trans_(fv->translation()),
       rot_(fv->rotation()),
-      shape_(DDSolidShape(static_cast<int>(fv->shape()))),
+      shape_(fv->shape()),
       ddname_(fv->name()),
       type_(type),
       params_(fv->parameters()),
@@ -137,7 +137,7 @@ GeometricTimingDet::GeometricTimingDet(const PGeometricTimingDet::Item& onePGD, 
            onePGD.a31_,
            onePGD.a32_,
            onePGD.a33_),
-      shape_(static_cast<DDSolidShape>(onePGD.shape_)),
+      shape_(cms::dd::name_from_value(cms::LegacySolidShapeMap, static_cast<LegacySolidShape>(onePGD.shape_))),
       ddd_(),
       ddname_(onePGD.name_),  //, "fromdb");
       type_(type),
@@ -258,5 +258,5 @@ std::unique_ptr<Bounds> GeometricTimingDet::bounds() const {
   const std::vector<double>& par = params_;
   TrackerShapeToBounds shapeToBounds;
   return std::unique_ptr<Bounds>(
-      shapeToBounds.buildBounds(cms::dd::name_from_value(cms::LegacySolidShapeMap, shape_), par));
+      shapeToBounds.buildBounds(shape_, par));
 }

--- a/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
+++ b/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
@@ -257,6 +257,5 @@ GeometricTimingDet::Rotation GeometricTimingDet::rotationBounds() const {
 std::unique_ptr<Bounds> GeometricTimingDet::bounds() const {
   const std::vector<double>& par = params_;
   TrackerShapeToBounds shapeToBounds;
-  return std::unique_ptr<Bounds>(
-      shapeToBounds.buildBounds(shape_, par));
+  return std::unique_ptr<Bounds>(shapeToBounds.buildBounds(shape_, par));
 }


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #29905 as mentioned in https://github.com/cms-sw/cmssw/issues/28914#issuecomment-659680418 . The residual dependence of GeometricTimingDet on the DDD class ```DDSolidShape``` is removed through the provided map, and ```cms::DDSolidShape``` is now used. No impact is expected outside of ```Geometry/MTDNumberingBuilder```.

#### PR validation:

The MTD geometry unit tests are ok, test wf 23234.0 runs smoothly. The full output of the ```MTDNumberingBuilder``` test shows the expected change in shape of polycones:

```
71c71
<  shape = DDSolidShape index:5, name: Polycone_rz
---
>  shape = DDSolidShape index:7, name: Polycone_rrz
127c127
<  shape = DDSolidShape index:5, name: Polycone_rz
---
>  shape = DDSolidShape index:7, name: Polycone_rrz
183c183
<  shape = DDSolidShape index:5, name: Polycone_rz
---
>  shape = DDSolidShape index:7, name: Polycone_rrz
```

which anyway should have no practical effect on the model built in memory and its use.