### PR TITLE
Migrate to c++17 filesystem in FWCore/Utilities

### DIFF
--- a/FWCore/Utilities/BuildFile.xml
+++ b/FWCore/Utilities/BuildFile.xml
@@ -1,10 +1,10 @@
 <use name="boost"/>
-<use name="boost_filesystem"/>
 <use name="boost_regex"/>
 <use name="libuuid"/>
 <use name="fmt"/>
 <use name="tbb"/>
 <use name="md5"/>
+<use name="stdcxx-fs"/>
 <export>
   <lib name="1"/>
 </export>

--- a/FWCore/Utilities/interface/stemFromPath.h
+++ b/FWCore/Utilities/interface/stemFromPath.h
@@ -10,7 +10,7 @@ namespace edm {
   // object lives long enough.
   //
   // The reason to have our own function instead of
-  // std/boost::filesystem is that tehcnically these paths are not
+  // std::filesystem is that tehcnically these paths are not
   // filesystem paths, but paths in CMS LFN/PFN space that (may) have
   // different rules.
   std::string_view stemFromPath(std::string_view path);

--- a/FWCore/Utilities/src/TestHelper.cc
+++ b/FWCore/Utilities/src/TestHelper.cc
@@ -3,6 +3,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <exception>
+#include <filesystem>
 #include <iostream>
 #include <string>
 
@@ -10,16 +11,13 @@
 #include <unistd.h>
 #include <cstring>
 
-#include "boost/version.hpp"
-#include "boost/filesystem/convenience.hpp"
-
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/RegexMatch.h"
 #include "FWCore/Utilities/interface/TestHelper.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
-namespace bf = boost::filesystem;
+namespace bf = std::filesystem;
 
 int run_script(std::string const& shell, std::string const& script) {
   pid_t pid = 0;
@@ -56,7 +54,7 @@ int run_script(std::string const& shell, std::string const& script) {
 }
 
 int do_work(int argc, char* argv[], char** env) {
-  bf::path currentPath(bf::initial_path().string());
+  bf::path currentPath(bf::current_path().string());
 
   if (argc < 4) {
     std::cout << "Usage: " << argv[0] << " shell subdir script1 script2 ... scriptN\n\n"
@@ -106,11 +104,8 @@ int do_work(int argc, char* argv[], char** env) {
   if (!arch) {
     // Try to synthesize SCRAM_ARCH value.
     bf::path exepath(argv[0]);
-#if (BOOST_VERSION / 100000) >= 1 && ((BOOST_VERSION / 100) % 1000) >= 47
     std::string maybe_arch = exepath.parent_path().filename().string();
-#else
-    std::string maybe_arch = exepath.branch_path().leaf();
-#endif
+
     if (setenv("SCRAM_ARCH", maybe_arch.c_str(), 1) != 0) {
       std::cerr << "SCRAM_ARCH not set and attempt to set it failed\n";
       return -1;

--- a/FWCore/Utilities/src/resolveSymbolicLinks.cc
+++ b/FWCore/Utilities/src/resolveSymbolicLinks.cc
@@ -1,15 +1,13 @@
 #include "FWCore/Utilities/interface/resolveSymbolicLinks.h"
 #include "FWCore/Utilities/interface/Parse.h"
 
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
-
+#include <filesystem>
 #include <vector>
 
 namespace edm {
 
   namespace {
-    namespace bf = boost::filesystem;
+    namespace bf = std::filesystem;
     bool resolveOneSymbolicLink(std::string& fullPath) {
       if (fullPath.empty())
         return false;


### PR DESCRIPTION
#### PR description:
C++17 filesystem has very similar functionality as boost::filesystem. If possible, we should strive to use the standard library.

Change: 
-  replaced boost::filesystem::initial_path for std::filesystem::current_path. I believe this change makes no difference in this use case.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 
