### PR TITLE
speed up TrackExtenderWithMTDT

### DIFF
--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -905,19 +905,19 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
 
   using namespace std::placeholders;
   auto find_hits = std::bind(find_hits_in_dets,
-                             hits,
-                             traj,
+                             std::cref(hits),
+                             std::cref(traj),
                              ilay,
-                             tsos,
+                             std::cref(tsos),
                              pmag2,
                              pathlength0,
                              _1,
-                             bs,
+                             std::cref(bs),
                              bsTimeSpread_,
                              prop,
                              theEstimator.get(),
                              _2,
-                             hitsInLayer);
+                             std::ref(hitsInLayer));
 
   if (useVertex_ && matchVertex)
     find_hits(vtxTime, true);

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -254,19 +254,15 @@ namespace {
       const auto& propresult2 =
           thePropagator->propagateWithPath(tscbl.trackStateAtPCA(), traj.firstMeasurement().updatedState().surface());
       pathlength2 = propresult2.second;
-      if (pathlength2 == 0.) {
-        validpropagation = false;
-      }
-      pathlength = pathlength1 + pathlength2;
     } else {
       const auto& propresult2 =
           thePropagator->propagateWithPath(tscbl.trackStateAtPCA(), traj.lastMeasurement().updatedState().surface());
       pathlength2 = propresult2.second;
-      if (pathlength2 == 0.) {
-        validpropagation = false;
-      }
-      pathlength = pathlength1 + pathlength2;
     }
+    if (pathlength2 == 0.) {
+      validpropagation = false;
+    }
+    pathlength = pathlength1 + pathlength2;
 
     return validpropagation;
   }

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -650,7 +650,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
                                            trackVtxTime != 0.,
                                            mBTL);
         mtdthits.insert(mtdthits.end(), btlhits.begin(), btlhits.end());
-        
+
         // in the future this should include an intermediate refit before propagating to the ETL
         // for now it is ok
         const auto& etlhits = tryETLLayers(tsos,
@@ -667,7 +667,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
                                            mETL);
         mtdthits.insert(mtdthits.end(), etlhits.begin(), etlhits.end());
       }
