### PR TITLE
Added links to inspect bin by bin comparison with a raw rootjs viewer

### DIFF
--- a/DQMServices/FileIO/scripts/compareDQMOutput.py
+++ b/DQMServices/FileIO/scripts/compareDQMOutput.py
@@ -43,8 +43,18 @@ def compare(base_dir, pr_dir, output_dir, files, pr_number, test_number, release
             base_dataset = '/' + '/'.join(base_output_filename.rstrip('.root').split('__')[1:])
             pr_dataset = '/' + '/'.join(pr_output_filename.rstrip('.root').split('__')[1:])
             
+            cmssw_version = '_'.join(release_format.split('_')[:4])
+            cmssw_version = cmssw_version[:-1] + 'x'
+            root_file_dir_in_gui = 'ROOT/RelValData/%s/' % cmssw_version
+            if 'R000000001__RelVal' in base_output_filename:
+                root_file_dir_in_gui = 'ROOT/RelVal/%s/' % cmssw_version
+
+            base_file_path_in_gui = root_file_dir_in_gui + base_output_filename
+            pr_file_path_in_gui = root_file_dir_in_gui + pr_output_filename
+            
             COMPARISON_RESULTS.append({'workflow': workflow, 'base_dataset': base_dataset, 'pr_dataset': pr_dataset, 'run_nr': run_nr,\
-                'changed_elements': int(output_numbers[0]), 'removed_elements': int(output_numbers[1]), 'added_elements': int(output_numbers[2])})
+                'changed_elements': int(output_numbers[0]), 'removed_elements': int(output_numbers[1]), 'added_elements': int(output_numbers[2]),
+                'base_file_path_in_gui': base_file_path_in_gui, 'pr_file_path_in_gui': pr_file_path_in_gui})
         except Exception as ex:
             print('Exception comparing two root files: %s' % ex)
     
@@ -111,11 +121,15 @@ def generate_summary_html(output_dir, pr_list, summary_dir):
         pr_url = 'https://cmsweb.cern.ch/dqm/dev/start?runnr=%s;dataset%%3D%s;sampletype%%3Doffline_relval;workspace%%3DEverything;' % (comp['run_nr'], comp['pr_dataset'])
         overlay_url = 'https://cmsweb.cern.ch/dqm/dev/start?runnr=%s;dataset%%3D%s;referenceshow%%3Dall;referencenorm=False;referenceobj1%%3Dother::%s::;sampletype%%3Doffline_relval;workspace%%3DEverything;' \
             % (comp['run_nr'], comp['pr_dataset'], comp['base_dataset'])
+        base_raw_url = 'https://cmsweb.cern.ch/dqm/dev/jsroot/index.htm?file=https://cmsweb.cern.ch/dqm/dev/data/browse/%s' % comp['base_file_path_in_gui']
+        pr_raw_url = 'https://cmsweb.cern.ch/dqm/dev/jsroot/index.htm?file=https://cmsweb.cern.ch/dqm/dev/data/browse/%s' % comp['pr_file_path_in_gui']
 
         table_items += '        <tr>\n'
         table_items += '            <td><a href="%s" target="_blank">%s baseline GUI</a><span> (%s)</span></td>\n' % (base_url, comp['workflow'], baseline_count)
         table_items += '            <td><a href="%s" target="_blank">%s pr GUI</a><span> (%s)</span></td>\n' % (pr_url, comp['workflow'], pr_count)
         table_items += '            <td><a href="%s" target="_blank">%s overlay GUI</a><span> (%s)</span></td>\n' % (overlay_url, comp['workflow'], overlay_count)
+        table_items += '            <td><a href="%s" target="_blank">%s baseline rootjs</a><span> (%s)</span></td>\n' % (base_raw_url, comp['workflow'], baseline_count)
+        table_items += '            <td><a href="%s" target="_blank">%s pr rootjs</a><span> (%s)</span></td>\n' % (pr_raw_url, comp['workflow'], pr_count)
         table_items += '            <td><span class="removed">-%s</span><span class="added">+%s</span><span class="changed">%s</span></td>\n' \
             % (comp['removed_elements'], comp['added_elements'], comp['changed_elements'])
         table_items += '        </tr>\n'
@@ -144,7 +158,7 @@ if __name__ == '__main__':
     parser.add_argument('-j', '--nprocs', help='Number of processes', default=1, type=int)
     parser.add_argument('-n', '--pr-number', help='This is obsolete and should NOT be used.', required=False)
     parser.add_argument('-t', '--test-number', help='Unique test number to distinguish different comparisons of the same PR.', default='1')
-    parser.add_argument('-r', '--release-format', help='Release format in this format: CMSSW_10_5_X_2019-02-17-0000', required=True)
+    parser.add_argument('-r', '--release-format', help='Release format in this format: CMSSW_10_5_X_2019-02-17-0000')
     parser.add_argument('-s', '--summary-dir', help='Directory where summary with all links will be saved', default='')
     parser.add_argument('-l', '--pr-list', help='A list of PRs participating in the comparison', default='')
     args = parser.parse_args()
@@ -156,6 +170,14 @@ if __name__ == '__main__':
     except:
         pass
 
-    collect_and_compare_files(args.base_dir, args.pr_dir, args.output_dir, args.nprocs, pr_number, args.test_number, args.release_format)
+    release_format = args.release_format
+    if not release_format:
+        try:
+            release_format = os.environ['CMSSW_VERSION']
+        except:
+            print('You are not in a CMSSW release. Please provide a valid release-format (-r option)')
+            os._exit(1)
+
+    collect_and_compare_files(args.base_dir, args.pr_dir, args.output_dir, args.nprocs, pr_number, args.test_number, release_format)
     upload_to_gui(args.output_dir, args.nprocs)
     generate_summary_html(args.output_dir, args.pr_list, args.summary_dir)

--- a/DQMServices/FileIO/scripts/dqm-histo-comparison-summary-template.html
+++ b/DQMServices/FileIO/scripts/dqm-histo-comparison-summary-template.html
@@ -9,7 +9,7 @@
 			font-family: arial, sans-serif;
 		}
 
-		h4, h3, h2 {
+		p, h4, h3, h2 {
 			padding-left: 6px;
 		}
 
@@ -57,11 +57,17 @@
 
 	<h3>URLs for each individual workflow ($NUMBER_OF_WORKFLOWS$):</h3>
 
+	<p><i>Baseline</i>, <i>pull request</i> and <i>overlay</i> links point to the DQM GUI. <br>
+		Some changes in DQM files might not be clearly displayed in the DQM GUI, like presence/absence of efficiency flag or changed QT result when the ME that was tested didn't change. <br>
+		For this reason, you can use <i>raw baseline</i> and <i>raw pull request</i> links to inspect ROOT files without interpreting them as DQM ROOT file.</p>
+
 	<table>
 		<tr>
 			<th>Baseline</th>
 			<th>Pull Request</th>
 			<th>Overlay (PR + base)</th>
+			<th>Raw baseline</th>
+			<th>Raw pull request</th>
 			<th>Removed, added and changed plots</th>
 		</tr>
 $PER_WORKFLOW_LIST$


### PR DESCRIPTION
#### PR description:

Sometimes there are changes to DQM files that are not fully visualised
by the DQM GUI. For example when efficiency flag was added/removed or
when a QT test result changes but the ME that was tested does not. This
change allows to inspect resulting comparison files without treating them as DQM files.

#### PR validation:

PR vas validated locally with the Development DQM GUI.