### PR TITLE
Remove use of boost::mpl from Ref.h

### DIFF
--- a/DataFormats/Common/interface/FwdRef.h
+++ b/DataFormats/Common/interface/FwdRef.h
@@ -113,6 +113,8 @@ FwdRef: A template for a interproduct reference to a member of a product.
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Common/interface/Ref.h"
 
+#include <boost/functional.hpp>
+
 namespace edm {
 
   template <typename C,
@@ -126,7 +128,7 @@ namespace edm {
     typedef T const element_type;  //used for generic programming
     typedef F finder_type;
     typedef typename boost::binary_traits<F>::second_argument_type argument_type;
-    typedef typename boost::remove_cv<typename boost::remove_reference<argument_type>::type>::type key_type;
+    typedef typename std::remove_cv<typename std::remove_reference<argument_type>::type>::type key_type;
     /// C is the type of the collection
     /// T is the type of a member the collection
 

--- a/L1Trigger/TrackFindingTMTT/interface/TrackerModule.h
+++ b/L1Trigger/TrackFindingTMTT/interface/TrackerModule.h
@@ -10,6 +10,7 @@
 #include <set>
 #include <array>
 #include <map>
+#include <cmath>
 
 class TrackerGeometry;
 class TrackerTopology;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cmath>
 //---------------------------------------------------------------------------
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"


### PR DESCRIPTION
#### PR description:

Using C++17 features allowed implementing the same traits check in a relatively simple manner.

This was done based on a discussion in the Core meeting about the difficulty boost::mpl poses for ROOT modules.

#### PR validation:

The code compiles. Checks were done on the `edm::has_key_compare` implementation using compiler explorer.