### PR TITLE
Modernize modules in CalibTracker/SiStripCommon

### DIFF
--- a/CalibTracker/SiStripCommon/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/Scalers"/>
 <use name="DataFormats/OnlineMetaData"/>
+<use name="SimDataFormats/TrackingAnalysis"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/CalibTracker/SiStripCommon/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/plugins/BuildFile.xml
@@ -7,7 +7,6 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/RunInfo"/>
 <use name="RecoLocalTracker/SiStripClusterizer"/>
-<use name="SimDataFormats/TrackingAnalysis"/>
 <library file="*.cc" name="CalibTrackerSiStripCommonPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/CalibTracker/SiStripCommon/plugins/ShallowDigisProducer.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowDigisProducer.h
@@ -1,13 +1,13 @@
 #ifndef SHALLOW_DIGIS_PRODUCER
 #define SHALLOW_DIGIS_PRODUCER
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 class SiStripNoises;
 
-class ShallowDigisProducer : public edm::EDProducer {
+class ShallowDigisProducer : public edm::stream::EDProducer<> {
 public:
   explicit ShallowDigisProducer(const edm::ParameterSet &);
 

--- a/CalibTracker/SiStripCommon/plugins/ShallowGainCalibration.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowGainCalibration.h
@@ -1,7 +1,7 @@
 #ifndef SHALLOW_GAINCALIBRATION_PRODUCER
 #define SHALLOW_GAINCALIBRATION_PRODUCER
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "CalibTracker/SiStripCommon/interface/ShallowTools.h"
@@ -16,6 +16,8 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
 #include "CondFormats/DataRecord/interface/SiStripLorentzAngleRcd.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
@@ -48,43 +50,41 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/TrackReco/interface/DeDxHit.h"
-#include "DataFormats/TrackReco/interface/TrackDeDxHits.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
-#include <ext/hash_map>
+using DetIdMap = std::map<uint32_t, double>;
 
-class ShallowGainCalibration : public edm::stream::EDProducer<> {
+namespace shallowGainCalibration {
+  struct bundle {
+    bundle(const TrackerGeometry* trackerG) : tkGeo_(trackerG), value_({{0, 0.}}) {}
+    void updateMap(uint32_t id, double thickness) { value_.insert(std::make_pair(id, thickness)); }
+    DetIdMap getThicknessMap() { return value_; }
+    const TrackerGeometry* getTrackerGeometry() { return tkGeo_; }
+
+  private:
+    const TrackerGeometry* tkGeo_;
+    DetIdMap value_;
+  };
+}  // namespace shallowGainCalibration
+
+class ShallowGainCalibration : public edm::global::EDProducer<edm::RunCache<shallowGainCalibration::bundle> > {
 public:
   explicit ShallowGainCalibration(const edm::ParameterSet&);
+  std::shared_ptr<shallowGainCalibration::bundle> globalBeginRun(edm::Run const&,
+                                                                 edm::EventSetup const&) const override;
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const override;
 
 private:
   const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
   const edm::EDGetTokenT<TrajTrackAssociationCollection> association_token_;
-
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometry_token_;
-  const edm::ESGetToken<SiStripGain, SiStripGainRcd> gain_token_;
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeom_token_;
-
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<SiStripGain, SiStripGainRcd> gainToken_;
   std::string Suffix;
   std::string Prefix;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  //  virtual void beginJob(EventSetup const&);
-  //  virtual void beginRun(Run&, EventSetup const&);
-  bool IsFarFromBorder(TrajectoryStateOnSurface* trajState, const uint32_t detid, const edm::EventSetup* iSetup);
-  double thickness(DetId id);
-
-  const TrackerGeometry* m_tracker;
-  std::map<DetId, double> m_thicknessMap;
-
-  /*
-  struct stAPVGain{int DetId; int APVId; double PreviousGain;};
-  class isEqual{
-      public:
-              template <class T> bool operator () (const T& PseudoDetId1, const T& PseudoDetId2) { return PseudoDetId1==PseudoDetId2; }
-  };
-  std::vector<stAPVGain*> APVsCollOrdered;
-  hash_map<unsigned int, stAPVGain*,  hash<unsigned int>, isEqual > APVsColl;
-*/
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  bool isFarFromBorder(TrajectoryStateOnSurface* trajState,
+                       const uint32_t detid,
+                       const TrackerGeometry* trackerG) const;
 };
 #endif

--- a/CalibTracker/SiStripCommon/plugins/ShallowRechitClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowRechitClustersProducer.cc
@@ -1,7 +1,5 @@
 #include "ShallowRechitClustersProducer.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -13,6 +11,7 @@
 ShallowRechitClustersProducer::ShallowRechitClustersProducer(const edm::ParameterSet& iConfig)
     : Suffix(iConfig.getParameter<std::string>("Suffix")),
       Prefix(iConfig.getParameter<std::string>("Prefix")),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
       clusters_token_(consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("Clusters"))) {
   std::vector<edm::InputTag> rec_hits_tags = iConfig.getParameter<std::vector<edm::InputTag>>("InputTags");
   for (const auto& itag : rec_hits_tags) {
@@ -44,8 +43,7 @@ void ShallowRechitClustersProducer::produce(edm::Event& iEvent, const edm::Event
   auto globaly = std::make_unique<std::vector<float>>(size, -10000);
   auto globalz = std::make_unique<std::vector<float>>(size, -10000);
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry = iSetup.getHandle(geomToken_);
 
   for (auto recHit_token : rec_hits_tokens_) {
     edm::Handle<SiStripRecHit2DCollection> recHits;

--- a/CalibTracker/SiStripCommon/plugins/ShallowRechitClustersProducer.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowRechitClustersProducer.h
@@ -1,24 +1,26 @@
 #ifndef SHALLOW_RECHITCLUSTERS_PRODUCER
 #define SHALLOW_RECHITCLUSTERS_PRODUCER
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
-class ShallowRechitClustersProducer : public edm::EDProducer {
+class ShallowRechitClustersProducer : public edm::stream::EDProducer<> {
 public:
-  explicit ShallowRechitClustersProducer(const edm::ParameterSet &);
+  explicit ShallowRechitClustersProducer(const edm::ParameterSet&);
 
 private:
   std::string Suffix;
   std::string Prefix;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_token_;
   std::vector<edm::EDGetTokenT<SiStripRecHit2DCollection> > rec_hits_tokens_;
-  //std::vector<edm::InputTag> inputTags;
-  void produce(edm::Event &, const edm::EventSetup &) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/plugins/ShallowSimTracksProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowSimTracksProducer.cc
@@ -30,7 +30,7 @@ ShallowSimTracksProducer::ShallowSimTracksProducer(const edm::ParameterSet& conf
   produces<std::vector<double>>(Prefix + "vz" + Suffix);
 }
 
-void ShallowSimTracksProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+void ShallowSimTracksProducer::produce(edm::Event& event, const edm::EventSetup& iSetup) {
   edm::Handle<edm::View<reco::Track>> tracks;
   event.getByToken(tracks_token_, tracks);
   edm::Handle<TrackingParticleCollection> trackingParticles;

--- a/CalibTracker/SiStripCommon/plugins/ShallowSimTracksProducer.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowSimTracksProducer.h
@@ -1,7 +1,7 @@
 #ifndef SHALLOW_SIMTRACKS_PRODUCER
 #define SHALLOW_SIMTRACKS_PRODUCER
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
@@ -9,9 +9,9 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
-class ShallowSimTracksProducer : public edm::EDProducer {
+class ShallowSimTracksProducer : public edm::stream::EDProducer<> {
 public:
-  explicit ShallowSimTracksProducer(const edm::ParameterSet &);
+  explicit ShallowSimTracksProducer(const edm::ParameterSet&);
 
 private:
   const std::string Prefix;
@@ -19,6 +19,6 @@ private:
   const edm::EDGetTokenT<TrackingParticleCollection> trackingParticles_token_;
   const edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> associator_token_;
   const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
-  void produce(edm::Event &, const edm::EventSetup &) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 };
 #endif

--- a/CalibTracker/SiStripCommon/plugins/ShallowSimhitClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowSimhitClustersProducer.cc
@@ -2,13 +2,6 @@
 
 #include "CalibTracker/SiStripCommon/interface/ShallowTools.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
-#include "CondFormats/DataRecord/interface/SiStripLorentzAngleRcd.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -17,6 +10,10 @@
 
 ShallowSimhitClustersProducer::ShallowSimhitClustersProducer(const edm::ParameterSet& iConfig)
     : clusters_token_(consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("Clusters"))),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+      magFieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord>()),
+      laToken_(esConsumes<SiStripLorentzAngle, SiStripLorentzAngleRcd>(
+          edm::ESInputTag(iConfig.getParameter<std::string>("runningMode")))),
       Prefix(iConfig.getParameter<std::string>("Prefix")),
       runningmode_(iConfig.getParameter<std::string>("runningMode")) {
   std::vector<edm::InputTag> simhits_tags = iConfig.getParameter<std::vector<edm::InputTag>>("InputTags");
@@ -55,12 +52,9 @@ void ShallowSimhitClustersProducer::produce(edm::Event& iEvent, const edm::Event
   auto particle = std::make_unique<std::vector<int>>(size, -500);
   auto process = std::make_unique<std::vector<unsigned short>>(size, 0);
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
-  edm::ESHandle<MagneticField> magfield;
-  iSetup.get<IdealMagneticFieldRecord>().get(magfield);
-  edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle;
-  iSetup.get<SiStripLorentzAngleRcd>().get(runningmode_, SiStripLorentzAngle);
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry = iSetup.getHandle(geomToken_);
+  edm::ESHandle<MagneticField> magfield = iSetup.getHandle(magFieldToken_);
+  edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle = iSetup.getHandle(laToken_);
   edm::Handle<edmNew::DetSetVector<SiStripCluster>> clusters;
   iEvent.getByLabel("siStripClusters", "", clusters);
 

--- a/CalibTracker/SiStripCommon/plugins/ShallowSimhitClustersProducer.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowSimhitClustersProducer.h
@@ -1,22 +1,30 @@
 #ifndef SHALLOW_SIMHITCLUSTERS_PRODUCER
 #define SHALLOW_SIMHITCLUSTERS_PRODUCER
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CalibTracker/SiStripCommon/interface/ShallowTools.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
+#include "CondFormats/DataRecord/interface/SiStripLorentzAngleRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
-class ShallowSimhitClustersProducer : public edm::EDProducer {
+class ShallowSimhitClustersProducer : public edm::stream::EDProducer<> {
 public:
   explicit ShallowSimhitClustersProducer(const edm::ParameterSet&);
 
 private:
-  //std::vector<edm::InputTag> inputTags;
   std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simhits_tokens_;
   const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_token_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleRcd> laToken_;
   std::string Prefix;
   std::string runningmode_;
 

--- a/CalibTracker/SiStripCommon/plugins/ShallowTrackClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTrackClustersProducer.cc
@@ -7,26 +7,21 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
-#include "CondFormats/DataRecord/interface/SiStripLorentzAngleRcd.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "CalibTracker/Records/interface/SiStripDependentRecords.h"
 #include <map>
 
 ShallowTrackClustersProducer::ShallowTrackClustersProducer(const edm::ParameterSet& iConfig)
     : tracks_token_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("Tracks"))),
       association_token_(consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("Tracks"))),
       clusters_token_(consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("Clusters"))),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+      magFieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord>()),
+      laToken_(esConsumes<SiStripLorentzAngle, SiStripLorentzAngleDepRcd>()),
       Suffix(iConfig.getParameter<std::string>("Suffix")),
       Prefix(iConfig.getParameter<std::string>("Prefix")) {
   produces<std::vector<int>>(Prefix + "clusterIdx" + Suffix);          //link: on trk cluster --> general cluster info
@@ -154,12 +149,9 @@ void ShallowTrackClustersProducer::produce(edm::Event& iEvent, const edm::EventS
   auto globalZofunitlocalY = std::make_unique<std::vector<float>>();
   globalZofunitlocalY->reserve(size);
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
-  edm::ESHandle<MagneticField> magfield;
-  iSetup.get<IdealMagneticFieldRecord>().get(magfield);
-  edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle;
-  iSetup.get<SiStripLorentzAngleDepRcd>().get(SiStripLorentzAngle);
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry = iSetup.getHandle(geomToken_);
+  edm::ESHandle<MagneticField> magfield = iSetup.getHandle(magFieldToken_);
+  edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle = iSetup.getHandle(laToken_);
 
   edm::Handle<TrajTrackAssociationCollection> associations;
   iEvent.getByToken(association_token_, associations);

--- a/CalibTracker/SiStripCommon/plugins/ShallowTrackClustersProducer.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTrackClustersProducer.h
@@ -1,15 +1,22 @@
 #ifndef SHALLOW_TRACKCLUSTERS_PRODUCER
 #define SHALLOW_TRACKCLUSTERS_PRODUCER
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
+#include "CondFormats/DataRecord/interface/SiStripLorentzAngleRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "CalibTracker/Records/interface/SiStripDependentRecords.h"
 
-class ShallowTrackClustersProducer : public edm::EDProducer {
+class ShallowTrackClustersProducer : public edm::stream::EDProducer<> {
 public:
   explicit ShallowTrackClustersProducer(const edm::ParameterSet &);
 
@@ -17,6 +24,9 @@ private:
   const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
   const edm::EDGetTokenT<TrajTrackAssociationCollection> association_token_;
   const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_token_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleDepRcd> laToken_;
   std::string Suffix;
   std::string Prefix;
 

--- a/CalibTracker/SiStripCommon/plugins/SiStripBFieldFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripBFieldFilter.cc
@@ -1,9 +1,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 #include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
@@ -11,12 +11,13 @@
 // -- Class Deleration
 //
 
-class SiStripBFieldFilter : public edm::EDFilter {
+class SiStripBFieldFilter : public edm::stream::EDFilter<> {
 public:
   SiStripBFieldFilter(const edm::ParameterSet&);
   ~SiStripBFieldFilter() override;
 
 private:
+  const edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
   double MagFieldCurrentTh_; /*!<  Threshold for the Magnet current. */
   bool HIpassFilter_;        /*!<  Swith for HI/Low filter. */
 
@@ -26,7 +27,8 @@ private:
 //
 // -- Constructor
 //
-SiStripBFieldFilter::SiStripBFieldFilter(const edm::ParameterSet& pset) {
+SiStripBFieldFilter::SiStripBFieldFilter(const edm::ParameterSet& pset)
+    : runInfoToken_(esConsumes<RunInfo, RunInfoRcd>()) {
   MagFieldCurrentTh_ = pset.getUntrackedParameter<double>("MagFieldCurrentTh", 2000.);
   HIpassFilter_ = pset.getUntrackedParameter<bool>("HIpassFilter", true);
 }
@@ -37,9 +39,7 @@ SiStripBFieldFilter::SiStripBFieldFilter(const edm::ParameterSet& pset) {
 SiStripBFieldFilter::~SiStripBFieldFilter() {}
 
 bool SiStripBFieldFilter::filter(edm::Event& evt, edm::EventSetup const& es) {
-  edm::ESHandle<RunInfo> runInfo;
-  es.get<RunInfoRcd>().get(runInfo);
-
+  edm::ESHandle<RunInfo> runInfo = es.getHandle(runInfoToken_);
   double average_current = runInfo.product()->m_avg_current;
 
   return ((HIpassFilter_) ? average_current > MagFieldCurrentTh_ : average_current < MagFieldCurrentTh_);


### PR DESCRIPTION
#### PR description:

Title says it all, part of #25090.
Profited to clean-up some commented code too.

#### PR validation:

Code compiles + run `runTheMatrix.py -l 1001.0 -t 4`.
Also exercised the unit tests of `CalibTracker/SiStripCommon` and `CalibTracker/SiStripChannelGain`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.
