### PR TITLE
GFlash updated

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -69,6 +69,7 @@ public:
 
 protected:
   virtual double getEnergyDeposit(const G4Step* step);
+  virtual double EnergyCorrected(const G4Step& step, const G4Track*);
   virtual bool getFromLibrary(const G4Step* step);
 
   G4ThreeVector setToLocal(const G4ThreeVector&, const G4VTouchable*) const;

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -16,7 +16,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-//#include "G4String.hh"
 #ifdef plotDebug
 #include <TH2F.h>
 #endif
@@ -42,7 +41,7 @@ protected:
   double getEnergyDeposit(const G4Step *) override;
   int getTrackID(const G4Track *) override;
   uint16_t getDepth(const G4Step *) override;
-  double EnergyCorrected(const G4Step&, const G4Track*) override;
+  double EnergyCorrected(const G4Step &, const G4Track *) override;
 
 private:
   void initMap();

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -16,7 +16,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4String.hh"
+//#include "G4String.hh"
 #ifdef plotDebug
 #include <TH2F.h>
 #endif
@@ -42,6 +42,7 @@ protected:
   double getEnergyDeposit(const G4Step *) override;
   int getTrackID(const G4Track *) override;
   uint16_t getDepth(const G4Step *) override;
+  double EnergyCorrected(const G4Step&, const G4Track*) override;
 
 private:
   void initMap();

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -187,7 +187,9 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
   const G4Track* track = aSpot->GetOriginatorTrack()->GetPrimaryTrack();
 
   double edep = aSpot->GetEnergySpot()->GetEnergy();
-  if (edep <= 0.0) { return false; }
+  if (edep <= 0.0) {
+    return false;
+  }
 
   G4Step fFakeStep;
   G4StepPoint* fFakePreStepPoint = fFakeStep.GetPreStepPoint();
@@ -198,8 +200,10 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
   G4TouchableHandle fTouchableHandle = aSpot->GetTouchableHandle();
   fFakePreStepPoint->SetTouchableHandle(fTouchableHandle);
   fFakeStep.SetTotalEnergyDeposit(edep);
-  edep = EnergyCorrected(fFakeStep, track); 
-  if (edep <= 0.0) { return false; }
+  edep = EnergyCorrected(fFakeStep, track);
+  if (edep <= 0.0) {
+    return false;
+  }
 
   if (G4TrackToParticleID::isGammaElectronPositron(track)) {
     edepositEM = edep;
@@ -245,7 +249,7 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
 
 double CaloSD::getEnergyDeposit(const G4Step* aStep) { return aStep->GetTotalEnergyDeposit(); }
 
-double CaloSD::EnergyCorrected(const G4Step& aStep, const G4Track*) { return aStep.GetTotalEnergyDeposit(); } 
+double CaloSD::EnergyCorrected(const G4Step& aStep, const G4Track*) { return aStep.GetTotalEnergyDeposit(); }
 
 bool CaloSD::getFromLibrary(const G4Step*) { return false; }
 

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -185,14 +185,10 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
 bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
   edepositEM = edepositHAD = 0.f;
   const G4Track* track = aSpot->GetOriginatorTrack()->GetPrimaryTrack();
-  if (!G4TrackToParticleID::isGammaElectronPositron(track)) {
-    return false;
-  }
+
   double edep = aSpot->GetEnergySpot()->GetEnergy();
-  if (edep <= 0.0) {
-    return false;
-  }
-  edepositEM = edep;
+  if (edep <= 0.0) { return false; }
+
   G4Step fFakeStep;
   G4StepPoint* fFakePreStepPoint = fFakeStep.GetPreStepPoint();
   G4StepPoint* fFakePostStepPoint = fFakeStep.GetPostStepPoint();
@@ -202,6 +198,14 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
   G4TouchableHandle fTouchableHandle = aSpot->GetTouchableHandle();
   fFakePreStepPoint->SetTouchableHandle(fTouchableHandle);
   fFakeStep.SetTotalEnergyDeposit(edep);
+  edep = EnergyCorrected(fFakeStep, track); 
+  if (edep <= 0.0) { return false; }
+
+  if (G4TrackToParticleID::isGammaElectronPositron(track)) {
+    edepositEM = edep;
+  } else {
+    edepositHAD = edep;
+  }
 
   unsigned int unitID = setDetUnitId(&fFakeStep);
 
@@ -240,6 +244,8 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
 }
 
 double CaloSD::getEnergyDeposit(const G4Step* aStep) { return aStep->GetTotalEnergyDeposit(); }
+
+double CaloSD::EnergyCorrected(const G4Step& aStep, const G4Track*) { return aStep.GetTotalEnergyDeposit(); } 
 
 bool CaloSD::getFromLibrary(const G4Step*) { return false; }
 

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -222,7 +222,7 @@ double ECalSD::EnergyCorrected(const G4Step& step, const G4Track* track) {
     auto ite = xtalLMap.find(lv);
     crystalLength = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
     crystalDepth = (ite == xtalLMap.end()) ? 0.0 : (std::abs(0.5 * (ite->second) + currentLocalPoint.z()));
-    edep *= curve_LY(lv)*getResponseWt(track);
+    edep *= curve_LY(lv) * getResponseWt(track);
   }
   return edep;
 }

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -212,6 +212,21 @@ double ECalSD::getEnergyDeposit(const G4Step* aStep) {
   return edep;
 }
 
+double ECalSD::EnergyCorrected(const G4Step& step, const G4Track* track) {
+  double edep = step.GetTotalEnergyDeposit();
+  const G4StepPoint* hitPoint = step.GetPreStepPoint();
+  const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+
+  if (useWeight && !any(noWeight, lv)) {
+    currentLocalPoint = setToLocal(hitPoint->GetPosition(), hitPoint->GetTouchable());
+    auto ite = xtalLMap.find(lv);
+    crystalLength = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
+    crystalDepth = (ite == xtalLMap.end()) ? 0.0 : (std::abs(0.5 * (ite->second) + currentLocalPoint.z()));
+    edep *= curve_LY(lv)*getResponseWt(track);
+  }
+  return edep;
+}
+
 int ECalSD::getTrackID(const G4Track* aTrack) {
   int primaryID(0);
   if (storeTrack && depth > 0) {


### PR DESCRIPTION
#### PR description:
WHen GFlash method is used in ECAL hit simulation corrections due to light attenuation are now taken into account. This PR should not affect mainstream simulation.


#### PR validation:
private


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
no backport
