### PR TITLE
fix index typo in PFRecoTauClusterVariables

### DIFF
--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -242,7 +242,7 @@ namespace reco {
           mvaInput[3] = neutralIsoPtSum;               //tauID("neutralIsoPtSum");
           mvaInput[4] = puCorrPtSum;                   //tauID("puCorrPtSum");
           mvaInput[5] = photonPtSumOutsideSignalCone;  //tauID("photonPtSumOutsideSignalCone");
-          mvaInput[7] = tauDecayMode;                  //tau.decayMode();
+          mvaInput[6] = tauDecayMode;                  //tau.decayMode();
           mvaInput[7] = tau.signalGammaCands().size();
           mvaInput[8] = tau.isolationGammaCands().size();
 


### PR DESCRIPTION
@swozniewski @mbluj 

I expect that this should get rid of non-reproducible behavior in phase-2 workflows in tau ID outputs