### PR TITLE
106X backport of: Pile-Up ID training and WPs for 2017 UL samples

### DIFF
--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -21,91 +21,88 @@
 // ----------------------------------------------------------------------------------------------------
 class PileupJetIdAlgo {
 public:
-	enum version_t { USER=-1, PHILv0=0 };
+  enum version_t { USER = -1, PHILv0 = 0 };
 
-	class AlgoGBRForestsAndConstants;
+  class AlgoGBRForestsAndConstants;
 
-	PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache);
-	~PileupJetIdAlgo(); 
-	
-	PileupJetIdentifier computeIdVariables(const reco::Jet * jet, 
-					       float jec, const reco::Vertex *, const reco::VertexCollection &, double rho, bool usePuppi);
+  PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache);
+  ~PileupJetIdAlgo();
 
-	void set(const PileupJetIdentifier &);
-        float getMVAval(const std::vector<std::string> &, const std::unique_ptr<const GBRForest> &);
-	PileupJetIdentifier computeMva();
-	const std::string method() const { return cache_->tmvaMethod(); }
+  PileupJetIdentifier computeIdVariables(
+      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, bool usePuppi);
 
-	std::string dumpVariables() const;
+  void set(const PileupJetIdentifier&);
+  float getMVAval(const std::vector<std::string>&, const std::unique_ptr<const GBRForest>&);
+  PileupJetIdentifier computeMva();
+  const std::string method() const { return cache_->tmvaMethod(); }
 
-	typedef std::map<std::string,std::pair<float *,float> > variables_list_t;
+  std::string dumpVariables() const;
 
-	std::pair<int,int> getJetIdKey(float jetPt, float jetEta);
-	int computeCutIDflag(float betaStarClassic,float dR2Mean,float nvtx, float jetPt, float jetEta);
-	int computeIDflag   (float mva, float jetPt, float jetEta);
-	int computeIDflag   (float mva,int ptId,int etaId);
+  typedef std::map<std::string, std::pair<float*, float>> variables_list_t;
 
-	/// const PileupJetIdentifier::variables_list_t & getVariables() const { return variables_; };
-	const variables_list_t & getVariables() const { return variables_; };
+  std::pair<int, int> getJetIdKey(float jetPt, float jetEta);
+  int computeCutIDflag(float betaStarClassic, float dR2Mean, float nvtx, float jetPt, float jetEta);
+  int computeIDflag(float mva, float jetPt, float jetEta);
+  int computeIDflag(float mva, int ptId, int etaId);
 
-        // In multithreaded mode, each PileupIdAlgo object will get duplicated
-        // on every stream. Some of the data it contains never changes after
-        // construction and can be shared by all streams. This nested class contains
-        // the data members that can be shared across streams. In particular
-        // the GBRForests take significant time to initialize and can be shared.
-        class AlgoGBRForestsAndConstants {
-        public:
+  /// const PileupJetIdentifier::variables_list_t & getVariables() const { return variables_; };
+  const variables_list_t& getVariables() const { return variables_; };
 
-          AlgoGBRForestsAndConstants(edm::ParameterSet const&, bool runMvas);
+  // In multithreaded mode, each PileupIdAlgo object will get duplicated
+  // on every stream. Some of the data it contains never changes after
+  // construction and can be shared by all streams. This nested class contains
+  // the data members that can be shared across streams. In particular
+  // the GBRForests take significant time to initialize and can be shared.
+  class AlgoGBRForestsAndConstants {
+  public:
+    AlgoGBRForestsAndConstants(edm::ParameterSet const&, bool runMvas);
 
-          std::unique_ptr<const GBRForest> const& reader() const { return reader_; }
-          std::vector<std::unique_ptr<const GBRForest>> const& etaReader() const { return etaReader_; }
-          bool cutBased() const { return cutBased_; }
-          bool etaBinnedWeights() const { return etaBinnedWeights_; }
-          bool runMvas() const { return runMvas_; }
-          int  nEtaBins() const { return nEtaBins_; }
-          std::vector<double> const& jEtaMin() const { return jEtaMin_; }
-          std::vector<double> const& jEtaMax() const { return jEtaMax_; }
-          std::string const& label() const { return label_; }
-          std::string const& tmvaMethod() const { return tmvaMethod_; }
-          std::vector<std::string> const& tmvaVariables() const { return tmvaVariables_; }
-          std::vector<std::vector<std::string>> const& tmvaEtaVariables() const { return tmvaEtaVariables_; }
+    std::unique_ptr<const GBRForest> const& reader() const { return reader_; }
+    std::vector<std::unique_ptr<const GBRForest>> const& etaReader() const { return etaReader_; }
+    bool cutBased() const { return cutBased_; }
+    bool etaBinnedWeights() const { return etaBinnedWeights_; }
+    bool runMvas() const { return runMvas_; }
+    int nEtaBins() const { return nEtaBins_; }
+    std::vector<double> const& jEtaMin() const { return jEtaMin_; }
+    std::vector<double> const& jEtaMax() const { return jEtaMax_; }
+    std::string const& label() const { return label_; }
+    std::string const& tmvaMethod() const { return tmvaMethod_; }
+    std::vector<std::string> const& tmvaVariables() const { return tmvaVariables_; }
+    std::vector<std::vector<std::string>> const& tmvaEtaVariables() const { return tmvaEtaVariables_; }
 
-          typedef float array_t[3][5][4];
-          array_t const& mvacut() const { return mvacut_; }
-          array_t const& rmsCut() const { return rmsCut_; }
-          array_t const& betaStarCut() const { return betaStarCut_; }
+    typedef float array_t[3][5][4];
+    array_t const& mvacut() const { return mvacut_; }
+    array_t const& rmsCut() const { return rmsCut_; }
+    array_t const& betaStarCut() const { return betaStarCut_; }
 
-        private:
+  private:
+    std::unique_ptr<const GBRForest> reader_;
+    std::vector<std::unique_ptr<const GBRForest>> etaReader_;
+    bool cutBased_;
+    bool etaBinnedWeights_;
+    bool runMvas_;
+    int nEtaBins_;
+    std::vector<double> jEtaMin_;
+    std::vector<double> jEtaMax_;
+    std::string label_;
+    std::string tmvaMethod_;
+    std::vector<std::string> tmvaVariables_;
+    std::vector<std::vector<std::string>> tmvaEtaVariables_;
 
-          std::unique_ptr<const GBRForest> reader_;
-          std::vector<std::unique_ptr<const GBRForest>> etaReader_;
-          bool cutBased_;
-          bool etaBinnedWeights_;
-          bool runMvas_;
-          int  nEtaBins_;
-          std::vector<double> jEtaMin_;
-          std::vector<double> jEtaMax_;
-          std::string label_;
-          std::string tmvaMethod_;
-          std::vector<std::string> tmvaVariables_;
-          std::vector<std::vector<std::string>> tmvaEtaVariables_;
+    float mvacut_[3][5][4];       //Keep the array fixed
+    float rmsCut_[3][5][4];       //Keep the array fixed
+    float betaStarCut_[3][5][4];  //Keep the array fixed
 
-          float mvacut_     [3][5][4]; //Keep the array fixed
-          float rmsCut_     [3][5][4]; //Keep the array fixed
-          float betaStarCut_[3][5][4]; //Keep the array fixed
-
-          std::map<std::string,std::string> tmvaNames_;
-        };
+    std::map<std::string, std::string> tmvaNames_;
+  };
 
 protected:
+  void runMva();
+  void resetVariables();
+  void initVariables();
 
-	void runMva(); 
-	void resetVariables();
-	void initVariables();
-
-	PileupJetIdentifier internalId_;
-	variables_list_t variables_;
-	AlgoGBRForestsAndConstants const* cache_;
+  PileupJetIdentifier internalId_;
+  variables_list_t variables_;
+  AlgoGBRForestsAndConstants const* cache_;
 };
 #endif

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -71,7 +71,7 @@ public:
           std::vector<std::string> const& tmvaVariables() const { return tmvaVariables_; }
           std::vector<std::vector<std::string>> const& tmvaEtaVariables() const { return tmvaEtaVariables_; }
 
-          typedef float array_t[3][4][4];
+          typedef float array_t[3][5][4];
           array_t const& mvacut() const { return mvacut_; }
           array_t const& rmsCut() const { return rmsCut_; }
           array_t const& betaStarCut() const { return betaStarCut_; }
@@ -91,9 +91,9 @@ public:
           std::vector<std::string> tmvaVariables_;
           std::vector<std::vector<std::string>> tmvaEtaVariables_;
 
-          float mvacut_     [3][4][4]; //Keep the array fixed
-          float rmsCut_     [3][4][4]; //Keep the array fixed
-          float betaStarCut_[3][4][4]; //Keep the array fixed
+          float mvacut_     [3][5][4]; //Keep the array fixed
+          float rmsCut_     [3][5][4]; //Keep the array fixed
+          float betaStarCut_[3][5][4]; //Keep the array fixed
 
           std::map<std::string,std::string> tmvaNames_;
         };

--- a/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
@@ -10,19 +10,22 @@ full_81x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
     Pt1020_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
     Pt2030_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
-    Pt3050_Tight   = cms.vdouble( 0.86, -0.10, -0.05, -0.01),
+    Pt3040_Tight   = cms.vdouble( 0.86, -0.10, -0.05, -0.01),
+    Pt4050_Tight   = cms.vdouble( 0.86, -0.10, -0.05, -0.01),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
     Pt1020_Medium  = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
     Pt2030_Medium  = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
-    Pt3050_Medium  = cms.vdouble( 0.61, -0.35, -0.23, -0.17),
+    Pt3040_Medium  = cms.vdouble( 0.61, -0.35, -0.23, -0.17),
+    Pt4050_Medium  = cms.vdouble( 0.61, -0.35, -0.23, -0.17),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
     Pt1020_Loose   = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
     Pt2030_Loose   = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
-    Pt3050_Loose   = cms.vdouble(-0.89, -0.52, -0.38, -0.30)
+    Pt3040_Loose   = cms.vdouble(-0.89, -0.52, -0.38, -0.30),
+    Pt4050_Loose   = cms.vdouble(-0.89, -0.52, -0.38, -0.30)
 )
 
 ###########################################################
@@ -35,6 +38,34 @@ full_102x_chs_wp = full_81x_chs_wp.clone()
 ###########################################################
 full_94x_chs_wp = full_81x_chs_wp.clone()
 
+##########################################################
+## Working points for the 106X UL17 training
+###########################################################
+full_106x_UL17_chs_wp = cms.PSet(
+    # 4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
+    # 5 Pt Categories   0-10, 10-20, 20-30, 30-40, 40-50
+
+    #Tight Id
+    Pt010_Tight  = cms.vdouble( 0.77, 0.38, -0.31, -0.21),
+    Pt1020_Tight = cms.vdouble( 0.77, 0.38, -0.31, -0.21),
+    Pt2030_Tight = cms.vdouble( 0.90, 0.60, -0.12, -0.13),
+    Pt3040_Tight = cms.vdouble( 0.96, 0.82, 0.20, 0.09),
+    Pt4050_Tight = cms.vdouble( 0.98, 0.92, 0.47, 0.29),
+
+    #Medium Id
+    Pt010_Medium  = cms.vdouble( 0.26, -0.33, -0.54, -0.37),
+    Pt1020_Medium = cms.vdouble( 0.26, -0.33, -0.54, -0.37),
+    Pt2030_Medium = cms.vdouble( 0.68, -0.04, -0.43, -0.30),
+    Pt3040_Medium = cms.vdouble( 0.90, 0.36, -0.16, -0.09),
+    Pt4050_Medium = cms.vdouble( 0.96, 0.61, 0.14, 0.12),
+
+    #Loose Id
+    Pt010_Loose  = cms.vdouble(-0.95, -0.72, -0.68, -0.47),
+    Pt1020_Loose = cms.vdouble(-0.95, -0.72, -0.68, -0.47),
+    Pt2030_Loose = cms.vdouble(-0.88, -0.55, -0.60, -0.43),
+    Pt3040_Loose = cms.vdouble(-0.63, -0.18, -0.43, -0.24),
+    Pt4050_Loose = cms.vdouble(-0.19, 0.22, -0.13, -0.03)
+)
 
 ###########################################################
 ## Working points for the 80X training
@@ -46,19 +77,22 @@ full_80x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
     Pt1020_Tight   = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
     Pt2030_Tight   = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
-    Pt3050_Tight   = cms.vdouble( 0.62, -0.21, -0.07, -0.03),
+    Pt3040_Tight   = cms.vdouble( 0.62, -0.21, -0.07, -0.03),
+    Pt4050_Tight   = cms.vdouble( 0.62, -0.21, -0.07, -0.03),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.49, -0.53, -0.44, -0.42),
     Pt1020_Medium  = cms.vdouble(-0.49, -0.53, -0.44, -0.42),
     Pt2030_Medium  = cms.vdouble(-0.49, -0.53, -0.44, -0.42),
-    Pt3050_Medium  = cms.vdouble(-0.06, -0.42, -0.3 , -0.23),
+    Pt3040_Medium  = cms.vdouble(-0.06, -0.42, -0.3 , -0.23),
+    Pt4050_Medium  = cms.vdouble(-0.06, -0.42, -0.3 , -0.23),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.96, -0.64, -0.56, -0.54),
     Pt1020_Loose   = cms.vdouble(-0.96, -0.64, -0.56, -0.54),
     Pt2030_Loose   = cms.vdouble(-0.96, -0.64, -0.56, -0.54),
-    Pt3050_Loose   = cms.vdouble(-0.92, -0.56, -0.44, -0.39)
+    Pt3040_Loose   = cms.vdouble(-0.92, -0.56, -0.44, -0.39),
+    Pt4050_Loose   = cms.vdouble(-0.92, -0.56, -0.44, -0.39)
 )
 
 ###########################################################
@@ -71,19 +105,22 @@ full_76x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(0.09,-0.37,-0.24,-0.21),
     Pt1020_Tight   = cms.vdouble(0.09,-0.37,-0.24,-0.21),
     Pt2030_Tight   = cms.vdouble(0.09,-0.37,-0.24,-0.21),
-    Pt3050_Tight   = cms.vdouble(0.52,-0.19,-0.06,-0.03),
+    Pt3040_Tight   = cms.vdouble(0.52,-0.19,-0.06,-0.03),
+    Pt4050_Tight   = cms.vdouble(0.52,-0.19,-0.06,-0.03),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.58,-0.52,-0.40,-0.36),
     Pt1020_Medium  = cms.vdouble(-0.58,-0.52,-0.40,-0.36),
     Pt2030_Medium  = cms.vdouble(-0.58,-0.52,-0.40,-0.36),
