### PR TITLE
Removed use of boost::mpl::vector for dependent Records

### DIFF
--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h
@@ -5,7 +5,7 @@
 #ifndef ECALLASERCORRECTION_ECALLASERDBRECORD_H
 #define ECALLASERCORRECTION_ECALLASERDBRECORD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 // #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
@@ -18,9 +18,9 @@
 
 class EcalLaserDbRecord
     : public edm::eventsetup::DependentRecordImplementation<EcalLaserDbRecord,
-                                                            boost::mpl::vector<EcalLaserAlphasRcd,
-                                                                               EcalLaserAPDPNRatiosRefRcd,
-                                                                               EcalLaserAPDPNRatiosRcd,
-                                                                               EcalLinearCorrectionsRcd> > {};
+                                                            edm::mpl::Vector<EcalLaserAlphasRcd,
+                                                                             EcalLaserAPDPNRatiosRefRcd,
+                                                                             EcalLaserAPDPNRatiosRcd,
+                                                                             EcalLinearCorrectionsRcd> > {};
 
 #endif /* ECALLASERCORRECTION_ECALLASERDBRECORD_H */

--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h
@@ -5,7 +5,7 @@
 #ifndef ECALLASERCORRECTION_ECALLASERDBRECORDMC_H
 #define ECALLASERCORRECTION_ECALLASERDBRECORDMC_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 #include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
@@ -15,9 +15,9 @@
 
 class EcalLaserDbRecordMC
     : public edm::eventsetup::DependentRecordImplementation<EcalLaserDbRecordMC,
-                                                            boost::mpl::vector<EcalLaserAlphasRcd,
-                                                                               EcalLaserAPDPNRatiosRefRcd,
-                                                                               EcalLaserAPDPNRatiosMCRcd,
-                                                                               EcalLinearCorrectionsRcd> > {};
+                                                            edm::mpl::Vector<EcalLaserAlphasRcd,
+                                                                             EcalLaserAPDPNRatiosRefRcd,
+                                                                             EcalLaserAPDPNRatiosMCRcd,
+                                                                             EcalLinearCorrectionsRcd> > {};
 
 #endif /* ECALLASERCORRECTION_ECALLASERDBRECORDMC_H */

--- a/CalibFormats/CaloTPG/interface/CaloTPGRecord.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGRecord.h
@@ -25,7 +25,7 @@
 
 class CaloTPGRecord
     : public edm::eventsetup::DependentRecordImplementation<CaloTPGRecord,
