### PR TITLE
[10_6_X] Validate GsfElectron before running MVA to avoid reading wrong DataFormat (#30052)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducers.cc
+++ b/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducers.cc
@@ -1,11 +1,13 @@
 #include "ModifiedObjectProducer.h"
 
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
+typedef pat::ModifiedObjectProducer<reco::GsfElectron> ModifiedGsfElectronProducer;
 typedef pat::ModifiedObjectProducer<pat::Electron> ModifiedElectronProducer;
 typedef pat::ModifiedObjectProducer<pat::Photon>   ModifiedPhotonProducer;
 typedef pat::ModifiedObjectProducer<pat::Muon>     ModifiedMuonProducer;
@@ -13,6 +15,7 @@ typedef pat::ModifiedObjectProducer<pat::Tau>      ModifiedTauProducer;
 typedef pat::ModifiedObjectProducer<pat::Jet>      ModifiedJetProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(ModifiedGsfElectronProducer);
 DEFINE_FWK_MODULE(ModifiedElectronProducer);
 DEFINE_FWK_MODULE(ModifiedPhotonProducer);
 DEFINE_FWK_MODULE(ModifiedMuonProducer);

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -301,10 +301,22 @@ def miniAOD_customizeCommon(process):
                     'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff',
                     ]
     switchOnVIDElectronIdProducer(process,DataFormat.MiniAOD, task)
-    process.egmGsfElectronIDs.physicsObjectSrc = \
-        cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
-    process.electronMVAValueMapProducer.src = \
-        cms.InputTag('reducedEgamma','reducedGedGsfElectrons')
+    process.egmGsfElectronIDs.physicsObjectSrc = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.electronMVAValueMapProducer.src = cms.InputTag('reducedEgamma','reducedGedGsfElectrons')
+
+    # To use older DataFormats, the electronMVAValueMapProducer MUST take a updated electron collection
+    # such that the conversion variables are filled correctly.
+    process.load("RecoEgamma.EgammaTools.gedGsfElectronsTo106X_cff")
+    run2_miniAOD_80XLegacy.toModify(task, func=lambda t: t.add(process.gedGsfElectronsFrom80XTo106XTask))
+    run2_miniAOD_80XLegacy.toModify(process.electronMVAValueMapProducer,
+                                     keysForValueMaps = cms.InputTag('reducedEgamma','reducedGedGsfElectrons'),
+                                     src = cms.InputTag("gedGsfElectronsFrom80XTo106X"))
+
+    run2_miniAOD_94XFall17.toModify(task, func=lambda t: t.add(process.gedGsfElectronsFrom94XTo106XTask))
+    run2_miniAOD_94XFall17.toModify(process.electronMVAValueMapProducer,
+                                     keysForValueMaps = cms.InputTag('reducedEgamma','reducedGedGsfElectrons'),
+                                     src = cms.InputTag("gedGsfElectronsFrom94XTo106X"))
+
     for idmod in electron_ids:
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection,None,False,task)
 
@@ -317,10 +329,8 @@ def miniAOD_customizeCommon(process):
                   'RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring16_V2p2_cff',
                   'RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring16_nonTrig_V1_cff']
     switchOnVIDPhotonIdProducer(process,DataFormat.AOD, task) 
-    process.egmPhotonIDs.physicsObjectSrc = \
-        cms.InputTag("reducedEgamma","reducedGedPhotons")
-    process.photonMVAValueMapProducer.src = \
-        cms.InputTag('reducedEgamma','reducedGedPhotons')
+    process.egmPhotonIDs.physicsObjectSrc = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.photonMVAValueMapProducer.src = cms.InputTag('reducedEgamma','reducedGedPhotons')
     for idmod in photon_ids:
         setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection,None,False,task)
  

--- a/RecoEgamma/EgammaTools/interface/validateEgammaCandidate.h
+++ b/RecoEgamma/EgammaTools/interface/validateEgammaCandidate.h
@@ -1,0 +1,19 @@
+#ifndef __RecoEgamma_EgammaTools_EgammaCandidateValidation_H__
+#define __RecoEgamma_EgammaTools_EgammaCandidateValidation_H__
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+
+namespace egammaTools {
+
+  void validateGsfElectron(reco::GsfElectron const& electron);
+
+  template <class Candidate>
+  void validateEgammaCandidate(Candidate const& candidate) {
+    if constexpr (std::is_same<Candidate, reco::GsfElectron>()) {
+      validateGsfElectron(candidate);
+    }
+  }
+
+}  // namespace egammaTools
+
+#endif

