### PR TITLE
Clean up L1TTrackMatch producers

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
@@ -9,7 +9,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,6 +31,8 @@
 // for L1Tracks:
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
+#include "DataFormats/Math/interface/deltaR.h"
+
 #include <string>
 #include <cmath>
 
@@ -42,7 +44,7 @@ using namespace l1t;
 // class declaration
 //
 
-class L1TkEmParticleProducer : public edm::EDProducer {
+class L1TkEmParticleProducer : public edm::stream::EDProducer<> {
 public:
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
@@ -52,23 +54,14 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  float DeltaPhi(float phi1, float phi2);
-  float deltaR(float eta1, float eta2, float phi1, float phi2);
-  float CorrectedEta(float eta, float zv);
+  float CorrectedEta(float eta, float zv) const;
 
 private:
-  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
-
-  //virtual void beginRun(edm::Run&, edm::EventSetup const&);
-  //virtual void endRun(edm::Run&, edm::EventSetup const&);
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
-  //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
 
   // ----------member data ---------------------------
 
-  std::string label;
+  std::string label_;
 
   float etMin_;  // min ET in GeV of L1EG objects
 
@@ -84,20 +77,20 @@ private:
   float isoCut_;
   bool relativeIsolation_;
 
-  const edm::EDGetTokenT<EGammaBxCollection> egToken;
-  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken;
-  const edm::EDGetTokenT<TkPrimaryVertexCollection> vertexToken;
+  const edm::EDGetTokenT<EGammaBxCollection> egToken_;
+  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken_;
+  const edm::EDGetTokenT<TkPrimaryVertexCollection> vertexToken_;
 };
 
 //
 // constructors and destructor
 //
 L1TkEmParticleProducer::L1TkEmParticleProducer(const edm::ParameterSet& iConfig)
-    : egToken(consumes<EGammaBxCollection>(iConfig.getParameter<edm::InputTag>("L1EGammaInputTag"))),
-      trackToken(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
+    : egToken_(consumes<EGammaBxCollection>(iConfig.getParameter<edm::InputTag>("L1EGammaInputTag"))),
+      trackToken_(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
           iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))),
