### PR TITLE
HLT TDR event content refinements: 11_2_X

### DIFF
--- a/HLTrigger/Configuration/python/HLTPhase2TDR_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTPhase2TDR_EventContent_cff.py
@@ -33,12 +33,8 @@ HLTPhase2TDR = cms.PSet(
         'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTClusterAssociationMap_TTClusterAssociatorFromPixelDigis_ClusterAccepted_HLT',
         'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersHAD__*',
         'drop recoTrackExtras_electronGsfTracksFromMultiCl__*',
-        'drop recoGsfElectrons_ecalDrivenGsfElectronsFromMultiCl__*',
-        'drop l1tHGCalMulticlusterBXVector_hgcalBackEndLayer2Producer_HGCalBackendLayer2Processor3DClustering_*',
         'drop Phase2TrackerDigiedmDetSetVectorPhase2TrackerDigiPhase2TrackerDigiedmrefhelperFindForDetSetVectoredmRefTTStubAssociationMap_TTStubAssociatorFromPixelDigis_StubAccepted_HLT',
-        'drop recoGsfTracks_electronGsfTracks__*',
         'drop CaloTowersSorted_towerMaker__*',
-        'drop recoGsfTracks_electronGsfTracksFromMultiCl__*',
         'drop l1tHGCalTowerBXVector_hgcalTowerProducer_HGCalTowerProcessor_*',
         'drop TrackingRecHitsOwned_electronGsfTracks__*',
         'drop recoHGCalMultiClusters_ticlMultiClustersFromTrackstersEM__*',
@@ -50,7 +46,27 @@ HLTPhase2TDR = cms.PSet(
         'drop *_simGmtStage2Digis_*_HLT',
         'drop *_simGtStage2Digis_*_HLT',
         'drop *_simOmtfDigis_*_HLT',
-        
+        'keep *_TTClusterAssociatorFromPixelDigis_ClusterAccepted_*',
+        'drop *_TTClusterAssociatorFromPixelDigis_*_HLT',
+        'keep *_particleFlowTmpBarrel_*_*',
+        'keep *_muons_muons1stStep2muonsMap_*',
+        'drop recoElectronSeeds_electronMergedSeeds__*',
+        #low pt GsfElectrons which are pointless for HLT TDR
+        'drop recoCaloClusters_lowPtGsfElectronSuperClusters__*',
+        'drop recoGsfElectrons_lowPtGsfElectrons__*',
+        'drop recoGsfTracks_lowPtGsfEleGsfTracks__*',
+        'drop recoSuperClusters_lowPtGsfElectronSuperClusters__*',
+        'drop recoGsfElectronCores_lowPtGsfElectronCores__*',
+        'drop floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_*',
+        'drop floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_*',
+        'drop recoTracksedmAssociation_lowPtGsfToTrackLinks__*',
+        'drop floatedmValueMap_lowPtGsfElectronID__*',
+        'drop *_gsfTracksOpenConversions_*_*',
+        #e/gamma for ecal debugging, out of scope for tdr
+        'drop recoGsfElectrons_uncleanedOnlyGsfElectrons__*',
+        'drop recoGsfElectronCores_uncleanedOnlyGsfElectronCores__*',
+        #tracking debugging not needed
+        'drop TrackingRecHitsOwned_electronGsfTracksFromMultiCl__*',
     ) )
 )
 


### PR DESCRIPTION
#### PR description:

This should be the final event content refinement for the HLT TDR. 

It removes the electron pixel seeds which are not necessary and take about 0.6MB. It adds in particleFlow in the barrel so it can be easily recombined with pfTICL candidates to make the full pf collection. It also tweaks the egamma event format, adding back in the gsftracks and gsfelectrons which are useful for particle flow integrations (and do not take up much space).  As well as adding muons1stStep2muonsMap for particle flow combinations. 

It adds in the TTCluster association map of accepted clusters needed for tracking particle association to L1 tracks. As well L1 HGCAL multi clusters mainly as they take up little space and could possibly be useful. 

Finally it cleans out the lowPt electrons and uncleaned electron collections as both are not really needed (uncleaned is ecal debuging, lowPt, well we're not going to be triggering <2 GeV electrons at 200 PU, at least not in the TDR





#### PR validation:

event content looks as expected 
