### PR TITLE
106X backport of #30738 (Use dxy sign of GSF track instead of IPTools for pat::Electron)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -91,6 +91,7 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet & iConfig) :
   embedHighLevelSelection_(iConfig.getParameter<bool>("embedHighLevelSelection")),
   beamLineToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamLineSrc"))),
   pvToken_(mayConsume<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("pvSrc"))),  
+  getdBFromTrack_(iConfig.getParameter<bool>("getdBFromTrack")),
   addElecID_(iConfig.getParameter<bool>( "addElectronID" )),
   pTComparator_(),
   isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false) ,
@@ -1131,6 +1132,7 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
                  )->setComment("input with high level selection");
   iDesc.addNode( edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true)
                  )->setComment("input with high level selection");
+  iDesc.add<bool>("getdBFromTrack", true)->setComment("switch IP2D computation to use the GSF track instead of IPTools");
 
   descriptions.add("PATElectronProducer", iDesc);
 
@@ -1149,59 +1151,49 @@ void PATElectronProducer::embedHighLevel( pat::Electron & anElectron,
 					  )
 {
   // Correct to PV
+  std::pair<bool,Measurement1D> result;
+  double d0_corr, d0_err;
 
   // PV2D
-  std::pair<bool,Measurement1D> result =
-    IPTools::signedTransverseImpactParameter(tt,
-					     GlobalVector(track->px(),
-							  track->py(),
-							  track->pz()),
-					     primaryVertex);
-  double d0_corr = result.second.value();
-  double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  anElectron.setDB( d0_corr, d0_err, pat::Electron::PV2D);
-
+  if (getdBFromTrack_)
+    anElectron.setDB(track->dxy(primaryVertex.position()),
+                     track->dxyError(primaryVertex.position(), primaryVertex.covariance()),
+                     pat::Electron::PV2D);
+  else {
+    result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
+    d0_corr = result.second.value();
+    d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
+    anElectron.setDB(d0_corr, d0_err, pat::Electron::PV2D);
+  }
 
   // PV3D
-  result =
-    IPTools::signedImpactParameter3D(tt,
-				     GlobalVector(track->px(),
-						  track->py(),
-						  track->pz()),
-				     primaryVertex);
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   d0_corr = result.second.value();
   d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  anElectron.setDB( d0_corr, d0_err, pat::Electron::PV3D);
-
+  anElectron.setDB(d0_corr, d0_err, pat::Electron::PV3D);
 
   // Correct to beam spot
   // make a fake vertex out of beam spot
   reco::Vertex vBeamspot(beamspot.position(), beamspot.covariance3D());
 
   // BS2D
-  result =
-    IPTools::signedTransverseImpactParameter(tt,
-					     GlobalVector(track->px(),
-							  track->py(),
-							  track->pz()),
-					     vBeamspot);
-  d0_corr = result.second.value();
-  d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  anElectron.setDB( d0_corr, d0_err, pat::Electron::BS2D);
+  if (getdBFromTrack_)
+    anElectron.setDB(track->dxy(beamspot), track->dxyError(beamspot), pat::Electron::BS2D);
+  else {
+    result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
+    d0_corr = result.second.value();
+    d0_err = beamspotIsValid ? result.second.error() : -1.0;
+    anElectron.setDB(d0_corr, d0_err, pat::Electron::BS2D);
+  }
 
   // BS3D
-  result =
-    IPTools::signedImpactParameter3D(tt,
-				     GlobalVector(track->px(),
-						  track->py(),
-						  track->pz()),
-				     vBeamspot);
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  anElectron.setDB( d0_corr, d0_err, pat::Electron::BS3D);
+  anElectron.setDB(d0_corr, d0_err, pat::Electron::BS3D);
 
-    // PVDZ
-  anElectron.setDB( track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ );
+  // PVDZ
+  anElectron.setDB(track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -1132,7 +1132,7 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
                  )->setComment("input with high level selection");
   iDesc.addNode( edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true)
                  )->setComment("input with high level selection");
-  iDesc.add<bool>("getdBFromTrack", true)->setComment("switch IP2D computation to use the GSF track instead of IPTools");
+  iDesc.add<bool>("getdBFromTrack", false)->setComment("switch IP2D computation to use the GSF track instead of IPTools");
 
   descriptions.add("PATElectronProducer", iDesc);
 

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
@@ -114,6 +114,7 @@ namespace pat {
       const bool          embedHighLevelSelection_;
       const edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
       const edm::EDGetTokenT<std::vector<reco::Vertex> > pvToken_;
+      bool                getdBFromTrack_;
 
       typedef edm::RefToBase<reco::GsfElectron> ElectronBaseRef;
       typedef std::vector< edm::Handle< edm::ValueMap<IsoDeposit> > > IsoDepositMaps;

--- a/PhysicsTools/PatAlgos/python/producersLayer1/electronProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/electronProducer_cfi.py
@@ -83,6 +83,7 @@ patElectrons = cms.EDProducer("PATElectronProducer",
     embedHighLevelSelection = cms.bool(True),
     beamLineSrc             = cms.InputTag("offlineBeamSpot"),
     pvSrc                   = cms.InputTag("offlinePrimaryVertices"),
+    getdBFromTrack          = cms.bool(False),
 
     # PFClusterIso
     addPFClusterIso = cms.bool(False),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -55,6 +55,7 @@ def miniAOD_customizeCommon(process):
     process.patElectrons.usePfCandidateMultiMap = True
     process.patElectrons.pfCandidateMultiMap    = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap")
     process.patElectrons.electronIDSources = cms.PSet()
+    run2_miniAOD_devel.toModify( process.patElectrons, getdBFromTrack = True) 
     from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
     run2_miniAOD_80XLegacy.toModify(process.patElectrons,
                                     addPFClusterIso = cms.bool(True),


### PR DESCRIPTION
#### PR description:

Backport #30738 in the same way as #29537, with extra switch to activate the fix, and the same era modifier to activate said switch.

#### PR validation:

The same validation as #30738.

#### if this PR is a backport please specify the original PR and why you need to backport that P R:

#30738 for use in UL reminiAOD.
