### PR TITLE
Migrate from boost::filesystem to standard C++17 std::filesystem on FWCore/PluginManager

### DIFF
--- a/FWCore/ParameterSet/bin/edmPluginHelp.cpp
+++ b/FWCore/ParameterSet/bin/edmPluginHelp.cpp
@@ -73,7 +73,7 @@ namespace {
       return;
     previousName = pluginInfo.name_;
 
-    if (!library.empty() && pluginInfo.loadable_.leaf() != library) {
+    if (!library.empty() && pluginInfo.loadable_.filename() != library) {
       return;
     }
 
@@ -137,13 +137,13 @@ namespace {
       os << std::setw(6) << iPlugin << " ";
       os << std::setw(50) << pluginInfo.name_;
       os << std::setw(24) << baseType;
-      os << pluginInfo.loadable_.leaf() << "\n";
+      os << pluginInfo.loadable_.filename() << "\n";
       os.flags(oldFlags);
       return;
     }
 
-    os << std::left << iPlugin << "  " << pluginInfo.name_ << "  (" << baseType << ")  " << pluginInfo.loadable_.leaf()
-       << "\n";
+    os << std::left << iPlugin << "  " << pluginInfo.name_ << "  (" << baseType << ")  "
+       << pluginInfo.loadable_.filename() << "\n";
     os.flags(oldFlags);
 
     edm::ConfigurationDescriptions descriptions(filler->baseType(), pluginInfo.name_);

--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -48,6 +48,7 @@
 #include <iostream>
 #include <vector>
 #include <exception>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -77,7 +78,7 @@ namespace {
     previousName = pluginInfo.name_;
 
     // If the library matches save the name
-    if (pluginInfo.loadable_.leaf() == library) {
+    if (pluginInfo.loadable_.filename() == library) {
       pluginNames.push_back(pluginInfo.name_);
     }
   }
@@ -140,7 +141,7 @@ int main(int argc, char** argv) try {
   edm::FileInPath::disableFileLookup();
 
   using std::placeholders::_1;
-  boost::filesystem::path initialWorkingDirectory = boost::filesystem::initial_path<boost::filesystem::path>();
+  std::filesystem::path initialWorkingDirectory = std::filesystem::current_path();
 
   // Process the command line arguments
   std::string descString(argv[0]);
@@ -246,7 +247,7 @@ int main(int argc, char** argv) try {
         pfm->newFactory_.connect(std::bind(std::mem_fn(&Listener::newFactory), &listener, _1));
         edm::for_all(*pfm, std::bind(std::mem_fn(&Listener::newFactory), &listener, _1));
 
-        boost::filesystem::path loadableFile(library);
+        std::filesystem::path loadableFile(library);
 
         // If it is just a filename without any directories,
         // then turn it into an absolute path using the current

--- a/FWCore/PluginManager/BuildFile.xml
+++ b/FWCore/PluginManager/BuildFile.xml
@@ -1,8 +1,8 @@
 <use name="boost"/>
 <use name="tbb"/>
 <use name="rootcore"/>
-<use name="boost_filesystem"/>
 <use name="FWCore/Utilities"/>
+<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/FWCore/PluginManager/bin/refresh.cc
+++ b/FWCore/PluginManager/bin/refresh.cc
@@ -8,11 +8,11 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-#include <boost/filesystem/operations.hpp>
 #include <boost/program_options.hpp>
 
 #include <algorithm>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -116,7 +116,7 @@ int main(int argc, char** argv) try {
     return 0;
   }
 
-  using boost::filesystem::path;
+  using std::filesystem::path;
 
   /*if(argc == 1) {
     std::cerr << "Requires at least one argument.  Please pass either one directory or a list of files (all in the same directory)." << std::endl;
@@ -132,7 +132,7 @@ int main(int argc, char** argv) try {
     path directory(requestedPaths[0]);
     std::vector<std::string> files;
     bool removeMissingFiles = false;
-    if (boost::filesystem::is_directory(directory)) {
+    if (std::filesystem::is_directory(directory)) {
       if (requestedPaths.size() > 1) {
         std::cerr << "if a directory is given then only one argument is allowed" << std::endl;
         return 1;
@@ -141,13 +141,13 @@ int main(int argc, char** argv) try {
       //if asked to look at whole directory, then we can also remove missing files
       removeMissingFiles = true;
 
-      boost::filesystem::directory_iterator file(directory);
-      boost::filesystem::directory_iterator end;
+      std::filesystem::directory_iterator file(directory);
+      std::filesystem::directory_iterator end;
 
       path cacheFile(directory);
       cacheFile /= standard::cachefileName();
 
-      std::time_t cacheLastChange(0);
+      std::filesystem::file_time_type cacheLastChange;
       if (exists(cacheFile)) {
         cacheLastChange = last_write_time(cacheFile);
       }
@@ -170,10 +170,10 @@ int main(int argc, char** argv) try {
       }
     } else {
       //we have files
-      directory = directory.branch_path();
+      directory = directory.parent_path();
       for (std::vector<std::string>::iterator it = requestedPaths.begin(), itEnd = requestedPaths.end(); it != itEnd;
            ++it) {
-        boost::filesystem::path f(*it);
+        std::filesystem::path f(*it);
         if (!exists(f)) {
           std::cerr << "the file '" << f.string() << "' does not exist" << std::endl;
           return 1;
@@ -182,7 +182,7 @@ int main(int argc, char** argv) try {
           std::cerr << "either one directory or a list of files are allowed as arguments" << std::endl;
           return 1;
         }
-        if (directory != f.branch_path()) {
+        if (directory != f.parent_path()) {
           std::cerr << "all files must have be in the same directory (" << directory.string()
                     << ")\n"
                        " the file "

--- a/FWCore/PluginManager/interface/CacheParser.h
+++ b/FWCore/PluginManager/interface/CacheParser.h
@@ -24,12 +24,11 @@ If a space exists in either of these three fields, it will be replaced with a %,
 //
 
 // system include files
+#include <filesystem>
 #include <iosfwd>
 #include <string>
 #include <map>
 #include <vector>
-#include <boost/filesystem/path.hpp>
-
 // user include files
 #include "FWCore/PluginManager/interface/PluginInfo.h"
 
@@ -42,7 +41,7 @@ namespace edmplugin {
     typedef std::map<std::string, std::vector<PluginInfo> > CategoryToInfos;
     typedef std::pair<std::string, std::string> NameAndType;
     typedef std::vector<NameAndType> NameAndTypes;
-    typedef std::map<boost::filesystem::path, NameAndTypes> LoadableToPlugins;
+    typedef std::map<std::filesystem::path, NameAndTypes> LoadableToPlugins;
 
     // ---------- const member functions ---------------------
 
@@ -53,7 +52,7 @@ namespace edmplugin {
         PluginInfo.name_ where identical names are ordered by the order they are passed to read.
         In this way multiple calls to read for different directories will preserve the ordering
         */
-    static void read(std::istream&, const boost::filesystem::path& iDirectory, CategoryToInfos& oOut);
+    static void read(std::istream&, const std::filesystem::path& iDirectory, CategoryToInfos& oOut);
     static void write(const CategoryToInfos&, std::ostream&);
 
     static void read(std::istream&, LoadableToPlugins& oOut);
@@ -67,7 +66,7 @@ namespace edmplugin {
     const CacheParser& operator=(const CacheParser&) = delete;  // stop default
 
     static bool readline(std::istream& iIn,
-                         const boost::filesystem::path& iDirectory,
+                         const std::filesystem::path& iDirectory,
                          unsigned long iRecordNumber,
                          PluginInfo& oInfo,
                          std::string& oPluginType);

--- a/FWCore/PluginManager/interface/PluginCapabilities.h
+++ b/FWCore/PluginManager/interface/PluginCapabilities.h
@@ -58,7 +58,7 @@ namespace edmplugin {
     const PluginCapabilities& operator=(const PluginCapabilities&) = delete;  // stop default
 
     // ---------- member data --------------------------------
-    std::map<std::string, boost::filesystem::path> classToLoadable_;
+    std::map<std::string, std::filesystem::path> classToLoadable_;
   };
 
 }  // namespace edmplugin

--- a/FWCore/PluginManager/interface/PluginInfo.h
+++ b/FWCore/PluginManager/interface/PluginInfo.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 // user include files
 
@@ -27,7 +27,7 @@
 namespace edmplugin {
   struct PluginInfo {
     std::string name_;
-    boost::filesystem::path loadable_;
+    std::filesystem::path loadable_;
   };
 }  // namespace edmplugin
 #endif

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -19,13 +19,13 @@
 //
 
 // system include files
-#include <vector>
+#include <filesystem>
 #include <map>
-#include <string>
-#include <mutex>
-
-#include <boost/filesystem/path.hpp>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include "tbb/concurrent_unordered_map.h"
 
 // user include files
@@ -39,7 +39,7 @@ namespace edmplugin {
   class PluginFactoryBase;
 
   struct PluginManagerPathHasher {
-    size_t operator()(boost::filesystem::path const& iPath) const { return std::hash<std::string>{}(iPath.native()); }
+    size_t operator()(std::filesystem::path const& iPath) const { return std::hash<std::string>{}(iPath.native()); }
   };
 
   class PluginManager {
@@ -72,7 +72,7 @@ namespace edmplugin {
     // ---------- const member functions ---------------------
     const SharedLibrary& load(const std::string& iCategory, const std::string& iPlugin);
 
-    const boost::filesystem::path& loadableFor(const std::string& iCategory, const std::string& iPlugin);
+    const std::filesystem::path& loadableFor(const std::string& iCategory, const std::string& iPlugin);
 
     /**The container is ordered by category, then plugin name and then by precidence order of the plugin files.
         Therefore the first match on category and plugin name will be the proper file to load
@@ -95,7 +95,7 @@ namespace edmplugin {
     static bool isAvailable();
 
     // ---------- member functions ---------------------------
-    edm::signalslot::Signal<void(const boost::filesystem::path&)> goingToLoad_;
+    edm::signalslot::Signal<void(const std::filesystem::path&)> goingToLoad_;
     edm::signalslot::Signal<void(const SharedLibrary&)> justLoaded_;
     edm::signalslot::Signal<void(const std::string&, const std::string&)> askedToLoadCategoryWithPlugin_;
 
@@ -111,12 +111,12 @@ namespace edmplugin {
 
     std::recursive_mutex& pluginLoadMutex() { return pluginLoadMutex_; }
 
-    const boost::filesystem::path& loadableFor_(const std::string& iCategory,
-                                                const std::string& iPlugin,
-                                                bool& ioThrowIfFailElseSucceedStatus);
+    const std::filesystem::path& loadableFor_(const std::string& iCategory,
+                                              const std::string& iPlugin,
+                                              bool& ioThrowIfFailElseSucceedStatus);
     // ---------- member data --------------------------------
     SearchPath searchPath_;
-    tbb::concurrent_unordered_map<boost::filesystem::path, std::shared_ptr<SharedLibrary>, PluginManagerPathHasher>
+    tbb::concurrent_unordered_map<std::filesystem::path, std::shared_ptr<SharedLibrary>, PluginManagerPathHasher>
         loadables_;
 
     CategoryToInfos categoryToInfos_;

--- a/FWCore/PluginManager/interface/SharedLibrary.h
+++ b/FWCore/PluginManager/interface/SharedLibrary.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 // user include files
 
@@ -28,12 +28,12 @@
 namespace edmplugin {
   class SharedLibrary {
   public:
-    SharedLibrary(const boost::filesystem::path& iName);
+    SharedLibrary(const std::filesystem::path& iName);
     ~SharedLibrary();
 
     // ---------- const member functions ---------------------
     bool symbol(const std::string& iSymbolName, void*& iSymbol) const;
-    const boost::filesystem::path& path() const { return path_; }
+    const std::filesystem::path& path() const { return path_; }
 
     // ---------- static member functions --------------------
 
@@ -46,7 +46,7 @@ namespace edmplugin {
 
     // ---------- member data --------------------------------
     void* libraryHandle_;
-    boost::filesystem::path path_;
+    std::filesystem::path path_;
   };
 
 }  // namespace edmplugin

--- a/FWCore/PluginManager/interface/standard.h
+++ b/FWCore/PluginManager/interface/standard.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
+#include <filesystem>
 #include <string>
-#include <boost/filesystem/path.hpp>
 
 // user include files
 #include "FWCore/PluginManager/interface/PluginManager.h"
@@ -32,8 +32,8 @@ namespace edmplugin {
 
     PluginManager::Config config();
 
-    const boost::filesystem::path& cachefileName();
-    const boost::filesystem::path& poisonedCachefileName();
+    const std::filesystem::path& cachefileName();
+    const std::filesystem::path& poisonedCachefileName();
 
     const std::string& pluginPrefix();
   }  // namespace standard

--- a/FWCore/PluginManager/src/CacheParser.cc
+++ b/FWCore/PluginManager/src/CacheParser.cc
@@ -80,7 +80,7 @@ namespace edmplugin {
   }
 
   bool CacheParser::readline(std::istream& iIn,
-                             const boost::filesystem::path& iDirectory,
+                             const std::filesystem::path& iDirectory,
                              unsigned long iRecordNumber,
                              PluginInfo& oInfo,
                              std::string& oPluginType) {
@@ -118,7 +118,7 @@ namespace edmplugin {
   }  // namespace
 
   void CacheParser::read(std::istream& iIn,
-                         const boost::filesystem::path& iDirectory,
+                         const std::filesystem::path& iDirectory,
                          CacheParser::CategoryToInfos& iOut) {
     unsigned long recordNumber = 0;
 
@@ -180,7 +180,7 @@ namespace edmplugin {
 
     PluginInfo info;
     NameAndType pat;
-    boost::filesystem::path empty;
+    std::filesystem::path empty;
 
     while (iIn) {
       ++recordNumber;

--- a/FWCore/PluginManager/src/PluginCapabilities.cc
+++ b/FWCore/PluginManager/src/PluginCapabilities.cc
@@ -135,7 +135,7 @@ namespace edmplugin {
     std::vector<PluginInfo> infos;
     infos.reserve(classToLoadable_.size());
 
-    for (std::map<std::string, boost::filesystem::path>::const_iterator it = classToLoadable_.begin();
+    for (std::map<std::string, std::filesystem::path>::const_iterator it = classToLoadable_.begin();
          it != classToLoadable_.end();
          ++it) {
       info.name_ = it->first;

--- a/FWCore/PluginManager/src/PluginFactoryBase.cc
+++ b/FWCore/PluginManager/src/PluginFactoryBase.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <cassert>
 
 // user include files
 #include "FWCore/PluginManager/interface/PluginFactoryBase.h"
@@ -57,7 +58,7 @@ namespace edmplugin {
 
   void PluginFactoryBase::newPlugin(const std::string& iName) {
     PluginInfo info;
-    info.loadable_ = boost::filesystem::path(PluginManager::loadingFile());
+    info.loadable_ = std::filesystem::path(PluginManager::loadingFile());
     info.name_ = iName;
     newPluginAdded_(category(), info);
   }

--- a/FWCore/PluginManager/src/SharedLibrary.cc
+++ b/FWCore/PluginManager/src/SharedLibrary.cc
@@ -31,7 +31,7 @@ namespace edmplugin {
   //
   // constructors and destructor
   //
-  SharedLibrary::SharedLibrary(const boost::filesystem::path& iName)
+  SharedLibrary::SharedLibrary(const std::filesystem::path& iName)
       : libraryHandle_(::dlopen(iName.string().c_str(), RTLD_LAZY | RTLD_GLOBAL)), path_(iName) {
     if (libraryHandle_ == nullptr) {
       char const* err = dlerror();

--- a/FWCore/PluginManager/src/standard.cc
+++ b/FWCore/PluginManager/src/standard.cc
@@ -44,13 +44,13 @@ namespace edmplugin {
       return returnValue;
     }
 
-    const boost::filesystem::path& cachefileName() {
-      static const boost::filesystem::path s_path(".edmplugincache");
+    const std::filesystem::path& cachefileName() {
+      static const std::filesystem::path s_path(".edmplugincache");
       return s_path;
     }
 
-    const boost::filesystem::path& poisonedCachefileName() {
-      static const boost::filesystem::path s_path(".poisonededmplugincache");
+    const std::filesystem::path& poisonedCachefileName() {
+      static const std::filesystem::path s_path(".poisonededmplugincache");
       return s_path;
     }
 

--- a/FWCore/PluginManager/test/pluginmanager_t.cc
+++ b/FWCore/PluginManager/test/pluginmanager_t.cc
@@ -86,7 +86,7 @@ void TestPluginManager::test() {
 
   unsigned int nTimesGoingToLoad = 0;
   edmplugin::PluginManager::get()->goingToLoad_.connect(
-      [&nTimesGoingToLoad](const boost::filesystem::path&) { ++nTimesGoingToLoad; });
+      [&nTimesGoingToLoad](const std::filesystem::path&) { ++nTimesGoingToLoad; });
 
   unsigned int nTimesLoaded = 0;
   edmplugin::PluginManager::get()->justLoaded_.connect(

--- a/FWCore/Services/plugins/PrintLoadingPlugins.cc
+++ b/FWCore/Services/plugins/PrintLoadingPlugins.cc
@@ -34,7 +34,7 @@ public:
   PrintLoadingPlugins();
   virtual ~PrintLoadingPlugins();
 
-  void goingToLoad(const boost::filesystem::path&);
+  void goingToLoad(const std::filesystem::path&);
 
   void askedToLoad(const std::string&, const std::string&);
 
@@ -130,7 +130,7 @@ void PrintLoadingPlugins::askedToLoad(const std::string& iCategory, const std::s
     std::pair<PIItr, PIItr> range = std::equal_range(itFound->second.begin(), itFound->second.end(), i, PICompare());
 
     if (range.second - range.first > 1) {
-      const boost::filesystem::path& loadable = range.first->loadable_;
+      const std::filesystem::path& loadable = range.first->loadable_;
 
       libname = loadable.string();
     }
@@ -140,7 +140,7 @@ void PrintLoadingPlugins::askedToLoad(const std::string& iCategory, const std::s
   }
 }
 
-void PrintLoadingPlugins::goingToLoad(const boost::filesystem::path& Loadable_)
+void PrintLoadingPlugins::goingToLoad(const std::filesystem::path& Loadable_)
 
 {
   edm::LogAbsolute("LoadLib") << "Loading> " << Loadable_.string() << std::endl;

--- a/PhysicsTools/MVAComputer/src/VarProcessor.cc
+++ b/PhysicsTools/MVAComputer/src/VarProcessor.cc
@@ -12,6 +12,8 @@
 // Created:     Sat Apr 24 15:18 CEST 2007
 //
 
+#include <cassert>
+
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "FWCore/PluginManager/interface/PluginManager.h"


### PR DESCRIPTION
#### PR description:
C++17 filesystem has very similar functionality as boost::filesystem. If possible, we should strive to use the standard library.

Changes: 
- "branch_path" and "leaf" functions are deprecated in boost, and were renamed, stl filesystem uses the new names: 
https://www.boost.org/doc/libs/1_57_0/libs/filesystem/doc/deprecated.html

-  replaced boost::filesystem::initial_path for std::filesystem::current_path. I believe this change makes no difference in this use case.

-  the return type of  filesystem::last_write_time() is different in boost and stl filesystem.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 
