### PR TITLE
Shorten upgrade workflow names, reorganize premixing workflow setup and add to PR tests for phase 2

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -264,10 +264,10 @@ class MatrixInjector(object):
             wmsplit['RECOUP15']=1 
             wmsplit['RECOAODUP15']=5
             wmsplit['DBLMINIAODMCUP15NODQM']=5
-            wmsplit['DigiFull']=5
-            wmsplit['RecoFull']=5
-            wmsplit['DigiFullPU']=1
-            wmsplit['RecoFullPU']=1
+            wmsplit['Digi']=5
+            wmsplit['Reco']=5
+            wmsplit['DigiPU']=1
+            wmsplit['RecoPU']=1
             wmsplit['RECOHID11']=1
             wmsplit['DIGIUP17']=1
             wmsplit['RECOUP17']=1
@@ -289,8 +289,8 @@ class MatrixInjector(object):
             from .upgradeWorkflowComponents import upgradeKeys
             for key in upgradeKeys[2026]:
                 if not "PU" in key: continue
-                wmsplit['DigiFullTriggerPU_'+key] = 1
-                wmsplit['RecoFullGlobalPU_'+key] = 1
+                wmsplit['DigiTriggerPU_'+key] = 1
+                wmsplit['RecoGlobalPU_'+key] = 1
                          
             #import pprint
             #pprint.pprint(wmsplit)            

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -183,6 +183,11 @@ class MatrixReader(object):
             wfName = wfInfo[0]
             stepList = wfInfo[1]
             stepOverrides=wfInfo.overrides
+            # upgrade case: special workflow has basic name and then suffix
+            wfSuffix = ""
+            if isinstance(wfName, list) and len(wfName)>1:
+                wfSuffix = wfName[1]
+                wfName = wfName[0]
             # if no explicit name given for the workflow, use the name of step1
             if wfName.strip() == '': wfName = stepList[0]
             # option to specialize the wf as the third item in the WF list
@@ -199,6 +204,8 @@ class MatrixReader(object):
                         addTo.append(0)
 
             name=wfName
+            # separate suffix by + because show() excludes first part of name
+            if len(wfSuffix)>0: name = name+'+'+wfSuffix[1:]
             stepIndex=0
             ranStepList=[]
 
@@ -249,8 +256,10 @@ class MatrixReader(object):
                         stepName = step+"INPUT"
                         stepList.remove(step)
                         stepList.insert(stepIndex,stepName)
-                """    
-                name += stepName
+                """
+                stepNameTmp = stepName
+                if len(wfSuffix)>0: stepNameTmp = stepName.replace(wfSuffix,"")
+                name += stepNameTmp
                 if addCom and (not addTo or addTo[stepIndex]==1):
                     from Configuration.PyReleaseValidation.relval_steps import merge
                     copyStep=merge(addCom+[self.makeStep(self.relvalModule.steps[stepName],stepOverrides)])

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -183,10 +183,12 @@ class MatrixReader(object):
             wfName = wfInfo[0]
             stepList = wfInfo[1]
             stepOverrides=wfInfo.overrides
-            # upgrade case: special workflow has basic name and then suffix
+            # upgrade case: workflow has basic name, key[, suffix (only special workflows)]
+            wfKey = ""
             wfSuffix = ""
             if isinstance(wfName, list) and len(wfName)>1:
-                wfSuffix = wfName[1]
+                if len(wfName)>2: wfSuffix = wfName[2]
+                wfKey = wfName[1]
                 wfName = wfName[0]
             # if no explicit name given for the workflow, use the name of step1
             if wfName.strip() == '': wfName = stepList[0]
@@ -204,8 +206,10 @@ class MatrixReader(object):
                         addTo.append(0)
 
             name=wfName
-            # separate suffix by + because show() excludes first part of name
-            if len(wfSuffix)>0: name = name+'+'+wfSuffix[1:]
+            # separate suffixes by + because show() excludes first part of name
+            if len(wfKey)>0:
+                name = name+'+'+wfKey
+                if len(wfSuffix)>0: name = name+wfSuffix
             stepIndex=0
             ranStepList=[]
 