-    Pt3050_Medium  = cms.vdouble(-0.20,-0.39,-0.24,-0.19),
+    Pt3040_Medium  = cms.vdouble(-0.20,-0.39,-0.24,-0.19),
+    Pt4050_Medium  = cms.vdouble(-0.20,-0.39,-0.24,-0.19),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
     Pt1020_Loose   = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
     Pt2030_Loose   = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
-    Pt3050_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31)
+    Pt3040_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31),
+    Pt4050_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31)
 )
 
 ###########################################################
@@ -96,19 +133,22 @@ full_74x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt1020_Tight   = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt2030_Tight   = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
-    Pt3050_Tight   = cms.vdouble(-0.5,-0.77,-0.80,-0.98),
+    Pt3040_Tight   = cms.vdouble(-0.5,-0.77,-0.80,-0.98),
+    Pt4050_Tight   = cms.vdouble(-0.5,-0.77,-0.80,-0.98),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt1020_Medium  = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt2030_Medium  = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
-    Pt3050_Medium  = cms.vdouble(-0.6,-0.85,-0.85,-0.99),
+    Pt3040_Medium  = cms.vdouble(-0.6,-0.85,-0.85,-0.99),
+    Pt4050_Medium  = cms.vdouble(-0.6,-0.85,-0.85,-0.99),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
     Pt1020_Loose   = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
     Pt2030_Loose   = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
-    Pt3050_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99)
+    Pt3040_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99),
+    Pt4050_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99)
 )
 
 ###########################################################
@@ -121,25 +161,29 @@ full_53x_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt1020_Tight   = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt2030_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
-    Pt3050_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
+    Pt3040_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
+    Pt4050_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt2030_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
-    Pt3050_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
+    Pt3040_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
+    Pt4050_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt2030_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
-    Pt3050_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
+    Pt3040_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
+    Pt4050_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
 
     #MET
     Pt010_MET	   = cms.vdouble( 0.  ,-0.6,-0.4,-0.4),
     Pt1020_MET     = cms.vdouble( 0.3 ,-0.2,-0.4,-0.4),
     Pt2030_MET     = cms.vdouble( 0.  , 0. , 0. , 0. ),
-    Pt3050_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2)
+    Pt3040_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2),
+    Pt4050_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2)
     )
 
 full_53x_chs_wp  = cms.PSet(
@@ -149,19 +193,22 @@ full_53x_chs_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt1020_Tight   = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt2030_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
-    Pt3050_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
+    Pt3040_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
+    Pt4050_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt2030_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
-    Pt3050_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
+    Pt3040_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
+    Pt4050_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt2030_Loose   = cms.vdouble(-0.15,-0.26,-0.16,-0.16),
-    Pt3050_Loose   = cms.vdouble(-0.15,-0.26,-0.16,-0.16),
+    Pt3040_Loose   = cms.vdouble(-0.15,-0.26,-0.16,-0.16),
+    Pt4050_Loose   = cms.vdouble(-0.15,-0.26,-0.16,-0.16)
     )
 
 met_53x_wp  = cms.PSet(
@@ -170,26 +217,30 @@ met_53x_wp  = cms.PSet(
     Pt010_Tight    = cms.vdouble(-2, -2, -2, -2, -2),
     Pt1020_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
     Pt2030_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
-    Pt3050_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt3040_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt4050_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
 
                     #Medium Id
     Pt010_Medium   = cms.vdouble(-2, -2, -2, -2, -2),
     Pt1020_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
     Pt2030_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
-    Pt3050_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt3040_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt4050_Medium  = cms.vdouble(-2, -2, -2, -2, -2),
 
                     #Loose Id
     Pt010_Loose    = cms.vdouble(-2, -2, -2, -2, -2),
     Pt1020_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
     Pt2030_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
-    Pt3050_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt3040_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
+    Pt4050_Loose   = cms.vdouble(-2, -2, -2, -2, -2),
 
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
     #MET
     Pt010_MET      = cms.vdouble(-0.2 ,-0.3,-0.5,-0.5),
     Pt1020_MET     = cms.vdouble(-0.2 ,-0.2,-0.5,-0.3),
     Pt2030_MET     = cms.vdouble(-0.2 ,-0.2,-0.2, 0.1),
-    Pt3050_MET     = cms.vdouble(-0.2 ,-0.2, 0. , 0.2)
+    Pt3040_MET     = cms.vdouble(-0.2 ,-0.2, 0. , 0.2),
+    Pt4050_MET     = cms.vdouble(-0.2 ,-0.2, 0. , 0.2)
     )
 
 metfull_53x_wp  = cms.PSet(
@@ -197,7 +248,8 @@ metfull_53x_wp  = cms.PSet(
     Pt010_MET      = cms.vdouble(-0.2 ,-0.3,-0.5,-0.5),
     Pt1020_MET     = cms.vdouble(-0.2 ,-0.2,-0.5,-0.3),
     Pt2030_MET     = cms.vdouble( 0.  , 0. , 0. , 0. ),
-    Pt3050_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2)
+    Pt3040_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2),
+    Pt4050_MET     = cms.vdouble( 0.  , 0. ,-0.1,-0.2)
     )
 
 
@@ -211,19 +263,22 @@ full_5x_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.47,-0.92,-0.92,-0.94),
     Pt1020_Tight   = cms.vdouble(-0.47,-0.92,-0.92,-0.94),
     Pt2030_Tight   = cms.vdouble(+0.32,-0.49,-0.61,-0.74),
-    Pt3050_Tight   = cms.vdouble(+0.32,-0.49,-0.61,-0.74),
+    Pt3040_Tight   = cms.vdouble(+0.32,-0.49,-0.61,-0.74),
+    Pt4050_Tight   = cms.vdouble(+0.32,-0.49,-0.61,-0.74),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.96,-0.95,-0.96),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.96,-0.95,-0.96),
     Pt2030_Medium  = cms.vdouble(-0.40,-0.74,-0.76,-0.81),
-    Pt3050_Medium  = cms.vdouble(-0.40,-0.74,-0.76,-0.81),
-
+    Pt3040_Medium  = cms.vdouble(-0.40,-0.74,-0.76,-0.81),
+    Pt4050_Medium  = cms.vdouble(-0.40,-0.74,-0.76,-0.81),
+    
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.97,-0.97,-0.97),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.97,-0.97,-0.97),
     Pt2030_Loose   = cms.vdouble(-0.80,-0.85,-0.84,-0.85),
-    Pt3050_Loose   = cms.vdouble(-0.80,-0.85,-0.84,-0.85)
+    Pt3040_Loose   = cms.vdouble(-0.80,-0.85,-0.84,-0.85),
+    Pt4050_Loose   = cms.vdouble(-0.80,-0.85,-0.84,-0.85)
 )
 
 simple_5x_wp = cms.PSet(
@@ -233,19 +288,22 @@ simple_5x_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.54,-0.93,-0.93,-0.94),
     Pt1020_Tight   = cms.vdouble(-0.54,-0.93,-0.93,-0.94),
     Pt2030_Tight   = cms.vdouble(+0.26,-0.54,-0.63,-0.74),
-    Pt3050_Tight   = cms.vdouble(+0.26,-0.54,-0.63,-0.74),
+    Pt3040_Tight   = cms.vdouble(+0.26,-0.54,-0.63,-0.74),
+    Pt4050_Tight   = cms.vdouble(+0.26,-0.54,-0.63,-0.74),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.85,-0.96,-0.95,-0.96),
     Pt1020_Medium  = cms.vdouble(-0.85,-0.96,-0.95,-0.96),
     Pt2030_Medium  = cms.vdouble(-0.40,-0.73,-0.74,-0.80),
-    Pt3050_Medium  = cms.vdouble(-0.40,-0.73,-0.74,-0.80),
+    Pt3040_Medium  = cms.vdouble(-0.40,-0.73,-0.74,-0.80),
+    Pt4050_Medium  = cms.vdouble(-0.40,-0.73,-0.74,-0.80),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.97,-0.96,-0.97),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.97,-0.96,-0.97),
     Pt2030_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84),
-    Pt3050_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84)
+    Pt3040_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84),
+    Pt4050_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84)
 
 )
 
@@ -259,19 +317,22 @@ full_5x_chs_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.59,-0.75,-0.78,-0.80),
     Pt1020_Tight   = cms.vdouble(-0.59,-0.75,-0.78,-0.80),
     Pt2030_Tight   = cms.vdouble(+0.41,-0.10,-0.20,-0.45),
-    Pt3050_Tight   = cms.vdouble(+0.41,-0.10,-0.20,-0.45),
+    Pt3040_Tight   = cms.vdouble(+0.41,-0.10,-0.20,-0.45),
+    Pt4050_Tight   = cms.vdouble(+0.41,-0.10,-0.20,-0.45),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.94,-0.91,-0.91,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.94,-0.91,-0.91,-0.92),
     Pt2030_Medium  = cms.vdouble(-0.58,-0.65,-0.57,-0.67),
-    Pt3050_Medium  = cms.vdouble(-0.58,-0.65,-0.57,-0.67),
+    Pt3040_Medium  = cms.vdouble(-0.58,-0.65,-0.57,-0.67),
+    Pt4050_Medium  = cms.vdouble(-0.58,-0.65,-0.57,-0.67),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.98,-0.95,-0.94,-0.94),
     Pt1020_Loose   = cms.vdouble(-0.98,-0.95,-0.94,-0.94),
     Pt2030_Loose   = cms.vdouble(-0.89,-0.77,-0.69,-0.75),
-    Pt3050_Loose   = cms.vdouble(-0.89,-0.77,-0.69,-0.57)
+    Pt3040_Loose   = cms.vdouble(-0.89,-0.77,-0.69,-0.57),
+    Pt4050_Loose   = cms.vdouble(-0.89,-0.77,-0.69,-0.57)
 )
 
 simple_5x_chs_wp = cms.PSet(
@@ -281,19 +342,22 @@ simple_5x_chs_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.60,-0.74,-0.78,-0.81),
     Pt1020_Tight   = cms.vdouble(-0.60,-0.74,-0.78,-0.81),
     Pt2030_Tight   = cms.vdouble(-0.47,-0.06,-0.23,-0.47),
-    Pt3050_Tight   = cms.vdouble(-0.47,-0.06,-0.23,-0.47),
+    Pt3040_Tight   = cms.vdouble(-0.47,-0.06,-0.23,-0.47),
+    Pt4050_Tight   = cms.vdouble(-0.47,-0.06,-0.23,-0.47),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.95,-0.94,-0.92,-0.91),
     Pt1020_Medium  = cms.vdouble(-0.95,-0.94,-0.92,-0.91),
     Pt2030_Medium  = cms.vdouble(-0.59,-0.65,-0.56,-0.68),
-    Pt3050_Medium  = cms.vdouble(-0.59,-0.65,-0.56,-0.68),
+    Pt3040_Medium  = cms.vdouble(-0.59,-0.65,-0.56,-0.68),
+    Pt4050_Medium  = cms.vdouble(-0.59,-0.65,-0.56,-0.68),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.98,-0.96,-0.94,-0.94),
     Pt1020_Loose   = cms.vdouble(-0.98,-0.96,-0.94,-0.94),
     Pt2030_Loose   = cms.vdouble(-0.89,-0.75,-0.72,-0.75),
-    Pt3050_Loose   = cms.vdouble(-0.89,-0.75,-0.72,-0.75)
+    Pt3040_Loose   = cms.vdouble(-0.89,-0.75,-0.72,-0.75),
+    Pt4050_Loose   = cms.vdouble(-0.89,-0.75,-0.72,-0.75)
 )
 
 
@@ -307,19 +371,22 @@ PuJetIdOptMVA_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.5,-0.2,-0.83,-0.7),
     Pt1020_Tight   = cms.vdouble(-0.5,-0.2,-0.83,-0.7),
     Pt2030_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
-    Pt3050_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
+    Pt3040_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
+    Pt4050_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.73,-0.89,-0.89,-0.83),
     Pt1020_Medium  = cms.vdouble(-0.73,-0.89,-0.89,-0.83),
     Pt2030_Medium  = cms.vdouble(0.1,  -0.4, -0.4, -0.45),
-    Pt3050_Medium  = cms.vdouble(0.1,  -0.4, -0.4, -0.45),
+    Pt3040_Medium  = cms.vdouble(0.1,  -0.4, -0.4, -0.45),
+    Pt4050_Medium  = cms.vdouble(0.1,  -0.4, -0.4, -0.45),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.9,-0.9, -0.9,-0.9),
     Pt1020_Loose   = cms.vdouble(-0.9,-0.9, -0.9,-0.9),
     Pt2030_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6),
-    Pt3050_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6)
+    Pt3040_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6),
+    Pt4050_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6)
 )
 
 PuJetIdMinMVA_wp = cms.PSet(
@@ -329,19 +396,22 @@ PuJetIdMinMVA_wp = cms.PSet(
     Pt010_Tight    = cms.vdouble(-0.5,-0.2,-0.83,-0.7),
     Pt1020_Tight   = cms.vdouble(-0.5,-0.2,-0.83,-0.7),
     Pt2030_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
-    Pt3050_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
+    Pt3040_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
+    Pt4050_Tight   = cms.vdouble(-0.2,  0.,    0.,  0.),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.73,-0.89,-0.89,-0.83),
     Pt1020_Medium  = cms.vdouble(-0.73,-0.89,-0.89,-0.83),
     Pt2030_Medium  = cms.vdouble(0.1,  -0.4, -0.5, -0.45),
-    Pt3050_Medium  = cms.vdouble(0.1,  -0.4, -0.5, -0.45),
+    Pt3040_Medium  = cms.vdouble(0.1,  -0.4, -0.5, -0.45),
+    Pt4050_Medium  = cms.vdouble(0.1,  -0.4, -0.5, -0.45),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.9,-0.9, -0.94,-0.9),
     Pt1020_Loose   = cms.vdouble(-0.9,-0.9, -0.94,-0.9),
     Pt2030_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6),
