### PR TITLE
Online BeamSpot ESProducer for Run3 workflow

### DIFF
--- a/CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h
@@ -22,10 +22,11 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
 
 class BeamSpotTransientObjectsRcd
     : public edm::eventsetup::DependentRecordImplementation<
           BeamSpotTransientObjectsRcd,
-          edm::mpl::Vector<BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineLegacyObjectsRcd> > {};
+          edm::mpl::Vector<BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineLegacyObjectsRcd, BeamSpotObjectsRcd> > {};
 
 #endif

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -5,32 +5,39 @@
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondCore/DBOutputService"/>
+
 <use name="root"/>
 <use name="rootminuit"/>
 <use name="RecoVertex/BeamSpotProducer"/>
+
 <library file="BeamSpotProducer.cc" name="BeamSpotProducer">
   <flags EDM_PLUGIN="1"/>
 </library>
-
 <library file="BeamSpotOnlineProducer.cc" name="BeamSpotOnlineProducer">
   <flags EDM_PLUGIN="1"/>
   <use name="DataFormats/L1GlobalTrigger"/>
   <use name="DataFormats/Scalers"/>
 </library>
-
 <library file="BeamSpotAnalyzer.cc" name="BeamSpotAnalyzer">
   <use name="clhep"/>
   <flags EDM_PLUGIN="1"/>
 </library>
-
 <library file="BeamSpotWrite2DB.cc" name="BeamSpotWrite2DB">
   <flags EDM_PLUGIN="1"/>
 </library>
-
 <library file="BeamSpotFakeConditions.cc" name="BeamSpotFakeConditions">
   <flags EDM_PLUGIN="1"/>
 </library>
-
 <library file="BeamSpotFromDB.cc" name="BeamSpotFromDB">
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="OnlineBeamSpotFromDB.cc" name="OnlineBeamSpotFromDB">
+  <flags EDM_PLUGIN="1"/>
+</library>
+<library file="OnlineBeamSpotESProducer.cc" name="OnlineBeamSpotESProducer">
+  <flags EDM_PLUGIN="1"/>
+</library>
+<library file="OfflineToTransientBeamSpotESProducer.cc" name="OfflineToTransientBeamSpotESProducer">
+  <flags EDM_PLUGIN="1"/>
+</library>
+

