### PR TITLE
move dictionaries for TrackingParticle and TrajectoryStateOnSurface to proper package 

### DIFF
--- a/Alignment/LaserAlignment/src/classes_def.xml
+++ b/Alignment/LaserAlignment/src/classes_def.xml
@@ -1,6 +1,4 @@
 <lcgdict>
-  <class name="edm::Wrapper<TsosVectorCollection>" persistent="false"/>
-  <class name="TsosVectorCollection"/>
 <!-- <class name="LASCommissioningData"/> -->
 <!-- <class name="LASGlobalLoop"/> -->
   <class name="LASGlobalData<int>"/>

--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -18,6 +18,9 @@
   <class name="edm::Wrapper<std::vector<TrackingParticle> >" />
   <class name="edm::RefProd<std::vector<TrackingParticle> >" />
   <class name="TrackingParticleRef" />
+  <class name="edm::Ptr<TrackingParticle>" />
+  <class name="std::vector<edm::Ptr<TrackingParticle>>" />
+
   <class name="TrackingParticleRefVector" />
   <class name="edm::Wrapper<TrackingParticleRefVector>"/>
  

--- a/SimGeneral/TrackingAnalysis/src/classes_def.xml
+++ b/SimGeneral/TrackingAnalysis/src/classes_def.xml
@@ -2,8 +2,6 @@
   <class name="std::pair<TrackingParticleRef, TrackPSimHitRef>" persistent="true" /> 
   <class name="std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> >" persistent="true" /> 
   <class name="edm::Wrapper<std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> > >" />
-  <class name="edm::Ptr<TrackingParticle>" />
-  <class name="std::vector<edm::Ptr<TrackingParticle>>" />
 
   <class name="std::pair< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > >, edm::Ptr< TrackingParticle > >" />
   <class name="std::pair< edm::Ptr< TrackingParticle >, vector< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > >, allocator< edm::Ptr< TTTrack< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi, edm::refhelper::FindForDetSetVector< Phase2TrackerDigi > > > > > > >" />

--- a/TrackingTools/TrajectoryState/src/classes_def.xml
+++ b/TrackingTools/TrajectoryState/src/classes_def.xml
@@ -3,6 +3,8 @@
   <class name="TrajectoryStateOnSurface"/>
   <class name="std::vector<TrajectoryStateOnSurface>" persistent="false"/>
   <class name="edm::Wrapper<std::vector<TrajectoryStateOnSurface> >" persistent="false"/>
+  <class name="std::vector<std::vector<TrajectoryStateOnSurface>>" persistent="false"/>
+  <class name="edm::Wrapper<std::vector<std::vector<TrajectoryStateOnSurface>>>" persistent="false"/>
   <class name="edm::RefProd<std::vector<TrajectoryStateOnSurface> >"/>
   <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,std::vector<TrajectoryStateOnSurface>, unsigned int> >" >
     <field name="transientMap_" transient="true" />


### PR DESCRIPTION
These misplaced dictionaries cause runtime errors in the modules IB. 

I made the vector<vector<TrajectoryStateOnSurface>> transient to match other dictionaries involving this class. If that is not proper, then more significant changes are needed to CMSSW.