### PR TITLE
Add packed TDC information to HBHERecHit

### DIFF
--- a/DataFormats/HcalRecHit/interface/HBHERecHit.h
+++ b/DataFormats/HcalRecHit/interface/HBHERecHit.h
@@ -21,8 +21,9 @@ public:
         rawEnergy_(-1.0e21),
         auxEnergy_(-1.0e21),
         auxHBHE_(0),
-        auxPhase1_(0) {}
-  //HBHERecHit(const HcalDetId& id, float energy, float time);
+        auxPhase1_(0),
+        auxTDC_(0) {}
+
   constexpr HBHERecHit(const HcalDetId& id, float energy, float timeRising, float timeFalling = 0)
       : CaloRecHit(id, energy, timeRising),
         timeFalling_(timeFalling),
@@ -30,7 +31,8 @@ public:
         rawEnergy_(-1.0e21),
         auxEnergy_(-1.0e21),
         auxHBHE_(0),
-        auxPhase1_(0) {}
+        auxPhase1_(0),
+        auxTDC_(0) {}
 
   /// get the hit falling time
   constexpr inline float timeFalling() const { return timeFalling_; }
@@ -53,6 +55,9 @@ public:
   constexpr inline void setAuxPhase1(const uint32_t aux) { auxPhase1_ = aux; }
   constexpr inline uint32_t auxPhase1() const { return auxPhase1_; }
 
+  constexpr inline void setAuxTDC(const uint32_t aux) { auxTDC_ = aux; }
+  constexpr inline uint32_t auxTDC() const { return auxTDC_; }
+
   // The following method returns "true" for "Plan 1" merged rechits
   bool isMerged() const;
 
@@ -71,6 +76,7 @@ private:
   float auxEnergy_;
   uint32_t auxHBHE_;
   uint32_t auxPhase1_;
+  uint32_t auxTDC_;
 };
 
 std::ostream& operator<<(std::ostream& s, const HBHERecHit& hit);

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-   <class name="HBHERecHit" ClassVersion="18">
+   <class name="HBHERecHit" ClassVersion="19">
+    <version ClassVersion="19" checksum="3024868190"/>
     <version ClassVersion="18" checksum="642851014"/>
     <version ClassVersion="17" checksum="4076697378"/>
     <version ClassVersion="16" checksum="2359330573"/>

--- a/DataFormats/HcalRecHit/test/HcalRecHitDump.cc
+++ b/DataFormats/HcalRecHit/test/HcalRecHitDump.cc
@@ -12,6 +12,7 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
 
 namespace {
   std::ostream& operator<<(std::ostream& s, const HFQIE10Info& i) {
@@ -74,6 +75,17 @@ namespace {
       allbits[3] = i.auxPhase1();
       s << "; bits: ";
       printBits(s, allbits, bits);
+    }
+
+    // Dump TDC data
+    s << "; tdc:";
+    const uint32_t auxTDC = i.auxTDC();
+    if (auxTDC) {
+      const unsigned six_bits_mask = 0x3f;
+      for (unsigned ts = 0; ts < 5; ++ts)
+        s << ' ' << CaloRecHitAuxSetter::getField(auxTDC, six_bits_mask, ts * 6);
+    } else {
+      s << " none";
     }
   }
 


### PR DESCRIPTION
Added packed TDC information to HBHERecHit class in an additional uint32_t member. This info will be used for Hcal timing studies. Also, added the code which fills this info and updated the rechit dumping code accordingly.

No changes expected in any relval outputs.

#### PR validation:

The usual runTheMatrix tests were run.