### PR TITLE
Add DB utilties for SiPixelVCal

### DIFF
--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -43,3 +43,12 @@
   <use name="CalibTracker/SiPixelESProducers"/>
   <use name="boost_python"/>
 </library>
+
+<library file="SiPixelVCal_PayloadInspector.cc" name="SiPixelVCal_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/Common"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
+  <use name="boost_python"/>
+</library>

--- a/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
@@ -123,7 +123,7 @@ namespace {
                                              o_extrema.second + o_range);
 
       for (unsigned int i = 1; i <= 2; i++) {
-        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.06, 0.12, 0.12, 0.05);
+        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.06, 0.12, 0.08, 0.03);
       }
 
       for (const auto &slope : slopes) {
@@ -187,6 +187,7 @@ namespace {
       histo->Draw("bar2");
       SiPixelPI::makeNicePlotStyle(histo.get());
       histo->SetStats(true);
+      histo->GetYaxis()->SetTitleOffset(0.9);
     }
   };
 
@@ -235,8 +236,8 @@ namespace {
 
       auto myPlots = PixelRegions::PixelRegionContainers(&tTopo, (Map_.size() == SiPixelPI::phase1size));
       myPlots.bookAll((myType == SiPixelVCalPI::t_slope) ? "SiPixel VCal slope value" : "SiPixel VCal offset value",
-                      (myType == SiPixelVCalPI::t_slope) ? "SiPixel VCal slope value [#electrons/VCal units]"
-                                                         : "SiPixel VCal offset value [#electrons]",
+                      (myType == SiPixelVCalPI::t_slope) ? "SiPixel VCal slope value [ADC/VCal units]"
+                                                         : "SiPixel VCal offset value [ADC]",
                       "#modules",
                       50,
                       extrema.first - range,
@@ -261,7 +262,7 @@ namespace {
       unsigned int maxPads = isBarrel ? 4 : 12;
       for (unsigned int c = 1; c <= maxPads; c++) {
         canvas.cd(c);
-        SiPixelPI::adjustCanvasMargins(canvas.cd(c), 0.07, 0.12, 0.12, 0.05);
+        SiPixelPI::adjustCanvasMargins(canvas.cd(c), 0.06, 0.12, 0.12, 0.05);
         legend.Draw("same");
         canvas.cd(c)->Update();
       }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
@@ -116,12 +116,11 @@ namespace {
                                  s_extrema.first * 0.9,
                                  s_extrema.second * 1.1);
 
-      auto h_offset =
-          std::make_shared<TH1F>("offset value",
-                                 "SiPixel VCal offset value;SiPixel VCal offset value [ADC];# modules",
-                                 50,
-                                 o_extrema.first - o_range,
-                                 o_extrema.second + o_range);
+      auto h_offset = std::make_shared<TH1F>("offset value",
+                                             "SiPixel VCal offset value;SiPixel VCal offset value [ADC];# modules",
+                                             50,
+                                             o_extrema.first - o_range,
+                                             o_extrema.second + o_range);
 
       for (unsigned int i = 1; i <= 2; i++) {
         SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.06, 0.12, 0.12, 0.05);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
@@ -1,0 +1,81 @@
+/*!
+  \file SiPixelVCal_PayloadInspector
+  \Payload Inspector Plugin for SiPixel Lorentz angles
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2019/06/20 10:59:56 $
+*/
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelVCal.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+#include "CondCore/SiPixelPlugins/interface/PixelRegionContainers.h"
+
+#include <memory>
+#include <sstream>
+
+// include ROOT
+#include "TH2F.h"
+#include "TH1F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+#include "TGaxis.h"
+
+namespace {
+
+  namespace SiPixelVCalPI {
+    enum type { t_slope = 0, t_offset = 1 };
+  }
+
+  /************************************************
+    1d histogram of SiPixelVCal of 1 IOV 
+  *************************************************/
+  // inherit from one of the predefined plot class: Histogram1D
+  template <SiPixelVCalPI::type myType>
+  class SiPixelVCalValue : public cond::payloadInspector::Histogram1D<SiPixelVCal, cond::payloadInspector::SINGLE_IOV> {
+  public:
+    SiPixelVCalValue()
+        : cond::payloadInspector::Histogram1D<SiPixelVCal, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixel VCal values",
+              "SiPixel VCal values",
+              100,
+              myType == SiPixelVCalPI::t_slope ? 40. : -700,
+              myType == SiPixelVCalPI::t_slope ? 60. : 0) {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const &iov : tag.iovs) {
+        std::shared_ptr<SiPixelVCal> payload = Base::fetchPayload(std::get<1>(iov));
+        if (payload.get()) {
+          auto VCalMap_ = payload->getSlopeAndOffset();
+          for (const auto &element : VCalMap_) {
+            if (myType == SiPixelVCalPI::t_slope) {
+              fillWithValue(element.second.slope);
+            } else if (myType == SiPixelVCalPI::t_offset) {
+              fillWithValue(element.second.offset);
+            }
+          }
+        }  // payload
+      }    // iovs
+      return true;
+    }  // fill
+  };
+
+  using SiPixelVCalSlopeValue = SiPixelVCalValue<SiPixelVCalPI::t_slope>;
+  using SiPixelVCalOffsetValue = SiPixelVCalValue<SiPixelVCalPI::t_offset>;
+
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(SiPixelVCal) {
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopeValue);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetValue);
+}

