### PR TITLE
Correct a container type in ALCT processor

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -296,8 +296,8 @@ void CSCAnodeLCTProcessor::run(const std::vector<int> wire[CSCConstants::NUM_LAY
   int ALCTIndex_[CSCConstants::MAX_ALCT_TBINS] = {};
 
   // define a new pattern map
-  // for each key half strip, and for each pattern, store the 2D collection of fired comparator digis
-  std::map<int, std::map<int, CSCCLCTDigi::ComparatorContainer>> hits_in_patterns;
+  // for each key wiregroup, and for each pattern, store the 2D collection of fired wire digis
+  std::map<int, std::map<int, CSCALCTDigi::WireContainer>> hits_in_patterns;
   hits_in_patterns.clear();
 
   // Only do the rest of the processing if chamber is not empty.


### PR DESCRIPTION
#### PR description:

I noticed [here](https://github.com/cms-sw/cmssw/pull/30301#discussion_r461352863) in https://github.com/cms-sw/cmssw/pull/30301 that the ALCT processor uses a `CSCCLCTDigi::ComparatorContainer`. This should obviously be a `CSCALCTDigi::WireContainer`. Both are 2D vectors of ints though.

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A