-                                                            boost::mpl::vector<HcalLutMetadataRcd, CaloGeometryRecord> > {
+                                                            edm::mpl::Vector<HcalLutMetadataRcd, CaloGeometryRecord> > {
 };
 
 #endif

--- a/CalibFormats/CastorObjects/interface/CastorDbRecord.h
+++ b/CalibFormats/CastorObjects/interface/CastorDbRecord.h
@@ -13,7 +13,7 @@
     <usage>
 */
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 // #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
@@ -28,12 +28,12 @@
 
 class CastorDbRecord
     : public edm::eventsetup::DependentRecordImplementation<CastorDbRecord,
-                                                            boost::mpl::vector<CastorPedestalsRcd,
-                                                                               CastorPedestalWidthsRcd,
-                                                                               CastorGainsRcd,
-                                                                               CastorGainWidthsRcd,
-                                                                               CastorQIEDataRcd,
-                                                                               CastorChannelQualityRcd,
-                                                                               CastorElectronicsMapRcd> > {};
+                                                            edm::mpl::Vector<CastorPedestalsRcd,
+                                                                             CastorPedestalWidthsRcd,
+                                                                             CastorGainsRcd,
+                                                                             CastorGainWidthsRcd,
+                                                                             CastorQIEDataRcd,
+                                                                             CastorChannelQualityRcd,
+                                                                             CastorElectronicsMapRcd> > {};
 
 #endif /* CASTORDBPRODUCER_CASTORDBRECORD_H */

--- a/CalibFormats/CastorObjects/interface/CastorTPGRecord.h
+++ b/CalibFormats/CastorObjects/interface/CastorTPGRecord.h
@@ -14,6 +14,6 @@
 #include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
 
 class CastorTPGRecord
-    : public edm::eventsetup::DependentRecordImplementation<CastorTPGRecord, boost::mpl::vector<CastorDbRecord> > {};
+    : public edm::eventsetup::DependentRecordImplementation<CastorTPGRecord, edm::mpl::Vector<CastorDbRecord> > {};
 
 #endif

--- a/CalibFormats/HcalObjects/interface/HcalDbRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbRecord.h
@@ -17,7 +17,7 @@
 // Author:
 // Created:     Tue Aug  9 19:10:36 CDT 2005
 //
-#include "boost/mpl/vector/vector30.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 // #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
@@ -27,32 +27,31 @@
 
 // class HcalDbRecord : public edm::eventsetup::EventSetupRecordImplementation<HcalDbRecord> {};
 
-class HcalDbRecord
-    : public edm::eventsetup::DependentRecordImplementation<HcalDbRecord,
-                                                            boost::mpl::vector25<HcalRecNumberingRecord,
-                                                                                 IdealGeometryRecord,
-                                                                                 HcalPedestalsRcd,
-                                                                                 HcalPedestalWidthsRcd,
-                                                                                 HcalGainsRcd,
-                                                                                 HcalGainWidthsRcd,
-                                                                                 HcalQIEDataRcd,
-                                                                                 HcalQIETypesRcd,
-                                                                                 HcalChannelQualityRcd,
-                                                                                 HcalZSThresholdsRcd,
-                                                                                 HcalRespCorrsRcd,
-                                                                                 HcalL1TriggerObjectsRcd,
-                                                                                 HcalElectronicsMapRcd,
-                                                                                 HcalTimeCorrsRcd,
-                                                                                 HcalLUTCorrsRcd,
-                                                                                 HcalPFCorrsRcd,
-                                                                                 HcalFrontEndMapRcd,
-                                                                                 HcalSiPMCharacteristicsRcd,
-                                                                                 HcalSiPMParametersRcd,
-                                                                                 HcalTPParametersRcd,
-                                                                                 HcalTPChannelParametersRcd,
-                                                                                 HcalLutMetadataRcd,
-                                                                                 HcalMCParamsRcd,
-                                                                                 HcalRecoParamsRcd,
-                                                                                 HcalTimeSlewRecord> > {};
+class HcalDbRecord : public edm::eventsetup::DependentRecordImplementation<HcalDbRecord,
+                                                                           edm::mpl::Vector<HcalRecNumberingRecord,
+                                                                                            IdealGeometryRecord,
+                                                                                            HcalPedestalsRcd,
+                                                                                            HcalPedestalWidthsRcd,
+                                                                                            HcalGainsRcd,
+                                                                                            HcalGainWidthsRcd,
+                                                                                            HcalQIEDataRcd,
+                                                                                            HcalQIETypesRcd,
+                                                                                            HcalChannelQualityRcd,
+                                                                                            HcalZSThresholdsRcd,
+                                                                                            HcalRespCorrsRcd,
+                                                                                            HcalL1TriggerObjectsRcd,
+                                                                                            HcalElectronicsMapRcd,
+                                                                                            HcalTimeCorrsRcd,
+                                                                                            HcalLUTCorrsRcd,
+                                                                                            HcalPFCorrsRcd,
+                                                                                            HcalFrontEndMapRcd,
+                                                                                            HcalSiPMCharacteristicsRcd,
+                                                                                            HcalSiPMParametersRcd,
+                                                                                            HcalTPParametersRcd,
+                                                                                            HcalTPChannelParametersRcd,
+                                                                                            HcalLutMetadataRcd,
+                                                                                            HcalMCParamsRcd,
+                                                                                            HcalRecoParamsRcd,
+                                                                                            HcalTimeSlewRecord> > {};
 
 #endif /* HCALDBPRODUCER_HCALDBRECORD_H */

--- a/CalibFormats/HcalObjects/interface/HcalTPGRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalTPGRecord.h
@@ -24,6 +24,6 @@
 
 class HcalTPGRecord : public edm::eventsetup::DependentRecordImplementation<
                           HcalTPGRecord,
-                          boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord, HcalDbRecord> > {};
+                          edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord, HcalDbRecord> > {};
 
 #endif

--- a/CalibTracker/Records/interface/SiPixel2DTemplateDBObjectESProducerRcd.h
+++ b/CalibTracker/Records/interface/SiPixel2DTemplateDBObjectESProducerRcd.h
@@ -7,11 +7,11 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObjectRcd.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class SiPixel2DTemplateDBObjectESProducerRcd
     : public edm::eventsetup::DependentRecordImplementation<
           SiPixel2DTemplateDBObjectESProducerRcd,
-          boost::mpl::vector<IdealMagneticFieldRecord, SiPixel2DTemplateDBObjectRcd> > {};
+          edm::mpl::Vector<IdealMagneticFieldRecord, SiPixel2DTemplateDBObjectRcd> > {};
 
 #endif

--- a/CalibTracker/Records/interface/SiPixelFEDChannelContainerESProducerRcd.h
+++ b/CalibTracker/Records/interface/SiPixelFEDChannelContainerESProducerRcd.h
@@ -3,11 +3,11 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "CondFormats/DataRecord/interface/SiPixelStatusScenariosRcd.h"
 
 class SiPixelFEDChannelContainerESProducerRcd
     : public edm::eventsetup::DependentRecordImplementation<SiPixelFEDChannelContainerESProducerRcd,
-                                                            boost::mpl::vector<SiPixelStatusScenariosRcd> > {};
+                                                            edm::mpl::Vector<SiPixelStatusScenariosRcd> > {};
 
 #endif

--- a/CalibTracker/Records/interface/SiPixelGenErrorDBObjectESProducerRcd.h
+++ b/CalibTracker/Records/interface/SiPixelGenErrorDBObjectESProducerRcd.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiPixelGenErrorDBObjectRcd.h"
@@ -11,6 +11,6 @@
 class SiPixelGenErrorDBObjectESProducerRcd
     : public edm::eventsetup::DependentRecordImplementation<
           SiPixelGenErrorDBObjectESProducerRcd,
-          boost::mpl::vector<IdealMagneticFieldRecord, SiPixelGenErrorDBObjectRcd> > {};
+          edm::mpl::Vector<IdealMagneticFieldRecord, SiPixelGenErrorDBObjectRcd> > {};
 
 #endif

--- a/CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h
+++ b/CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiPixelTemplateDBObjectRcd.h"
@@ -11,6 +11,6 @@
 class SiPixelTemplateDBObjectESProducerRcd
     : public edm::eventsetup::DependentRecordImplementation<
           SiPixelTemplateDBObjectESProducerRcd,
-          boost::mpl::vector<IdealMagneticFieldRecord, SiPixelTemplateDBObjectRcd> > {};
+          edm::mpl::Vector<IdealMagneticFieldRecord, SiPixelTemplateDBObjectRcd> > {};
 
 #endif

--- a/CalibTracker/Records/interface/SiStripDependentRecords.h
+++ b/CalibTracker/Records/interface/SiStripDependentRecords.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -14,55 +14,54 @@
 
 class SiStripFecCablingRcd
     : public edm::eventsetup::DependentRecordImplementation<SiStripFecCablingRcd,
-                                                            boost::mpl::vector<SiStripFedCablingRcd> > {};
+                                                            edm::mpl::Vector<SiStripFedCablingRcd> > {};
 
 class SiStripDetCablingRcd : public edm::eventsetup::DependentRecordImplementation<
                                  SiStripDetCablingRcd,
-                                 boost::mpl::vector<SiStripFedCablingRcd, TrackerTopologyRcd, IdealGeometryRecord> > {};
+                                 edm::mpl::Vector<SiStripFedCablingRcd, TrackerTopologyRcd, IdealGeometryRecord> > {};
 
 class SiStripRegionCablingRcd
     : public edm::eventsetup::DependentRecordImplementation<
           SiStripRegionCablingRcd,
-          boost::mpl::vector<SiStripDetCablingRcd, TrackerDigiGeometryRecord, TrackerTopologyRcd> > {};
+          edm::mpl::Vector<SiStripDetCablingRcd, TrackerDigiGeometryRecord, TrackerTopologyRcd> > {};
 
-// class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainRcd, boost::mpl::vector<SiStripApvGainRcd> > {};
+// class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainRcd, edm::mpl::Vector<SiStripApvGainRcd> > {};
 class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<
                            SiStripGainRcd,
-                           boost::mpl::vector<SiStripApvGainRcd, SiStripApvGain2Rcd, SiStripApvGain3Rcd> > {};
+                           edm::mpl::Vector<SiStripApvGainRcd, SiStripApvGain2Rcd, SiStripApvGain3Rcd> > {};
 class SiStripGainSimRcd
-    : public edm::eventsetup::DependentRecordImplementation<SiStripGainSimRcd,
-                                                            boost::mpl::vector<SiStripApvGainSimRcd> > {};
+    : public edm::eventsetup::DependentRecordImplementation<SiStripGainSimRcd, edm::mpl::Vector<SiStripApvGainSimRcd> > {
+};
 
 class SiStripDelayRcd
-    : public edm::eventsetup::DependentRecordImplementation<SiStripDelayRcd, boost::mpl::vector<SiStripBaseDelayRcd> > {
-};
+    : public edm::eventsetup::DependentRecordImplementation<SiStripDelayRcd, edm::mpl::Vector<SiStripBaseDelayRcd> > {};
 
 class SiStripLorentzAngleDepRcd : public edm::eventsetup::DependentRecordImplementation<
                                       SiStripLorentzAngleDepRcd,
-                                      boost::mpl::vector<SiStripLatencyRcd, SiStripLorentzAngleRcd> > {};
+                                      edm::mpl::Vector<SiStripLatencyRcd, SiStripLorentzAngleRcd> > {};
 
 class SiStripBackPlaneCorrectionDepRcd : public edm::eventsetup::DependentRecordImplementation<
                                              SiStripBackPlaneCorrectionDepRcd,
-                                             boost::mpl::vector<SiStripLatencyRcd, SiStripBackPlaneCorrectionRcd> > {};
+                                             edm::mpl::Vector<SiStripLatencyRcd, SiStripBackPlaneCorrectionRcd> > {};
 
 class SiStripHashedDetIdRcd
     : public edm::eventsetup::DependentRecordImplementation<SiStripHashedDetIdRcd,
-                                                            boost::mpl::vector<TrackerDigiGeometryRecord> > {};
+                                                            edm::mpl::Vector<TrackerDigiGeometryRecord> > {};
 
 class SiStripBadModuleFedErrRcd
     : public edm::eventsetup::DependentRecordImplementation<SiStripBadModuleFedErrRcd,
-                                                            boost::mpl::vector<SiStripFedCablingRcd> > {};
+                                                            edm::mpl::Vector<SiStripFedCablingRcd> > {};
 
 class SiStripQualityRcd
     : public edm::eventsetup::DependentRecordImplementation<SiStripQualityRcd,
-                                                            boost::mpl::vector<SiStripBadModuleRcd,
-                                                                               SiStripBadFiberRcd,
-                                                                               SiStripBadChannelRcd,
-                                                                               SiStripBadStripRcd,
-                                                                               SiStripDetCablingRcd,
-                                                                               SiStripDCSStatusRcd,
-                                                                               SiStripDetVOffRcd,
-                                                                               RunInfoRcd,
-                                                                               SiStripBadModuleFedErrRcd> > {};
+                                                            edm::mpl::Vector<SiStripBadModuleRcd,
+                                                                             SiStripBadFiberRcd,
+                                                                             SiStripBadChannelRcd,
+                                                                             SiStripBadStripRcd,
+                                                                             SiStripDetCablingRcd,
+                                                                             SiStripDCSStatusRcd,
+                                                                             SiStripDetVOffRcd,
+                                                                             RunInfoRcd,
+                                                                             SiStripBadModuleFedErrRcd> > {};
 
 #endif

--- a/CondFormats/AlignmentRecord/interface/HcalAlignmentErrorRcd.h
+++ b/CondFormats/AlignmentRecord/interface/HcalAlignmentErrorRcd.h
@@ -16,11 +16,11 @@
 #include "CondFormats/AlignmentRecord/interface/HOAlignmentErrorRcd.h"
 #include "CondFormats/AlignmentRecord/interface/HEAlignmentErrorRcd.h"
 #include "CondFormats/AlignmentRecord/interface/HFAlignmentErrorRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class HcalAlignmentErrorRcd
     : public edm::eventsetup::DependentRecordImplementation<
           HcalAlignmentErrorRcd,
-          boost::mpl::vector<HBAlignmentErrorRcd, HOAlignmentErrorRcd, HEAlignmentErrorRcd, HFAlignmentErrorRcd> > {};
+          edm::mpl::Vector<HBAlignmentErrorRcd, HOAlignmentErrorRcd, HEAlignmentErrorRcd, HFAlignmentErrorRcd> > {};
 
 #endif /* RECORDS_HCALALIGNMENTERRORRCD_H */

--- a/CondFormats/AlignmentRecord/interface/HcalAlignmentRcd.h
+++ b/CondFormats/AlignmentRecord/interface/HcalAlignmentRcd.h
@@ -16,10 +16,10 @@
 #include "CondFormats/AlignmentRecord/interface/HOAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/HEAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/HFAlignmentRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class HcalAlignmentRcd : public edm::eventsetup::DependentRecordImplementation<
                              HcalAlignmentRcd,
-                             boost::mpl::vector<HBAlignmentRcd, HOAlignmentRcd, HEAlignmentRcd, HFAlignmentRcd> > {};
+                             edm::mpl::Vector<HBAlignmentRcd, HOAlignmentRcd, HEAlignmentRcd, HFAlignmentRcd> > {};
 
 #endif /* RECORDS_HCALALIGNMENTRCD_H */

--- a/CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
@@ -18,7 +18,7 @@
 // Created:     Tue Mar  6 19:34:33 CST 2007
 // $Id$
 //
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
@@ -26,6 +26,6 @@
 class BeamSpotTransientObjectsRcd
     : public edm::eventsetup::DependentRecordImplementation<
           BeamSpotTransientObjectsRcd,
-          boost::mpl::vector<BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineLegacyObjectsRcd> > {};
+          edm::mpl::Vector<BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineLegacyObjectsRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/CSCDBL1TPParametersRcd.h
+++ b/CondFormats/DataRecord/interface/CSCDBL1TPParametersRcd.h
@@ -32,7 +32,7 @@
 
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -42,7 +42,6 @@
 //class CSCDBL1TPParametersRcd : public edm::eventsetup::EventSetupRecordImplementation<CSCDBL1TPParametersRcd> {};
 class CSCDBL1TPParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<CSCDBL1TPParametersRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/CSCL1TPParametersRcd.h
+++ b/CondFormats/DataRecord/interface/CSCL1TPParametersRcd.h
@@ -32,7 +32,7 @@
 
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -42,7 +42,6 @@
 //class CSCL1TPParametersRcd : public edm::eventsetup::EventSetupRecordImplementation<CSCL1TPParametersRcd> {};
 class CSCL1TPParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<CSCL1TPParametersRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h
+++ b/CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h
@@ -9,9 +9,9 @@
 
 #include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class CTPPSBeamParametersRcd
-    : public edm::eventsetup::DependentRecordImplementation<CTPPSBeamParametersRcd, boost::mpl::vector<LHCInfoRcd>> {};
+    : public edm::eventsetup::DependentRecordImplementation<CTPPSBeamParametersRcd, edm::mpl::Vector<LHCInfoRcd>> {};
 
 #endif

--- a/CondFormats/DataRecord/interface/CTPPSInterpolatedOpticsRcd.h
+++ b/CondFormats/DataRecord/interface/CTPPSInterpolatedOpticsRcd.h
@@ -8,10 +8,10 @@
 #include "CondFormats/DataRecord/interface/CTPPSOpticsRcd.h"
 #include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class CTPPSInterpolatedOpticsRcd
     : public edm::eventsetup::DependentRecordImplementation<CTPPSInterpolatedOpticsRcd,
-                                                            boost::mpl::vector<CTPPSOpticsRcd, LHCInfoRcd>> {};
+                                                            edm::mpl::Vector<CTPPSOpticsRcd, LHCInfoRcd>> {};
 
 #endif

--- a/CondFormats/DataRecord/interface/DTT0Rcd.h
+++ b/CondFormats/DataRecord/interface/DTT0Rcd.h
@@ -7,8 +7,9 @@
 
 #include <vector>
 class DTT0Rcd
-    : public edm::eventsetup::
-          DependentRecordImplementation<DTT0Rcd, boost::mpl::vector<IdealGeometryRecord, MuonNumberingRecord> > {};
+    : public edm::eventsetup::DependentRecordImplementation<DTT0Rcd,
+                                                            edm::mpl::Vector<IdealGeometryRecord, MuonNumberingRecord> > {
+};
 
 //class DTT0Rcd : public edm::eventsetup::EventSetupRecordImplementation<DTT0Rcd> {};
 #endif

--- a/CondFormats/DataRecord/interface/DTT0RefRcd.h
+++ b/CondFormats/DataRecord/interface/DTT0RefRcd.h
@@ -7,7 +7,8 @@
 
 #include <vector>
 class DTT0RefRcd
-    : public edm::eventsetup::
-          DependentRecordImplementation<DTT0RefRcd, boost::mpl::vector<IdealGeometryRecord, MuonNumberingRecord> > {};
+    : public edm::eventsetup::DependentRecordImplementation<DTT0RefRcd,
+                                                            edm::mpl::Vector<IdealGeometryRecord, MuonNumberingRecord> > {
+};
 
 #endif

--- a/CondFormats/DataRecord/interface/ElectronLikelihoodRcd.h
+++ b/CondFormats/DataRecord/interface/ElectronLikelihoodRcd.h
@@ -8,10 +8,10 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/ElectronLikelihoodPdfsRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class ElectronLikelihoodRcd
     : public edm::eventsetup::DependentRecordImplementation<ElectronLikelihoodRcd,
-                                                            boost::mpl::vector<ElectronLikelihoodPdfsRcd> > {};
+                                                            edm::mpl::Vector<ElectronLikelihoodPdfsRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalCalibrationQIEDataRcd.h
+++ b/CondFormats/DataRecord/interface/HcalCalibrationQIEDataRcd.h
@@ -24,6 +24,6 @@
 
 class HcalCalibrationQIEDataRcd : public edm::eventsetup::DependentRecordImplementation<
                                       HcalCalibrationQIEDataRcd,
-                                      boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                      edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalChannelQualityRcd.h
+++ b/CondFormats/DataRecord/interface/HcalChannelQualityRcd.h
@@ -7,5 +7,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalChannelQualityRcd : public edm::eventsetup::DependentRecordImplementation<
                                   HcalChannelQualityRcd,
-                                  boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                  edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalElectronicsMapRcd.h
+++ b/CondFormats/DataRecord/interface/HcalElectronicsMapRcd.h
@@ -7,6 +7,6 @@
 
 class HcalElectronicsMapRcd : public edm::eventsetup::DependentRecordImplementation<
                                   HcalElectronicsMapRcd,
-                                  boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                  edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalFlagHFDigiTimeParamsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalFlagHFDigiTimeParamsRcd.h
@@ -5,5 +5,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalFlagHFDigiTimeParamsRcd : public edm::eventsetup::DependentRecordImplementation<
                                         HcalFlagHFDigiTimeParamsRcd,
-                                        boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                        edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalFrontEndMapRcd.h
+++ b/CondFormats/DataRecord/interface/HcalFrontEndMapRcd.h
@@ -6,5 +6,5 @@
 
 class HcalFrontEndMapRcd : public edm::eventsetup::DependentRecordImplementation<
                                HcalFrontEndMapRcd,
-                               boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                               edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalGainWidthsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalGainWidthsRcd.h
@@ -7,5 +7,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalGainWidthsRcd : public edm::eventsetup::DependentRecordImplementation<
                               HcalGainWidthsRcd,
-                              boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                              edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalGainsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalGainsRcd.h
@@ -5,7 +5,8 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-class HcalGainsRcd : public edm::eventsetup::DependentRecordImplementation<
-                         HcalGainsRcd,
-                         boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+class HcalGainsRcd
+    : public edm::eventsetup::
+          DependentRecordImplementation<HcalGainsRcd, edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {
+};
 #endif

--- a/CondFormats/DataRecord/interface/HcalL1TriggerObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalL1TriggerObjectsRcd.h
@@ -24,6 +24,6 @@
 
 class HcalL1TriggerObjectsRcd : public edm::eventsetup::DependentRecordImplementation<
                                     HcalL1TriggerObjectsRcd,
-                                    boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                    edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalLUTCorrsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalLUTCorrsRcd.h
@@ -24,6 +24,6 @@
 
 class HcalLUTCorrsRcd : public edm::eventsetup::DependentRecordImplementation<
                             HcalLUTCorrsRcd,
-                            boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                            edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalLongRecoParamsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalLongRecoParamsRcd.h
@@ -5,5 +5,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalLongRecoParamsRcd : public edm::eventsetup::DependentRecordImplementation<
                                   HcalLongRecoParamsRcd,
-                                  boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                  edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalLutMetadataRcd.h
+++ b/CondFormats/DataRecord/interface/HcalLutMetadataRcd.h
@@ -24,6 +24,6 @@
 
 class HcalLutMetadataRcd : public edm::eventsetup::DependentRecordImplementation<
                                HcalLutMetadataRcd,
-                               boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                               edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalMCParamsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalMCParamsRcd.h
@@ -5,5 +5,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalMCParamsRcd : public edm::eventsetup::DependentRecordImplementation<
                             HcalMCParamsRcd,
-                            boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                            edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalPFCorrsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalPFCorrsRcd.h
@@ -24,6 +24,6 @@
 
 class HcalPFCorrsRcd : public edm::eventsetup::DependentRecordImplementation<
                            HcalPFCorrsRcd,
-                           boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                           edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalPedestalWidthsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalPedestalWidthsRcd.h
@@ -7,5 +7,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalPedestalWidthsRcd : public edm::eventsetup::DependentRecordImplementation<
                                   HcalPedestalWidthsRcd,
-                                  boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                  edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalPedestalsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalPedestalsRcd.h
@@ -8,5 +8,5 @@
 
 class HcalPedestalsRcd : public edm::eventsetup::DependentRecordImplementation<
                              HcalPedestalsRcd,
-                             boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                             edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalQIEDataRcd.h
+++ b/CondFormats/DataRecord/interface/HcalQIEDataRcd.h
@@ -7,5 +7,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalQIEDataRcd : public edm::eventsetup::DependentRecordImplementation<
                            HcalQIEDataRcd,
-                           boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                           edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalQIETypesRcd.h
+++ b/CondFormats/DataRecord/interface/HcalQIETypesRcd.h
@@ -24,6 +24,6 @@
 
 class HcalQIETypesRcd : public edm::eventsetup::DependentRecordImplementation<
                             HcalQIETypesRcd,
-                            boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                            edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalRecoParamsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalRecoParamsRcd.h
@@ -5,5 +5,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalRecoParamsRcd : public edm::eventsetup::DependentRecordImplementation<
                               HcalRecoParamsRcd,
-                              boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                              edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalRespCorrsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalRespCorrsRcd.h
@@ -27,6 +27,6 @@
 class HcalRespCorrsRcd
     : public edm::eventsetup::DependentRecordImplementation<
           HcalRespCorrsRcd,
-          boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord, HBHEDarkeningRecord, HcalTimeSlewRecord> > {};
+          edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord, HBHEDarkeningRecord, HcalTimeSlewRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalSiPMParametersRcd.h
+++ b/CondFormats/DataRecord/interface/HcalSiPMParametersRcd.h
@@ -6,5 +6,5 @@
 
 class HcalSiPMParametersRcd : public edm::eventsetup::DependentRecordImplementation<
                                   HcalSiPMParametersRcd,
-                                  boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                  edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalTPChannelParametersRcd.h
+++ b/CondFormats/DataRecord/interface/HcalTPChannelParametersRcd.h
@@ -6,5 +6,5 @@
 
 class HcalTPChannelParametersRcd : public edm::eventsetup::DependentRecordImplementation<
                                        HcalTPChannelParametersRcd,
-                                       boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                       edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalTimeCorrsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalTimeCorrsRcd.h
@@ -24,6 +24,6 @@
 
 class HcalTimeCorrsRcd : public edm::eventsetup::DependentRecordImplementation<
                              HcalTimeCorrsRcd,
-                             boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                             edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalTimingParamsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalTimingParamsRcd.h
@@ -5,5 +5,5 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 class HcalTimingParamsRcd : public edm::eventsetup::DependentRecordImplementation<
                                 HcalTimingParamsRcd,
-                                boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/interface/HcalValidationCorrsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalValidationCorrsRcd.h
@@ -24,6 +24,6 @@
 
 class HcalValidationCorrsRcd : public edm::eventsetup::DependentRecordImplementation<
                                    HcalValidationCorrsRcd,
-                                   boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                   edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalZDCLowGainFractionsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalZDCLowGainFractionsRcd.h
@@ -24,6 +24,6 @@
 
 class HcalZDCLowGainFractionsRcd : public edm::eventsetup::DependentRecordImplementation<
                                        HcalZDCLowGainFractionsRcd,
-                                       boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                       edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/HcalZSThresholdsRcd.h
+++ b/CondFormats/DataRecord/interface/HcalZSThresholdsRcd.h
@@ -24,6 +24,6 @@
 
 class HcalZSThresholdsRcd : public edm::eventsetup::DependentRecordImplementation<
                                 HcalZSThresholdsRcd,
-                                boost::mpl::vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
+                                edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1CaloEcalScaleRcd.h
+++ b/CondFormats/DataRecord/interface/L1CaloEcalScaleRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1CaloEcalScaleRcd_h
 #define CondFormatsDataRecord_L1CaloEcalScaleRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1CaloEcalScaleRcd : public edm::eventsetup::EventSetupRecordImplementation<L1CaloEcalScaleRcd> {};
 class L1CaloEcalScaleRcd
     : public edm::eventsetup::DependentRecordImplementation<L1CaloEcalScaleRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1CaloGeometryRecord.h
+++ b/CondFormats/DataRecord/interface/L1CaloGeometryRecord.h
@@ -29,7 +29,6 @@
 /* {}; */
 class L1CaloGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<L1CaloGeometryRecord,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1CaloHcalScaleRcd.h
+++ b/CondFormats/DataRecord/interface/L1CaloHcalScaleRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1CaloHcalScaleRcd_h
 #define CondFormatsDataRecord_L1CaloHcalScaleRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -12,6 +12,6 @@
 //class L1CaloHcalScaleRcd : public edm::eventsetup::EventSetupRecordImplementation<L1CaloHcalScaleRcd> {};
 class L1CaloHcalScaleRcd : public edm::eventsetup::DependentRecordImplementation<
                                L1CaloHcalScaleRcd,
-                               boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd, CaloGeometryRecord> > {};
+                               edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd, CaloGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1EmEtScaleRcd.h
+++ b/CondFormats/DataRecord/interface/L1EmEtScaleRcd.h
@@ -19,7 +19,7 @@
 // $Id:
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -29,7 +29,6 @@
 //class L1EmEtScaleRcd : public edm::eventsetup::EventSetupRecordImplementation<L1EmEtScaleRcd> {};
 class L1EmEtScaleRcd
     : public edm::eventsetup::DependentRecordImplementation<L1EmEtScaleRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GctChannelMaskRcd.h
+++ b/CondFormats/DataRecord/interface/L1GctChannelMaskRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1GctChannelMaskRcd_h
 #define CondFormatsDataRecord_L1GctChannelMaskRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1GctChannelMaskRcd : public edm::eventsetup::EventSetupRecordImplementation<L1GctChannelMaskRcd> {};
 class L1GctChannelMaskRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GctChannelMaskRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GctJetFinderParamsRcd.h
+++ b/CondFormats/DataRecord/interface/L1GctJetFinderParamsRcd.h
@@ -19,7 +19,7 @@
 // $Id: L1GctJetFinderParamsRcd.h,v 1.2 2008/03/03 07:09:47 wsun Exp $
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -30,6 +30,6 @@
 //class L1GctJetFinderParamsRcd : public edm::eventsetup::EventSetupRecordImplementation<L1GctJetFinderParamsRcd> {};
 class L1GctJetFinderParamsRcd : public edm::eventsetup::DependentRecordImplementation<
                                     L1GctJetFinderParamsRcd,
-                                    boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd, L1CaloGeometryRecord> > {};
+                                    edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd, L1CaloGeometryRecord> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtBoardMapsRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtBoardMapsRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -38,7 +38,6 @@
 // };
 class L1GtBoardMapsRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtBoardMapsRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtParametersRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtParametersRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -37,7 +37,6 @@
 // };
 class L1GtParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtParametersRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -37,7 +37,6 @@
 // };
 class L1GtPrescaleFactorsAlgoTrigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtPrescaleFactorsAlgoTrigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtPrescaleFactorsTechTrigRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtPrescaleFactorsTechTrigRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -37,7 +37,6 @@
 // };
 class L1GtPrescaleFactorsTechTrigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtPrescaleFactorsTechTrigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtPsbSetupRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtPsbSetupRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -38,7 +38,6 @@
 // };
 class L1GtPsbSetupRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtPsbSetupRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtStableParametersRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtStableParametersRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -38,7 +38,6 @@
 // };
 class L1GtStableParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtStableParametersRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -38,7 +38,6 @@
 // };
 class L1GtTriggerMaskAlgoTrigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtTriggerMaskAlgoTrigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -38,7 +38,6 @@
 // };
 class L1GtTriggerMaskTechTrigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtTriggerMaskTechTrigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtTriggerMaskVetoAlgoTrigRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtTriggerMaskVetoAlgoTrigRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -38,7 +38,6 @@
 // };
 class L1GtTriggerMaskVetoAlgoTrigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtTriggerMaskVetoAlgoTrigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtTriggerMaskVetoTechTrigRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtTriggerMaskVetoTechTrigRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -38,7 +38,6 @@
 // };
 class L1GtTriggerMaskVetoTechTrigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1GtTriggerMaskVetoTechTrigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h
+++ b/CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -31,7 +31,7 @@
 // class declaration - record depends on L1GtStableParametersRcd
 class L1GtTriggerMenuRcd : public edm::eventsetup::DependentRecordImplementation<
                                L1GtTriggerMenuRcd,
-                               boost::mpl::vector<L1GtStableParametersRcd, L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
+                               edm::mpl::Vector<L1GtStableParametersRcd, L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
   // empty
 };
 

