### PR TITLE
Better GEM handling in CSCDigiToRaw

### DIFF
--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
@@ -153,7 +153,6 @@ void CSCDigiToRawModule::produce(edm::StreamID, edm::Event& e, const edm::EventS
   edm::Handle<CSCComparatorDigiCollection> comparatorDigis;
   edm::Handle<CSCALCTDigiCollection> alctDigis;
   edm::Handle<CSCCLCTDigiCollection> clctDigis;
-  edm::Handle<CSCCLCTPreTriggerCollection> preTriggers;
   edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedLCTDigis;
 
   e.getByToken(wd_token, wireDigis);
@@ -161,8 +160,9 @@ void CSCDigiToRawModule::produce(edm::StreamID, edm::Event& e, const edm::EventS
   e.getByToken(cd_token, comparatorDigis);
   e.getByToken(al_token, alctDigis);
   e.getByToken(cl_token, clctDigis);
+  CSCCLCTPreTriggerCollection const* preTriggersPtr = nullptr;
   if (usePreTriggers)
-    e.getByToken(pr_token, preTriggers);
+    preTriggersPtr = &e.get(pr_token);
   e.getByToken(co_token, correlatedLCTDigis);
   const GEMPadDigiClusterCollection* padDigiClustersPtr = nullptr;
   if (useGEMs_) {
@@ -174,14 +174,13 @@ void CSCDigiToRawModule::produce(edm::StreamID, edm::Event& e, const edm::EventS
                             *comparatorDigis,
                             *alctDigis,
                             *clctDigis,
-                            *preTriggers,
+                            preTriggersPtr,
                             *correlatedLCTDigis,
                             padDigiClustersPtr,
                             fed_buffers,
                             theMapping,
-                            e,
+                            e.id(),
                             theFormatVersion,
-                            usePreTriggers,
                             packEverything_);
 
   // put the raw data to the event

--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
@@ -155,7 +155,6 @@ void CSCDigiToRawModule::produce(edm::StreamID, edm::Event& e, const edm::EventS
   edm::Handle<CSCCLCTDigiCollection> clctDigis;
   edm::Handle<CSCCLCTPreTriggerCollection> preTriggers;
   edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedLCTDigis;
-  edm::Handle<GEMPadDigiClusterCollection> padDigiClusters;
 
   e.getByToken(wd_token, wireDigis);
   e.getByToken(sd_token, stripDigis);
@@ -165,8 +164,9 @@ void CSCDigiToRawModule::produce(edm::StreamID, edm::Event& e, const edm::EventS
   if (usePreTriggers)
     e.getByToken(pr_token, preTriggers);
   e.getByToken(co_token, correlatedLCTDigis);
+  const GEMPadDigiClusterCollection* padDigiClustersPtr = nullptr;
   if (useGEMs_) {
-    e.getByToken(gem_token, padDigiClusters);
+    padDigiClustersPtr = &e.get(gem_token);
   }
   // Create the packed data
   packer_->createFedBuffers(*stripDigis,
@@ -176,13 +176,12 @@ void CSCDigiToRawModule::produce(edm::StreamID, edm::Event& e, const edm::EventS
                             *clctDigis,
                             *preTriggers,
                             *correlatedLCTDigis,
-                            *padDigiClusters,
+                            padDigiClustersPtr,
                             fed_buffers,
                             theMapping,
                             e,
                             theFormatVersion,
                             usePreTriggers,
-                            useGEMs_,
                             packEverything_);
 
   // put the raw data to the event

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -343,13 +343,12 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                                     const CSCCLCTDigiCollection& clctDigis,
                                     const CSCCLCTPreTriggerCollection& preTriggers,
                                     const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
-                                    const GEMPadDigiClusterCollection& gemPadDigiClusters,
+                                    const GEMPadDigiClusterCollection* gemPadDigiClusters,
                                     FEDRawDataCollection& fed_buffers,
                                     const CSCChamberMap* mapping,
-                                    Event& e,
+                                    const Event& e,
                                     uint16_t format_version,
                                     bool use_pre_triggers,
-                                    bool useGEMs,
                                     bool packEverything) const {
   //bits of code from ORCA/Muon/METBFormatter - thanks, Rick:)!
 
@@ -361,8 +360,8 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
   add(comparatorDigis, clctDigis, fedInfo, packEverything);
   add(correlatedLCTDigis, fedInfo);
   // Starting Run-3, the CSC DAQ will pack/unpack GEM clusters
-  if (useGEMs) {
-    add(gemPadDigiClusters, fedInfo);
+  if (gemPadDigiClusters) {
+    add(*gemPadDigiClusters, fedInfo);
   }
   int l1a = e.id().event();  //need to add increments or get it from lct digis
   int bx = l1a;              //same as above

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -18,7 +18,7 @@
 #include "CondFormats/CSCObjects/interface/CSCChamberMap.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/Event.h"
+
 #include <algorithm>
 
 using namespace edm;
@@ -137,9 +137,8 @@ CSCEventData& CSCDigiToRaw::findEventData(const CSCDetId& cscDetId, FindEventDat
 }
 
 void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
-                       const CSCCLCTPreTriggerCollection& preTriggers,
+                       const CSCCLCTPreTriggerCollection* preTriggers,
                        FindEventDataInfo& fedInfo,
-                       bool usePreTriggers,
                        bool packEverything) const {  //iterate over chambers with strip digis in them
   for (CSCStripDigiCollection::DigiRangeIterator j = stripDigis.begin(); j != stripDigis.end(); ++j) {
     CSCDetId cscDetId = (*j).first;
@@ -147,9 +146,10 @@ void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
 
     bool me1abCheck = fedInfo.formatVersion_ == 2013;
     /* !!! Testing. Uncomment for production */
+    const bool usePreTriggers = preTriggers != nullptr;
     if (!usePreTriggers || packEverything ||
         (usePreTriggers &&
-         cscd2r::accept(cscDetId, preTriggers, preTriggerWindowMin_, preTriggerWindowMax_, me1abCheck))) {
+         cscd2r::accept(cscDetId, *preTriggers, preTriggerWindowMin_, preTriggerWindowMax_, me1abCheck))) {
       bool me1a = (cscDetId.station() == 1) && (cscDetId.ring() == 4);
       bool zplus = (cscDetId.endcap() == 1);
       bool me1b = (cscDetId.station() == 1) && (cscDetId.ring() == 1);
@@ -341,21 +341,20 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                                     const CSCComparatorDigiCollection& comparatorDigis,
                                     const CSCALCTDigiCollection& alctDigis,
                                     const CSCCLCTDigiCollection& clctDigis,
-                                    const CSCCLCTPreTriggerCollection& preTriggers,
+                                    const CSCCLCTPreTriggerCollection* preTriggers,
                                     const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
                                     const GEMPadDigiClusterCollection* gemPadDigiClusters,
                                     FEDRawDataCollection& fed_buffers,
                                     const CSCChamberMap* mapping,
-                                    const Event& e,
+                                    const EventID& eid,
                                     uint16_t format_version,
-                                    bool use_pre_triggers,
                                     bool packEverything) const {
   //bits of code from ORCA/Muon/METBFormatter - thanks, Rick:)!
 
   //get fed object from fed_buffers
   // make a map from the index of a chamber to the event data from it
   FindEventDataInfo fedInfo{mapping, format_version};
-  add(stripDigis, preTriggers, fedInfo, use_pre_triggers, packEverything);
+  add(stripDigis, preTriggers, fedInfo, packEverything);
   add(wireDigis, alctDigis, fedInfo, packEverything);
   add(comparatorDigis, clctDigis, fedInfo, packEverything);
   add(correlatedLCTDigis, fedInfo);
@@ -363,8 +362,8 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
   if (gemPadDigiClusters) {
     add(*gemPadDigiClusters, fedInfo);
   }
-  int l1a = e.id().event();  //need to add increments or get it from lct digis
-  int bx = l1a;              //same as above
+  int l1a = eid.event();  //need to add increments or get it from lct digis
+  int bx = l1a;           //same as above
   //int startingFED = FEDNumbering::MINCSCFEDID;
 
   if (fedInfo.formatVersion_ == 2005)  /// Handle pre-LS1 format data

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.h
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.h
@@ -34,13 +34,12 @@ public:
                         const CSCCLCTDigiCollection& clctDigis,
                         const CSCCLCTPreTriggerCollection& preTriggers,
                         const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
-                        const GEMPadDigiClusterCollection& padDigiClusters,
+                        const GEMPadDigiClusterCollection* padDigiClusters,
                         FEDRawDataCollection& fed_buffers,
                         const CSCChamberMap* theMapping,
-                        edm::Event& e,
+                        const edm::Event& e,
                         uint16_t theFormatVersion = 2005,
                         bool usePreTriggers = true,
-                        bool useGEMs = false,
                         bool packEverything = false) const;
 
 private:

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.h
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.h
@@ -6,7 +6,7 @@
  *  \author A. Tumanov - Rice
  */
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
@@ -16,6 +16,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCEventData.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class FEDRawDataCollection;
 class CSCReadoutMappingFromFile;
@@ -32,14 +33,13 @@ public:
                         const CSCComparatorDigiCollection& comparatorDigis,
                         const CSCALCTDigiCollection& alctDigis,
                         const CSCCLCTDigiCollection& clctDigis,
-                        const CSCCLCTPreTriggerCollection& preTriggers,
+                        const CSCCLCTPreTriggerCollection* preTriggers,
                         const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
                         const GEMPadDigiClusterCollection* padDigiClusters,
                         FEDRawDataCollection& fed_buffers,
                         const CSCChamberMap* theMapping,
-                        const edm::Event& e,
+                        const edm::EventID& eid,
                         uint16_t theFormatVersion = 2005,
-                        bool usePreTriggers = true,
                         bool packEverything = false) const;
 
 private:
@@ -54,9 +54,8 @@ private:
 
   // specialized because it reverses strip direction
   void add(const CSCStripDigiCollection& stripDigis,
-           const CSCCLCTPreTriggerCollection& preTriggers,
+           const CSCCLCTPreTriggerCollection* preTriggers,
            FindEventDataInfo&,
-           bool usePreTriggers,
            bool packEverything) const;
   void add(const CSCWireDigiCollection& wireDigis,
            const CSCALCTDigiCollection& alctDigis,


### PR DESCRIPTION
#### PR description:

Changed the interface so no longer have to dereference a nullptr when GEM is not being used.

This problem was discovered by the ASAN build. This also uncovered a bug in the framework where dereferencing a defaultly constructed `edm::Handle` was not causing an exception to be thrown. Once that bug is fixed, the orginal version of this code would be causing an exception to happen whenever GEM is not being used.

#### PR validation:

The code compiles.