### PR TITLE
remove hltSiPixelPhase1TrackClustersAnalyzer from path

### DIFF
--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -5,5 +5,5 @@ from DQMOffline.Trigger.SiPixel_OfflineMonitoring_TrackCluster_cff import *
 
 sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelPhase1ClustersAnalyzer
-    + hltSiPixelPhase1TrackClustersAnalyzer
+    #+ hltSiPixelPhase1TrackClustersAnalyzer
 )    


### PR DESCRIPTION
resolves #30911

#### PR description:

As discussed in https://github.com/cms-sw/cmssw/issues/30911#issuecomment-663854072 this proposes a minimal fix, by removing `hltSiPixelPhase1TrackClustersAnalyzer` from being executed (it was not giving any meaningful outcome anyway).
The real bug-fix should still be validated and is expected in the coming weeks.

#### PR validation:

I've run wf. `11634.0` and step3 does not get any warning.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.

cc:
@mtosi @arossi83 
