### PR TITLE
Refactor parts of the thinning code

### DIFF
--- a/DataFormats/Common/interface/EDProductGetter.h
+++ b/DataFormats/Common/interface/EDProductGetter.h
@@ -19,7 +19,9 @@
 // user include files
 
 // system include files
+#include <optional>
 #include <string>
+#include <tuple>
 #include <vector>
 
 // forward declarations
@@ -44,11 +46,11 @@ namespace edm {
     // getThinnedProduct assumes getIt was already called and failed to find
     // the product. The input key is the index of the desired element in the
     // container identified by ProductID (which cannot be found).
-    // If the return value is not null, then the desired element was found
-    // in a thinned container and key is modified to be the index into
-    // that thinned container. If the desired element is not found, then
-    // nullptr is returned.
-    virtual WrapperBase const* getThinnedProduct(ProductID const&, unsigned int& key) const = 0;
+    // If the return value is not null, then the desired element was
+    // found in a thinned container. If the desired element is not
+    // found, then an optional without a value is returned.
+    virtual std::optional<std::tuple<WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,
+                                                                                          unsigned int key) const = 0;
 
     // getThinnedProducts assumes getIt was already called and failed to find
     // the product. The input keys are the indexes into the container identified

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -182,15 +182,15 @@ namespace edm {
         WrapperBase const* prod = getter->getIt(core_.id());
         unsigned int iKey = key_;
         if (prod == nullptr) {
-          std::optional optProd = getter->getThinnedProduct(core_.id(), key_);
-          if (not optProd.has_value()) {
+          auto optionalProd = getter->getThinnedProduct(core_.id(), key_);
+          if (not optionalProd.has_value()) {
             if (throwIfNotFound) {
               core_.productNotFoundException(typeid(T));
             } else {
               return;
             }
           }
-          std::tie(prod, iKey) = *optProd;
+          std::tie(prod, iKey) = *optionalProd;
         }
         void const* ad = nullptr;
         prod->setPtr(typeid(T), iKey, ad);

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -182,14 +182,15 @@ namespace edm {
         WrapperBase const* prod = getter->getIt(core_.id());
         unsigned int iKey = key_;
         if (prod == nullptr) {
-          prod = getter->getThinnedProduct(core_.id(), iKey);
-          if (prod == nullptr) {
+          std::optional optProd = getter->getThinnedProduct(core_.id(), key_);
+          if (not optProd.has_value()) {
             if (throwIfNotFound) {
               core_.productNotFoundException(typeid(T));
             } else {
               return;
             }
           }
+          std::tie(prod, iKey) = *optProd;
         }
         void const* ad = nullptr;
         prod->setPtr(typeid(T), iKey, ad);

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -86,11 +86,13 @@ namespace edm {
 
     WrapperBase const* tryToGetProductPtr(std::type_info const& type, EDProductGetter const* prodGetter) const;
 
-    WrapperBase const* getThinnedProductPtr(std::type_info const& type,
-                                            unsigned int& thinnedKey,
-                                            EDProductGetter const* prodGetter) const;
+    // argument 'key' is the key to parent, key to thinned is returned
+    std::tuple<WrapperBase const*, unsigned int> getThinnedProductPtr(std::type_info const& type,
+                                                                      unsigned int key,
+                                                                      EDProductGetter const* prodGetter) const;
 
-    bool isThinnedAvailable(unsigned int thinnedKey, EDProductGetter const* prodGetter) const;
+    // argument 'key' is the key to parent
+    bool isThinnedAvailable(unsigned int key, EDProductGetter const* prodGetter) const;
 
     void productNotFoundException(std::type_info const& type) const;
 

--- a/DataFormats/Common/interface/RefCoreGet.h
+++ b/DataFormats/Common/interface/RefCoreGet.h
@@ -103,17 +103,19 @@ namespace edm {
 
   namespace refcore {
     template <typename T>
-    inline T const* getThinnedProduct_(RefCore const& ref,
-                                       unsigned int& thinnedKey,
-                                       EDProductGetter const* prodGetter) {
-      WrapperBase const* product = ref.getThinnedProductPtr(typeid(T), thinnedKey, prodGetter);
+    inline std::tuple<T const*, unsigned int> getThinnedProduct_(RefCore const& ref,
+                                                                 unsigned int key,
+                                                                 EDProductGetter const* prodGetter) {
+      auto [product, thinnedKey] = ref.getThinnedProductPtr(typeid(T), key, prodGetter);
       Wrapper<T> const* wrapper = static_cast<Wrapper<T> const*>(product);
-      return wrapper->product();
+      return std::tuple(wrapper->product(), thinnedKey);
     }
   }  // namespace refcore
 
   template <typename T>
-  inline T const* getThinnedProduct(RefCore const& ref, unsigned int& thinnedKey, EDProductGetter const* prodGetter) {
+  inline std::tuple<T const*, unsigned int> getThinnedProduct(RefCore const& ref,
+                                                              unsigned int key,
+                                                              EDProductGetter const* prodGetter) {
     // The pointer to a thinned collection will never be cached
     // T const* p = static_cast<T const*>(ref.productPtr());
     // if (p != 0) return p;
@@ -121,7 +123,7 @@ namespace edm {
     if (ref.isTransient()) {
       ref.nullPointerForTransientException(typeid(T));
     }
-    return refcore::getThinnedProduct_<T>(ref, thinnedKey, prodGetter);
+    return refcore::getThinnedProduct_<T>(ref, key, prodGetter);
   }
 }  // namespace edm
 #endif

--- a/DataFormats/Common/interface/RefItemGet.h
+++ b/DataFormats/Common/interface/RefItemGet.h
@@ -71,8 +71,8 @@ namespace edm {
           product.setProductPtr(item);
           return item;
         }
-        unsigned int thinnedKey = key;
-        prod = edm::template getThinnedProduct<C>(product, thinnedKey, getter);
+        unsigned int thinnedKey;
+        std::tie(prod, thinnedKey) = edm::template getThinnedProduct<C>(product, key, getter);
         F func;
         item = func(*prod, thinnedKey);
         product.setProductPtr(item);

--- a/DataFormats/Common/interface/ThinnedAssociation.h
+++ b/DataFormats/Common/interface/ThinnedAssociation.h
@@ -21,7 +21,7 @@ namespace edm {
     std::vector<unsigned int> const& indexesIntoParent() const { return indexesIntoParent_; }
 
     // If this association contains the parent index, return the
-    // corresponding index into the thinned colleciton. Otherwise
+    // corresponding index into the thinned collection. Otherwise
     // return null std::optional.
     std::optional<unsigned int> getThinnedIndex(unsigned int parentIndex) const;
 

--- a/DataFormats/Common/interface/ThinnedAssociation.h
+++ b/DataFormats/Common/interface/ThinnedAssociation.h
@@ -7,6 +7,7 @@
 
 #include "DataFormats/Provenance/interface/ProductID.h"
 
+#include <optional>
 #include <vector>
 
 namespace edm {
@@ -19,7 +20,10 @@ namespace edm {
     ProductID const& thinnedCollectionID() const { return thinnedCollectionID_; }
     std::vector<unsigned int> const& indexesIntoParent() const { return indexesIntoParent_; }
 
-    bool hasParentIndex(unsigned int parentIndex, unsigned int& thinnedIndex) const;
+    // If this association contains the parent index, return the
+    // corresponding index into the thinned colleciton. Otherwise
+    // return null std::optional.
+    std::optional<unsigned int> getThinnedIndex(unsigned int parentIndex) const;
 
     void setParentCollectionID(ProductID const& v) { parentCollectionID_ = v; }
     void setThinnedCollectionID(ProductID const& v) { thinnedCollectionID_ = v; }

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -95,7 +95,7 @@ namespace edm {
                             ThinnedAssociationsHelper const& thinnedAssociationsHelper,
                             F1&& pidToBid,
                             F2&& getThinnedAssociation,
-                            F3&& getProductByID,
+                            F3&& getByProductID,
                             std::vector<WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) {
       BranchID parent = pidToBid(pid);
@@ -137,7 +137,7 @@ namespace edm {
         // Get the thinned container and set the pointers and indexes into
         // it (if we can find it)
         ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
-        WrapperBase const* thinnedCollection = getProductByID(thinnedCollectionPID);
+        WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID);
         if (thinnedCollection == nullptr) {
           // Thinned container is not found, try looking recursively in thinned containers
           // which were made by selecting elements from this thinned container.
@@ -145,7 +145,7 @@ namespace edm {
                              thinnedAssociationsHelper,
                              std::forward<F1>(pidToBid),
                              std::forward<F2>(getThinnedAssociation),
-                             std::forward<F3>(getProductByID),
+                             std::forward<F3>(getByProductID),
                              foundContainers,
                              thinnedIndexes);
           for (unsigned k = 0; k < nKeys; ++k) {

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -28,9 +28,9 @@ namespace edm {
         ProductID const& pid,
         unsigned int key,
         ThinnedAssociationsHelper const& thinnedAssociationsHelper,
-        F1&& pidToBid,
-        F2&& getThinnedAssociation,
-        F3&& getByProductID) {
+        F1 pidToBid,
+        F2 getThinnedAssociation,
+        F3 getByProductID) {
       BranchID parent = pidToBid(pid);
 
       // Loop over thinned containers which were made by selecting elements from the parent container
@@ -61,9 +61,9 @@ namespace edm {
           auto thinnedCollectionKey = getThinnedProduct(thinnedCollectionPID,
                                                         thinnedIndex,
                                                         thinnedAssociationsHelper,
-                                                        std::forward<F1>(pidToBid),
-                                                        std::forward<F2>(getThinnedAssociation),
-                                                        std::forward<F3>(getByProductID));
+                                                        pidToBid,
+                                                        getThinnedAssociation,
+                                                        getByProductID);
           if (thinnedCollectionKey.has_value()) {
             return thinnedCollectionKey;
           } else {
@@ -93,9 +93,9 @@ namespace edm {
     template <typename F1, typename F2, typename F3>
     void getThinnedProducts(ProductID const& pid,
                             ThinnedAssociationsHelper const& thinnedAssociationsHelper,
-                            F1&& pidToBid,
-                            F2&& getThinnedAssociation,
-                            F3&& getByProductID,
+                            F1 pidToBid,
+                            F2 getThinnedAssociation,
+                            F3 getByProductID,
                             std::vector<WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) {
       BranchID parent = pidToBid(pid);
@@ -143,9 +143,9 @@ namespace edm {
           // which were made by selecting elements from this thinned container.
           getThinnedProducts(thinnedCollectionPID,
                              thinnedAssociationsHelper,
-                             std::forward<F1>(pidToBid),
-                             std::forward<F2>(getThinnedAssociation),
-                             std::forward<F3>(getByProductID),
+                             pidToBid,
+                             getThinnedAssociation,
+                             getByProductID,
                              foundContainers,
                              thinnedIndexes);
           for (unsigned k = 0; k < nKeys; ++k) {

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -1,0 +1,172 @@
+#ifndef DataFormats_Common_getThinned_implementation_h
+#define DataFormats_Common_getThinned_implementation_h
+
+#include <optional>
+#include <tuple>
+
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+
+namespace edm {
+  class WrapperBase;
+
+  namespace detail {
+    // This function provides a common implementation of
+    // EDProductGetter::getThinnedProduct() for EventPrincipal,
+    // DataGetterHelper, and BareRootProductGetter.
+    //
+    // getThinnedProduct assumes getIt was already called and failed to find
+    // the product. The input key is the index of the desired element in the
+    // container identified by ProductID (which cannot be found).
+    // If the return value is not null, then the desired element was
+    // found in a thinned container. If the desired element is not
+    // found, then an optional without a value is returned.
+    template <typename F1, typename F2, typename F3>
+    std::optional<std::tuple<WrapperBase const*, unsigned int> > getThinnedProduct(
+        ProductID const& pid,
+        unsigned int key,
+        ThinnedAssociationsHelper const& thinnedAssociationsHelper,
+        F1&& pidToBid,
+        F2&& getThinnedAssociation,
+        F3&& getByProductID) {
+      BranchID parent = pidToBid(pid);
+
+      // Loop over thinned containers which were made by selecting elements from the parent container
+      for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
+                iEnd = thinnedAssociationsHelper.parentEnd(parent);
+           associatedBranches != iEnd;
+           ++associatedBranches) {
+        ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(associatedBranches->association());
+        if (thinnedAssociation == nullptr)
+          continue;
+
+        if (associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
+          continue;
+        }
+
+        unsigned int thinnedIndex = 0;
+        // Does this thinned container have the element referenced by key?
+        // If yes, thinnedIndex is set to point to it in the thinned container
+        if (!thinnedAssociation->hasParentIndex(key, thinnedIndex)) {
+          continue;
+        }
+        // Get the thinned container and return a pointer if we can find it
+        ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
+        WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID);
+        if (thinnedCollection == nullptr) {
+          // Thinned container is not found, try looking recursively in thinned containers
+          // which were made by selecting elements from this thinned container.
+          auto thinnedCollectionKey = getThinnedProduct(thinnedCollectionPID,
+                                                        thinnedIndex,
+                                                        thinnedAssociationsHelper,
+                                                        std::forward<F1>(pidToBid),
+                                                        std::forward<F2>(getThinnedAssociation),
+                                                        std::forward<F3>(getByProductID));
+          if (thinnedCollectionKey.has_value()) {
+            return thinnedCollectionKey;
+          } else {
+            continue;
+          }
+        }
+        return std::tuple(thinnedCollection, thinnedIndex);
+      }
+      return std::nullopt;
+    }
+
+    // This function provides a common implementation of
+    // EDProductGetter::getThinnedProducts() for EventPrincipal,
+    // DataGetterHelper, and BareRootProductGetter.
+    //
+    // getThinnedProducts assumes getIt was already called and failed to find
+    // the product. The input keys are the indexes into the container identified
+    // by ProductID (which cannot be found). On input the WrapperBase pointers
+    // must all be set to nullptr (except when the function calls itself
+    // recursively where non-null pointers mark already found elements).
+    // Thinned containers derived from the product are searched to see
+    // if they contain the desired elements. For each that is
+    // found, the corresponding WrapperBase pointer is set and the key
+    // is modified to be the key into the container where the element
+    // was found. The WrapperBase pointers might or might not all point
+    // to the same thinned container.
+    template <typename F1, typename F2, typename F3>
+    void getThinnedProducts(ProductID const& pid,
+                            ThinnedAssociationsHelper const& thinnedAssociationsHelper,
+                            F1&& pidToBid,
+                            F2&& getThinnedAssociation,
+                            F3&& getProductByID,
+                            std::vector<WrapperBase const*>& foundContainers,
+                            std::vector<unsigned int>& keys) {
+      BranchID parent = pidToBid(pid);
+
+      // Loop over thinned containers which were made by selecting elements from the parent container
+      for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
+                iEnd = thinnedAssociationsHelper.parentEnd(parent);
+           associatedBranches != iEnd;
+           ++associatedBranches) {
+        ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(associatedBranches->association());
+        if (thinnedAssociation == nullptr)
+          continue;
+
+        if (associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
+          continue;
+        }
+
+        unsigned nKeys = keys.size();
+        unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
+        std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
+        bool hasAny = false;
+        for (unsigned k = 0; k < nKeys; ++k) {
+          // Already found this one
+          if (foundContainers[k] != nullptr)
+            continue;
+          // Already know this one is not in this thinned container
+          if (keys[k] == doNotLookForThisIndex)
+            continue;
+          // Does the thinned container hold the entry of interest?
+          // Modifies thinnedIndexes[k] only if it returns true and
+          // sets it to the index in the thinned collection.
+          if (thinnedAssociation->hasParentIndex(keys[k], thinnedIndexes[k])) {
+            hasAny = true;
+          }
+        }
+        if (!hasAny) {
+          continue;
+        }
+        // Get the thinned container and set the pointers and indexes into
+        // it (if we can find it)
+        ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
+        WrapperBase const* thinnedCollection = getProductByID(thinnedCollectionPID);
+        if (thinnedCollection == nullptr) {
+          // Thinned container is not found, try looking recursively in thinned containers
+          // which were made by selecting elements from this thinned container.
+          getThinnedProducts(thinnedCollectionPID,
+                             thinnedAssociationsHelper,
+                             std::forward<F1>(pidToBid),
+                             std::forward<F2>(getThinnedAssociation),
+                             std::forward<F3>(getProductByID),
+                             foundContainers,
+                             thinnedIndexes);
+          for (unsigned k = 0; k < nKeys; ++k) {
+            if (foundContainers[k] == nullptr)
+              continue;
+            if (thinnedIndexes[k] == doNotLookForThisIndex)
+              continue;
+            keys[k] = thinnedIndexes[k];
+          }
+        } else {
+          for (unsigned k = 0; k < nKeys; ++k) {
+            if (thinnedIndexes[k] == doNotLookForThisIndex)
+              continue;
+            keys[k] = thinnedIndexes[k];
+            foundContainers[k] = thinnedCollection;
+          }
+        }
+      }
+    }
+
+  }  // namespace detail
+}  // namespace edm
+
+#endif

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -114,7 +114,7 @@ namespace edm {
         }
 
         unsigned nKeys = keys.size();
-        unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
+        constexpr unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
         std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
         bool hasAny = false;
         for (unsigned k = 0; k < nKeys; ++k) {

--- a/DataFormats/Common/src/ThinnedAssociation.cc
+++ b/DataFormats/Common/src/ThinnedAssociation.cc
@@ -6,12 +6,11 @@ namespace edm {
 
   ThinnedAssociation::ThinnedAssociation() {}
 
-  bool ThinnedAssociation::hasParentIndex(unsigned int parentIndex, unsigned int& thinnedIndex) const {
+  std::optional<unsigned int> ThinnedAssociation::getThinnedIndex(unsigned int parentIndex) const {
     auto iter = std::lower_bound(indexesIntoParent_.begin(), indexesIntoParent_.end(), parentIndex);
     if (iter != indexesIntoParent_.end() && *iter == parentIndex) {
-      thinnedIndex = iter - indexesIntoParent_.begin();
-      return true;
+      return iter - indexesIntoParent_.begin();
     }
-    return false;
+    return std::nullopt;
   }
 }  // namespace edm

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -158,15 +158,18 @@ namespace {
   template <typename T>
   struct DSVGetter : edm::EDProductGetter {
     DSVGetter() : edm::EDProductGetter(), prod_(nullptr) {}
-    virtual WrapperBase const* getIt(ProductID const&) const override { return prod_; }
+    WrapperBase const* getIt(ProductID const&) const override { return prod_; }
 
-    virtual WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override { return nullptr; }
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,
+                                                                                       unsigned int) const override {
+      return std::nullopt;
+    }
 
-    virtual void getThinnedProducts(ProductID const& pid,
-                                    std::vector<WrapperBase const*>& wrappers,
-                                    std::vector<unsigned int>& keys) const override {}
+    void getThinnedProducts(ProductID const& pid,
+                            std::vector<WrapperBase const*>& wrappers,
+                            std::vector<unsigned int>& keys) const override {}
 
-    virtual unsigned int transitionIndex_() const override { return 0U; }
+    unsigned int transitionIndex_() const override { return 0U; }
 
     edm::Wrapper<T> const* prod_;
   };

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -21,7 +21,7 @@ public:
 
   size_t size() const { return database.size(); }
 
-  virtual edm::WrapperBase const* getIt(edm::ProductID const& id) const override {
+  edm::WrapperBase const* getIt(edm::ProductID const& id) const override {
     map_t::const_iterator i = database.find(id);
     if (i == database.end()) {
       edm::Exception e(edm::errors::ProductNotFound, "InvalidID");
@@ -31,16 +31,17 @@ public:
     return i->second.get();
   }
 
-  virtual edm::WrapperBase const* getThinnedProduct(edm::ProductID const&, unsigned int&) const override {
-    return nullptr;
+  std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(edm::ProductID const&,
+                                                                                     unsigned int) const override {
+    return std::nullopt;
   }
 
-  virtual void getThinnedProducts(edm::ProductID const& pid,
-                                  std::vector<edm::WrapperBase const*>& wrappers,
-                                  std::vector<unsigned int>& keys) const override {}
+  void getThinnedProducts(edm::ProductID const& pid,
+                          std::vector<edm::WrapperBase const*>& wrappers,
+                          std::vector<unsigned int>& keys) const override {}
 
 private:
-  virtual unsigned int transitionIndex_() const override { return 0U; }
+  unsigned int transitionIndex_() const override { return 0U; }
 
   map_t database;
 };

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -288,14 +288,17 @@ void testPtr::comparisonTest() {
 namespace {
   struct TestGetter : public edm::EDProductGetter {
     WrapperBase const* hold_;
-    virtual WrapperBase const* getIt(ProductID const&) const override { return hold_; }
-    virtual WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override { return nullptr; }
+    WrapperBase const* getIt(ProductID const&) const override { return hold_; }
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,
+                                                                                       unsigned int) const override {
+      return std::nullopt;
+    }
 
-    virtual void getThinnedProducts(ProductID const& pid,
-                                    std::vector<WrapperBase const*>& wrappers,
-                                    std::vector<unsigned int>& keys) const override {}
+    void getThinnedProducts(ProductID const& pid,
+                            std::vector<WrapperBase const*>& wrappers,
+                            std::vector<unsigned int>& keys) const override {}
 
-    virtual unsigned int transitionIndex_() const override { return 0U; }
+    unsigned int transitionIndex_() const override { return 0U; }
 
     TestGetter() : hold_() {}
   };

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -41,16 +41,17 @@ namespace testPtr {
 
   struct TestGetter : public edm::EDProductGetter {
     edm::WrapperBase const* hold_;
-    virtual edm::WrapperBase const* getIt(edm::ProductID const&) const override { return hold_; }
-    virtual edm::WrapperBase const* getThinnedProduct(edm::ProductID const&, unsigned int&) const override {
-      return nullptr;
+    edm::WrapperBase const* getIt(edm::ProductID const&) const override { return hold_; }
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(edm::ProductID const&,
+                                                                                       unsigned int) const override {
+      return std::nullopt;
     }
 
-    virtual void getThinnedProducts(edm::ProductID const& pid,
-                                    std::vector<edm::WrapperBase const*>& wrappers,
-                                    std::vector<unsigned int>& keys) const override {}
+    void getThinnedProducts(edm::ProductID const& pid,
+                            std::vector<edm::WrapperBase const*>& wrappers,
+                            std::vector<unsigned int>& keys) const override {}
 
-    virtual unsigned int transitionIndex_() const override { return 0U; }
+    unsigned int transitionIndex_() const override { return 0U; }
 
     TestGetter() : hold_() {}
   };
@@ -74,11 +75,11 @@ void testPtrVector::check() {
   std::vector<Inherit1> v1(2, Inherit1());
   std::vector<Inherit2> v2(2, Inherit2());
 
-  TestHandle<std::vector<Inherit1> > h1(&v1, ProductID(1, 1));
+  TestHandle<std::vector<Inherit1>> h1(&v1, ProductID(1, 1));
   PtrVector<Inherit1> rv1;
   rv1.push_back(Ptr<Inherit1>(h1, 0));
   rv1.push_back(Ptr<Inherit1>(h1, 1));
-  TestHandle<std::vector<Inherit2> > h2(&v2, ProductID(1, 2));
+  TestHandle<std::vector<Inherit2>> h2(&v2, ProductID(1, 2));
   PtrVector<Inherit2> rv2;
   rv2.push_back(Ptr<Inherit2>(h2, 0));
   rv2.push_back(Ptr<Inherit2>(h2, 1));

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -161,7 +161,7 @@ void testRef::comparisonTest() {
     CPPUNIT_ASSERT(dummyRef21 < dummyRef22);
     CPPUNIT_ASSERT(!(dummyRef22 < dummyRef21));
 
-    typedef std::map<int, double, std::greater<int> > DummyCollection3;
+    typedef std::map<int, double, std::greater<int>> DummyCollection3;
     ProductID const pid3(1, 3);
     DummyCollection3 dummyCollection3;
     dummyCollection3.insert(std::make_pair(1, 1.0));
@@ -178,15 +178,18 @@ void testRef::comparisonTest() {
 namespace {
   struct TestGetter : public edm::EDProductGetter {
     WrapperBase const* hold_;
-    virtual WrapperBase const* getIt(ProductID const&) const override { return hold_; }
+    WrapperBase const* getIt(ProductID const&) const override { return hold_; }
 
-    virtual WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override { return nullptr; }
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,
+                                                                                       unsigned int) const override {
+      return std::nullopt;
+    }
 
-    virtual void getThinnedProducts(ProductID const& pid,
-                                    std::vector<WrapperBase const*>& wrappers,
-                                    std::vector<unsigned int>& keys) const override {}
+    void getThinnedProducts(ProductID const& pid,
+                            std::vector<WrapperBase const*>& wrappers,
+                            std::vector<unsigned int>& keys) const override {}
 
-    virtual unsigned int transitionIndex_() const override { return 0U; }
+    unsigned int transitionIndex_() const override { return 0U; }
     TestGetter() : hold_(nullptr) {}
   };
 

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -174,16 +174,17 @@ void testRefToBaseProd::constructTest() {
 namespace {
   struct TestGetter : public edm::EDProductGetter {
     WrapperBase const* hold_;
-    virtual WrapperBase const* getIt(ProductID const&) const override { return hold_; }
-    virtual edm::WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override {
-      return nullptr;
+    WrapperBase const* getIt(ProductID const&) const override { return hold_; }
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,
+                                                                                       unsigned int) const override {
+      return std::nullopt;
     }
 
-    virtual void getThinnedProducts(ProductID const& pid,
-                                    std::vector<WrapperBase const*>& wrappers,
-                                    std::vector<unsigned int>& keys) const override {}
+    void getThinnedProducts(ProductID const& pid,
+                            std::vector<WrapperBase const*>& wrappers,
+                            std::vector<unsigned int>& keys) const override {}
 
-    virtual unsigned int transitionIndex_() const override { return 0U; }
+    unsigned int transitionIndex_() const override { return 0U; }
 
     TestGetter() : hold_() {}
   };

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -109,7 +109,8 @@ namespace fwlite {
     // ---------- member functions ---------------------------
 
     edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
-    edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(edm::ProductID const& pid,
+                                                                                       unsigned int key) const;
 
     void getThinnedProducts(edm::ProductID const& pid,
                             std::vector<edm::WrapperBase const*>& foundContainers,

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -69,7 +69,9 @@ namespace fwlite {
     virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*, Long_t) const;
 
     edm::WrapperBase const* getByProductID(edm::ProductID const& pid, Long_t eventEntry) const;
-    edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key, Long_t eventEntry) const;
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(edm::ProductID const& pid,
+                                                                                       unsigned int key,
+                                                                                       Long_t eventEntry) const;
     void getThinnedProducts(edm::ProductID const& pid,
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys,

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -163,7 +163,8 @@ namespace fwlite {
     edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
 
     edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
-    edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(edm::ProductID const& pid,
+                                                                                       unsigned int key) const;
     void getThinnedProducts(edm::ProductID const& pid,
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const;

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -121,7 +121,8 @@ namespace fwlite {
 
     edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
 
-    edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
+    std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(edm::ProductID const& pid,
+                                                                                       unsigned int key) const;
 
     void getThinnedProducts(edm::ProductID const& pid,
                             std::vector<edm::WrapperBase const*>& foundContainers,

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -218,7 +218,8 @@ namespace fwlite {
     return event_->getByProductID(iID);
   }
 
-  edm::WrapperBase const* ChainEvent::getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const {
+  std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> ChainEvent::getThinnedProduct(
+      edm::ProductID const& pid, unsigned int key) const {
     return event_->getThinnedProduct(pid, key);
   }
 

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -23,6 +23,7 @@
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/Common/interface/getThinned_implementation.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 
 #include "FWCore/FWLite/interface/setRefStreamer.h"
@@ -402,49 +403,16 @@ namespace fwlite {
   edm::WrapperBase const* DataGetterHelper::getThinnedProduct(edm::ProductID const& pid,
                                                               unsigned int& key,
                                                               Long_t eventEntry) const {
-    edm::BranchID parent = branchMap_->productToBranchID(pid);
-    if (!parent.isValid())
-      return nullptr;
-    edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper = branchMap_->thinnedAssociationsHelper();
-
-    // Loop over thinned containers which were made by selecting elements from the parent container
-    for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
-              iEnd = thinnedAssociationsHelper.parentEnd(parent);
-         associatedBranches != iEnd;
-         ++associatedBranches) {
-      edm::ThinnedAssociation const* thinnedAssociation =
-          getThinnedAssociation(associatedBranches->association(), eventEntry);
-      if (thinnedAssociation == nullptr)
-        continue;
-
-      if (associatedBranches->parent() != branchMap_->productToBranchID(thinnedAssociation->parentCollectionID())) {
-        continue;
-      }
-
-      unsigned int thinnedIndex = 0;
-      // Does this thinned container have the element referenced by key?
-      // If yes, thinnedIndex is set to point to it in the thinned container
-      if (!thinnedAssociation->hasParentIndex(key, thinnedIndex)) {
-        continue;
-      }
-      // Get the thinned container and return a pointer if we can find it
-      edm::ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
-      edm::WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID, eventEntry);
-
-      if (thinnedCollection == nullptr) {
-        // Thinned container is not found, try looking recursively in thinned containers
-        // which were made by selecting elements from this thinned container.
-        edm::WrapperBase const* thinnedFromRecursiveCall =
-            getThinnedProduct(thinnedCollectionPID, thinnedIndex, eventEntry);
-        if (thinnedFromRecursiveCall != nullptr) {
-          key = thinnedIndex;
-          return thinnedFromRecursiveCall;
-        } else {
-          continue;
-        }
-      }
-      key = thinnedIndex;
-      return thinnedCollection;
+    auto wrapperKey = edm::detail::getThinnedProduct(
+        pid,
+        key,
+        branchMap_->thinnedAssociationsHelper(),
+        [this](edm::ProductID const& p) { return branchMap_->productToBranchID(p); },
+        [this, eventEntry](edm::BranchID const& b) { return getThinnedAssociation(b, eventEntry); },
+        [this, eventEntry](edm::ProductID const& p) { return getByProductID(p, eventEntry); });
+    if (wrapperKey.has_value()) {
+      key = std::get<unsigned int>(*wrapperKey);
+      return std::get<edm::WrapperBase const*>(*wrapperKey);
     }
     return nullptr;
   }
@@ -453,71 +421,14 @@ namespace fwlite {
                                             std::vector<edm::WrapperBase const*>& foundContainers,
                                             std::vector<unsigned int>& keys,
                                             Long_t eventEntry) const {
-    edm::BranchID parent = branchMap_->productToBranchID(pid);
-    if (!parent.isValid())
-      return;
-    edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper = branchMap_->thinnedAssociationsHelper();
-
-    // Loop over thinned containers which were made by selecting elements from the parent container
-    for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
-              iEnd = thinnedAssociationsHelper.parentEnd(parent);
-         associatedBranches != iEnd;
-         ++associatedBranches) {
-      edm::ThinnedAssociation const* thinnedAssociation =
-          getThinnedAssociation(associatedBranches->association(), eventEntry);
-      if (thinnedAssociation == nullptr)
-        continue;
-
-      if (associatedBranches->parent() != branchMap_->productToBranchID(thinnedAssociation->parentCollectionID())) {
-        continue;
-      }
-
-      unsigned int nKeys = keys.size();
-      unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
-      std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
-      bool hasAny = false;
-      for (unsigned k = 0; k < nKeys; ++k) {
-        // Already found this one
-        if (foundContainers[k] != nullptr)
-          continue;
-        // Already know this one is not in this thinned container
-        if (keys[k] == doNotLookForThisIndex)
-          continue;
-        // Does the thinned container hold the entry of interest?
-        // Modifies thinnedIndexes[k] only if it returns true and
-        // sets it to the index in the thinned collection.
-        if (thinnedAssociation->hasParentIndex(keys[k], thinnedIndexes[k])) {
-          hasAny = true;
-        }
-      }
-      if (!hasAny) {
-        continue;
-      }
-      // Get the thinned container and set the pointers and indexes into
-      // it (if we can find it)
-      edm::ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
-      edm::WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID, eventEntry);
-
-      if (thinnedCollection == nullptr) {
-        // Thinned container is not found, try looking recursively in thinned containers
-        // which were made by selecting elements from this thinned container.
-        getThinnedProducts(thinnedCollectionPID, foundContainers, thinnedIndexes, eventEntry);
-        for (unsigned k = 0; k < nKeys; ++k) {
-          if (foundContainers[k] == nullptr)
-            continue;
-          if (thinnedIndexes[k] == doNotLookForThisIndex)
-            continue;
-          keys[k] = thinnedIndexes[k];
-        }
-      } else {
-        for (unsigned k = 0; k < nKeys; ++k) {
-          if (thinnedIndexes[k] == doNotLookForThisIndex)
-            continue;
-          keys[k] = thinnedIndexes[k];
-          foundContainers[k] = thinnedCollection;
-        }
-      }
-    }
+    edm::detail::getThinnedProducts(
+        pid,
+        branchMap_->thinnedAssociationsHelper(),
+        [this](edm::ProductID const& p) { return branchMap_->productToBranchID(p); },
+        [this, eventEntry](edm::BranchID const& b) { return getThinnedAssociation(b, eventEntry); },
+        [this, eventEntry](edm::ProductID const& p) { return getByProductID(p, eventEntry); },
+        foundContainers,
+        keys);
   }
 
   edm::ThinnedAssociation const* DataGetterHelper::getThinnedAssociation(edm::BranchID const& branchID,

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -344,7 +344,7 @@ namespace fwlite {
   edm::WrapperBase const* DataGetterHelper::getByProductID(edm::ProductID const& iID, Long_t eventEntry) const {
     typedef std::pair<edm::ProductID, edm::BranchListIndex> IDPair;
     IDPair theID = std::make_pair(iID, branchMap_->branchListIndexes()[iID.processIndex() - 1]);
-    std::map<IDPair, std::shared_ptr<internal::Data> >::const_iterator itFound = idToData_.find(theID);
+    std::map<IDPair, std::shared_ptr<internal::Data>>::const_iterator itFound = idToData_.find(theID);
 
     if (itFound == idToData_.end()) {
       edm::BranchDescription const& bDesc = branchMap_->productToBranch(iID);
@@ -400,21 +400,15 @@ namespace fwlite {
         wrapperBaseTypeWithDict.pointerToBaseType(objectWithDict.address(), objectWithDict.typeOf()));
   }
 
-  edm::WrapperBase const* DataGetterHelper::getThinnedProduct(edm::ProductID const& pid,
-                                                              unsigned int& key,
-                                                              Long_t eventEntry) const {
-    auto wrapperKey = edm::detail::getThinnedProduct(
+  std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> DataGetterHelper::getThinnedProduct(
+      edm::ProductID const& pid, unsigned int key, Long_t eventEntry) const {
+    return edm::detail::getThinnedProduct(
         pid,
         key,
         branchMap_->thinnedAssociationsHelper(),
         [this](edm::ProductID const& p) { return branchMap_->productToBranchID(p); },
         [this, eventEntry](edm::BranchID const& b) { return getThinnedAssociation(b, eventEntry); },
         [this, eventEntry](edm::ProductID const& p) { return getByProductID(p, eventEntry); });
-    if (wrapperKey.has_value()) {
-      key = std::get<unsigned int>(*wrapperKey);
-      return std::get<edm::WrapperBase const*>(*wrapperKey);
-    }
-    return nullptr;
   }
 
   void DataGetterHelper::getThinnedProducts(edm::ProductID const& pid,

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -64,11 +64,11 @@ namespace fwlite {
       // getThinnedProduct assumes getIt was already called and failed to find
       // the product. The input key is the index of the desired element in the
       // container identified by ProductID (which cannot be found).
-      // If the return value is not null, then the desired element was found
-      // in a thinned container and key is modified to be the index into
-      // that thinned container. If the desired element is not found, then
-      // nullptr is returned.
-      edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const override {
+      // If the return value is not null, then the desired element was
+      // found in a thinned container. If the desired element is not
+      // found, then an optional without a value is returned.
+      std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(
+          edm::ProductID const& pid, unsigned int key) const override {
         return event_->getThinnedProduct(pid, key);
       }
 
@@ -366,7 +366,8 @@ namespace fwlite {
     return dataHelper_.getByProductID(iID, eventEntry);
   }
 
-  edm::WrapperBase const* Event::getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const {
+  std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> Event::getThinnedProduct(edm::ProductID const& pid,
+                                                                                            unsigned int key) const {
     Long_t eventEntry = branchMap_.getEventEntry();
     return dataHelper_.getThinnedProduct(pid, key, eventEntry);
   }

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -33,7 +33,8 @@ namespace fwlite {
 
       edm::WrapperBase const* getIt(edm::ProductID const& iID) const override { return event_->getByProductID(iID); }
 
-      edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const override {
+      std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(
+          edm::ProductID const& pid, unsigned int key) const override {
         return event_->getThinnedProduct(pid, key);
       }
 
@@ -319,11 +320,12 @@ namespace fwlite {
     return edp;
   }
 
-  edm::WrapperBase const* MultiChainEvent::getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const {
+  std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> MultiChainEvent::getThinnedProduct(
+      edm::ProductID const& pid, unsigned int key) const {
     // First try the first file
-    edm::WrapperBase const* edp = event1_->getThinnedProduct(pid, key);
+    auto edp = event1_->getThinnedProduct(pid, key);
     // Did not find the product, try secondary file
-    if (edp == nullptr) {
+    if (not edp.has_value()) {
       (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
       edp = event2_->getThinnedProduct(pid, key);
     }

--- a/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
+++ b/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
@@ -47,7 +47,6 @@ namespace edm {
 
     std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > associationToBranches() const;
 
-    void sort();
     void clear() { vThinnedAssociationBranches_.clear(); }
 
     void selectAssociationProducts(std::vector<BranchDescription const*> const& associationDescriptions,
@@ -77,6 +76,8 @@ namespace edm {
         std::set<BranchID>& branchesInRecursion,
         std::set<BranchID> const& keptProductsInEvent,
         std::map<BranchID, bool>& keepAssociation) const;
+    std::vector<ThinnedAssociationBranches>::const_iterator lower_bound(
+        ThinnedAssociationBranches const& branches) const;
 
     std::vector<ThinnedAssociationBranches> vThinnedAssociationBranches_;
   };

--- a/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
+++ b/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
@@ -44,23 +44,25 @@ namespace edm {
                             });
   }
 
-  void ThinnedAssociationsHelper::sort() {
-    std::sort(vThinnedAssociationBranches_.begin(),
-              vThinnedAssociationBranches_.end(),
-              [](ThinnedAssociationBranches const& x, ThinnedAssociationBranches const& y) {
-                return x.parent() < y.parent() ? true
-                                               : y.parent() < x.parent() ? false : x.association() < y.association();
-              });
+  std::vector<ThinnedAssociationBranches>::const_iterator ThinnedAssociationsHelper::lower_bound(
+      ThinnedAssociationBranches const& branches) const {
+    return std::lower_bound(
+        vThinnedAssociationBranches_.begin(),
+        vThinnedAssociationBranches_.end(),
+        branches,
+        [](ThinnedAssociationBranches const& x, ThinnedAssociationBranches const& y) {
+          return x.parent() < y.parent() ? true : y.parent() < x.parent() ? false : x.association() < y.association();
+        });
   }
 
   void ThinnedAssociationsHelper::addAssociation(BranchID const& parent,
                                                  BranchID const& association,
                                                  BranchID const& thinned) {
-    vThinnedAssociationBranches_.push_back(ThinnedAssociationBranches(parent, association, thinned));
+    addAssociation(ThinnedAssociationBranches(parent, association, thinned));
   }
 
   void ThinnedAssociationsHelper::addAssociation(ThinnedAssociationBranches const& branches) {
-    vThinnedAssociationBranches_.push_back(branches);
+    vThinnedAssociationBranches_.insert(lower_bound(branches), branches);
   }
 
   std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> >
@@ -222,7 +224,6 @@ namespace edm {
         addAssociation(parent, associationBranches.association(), thinned);
       }
     }
-    sort();
   }
 
   void ThinnedAssociationsHelper::initAssociationsFromSecondary(
@@ -248,6 +249,5 @@ namespace edm {
       }
       addAssociation(*(branches->second));
     }
-    sort();
   }
 }  // namespace edm

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -209,7 +209,9 @@
 
  <class name="std::vector<TFormula*>"/>
 
- <class name="edm::ThinnedAssociationBranches"/>
+ <class name="edm::ThinnedAssociationBranches" ClassVersion="4">
+  <version ClassVersion="4" checksum="377132180"/>
+ </class>
  <class name="std::vector<edm::ThinnedAssociationBranches>"/>
  <class name="edm::ThinnedAssociationsHelper" ClassVersion="10">
   <version ClassVersion="10" checksum="3444973106"/>

--- a/FWCore/FWLite/src/BareRootProductGetter.cc
+++ b/FWCore/FWLite/src/BareRootProductGetter.cc
@@ -158,20 +158,16 @@ edm::WrapperBase const* BareRootProductGetter::getIt(edm::BranchID const& branch
   return buffer->product_.get();
 }
 
-edm::WrapperBase const* BareRootProductGetter::getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const {
+std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> BareRootProductGetter::getThinnedProduct(
+    edm::ProductID const& pid, unsigned int key) const {
   Long_t eventEntry = branchMap_.getEventTree()->GetReadEntry();
-  auto wrapperKey = edm::detail::getThinnedProduct(
+  return edm::detail::getThinnedProduct(
       pid,
       key,
       branchMap_.thinnedAssociationsHelper(),
       [this](edm::ProductID const& p) { return branchMap_.productToBranchID(p); },
       [this, eventEntry](edm::BranchID const& b) { return getThinnedAssociation(b, eventEntry); },
       [this](edm::ProductID const& p) { return getIt(p); });
-  if (wrapperKey.has_value()) {
-    key = std::get<unsigned int>(*wrapperKey);
-    return std::get<edm::WrapperBase const*>(*wrapperKey);
-  }
-  return nullptr;
 }
 
 void BareRootProductGetter::getThinnedProducts(edm::ProductID const& pid,

--- a/FWCore/FWLite/src/BareRootProductGetter.cc
+++ b/FWCore/FWLite/src/BareRootProductGetter.cc
@@ -14,6 +14,7 @@
 #include "FWCore/FWLite/src/BareRootProductGetter.h"
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/getThinned_implementation.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
@@ -159,47 +160,16 @@ edm::WrapperBase const* BareRootProductGetter::getIt(edm::BranchID const& branch
 
 edm::WrapperBase const* BareRootProductGetter::getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const {
   Long_t eventEntry = branchMap_.getEventTree()->GetReadEntry();
-  edm::BranchID parent = branchMap_.productToBranchID(pid);
-  if (!parent.isValid())
-    return nullptr;
-  edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper = branchMap_.thinnedAssociationsHelper();
-
-  // Loop over thinned containers which were made by selecting elements from the parent container
-  for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
-            iEnd = thinnedAssociationsHelper.parentEnd(parent);
-       associatedBranches != iEnd;
-       ++associatedBranches) {
-    edm::ThinnedAssociation const* thinnedAssociation =
-        getThinnedAssociation(associatedBranches->association(), eventEntry);
-    if (thinnedAssociation == nullptr)
-      continue;
-
-    if (associatedBranches->parent() != branchMap_.productToBranchID(thinnedAssociation->parentCollectionID())) {
-      continue;
-    }
-
-    unsigned int thinnedIndex = 0;
-    // Does this thinned container have the element referenced by key?
-    // If yes, thinnedIndex is set to point to it in the thinned container
-    if (!thinnedAssociation->hasParentIndex(key, thinnedIndex)) {
-      continue;
-    }
-    // Get the thinned container and return a pointer if we can find it
-    edm::ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
-    edm::WrapperBase const* thinnedCollection = getIt(thinnedCollectionPID);
-    if (thinnedCollection == nullptr) {
-      // Thinned container is not found, try looking recursively in thinned containers
-      // which were made by selecting elements from this thinned container.
-      edm::WrapperBase const* thinnedFromRecursiveCall = getThinnedProduct(thinnedCollectionPID, thinnedIndex);
-      if (thinnedFromRecursiveCall != nullptr) {
-        key = thinnedIndex;
-        return thinnedFromRecursiveCall;
-      } else {
-        continue;
-      }
-    }
-    key = thinnedIndex;
-    return thinnedCollection;
+  auto wrapperKey = edm::detail::getThinnedProduct(
+      pid,
+      key,
+      branchMap_.thinnedAssociationsHelper(),
+      [this](edm::ProductID const& p) { return branchMap_.productToBranchID(p); },
+      [this, eventEntry](edm::BranchID const& b) { return getThinnedAssociation(b, eventEntry); },
+      [this](edm::ProductID const& p) { return getIt(p); });
+  if (wrapperKey.has_value()) {
+    key = std::get<unsigned int>(*wrapperKey);
+    return std::get<edm::WrapperBase const*>(*wrapperKey);
   }
   return nullptr;
 }
@@ -208,71 +178,14 @@ void BareRootProductGetter::getThinnedProducts(edm::ProductID const& pid,
                                                std::vector<edm::WrapperBase const*>& foundContainers,
                                                std::vector<unsigned int>& keys) const {
   Long_t eventEntry = branchMap_.getEventTree()->GetReadEntry();
-  edm::BranchID parent = branchMap_.productToBranchID(pid);
-  if (!parent.isValid())
-    return;
-  edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper = branchMap_.thinnedAssociationsHelper();
-
-  // Loop over thinned containers which were made by selecting elements from the parent container
-  for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
-            iEnd = thinnedAssociationsHelper.parentEnd(parent);
-       associatedBranches != iEnd;
-       ++associatedBranches) {
-    edm::ThinnedAssociation const* thinnedAssociation =
-        getThinnedAssociation(associatedBranches->association(), eventEntry);
-    if (thinnedAssociation == nullptr)
-      continue;
-
-    if (associatedBranches->parent() != branchMap_.productToBranchID(thinnedAssociation->parentCollectionID())) {
-      continue;
-    }
-
-    unsigned int nKeys = keys.size();
-    unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
-    std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
-    bool hasAny = false;
-    for (unsigned k = 0; k < nKeys; ++k) {
-      // Already found this one
-      if (foundContainers[k] != nullptr)
-        continue;
-      // Already know this one is not in this thinned container
-      if (keys[k] == doNotLookForThisIndex)
-        continue;
-      // Does the thinned container hold the entry of interest?
-      // Modifies thinnedIndexes[k] only if it returns true and
-      // sets it to the index in the thinned collection.
-      if (thinnedAssociation->hasParentIndex(keys[k], thinnedIndexes[k])) {
-        hasAny = true;
-      }
-    }
-    if (!hasAny) {
-      continue;
-    }
-    // Get the thinned container and set the pointers and indexes into
-    // it (if we can find it)
-    edm::ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
-    edm::WrapperBase const* thinnedCollection = getIt(thinnedCollectionPID);
-
-    if (thinnedCollection == nullptr) {
-      // Thinned container is not found, try looking recursively in thinned containers
-      // which were made by selecting elements from this thinned container.
-      getThinnedProducts(thinnedCollectionPID, foundContainers, thinnedIndexes);
-      for (unsigned k = 0; k < nKeys; ++k) {
-        if (foundContainers[k] == nullptr)
-          continue;
-        if (thinnedIndexes[k] == doNotLookForThisIndex)
-          continue;
-        keys[k] = thinnedIndexes[k];
-      }
-    } else {
-      for (unsigned k = 0; k < nKeys; ++k) {
-        if (thinnedIndexes[k] == doNotLookForThisIndex)
-          continue;
-        keys[k] = thinnedIndexes[k];
-        foundContainers[k] = thinnedCollection;
-      }
-    }
-  }
+  edm::detail::getThinnedProducts(
+      pid,
+      branchMap_.thinnedAssociationsHelper(),
+      [this](edm::ProductID const& p) { return branchMap_.productToBranchID(p); },
+      [this, eventEntry](edm::BranchID const& b) { return getThinnedAssociation(b, eventEntry); },
+      [this](edm::ProductID const& p) { return getIt(p); },
+      foundContainers,
+      keys);
 }
 
 BareRootProductGetter::Buffer* BareRootProductGetter::createNewBuffer(edm::BranchID const& branchID) const {

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -51,11 +51,11 @@ public:
   // getThinnedProduct assumes getIt was already called and failed to find
   // the product. The input key is the index of the desired element in the
   // container identified by ProductID (which cannot be found).
-  // If the return value is not null, then the desired element was found
-  // in a thinned container and key is modified to be the index into
-  // that thinned container. If the desired element is not found, then
-  // nullptr is returned.
-  edm::WrapperBase const* getThinnedProduct(edm::ProductID const&, unsigned int& key) const override;
+  // If the return value is not null, then the desired element was
+  // found in a thinned container. If the desired element is not
+  // found, then an optional without a value is returned.
+  std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(edm::ProductID const&,
+                                                                                     unsigned int key) const override;
 
   // getThinnedProducts assumes getIt was already called and failed to find
   // the product. The input keys are the indexes into the container identified

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -132,7 +132,8 @@ namespace edm {
                    std::optional<ProductProvenance> productProvenance) const;
 
     WrapperBase const* getIt(ProductID const& pid) const override;
-    WrapperBase const* getThinnedProduct(ProductID const& pid, unsigned int& key) const override;
+    std::optional<std::tuple<WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const& pid,
+                                                                                  unsigned int key) const override;
     void getThinnedProducts(ProductID const& pid,
                             std::vector<WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const override;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -232,7 +232,8 @@ namespace edm {
     void addParentProcessProduct(std::shared_ptr<BranchDescription const> bd);
 
     WrapperBase const* getIt(ProductID const&) const override;
-    WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override;
+    std::optional<std::tuple<WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,
+                                                                                  unsigned int) const override;
     void getThinnedProducts(ProductID const&,
                             std::vector<WrapperBase const*>&,
                             std::vector<unsigned int>&) const override;

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -65,8 +65,8 @@ namespace edm {
     ParameterSetDescription desc;
     desc.setComment("Produces thinned collections and associations to them");
     desc.add<edm::InputTag>("inputTag");
-    Selector::fillDescription(desc);
-    descriptions.addDefault(desc);
+    Selector::fillPSetDescription(desc);
+    descriptions.addWithDefaultLabel(desc);
   }
 
   template <typename Collection, typename Selector>

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/FunctorHandleExceptionFactory.h"
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/getThinned_implementation.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
@@ -301,43 +302,16 @@ namespace edm {
   WrapperBase const* EventPrincipal::getIt(ProductID const& pid) const { return getByProductID(pid).wrapper(); }
 
   WrapperBase const* EventPrincipal::getThinnedProduct(ProductID const& pid, unsigned int& key) const {
-    BranchID parent = pidToBid(pid);
-
-    // Loop over thinned containers which were made by selecting elements from the parent container
-    for (auto associatedBranches = thinnedAssociationsHelper_->parentBegin(parent),
-              iEnd = thinnedAssociationsHelper_->parentEnd(parent);
-         associatedBranches != iEnd;
-         ++associatedBranches) {
-      ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(associatedBranches->association());
-      if (thinnedAssociation == nullptr)
-        continue;
-
-      if (associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
-        continue;
-      }
-
-      unsigned int thinnedIndex = 0;
-      // Does this thinned container have the element referenced by key?
-      // If yes, thinnedIndex is set to point to it in the thinned container
-      if (!thinnedAssociation->hasParentIndex(key, thinnedIndex)) {
-        continue;
-      }
-      // Get the thinned container and return a pointer if we can find it
-      ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
-      BasicHandle bhThinned = getByProductID(thinnedCollectionPID);
-      if (!bhThinned.isValid()) {
-        // Thinned container is not found, try looking recursively in thinned containers
-        // which were made by selecting elements from this thinned container.
-        WrapperBase const* wrapperBase = getThinnedProduct(thinnedCollectionPID, thinnedIndex);
-        if (wrapperBase != nullptr) {
-          key = thinnedIndex;
-          return wrapperBase;
-        } else {
-          continue;
-        }
-      }
-      key = thinnedIndex;
-      return bhThinned.wrapper();
+    auto wrapperKey = detail::getThinnedProduct(
+        pid,
+        key,
+        *thinnedAssociationsHelper_,
+        [this](ProductID const& p) { return pidToBid(p); },
+        [this](BranchID const& b) { return getThinnedAssociation(b); },
+        [this](ProductID const& p) { return getIt(p); });
+    if (wrapperKey.has_value()) {
+      key = std::get<unsigned int>(*wrapperKey);
+      return std::get<WrapperBase const*>(*wrapperKey);
     }
     return nullptr;
   }
@@ -345,66 +319,14 @@ namespace edm {
   void EventPrincipal::getThinnedProducts(ProductID const& pid,
                                           std::vector<WrapperBase const*>& foundContainers,
                                           std::vector<unsigned int>& keys) const {
-    BranchID parent = pidToBid(pid);
-
-    // Loop over thinned containers which were made by selecting elements from the parent container
-    for (auto associatedBranches = thinnedAssociationsHelper_->parentBegin(parent),
-              iEnd = thinnedAssociationsHelper_->parentEnd(parent);
-         associatedBranches != iEnd;
-         ++associatedBranches) {
-      ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(associatedBranches->association());
-      if (thinnedAssociation == nullptr)
-        continue;
-
-      if (associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
-        continue;
-      }
-
-      unsigned nKeys = keys.size();
-      unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
-      std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
-      bool hasAny = false;
-      for (unsigned k = 0; k < nKeys; ++k) {
-        // Already found this one
-        if (foundContainers[k] != nullptr)
-          continue;
-        // Already know this one is not in this thinned container
-        if (keys[k] == doNotLookForThisIndex)
-          continue;
-        // Does the thinned container hold the entry of interest?
-        // Modifies thinnedIndexes[k] only if it returns true and
-        // sets it to the index in the thinned collection.
-        if (thinnedAssociation->hasParentIndex(keys[k], thinnedIndexes[k])) {
-          hasAny = true;
-        }
-      }
-      if (!hasAny) {
-        continue;
-      }
-      // Get the thinned container and set the pointers and indexes into
-      // it (if we can find it)
-      ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
-      BasicHandle bhThinned = getByProductID(thinnedCollectionPID);
-      if (!bhThinned.isValid()) {
-        // Thinned container is not found, try looking recursively in thinned containers
-        // which were made by selecting elements from this thinned container.
-        getThinnedProducts(thinnedCollectionPID, foundContainers, thinnedIndexes);
-        for (unsigned k = 0; k < nKeys; ++k) {
-          if (foundContainers[k] == nullptr)
-            continue;
-          if (thinnedIndexes[k] == doNotLookForThisIndex)
-            continue;
-          keys[k] = thinnedIndexes[k];
-        }
-      } else {
-        for (unsigned k = 0; k < nKeys; ++k) {
-          if (thinnedIndexes[k] == doNotLookForThisIndex)
-            continue;
-          keys[k] = thinnedIndexes[k];
-          foundContainers[k] = bhThinned.wrapper();
-        }
-      }
-    }
+    detail::getThinnedProducts(
+        pid,
+        *thinnedAssociationsHelper_,
+        [this](ProductID const& p) { return pidToBid(p); },
+        [this](BranchID const& b) { return getThinnedAssociation(b); },
+        [this](ProductID const& p) { return getIt(p); },
+        foundContainers,
+        keys);
   }
 
   Provenance EventPrincipal::getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const {

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -301,19 +301,15 @@ namespace edm {
 
   WrapperBase const* EventPrincipal::getIt(ProductID const& pid) const { return getByProductID(pid).wrapper(); }
 
-  WrapperBase const* EventPrincipal::getThinnedProduct(ProductID const& pid, unsigned int& key) const {
-    auto wrapperKey = detail::getThinnedProduct(
+  std::optional<std::tuple<WrapperBase const*, unsigned int>> EventPrincipal::getThinnedProduct(
+      ProductID const& pid, unsigned int key) const {
+    return detail::getThinnedProduct(
         pid,
         key,
         *thinnedAssociationsHelper_,
         [this](ProductID const& p) { return pidToBid(p); },
         [this](BranchID const& b) { return getThinnedAssociation(b); },
         [this](ProductID const& p) { return getIt(p); });
-    if (wrapperKey.has_value()) {
-      key = std::get<unsigned int>(*wrapperKey);
-      return std::get<WrapperBase const*>(*wrapperKey);
-    }
-    return nullptr;
   }
 
   void EventPrincipal::getThinnedProducts(ProductID const& pid,

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -882,9 +882,10 @@ namespace edm {
     return nullptr;
   }
 
-  WrapperBase const* Principal::getThinnedProduct(ProductID const&, unsigned int&) const {
+  std::optional<std::tuple<WrapperBase const*, unsigned int>> Principal::getThinnedProduct(ProductID const&,
+                                                                                           unsigned int) const {
     assert(false);
-    return nullptr;
+    return std::nullopt;
   }
 
   void Principal::getThinnedProducts(ProductID const&,

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -722,7 +722,6 @@ namespace edm {
     for (auto const& worker : streamSchedules_[0]->allWorkers()) {
       worker->registerThinnedAssociations(preg, thinnedAssociationsHelper);
     }
-    thinnedAssociationsHelper.sort();
 
     // The output modules consume products in kept branches.
     // So we must set this up before freezing.

--- a/FWCore/Integration/test/ThinningThingProducer.cc
+++ b/FWCore/Integration/test/ThinningThingProducer.cc
@@ -30,7 +30,7 @@ namespace edmtest {
   public:
     ThinningThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc);
 
-    static void fillDescription(edm::ParameterSetDescription& desc);
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
     void preChoose(edm::Handle<edmtest::ThingCollection> tc, edm::Event const& event, edm::EventSetup const& es);
 
@@ -49,7 +49,7 @@ namespace edmtest {
     expectedCollectionSize_ = pset.getParameter<unsigned int>("expectedCollectionSize");
   }
 
-  void ThinningThingSelector::fillDescription(edm::ParameterSetDescription& desc) {
+  void ThinningThingSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
     desc.add<edm::InputTag>("trackTag");
     desc.add<unsigned int>("offsetToThinnedKey");
     desc.add<unsigned int>("expectedCollectionSize");

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -93,7 +93,8 @@ namespace edm {
       ~EventPrincipalHolder() override;
 
       WrapperBase const* getIt(ProductID const& id) const override;
-      WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override;
+      std::optional<std::tuple<edm::WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,
+                                                                                         unsigned int) const override;
       void getThinnedProducts(ProductID const& pid,
                               std::vector<WrapperBase const*>& wrappers,
                               std::vector<unsigned int>& keys) const override;

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -480,9 +480,11 @@ namespace edm {
     return eventPrincipal_ ? eventPrincipal_->getIt(id) : nullptr;
   }
 
-  WrapperBase const* StreamerInputSource::EventPrincipalHolder::getThinnedProduct(edm::ProductID const& id,
-                                                                                  unsigned int& index) const {
-    return eventPrincipal_ ? eventPrincipal_->getThinnedProduct(id, index) : nullptr;
+  std::optional<std::tuple<edm::WrapperBase const*, unsigned int>>
+  StreamerInputSource::EventPrincipalHolder::getThinnedProduct(edm::ProductID const& id, unsigned int index) const {
+    if (eventPrincipal_)
+      return eventPrincipal_->getThinnedProduct(id, index);
+    return std::nullopt;
   }
 
   void StreamerInputSource::EventPrincipalHolder::getThinnedProducts(ProductID const& pid,


### PR DESCRIPTION
#### PR description:

This PR is a preparatory step to introduce (constrained) support for slimming objects when performing thinning of collections, as outlined in the discussion of #30544. More specifically, this PR
* Renames `ThinningProducer::fillDescription()` to `ThinningProducer::fillPSetDescription()` to follow a naming convention established elsewhere, and calls `ConfigurationDescriptions::addWithDefaultLabel()` to also generate the cfi (by @bendavid)
* Changes ThinnedAssociationsHelper::vThinnedAssociationBranches_` to be always sorted instead of sorting once at the end
  * When introducing the support for slimming, I'm planning to check after each insertion if the constraints for slimmed collections are still met in the hope of being able to provide easier-to-interpret error messages. This check will be more efficient if `vThinnedAssociationBranches_` is always sorted.
  * The overall worst-case complexity of the insertions+sort does increase from O(n log n) to O(n^2)
* Add class version for `ThinnedAssociationBranches`
  * Will add a new member in a subsequent PR
* Abstract the implementations of `getThinnedProduct()` and `getThinnedProducts()` in `EventPrincipal`, `DataGetterHelper`, and `BareRootProductGetter` into single functions
  * Having only one implementation for each  will simplify the slimming development
* Change the interface of `getThinnedProduct()` to return `WrapperBase const*` and the key to thinned collection via `std::optional` instead of the mixture of return value and output argument in the hope of making the calling code easier to understand
   * makes it clear by reading the code alone when the key to thinned collection is used and when not


#### PR validation:

Framework unit tests pass.