### PR TITLE
Migrate Simulation from boost::format to {fmt}

### DIFF
--- a/SimG4CMS/Calo/plugins/HitParentTest.cc
+++ b/SimG4CMS/Calo/plugins/HitParentTest.cc
@@ -1,37 +1,33 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
-
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
-#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
-#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "SimG4CMS/Calo/interface/CaloHitID.h"
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include <TH1F.h>
 
-#include <boost/format.hpp>
-#include <algorithm>
-#include <memory>
-#include <iostream>
-#include <fstream>
-#include <vector>
-#include <map>
-#include <string>
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+#include "SimG4CMS/Calo/interface/CaloHitID.h"
 
 class HitParentTest : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
@@ -256,8 +252,8 @@ void HitParentTest::endJob() {
                                     << "(pid/frequency):";
   for (unsigned i = 0; i < sorted_pids.size(); ++i) {
     int pid = sorted_pids[i];
-    edm::LogVerbatim("HitParentTest") << "  pid " << boost::format("%6d") % pid << ": count "
-                                      << boost::format("%6d") % particle_type_count[pid];
+    edm::LogVerbatim("HitParentTest") << "  pid " << std::setw(6) << pid << ": count " << std::setw(6)
+                                      << particle_type_count[pid];
   }
 }
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
@@ -1,38 +1,37 @@
+#include <iomanip>
+#include <iostream>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
-#include <iostream>
-#include <iomanip>
 
-#include "boost/format.hpp"
-
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/ParameterSet/interface/types.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/Math/interface/Vector3D.h"
-#include "DetectorDescription/Core/interface/DDFilteredView.h"
-#include "DetectorDescription/Core/interface/DDCompactView.h"
-#include "DetectorDescription/Core/interface/DDMaterial.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include <fmt/printf.h>
 
 // ROOT
-#include <TROOT.h>
-#include <TProfile2D.h>
-#include <TColor.h>
-#include <TStyle.h>
 #include <TCanvas.h>
+#include <TColor.h>
 #include <TFrame.h>
-#include <TText.h>
 #include <TLegend.h>
 #include <TLegendEntry.h>
 #include <TLine.h>
+#include <TProfile2D.h>
+#include <TROOT.h>
+#include <TStyle.h>
+#include <TText.h>
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/Core/interface/DDFilteredView.h"
+#include "DetectorDescription/Core/interface/DDMaterial.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/types.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include "MaterialAccountingGroup.h"
 #include "TrackingMaterialPlotter.h"