--- a/CondFormats/DataRecord/interface/L1HfRingEtScaleRcd.h
+++ b/CondFormats/DataRecord/interface/L1HfRingEtScaleRcd.h
@@ -19,7 +19,7 @@
 // $Id:
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -29,7 +29,6 @@
 //class L1HfRingEtScaleRcd : public edm::eventsetup::EventSetupRecordImplementation<L1HfRingEtScaleRcd> {};
 class L1HfRingEtScaleRcd
     : public edm::eventsetup::DependentRecordImplementation<L1HfRingEtScaleRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1HtMissScaleRcd.h
+++ b/CondFormats/DataRecord/interface/L1HtMissScaleRcd.h
@@ -19,7 +19,7 @@
 // $Id:
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -29,7 +29,6 @@
 //class L1HtMissScaleRcd : public edm::eventsetup::EventSetupRecordImplementation<L1HtMissScaleRcd> {};
 class L1HtMissScaleRcd
     : public edm::eventsetup::DependentRecordImplementation<L1HtMissScaleRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1JetEtScaleRcd.h
+++ b/CondFormats/DataRecord/interface/L1JetEtScaleRcd.h
@@ -19,7 +19,7 @@
 // $Id: L1JetEtScaleRcd.h,v 1.1 2007/03/16 13:51:29 heath Exp $
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -29,7 +29,6 @@
 //class L1JetEtScaleRcd : public edm::eventsetup::EventSetupRecordImplementation<L1JetEtScaleRcd> {};
 class L1JetEtScaleRcd
     : public edm::eventsetup::DependentRecordImplementation<L1JetEtScaleRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuCSCPtLutRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuCSCPtLutRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1MuCSCPtLutRcd_h
 #define CondFormatsDataRecord_L1MuCSCPtLutRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuCSCPtLutRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuCSCPtLutRcd> {};
 class L1MuCSCPtLutRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuCSCPtLutRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuCSCTFAlignmentRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuCSCTFAlignmentRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1MuCSCTFAlignmentRcd_h
 #define CondFormatsDataRecord_L1MuCSCTFAlignmentRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuCSCTFAlignmentRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuCSCTFAlignmentRcd> {};
 class L1MuCSCTFAlignmentRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuCSCTFAlignmentRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuCSCTFConfigurationRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuCSCTFConfigurationRcd.h
@@ -2,7 +2,7 @@
 
 #define CondFormatsDataRecord_L1MuCSCTFConfigurationRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -12,7 +12,6 @@
 //class L1MuCSCTFConfigurationRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuCSCTFConfigurationRcd> {};
 class L1MuCSCTFConfigurationRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuCSCTFConfigurationRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuDTEtaPatternLutRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuDTEtaPatternLutRcd.h
@@ -1,7 +1,7 @@
 #ifndef L1MuDTEtaPatternLutRCD_H
 #define L1MuDTEtaPatternLutRCD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuDTEtaPatternLutRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuDTEtaPatternLutRcd> {};
 class L1MuDTEtaPatternLutRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuDTEtaPatternLutRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuDTExtLutRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuDTExtLutRcd.h
@@ -1,7 +1,7 @@
 #ifndef L1MuDTExtLutRCD_H
 #define L1MuDTExtLutRCD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuDTExtLutRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuDTExtLutRcd> {};
 class L1MuDTExtLutRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuDTExtLutRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuDTPhiLutRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuDTPhiLutRcd.h
@@ -1,7 +1,7 @@
 #ifndef L1MuDTPhiLutRCD_H
 #define L1MuDTPhiLutRCD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuDTPhiLutRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuDTPhiLutRcd> {};
 class L1MuDTPhiLutRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuDTPhiLutRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuDTPtaLutRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuDTPtaLutRcd.h
@@ -1,7 +1,7 @@
 #ifndef L1MuDTPtaLutRCD_H
 #define L1MuDTPtaLutRCD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuDTPtaLutRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuDTPtaLutRcd> {};
 class L1MuDTPtaLutRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuDTPtaLutRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuDTQualPatternLutRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuDTQualPatternLutRcd.h
@@ -1,7 +1,7 @@
 #ifndef L1MuDTQualPatternLutRCD_H
 #define L1MuDTQualPatternLutRCD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuDTQualPatternLutRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuDTQualPatternLutRcd> {};
 class L1MuDTQualPatternLutRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuDTQualPatternLutRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuDTTFMasksRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuDTTFMasksRcd.h
@@ -1,7 +1,7 @@
 #ifndef L1MuDTTFMasksRCD_H
 #define L1MuDTTFMasksRCD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
@@ -9,7 +9,6 @@
 
 class L1MuDTTFMasksRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuDTTFMasksRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuDTTFParametersRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuDTTFParametersRcd.h
@@ -1,7 +1,7 @@
 #ifndef L1MuDTTFParametersRCD_H
 #define L1MuDTTFParametersRCD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
@@ -9,7 +9,6 @@
 
 class L1MuDTTFParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuDTTFParametersRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuGMTChannelMaskRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuGMTChannelMaskRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1MuGMTChannelMaskRcd_h
 #define CondFormatsDataRecord_L1MuGMTChannelMaskRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
@@ -9,7 +9,6 @@
 
 class L1MuGMTChannelMaskRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuGMTChannelMaskRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuGMTParametersRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuGMTParametersRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1MuGMTParametersRcd_h
 #define CondFormatsDataRecord_L1MuGMTParametersRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuGMTParametersRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuGMTParametersRcd> {};
 class L1MuGMTParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuGMTParametersRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuGMTScalesRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuGMTScalesRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1MuGMTScalesRcd_h
 #define CondFormatsDataRecord_L1MuGMTScalesRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuGMTScalesRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuGMTScalesRcd> {};
 class L1MuGMTScalesRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuGMTScalesRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuTriggerPtScaleRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuTriggerPtScaleRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1MuTriggerPtScaleRcd_h
 #define CondFormatsDataRecord_L1MuTriggerPtScaleRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuTriggerPtScaleRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuTriggerPtScaleRcd> {};
 class L1MuTriggerPtScaleRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuTriggerPtScaleRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1MuTriggerScalesRcd.h
+++ b/CondFormats/DataRecord/interface/L1MuTriggerScalesRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1MuTriggerScalesRcd_h
 #define CondFormatsDataRecord_L1MuTriggerScalesRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1MuTriggerScalesRcd : public edm::eventsetup::EventSetupRecordImplementation<L1MuTriggerScalesRcd> {};
 class L1MuTriggerScalesRcd
     : public edm::eventsetup::DependentRecordImplementation<L1MuTriggerScalesRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RCTChannelMaskRcd.h
+++ b/CondFormats/DataRecord/interface/L1RCTChannelMaskRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1RCTChannelMaskRcd_h
 #define CondFormatsDataRecord_L1RCTChannelMaskRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1RCTChannelMaskRcd : public edm::eventsetup::EventSetupRecordImplementation<L1RCTChannelMaskRcd> {};
 class L1RCTChannelMaskRcd
     : public edm::eventsetup::DependentRecordImplementation<L1RCTChannelMaskRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RCTNoisyChannelMaskRcd.h
+++ b/CondFormats/DataRecord/interface/L1RCTNoisyChannelMaskRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1RCTNoisyChannelMaskRcd_h
 #define CondFormatsDataRecord_L1RCTNoisyChannelMaskRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1RCTChannelMaskRcd : public edm::eventsetup::EventSetupRecordImplementation<L1RCTChannelMaskRcd> {};
 class L1RCTNoisyChannelMaskRcd
     : public edm::eventsetup::DependentRecordImplementation<L1RCTNoisyChannelMaskRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RCTParametersRcd.h
+++ b/CondFormats/DataRecord/interface/L1RCTParametersRcd.h
@@ -1,7 +1,7 @@
 #ifndef CondFormatsDataRecord_L1RCTParametersRcd_h
 #define CondFormatsDataRecord_L1RCTParametersRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -11,7 +11,6 @@
 //class L1RCTParametersRcd : public edm::eventsetup::EventSetupRecordImplementation<L1RCTParametersRcd> {};
 class L1RCTParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<L1RCTParametersRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RPCBxOrConfigRcd.h
+++ b/CondFormats/DataRecord/interface/L1RPCBxOrConfigRcd.h
@@ -14,7 +14,7 @@
 
 */
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
@@ -22,7 +22,6 @@
 
 class L1RPCBxOrConfigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1RPCBxOrConfigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RPCConeBuilderRcd.h
+++ b/CondFormats/DataRecord/interface/L1RPCConeBuilderRcd.h
@@ -27,10 +27,10 @@
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
 #include "CondFormats/DataRecord/interface/L1RPCConeDefinitionRcd.h"
-#include <boost/mpl/vector.hpp>
+#include <FWCore/Utilities/interface/mplVector.h>
 class L1RPCConeBuilderRcd
     : public edm::eventsetup::DependentRecordImplementation<
           L1RPCConeBuilderRcd,
-          boost::mpl::vector<MuonGeometryRecord, L1TriggerKeyListRcd, L1TriggerKeyRcd, L1RPCConeDefinitionRcd> > {};
+          edm::mpl::Vector<MuonGeometryRecord, L1TriggerKeyListRcd, L1TriggerKeyRcd, L1RPCConeDefinitionRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RPCConeDefinitionRcd.h
+++ b/CondFormats/DataRecord/interface/L1RPCConeDefinitionRcd.h
@@ -12,10 +12,9 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-#include <boost/mpl/vector.hpp>
+#include <FWCore/Utilities/interface/mplVector.h>
 class L1RPCConeDefinitionRcd
     : public edm::eventsetup::DependentRecordImplementation<L1RPCConeDefinitionRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RPCConfigRcd.h
+++ b/CondFormats/DataRecord/interface/L1RPCConfigRcd.h
@@ -19,7 +19,7 @@
 // $Id: L1RPCConfigRcd.h,v 1.1 2007/03/23 14:36:40 wsun Exp $
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -29,7 +29,6 @@
 //class L1RPCConfigRcd : public edm::eventsetup::EventSetupRecordImplementation<L1RPCConfigRcd> {};
 class L1RPCConfigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1RPCConfigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RPCHsbConfigRcd.h
+++ b/CondFormats/DataRecord/interface/L1RPCHsbConfigRcd.h
@@ -14,7 +14,7 @@
 
 */
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
@@ -22,7 +22,6 @@
 
 class L1RPCHsbConfigRcd
     : public edm::eventsetup::DependentRecordImplementation<L1RPCHsbConfigRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1RPCHwConfigRcd.h
+++ b/CondFormats/DataRecord/interface/L1RPCHwConfigRcd.h
@@ -4,12 +4,12 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 class L1RPCHwConfigRcd : public edm::eventsetup::EventSetupRecordImplementation<L1RPCHwConfigRcd> {};
 
-//#include "boost/mpl/vector.hpp"
+//#include "FWCore/Utilities/interface/mplVector.h"
 //
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
 //
-//class L1RPCHwConfigRcd : public edm::eventsetup::DependentRecordImplementation<L1RPCHwConfigRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1RPCHwConfigRcd : public edm::eventsetup::DependentRecordImplementation<L1RPCHwConfigRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TCaloConfigRcd.h
+++ b/CondFormats/DataRecord/interface/L1TCaloConfigRcd.h
@@ -19,6 +19,6 @@ class L1TCaloConfigRcd : public edm::eventsetup::EventSetupRecordImplementation<
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TCaloConfigRcd : public edm::eventsetup::DependentRecordImplementation<L1TCaloConfigRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TCaloConfigRcd : public edm::eventsetup::DependentRecordImplementation<L1TCaloConfigRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TCaloParamsO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TCaloParamsO2ORcd.h
@@ -17,6 +17,6 @@
 #include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
 class L1TCaloParamsO2ORcd : public edm::eventsetup::DependentRecordImplementation<
                                 L1TCaloParamsO2ORcd,
-                                boost::mpl::vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TCaloParamsRcd> > {};
+                                edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TCaloParamsRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TCaloParamsRcd.h
+++ b/CondFormats/DataRecord/interface/L1TCaloParamsRcd.h
@@ -19,6 +19,6 @@ class L1TCaloParamsRcd : public edm::eventsetup::EventSetupRecordImplementation<
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TCaloParamsRcd : public edm::eventsetup::DependentRecordImplementation<L1TCaloParamsRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TCaloParamsRcd : public edm::eventsetup::DependentRecordImplementation<L1TCaloParamsRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosO2ORcd.h
@@ -13,6 +13,6 @@
 class L1TGlobalPrescalesVetosO2ORcd
     : public edm::eventsetup::DependentRecordImplementation<
           L1TGlobalPrescalesVetosO2ORcd,
-          boost::mpl::vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TGlobalPrescalesVetosRcd> > {};
+          edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TGlobalPrescalesVetosRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosRcd.h
+++ b/CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosRcd.h
@@ -15,6 +15,6 @@ class L1TGlobalPrescalesVetosRcd : public edm::eventsetup::EventSetupRecordImple
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TGlobalPrescalesVetosRcd : public edm::eventsetup::DependentRecordImplementation<L1TGlobalPrescalesVetosRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TGlobalPrescalesVetosRcd : public edm::eventsetup::DependentRecordImplementation<L1TGlobalPrescalesVetosRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TGlobalStableParametersRcd.h
+++ b/CondFormats/DataRecord/interface/L1TGlobalStableParametersRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -38,7 +38,6 @@
 // };
 class L1TGlobalStableParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<L1TGlobalStableParametersRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
-};
+                                                            edm::mpl::Vector<L1TriggerKeyListRcd, L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TGlobalTriggerMenuRcd.h
+++ b/CondFormats/DataRecord/interface/L1TGlobalTriggerMenuRcd.h
@@ -18,7 +18,7 @@
  */
 
 // system include files
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // user include files
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -32,7 +32,7 @@
 class L1TGlobalTriggerMenuRcd
     : public edm::eventsetup::DependentRecordImplementation<
           L1TGlobalTriggerMenuRcd,
-          boost::mpl::vector<L1TGlobalStableParametersRcd, L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
+          edm::mpl::Vector<L1TGlobalStableParametersRcd, L1TriggerKeyListRcd, L1TriggerKeyRcd> > {
   // empty
 };
 

--- a/CondFormats/DataRecord/interface/L1TMuonBarrelParamsO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonBarrelParamsO2ORcd.h
@@ -15,6 +15,6 @@
 class L1TMuonBarrelParamsO2ORcd
     : public edm::eventsetup::DependentRecordImplementation<
           L1TMuonBarrelParamsO2ORcd,
-          boost::mpl::vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonBarrelParamsRcd> > {};
+          edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonBarrelParamsRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonEndCapForestO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonEndCapForestO2ORcd.h
@@ -9,6 +9,6 @@
 class L1TMuonEndCapForestO2ORcd
     : public edm::eventsetup::DependentRecordImplementation<
           L1TMuonEndCapForestO2ORcd,
-          boost::mpl::vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonEndCapForestRcd> > {};
+          edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonEndCapForestRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonEndCapForestRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonEndCapForestRcd.h
@@ -14,6 +14,6 @@ class L1TMuonEndCapForestRcd : public edm::eventsetup::EventSetupRecordImplement
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TMuonEndCapForestRcd : public edm::eventsetup::DependentRecordImplementation<L1TMuonEndCapForestRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TMuonEndCapForestRcd : public edm::eventsetup::DependentRecordImplementation<L1TMuonEndCapForestRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonEndCapParamsO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonEndCapParamsO2ORcd.h
@@ -16,6 +16,6 @@
 class L1TMuonEndCapParamsO2ORcd
     : public edm::eventsetup::DependentRecordImplementation<
           L1TMuonEndCapParamsO2ORcd,