-    Pt3050_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6)
+    Pt3040_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6),
+    Pt4050_Loose   = cms.vdouble(-0.4,-0.85,-0.7,-0.6)
 )
 
 EmptyJetIdParams = cms.PSet(
@@ -351,19 +421,22 @@ EmptyJetIdParams = cms.PSet(
     Pt010_Tight    = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt1020_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt2030_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
-    Pt3050_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt3040_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt4050_Tight   = cms.vdouble(-999.,-999.,-999.,-999.),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt1020_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt2030_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
-    Pt3050_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt3040_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt4050_Medium  = cms.vdouble(-999.,-999.,-999.,-999.),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt1020_Loose   = cms.vdouble(-999.,-999.,-999.,-999.),
     Pt2030_Loose   = cms.vdouble(-999.,-999.,-999.,-999.),
-    Pt3050_Loose   = cms.vdouble(-999.,-999.,-999.,-999.)
+    Pt3040_Loose   = cms.vdouble(-999.,-999.,-999.,-999.),
+    Pt4050_Loose   = cms.vdouble(-999.,-999.,-999.,-999.)
 )
 
 
@@ -374,38 +447,44 @@ PuJetIdCutBased_wp = cms.PSet(
     Pt010_BetaStarTight    = cms.vdouble( 0.15, 0.15, 999., 999.),
     Pt1020_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
     Pt2030_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
-    Pt3050_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
-
+    Pt3040_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
+    Pt4050_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
+    
     #Medium Id => Daniele
     Pt010_BetaStarMedium   = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt1020_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt2030_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
-    Pt3050_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
+    Pt3040_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
+    Pt4050_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
 
     #Loose Id
     Pt010_BetaStarLoose    = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt1020_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt2030_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
-    Pt3050_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
+    Pt3040_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
+    Pt4050_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
 
     #RMS variable
     #Tight Id
     Pt010_RMSTight         = cms.vdouble( 0.06, 0.07, 0.04, 0.05),
     Pt1020_RMSTight        = cms.vdouble( 0.06, 0.07, 0.04, 0.05),
     Pt2030_RMSTight        = cms.vdouble( 0.05, 0.07, 0.03, 0.045),
-    Pt3050_RMSTight        = cms.vdouble( 0.05, 0.06, 0.03, 0.04),
-
+    Pt3040_RMSTight        = cms.vdouble( 0.05, 0.06, 0.03, 0.04),
+    Pt4050_RMSTight        = cms.vdouble( 0.05, 0.06, 0.03, 0.04),
+    
     #Medium Id => Daniele
     Pt010_RMSMedium        = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt1020_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt2030_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
-    Pt3050_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
+    Pt3040_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
+    Pt4050_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
 
     #Loose Id
     Pt010_RMSLoose         = cms.vdouble( 0.06, 0.05, 0.05, 0.07),
     Pt1020_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.07),
     Pt2030_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.055),
-    Pt3050_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.055)
+    Pt3040_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.055),
+    Pt4050_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.055)
     )
 
 
@@ -416,18 +495,21 @@ JetIdParams = cms.PSet(
     Pt010_Tight    = cms.vdouble( 0.5,0.6,0.6,0.9),
     Pt1020_Tight   = cms.vdouble(-0.2,0.2,0.2,0.6),
     Pt2030_Tight   = cms.vdouble( 0.3,0.4,0.7,0.8),
-    Pt3050_Tight   = cms.vdouble( 0.5,0.4,0.8,0.9),
+    Pt3040_Tight   = cms.vdouble( 0.5,0.4,0.8,0.9),
+    Pt4050_Tight   = cms.vdouble( 0.5,0.4,0.8,0.9),
 
     #Medium Id
     Pt010_Medium   = cms.vdouble( 0.2,0.4,0.2,0.6),
     Pt1020_Medium  = cms.vdouble(-0.3,0. ,0. ,0.5),
     Pt2030_Medium  = cms.vdouble( 0.2,0.2,0.5,0.7),
-    Pt3050_Medium  = cms.vdouble( 0.3,0.2,0.7,0.8),
+    Pt3040_Medium  = cms.vdouble( 0.3,0.2,0.7,0.8),
+    Pt4050_Medium  = cms.vdouble( 0.3,0.2,0.7,0.8),
 
     #Loose Id
     Pt010_Loose    = cms.vdouble( 0. , 0. , 0. ,0.2),
     Pt1020_Loose   = cms.vdouble(-0.4,-0.4,-0.4,0.4),
     Pt2030_Loose   = cms.vdouble( 0. , 0. , 0.2,0.6),
-    Pt3050_Loose   = cms.vdouble( 0. , 0. , 0.6,0.2)
+    Pt3040_Loose   = cms.vdouble( 0. , 0. , 0.6,0.2),
+    Pt4050_Loose   = cms.vdouble( 0. , 0. , 0.6,0.2)
 )
 

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -150,6 +150,18 @@ full_94x_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_
 full_94x_chs.trainings[3].tmvaVariables = trainingVariables_94X_Eta3To5
 
 
+####################################################################################################################
+trainingVariables_106X_Eta0To3 = list(trainingVariables_102X_Eta0To3)
+trainingVariables_106X_Eta3To5 = list(trainingVariables_102X_Eta3To5)
+full_106x_UL17_chs = full_81x_chs.clone(JetIdParams = full_106x_UL17_chs_wp)
+full_106x_UL17_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta0p0To2p5_chs_BDT.weights.xml.gz"
+full_106x_UL17_chs.trainings[0].tmvaVariables = trainingVariables_106X_Eta0To3
+full_106x_UL17_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta2p5To2p75_chs_BDT.weights.xml.gz"
+full_106x_UL17_chs.trainings[1].tmvaVariables = trainingVariables_106X_Eta0To3
+full_106x_UL17_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta2p75To3p0_chs_BDT.weights.xml.gz"
+full_106x_UL17_chs.trainings[2].tmvaVariables = trainingVariables_106X_Eta0To3
+full_106x_UL17_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta3p0To5p0_chs_BDT.weights.xml.gz"
+full_106x_UL17_chs.trainings[3].tmvaVariables = trainingVariables_106X_Eta3To5
 
 ####################################################################################################################
 full_80x_chs = cms.PSet(

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -13,8 +13,9 @@ _chsalgos_80x = cms.VPSet(full_80x_chs,cutbased)
 _chsalgos_81x = cms.VPSet(full_81x_chs,cutbased)
 _chsalgos_94x = cms.VPSet(full_94x_chs,cutbased)
 _chsalgos_102x = cms.VPSet(full_102x_chs,cutbased)
+_chsalgos_106X_UL17 = cms.VPSet(full_106x_UL17_chs,cutbased)
 
-_stdalgos    = _chsalgos_81x
+_stdalgos    = _chsalgos_106X_UL17
 
 # Calculate+store variables and run MVAs
 pileupJetId = cms.EDProducer('PileupJetIdProducer',
@@ -32,7 +33,7 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
      usePuppi = cms.bool(False),
 #     residualsTxt     = cms.FileInPath("RecoJets/JetProducers/data/download.url") # must be an existing file
 )
-run2_miniAOD_devel.toModify(pileupJetId, algos = _chsalgos_102x)
+run2_miniAOD_devel.toModify(pileupJetId, algos = _chsalgos_106X_UL17)
 
 # Calculate variables, but don't run MVAs
 pileupJetIdCalculator = pileupJetId.clone(

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -15,7 +15,7 @@ _chsalgos_94x = cms.VPSet(full_94x_chs,cutbased)
 _chsalgos_102x = cms.VPSet(full_102x_chs,cutbased)
 _chsalgos_106X_UL17 = cms.VPSet(full_106x_UL17_chs,cutbased)
 
-_stdalgos    = _chsalgos_106X_UL17
+_stdalgos    = _chsalgos_81x
 
 # Calculate+store variables and run MVAs
 pileupJetId = cms.EDProducer('PileupJetIdProducer',

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -70,24 +70,28 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
       std::vector<double> pt010  = jetConfig.getParameter<std::vector<double> >(("Pt010_" +lFullCutType).c_str());
       std::vector<double> pt1020 = jetConfig.getParameter<std::vector<double> >(("Pt1020_"+lFullCutType).c_str());
       std::vector<double> pt2030 = jetConfig.getParameter<std::vector<double> >(("Pt2030_"+lFullCutType).c_str());
-      std::vector<double> pt3050 = jetConfig.getParameter<std::vector<double> >(("Pt3050_"+lFullCutType).c_str());
+      std::vector<double> pt3040 = jetConfig.getParameter<std::vector<double> >(("Pt3040_" + lFullCutType).c_str());
+      std::vector<double> pt4050 = jetConfig.getParameter<std::vector<double> >(("Pt4050_" + lFullCutType).c_str());
       if (!cutBased_) {
         for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][0][i2] = pt010 [i2];
         for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][1][i2] = pt1020[i2];
         for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][3][i2] = pt3050[i2];
+        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][3][i2] = pt3040[i2];
+	for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][4][i2] = pt4050[i2];
       }
       if (cutBased_ && i1 == 0) {
         for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][0][i2] = pt010 [i2];
         for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][1][i2] = pt1020[i2];
         for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][3][i2] = pt3050[i2];
+        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][3][i2] = pt3040[i2];
+	for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][4][i2] = pt4050[i2];
       }
       if (cutBased_ && i1 == 1) {
         for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][0][i2] = pt010 [i2];
         for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][1][i2] = pt1020[i2];
         for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][3][i2] = pt3050[i2];
+        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][3][i2] = pt3040[i2];
+	for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][4][i2] = pt4050[i2];
       }
     }
   }
@@ -186,7 +190,8 @@ std::pair<int,int> PileupJetIdAlgo::getJetIdKey(float jetPt, float jetEta)
   int ptId = 0;
   if(jetPt >= 10 && jetPt < 20) ptId = 1;                                                                                 
   if(jetPt >= 20 && jetPt < 30) ptId = 2;                                                                                 
-  if(jetPt >= 30              ) ptId = 3;                                                                                          
+  if(jetPt >= 30 && jetPt < 40) ptId = 3;
+  if(jetPt >= 40              ) ptId = 4;
   
   int etaId = 0;
   if(std::abs(jetEta) >= 2.5  && std::abs(jetEta) < 2.75) etaId = 1;                                                              

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -18,17 +18,15 @@ const float large_val = std::numeric_limits<float>::max();
 
 // ------------------------------------------------------------------------------------------
 
-PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::ParameterSet const& ps, bool runMvas) :
-  cutBased_(ps.getParameter<bool>("cutBased")),
-  etaBinnedWeights_(false),
-  runMvas_(runMvas),
-  nEtaBins_(0),
-  label_(ps.getParameter<std::string>("label")),
-  mvacut_{},
-  rmsCut_{},
-  betaStarCut_{}
- {
-
+PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::ParameterSet const& ps, bool runMvas)
+    : cutBased_(ps.getParameter<bool>("cutBased")),
+      etaBinnedWeights_(false),
+      runMvas_(runMvas),
+      nEtaBins_(0),
+      label_(ps.getParameter<std::string>("label")),
+      mvacut_{},
+      rmsCut_{},
+      betaStarCut_{} {
   std::vector<edm::FileInPath> tmvaEtaWeights;
   std::vector<std::string> tmvaSpectators;
   int version;
@@ -36,15 +34,15 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
   if (!cutBased_) {
     etaBinnedWeights_ = ps.getParameter<bool>("etaBinnedWeights");
     if (etaBinnedWeights_) {
-      const std::vector<edm::ParameterSet>& trainings = ps.getParameter<std::vector <edm::ParameterSet> >("trainings");
+      const std::vector<edm::ParameterSet>& trainings = ps.getParameter<std::vector<edm::ParameterSet> >("trainings");
       nEtaBins_ = ps.getParameter<int>("nEtaBins");
       for (int v = 0; v < nEtaBins_; v++) {
         tmvaEtaWeights.push_back(trainings.at(v).getParameter<edm::FileInPath>("tmvaWeights"));
-        jEtaMin_.push_back( trainings.at(v).getParameter<double>("jEtaMin") );
-        jEtaMax_.push_back( trainings.at(v).getParameter<double>("jEtaMax") );
+        jEtaMin_.push_back(trainings.at(v).getParameter<double>("jEtaMin"));
+        jEtaMax_.push_back(trainings.at(v).getParameter<double>("jEtaMax"));
       }
       for (int v = 0; v < nEtaBins_; v++) {
-        tmvaEtaVariables_.push_back( trainings.at(v).getParameter<std::vector<std::string> >("tmvaVariables") );
+        tmvaEtaVariables_.push_back(trainings.at(v).getParameter<std::vector<std::string> >("tmvaVariables"));
       }
     } else {
       tmvaVariables_ = ps.getParameter<std::vector<std::string> >("tmvaVariables");
@@ -58,49 +56,69 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
 
   edm::ParameterSet jetConfig = ps.getParameter<edm::ParameterSet>("JetIdParams");
   for (int i0 = 0; i0 < 3; i0++) {
-    std::string lCutType                             = "Tight";
-    if (i0 == PileupJetIdentifier::kMedium) lCutType = "Medium";
-    if (i0 == PileupJetIdentifier::kLoose)  lCutType = "Loose";
+    std::string lCutType = "Tight";
+    if (i0 == PileupJetIdentifier::kMedium)
+      lCutType = "Medium";
+    if (i0 == PileupJetIdentifier::kLoose)
+      lCutType = "Loose";
     int nCut = 1;
-    if(cutBased_) nCut++;
+    if (cutBased_)
+      nCut++;
     for (int i1 = 0; i1 < nCut; i1++) {
       std::string lFullCutType = lCutType;
-      if (cutBased_ && i1 == 0) lFullCutType = "BetaStar"+ lCutType;
-      if (cutBased_ && i1 == 1) lFullCutType = "RMS"     + lCutType;
-      std::vector<double> pt010  = jetConfig.getParameter<std::vector<double> >(("Pt010_" +lFullCutType).c_str());
-      std::vector<double> pt1020 = jetConfig.getParameter<std::vector<double> >(("Pt1020_"+lFullCutType).c_str());
-      std::vector<double> pt2030 = jetConfig.getParameter<std::vector<double> >(("Pt2030_"+lFullCutType).c_str());
+      if (cutBased_ && i1 == 0)
+        lFullCutType = "BetaStar" + lCutType;
+      if (cutBased_ && i1 == 1)
+        lFullCutType = "RMS" + lCutType;
+      std::vector<double> pt010 = jetConfig.getParameter<std::vector<double> >(("Pt010_" + lFullCutType).c_str());
+      std::vector<double> pt1020 = jetConfig.getParameter<std::vector<double> >(("Pt1020_" + lFullCutType).c_str());
+      std::vector<double> pt2030 = jetConfig.getParameter<std::vector<double> >(("Pt2030_" + lFullCutType).c_str());
       std::vector<double> pt3040 = jetConfig.getParameter<std::vector<double> >(("Pt3040_" + lFullCutType).c_str());
       std::vector<double> pt4050 = jetConfig.getParameter<std::vector<double> >(("Pt4050_" + lFullCutType).c_str());
       if (!cutBased_) {
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][0][i2] = pt010 [i2];
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][1][i2] = pt1020[i2];
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][3][i2] = pt3040[i2];
-	for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][4][i2] = pt4050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][0][i2] = pt010[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][1][i2] = pt1020[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][2][i2] = pt2030[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][3][i2] = pt3040[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][4][i2] = pt4050[i2];
       }
       if (cutBased_ && i1 == 0) {
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][0][i2] = pt010 [i2];
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][1][i2] = pt1020[i2];
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][3][i2] = pt3040[i2];
-	for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][4][i2] = pt4050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][0][i2] = pt010[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][1][i2] = pt1020[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][2][i2] = pt2030[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][3][i2] = pt3040[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][4][i2] = pt4050[i2];
       }
       if (cutBased_ && i1 == 1) {
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][0][i2] = pt010 [i2];
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][1][i2] = pt1020[i2];
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][3][i2] = pt3040[i2];
-	for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][4][i2] = pt4050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][0][i2] = pt010[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][1][i2] = pt1020[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][2][i2] = pt2030[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][3][i2] = pt3040[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][4][i2] = pt4050[i2];
       }
     }
   }
 
