### PR TITLE
MET filter fix for nanoAOD step in extraflags_cff file i.e. addition of slimmedOfflinePrimaryVertices input tag (follow up of PR 30015)

### DIFF
--- a/PhysicsTools/NanoAOD/python/extraflags_cff.py
+++ b/PhysicsTools/NanoAOD/python/extraflags_cff.py
@@ -15,6 +15,7 @@ from RecoMET.METFilters.BadPFMuonFilter_cfi import BadPFMuonFilter
 BadPFMuonTagger = BadPFMuonFilter.clone(
     PFCandidates = cms.InputTag("packedPFCandidates"),
     muons = cms.InputTag("slimmedMuons"),
+    vtx = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taggingMode = True,
 )
 
@@ -23,6 +24,7 @@ from RecoMET.METFilters.BadChargedCandidateFilter_cfi import BadChargedCandidate
 BadChargedCandidateTagger = BadChargedCandidateFilter.clone(
     PFCandidates = cms.InputTag("packedPFCandidates"),
     muons = cms.InputTag("slimmedMuons"),
+    vtx = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taggingMode = True,
 )
 


### PR DESCRIPTION
MET filter fix for nanoAOD step in extraflags_cff file i.e. addition of slimmedOfflinePrimaryVertices input tag (follow up of #30015).
This PR fixes the error found in wf 136.7722 and 1329.1 since `CMSSW_11_2_X_2020-07-28-2300` (#30015)
```
----- Begin Fatal Exception 29-Jul-2020 04:47:17 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 283877 lumi: 11 event: 18172717 stream: 3
   [1] Running path 'nanoAOD_step'
   [2] Calling method for module BadParticleFilter/'BadPFMuonTagger'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: std::vector&lt;reco::Vertex&gt;
Looking for module label: offlinePrimaryVertices
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```
