### PR TITLE
plugin cache fix: initialize with file_time_type::min

### DIFF
--- a/FWCore/PluginManager/bin/refresh.cc
+++ b/FWCore/PluginManager/bin/refresh.cc
@@ -147,7 +147,7 @@ int main(int argc, char** argv) try {
       path cacheFile(directory);
       cacheFile /= standard::cachefileName();
 
-      std::filesystem::file_time_type cacheLastChange;
+      std::filesystem::file_time_type cacheLastChange = std::filesystem::file_time_type::min();
       if (exists(cacheFile)) {
         cacheLastChange = last_write_time(cacheFile);
       }


### PR DESCRIPTION
This change should fix the GCC9 plugin cache issue. Here we propose to initialize the value with `file_time_type::min()`
FYi @makortel 