### PR TITLE
PFProducer fix for PFMuonAlgo's fillPSetDescription

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -170,10 +170,20 @@ def customiseFor2017DtUnpacking(process):
 
     return process
 
+def customiseFor30936(process):
+    """PFProducer fix for PFMuonAlgo's fillPSetDescription"""
+
+    for producer in producers_by_type(process, "PFProducer"):
+        del producer.PFMuonAlgoParameters
+        # The parameters should be populated automatically via fillPSetDescription
+        
+    return process
+            
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseFor30936(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -176,6 +176,18 @@ def customiseFor30936(process):
     for producer in producers_by_type(process, "PFProducer"):
         del producer.PFMuonAlgoParameters
         # The parameters should be populated automatically via fillPSetDescription
+
+    # for PFBlockProducer
+    for producer in producers_by_type(process, "PFBlockProducer"):
+        if hasattr(producer,'elementImporters'):
+            for ps in producer.elementImporters.value():
+                if hasattr(ps,'importerName') and (ps.importerName == 'GeneralTracksImporter'):
+                    if not hasattr(ps,'muonMaxDPtOPt'):
+                        ps.muonMaxDPtOPt = cms.double(1)            # <== to be added
+                    if not hasattr(ps,'trackQuality'):
+                        ps.trackQuality = cms.string("highPurity")  # <== to be added
+                    if not hasattr(ps,'cleanBadConvertedBrems'):
+                        ps.cleanBadConvertedBrems = cms.bool(False) # <== to be added
         
     return process
             

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -56,10 +56,13 @@ particleFlowBlock.elementImporters = cms.VPSet(
     cms.PSet( importerName = cms.string("GeneralTracksImporter"),
               source = cms.InputTag("pfTrack"),
               muonSrc = cms.InputTag("hiMuons1stStep"),
+              trackQuality = cms.string("highPurity"),
+              cleanBadConvertedBrems = cms.bool(False),
               useIterativeTracking = cms.bool(False),
               DPtOverPtCuts_byTrackAlgo = cms.vdouble(-1.0,-1.0,-1.0,
                                                        1.0,1.0),
-              NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3)
+              NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3),
+              muonMaxDPtOPt = cms.double(1)
               ),
     # to properly set SC based links you need to run ECAL importer
     # after you've imported all SCs to the block

--- a/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
@@ -40,7 +40,7 @@ public:
   static void printMuonProperties(const reco::MuonRef& muonRef);
 
   ////POST CLEANING AND MOMEMNTUM ASSIGNMENT
-  bool hasValidTrack(const reco::MuonRef& muonRef, bool loose = false);
+  static bool hasValidTrack(const reco::MuonRef& muonRef, bool loose, double maxDPtOPt);
 
   //Make a PF Muon : Basic method
   bool reconstructMuon(reco::PFCandidate&, const reco::MuonRef&, bool allowLoose = false);
@@ -76,16 +76,13 @@ public:
     return std::move(pfAddedMuonCandidates_);
   }
 
+  static std::vector<reco::Muon::MuonTrackTypePair> muonTracks(const reco::MuonRef& muon,
+                                                               double maxDPtOPt = 1e+9,
+                                                               bool includeSA = false);
+
 private:
-  //Gives the track with the smallest Dpt/Pt
+  //Give the track with the smallest Dpt/Pt
   MuonTrackTypePair getTrackWithSmallestError(const std::vector<MuonTrackTypePair>&);
-
-  std::vector<reco::Muon::MuonTrackTypePair> muonTracks(const reco::MuonRef& muon,
-                                                        bool includeSA = false,
-                                                        double dpt = 1e+9);
-
-  //Gets the good tracks
-  std::vector<reco::Muon::MuonTrackTypePair> goodMuonTracks(const reco::MuonRef& muon, bool includeSA = false);
 
   //Estimate MET and SUmET for post cleaning
   void estimateEventQuantities(const reco::PFCandidateCollection*);

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -144,8 +144,10 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig)
 
   // Reading new EGamma selection cuts
   bool useProtectionsForJetMET(false);
+
   // Reading new EGamma ubiased collections and value maps
   if (use_EGammaFilters_) {
+
     inputTagPFEGammaCandidates_ =
         consumes<edm::View<reco::PFCandidate>>((iConfig.getParameter<edm::InputTag>("PFEGammaCandidates")));
     inputTagValueMapGedElectrons_ =
@@ -153,7 +155,15 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig)
     inputTagValueMapGedPhotons_ =
         consumes<edm::ValueMap<reco::PhotonRef>>(iConfig.getParameter<edm::InputTag>("GedPhotonValueMap"));
     useProtectionsForJetMET = iConfig.getParameter<bool>("useProtectionsForJetMET");
+
+    const edm::ParameterSet pfEGammaFiltersParams =
+        iConfig.getParameter<edm::ParameterSet>("PFEGammaFiltersParameters");
+    pfegamma_ = std::make_unique<PFEGammaFilters>(pfEGammaFiltersParams);
+
   }
+
+  // EGamma filters
+  pfAlgo_.setEGammaParameters(use_EGammaFilters_, useProtectionsForJetMET);
 
   //Secondary tracks and displaced vertices parameters
 
@@ -173,15 +183,6 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig)
 
   if (useCalibrationsFromDB_)
     calibrationsLabel_ = iConfig.getParameter<std::string>("calibrationsLabel");