--- a/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <sstream>
+#include <fmt/printf.h>
 
 // include ROOT
 #include "TH2F.h"
@@ -73,9 +74,574 @@ namespace {
   using SiPixelVCalSlopeValue = SiPixelVCalValue<SiPixelVCalPI::t_slope>;
   using SiPixelVCalOffsetValue = SiPixelVCalValue<SiPixelVCalPI::t_offset>;
 
+  /************************************************
+    1d histogram of SiPixelVCal of 1 IOV 
+  *************************************************/
+  class SiPixelVCalValues : public cond::payloadInspector::PlotImage<SiPixelVCal, cond::payloadInspector::SINGLE_IOV> {
+  public:
+    SiPixelVCalValues()
+        : cond::payloadInspector::PlotImage<SiPixelVCal, cond::payloadInspector::SINGLE_IOV>("SiPixelVCal Values") {}
+
+    bool fill() override {
+      gStyle->SetOptStat("emr");
+
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      std::shared_ptr<SiPixelVCal> payload = fetchPayload(std::get<1>(iov));
+      auto VCalMap_ = payload->getSlopeAndOffset();
+
+      auto slopes = payload->getAllSlopes();
+      auto offsets = payload->getAllOffsets();
+
+      /*
+      std::transform(VCalMap_.begin(),
+		     VCalMap_.end(),
+		     std::inserter(slopes,slopes.end()),
+		     [](std::pair<unsigned int, SiPixelVCal::VCal> vcalentry) -> std::pair<uint32_t,float> { return std::make_pair(vcalentry.first,vcalentry.second.slope); });
+      
+      */
+
+      auto s_extrema = SiPixelPI::findMinMaxInMap(slopes);
+      auto o_extrema = SiPixelPI::findMinMaxInMap(offsets);
+
+      auto o_range = (o_extrema.second - o_extrema.first) / 10.;
+
+      TCanvas canvas("Canv", "Canv", 1000, 1000);
+      canvas.Divide(1, 2);
+      canvas.cd();
+      auto h_slope =
+          std::make_shared<TH1F>("slope value",
+                                 "SiPixel VCal slope value;SiPixel VCal slope value [ADC/VCal units];# modules",
+                                 50,
+                                 s_extrema.first * 0.9,
+                                 s_extrema.second * 1.1);
+
+      auto h_offset =
+          std::make_shared<TH1F>("offset value",
+                                 "SiPixel VCal offset value;SiPixel VCal offset value [ADC];# modules",
+                                 50,
+                                 o_extrema.first - o_range,
+                                 o_extrema.second + o_range);
+
+      for (unsigned int i = 1; i <= 2; i++) {
+        SiPixelPI::adjustCanvasMargins(canvas.cd(i), 0.06, 0.12, 0.12, 0.05);
+      }
+
+      for (const auto &slope : slopes) {
+        h_slope->Fill(slope.second);
+      }
+
+      for (const auto &offset : offsets) {
+        h_offset->Fill(offset.second);
+      }
+
+      canvas.cd(1);
+      adjustHisto(h_slope);
+      canvas.Update();
+
+      TLegend legend = TLegend(0.40, 0.83, 0.94, 0.93);
+      legend.SetHeader(("Payload hash: #bf{" + (std::get<1>(iov)) + "}").c_str(),
+                       "C");  // option "C" allows to center the header
+      legend.AddEntry(h_slope.get(), ("TAG: " + tag.name).c_str(), "F");
+      legend.SetTextSize(0.035);
+      legend.SetLineColor(10);
+      legend.Draw("same");
+
+      TPaveStats *st = (TPaveStats *)h_slope->FindObject("stats");
+      st->SetTextSize(0.035);
+      SiPixelPI::adjustStats(st, 0.15, 0.83, 0.30, 0.93);
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                       1 - gPad->GetTopMargin() + 0.01,
+                       ("SiPixel VCal Slope IOV:" + std::to_string(std::get<0>(iov))).c_str());
+
+      canvas.cd(2);
+      adjustHisto(h_offset);
+      canvas.Update();
+      legend.Draw("same");
+
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                       1 - gPad->GetTopMargin() + 0.01,
+                       ("SiPixel VCal Offset IOV:" + std::to_string(std::get<0>(iov))).c_str());
+
+      TPaveStats *st2 = (TPaveStats *)h_offset->FindObject("stats");
+      st2->SetTextSize(0.035);
+      SiPixelPI::adjustStats(st2, 0.15, 0.83, 0.30, 0.93);
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+  private:
+    void adjustHisto(const std::shared_ptr<TH1F> &histo) {
+      histo->SetTitle("");
+      histo->GetYaxis()->SetRangeUser(0., histo->GetMaximum() * 1.30);
+      histo->SetFillColor(kRed);
+      histo->SetMarkerStyle(20);
+      histo->SetMarkerSize(1);
+      histo->Draw("bar2");
+      SiPixelPI::makeNicePlotStyle(histo.get());
+      histo->SetStats(true);
+    }
+  };
+
+  /************************************************
+      1d histogram of SiPixelVCal of 1 IOV per region
+  *************************************************/
+  template <bool isBarrel, SiPixelVCalPI::type myType>
+  class SiPixelVCalValuesPerRegion
+      : public cond::payloadInspector::PlotImage<SiPixelVCal, cond::payloadInspector::SINGLE_IOV> {
+  public:
+    SiPixelVCalValuesPerRegion()
+        : cond::payloadInspector::PlotImage<SiPixelVCal, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelVCal Values per region") {}
+
+    bool fill() override {
+      gStyle->SetOptStat("emr");
+
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      std::shared_ptr<SiPixelVCal> payload = fetchPayload(std::get<1>(iov));
+      SiPixelVCal::mapToDetId Map_;
+      if (myType == SiPixelVCalPI::t_slope) {
+        Map_ = payload->getAllSlopes();
+      } else {
+        Map_ = payload->getAllOffsets();
+      }
+      auto extrema = SiPixelPI::findMinMaxInMap(Map_);
+      auto range = (extrema.second - extrema.first) / 10.;
+
+      TCanvas canvas("Canv", "Canv", isBarrel ? 1400 : 1800, 1200);
+      if (Map_.size() > SiPixelPI::phase1size) {
+        SiPixelPI::displayNotSupported(canvas, Map_.size());
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+        return false;
+      }
+
+      canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
+      canvas.cd();
+
+      const char *path_toTopologyXML = (Map_.size() == SiPixelPI::phase0size)
+                                           ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
+                                           : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      TrackerTopology tTopo =
+          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
+
+      auto myPlots = PixelRegions::PixelRegionContainers(&tTopo, (Map_.size() == SiPixelPI::phase1size));
+      myPlots.bookAll((myType == SiPixelVCalPI::t_slope) ? "SiPixel VCal slope value" : "SiPixel VCal offset value",
+                      (myType == SiPixelVCalPI::t_slope) ? "SiPixel VCal slope value [#electrons/VCal units]"
+                                                         : "SiPixel VCal offset value [#electrons]",
+                      "#modules",
+                      50,
+                      extrema.first - range,
+                      extrema.second + range);
+
+      canvas.Modified();
+
+      for (const auto &element : Map_) {
+        myPlots.fill(element.first, element.second);
+      }
+
+      myPlots.beautify();
+      myPlots.draw(canvas, isBarrel);
+
+      TLegend legend = TLegend(0.40, 0.88, 0.93, 0.90);
+      legend.SetHeader(("Hash: #bf{" + (std::get<1>(iov)) + "}").c_str(),
+                       "C");  // option "C" allows to center the header
+      //legend.AddEntry(h1.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
+      legend.SetTextSize(0.025);
+      legend.SetLineColor(10);
+
+      unsigned int maxPads = isBarrel ? 4 : 12;
+      for (unsigned int c = 1; c <= maxPads; c++) {
+        canvas.cd(c);
+        SiPixelPI::adjustCanvasMargins(canvas.cd(c), 0.07, 0.12, 0.12, 0.05);
+        legend.Draw("same");
+        canvas.cd(c)->Update();
+      }
+
+      myPlots.stats();
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+
+      for (unsigned int c = 1; c <= maxPads; c++) {
+        auto index = isBarrel ? c - 1 : c + 3;
+
+        canvas.cd(c);
+        ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                         1 - gPad->GetTopMargin() + 0.01,
+                         (PixelRegions::IDlabels.at(index) + ", IOV:" + std::to_string(std::get<0>(iov))).c_str());
+      }
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+  };
+
+  using SiPixelVCalSlopeValuesBarrel = SiPixelVCalValuesPerRegion<true, SiPixelVCalPI::t_slope>;
+  using SiPixelVCalSlopeValuesEndcap = SiPixelVCalValuesPerRegion<false, SiPixelVCalPI::t_slope>;
+
+  using SiPixelVCalOffsetValuesBarrel = SiPixelVCalValuesPerRegion<true, SiPixelVCalPI::t_offset>;
+  using SiPixelVCalOffsetValuesEndcap = SiPixelVCalValuesPerRegion<false, SiPixelVCalPI::t_offset>;
+
+  /************************************************
+      1d histogram of SiPixelVCal (slope or offset) of 2 IOV per region
+  *************************************************/
+  template <bool isBarrel, int ntags, SiPixelVCalPI::type myType>
+  class SiPixelVCalValuesComparisonPerRegion
+      : public cond::payloadInspector::PlotImage<SiPixelVCal, cond::payloadInspector::MULTI_IOV, ntags> {
+  public:
+    SiPixelVCalValuesComparisonPerRegion()
+        : cond::payloadInspector::PlotImage<SiPixelVCal, cond::payloadInspector::MULTI_IOV, ntags>(
+              Form("SiPixelVCal Values Comparisons per region %i tags(s)", ntags)) {}
+
+    bool fill() override {
+      gStyle->SetOptStat("emr");
+
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      SiPixelVCal::mapToDetId l_Map_;
+      SiPixelVCal::mapToDetId f_Map_;
+
+      std::shared_ptr<SiPixelVCal> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      if (myType == SiPixelVCalPI::t_slope) {
+        l_Map_ = last_payload->getAllSlopes();
+      } else {
+        l_Map_ = last_payload->getAllOffsets();
+      }
+      auto l_extrema = SiPixelPI::findMinMaxInMap(l_Map_);
+
+      std::shared_ptr<SiPixelVCal> first_payload = this->fetchPayload(std::get<1>(firstiov));
+      if (myType == SiPixelVCalPI::t_slope) {
+        f_Map_ = first_payload->getAllSlopes();
+      } else {
+        f_Map_ = first_payload->getAllOffsets();
+      }
+
+      auto f_extrema = SiPixelPI::findMinMaxInMap(f_Map_);
+
+      auto max = (l_extrema.second > f_extrema.second) ? l_extrema.second : f_extrema.second;
+      auto min = (l_extrema.first < f_extrema.first) ? l_extrema.first : f_extrema.first;
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      TCanvas canvas("Canv", "Canv", isBarrel ? 1400 : 1800, 1200);
+      if ((f_Map_.size() > SiPixelPI::phase1size) || (l_Map_.size() > SiPixelPI::phase1size)) {
+        SiPixelPI::displayNotSupported(canvas, std::max(f_Map_.size(), l_Map_.size()));
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+        return false;
+      }
+
+      canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
+      canvas.cd();
+
+      // deal with last IOV
+
+      const char *path_toTopologyXML = (l_Map_.size() == SiPixelPI::phase0size)
+                                           ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
+                                           : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+
+      auto l_tTopo =
+          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
+
+      auto l_myPlots = PixelRegions::PixelRegionContainers(&l_tTopo, (l_Map_.size() == SiPixelPI::phase1size));
+      l_myPlots.bookAll(
+          fmt::sprintf("SiPixel VCal %s,last", (myType == SiPixelVCalPI::t_slope ? "slope" : "offset")),
+          fmt::sprintf("SiPixel VCal %s", (myType == SiPixelVCalPI::t_slope ? " slope [ADC/VCal]" : " offset [ADC]")),
+          "#modules",
+          50,
+          min * 0.9,
+          max * 1.1);
+
+      for (const auto &element : l_Map_) {
+        l_myPlots.fill(element.first, element.second);
+      }
+
+      l_myPlots.beautify();
+      l_myPlots.draw(canvas, isBarrel, "bar2", true);
+
+      // deal with first IOV
+
+      path_toTopologyXML = (f_Map_.size() == SiPixelPI::phase0size)
+                               ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
+                               : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+
+      auto f_tTopo =
+          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
+
+      auto f_myPlots = PixelRegions::PixelRegionContainers(&f_tTopo, (f_Map_.size() == SiPixelPI::phase1size));
+      f_myPlots.bookAll(
+          fmt::sprintf("SiPixel VCal %s,first", (myType == SiPixelVCalPI::t_slope ? "slope" : "offset")),
+          fmt::sprintf("SiPixel VCal %s", (myType == SiPixelVCalPI::t_slope ? " slope [ADC/VCal]" : " offset [ADC]")),
+          "#modules",
+          50,
+          min * 0.9,
+          max * 1.1);
+
+      for (const auto &element : f_Map_) {
+        f_myPlots.fill(element.first, element.second);
+      }
+
+      f_myPlots.beautify(kAzure, kBlue);
+      f_myPlots.draw(canvas, isBarrel, "HISTsames", true);
+
+      // rescale the y-axis ranges in order to fit the canvas
+      l_myPlots.rescaleMax(f_myPlots);
+
+      // done dealing with IOVs
+
+      auto colorTag = isBarrel ? PixelRegions::L1 : PixelRegions::Rm1l;
+      std::unique_ptr<TLegend> legend;
+      if (this->m_plotAnnotations.ntags == 2) {
+        legend = std::make_unique<TLegend>(0.36, 0.86, 0.94, 0.92);
+        legend->AddEntry(l_myPlots.getHistoFromMap(colorTag).get(), ("#color[2]{" + tagname2 + "}").c_str(), "F");
+        legend->AddEntry(f_myPlots.getHistoFromMap(colorTag).get(), ("#color[4]{" + tagname1 + "}").c_str(), "F");
+        legend->SetTextSize(0.024);
+      } else {
+        legend = std::make_unique<TLegend>(0.58, 0.80, 0.90, 0.92);
+        legend->AddEntry(l_myPlots.getHistoFromMap(colorTag).get(), ("#color[2]{" + lastIOVsince + "}").c_str(), "F");
+        legend->AddEntry(f_myPlots.getHistoFromMap(colorTag).get(), ("#color[4]{" + firstIOVsince + "}").c_str(), "F");
+        legend->SetTextSize(0.040);
+      }
+      legend->SetLineColor(10);
+
+      unsigned int maxPads = isBarrel ? 4 : 12;
+      for (unsigned int c = 1; c <= maxPads; c++) {
+        canvas.cd(c);
+        SiPixelPI::adjustCanvasMargins(canvas.cd(c), 0.06, 0.12, 0.12, 0.05);
+        legend->Draw("same");
+        canvas.cd(c)->Update();
+      }
+
+      f_myPlots.stats(0);
+      l_myPlots.stats(1);
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+
+      for (unsigned int c = 1; c <= maxPads; c++) {
+        auto index = isBarrel ? c - 1 : c + 3;
+        canvas.cd(c);
+        ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                         1 - gPad->GetTopMargin() + 0.01,
+                         (PixelRegions::IDlabels.at(index) + " : #color[4]{" + std::to_string(std::get<0>(firstiov)) +
+                          "} vs #color[2]{" + std::to_string(std::get<0>(lastiov)) + "}")
+                             .c_str());
+      }
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+  };
+
+  using SiPixelVCalSlopesBarrelCompareSingleTag = SiPixelVCalValuesComparisonPerRegion<true, 1, SiPixelVCalPI::t_slope>;
+  using SiPixelVCalOffsetsBarrelCompareSingleTag =
+      SiPixelVCalValuesComparisonPerRegion<true, 1, SiPixelVCalPI::t_offset>;
+
+  using SiPixelVCalSlopesEndcapCompareSingleTag =
+      SiPixelVCalValuesComparisonPerRegion<false, 1, SiPixelVCalPI::t_slope>;
+  using SiPixelVCalOffsetsEndcapCompareSingleTag =
+      SiPixelVCalValuesComparisonPerRegion<false, 1, SiPixelVCalPI::t_offset>;
+
+  using SiPixelVCalSlopesBarrelCompareTwoTags = SiPixelVCalValuesComparisonPerRegion<true, 2, SiPixelVCalPI::t_slope>;
+  using SiPixelVCalOffsetsBarrelCompareTwoTags = SiPixelVCalValuesComparisonPerRegion<true, 2, SiPixelVCalPI::t_offset>;
+
+  using SiPixelVCalSlopesEndcapCompareTwoTags = SiPixelVCalValuesComparisonPerRegion<false, 2, SiPixelVCalPI::t_slope>;
+  using SiPixelVCalOffsetsEndcapCompareTwoTags =
+      SiPixelVCalValuesComparisonPerRegion<false, 2, SiPixelVCalPI::t_offset>;
+
+  /************************************************
+      1d histogram of SiPixelVCal of 1 IOV
+  *************************************************/
+
+  template <SiPixelVCalPI::type myType>
+  class SiPixelVCalValueComparisonBase : public cond::payloadInspector::PlotImage<SiPixelVCal> {
+  public:
+    SiPixelVCalValueComparisonBase()
+        : cond::payloadInspector::PlotImage<SiPixelVCal>("SiPixelVCal Values Comparison") {}
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
+      TH1F::SetDefaultSumw2(true);
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+      // make absolute sure the IOVs are sortd by since
+      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {
+        return std::get<0>(t1) < std::get<0>(t2);
+      });
+      auto firstiov = sorted_iovs.front();
+      auto lastiov = sorted_iovs.back();
+
+      SiPixelVCal::mapToDetId l_Map_;
+      SiPixelVCal::mapToDetId f_Map_;
+
+      std::shared_ptr<SiPixelVCal> last_payload = fetchPayload(std::get<1>(lastiov));
+      if (myType == SiPixelVCalPI::t_slope) {
+        l_Map_ = last_payload->getAllSlopes();
+      } else {
+        l_Map_ = last_payload->getAllOffsets();
+      }
+      auto l_extrema = SiPixelPI::findMinMaxInMap(l_Map_);
+
+      std::shared_ptr<SiPixelVCal> first_payload = fetchPayload(std::get<1>(firstiov));
+      if (myType == SiPixelVCalPI::t_slope) {
+        f_Map_ = first_payload->getAllSlopes();
+      } else {
+        f_Map_ = first_payload->getAllOffsets();
+      }
+      auto f_extrema = SiPixelPI::findMinMaxInMap(f_Map_);
+
+      auto max = (l_extrema.second > f_extrema.second) ? l_extrema.second : f_extrema.second;
+      auto min = (l_extrema.first < f_extrema.first) ? l_extrema.first : f_extrema.first;
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      TCanvas canvas("Canv", "Canv", 1200, 1000);
+      canvas.cd();
+      auto hfirst = std::unique_ptr<TH1F>(
+          new TH1F("value_first",
+                   fmt::sprintf("SiPixel VCal %s value;SiPixel VCal %s ;# modules",
+                                (myType == SiPixelVCalPI::t_slope ? "slope" : "offset"),
+                                (myType == SiPixelVCalPI::t_slope ? " slope [ADC/VCal]" : " offset [ADC]"))
+                       .c_str(),
+                   50,
+                   min * 0.9,
+                   max * 1.1));
+      hfirst->SetStats(false);
+
+      auto hlast = std::unique_ptr<TH1F>(
+          new TH1F("value_last",
+                   fmt::sprintf("SiPixel VCal %s value;SiPixel VCal %s ;# modules",
+                                (myType == SiPixelVCalPI::t_slope ? "slope" : "offset"),
+                                (myType == SiPixelVCalPI::t_slope ? " slope [ADC/VCal]" : " offset [ADC]"))
+                       .c_str(),
+                   50,
+                   min * 0.9,
+                   max * 1.1));
+      hlast->SetStats(false);
+
+      SiPixelPI::adjustCanvasMargins(canvas.cd(), 0.06, 0.12, 0.12, 0.05);
+      canvas.Modified();
+
+      for (const auto &element : f_Map_) {
+        hfirst->Fill(element.second);
+      }
+
+      for (const auto &element : l_Map_) {
+        hlast->Fill(element.second);
+      }
+
+      auto extrema = SiPixelPI::getExtrema(hfirst.get(), hlast.get());
+      hfirst->GetYaxis()->SetRangeUser(extrema.first, extrema.second * 1.10);
+
+      hfirst->SetTitle("");
+      hfirst->SetFillColor(kRed);
+      hfirst->SetBarWidth(0.95);
+      hfirst->Draw("histbar");
+
+      hlast->SetTitle("");
+      hlast->SetFillColorAlpha(kBlue, 0.20);
+      hlast->SetBarWidth(0.95);
+      hlast->Draw("histbarsame");
+
+      SiPixelPI::makeNicePlotStyle(hfirst.get());
+      SiPixelPI::makeNicePlotStyle(hlast.get());
+
+      canvas.Update();
+
+      TLegend legend = TLegend(0.30, 0.86, 0.95, 0.94);
+      legend.AddEntry(hfirst.get(), ("payload: #color[2]{" + std::get<1>(firstiov) + "}").c_str(), "F");
+      legend.AddEntry(hlast.get(), ("payload: #color[4]{" + std::get<1>(lastiov) + "}").c_str(), "F");
+      legend.SetTextSize(0.025);
+      legend.Draw("same");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.047);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                       1 - gPad->GetTopMargin() + 0.01,
+                       ("SiPixel VCal IOV: #color[2]{" + std::to_string(std::get<0>(firstiov)) +
+                        "} vs IOV: #color[4]{" + std::to_string(std::get<0>(lastiov)) + "}")
+                           .c_str());
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+  };
+
+  template <SiPixelVCalPI::type myType>
+  class SiPixelVCalValueComparisonSingleTag : public SiPixelVCalValueComparisonBase<myType> {
+  public:
+    SiPixelVCalValueComparisonSingleTag() : SiPixelVCalValueComparisonBase<myType>() { this->setSingleIov(false); }
+  };
+
+  template <SiPixelVCalPI::type myType>
+  class SiPixelVCalValueComparisonTwoTags : public SiPixelVCalValueComparisonBase<myType> {
+  public:
+    SiPixelVCalValueComparisonTwoTags() : SiPixelVCalValueComparisonBase<myType>() { this->setTwoTags(true); }
+  };
+
+  using SiPixelVCalSlopesComparisonSingleTag = SiPixelVCalValueComparisonSingleTag<SiPixelVCalPI::t_slope>;
+  using SiPixelVCalOffsetsComparisonSingleTag = SiPixelVCalValueComparisonSingleTag<SiPixelVCalPI::t_offset>;
+
+  using SiPixelVCalSlopesComparisonTwoTags = SiPixelVCalValueComparisonTwoTags<SiPixelVCalPI::t_slope>;
+  using SiPixelVCalOffsetsComparisonTwoTags = SiPixelVCalValueComparisonTwoTags<SiPixelVCalPI::t_offset>;
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(SiPixelVCal) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopeValue);
   PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetValue);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalValues);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopeValuesBarrel);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopeValuesEndcap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetValuesBarrel);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetValuesEndcap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopesBarrelCompareSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetsBarrelCompareSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopesEndcapCompareSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetsEndcapCompareSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopesBarrelCompareTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetsBarrelCompareTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopesEndcapCompareTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetsEndcapCompareTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopesComparisonSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetsComparisonSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalSlopesComparisonTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelVCalOffsetsComparisonTwoTags);
 }

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -5,6 +5,7 @@
 #include "CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc"
