### PR TITLE
Replace snprintf() and string copies with fmt::format() in Validation/Mixing/src/GlobalTest.cc

### DIFF
--- a/Validation/Mixing/BuildFile.xml
+++ b/Validation/Mixing/BuildFile.xml
@@ -3,3 +3,4 @@
 <use name="FWCore/Utilities"/>
 <use name="DQMServices/Core"/>
 <use name="SimDataFormats/CrossingFrame"/>
+<use name="fmt"/>

--- a/Validation/Mixing/interface/GlobalTest.h
+++ b/Validation/Mixing/interface/GlobalTest.h
@@ -43,7 +43,6 @@ class TFile;
 class GlobalTest : public DQMEDAnalyzer {
 public:
   explicit GlobalTest(const edm::ParameterSet &);
-  ~GlobalTest() override;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
@@ -61,9 +60,6 @@ private:
   MonitorElement *trackPartIdH_[nMaxH];
   MonitorElement *caloEnergyEBH_[nMaxH];
   MonitorElement *caloEnergyEEH_[nMaxH];
-
-  const static int nrHistos = 6;
-  char *labels[nrHistos];
 
   edm::EDGetTokenT<CrossingFrame<SimTrack>> cfTrackToken_;
   edm::EDGetTokenT<CrossingFrame<SimTrack>> cfVertexToken_;

--- a/Validation/Mixing/src/GlobalTest.cc
+++ b/Validation/Mixing/src/GlobalTest.cc
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include <fmt/format.h>
+
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -50,57 +52,25 @@ GlobalTest::GlobalTest(const edm::ParameterSet &iConfig)
             << ", maxbunch: " << maxbunch_ << std::endl;
 }
 
-GlobalTest::~GlobalTest() {
-  for (int i = 0; i < 6; i++)
-    delete[] labels[i];
-}
-
 void GlobalTest::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
   using namespace std;
 
   ibooker.setCurrentFolder("MixingV/Mixing");
   // book histos
-  std::string NrPileupEvts = "NrPileupEvts";
-  size_t NrPileupEvtsSize = NrPileupEvts.size() + 1;
-  std::string NrVertices = "NrVertices";
-  size_t NrVerticesSize = NrVertices.size() + 1;
-  std::string NrTracks = "NrTracks";
-  size_t NrTracksSize = NrTracks.size() + 1;
-  std::string TrackPartId = "TrackPartId";
-  size_t TrackPartIdSize = TrackPartId.size() + 1;
-  std::string CaloEnergyEB = "CaloEnergyEB";
-  size_t CaloEnergyEBSize = CaloEnergyEB.size() + 1;
-  std::string CaloEnergyEE = "CaloEnergyEE";
-  size_t CaloEnergyEESize = CaloEnergyEE.size() + 1;
 
-  labels[0] = new char[NrPileupEvtsSize];
-  strncpy(labels[0], NrPileupEvts.c_str(), NrPileupEvtsSize);
-  labels[1] = new char[NrVerticesSize];
-  strncpy(labels[1], NrVertices.c_str(), NrVerticesSize);
-  labels[2] = new char[NrTracksSize];
-  strncpy(labels[2], NrTracks.c_str(), NrTracksSize);
-  labels[3] = new char[TrackPartIdSize];
-  strncpy(labels[3], TrackPartId.c_str(), TrackPartIdSize);
-  labels[4] = new char[CaloEnergyEBSize];
-  strncpy(labels[4], CaloEnergyEB.c_str(), CaloEnergyEBSize);
-  labels[5] = new char[CaloEnergyEESize];
-  strncpy(labels[5], CaloEnergyEE.c_str(), CaloEnergyEESize);
-
-  // FIXME: test for max nr of histos
   for (int i = minbunch_; i <= maxbunch_; ++i) {
     int ii = i - minbunch_;
-    char label[50];
-    sprintf(label, "%s_%d", labels[0], i);
+    auto label = fmt::format("NrPileupEvts_{}", i);
     nrPileupsH_[ii] = ibooker.book1D(label, label, 100, 0, 100);
-    sprintf(label, "%s_%d", labels[1], i);
+    label = fmt::format("NrVertices_{}", i);
     nrVerticesH_[ii] = ibooker.book1D(label, label, 100, 0, 5000);
-    sprintf(label, "%s_%d", labels[2], i);
+    label = fmt::format("NrTracks_{}", i);
     nrTracksH_[ii] = ibooker.book1D(label, label, 100, 0, 10000);
-    sprintf(label, "%s_%d", labels[3], i);
+    label = fmt::format("TrackPartId", i);
     trackPartIdH_[ii] = ibooker.book1D(label, label, 100, 0, 100);
-    sprintf(label, "%s_%d", labels[4], i);
+    label = fmt::format("CaloEnergyEB", i);
     caloEnergyEBH_[ii] = ibooker.book1D(label, label, 100, 0., 1000.);
-    sprintf(label, "%s_%d", labels[5], i);
+    label = fmt::format("CaloEnergyEE", i);
     caloEnergyEEH_[ii] = ibooker.book1D(label, label, 100, 0., 1000.);
   }
 }


### PR DESCRIPTION
#### PR description:

GCC 10 warns
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/6bfeb1b59c2a9e14c52cd5c5d0709cec/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_11_2_X_2020-07-24-2300/src/Validation/Mixing/src/GlobalTest.cc: In member function 'virtual void GlobalTest::bookHistograms(dqm::legacy::DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/6bfeb1b59c2a9e14c52cd5c5d0709cec/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_11_2_X_2020-07-24-2300/src/Validation/Mixing/src/GlobalTest.cc:77:10: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 13 equals destination size [-Wstringop-truncation]
    77 |   strncpy(labels[0], NrPileupEvts.c_str(), NrPileupEvtsSize);
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This was discussed in Core Software meeting a few weeks ago, and the consensus was that the warning is likely wrong and the sizes are fine. On the other hand, the code creates an `std::string`, copies that to a `char[]`, which is then passed to `snprintf()`. This PR proposes to replace all that with a single call to `fmt::format()` (per label).


#### PR validation:

Code compiles.