-          boost::mpl::vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonEndCapParamsRcd> > {};
+          edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonEndCapParamsRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonEndCapParamsRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonEndCapParamsRcd.h
@@ -14,6 +14,6 @@ class L1TMuonEndCapParamsRcd : public edm::eventsetup::EventSetupRecordImplement
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TMuonEndCapParamsRcd : public edm::eventsetup::DependentRecordImplementation<L1TMuonEndCapParamsRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TMuonEndCapParamsRcd : public edm::eventsetup::DependentRecordImplementation<L1TMuonEndCapParamsRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonEndcapParamsRcd_deprecated.h
+++ b/CondFormats/DataRecord/interface/L1TMuonEndcapParamsRcd_deprecated.h
@@ -18,6 +18,6 @@ class L1TMuonEndcapParamsRcd : public edm::eventsetup::EventSetupRecordImplement
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TMuonEndcapParamsRcd : public edm::eventsetup::DependentRecordImplementation<L1TMuonEndcapParamsRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TMuonEndcapParamsRcd : public edm::eventsetup::DependentRecordImplementation<L1TMuonEndcapParamsRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonGlobalParamsO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonGlobalParamsO2ORcd.h
@@ -26,6 +26,6 @@
 class L1TMuonGlobalParamsO2ORcd
     : public edm::eventsetup::DependentRecordImplementation<
           L1TMuonGlobalParamsO2ORcd,
-          boost::mpl::vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonGlobalParamsRcd> > {};
+          edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonGlobalParamsRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonOverlapParamsO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonOverlapParamsO2ORcd.h
@@ -25,7 +25,7 @@
 class L1TMuonOverlapParamsO2ORcd
     : public edm::eventsetup::DependentRecordImplementation<
           L1TMuonOverlapParamsO2ORcd,
-          boost::mpl::vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonOverlapParamsRcd> > {};
+          edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonOverlapParamsRcd> > {};
 
 //class L1TMuonOverlapParamsRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonOverlapParamsRcd> {};
 

--- a/CondFormats/DataRecord/interface/L1TUtmAlgorithmRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmAlgorithmRcd.h
@@ -14,6 +14,6 @@ class L1TUtmAlgorithmRcd : public edm::eventsetup::EventSetupRecordImplementatio
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmAlgorithmRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmAlgorithmRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TUtmAlgorithmRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmAlgorithmRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TUtmBinRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmBinRcd.h
@@ -14,6 +14,6 @@ class L1TUtmBinRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TU
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmBinRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmBinRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TUtmBinRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmBinRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TUtmConditionRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmConditionRcd.h
@@ -14,6 +14,6 @@ class L1TUtmConditionRcd : public edm::eventsetup::EventSetupRecordImplementatio
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmConditionRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmConditionRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TUtmConditionRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmConditionRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TUtmCutRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmCutRcd.h
@@ -14,6 +14,6 @@ class L1TUtmCutRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TU
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmCutRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmCutRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TUtmCutRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmCutRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TUtmCutValueRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmCutValueRcd.h
@@ -14,6 +14,6 @@ class L1TUtmCutValueRcd : public edm::eventsetup::EventSetupRecordImplementation
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmCutValueRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmCutValueRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TUtmCutValueRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmCutValueRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TUtmObjectRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmObjectRcd.h
@@ -14,6 +14,6 @@ class L1TUtmObjectRcd : public edm::eventsetup::EventSetupRecordImplementation<L
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmObjectRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmObjectRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TUtmObjectRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmObjectRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TUtmScaleRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmScaleRcd.h
@@ -14,6 +14,6 @@ class L1TUtmScaleRcd : public edm::eventsetup::EventSetupRecordImplementation<L1
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmScaleRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmScaleRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TUtmScaleRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmScaleRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TUtmTriggerMenuO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmTriggerMenuO2ORcd.h
@@ -16,6 +16,6 @@
 #include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
 class L1TUtmTriggerMenuO2ORcd : public edm::eventsetup::DependentRecordImplementation<
                                     L1TUtmTriggerMenuO2ORcd,
-                                    boost::mpl::vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd> > {};
+                                    edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h
+++ b/CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h
@@ -14,6 +14,6 @@ class L1TUtmTriggerMenuRcd : public edm::eventsetup::EventSetupRecordImplementat
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class L1TUtmTriggerMenuRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmTriggerMenuRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class L1TUtmTriggerMenuRcd : public edm::eventsetup::DependentRecordImplementation<L1TUtmTriggerMenuRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h
+++ b/CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h
@@ -1,12 +1,12 @@
 #ifndef DataRecord_L1TriggerKeyExtRcd_h
 #define DataRecord_L1TriggerKeyExtRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
 
 class L1TriggerKeyExtRcd
     : public edm::eventsetup::DependentRecordImplementation<L1TriggerKeyExtRcd,
-                                                            boost::mpl::vector<L1TriggerKeyListExtRcd> > {};
+                                                            edm::mpl::Vector<L1TriggerKeyListExtRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TriggerKeyRcd.h
+++ b/CondFormats/DataRecord/interface/L1TriggerKeyRcd.h
@@ -19,7 +19,7 @@
 // $Id: L1TriggerKeyRcd.h,v 1.1 2007/08/22 14:20:13 jbrooke Exp $
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
@@ -28,7 +28,6 @@
 //class L1TriggerKeyRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TriggerKeyRcd> {};
 
 class L1TriggerKeyRcd
-    : public edm::eventsetup::DependentRecordImplementation<L1TriggerKeyRcd, boost::mpl::vector<L1TriggerKeyListRcd> > {
-};
+    : public edm::eventsetup::DependentRecordImplementation<L1TriggerKeyRcd, edm::mpl::Vector<L1TriggerKeyListRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/RPCInverseCPPFLinkMapRcd.h
+++ b/CondFormats/DataRecord/interface/RPCInverseCPPFLinkMapRcd.h
@@ -1,13 +1,13 @@
 #ifndef CondFormats_DataRecord_RPCInverseCPPFLinkMapRcd_h
 #define CondFormats_DataRecord_RPCInverseCPPFLinkMapRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 #include "CondFormats/DataRecord/interface/RPCCPPFLinkMapRcd.h"
 
 class RPCInverseCPPFLinkMapRcd
     : public edm::eventsetup::DependentRecordImplementation<RPCInverseCPPFLinkMapRcd,
-                                                            boost::mpl::vector<RPCCPPFLinkMapRcd> > {};
+                                                            edm::mpl::Vector<RPCCPPFLinkMapRcd> > {};
 
 #endif  // CondFormats_DataRecord_RPCInverseCPPFLinkMapRcd_h

--- a/CondFormats/DataRecord/interface/RPCInverseLBLinkMapRcd.h
+++ b/CondFormats/DataRecord/interface/RPCInverseLBLinkMapRcd.h
@@ -1,13 +1,13 @@
 #ifndef CondFormats_DataRecord_RPCInverseLBLinkMapRcd_h
 #define CondFormats_DataRecord_RPCInverseLBLinkMapRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 #include "CondFormats/DataRecord/interface/RPCLBLinkMapRcd.h"
 
 class RPCInverseLBLinkMapRcd
-    : public edm::eventsetup::DependentRecordImplementation<RPCInverseLBLinkMapRcd,
-                                                            boost::mpl::vector<RPCLBLinkMapRcd> > {};
+    : public edm::eventsetup::DependentRecordImplementation<RPCInverseLBLinkMapRcd, edm::mpl::Vector<RPCLBLinkMapRcd> > {
+};
 
 #endif  // CondFormats_DataRecord_RPCInverseLBLinkMapRcd_h

--- a/CondFormats/DataRecord/interface/RPCInverseOMTFLinkMapRcd.h
+++ b/CondFormats/DataRecord/interface/RPCInverseOMTFLinkMapRcd.h
@@ -1,13 +1,13 @@
 #ifndef CondFormats_DataRecord_RPCInverseOMTFLinkMapRcd_h
 #define CondFormats_DataRecord_RPCInverseOMTFLinkMapRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 #include "CondFormats/DataRecord/interface/RPCOMTFLinkMapRcd.h"
 
 class RPCInverseOMTFLinkMapRcd
     : public edm::eventsetup::DependentRecordImplementation<RPCInverseOMTFLinkMapRcd,
-                                                            boost::mpl::vector<RPCOMTFLinkMapRcd> > {};
+                                                            edm::mpl::Vector<RPCOMTFLinkMapRcd> > {};
 
 #endif  // CondFormats_DataRecord_RPCInverseOMTFLinkMapRcd_h

--- a/CondFormats/DataRecord/interface/RPCInverseTwinMuxLinkMapRcd.h
+++ b/CondFormats/DataRecord/interface/RPCInverseTwinMuxLinkMapRcd.h
@@ -1,13 +1,13 @@
 #ifndef CondFormats_DataRecord_RPCInverseTwinMuxLinkMapRcd_h
 #define CondFormats_DataRecord_RPCInverseTwinMuxLinkMapRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 #include "CondFormats/DataRecord/interface/RPCTwinMuxLinkMapRcd.h"
 
 class RPCInverseTwinMuxLinkMapRcd
     : public edm::eventsetup::DependentRecordImplementation<RPCInverseTwinMuxLinkMapRcd,
-                                                            boost::mpl::vector<RPCTwinMuxLinkMapRcd> > {};
+                                                            edm::mpl::Vector<RPCTwinMuxLinkMapRcd> > {};
 
 #endif  // CondFormats_DataRecord_RPCInverseTwinMuxLinkMapRcd_h

--- a/CondFormats/DataRecord/interface/SiPixelQualityRcd.h
+++ b/CondFormats/DataRecord/interface/SiPixelQualityRcd.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "CondFormats/DataRecord/interface/SiPixelQualityFromDbRcd.h"
 //#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
@@ -12,6 +12,6 @@ class SiPixelDetVOffRcd : public edm::eventsetup::EventSetupRecordImplementation
 
 class SiPixelQualityRcd : public edm::eventsetup::DependentRecordImplementation<
                               SiPixelQualityRcd,
-                              boost::mpl::vector<SiPixelQualityFromDbRcd, SiPixelDetVOffRcd> > {};
+                              edm::mpl::Vector<SiPixelQualityFromDbRcd, SiPixelDetVOffRcd> > {};
 
 #endif

--- a/CondFormats/DataRecord/interface/SiStripCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiStripCondDataRecords.h
@@ -14,8 +14,8 @@ class SiStripApvGainSimRcd : public edm::eventsetup::EventSetupRecordImplementat
 class SiStripBadChannelRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripBadChannelRcd> {};
 class SiStripBadFiberRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripBadFiberRcd> {};
 class SiStripBadModuleRcd
-    : public edm::eventsetup::DependentRecordImplementation<SiStripBadModuleRcd,
-                                                            boost::mpl::vector<TrackerTopologyRcd> > {};
+    : public edm::eventsetup::DependentRecordImplementation<SiStripBadModuleRcd, edm::mpl::Vector<TrackerTopologyRcd> > {
+};
 class SiStripBadStripRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripBadStripRcd> {};
 class SiStripDCSStatusRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripDCSStatusRcd> {};
 
@@ -24,12 +24,12 @@ class SiStripFedCablingRcd : public edm::eventsetup::EventSetupRecordImplementat
 /*Recod associated to SiStripLorenzaAngle Object: the SimRcd is used in simulation only*/
 class SiStripLorentzAngleRcd
     : public edm::eventsetup::DependentRecordImplementation<SiStripLorentzAngleRcd,
-                                                            boost::mpl::vector<TrackerTopologyRcd> > {};
+                                                            edm::mpl::Vector<TrackerTopologyRcd> > {};
 class SiStripLorentzAngleSimRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripLorentzAngleSimRcd> {};
 
 class SiStripBackPlaneCorrectionRcd
     : public edm::eventsetup::DependentRecordImplementation<SiStripBackPlaneCorrectionRcd,
-                                                            boost::mpl::vector<TrackerTopologyRcd> > {};
+                                                            edm::mpl::Vector<TrackerTopologyRcd> > {};
 
 class SiStripDetVOffRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripDetVOffRcd> {};
 
@@ -38,8 +38,7 @@ class SiStripLatencyRcd : public edm::eventsetup::EventSetupRecordImplementation
 class SiStripBaseDelayRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripBaseDelayRcd> {};
 
 class SiStripNoisesRcd
-    : public edm::eventsetup::DependentRecordImplementation<SiStripNoisesRcd, boost::mpl::vector<TrackerTopologyRcd> > {
-};
+    : public edm::eventsetup::DependentRecordImplementation<SiStripNoisesRcd, edm::mpl::Vector<TrackerTopologyRcd> > {};
 
 class SiStripPedestalsRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripPedestalsRcd> {};
 

--- a/EventFilter/EcalRawToDigi/interface/EcalRegionCablingRecord.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalRegionCablingRecord.h
@@ -4,10 +4,10 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class EcalRegionCablingRecord
-    : public edm::eventsetup::DependentRecordImplementation<EcalRegionCablingRecord,
-                                                            boost::mpl::vector<EcalMappingRcd> > {};
+    : public edm::eventsetup::DependentRecordImplementation<EcalRegionCablingRecord, edm::mpl::Vector<EcalMappingRcd> > {
+};
 
 #endif

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -19,8 +19,6 @@
 //
 
 // system include files
-#include "boost/mpl/begin_end.hpp"
-#include "boost/mpl/find.hpp"
 #include <sstream>
 #include <type_traits>
 
@@ -30,6 +28,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/DependentRecordTag.h"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 //This is here only because too many modules depend no
 // getting this header from this file (before EventSetupImpl)