-
-  // EGamma filters
-  pfAlgo_.setEGammaParameters(use_EGammaFilters_, useProtectionsForJetMET);
-
-  if (use_EGammaFilters_) {
-    const edm::ParameterSet pfEGammaFiltersParams =
-        iConfig.getParameter<edm::ParameterSet>("PFEGammaFiltersParameters");
-    pfegamma_ = std::make_unique<PFEGammaFilters>(pfEGammaFiltersParams);
-  }
 
   // Secondary tracks and displaced vertices parameters
   pfAlgo_.setDisplacedVerticesParameters(
@@ -349,7 +350,7 @@ void PFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
   // For PFMuonAlgo
   edm::ParameterSetDescription psd_PFMuonAlgo;
-  PFEGammaFilters::fillPSetDescription(psd_PFMuonAlgo);
+  PFMuonAlgo::fillPSetDescription(psd_PFMuonAlgo);
   desc.add<edm::ParameterSetDescription>("PFMuonAlgoParameters", psd_PFMuonAlgo);
 
   // Input displaced vertices

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -147,7 +147,6 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig)
 
   // Reading new EGamma ubiased collections and value maps
   if (use_EGammaFilters_) {
-
     inputTagPFEGammaCandidates_ =
         consumes<edm::View<reco::PFCandidate>>((iConfig.getParameter<edm::InputTag>("PFEGammaCandidates")));
     inputTagValueMapGedElectrons_ =
@@ -159,7 +158,6 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig)
     const edm::ParameterSet pfEGammaFiltersParams =
         iConfig.getParameter<edm::ParameterSet>("PFEGammaFiltersParameters");
     pfegamma_ = std::make_unique<PFEGammaFilters>(pfEGammaFiltersParams);
-
   }
 
   // EGamma filters

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -1,12 +1,10 @@
-#include <memory>
-
-#include "DataFormats/Common/interface/ValueMap.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 
@@ -17,18 +15,12 @@ public:
         src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
         veto_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("veto"))),
         muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
-        trackQuality_((conf.existsAs<std::string>("trackQuality"))
-                          ? reco::TrackBase::qualityByName(conf.getParameter<std::string>("trackQuality"))
-                          : reco::TrackBase::highPurity),
+        trackQuality_(reco::TrackBase::qualityByName(conf.getParameter<std::string>("trackQuality"))),
         DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
         NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
         useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
-        cleanBadConvBrems_(
-            conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false) {
-    bool postMuonCleaning =
-        conf.existsAs<bool>("postMuonCleaning") ? conf.getParameter<bool>("postMuonCleaning") : false;
-    pfmu_ = std::make_unique<PFMuonAlgo>(conf, postMuonCleaning);
-  }
+        cleanBadConvBrems_(conf.getParameter<bool>("cleanBadConvertedBrems")),
+        muonMaxDPtOPt_(conf.getParameter<double>("muonMaxDPtOPt")) {}
 
   void importToBlock(const edm::Event&, ElementList&) const override;
 
@@ -41,8 +33,7 @@ private:
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
   const bool useIterTracking_, cleanBadConvBrems_;
-
-  std::unique_ptr<PFMuonAlgo> pfmu_;
+  const double muonMaxDPtOPt_;
 };
 
 DEFINE_EDM_PLUGIN(BlockElementImporterFactory, GeneralTracksImporterWithVeto, "GeneralTracksImporterWithVeto");
@@ -126,8 +117,9 @@ void GeneralTracksImporterWithVeto::importToBlock(const edm::Event& e,
     bool thisIsAPotentialMuon = false;
     if (muId != -1) {
       muonref = reco::MuonRef(muons, muId);
-      thisIsAPotentialMuon = ((pfmu_->hasValidTrack(muonref, true) && PFMuonAlgo::isLooseMuon(muonref)) ||
-                              (pfmu_->hasValidTrack(muonref, false) && PFMuonAlgo::isMuon(muonref)));
+      thisIsAPotentialMuon =
+          ((PFMuonAlgo::hasValidTrack(muonref, true, muonMaxDPtOPt_) && PFMuonAlgo::isLooseMuon(muonref)) ||
+           (PFMuonAlgo::hasValidTrack(muonref, false, muonMaxDPtOPt_) && PFMuonAlgo::isMuon(muonref)));
     }
     if (thisIsAPotentialMuon || PFTrackAlgoTools::goodPtResolution(
                                     pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_)) {

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -46,7 +46,8 @@ particleFlowBlock = cms.EDProducer(
                   useIterativeTracking = cms.bool(True),
                   DPtOverPtCuts_byTrackAlgo = cms.vdouble(10.0,10.0,10.0,
                                                            10.0,10.0,5.0),
-                  NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,3)
+                  NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,3),
+                  muonMaxDPtOPt = cms.double(1)
                   ),
         # secondary GSF tracks are also turned off
         #cms.PSet( importerName = cms.string("GSFTrackImporter"),


### PR DESCRIPTION
#### PR description:

Use the PFMuonAlgo's fillPSetDescription for PFMuonAlgo (instead of PFEGammaFilters's one). This was an oversight of the previous refactor work.
This fix was made based on the issue reported here: https://github.com/cms-sw/cmssw/issues/30849.

Also, some functions of PFMuonAlgo were made static to simpler calls from GeneralTracksImporter(WithVeto).

#### PR validation:
 
Made sure it compiles. Also ran matrix test 10824.0 (2018 ttbar) and made sure that the output doesn't have any change.
Also tested with 11634.0 (ttbar 2021) and 23234.0 (ttbar 2026D49).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

@bendavid @guitargeek 
