### PR TITLE
add centrality bin to HI miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -139,6 +139,7 @@ _pp_on_AA_extraCommands = [
     'keep floatedmValueMap_packedPFCandidateTrackChi2_*_*',
     'keep floatedmValueMap_lostTrackChi2_*_*',
     'keep recoCentrality_hiCentrality_*_*',
+    'keep int_centralityBin_*_*',
 ]
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -135,9 +135,10 @@ run3_common.toModify(MicroEventContent, outputCommands = MicroEventContent.outpu
 
 _pp_on_AA_extraCommands = [
     'keep patPackedCandidates_hiPixelTracks_*_*',
-	  'keep *_packedCandidateMuonID_*_*',
-	  'keep floatedmValueMap_packedPFCandidateTrackChi2_*_*',
-	  'keep floatedmValueMap_lostTrackChi2_*_*'
+    'keep *_packedCandidateMuonID_*_*',
+    'keep floatedmValueMap_packedPFCandidateTrackChi2_*_*',
+    'keep floatedmValueMap_lostTrackChi2_*_*',
+    'keep recoCentrality_hiCentrality_*_*',
 ]
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -68,12 +68,11 @@ from PhysicsTools.PatAlgos.slimming.hiPixelTracks_cfi import hiPixelTracks
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from PhysicsTools.PatAlgos.packedCandidateMuonID_cfi import packedCandidateMuonID
 from PhysicsTools.PatAlgos.packedPFCandidateTrackChi2_cfi import packedPFCandidateTrackChi2
+from RecoHI.HiCentralityAlgos.CentralityBin_cfi import centralityBin
 lostTrackChi2 = packedPFCandidateTrackChi2.clone(candidates = "lostTracks", doLostTracks = True)
-(pp_on_AA_2018 | pp_on_PbPb_run3).toReplaceWith(slimmingTask, 
-	cms.Task(slimmingTask.copy(), packedCandidateMuonID, 
-	packedPFCandidateTrackChi2, lostTrackChi2))
-
-
+(pp_on_AA_2018 | pp_on_PbPb_run3).toReplaceWith(
+    slimmingTask, 
+    cms.Task(slimmingTask.copy(), packedCandidateMuonID, packedPFCandidateTrackChi2, lostTrackChi2, centralityBin))
 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 _phase2_timing_slimmingTask = cms.Task(slimmingTask.copy(),

--- a/RecoHI/HiCentralityAlgos/plugins/CentralityBinProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityBinProducer.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -43,7 +43,7 @@
 // class declaration
 //
 
-class CentralityBinProducer : public edm::EDProducer {
+class CentralityBinProducer : public edm::stream::EDProducer<> {
   enum VariableType {
     HFtowers = 0,
     HFtowersPlus = 1,


### PR DESCRIPTION
#### PR description:

This PR add the centrality bin producer to the HI miniAOD workflow.
This producer has long been in cmssw, and was once part of the reconstruction. 
It consumes the tag that was added in #30930 

#### PR validation:

Tested with workflow 158.01

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