+#include "CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -144,6 +145,24 @@ int main(int argc, char** argv) {
   SiPixelTemplateLAFPixMap histo19;
   histo19.process(connectionString, PI::mk_input(tag, end, end));
   edm::LogPrint("testSiPixelPayloadInspector") << histo19.data() << std::endl;
+
+  // SiPixelVCal
+
+  tag = "SiPixelVCal_v1";
+
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising SiPixelVCal plots " << std::endl;
+
+  SiPixelVCalValues histo20;
+  histo20.process("frontier://FrontierPrep/CMS_CONDITIONS", PI::mk_input(tag, 1, 1));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo20.data() << std::endl;
+
+  SiPixelVCalSlopeValuesBarrel histo21;
+  histo21.process("frontier://FrontierPrep/CMS_CONDITIONS", PI::mk_input(tag, 1, 1));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo21.data() << std::endl;
+
+  SiPixelVCalOffsetValuesEndcap histo22;
+  histo22.process("frontier://FrontierPrep/CMS_CONDITIONS", PI::mk_input(tag, 1, 1));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo22.data() << std::endl;
 
   inputs.clear();
 #if PY_MAJOR_VERSION >= 3

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -249,6 +249,7 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(SiPixelQuality);
   PAYLOAD_2XML_CLASS(SiPixelFEDChannelContainer);
   PAYLOAD_2XML_CLASS(SiPixelQualityProbabilities);
