### PR TITLE
Throw if dereference an unset edm::Handle

### DIFF
--- a/DataFormats/Common/src/HandleBase.cc
+++ b/DataFormats/Common/src/HandleBase.cc
@@ -1,18 +1,38 @@
 #include "DataFormats/Common/interface/HandleBase.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/Likely.h"
+
+namespace {
+  void throwInvalidHandleDeref() {
+    throw cms::Exception("DereferenceUnsetHandle")
+        << "An attempt was made to dereference an edm::Handle which was never set.";
+  }
+  void throwInvalidHandleProv() {
+    throw cms::Exception("ProvenanceFromUnsetHandle")
+        << "An attempt was made to get the ProductId from an edm::Handle which was never set.";
+  }
+}  // namespace
 
 namespace edm {
   void const* HandleBase::productStorage() const {
-    if (whyFailedFactory_) {
-      whyFailedFactory_->make()->raise();
+    if UNLIKELY (not product_) {
+      if LIKELY (static_cast<bool>(whyFailedFactory_)) {
+        whyFailedFactory_->make()->raise();
+      } else {
+        throwInvalidHandleDeref();
+      }
     }
     return product_;
   }
 
   ProductID HandleBase::id() const {
-    if (whyFailedFactory_) {
-      whyFailedFactory_->make()->raise();
+    if UNLIKELY (not prov_) {
+      if LIKELY (static_cast<bool>(whyFailedFactory_)) {
+        whyFailedFactory_->make()->raise();
+      } else {
+        throwInvalidHandleProv();
+      }
     }
     return prov_->productID();
   }


### PR DESCRIPTION
#### PR description:

Consistently throw if an edm::Handle is invalid. Previously it would only throw if the edm::Handle was used as part of a get call. Now also throw if the edm::Handle was never set.

#### PR validation:

The code compiles. Framework unit tests pass.