@@ -258,7 +262,8 @@ class MatrixReader(object):
                         stepList.insert(stepIndex,stepName)
                 """
                 stepNameTmp = stepName
-                if len(wfSuffix)>0: stepNameTmp = stepName.replace(wfSuffix,"")
+                if len(wfKey)>0: stepNameTmp = stepNameTmp.replace('_'+wfKey,"")
+                if len(wfSuffix)>0: stepNameTmp = stepNameTmp.replace(wfSuffix,"")
                 name += stepNameTmp
                 if addCom and (not addTo or addTo[stepIndex]==1):
                     from Configuration.PyReleaseValidation.relval_steps import merge

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -229,7 +229,7 @@ class MatrixReader(object):
                     else:
                         testName=step+'INPUT'
                     #print "JR",stepI,stepIr,testName,stepList
-                    if testName in self.relvalModule.steps.keys():
+                    if testName in self.relvalModule.steps:
                         #print "JR",stepI,stepIr
                         stepList[stepI]=testName
                         #pop the rest in the list

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -16,7 +16,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 numWFIB = []
 numWFIB.extend([23234.0]) #2026D49
 numWFIB.extend([23461.97]) #2026D49 premixing stage1 (NuGun+PU)
-numWFIB.extend([23434.99]) #2026D49 premixing combined stage1+stage2 (ttbar+PU)
+numWFIB.extend([23434.99,23434.999]) #2026D49 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([23234.21,23434.21]) #2026D49 prodlike, prodlike PU
 numWFIB.extend([23234.103]) #2026D49 aging
 numWFIB.extend([23634.0]) #2026D51

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1752,16 +1752,8 @@ digiPremixUp2015Defaults25ns = {
     '--procModifiers': 'premix_stage2',
     '--era'          : 'Run2_2016'
     }
-# Specifying explicitly the --filein is not nice but that was the
-# easiest way to "skip" the output of step2 (=premixing stage1) for
-# filein (as it goes to pileup_input). It works (a bit accidentally
-# though) also for "-i all" because in that case the --filein for DAS
-# input is after this one in the list of command line arguments to
-# cmsDriver, and gets then used in practice.
-digiPremixLocalPileup = {
-    "--filein": "file:step1.root",
-    "--pileup_input": "file:step2.root"
-}
+
+from .upgradeWorkflowComponents import digiPremixLocalPileup
 digiPremixLocalPileupUp2015Defaults25ns = merge([digiPremixLocalPileup,
                                                  digiPremixUp2015Defaults25ns])
 digiPremixUp2015Defaults50ns=merge([{'-s':'DIGI:pdigi_valid,DATAMIX,L1,DIGI2RAW,HLT:@relval50ns'},
@@ -3387,73 +3379,18 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     # setup PU
     if k2 in PUDataSets:
-        # Setup premixing stage1
-        #
-        # Has to be done before the overall PU definition in order to benefit from that
-        #
-        # It is a complete overkill to define premixing step for
-        # each generator fragment, but let's worry about
-        # simplification later
-        for step in upgradeWFs['baseline'].steps:
-            if "GenSim" in step:
-                stepNamePmx = step.replace('GenSim', 'Premix') + 'PU' + upgradeWFs['Premix'].suffix
-                d = merge([{'-s'            : 'GEN,SIM,DIGI:pdigi_valid',
-                            '--datatier'    : 'PREMIX',
-                            '--eventcontent': 'PREMIX',
-                            '--procModifiers': 'premix_stage1',
-                           },
-                           PUDataSets[k2],upgradeStepDict[step][k]])
-                upgradeStepDict[stepNamePmx][k] = d
-
         for specialType,specialWF in six.iteritems(upgradeWFs):
-            if "Premix" in specialType:
-                # Premix stage1 is already set above, and there are no non-PU steps so has to be ignored here
-                continue
             for step in specialWF.PU:
-                stepName = step + specialWF.suffix
-                stepNamePU = step + 'PU' + specialWF.suffix
-                stepNamePUpmx = step + 'PUPRMX' + specialWF.suffix
+                stepName = specialWF.getStepName(step)
+                stepNamePU = specialWF.getStepNamePU(step)
                 if k not in upgradeStepDict[stepName] or upgradeStepDict[stepName][k] is None:
                     upgradeStepDict[stepNamePU][k] = None
-                elif stepNamePU in upgradeStepDict and k in upgradeStepDict[stepNamePU]:
-                    # in case special WF had PU-specific changes
-                    upgradeStepDict[stepNamePU][k]=merge([PUDataSets[k2],upgradeStepDict[stepNamePU][k]])
                 else:
                     upgradeStepDict[stepNamePU][k]=merge([PUDataSets[k2],upgradeStepDict[stepName][k]])
 
-                # Setup premixing stage2
-                if "Digi" in step or "Reco" in step:
-                    d = merge([upgradeStepDict[stepName][k]])
-                    if d is None: continue
-                    if "Digi" in step:
-                        tmpsteps = []
-                        for s in d["-s"].split(","):
-                            if s == "DIGI" or "DIGI:" in s:
-                                tmpsteps.extend([s, "DATAMIX"])
-                            else:
-                                tmpsteps.append(s)
-                        d = merge([{"-s"             : ",".join(tmpsteps),
-                                    "--datamix"      : "PreMix",
-                                    "--procModifiers": "premix_stage2"},
-                                   d])
-                    elif "Reco" in step:
-                        if "--procModifiers" in d:
-                            d["--procModifiers"] += ",premix_stage2"
-                        else:
-                            d["--procModifiers"] = "premix_stage2"
-                    upgradeStepDict[stepNamePUpmx][k] = d
-                    # For combined stage1+stage2
-                    if "Digi" in step:
-                        upgradeStepDict[stepNamePUpmx+"Combined"][k] = merge([digiPremixLocalPileup, d])
-                # Increase the input file step number by one for Nano in combined stage1+stage2
-                if "Nano" in step:
-                    d = merge([upgradeStepDict[stepName][k]])
-                    if "--filein" in d:
-                        filein = d["--filein"]
-                        m = re.search("step(?P<ind>\d+)_", filein)
-                        if m:
-                            d["--filein"] = filein.replace(m.group(), "step%d_"%(int(m.group("ind"))+1))
-                    upgradeStepDict[stepNamePUpmx+"Combined"][k] = d
+            # in case special WF has PU-specific changes: apply *after* basic PU step is created
+            specialWF.setupPU(upgradeStepDict, k, upgradeProperties[year][k])
+
 for step in upgradeStepDict.keys():
     # we need to do this for each fragment
    if 'Sim' in step or 'Premix' in step:
@@ -3461,7 +3398,7 @@ for step in upgradeStepDict.keys():
             howMuch=info.howMuch
             for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:
                 k=frag[:-4]+'_'+key+'_'+step
-                if (step in upgradeStepDict or step.replace("PUPRMX", "PU")) and key in upgradeStepDict[step]:
+                if step in upgradeStepDict and key in upgradeStepDict[step]:
                     if upgradeStepDict[step][key] is None:
                         steps[k]=None
                     elif 'Premix' in step:

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3253,7 +3253,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     beamspot=upgradeProperties[year][k].get('BeamSpot', None)
 
     # setup baseline steps
-    upgradeStepDict['GenSimFull'][k]= {'-s' : 'GEN,SIM',
+    upgradeStepDict['GenSim'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
                                        '--beamspot' : 'Realistic25ns13TeVEarly2017Collision',
@@ -3261,9 +3261,9 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom
                                        }
-    if beamspot is not None: upgradeStepDict['GenSimFull'][k]['--beamspot']=beamspot
+    if beamspot is not None: upgradeStepDict['GenSim'][k]['--beamspot']=beamspot
 
-    upgradeStepDict['GenSimHLBeamSpotFull'][k]= {'-s' : 'GEN,SIM',
+    upgradeStepDict['GenSimHLBeamSpot'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
                                        '--beamspot' : 'HLLHC',
@@ -3272,7 +3272,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--geometry' : geom
                                        }
 
-    upgradeStepDict['GenSimHLBeamSpotFull14'][k]= {'-s' : 'GEN,SIM',
+    upgradeStepDict['GenSimHLBeamSpot14'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
                                        '--beamspot' : 'HLLHC14TeV',
@@ -3281,7 +3281,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--geometry' : geom
                                        }
 
-    upgradeStepDict['DigiFull'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:%s'%(hltversion),
+    upgradeStepDict['Digi'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',
                                       '-n':'10',
@@ -3290,7 +3290,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       }
 
     # Adding Track trigger step in step2
-    upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:%s'%(hltversion),
+    upgradeStepDict['DigiTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',
                                       '-n':'10',
@@ -3298,7 +3298,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
-    upgradeStepDict['RecoFull'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM',
+    upgradeStepDict['Reco'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM',
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-RECO,MINIAODSIM,DQMIO',
                                       '-n':'10',
@@ -3306,7 +3306,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
-    upgradeStepDict['RecoFullGlobal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM',
+    upgradeStepDict['RecoGlobal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM',
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-RECO,MINIAODSIM,DQMIO',
                                       '-n':'10',
@@ -3314,7 +3314,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
-    upgradeStepDict['RecoFullLocal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO:localreco',
+    upgradeStepDict['RecoLocal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO:localreco',
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-RECO',
                                       '-n':'10',
@@ -3322,7 +3322,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
-    upgradeStepDict['MiniAODFullGlobal'][k] = {'-s':'PAT',
+    upgradeStepDict['MiniAOD'][k] = {'-s':'PAT',
                                       '--conditions':gt,
                                       '--datatier':'MINIAODSIM',
                                       '-n':'10',
@@ -3330,7 +3330,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
-    upgradeStepDict['HARVESTFull'][k]={'-s':'HARVESTING:@standardValidation+@standardDQM+@ExtraHLT+@miniAODValidation+@miniAODDQM',
+    upgradeStepDict['HARVEST'][k]={'-s':'HARVESTING:@standardValidation+@standardDQM+@ExtraHLT+@miniAODValidation+@miniAODDQM',
                                     '--conditions':gt,
                                     '--mc':'',
                                     '--geometry' : geom,
@@ -3338,9 +3338,9 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                     '--filetype':'DQM',
                                     }
 
-    upgradeStepDict['HARVESTFullGlobal'][k] = merge([{'-s': 'HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM'}, upgradeStepDict['HARVESTFull'][k]])
+    upgradeStepDict['HARVESTGlobal'][k] = merge([{'-s': 'HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM'}, upgradeStepDict['HARVEST'][k]])
 
-    upgradeStepDict['ALCAFull'][k] = {'-s':'ALCA:SiPixelCalSingleMuon+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+HcalCalHBHEMuonFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+SiStripCalMinBias',
+    upgradeStepDict['ALCA'][k] = {'-s':'ALCA:SiPixelCalSingleMuon+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+HcalCalHBHEMuonFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+SiStripCalMinBias',
                                       '--conditions':gt,
                                       '--datatier':'ALCARECO',
                                       '-n':'10',
@@ -3364,7 +3364,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                     '--scenario' : 'pp'
                                     }
 
-    upgradeStepDict['NanoFull'][k] = {'-s':'NANO',
+    upgradeStepDict['Nano'][k] = {'-s':'NANO',
                                       '--conditions':gt,
                                       '--datatier':'NANOAODSIM',
                                       '-n':'10',

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -39,71 +39,30 @@ for year in upgradeKeys:
                 if 'HARVEST' in step: hasHarvest = True
 
                 for specialType,specialWF in six.iteritems(upgradeWFs):
-                    # use variation only when available
-                    if specialType == 'Premix':
-                        # Premixing stage1
-                        #
-                        # This is a hack which should be placed somewhere else, but likely requires more massive changes for "proper" PUPRMX treatment
-                        #
-                        # On one hand the place where upgradeWorkflowComponents.upgradeProperties[year][...PU]
-                        # are defined from the noPU workflows would be a logical place. On the other hand, that
-                        # would need the premixing workflows to be defined in upgradeWorkflowComponents.upgradeKeys[year]
-                        # dictionary, which would further mean that we would get full set of additional workflows for
-                        # premixing, while the preferred solution would be to define the premixing workflows as variations of the PU workflows.
-                        s = step.replace('GenSim', 'Premix')
-                        if not s in specialWF.PU:
-                            continue
-                        s = s + 'PU' # later processing requires to have PU here
-                        # Hardcode nu gun fragment below in order to use it for combined stage1+stage2
-                        # Anyway all other fragments are irrelevant for premixing stage1
-                        stepList[specialType].append(stepMaker(key,'PREMIX',s,specialWF.suffix))
-                    elif (specialType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
+                    if (specialType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,specialWF.suffix))
                         # hack to add an extra step
                         if (specialType == 'ProdLike' or specialType == 'TestOldDigiProdLike') and 'RecoFullGlobal' in step:
                             stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFullGlobal','MiniAODFullGlobal'),specialWF.suffix))
                         elif specialType == 'ProdLike' and 'RecoFull' in step:
                             stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFull','MiniAODFullGlobal'),specialWF.suffix))
+                        # similar hacks for premixing
+                        elif 'premix' in specialType:
+                            if 'GenSim' in step:
+                                s = step.replace('GenSim','Premix')+'PU' # later processing requires to have PU here
+                                if step in specialWF.PU:
+                                    stepMade = stepMaker(key,'PREMIX',s,specialWF.suffix)
+                                    # append for combined
+                                    if 'S2' in specialType: stepList[specialType].append(stepMade)
+                                    # replace for s1
+                                    else: stepList[specialType][-1] = stepMade
                     else:
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,''))
 
             for specialType,specialWF in six.iteritems(upgradeWFs):
+                # remove other steps for premixS1
+                if specialType=="premixS1":
+                    stepList[specialType] = stepList[specialType][:1]
                 specialWF.workflow(workflows, numWF, info.dataset, stepList[specialType], key, hasHarvest)
-
-            inclPremix = 'PU' in key
-            if inclPremix:
-                inclPremix = False
-                for y in ['2021', '2023', '2024', '2026']:
-                    if y in key:
-                        inclPremix = True
-                        continue
-            if inclPremix:
-                # premixing stage1, only for NuGun
-                if info.dataset=="NuGun":
-                    # The first element of the list sets the dataset name(?)
-                    datasetName = 'PREMIXUP' + key[2:].replace("PU", "").replace("Design", "") + '_PU25'
-                    workflows[numWF+upgradeWFs['Premix'].offset] = [datasetName, stepList['Premix']]
-
-                # premixing stage2
-                slist = []
-                for step in stepList['baseline']:
-                    s = step
-                    if "Digi" in step or "Reco" in step:
-                        s = s.replace("PU", "PUPRMX", 1)
-                    slist.append(s)
-                workflows[numWF+upgradeWFs['premixS2'].offset] = [info.dataset, slist]
-
-                # Combined stage1+stage2
-                def nano(s):
-                    if "Nano" in s:
-                        if "_" in s:
-                            return s.replace("_", "PUPRMXCombined_")
-                        return s+"PUPRMXCombined"
-                    return s
-                workflows[numWF+upgradeWFs['premixS1S2'].offset] = [info.dataset, # Signal fragment
-                                                      [slist[0]] +                      # Start with signal generation
-                                                      stepList['Premix'] +              # Premixing stage1
-                                                      [slist[1].replace("PUPRMX", "PUPRMXCombined")] + # Premixing stage2, customized for the combined (defined in relval_steps.py)
-                                                      list(map(nano, slist[2:]))]             # Remaining standard steps
 
             numWF+=1

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -32,8 +32,8 @@ for year in upgradeKeys:
             for step in upgradeProperties[year][key]['ScenToRun']:                    
                 stepMaker = makeStepName
                 if 'Sim' in step:
-                    if 'HLBeamSpotFull' in step and '14TeV' in frag:
-                        step = 'GenSimHLBeamSpotFull14'
+                    if 'HLBeamSpot' in step and '14TeV' in frag:
+                        step = 'GenSimHLBeamSpot14'
                     stepMaker = makeStepNameSim
                 
                 if 'HARVEST' in step: hasHarvest = True
@@ -42,10 +42,10 @@ for year in upgradeKeys:
                     if (specialType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,specialWF.suffix))
                         # hack to add an extra step
-                        if (specialType == 'ProdLike' or specialType == 'TestOldDigiProdLike') and 'RecoFullGlobal' in step:
-                            stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFullGlobal','MiniAODFullGlobal'),specialWF.suffix))
-                        elif specialType == 'ProdLike' and 'RecoFull' in step:
-                            stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFull','MiniAODFullGlobal'),specialWF.suffix))
+                        if (specialType == 'ProdLike' or specialType == 'TestOldDigiProdLike') and 'RecoGlobal' in step:
+                            stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoGlobal','MiniAOD'),specialWF.suffix))
+                        elif specialType == 'ProdLike' and 'Reco' in step:
+                            stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('Reco','MiniAOD'),specialWF.suffix))
                         # similar hacks for premixing
                         elif 'PMX' in specialType:
                             if 'GenSim' in step:

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -47,7 +47,7 @@ for year in upgradeKeys:
                         elif specialType == 'ProdLike' and 'RecoFull' in step:
                             stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFull','MiniAODFullGlobal'),specialWF.suffix))
                         # similar hacks for premixing
-                        elif 'premix' in specialType:
+                        elif 'PMX' in specialType:
                             if 'GenSim' in step:
                                 s = step.replace('GenSim','Premix')+'PU' # later processing requires to have PU here
                                 if step in specialWF.PU:
@@ -61,7 +61,7 @@ for year in upgradeKeys:
 
             for specialType,specialWF in six.iteritems(upgradeWFs):
                 # remove other steps for premixS1
-                if specialType=="premixS1":
+                if specialType=="PMXS1":
                     stepList[specialType] = stepList[specialType][:1]
                 specialWF.workflow(workflows, numWF, info.dataset, stepList[specialType], key, hasHarvest)
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -793,6 +793,9 @@ class UpgradeWorkflowAdjustPU(UpgradeWorkflowPremix):
         if '--pileup' in stepDict[stepName][k]:
             stepDict[stepName][k]['--pileup'] = 'AVE_50_BX_25ns_m3p3'
         super(UpgradeWorkflowAdjustPU,self).setupPU_(step, stepName, stepDict, k, properties)
+    def condition(self, fragment, stepList, key, hasHarvest):
+        # restrict to phase2
+        return super(UpgradeWorkflowAdjustPU,self).condition(fragment, stepList, key, hasHarvest) and '2026' in key
 upgradeWFs['PMXS1S2PR'] = UpgradeWorkflowAdjustPU(
     steps = [],
     PU = [

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -711,7 +711,7 @@ class UpgradeWorkflowPremix(UpgradeWorkflow):
                             "--procModifiers": "premix_stage2"},
                            d])
                 # for combined stage1+stage2
-                if "_premixS1S2" in self.suffix:
+                if "_PMXS1S2" in self.suffix:
                     d = merge([digiPremixLocalPileup, d])
             elif "Reco" in step:
                 if "--procModifiers" in d:
@@ -744,7 +744,7 @@ class UpgradeWorkflowPremix(UpgradeWorkflow):
         else:
             super(UpgradeWorkflowPremix,self).workflow_(workflows, num, fragment, stepList, key)
 # Premix stage1
-upgradeWFs['premixS1'] = UpgradeWorkflowPremix(
+upgradeWFs['PMXS1'] = UpgradeWorkflowPremix(
     steps = [
     ],
     PU = [
@@ -752,11 +752,11 @@ upgradeWFs['premixS1'] = UpgradeWorkflowPremix(
         'GenSimHLBeamSpotFull',
         'GenSimHLBeamSpotFull14',
     ],
-    suffix = '_premixS1',
+    suffix = '_PMXS1',
     offset = 0.97,
 )
 # Premix stage2
-upgradeWFs['premixS2'] = UpgradeWorkflowPremix(
+upgradeWFs['PMXS2'] = UpgradeWorkflowPremix(
     steps = [],
     PU = [
         'DigiFull',
@@ -766,11 +766,11 @@ upgradeWFs['premixS2'] = UpgradeWorkflowPremix(
         'RecoFullGlobal',
         'NanoFull',
     ],
-    suffix = '_premixS2',
+    suffix = '_PMXS2',
     offset = 0.98,
 )
 # Premix combined stage1+stage2
-upgradeWFs['premixS1S2'] = UpgradeWorkflowPremix(
+upgradeWFs['PMXS1S2'] = UpgradeWorkflowPremix(
     steps = [],
     PU = [
         'GenSimFull',
@@ -783,7 +783,7 @@ upgradeWFs['premixS1S2'] = UpgradeWorkflowPremix(
         'RecoFullGlobal',
         'NanoFull',
     ],
-    suffix = '_premixS1S2',
+    suffix = '_PMXS1S2',
     offset = 0.99,
 )
 # Alternative version of above w/ less PU for PR tests
@@ -793,7 +793,7 @@ class UpgradeWorkflowAdjustPU(UpgradeWorkflowPremix):
         if '--pileup' in stepDict[stepName][k]:
             stepDict[stepName][k]['--pileup'] = 'AVE_50_BX_25ns_m3p3'
         super(UpgradeWorkflowAdjustPU,self).setupPU_(step, stepName, stepDict, k, properties)
-upgradeWFs['premixS1S2PR'] = UpgradeWorkflowAdjustPU(
+upgradeWFs['PMXS1S2PR'] = UpgradeWorkflowAdjustPU(
     steps = [],
     PU = [
         'GenSimFull',
@@ -808,7 +808,7 @@ upgradeWFs['premixS1S2PR'] = UpgradeWorkflowAdjustPU(
         'HARVESTFull',
         'HARVESTFullGlobal',
     ],
-    suffix = '_premixS1S2PR',
+    suffix = '_PMXS1S2PR',
     offset = 0.999,
 )
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -138,32 +138,32 @@ class UpgradeWorkflow_baseline(UpgradeWorkflow):
         return True
 upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
     steps =  [
-        'GenSimFull',
-        'GenSimHLBeamSpotFull',
-        'GenSimHLBeamSpotFull14',
-        'DigiFull',
-        'DigiFullTrigger',
-        'RecoFullLocal',
-        'RecoFull',
-        'RecoFullGlobal',
-        'HARVESTFull',
+        'GenSim',
+        'GenSimHLBeamSpot',
+        'GenSimHLBeamSpot14',
+        'Digi',
+        'DigiTrigger',
+        'RecoLocal',
+        'Reco',
+        'RecoGlobal',
+        'HARVEST',
         'FastSim',
         'HARVESTFast',
-        'HARVESTFullGlobal',
-        'ALCAFull',
-        'NanoFull',
-        'MiniAODFullGlobal',
+        'HARVESTGlobal',
+        'ALCA',
+        'Nano',
+        'MiniAOD',
     ],
     PU =  [
-        'DigiFullTrigger',
-        'RecoFullLocal',
-        'RecoFullGlobal',
-        'DigiFull',
-        'RecoFull',
-        'HARVESTFull',
-        'HARVESTFullGlobal',
-        'MiniAODFullGlobal',
-        'NanoFull',
+        'DigiTrigger',
+        'RecoLocal',
+        'RecoGlobal',
+        'Digi',
+        'Reco',
+        'HARVEST',
+        'HARVESTGlobal',
+        'MiniAOD',
+        'Nano',
     ],
     suffix = '',
     offset = 0.0,
@@ -188,10 +188,10 @@ class UpgradeWorkflow_trackingOnly(UpgradeWorkflowTracking):
         elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
 upgradeWFs['trackingOnly'] = UpgradeWorkflow_trackingOnly(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
-        'RecoFullGlobal',
-        'HARVESTFullGlobal',
+        'Reco',
+        'HARVEST',
+        'RecoGlobal',
+        'HARVESTGlobal',
     ],
     PU = [],
     suffix = '_trackingOnly',
@@ -213,7 +213,7 @@ class UpgradeWorkflow_trackingRun2(UpgradeWorkflowTracking):
         return '2017' in key
 upgradeWFs['trackingRun2'] = UpgradeWorkflow_trackingRun2(
     steps = [
-        'RecoFull',
+        'Reco',
     ],
     PU = [],
     suffix = '_trackingRun2',
@@ -229,8 +229,8 @@ class UpgradeWorkflow_trackingOnlyRun2(UpgradeWorkflowTracking):
         return '2017' in key
 upgradeWFs['trackingOnlyRun2'] = UpgradeWorkflow_trackingOnlyRun2(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
+        'Reco',
+        'HARVEST',
     ],
     PU = [],
     suffix = '_trackingOnlyRun2',
@@ -246,7 +246,7 @@ class UpgradeWorkflow_trackingLowPU(UpgradeWorkflowTracking):
         return '2017' in key
 upgradeWFs['trackingLowPU'] = UpgradeWorkflow_trackingLowPU(
     steps = [
-        'RecoFull',
+        'Reco',
     ],
     PU = [],
     suffix = '_trackingLowPU',
@@ -261,10 +261,10 @@ class UpgradeWorkflow_pixelTrackingOnly(UpgradeWorkflowTracking):
         return '2017' in key or '2018' in key or '2021' in key
 upgradeWFs['pixelTrackingOnly'] = UpgradeWorkflow_pixelTrackingOnly(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
-        'RecoFullGlobal',
-        'HARVESTFullGlobal',
+        'Reco',
+        'HARVEST',
+        'RecoGlobal',
+        'HARVESTGlobal',
     ],
     PU = [],
     suffix = '_pixelTrackingOnly',
@@ -283,8 +283,8 @@ class UpgradeWorkflow_trackingMkFit(UpgradeWorkflowTracking):
         return '2017' in key or '2021' in key
 upgradeWFs['trackingMkFit'] = UpgradeWorkflow_trackingMkFit(
     steps = [
-        'RecoFull',
-        'RecoFullGlobal',
+        'Reco',
+        'RecoGlobal',
     ],
     PU = [],
     suffix = '_trackingMkFit',
@@ -323,10 +323,10 @@ class UpgradeWorkflowPatatrack_PixelOnlyCPU(UpgradeWorkflowPatatrack):
 
 upgradeWFs['PatatrackPixelOnlyCPU'] = UpgradeWorkflowPatatrack_PixelOnlyCPU(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
-        'RecoFullGlobal',
-        'HARVESTFullGlobal',
+        'Reco',
+        'HARVEST',
+        'RecoGlobal',
+        'HARVESTGlobal',
     ],
     PU = [],
     suffix = 'Patatrack_PixelOnlyCPU',
@@ -352,10 +352,10 @@ class UpgradeWorkflowPatatrack_PixelOnlyGPU(UpgradeWorkflowPatatrack):
 
 upgradeWFs['PatatrackPixelOnlyGPU'] = UpgradeWorkflowPatatrack_PixelOnlyGPU(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
-        'RecoFullGlobal',
-        'HARVESTFullGlobal',
+        'Reco',
+        'HARVEST',
+        'RecoGlobal',
+        'HARVESTGlobal',
     ],
     PU = [],
     suffix = 'Patatrack_PixelOnlyGPU',
@@ -381,10 +381,10 @@ class UpgradeWorkflowPatatrack_ECALOnlyCPU(UpgradeWorkflowPatatrack):
 
 upgradeWFs['PatatrackECALOnlyCPU'] = UpgradeWorkflowPatatrack_ECALOnlyCPU(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
-        'RecoFullGlobal',
-        'HARVESTFullGlobal',
+        'Reco',
+        'HARVEST',
+        'RecoGlobal',
+        'HARVESTGlobal',
     ],
     PU = [],
     suffix = 'Patatrack_ECALOnlyCPU',
@@ -409,10 +409,10 @@ class UpgradeWorkflowPatatrack_ECALOnlyGPU(UpgradeWorkflowPatatrack):
 
 upgradeWFs['PatatrackECALOnlyGPU'] = UpgradeWorkflowPatatrack_ECALOnlyGPU(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
-        'RecoFullGlobal',
-        'HARVESTFullGlobal',
+        'Reco',
+        'HARVEST',
+        'RecoGlobal',
+        'HARVESTGlobal',
     ],
     PU = [],
     suffix = 'Patatrack_ECALOnlyGPU',
@@ -438,10 +438,10 @@ class UpgradeWorkflowPatatrack_HCALOnlyCPU(UpgradeWorkflowPatatrack):
 
 upgradeWFs['PatatrackHCALOnlyCPU'] = UpgradeWorkflowPatatrack_HCALOnlyCPU(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
-        'RecoFullGlobal',
-        'HARVESTFullGlobal',
+        'Reco',
+        'HARVEST',
+        'RecoGlobal',
+        'HARVESTGlobal',
     ],
     PU = [],
     suffix = 'Patatrack_HCALOnlyCPU',
@@ -466,10 +466,10 @@ class UpgradeWorkflowPatatrack_HCALOnlyGPU(UpgradeWorkflowPatatrack):
 
 upgradeWFs['PatatrackHCALOnlyGPU'] = UpgradeWorkflowPatatrack_HCALOnlyGPU(
     steps = [
-        'RecoFull',
-        'HARVESTFull',
-        'RecoFullGlobal',
-        'HARVESTFullGlobal',
+        'Reco',
+        'HARVEST',
+        'RecoGlobal',
+        'HARVESTGlobal',
     ],
     PU = [],
     suffix = 'Patatrack_HCALOnlyGPU',
@@ -503,24 +503,24 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
         return fragment=="TTbar_14TeV" and ('2026' in key or '2021' in key)
 upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
     steps = [
-        'DigiFull',
-        'RecoFull',
-        'RecoFullGlobal',
-        'HARVESTFull',
-        'HARVESTFullGlobal',
-        'MiniAODFullGlobal',
-        'ALCAFull',
-        'NanoFull',
+        'Digi',
+        'Reco',
+        'RecoGlobal',
+        'HARVEST',
+        'HARVESTGlobal',
+        'MiniAOD',
+        'ALCA',
+        'Nano',
     ],
     PU = [
-        'DigiFull',
-        'RecoFull',
-        'RecoFullGlobal',
-        'HARVESTFull',
-        'HARVESTFullGlobal',
-        'MiniAODFullGlobal',
-        'ALCAFull',
-        'NanoFull',
+        'Digi',
+        'Reco',
+        'RecoGlobal',
+        'HARVEST',
+        'HARVESTGlobal',
+        'MiniAOD',
+        'ALCA',
+        'Nano',
     ],
     suffix = '_ProdLike',
     offset = 0.21,
@@ -541,15 +541,15 @@ class UpgradeWorkflow_Neutron(UpgradeWorkflow):
         return any(fragment==nfrag for nfrag in self.neutronFrags) and any(nkey in key for nkey in self.neutronKeys)
 upgradeWFs['Neutron'] = UpgradeWorkflow_Neutron(
     steps = [
-        'GenSimFull',
-        'GenSimHLBeamSpotFull',
-        'GenSimHLBeamSpotFull14',
-        'DigiFull',
-        'DigiFullTrigger',
+        'GenSim',
+        'GenSimHLBeamSpot',
+        'GenSimHLBeamSpot14',
+        'Digi',
+        'DigiTrigger',
     ],
     PU = [
-        'DigiFull',
-        'DigiFullTrigger',
+        'Digi',
+        'DigiTrigger',
     ],
     suffix = '_Neutron',
     offset = 0.12,
@@ -565,16 +565,16 @@ class UpgradeWorkflow_heCollapse(UpgradeWorkflow):
         return fragment=="TTbar_13" and '2018' in key
 upgradeWFs['heCollapse'] = UpgradeWorkflow_heCollapse(
     steps = [
-        'GenSimFull',
-        'DigiFull',
-        'RecoFull',
-        'HARVESTFull',
-        'ALCAFull',
+        'GenSim',
+        'Digi',
+        'Reco',
+        'HARVEST',
+        'ALCA',
     ],
     PU = [
-        'DigiFull',
-        'RecoFull',
-        'HARVESTFull',
+        'Digi',
+        'Reco',
+        'HARVEST',
     ],
     suffix = '_heCollapse',
     offset = 0.6,
@@ -589,16 +589,16 @@ class UpgradeWorkflow_0T(UpgradeWorkflow):
         return (fragment=="TTbar_13" or fragment=="TTbar_14TeV") and ('2017' in key or '2018' in key or '2021' in key)
 upgradeWFs['0T'] = UpgradeWorkflow_0T(
     steps = [
-        'GenSimFull',
-        'DigiFull',
-        'RecoFull',
-        'HARVESTFull',
-        'ALCAFull',
+        'GenSim',
+        'Digi',
+        'Reco',
+        'HARVEST',
+        'ALCA',
     ],
     PU = [
-        'DigiFull',
-        'RecoFull',
-        'HARVESTFull',
+        'Digi',
+        'Reco',
+        'HARVEST',
     ],
     suffix = '_0T',
     offset = 0.24,
@@ -612,7 +612,7 @@ class UpgradeWorkflow_ParkingBPH(UpgradeWorkflow):
         return fragment=="TTbar_13" and '2018' in key
 upgradeWFs['ParkingBPH'] = UpgradeWorkflow_ParkingBPH(
     steps = [
-        'RecoFull',
+        'Reco',
     ],
     PU = [],
     suffix = '_ParkingBPH',
@@ -627,7 +627,7 @@ class UpgradeWorkflow_JMENano(UpgradeWorkflow):
         return fragment=="TTbar_13" and ('2017' in key or '2018' in key)
 upgradeWFs['JMENano'] = UpgradeWorkflow_JMENano(
     steps = [
-        'NanoFull',
+        'Nano',
     ],
     PU = [],
     suffix = '_JMENano',
@@ -645,18 +645,18 @@ class UpgradeWorkflowAging(UpgradeWorkflow):
 # define several of them
 upgradeWFs['Aging1000'] = UpgradeWorkflowAging(
     steps =  [
-        'DigiFull',
-        'DigiFullTrigger',
-        'RecoFullLocal',
-        'RecoFull',
-        'RecoFullGlobal',
+        'Digi',
+        'DigiTrigger',
+        'RecoLocal',
+        'Reco',
+        'RecoGlobal',
     ],
     PU =  [
-        'DigiFull',
-        'DigiFullTrigger',
-        'RecoFullLocal',
-        'RecoFull',
-        'RecoFullGlobal',
+        'Digi',
+        'DigiTrigger',
+        'RecoLocal',
+        'Reco',
+        'RecoGlobal',
     ],
     suffix = 'Aging1000',
     offset = 0.101,
@@ -750,9 +750,9 @@ upgradeWFs['PMXS1'] = UpgradeWorkflowPremix(
     steps = [
     ],
     PU = [
-        'GenSimFull',
-        'GenSimHLBeamSpotFull',
-        'GenSimHLBeamSpotFull14',
+        'GenSim',
+        'GenSimHLBeamSpot',
+        'GenSimHLBeamSpot14',
     ],
     suffix = '_PMXS1',
     offset = 0.97,
@@ -761,12 +761,12 @@ upgradeWFs['PMXS1'] = UpgradeWorkflowPremix(
 upgradeWFs['PMXS2'] = UpgradeWorkflowPremix(
     steps = [],
     PU = [
-        'DigiFull',
-        'DigiFullTrigger',
-        'RecoFullLocal',
-        'RecoFull',
-        'RecoFullGlobal',
-        'NanoFull',
+        'Digi',
+        'DigiTrigger',
+        'RecoLocal',
+        'Reco',
+        'RecoGlobal',
+        'Nano',
     ],
     suffix = '_PMXS2',
     offset = 0.98,
@@ -775,15 +775,15 @@ upgradeWFs['PMXS2'] = UpgradeWorkflowPremix(
 upgradeWFs['PMXS1S2'] = UpgradeWorkflowPremix(
     steps = [],
     PU = [
-        'GenSimFull',
-        'GenSimHLBeamSpotFull',
-        'GenSimHLBeamSpotFull14',
-        'DigiFull',
-        'DigiFullTrigger',
-        'RecoFullLocal',
-        'RecoFull',
-        'RecoFullGlobal',
-        'NanoFull',
+        'GenSim',
+        'GenSimHLBeamSpot',
+        'GenSimHLBeamSpot14',
+        'Digi',
+        'DigiTrigger',
+        'RecoLocal',
+        'Reco',
+        'RecoGlobal',
+        'Nano',
     ],
     suffix = '_PMXS1S2',
     offset = 0.99,
@@ -801,17 +801,17 @@ class UpgradeWorkflowAdjustPU(UpgradeWorkflowPremix):
 upgradeWFs['PMXS1S2PR'] = UpgradeWorkflowAdjustPU(
     steps = [],
     PU = [
-        'GenSimFull',
-        'GenSimHLBeamSpotFull',
-        'GenSimHLBeamSpotFull14',
-        'DigiFull',
-        'DigiFullTrigger',
-        'RecoFullLocal',
-        'RecoFull',
-        'RecoFullGlobal',
-        'NanoFull',
-        'HARVESTFull',
-        'HARVESTFullGlobal',
+        'GenSim',
+        'GenSimHLBeamSpot',
+        'GenSimHLBeamSpot14',
+        'Digi',
+        'DigiTrigger',
+        'RecoLocal',
+        'Reco',
+        'RecoGlobal',
+        'Nano',
+        'HARVEST',
+        'HARVESTGlobal',
     ],
     suffix = '_PMXS1S2PR',
     offset = 0.999,
@@ -824,11 +824,11 @@ class UpgradeWorkflow_DD4hep(UpgradeWorkflow):
         return (fragment=='TTbar_13' or fragment=='ZMM_13' or fragment=='SingleMuPt10') and '2021' in key
 upgradeWFs['DD4hep'] = UpgradeWorkflow_DD4hep(
     steps = [
-        'GenSimFull',
-        'DigiFull',
-        'RecoFull',
-        'HARVESTFull',
-        'ALCAFull',
+        'GenSim',
+        'Digi',
+        'Reco',
+        'HARVEST',
+        'ALCA',
     ],
     PU = [],
     suffix = '_DD4hep',
@@ -850,7 +850,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2017_realistic',
         'HLTmenu': '@relval2017',
         'Era' : 'Run2_2017',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull','NanoFull'],
+        'ScenToRun' : ['GenSim','Digi','Reco','HARVEST','ALCA','Nano'],
     },
     '2017Design' : {
         'Geom' : 'DB:Extended',
@@ -858,7 +858,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2017',
         'Era' : 'Run2_2017',
         'BeamSpot': 'GaussSigmaZ4cm',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+        'ScenToRun' : ['GenSim','Digi','Reco','HARVEST'],
     },
     '2018' : {
         'Geom' : 'DB:Extended',
@@ -866,7 +866,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2018',
         'Era' : 'Run2_2018',
         'BeamSpot': 'Realistic25ns13TeVEarly2018Collision',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull','NanoFull'],
+        'ScenToRun' : ['GenSim','Digi','Reco','HARVEST','ALCA','Nano'],
     },
     '2018Design' : {
         'Geom' : 'DB:Extended',
@@ -874,7 +874,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2018',
         'Era' : 'Run2_2018',
         'BeamSpot': 'GaussSigmaZ4cm',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+        'ScenToRun' : ['GenSim','Digi','Reco','HARVEST'],
     },
     '2021' : {
         'Geom' : 'DB:Extended',
@@ -882,7 +882,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2021',
         'Era' : 'Run3',
         'BeamSpot': 'Run3RoundOptics25ns13TeVLowSigmaZ',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
+        'ScenToRun' : ['GenSim','Digi','Reco','HARVEST','ALCA'],
     },
     '2021Design' : {
         'Geom' : 'DB:Extended',
@@ -890,7 +890,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2021',
         'Era' : 'Run3',
         'BeamSpot': 'GaussSigmaZ4cm',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+        'ScenToRun' : ['GenSim','Digi','Reco','HARVEST'],
     },
     '2023' : {
         'Geom' : 'DB:Extended',
@@ -898,7 +898,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2021',
         'Era' : 'Run3',
         'BeamSpot': 'Run3RoundOptics25ns13TeVLowSigmaZ',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
+        'ScenToRun' : ['GenSim','Digi','Reco','HARVEST','ALCA'],
     },
     '2024' : {
         'Geom' : 'DB:Extended',
@@ -906,15 +906,15 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2021',
         'Era' : 'Run3',
         'BeamSpot': 'Run3RoundOptics25ns13TeVLowSigmaZ',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
+        'ScenToRun' : ['GenSim','Digi','Reco','HARVEST','ALCA'],
     },
 }
 
 # standard PU sequences
 for key in list(upgradeProperties[2017].keys()):
     upgradeProperties[2017][key+'PU'] = deepcopy(upgradeProperties[2017][key])
-    upgradeProperties[2017][key+'PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU'] + \
-                                                     (['NanoFull'] if 'Design' not in key else [])
+    upgradeProperties[2017][key+'PU']['ScenToRun'] = ['GenSim','DigiPU','RecoPU','HARVESTPU'] + \
+                                                     (['Nano'] if 'Design' not in key else [])
 
 upgradeProperties[2026] = {
     '2026D49' : {
@@ -922,21 +922,21 @@ upgradeProperties[2026] = {
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T15',
         'Era' : 'Phase2C9',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D51' : {
         'Geom' : 'Extended2026D51',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T15',
         'Era' : 'Phase2C9',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D53' : {
         'Geom' : 'Extended2026D53',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T15',
         'Era' : 'Phase2C9',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D54' : {
         'Geom' : 'Extended2026D54',
@@ -944,42 +944,42 @@ upgradeProperties[2026] = {
         'GT' : 'auto:phase2_realistic_T19',
         'ProcessModifier': 'phase2_PixelCPEGeneric',
         'Era' : 'Phase2C9',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D56' : {
         'Geom' : 'Extended2026D56',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T20',
         'Era' : 'Phase2C9',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D57' : {
         'Geom' : 'Extended2026D57',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T17',
         'Era' : 'Phase2C11',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D58' : {
         'Geom' : 'Extended2026D58',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T17',
         'Era' : 'Phase2C12',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D59' : {
         'Geom' : 'Extended2026D59',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T17',
         'Era' : 'Phase2C11',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D60' : {
         'Geom' : 'Extended2026D60',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T15',
         'Era' : 'Phase2C10',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D61' : {
         'Geom' : 'Extended2026D61',
@@ -987,21 +987,21 @@ upgradeProperties[2026] = {
         'GT' : 'auto:phase2_realistic_T17',
         'ProcessModifier': 'phase2_PixelCPEGeneric',
         'Era' : 'Phase2C9',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D62' : {
         'Geom' : 'Extended2026D62',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T17',
         'Era' : 'Phase2C11',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
 }
 
 # standard PU sequences
 for key in list(upgradeProperties[2026].keys()):
     upgradeProperties[2026][key+'PU'] = deepcopy(upgradeProperties[2026][key])
-    upgradeProperties[2026][key+'PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+    upgradeProperties[2026][key+'PU']['ScenToRun'] = ['GenSimHLBeamSpot','DigiTriggerPU','RecoGlobalPU', 'HARVESTGlobalPU']
 
 # for relvals
 defaultDataSets = {}

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -90,6 +90,7 @@ class UpgradeWorkflow(object):
                 self.steps.append(step)
 
         self.suffix = suffix
+        if len(self.suffix)>0 and self.suffix[0]!='_': self.suffix = '_'+self.suffix
         self.offset = offset
         if self.offset < 0.0 or self.offset > 1.0:
             raise ValueError("Special workflow offset must be between 0.0 and 1.0")
@@ -118,7 +119,9 @@ class UpgradeWorkflow(object):
         if self.condition(fragment, stepList, key, hasHarvest):
             self.workflow_(workflows, num, fragment, stepList, key)
     def workflow_(self, workflows, num, fragment, stepList, key):
-        workflows[num+self.offset] = [ fragment, stepList ]
+        fragmentTmp = fragment
+        if len(self.suffix)>0: fragmentTmp = [fragment, self.suffix]
+        workflows[num+self.offset] = [ fragmentTmp, stepList ]
     def condition(self, fragment, stepList, key, hasHarvest):
         return False
 upgradeWFs = OrderedDict()
@@ -738,11 +741,10 @@ class UpgradeWorkflowPremix(UpgradeWorkflow):
             return "NuGun" in fragment
         return True
     def workflow_(self, workflows, num, fragment, stepList, key):
+        fragmentTmp = fragment
         if self.suffix.endswith("S1"):
-            datasetName = 'PREMIXUP' + key[2:].replace("PU", "").replace("Design", "") + '_PU25'
-            workflows[num+self.offset] = [ datasetName, stepList ]
-        else:
-            super(UpgradeWorkflowPremix,self).workflow_(workflows, num, fragment, stepList, key)
+            fragmentTmp = 'PREMIXUP' + key[2:].replace("PU", "").replace("Design", "") + '_PU25'
+        super(UpgradeWorkflowPremix,self).workflow_(workflows, num, fragmentTmp, stepList, key)
 # Premix stage1
 upgradeWFs['PMXS1'] = UpgradeWorkflowPremix(
     steps = [

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -119,8 +119,8 @@ class UpgradeWorkflow(object):
         if self.condition(fragment, stepList, key, hasHarvest):
             self.workflow_(workflows, num, fragment, stepList, key)
     def workflow_(self, workflows, num, fragment, stepList, key):
-        fragmentTmp = fragment
-        if len(self.suffix)>0: fragmentTmp = [fragment, self.suffix]
+        fragmentTmp = [fragment, key]
+        if len(self.suffix)>0: fragmentTmp.append(self.suffix)
         workflows[num+self.offset] = [ fragmentTmp, stepList ]
     def condition(self, fragment, stepList, key, hasHarvest):
         return False

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
-                     23434.99, #2026D49 ttbar premixing stage1+stage2
+                     23434.999, #2026D49 ttbar premixing stage1+stage2, PU50
                      28234.0, #2026D60 (exercise HF nose)
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -86,6 +86,7 @@ if __name__ == '__main__':
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
+                     23434.99, #2026D49 ttbar premixing stage1+stage2
                      28234.0, #2026D60 (exercise HF nose)
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix

--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -144,6 +144,7 @@ addMixingScenario("AVE_40_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON
 addMixingScenario("AVE_45_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 45})
 addMixingScenario("AVE_50_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 50})
 addMixingScenario("AVE_50_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 50})
+addMixingScenario("AVE_50_BX_25ns_m3p3",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-3,3), 'N': 50})
 addMixingScenario("AVE_70_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 70})
 addMixingScenario("AVE_70_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 70})
 addMixingScenario("AVE_75_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 75})


### PR DESCRIPTION
#### PR description:

The upgrade premixing workflow setup is reimplemented to use the special workflow approach. This reduces the number of hacks necessary (though a few are still needed). To facilitate this, PU steps are first added to the list and then specialized (this allows changing PU-related parameters).

The names of the premix workflows are adjusted slightly to try to keep the length down.

A new workflow is added for phase2 premixing using PU50 (rather than PU200, to reduce CPU/mem/disk usage). This will automatically generate PR comparison plots, which helps to test and validate PRs that impact Phase 2 premixing. The PU50 scenario used in this workflow only considers bunch crossings -3,3, as with the other phase 2 PU scenarios.

The upgrade workflow names are shortened by eliminating unnecessary words from step names (mostly 'Full'), and preventing the key and special workflow suffix (if any) from being repeated in the names. This also entails a small amount of reorganization in the order of information in the names (key and suffix now come first). The directory and display names were originally:
```
23461.999_NuGun+SingleNuE10_2026D49PU_GenSimHLBeamSpotFull_PMXS1S2PR+PREMIX_2026D49PU_PremixHLBeamSpotFullPU_PMXS1S2PR+DigiFullTriggerPU_PMXS1S2PR_2026D49PU+RecoFullGlobalPU_PMXS1S2PR_2026D49PU+HARVESTFullGlobalPU_PMXS1S2PR_2026D49PU
23461.999 SingleNuE10_2026D49PU_GenSimHLBeamSpotFull_PMXS1S2PR+PREMIX_2026D49PU_PremixHLBeamSpotFullPU_PMXS1S2PR+DigiFullTriggerPU_PMXS1S2PR_2026D49PU+RecoFullGlobalPU_PMXS1S2PR_2026D49PU+HARVESTFullGlobalPU_PMXS1S2PR_2026D49PU
```
and are now reduced to:
```
23461.999_NuGun+2026D49PU_PMXS1S2PR+SingleNuE10_GenSimHLBeamSpot+PREMIX_PremixHLBeamSpotPU+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU
23461.999 2026D49PU_PMXS1S2PR+SingleNuE10_GenSimHLBeamSpot+PREMIX_PremixHLBeamSpotPU+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
```

#### PR validation:

Compared the commands generated by `runTheMatrix.py -w upgrade -l 23461.97,23461.98,23461.99 --dryRun` before and after this PR to see that they contain the same flags. Also tested the commands for 23461.999.
