### PR TITLE
Modified radiation damage assumption for 2021 0T pixel templates [11_1_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -67,13 +67,13 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '111X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '111X_mcRun3_2021_design_v6', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '111X_mcRun3_2021_design_v7', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '111X_mcRun3_2021_realistic_v6', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '111X_mcRun3_2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '111X_mcRun3_2021cosmics_realistic_deco_v6',
+    'phase1_2021_cosmics'      : '111X_mcRun3_2021cosmics_realistic_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '111X_mcRun3_2021_realistic_HI_v7',
+    'phase1_2021_realistic_hi' : '111X_mcRun3_2021_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'    : '111X_mcRun3_2023_realistic_v6', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:

This is a backport of PR #30907 with identical changes to the tag content of the global tags. See the description of that PR for details.

The GT diffs are as follows:

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_design_v6/111X_mcRun3_2021_design_v7

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_realistic_v6/111X_mcRun3_2021_realistic_v7

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021cosmics_realistic_deco_v6/111X_mcRun3_2021cosmics_realistic_deco_v7

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_realistic_HI_v7/111X_mcRun3_2021_realistic_HI_v9

#### PR validation:

See the description of PR #30907 for details. In addition, a technical test was performed: `runTheMatrix.py -l limited,12024.0,7.23,159.0 --ibeos`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of PR #30907, requested by pixel experts.
