### PR TITLE
Add number of partitions in GEM TPs

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigi.h
@@ -3,7 +3,7 @@
 
 /** \class GEMPadDigi
  *
- * Digi for GEM-CSC trigger pads
+ * Digi for GEM trigger pads
  *
  * \author Vadim Khotilovich
  *
@@ -17,8 +17,12 @@
 class GEMPadDigi {
 public:
   enum InValid { ME0InValid = 255, GE11InValid = 255, GE21InValid = 511 };
+  enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
 
-  explicit GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11);
+  explicit GEMPadDigi(uint16_t pad,
+                      int16_t bx,
+                      enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11,
+                      enum NumberPartitions nPart = NumberPartitions::GE11);
   GEMPadDigi();
 
   bool operator==(const GEMPadDigi& digi) const;
@@ -33,12 +37,19 @@ public:
   int16_t bx() const { return bx_; }
   GEMSubDetId::Station station() const { return station_; }
 
+  // Newer GE2/1 geometries will have 16! eta partitions
+  // instead of the usual 8.
+  void setNPartitions(enum NumberPartitions nPart) { part_ = nPart; }
+  enum NumberPartitions nPartitions() const { return part_; }
+
   void print() const;
 
 private:
   uint16_t pad_;
   int16_t bx_;
   GEMSubDetId::Station station_;
+  // number of eta partitions
+  enum NumberPartitions part_;
 };
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi);

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -19,10 +19,12 @@
 class GEMPadDigiCluster {
 public:
   enum InValid { GE11InValid = 255, GE21InValid = 511 };
+  enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
 
   explicit GEMPadDigiCluster(std::vector<uint16_t> pads,
                              int16_t bx,
-                             enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11);
+                             enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11,
+                             enum NumberPartitions nPart = NumberPartitions::GE11);
   GEMPadDigiCluster();
 
   bool operator==(const GEMPadDigiCluster& digi) const;
@@ -36,12 +38,19 @@ public:
   int bx() const { return bx_; }
   GEMSubDetId::Station station() const { return station_; }
 
+  // Newer GE2/1 geometries will have 16! eta partitions
+  // instead of the usual 8.
+  void setNPartitions(enum NumberPartitions nPart) { part_ = nPart; }
+  enum NumberPartitions nPartitions() const { return part_; }
+
   void print() const;
 
 private:
   std::vector<uint16_t> v_;
   int32_t bx_;
   GEMSubDetId::Station station_;
+  // number of eta partitions
+  enum NumberPartitions part_;
 };
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi);

--- a/DataFormats/GEMDigi/src/GEMPadDigi.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigi.cc
@@ -1,10 +1,11 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include <iostream>
 
-GEMPadDigi::GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station)
-    : pad_(pad), bx_(bx), station_(station) {}
+GEMPadDigi::GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station, enum NumberPartitions nPart)
+    : pad_(pad), bx_(bx), station_(station), part_(nPart) {}
 
-GEMPadDigi::GEMPadDigi() : pad_(GE11InValid), bx_(-99), station_(GEMSubDetId::Station::GE11) {}
+GEMPadDigi::GEMPadDigi()
+    : pad_(GE11InValid), bx_(-99), station_(GEMSubDetId::Station::GE11), part_(NumberPartitions::GE11) {}
 
 // Comparison
 bool GEMPadDigi::operator==(const GEMPadDigi& digi) const {

--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -1,10 +1,14 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include <iostream>
 
-GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads, int16_t bx, enum GEMSubDetId::Station station)
-    : v_(pads), bx_(bx), station_(station) {}
+GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads,
+                                     int16_t bx,
+                                     enum GEMSubDetId::Station station,
+                                     enum NumberPartitions nPart)
+    : v_(pads), bx_(bx), station_(station), part_(nPart) {}
 
-GEMPadDigiCluster::GEMPadDigiCluster() : v_(std::vector<uint16_t>()), bx_(-99), station_(GEMSubDetId::Station::GE11) {}
+GEMPadDigiCluster::GEMPadDigiCluster()
+    : v_(std::vector<uint16_t>()), bx_(-99), station_(GEMSubDetId::Station::GE11), part_(NumberPartitions::GE11) {}
 
 // Comparison
 bool GEMPadDigiCluster::operator==(const GEMPadDigiCluster& digi) const {

--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -37,10 +37,10 @@ bool GEMPadDigiCluster::isValid() const {
 }
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi) {
-  o << " bx: " << digi.bx() << " pads: ";
+  o << " bx: " << digi.bx() << " pads: [";
   for (auto p : digi.pads())
     o << " " << p;
-  o << std::endl;
+  o << "]";
   return o;
 }
 

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -9,19 +9,21 @@
 <class name="MuonDigiCollection<GEMDetId,GEMDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMDigi> >" splitLevel="0"/>
 
-<class name="GEMPadDigi" ClassVersion="13">
+<class name="GEMPadDigi" ClassVersion="14">
  <version ClassVersion="11" checksum="426510066"/>
  <version ClassVersion="12" checksum="3838591655"/>
  <version ClassVersion="13" checksum="2944221332"/>
+ <version ClassVersion="14" checksum="2559685204"/>
 </class>
 <class name="std::vector<GEMPadDigi>"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigi> >"/>
 <class name="MuonDigiCollection<GEMDetId,GEMPadDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigi> >" splitLevel="0"/>
 
-<class name="GEMPadDigiCluster" ClassVersion="11">
+<class name="GEMPadDigiCluster" ClassVersion="12">
  <version ClassVersion="10" checksum="2569340006"/>
  <version ClassVersion="11" checksum="3372991553"/>
+ <version ClassVersion="12" checksum="1156181001"/>
 </class>
 <class name="std::vector<GEMPadDigiCluster>"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigiCluster> >"/>
@@ -42,8 +44,8 @@
 </class>
 <class name="std::vector<GEMVfatStatusDigi>"/>
 <class name="std::map<GEMDetId,std::vector<GEMVfatStatusDigi> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMVfatStatusDigi>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMVfatStatusDigi> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<GEMDetId,GEMVfatStatusDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMVfatStatusDigi> >" splitLevel="0"/>
 
 <class name="gem::GEBdata" ClassVersion="3">
   <version ClassVersion="3" checksum="3127786112"/>

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -227,6 +227,11 @@ public:
     return rawid;
   }
 
+  // subsystem
+  bool isGE11() const;
+  bool isGE21() const;
+  bool isME0() const;
+
 private:
   constexpr void v12FromV11(const uint32_t& rawid) { id_ = v12Form(rawid); }
 

--- a/DataFormats/MuonDetId/src/GEMDetId.cc
+++ b/DataFormats/MuonDetId/src/GEMDetId.cc
@@ -4,6 +4,12 @@
 
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 
+bool GEMDetId::isGE11() const { return GEMSubDetId::Station(station()) == GEMSubDetId::Station::GE11; }
+
+bool GEMDetId::isGE21() const { return GEMSubDetId::Station(station()) == GEMSubDetId::Station::GE21; }
+
+bool GEMDetId::isME0() const { return GEMSubDetId::Station(station()) == GEMSubDetId::Station::ME0; }
+
 std::ostream& operator<<(std::ostream& os, const GEMDetId& id) {
   os << " Re " << id.region() << " Ri " << id.ring() << " St " << id.station() << " La " << id.layer() << " Ch "
      << id.chamber() << " Ro " << id.roll() << " ";

--- a/Geometry/GEMGeometry/interface/GEMEtaPartition.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartition.h
@@ -78,6 +78,11 @@ public:
   /// returns last strip (INT number [0,nstrip-1]) for pad (an integer [0,npads-1])
   int lastStripInPad(int pad) const;
 
+  // subsystem
+  bool isGE11() const;
+  bool isGE21() const;
+  bool isME0() const;
+
 private:
   GEMDetId id_;
   GEMEtaPartitionSpecs* specs_;

--- a/Geometry/GEMGeometry/interface/GEMGeometry.h
+++ b/Geometry/GEMGeometry/interface/GEMGeometry.h
@@ -109,6 +109,11 @@ public:
   /// Add a GEMEtaPartition  to the Geometry
   void add(const GEMEtaPartition* etaPartition);
 
+  // check if a certain station exists
+  bool hasGE11() const;
+  bool hasGE21() const;
+  bool hasME0() const;
+
 private:
   DetContainer theEtaPartitions;
   DetContainer theDets;

--- a/Geometry/GEMGeometry/src/GEMEtaPartition.cc
+++ b/Geometry/GEMGeometry/src/GEMEtaPartition.cc
@@ -71,3 +71,9 @@ int GEMEtaPartition::lastStripInPad(int pad) const {
   LocalPoint lp = specificPadTopology().localPosition(p);
   return static_cast<int>(strip(lp));
 }
+
+bool GEMEtaPartition::isGE11() const { return id_.isGE11(); }
+
+bool GEMEtaPartition::isGE21() const { return id_.isGE21(); }
+
+bool GEMEtaPartition::isME0() const { return id_.isME0(); }

--- a/Geometry/GEMGeometry/src/GEMGeometry.cc
+++ b/Geometry/GEMGeometry/src/GEMGeometry.cc
@@ -107,3 +107,9 @@ void GEMGeometry::add(const GEMChamber* chamber) {
   theDetIds.emplace_back(chamber->geographicalId());
   theMap.insert(std::make_pair((chamber->geographicalId()).rawId(), chamber));
 }
+
+bool GEMGeometry::hasGE11() const { return station(1, 1) != nullptr and station(-1, 1) != nullptr; }
+
+bool GEMGeometry::hasGE21() const { return station(1, 2) != nullptr and station(-1, 2) != nullptr; }
+
+bool GEMGeometry::hasME0() const { return station(1, 0) != nullptr and station(-1, 0) != nullptr; }

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -59,7 +59,15 @@ std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_
       // now let's correlate the pads in two layers of this partition
       const auto& pads_range = (*det_range).second;
       for (auto p = pads_range.first; p != pads_range.second; ++p) {
+        // only consider valid pads
+        if (!p->isValid())
+          continue;
+
         for (auto co_p = co_pads_range.first; co_p != co_pads_range.second; ++co_p) {
+          // only consider valid pads
+          if (!co_p->isValid())
+            continue;
+
           // check the match in pad
           if ((unsigned)std::abs(p->pad() - co_p->pad()) > maxDeltaPad_)
             continue;
@@ -91,6 +99,10 @@ void GEMCoPadProcessor::declusterize(const GEMPadDigiClusterCollection* in_clust
     const GEMDetId& id = (*detUnitIt).first;
     const auto& range = (*detUnitIt).second;
     for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
+      // only consider valid clusters
+      if (!digiIt->isValid())
+        continue;
+
       for (const auto& p : digiIt->pads()) {
         out_pads.insertDigi(id, GEMPadDigi(p, digiIt->bx()));
       }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -189,8 +189,14 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
   for (const auto& part : geometry_->etaPartitions()) {
     // clusters are not build for ME0
     // -> ignore hits from station 0
-    if (part->id().station() == 0)
+    if (part->isME0())
       continue;
+
+    // number of eta partitions
+    auto nPart = GEMPadDigiCluster::NumberPartitions::GE11;
+    if (part->isGE21()) {
+      nPart = GEMPadDigiCluster::NumberPartitions::GE21;
+    }
 
     GEMPadDigiClusters all_pad_clusters;
 
@@ -211,7 +217,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
           cl.push_back((*d).pad());
         } else {
           // put the current cluster in the proto collection
-          GEMPadDigiCluster pad_cluster(cl, startBX, GEMSubDetId::station(part->id().station()));
+          GEMPadDigiCluster pad_cluster(cl, startBX, GEMSubDetId::station(part->id().station()), nPart);
 
           // check if the output cluster is valid
           checkValid(pad_cluster, part->id());
@@ -228,7 +234,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
 
     // put the last cluster in the proto collection
     if (pads.first != pads.second) {
-      GEMPadDigiCluster pad_cluster(cl, startBX, GEMSubDetId::station(part->id().station()));
+      GEMPadDigiCluster pad_cluster(cl, startBX, GEMSubDetId::station(part->id().station()), nPart);
 
       // check if the output cluster is valid
       checkValid(pad_cluster, part->id());
@@ -249,9 +255,7 @@ void GEMPadDigiClusterProducer::sortClusters(const GEMPadDigiClusterContainer& p
 
   for (const auto& ch : geometry_->chambers()) {
     // check the station number
-    const int station = ch->id().station();
-    const bool isGE11 = (station == 1);
-    const unsigned nOH = isGE11 ? nOHGE11_ : nOHGE21_;
+    const unsigned nOH = ch->id().isGE11() ? nOHGE11_ : nOHGE21_;
     const unsigned nPartOH = ch->nEtaPartitions() / nOH;
 
     std::vector<std::vector<std::pair<GEMDetId, GEMPadDigiClusters> > > temp_clustersCH;
@@ -280,9 +284,7 @@ void GEMPadDigiClusterProducer::selectClusters(const GEMPadDigiClusterSortedCont
                                                GEMPadDigiClusterCollection& out_clusters) const {
   // loop over chambers
   for (const auto& ch : geometry_->chambers()) {
-    const int station = ch->id().station();
-    const bool isGE11 = (station == 1);
-    const unsigned maxClustersOH = isGE11 ? maxClustersOHGE11_ : maxClustersOHGE21_;
+    const unsigned maxClustersOH = ch->id().isGE11() ? maxClustersOHGE11_ : maxClustersOHGE21_;
 
     // loop over the optohybrids
     for (const auto& optohybrid : sorted_clusters.at(ch->id())) {

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -93,11 +93,9 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 }
 
 void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
-
   // check that ME0 has 8-eta partitions
   if (geometry_->hasME0()) {
-    if (geometry_->station(1, 0)->superChamber(1)->chamber(1)->nEtaPartitions() !=
-        GEMPadDigi::NumberPartitions::ME0) {
+    if (geometry_->station(1, 0)->superChamber(1)->chamber(1)->nEtaPartitions() != GEMPadDigi::NumberPartitions::ME0) {
       edm::LogError("GEMPadDigiProducer") << "ME0 geometry appears corrupted";
     }
   }
@@ -109,8 +107,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
 
   // check that GE2/1 has 8-eta partitions
   if (geometry_->hasGE21()) {
-    if (geometry_->station(1, 2)->superChamber(1)->chamber(1)->nEtaPartitions() !=
-        GEMPadDigi::NumberPartitions::GE21) {
+    if (geometry_->station(1, 2)->superChamber(1)->chamber(1)->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE21) {
       edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (8 partition) appears corrupted";
     }
   }
@@ -136,8 +133,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
         nPart = GEMPadDigi::NumberPartitions::GE21;
       }
       // check that the input digi is valid
-      if ((p->isME0() and pad_num == GEMPadDigi::ME0InValid) or
-          (p->isGE11() and pad_num == GEMPadDigi::GE11InValid) or
+      if ((p->isME0() and pad_num == GEMPadDigi::ME0InValid) or (p->isGE11() and pad_num == GEMPadDigi::GE11InValid) or
           (p->isGE21() and pad_num == GEMPadDigi::GE21InValid)) {
         edm::LogWarning("GEMPadDigiProducer") << "Invalid " << pad_num << " from  " << *d << " in " << p->id();
       }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -100,7 +100,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
       continue;
 
     // check that ME0 has 8-eta partitions
-    if (geometry_->stations().size() == 3) {
+    if (geometry_->hasME0()) {
       if (geometry_->station(1, 0)->superChamber(1)->chamber(1)->nEtaPartitions() !=
           GEMPadDigi::NumberPartitions::ME0) {
         edm::LogError("GEMPadDigiProducer") << "ME0 geometry appears corrupted";
@@ -113,7 +113,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
     }
 
     // check that GE2/1 has 8-eta partitions
-    if (geometry_->stations().size() == 2) {
+    if (geometry_->hasGE21()) {
       if (geometry_->station(1, 2)->superChamber(1)->chamber(1)->nEtaPartitions() !=
           GEMPadDigi::NumberPartitions::GE21) {
         edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (8 partition) appears corrupted";
@@ -165,7 +165,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
       continue;
 
     // check that GE2/1 has 16-eta partitions
-    if (geometry_->stations().size() == 2) {
+    if (geometry_->hasGE21()) {
       if (geometry_->station(1, 2)->superChamber(1)->chamber(1)->nEtaPartitions() !=
           GEMPadDigi::NumberPartitions::GE21SplitStrip) {
         edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (16 partition) appears corrupted";

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -168,7 +168,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
 }
 
 void GEMPadDigiProducer::checkValid(const GEMPadDigi& pad, const GEMDetId& id) const {
-  // check if the cluster is valid
+  // check if the pad is valid
   // in principle, invalid pads can appear in the CMS raw data
   if (!pad.isValid()) {
     edm::LogWarning("GEMPadDigiProducer") << "Invalid " << pad << " in " << id;


### PR DESCRIPTION
#### PR description:

- I added a few statements to ignore invalid pads and clusters in the GEM-CSC trigger. I also added checks (LogWarnings, not selections) in the GEM trigger primitive producers.

- The new GE2/1 geometry has 16 eta partitions (each strip split in 2), instead of 8 eta partitions. To prevent a miscommunication between GE2/1 TPs and the EMTF, or the GEM packer/unpacker, I added a member `part_` in the `GEMPadDigi` and `GEMPadDigiCluster`. This was requested by EMTF folks. This way it should be relatively easy to check which geometry you are dealing with by calling `nPartitions()`. 

Note: this supersedes PR #30624.

#### PR validation:

Tested with WF 23234.0.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A