### PR TITLE
Update HLT jet energy corrections in offline data GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '112X_dataRun2_v2',
+    'run1_data'         :   '112X_dataRun2_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '112X_dataRun2_v2',
+    'run2_data'         :   '112X_dataRun2_v3',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v2',
+    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '112X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '112X_dataRun2_relval_v3',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR updates the HLT jet energy corrections in the offline data GTs to use the HLT jet energy corrections used in the HLT GT, for example, [111X_dataRun3_HLT_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/111X_dataRun3_HLT_v1). This change resolves the warning messages reported in the [cms-hlt e-group thread](https://groups.cern.ch/group/cms-hlt/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fcms%2Dhlt%2FLists%2FArchive%2FFlood%20of%20SimpleJetCorrector%20in%20HLT%20addOnTests&FolderCTID=0x012002005CF9F426540B9C4D8205911CC3985E98).

The GT diffs given below are the same for all GTs.

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_v2/112X_dataRun2_v3

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HEfail_v2/112X_dataRun2_HEfail_v3

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_relval_v2/112X_dataRun2_relval_v3

Attn: @missirol 

#### PR validation:

In addition, two technical tests were performed: `runTheMatrix.py -l limited --ibeos` and `addOnTests.py`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 11_1_X. It will _not_ be backported to 10_6_X as the legacy production did not use an offline GT for the HLT step. Also, the code that prints the warning regarding negative jet energy corrections was not backported to 10_6_X, so this change is not needed for that reason.