### PR TITLE
Remove superfluous semicolon at the end of namespace in ParameterSetReader.h

### DIFF
--- a/FWCore/ParameterSetReader/interface/ParameterSetReader.h
+++ b/FWCore/ParameterSetReader/interface/ParameterSetReader.h
@@ -15,5 +15,5 @@ namespace edm {
 
   std::unique_ptr<edm::ParameterSet> readPSetsFrom(std::string const& fileOrString);
 
-};  // namespace edm
+}  // namespace edm
 #endif


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/30844

#### PR validation:

None