--- a/RecoEgamma/EgammaTools/python/gedGsfElectronsTo106X_cff.py
+++ b/RecoEgamma/EgammaTools/python/gedGsfElectronsTo106X_cff.py
@@ -1,0 +1,60 @@
+#
+# While reducing the AOD data tier produced in 80X to miniAOD, the electron
+# MVAs are computed before slimming. However, the object updators in
+# egammaObjectModificationsInMiniAOD_cff are written for pat::Electrons.
+# Therefore, we must adapt the object modifiers to the AOD level such that the
+# MVA producer can run on electrons that are updated and correctly store the
+# conversion rejection variables.
+#
+# Little annoyance: updating the object also requires computing the HEEP value
+# maps for the gedGsfElectrons, even though they are recomputed later from the
+# reducedEgamma collections. Unfortunately we can't use these HEEP value maps
+# that already exists, because reducedEgamma in turn depends on the
+# electronMVAValueMap producer. Hence, this is a problem of circular
+# dependency.
+#
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+from RecoEgamma.EgammaTools.egammaObjectModificationsInMiniAOD_cff import (
+    egamma8XObjectUpdateModifier,
+    egamma9X105XUpdateModifier,
+)
+from RecoEgamma.ElectronIdentification.heepIdVarValueMapProducer_cfi import heepIDVarValueMaps
+
+heepIDVarValueMapsAOD = heepIDVarValueMaps.copy()
+heepIDVarValueMapsAOD.dataFormat = 1
+
+gsfElectron8XObjectUpdateModifier = egamma8XObjectUpdateModifier.clone(
+    ecalRecHitsEB="reducedEcalRecHitsEB", ecalRecHitsEE="reducedEcalRecHitsEE"
+)
+gsfElectron9X105XUpdateModifier = egamma9X105XUpdateModifier.clone(
+    eleCollVMsAreKeyedTo="gedGsfElectrons",
+    eleTrkIso="heepIDVarValueMapsAOD:eleTrkPtIso",
+    eleTrkIso04="heepIDVarValueMapsAOD:eleTrkPtIso04",
+    conversions="allConversions",
+    ecalRecHitsEB="reducedEcalRecHitsEB",
+    ecalRecHitsEE="reducedEcalRecHitsEE",
+)
+
+# we have dataformat changes to 106X so to read older releases we use egamma updators
+gedGsfElectronsFrom80XTo106X = cms.EDProducer(
+    "ModifiedGsfElectronProducer",
+    src=cms.InputTag("gedGsfElectrons"),
+    modifierConfig=cms.PSet(
+        modifications=cms.VPSet(gsfElectron8XObjectUpdateModifier, gsfElectron9X105XUpdateModifier)
+    ),
+)
+
+gedGsfElectronsFrom80XTo106XTask = cms.Task(heepIDVarValueMapsAOD, gedGsfElectronsFrom80XTo106X)
+
+gedGsfElectronsFrom94XTo106X = cms.EDProducer(
+    "ModifiedGsfElectronProducer",
+    src=cms.InputTag("gedGsfElectrons"),
+    modifierConfig=cms.PSet(
+        modifications=cms.VPSet(gsfElectron9X105XUpdateModifier)
+    ),
+)
+
+gedGsfElectronsFrom94XTo106XTask = cms.Task(heepIDVarValueMapsAOD, gedGsfElectronsFrom94XTo106X)

--- a/RecoEgamma/EgammaTools/src/validateEgammaCandidate.cc
+++ b/RecoEgamma/EgammaTools/src/validateEgammaCandidate.cc
@@ -1,0 +1,13 @@
+#include "RecoEgamma/EgammaTools/interface/validateEgammaCandidate.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+
+void egammaTools::validateGsfElectron(reco::GsfElectron const& electron) {
+  if (electron.convVtxFitProb() > 1.0f) {
+    throw cms::Exception("EgammaError")
+        << "invalid value " << electron.convVtxFitProb() << " for reco::GsfElectron.conversionRejection_.vtxFitProb\n"
+        << "It should be either beween 0.0f and 1.0f or negative in case no matching conversion was found.\n"
+        << "Probably you need to update the electron collection with the EG9X105XObjectUpdateModifier plugin:\n"
+        << "see PhysicsTools/NanoAOD/python/electrons_cff.py for an example.\n";
+  }
+}


### PR DESCRIPTION
#### PR description:

**Backport of https://github.com/cms-sw/cmssw/pull/30052 to 10_6_X**.

Yesterday, @jainshilpi asked me about running VID for `reco::GsfElectrons` in 10_6_X, which is a requirement by her analysis if I understood correctly. This is not supported by the EgammaPostRecoTools [1]. It is actually a bit dangerous because if one forgets to update the GsfElectron format, the ID will silently give wrong results.

Hence, we naturally started discussing about https://github.com/cms-sw/cmssw/pull/30052, which added a protection against running on the wrong DataFormat and also a configuration to update the GsfElectron format. Both @jainshilpi and @swagata87 were advocating a backport of this PR to the widely used 10_6_X release. We would not have to worry about a possible wrong use of the Electron ID in 10_6_X anymore.

This backport was fortunately almost trivial, except for some very minor manual fixes in `MVAValueMapProducer.h` due to the absence of https://github.com/cms-sw/cmssw/pull/26814 in 10_6_X. 

The original PR also contains a more detailed quantification of how forgetting to update the DataFormat affects the MVA values and efficiencies:
https://github.com/cms-sw/cmssw/pull/30052#issuecomment-643824398

Thank you very much for considering this!

[1] https://github.com/cms-egamma/EgammaPostRecoTools/blob/master/python/EgammaPostRecoTools.py#L231

#### PR validation:

CMSSW compiles and local matrix tests pass. Differences expected in the re-MiniAOD workflows that missed updating the DataFormats before, which should be 136.8311 and 136.7611 (see https://github.com/cms-sw/cmssw/pull/30052).