### PR TITLE
Update centrality table for 2018 and 2021 heavy ion MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -59,7 +59,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v1',
+    'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
@@ -73,7 +73,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v5',
+    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:

This PR updates the centrality table for 2018 and "2021" heavy ion MC. An update to the data GT will be necessary at some point in the future, prior to the re-miniAOD of the HI data, but we will wait until the release and strategy for that re-miniAOD is available prior to performing that update. This is the plan that was agreed upon with HI experts in the AlCaDB meeting of July 27, 2020.

The GT diffs are as follows:

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_HI_v1/112X_upgrade2018_realistic_HI_v2

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v5/112X_mcRun3_2021_realistic_HI_v6

Attn: @mandrenguyen 

#### PR validation:

Please see the [presentations](https://indico.cern.ch/event/942206/#27-updated-2018-and-run-3-hi-c) at the July 27, 2020 AlCa/DB meeting for details of the validation. In addition, a technical test was performed:

`runTheMatrix.py -l limited,159.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but may later be backported, depending upon in which release the re-miniAOD will be performed.
