### PR TITLE
Modified radiation damage assumption for 2021 0T pixel templates

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -67,13 +67,13 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '112X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '112X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '112X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v5', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v4',
+    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v4',
+    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:

This PR updates the pixel templates used for zero-field 2021 MC with a different radiation damage assumption. Please see the [HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4313/1/1.html) and references therein for details.

The GT diffs are:

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_design_v4/112X_mcRun3_2021_design_v5 

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v4/112X_mcRun3_2021_realistic_v5 

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v4/112X_mcRun3_2021cosmics_realistic_deco_v5 

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v4/112X_mcRun3_2021_realistic_HI_v5 

#### PR validation:

Please see the [HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4313/1/1.html) and references therein for details.

In addition, a technical test was performed: `runTheMatrix.py -l limited,12024.0,7.23,159.0,7.24 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport but will be backported to 11_1_X.
