### PR TITLE
DQM: Optimize DQMIO memory use

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -658,6 +658,10 @@ void DQMRootSource::readElements() {
   if (metadata.m_type != kNoTypesStored) {
     std::shared_ptr<TreeReaderBase> reader = m_treeReaders[metadata.m_type];
     TTree* tree = dynamic_cast<TTree*>(metadata.m_file->Get(kTypeNames[metadata.m_type]));
+    // The Reset() below screws up the tree, so we need to re-read it from file
+    // before use here.
+    tree->Refresh();
+
     reader->setTree(tree);
 
     ULong64_t index = metadata.m_firstIndex;

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -666,6 +666,9 @@ void DQMRootSource::readElements() {
     for (; index != endIndex; ++index) {
       reader->read(index, edm::Service<DQMStore>().operator->(), metadata.m_run, metadata.m_lumi);
     }
+    // Drop buffers in the TTree. This reduces memory consuption while the tree
+    // just sits there and waits for the next block to be read.
+    tree->Reset();
   }
 }
 


### PR DESCRIPTION
#### PR description:

As suggested by @dpiparo around ROOT-10927, the way we use TTrees in DQMIO reading is not very optimal from memory utilization point of view.

I suggested that we could create/destroy the trees as needed (since in the end, we only do a fairly small number of sequential reads), but that lead to segfaults everywhere (at least in my stand-alone test). But, a tactically placed `TTree::Reset` call might give us the same benefit, for very little effort, so that is what I try here.

#### PR validation:

So far I only tried Phat's merge job sample (with the huge HGCAL MEs in it). Results look like this: https://mschneid.web.cern.ch/mschneid/merge/mbGraph.html#?profile=withreset.json&reference=base.json&pid=_sum

There is a slight reduction in memory usage. It might be more on a job where the TTree baskets are more significant compared to the total job; we expect maybe saving 10MB in each of 10 trees? Not sure.

Also, needs more tests to see if the slowdown is systematic or just a random variation.