### PR TITLE
Fix AssociationMap initialization for TrackAssociatorByChi2

### DIFF
--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.cc
@@ -22,7 +22,7 @@ RecoToSimCollection TrackAssociatorByChi2Impl::associateRecoToSim(
     const edm::RefToBaseVector<reco::Track>& tC, const edm::RefVector<TrackingParticleCollection>& tPCH) const {
   const reco::BeamSpot& bs = *theBeamSpot;
 
-  RecoToSimCollection outputCollection;
+  RecoToSimCollection outputCollection(productGetter_);
 
   //dereference the edm::Refs only once
   std::vector<TrackingParticle const*> tPC;

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
@@ -22,7 +22,7 @@
 //Note that the Association Map is filled with -ch2 and not chi2 because it is ordered using std::greater:
 //the track with the lowest association chi2 will be the first in the output map.
 
-namespace edm {  
+namespace edm {
   class EDProductGetter;
 }
 
@@ -56,11 +56,11 @@ public:
   */
 
   /// Constructor
-  TrackAssociatorByChi2Impl(edm::EDProductGetter const& productGetter, 
-			    const MagneticField& mF, 
-			    const reco::BeamSpot& bs, 
-			    double chi2Cut, 
-			    bool onlyDiag)
+  TrackAssociatorByChi2Impl(edm::EDProductGetter const& productGetter,
+                            const MagneticField& mF,
+                            const reco::BeamSpot& bs,
+                            double chi2Cut,
+                            bool onlyDiag)
       : productGetter_(&productGetter), theMF(&mF), theBeamSpot(&bs), chi2cut(chi2Cut), onlyDiagonal(onlyDiag) {}
 
   /// Association Reco To Sim with Collections

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
@@ -22,6 +22,11 @@
 //Note that the Association Map is filled with -ch2 and not chi2 because it is ordered using std::greater:
 //the track with the lowest association chi2 will be the first in the output map.
 
+namespace edm
+{  
+   class EDProductGetter;
+}
+
 namespace reco {
   typedef edm::AssociationMap<
       edm::OneToManyWithQualityGeneric<reco::GenParticleCollection, edm::View<reco::Track>, double> >
@@ -52,8 +57,8 @@ public:
   */
 
   /// Constructor
-  TrackAssociatorByChi2Impl(const MagneticField& mF, const reco::BeamSpot& bs, double chi2Cut, bool onlyDiag)
-      : theMF(&mF), theBeamSpot(&bs), chi2cut(chi2Cut), onlyDiagonal(onlyDiag) {}
+  TrackAssociatorByChi2Impl(edm::EDProductGetter const& productGetter, const MagneticField& mF, const reco::BeamSpot& bs, double chi2Cut, bool onlyDiag)
+      : productGetter_(&productGetter), theMF(&mF), theBeamSpot(&bs), chi2cut(chi2Cut), onlyDiagonal(onlyDiag) {}
 
   /// Association Reco To Sim with Collections
 
@@ -87,6 +92,7 @@ private:
                  int charge,
                  const reco::BeamSpot&) const;
 
+  edm::EDProductGetter const* productGetter_;
   const MagneticField* theMF;
   const reco::BeamSpot* theBeamSpot;
   double chi2cut;

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
@@ -22,9 +22,8 @@
 //Note that the Association Map is filled with -ch2 and not chi2 because it is ordered using std::greater:
 //the track with the lowest association chi2 will be the first in the output map.
 
-namespace edm
-{  
-   class EDProductGetter;
+namespace edm {  
+  class EDProductGetter;
 }
 
 namespace reco {
@@ -57,7 +56,11 @@ public:
   */
 
   /// Constructor
-  TrackAssociatorByChi2Impl(edm::EDProductGetter const& productGetter, const MagneticField& mF, const reco::BeamSpot& bs, double chi2Cut, bool onlyDiag)
+  TrackAssociatorByChi2Impl(edm::EDProductGetter const& productGetter, 
+			    const MagneticField& mF, 
+			    const reco::BeamSpot& bs, 
+			    double chi2Cut, 
+			    bool onlyDiag)
       : productGetter_(&productGetter), theMF(&mF), theBeamSpot(&bs), chi2cut(chi2Cut), onlyDiagonal(onlyDiag) {}
 
   /// Association Reco To Sim with Collections

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Producer.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Producer.cc
@@ -99,7 +99,7 @@ void TrackAssociatorByChi2Producer::produce(edm::StreamID, edm::Event& iEvent, c
 
   {
     std::unique_ptr<reco::TrackToTrackingParticleAssociatorBaseImpl> impl(
-        new TrackAssociatorByChi2Impl(*magField, *beamSpot, chi2cut_, onlyDiagonal_));
+        new TrackAssociatorByChi2Impl(iEvent.productGetter(), *magField, *beamSpot, chi2cut_, onlyDiagonal_));
 
     std::unique_ptr<reco::TrackToTrackingParticleAssociator> assoc(
         new reco::TrackToTrackingParticleAssociator(std::move(impl)));


### PR DESCRIPTION
This update fixes the following error when running the associateRecoToSim method of the TrackAssociatorByChi2 associator:

Can't insert into AssociationMap unless it was properly initialized.
The most common fix for this is to add arguments to the call to the
AssociationMap constructor that are valid Handle's to the containers.
If you don't have valid handles or either template parameter to the
AssociationMap is a View, then see the comments in AssociationMap.h.
(note this was a new requirement added in the 7_5_X release series)