--- a/RecoVertex/BeamSpotProducer/plugins/OfflineToTransientBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OfflineToTransientBeamSpotESProducer.cc
@@ -22,13 +22,10 @@ using namespace edm;
 class OfflineToTransientBeamSpotESProducer : public edm::ESProducer {
 public:
   OfflineToTransientBeamSpotESProducer(const edm::ParameterSet& p);
-  //  ~OfflineToTransientBeamSpotESProducer() override;
   std::shared_ptr<const BeamSpotObjects> produce(const BeamSpotTransientObjectsRcd&);
   static void fillDescriptions(edm::ConfigurationDescriptions& desc);
 
 private:
-  //const BeamSpotObjects* theOfflineBS_;
-  //const BeamSpotObjects *transientBS_ = nullptr;
   const BeamSpotObjects dummyBS_;
   edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> const bsToken_;
   edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> bsOfflineToken_;
@@ -40,9 +37,6 @@ OfflineToTransientBeamSpotESProducer::OfflineToTransientBeamSpotESProducer(const
   bsOfflineToken_ = cc.consumesFrom<BeamSpotObjects, BeamSpotObjectsRcd>();
 }
 
-//OfflineToTransientBeamSpotESProducer::~OfflineToTransientBeamSpotESProducer() {
-//delete theOfflineBS_;
-//}
 void OfflineToTransientBeamSpotESProducer::fillDescriptions(edm::ConfigurationDescriptions& desc) {
   edm::ParameterSetDescription dsc;
   desc.addWithDefaultLabel(dsc);

--- a/RecoVertex/BeamSpotProducer/plugins/OfflineToTransientBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OfflineToTransientBeamSpotESProducer.cc
@@ -22,7 +22,7 @@ using namespace edm;
 class OfflineToTransientBeamSpotESProducer : public edm::ESProducer {
 public:
   OfflineToTransientBeamSpotESProducer(const edm::ParameterSet& p);
-  ~OfflineToTransientBeamSpotESProducer() override;
+  //  ~OfflineToTransientBeamSpotESProducer() override;
   std::shared_ptr<const BeamSpotObjects> produce(const BeamSpotTransientObjectsRcd&);
   static void fillDescriptions(edm::ConfigurationDescriptions& desc);
 
@@ -40,9 +40,9 @@ OfflineToTransientBeamSpotESProducer::OfflineToTransientBeamSpotESProducer(const
   bsOfflineToken_ = cc.consumesFrom<BeamSpotObjects, BeamSpotObjectsRcd>();
 }
 
-OfflineToTransientBeamSpotESProducer::~OfflineToTransientBeamSpotESProducer() {
-  //delete theOfflineBS_;
-}
+//OfflineToTransientBeamSpotESProducer::~OfflineToTransientBeamSpotESProducer() {
+//delete theOfflineBS_;
+//}
 void OfflineToTransientBeamSpotESProducer::fillDescriptions(edm::ConfigurationDescriptions& desc) {
   edm::ParameterSetDescription dsc;
   desc.addWithDefaultLabel(dsc);

--- a/RecoVertex/BeamSpotProducer/plugins/OfflineToTransientBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OfflineToTransientBeamSpotESProducer.cc
@@ -1,0 +1,59 @@
+#include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Utilities/interface/do_nothing_deleter.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace edm;
+class OfflineToTransientBeamSpotESProducer : public edm::ESProducer {
+public:
+  OfflineToTransientBeamSpotESProducer(const edm::ParameterSet& p);
+  ~OfflineToTransientBeamSpotESProducer() override;
+  std::shared_ptr<const BeamSpotObjects> produce(const BeamSpotTransientObjectsRcd&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& desc);
+
+private:
+  //const BeamSpotObjects* theOfflineBS_;
+  //const BeamSpotObjects *transientBS_ = nullptr;
+  const BeamSpotObjects dummyBS_;
+  edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> const bsToken_;
+  edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> bsOfflineToken_;
+};
+
+OfflineToTransientBeamSpotESProducer::OfflineToTransientBeamSpotESProducer(const edm::ParameterSet& p) {
+  auto cc = setWhatProduced(this);
+
+  bsOfflineToken_ = cc.consumesFrom<BeamSpotObjects, BeamSpotObjectsRcd>();
+}
+
+OfflineToTransientBeamSpotESProducer::~OfflineToTransientBeamSpotESProducer() {
+  //delete theOfflineBS_;
+}
+void OfflineToTransientBeamSpotESProducer::fillDescriptions(edm::ConfigurationDescriptions& desc) {
+  edm::ParameterSetDescription dsc;
+  desc.addWithDefaultLabel(dsc);
+}
+std::shared_ptr<const BeamSpotObjects> OfflineToTransientBeamSpotESProducer::produce(
+    const BeamSpotTransientObjectsRcd& iRecord) {
+  auto optionalRec = iRecord.tryToGetRecord<BeamSpotObjectsRcd>();
+  if (not optionalRec) {
+    return std::shared_ptr<const BeamSpotObjects>(&dummyBS_, edm::do_nothing_deleter());
+  }
+  return std::shared_ptr<const BeamSpotObjects>(&optionalRec->get(bsOfflineToken_), edm::do_nothing_deleter());
+};
+
+DEFINE_FWK_EVENTSETUP_MODULE(OfflineToTransientBeamSpotESProducer);

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -31,7 +31,7 @@ public:
 
 private:
   const BeamSpotOnlineObjects* compareBS(const BeamSpotOnlineObjects* bs1, const BeamSpotOnlineObjects* bs2);
-  std::shared_ptr<BeamSpotObjects> fakeBS_;
+  BeamSpotObjects fakeBS_;
 
   edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> const bsToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> bsHLTToken_;
@@ -40,12 +40,11 @@ private:
 OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p) {
   auto cc = setWhatProduced(this);
 
-  fakeBS_ = std::make_shared<BeamSpotOnlineObjects>();
-  fakeBS_->SetBeamWidthX(0.1);
-  fakeBS_->SetBeamWidthY(0.1);
-  fakeBS_->SetSigmaZ(15.);
-  fakeBS_->SetPosition(0., 0., 0.);
-  fakeBS_->SetType(-1);
+  fakeBS_.SetBeamWidthX(0.1);
+  fakeBS_.SetBeamWidthY(0.1);
+  fakeBS_.SetSigmaZ(15.);
+  fakeBS_.SetPosition(0., 0., 0.);
+  fakeBS_.SetType(-1);
 
   bsHLTToken_ = cc.consumesFrom<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd>();
   bsLegacyToken_ = cc.consumesFrom<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd>();
@@ -79,7 +78,8 @@ std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const B
   auto legacyRec = iRecord.tryToGetRecord<BeamSpotOnlineLegacyObjectsRcd>();
   auto hltRec = iRecord.tryToGetRecord<BeamSpotOnlineHLTObjectsRcd>();
   if (not legacyRec and not hltRec) {
-    return std::shared_ptr<const BeamSpotObjects>(&(*fakeBS_), edm::do_nothing_deleter());
+    return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
+    //return fakeBS_;
     // or copy in case 'const BeamSpotObjects fakeBS_' member would not be preferred
     //return std::make_shared<BeamSpotObjects>(fakeBS_);
   }

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -32,26 +32,15 @@ public:
 
 private:
   const BeamSpotOnlineObjects* compareBS(const BeamSpotOnlineObjects* bs1, const BeamSpotOnlineObjects* bs2);
-  const BeamSpotOnlineObjects* theHLTBS_ = nullptr;
-  const BeamSpotOnlineObjects* theLegacyBS_ = nullptr;
-  const BeamSpotObjects* transientBS_ = nullptr;
   BeamSpotObjects* fakeBS_;
-  bool newHLT_;
-  bool newLegacy_;
-
+  
   edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> const bsToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> bsHLTToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> bsLegacyToken_;
-  //using HostType =
-  //  edm::ESProductHost<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineLegacyObjectsRcd>;
-
-  //edm::ReusableObjectHolder<HostType> holder_;
 };
 OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p) {
   auto cc = setWhatProduced(this);
 
-  // theHLTBS_ = new BeamSpotOnlineObjects;
-  //theLegacyBS_ = new BeamSpotOnlineObjects;
   fakeBS_ = new BeamSpotOnlineObjects;
   fakeBS_->SetBeamWidthX(0.1);
   fakeBS_->SetBeamWidthY(0.1);
@@ -87,10 +76,7 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
   }
 }
 OnlineBeamSpotESProducer::~OnlineBeamSpotESProducer() {
-  delete theHLTBS_;
-  delete theLegacyBS_;
-  //delete transientBS_;
-  delete fakeBS_;
+  //delete fakeBS_;
 }
 
 std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const BeamSpotTransientObjectsRcd& iRecord) {

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -6,7 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
-//#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
@@ -79,9 +78,6 @@ std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const B
   auto hltRec = iRecord.tryToGetRecord<BeamSpotOnlineHLTObjectsRcd>();
   if (not legacyRec and not hltRec) {
     return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
-    //return fakeBS_;
-    // or copy in case 'const BeamSpotObjects fakeBS_' member would not be preferred
-    //return std::make_shared<BeamSpotObjects>(fakeBS_);
   }
 
   const BeamSpotOnlineObjects* best;

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -33,7 +33,7 @@ public:
 private:
   const BeamSpotOnlineObjects* compareBS(const BeamSpotOnlineObjects* bs1, const BeamSpotOnlineObjects* bs2);
   BeamSpotObjects* fakeBS_;
-  
+
   edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> const bsToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> bsHLTToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> bsLegacyToken_;

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -1,0 +1,116 @@
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Utilities/interface/do_nothing_deleter.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+//#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <memory>
+#include <iostream>
+#include <string>
+
+using namespace edm;
+
+class OnlineBeamSpotESProducer : public edm::ESProducer {
+public:
+  OnlineBeamSpotESProducer(const edm::ParameterSet& p);
+  ~OnlineBeamSpotESProducer() override;
+  std::shared_ptr<const BeamSpotObjects> produce(const BeamSpotTransientObjectsRcd&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& desc);
+
+private:
+  const BeamSpotOnlineObjects* compareBS(const BeamSpotOnlineObjects* bs1, const BeamSpotOnlineObjects* bs2);
+  const BeamSpotOnlineObjects* theHLTBS_ = nullptr;
+  const BeamSpotOnlineObjects* theLegacyBS_ = nullptr;
+  const BeamSpotObjects* transientBS_ = nullptr;
+  BeamSpotObjects* fakeBS_;
+  bool newHLT_;
+  bool newLegacy_;
+
+  edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> const bsToken_;
+  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> bsHLTToken_;
+  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> bsLegacyToken_;
+  //using HostType =
+  //  edm::ESProductHost<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineLegacyObjectsRcd>;
+
+  //edm::ReusableObjectHolder<HostType> holder_;
+};
+OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p) {
+  auto cc = setWhatProduced(this);
+
+  // theHLTBS_ = new BeamSpotOnlineObjects;
+  //theLegacyBS_ = new BeamSpotOnlineObjects;
+  fakeBS_ = new BeamSpotOnlineObjects;
+  fakeBS_->SetBeamWidthX(0.1);
+  fakeBS_->SetBeamWidthY(0.1);
+  fakeBS_->SetSigmaZ(15.);
+  fakeBS_->SetPosition(0., 0., 0.);
+  fakeBS_->SetType(-1);
+
+  bsHLTToken_ = cc.consumesFrom<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd>();
+  bsLegacyToken_ = cc.consumesFrom<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd>();
+}
+
+void OnlineBeamSpotESProducer::fillDescriptions(edm::ConfigurationDescriptions& desc) {
+  edm::ParameterSetDescription dsc;
+  desc.addWithDefaultLabel(dsc);
+}
+
+const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotOnlineObjects* bs1,
+                                                                 const BeamSpotOnlineObjects* bs2) {
+  //Random logic so far ...
+  if (bs1->GetSigmaZ() - 0.0001 < bs2->GetSigmaZ()) {  //just temporary for debugging
+    if (bs1->GetSigmaZ() > 5.) {
+      return bs1;
+    } else {
+      return bs2;
+    }
+
+  } else {
+    if (bs2->GetSigmaZ() > 5.) {
+      return bs2;
+    } else {
+      return bs1;
+    }
+  }
+}
+OnlineBeamSpotESProducer::~OnlineBeamSpotESProducer() {
+  delete theHLTBS_;
+  delete theLegacyBS_;
+  //delete transientBS_;
+  delete fakeBS_;
+}
+
+std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const BeamSpotTransientObjectsRcd& iRecord) {
+  auto legacyRec = iRecord.tryToGetRecord<BeamSpotOnlineLegacyObjectsRcd>();
+  auto hltRec = iRecord.tryToGetRecord<BeamSpotOnlineHLTObjectsRcd>();
+  if (not legacyRec and not hltRec) {
+    return std::shared_ptr<const BeamSpotObjects>(&(*fakeBS_), edm::do_nothing_deleter());
+    // or copy in case 'const BeamSpotObjects fakeBS_' member would not be preferred
+    //return std::make_shared<BeamSpotObjects>(fakeBS_);
+  }
+
+  const BeamSpotOnlineObjects* best;
+  if (legacyRec and hltRec) {
+    best = compareBS(&legacyRec->get(bsLegacyToken_), &hltRec->get(bsHLTToken_));
+  } else if (legacyRec) {
+    best = &legacyRec->get(bsLegacyToken_);
+  } else {
+    best = &hltRec->get(bsHLTToken_);
+  }
+  return std::shared_ptr<const BeamSpotObjects>(best, edm::do_nothing_deleter());
+};
+
+DEFINE_FWK_EVENTSETUP_MODULE(OnlineBeamSpotESProducer);

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -26,13 +26,12 @@ using namespace edm;
 class OnlineBeamSpotESProducer : public edm::ESProducer {
 public:
   OnlineBeamSpotESProducer(const edm::ParameterSet& p);
-  ~OnlineBeamSpotESProducer() override;
   std::shared_ptr<const BeamSpotObjects> produce(const BeamSpotTransientObjectsRcd&);
   static void fillDescriptions(edm::ConfigurationDescriptions& desc);
 
 private:
   const BeamSpotOnlineObjects* compareBS(const BeamSpotOnlineObjects* bs1, const BeamSpotOnlineObjects* bs2);
-  BeamSpotObjects* fakeBS_;
+  std::shared_ptr<BeamSpotObjects> fakeBS_;
 
   edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> const bsToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> bsHLTToken_;
@@ -41,7 +40,7 @@ private:
 OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p) {
   auto cc = setWhatProduced(this);
 
-  fakeBS_ = new BeamSpotOnlineObjects;
+  fakeBS_ = std::make_shared<BeamSpotOnlineObjects>();
   fakeBS_->SetBeamWidthX(0.1);
   fakeBS_->SetBeamWidthY(0.1);
   fakeBS_->SetSigmaZ(15.);
@@ -74,9 +73,6 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
       return bs1;
     }
   }
