### PR TITLE
Rivet ParticleLevelProducer and HTXS multi-threading

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -41,8 +41,8 @@ private:
 
   reco::Particle::Point genVertex_;
 
-  Rivet::RivetAnalysis* rivetAnalysis_;
-  Rivet::AnalysisHandler* analysisHandler_;
+  Rivet::RivetAnalysis* rivetAnalysis_ = 0;
+  Rivet::AnalysisHandler* analysisHandler_ = 0;
 
   bool _isFirstEvent;
 };

--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -2,7 +2,7 @@
 #define GeneratorInterface_RivetInterface_ParticleLevelProducer_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,7 +15,7 @@
 #include "Rivet/AnalysisHandler.hh"
 #include "GeneratorInterface/RivetInterface/interface/RivetAnalysis.h"
 
-class ParticleLevelProducer : public edm::stream::EDProducer<> {
+class ParticleLevelProducer : public edm::one::EDProducer<edm::one::SharedResources> {
 public:
   ParticleLevelProducer(const edm::ParameterSet& pset);
   ~ParticleLevelProducer() override {}

--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -2,7 +2,7 @@
 #define GeneratorInterface_RivetInterface_ParticleLevelProducer_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,7 +15,7 @@
 #include "Rivet/AnalysisHandler.hh"
 #include "GeneratorInterface/RivetInterface/interface/RivetAnalysis.h"
 
-class ParticleLevelProducer : public edm::one::EDProducer<edm::one::SharedResources> {
+class ParticleLevelProducer : public edm::stream::EDProducer<> {
 public:
   ParticleLevelProducer(const edm::ParameterSet& pset);
   ~ParticleLevelProducer() override {}
@@ -37,11 +37,14 @@ private:
   }
 
   const edm::EDGetTokenT<edm::HepMCProduct> srcToken_;
-
+  const edm::ParameterSet pset_;
+  
   reco::Particle::Point genVertex_;
 
   Rivet::RivetAnalysis* rivetAnalysis_;
-  Rivet::AnalysisHandler analysisHandler_;
+  Rivet::AnalysisHandler* analysisHandler_;
+  
+  bool _isFirstEvent;
 };
 
 #endif

--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -41,8 +41,8 @@ private:
 
   reco::Particle::Point genVertex_;
 
-  Rivet::RivetAnalysis* rivetAnalysis_ = 0;
-  Rivet::AnalysisHandler* analysisHandler_ = 0;
+  Rivet::RivetAnalysis* rivetAnalysis_ = nullptr;
+  Rivet::AnalysisHandler* analysisHandler_ = nullptr;
 
   bool _isFirstEvent;
 };

--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -38,12 +38,12 @@ private:
 
   const edm::EDGetTokenT<edm::HepMCProduct> srcToken_;
   const edm::ParameterSet pset_;
-  
+
   reco::Particle::Point genVertex_;
 
   Rivet::RivetAnalysis* rivetAnalysis_;
   Rivet::AnalysisHandler* analysisHandler_;
-  
+
   bool _isFirstEvent;
 };
 

--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -42,9 +42,8 @@ private:
   reco::Particle::Point genVertex_;
 
   Rivet::RivetAnalysis* rivetAnalysis_ = nullptr;
-  Rivet::AnalysisHandler* analysisHandler_ = nullptr;
+  std::unique_ptr<Rivet::AnalysisHandler> analysisHandler_;
 
-  bool _isFirstEvent;
 };
 
 #endif

--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -43,7 +43,6 @@ private:
 
   Rivet::RivetAnalysis* rivetAnalysis_ = nullptr;
   std::unique_ptr<Rivet::AnalysisHandler> analysisHandler_;
-
 };
 
 #endif

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -27,12 +27,11 @@ using namespace Rivet;
 using namespace edm;
 using namespace std;
 
