### PR TITLE
Moving boost dependency to c++ stl alternatives in CommonTools/Utils

### DIFF
--- a/CommonTools/Utils/src/AnyMethodArgument.h
+++ b/CommonTools/Utils/src/AnyMethodArgument.h
@@ -6,13 +6,10 @@
 #include "CommonTools/Utils/interface/Exception.h"
 
 #include <algorithm>
-#include <string>
 #include <cstdint>
-
-#include <boost/variant.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/mpl/if.hpp>
+#include <string>
 #include <type_traits>
+#include <variant>
 
 namespace reco {
   namespace parser {
@@ -21,34 +18,33 @@ namespace reco {
     // AnyMethodArgument variant
     template <typename T>
     struct matches_another_integral_type {
-      static bool const value = boost::is_same<T, int8_t>::value || boost::is_same<T, uint8_t>::value ||
-                                boost::is_same<T, int16_t>::value || boost::is_same<T, uint16_t>::value ||
-                                boost::is_same<T, int32_t>::value || boost::is_same<T, uint32_t>::value ||
-                                boost::is_same<T, int64_t>::value || boost::is_same<T, uint64_t>::value;
+      static bool const value = std::is_same<T, int8_t>::value || std::is_same<T, uint8_t>::value ||
+                                std::is_same<T, int16_t>::value || std::is_same<T, uint16_t>::value ||
+                                std::is_same<T, int32_t>::value || std::is_same<T, uint32_t>::value ||
+                                std::is_same<T, int64_t>::value || std::is_same<T, uint64_t>::value;
     };
 
     // size_t on 32-bit Os X is type unsigned long, which doesn't match uint32_t,
     // so add unsigned long if it doesn't match any of the other integral types.
     // Use "unsigned long" rather than size_t as PtrVector has unsigned long as
     // size_type
-    typedef boost::mpl::if_<
-        matches_another_integral_type<unsigned long>,
-        boost::
-            variant<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, double, float, std::string>,
-        boost::variant<int8_t,
-                       uint8_t,
-                       int16_t,
-                       uint16_t,
-                       int32_t,
-                       uint32_t,
-                       int64_t,
-                       uint64_t,
-                       unsigned long,
-                       double,
-                       float,
-                       std::string> >::type AnyMethodArgument;
+    typedef std::conditional<
+        matches_another_integral_type<unsigned long>::value,
+        std::variant<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, double, float, std::string>,
+        std::variant<int8_t,
+                     uint8_t,
+                     int16_t,
+                     uint16_t,
+                     int32_t,
+                     uint32_t,
+                     int64_t,
+                     uint64_t,
+                     unsigned long,
+                     double,
+                     float,
+                     std::string> >::type AnyMethodArgument;
 
-    class AnyMethodArgumentFixup : public boost::static_visitor<std::pair<AnyMethodArgument, int> > {
+    class AnyMethodArgumentFixup {
     private:
       edm::TypeWithDict dataType_;
       template <typename From, typename To>
@@ -133,7 +129,7 @@ namespace reco {
       }
     };
 
-    class AnyMethodArgument2VoidPtr : public boost::static_visitor<void *> {
+    class AnyMethodArgument2VoidPtr {
     public:
       template <typename T>
       void *operator()(const T &t) const {

--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -71,7 +71,7 @@ MethodInvoker& MethodInvoker::operator=(const MethodInvoker& rhs) {
 
 void MethodInvoker::setArgs() {
   for (size_t i = 0; i < ints_.size(); ++i) {
-    args_.push_back(boost::apply_visitor(AnyMethodArgument2VoidPtr(), ints_[i]));
+    args_.push_back(std::visit(AnyMethodArgument2VoidPtr(), ints_[i]));
   }
 }
 

--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -6,6 +6,7 @@
 #include "FWCore/Reflection/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
+#include <typeindex>
 #include <cassert>
 
 using AnyMethodArgument = reco::parser::AnyMethodArgument;
@@ -82,8 +83,7 @@ namespace reco {
       size_t i = 0;
       for (auto const& param : mem) {
         edm::TypeWithDict parameter(param);
-        std::pair<AnyMethodArgument, int> fixup =
-            boost::apply_visitor(reco::parser::AnyMethodArgumentFixup(parameter), args[i]);
+        std::pair<AnyMethodArgument, int> fixup = std::visit(reco::parser::AnyMethodArgumentFixup(parameter), args[i]);
         //std::cerr <<
         //  "\t ARG " <<
         //  i <<
@@ -162,7 +162,8 @@ namespace reco {
       if (!theArgs.empty()) {
         theArgs += ',';
       }
-      theArgs += edm::TypeID(item.type()).className();
+      theArgs += edm::TypeID(std::visit([](auto& variant) -> const std::type_info& { return typeid(variant); }, item))
+                     .className();
     }
     edm::FunctionWithDict f = type.functionMemberByName(name, theArgs, true);
     if (bool(f)) {


### PR DESCRIPTION
#### PR description:
We can use std::variant instead of using boost::variant. We can also remove the boost::mpl dependency.
 When possible we should strive to use standard library over boost.

#### PR validation:
Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@vgvassilev @davidlange6 