### PR TITLE
cleanup Buildfiles; remove used ADD_SUBDIR flag

### DIFF
--- a/L1Trigger/L1TGlobal/BuildFile.xml
+++ b/L1Trigger/L1TGlobal/BuildFile.xml
@@ -14,4 +14,3 @@
 <export>
   <lib name="1"/>
 </export>
-<flags ADD_SUBDIR="1"/>

--- a/L1Trigger/L1THGCalUtilities/BuildFile.xml
+++ b/L1Trigger/L1THGCalUtilities/BuildFile.xml
@@ -5,4 +5,3 @@
 <export>
   <lib name="1"/>
 </export>
-<flags ADD_SUBDIR="1"/>

--- a/L1Trigger/L1TMuonBarrel/BuildFile.xml
+++ b/L1Trigger/L1TMuonBarrel/BuildFile.xml
@@ -13,4 +13,3 @@
 <export>
   <lib name="1"/>
 </export>
-<flags ADD_SUBDIR="1"/>

--- a/L1Trigger/L1TMuonOverlap/BuildFile.xml
+++ b/L1Trigger/L1TMuonOverlap/BuildFile.xml
@@ -1,14 +1,5 @@
 <export>
   <lib name="1"/>
-  <use name="DataFormats/L1TMuon"/>
-  <use name="L1Trigger/RPCTrigger"/>
-  <use name="DataFormats/L1TMuon"/>
-  <use name="Geometry/Records"/>
-  <use name="Geometry/DTGeometry"/>
-  <use name="Geometry/CSCGeometry"/>
-  <use name="Geometry/RPCGeometry"/>
-  <use name="root"/>
-  <use name="xerces-c"/>
 </export>
 <use name="xerces-c"/>
 <use name="root"/>
@@ -20,4 +11,3 @@
 <use name="Geometry/RPCGeometry"/>
 <use name="L1Trigger/CSCCommonTrigger"/>
 <use name="L1Trigger/DTUtilities"/>
-<flags ADD_SUBDIR="1"/>

--- a/L1Trigger/L1TTwinMux/BuildFile.xml
+++ b/L1Trigger/L1TTwinMux/BuildFile.xml
@@ -9,4 +9,3 @@
 <export>
   <lib name="1"/>
 </export>
-<flags ADD_SUBDIR="1"/>


### PR DESCRIPTION
Cleaning up L1 BuildFiles to drop unused `<flags ADD_SUBDIR="1"/>` flag. this flag is only needed if you have extra sources under `Package/src/<subdirs>` . Also cleaned up `export` section to not explicitly export the dependency. SCRAM by default do it.