### PR TITLE
Memory efficient implementation of timing information for HGCDigitizer module for Premix Workflow.

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -153,6 +153,7 @@ private:
   static const unsigned int thisBx_ = 9;
   std::vector<float> cce_;
   std::unordered_map<uint32_t, std::vector<std::pair<float, float> > > hitRefs_bx0;
+  std::unordered_map<uint32_t, std::vector<std::tuple<float, float, float> > > PhitRefs_bx0;
   std::unordered_map<uint32_t, bool> hitOrder_monitor;
 };
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -25,8 +25,9 @@
 //#define EDM_ML_DEBUG
 using namespace std;
 using namespace hgc_digi;
+
 typedef std::vector<std::pair<float, float>>::iterator itr;
-typedef std::map<uint32_t, std::vector<std::pair<float, float>>> IdHit_Map;
+typedef std::unordered_map<uint32_t, std::vector<std::pair<float, float>>> IdHit_Map;
 typedef std::tuple<float, float, float> hit_timeStamp;
 typedef std::unordered_map<uint32_t, std::vector<hit_timeStamp>> hitRec_container;
 typedef std::vector<hit_timeStamp>::iterator hitRec_itr;
@@ -147,8 +148,6 @@ namespace {
     simResult.shrink_to_fit();
   }
 
-  typedef std::vector<std::pair<float, float>>::iterator itr;
-  typedef std::unordered_map<uint32_t, std::vector<std::pair<float, float>>> IdHit_Map;
   template <typename GEOM>
   void loadSimHitAccumulator_forPreMix(hgc::HGCSimHitDataAccumulator& simData,
                                        hgc::HGCPUSimHitDataAccumulator& PUSimData,
@@ -416,15 +415,6 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
   }
 
   hgc::HGCSimHitDataAccumulator().swap(*simHitAccumulator_);