-}
-OnlineBeamSpotESProducer::~OnlineBeamSpotESProducer() {
-  //delete fakeBS_;
 }
 
 std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const BeamSpotTransientObjectsRcd& iRecord) {

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotFromDB.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotFromDB.cc
@@ -31,7 +31,6 @@ ________________________________________________________________**/
 class OnlineBeamSpotFromDB : public edm::one::EDAnalyzer<> {
 public:
   explicit OnlineBeamSpotFromDB(const edm::ParameterSet& iConfig);
-  ~OnlineBeamSpotFromDB() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& desc);
   edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> bsToken_;
 
@@ -42,20 +41,11 @@ private:
 OnlineBeamSpotFromDB::OnlineBeamSpotFromDB(const edm::ParameterSet& iConfig)
     : bsToken_(esConsumes<BeamSpotObjects, BeamSpotTransientObjectsRcd>()) {}
 
-OnlineBeamSpotFromDB::~OnlineBeamSpotFromDB() {}
-
 void OnlineBeamSpotFromDB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  //edm::ESHandle<BeamSpotObjects> beamGThandle;
-
   auto const& mybeamspot = iSetup.getData(bsToken_);
-  //iSetup.get<BeamSpotTransientObjectsRcd>().get(beamhandle);
-  //const BeamSpotObjects* mybeamspot = beamhandle.product();
-  //iSetup.get<BeamSpotObjectsRcd>().get(beamGThandle);
-  //const BeamSpotObjects* myGTbeamspot = beamGThandle.product();
 
   edm::LogInfo("Run numver: ") << iEvent.id().run();
   edm::LogInfo("beamspot from HLT ") << mybeamspot;
-  //edm::LogInfo("beamspot from GT ")<<*myGTbeamspot;
 }
 void OnlineBeamSpotFromDB::fillDescriptions(edm::ConfigurationDescriptions& desc) {
   edm::ParameterSetDescription dsc;

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotFromDB.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotFromDB.cc
@@ -1,0 +1,66 @@
+/**_________________________________________________________________
+   class:   OnlineBeamSpotFromDB.cc
+   package: RecoVertex/BeamSpotProducer
+   
+
+
+ author: Francisco Yumiceva, Fermilab (yumiceva@fnal.gov)
+
+
+________________________________________________________________**/
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include <string>
+
+class OnlineBeamSpotFromDB : public edm::one::EDAnalyzer<> {
+public:
+  explicit OnlineBeamSpotFromDB(const edm::ParameterSet& iConfig);
+  ~OnlineBeamSpotFromDB() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& desc);
+  edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> bsToken_;
+
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+};
+
+OnlineBeamSpotFromDB::OnlineBeamSpotFromDB(const edm::ParameterSet& iConfig)
+    : bsToken_(esConsumes<BeamSpotObjects, BeamSpotTransientObjectsRcd>()) {}
+
+OnlineBeamSpotFromDB::~OnlineBeamSpotFromDB() {}
+
+void OnlineBeamSpotFromDB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  //edm::ESHandle<BeamSpotObjects> beamGThandle;
+
+  auto const& mybeamspot = iSetup.getData(bsToken_);
+  //iSetup.get<BeamSpotTransientObjectsRcd>().get(beamhandle);
+  //const BeamSpotObjects* mybeamspot = beamhandle.product();
+  //iSetup.get<BeamSpotObjectsRcd>().get(beamGThandle);
+  //const BeamSpotObjects* myGTbeamspot = beamGThandle.product();
+
+  edm::LogInfo("Run numver: ") << iEvent.id().run();
+  edm::LogInfo("beamspot from HLT ") << mybeamspot;
+  //edm::LogInfo("beamspot from GT ")<<*myGTbeamspot;
+}
+void OnlineBeamSpotFromDB::fillDescriptions(edm::ConfigurationDescriptions& desc) {
+  edm::ParameterSetDescription dsc;
+  desc.addWithDefaultLabel(dsc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(OnlineBeamSpotFromDB);

--- a/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
+++ b/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
@@ -7,7 +7,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("CondCore.DBCommon.CondDBSetup_cfi")
 
 
-"""
+
 process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
                                         process.CondDBSetup,
                                         toGet = cms.VPSet(
@@ -30,11 +30,11 @@ cms.PSet(
                                         connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
                                         #connect = cms.string('frontier://PromptProd/CMS_COND_31X_BEAMSPOT')
                                         )
-"""
-from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
-process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
-process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
-#process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+
+#from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
+#process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
+#process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
+process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
 
 process.MessageLogger.destinations = cms.untracked.vstring('detailedInfo')
 process.MessageLogger.detailedInfo   = cms.untracked.PSet(threshold = cms.untracked.string('INFO'))

--- a/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
+++ b/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("readDB")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+
+process.load("CondCore.DBCommon.CondDBSetup_cfi")
+
+
+
+process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
+                                        process.CondDBSetup,
+                                        toGet = cms.VPSet(
+
+
+cms.PSet(
+    record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
+    tag = cms.string("BeamSpotOnlineTestLegacy"),
+    refreshTime = cms.uint64(1)
+
+    ),
+#cms.PSet(
+#    record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
+#    tag = cms.string('BSOnLineHLT_tag'),
+#    refreshTime = cms.uint64(1)
+#    )
+
+),
+#                                        connect = cms.string('sqlite_file:BeamSpotOnlineLegacy_JetHT.db')
+                                        connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+                                        #connect = cms.string('frontier://PromptProd/CMS_COND_31X_BEAMSPOT')
+                                        )
+
+#from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
+#process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
+#process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
+process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+
+process.MessageLogger.destinations = cms.untracked.vstring('detailedInfo')
+process.MessageLogger.detailedInfo   = cms.untracked.PSet(threshold = cms.untracked.string('INFO'))
+
+process.source = cms.Source("EmptySource")
+process.source.numberEventsInRun=cms.untracked.uint32(2)
+process.source.firstRun = cms.untracked.uint32(336365)
+process.source.firstLuminosityBlock = cms.untracked.uint32(13)
+process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(1)
+process.maxEvents = cms.untracked.PSet(
+            input = cms.untracked.int32(5)
+                    )
+process.beamspot = cms.EDAnalyzer("OnlineBeamSpotFromDB")
+
+
+process.p = cms.Path(process.beamspot)
+

--- a/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
+++ b/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
@@ -7,7 +7,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("CondCore.DBCommon.CondDBSetup_cfi")
 
 
-
+"""
 process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
                                         process.CondDBSetup,
                                         toGet = cms.VPSet(
@@ -30,11 +30,12 @@ cms.PSet(
                                         connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
                                         #connect = cms.string('frontier://PromptProd/CMS_COND_31X_BEAMSPOT')
                                         )
-
-#from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
-#process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
-#process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
 process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+"""
+from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
+process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
+process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
+
 
 process.MessageLogger.destinations = cms.untracked.vstring('detailedInfo')
 process.MessageLogger.detailedInfo   = cms.untracked.PSet(threshold = cms.untracked.string('INFO'))

--- a/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
+++ b/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
@@ -7,7 +7,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("CondCore.DBCommon.CondDBSetup_cfi")
 
 
-
+"""
 process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
                                         process.CondDBSetup,
                                         toGet = cms.VPSet(
@@ -30,11 +30,11 @@ cms.PSet(
                                         connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
                                         #connect = cms.string('frontier://PromptProd/CMS_COND_31X_BEAMSPOT')
                                         )
-
-#from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
-#process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
-#process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
-process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+"""
+from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
+process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
+process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
+#process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
 
 process.MessageLogger.destinations = cms.untracked.vstring('detailedInfo')
 process.MessageLogger.detailedInfo   = cms.untracked.PSet(threshold = cms.untracked.string('INFO'))

--- a/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
+++ b/RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py
@@ -7,34 +7,34 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("CondCore.DBCommon.CondDBSetup_cfi")
 
 
-"""
-process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
+tesOnLineESProducer = True
+
+if tesOnLineESProducer:
+    process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
                                         process.CondDBSetup,
                                         toGet = cms.VPSet(
+                                            cms.PSet(
+                                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
+                                                tag = cms.string("BeamSpotOnlineTestLegacy"),
+                                                refreshTime = cms.uint64(1)
 
+                                            ),
+                                            #cms.PSet(
+                                            #    record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
+                                            #    tag = cms.string('BSOnLineHLT_tag'),
+                                            #    refreshTime = cms.uint64(1)
+                                            #    )
 
-cms.PSet(
-    record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
-    tag = cms.string("BeamSpotOnlineTestLegacy"),
-    refreshTime = cms.uint64(1)
-
-    ),
-#cms.PSet(
-#    record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
-#    tag = cms.string('BSOnLineHLT_tag'),
-#    refreshTime = cms.uint64(1)
-#    )
-
-),
-#                                        connect = cms.string('sqlite_file:BeamSpotOnlineLegacy_JetHT.db')
+                                ),
                                         connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
-                                        #connect = cms.string('frontier://PromptProd/CMS_COND_31X_BEAMSPOT')
+
                                         )
-process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
-"""
-from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
-process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
-process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
+    process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+
+else:
+    from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
+    process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
+    process.BeamSpotESProducer = cms.ESProducer("OfflineToTransientBeamSpotESProducer")
 
 
 process.MessageLogger.destinations = cms.untracked.vstring('detailedInfo')


### PR DESCRIPTION
#### PR description:

This is a cleanup version of a past PR #30591, introducing a new ESProducer to make a beamspot transient record to replace the old way (Run3) to access beamspot position at HLT
#### PR validation:

I have run the RecoVertex/BeamSpotProducer/test/readOnlineBeamSpotFromDB.py  to test the ESProducer is working as expected. Another producer and a Analyzer have been added for further checks and future developments.

A Backporting to 11_1_X for the next MWGR (September) will be needed
