### PR TITLE
Add --nStreams option in runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -57,6 +57,9 @@ class MatrixInjector(object):
         self.memoryOffset = opt.memoryOffset
         self.memPerCore = opt.memPerCore
         self.numberEventsInLuminosityBlock = opt.numberEventsInLuminosityBlock
+        self.numberOfStreams = 0
+        if(opt.nStreams>0):
+            self.numberOfStreams = opt.nStreams
         self.batchName = ''
         self.batchTime = str(int(time.time()))
         if(opt.batchName):
@@ -138,6 +141,7 @@ class MatrixInjector(object):
             "PrimaryDataset" : None,                          #Primary Dataset to be created
             "nowmIO": {},
             "Multicore" : opt.nThreads,                  # this is the per-taskchain Multicore; it's the default assigned to a task if it has no value specified 
+            "EventStreams": self.numberOfStreams,
             "KeepOutput" : False
             }
         self.defaultInput={
@@ -149,6 +153,7 @@ class MatrixInjector(object):
             "LumisPerJob" : 10,               #Size of jobs in terms of splitting algorithm
             "nowmIO": {},
             "Multicore" : opt.nThreads,                       # this is the per-taskchain Multicore; it's the default assigned to a task if it has no value specified 
+            "EventStreams": self.numberOfStreams,
             "KeepOutput" : False
             }
         self.defaultTask={
@@ -161,6 +166,7 @@ class MatrixInjector(object):
             "LumisPerJob" : 10,               #Size of jobs in terms of splitting algorithm
             "nowmIO": {},
             "Multicore" : opt.nThreads,                       # this is the per-taskchain Multicore; it's the default assigned to a task if it has no value specified 
+            "EventStreams": self.numberOfStreams,
             "KeepOutput" : False
             }
 

--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -59,7 +59,7 @@ class MatrixRunner(object):
 
             print('\nPreparing to run %s %s' % (wf.numId, item))
             sys.stdout.flush()
-            current = WorkFlowRunner(wf,noRun,dryRun,cafVeto, opt.dasOptions, opt.jobReports, opt.nThreads, opt.maxSteps)
+            current = WorkFlowRunner(wf,noRun,dryRun,cafVeto, opt.dasOptions, opt.jobReports, opt.nThreads, opt.nStreams, opt.maxSteps)
             self.threadList.append(current)
             current.start()
             if not dryRun:

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -8,7 +8,7 @@ from os.path import exists, basename, join
 from datetime import datetime
 
 class WorkFlowRunner(Thread):
-    def __init__(self, wf, noRun=False,dryRun=False,cafVeto=True,dasOptions="",jobReport=False, nThreads=1, maxSteps=9999):
+    def __init__(self, wf, noRun=False,dryRun=False,cafVeto=True,dasOptions="",jobReport=False, nThreads=1, nStreams=0, maxSteps=9999):
         Thread.__init__(self)
         self.wf = wf
 
@@ -22,7 +22,8 @@ class WorkFlowRunner(Thread):
         self.dasOptions=dasOptions
         self.jobReport=jobReport
         self.nThreads=nThreads
-        self.maxSteps = maxSteps
+        self.nStreams=nStreams
+        self.maxSteps=maxSteps
         
         self.wfDir=str(self.wf.numId)+'_'+self.wf.nameId
         return
@@ -163,6 +164,8 @@ class WorkFlowRunner(Thread):
                   cmd += ' --suffix "-j JobReport%s.xml " ' % istep
                 if (self.nThreads > 1) and ('HARVESTING' not in cmd) and ('ALCAHARVEST' not in cmd):
                   cmd += ' --nThreads %s' % self.nThreads
+                if (self.nStreams > 0) and ('HARVESTING' not in cmd) and ('ALCAHARVEST' not in cmd):
+                  cmd += ' --nStreams %s' % self.nStreams
                 cmd+=closeCmd(istep,self.wf.nameId)            
                 retStep = 0
                 if istep>self.maxSteps:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -127,6 +127,11 @@ if __name__ == '__main__':
                       dest='nThreads',
                       default=1
                      )
+    parser.add_option('--nStreams',
+                      help='number of streams to use in cmsRun.',
+                      dest='nStreams',
+                      default=0
+                     )
     parser.add_option('--numberEventsInLuminosityBlock',
                       help='number of events in a luminosity block',
                       dest='numberEventsInLuminosityBlock',
@@ -340,6 +345,7 @@ if __name__ == '__main__':
     if opt.fromScratch: opt.fromScratch = opt.fromScratch.split(',')
     if opt.nProcs: opt.nProcs=int(opt.nProcs)
     if opt.nThreads: opt.nThreads=int(opt.nThreads)
+    if opt.nStreams: opt.nStreams=int(opt.nStreams)
     if (opt.numberEventsInLuminosityBlock): opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
     if (opt.memoryOffset): opt.memoryOffset=int(opt.memoryOffset)
     if (opt.memPerCore): opt.memPerCore=int(opt.memPerCore)


### PR DESCRIPTION
#### PR description:
Enable "--nStreams" option to runTheMatrix, and add "EventStreams" to the relvals workflow.

#### PR validation:
Test with runTheMatrix command, the workflow looks OK.
runTheMatrix.py --what upgrade -l 23234.21 -t 8 -m 5400 --nStreams 0 --wm init
runTheMatrix.py --what upgrade -l 23234.21 -t 8 -m 5400 --nStreams 4 --wm init
runTheMatrix.py --what upgrade -l 23234.21 -t 8 -m 5400 --wm init

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Maybe 11_1, but we can use dirty fix for prod-like HLTTDR relvals for now (as urgent need)
