### PR TITLE
Fix tmpnam warning in GenIface

### DIFF
--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -363,9 +363,10 @@ void EvtGenInterface::init() {
 
   if (fPSet->exists("user_decay_embedded")) {
     std::vector<std::string> user_decay_lines = fPSet->getParameter<std::vector<std::string> >("user_decay_embedded");
-    std::string user_decay_tmp = std::tmpnam(nullptr);
-    FILE* tmpf = std::fopen(user_decay_tmp.c_str(), "w");
-    if (!tmpf) {
+    char user_decay_tmp[] = "/tmp/user_decay_tmpfileXXXXXX";
+    int tmp_creation = mkstemp(user_decay_tmp);
+    FILE* tmpf = std::fopen(user_decay_tmp, "w");
+    if (!tmpf || (tmp_creation == -1)) {
       edm::LogError("EvtGenInterface::~EvtGenInterface")
           << "EvtGenInterface::init() fails when trying to open a temporary file for embedded user.dec. Terminating "
              "program ";
@@ -376,7 +377,7 @@ void EvtGenInterface::init() {
       std::fputs(user_decay_lines.at(i).c_str(), tmpf);
     }
     std::fclose(tmpf);
-    m_EvtGen->readUDecay(user_decay_tmp.c_str());
+    m_EvtGen->readUDecay(user_decay_tmp);
   }
 
   // setup pdgid which the generator/hadronizer should not decay


### PR DESCRIPTION
#### PR description:

After https://github.com/cms-sw/cmssw/pull/30692 this warning poped:
`warning: the use of tmpnam is dangerous, better use mkstemp`
I'm following what the compiler suggested

#### PR validation:

builds and tests ran, checked the tmpfile creation in standalone example, it worked as described in 
https://www.man7.org/linux/man-pages/man3/mkstemp.3.html