-    }//!trajs.empty()
+    }  //!trajs.empty()
 
     auto ordering = checkRecHitsOrdering(thits);
     if (ordering == RefitDirection::insideOut) {

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -250,15 +250,10 @@ namespace {
     }
 
     //add distance from bs to first measurement
-    if (traj.direction() == alongMomentum) {
-      const auto& propresult2 =
-          thePropagator->propagateWithPath(tscbl.trackStateAtPCA(), traj.firstMeasurement().updatedState().surface());
-      pathlength2 = propresult2.second;
-    } else {
-      const auto& propresult2 =
-          thePropagator->propagateWithPath(tscbl.trackStateAtPCA(), traj.lastMeasurement().updatedState().surface());
-      pathlength2 = propresult2.second;
-    }
+    auto const& tscblPCA = tscbl.trackStateAtPCA();
+    auto const& aSurface = traj.direction() == alongMomentum ? traj.firstMeasurement().updatedState().surface()
+                                                             : traj.lastMeasurement().updatedState().surface();
+    pathlength2 = thePropagator->propagateWithPath(tscblPCA, aSurface).second;
     if (pathlength2 == 0.) {
       validpropagation = false;
     }

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -707,16 +707,10 @@ namespace {
   bool cmp_for_detset(const unsigned one, const unsigned two) { return one < two; };
 
   bool trackPathLength(const Trajectory& traj,
-                       const reco::BeamSpot& bs,
+                       const TrajectoryStateClosestToBeamLine& tscbl,
                        const Propagator* thePropagator,
                        double& pathlength) {
     pathlength = 0.;
-
-    TrajectoryStateClosestToBeamLine tscbl;
-    bool tscbl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
-
-    if (!tscbl_status)
-      return false;
 
     bool validpropagation = true;
     double pathlength1 = 0.;
@@ -754,6 +748,21 @@ namespace {
     return validpropagation;
   }
 
+  bool trackPathLength(const Trajectory& traj,
+                       const reco::BeamSpot& bs,
+                       const Propagator* thePropagator,
+                       double& pathlength) {
+    pathlength = 0.;
+
+    TrajectoryStateClosestToBeamLine tscbl;
+    bool tscbl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
+
+    if (!tscbl_status)
+      return false;
+
+    return trackPathLength(traj, tscbl, thePropagator, pathlength);
+  }
+
   void find_hits_in_dets(const MTDTrackingDetSetVector& hits,
                          const Trajectory& traj,
                          const DetLayer* layer,
@@ -769,7 +778,7 @@ namespace {
     GlobalVector p = tscbl.trackStateAtPCA().momentum();
 
     double pathlength;
-    trackPathLength(traj, bs, prop, pathlength);
+    trackPathLength(traj, tscbl, prop, pathlength);
 
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, *prop, *theEstimator);
     if (comp.first) {

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -927,11 +927,12 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
   //just take the first hit because the hits are sorted on their matching quality
   if (!hitsInLayer.empty()) {
     //check hits to pass minimum quality matching requirements
-    if (hitsInLayer.begin()->estChi2 < etlChi2Cut_ && hitsInLayer.begin()->timeChi2 < etlTimeChi2Cut_) {
+    auto const& firstHit = *hitsInLayer.begin();
+    if (firstHit.estChi2 < etlChi2Cut_ && firstHit.timeChi2 < etlTimeChi2Cut_) {
       hitMatched = true;
-      output.push_back(hitbuilder_->build(hitsInLayer.begin()->hit));
-      if (*(hitsInLayer.begin()) < bestHit)
-        bestHit = *(hitsInLayer.begin());
+      output.push_back(hitbuilder_->build(firstHit.hit));
+      if (firstHit < bestHit)
+        bestHit = firstHit;
     }
   }
 
@@ -940,12 +941,13 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
     hitsInLayer.clear();
     find_hits(0, false);
     if (!hitsInLayer.empty()) {
-      if (hitsInLayer.begin()->timeChi2 < etlTimeChi2Cut_) {
-        if (hitsInLayer.begin()->estChi2 < etlChi2Cut_) {
+      auto const& firstHit = *hitsInLayer.begin();
+      if (firstHit.timeChi2 < etlTimeChi2Cut_) {
+        if (firstHit.estChi2 < etlChi2Cut_) {
           hitMatched = true;
-          output.push_back(hitbuilder_->build(hitsInLayer.begin()->hit));
-          if ((*hitsInLayer.begin()) < bestHit)
-            bestHit = *(hitsInLayer.begin());
+          output.push_back(hitbuilder_->build(firstHit.hit));
+          if (firstHit < bestHit)
+            bestHit = firstHit;
         }
       }
     }

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -678,7 +678,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
       thits.swap(mtdthits);
     }
 
-    const auto& trajwithmtd = theTransformer->transform(ttrack, thits);
+    const auto& trajwithmtd = mtdthits.empty() ? trajs : theTransformer->transform(ttrack, thits);
     float pMap = 0.f, betaMap = 0.f, t0Map = 0.f, sigmat0Map = -1.f, pathLengthMap = -1.f, tmtdMap = 0.f,
           sigmatmtdMap = -1.f;
     int iMap = -1;

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -783,12 +783,12 @@ namespace {
                          const reco::BeamSpot& bs,
                          const float bsTimeSpread,
                          const Propagator* prop,
-                         const std::unique_ptr<MeasurementEstimator>& theEstimator,
+                         const MeasurementEstimator* estimator,
                          bool useVtxConstraint,
                          std::set<MTDHitMatchingInfo>& out) {
-    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, *prop, *theEstimator);
+    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, *prop, *estimator);
     if (comp.first) {
-      const vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, *prop, *theEstimator);
+      const vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, *prop, *estimator);
       if (!compDets.empty()) {
         for (const auto& detWithState : compDets) {
           auto range = hits.equal_range(detWithState.first->geographicalId(), cmp_for_detset);
@@ -809,7 +809,7 @@ namespace {
 
           for (auto detitr = range.first; detitr != range.second; ++detitr) {
             for (const auto& hit : *detitr) {
-              auto est = theEstimator->estimate(detWithState.second, hit);
+              auto est = estimator->estimate(detWithState.second, hit);
               if (!est.first)
                 continue;
 
@@ -915,9 +915,9 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
                              bs,
                              bsTimeSpread_,
                              prop,
-                             std::ref(theEstimator),
+                             theEstimator.get(),
                              _2,
-                             std::ref(hitsInLayer));
+                             hitsInLayer);
 
   if (useVertex_ && matchVertex)
     find_hits(vtxTime, true);

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -487,32 +487,28 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   std::vector<float> sigmatmtdOrigTrkRaw;
   std::vector<int> assocOrigTrkRaw;
 
-  edm::Handle<InputCollection> tracksH;
-  ev.getByToken(tracksToken_, tracksH);
+  auto const tracksH = ev.getHandle(tracksToken_);
   const auto& tracks = *tracksH;
 
-  edm::Handle<MTDTrackingDetSetVector> hitsH;
-  ev.getByToken(hitsToken_, hitsH);
-  const auto& hits = *hitsH;
+  //MTD hits DetSet
+  const auto& hits = ev.get(hitsToken_);
 
-  edm::Handle<reco::BeamSpot> bsH;
-  ev.getByToken(bsToken_, bsH);
-  const auto& bs = *bsH;
+  //beam spot
+  const auto& bs = ev.get(bsToken_);
 
   const Vertex* pv = nullptr;
   if (useVertex_ && !useSimVertex_) {
-    edm::Handle<VertexCollection> vtxH;
-    ev.getByToken(vtxToken_, vtxH);
-    if (!vtxH.product()->empty())
-      pv = &(vtxH.product()->at(0));
+    auto const& vtxs = ev.get(vtxToken_);
+    if (!vtxs.empty())
+      pv = &vtxs[0];
   }
 
   std::unique_ptr<math::XYZTLorentzVectorF> genPV(nullptr);
   if (useVertex_ && useSimVertex_) {
-    const auto& genVtxPositionHandle = ev.getHandle(genVtxPositionToken_);
-    const auto& genVtxTimeHandle = ev.getHandle(genVtxTimeToken_);
+    const auto& genVtxPosition = ev.get(genVtxPositionToken_);
+    const auto& genVtxTime = ev.get(genVtxTimeToken_);
     genPV = std::make_unique<math::XYZTLorentzVectorF>(
-        genVtxPositionHandle->x(), genVtxPositionHandle->y(), genVtxPositionHandle->z(), *(genVtxTimeHandle));
+        genVtxPosition.x(), genVtxPosition.y(), genVtxPosition.z(), genVtxTime);
   }
 
   double vtxTime = 0.;


### PR DESCRIPTION
using D49 ttbar with PU200 (23434.21) I get 4.8 times speedup in TrackExtenderWithMTDT, or about 10% reco time (less I/O; 7% with I/O included).

There are several parts
- std::bind case is the worst offender and I'm mostly to blame for this, as it came out in review of #28815
- after the std::bind fix, other updates are just moving repeated computations out to a common place and add up to 30% additional speedup

I checked that the reco comparisons of trackExtenderWithMTDT are the same on 50 events

Profiler report as of 376a099 (before the last commit 
9ac0a76  which sped up by about 10% fractionally) is at https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/CMSSW_11_2_X_2020-07-21-2300-sign1106.376a0992c5d.23434.21.step3.50.pp/94
