### PR TITLE
Update PPS records for 2018 and Run-3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -55,29 +55,29 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '112X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '111X_upgrade2018_design_v1',
+    'phase1_2018_design'       :  '112X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v5',
+    'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v1',
+    'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '112X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '112X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '112X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak' :   '112X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '112X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '112X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v3',
+    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' :  '112X_mcRun3_2021_realistic_HI_v3',
+    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v3', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v3', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v4', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

This PR is a technical update to include three PPS tags in 2018 and Run-3 GTs:

- `CTPPSPixelAnalysisMask_v1_mc`
- `CTPPSPixelDAQMapping_v1_mc`
- `CTPPSPixelGainCalibrations_v1_mc`

For 2018 GTs, this replaces the same tags but without the "_v1" string in the tag name. For Run-3 GTs, no `CTPPSPixelAnalysisMaskRcd`, `CTPPSPixelDAQMappingRcd` or `CTPPSPixelGainCalibrationsRcd` records were previously present in the GT. The absence of these records causes spurious issues when testing PPS simulation pull requests.

In addition, an obsolete unlabeled `SiPixel2DTemplateDBObjectRcd` is removed from the `auto:phase1_2018_realistic_hi` GT.

No changes are expected in any workflow as the PPS simulation is not yet present.

The GT diffs are as follows:

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_design_v1/112X_upgrade2018_design_v1

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_v1/112X_upgrade2018_realistic_v2

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HI_v5/112X_upgrade2018_realistic_HI_v1

**2018 realistic (HE fail)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_HEfail_v1/112X_upgrade2018_realistic_HEfail_v2

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018cosmics_realistic_deco_v1/112X_upgrade2018cosmics_realistic_deco_v2

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018cosmics_realistic_peak_v1/112X_upgrade2018cosmics_realistic_peak_v2

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_design_v3/112X_mcRun3_2021_design_v4

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v3/112X_mcRun3_2021_realistic_v4

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v3/112X_mcRun3_2021cosmics_realistic_deco_v4

**2021 heavy ion** 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v3/112X_mcRun3_2021_realistic_HI_v4  

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2023_realistic_v3/112X_mcRun3_2023_realistic_v4

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2024_realistic_v3/112X_mcRun3_2024_realistic_v4

#### PR validation:

The new PPS payloads have already been [used in the offline data GT since 2018](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3588.html).

In addition, a technical test was performed:

`runTheMatrix.py -l limited,12024.0,7.23,159.0,12834.0,11224.0,11024.2,7.4 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and should not be backported.