-      vertexToken(consumes<TkPrimaryVertexCollection>(iConfig.getParameter<edm::InputTag>("L1VertexInputTag"))) {
-  label = iConfig.getParameter<std::string>("label");  // label of the collection produced
+      vertexToken_(consumes<TkPrimaryVertexCollection>(iConfig.getParameter<edm::InputTag>("L1VertexInputTag"))) {
+  label_ = iConfig.getParameter<std::string>("label");  // label of the collection produced
   // e.g. EG or IsoEG if all objects are kept
   // EGIsoTrk or IsoEGIsoTrk if only the EG or IsoEG
   // objects that pass a cut RelIso < isoCut_ are written
@@ -112,13 +105,12 @@ L1TkEmParticleProducer::L1TkEmParticleProducer(const edm::ParameterSet& iConfig)
   dRMin_ = (float)iConfig.getParameter<double>("DRmin");
   dRMax_ = (float)iConfig.getParameter<double>("DRmax");
   primaryVtxConstrain_ = iConfig.getParameter<bool>("PrimaryVtxConstrain");
-  //DeltaZConstrain = iConfig.getParameter<bool>("DeltaZConstrain");
   deltaZMax_ = (float)iConfig.getParameter<double>("DeltaZMax");
   // cut applied on the isolation (if this number is <= 0, no cut is applied)
   isoCut_ = (float)iConfig.getParameter<double>("IsoCut");
   relativeIsolation_ = iConfig.getParameter<bool>("RelativeIsolation");
 
-  produces<TkEmCollection>(label);
+  produces<TkEmCollection>(label_);
 }
 
 L1TkEmParticleProducer::~L1TkEmParticleProducer() {}
@@ -127,24 +119,22 @@ L1TkEmParticleProducer::~L1TkEmParticleProducer() {}
 void L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  std::unique_ptr<TkEmCollection> result(new TkEmCollection);
+  auto result = std::make_unique<TkEmCollection>();
 
   // the L1EGamma objects
   edm::Handle<EGammaBxCollection> eGammaHandle;
-  iEvent.getByToken(egToken, eGammaHandle);
+  iEvent.getByToken(egToken_, eGammaHandle);
   EGammaBxCollection eGammaCollection = (*eGammaHandle.product());
   EGammaBxCollection::const_iterator egIter;
 
   // the L1Tracks
   edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > L1TTTrackHandle;
-  iEvent.getByToken(trackToken, L1TTTrackHandle);
-  L1TTTrackCollectionType::const_iterator trackIter;
+  iEvent.getByToken(trackToken_, L1TTTrackHandle);
 
   // the primary vertex (used only if primaryVtxConstrain_ = true)
   float zvtxL1tk = -999;
-  //if (primaryVtxConstrain_) {
   edm::Handle<TkPrimaryVertexCollection> L1VertexHandle;
-  iEvent.getByToken(vertexToken, L1VertexHandle);
+  iEvent.getByToken(vertexToken_, L1VertexHandle);
   if (!L1VertexHandle.isValid()) {
     LogWarning("L1TkEmParticleProducer")
         << "Warning: TkPrimaryVertexCollection not found in the event. Won't use any PrimaryVertex constraint."
@@ -156,7 +146,6 @@ void L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     // be used by default
     zvtxL1tk = vtxIter->zvertex();
   }
-  //}
 
   if (!L1TTTrackHandle.isValid()) {
     LogError("L1TkEmParticleProducer") << "\nWarning: L1TTTrackCollectionType not found in the event. Exit."
@@ -197,57 +186,28 @@ void L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     float sumPtPV = 0;
     float trkisolPV = -999;
 
-    //std::cout << " here an EG w et = " << et << std::endl;
-
-    //float z_leadingTrack = -999;
-    //float Pt_leadingTrack = -999;
-
-    /*
-	if (DeltaZConstrain) {
-	// first loop over the tracks to find the leading one in DR < dRMax_
-	for (trackIter = L1TTTrackHandle->begin(); trackIter != L1TTTrackHandle->end(); ++trackIter) {
-	float Pt = trackIter->momentum().perp();
-	float Eta = trackIter->momentum().eta();
-	float Phi = trackIter->momentum().phi();
-	float z  = trackIter->POCA().z();
-	if (fabs(z) > zMax_) continue;
-	if (Pt < pTMinTra_) continue;
-	float chi2 = trackIter->chi2();
-	if (chi2 > chi2Max_) continue;
-	float dr = deltaR(Eta, eta, Phi,phi);
-	if (dr < dRMax_) {
-	if (Pt > Pt_leadingTrack) {
-	Pt_leadingTrack = Pt;
-	z_leadingTrack = z;
-	}
-	}
-	} // end loop over the tracks
-	} // endif DeltaZConstrain
-      */
-
-    for (trackIter = L1TTTrackHandle->begin(); trackIter != L1TTTrackHandle->end(); ++trackIter) {
-      float Pt = trackIter->momentum().perp();
-      float Eta = trackIter->momentum().eta();
-      float Phi = trackIter->momentum().phi();
-      float z = trackIter->POCA().z();
+    for (const auto& track : *L1TTTrackHandle) {
+      float Pt = track.momentum().perp();
+      float Eta = track.momentum().eta();
+      float Phi = track.momentum().phi();
+      float z = track.POCA().z();
       if (fabs(z) > zMax_)
         continue;
       if (Pt < pTMinTra_)
         continue;
-      float chi2 = trackIter->chi2();
+      float chi2 = track.chi2();
       if (chi2 > chi2Max_)
         continue;
 
-      float dr = deltaR(Eta, eta, Phi, phi);
+      float dr = reco::deltaR(Eta, Phi, eta, phi);
       if (dr < dRMax_ && dr >= dRMin_) {
-        //std::cout << " a track in the cone, z Pt = " << z << " " << Pt << std::endl;
         sumPt += Pt;
       }
 
-      if (zvtxL1tk > -999 && fabs(z - zvtxL1tk) >= deltaZMax_)
+      if (zvtxL1tk > -999 && std::abs(z - zvtxL1tk) >= deltaZMax_)
         continue;  // Now, PV constrained trackSum:
 
-      dr = deltaR(Eta, etaPV, Phi, phi);  // recompute using the corrected eta
+      dr = reco::deltaR(Eta, Phi, etaPV, phi);  // recompute using the corrected eta
 
       if (dr < dRMax_ && dr >= dRMin_) {
         sumPtPV += Pt;
@@ -285,15 +245,15 @@ void L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
 
   }  // end loop over EGamma objects
 
-  iEvent.put(std::move(result), label);
+  iEvent.put(std::move(result), label_);
 }
 
 // --------------------------------------------------------------------------------------
 
-float L1TkEmParticleProducer::CorrectedEta(float eta, float zv) {
+float L1TkEmParticleProducer::CorrectedEta(float eta, float zv) const {
   // Correct the eta of the L1EG object once we know the zvertex
 
-  bool IsBarrel = (fabs(eta) < EtaECal);
+  bool IsBarrel = (std::abs(eta) < EtaECal);
 
   float theta = 2. * atan(exp(-eta));
   if (theta < 0)
@@ -319,65 +279,6 @@ float L1TkEmParticleProducer::CorrectedEta(float eta, float zv) {
   float etaprime = -log(tan(thetaprime / 2.));
   return etaprime;
 }
-
-// --------------------------------------------------------------------------------------
-
-float L1TkEmParticleProducer::DeltaPhi(float phi1, float phi2) {
-  // dPhi between 0 and Pi
-  float dphi = phi1 - phi2;
-  if (dphi < 0)
-    dphi = dphi + 2. * M_PI;
-  if (dphi > M_PI)
-    dphi = 2. * M_PI - dphi;
-  return dphi;
-}
-
-// --------------------------------------------------------------------------------------
-
-float L1TkEmParticleProducer::deltaR(float eta1, float eta2, float phi1, float phi2) {
-  float deta = eta1 - eta2;
-  float dphi = DeltaPhi(phi1, phi2);
-  float DR = sqrt(deta * deta + dphi * dphi);
-  return DR;
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void L1TkEmParticleProducer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void L1TkEmParticleProducer::endJob() {}
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void
-L1TkEmParticleProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void
-L1TkEmParticleProducer::endRun(edm::Run&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-L1TkEmParticleProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-L1TkEmParticleProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TkEmParticleProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
@@ -13,7 +13,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/Common/interface/Handle.h"

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
@@ -9,7 +9,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -44,7 +44,7 @@ using namespace l1t;
 // class declaration
 //
 
-class L1TkEmParticleProducer : public edm::stream::EDProducer<> {
+class L1TkEmParticleProducer : public edm::global::EDProducer<> {
 public:
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
@@ -57,7 +57,7 @@ public:
   float CorrectedEta(float eta, float zv) const;
 
 private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
 
@@ -116,7 +116,7 @@ L1TkEmParticleProducer::L1TkEmParticleProducer(const edm::ParameterSet& iConfig)
 L1TkEmParticleProducer::~L1TkEmParticleProducer() {}
 
 // ------------ method called to produce the data  ------------
-void L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void L1TkEmParticleProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   auto result = std::make_unique<TkEmCollection>();
@@ -135,11 +135,12 @@ void L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   float zvtxL1tk = -999;
   edm::Handle<TkPrimaryVertexCollection> L1VertexHandle;
   iEvent.getByToken(vertexToken_, L1VertexHandle);
+  bool primaryVtxConstrain = primaryVtxConstrain_;
   if (!L1VertexHandle.isValid()) {
     LogWarning("L1TkEmParticleProducer")
         << "Warning: TkPrimaryVertexCollection not found in the event. Won't use any PrimaryVertex constraint."
         << std::endl;
-    primaryVtxConstrain_ = false;
+    primaryVtxConstrain = false;
   } else {
     std::vector<TkPrimaryVertex>::const_iterator vtxIter = L1VertexHandle->begin();
     // by convention, the first vertex in the collection is the one that should
@@ -225,7 +226,7 @@ void L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     }
 
     float isolation = trkisol;
-    if (primaryVtxConstrain_) {
+    if (primaryVtxConstrain) {
       isolation = trkisolPV;
     }
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
@@ -12,7 +12,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -46,7 +46,7 @@ using namespace l1t;
 // class declaration
 //
 
-class L1TkFastVertexProducer : public edm::EDProducer {
+class L1TkFastVertexProducer : public edm::stream::EDProducer<> {
 public:
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
@@ -57,11 +57,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
-
-  //virtual void beginRun(edm::Run&, edm::EventSetup const&);
 
   // ----------member data ---------------------------
 
@@ -89,9 +85,9 @@ private:
   TH1F* htmp_;
   TH1F* htmp_weight_;
 
-  const edm::EDGetTokenT<edm::HepMCProduct> hepmcToken;
-  const edm::EDGetTokenT<std::vector<reco::GenParticle> > genparticleToken;
-  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken;
+  const edm::EDGetTokenT<edm::HepMCProduct> hepmcToken_;
+  const edm::EDGetTokenT<std::vector<reco::GenParticle> > genparticleToken_;
+  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken_;
 };
 
 //
@@ -106,10 +102,10 @@ private:
 // constructors and destructor
 //
 L1TkFastVertexProducer::L1TkFastVertexProducer(const edm::ParameterSet& iConfig)
-    : hepmcToken(consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("HepMCInputTag"))),
-      genparticleToken(
+    : hepmcToken_(consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("HepMCInputTag"))),
+      genparticleToken_(
           consumes<std::vector<reco::GenParticle> >(iConfig.getParameter<edm::InputTag>("GenParticleInputTag"))),
-      trackToken(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
+      trackToken_(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
           iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))) {
   zMax_ = (float)iConfig.getParameter<double>("ZMAX");
   chi2Max_ = (float)iConfig.getParameter<double>("CHI2MAX");
@@ -151,7 +147,7 @@ L1TkFastVertexProducer::~L1TkFastVertexProducer() {
 void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  std::unique_ptr<TkPrimaryVertexCollection> result(new TkPrimaryVertexCollection);
+  auto result = std::make_unique<TkPrimaryVertexCollection>();
 
   // Tracker Topology
   edm::ESHandle<TrackerTopology> tTopoHandle_;
@@ -166,10 +162,10 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   if (monteCarloVertex_) {
     // MC info  ... retrieve the zvertex
     edm::Handle<edm::HepMCProduct> HepMCEvt;
-    iEvent.getByToken(hepmcToken, HepMCEvt);
+    iEvent.getByToken(hepmcToken_, HepMCEvt);
 
     edm::Handle<std::vector<reco::GenParticle> > GenParticleHandle;
-    iEvent.getByToken(genparticleToken, GenParticleHandle);
+    iEvent.getByToken(genparticleToken_, GenParticleHandle);
 
     const double mm = 0.1;
     float zvtx_gen = -999;
@@ -201,25 +197,22 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
       }         // end loop over gen vertices
 
     } else if (GenParticleHandle.isValid()) {
-      std::vector<reco::GenParticle>::const_iterator genpartIter;
-      for (genpartIter = GenParticleHandle->begin(); genpartIter != GenParticleHandle->end(); ++genpartIter) {
-        int status = genpartIter->status();
+      for (const auto& genpart : *GenParticleHandle) {
+        int status = genpart.status();
         if (status != 3)
           continue;
-        if (genpartIter->numberOfMothers() == 0)
+        if (genpart.numberOfMothers() == 0)
           continue;  // the incoming hadrons
-        float part_zvertex = genpartIter->vz();
+        float part_zvertex = genpart.vz();
         zvtx_gen = part_zvertex;
         break;  //
       }
     } else {
       throw cms::Exception("L1TkFastVertexProducer")
           << "\nerror: try to retrieve the MC vertex (monteCarloVertex_ = True) "
-          << "\nbut the input file contains neither edm::HepMCProduct>  nor vector<reco::GenParticle>. Exit"
+          << "\nbut the input file contains neither edm::HepMCProduct> nor vector<reco::GenParticle>. Exit"
           << std::endl;
     }
-
-    //     std::cout<<zvtx_gen<<endl;
 
     TkPrimaryVertex genvtx(zvtx_gen, -999.);
 
@@ -229,7 +222,7 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   }
 
   edm::Handle<L1TTTrackCollectionType> L1TTTrackHandle;
-  iEvent.getByToken(trackToken, L1TTTrackHandle);
+  iEvent.getByToken(trackToken_, L1TTTrackHandle);
 
   if (!L1TTTrackHandle.isValid()) {
     throw cms::Exception("L1TkFastVertexProducer")
@@ -237,12 +230,11 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     return;
   }
 
-  L1TTTrackCollectionType::const_iterator trackIter;
-  for (trackIter = L1TTTrackHandle->begin(); trackIter != L1TTTrackHandle->end(); ++trackIter) {
-    float z = trackIter->POCA().z();
-    float chi2 = trackIter->chi2();
-    float pt = trackIter->momentum().perp();
-    float eta = trackIter->momentum().eta();
+  for (const auto& track : *L1TTTrackHandle) {
+    float z = track.POCA().z();
+    float chi2 = track.chi2();
+    float pt = track.momentum().perp();
+    float eta = track.momentum().eta();
 
     //..............................................................
     float wt = pow(pt, weight_);  // calculating the weight for tks in as pt^0,pt^1 or pt^2 based on weight_
@@ -268,7 +260,7 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
 
     // get pointers to stubs associated to the L1 track
     const std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >&
-        theStubs = trackIter->getStubRefs();
+        theStubs = track.getStubRefs();
 
     int tmp_trk_nstub = (int)theStubs.size();
     if (tmp_trk_nstub < 0) {
@@ -278,10 +270,10 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     }
 
     // loop over the stubs
-    for (unsigned int istub = 0; istub < (unsigned int)theStubs.size(); istub++) {
+    for (const auto& stub : theStubs) {
       nstubs++;
       bool isPS = false;
-      DetId detId(theStubs.at(istub)->getDetId());
+      DetId detId(stub->getDetId());
       if (detId.det() == DetId::Detector::Tracker) {
         if (detId.subdetId() == StripSubdetector::TOB && tTopo->tobLayer(detId) <= 3)
           isPS = true;
@@ -297,13 +289,11 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
       continue;
 
     // quality cuts from Louise S, based on the pt-stub compatibility (June 20, 2014)
-    int trk_nstub = (int)trackIter->getStubRefs().size();
+    int trk_nstub = (int)track.getStubRefs().size();
     float chi2dof = chi2 / (2 * trk_nstub - 4);
 
     if (doPtComp_) {
-      float trk_consistency = trackIter->stubPtConsistency();
-      //if (trk_nstub < 4) continue;	// done earlier
-      //if (chi2 > 100.0) continue;	// done earlier
+      float trk_consistency = track.stubPtConsistency();
       if (trk_nstub == 4) {
         if (std::abs(eta) < 2.2 && trk_consistency > 10)
           continue;
@@ -362,15 +352,6 @@ void L1TkFastVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
 
   iEvent.put(std::move(result));
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void L1TkFastVertexProducer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void L1TkFastVertexProducer::endJob() {}
-
-// ------------ method called when starting to processes a run  ------------
-//void L1TkFastVertexProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TkFastVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
@@ -18,7 +18,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
@@ -88,6 +88,7 @@ private:
   const edm::EDGetTokenT<edm::HepMCProduct> hepmcToken_;
   const edm::EDGetTokenT<std::vector<reco::GenParticle> > genparticleToken_;
   const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
 };
 
 //
@@ -106,7 +107,8 @@ L1TkFastVertexProducer::L1TkFastVertexProducer(const edm::ParameterSet& iConfig)
       genparticleToken_(
           consumes<std::vector<reco::GenParticle> >(iConfig.getParameter<edm::InputTag>("GenParticleInputTag"))),
       trackToken_(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
-          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))) {
+          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()) {
   zMax_ = (float)iConfig.getParameter<double>("ZMAX");
   chi2Max_ = (float)iConfig.getParameter<double>("CHI2MAX");
   pTMinTra_ = (float)iConfig.getParameter<double>("PTMINTRA");
@@ -143,9 +145,8 @@ void L1TkFastVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
   auto result = std::make_unique<TkPrimaryVertexCollection>();
 
   // Tracker Topology
-  edm::ESHandle<TrackerTopology> tTopoHandle_;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle_);
-  const TrackerTopology* tTopo = tTopoHandle_.product();
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
+  const TrackerTopology* tTopo = tTopoHandle.product();
 
   TH1F htmp("htmp", ";z (cm); Tracks", nBinning_, xmin_, xmax_);
   TH1F htmp_weight("htmp_weight", ";z (cm); Tracks", nBinning_, xmin_, xmax_);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -5,7 +5,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -43,7 +43,7 @@ static constexpr float max_mu_propagator_eta = 2.5;
 
 using namespace l1t;
 
-class L1TkMuonProducer : public edm::EDProducer {
+class L1TkMuonProducer : public edm::global::EDProducer<> {
 public:
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
@@ -67,7 +67,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   PropState propagateToGMT(const L1TTTrackType& l1tk) const;
   double sigmaEtaTP(const RegionalMuonCand& mu) const;
   double sigmaPhiTP(const RegionalMuonCand& mu) const;
@@ -90,18 +90,12 @@ private:
                                const edm::Handle<RegionalMuonCandBxCollection>& muonH,
                                int detector) const;
 
-  // as above, but for the TkMu that were built from a EMTFCollection - do not produce a valid muon ref
-  void build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
-                               const std::vector<int>& matches,
-                               const edm::Handle<L1TTTrackCollectionType>& l1tksH,
-                               int detector) const;
-
   // dump and convert tracks to the format needed for the MAnTra correlator
-  std::vector<L1TkMuMantraDF::track_df> product_to_trkvec(const L1TTTrackCollectionType& l1tks);  // tracks
+  std::vector<L1TkMuMantraDF::track_df> product_to_trkvec(const L1TTTrackCollectionType& l1tks) const;  // tracks
   // regional muon finder
-  std::vector<L1TkMuMantraDF::muon_df> product_to_muvec(const RegionalMuonCandBxCollection& l1mtfs);
+  std::vector<L1TkMuMantraDF::muon_df> product_to_muvec(const RegionalMuonCandBxCollection& l1mtfs) const;
   // endcap muon finder - eventually to be moved to regional candidate
-  std::vector<L1TkMuMantraDF::muon_df> product_to_muvec(const EMTFTrackCollection& l1mus);
+  std::vector<L1TkMuMantraDF::muon_df> product_to_muvec(const EMTFTrackCollection& l1mus) const;
 
   float etaMin_;
   float etaMax_;
@@ -130,7 +124,7 @@ private:
   const edm::EDGetTokenT<RegionalMuonCandBxCollection> emtfToken_;
   // the track collection, directly from the EMTF and not formatted by GT
   const edm::EDGetTokenT<EMTFTrackCollection> emtfTCToken_;
-  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken;
+  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken_;
 };
 
 L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
@@ -147,7 +141,7 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
       omtfToken_(consumes<RegionalMuonCandBxCollection>(iConfig.getParameter<edm::InputTag>("L1OMTFInputTag"))),
       emtfToken_(consumes<RegionalMuonCandBxCollection>(iConfig.getParameter<edm::InputTag>("L1EMTFInputTag"))),
       emtfTCToken_(consumes<EMTFTrackCollection>(iConfig.getParameter<edm::InputTag>("L1EMTFTrackCollectionInputTag"))),
-      trackToken(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
+      trackToken_(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
           iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))) {
   // --------------------- configuration of the muon algorithm type
 
@@ -177,8 +171,6 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
     throw cms::Exception("TkMuAlgoConfig")
         << "the ID " << bmtfMatchAlgoVersionString << " of the BMTF algo matcher passed is invalid\n";
 
-  //
-
   if (omtfMatchAlgoVersionString == "tp")
     omtfMatchAlgoVersion_ = kTP;
   else if (omtfMatchAlgoVersionString == "mantra")
@@ -186,8 +178,6 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
   else
     throw cms::Exception("TkMuAlgoConfig")
         << "the ID " << omtfMatchAlgoVersionString << " of the OMTF algo matcher passed is invalid\n";
-
-  //
 
   if (emtfMatchAlgoVersionString == "tp")
     emtfMatchAlgoVersion_ = kTP;
@@ -211,7 +201,7 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
     std::string fIn_bounds_name = iConfig.getParameter<edm::FileInPath>("emtfcorr_boundaries").fullPath();
     std::string fIn_theta_name = iConfig.getParameter<edm::FileInPath>("emtfcorr_theta_windows").fullPath();
     std::string fIn_phi_name = iConfig.getParameter<edm::FileInPath>("emtfcorr_phi_windows").fullPath();
-    auto bounds = L1TkMuCorrDynamicWindows::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
+    const auto& bounds = L1TkMuCorrDynamicWindows::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
     TFile* fIn_theta = TFile::Open(fIn_theta_name.c_str());
     TFile* fIn_phi = TFile::Open(fIn_phi_name.c_str());
     dwcorr_ = std::make_unique<L1TkMuCorrDynamicWindows>(bounds, fIn_theta, fIn_phi);
@@ -229,7 +219,6 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
 
     dwcorr_->set_do_relax_factor(iConfig.getParameter<bool>("do_relax_factors"));
 
-    //
     dwcorr_->set_n_trk_par(iConfig.getParameter<int>("n_trk_par"));
     dwcorr_->set_min_trk_p(iConfig.getParameter<double>("min_trk_p"));
     dwcorr_->set_max_trk_aeta(iConfig.getParameter<double>("max_trk_aeta"));
@@ -243,7 +232,7 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
     std::string fIn_theta_name = iConfig.getParameter<edm::FileInPath>("mantra_bmtfcorr_theta_windows").fullPath();
     std::string fIn_phi_name = iConfig.getParameter<edm::FileInPath>("mantra_bmtfcorr_phi_windows").fullPath();
 
-    auto bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
+    const auto& bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
 
     TFile* fIn_theta = TFile::Open(fIn_theta_name.c_str());
     TFile* fIn_phi = TFile::Open(fIn_phi_name.c_str());
@@ -263,7 +252,7 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
     std::string fIn_theta_name = iConfig.getParameter<edm::FileInPath>("mantra_omtfcorr_theta_windows").fullPath();
     std::string fIn_phi_name = iConfig.getParameter<edm::FileInPath>("mantra_omtfcorr_phi_windows").fullPath();
 
-    auto bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
+    const auto& bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
 
     TFile* fIn_theta = TFile::Open(fIn_theta_name.c_str());
     TFile* fIn_phi = TFile::Open(fIn_phi_name.c_str());
@@ -283,7 +272,7 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
     std::string fIn_theta_name = iConfig.getParameter<edm::FileInPath>("mantra_emtfcorr_theta_windows").fullPath();
     std::string fIn_phi_name = iConfig.getParameter<edm::FileInPath>("mantra_emtfcorr_phi_windows").fullPath();
 
-    auto bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
+    const auto& bounds = L1TkMuMantra::prepare_corr_bounds(fIn_bounds_name, "h_dphi_l");
 
     TFile* fIn_theta = TFile::Open(fIn_theta_name.c_str());
     TFile* fIn_phi = TFile::Open(fIn_phi_name.c_str());
@@ -302,7 +291,7 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
 L1TkMuonProducer::~L1TkMuonProducer() {}
 
 // ------------ method called to produce the data  ------------
-void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void L1TkMuonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   // the L1Mu objects
   edm::Handle<RegionalMuonCandBxCollection> l1bmtfH;
   edm::Handle<RegionalMuonCandBxCollection> l1omtfH;
@@ -316,7 +305,7 @@ void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   // the L1Tracks
   edm::Handle<L1TTTrackCollectionType> l1tksH;
-  iEvent.getByToken(trackToken, l1tksH);
+  iEvent.getByToken(trackToken_, l1tksH);
 
   TkMuonCollection oc_bmtf_tkmuon;
   TkMuonCollection oc_omtf_tkmuon;
@@ -333,8 +322,8 @@ void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   if (bmtfMatchAlgoVersion_ == kTP)
     runOnMTFCollection_v1(l1bmtfH, l1tksH, oc_bmtf_tkmuon, barrel_MTF_region);
   else if (bmtfMatchAlgoVersion_ == kMantra) {
-    auto muons = product_to_muvec(*l1bmtfH.product());
-    auto match_idx = mantracorr_barr_->find_match(mantradf_tracks, muons);
+    const auto& muons = product_to_muvec(*l1bmtfH.product());
+    const auto& match_idx = mantracorr_barr_->find_match(mantradf_tracks, muons);
     build_tkMuons_from_idxs(oc_bmtf_tkmuon, match_idx, l1tksH, l1bmtfH, barrel_MTF_region);
   } else
     throw cms::Exception("TkMuAlgoConfig") << " barrel : trying to run an invalid algorithm version "
@@ -344,8 +333,8 @@ void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   if (omtfMatchAlgoVersion_ == kTP)
     runOnMTFCollection_v1(l1omtfH, l1tksH, oc_omtf_tkmuon, overlap_MTF_region);
   else if (omtfMatchAlgoVersion_ == kMantra) {
-    auto muons = product_to_muvec(*l1omtfH.product());
-    auto match_idx = mantracorr_ovrl_->find_match(mantradf_tracks, muons);
+    const auto& muons = product_to_muvec(*l1omtfH.product());
+    const auto& match_idx = mantracorr_ovrl_->find_match(mantradf_tracks, muons);
     build_tkMuons_from_idxs(oc_omtf_tkmuon, match_idx, l1tksH, l1omtfH, overlap_MTF_region);
   } else
     throw cms::Exception("TkMuAlgoConfig") << " overlap : trying to run an invalid algorithm version "
@@ -357,9 +346,11 @@ void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   else if (emtfMatchAlgoVersion_ == kDynamicWindows)
     runOnMTFCollection_v2(l1emtfTCH, l1tksH, oc_emtf_tkmuon);
   else if (emtfMatchAlgoVersion_ == kMantra) {
-    auto muons = product_to_muvec(*l1emtfTCH.product());
-    auto match_idx = mantracorr_endc_->find_match(mantradf_tracks, muons);
-    build_tkMuons_from_idxs(oc_emtf_tkmuon, match_idx, l1tksH, endcap_MTF_region);
+    const auto& muons = product_to_muvec(*l1emtfTCH.product());
+    const auto& match_idx = mantracorr_endc_->find_match(mantradf_tracks, muons);
+    //for the TkMu that were built from a EMTFCollection - do not produce a valid muon ref
+    edm::Handle<RegionalMuonCandBxCollection> invalidMuonH;
+    build_tkMuons_from_idxs(oc_emtf_tkmuon, match_idx, l1tksH, invalidMuonH, endcap_MTF_region);
   } else
     throw cms::Exception("TkMuAlgoConfig") << "endcap : trying to run an invalid algorithm version "
                                            << emtfMatchAlgoVersion_ << " (this should never happen)\n";
@@ -392,16 +383,13 @@ void L1TkMuonProducer::runOnMTFCollection_v1(const edm::Handle<RegionalMuonCandB
     float l1mu_phi =
         MicroGMTConfiguration::calcGlobalPhi(l1mu->hwPhi(), l1mu->trackFinderType(), l1mu->processor()) * phi_scale;
 
-    float l1mu_feta = fabs(l1mu_eta);
+    float l1mu_feta = std::abs(l1mu_eta);
     if (l1mu_feta < etaMin_)
       continue;
     if (l1mu_feta > etaMax_)
       continue;
 
     float drmin = 999;
-    float ptmax = -1;
-    if (ptmax < 0)
-      ptmax = -1;  // dummy
 
     PropState matchProp;
     int match_idx = -1;
@@ -417,7 +405,7 @@ void L1TkMuonProducer::runOnMTFCollection_v1(const edm::Handle<RegionalMuonCandB
         continue;
 
       float l1tk_z = l1tk.POCA().z();
-      if (fabs(l1tk_z) > zMax_)
+      if (std::abs(l1tk_z) > zMax_)
         continue;
 
       float l1tk_chi2 = l1tk.chi2();
@@ -431,7 +419,7 @@ void L1TkMuonProducer::runOnMTFCollection_v1(const edm::Handle<RegionalMuonCandB
       float l1tk_eta = l1tk.momentum().eta();
       float l1tk_phi = l1tk.momentum().phi();
 
-      float dr2 = deltaR2(l1mu_eta, l1mu_phi, l1tk_eta, l1tk_phi);
+      float dr2 = reco::deltaR2(l1mu_eta, l1mu_phi, l1tk_eta, l1tk_phi);
       if (dr2 > dr2_cutoff)
         continue;
 
@@ -441,7 +429,7 @@ void L1TkMuonProducer::runOnMTFCollection_v1(const edm::Handle<RegionalMuonCandB
       if (!pstate.valid)
         continue;
 
-      float dr2prop = deltaR2(l1mu_eta, l1mu_phi, pstate.eta, pstate.phi);
+      float dr2prop = reco::deltaR2(l1mu_eta, l1mu_phi, pstate.eta, pstate.phi);
       // FIXME: check if this matching procedure can be improved with
       // a pT dependent dR window
       if (dr2prop < drmin) {
@@ -497,7 +485,7 @@ void L1TkMuonProducer::runOnMTFCollection_v2(const edm::Handle<EMTFTrackCollecti
                                              TkMuonCollection& tkMuons) const {
   const EMTFTrackCollection& l1mus = (*muonH.product());
   const L1TTTrackCollectionType& l1trks = (*l1tksH.product());
-  auto corr_mu_idxs = dwcorr_->find_match(l1mus, l1trks);
+  const auto& corr_mu_idxs = dwcorr_->find_match(l1mus, l1trks);
   // it's a vector with as many entries as the L1TT vector.
   // >= 0 : the idx in the EMTF vector of matched mu
   // < 0: no match
@@ -508,7 +496,7 @@ void L1TkMuonProducer::runOnMTFCollection_v2(const edm::Handle<EMTFTrackCollecti
         << "the size of tkmu indices does not match the size of input trk collection\n";
 
   for (uint il1ttrack = 0; il1ttrack < corr_mu_idxs.size(); ++il1ttrack) {
-    int emtf_idx = corr_mu_idxs.at(il1ttrack);
+    int emtf_idx = corr_mu_idxs[il1ttrack];
     if (emtf_idx < 0)
       continue;
 
@@ -584,10 +572,7 @@ L1TkMuonProducer::PropState L1TkMuonProducer::propagateToGMT(const L1TkMuonProdu
     deta = deta * tanh(tk_eta);
   }
   float resPhi = tk_phi - 1.464 * tk_q * cosh(1.7) / cosh(etaProp) / tk_pt * dzCorrPhi - M_PI / 144.;
-  if (resPhi > M_PI)
-    resPhi -= 2. * M_PI;
-  if (resPhi < -M_PI)
-    resPhi += 2. * M_PI;
+  resPhi = reco::reduceRange(resPhi);
 
   dest.eta = tk_eta + deta;
   dest.phi = resPhi;
@@ -613,24 +598,24 @@ double L1TkMuonProducer::sigmaPhiTP(const RegionalMuonCand& mu) const { return 0
 
 // ------------------------------------------------------------------------------------------------------------
 
-std::vector<L1TkMuMantraDF::track_df> L1TkMuonProducer::product_to_trkvec(const L1TTTrackCollectionType& l1tks) {
+std::vector<L1TkMuMantraDF::track_df> L1TkMuonProducer::product_to_trkvec(const L1TTTrackCollectionType& l1tks) const {
   std::vector<L1TkMuMantraDF::track_df> result(l1tks.size());
   for (uint itrk = 0; itrk < l1tks.size(); ++itrk) {
-    auto& trk = l1tks.at(itrk);
+    auto& trk = l1tks[itrk];
 
-    result.at(itrk).pt = trk.momentum().perp();
-    result.at(itrk).eta = trk.momentum().eta();
-    result.at(itrk).theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(trk.momentum().eta()));
-    result.at(itrk).phi = trk.momentum().phi();
-    result.at(itrk).nstubs = trk.getStubRefs().size();
-    result.at(itrk).chi2 = trk.chi2();
-    result.at(itrk).charge = (trk.rInv() > 0 ? 1 : -1);
+    result[itrk].pt = trk.momentum().perp();
+    result[itrk].eta = trk.momentum().eta();
+    result[itrk].theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(trk.momentum().eta()));
+    result[itrk].phi = trk.momentum().phi();
+    result[itrk].nstubs = trk.getStubRefs().size();
+    result[itrk].chi2 = trk.chi2();
+    result[itrk].charge = (trk.rInv() > 0 ? 1 : -1);
   }
 
   return result;
 }
 
-std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const RegionalMuonCandBxCollection& l1mtfs) {
+std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const RegionalMuonCandBxCollection& l1mtfs) const {
   std::vector<L1TkMuMantraDF::muon_df> result;
   for (auto l1mu = l1mtfs.begin(0); l1mu != l1mtfs.end(0); ++l1mu)  // considering BX = 0 only
   {
@@ -646,15 +631,15 @@ std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const Re
   return result;
 }
 
-std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const EMTFTrackCollection& l1mus) {
+std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const EMTFTrackCollection& l1mus) const {
   std::vector<L1TkMuMantraDF::muon_df> result(l1mus.size());
   for (uint imu = 0; imu < l1mus.size(); ++imu) {
-    auto& mu = l1mus.at(imu);
-    result.at(imu).pt = mu.Pt();
-    result.at(imu).eta = mu.Eta();
-    result.at(imu).theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(mu.Eta()));
-    result.at(imu).phi = L1TkMuMantra::deg_to_rad(mu.Phi_glob());
-    result.at(imu).charge = mu.Charge();
+    auto& mu = l1mus[imu];
+    result[imu].pt = mu.Pt();
+    result[imu].eta = mu.Eta();
+    result[imu].theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(mu.Eta()));
+    result[imu].phi = L1TkMuMantra::deg_to_rad(mu.Phi_glob());
+    result[imu].charge = mu.Charge();
   }
   return result;
 }
@@ -665,7 +650,7 @@ void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
                                                const edm::Handle<RegionalMuonCandBxCollection>& muonH,
                                                int detector) const {
   for (uint imatch = 0; imatch < matches.size(); ++imatch) {
-    int match_trk_idx = matches.at(imatch);
+    int match_trk_idx = matches[imatch];
     if (match_trk_idx < 0)
       continue;  // this muon was not matched to any candidate
 
@@ -677,37 +662,7 @@ void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
     math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
 
     edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, match_trk_idx);
-    edm::Ref<RegionalMuonCandBxCollection> l1muRef(muonH, imatch);
-
-    float trkisol = -999;
-    TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);
-    l1tkmu.setTrackCurvature(matchTk.rInv());
-    l1tkmu.setTrkzVtx((float)tkv3.z());
-    l1tkmu.setMuonDetector(detector);
-    tkMuons.push_back(l1tkmu);
-  }
-  return;
-}
-
-void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
-                                               const std::vector<int>& matches,
-                                               const edm::Handle<L1TTTrackCollectionType>& l1tksH,
-                                               int detector) const {
-  for (uint imatch = 0; imatch < matches.size(); ++imatch) {
-    int match_trk_idx = matches.at(imatch);
-    if (match_trk_idx < 0)
-      continue;  // this muon was not matched to any candidate
-
-    // take properties of the track
-    const L1TTTrackType& matchTk = (*l1tksH.product())[match_trk_idx];
-    const auto& p3 = matchTk.momentum();
-    const auto& tkv3 = matchTk.POCA();
-    float p4e = sqrt(mu_mass * mu_mass + p3.mag2());
-    math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
-
-    edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, match_trk_idx);
-    edm::Ref<RegionalMuonCandBxCollection>
-        l1muRef;  // NOTE: this is the only difference from the function above, but could not find a way to make a conditional constructor
+    auto l1muRef = muonH.isValid() ? edm::Ref<RegionalMuonCandBxCollection>(muonH, imatch) : edm::Ref<RegionalMuonCandBxCollection>();
 
     float trkisol = -999;
     TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -615,7 +615,8 @@ std::vector<L1TkMuMantraDF::track_df> L1TkMuonProducer::product_to_trkvec(const 
   return result;
 }
 
-std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const RegionalMuonCandBxCollection& l1mtfs) const {
+std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(
+    const RegionalMuonCandBxCollection& l1mtfs) const {
   std::vector<L1TkMuMantraDF::muon_df> result;
   for (auto l1mu = l1mtfs.begin(0); l1mu != l1mtfs.end(0); ++l1mu)  // considering BX = 0 only
   {
@@ -662,7 +663,8 @@ void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
     math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
 
     edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, match_trk_idx);
-    auto l1muRef = muonH.isValid() ? edm::Ref<RegionalMuonCandBxCollection>(muonH, imatch) : edm::Ref<RegionalMuonCandBxCollection>();
+    auto l1muRef = muonH.isValid() ? edm::Ref<RegionalMuonCandBxCollection>(muonH, imatch)
+                                   : edm::Ref<RegionalMuonCandBxCollection>();
 
     float trkisol = -999;
     TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -8,7 +8,6 @@
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 


### PR DESCRIPTION
#### PR description:

@Dr15Jones pointed out that the producers introduced in #30363 were not converted from legacy producers to modern producers. I converted them and applied the usual code review comments that were skipped/ignored in the original PR:
* delete commented-out code
* use std::make_unique, std::abs, reco::deltaR, reco::reduceRange
* member variables end in underscore
* range-based loops
* capture returned temporaries with const auto&
* etc.

#### PR validation:

Ran workflow 23234.0 successfully.

Should this be backported to 11_1_X?