### PR TITLE
changes needed for HLT TDR event content : 11_1

### DIFF
--- a/HLTrigger/Configuration/python/HLTPhase2TDR_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTPhase2TDR_EventContent_cff.py
@@ -1,0 +1,68 @@
+import FWCore.ParameterSet.Config as cms
+
+HLTPhase2TDR = cms.PSet(
+    outputCommands = cms.vstring( *(
+        'keep *_TTTrackAssociatorFromPixelDigis_*_*',  
+        'keep *_TTStubAssociatorFromPixelDigis_*_*',  
+        'drop *_TTStubsFromPhase2TrackerDigis_*_HLT',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusteredmNewDetSetVector_TTClustersFromPhase2TrackerDigis_ClusterInclusive_*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterInclusive_*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterAccepted_*',
+        'drop recoPFClusters_particleFlowClusterHGCal__*',
+        'drop l1tHGCalTriggerCellBXVector_hgcalVFEProducer_HGCalVFEProcessorSums_*',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersMerge__*',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersTrk__*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusteredmNewDetSetVector_TTClustersFromPhase2TrackerDigis_ClusterInclusive_HLT',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersMIP__*',
+        'drop recoPFClusters_particleFlowClusterHGCalFromMultiCl__*',
+        'drop l1tHGCalClusterBXVector_hgcalBackEndLayer1Producer_HGCalBackendLayer1Processor2DClustering_*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterInclusive_HLT',
+        'drop l1tHGCalTowerMapBXVector_hgcalTowerMapProducer_HGCalTowerMapProcessor_*',
+        'drop recoGsfTrackExtras_electronGsfTracks__*',
+        'drop recoCaloClusters_particleFlowSuperClusterHGCal__*',
+        'drop l1tHGCalTriggerCellBXVector_hgcalConcentratorProducer_HGCalConcentratorProcessorSelection_*',
+        'drop recoSuperClusters_particleFlowSuperClusterHGCal__*',
+        'drop recoGsfTrackExtras_electronGsfTracksFromMultiCl__*',
+        'drop recoHGCalMultiClusters_hgcalMultiClusters__*',
+        'drop recoGsfTrackExtras_electronGsfTracks__*',
+        'drop recoCaloClusters_particleFlowSuperClusterHGCalFromMultiCl__*',
+        'drop recoSuperClusters_particleFlowSuperClusterHGCalFromMultiCl__*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusteredmNewDetSetVector_TTStubsFromPhase2TrackerDigis_ClusterAccepted_HLT',
+        'drop recoElectronSeeds_electronMergedSeedsFromMultiCl__*',
+        'drop recoTrackExtras_electronGsfTracks__*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterAccepted_HLT',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersHAD__*',
+        'drop recoTrackExtras_electronGsfTracksFromMultiCl__*',
+        'drop recoGsfElectrons_ecalDrivenGsfElectronsFromMultiCl__*',
+        'drop l1tHGCalMulticlusterBXVector_hgcalBackEndLayer2Producer_HGCalBackendLayer2Processor3DClustering_*',
+        'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTStubAssociationMap_TTStubAssociatorFromPixelDigis_StubAccepted_HLT',
+        'drop recoGsfTracks_electronGsfTracks__*',
+        'drop CaloTowersSorted_towerMaker__*',
+        'drop recoGsfTracks_electronGsfTracksFromMultiCl__*',
+        'drop l1tHGCalTowerBXVector_hgcalTowerProducer_HGCalTowerProcessor_*',
+        'drop TrackingRecHitsOwned_electronGsfTracks__*',
+        'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersEM__*',
+        'drop *_hltGtStage2Digis_*_HLT',
+        'drop *_simBmtfDigis_*_HLT',
+        'drop *_simCaloStage2Digis_*_HLT',
+        'drop *_simCaloStage2Layer1Digis_*_HLT',
+        'drop *_simEmtfDigis_*_HLT',
+        'drop *_simGmtStage2Digis_*_HLT',
+        'drop *_simGtStage2Digis_*_HLT',
+        'drop *_simOmtfDigis_*_HLT',
+        
+    ) )
+)
+
+def extendInputEvtContentForHLTTDR(source):
+    if not hasattr(source,"inputCommands"):
+        source.inputCommands = cms.untracked.vstring("keep *")
+    source.inputCommands.extend(HLTPhase2TDR.outputCommands)        
+    source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
+
+def extendOutputEvtContentForHLTTDR(output):
+    if not hasattr(output,"outputCommands"):
+        output.outputCommands = cms.untracked.vstring("keep *")
+    output.outputCommands.extend(HLTPhase2TDR.outputCommands)        
+
+

--- a/L1Trigger/Configuration/python/customisePhase2TTOn110.py
+++ b/L1Trigger/Configuration/python/customisePhase2TTOn110.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+def customisePhase2TTOn110(process):
+    process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
+    #when running directly, the ttclusterassoc uses the "mix" product name
+    #however its ediased to simSiPixelDigis so its output with that name
+    #so we have to adjust the input tag
+    process.TTClusterAssociatorFromPixelDigis.digiSimLinks = cms.InputTag('simSiPixelDigis','Tracker')
+
+    return process


### PR DESCRIPTION
#### PR description:

Changes to reduce the event size for the HLT TDR. Drops it from 117MB -> 80MB an event on TTBar

if this PR is a backport please specify the original PR and why you need to backport that PR:

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
backport of #30899 necessary for HLT TDR production