-  if ( ! cutBased_ ) {
-    assert( tmvaMethod_.empty() || ((! tmvaVariables_.empty() || ( !tmvaEtaVariables_.empty() )) && version == USER) );
+  if (!cutBased_) {
+    assert(tmvaMethod_.empty() || ((!tmvaVariables_.empty() || (!tmvaEtaVariables_.empty())) && version == USER));
   }
 
-  if (( ! cutBased_ ) && (runMvas_)) {
+  if ((!cutBased_) && (runMvas_)) {
     if (etaBinnedWeights_) {
       for (int v = 0; v < nEtaBins_; v++) {
         etaReader_.push_back(createGBRForest(tmvaEtaWeights.at(v)));
@@ -111,66 +129,56 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
   }
 }
 
-PileupJetIdAlgo::PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache) :
-  cache_(cache) {
+PileupJetIdAlgo::PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache) : cache_(cache) { initVariables(); }
 
-  initVariables();
+// ------------------------------------------------------------------------------------------
+PileupJetIdAlgo::~PileupJetIdAlgo() {}
+
+// ------------------------------------------------------------------------------------------
+void assign(const std::vector<float>& vec, float& a, float& b, float& c, float& d) {
+  size_t sz = vec.size();
+  a = (sz > 0 ? vec[0] : 0.);
+  b = (sz > 1 ? vec[1] : 0.);
+  c = (sz > 2 ? vec[2] : 0.);
+  d = (sz > 3 ? vec[3] : 0.);
+}
+// ------------------------------------------------------------------------------------------
+void setPtEtaPhi(const reco::Candidate& p, float& pt, float& eta, float& phi) {
+  pt = p.pt();
+  eta = p.eta();
+  phi = p.phi();
 }
 
 // ------------------------------------------------------------------------------------------
-PileupJetIdAlgo::~PileupJetIdAlgo() 
-{
-}
-
-// ------------------------------------------------------------------------------------------
-void assign(const std::vector<float> & vec, float & a, float & b, float & c, float & d )
-{
-	size_t sz = vec.size();
-	a = ( sz > 0 ? vec[0] : 0. );
-	b = ( sz > 1 ? vec[1] : 0. );
-	c = ( sz > 2 ? vec[2] : 0. );
-	d = ( sz > 3 ? vec[3] : 0. );
-}
-// ------------------------------------------------------------------------------------------
-void setPtEtaPhi(const reco::Candidate & p, float & pt, float & eta, float &phi )
-{
-	pt  = p.pt();
-	eta = p.eta();
-	phi = p.phi();
-}
-
-// ------------------------------------------------------------------------------------------
-void PileupJetIdAlgo::set(const PileupJetIdentifier & id)
-{
-	internalId_ = id;
-}
+void PileupJetIdAlgo::set(const PileupJetIdentifier& id) { internalId_ = id; }
 
 // ------------------------------------------------------------------------------------------
 
-float PileupJetIdAlgo::getMVAval(const std::vector<std::string> &varList, const std::unique_ptr<const GBRForest> &reader)
-{
-        std::vector<float> vars;
-        for(std::vector<std::string>::const_iterator it=varList.begin(); it!=varList.end(); ++it) {
-            std::pair<float *,float> var = variables_.at(*it);
-            vars.push_back( *var.first );
-        }
-        return reader->GetClassifier(vars.data());
+float PileupJetIdAlgo::getMVAval(const std::vector<std::string>& varList,
+                                 const std::unique_ptr<const GBRForest>& reader) {
+  std::vector<float> vars;
+  for (std::vector<std::string>::const_iterator it = varList.begin(); it != varList.end(); ++it) {
+    std::pair<float*, float> var = variables_.at(*it);
+    vars.push_back(*var.first);
+  }
+  return reader->GetClassifier(vars.data());
 }
 
-void PileupJetIdAlgo::runMva()
-{
-  if( cache_->cutBased() ) {
-    internalId_.idFlag_ = computeCutIDflag(internalId_.betaStarClassic_,internalId_.dR2Mean_,internalId_.nvtx_,internalId_.jetPt_,internalId_.jetEta_);
+void PileupJetIdAlgo::runMva() {
+  if (cache_->cutBased()) {
+    internalId_.idFlag_ = computeCutIDflag(
+        internalId_.betaStarClassic_, internalId_.dR2Mean_, internalId_.nvtx_, internalId_.jetPt_, internalId_.jetEta_);
   } else {
-    if(std::abs(internalId_.jetEta_) >= 5.0) {
+    if (std::abs(internalId_.jetEta_) >= 5.0) {
       internalId_.mva_ = -2.;
     } else {
-      if(cache_->etaBinnedWeights()){
-        if(std::abs(internalId_.jetEta_) > cache_->jEtaMax().at(cache_->nEtaBins() - 1)) {
+      if (cache_->etaBinnedWeights()) {
+        if (std::abs(internalId_.jetEta_) > cache_->jEtaMax().at(cache_->nEtaBins() - 1)) {
           internalId_.mva_ = -2.;
         } else {
-          for(int v = 0; v < cache_->nEtaBins(); v++){
-            if(std::abs(internalId_.jetEta_) >= cache_->jEtaMin().at(v) && std::abs(internalId_.jetEta_) < cache_->jEtaMax().at(v)) {
+          for (int v = 0; v < cache_->nEtaBins(); v++) {
+            if (std::abs(internalId_.jetEta_) >= cache_->jEtaMin().at(v) &&
+                std::abs(internalId_.jetEta_) < cache_->jEtaMax().at(v)) {
               internalId_.mva_ = getMVAval(cache_->tmvaEtaVariables().at(v), cache_->etaReader().at(v));
               break;
             }
@@ -180,630 +188,690 @@ void PileupJetIdAlgo::runMva()
         internalId_.mva_ = getMVAval(cache_->tmvaVariables(), cache_->reader());
       }
     }
-    internalId_.idFlag_ = computeIDflag(internalId_.mva_,internalId_.jetPt_,internalId_.jetEta_);
+    internalId_.idFlag_ = computeIDflag(internalId_.mva_, internalId_.jetPt_, internalId_.jetEta_);
   }
 }
 
 // ------------------------------------------------------------------------------------------
-std::pair<int,int> PileupJetIdAlgo::getJetIdKey(float jetPt, float jetEta)
-{
+std::pair<int, int> PileupJetIdAlgo::getJetIdKey(float jetPt, float jetEta) {
   int ptId = 0;
-  if(jetPt >= 10 && jetPt < 20) ptId = 1;                                                                                 
-  if(jetPt >= 20 && jetPt < 30) ptId = 2;                                                                                 
-  if(jetPt >= 30 && jetPt < 40) ptId = 3;
-  if(jetPt >= 40              ) ptId = 4;
-  
+  if (jetPt >= 10 && jetPt < 20)
+    ptId = 1;
+  if (jetPt >= 20 && jetPt < 30)
+    ptId = 2;
+  if (jetPt >= 30 && jetPt < 40)
+    ptId = 3;
+  if (jetPt >= 40)
+    ptId = 4;
+
   int etaId = 0;
-  if(std::abs(jetEta) >= 2.5  && std::abs(jetEta) < 2.75) etaId = 1;                                                              
-  if(std::abs(jetEta) >= 2.75 && std::abs(jetEta) < 3.0 ) etaId = 2;                                                              
-  if(std::abs(jetEta) >= 3.0  && std::abs(jetEta) < 5.0 ) etaId = 3;                                 
+  if (std::abs(jetEta) >= 2.5 && std::abs(jetEta) < 2.75)
+    etaId = 1;
+  if (std::abs(jetEta) >= 2.75 && std::abs(jetEta) < 3.0)
+    etaId = 2;
+  if (std::abs(jetEta) >= 3.0 && std::abs(jetEta) < 5.0)
+    etaId = 3;
 
-  return std::pair<int,int>(ptId,etaId);
+  return std::pair<int, int>(ptId, etaId);
 }
 // ------------------------------------------------------------------------------------------
-int PileupJetIdAlgo::computeCutIDflag(float betaStarClassic,float dR2Mean,float nvtx, float jetPt, float jetEta)
-{
-  std::pair<int,int> jetIdKey = getJetIdKey(jetPt,jetEta);
-  float betaStarModified = betaStarClassic/log(nvtx-0.64);
+int PileupJetIdAlgo::computeCutIDflag(float betaStarClassic, float dR2Mean, float nvtx, float jetPt, float jetEta) {
+  std::pair<int, int> jetIdKey = getJetIdKey(jetPt, jetEta);
+  float betaStarModified = betaStarClassic / log(nvtx - 0.64);
   int idFlag(0);
-  if(betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kTight ][jetIdKey.first][jetIdKey.second] &&
-     dR2Mean          < cache_->rmsCut()     [PileupJetIdentifier::kTight ][jetIdKey.first][jetIdKey.second]
-     ) idFlag += 1 <<  PileupJetIdentifier::kTight;
+  if (betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kTight][jetIdKey.first][jetIdKey.second] &&
+      dR2Mean < cache_->rmsCut()[PileupJetIdentifier::kTight][jetIdKey.first][jetIdKey.second])
+    idFlag += 1 << PileupJetIdentifier::kTight;
 
-  if(betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kMedium ][jetIdKey.first][jetIdKey.second] &&
-     dR2Mean          < cache_->rmsCut()     [PileupJetIdentifier::kMedium ][jetIdKey.first][jetIdKey.second]
-     ) idFlag += 1 <<  PileupJetIdentifier::kMedium;
-  
-  if(betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kLoose  ][jetIdKey.first][jetIdKey.second] &&
-     dR2Mean          < cache_->rmsCut()     [PileupJetIdentifier::kLoose  ][jetIdKey.first][jetIdKey.second]
-     ) idFlag += 1 <<  PileupJetIdentifier::kLoose;
+  if (betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kMedium][jetIdKey.first][jetIdKey.second] &&
+      dR2Mean < cache_->rmsCut()[PileupJetIdentifier::kMedium][jetIdKey.first][jetIdKey.second])
+    idFlag += 1 << PileupJetIdentifier::kMedium;
+
+  if (betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kLoose][jetIdKey.first][jetIdKey.second] &&
+      dR2Mean < cache_->rmsCut()[PileupJetIdentifier::kLoose][jetIdKey.first][jetIdKey.second])
+    idFlag += 1 << PileupJetIdentifier::kLoose;
   return idFlag;
 }
 // ------------------------------------------------------------------------------------------
-int PileupJetIdAlgo::computeIDflag(float mva, float jetPt, float jetEta)
-{
-  std::pair<int,int> jetIdKey = getJetIdKey(jetPt,jetEta);
-  return computeIDflag(mva,jetIdKey.first,jetIdKey.second);
+int PileupJetIdAlgo::computeIDflag(float mva, float jetPt, float jetEta) {
+  std::pair<int, int> jetIdKey = getJetIdKey(jetPt, jetEta);
+  return computeIDflag(mva, jetIdKey.first, jetIdKey.second);
 }
 
 // ------------------------------------------------------------------------------------------
-int PileupJetIdAlgo::computeIDflag(float mva,int ptId,int etaId)
-{
+int PileupJetIdAlgo::computeIDflag(float mva, int ptId, int etaId) {
   int idFlag(0);
-  if(mva > cache_->mvacut()[PileupJetIdentifier::kTight ][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kTight;
-  if(mva > cache_->mvacut()[PileupJetIdentifier::kMedium][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kMedium;
-  if(mva > cache_->mvacut()[PileupJetIdentifier::kLoose ][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kLoose;
+  if (mva > cache_->mvacut()[PileupJetIdentifier::kTight][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kTight;
+  if (mva > cache_->mvacut()[PileupJetIdentifier::kMedium][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kMedium;
+  if (mva > cache_->mvacut()[PileupJetIdentifier::kLoose][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kLoose;
   return idFlag;
 }
 
-
 // ------------------------------------------------------------------------------------------
-PileupJetIdentifier PileupJetIdAlgo::computeMva()
-{
-	runMva();
-	return PileupJetIdentifier(internalId_);
+PileupJetIdentifier PileupJetIdAlgo::computeMva() {
+  runMva();
+  return PileupJetIdentifier(internalId_);
 }
 
 // ------------------------------------------------------------------------------------------
-PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, float jec, const reco::Vertex * vtx,
-							const reco::VertexCollection & allvtx, double rho, bool usePuppi) 
-{
-	
-	// initialize all variables to 0
-	resetVariables();
-	
-	// loop over constituents, accumulate sums and find leading candidates
-	const pat::Jet * patjet = dynamic_cast<const pat::Jet *>(jet);
-	const reco::PFJet * pfjet = dynamic_cast<const reco::PFJet *>(jet);
-	assert( patjet != nullptr || pfjet != nullptr );
-	if( patjet != nullptr && jec == 0. ) { // if this is a pat jet and no jec has been passed take the jec from the object
-	  jec = patjet->pt()/patjet->correctedJet(0).pt();
-	}
-	if( jec <= 0. ) {
-	  jec = 1.;
-	}
-	
-	const reco::Candidate* lLead = nullptr, *lSecond = nullptr, *lLeadNeut = nullptr, *lLeadEm = nullptr, *lLeadCh = nullptr, *lTrail = nullptr;
-	std::vector<float> frac, fracCh, fracEm, fracNeut;
-	float cones[] = { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7 };
-	size_t ncones = sizeof(cones)/sizeof(float);
-	float * coneFracs[]     = { &internalId_.frac01_, &internalId_.frac02_, &internalId_.frac03_, &internalId_.frac04_, 
-				    &internalId_.frac05_,  &internalId_.frac06_,  &internalId_.frac07_ };
-	float * coneEmFracs[]   = { &internalId_.emFrac01_, &internalId_.emFrac02_, &internalId_.emFrac03_, &internalId_.emFrac04_, 
-				    &internalId_.emFrac05_, &internalId_.emFrac06_, &internalId_.emFrac07_ }; 
-	float * coneNeutFracs[] = { &internalId_.neutFrac01_, &internalId_.neutFrac02_, &internalId_.neutFrac03_, &internalId_.neutFrac04_, 
-				    &internalId_.neutFrac05_, &internalId_.neutFrac06_, &internalId_.neutFrac07_ }; 
-	float * coneChFracs[]   = { &internalId_.chFrac01_, &internalId_.chFrac02_, &internalId_.chFrac03_, &internalId_.chFrac04_, 
-				    &internalId_.chFrac05_, &internalId_.chFrac06_, &internalId_.chFrac07_ }; 
-	TMatrixDSym covMatrix(2); covMatrix = 0.;
-	float jetPt = jet->pt() / jec; // use uncorrected pt for shape variables
-	float sumPt = 0., sumPt2 = 0., sumTkPt = 0.,sumPtCh=0,sumPtNe = 0;
-	float multNeut = 0.0;
-	setPtEtaPhi(*jet,internalId_.jetPt_,internalId_.jetEta_,internalId_.jetPhi_); // use corrected pt for jet kinematics
-	internalId_.jetM_ = jet->mass(); 
-	internalId_.nvtx_ = allvtx.size();
-	internalId_.rho_ = rho;
+PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
+                                                        float jec,
+                                                        const reco::Vertex* vtx,
+                                                        const reco::VertexCollection& allvtx,
+                                                        double rho,
+                                                        bool usePuppi) {
+  // initialize all variables to 0
+  resetVariables();
 
-	float dRmin(1000);
+  // loop over constituents, accumulate sums and find leading candidates
+  const pat::Jet* patjet = dynamic_cast<const pat::Jet*>(jet);
+  const reco::PFJet* pfjet = dynamic_cast<const reco::PFJet*>(jet);
+  assert(patjet != nullptr || pfjet != nullptr);
+  if (patjet != nullptr && jec == 0.) {  // if this is a pat jet and no jec has been passed take the jec from the object
+    jec = patjet->pt() / patjet->correctedJet(0).pt();
+  }
+  if (jec <= 0.) {
+    jec = 1.;
+  }
 
-	for ( unsigned i = 0; i < jet->numberOfSourceCandidatePtrs(); ++i ) {
-	  reco::CandidatePtr pfJetConstituent = jet->sourceCandidatePtr(i);
-  
-	  const reco::Candidate* icand = pfJetConstituent.get();
-	  const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate *>( icand );
-	  const reco::PFCandidate *lPF=dynamic_cast<const reco::PFCandidate*>( icand );
-	  bool isPacked = true;
-	  if (lPack == nullptr){
-	    isPacked = false;
-	  }
-	    float candPuppiWeight = 1.0;
-	    if (usePuppi && isPacked) candPuppiWeight = lPack->puppiWeight();
-	    float candPt = (icand->pt())*candPuppiWeight;
-	    float candPtFrac = candPt/jetPt;
-	    float candDr   = reco::deltaR(*icand,*jet);
-	    float candDeta = icand->eta() - jet->eta();
-	    float candDphi = reco::deltaPhi(*icand,*jet);
-	    float candPtDr = candPt * candDr;
-	    size_t icone = std::lower_bound(&cones[0],&cones[ncones],candDr) - &cones[0];
+  const reco::Candidate *lLead = nullptr, *lSecond = nullptr, *lLeadNeut = nullptr, *lLeadEm = nullptr,
+                        *lLeadCh = nullptr, *lTrail = nullptr;
+  std::vector<float> frac, fracCh, fracEm, fracNeut;
+  float cones[] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7};
+  size_t ncones = sizeof(cones) / sizeof(float);
+  float* coneFracs[] = {&internalId_.frac01_,
+                        &internalId_.frac02_,
+                        &internalId_.frac03_,
+                        &internalId_.frac04_,
+                        &internalId_.frac05_,
+                        &internalId_.frac06_,
+                        &internalId_.frac07_};
+  float* coneEmFracs[] = {&internalId_.emFrac01_,
+                          &internalId_.emFrac02_,
+                          &internalId_.emFrac03_,
+                          &internalId_.emFrac04_,
+                          &internalId_.emFrac05_,
+                          &internalId_.emFrac06_,
+                          &internalId_.emFrac07_};
+  float* coneNeutFracs[] = {&internalId_.neutFrac01_,
+                            &internalId_.neutFrac02_,
+                            &internalId_.neutFrac03_,
+                            &internalId_.neutFrac04_,
+                            &internalId_.neutFrac05_,
+                            &internalId_.neutFrac06_,
+                            &internalId_.neutFrac07_};
+  float* coneChFracs[] = {&internalId_.chFrac01_,
+                          &internalId_.chFrac02_,
+                          &internalId_.chFrac03_,
+                          &internalId_.chFrac04_,
+                          &internalId_.chFrac05_,
+                          &internalId_.chFrac06_,
+                          &internalId_.chFrac07_};
+  TMatrixDSym covMatrix(2);
+  covMatrix = 0.;
+  float jetPt = jet->pt() / jec;  // use uncorrected pt for shape variables
+  float sumPt = 0., sumPt2 = 0., sumTkPt = 0., sumPtCh = 0, sumPtNe = 0;
+  float multNeut = 0.0;
+  setPtEtaPhi(
+      *jet, internalId_.jetPt_, internalId_.jetEta_, internalId_.jetPhi_);  // use corrected pt for jet kinematics
+  internalId_.jetM_ = jet->mass();
+  internalId_.nvtx_ = allvtx.size();
+  internalId_.rho_ = rho;
 
-	    if(candDr < dRmin) dRmin = candDr;
+  float dRmin(1000);
 
-		// // all particles
-		if( lLead == nullptr || candPt > lLead->pt() ) {
-			lSecond = lLead;
-			lLead = icand; 
-		} else if( (lSecond == nullptr || candPt > lSecond->pt()) && (candPt < lLead->pt()) ) {
-			lSecond = icand;
-		}
+  for (unsigned i = 0; i < jet->numberOfSourceCandidatePtrs(); ++i) {
+    reco::CandidatePtr pfJetConstituent = jet->sourceCandidatePtr(i);
 
-		// // average shapes
-		internalId_.dRMean_     += candPtDr;
-		internalId_.dR2Mean_    += candPtDr*candPtDr;
-		covMatrix(0,0) += candPt*candPt*candDeta*candDeta;
-		covMatrix(0,1) += candPt*candPt*candDeta*candDphi;
-		covMatrix(1,1) += candPt*candPt*candDphi*candDphi;
-		internalId_.ptD_ += candPt*candPt;
-		sumPt += candPt;
-		sumPt2 += candPt*candPt;
-		
-		// single most energetic candiates and jet shape profiles
-		frac.push_back(candPtFrac);
-		
-		if( icone < ncones ) { *coneFracs[icone] += candPt; }
-	
-		// neutrals
-		if( abs(icand->pdgId()) == 130) {
-			if (lLeadNeut == nullptr || candPt > lLeadNeut->pt()) { lLeadNeut = icand; }
-			internalId_.dRMeanNeut_ += candPtDr;
-			fracNeut.push_back(candPtFrac);
-			if( icone < ncones ) { *coneNeutFracs[icone] += candPt; }
-			internalId_.ptDNe_    += candPt*candPt;
-			sumPtNe               += candPt;
-			multNeut += candPuppiWeight;
-		}
-		// EM candidated
-		if( icand->pdgId() == 22 ) {
-			if(lLeadEm == nullptr || candPt > lLeadEm->pt())  { lLeadEm = icand; }
-			internalId_.dRMeanEm_ += candPtDr;
-			fracEm.push_back(candPtFrac);
-			if( icone < ncones ) { *coneEmFracs[icone] += candPt; }
-			internalId_.ptDNe_    += candPt*candPt;
-			sumPtNe               += candPt;
-			multNeut += candPuppiWeight;
-		}
-		if((abs(icand->pdgId()) == 1) || (abs(icand->pdgId()) == 2)) multNeut += candPuppiWeight;
+    const reco::Candidate* icand = pfJetConstituent.get();
+    const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate*>(icand);
+    const reco::PFCandidate* lPF = dynamic_cast<const reco::PFCandidate*>(icand);
+    bool isPacked = true;
+    if (lPack == nullptr) {
+      isPacked = false;
+    }
+    float candPuppiWeight = 1.0;
+    if (usePuppi && isPacked)
+      candPuppiWeight = lPack->puppiWeight();
+    float candPt = (icand->pt()) * candPuppiWeight;
+    float candPtFrac = candPt / jetPt;
+    float candDr = reco::deltaR(*icand, *jet);
+    float candDeta = icand->eta() - jet->eta();
+    float candDphi = reco::deltaPhi(*icand, *jet);
+    float candPtDr = candPt * candDr;
+    size_t icone = std::lower_bound(&cones[0], &cones[ncones], candDr) - &cones[0];
 
-		// Charged  particles
-		if(  icand->charge() != 0 ) {
-		        if (lLeadCh == nullptr || candPt > lLeadCh->pt()) { 
-			  lLeadCh = icand;
-			
-			  const reco::Track* pfTrk = icand->bestTrack();
-			  if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr){
-			    reco::MuonRef lmuRef = lPF->muonRef();
-			    if (lmuRef.isNonnull()){
-			      const reco::Muon& lmu = *lmuRef.get();
-			      pfTrk = lmu.bestTrack();
-			      edm::LogWarning("BadMuon")<<"Found a PFCandidate muon without a trackRef: falling back to Muon::bestTrack ";
-			    }
-			  }
-			  if(pfTrk==nullptr) { //protection against empty pointers for the miniAOD case
-			    //To handle the electron case
-			    if(isPacked) {
-			      internalId_.d0_ = std::abs(lPack->dxy(vtx->position()));
-			      internalId_.dZ_ = std::abs(lPack->dz(vtx->position()));
-			    }
-			    else if(lPF!=nullptr) {
-			      pfTrk=(lPF->trackRef().get()==nullptr)?lPF->gsfTrackRef().get():lPF->trackRef().get();
-			      internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
-			      internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
-			    }
-			  }
-			  else {
-			    internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
-			    internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
-			  }
-			}
-			internalId_.dRMeanCh_  += candPtDr;
-			internalId_.ptDCh_     += candPt*candPt;
-			fracCh.push_back(candPtFrac);
-			if( icone < ncones ) { *coneChFracs[icone] += candPt; }
-			sumPtCh                += candPt;
-		}
-		// // beta and betastar		
-		if( icand->charge() != 0 ) {
-		      if (!isPacked){
-			   if(lPF->trackRef().isNonnull() ) { 
-	      			float tkpt = candPt;
-				sumTkPt += tkpt;
-				// 'classic' beta definition based on track-vertex association
-				bool inVtx0 = vtx->trackWeight ( lPF->trackRef()) > 0 ;
+    if (candDr < dRmin)
+      dRmin = candDr;
 
-				bool inAnyOther = false;
-				// alternative beta definition based on track-vertex distance of closest approach
-				double dZ0 = std::abs(lPF->trackRef()->dz(vtx->position()));
-				double dZ = dZ0;
-				for(reco::VertexCollection::const_iterator  vi=allvtx.begin(); vi!=allvtx.end(); ++vi ) {
-				    const reco::Vertex & iv = *vi;
-				    if( iv.isFake() || iv.ndof() < 4 ) { continue; }
-				        // the primary vertex may have been copied by the user: check identity by position
-				        bool isVtx0  = (iv.position() - vtx->position()).r() < 0.02;
-					// 'classic' beta definition: check if the track is associated with
-					// any vertex other than the primary one
-					if( ! isVtx0 && ! inAnyOther ) {
-					  inAnyOther =  vtx->trackWeight ( lPF->trackRef()) <= 0 ;
-					}
-					// alternative beta: find closest vertex to the track
-					dZ = std::min(dZ,std::abs(lPF->trackRef()->dz(iv.position())));
-				}
-				// classic beta/betaStar
-				if( inVtx0 && ! inAnyOther ) {
-				    internalId_.betaClassic_ += tkpt;
-				} else if( ! inVtx0 && inAnyOther ) {
-				    internalId_.betaStarClassic_ += tkpt;
-				}
-				// alternative beta/betaStar
-				if( dZ0 < 0.2 ) {
-				    internalId_.beta_ += tkpt;
-				} else if( dZ < 0.2 ) {
-				    internalId_.betaStar_ += tkpt;
-				}
-			   } 
-		        }
-			else{
-			        float tkpt = candPt;
-			        sumTkPt += tkpt;
-				bool inVtx0 = false; 
-				bool inVtxOther = false; 
-				double dZ0=9999.;
-				double dZ_tmp = 9999.;
-				for (unsigned vtx_i = 0 ; vtx_i < allvtx.size() ; vtx_i++ ) {
-         			        auto iv = allvtx[vtx_i];
+    // // all particles
+    if (lLead == nullptr || candPt > lLead->pt()) {
+      lSecond = lLead;
+      lLead = icand;
+    } else if ((lSecond == nullptr || candPt > lSecond->pt()) && (candPt < lLead->pt())) {
+      lSecond = icand;
+    }
 
-					if (iv.isFake())
-						continue;
+    // // average shapes
+    internalId_.dRMean_ += candPtDr;
+    internalId_.dR2Mean_ += candPtDr * candPtDr;
+    covMatrix(0, 0) += candPt * candPt * candDeta * candDeta;
+    covMatrix(0, 1) += candPt * candPt * candDeta * candDphi;
+    covMatrix(1, 1) += candPt * candPt * candDphi * candDphi;
+    internalId_.ptD_ += candPt * candPt;
+    sumPt += candPt;
+    sumPt2 += candPt * candPt;
 
-					// Match to vertex in case of copy as above
-                                        bool isVtx0  = (iv.position() - vtx->position()).r() < 0.02;
+    // single most energetic candiates and jet shape profiles
+    frac.push_back(candPtFrac);
 
-					if (isVtx0) {
-					    if (lPack->fromPV(vtx_i) == pat::PackedCandidate::PVUsedInFit) inVtx0 = true;
-					    if (lPack->fromPV(vtx_i) == 0) inVtxOther = true;
-					    dZ0 = lPack->dz(iv.position());
-					}
+    if (icone < ncones) {
+      *coneFracs[icone] += candPt;
+    }
 
-					if (fabs(lPack->dz(iv.position())) < fabs(dZ_tmp)) {
-						dZ_tmp = lPack->dz(iv.position());
-					}
-				}
-				if (inVtx0){
-					internalId_.betaClassic_ += tkpt;
-				} else if (inVtxOther){
-					internalId_.betaStarClassic_ += tkpt;
-				}
-				if (fabs(dZ0) < 0.2){
-					internalId_.beta_ += tkpt;
-				} else if (fabs(dZ_tmp) < 0.2){
-					internalId_.betaStar_ += tkpt;
-				}
-			}
-		}
+    // neutrals
+    if (abs(icand->pdgId()) == 130) {
+      if (lLeadNeut == nullptr || candPt > lLeadNeut->pt()) {
+        lLeadNeut = icand;
+      }
+      internalId_.dRMeanNeut_ += candPtDr;
+      fracNeut.push_back(candPtFrac);
+      if (icone < ncones) {
+        *coneNeutFracs[icone] += candPt;
+      }
+      internalId_.ptDNe_ += candPt * candPt;
+      sumPtNe += candPt;
+      multNeut += candPuppiWeight;
+    }
+    // EM candidated
+    if (icand->pdgId() == 22) {
+      if (lLeadEm == nullptr || candPt > lLeadEm->pt()) {
+        lLeadEm = icand;
+      }
+      internalId_.dRMeanEm_ += candPtDr;
+      fracEm.push_back(candPtFrac);
+      if (icone < ncones) {
+        *coneEmFracs[icone] += candPt;
+      }
+      internalId_.ptDNe_ += candPt * candPt;
+      sumPtNe += candPt;
+      multNeut += candPuppiWeight;
+    }
+    if ((abs(icand->pdgId()) == 1) || (abs(icand->pdgId()) == 2))
+      multNeut += candPuppiWeight;
 
-		// trailing candidate
-		if( lTrail == nullptr || candPt < lTrail->pt() ) {
-			lTrail = icand; 
-		}
-	
-	}
+    // Charged  particles
+    if (icand->charge() != 0) {
+      if (lLeadCh == nullptr || candPt > lLeadCh->pt()) {
+        lLeadCh = icand;
 
-	// // Finalize all variables
-	assert( !(lLead == nullptr) );
-
-	if ( lSecond == nullptr )   { lSecond   = lTrail; }
-	if ( lLeadNeut == nullptr ) { lLeadNeut = lTrail; }
-	if ( lLeadEm == nullptr )   { lLeadEm   = lTrail; }
-	if ( lLeadCh == nullptr )   { lLeadCh   = lTrail; }
-	
-	if( patjet != nullptr ) { // to enable running on MiniAOD slimmedJets
-	 internalId_.nCharged_    = patjet->chargedMultiplicity();
-	 internalId_.nNeutrals_   = patjet->neutralMultiplicity();
-	 internalId_.chgEMfrac_   = patjet->chargedEmEnergy()    /jet->energy();
-	 internalId_.neuEMfrac_   = patjet->neutralEmEnergy()    /jet->energy();
-	 internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy()/jet->energy();
-	 internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy()/jet->energy();
-	 if (usePuppi) internalId_.nNeutrals_ = multNeut;
-	} else {
-	 internalId_.nCharged_    = pfjet->chargedMultiplicity();
-	 internalId_.nNeutrals_   = pfjet->neutralMultiplicity();
-	 internalId_.chgEMfrac_   = pfjet->chargedEmEnergy()    /jet->energy();
-	 internalId_.neuEMfrac_   = pfjet->neutralEmEnergy()    /jet->energy();
-	 internalId_.chgHadrfrac_ = pfjet->chargedHadronEnergy()/jet->energy();
-	 internalId_.neuHadrfrac_ = pfjet->neutralHadronEnergy()/jet->energy();
-	}
-        internalId_.nParticles_   = jet->nConstituents();
-
-	///////////////////////pull variable///////////////////////////////////
-	float sumW2(0.0);
-	float sum_deta(0.0),sum_dphi(0.0);
-	float ave_deta(0.0), ave_dphi(0.0);
-	for (size_t j = 0; j < jet->numberOfDaughters(); j++) {
-	  const auto& part = jet->daughterPtr(j);
-	  if (!(part.isAvailable() && part.isNonnull()) ){
-            continue;
-	  }
-
-	  float partPuppiWeight=1.0;
-	  if (usePuppi){
-	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );
-	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
-	  }
-
-	  float weight = (part->pt())*partPuppiWeight;
-	  float weight2 = weight * weight;
-	  sumW2        += weight2;
-	  float deta = part->eta() - jet->eta();
-	  float dphi = reco::deltaPhi(*part, *jet);
-	  sum_deta     += deta*weight2;
-	  sum_dphi     += dphi*weight2;
-	  if (sumW2 > 0) {
-	    ave_deta = sum_deta/sumW2;
-	    ave_dphi = sum_dphi/sumW2;
-	  }
-	}
-
-	float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);
-	for (size_t i = 0; i < jet->numberOfDaughters(); i++) {
-	  const auto& part = jet->daughterPtr(i);
-	  if (!(part.isAvailable() && part.isNonnull()) ){
-            continue;
+        const reco::Track* pfTrk = icand->bestTrack();
+        if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr) {
+          reco::MuonRef lmuRef = lPF->muonRef();
+          if (lmuRef.isNonnull()) {
+            const reco::Muon& lmu = *lmuRef.get();
+            pfTrk = lmu.bestTrack();
+            edm::LogWarning("BadMuon")
+                << "Found a PFCandidate muon without a trackRef: falling back to Muon::bestTrack ";
           }
- 
-	  float partPuppiWeight=1.0;
-	  if (usePuppi){
-	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );
-	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
-	  }
+        }
+        if (pfTrk == nullptr) {  //protection against empty pointers for the miniAOD case
+          //To handle the electron case
+          if (isPacked) {
+            internalId_.d0_ = std::abs(lPack->dxy(vtx->position()));
+            internalId_.dZ_ = std::abs(lPack->dz(vtx->position()));
+          } else if (lPF != nullptr) {
+            pfTrk = (lPF->trackRef().get() == nullptr) ? lPF->gsfTrackRef().get() : lPF->trackRef().get();
+            internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+            internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
+          }
+        } else {
+          internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+          internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
+        }
+      }
+      internalId_.dRMeanCh_ += candPtDr;
+      internalId_.ptDCh_ += candPt * candPt;
+      fracCh.push_back(candPtFrac);
+      if (icone < ncones) {
+        *coneChFracs[icone] += candPt;
+      }
+      sumPtCh += candPt;
+    }
+    // // beta and betastar
+    if (icand->charge() != 0) {
+      if (!isPacked) {
+        if (lPF->trackRef().isNonnull()) {
+          float tkpt = candPt;
+          sumTkPt += tkpt;
+          // 'classic' beta definition based on track-vertex association
+          bool inVtx0 = vtx->trackWeight(lPF->trackRef()) > 0;
 
-	  float weight = partPuppiWeight*(part->pt())*partPuppiWeight*(part->pt());
-	  float deta = part->eta() - jet->eta();
-	  float dphi = reco::deltaPhi(*part, *jet);
-	  float ddeta, ddphi, ddR;
-	  ddeta = deta - ave_deta ;
-	  ddphi = dphi-ave_dphi;
-	  ddR = sqrt(ddeta*ddeta + ddphi*ddphi);
-	  ddetaR_sum += ddR*ddeta*weight;
-	  ddphiR_sum += ddR*ddphi*weight;
-	}
-	if (sumW2 > 0) {
-	  float ddetaR_ave = ddetaR_sum/sumW2;
-	  float ddphiR_ave = ddphiR_sum/sumW2;
-	  pull_tmp = sqrt(ddetaR_ave*ddetaR_ave+ddphiR_ave*ddphiR_ave);
-	}
-	internalId_.pull_ = pull_tmp;
-	///////////////////////////////////////////////////////////////////////
- 
+          bool inAnyOther = false;
+          // alternative beta definition based on track-vertex distance of closest approach
+          double dZ0 = std::abs(lPF->trackRef()->dz(vtx->position()));
+          double dZ = dZ0;
+          for (reco::VertexCollection::const_iterator vi = allvtx.begin(); vi != allvtx.end(); ++vi) {
+            const reco::Vertex& iv = *vi;
+            if (iv.isFake() || iv.ndof() < 4) {
+              continue;
+            }
+            // the primary vertex may have been copied by the user: check identity by position
+            bool isVtx0 = (iv.position() - vtx->position()).r() < 0.02;
+            // 'classic' beta definition: check if the track is associated with
+            // any vertex other than the primary one
+            if (!isVtx0 && !inAnyOther) {
+              inAnyOther = vtx->trackWeight(lPF->trackRef()) <= 0;
+            }
+            // alternative beta: find closest vertex to the track
+            dZ = std::min(dZ, std::abs(lPF->trackRef()->dz(iv.position())));
+          }
+          // classic beta/betaStar
+          if (inVtx0 && !inAnyOther) {
+            internalId_.betaClassic_ += tkpt;
+          } else if (!inVtx0 && inAnyOther) {
+            internalId_.betaStarClassic_ += tkpt;
+          }
+          // alternative beta/betaStar
+          if (dZ0 < 0.2) {
+            internalId_.beta_ += tkpt;
+          } else if (dZ < 0.2) {
+            internalId_.betaStar_ += tkpt;
+          }
+        }
+      } else {
+        float tkpt = candPt;
+        sumTkPt += tkpt;
+        bool inVtx0 = false;
+        bool inVtxOther = false;
+        double dZ0 = 9999.;
+        double dZ_tmp = 9999.;
+        for (unsigned vtx_i = 0; vtx_i < allvtx.size(); vtx_i++) {
+          auto iv = allvtx[vtx_i];
 
-	setPtEtaPhi(*lLead,internalId_.leadPt_,internalId_.leadEta_,internalId_.leadPhi_);                 
-	setPtEtaPhi(*lSecond,internalId_.secondPt_,internalId_.secondEta_,internalId_.secondPhi_);	      
-	setPtEtaPhi(*lLeadNeut,internalId_.leadNeutPt_,internalId_.leadNeutEta_,internalId_.leadNeutPhi_); 
-	setPtEtaPhi(*lLeadEm,internalId_.leadEmPt_,internalId_.leadEmEta_,internalId_.leadEmPhi_);	      
-	setPtEtaPhi(*lLeadCh,internalId_.leadChPt_,internalId_.leadChEta_,internalId_.leadChPhi_);         
+          if (iv.isFake())
+            continue;
 
-	std::sort(frac.begin(),frac.end(),std::greater<float>());
-	std::sort(fracCh.begin(),fracCh.end(),std::greater<float>());
-	std::sort(fracEm.begin(),fracEm.end(),std::greater<float>());
-	std::sort(fracNeut.begin(),fracNeut.end(),std::greater<float>());
-	assign(frac,    internalId_.leadFrac_,    internalId_.secondFrac_,    internalId_.thirdFrac_,    internalId_.fourthFrac_);
-	assign(fracCh,  internalId_.leadChFrac_,  internalId_.secondChFrac_,  internalId_.thirdChFrac_,  internalId_.fourthChFrac_);
-	assign(fracEm,  internalId_.leadEmFrac_,  internalId_.secondEmFrac_,  internalId_.thirdEmFrac_,  internalId_.fourthEmFrac_);
-	assign(fracNeut,internalId_.leadNeutFrac_,internalId_.secondNeutFrac_,internalId_.thirdNeutFrac_,internalId_.fourthNeutFrac_);
-	
-	covMatrix(0,0) /= sumPt2;
-	covMatrix(0,1) /= sumPt2;
-	covMatrix(1,1) /= sumPt2;
-	covMatrix(1,0)  = covMatrix(0,1);
-	internalId_.etaW_ = sqrt(covMatrix(0,0));
-	internalId_.phiW_ = sqrt(covMatrix(1,1));
-	internalId_.jetW_ = 0.5*(internalId_.etaW_+internalId_.phiW_);
-	TVectorD eigVals(2); eigVals = TMatrixDSymEigen(covMatrix).GetEigenValues();
-	internalId_.majW_ = sqrt(std::abs(eigVals(0)));
-	internalId_.minW_ = sqrt(std::abs(eigVals(1)));
-	if( internalId_.majW_ < internalId_.minW_ ) { std::swap(internalId_.majW_,internalId_.minW_); }
-	
-	internalId_.dRLeadCent_ = reco::deltaR(*jet,*lLead);
-	if( lSecond == nullptr ) { internalId_.dRLead2nd_  = reco::deltaR(*jet,*lSecond); }
-	internalId_.dRMean_     /= jetPt;
-	internalId_.dRMeanNeut_ /= jetPt;
-	internalId_.dRMeanEm_   /= jetPt;
-	internalId_.dRMeanCh_   /= jetPt;
-	internalId_.dR2Mean_    /= sumPt2;
+          // Match to vertex in case of copy as above
+          bool isVtx0 = (iv.position() - vtx->position()).r() < 0.02;
 
-	for(size_t ic=0; ic<ncones; ++ic){
-		*coneFracs[ic]     /= jetPt;
-		*coneEmFracs[ic]   /= jetPt;
-		*coneNeutFracs[ic] /= jetPt;
-		*coneChFracs[ic]   /= jetPt;
-	}
-	//http://jets.physics.harvard.edu/qvg/
-	double ptMean = sumPt/internalId_.nParticles_;
-	double ptRMS  = 0;
-	for(unsigned int i0 = 0; i0 < frac.size(); i0++) {ptRMS+=(frac[i0]-ptMean)*(frac[i0]-ptMean);}
-	ptRMS/=internalId_.nParticles_;
-	ptRMS=sqrt(ptRMS);
-	
-	internalId_.ptMean_  = ptMean;
-	internalId_.ptRMS_   = ptRMS/jetPt;
-	internalId_.pt2A_    = sqrt( internalId_.ptD_     /internalId_.nParticles_)/jetPt;
-	internalId_.ptD_     = sqrt( internalId_.ptD_)    / sumPt;
-	internalId_.ptDCh_   = sqrt( internalId_.ptDCh_)  / sumPtCh;
-	internalId_.ptDNe_   = sqrt( internalId_.ptDNe_)  / sumPtNe;
-	internalId_.sumPt_   = sumPt;
-	internalId_.sumChPt_ = sumPtCh;
-	internalId_.sumNePt_ = sumPtNe;
+          if (isVtx0) {
+            if (lPack->fromPV(vtx_i) == pat::PackedCandidate::PVUsedInFit)
+              inVtx0 = true;
+            if (lPack->fromPV(vtx_i) == 0)
+              inVtxOther = true;
+            dZ0 = lPack->dz(iv.position());
+          }
 
-	internalId_.jetR_    = lLead->pt()/sumPt;
-	internalId_.jetRchg_ = lLeadCh->pt()/sumPt;
-	internalId_.dRMatch_ = dRmin;
+          if (fabs(lPack->dz(iv.position())) < fabs(dZ_tmp)) {
+            dZ_tmp = lPack->dz(iv.position());
+          }
+        }
+        if (inVtx0) {
+          internalId_.betaClassic_ += tkpt;
+        } else if (inVtxOther) {
+          internalId_.betaStarClassic_ += tkpt;
+        }
+        if (fabs(dZ0) < 0.2) {
+          internalId_.beta_ += tkpt;
+        } else if (fabs(dZ_tmp) < 0.2) {
+          internalId_.betaStar_ += tkpt;
+        }
+      }
+    }
 
-	if( sumTkPt != 0. ) {
-		internalId_.beta_     /= sumTkPt;
-		internalId_.betaStar_ /= sumTkPt;
-		internalId_.betaClassic_ /= sumTkPt;
-		internalId_.betaStarClassic_ /= sumTkPt;
-	} else {
-		assert( internalId_.beta_ == 0. && internalId_.betaStar_ == 0.&& internalId_.betaClassic_ == 0. && internalId_.betaStarClassic_ == 0. );
-	}
+    // trailing candidate
+    if (lTrail == nullptr || candPt < lTrail->pt()) {
+      lTrail = icand;
+    }
+  }
 
-	if( cache_->runMvas() ) {
-		runMva();
-	}
-	
-	return PileupJetIdentifier(internalId_);
+  // // Finalize all variables
+  assert(!(lLead == nullptr));
+
+  if (lSecond == nullptr) {
+    lSecond = lTrail;
+  }
+  if (lLeadNeut == nullptr) {
+    lLeadNeut = lTrail;
+  }
+  if (lLeadEm == nullptr) {
+    lLeadEm = lTrail;
+  }
+  if (lLeadCh == nullptr) {
+    lLeadCh = lTrail;
+  }
+
+  if (patjet != nullptr) {  // to enable running on MiniAOD slimmedJets
+    internalId_.nCharged_ = patjet->chargedMultiplicity();
+    internalId_.nNeutrals_ = patjet->neutralMultiplicity();
+    internalId_.chgEMfrac_ = patjet->chargedEmEnergy() / jet->energy();
+    internalId_.neuEMfrac_ = patjet->neutralEmEnergy() / jet->energy();
+    internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy() / jet->energy();
+    internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy() / jet->energy();
+    if (usePuppi)
+      internalId_.nNeutrals_ = multNeut;
+  } else {
+    internalId_.nCharged_ = pfjet->chargedMultiplicity();
+    internalId_.nNeutrals_ = pfjet->neutralMultiplicity();
+    internalId_.chgEMfrac_ = pfjet->chargedEmEnergy() / jet->energy();
+    internalId_.neuEMfrac_ = pfjet->neutralEmEnergy() / jet->energy();
+    internalId_.chgHadrfrac_ = pfjet->chargedHadronEnergy() / jet->energy();
+    internalId_.neuHadrfrac_ = pfjet->neutralHadronEnergy() / jet->energy();
+  }
+  internalId_.nParticles_ = jet->nConstituents();
+
+  ///////////////////////pull variable///////////////////////////////////
+  float sumW2(0.0);
+  float sum_deta(0.0), sum_dphi(0.0);
+  float ave_deta(0.0), ave_dphi(0.0);
+  for (size_t j = 0; j < jet->numberOfDaughters(); j++) {
+    const auto& part = jet->daughterPtr(j);
+    if (!(part.isAvailable() && part.isNonnull())) {
+      continue;
+    }
+
+    float partPuppiWeight = 1.0;
+    if (usePuppi) {
+      const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
+      if (partpack != nullptr)
+        partPuppiWeight = partpack->puppiWeight();
+    }
+
+    float weight = (part->pt()) * partPuppiWeight;
+    float weight2 = weight * weight;
+    sumW2 += weight2;
+    float deta = part->eta() - jet->eta();
+    float dphi = reco::deltaPhi(*part, *jet);
+    sum_deta += deta * weight2;
+    sum_dphi += dphi * weight2;
+    if (sumW2 > 0) {
+      ave_deta = sum_deta / sumW2;
+      ave_dphi = sum_dphi / sumW2;
+    }
+  }
+
+  float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);
+  for (size_t i = 0; i < jet->numberOfDaughters(); i++) {
+    const auto& part = jet->daughterPtr(i);
+    if (!(part.isAvailable() && part.isNonnull())) {
+      continue;
+    }
+
+    float partPuppiWeight = 1.0;
+    if (usePuppi) {
+      const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
+      if (partpack != nullptr)
+        partPuppiWeight = partpack->puppiWeight();
+    }
+
+    float weight = partPuppiWeight * (part->pt()) * partPuppiWeight * (part->pt());
+    float deta = part->eta() - jet->eta();
+    float dphi = reco::deltaPhi(*part, *jet);
+    float ddeta, ddphi, ddR;
+    ddeta = deta - ave_deta;
+    ddphi = dphi - ave_dphi;
+    ddR = sqrt(ddeta * ddeta + ddphi * ddphi);
+    ddetaR_sum += ddR * ddeta * weight;
+    ddphiR_sum += ddR * ddphi * weight;
+  }
+  if (sumW2 > 0) {
+    float ddetaR_ave = ddetaR_sum / sumW2;
+    float ddphiR_ave = ddphiR_sum / sumW2;
+    pull_tmp = sqrt(ddetaR_ave * ddetaR_ave + ddphiR_ave * ddphiR_ave);
+  }
+  internalId_.pull_ = pull_tmp;
+  ///////////////////////////////////////////////////////////////////////
+
+  setPtEtaPhi(*lLead, internalId_.leadPt_, internalId_.leadEta_, internalId_.leadPhi_);
+  setPtEtaPhi(*lSecond, internalId_.secondPt_, internalId_.secondEta_, internalId_.secondPhi_);
+  setPtEtaPhi(*lLeadNeut, internalId_.leadNeutPt_, internalId_.leadNeutEta_, internalId_.leadNeutPhi_);
+  setPtEtaPhi(*lLeadEm, internalId_.leadEmPt_, internalId_.leadEmEta_, internalId_.leadEmPhi_);
+  setPtEtaPhi(*lLeadCh, internalId_.leadChPt_, internalId_.leadChEta_, internalId_.leadChPhi_);
+
+  std::sort(frac.begin(), frac.end(), std::greater<float>());
+  std::sort(fracCh.begin(), fracCh.end(), std::greater<float>());
+  std::sort(fracEm.begin(), fracEm.end(), std::greater<float>());
+  std::sort(fracNeut.begin(), fracNeut.end(), std::greater<float>());
+  assign(frac, internalId_.leadFrac_, internalId_.secondFrac_, internalId_.thirdFrac_, internalId_.fourthFrac_);
+  assign(
+      fracCh, internalId_.leadChFrac_, internalId_.secondChFrac_, internalId_.thirdChFrac_, internalId_.fourthChFrac_);
+  assign(
+      fracEm, internalId_.leadEmFrac_, internalId_.secondEmFrac_, internalId_.thirdEmFrac_, internalId_.fourthEmFrac_);
+  assign(fracNeut,
+         internalId_.leadNeutFrac_,
+         internalId_.secondNeutFrac_,
+         internalId_.thirdNeutFrac_,
+         internalId_.fourthNeutFrac_);
+
+  covMatrix(0, 0) /= sumPt2;
+  covMatrix(0, 1) /= sumPt2;
+  covMatrix(1, 1) /= sumPt2;
+  covMatrix(1, 0) = covMatrix(0, 1);
+  internalId_.etaW_ = sqrt(covMatrix(0, 0));
+  internalId_.phiW_ = sqrt(covMatrix(1, 1));
+  internalId_.jetW_ = 0.5 * (internalId_.etaW_ + internalId_.phiW_);
+  TVectorD eigVals(2);
+  eigVals = TMatrixDSymEigen(covMatrix).GetEigenValues();
+  internalId_.majW_ = sqrt(std::abs(eigVals(0)));
+  internalId_.minW_ = sqrt(std::abs(eigVals(1)));
+  if (internalId_.majW_ < internalId_.minW_) {
+    std::swap(internalId_.majW_, internalId_.minW_);
+  }
+
+  internalId_.dRLeadCent_ = reco::deltaR(*jet, *lLead);
+  if (lSecond == nullptr) {
+    internalId_.dRLead2nd_ = reco::deltaR(*jet, *lSecond);
+  }
+  internalId_.dRMean_ /= jetPt;
+  internalId_.dRMeanNeut_ /= jetPt;
+  internalId_.dRMeanEm_ /= jetPt;
+  internalId_.dRMeanCh_ /= jetPt;
+  internalId_.dR2Mean_ /= sumPt2;
+
+  for (size_t ic = 0; ic < ncones; ++ic) {
+    *coneFracs[ic] /= jetPt;
+    *coneEmFracs[ic] /= jetPt;
+    *coneNeutFracs[ic] /= jetPt;
+    *coneChFracs[ic] /= jetPt;
+  }
+  //http://jets.physics.harvard.edu/qvg/
+  double ptMean = sumPt / internalId_.nParticles_;
+  double ptRMS = 0;
+  for (unsigned int i0 = 0; i0 < frac.size(); i0++) {
+    ptRMS += (frac[i0] - ptMean) * (frac[i0] - ptMean);
+  }
+  ptRMS /= internalId_.nParticles_;
+  ptRMS = sqrt(ptRMS);
+
+  internalId_.ptMean_ = ptMean;
+  internalId_.ptRMS_ = ptRMS / jetPt;
+  internalId_.pt2A_ = sqrt(internalId_.ptD_ / internalId_.nParticles_) / jetPt;
+  internalId_.ptD_ = sqrt(internalId_.ptD_) / sumPt;
+  internalId_.ptDCh_ = sqrt(internalId_.ptDCh_) / sumPtCh;
+  internalId_.ptDNe_ = sqrt(internalId_.ptDNe_) / sumPtNe;
+  internalId_.sumPt_ = sumPt;
+  internalId_.sumChPt_ = sumPtCh;
+  internalId_.sumNePt_ = sumPtNe;
+
+  internalId_.jetR_ = lLead->pt() / sumPt;
+  internalId_.jetRchg_ = lLeadCh->pt() / sumPt;
+  internalId_.dRMatch_ = dRmin;
+
+  if (sumTkPt != 0.) {
+    internalId_.beta_ /= sumTkPt;
+    internalId_.betaStar_ /= sumTkPt;
+    internalId_.betaClassic_ /= sumTkPt;
+    internalId_.betaStarClassic_ /= sumTkPt;
+  } else {
+    assert(internalId_.beta_ == 0. && internalId_.betaStar_ == 0. && internalId_.betaClassic_ == 0. &&
+           internalId_.betaStarClassic_ == 0.);
+  }
+
+  if (cache_->runMvas()) {
+    runMva();
+  }
+
+  return PileupJetIdentifier(internalId_);
 }
 
-
-
 // ------------------------------------------------------------------------------------------
-std::string PileupJetIdAlgo::dumpVariables() const
-{
-	std::stringstream out;
-	for(variables_list_t::const_iterator it=variables_.begin(); 
-	    it!=variables_.end(); ++it ) {
-		out << std::setw(15) << it->first << std::setw(3) << "=" 
-		    << std::setw(5) << *it->second.first 
-		    << " (" << std::setw(5) << it->second.second << ")" << std::endl;
-	}
-	return out.str();
+std::string PileupJetIdAlgo::dumpVariables() const {
+  std::stringstream out;
+  for (variables_list_t::const_iterator it = variables_.begin(); it != variables_.end(); ++it) {
+    out << std::setw(15) << it->first << std::setw(3) << "=" << std::setw(5) << *it->second.first << " ("
+        << std::setw(5) << it->second.second << ")" << std::endl;
+  }
+  return out.str();
 }
 
 // ------------------------------------------------------------------------------------------
-void PileupJetIdAlgo::resetVariables()
-{
-	internalId_.idFlag_    = 0;
-	for(variables_list_t::iterator it=variables_.begin(); 
-	    it!=variables_.end(); ++it ) {
-		*it->second.first = it->second.second;
-	}
+void PileupJetIdAlgo::resetVariables() {
+  internalId_.idFlag_ = 0;
+  for (variables_list_t::iterator it = variables_.begin(); it != variables_.end(); ++it) {
+    *it->second.first = it->second.second;
+  }
 }
 
 // ------------------------------------------------------------------------------------------
-#define INIT_VARIABLE(NAME,TMVANAME,VAL)	\
-	internalId_.NAME ## _ = VAL; \
-	variables_[ # NAME   ] = std::make_pair(& internalId_.NAME ## _, VAL);
+#define INIT_VARIABLE(NAME, TMVANAME, VAL) \
+  internalId_.NAME##_ = VAL;               \
+  variables_[#NAME] = std::make_pair(&internalId_.NAME##_, VAL);
 
 // ------------------------------------------------------------------------------------------
-void PileupJetIdAlgo::initVariables()
-{
-	internalId_.idFlag_    = 0;
-  	INIT_VARIABLE(mva        , "", -100.);
-	//INIT_VARIABLE(jetPt      , "jspt_1", 0.);
-	//INIT_VARIABLE(jetEta     , "jseta_1", large_val);
-	INIT_VARIABLE(jetPt      , "", 0.);
-	INIT_VARIABLE(jetEta     , "", large_val);
-	INIT_VARIABLE(jetPhi     , "jsphi_1", large_val);
-	INIT_VARIABLE(jetM       , "jm_1", 0.);
+void PileupJetIdAlgo::initVariables() {
+  internalId_.idFlag_ = 0;
+  INIT_VARIABLE(mva, "", -100.);
+  //INIT_VARIABLE(jetPt      , "jspt_1", 0.);
+  //INIT_VARIABLE(jetEta     , "jseta_1", large_val);
+  INIT_VARIABLE(jetPt, "", 0.);
+  INIT_VARIABLE(jetEta, "", large_val);
+  INIT_VARIABLE(jetPhi, "jsphi_1", large_val);
+  INIT_VARIABLE(jetM, "jm_1", 0.);
 
-	INIT_VARIABLE(nCharged   , "", 0.);
-	INIT_VARIABLE(nNeutrals  , "", 0.);
-	
-	INIT_VARIABLE(chgEMfrac  , "", 0.);
-	INIT_VARIABLE(neuEMfrac  , "", 0.);
-	INIT_VARIABLE(chgHadrfrac, "", 0.);
-	INIT_VARIABLE(neuHadrfrac, "", 0.);
-	
-	INIT_VARIABLE(d0         , "jd0_1"    , -1000.);   
-	INIT_VARIABLE(dZ         , "jdZ_1"    , -1000.);  
-	//INIT_VARIABLE(nParticles , "npart_1"  , 0.);  
-	INIT_VARIABLE(nParticles , ""  , 0.);  
-	
-	INIT_VARIABLE(leadPt     , "lpt_1"    , 0.);  
-	INIT_VARIABLE(leadEta    , "leta_1"   , large_val);  
-	INIT_VARIABLE(leadPhi    , "lphi_1"   , large_val);  
-	INIT_VARIABLE(secondPt   , "spt_1"    , 0.);  
-	INIT_VARIABLE(secondEta  , "seta_1"   , large_val);  
-	INIT_VARIABLE(secondPhi  , "sphi_1"   , large_val);  
-	INIT_VARIABLE(leadNeutPt , "lnept_1"    , 0.);  
-	INIT_VARIABLE(leadNeutEta, "lneeta_1"   , large_val);  
-	INIT_VARIABLE(leadNeutPhi, "lnephi_1"   , large_val);  
-	INIT_VARIABLE(leadEmPt   , "lempt_1"  , 0.);  
-	INIT_VARIABLE(leadEmEta  , "lemeta_1" , large_val);  
-	INIT_VARIABLE(leadEmPhi  , "lemphi_1" , large_val);  
-	INIT_VARIABLE(leadChPt   , "lchpt_1"  , 0.);  
-	INIT_VARIABLE(leadChEta  , "lcheta_1" , large_val);  
-	INIT_VARIABLE(leadChPhi  , "lchphi_1" , large_val);  
-	INIT_VARIABLE(leadFrac   , "lLfr_1"   , 0.);  
-	
-	INIT_VARIABLE(dRLeadCent , "drlc_1"   , 0.);  
-	INIT_VARIABLE(dRLead2nd  , "drls_1"   , 0.);  
-	INIT_VARIABLE(dRMean     , "drm_1"    , 0.);  
-	INIT_VARIABLE(dRMean     , ""    , 0.);  
-	INIT_VARIABLE(pull       , ""    , 0.);
-	INIT_VARIABLE(dRMeanNeut , "drmne_1"  , 0.);  
-	INIT_VARIABLE(dRMeanEm   , "drem_1"   , 0.);  
-	INIT_VARIABLE(dRMeanCh   , "drch_1"   , 0.);  
-	INIT_VARIABLE(dR2Mean    , ""         , 0.);  
-		
-	INIT_VARIABLE(ptD        , "", 0.);
-	INIT_VARIABLE(ptMean     , "", 0.);
-	INIT_VARIABLE(ptRMS      , "", 0.);
-	INIT_VARIABLE(pt2A       , "", 0.);
-	INIT_VARIABLE(ptDCh      , "", 0.);
-	INIT_VARIABLE(ptDNe      , "", 0.);
-	INIT_VARIABLE(sumPt      , "", 0.);
-	INIT_VARIABLE(sumChPt    , "", 0.);
-	INIT_VARIABLE(sumNePt    , "", 0.);
+  INIT_VARIABLE(nCharged, "", 0.);
+  INIT_VARIABLE(nNeutrals, "", 0.);
 
-	INIT_VARIABLE(secondFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthFrac  ,"" ,0.);  
+  INIT_VARIABLE(chgEMfrac, "", 0.);
+  INIT_VARIABLE(neuEMfrac, "", 0.);
+  INIT_VARIABLE(chgHadrfrac, "", 0.);
+  INIT_VARIABLE(neuHadrfrac, "", 0.);
 
-	INIT_VARIABLE(leadChFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondChFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdChFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthChFrac  ,"" ,0.);  
+  INIT_VARIABLE(d0, "jd0_1", -1000.);
+  INIT_VARIABLE(dZ, "jdZ_1", -1000.);
+  //INIT_VARIABLE(nParticles , "npart_1"  , 0.);
+  INIT_VARIABLE(nParticles, "", 0.);
 
-	INIT_VARIABLE(leadNeutFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondNeutFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdNeutFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthNeutFrac  ,"" ,0.);  
+  INIT_VARIABLE(leadPt, "lpt_1", 0.);
+  INIT_VARIABLE(leadEta, "leta_1", large_val);
+  INIT_VARIABLE(leadPhi, "lphi_1", large_val);
+  INIT_VARIABLE(secondPt, "spt_1", 0.);
+  INIT_VARIABLE(secondEta, "seta_1", large_val);
+  INIT_VARIABLE(secondPhi, "sphi_1", large_val);
+  INIT_VARIABLE(leadNeutPt, "lnept_1", 0.);
+  INIT_VARIABLE(leadNeutEta, "lneeta_1", large_val);
+  INIT_VARIABLE(leadNeutPhi, "lnephi_1", large_val);
+  INIT_VARIABLE(leadEmPt, "lempt_1", 0.);
+  INIT_VARIABLE(leadEmEta, "lemeta_1", large_val);
+  INIT_VARIABLE(leadEmPhi, "lemphi_1", large_val);
+  INIT_VARIABLE(leadChPt, "lchpt_1", 0.);
+  INIT_VARIABLE(leadChEta, "lcheta_1", large_val);
+  INIT_VARIABLE(leadChPhi, "lchphi_1", large_val);
+  INIT_VARIABLE(leadFrac, "lLfr_1", 0.);
 
-	INIT_VARIABLE(leadEmFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondEmFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdEmFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthEmFrac  ,"" ,0.);  
+  INIT_VARIABLE(dRLeadCent, "drlc_1", 0.);
+  INIT_VARIABLE(dRLead2nd, "drls_1", 0.);
+  INIT_VARIABLE(dRMean, "drm_1", 0.);
+  INIT_VARIABLE(dRMean, "", 0.);
+  INIT_VARIABLE(pull, "", 0.);
+  INIT_VARIABLE(dRMeanNeut, "drmne_1", 0.);
+  INIT_VARIABLE(dRMeanEm, "drem_1", 0.);
+  INIT_VARIABLE(dRMeanCh, "drch_1", 0.);
+  INIT_VARIABLE(dR2Mean, "", 0.);
 
-	INIT_VARIABLE(jetW  ,"" ,1.);  
-	INIT_VARIABLE(etaW  ,"" ,1.);  
-	INIT_VARIABLE(phiW  ,"" ,1.);  
+  INIT_VARIABLE(ptD, "", 0.);
+  INIT_VARIABLE(ptMean, "", 0.);
+  INIT_VARIABLE(ptRMS, "", 0.);
+  INIT_VARIABLE(pt2A, "", 0.);
+  INIT_VARIABLE(ptDCh, "", 0.);
+  INIT_VARIABLE(ptDNe, "", 0.);
+  INIT_VARIABLE(sumPt, "", 0.);
+  INIT_VARIABLE(sumChPt, "", 0.);
+  INIT_VARIABLE(sumNePt, "", 0.);
 
-	INIT_VARIABLE(majW  ,"" ,1.);  
-	INIT_VARIABLE(minW  ,"" ,1.);  
+  INIT_VARIABLE(secondFrac, "", 0.);
+  INIT_VARIABLE(thirdFrac, "", 0.);
+  INIT_VARIABLE(fourthFrac, "", 0.);
 
-	INIT_VARIABLE(frac01    ,"" ,0.);  
-	INIT_VARIABLE(frac02    ,"" ,0.);  
-	INIT_VARIABLE(frac03    ,"" ,0.);  
-	INIT_VARIABLE(frac04    ,"" ,0.);
-	INIT_VARIABLE(frac05   ,"" ,0.);  
-	INIT_VARIABLE(frac06   ,"" ,0.);  
-	INIT_VARIABLE(frac07   ,"" ,0.);
-		
-	INIT_VARIABLE(chFrac01    ,"" ,0.);  
-	INIT_VARIABLE(chFrac02    ,"" ,0.);
-	INIT_VARIABLE(chFrac03    ,"" ,0.);  
-	INIT_VARIABLE(chFrac04    ,"" ,0.);  
-	INIT_VARIABLE(chFrac05   ,"" ,0.);  
-	INIT_VARIABLE(chFrac06   ,"" ,0.);  
-	INIT_VARIABLE(chFrac07   ,"" ,0.);  
+  INIT_VARIABLE(leadChFrac, "", 0.);
+  INIT_VARIABLE(secondChFrac, "", 0.);
+  INIT_VARIABLE(thirdChFrac, "", 0.);
+  INIT_VARIABLE(fourthChFrac, "", 0.);
 
-	INIT_VARIABLE(neutFrac01    ,"" ,0.);  
-	INIT_VARIABLE(neutFrac02    ,"" ,0.);  
-	INIT_VARIABLE(neutFrac03    ,"" ,0.);  
-	INIT_VARIABLE(neutFrac04    ,"" ,0.);  
-	INIT_VARIABLE(neutFrac05   ,"" ,0.);  
-	INIT_VARIABLE(neutFrac06   ,"" ,0.);  
-	INIT_VARIABLE(neutFrac07   ,"" ,0.);  
+  INIT_VARIABLE(leadNeutFrac, "", 0.);
+  INIT_VARIABLE(secondNeutFrac, "", 0.);
+  INIT_VARIABLE(thirdNeutFrac, "", 0.);
+  INIT_VARIABLE(fourthNeutFrac, "", 0.);
 
-	INIT_VARIABLE(emFrac01    ,"" ,0.);  
-	INIT_VARIABLE(emFrac02    ,"" ,0.);  
-	INIT_VARIABLE(emFrac03    ,"" ,0.);  
-	INIT_VARIABLE(emFrac04    ,"" ,0.);  
-	INIT_VARIABLE(emFrac05   ,"" ,0.);  
-	INIT_VARIABLE(emFrac06   ,"" ,0.);  
-	INIT_VARIABLE(emFrac07   ,"" ,0.);  
+  INIT_VARIABLE(leadEmFrac, "", 0.);
+  INIT_VARIABLE(secondEmFrac, "", 0.);
+  INIT_VARIABLE(thirdEmFrac, "", 0.);
+  INIT_VARIABLE(fourthEmFrac, "", 0.);
 
-	INIT_VARIABLE(beta   ,"" ,0.);  
-	INIT_VARIABLE(betaStar   ,"" ,0.);  
-	INIT_VARIABLE(betaClassic   ,"" ,0.);  
-	INIT_VARIABLE(betaStarClassic   ,"" ,0.);  
+  INIT_VARIABLE(jetW, "", 1.);
+  INIT_VARIABLE(etaW, "", 1.);
+  INIT_VARIABLE(phiW, "", 1.);
 
-	INIT_VARIABLE(nvtx   ,"" ,0.);  
-	INIT_VARIABLE(rho   ,"" ,0.);  
-	INIT_VARIABLE(nTrueInt   ,"" ,0.);
+  INIT_VARIABLE(majW, "", 1.);
+  INIT_VARIABLE(minW, "", 1.);
 
-	INIT_VARIABLE(jetR       , "", 0.);
-	INIT_VARIABLE(jetRchg    , "", 0.);
-	INIT_VARIABLE(dRMatch    , "", 0.);
-	
+  INIT_VARIABLE(frac01, "", 0.);
+  INIT_VARIABLE(frac02, "", 0.);
+  INIT_VARIABLE(frac03, "", 0.);
+  INIT_VARIABLE(frac04, "", 0.);
+  INIT_VARIABLE(frac05, "", 0.);
+  INIT_VARIABLE(frac06, "", 0.);
+  INIT_VARIABLE(frac07, "", 0.);
+
+  INIT_VARIABLE(chFrac01, "", 0.);
+  INIT_VARIABLE(chFrac02, "", 0.);
+  INIT_VARIABLE(chFrac03, "", 0.);
+  INIT_VARIABLE(chFrac04, "", 0.);
+  INIT_VARIABLE(chFrac05, "", 0.);
+  INIT_VARIABLE(chFrac06, "", 0.);
+  INIT_VARIABLE(chFrac07, "", 0.);
+
+  INIT_VARIABLE(neutFrac01, "", 0.);
+  INIT_VARIABLE(neutFrac02, "", 0.);
+  INIT_VARIABLE(neutFrac03, "", 0.);
+  INIT_VARIABLE(neutFrac04, "", 0.);
+  INIT_VARIABLE(neutFrac05, "", 0.);
+  INIT_VARIABLE(neutFrac06, "", 0.);
+  INIT_VARIABLE(neutFrac07, "", 0.);
+
+  INIT_VARIABLE(emFrac01, "", 0.);
+  INIT_VARIABLE(emFrac02, "", 0.);
+  INIT_VARIABLE(emFrac03, "", 0.);
+  INIT_VARIABLE(emFrac04, "", 0.);
+  INIT_VARIABLE(emFrac05, "", 0.);
+  INIT_VARIABLE(emFrac06, "", 0.);
+  INIT_VARIABLE(emFrac07, "", 0.);
+
+  INIT_VARIABLE(beta, "", 0.);
+  INIT_VARIABLE(betaStar, "", 0.);
+  INIT_VARIABLE(betaClassic, "", 0.);
+  INIT_VARIABLE(betaStarClassic, "", 0.);
+
+  INIT_VARIABLE(nvtx, "", 0.);
+  INIT_VARIABLE(rho, "", 0.);
+  INIT_VARIABLE(nTrueInt, "", 0.);
+
+  INIT_VARIABLE(jetR, "", 0.);
+  INIT_VARIABLE(jetRchg, "", 0.);
+  INIT_VARIABLE(dRMatch, "", 0.);
 }
 
 #undef INIT_VARIABLE


### PR DESCRIPTION
#### PR description:

This PR is a backport to 106X release. 
The original PR is [#30773](https://github.com/cms-sw/cmssw/pull/30773) and is already merged to the master branch.

There are two commits, the first (2f6a515) includes the actual changes for the UL17 WPs inclusion and the second  
(0d2effe) includes the automatic changes after:
scram build code-checks
scram build code-format
which introduces the large number of lines added/changed with respect to #30773. 
After the second commit, the files:
  RecoJets/JetProducers/interface/PileupJetIdAlgo.h and
  RecoJets/JetProducers/src/PileupJetIdAlgo.cc 
are now identical to the ones in the master branch.


FYI: @alefisico @camclean @singh-ramanpreet