-
-  if (pusimHitAccumulator_->size() > 1) {
-    for (const auto itr : *pusimHitAccumulator_) {
-      auto stuff = itr.second.PUhit_info;
-      auto charge_series = stuff[0][9];
-      auto time_series = stuff[1][9];
-    }
-  }
-
   hgc::HGCPUSimHitDataAccumulator().swap(*pusimHitAccumulator_);
 }
 void HGCDigitizer::accumulate_forPreMix(edm::Event const& e,

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -27,6 +27,11 @@ using namespace std;
 using namespace hgc_digi;
 typedef std::vector<std::pair<float, float>>::iterator itr;
 typedef std::map<uint32_t, std::vector<std::pair<float, float>>> IdHit_Map;
+typedef std::tuple<float, float, float> hit_timeStamp;
+typedef std::unordered_map<uint32_t, std::vector<hit_timeStamp > > hitRec_container;
+typedef std::vector<hit_timeStamp >::iterator hitRec_itr;
+
+
 namespace {
 
   constexpr std::array<double, 4> occupancyGuesses = {{0.5, 0.2, 0.2, 0.8}};
@@ -338,7 +343,9 @@ void HGCDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& e
 //
 void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP::HepRandomEngine* hre) {
   hitRefs_bx0.clear();
+  PhitRefs_bx0.clear();
   hitOrder_monitor.clear();
+
   const CaloSubdetectorGeometry* theGeom = (nullptr == gHGCal_ ? static_cast<const CaloSubdetectorGeometry*>(gHcal_)
                                                                : static_cast<const CaloSubdetectorGeometry*>(gHGCal_));
 
@@ -353,17 +360,18 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
   //update occupancy guess
   const double thisOcc = simHitAccumulator_->size() / ((double)validIds_.size());
   averageOccupancies_[idx] = (averageOccupancies_[idx] * (nEvents_ - 1) + thisOcc) / nEvents_;
-
+  
   if (premixStage1_) {
     auto simRecord = std::make_unique<PHGCSimAccumulator>();
 
     if (!pusimHitAccumulator_->empty()) {
+      
       saveSimHitAccumulator_forPreMix(
           *simRecord, *pusimHitAccumulator_, validIds_, premixStage1MinCharge_, premixStage1MaxCharge_);
     }
-
+    
     e.put(std::move(simRecord), digiCollection());
-
+    
   } else {
     if (producesEEDigis()) {
       auto digiResult = std::make_unique<HGCalDigiCollection>();
@@ -408,14 +416,28 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
       e.put(std::move(digiResult), digiCollection());
     }
   }
-
+  
   hgc::HGCSimHitDataAccumulator().swap(*simHitAccumulator_);
+  
+  if (pusimHitAccumulator_->size() > 1) {
+    
+    for(const auto itr : *pusimHitAccumulator_) {
+      auto stuff = itr.second.PUhit_info;
+      auto charge_series = stuff[0][9];
+      auto time_series   = stuff[1][9];
+      
+    }
+
+  }
+    
   hgc::HGCPUSimHitDataAccumulator().swap(*pusimHitAccumulator_);
+  
 }
 void HGCDigitizer::accumulate_forPreMix(edm::Event const& e,
                                         edm::EventSetup const& eventSetup,
                                         CLHEP::HepRandomEngine* hre) {
   //get inputs
+  
   edm::Handle<edm::PCaloHitContainer> hits;
   e.getByLabel(edm::InputTag("g4SimHits", hitCollection_), hits);
   if (!hits.isValid()) {
@@ -458,6 +480,7 @@ void HGCDigitizer::accumulate(edm::Event const& e, edm::EventSetup const& eventS
 void HGCDigitizer::accumulate_forPreMix(PileUpEventPrincipal const& e,
                                         edm::EventSetup const& eventSetup,
                                         CLHEP::HepRandomEngine* hre) {
+  
   edm::Handle<edm::PCaloHitContainer> hits;
   e.getByLabel(edm::InputTag("g4SimHits", hitCollection_), hits);
 
@@ -506,11 +529,13 @@ void HGCDigitizer::accumulate_forPreMix(edm::Handle<edm::PCaloHitContainer> cons
                                         CLHEP::HepRandomEngine* hre) {
   if (nullptr == geom)
     return;
-
+  
   float keV2fC(0.f);
-
+  //configuration to apply for the computation of time-of-flight
+  std::array<float, 3> tdcForToAOnset{{0.f, 0.f, 0.f}};
+  
   int nchits = (int)hits->size();
-
+  int count_thisbx = 0;
   std::vector<HGCCaloHitTuple_t> hitRefs;
   hitRefs.reserve(nchits);
   for (int i = 0; i < nchits; ++i) {
@@ -530,7 +555,7 @@ void HGCDigitizer::accumulate_forPreMix(edm::Handle<edm::PCaloHitContainer> cons
     if (!validIds_.count(id))
       continue;
 
-    HGCPUSimHitDataAccumulator::iterator simHitIt = pusimHitAccumulator_->emplace(id, HGCCellHitInfo()).first;
+    
     if (id == 0)
       continue;
 
@@ -545,17 +570,87 @@ void HGCDigitizer::accumulate_forPreMix(edm::Handle<edm::PCaloHitContainer> cons
     if (itime < 0 || itime > (int)maxBx_)
       continue;
 
-    if (itime >= (int)simHitIt->second.PUhit_info[0].size())
+    if (itime >= (int)(maxBx_+1))
       continue;
-    (simHitIt->second).PUhit_info[1][itime].push_back(tof);
-    (simHitIt->second).PUhit_info[0][itime].push_back(charge);
+    
+    int waferThickness = getCellThickness(geom, id);
+    if (itime == (int)thisBx_) {
+      ++count_thisbx;
+      if(PhitRefs_bx0[id].empty()){
+	PhitRefs_bx0[id].emplace_back(charge, charge, tof);
+      }
+      else if(tof > std::get<2>(PhitRefs_bx0[id].back())){
+	PhitRefs_bx0[id].emplace_back(charge, charge + std::get<1>(PhitRefs_bx0[id].back()), tof);
+      }
+      else if(tof == std::get<2>(PhitRefs_bx0[id].back())){
+	
+	std::get<0>(PhitRefs_bx0[id].back()) += charge;
+	std::get<1>(PhitRefs_bx0[id].back()) += charge;
+      }
+      else{
+	//find position to insert new entry preserving time sorting
+	hitRec_itr findPos =
+	  std::upper_bound(PhitRefs_bx0[id].begin(),
+			   PhitRefs_bx0[id].end(),
+			   hit_timeStamp(charge, 0.f, tof),
+			   [](const auto& i, const auto& j) { return std::get<2>(i) <= std::get<2>(j); });
+	
+	hitRec_itr insertedPos = findPos;
+	
+	if(tof == std::get<2>(*(findPos-1))){
+	  
+	  std::get<0>(*(findPos-1)) += charge;
+	  std::get<1>(*(findPos-1)) += charge;
+
+	}
+	else {
+	  insertedPos = PhitRefs_bx0[id].insert(findPos,
+						(findPos == PhitRefs_bx0[id].begin())
+						? hit_timeStamp(charge, charge, tof)
+						: hit_timeStamp(charge, charge + std::get<1>(*(findPos-1)), tof));
+	
+	}
+	//cumulate the charge of new entry for all elements that follow in the sorted list                                         
+	//and resize list accounting for cases when the inserted element itself crosses the threshold 
+	
+	for (hitRec_itr step = insertedPos; step != PhitRefs_bx0[id].end(); ++step) {
+	  if (step != insertedPos)
+	    std::get<1>(*(step)) += charge;
+
+	  // resize the list stopping with the first timeStamp with cumulative charge above threshold
+	  if (std::get<1>(*step) > tdcForToAOnset[waferThickness - 1] && 
+	      std::get<2>(*step) != std::get<2>(PhitRefs_bx0[id].back())) {
+	    PhitRefs_bx0[id].resize(std::upper_bound(PhitRefs_bx0[id].begin(),
+						     PhitRefs_bx0[id].end(),
+						     hit_timeStamp(charge, 0.f, std::get<2>(*step)),
+						     [](const auto& i, const auto& j) { return std::get<2>(i) < std::get<2>(j); }) -
+				    PhitRefs_bx0[id].begin());
+	    for (auto stepEnd = step + 1; stepEnd != PhitRefs_bx0[id].end(); ++stepEnd)
+	      std::get<1>(*stepEnd) += charge;
+	    break;
+	  }
+	}
+      }
+    }
   }
+  
+  for(const auto& hitCollection : PhitRefs_bx0){
+    const uint32_t detectorId = hitCollection.first;
+    auto simHitIt = pusimHitAccumulator_->emplace(detectorId, HGCCellHitInfo()).first;
+    
+    for(const auto& hit_timestamp: PhitRefs_bx0[detectorId]){
+      (simHitIt->second).PUhit_info[1][thisBx_].push_back(std::get<2>(hit_timestamp));
+      (simHitIt->second).PUhit_info[0][thisBx_].push_back(std::get<0>(hit_timestamp));
+    }
+  }
+  
   if (nchits == 0) {
     HGCPUSimHitDataAccumulator::iterator simHitIt = pusimHitAccumulator_->emplace(0, HGCCellHitInfo()).first;
     (simHitIt->second).PUhit_info[1][9].push_back(0.0);
     (simHitIt->second).PUhit_info[0][9].push_back(0.0);
   }
   hitRefs.clear();
+  PhitRefs_bx0.clear();
 }
 
 //


### PR DESCRIPTION
#### PR description:

<The HGCDigitizer module, in it's current form, store timing information of all the incoming hits from the minbias events  in PreMixStage1 of the Premix Workflow. This PR aims to drop the timing information from redundant hits from the minbias events, once a HGCal cell reaches it's fire-off threshold of accumulated charge. 

I found the PR to improve the performance of the code in terms of CPU performance, reduced memory and disk usage. The quantitative figures are mentioned below -
**CPU Performance -** 
For BaseLine Igprof summary, I got the following

       88.1  ...............  211'531'179'858 / 211'531'179'858    1'008'942'599 / 1'008'942'599      edm::BMixingModule::produce(edm::Event&, edm::EventSetup const&) [16]
        2.3  ...............    5'484'689'754 / 5'484'689'754             13'591 / 13'591             edm::PoolOutputModule::write(edm::EventForOutput const&) [201]

###############################################################################
And for the new Premix method, I got

       80.8  ...............  109'380'472'943 / 109'380'472'943      957'052'716 / 957'052'716        edm::BMixingModule::produce(edm::Event&, edm::EventSetup const&) [16]
        2.2  ...............    2'970'142'735 / 2'970'142'735             11'298 / 11'298             edm::PoolOutputModule::write(edm::EventForOutput const&) [280]

**Disk Usage -**

PHGCSimAccumulator_simHGCalUnsuppressedDigis_EE_DIGI. 2.57756e+08 4.29255e+06
PHGCSimAccumulator_simHGCalUnsuppressedDigis_HEfront_DIGI. 3.5771e+07 621998
PHGCSimAccumulator_simHGCalUnsuppressedDigis_HEback_DIGI. 7.30215e+06 119472

For my new method, disk usage

PHGCSimAccumulator_simHGCalUnsuppressedDigis_EE_DIGI. 6.85587e+07 4.08996e+06
PHGCSimAccumulator_simHGCalUnsuppressedDigis_HEfront_DIGI. 6.34798e+06 333652
PHGCSimAccumulator_simHGCalUnsuppressedDigis_HEback_DIGI. 760055 51035.3

**MemoryInfo-**

FOr the addPileup method, the new proposed procedure uses almost an order of magnitude less memory(as shown in the attached screenshot; Black background screenshot- Baseline method, White background screenshot- My new method
<img width="772" alt="BaseLine" src="https://user-images.githubusercontent.com/29214321/88804940-94c04580-d17c-11ea-9eb0-8fc652776699.png">
<img width="774" alt="NewPreMix" src="https://user-images.githubusercontent.com/29214321/88804951-97229f80-d17c-11ea-8639-f352963bc58c.png">

)



 >

#### PR validation:

<I ran a validation test by comparing results from WorkFlow # 20634.0(standard mix) and # 20634.99(premix) using custom validation package here - https://github.com/amartelli/HGCTimingAnalysis/tree/TimingAnalysis_11_1_X >