+  PAYLOAD_2XML_CLASS(SiPixelVCal);
   PAYLOAD_2XML_CLASS(SiPixelTemplateDBObject);
   PAYLOAD_2XML_CLASS(SiStripApvGain);
   PAYLOAD_2XML_CLASS(SiStripApvSimulationParameters);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -285,6 +285,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE(SiPixelQualityProbabilities)
       FETCH_PAYLOAD_CASE(SiPixelTemplateDBObject)
       FETCH_PAYLOAD_CASE(SiPixel2DTemplateDBObject)
+      FETCH_PAYLOAD_CASE(SiPixelVCal)
       FETCH_PAYLOAD_CASE(SiStripApvGain)
       FETCH_PAYLOAD_CASE(SiStripApvSimulationParameters)
       FETCH_PAYLOAD_CASE(SiStripBackPlaneCorrection)

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -311,6 +311,7 @@ namespace cond {
         IMPORT_PAYLOAD_CASE(SiPixelQualityProbabilities)
         IMPORT_PAYLOAD_CASE(SiPixelTemplateDBObject)
         IMPORT_PAYLOAD_CASE(SiPixel2DTemplateDBObject)
+        IMPORT_PAYLOAD_CASE(SiPixelVCal)
         IMPORT_PAYLOAD_CASE(SiStripApvGain)
         IMPORT_PAYLOAD_CASE(SiStripApvSimulationParameters)
         IMPORT_PAYLOAD_CASE(SiStripBadStrip)

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -146,6 +146,7 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelQualityProbabilities.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelVCal.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h"
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"

--- a/CondFormats/SiPixelObjects/interface/SiPixelVCal.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelVCal.h
@@ -11,6 +11,8 @@ public:
   SiPixelVCal(){};
   ~SiPixelVCal(){};
 
+  using mapToDetId = std::map<uint32_t, float>;
+
   struct VCal {
     float slope = 47.;
     float offset = -60.;
@@ -23,6 +25,8 @@ public:
   VCal getSlopeAndOffset(const uint32_t&) const;
   float getSlope(const uint32_t&) const;
   float getOffset(const uint32_t&) const;
+  mapToDetId getAllSlopes() const;
+  mapToDetId getAllOffsets() const;
   // uint32_t is pixid, see CondTools/SiPixel/test/SiPixelVCalDB.h
 
 private:

--- a/CondFormats/SiPixelObjects/src/SiPixelVCal.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelVCal.cc
@@ -40,3 +40,25 @@ float SiPixelVCal::getOffset(const uint32_t& pixid) const {
     edm::LogError("SiPixelVCal") << "SiPixelVCal offset for pixid " << pixid << " is not stored" << std::endl;
   return -60.;
 }
+
+SiPixelVCal::mapToDetId SiPixelVCal::getAllSlopes() const {
+  std::map<uint32_t, float> slopes;
+  std::transform(m_vcal.begin(),
+                 m_vcal.end(),
+                 std::inserter(slopes, slopes.end()),
+                 [](std::pair<uint32_t, SiPixelVCal::VCal> vcalentry) -> std::pair<uint32_t, float> {
+                   return std::make_pair(vcalentry.first, vcalentry.second.slope);
+                 });
+  return slopes;
+}
+
+SiPixelVCal::mapToDetId SiPixelVCal::getAllOffsets() const {
+  std::map<uint32_t, float> offsets;
+  std::transform(m_vcal.begin(),
+                 m_vcal.end(),
+                 std::inserter(offsets, offsets.end()),
+                 [](std::pair<uint32_t, SiPixelVCal::VCal> vcalentry) -> std::pair<uint32_t, float> {
+                   return std::make_pair(vcalentry.first, vcalentry.second.offset);
+                 });
+  return offsets;
+}


### PR DESCRIPTION
#### PR description:

This PR adds few utilities to be able to inspect payloads of the type `SiPixelVCal` introduced in PR https://github.com/cms-sw/cmssw/pull/29829.
It does:
   * introduce a series of classes for the Pixel Payload Inspector to plot payloads of the type `SiPixelVCal`;
   * adds amenities to dump,fetch, import the new DB format;
   * improves the related unit-tests;
   * in order to avoid replication of boiter-plate code a couple of new getter methods: `SiPixelVCal::getAllSlopes()` and `SiPixelVCal::getAllOffsets()` are added to the CondFormat.

Here is an example of plot that can be produced with the new code:  

![image](https://user-images.githubusercontent.com/5082376/88553436-9297a300-d025-11ea-90b3-dbd16b8f6b20.png)

#### PR validation:

Relies on the exiting unit-tests, which have been upgraded in this PR.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport is needed.
cc:
@tvami 
