### PR TITLE
changes needed for HLT TDR event content : 11_2

### DIFF
--- a/HLTrigger/Configuration/python/HLTPhase2TDR_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTPhase2TDR_EventContent_cff.py
@@ -1,0 +1,68 @@
+import FWCore.ParameterSet.Config as cms
+
+HLTPhase2TDR = cms.PSet(
+    outputCommands = cms.vstring( *(
+        'keep *_TTTrackAssociatorFromPixelDigis_*_*',  
+        'keep *_TTStubAssociatorFromPixelDigis_*_*',  
+        'drop *_TTStubsFromPhase2TrackerDigis_*_HLT',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusteredmNewDetSetVector_TTClustersFromPhase2TrackerDigis_ClusterInclusive_*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterInclusive_*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterAccepted_*',
+        'drop recoPFClusters_particleFlowClusterHGCal__*',
+        'drop l1tHGCalTriggerCellBXVector_hgcalVFEProducer_HGCalVFEProcessorSums_*',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersMerge__*',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersTrk__*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusteredmNewDetSetVector_TTClustersFromPhase2TrackerDigis_ClusterInclusive_HLT',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersMIP__*',
+        'drop recoPFClusters_particleFlowClusterHGCalFromMultiCl__*',
+        'drop l1tHGCalClusterBXVector_hgcalBackEndLayer1Producer_HGCalBackendLayer1Processor2DClustering_*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterInclusive_HLT',
+        'drop l1tHGCalTowerMapBXVector_hgcalTowerMapProducer_HGCalTowerMapProcessor_*',
+        'drop recoGsfTrackExtras_electronGsfTracks__*',
+        'drop recoCaloClusters_particleFlowSuperClusterHGCal__*',
+        'drop l1tHGCalTriggerCellBXVector_hgcalConcentratorProducer_HGCalConcentratorProcessorSelection_*',
+        'drop recoSuperClusters_particleFlowSuperClusterHGCal__*',
+        'drop recoGsfTrackExtras_electronGsfTracksFromMultiCl__*',
+        'drop recoHGCalMultiClusters_hgcalMultiClusters__*',
+        'drop recoGsfTrackExtras_electronGsfTracks__*',
+        'drop recoCaloClusters_particleFlowSuperClusterHGCalFromMultiCl__*',
+        'drop recoSuperClusters_particleFlowSuperClusterHGCalFromMultiCl__*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusteredmNewDetSetVector_TTStubsFromPhase2TrackerDigis_ClusterAccepted_HLT',
+        'drop recoElectronSeeds_electronMergedSeedsFromMultiCl__*',
+        'drop recoTrackExtras_electronGsfTracks__*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterAccepted_HLT',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersHAD__*',
+        'drop recoTrackExtras_electronGsfTracksFromMultiCl__*',
+        'drop recoGsfElectrons_ecalDrivenGsfElectronsFromMultiCl__*',
+        'drop l1tHGCalMulticlusterBXVector_hgcalBackEndLayer2Producer_HGCalBackendLayer2Processor3DClustering_*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTStubAssociationMap_TTStubAssociatorFromPixelDigis_StubAccepted_HLT',
+        'drop recoGsfTracks_electronGsfTracks__*',
+        'drop CaloTowersSorted_towerMaker__*',
+        'drop recoGsfTracks_electronGsfTracksFromMultiCl__*',
+        'drop l1tHGCalTowerBXVector_hgcalTowerProducer_HGCalTowerProcessor_*',
+        'drop TrackingRecHitsOwned_electronGsfTracks__*',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersEM__*',
+        'drop *_hltGtStage2Digis_*_HLT',
+        'drop *_simBmtfDigis_*_HLT',
+        'drop *_simCaloStage2Digis_*_HLT',
+        'drop *_simCaloStage2Layer1Digis_*_HLT',
+        'drop *_simEmtfDigis_*_HLT',
+        'drop *_simGmtStage2Digis_*_HLT',
+        'drop *_simGtStage2Digis_*_HLT',
+        'drop *_simOmtfDigis_*_HLT',
+        
+    ) )
+)
+
+def extendInputEvtContentForHLTTDR(source):
+    if not hasattr(source,"inputCommands"):
+        source.inputCommands = cms.untracked.vstring("keep *")
+    source.inputCommands.extend(HLTPhase2TDR.outputCommands)        
+    source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
+
+def extendOutputEvtContentForHLTTDR(output):
+    if not hasattr(output,"outputCommands"):
+        output.outputCommands = cms.untracked.vstring("keep *")
+    output.outputCommands.extend(HLTPhase2TDR.outputCommands)        
+
+

--- a/L1Trigger/Configuration/python/customisePhase2TTOn110.py
+++ b/L1Trigger/Configuration/python/customisePhase2TTOn110.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+def customisePhase2TTOn110(process):
+    process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
+    #when running directly, the ttclusterassoc uses the "mix" product name
+    #however its ediased to simSiPixelDigis so its output with that name
+    #so we have to adjust the input tag
+    process.TTClusterAssociatorFromPixelDigis.digiSimLinks = cms.InputTag('simSiPixelDigis','Tracker')
+
+    return process


### PR DESCRIPTION
#### PR description:

This PR adds in changes needed for the HLT event content. Suggestions on how to achieve this are welcome if the way I've done it is incorrect

At the same time it adds customisePhase2TTOn110 which reinstates the track trigger tracking particle associators which are useful and should be kept. 

Finally the content is still being checked but should be reasonably close to final. 


#### PR validation:

On testing with 

```
cmsDriver.py step2 --conditions 111X_mcRun4_realistic_T15_v1 -n 10 --era Phase2C9 --eventcontent RECOSIM --runUnscheduled -s RAW2DIGI,L1TrackTrigger,L1,RECO,RECOSIM,PAT --datatier FEVT --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 --geometry Extended2026D49 --customise_command "process.RECOSIMoutput.outputCommands.append('keep *_*_*_HLT') \n process.RECOSIMoutput.outputCommands.append('keep *_*_*_SIM') \n process.RECOSIMoutput.outputCommands.extend(process.L1TriggerFEVTDEBUG.outputCommands) \n process.RECOSIMoutput.outputCommands.extend(process.MicroEventContentMC.outputCommands) \n process.load('HLTrigger.Configuration.HLTPhase2TDR_EventContent_cff') \n process.RECOSIMoutput.outputCommands.extend(process.HLTPhase2TDR.outputCommands) \n " --mc --io HLTTDR2026D49ProdOneGo_Test.io --python HLTTDR2026D49ProdOneGo_Test.py --nStreams 4 --no_exec --filein file:/data1/harper/mcFiles/TT_TuneCP5_14TeV-powheg-pythia8__Phase2HLTTDRWinter20DIGI__PU200_110X_mcRun4_realistic_v3-v2__GEN-SIM-DIGI-RAW__5F12BF73-60EA-A74E-AD2E-36F78AE70B96.root --fileout file:test_cmsDriverCMD.root --nThreads 8
```

the expected event content was produced 

