### PR TITLE
Phase2 D49 premix workflows in IBs

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -15,6 +15,8 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #2026 WFs to run in IB (TTbar)
 numWFIB = []
 numWFIB.extend([23234.0]) #2026D49
+numWFIB.extend([23461.97]) #2026D49 premixing stage1 (NuGun+PU)
+numWFIB.extend([23434.99]) #2026D49 premixing combined stage1+stage2 (ttbar+PU)
 numWFIB.extend([23234.21,23434.21]) #2026D49 prodlike, prodlike PU
 numWFIB.extend([23234.103]) #2026D49 aging
 numWFIB.extend([23634.0]) #2026D51


### PR DESCRIPTION
#### PR description:

In #30645, the D41 detector and its associated workflows were removed. This left premixing workflows out of the IB testing entirely. D49 premixing workflows are now added to ensure that Phase 2 premixing remains functional and can be easily tested.

#### PR validation:

Ran the added workflows successfully.