### PR TITLE
Fix break condition

### DIFF
--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -108,7 +108,7 @@ void DeepMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     input_cat2_.tensor<float, 3>()(0, i_pf, 0) = pf.fromPV();
 
     ++i_pf;
-    if (i_pf > max_n_pf_) {
+    if (i_pf == max_n_pf_) {
       break;  // output a warning?
     }
   }


### PR DESCRIPTION
#### PR description:

Addresses invalid memory write in DeepMETProducer described here https://github.com/cms-sw/cmssw/issues/30920 and implements trivial fix described therein.

#### PR validation:

Tested matrix workflow 140.5611 (2018 heavy-ion data) before fix (failed) and after fix (passed).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
-