@@ -268,21 +267,20 @@ std::vector<std::pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > > ListGro
     if (eta >= 1.8) {
       lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> >(
           std::make_shared<TLine>(deltaZ.first, deltaZ.first * tan(theta), deltaZ.second, deltaZ.second * tan(theta)),
-          std::make_shared<TText>(deltaZ.first, deltaZ.first * tan(theta), str(boost::format("%2.1f") % eta).c_str())));
+          std::make_shared<TText>(deltaZ.first, deltaZ.first * tan(theta), fmt::sprintf("%2.1f", eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(33);
       lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> >(
           std::make_shared<TLine>(-deltaZ.first, deltaZ.first * tan(theta), -deltaZ.second, deltaZ.second * tan(theta)),
-          std::make_shared<TText>(
-              -deltaZ.first, deltaZ.first * tan(theta), str(boost::format("-%2.1f") % eta).c_str())));
+          std::make_shared<TText>(-deltaZ.first, deltaZ.first * tan(theta), fmt::sprintf("-%2.1f", eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(13);
     } else {
       lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> >(
           std::make_shared<TLine>(deltaR.first / tan(theta), deltaR.first, deltaR.second / tan(theta), deltaR.second),
-          std::make_shared<TText>(deltaR.first / tan(theta), deltaR.first, str(boost::format("%2.1f") % eta).c_str())));
+          std::make_shared<TText>(deltaR.first / tan(theta), deltaR.first, fmt::sprintf("%2.1f", eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(23);
@@ -290,8 +288,7 @@ std::vector<std::pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > > ListGro
         lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> >(
             std::make_shared<TLine>(
                 -deltaR.first / tan(theta), deltaR.first, -deltaR.second / tan(theta), deltaR.second),
-            std::make_shared<TText>(
-                -deltaR.first / tan(theta), deltaR.first, str(boost::format("-%2.1f") % eta).c_str())));
+            std::make_shared<TText>(-deltaR.first / tan(theta), deltaR.first, fmt::sprintf("-%2.1f", eta).c_str())));
         lines.back().second->SetTextFont(42);
         lines.back().second->SetTextSize(text_size);
         lines.back().second->SetTextAlign(23);

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.cc
@@ -6,7 +6,8 @@
 #include <stdexcept>
 #include <cstring>
 #include <cstdlib>
-#include <boost/format.hpp>
+
+#include <fmt/printf.h>
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -77,20 +78,27 @@ void TrackingMaterialAnalyser::saveParameters(const char* name) {
   for (unsigned int i = 0; i < m_groups.size(); ++i) {
     MaterialAccountingGroup& layer = *(m_groups[i]);
     std::cout << layer.name() << std::endl;
-    std::cout << boost::format("\tnumber of hits:               %9d") % layer.tracks() << std::endl;
-    std::cout << boost::format("\tnormalized segment length:    %9.1f ± %9.1f cm") % layer.averageLength() %
-                     layer.sigmaLength()
+    std::cout << fmt::sprintf("\tnumber of hits:               %9d", layer.tracks()) << std::endl;
+    std::cout << fmt::sprintf(
+                     "\tnormalized segment length:    %9.1f ± %9.1f cm", layer.averageLength(), layer.sigmaLength())
               << std::endl;
-    std::cout << boost::format("\tnormalized radiation lengths: %9.3f ± %9.3f") % layer.averageRadiationLengths() %
-                     layer.sigmaRadiationLengths()
+    std::cout << fmt::sprintf("\tnormalized radiation lengths: %9.3f ± %9.3f",
+                              layer.averageRadiationLengths(),
+                              layer.sigmaRadiationLengths())
               << std::endl;
-    std::cout << boost::format("\tnormalized energy loss:       %6.5fe-03 ± %6.5fe-03 GeV") %
-                     layer.averageEnergyLoss() % layer.sigmaEnergyLoss()
+    std::cout << fmt::sprintf("\tnormalized energy loss:       %6.5fe-03 ± %6.5fe-03 GeV",
+                              layer.averageEnergyLoss(),
+                              layer.sigmaEnergyLoss())
               << std::endl;
-    parameters << boost::format("%-20s\t%7d\t%5.1f ± %5.1f cm\t%6.4f ± %6.4f \t%6.4fe-03 ± %6.4fe-03 GeV") %
-                      layer.name() % layer.tracks() % layer.averageLength() % layer.sigmaLength() %
-                      layer.averageRadiationLengths() % layer.sigmaRadiationLengths() % layer.averageEnergyLoss() %
-                      layer.sigmaEnergyLoss()
+    parameters << fmt::sprintf("%-20s\t%7d\t%5.1f ± %5.1f cm\t%6.4f ± %6.4f \t%6.4fe-03 ± %6.4fe-03 GeV",
+                               layer.name(),
+                               layer.tracks(),
+                               layer.averageLength(),
+                               layer.sigmaLength(),
+                               layer.averageRadiationLengths(),
+                               layer.sigmaRadiationLengths(),
+                               layer.averageEnergyLoss(),
+                               layer.sigmaEnergyLoss())
                << std::endl;
   }
   std::cout << std::endl;

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_ListGroups.cc
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <iomanip>
 
-#include "boost/format.hpp"
+#include <fmt/printf.h>
 
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -336,21 +336,20 @@ std::vector<std::pair<std::shared_ptr<TLine>, std::shared_ptr<TText>>> DD4hep_Li
     if (eta >= 1.8) {
       lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText>>(
           std::make_shared<TLine>(deltaZ.first, deltaZ.first * tan(theta), deltaZ.second, deltaZ.second * tan(theta)),
-          std::make_shared<TText>(deltaZ.first, deltaZ.first * tan(theta), str(boost::format("%2.1f") % eta).c_str())));
+          std::make_shared<TText>(deltaZ.first, deltaZ.first * tan(theta), fmt::sprintf("%2.1f", eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(33);
       lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText>>(
           std::make_shared<TLine>(-deltaZ.first, deltaZ.first * tan(theta), -deltaZ.second, deltaZ.second * tan(theta)),
-          std::make_shared<TText>(
-              -deltaZ.first, deltaZ.first * tan(theta), str(boost::format("-%2.1f") % eta).c_str())));
+          std::make_shared<TText>(-deltaZ.first, deltaZ.first * tan(theta), fmt::sprintf("-%2.1f", eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(13);
     } else {
       lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText>>(
           std::make_shared<TLine>(deltaR.first / tan(theta), deltaR.first, deltaR.second / tan(theta), deltaR.second),
-          std::make_shared<TText>(deltaR.first / tan(theta), deltaR.first, str(boost::format("%2.1f") % eta).c_str())));
+          std::make_shared<TText>(deltaR.first / tan(theta), deltaR.first, fmt::sprintf("%2.1f", eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(23);
@@ -358,8 +357,7 @@ std::vector<std::pair<std::shared_ptr<TLine>, std::shared_ptr<TText>>> DD4hep_Li
         lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText>>(
             std::make_shared<TLine>(
                 -deltaR.first / tan(theta), deltaR.first, -deltaR.second / tan(theta), deltaR.second),
-            std::make_shared<TText>(
-                -deltaR.first / tan(theta), deltaR.first, str(boost::format("-%2.1f") % eta).c_str())));
+            std::make_shared<TText>(-deltaR.first / tan(theta), deltaR.first, fmt::sprintf("-%2.1f", eta).c_str())));
         lines.back().second->SetTextFont(42);
         lines.back().second->SetTextSize(text_size);
         lines.back().second->SetTextAlign(23);

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_TrackingMaterialAnalyser.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_TrackingMaterialAnalyser.cc
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <cstring>
 #include <cstdlib>
-#include <boost/format.hpp>
+#include <fmt/printf.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -77,25 +77,32 @@ void DD4hep_TrackingMaterialAnalyser::saveParameters(const char* name) {
     DD4hep_MaterialAccountingGroup& layer = *(m_groups[i]);
     edm::LogVerbatim("TrackerMaterialAnalysis") << "TrackingMaterialAnalyser" << layer.name() << std::endl;
     edm::LogVerbatim("TrackerMaterialAnalysis")
-        << "TrackingMaterialAnalyser" << boost::format("\tnumber of hits:               %9d") % layer.tracks()
+        << "TrackingMaterialAnalyser" << fmt::sprintf("\tnumber of hits:               %9d", layer.tracks())
+        << std::endl;
+    edm::LogVerbatim("TrackerMaterialAnalysis")
+        << "TrackingMaterialAnalyser"
+        << fmt::sprintf("\tnormalized segment length:    %9.1f ± %9.1f cm", layer.averageLength(), layer.sigmaLength())
         << std::endl;
     edm::LogVerbatim("TrackerMaterialAnalysis") << "TrackingMaterialAnalyser"
-                                                << boost::format("\tnormalized segment length:    %9.1f ± %9.1f cm") %
-                                                       layer.averageLength() % layer.sigmaLength()
-                                                << std::endl;
-    edm::LogVerbatim("TrackerMaterialAnalysis") << "TrackingMaterialAnalyser"
-                                                << boost::format("\tnormalized radiation lengths: %9.3f ± %9.3f") %
-                                                       layer.averageRadiationLengths() % layer.sigmaRadiationLengths()
+                                                << fmt::sprintf("\tnormalized radiation lengths: %9.3f ± %9.3f",
+                                                                layer.averageRadiationLengths(),
+                                                                layer.sigmaRadiationLengths())
                                                 << std::endl;
     edm::LogVerbatim("TrackerMaterialAnalysis")
         << "TrackingMaterialAnalyser"
-        << boost::format("\tnormalized energy loss:       %6.5fe-03 ± %6.5fe-03 GeV") % layer.averageEnergyLoss() %
-               layer.sigmaEnergyLoss()
+        << fmt::sprintf("\tnormalized energy loss:       %6.5fe-03 ± %6.5fe-03 GeV",
+                        layer.averageEnergyLoss(),
+                        layer.sigmaEnergyLoss())
         << std::endl;
-    parameters << boost::format("%-20s\t%7d\t%5.1f ± %5.1f cm\t%6.4f ± %6.4f \t%6.4fe-03 ± %6.4fe-03 GeV") %
-                      layer.name() % layer.tracks() % layer.averageLength() % layer.sigmaLength() %
-                      layer.averageRadiationLengths() % layer.sigmaRadiationLengths() % layer.averageEnergyLoss() %
-                      layer.sigmaEnergyLoss()
+    parameters << fmt::sprintf("%-20s\t%7d\t%5.1f ± %5.1f cm\t%6.4f ± %6.4f \t%6.4fe-03 ± %6.4fe-03 GeV",
+                               layer.name(),
+                               layer.tracks(),
+                               layer.averageLength(),
+                               layer.sigmaLength(),
+                               layer.averageRadiationLengths(),
+                               layer.sigmaRadiationLengths(),
+                               layer.averageEnergyLoss(),
+                               layer.sigmaEnergyLoss())
                << std::endl;
   }
   edm::LogVerbatim("TrackerMaterialAnalysis") << "TrackingMaterialAnalyser" << std::endl;


### PR DESCRIPTION
#### PR description:

Migrate from `boost::format` to `fmt::sprintf`.
