### PR TITLE
phase-2 reco CPU hotspot: PFElecTkProducer

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFRecTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecTrack.h
@@ -2,10 +2,8 @@
 #define DataFormats_ParticleFlowReco_PFRecTrack_h
 
 #include "DataFormats/ParticleFlowReco/interface/PFTrack.h"
-/* #include "DataFormats/Common/interface/RefToBase.h" */
+#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-
-#include <iostream>
 
 namespace reco {
 
@@ -51,6 +49,12 @@ namespace reco {
 
     /// \return the significance of the signed transverse impact parameter
     const float STIP() const { return STIP_; }
+
+    /// \return eta
+    inline auto eta() const { return trackRef_->eta(); }
+
+    /// \return phi
+    inline auto phi() const { return trackRef_->phi(); }
 
   private:
     /// type of fitting algorithm used to reconstruct the track

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -12,15 +12,17 @@
 \date January 2007
 
  PFElecTkProducer reads the merged GsfTracks collection
- built with the TrackerDriven and EcalDriven seeds 
+ built with the TrackerDriven and EcalDriven seeds
  and transform them in PFGsfRecTracks.
 */
 
 #include <memory>
 
+#include "CommonTools/Utils/interface/KinematicTables.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
@@ -50,7 +52,11 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
-#include "TMath.h"
+namespace {
+
+  constexpr float square(float x) { return x * x; };
+
+}  // namespace
 
 class PFElecTkProducer final : public edm::stream::EDProducer<edm::GlobalCache<convbremhelpers::HeavyObjectCache> > {
 public:
@@ -70,7 +76,9 @@ private:
   ///Produce the PFRecTrack collection
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  int FindPfRef(const reco::PFRecTrackCollection& PfRTkColl, const reco::GsfTrack&, bool);
+  int findPfRef(const reco::PFRecTrackCollection& pfRTkColl,
+                const reco::GsfTrack&,
+                edm::soa::EtaPhiTableView trackEtaPhiTable);
 
   bool applySelection(const reco::GsfTrack&);
 
@@ -230,7 +238,10 @@ void PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //read pfrectrack collection
   Handle<PFRecTrackCollection> thePfRecTrackCollection;
   iEvent.getByToken(pfTrackLabel_, thePfRecTrackCollection);
-  const PFRecTrackCollection& PfRTkColl = *(thePfRecTrackCollection.product());
+
+  // SoA structure for frequently used track information.
+  // Stored in a Lazy result so it is only filled when needed, i.e., when there is an electron in the event.
+  auto trackEtaPhiTable = edm::soa::makeEtaPhiTableLazy(*thePfRecTrackCollection);
 
   // PFClusters
   Handle<PFClusterCollection> theECPfClustCollection;
@@ -282,7 +293,7 @@ void PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   for (unsigned int igsf = 0; igsf < gsftracks.size(); igsf++) {
     GsfTrackRef trackRef(gsftrackscoll, igsf);
 
-    int kf_ind = FindPfRef(PfRTkColl, gsftracks[igsf], false);
+    int kf_ind = findPfRef(*thePfRecTrackCollection, gsftracks[igsf], trackEtaPhiTable.value());
 
     if (kf_ind >= 0) {
       PFRecTrackRef kf_ref(thePfRecTrackCollection, kf_ind);
@@ -458,70 +469,66 @@ void PFElecTkProducer::createGsfPFRecTrackRef(
   return;
 }
 // ------------- method for find the corresponding kf pfrectrack ---------------------
-int PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection& PfRTkColl,
+int PFElecTkProducer::findPfRef(const reco::PFRecTrackCollection& pfRTkColl,
                                 const reco::GsfTrack& gsftk,
-                                bool otherColl) {
-  if (gsftk.seedRef().get() == nullptr)
+                                edm::soa::EtaPhiTableView trackEtaPhiTable) {
+  if (gsftk.seedRef().get() == nullptr) {
     return -1;
-  auto const& ElSeedFromRef = static_cast<ElectronSeed const&>(*(gsftk.extra()->seedRef()));
+  }
+
+  // maximum delta_r2 for matching
+  constexpr float maxDR2 = square(0.05f);
+
+  // precompute expensive trigonometry
+  float gsftkEta = gsftk.eta();
+  float gsftkPhi = gsftk.phi();
+  auto const& gsftkHits = gsftk.seedRef()->recHits();
+
+  auto const& electronSeedFromRef = static_cast<ElectronSeed const&>(*(gsftk.extra()->seedRef()));
   //CASE 1 ELECTRONSEED DOES NOT HAVE A REF TO THE CKFTRACK
-  if (ElSeedFromRef.ctfTrack().isNull()) {
-    reco::PFRecTrackCollection::const_iterator pft = PfRTkColl.begin();
-    reco::PFRecTrackCollection::const_iterator pftend = PfRTkColl.end();
+  if (electronSeedFromRef.ctfTrack().isNull()) {
     unsigned int i_pf = 0;
     int ibest = -1;
     unsigned int ish_max = 0;
-    float dr_min = 1000;
+    float dr2_min = square(1000.f);
+
     //SEARCH THE PFRECTRACK THAT SHARES HITS WITH THE ELECTRON SEED
-    // Here the cpu time can be improved.
-    for (; pft != pftend; ++pft) {
+    // Here the cpu time has been be improved.
+    for (auto const& pft : trackEtaPhiTable) {
       unsigned int ish = 0;
 
-      float dph = fabs(pft->trackRef()->phi() - gsftk.phi());
-      if (dph > TMath::Pi())
-        dph -= TMath::TwoPi();
-      float det = fabs(pft->trackRef()->eta() - gsftk.eta());
-      float dr = sqrt(dph * dph + det * det);
+      using namespace edm::soa::col;
+      const float dr2 = reco::deltaR2(pft.get<Eta>(), pft.get<Phi>(), gsftkEta, gsftkPhi);
 
-      for (auto const& hhit : pft->trackRef()->recHits()) {
-        if (!hhit->isValid())
-          continue;
-        for (auto const& hit : gsftk.seedRef()->recHits()) {
-          if (!(hit.isValid()))
+      if (dr2 <= maxDR2) {
+        for (auto const& hhit : pfRTkColl[i_pf].trackRef()->recHits()) {
+          if (!hhit->isValid())
             continue;
-          if (hhit->sharesInput(&hit, TrackingRecHit::all))
-            ish++;
-          // if((hit->geographicalId()==hhit->geographicalId())&&
-          //     ((hhit->localPosition()-hit->localPosition()).mag()<0.01)) ish++;
+          for (auto const& hit : gsftkHits) {
+            if (hit.isValid() && hhit->sharesInput(&hit, TrackingRecHit::all))
+              ish++;
+          }
         }
-      }
 
-      if ((ish > ish_max) || ((ish == ish_max) && (dr < dr_min))) {
-        ish_max = ish;
-        dr_min = dr;
-        ibest = i_pf;
+        if ((ish > ish_max) || ((ish == ish_max) && (dr2 < dr2_min))) {
+          ish_max = ish;
+          dr2_min = dr2;
+          ibest = i_pf;
+        }
       }
 
       i_pf++;
     }
-    if (ibest < 0)
-      return -1;
 
-    if ((ish_max == 0) || (dr_min > 0.05))
-      return -1;
-    if (otherColl && (ish_max == 0))
-      return -1;
-    return ibest;
+    return ((ish_max == 0) || (dr2_min > maxDR2)) ? -1 : ibest;
   } else {
     //ELECTRON SEED HAS A REFERENCE
 
-    reco::PFRecTrackCollection::const_iterator pft = PfRTkColl.begin();
-    reco::PFRecTrackCollection::const_iterator pftend = PfRTkColl.end();
     unsigned int i_pf = 0;
 
-    for (; pft != pftend; ++pft) {
+    for (auto const& pft : pfRTkColl) {
       //REF COMPARISON
-      if (pft->trackRef() == ElSeedFromRef.ctfTrack()) {
+      if (pft.trackRef() == electronSeedFromRef.ctfTrack()) {
         return i_pf;
       }
       i_pf++;
@@ -609,13 +616,13 @@ bool PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>& GsfPF
           cout << " Entering angular superloose preselection " << endl;
 
         /* //now taken from cache below
-	TrajectoryStateOnSurface i_inTSOS = mtsTransform_.innerStateOnSurface((*iGsfTrack));
-	GlobalVector i_innMom;
-	float iPin = iGsfTrack->pMode();
-	if(i_inTSOS.isValid()){
-	  multiTrajectoryStateMode::momentumFromModeCartesian(i_inTSOS,i_innMom);  
-	  iPin = i_innMom.mag();
-	}
+        TrajectoryStateOnSurface i_inTSOS = mtsTransform_.innerStateOnSurface((*iGsfTrack));
+        GlobalVector i_innMom;
+        float iPin = iGsfTrack->pMode();
+        if(i_inTSOS.isValid()){
+          multiTrajectoryStateMode::momentumFromModeCartesian(i_inTSOS,i_innMom);
+          iPin = i_innMom.mag();
+        }
         */
         float iPin = gsfInnerMomentumCache_[iGsfTrack.key()];
 


### PR DESCRIPTION
#### PR description:

Speed up of another electron related Phase II bottleneck, reported in https://github.com/cms-sw/cmssw/issues/30953:

* precompute track eta and phi with `edm::soa::EtaPhiTable`
* skip expensive computation of number of shared hits if track lies outside of matching cone
* as consequence, cost of `PFElecTkProducer::FindPfRef` in workflow 23434.21 (step3) drops from 2.5 % to 0.01 % (see [this report](https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/30953_23434.21_with_PR_igreport_perf/3831))

#### PR validation:

CMSSW compiles and local matrix tests pass, plus profiling.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.