-class HTXSRivetProducer : public edm::one::EDProducer<edm::one::WatchRuns, edm::one::SharedResources> {
+class HTXSRivetProducer : public edm::stream::EDProducer<> {
 public:
   explicit HTXSRivetProducer(const edm::ParameterSet& cfg)
       : _hepmcCollection(consumes<HepMCProduct>(cfg.getParameter<edm::InputTag>("HepMCCollection"))),
         _lheRunInfo(consumes<LHERunInfoProduct, edm::InRun>(cfg.getParameter<edm::InputTag>("LHERunInfo"))) {
-    usesResource("Rivet");
 
     _HTXS = new Rivet::HiggsTemplateCrossSections();
 

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -32,7 +32,6 @@ public:
   explicit HTXSRivetProducer(const edm::ParameterSet& cfg)
       : _hepmcCollection(consumes<HepMCProduct>(cfg.getParameter<edm::InputTag>("HepMCCollection"))),
         _lheRunInfo(consumes<LHERunInfoProduct, edm::InRun>(cfg.getParameter<edm::InputTag>("LHERunInfo"))) {
-
     _HTXS = new Rivet::HiggsTemplateCrossSections();
 
     _isFirstEvent = true;

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -27,11 +27,12 @@ using namespace Rivet;
 using namespace edm;
 using namespace std;
 
-class HTXSRivetProducer : public edm::stream::EDProducer<> {
+class HTXSRivetProducer : public edm::one::EDProducer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit HTXSRivetProducer(const edm::ParameterSet& cfg)
       : _hepmcCollection(consumes<HepMCProduct>(cfg.getParameter<edm::InputTag>("HepMCCollection"))),
         _lheRunInfo(consumes<LHERunInfoProduct, edm::InRun>(cfg.getParameter<edm::InputTag>("LHERunInfo"))) {
+    usesResource("Rivet");
     _isFirstEvent = true;
     _prodMode = cfg.getParameter<string>("ProductionMode");
     m_HiggsProdMode = HTXS::UNKNOWN;

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -48,8 +48,8 @@ private:
   edm::EDGetTokenT<edm::HepMCProduct> _hepmcCollection;
   edm::EDGetTokenT<LHERunInfoProduct> _lheRunInfo;
 
-  Rivet::AnalysisHandler* _analysisHandler = 0;
-  Rivet::HiggsTemplateCrossSections* _HTXS = 0;
+  Rivet::AnalysisHandler* _analysisHandler = nullptr;
+  Rivet::HiggsTemplateCrossSections* _HTXS = nullptr;
 
   bool _isFirstEvent;
   std::string _prodMode;
@@ -108,11 +108,9 @@ void HTXSRivetProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
     }
 
     if (_isFirstEvent || !_HTXS->hasProjection("FS")) {
-      if (_analysisHandler)
-        delete _analysisHandler;
+      delete _analysisHandler;
+      delete _HTXS;
       _analysisHandler = new Rivet::AnalysisHandler();
-      if (_HTXS)
-        delete _HTXS;
       _HTXS = new Rivet::HiggsTemplateCrossSections();
       _analysisHandler->addAnalysis(_HTXS);
 

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -19,6 +19,8 @@
 #include "GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc"
 #include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
 
+#include <memory>
+
 #include <vector>
 #include <cstdio>
 #include <cstring>
@@ -107,7 +109,7 @@ void HTXSRivetProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
     }
 
     if (!_HTXS || !_HTXS->hasProjection("FS")) {
-      _analysisHandler = std::unique_ptr<Rivet::AnalysisHandler>(new Rivet::AnalysisHandler());
+      _analysisHandler = std::make_unique<Rivet::AnalysisHandler>();
       _HTXS = new Rivet::HiggsTemplateCrossSections();
       _analysisHandler->addAnalysis(_HTXS);
 

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -107,7 +107,6 @@ void HTXSRivetProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
     }
 
     if (!_HTXS || !_HTXS->hasProjection("FS")) {
-      delete _HTXS;
       _analysisHandler = std::unique_ptr<Rivet::AnalysisHandler>(new Rivet::AnalysisHandler());
       _HTXS = new Rivet::HiggsTemplateCrossSections();
       _analysisHandler->addAnalysis(_HTXS);

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -114,11 +114,9 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
   const HepMC::GenEvent* genEvent = srcHandle->GetEvent();
 
   if (_isFirstEvent || !rivetAnalysis_->hasProjection("FS")) {
-    if (rivetAnalysis_)
-      delete rivetAnalysis_;
+    delete rivetAnalysis_;
+    delete analysisHandler_;
     rivetAnalysis_ = new Rivet::RivetAnalysis(pset_);
-    if (analysisHandler_)
-      delete analysisHandler_;
     analysisHandler_ = new Rivet::AnalysisHandler();
 
     analysisHandler_->setIgnoreBeams(true);

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -113,7 +113,7 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
 
   const HepMC::GenEvent* genEvent = srcHandle->GetEvent();
   
-  if (_isFirstEvent) {
+  if (_isFirstEvent || !rivetAnalysis_->hasProjection("FS")) {
     rivetAnalysis_ = new Rivet::RivetAnalysis(pset_);
     analysisHandler_ = new Rivet::AnalysisHandler();
     

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -20,6 +20,7 @@ ParticleLevelProducer::ParticleLevelProducer(const edm::ParameterSet& pset)
     : srcToken_(consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"))),
       pset_(pset),
       _isFirstEvent(true) {
+  usesResource("Rivet");
   genVertex_ = reco::Particle::Point(0, 0, 0);
 
   produces<reco::GenParticleCollection>("neutrinos");

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -18,8 +18,8 @@ using namespace Rivet;
 
 ParticleLevelProducer::ParticleLevelProducer(const edm::ParameterSet& pset)
     : srcToken_(consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"))),
-      pset_(pset), _isFirstEvent(true) {
-
+      pset_(pset),
+      _isFirstEvent(true) {
   genVertex_ = reco::Particle::Point(0, 0, 0);
 
   produces<reco::GenParticleCollection>("neutrinos");
@@ -112,17 +112,17 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
   event.getByToken(srcToken_, srcHandle);
 
   const HepMC::GenEvent* genEvent = srcHandle->GetEvent();
-  
+
   if (_isFirstEvent || !rivetAnalysis_->hasProjection("FS")) {
     rivetAnalysis_ = new Rivet::RivetAnalysis(pset_);
     analysisHandler_ = new Rivet::AnalysisHandler();
-    
+
     analysisHandler_->setIgnoreBeams(true);
     analysisHandler_->addAnalysis(rivetAnalysis_);
-    
+
     _isFirstEvent = false;
   }
-  
+
   analysisHandler_->analyze(*genEvent);
 
   // Convert into edm objects

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -114,7 +114,11 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
   const HepMC::GenEvent* genEvent = srcHandle->GetEvent();
 
   if (_isFirstEvent || !rivetAnalysis_->hasProjection("FS")) {
+    if (rivetAnalysis_)
+      delete rivetAnalysis_;
     rivetAnalysis_ = new Rivet::RivetAnalysis(pset_);
+    if (analysisHandler_)
+      delete analysisHandler_;
     analysisHandler_ = new Rivet::AnalysisHandler();
 
     analysisHandler_->setIgnoreBeams(true);

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -114,7 +114,6 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
   const HepMC::GenEvent* genEvent = srcHandle->GetEvent();
 
   if (!rivetAnalysis_ || !rivetAnalysis_->hasProjection("FS")) {
-    delete rivetAnalysis_;
     rivetAnalysis_ = new Rivet::RivetAnalysis(pset_);
     analysisHandler_ = std::unique_ptr<Rivet::AnalysisHandler>(new Rivet::AnalysisHandler());
 

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -17,8 +19,7 @@ using namespace reco;
 using namespace Rivet;
 
 ParticleLevelProducer::ParticleLevelProducer(const edm::ParameterSet& pset)
-    : srcToken_(consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"))),
-      pset_(pset) {
+    : srcToken_(consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"))), pset_(pset) {
   usesResource("Rivet");
   genVertex_ = reco::Particle::Point(0, 0, 0);
 
@@ -115,7 +116,7 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
 
   if (!rivetAnalysis_ || !rivetAnalysis_->hasProjection("FS")) {
     rivetAnalysis_ = new Rivet::RivetAnalysis(pset_);
-    analysisHandler_ = std::unique_ptr<Rivet::AnalysisHandler>(new Rivet::AnalysisHandler());
+    analysisHandler_ = std::make_unique<Rivet::AnalysisHandler>();
 
     analysisHandler_->setIgnoreBeams(true);
     analysisHandler_->addAnalysis(rivetAnalysis_);


### PR DESCRIPTION
#### PR description:

Multi-threading in nanoaod step was broken due to new multi-thread feature in the recent Rivet update 3.1.2, see #30836

Seems to work fine when initialization is done for the first event of each thread in `produce`.

~As a bonus, the producers run as edm::stream modules now.~
Producers remain edm::one modules until Rivet becomes fully thread-safe.

#### PR validation:

* Standalone tests of ParticleLevelProducer and HTXS successful with 4 threads.
* Workflow 1302.18 with 2 threads in step5 (nanoaod)