### PR TITLE
improved printouts and G4 destruction

### DIFF
--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -60,7 +60,8 @@ ECalSD::ECalSD(const std::string& name,
   edm::ParameterSet m_EC = p.getParameter<edm::ParameterSet>("ECalSD");
   useBirk = m_EC.getParameter<bool>("UseBirkLaw");
   useBirkL3 = m_EC.getParameter<bool>("BirkL3Parametrization");
-  birk1 = m_EC.getParameter<double>("BirkC1") * (g / (MeV * cm2));
+  double bunit = (CLHEP::g / (CLHEP::MeV * CLHEP::cm2));
+  birk1 = m_EC.getParameter<double>("BirkC1") * bunit;
   birk2 = m_EC.getParameter<double>("BirkC2");
   birk3 = m_EC.getParameter<double>("BirkC3");
   birkSlope = m_EC.getParameter<double>("BirkSlope");
@@ -123,8 +124,8 @@ ECalSD::ECalSD(const std::string& name,
   edm::LogVerbatim("EcalSim") << "Constructing a ECalSD  with name " << GetName();
 #endif
   if (useWeight) {
-    edm::LogVerbatim("EcalSim") << "ECalSD:: Use of Birks law is set to      " << useBirk
-                                << "        with three constants kB = " << birk1 << ", C1 = " << birk2
+    edm::LogVerbatim("EcalSim") << "ECalSD:: Use of Birks law is set to " << useBirk
+                                << " with three constants kB = " << birk1 / bunit << ", C1 = " << birk2
                                 << ", C2 = " << birk3 << "\n         Use of L3 parametrization " << useBirkL3
                                 << " with slope " << birkSlope << " and cut off " << birkCut << "\n"
                                 << "         Slope for Light yield is set to " << slopeLY;

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -77,7 +77,8 @@ HCalSD::HCalSD(const std::string& name,
 
   edm::ParameterSet m_HC = p.getParameter<edm::ParameterSet>("HCalSD");
   useBirk = m_HC.getParameter<bool>("UseBirkLaw");
-  birk1 = m_HC.getParameter<double>("BirkC1") * (g / (MeV * cm2));
+  double bunit = (CLHEP::g / (CLHEP::MeV * CLHEP::cm2));
+  birk1 = m_HC.getParameter<double>("BirkC1") * bunit;
   birk2 = m_HC.getParameter<double>("BirkC2");
   birk3 = m_HC.getParameter<double>("BirkC3");
   useShowerLibrary = m_HC.getParameter<bool>("UseShowerLibrary");
@@ -112,11 +113,13 @@ HCalSD::HCalSD(const std::string& name,
                               << "***************************************************";
 #endif
   edm::LogVerbatim("HcalSim") << "HCalSD:: Use of HF code is set to " << useHF
-                              << "\nUse of shower parametrization set to " << useParam
-                              << "\nUse of shower library is set to " << useShowerLibrary << "\nUse PMT Hit is set to "
-                              << usePMTHit << " with beta Threshold " << betaThr << "\nUSe of FibreBundle Hit set to "
-                              << useFibreBundle << "\n         Use of Birks law is set to      " << useBirk
-                              << "  with three constants kB = " << birk1 << ", C1 = " << birk2 << ", C2 = " << birk3;
+                              << "\n         Use of shower parametrization set to " << useParam
+                              << "\n         Use of shower library is set to " << useShowerLibrary
+                              << "\n         Use PMT Hit is set to " << usePMTHit << " with beta Threshold " << betaThr
+                              << "\n         USe of FibreBundle Hit set to " << useFibreBundle
+                              << "\n         Use of Birks law is set to " << useBirk
+                              << " with three constants kB = " << birk1 / bunit << ", C1 = " << birk2
+                              << ", C2 = " << birk3;
   edm::LogVerbatim("HcalSim") << "HCalSD:: Suppression Flag " << suppressHeavy << " protons below " << kmaxProton
                               << " MeV,"
                               << " neutrons below " << kmaxNeutron << " MeV and"

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -64,9 +64,10 @@ public:
   std::vector<SensitiveCaloDetector*>& sensCaloDetectors();
   std::vector<std::shared_ptr<SimProducer> >& producers();
 
+  void initializeG4(RunManagerMT* runManagerMaster, const edm::EventSetup& es);
+
 private:
   void initializeTLS();
-  void initializeThread(RunManagerMT& runManagerMaster, const edm::EventSetup& es);
   void initializeUserActions();
 
   void initializeRun();

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -159,9 +159,9 @@ void OscarMTProducer::globalEndRun(const edm::Run& iRun, const edm::EventSetup& 
   iContext->global()->endRun();
 }
 
-void OscarMTProducer::globalEndJob(OscarMTMasterThread* masterThread) { 
+void OscarMTProducer::globalEndJob(OscarMTMasterThread* masterThread) {
   edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer::globalEndJob";
-  masterThread->stopThread(); 
+  masterThread->stopThread();
 }
 
 void OscarMTProducer::endRun(const edm::Run&, const edm::EventSetup&) {

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -174,8 +174,8 @@ void OscarMTProducer::endRun(const edm::Run&, const edm::EventSetup&) {
 
 void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   StaticRandomEngineSetUnset random(e.streamID());
-  edm::LogVerbatim("SimG4CoreApplication")
-      << "Produce event " << e.id() << " stream " << e.streamID() << " rand= " << G4UniformRand();
+  edm::LogVerbatim("SimG4CoreApplication") << "Produce event " << e.id() << " stream " << e.streamID();
+  LogDebug("SimG4CoreApplication") << "Before event rand= " << G4UniformRand();
 
   auto& sTk = m_runManagerWorker->sensTkDetectors();
   auto& sCalo = m_runManagerWorker->sensCaloDetectors();
@@ -225,8 +225,8 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   for (auto& prod : producers) {
     prod.get()->produce(e, es);
   }
-  edm::LogVerbatim("SimG4CoreApplication")
-      << "Event is produced " << e.id() << " stream " << e.streamID() << " rand= " << G4UniformRand();
+  edm::LogVerbatim("SimG4CoreApplication") << "Event is produced " << e.id() << " stream " << e.streamID();
+  LogDebug("SimG4CoreApplication") << "End of event rand= " << G4UniformRand();
 }
 
 StaticRandomEngineSetUnset::StaticRandomEngineSetUnset(edm::StreamID const& streamID) {

--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -54,8 +54,7 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
     runManagerMaster = std::make_shared<RunManagerMT>(iConfig);
     m_runManagerMaster = runManagerMaster;
 
-    edm::LogVerbatim("SimG4CoreApplication") 
-        << "OscarMTMasterThread: initialization of RunManagerMT finished";
+    edm::LogVerbatim("SimG4CoreApplication") << "OscarMTMasterThread: initialization of RunManagerMT finished";
 
     /////////////
     // State loop
@@ -81,11 +80,11 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
         isG4Alive = true;
       } else if (m_masterThreadState == ThreadState::EndRun) {
         // Stop Geant4
-	edm::LogVerbatim("OscarMTMasterThread") << "Master thread: Stopping Geant4";
+        edm::LogVerbatim("OscarMTMasterThread") << "Master thread: Stopping Geant4";
         runManagerMaster->stopG4();
         isG4Alive = false;
       } else if (m_masterThreadState == ThreadState::Destruct) {
-	edm::LogVerbatim("OscarMTMasterThread") << "Master thread: Breaking out of state loop";
+        edm::LogVerbatim("OscarMTMasterThread") << "Master thread: Breaking out of state loop";
         if (isG4Alive)
           throw edm::Exception(edm::errors::LogicError)
               << "Geant4 is still alive, master thread state must be set to EndRun before Destruct";

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -41,6 +41,8 @@
 #include "G4TransportationManager.hh"
 #include "G4ParticleTable.hh"
 #include "G4CascadeInterface.hh"
+#include "G4EmParameters.hh"
+#include "G4HadronicParameters.hh"
 
 #include "G4GDMLParser.hh"
 #include "G4SystemOfUnits.hh"
@@ -87,7 +89,7 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const& p)
   m_check = p.getUntrackedParameter<bool>("CheckGeometry", false);
 }
 
-RunManagerMT::~RunManagerMT() { stopG4(); }
+RunManagerMT::~RunManagerMT() {}
 
 void RunManagerMT::initG4(const DDCompactView* pDD,
                           const cms::DDCompactView* pDD4hep,
@@ -142,6 +144,8 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   if (phys == nullptr) {
     throw edm::Exception(edm::errors::Configuration, "Physics list construction failed!");
   }
+  G4EmParameters::Instance()->SetVerbose(verb);
+  G4EmParameters::Instance()->SetWorkerVerbose(verb - 1);
 
   // exotic particle physics
   double monopoleMass = m_pPhysics.getUntrackedParameter<double>("MonopoleMass", 0);
@@ -237,6 +241,7 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   m_stateManager->SetNewState(G4State_GeomClosed);
   m_currentRun = new G4Run();
   m_userRunAction->BeginOfRunAction(m_currentRun);
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT:: initG4 done";
 }
 
 void RunManagerMT::initializeUserActions() {
@@ -268,4 +273,5 @@ void RunManagerMT::terminateRun() {
     m_kernel->RunTermination();
   }
   m_runTerminated = true;
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT:: terminateRun done";
 }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -209,10 +209,10 @@ void RunManagerMTWorker::resetTLS() {
   --n_tls_shutdown_task;
 }
 
-void RunManagerMTWorker::endRun() { 
+void RunManagerMTWorker::endRun() {
   int thisID = getThreadIndex();
   edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::endRun for the thread " << thisID;
-  terminateRun(); 
+  terminateRun();
 }
 
 void RunManagerMTWorker::initializeTLS() {
@@ -467,9 +467,8 @@ std::unique_ptr<G4SimEvent> RunManagerMTWorker::produce(const edm::Event& inpevt
   // per-run initialization here by ourselves.
 
   if (!(m_tls && m_tls->threadInitialized)) {
-    edm::LogVerbatim("SimG4CoreApplication") 
-        << "RunManagerMTWorker::produce(): stream " << inpevt.streamID() << " thread " 
-        << getThreadIndex() << " initializing";
+    edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::produce(): stream " << inpevt.streamID()
+                                             << " thread " << getThreadIndex() << " initializing";
     initializeG4(&runManagerMaster, es);
     m_tls->threadInitialized = true;
   }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -164,13 +164,11 @@ RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::Co
   std::vector<edm::ParameterSet> watchers = iConfig.getParameter<std::vector<edm::ParameterSet> >("Watchers");
   m_hasWatchers = (watchers.empty()) ? false : true;
   initializeTLS();
+  int thisID = getThreadIndex();
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker is constructed for the thread " << thisID;
 }
 
 RunManagerMTWorker::~RunManagerMTWorker() {
-  if (m_tls && !m_tls->runTerminated) {
-    terminateRun();
-  }
-
   ++n_tls_shutdown_task;
   resetTLS();
 
@@ -211,7 +209,11 @@ void RunManagerMTWorker::resetTLS() {
   --n_tls_shutdown_task;
 }
 
-void RunManagerMTWorker::endRun() { terminateRun(); }
+void RunManagerMTWorker::endRun() { 
+  int thisID = getThreadIndex();
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::endRun for the thread " << thisID;
+  terminateRun(); 
+}
 
 void RunManagerMTWorker::initializeTLS() {
   if (m_tls) {
@@ -238,13 +240,12 @@ void RunManagerMTWorker::initializeTLS() {
   }
 }
 
-void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const edm::EventSetup& es) {
+void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm::EventSetup& es) {
   // I guess everything initialized here should be in thread_local storage
   initializeTLS();
 
   int thisID = getThreadIndex();
-
-  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::initializeThread " << thisID;
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::initializeThread " << thisID << " is started";
 
   // Initialize per-thread output
   G4Threading::G4SetThreadId(thisID);
@@ -275,7 +276,7 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
 
   // Set the geometry for the worker, share from master
-  auto worldPV = runManagerMaster.world().GetWorldVolume();
+  auto worldPV = runManagerMaster->world().GetWorldVolume();
   m_tls->kernel->WorkerDefineWorldVolume(worldPV);
   G4TransportationManager* tM = G4TransportationManager::GetTransportationManager();
   tM->SetWorldForTracking(worldPV);
@@ -308,7 +309,7 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   // attach sensitive detector
   AttachSD attach;
   auto sensDets =
-      attach.create(es, runManagerMaster.catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
+      attach.create(es, runManagerMaster->catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
 
   m_tls->sensTkDets.swap(sensDets.first);
   m_tls->sensCaloDets.swap(sensDets.second);
@@ -318,14 +319,14 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
       << " Tk type Producers, and " << m_tls->sensCaloDets.size() << " Calo type producers ";
 
   // Set the physics list for the worker, share from master
-  PhysicsList* physicsList = runManagerMaster.physicsListForWorker();
+  PhysicsList* physicsList = runManagerMaster->physicsListForWorker();
 
   edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker: start initialisation of PhysicsList for the thread";
 
   // Geant4 UI commands in PreInit state
-  if (!runManagerMaster.G4Commands().empty()) {
+  if (!runManagerMaster->G4Commands().empty()) {
     G4cout << "RunManagerMTWorker: Requested UI commands: " << G4endl;
-    for (const std::string& command : runManagerMaster.G4Commands()) {
+    for (const std::string& command : runManagerMaster->G4Commands()) {
       G4cout << "          " << command << G4endl;
       G4UImanager::GetUIpointer()->ApplyCommand(command);
     }
@@ -423,6 +424,8 @@ std::vector<std::shared_ptr<SimProducer> >& RunManagerMTWorker::producers() {
 }
 
 void RunManagerMTWorker::initializeRun() {
+  int thisID = getThreadIndex();
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::initializeRun " << thisID << " is started";
   m_tls->currentRun = new G4Run();
   G4StateManager::GetStateManager()->SetNewState(G4State_GeomClosed);
   if (m_tls->userRunAction) {
@@ -431,9 +434,12 @@ void RunManagerMTWorker::initializeRun() {
 }
 
 void RunManagerMTWorker::terminateRun() {
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::terminateRun ";
   if (!m_tls || m_tls->runTerminated) {
     return;
   }
+  int thisID = getThreadIndex();
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::terminateRun " << thisID << " is started";
   if (m_tls->userRunAction) {
     m_tls->userRunAction->EndOfRunAction(m_tls->currentRun);
     m_tls->userRunAction.reset();
@@ -461,9 +467,10 @@ std::unique_ptr<G4SimEvent> RunManagerMTWorker::produce(const edm::Event& inpevt
   // per-run initialization here by ourselves.
 
   if (!(m_tls && m_tls->threadInitialized)) {
-    LogDebug("SimG4CoreApplication") << "RunManagerMTWorker::produce(): stream " << inpevt.streamID() << " thread "
-                                     << getThreadIndex() << " initializing";
-    initializeThread(runManagerMaster, es);
+    edm::LogVerbatim("SimG4CoreApplication") 
+        << "RunManagerMTWorker::produce(): stream " << inpevt.streamID() << " thread " 
+        << getThreadIndex() << " initializing";
+    initializeG4(&runManagerMaster, es);
     m_tls->threadInitialized = true;
   }
   // Initialize run
@@ -492,27 +499,25 @@ std::unique_ptr<G4SimEvent> RunManagerMTWorker::produce(const edm::Event& inpevt
   }
   if (m_tls->currentEvent->GetNumberOfPrimaryVertex() == 0) {
     std::stringstream ss;
-    ss << "RunManagerMTWorker::produce(): event " << inpevt.id().event() << " with no G4PrimaryVertices \n";
+    ss << "RunManagerMTWorker::produce: event " << inpevt.id().event() << " with no G4PrimaryVertices \n";
     throw SimG4Exception(ss.str());
 
   } else {
     if (!m_tls->kernel) {
       std::stringstream ss;
-      ss << " RunManagerMT::produce(): "
+      ss << "RunManagerMTWorker::produce: "
          << " no G4WorkerRunManagerKernel yet for thread index" << getThreadIndex() << ", id " << std::hex
          << std::this_thread::get_id() << " \n";
       throw SimG4Exception(ss.str());
     }
 
     edm::LogVerbatim("SimG4CoreApplication")
-        << " RunManagerMTWorker::produce: start Event " << inpevt.id().event() << " stream id " << inpevt.streamID()
-        << " thread index " << getThreadIndex() << " of weight " << m_simEvent->weight() << " with "
-        << m_simEvent->nTracks() << " tracks and " << m_simEvent->nVertices() << " vertices, generated by "
-        << m_simEvent->nGenParts() << " particles ";
+        << "RunManagerMTWorker::produce: start EventID=" << inpevt.id().event() << " StreamID=" << inpevt.streamID()
+        << " threadIndex=" << getThreadIndex() << " weight=" << m_simEvent->weight() << "; "
+        << m_tls->currentEvent->GetNumberOfPrimaryVertex() << " vertices for Geant4; generator produced "
+        << m_simEvent->nGenParts() << " particles.";
 
     m_tls->kernel->GetEventManager()->ProcessOneEvent(m_tls->currentEvent.get());
-
-    edm::LogVerbatim("SimG4CoreApplication") << " RunManagerMTWorker::produce: ended Event " << inpevt.id().event();
   }
 
   //remove memory only needed during event processing
@@ -521,6 +526,7 @@ std::unique_ptr<G4SimEvent> RunManagerMTWorker::produce(const edm::Event& inpevt
   for (auto& sd : m_tls->sensCaloDets) {
     sd->reset();
   }
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::produce: ended Event " << inpevt.id().event();
 
   m_simEvent = nullptr;
   return simEvent;

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
@@ -20,7 +20,7 @@ FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) 
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EML: \n Flags for EM Physics: "
+  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMM: \n Flags for EM Physics: "
                                   << emPhys << "; Hadronic Physics: " << hadPhys << "; tracking cut: " << tracking
                                   << "; time limit(ns)= " << timeLimit / CLHEP::ns
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
@@ -20,7 +20,7 @@ FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) 
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMM: \n Flags for EM Physics: "
+  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMN: \n Flags for EM Physics: "
                                   << emPhys << "; Hadronic Physics: " << hadPhys << "; tracking cut: " << tracking
                                   << "; time limit(ns)= " << timeLimit / CLHEP::ns
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
@@ -20,11 +20,11 @@ FTFPCMS_BERT_EMV::FTFPCMS_BERT_EMV(const edm::ParameterSet& p) : PhysicsList(p) 
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogInfo("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMV \n Flags for EM Physics " << emPhys
-                              << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
-                              << "; time limit(ns)= " << timeLimit / CLHEP::ns
-                              << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
-                              << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
+  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMV \n Flags for EM Physics "
+                                  << emPhys << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
+                                  << "; time limit(ns)= " << timeLimit / CLHEP::ns
+                                  << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
+                                  << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 
   if (emPhys) {
     // EM Physics

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
@@ -20,11 +20,11 @@ FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) 
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogInfo("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMZ \n Flags for EM Physics " << emPhys
-                              << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
-                              << "   t(ns)= " << timeLimit / CLHEP::ns << "\n  transition energy Bertini/FTFP from "
-                              << minFTFP / CLHEP::GeV << " to " << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV
-                              << " GeV";
+  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMZ \n Flags for EM Physics "
+                                  << emPhys << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
+                                  << "   t(ns)= " << timeLimit / CLHEP::ns << "\n  transition energy Bertini/FTFP from "
+                                  << minFTFP / CLHEP::GeV << " to " << maxBERT / CLHEP::GeV << ":"
+                                  << maxBERTpi / CLHEP::GeV << " GeV";
 
   if (emPhys) {
     // EM Physics

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.cc
@@ -24,13 +24,14 @@ QGSPCMS_FTFP_BERT_EMN::QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet& p) : Physi
   double minQGSP = p.getParameter<double>("EminQGSP") * CLHEP::GeV;
   double maxFTFP = p.getParameter<double>("EmaxFTFP") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-                              << "QGSP_FTFP_BERT_EMN \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
-                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns
-                              << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
-                              << maxBERTpi / CLHEP::GeV << ":" << maxBERT / CLHEP::GeV << " GeV"
-                              << "\n  transition energy FTFP/QGSP from " << minQGSP / CLHEP::GeV << " to "
-                              << maxFTFP / CLHEP::GeV << " GeV";
+  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: "
+                                  << "QGSP_FTFP_BERT_EMN \n Flags for EM Physics " << emPhys
+                                  << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
+                                  << "   t(ns)= " << timeLimit / CLHEP::ns << "\n  transition energy Bertini/FTFP from "
+                                  << minFTFP / CLHEP::GeV << " to " << maxBERTpi / CLHEP::GeV << ":"
+                                  << maxBERT / CLHEP::GeV << " GeV"
+                                  << "\n  transition energy FTFP/QGSP from " << minQGSP / CLHEP::GeV << " to "
+                                  << maxFTFP / CLHEP::GeV << " GeV";
 
   if (emPhys) {
     // EM Physics

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMV.cc
@@ -24,13 +24,13 @@ QGSPCMS_FTFP_BERT_EMV::QGSPCMS_FTFP_BERT_EMV(const edm::ParameterSet& p) : Physi
   double minQGSP = p.getParameter<double>("EminQGSP") * CLHEP::GeV;
   double maxFTFP = p.getParameter<double>("EmaxFTFP") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogInfo("PhysicsList") << "You are using the simulation engine: QGSP_FTFP_BERT_EMV \n Flags for EM Physics "
-                              << emPhys << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
-                              << "   t(ns)= " << timeLimit / CLHEP::ns << "\n  transition energy Bertini/FTFP from "
-                              << minFTFP / CLHEP::GeV << " to " << maxBERTpi / CLHEP::GeV << ":" << maxBERT / CLHEP::GeV
-                              << " GeV"
-                              << "\n  transition energy FTFP/QGSP from " << minQGSP / CLHEP::GeV << " to "
-                              << maxFTFP / CLHEP::GeV << " GeV";
+  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: QGSP_FTFP_BERT_EMV \n Flags for EM Physics "
+                                  << emPhys << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
+                                  << "   t(ns)= " << timeLimit / CLHEP::ns << "\n  transition energy Bertini/FTFP from "
+                                  << minFTFP / CLHEP::GeV << " to " << maxBERTpi / CLHEP::GeV << ":"
+                                  << maxBERT / CLHEP::GeV << " GeV"
+                                  << "\n  transition energy FTFP/QGSP from " << minQGSP / CLHEP::GeV << " to "
+                                  << maxFTFP / CLHEP::GeV << " GeV";
 
   if (emPhys) {
     // EM Physics


### PR DESCRIPTION
#### PR description:
Several misprints and improvements are added, which are useful for debugging. 

From destructors of Geant4 interface classes removed operations to destruct Geant4 - this should be performed in endRun methods called by the Framework. Should address #30863.

This PR should not affect any result.

#### PR validation:
private


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
no backport expected


Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
