### PR TITLE
Migrate EventFilter from boost::format to {fmt}

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
@@ -1,32 +1,30 @@
-#include "EventFilter/EcalRawToDigi/interface/MatacqProducer.h"
-#include "EventFilter/EcalRawToDigi/src/Majority.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/FEDRawData/interface/FEDRawData.h"
-#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-#include "DataFormats/EcalDigi/interface/EcalMatacqDigi.h"
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-#include <boost/algorithm/string.hpp>
-#include <boost/format.hpp>
-
+#include <csignal>
+#include <cstdio>
+#include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 
-#include <cstdio>
-
-#include <fstream>
-#include <iomanip>
-
-#include "DataFormats/EcalDigi/interface/EcalMatacqDigi.h"
-
+#include <glob.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <csignal>
-#include <sys/stat.h>
-#include <glob.h>
+
+#include <fmt/printf.h>
+#include <boost/algorithm/string.hpp>
+
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/EcalDigi/interface/EcalMatacqDigi.h"
+#include "DataFormats/EcalDigi/interface/EcalMatacqDigi.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "EventFilter/EcalRawToDigi/interface/MatacqProducer.h"
+#include "EventFilter/EcalRawToDigi/src/Majority.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 using namespace std;
 using namespace boost;
@@ -540,7 +538,7 @@ bool MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId, bool* f
     return false;
 
   const string runNumberFormat = "%08d{,_*}";
-  string sRunNumber = str(boost::format(runNumberFormat) % runNumber);
+  string sRunNumber = fmt::sprintf(runNumberFormat, runNumber);
   //cout << "Run number string: " << sRunNumber << "\n";
   bool found = false;
   string fname;
@@ -1107,7 +1105,7 @@ std::string MatacqProducer::runSubDir(uint32_t runNumber) {
   int millions = runNumber / (1000 * 1000);
   int thousands = (runNumber - millions * 1000 * 1000) / 1000;
   int units = runNumber - millions * 1000 * 1000 - thousands * 1000;
-  return str(boost::format("%03d/%03d/%03d") % millions % thousands % units);
+  return fmt::sprintf("%03d/%03d/%03d", millions, thousands, units);
 }
 
 void MatacqProducer::newRun(int prevRun, int newRun) {

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <sstream>
 
-#include <fmt/printf.h>
+#include <fmt/format.h>
 
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
@@ -136,7 +136,7 @@ namespace sistrip {
 
           //need to construct full object to copy full header
           if (rawfedData.size() == 0)
-            warnings_.add("Invalid raw data for FED, skipping", fmt::sprintf("id %1%", *ifed));
+            warnings_.add("Invalid raw data for FED, skipping", fmt::format("id {0}", *ifed));
           const auto st_buffer = preconstructCheckFEDBuffer(rawfedData, true);
           if (FEDBufferStatusCode::SUCCESS != st_buffer) {
             edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
@@ -150,7 +150,7 @@ namespace sistrip {
                                          << " Could not construct FEDBuffer for FED " << *ifed << std::endl;
           }
           if (fedbuffer.headerType() == sistrip::HEADER_TYPE_INVALID) {
-            warnings_.add("Invalid header type for FED, skipping", fmt::sprintf("id %1%", *ifed));
+            warnings_.add("Invalid header type for FED, skipping", fmt::format("id {0}", *ifed));
             continue;
           }
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -1,19 +1,21 @@
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
-#include "SiStripDigiToRaw.h"
+#include <fmt/printf.h>
+
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
-#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include "FWCore/Utilities/interface/CRC16.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-#include <boost/format.hpp>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/CRC16.h"
+
+#include "SiStripDigiToRaw.h"
 
 namespace sistrip {
 
@@ -134,7 +136,7 @@ namespace sistrip {
 
           //need to construct full object to copy full header
           if (rawfedData.size() == 0)
-            warnings_.add("Invalid raw data for FED, skipping", (boost::format("id %1%") % *ifed).str());
+            warnings_.add("Invalid raw data for FED, skipping", fmt::sprintf("id %1%", *ifed));
           const auto st_buffer = preconstructCheckFEDBuffer(rawfedData, true);
           if (FEDBufferStatusCode::SUCCESS != st_buffer) {
             edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
@@ -148,7 +150,7 @@ namespace sistrip {
                                          << " Could not construct FEDBuffer for FED " << *ifed << std::endl;
           }
           if (fedbuffer.headerType() == sistrip::HEADER_TYPE_INVALID) {
-            warnings_.add("Invalid header type for FED, skipping", (boost::format("id %1%") % *ifed).str());
+            warnings_.add("Invalid header type for FED, skipping", fmt::sprintf("id %1%", *ifed));
             continue;
           }
 


### PR DESCRIPTION
#### PR description:

Migrate from `boost::format` to `fmt::format` or `fmt::sprintf`.