@@ -43,17 +42,15 @@ namespace edm {
     class DependentRecordImplementation : public EventSetupRecordImplementation<RecordT>, public DependentRecordTag {
     public:
       DependentRecordImplementation() {}
-      typedef ListT list_type;
+      using list_type = ListT;
       //virtual ~DependentRecordImplementation();
 
       // ---------- const member functions ---------------------
       template <class DepRecordT>
       const DepRecordT getRecord() const {
         //Make sure that DepRecordT is a type in ListT
-        typedef typename boost::mpl::end<ListT>::type EndItrT;
-        typedef typename boost::mpl::find<ListT, DepRecordT>::type FoundItrT;
         static_assert(
-            !std::is_same<FoundItrT, EndItrT>::value,
+            (list_type::template contains<DepRecordT>()),
             "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
         try {
           EventSetup const eventSetupT{
@@ -70,10 +67,8 @@ namespace edm {
       template <class DepRecordT>
       std::optional<DepRecordT> tryToGetRecord() const {
         //Make sure that DepRecordT is a type in ListT
-        typedef typename boost::mpl::end<ListT>::type EndItrT;
-        typedef typename boost::mpl::find<ListT, DepRecordT>::type FoundItrT;
         static_assert(
-            !std::is_same<FoundItrT, EndItrT>::value,
+            (list_type::template contains<DepRecordT>()),
             "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
         EventSetup const eventSetupT{
             this->eventSetup(), this->transitionID(), this->getTokenIndices(), this->requireTokens()};
@@ -85,9 +80,7 @@ namespace edm {
       template <typename ProductT, typename DepRecordT>
       ESHandle<ProductT> getHandle(ESGetToken<ProductT, DepRecordT> const& iToken) const {
         //Make sure that DepRecordT is a type in ListT
-        using EndItrT = typename boost::mpl::end<ListT>::type;
-        using FoundItrT = typename boost::mpl::find<ListT, DepRecordT>::type;
-        static_assert(!std::is_same<FoundItrT, EndItrT>::value,
+        static_assert((list_type::template contains<DepRecordT>()),
                       "Trying to get a product with an ESGetToken specifying a Record from another Record where the "
                       "second Record is not dependent on the first Record.");
         return getRecord<DepRecordT>().getHandle(iToken);
@@ -98,9 +91,7 @@ namespace edm {
       template <typename ProductT, typename DepRecordT>
       ESTransientHandle<ProductT> getTransientHandle(ESGetToken<ProductT, DepRecordT> const& iToken) const {
         //Make sure that DepRecordT is a type in ListT
-        using EndItrT = typename boost::mpl::end<ListT>::type;
-        using FoundItrT = typename boost::mpl::find<ListT, DepRecordT>::type;
-        static_assert(!std::is_same<FoundItrT, EndItrT>::value,
+        static_assert((list_type::template contains<DepRecordT>()),
                       "Trying to get a product with an ESGetToken specifying a Record from another Record where the "
                       "second Record is not dependent on the first Record.");
         return getRecord<DepRecordT>().getTransientHandle(iToken);
@@ -111,9 +102,7 @@ namespace edm {
       template <typename ProductT, typename DepRecordT>
       ProductT const& get(ESGetToken<ProductT, DepRecordT> const& iToken) const {
         //Make sure that DepRecordT is a type in ListT
-        using EndItrT = typename boost::mpl::end<ListT>::type;
-        using FoundItrT = typename boost::mpl::find<ListT, DepRecordT>::type;
-        static_assert(!std::is_same<FoundItrT, EndItrT>::value,
+        static_assert((list_type::template contains<DepRecordT>()),
                       "Trying to get a product with an ESGetToken specifying a Record from another Record where the "
                       "second Record is not dependent on the first Record.");
         return getRecord<DepRecordT>().get(iToken);

--- a/FWCore/Framework/interface/print_eventsetup_record_dependencies.h
+++ b/FWCore/Framework/interface/print_eventsetup_record_dependencies.h
@@ -20,11 +20,9 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/DependentRecordTag.h"
 
 // system include files
-#include "boost/mpl/begin_end.hpp"
-#include "boost/mpl/deref.hpp"
-#include "boost/mpl/next.hpp"
 
 #include <iostream>
 #include <string>
@@ -38,49 +36,36 @@ namespace edm {
   template <typename RecordT>
   void print_eventsetup_record_dependencies(std::ostream& oStream, std::string const& iIndent = std::string());
 
-  template <typename T>
-  void print_eventsetup_record_dependencies(std::ostream&, std::string, T const*, T const*) {}
-
-  template <typename TFirst, typename TEnd>
+  template <typename TFirst, typename TRemaining>
   void print_eventsetup_record_dependencies(std::ostream& oStream,
                                             std::string iIndent,
                                             TFirst const*,
-                                            TEnd const* iEnd) {
+                                            TRemaining const*) {
     iIndent += " ";
-    print_eventsetup_record_dependencies<typename boost::mpl::deref<TFirst>::type>(oStream, iIndent);
-    typename boost::mpl::next<TFirst>::type const* next(nullptr);
-    print_eventsetup_record_dependencies(oStream, iIndent, next, iEnd);
-  }
+    print_eventsetup_record_dependencies<TFirst>(oStream, iIndent);
 
-  namespace rec_dep {
-    boost::mpl::false_ inherits_from_DependentRecordTag(void const*) { return boost::mpl::false_(); }
-    boost::mpl::true_ inherits_from_DependentRecordTag(edm::eventsetup::DependentRecordTag const*) {
-      return boost::mpl::true_();
+    using Pop = edm::mpl::Pop<TRemaining>;
+    if constexpr (not Pop::empty) {
+      const typename Pop::Item* next(nullptr);
+      const typename Pop::Remaining* remaining(nullptr);
+
+      print_eventsetup_record_dependencies(oStream, iIndent, next, remaining);
     }
-  }  // namespace rec_dep
-
-  template <typename RecordT>
-  void print_eventsetup_record_dependencies_recursive(std::ostream& oStream,
-                                                      std::string const& iIndent,
-                                                      boost::mpl::true_) {
-    typedef typename RecordT::list_type list_type;
-
-    typename boost::mpl::begin<list_type>::type const* begin(nullptr);
-    typename boost::mpl::end<list_type>::type const* end(nullptr);
-    print_eventsetup_record_dependencies(oStream, iIndent, begin, end);
-  }
-
-  template <typename RecordT>
-  void print_eventsetup_record_dependencies_recursive(std::ostream&, std::string const&, boost::mpl::false_) {
-    return;
   }
 
   template <typename RecordT>
   void print_eventsetup_record_dependencies(std::ostream& oStream, std::string const& iIndent) {
     oStream << iIndent << edm::eventsetup::EventSetupRecordKey::makeKey<RecordT>().name() << std::endl;
 
-    print_eventsetup_record_dependencies_recursive<RecordT>(
-        oStream, iIndent, rec_dep::inherits_from_DependentRecordTag(static_cast<RecordT const*>(nullptr)));
+    if constexpr (std::is_base_of_v<edm::eventsetup::DependentRecordTag, RecordT>) {
+      using list_type = typename RecordT::list_type;
+      using Pop = edm::mpl::Pop<list_type>;
+
+      const typename Pop::Item* begin(nullptr);
+      const typename Pop::Remaining* remaining(nullptr);
+
+      print_eventsetup_record_dependencies(oStream, iIndent, begin, remaining);
+    }
   }
 }  // namespace edm
 

--- a/FWCore/Framework/interface/print_eventsetup_record_dependencies.h
+++ b/FWCore/Framework/interface/print_eventsetup_record_dependencies.h
@@ -21,6 +21,7 @@
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/DependentRecordTag.h"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 // system include files
 

--- a/FWCore/Framework/test/DepOn2Record.h
+++ b/FWCore/Framework/test/DepOn2Record.h
@@ -19,7 +19,6 @@
 //
 
 // system include files
-#include "boost/mpl/vector.hpp"
 
 // user include files
 
@@ -29,7 +28,7 @@
 #include "FWCore/Framework/test/Dummy2Record.h"
 
 class DepOn2Record
-    : public edm::eventsetup::DependentRecordImplementation<DepOn2Record,
-                                                            boost::mpl::vector<DummyRecord, Dummy2Record> > {};
+    : public edm::eventsetup::DependentRecordImplementation<DepOn2Record, edm::mpl::Vector<DummyRecord, Dummy2Record> > {
+};
 
 #endif

--- a/FWCore/Framework/test/DepRecord.h
+++ b/FWCore/Framework/test/DepRecord.h
@@ -19,7 +19,6 @@
 //
 
 // system include files
-#include "boost/mpl/vector.hpp"
 
 // user include files
 
@@ -27,6 +26,6 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "FWCore/Framework/test/DummyRecord.h"
 
-class DepRecord : public edm::eventsetup::DependentRecordImplementation<DepRecord, boost::mpl::vector<DummyRecord> > {};
+class DepRecord : public edm::eventsetup::DependentRecordImplementation<DepRecord, edm::mpl::Vector<DummyRecord> > {};
 
 #endif

--- a/FWCore/Integration/interface/ESTestRecords.h
+++ b/FWCore/Integration/interface/ESTestRecords.h
@@ -4,8 +4,6 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
-#include "boost/mpl/vector.hpp"
-
 class ESTestRecordA : public edm::eventsetup::EventSetupRecordImplementation<ESTestRecordA> {
 public:
   static constexpr bool allowConcurrentIOVs_ = false;
@@ -21,22 +19,24 @@ class ESTestRecordH : public edm::eventsetup::EventSetupRecordImplementation<EST
 
 class ESTestRecordE : public edm::eventsetup::EventSetupRecordImplementation<ESTestRecordE> {};
 
-class ESTestRecordD : public edm::eventsetup::DependentRecordImplementation<
-                          ESTestRecordD,
-                          boost::mpl::vector<ESTestRecordF, ESTestRecordG, ESTestRecordH> > {};
+class ESTestRecordD
+    : public edm::eventsetup::
+          DependentRecordImplementation<ESTestRecordD, edm::mpl::Vector<ESTestRecordF, ESTestRecordG, ESTestRecordH> > {
+};
 
-class ESTestRecordB : public edm::eventsetup::DependentRecordImplementation<
-                          ESTestRecordB,
-                          boost::mpl::vector<ESTestRecordC, ESTestRecordD, ESTestRecordE> > {};
+class ESTestRecordB
+    : public edm::eventsetup::
+          DependentRecordImplementation<ESTestRecordB, edm::mpl::Vector<ESTestRecordC, ESTestRecordD, ESTestRecordE> > {
+};
 
 class ESTestRecordZ : public edm::eventsetup::EventSetupRecordImplementation<ESTestRecordZ> {};
 
 class ESTestRecordK : public edm::eventsetup::EventSetupRecordImplementation<ESTestRecordK> {};
 
 class ESTestRecordI
-    : public edm::eventsetup::DependentRecordImplementation<ESTestRecordI, boost::mpl::vector<ESTestRecordK> > {};
+    : public edm::eventsetup::DependentRecordImplementation<ESTestRecordI, edm::mpl::Vector<ESTestRecordK> > {};
 
 class ESTestRecordJ
-    : public edm::eventsetup::DependentRecordImplementation<ESTestRecordJ, boost::mpl::vector<ESTestRecordK> > {};
+    : public edm::eventsetup::DependentRecordImplementation<ESTestRecordJ, edm::mpl::Vector<ESTestRecordK> > {};
 
 #endif

--- a/FWCore/Utilities/interface/mplVector.h
+++ b/FWCore/Utilities/interface/mplVector.h
@@ -1,0 +1,80 @@
+#ifndef FWCore_Utilities_mplVector_h
+#define FWCore_Utilities_mplVector_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     edm::mpl::Vector
+//
+/**\class edm::mpl::Vector mplVector.h "FWCore/Utilities/interface/mplVector.h"
+
+ Description: A meta-programming container of types
+
+ Usage:
+  The collection of types are specified in the template parameters.
+  \code
+    using Types = edm::mpl::Vector<A,B,C>;
+  \endcode
+
+  A check on if a type is held by the container can be done via the call to contains
+  \code
+  static_assert(edm::mpl::Vector<A,B,C>::contains<A>());
+  \endcode
+ 
+  It is possible to move through the sequence of types using the helper edm::mpl::Pop struct
+  \code
+     using edm::mpl;
+     //get the first item
+     static_assert(std::is_same_v<Pop<Vector<A,B>>::Item, A>);
+ 
+     //get a container holding what remains
+     static_assert(std::is_same_v<Vector<B>, Pop<Vector<A,B>::Remaining>);
+ 
+     //check if more there
+     static_assert(not Pop<Vector<B>>::empty);
+     static_assert(Pop<Vector<>>::empty);
+  \endcode
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Tues, 21 Jul 2020 14:29:51 GMT
+//
+
+// system include files
+#include <type_traits>
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  namespace mpl {
+    template <typename... T>
+    class Vector {
+    public:
+      ///Returns true if the type U is within the collection
+      template <typename U>
+      static constexpr bool contains() {
+        return (std::is_same_v<U, T> || ...);
+      }
+    };
+
+    template <typename T>
+    struct Pop;
+
+    template <typename F, typename... T>
+    struct Pop<Vector<F, T...>> {
+      constexpr static bool empty = false;
+      using Item = F;
+      using Remaining = Vector<T...>;
+    };
+
+    template <>
+    struct Pop<Vector<>> {
+      constexpr static bool empty = true;
+      using Item = void;
+      using Remaining = Vector<>;
+    };
+  }  // namespace mpl
+}  // namespace edm
+
+#endif

--- a/FastSimulation/ParticlePropagator/interface/MagneticFieldMapRecord.h
+++ b/FastSimulation/ParticlePropagator/interface/MagneticFieldMapRecord.h
@@ -22,10 +22,10 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "FastSimulation/TrackerSetup/interface/TrackerInteractionGeometryRecord.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MagneticFieldMapRecord : public edm::eventsetup::DependentRecordImplementation<
                                    MagneticFieldMapRecord,
-                                   boost::mpl::vector<IdealMagneticFieldRecord, TrackerInteractionGeometryRecord> > {};
+                                   edm::mpl::Vector<IdealMagneticFieldRecord, TrackerInteractionGeometryRecord> > {};
 
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/GeometryRecord.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/GeometryRecord.h
@@ -3,10 +3,10 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class GeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<GeometryRecord,
-                                                            boost::mpl::vector<TrackerRecoGeometryRecord> > {};
+                                                            edm::mpl::Vector<TrackerRecoGeometryRecord> > {};
 
 #endif

--- a/FastSimulation/TrackerSetup/interface/TrackerInteractionGeometryRecord.h
+++ b/FastSimulation/TrackerSetup/interface/TrackerInteractionGeometryRecord.h
@@ -21,10 +21,10 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TrackerInteractionGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<TrackerInteractionGeometryRecord,
-                                                            boost::mpl::vector<TrackerRecoGeometryRecord> > {};
+                                                            edm::mpl::Vector<TrackerRecoGeometryRecord> > {};
 
 #endif

--- a/Fireworks/Geometry/interface/DisplayGeomRecord.h
+++ b/Fireworks/Geometry/interface/DisplayGeomRecord.h
@@ -22,7 +22,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 class DisplayGeomRecord
-    : public edm::eventsetup::DependentRecordImplementation<DisplayGeomRecord, boost::mpl::vector<IdealGeometryRecord> > {
+    : public edm::eventsetup::DependentRecordImplementation<DisplayGeomRecord, edm::mpl::Vector<IdealGeometryRecord> > {
 };
 
 #endif

--- a/Fireworks/Geometry/interface/FWRecoGeometryRecord.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryRecord.h
@@ -9,6 +9,6 @@
 class FWRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           FWRecoGeometryRecord,
-          boost::mpl::vector<MuonGeometryRecord, GlobalTrackingGeometryRecord, CaloGeometryRecord> > {};
+          edm::mpl::Vector<MuonGeometryRecord, GlobalTrackingGeometryRecord, CaloGeometryRecord> > {};
 
 #endif  // GEOMETRY_FWRECO_GEOMETRY_RECORD_H

--- a/Fireworks/Geometry/interface/FWTGeoRecoGeometryRecord.h
+++ b/Fireworks/Geometry/interface/FWTGeoRecoGeometryRecord.h
@@ -9,6 +9,6 @@
 class FWTGeoRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           FWTGeoRecoGeometryRecord,
-          boost::mpl::vector<GlobalTrackingGeometryRecord, CaloGeometryRecord, TrackerTopologyRcd> > {};
+          edm::mpl::Vector<GlobalTrackingGeometryRecord, CaloGeometryRecord, TrackerTopologyRcd> > {};
 
 #endif  // GEOMETRY_FWTGEORECO_GEOMETRY_RECORD_H

--- a/Geometry/EcalMapping/interface/EcalMappingRcd.h
+++ b/Geometry/EcalMapping/interface/EcalMappingRcd.h
@@ -1,7 +1,7 @@
 #ifndef ECALMAPPINGRCD_H
 #define ECALMAPPINGRCD_H
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 // #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -14,6 +14,6 @@
 
 class EcalMappingRcd
     : public edm::eventsetup::DependentRecordImplementation<EcalMappingRcd,
-                                                            boost::mpl::vector<EcalMappingElectronicsRcd> > {};
+                                                            edm::mpl::Vector<EcalMappingElectronicsRcd> > {};
 
 #endif

--- a/Geometry/Records/interface/CaloGeometryRecord.h
+++ b/Geometry/Records/interface/CaloGeometryRecord.h
@@ -25,22 +25,22 @@
 #include "Geometry/Records/interface/CastorGeometryRecord.h"
 #include "Geometry/Records/interface/HGCalGeometryRecord.h"
 #include "Geometry/Records/interface/FastTimeGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class CaloGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<CaloGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               EcalBarrelGeometryRecord,
-                                                                               EcalEndcapGeometryRecord,
-                                                                               EcalPreshowerGeometryRecord,
-                                                                               HcalParametersRcd,
-                                                                               HcalSimNumberingRecord,
-                                                                               HcalRecNumberingRecord,
-                                                                               HcalGeometryRecord,
-                                                                               HGCalGeometryRecord,
-                                                                               FastTimeGeometryRecord,
-                                                                               CaloTowerGeometryRecord,
-                                                                               CastorGeometryRecord,
-                                                                               ZDCGeometryRecord> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             EcalBarrelGeometryRecord,
+                                                                             EcalEndcapGeometryRecord,
+                                                                             EcalPreshowerGeometryRecord,
+                                                                             HcalParametersRcd,
+                                                                             HcalSimNumberingRecord,
+                                                                             HcalRecNumberingRecord,
+                                                                             HcalGeometryRecord,
+                                                                             HGCalGeometryRecord,
+                                                                             FastTimeGeometryRecord,
+                                                                             CaloTowerGeometryRecord,
+                                                                             CastorGeometryRecord,
+                                                                             ZDCGeometryRecord> > {};
 
 #endif /* RECORDS_CALOGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/CaloTopologyRecord.h
+++ b/Geometry/Records/interface/CaloTopologyRecord.h
@@ -5,10 +5,10 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class CaloTopologyRecord
-    : public edm::eventsetup::DependentRecordImplementation<CaloTopologyRecord, boost::mpl::vector<CaloGeometryRecord> > {
+    : public edm::eventsetup::DependentRecordImplementation<CaloTopologyRecord, edm::mpl::Vector<CaloGeometryRecord> > {
 };
 
 #endif

--- a/Geometry/Records/interface/CaloTowerGeometryRecord.h
+++ b/Geometry/Records/interface/CaloTowerGeometryRecord.h
@@ -19,16 +19,16 @@
 #include "CondFormats/AlignmentRecord/interface/CaloTowerAlignmentErrorExtendedRcd.h"
 #include "Geometry/Records/interface/PCaloTowerRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class CaloTowerGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<CaloTowerGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               HcalRecNumberingRecord,
-                                                                               CaloTowerAlignmentRcd,
-                                                                               CaloTowerAlignmentErrorRcd,
-                                                                               CaloTowerAlignmentErrorExtendedRcd,
-                                                                               GlobalPositionRcd,
-                                                                               PCaloTowerRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             HcalRecNumberingRecord,
+                                                                             CaloTowerAlignmentRcd,
+                                                                             CaloTowerAlignmentErrorRcd,
+                                                                             CaloTowerAlignmentErrorExtendedRcd,
+                                                                             GlobalPositionRcd,
+                                                                             PCaloTowerRcd> > {};
 
 #endif /* RECORDS_CALOTOWERGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/CastorGeometryRecord.h
+++ b/Geometry/Records/interface/CastorGeometryRecord.h
@@ -18,15 +18,15 @@
 #include "CondFormats/AlignmentRecord/interface/CastorAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "Geometry/Records/interface/PCastorRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class CastorGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<CastorGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               CastorAlignmentRcd,
-                                                                               CastorAlignmentErrorRcd,
-                                                                               CastorAlignmentErrorExtendedRcd,
-                                                                               GlobalPositionRcd,
-                                                                               PCastorRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             CastorAlignmentRcd,
+                                                                             CastorAlignmentErrorRcd,
+                                                                             CastorAlignmentErrorExtendedRcd,
+                                                                             GlobalPositionRcd,
+                                                                             PCastorRcd> > {};
 
 #endif /* RECORDS_CastorGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/DDSpecParRegistryRcd.h
+++ b/Geometry/Records/interface/DDSpecParRegistryRcd.h
@@ -3,10 +3,10 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class DDSpecParRegistryRcd
-    : public edm::eventsetup::DependentRecordImplementation<DDSpecParRegistryRcd,
-                                                            boost::mpl::vector<IdealGeometryRecord>> {};
+    : public edm::eventsetup::DependentRecordImplementation<DDSpecParRegistryRcd, edm::mpl::Vector<IdealGeometryRecord>> {
+};
 
 #endif

--- a/Geometry/Records/interface/DDVectorRegistryRcd.h
+++ b/Geometry/Records/interface/DDVectorRegistryRcd.h
@@ -3,10 +3,10 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class DDVectorRegistryRcd
-    : public edm::eventsetup::DependentRecordImplementation<DDVectorRegistryRcd,
-                                                            boost::mpl::vector<IdealGeometryRecord>> {};
+    : public edm::eventsetup::DependentRecordImplementation<DDVectorRegistryRcd, edm::mpl::Vector<IdealGeometryRecord>> {
+};
 
 #endif

--- a/Geometry/Records/interface/EcalBarrelGeometryRecord.h
+++ b/Geometry/Records/interface/EcalBarrelGeometryRecord.h
@@ -18,15 +18,15 @@
 #include "CondFormats/AlignmentRecord/interface/EBAlignmentErrorRcd.h"
 #include "CondFormats/AlignmentRecord/interface/EBAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class EcalBarrelGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<EcalBarrelGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               EBAlignmentRcd,
-                                                                               EBAlignmentErrorRcd,
-                                                                               EBAlignmentErrorExtendedRcd,
-                                                                               GlobalPositionRcd,
-                                                                               PEcalBarrelRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             EBAlignmentRcd,
+                                                                             EBAlignmentErrorRcd,
+                                                                             EBAlignmentErrorExtendedRcd,
+                                                                             GlobalPositionRcd,
+                                                                             PEcalBarrelRcd> > {};
 
 #endif /* RECORDS_ECALBARRELGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/EcalEndcapGeometryRecord.h
+++ b/Geometry/Records/interface/EcalEndcapGeometryRecord.h
@@ -18,15 +18,15 @@
 #include "CondFormats/AlignmentRecord/interface/EEAlignmentErrorRcd.h"
 #include "CondFormats/AlignmentRecord/interface/EEAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class EcalEndcapGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<EcalEndcapGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               EEAlignmentRcd,
-                                                                               EEAlignmentErrorRcd,
-                                                                               EEAlignmentErrorExtendedRcd,
-                                                                               GlobalPositionRcd,
-                                                                               PEcalEndcapRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             EEAlignmentRcd,
+                                                                             EEAlignmentErrorRcd,
+                                                                             EEAlignmentErrorExtendedRcd,
+                                                                             GlobalPositionRcd,
+                                                                             PEcalEndcapRcd> > {};
 
 #endif /* RECORDS_ECALENDCAPGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/EcalPreshowerGeometryRecord.h
+++ b/Geometry/Records/interface/EcalPreshowerGeometryRecord.h
@@ -18,15 +18,15 @@
 #include "CondFormats/AlignmentRecord/interface/ESAlignmentErrorRcd.h"
 #include "CondFormats/AlignmentRecord/interface/ESAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class EcalPreshowerGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<EcalPreshowerGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               ESAlignmentRcd,
-                                                                               ESAlignmentErrorRcd,
-                                                                               ESAlignmentErrorExtendedRcd,
-                                                                               GlobalPositionRcd,
-                                                                               PEcalPreshowerRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             ESAlignmentRcd,
+                                                                             ESAlignmentErrorRcd,
+                                                                             ESAlignmentErrorExtendedRcd,
+                                                                             GlobalPositionRcd,
+                                                                             PEcalPreshowerRcd> > {};
 
 #endif /* RECORDS_ECALPRESHOWERGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/FastTimeGeometryRecord.h
+++ b/Geometry/Records/interface/FastTimeGeometryRecord.h
@@ -6,10 +6,10 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/PFastTimeRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class FastTimeGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
                                    FastTimeGeometryRecord,
-                                   boost::mpl::vector<IdealGeometryRecord, GlobalPositionRcd, PFastTimeRcd> > {};
+                                   edm::mpl::Vector<IdealGeometryRecord, GlobalPositionRcd, PFastTimeRcd> > {};
 
 #endif /* Records_FastTimeGeometryRecord_h */

--- a/Geometry/Records/interface/GlobalTrackingGeometryRecord.h
+++ b/Geometry/Records/interface/GlobalTrackingGeometryRecord.h
@@ -12,11 +12,11 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class GlobalTrackingGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           GlobalTrackingGeometryRecord,
-          boost::mpl::vector<TrackerDigiGeometryRecord, MTDDigiGeometryRecord, MuonGeometryRecord> > {};
+          edm::mpl::Vector<TrackerDigiGeometryRecord, MTDDigiGeometryRecord, MuonGeometryRecord> > {};
 
 #endif

--- a/Geometry/Records/interface/HGCalGeometryRecord.h
+++ b/Geometry/Records/interface/HGCalGeometryRecord.h
@@ -6,10 +6,10 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/PHGCalRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class HGCalGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
                                 HGCalGeometryRecord,
-                                boost::mpl::vector<IdealGeometryRecord, GlobalPositionRcd, PHGCalRcd> > {};
+                                edm::mpl::Vector<IdealGeometryRecord, GlobalPositionRcd, PHGCalRcd> > {};
 
 #endif /* RECORDS_HGCALGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/HcalGeometryRecord.h
+++ b/Geometry/Records/interface/HcalGeometryRecord.h
@@ -18,18 +18,18 @@
 #include "CondFormats/AlignmentRecord/interface/HcalAlignmentErrorExtendedRcd.h"
 #include "Geometry/Records/interface/PHcalRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class HcalGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<HcalGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               HcalParametersRcd,
-                                                                               HcalSimNumberingRecord,
-                                                                               HcalRecNumberingRecord,
-                                                                               HcalAlignmentRcd,
-                                                                               HcalAlignmentErrorRcd,
-                                                                               HcalAlignmentErrorExtendedRcd,
-                                                                               GlobalPositionRcd,
-                                                                               PHcalRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             HcalParametersRcd,
+                                                                             HcalSimNumberingRecord,
+                                                                             HcalRecNumberingRecord,
+                                                                             HcalAlignmentRcd,
+                                                                             HcalAlignmentErrorRcd,
+                                                                             HcalAlignmentErrorExtendedRcd,
+                                                                             GlobalPositionRcd,
+                                                                             PHcalRcd> > {};
 
 #endif /* RECORDS_HCALGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/HcalParametersRcd.h
+++ b/Geometry/Records/interface/HcalParametersRcd.h
@@ -3,10 +3,10 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class HcalParametersRcd
-    : public edm::eventsetup::DependentRecordImplementation<HcalParametersRcd, boost::mpl::vector<IdealGeometryRecord> > {
+    : public edm::eventsetup::DependentRecordImplementation<HcalParametersRcd, edm::mpl::Vector<IdealGeometryRecord> > {
 };
 
 #endif  // Geometry_Records_HcalParameters_H

--- a/Geometry/Records/interface/HcalRecNumberingRecord.h
+++ b/Geometry/Records/interface/HcalRecNumberingRecord.h
@@ -17,12 +17,12 @@
 // Author:
 // Created:     Thu Dec 24 16:41:02 PDT 2013
 //
-#include <boost/mpl/vector.hpp>
+#include <FWCore/Utilities/interface/mplVector.h>
 #include "Geometry/Records/interface/HcalSimNumberingRecord.h"
 
-class HcalRecNumberingRecord
-    : public edm::eventsetup::DependentRecordImplementation<
-          HcalRecNumberingRecord,
-          boost::mpl::vector<IdealGeometryRecord, HcalParametersRcd, HcalSimNumberingRecord> > {};
+class HcalRecNumberingRecord : public edm::eventsetup::DependentRecordImplementation<
+                                   HcalRecNumberingRecord,
+                                   edm::mpl::Vector<IdealGeometryRecord, HcalParametersRcd, HcalSimNumberingRecord> > {
+};
 
 #endif

--- a/Geometry/Records/interface/HcalSimNumberingRecord.h
+++ b/Geometry/Records/interface/HcalSimNumberingRecord.h
@@ -18,13 +18,13 @@
 // Created:     Thu Dec 24 16:41:02 PDT 2013
 //
 
-#include <boost/mpl/vector.hpp>
+#include <FWCore/Utilities/interface/mplVector.h>
 #include "Geometry/Records/interface/HcalParametersRcd.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 class HcalSimNumberingRecord
     : public edm::eventsetup::DependentRecordImplementation<HcalSimNumberingRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord, HcalParametersRcd> > {
+                                                            edm::mpl::Vector<IdealGeometryRecord, HcalParametersRcd> > {
 };
 
 #endif

--- a/Geometry/Records/interface/IdealGeometryRecord.h
+++ b/Geometry/Records/interface/IdealGeometryRecord.h
@@ -22,11 +22,11 @@
 #include "Geometry/Records/interface/GeometryFileRcd.h"
 #include "Geometry/Records/interface/PGeometricDetExtraRcd.h"
 #include "Geometry/Records/interface/PGeometricTimingDetExtraRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class IdealGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           IdealGeometryRecord,
-          boost::mpl::vector<GeometryFileRcd, PGeometricDetExtraRcd, PGeometricTimingDetExtraRcd> > {};
+          edm::mpl::Vector<GeometryFileRcd, PGeometricDetExtraRcd, PGeometricTimingDetExtraRcd> > {};
 
 #endif /* RECORDS_IDEALGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/MTDDigiGeometryRecord.h
+++ b/Geometry/Records/interface/MTDDigiGeometryRecord.h
@@ -10,16 +10,16 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
 #include "Geometry/Records/interface/PMTDParametersRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MTDDigiGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<MTDDigiGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               MTDAlignmentRcd,
-                                                                               MTDAlignmentErrorExtendedRcd,
-                                                                               MTDSurfaceDeformationRcd,
-                                                                               GlobalPositionRcd,
-                                                                               MTDTopologyRcd,
-                                                                               PMTDParametersRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             MTDAlignmentRcd,
+                                                                             MTDAlignmentErrorExtendedRcd,
+                                                                             MTDSurfaceDeformationRcd,
+                                                                             GlobalPositionRcd,
+                                                                             MTDTopologyRcd,
+                                                                             PMTDParametersRcd> > {};
 
 #endif /* RECORDS_MTDDIGIGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/MTDGeometryRecord.h
+++ b/Geometry/Records/interface/MTDGeometryRecord.h
@@ -8,11 +8,11 @@
 #include "Geometry/Records/interface/BTLGeometryRcd.h"
 #include "Geometry/Records/interface/ETLGeometryRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MTDGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           MTDGeometryRecord,
-          boost::mpl::vector<IdealGeometryRecord, BTLGeometryRcd, ETLGeometryRcd, GlobalPositionRcd, PFastTimeRcd> > {};
+          edm::mpl::Vector<IdealGeometryRecord, BTLGeometryRcd, ETLGeometryRcd, GlobalPositionRcd, PFastTimeRcd> > {};
 
 #endif /* RECORDS_MTDGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/MTDTopologyRcd.h
+++ b/Geometry/Records/interface/MTDTopologyRcd.h
@@ -5,11 +5,11 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/PMTDParametersRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MTDTopologyRcd
     : public edm::eventsetup::DependentRecordImplementation<MTDTopologyRcd,
-                                                            boost::mpl::vector<IdealGeometryRecord, PMTDParametersRcd> > {
+                                                            edm::mpl::Vector<IdealGeometryRecord, PMTDParametersRcd> > {
 };
 
 #endif

--- a/Geometry/Records/interface/MuonGeometryRcd.h
+++ b/Geometry/Records/interface/MuonGeometryRcd.h
@@ -9,15 +9,15 @@
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorRcd.h"
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MuonGeometryRcd
     : public edm::eventsetup::DependentRecordImplementation<MuonGeometryRcd,
-                                                            boost::mpl::vector<MuonNumberingRcd,
-                                                                               DDSpecParRegistryRcd,
-                                                                               GlobalPositionRcd,
-                                                                               DTAlignmentRcd,
-                                                                               DTAlignmentErrorRcd,
-                                                                               DTAlignmentErrorExtendedRcd,
-                                                                               DTRecoGeometryRcd>> {};
+                                                            edm::mpl::Vector<MuonNumberingRcd,
+                                                                             DDSpecParRegistryRcd,
+                                                                             GlobalPositionRcd,
+                                                                             DTAlignmentRcd,
+                                                                             DTAlignmentErrorRcd,
+                                                                             DTAlignmentErrorExtendedRcd,
+                                                                             DTRecoGeometryRcd>> {};
 #endif

--- a/Geometry/Records/interface/MuonGeometryRecord.h
+++ b/Geometry/Records/interface/MuonGeometryRecord.h
@@ -19,7 +19,7 @@
 #include "Geometry/Records/interface/CSCRecoGeometryRcd.h"
 #include "Geometry/Records/interface/DTRecoGeometryRcd.h"
 #include "Geometry/Records/interface/CSCRecoDigiParametersRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorRcd.h"
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h"
@@ -33,25 +33,25 @@
 
 class MuonGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<MuonGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               DDSpecParRegistryRcd,
-                                                                               GeometryFileRcd,
-                                                                               MuonNumberingRecord,
-                                                                               DTAlignmentRcd,
-                                                                               DTAlignmentErrorRcd,
-                                                                               DTAlignmentErrorExtendedRcd,
-                                                                               CSCAlignmentRcd,
-                                                                               CSCAlignmentErrorRcd,
-                                                                               CSCAlignmentErrorExtendedRcd,
-                                                                               GEMAlignmentRcd,
-                                                                               GEMAlignmentErrorRcd,
-                                                                               GEMAlignmentErrorExtendedRcd,
-                                                                               GlobalPositionRcd,
-                                                                               ME0RecoGeometryRcd,
-                                                                               GEMRecoGeometryRcd,
-                                                                               RPCRecoGeometryRcd,
-                                                                               DTRecoGeometryRcd,
-                                                                               CSCRecoGeometryRcd,
-                                                                               CSCRecoDigiParametersRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             DDSpecParRegistryRcd,
+                                                                             GeometryFileRcd,
+                                                                             MuonNumberingRecord,
+                                                                             DTAlignmentRcd,
+                                                                             DTAlignmentErrorRcd,
+                                                                             DTAlignmentErrorExtendedRcd,
+                                                                             CSCAlignmentRcd,
+                                                                             CSCAlignmentErrorRcd,
+                                                                             CSCAlignmentErrorExtendedRcd,
+                                                                             GEMAlignmentRcd,
+                                                                             GEMAlignmentErrorRcd,
+                                                                             GEMAlignmentErrorExtendedRcd,
+                                                                             GlobalPositionRcd,
+                                                                             ME0RecoGeometryRcd,
+                                                                             GEMRecoGeometryRcd,
+                                                                             RPCRecoGeometryRcd,
+                                                                             DTRecoGeometryRcd,
+                                                                             CSCRecoGeometryRcd,
+                                                                             CSCRecoDigiParametersRcd> > {};
 
 #endif

--- a/Geometry/Records/interface/MuonNumberingRcd.h
+++ b/Geometry/Records/interface/MuonNumberingRcd.h
@@ -3,9 +3,9 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/DDSpecParRegistryRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MuonNumberingRcd
-    : public edm::eventsetup::DependentRecordImplementation<MuonNumberingRcd, boost::mpl::vector<DDSpecParRegistryRcd>> {
+    : public edm::eventsetup::DependentRecordImplementation<MuonNumberingRcd, edm::mpl::Vector<DDSpecParRegistryRcd>> {
 };
 #endif

--- a/Geometry/Records/interface/MuonNumberingRecord.h
+++ b/Geometry/Records/interface/MuonNumberingRecord.h
@@ -18,7 +18,7 @@
 // Created:     Thu Sep 28 16:41:02 PDT 2006
 //
 
-#include <boost/mpl/vector.hpp>
+#include <FWCore/Utilities/interface/mplVector.h>
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/GeometryFileRcd.h"
 #include "Geometry/Records/interface/DDSpecParRegistryRcd.h"
@@ -29,11 +29,11 @@
 
 class MuonNumberingRecord
     : public edm::eventsetup::DependentRecordImplementation<MuonNumberingRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               CSCRecoDigiParametersRcd,
-                                                                               CSCRecoGeometryRcd,
-                                                                               DTRecoGeometryRcd,
-                                                                               DDSpecParRegistryRcd,
-                                                                               GeometryFileRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             CSCRecoDigiParametersRcd,
+                                                                             CSCRecoGeometryRcd,
+                                                                             DTRecoGeometryRcd,
+                                                                             DDSpecParRegistryRcd,
+                                                                             GeometryFileRcd> > {};
 
 #endif

--- a/Geometry/Records/interface/PFastTimeParametersRcd.h
+++ b/Geometry/Records/interface/PFastTimeParametersRcd.h
@@ -4,10 +4,10 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class PFastTimeParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<PFastTimeParametersRcd,
-                                                            boost::mpl::vector<IdealGeometryRecord> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord> > {};
 
 #endif  // PFastTimeParameters_H

--- a/Geometry/Records/interface/PHGCalParametersRcd.h
+++ b/Geometry/Records/interface/PHGCalParametersRcd.h
@@ -4,10 +4,10 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class PHGCalParametersRcd
-    : public edm::eventsetup::DependentRecordImplementation<PHGCalParametersRcd,
-                                                            boost::mpl::vector<IdealGeometryRecord> > {};
+    : public edm::eventsetup::DependentRecordImplementation<PHGCalParametersRcd, edm::mpl::Vector<IdealGeometryRecord> > {
+};
 
 #endif  // PHGCalParameters_H

--- a/Geometry/Records/interface/PMTDParametersRcd.h
+++ b/Geometry/Records/interface/PMTDParametersRcd.h
@@ -4,10 +4,10 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class PMTDParametersRcd
-    : public edm::eventsetup::DependentRecordImplementation<PMTDParametersRcd, boost::mpl::vector<IdealGeometryRecord> > {
+    : public edm::eventsetup::DependentRecordImplementation<PMTDParametersRcd, edm::mpl::Vector<IdealGeometryRecord> > {
 };
 
 #endif  // PMTDParameters_H

--- a/Geometry/Records/interface/PTrackerParametersRcd.h
+++ b/Geometry/Records/interface/PTrackerParametersRcd.h
@@ -4,10 +4,10 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class PTrackerParametersRcd
     : public edm::eventsetup::DependentRecordImplementation<PTrackerParametersRcd,
-                                                            boost::mpl::vector<IdealGeometryRecord> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord> > {};
 
 #endif  // PTrackerParameters_H

--- a/Geometry/Records/interface/StackedTrackerGeometryRecord.h
+++ b/Geometry/Records/interface/StackedTrackerGeometryRecord.h
@@ -15,11 +15,11 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class StackedTrackerGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<StackedTrackerGeometryRecord,
-                                                            boost::mpl::vector<TrackerDigiGeometryRecord> > {};
+                                                            edm::mpl::Vector<TrackerDigiGeometryRecord> > {};
 
 #endif
 

--- a/Geometry/Records/interface/TrackerDigiGeometryRecord.h
+++ b/Geometry/Records/interface/TrackerDigiGeometryRecord.h
@@ -10,16 +10,16 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TrackerDigiGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<TrackerDigiGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               TrackerAlignmentRcd,
-                                                                               TrackerAlignmentErrorExtendedRcd,
-                                                                               TrackerSurfaceDeformationRcd,
-                                                                               GlobalPositionRcd,
-                                                                               TrackerTopologyRcd,
-                                                                               PTrackerParametersRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             TrackerAlignmentRcd,
+                                                                             TrackerAlignmentErrorExtendedRcd,
+                                                                             TrackerSurfaceDeformationRcd,
+                                                                             GlobalPositionRcd,
+                                                                             TrackerTopologyRcd,
+                                                                             PTrackerParametersRcd> > {};
 
 #endif /* RECORDS_TRACKERDIGIGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/TrackerTopologyRcd.h
+++ b/Geometry/Records/interface/TrackerTopologyRcd.h
@@ -5,10 +5,10 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TrackerTopologyRcd : public edm::eventsetup::DependentRecordImplementation<
                                TrackerTopologyRcd,
-                               boost::mpl::vector<IdealGeometryRecord, PTrackerParametersRcd> > {};
+                               edm::mpl::Vector<IdealGeometryRecord, PTrackerParametersRcd> > {};
 
 #endif

--- a/Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h
+++ b/Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h
@@ -12,7 +12,7 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "CondFormats/AlignmentRecord/interface/RPMisalignedAlignmentRecord.h"
 
@@ -24,6 +24,6 @@
 class VeryForwardMisalignedGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           VeryForwardMisalignedGeometryRecord,
-          boost::mpl::vector<IdealGeometryRecord, RPMisalignedAlignmentRecord /*, ... */> > {};
+          edm::mpl::Vector<IdealGeometryRecord, RPMisalignedAlignmentRecord /*, ... */> > {};
 
 #endif

--- a/Geometry/Records/interface/VeryForwardRealGeometryRecord.h
+++ b/Geometry/Records/interface/VeryForwardRealGeometryRecord.h
@@ -12,7 +12,7 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "CondFormats/AlignmentRecord/interface/RPRealAlignmentRecord.h"
 
@@ -22,7 +22,6 @@
  **/
 class VeryForwardRealGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
                                           VeryForwardRealGeometryRecord,
-                                          boost::mpl::vector<IdealGeometryRecord, RPRealAlignmentRecord /*, ... */> > {
-};
+                                          edm::mpl::Vector<IdealGeometryRecord, RPRealAlignmentRecord /*, ... */> > {};
 
 #endif

--- a/Geometry/Records/interface/ZDCGeometryRecord.h
+++ b/Geometry/Records/interface/ZDCGeometryRecord.h
@@ -18,15 +18,15 @@
 #include "CondFormats/AlignmentRecord/interface/ZDCAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "Geometry/Records/interface/PZdcRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class ZDCGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<ZDCGeometryRecord,
-                                                            boost::mpl::vector<IdealGeometryRecord,
-                                                                               ZDCAlignmentRcd,
-                                                                               ZDCAlignmentErrorRcd,
-                                                                               ZDCAlignmentErrorExtendedRcd,
-                                                                               GlobalPositionRcd,
-                                                                               PZdcRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord,
+                                                                             ZDCAlignmentRcd,
+                                                                             ZDCAlignmentErrorRcd,
+                                                                             ZDCAlignmentErrorExtendedRcd,
+                                                                             GlobalPositionRcd,
+                                                                             PZdcRcd> > {};
 
 #endif /* RECORDS_ZDCGEOMETRYRECORD_H */

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceRcd.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceRcd.h
@@ -18,7 +18,7 @@
 // Created:     Tue Jul 31 19:49:12 CDT 2012
 //
 
-#include <boost/mpl/vector.hpp>
+#include <FWCore/Utilities/interface/mplVector.h>
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/FFTJetCorrectorParametersRcd.h"
@@ -26,7 +26,7 @@
 template <typename CT>
 struct FFTJetCorrectorSequenceRcd
     : public edm::eventsetup::DependentRecordImplementation<FFTJetCorrectorSequenceRcd<CT>,
-                                                            boost::mpl::vector<FFTJetCorrectorParametersRcd<CT> > > {
+                                                            edm::mpl::Vector<FFTJetCorrectorParametersRcd<CT> > > {
   typedef CT correction_type;
 };
 

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableRcd.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableRcd.h
@@ -18,7 +18,7 @@
 // Created:     Tue Jul 31 19:49:12 CDT 2012
 //
 
-#include <boost/mpl/vector.hpp>
+#include <FWCore/Utilities/interface/mplVector.h>
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/FFTJetCorrectorParametersRcd.h"
@@ -26,7 +26,7 @@
 template <typename CT>
 struct FFTJetLookupTableRcd
     : public edm::eventsetup::DependentRecordImplementation<FFTJetLookupTableRcd<CT>,
-                                                            boost::mpl::vector<FFTJetCorrectorParametersRcd<CT> > > {
+                                                            edm::mpl::Vector<FFTJetCorrectorParametersRcd<CT> > > {
   typedef CT correction_type;
 };
 

--- a/L1Trigger/L1TCommon/scripts/template.h
+++ b/L1Trigger/L1TCommon/scripts/template.h
@@ -1,4 +1,4 @@
-// XXXRcd                                                                                            
+// XXXRcd
 // Description: Record for XXX
 //
 // automatically generate by make_records.pl
@@ -14,6 +14,6 @@ class XXXRcd : public edm::eventsetup::EventSetupRecordImplementation<XXXRcd> {}
 //#include "FWCore/Framework/interface/DependentRecordImplementation.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
 //#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
-//class XXXRcd : public edm::eventsetup::DependentRecordImplementation<XXXRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+//class XXXRcd : public edm::eventsetup::DependentRecordImplementation<XXXRcd, edm::mpl::Vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
 
 #endif

--- a/L1Trigger/TrackTrigger/interface/TTClusterAlgorithmRecord.h
+++ b/L1Trigger/TrackTrigger/interface/TTClusterAlgorithmRecord.h
@@ -15,9 +15,9 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TTClusterAlgorithmRecord
     : public edm::eventsetup::DependentRecordImplementation<TTClusterAlgorithmRecord,
-                                                            boost::mpl::vector<IdealMagneticFieldRecord> > {};
+                                                            edm::mpl::Vector<IdealMagneticFieldRecord> > {};
 #endif

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithmRecord.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithmRecord.h
@@ -18,11 +18,11 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TTStubAlgorithmRecord
     : public edm::eventsetup::DependentRecordImplementation<
           TTStubAlgorithmRecord,
-          boost::mpl::vector<TrackerDigiGeometryRecord, TrackerTopologyRcd, IdealMagneticFieldRecord> > {};
+          edm::mpl::Vector<TrackerDigiGeometryRecord, TrackerTopologyRcd, IdealMagneticFieldRecord> > {};
 
 #endif

--- a/L1Trigger/TrackerDTC/interface/SetupRcd.h
+++ b/L1Trigger/TrackerDTC/interface/SetupRcd.h
@@ -10,16 +10,16 @@
 #include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
 #include "L1Trigger/TrackTrigger/interface/TTStubAlgorithmRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 namespace trackerDTC {
 
-  typedef boost::mpl::vector<TrackerDigiGeometryRecord,
-                             TrackerTopologyRcd,
-                             IdealMagneticFieldRecord,
-                             IdealGeometryRecord,
-                             TrackerDetToDTCELinkCablingMapRcd,
-                             TTStubAlgorithmRecord>
+  typedef edm::mpl::Vector<TrackerDigiGeometryRecord,
+                           TrackerTopologyRcd,
+                           IdealMagneticFieldRecord,
+                           IdealGeometryRecord,
+                           TrackerDetToDTCELinkCablingMapRcd,
+                           TTStubAlgorithmRecord>
       Rcds;
 
   class SetupRcd : public edm::eventsetup::DependentRecordImplementation<SetupRcd, Rcds> {};

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigManagerRcd.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigManagerRcd.h
@@ -20,7 +20,7 @@
 //		SV September 2008: create dependent record from DTCCBConfigRcd
 //
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/DTCCBConfigRcd.h"
 #include "CondFormats/DataRecord/interface/DTKeyedConfigListRcd.h"
@@ -30,7 +30,6 @@ class DTTPGParametersRcd;
 
 class DTConfigManagerRcd : public edm::eventsetup::DependentRecordImplementation<
                                DTConfigManagerRcd,
-                               boost::mpl::vector<DTCCBConfigRcd, DTKeyedConfigListRcd, DTT0Rcd, DTTPGParametersRcd> > {
-};
+                               edm::mpl::Vector<DTCCBConfigRcd, DTKeyedConfigListRcd, DTT0Rcd, DTTPGParametersRcd> > {};
 
 #endif

--- a/MagneticField/Records/interface/IdealMagneticFieldRecord.h
+++ b/MagneticField/Records/interface/IdealMagneticFieldRecord.h
@@ -6,10 +6,10 @@
 #include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 #include "CondFormats/DataRecord/interface/MagFieldConfigRcd.h"
 #include "CondFormats/DataRecord/interface/MFGeometryFileRcd.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class IdealMagneticFieldRecord : public edm::eventsetup::DependentRecordImplementation<
                                      IdealMagneticFieldRecord,
-                                     boost::mpl::vector<MFGeometryFileRcd, RunInfoRcd, MagFieldConfigRcd> > {};
+                                     edm::mpl::Vector<MFGeometryFileRcd, RunInfoRcd, MagFieldConfigRcd> > {};
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/KinematicResolutionRcd.h
+++ b/PhysicsTools/PatAlgos/interface/KinematicResolutionRcd.h
@@ -19,9 +19,9 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class KinematicResolutionRcd
     : public edm::eventsetup::DependentRecordImplementation<KinematicResolutionRcd,
-                                                            boost::mpl::vector<IdealMagneticFieldRecord> > {};
+                                                            edm::mpl::Vector<IdealMagneticFieldRecord> > {};
 #endif

--- a/RecoBTag/Records/interface/BTagPerformanceRecord.h
+++ b/RecoBTag/Records/interface/BTagPerformanceRecord.h
@@ -5,10 +5,10 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/PerformancePayloadRecord.h"
 #include "CondFormats/DataRecord/interface/PerformanceWPRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class BTagPerformanceRecord : public edm::eventsetup::DependentRecordImplementation<
                                   BTagPerformanceRecord,
-                                  boost::mpl::vector<PerformancePayloadRecord, PerformanceWPRecord> > {};
+                                  edm::mpl::Vector<PerformancePayloadRecord, PerformanceWPRecord> > {};
 
 #endif

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h
@@ -2,13 +2,13 @@
 #define RecoBTau_JetTagComputerRecord_h
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
-#include <boost/mpl/vector.hpp>
+#include <FWCore/Utilities/interface/mplVector.h>
 
 class BTauGenericMVAJetTagComputerRcd;
 class GBRWrapperRcd;
 
 class JetTagComputerRecord : public edm::eventsetup::DependentRecordImplementation<
                                  JetTagComputerRecord,
-                                 boost::mpl::vector<BTauGenericMVAJetTagComputerRcd, GBRWrapperRcd> > {};
+                                 edm::mpl::Vector<BTauGenericMVAJetTagComputerRcd, GBRWrapperRcd> > {};
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalNextToDeadChannelRcd.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalNextToDeadChannelRcd.h
@@ -1,7 +1,7 @@
 #ifndef EcalNextToDeadChannelRcd_h
 #define EcalNextToDeadChannelRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 
@@ -11,6 +11,6 @@
 
 class EcalNextToDeadChannelRcd
     : public edm::eventsetup::DependentRecordImplementation<EcalNextToDeadChannelRcd,
-                                                            boost::mpl::vector<EcalChannelStatusRcd> > {};
+                                                            edm::mpl::Vector<EcalChannelStatusRcd> > {};
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h
@@ -1,7 +1,7 @@
 #ifndef EcalSeverityLevelAlgoRcd_h
 #define EcalSeverityLevelAlgoRcd_h
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 
@@ -11,6 +11,6 @@
 
 class EcalSeverityLevelAlgoRcd
     : public edm::eventsetup::DependentRecordImplementation<EcalSeverityLevelAlgoRcd,
-                                                            boost::mpl::vector<EcalChannelStatusRcd> > {};
+                                                            edm::mpl::Vector<EcalChannelStatusRcd> > {};
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesAuxRecord.h
@@ -1,7 +1,7 @@
 #ifndef RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesAuxRecord_h_
 #define RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesAuxRecord_h_
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 class HcalRecNumberingRecord;
@@ -9,6 +9,6 @@ class HcalRecoParamsRcd;
 
 class HcalChannelPropertiesAuxRecord : public edm::eventsetup::DependentRecordImplementation<
                                            HcalChannelPropertiesAuxRecord,
-                                           boost::mpl::vector<HcalRecNumberingRecord, HcalRecoParamsRcd> > {};
+                                           edm::mpl::Vector<HcalRecNumberingRecord, HcalRecoParamsRcd> > {};
 
 #endif  // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesAuxRecord_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h
@@ -1,7 +1,6 @@
 #ifndef RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_
 #define RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_
 
-#include "boost/mpl/vector.hpp"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 class HcalDbRecord;
@@ -12,8 +11,8 @@ class HcalChannelPropertiesAuxRecord;
 class HcalChannelPropertiesRecord
     : public edm::eventsetup::DependentRecordImplementation<
           HcalChannelPropertiesRecord,
-          boost::mpl::
-              vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd, HcalChannelPropertiesAuxRecord> > {
+          edm::mpl::
+              Vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd, HcalChannelPropertiesAuxRecord> > {
 };
 
 #endif  // RecoLocalCalo_HcalRecAlgos_HcalChannelPropertiesRecord_h_

--- a/RecoLocalFastTime/Records/interface/MTDCPERecord.h
+++ b/RecoLocalFastTime/Records/interface/MTDCPERecord.h
@@ -5,10 +5,9 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MTDCPERecord
-    : public edm::eventsetup::DependentRecordImplementation<MTDCPERecord, boost::mpl::vector<MTDDigiGeometryRecord> > {
-};
+    : public edm::eventsetup::DependentRecordImplementation<MTDCPERecord, edm::mpl::Vector<MTDDigiGeometryRecord> > {};
 
 #endif

--- a/RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h
+++ b/RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h
@@ -6,11 +6,11 @@
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MTDTimeCalibRecord
     : public edm::eventsetup::DependentRecordImplementation<MTDTimeCalibRecord,
-                                                            boost::mpl::vector<MTDDigiGeometryRecord, MTDTopologyRcd> > {
+                                                            edm::mpl::Vector<MTDDigiGeometryRecord, MTDTopologyRcd> > {
 };
 
 #endif

--- a/RecoLocalTracker/Records/interface/SiStripClusterizerConditionsRcd.h
+++ b/RecoLocalTracker/Records/interface/SiStripClusterizerConditionsRcd.h
@@ -1,12 +1,12 @@
 #ifndef RecoLocalTracker_Records_SiStripClusterizerConditionsRcd_h
 #define RecoLocalTracker_Records_SiStripClusterizerConditionsRcd_h
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
 
 class SiStripClusterizerConditionsRcd : public edm::eventsetup::DependentRecordImplementation<
                                             SiStripClusterizerConditionsRcd,
-                                            boost::mpl::vector<SiStripGainRcd, SiStripNoisesRcd, SiStripQualityRcd>> {};
+                                            edm::mpl::Vector<SiStripGainRcd, SiStripNoisesRcd, SiStripQualityRcd>> {};
 
 #endif  // RecoLocalTracker_Records_SiStripClusterizerConditionsRcd_h

--- a/RecoLocalTracker/Records/interface/TkPixelCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkPixelCPERecord.h
@@ -13,16 +13,16 @@
 #include "CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h"
 #include "CalibTracker/Records/interface/SiPixel2DTemplateDBObjectESProducerRcd.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TkPixelCPERecord
     : public edm::eventsetup::DependentRecordImplementation<TkPixelCPERecord,
-                                                            boost::mpl::vector<TrackerDigiGeometryRecord,
-                                                                               IdealMagneticFieldRecord,
-                                                                               SiPixelLorentzAngleRcd,
-                                                                               SiPixelGenErrorDBObjectRcd,
-                                                                               SiPixelTemplateDBObjectESProducerRcd,
-                                                                               SiPixel2DTemplateDBObjectESProducerRcd,
-                                                                               TrackerTopologyRcd> > {};
+                                                            edm::mpl::Vector<TrackerDigiGeometryRecord,
+                                                                             IdealMagneticFieldRecord,
+                                                                             SiPixelLorentzAngleRcd,
+                                                                             SiPixelGenErrorDBObjectRcd,
+                                                                             SiPixelTemplateDBObjectESProducerRcd,
+                                                                             SiPixel2DTemplateDBObjectESProducerRcd,
+                                                                             TrackerTopologyRcd> > {};
 
 #endif

--- a/RecoLocalTracker/Records/interface/TkStripCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkStripCPERecord.h
@@ -8,18 +8,18 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TkStripCPERecord
     : public edm::eventsetup::DependentRecordImplementation<TkStripCPERecord,
-                                                            boost::mpl::vector<TrackerDigiGeometryRecord,
-                                                                               IdealMagneticFieldRecord,
-                                                                               SiStripLorentzAngleDepRcd,
-                                                                               SiStripBackPlaneCorrectionDepRcd,
-                                                                               SiStripConfObjectRcd,
-                                                                               SiStripLatencyRcd,
-                                                                               SiStripNoisesRcd,
-                                                                               SiStripApvGainRcd,
-                                                                               SiStripBadChannelRcd> > {};
+                                                            edm::mpl::Vector<TrackerDigiGeometryRecord,
+                                                                             IdealMagneticFieldRecord,
+                                                                             SiStripLorentzAngleDepRcd,
+                                                                             SiStripBackPlaneCorrectionDepRcd,
+                                                                             SiStripConfObjectRcd,
+                                                                             SiStripLatencyRcd,
+                                                                             SiStripNoisesRcd,
+                                                                             SiStripApvGainRcd,
+                                                                             SiStripBadChannelRcd> > {};
 
 #endif

--- a/RecoLocalTracker/Records/interface/TrackerCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TrackerCPERecord.h
@@ -7,10 +7,10 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TrackerCPERecord : public edm::eventsetup::DependentRecordImplementation<
                              TrackerCPERecord,
-                             boost::mpl::vector<TrackerDigiGeometryRecord, IdealMagneticFieldRecord> > {};
+                             edm::mpl::Vector<TrackerDigiGeometryRecord, IdealMagneticFieldRecord> > {};
 
 #endif

--- a/RecoMTD/Records/interface/MTDRecoGeometryRecord.h
+++ b/RecoMTD/Records/interface/MTDRecoGeometryRecord.h
@@ -12,10 +12,10 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MTDRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<MTDRecoGeometryRecord,
-                                                            boost::mpl::vector<MTDDigiGeometryRecord> > {};
+                                                            edm::mpl::Vector<MTDDigiGeometryRecord> > {};
 
 #endif

--- a/RecoMuon/Records/interface/MuonPerformanceRecord.h
+++ b/RecoMuon/Records/interface/MuonPerformanceRecord.h
@@ -5,10 +5,10 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/PerformancePayloadRecord.h"
 #include "CondFormats/DataRecord/interface/PerformanceWPRecord.h"
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MuonPerformanceRecord : public edm::eventsetup::DependentRecordImplementation<
                                   MuonPerformanceRecord,
-                                  boost::mpl::vector<PerformancePayloadRecord, PerformanceWPRecord> > {};
+                                  edm::mpl::Vector<PerformancePayloadRecord, PerformanceWPRecord> > {};
 
 #endif

--- a/RecoMuon/Records/interface/MuonRecoGeometryRecord.h
+++ b/RecoMuon/Records/interface/MuonRecoGeometryRecord.h
@@ -12,10 +12,10 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MuonRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<MuonRecoGeometryRecord,
-                                                            boost::mpl::vector<MuonGeometryRecord> > {};
+                                                            edm::mpl::Vector<MuonGeometryRecord> > {};
 
 #endif

--- a/RecoTracker/Record/interface/CkfComponentsRecord.h
+++ b/RecoTracker/Record/interface/CkfComponentsRecord.h
@@ -17,25 +17,25 @@
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"  // FIXME should be in the dependencies of the SiPixelQualityRcd
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class CkfComponentsRecord
     : public edm::eventsetup::DependentRecordImplementation<CkfComponentsRecord,
-                                                            boost::mpl::vector<TrackerDigiGeometryRecord,
-                                                                               TkPixelCPERecord,
-                                                                               TkStripCPERecord,
-                                                                               TransientRecHitRecord,
-                                                                               TrackingComponentsRecord,
-                                                                               TrackerRecoGeometryRecord,
-                                                                               TrackerTopologyRcd,
-                                                                               SiStripQualityRcd,
-                                                                               SiStripDetCablingRcd,
-                                                                               SiStripNoisesRcd,
-                                                                               SiStripRegionCablingRcd,
-                                                                               SiPixelQualityRcd,
-                                                                               SiPixelFedCablingMapRcd,
-                                                                               IdealMagneticFieldRecord,
-                                                                               SiPixelLorentzAngleRcd,
-                                                                               SiStripLorentzAngleDepRcd> > {};
+                                                            edm::mpl::Vector<TrackerDigiGeometryRecord,
+                                                                             TkPixelCPERecord,
+                                                                             TkStripCPERecord,
+                                                                             TransientRecHitRecord,
+                                                                             TrackingComponentsRecord,
+                                                                             TrackerRecoGeometryRecord,
+                                                                             TrackerTopologyRcd,
+                                                                             SiStripQualityRcd,
+                                                                             SiStripDetCablingRcd,
+                                                                             SiStripNoisesRcd,
+                                                                             SiStripRegionCablingRcd,
+                                                                             SiPixelQualityRcd,
+                                                                             SiPixelFedCablingMapRcd,
+                                                                             IdealMagneticFieldRecord,
+                                                                             SiPixelLorentzAngleRcd,
+                                                                             SiStripLorentzAngleDepRcd> > {};
 
 #endif

--- a/RecoTracker/Record/interface/MultiRecHitRecord.h
+++ b/RecoTracker/Record/interface/MultiRecHitRecord.h
@@ -7,10 +7,10 @@
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class MultiRecHitRecord
     : public edm::eventsetup::DependentRecordImplementation<
           MultiRecHitRecord,
-          boost::mpl::vector<TrackerDigiGeometryRecord, TransientRecHitRecord, CkfComponentsRecord> > {};
+          edm::mpl::Vector<TrackerDigiGeometryRecord, TransientRecHitRecord, CkfComponentsRecord> > {};
 #endif

--- a/RecoTracker/Record/interface/NavigationSchoolRecord.h
+++ b/RecoTracker/Record/interface/NavigationSchoolRecord.h
@@ -7,10 +7,10 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class NavigationSchoolRecord : public edm::eventsetup::DependentRecordImplementation<
                                    NavigationSchoolRecord,
-                                   boost::mpl::vector<IdealMagneticFieldRecord, TrackerRecoGeometryRecord> > {};
+                                   edm::mpl::Vector<IdealMagneticFieldRecord, TrackerRecoGeometryRecord> > {};
 
 #endif

--- a/RecoTracker/Record/interface/TkMSParameterizationRecord.h
+++ b/RecoTracker/Record/interface/TkMSParameterizationRecord.h
@@ -8,10 +8,10 @@
 #include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TkMSParameterizationRecord : public edm::eventsetup::DependentRecordImplementation<
                                        TkMSParameterizationRecord,
-                                       boost::mpl::vector<TrackingComponentsRecord, NavigationSchoolRecord> > {};
+                                       edm::mpl::Vector<TrackingComponentsRecord, NavigationSchoolRecord> > {};
 
 #endif

--- a/RecoTracker/Record/interface/TrackerRecoGeometryRecord.h
+++ b/RecoTracker/Record/interface/TrackerRecoGeometryRecord.h
@@ -6,10 +6,10 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TrackerRecoGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
                                       TrackerRecoGeometryRecord,
-                                      boost::mpl::vector<TrackerTopologyRcd, TrackerDigiGeometryRecord> > {};
+                                      edm::mpl::Vector<TrackerTopologyRcd, TrackerDigiGeometryRecord> > {};
 
 #endif

--- a/SimTracker/Records/interface/TrackAssociatorRecord.h
+++ b/SimTracker/Records/interface/TrackAssociatorRecord.h
@@ -13,11 +13,11 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TrackAssociatorRecord
     : public edm::eventsetup::DependentRecordImplementation<
           TrackAssociatorRecord,
-          boost::mpl::vector<IdealMagneticFieldRecord, TrackingComponentsRecord, GlobalTrackingGeometryRecord>> {};
+          edm::mpl::Vector<IdealMagneticFieldRecord, TrackingComponentsRecord, GlobalTrackingGeometryRecord>> {};
 
 #endif

--- a/TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h
+++ b/TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h
@@ -10,14 +10,13 @@
 //#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
 //#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
-class RecoGeometryRecord
-    : public edm::eventsetup::DependentRecordImplementation<
-          RecoGeometryRecord,
-          boost::mpl::vector<TrackerRecoGeometryRecord, MuonRecoGeometryRecord, MTDRecoGeometryRecord
-                             //,NavigationSchoolRecord,
-                             //IdealMagneticFieldRecord
-                             > > {};
+class RecoGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
+                               RecoGeometryRecord,
+                               edm::mpl::Vector<TrackerRecoGeometryRecord, MuonRecoGeometryRecord, MTDRecoGeometryRecord
+                                                //,NavigationSchoolRecord,
+                                                //IdealMagneticFieldRecord
+                                                > > {};
 
 #endif

--- a/TrackingTools/Records/interface/DetIdAssociatorRecord.h
+++ b/TrackingTools/Records/interface/DetIdAssociatorRecord.h
@@ -8,11 +8,11 @@
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class DetIdAssociatorRecord
     : public edm::eventsetup::DependentRecordImplementation<
           DetIdAssociatorRecord,
-          boost::mpl::vector<CaloGeometryRecord, GlobalTrackingGeometryRecord, CSCBadChambersRcd> > {};
+          edm::mpl::Vector<CaloGeometryRecord, GlobalTrackingGeometryRecord, CSCBadChambersRcd> > {};
 
 #endif

--- a/TrackingTools/Records/interface/TrackingComponentsRecord.h
+++ b/TrackingTools/Records/interface/TrackingComponentsRecord.h
@@ -7,10 +7,10 @@
 //#include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TrackingComponentsRecord : public edm::eventsetup::DependentRecordImplementation<
                                      TrackingComponentsRecord,
-                                     boost::mpl::vector<IdealMagneticFieldRecord, GlobalTrackingGeometryRecord> > {};
+                                     edm::mpl::Vector<IdealMagneticFieldRecord, GlobalTrackingGeometryRecord> > {};
 
 #endif

--- a/TrackingTools/Records/interface/TransientRecHitRecord.h
+++ b/TrackingTools/Records/interface/TransientRecHitRecord.h
@@ -9,13 +9,13 @@
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TransientRecHitRecord
     : public edm::eventsetup::DependentRecordImplementation<TransientRecHitRecord,
-                                                            boost::mpl::vector<CaloGeometryRecord,
-                                                                               TrackerDigiGeometryRecord,
-                                                                               TkStripCPERecord,
-                                                                               TkPixelCPERecord,
-                                                                               GlobalTrackingGeometryRecord> > {};
+                                                            edm::mpl::Vector<CaloGeometryRecord,
+                                                                             TrackerDigiGeometryRecord,
+                                                                             TkStripCPERecord,
+                                                                             TkPixelCPERecord,
+                                                                             GlobalTrackingGeometryRecord> > {};
 #endif

--- a/TrackingTools/Records/interface/TransientTrackRecord.h
+++ b/TrackingTools/Records/interface/TransientTrackRecord.h
@@ -6,9 +6,9 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TransientTrackRecord : public edm::eventsetup::DependentRecordImplementation<
                                  TransientTrackRecord,
-                                 boost::mpl::vector<IdealMagneticFieldRecord, GlobalTrackingGeometryRecord> > {};
+                                 edm::mpl::Vector<IdealMagneticFieldRecord, GlobalTrackingGeometryRecord> > {};
 #endif

--- a/TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h
+++ b/TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h
@@ -7,10 +7,10 @@
 #include "TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TrajectoryFitterRecord : public edm::eventsetup::DependentRecordImplementation<
                                    TrajectoryFitterRecord,
-                                   boost::mpl::vector<TrackingComponentsRecord, RecoGeometryRecord> > {};
+                                   edm::mpl::Vector<TrackingComponentsRecord, RecoGeometryRecord> > {};
 
 #endif


### PR DESCRIPTION
#### PR description:

Replace the use of boost::mpl::vector with our own edm::mpl::Vector class. The implementation is fairly simple when using C++17 features.

This change was based on a discussion at the Core meeting about the difficulties with boost mpl with respect to generating ROOT modules.
#### PR validation:

The code compiles and framework unit tests pass.