### PR TITLE
Modernize modules in CalibTracker/SiStripCommon

### DIFF
--- a/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
@@ -1,20 +1,32 @@
 #ifndef SHALLOW_EVENTDATA_PRODUCER
 #define SHALLOW_EVENTDATA_PRODUCER
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "DataFormats/Scalers/interface/LumiScalers.h"
-#include <string>
+#include <vector>
 
-class ShallowEventDataProducer : public edm::EDProducer {
+class ShallowEventDataProducer : public edm::global::EDProducer<> {
 public:
   explicit ShallowEventDataProducer(const edm::ParameterSet &);
 
 private:
-  void produce(edm::Event &, const edm::EventSetup &) override;
-  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> trig_token_;
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
   edm::EDGetTokenT<LumiScalersCollection> scalerToken_;
+
+  edm::EDPutTokenT<unsigned int> runPut_;
+  edm::EDPutTokenT<unsigned int> eventPut_;
+  edm::EDPutTokenT<unsigned int> lumiPut_;
+  edm::EDPutTokenT<unsigned int> bxPut_;
+  edm::EDPutTokenT<float> instLumiPut_;
+  edm::EDPutTokenT<float> puPut_;
+#ifdef ExtendedCALIBTree
+  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> trig_token_;
+  edm::EDPutTokenT<std::vector<bool>> trigTechPut_;
+  edm::EDPutTokenT<std::vector<bool>> trigPhPut_;
+#endif
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
@@ -1,7 +1,7 @@
 #ifndef SHALLOW_GAINCALIBRATION_PRODUCER
 #define SHALLOW_GAINCALIBRATION_PRODUCER
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "CalibTracker/SiStripCommon/interface/ShallowTools.h"
@@ -37,6 +37,9 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
+
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -50,13 +53,17 @@
 
 #include <ext/hash_map>
 
-class ShallowGainCalibration : public edm::EDProducer {
+class ShallowGainCalibration : public edm::stream::EDProducer<> {
 public:
   explicit ShallowGainCalibration(const edm::ParameterSet&);
 
 private:
   const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
   const edm::EDGetTokenT<TrajTrackAssociationCollection> association_token_;
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometry_token_;
+  const edm::ESGetToken<SiStripGain, SiStripGainRcd> gain_token_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeom_token_;
 
   std::string Suffix;
   std::string Prefix;

--- a/CalibTracker/SiStripCommon/interface/ShallowTracksProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowTracksProducer.h
@@ -1,20 +1,47 @@
 #ifndef SHALLOW_TRACKS_PRODUCER
 #define SHALLOW_TRACKS_PRODUCER
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-class ShallowTracksProducer : public edm::EDProducer {
+class ShallowTracksProducer : public edm::global::EDProducer<> {
 public:
   explicit ShallowTracksProducer(const edm::ParameterSet &);
 
 private:
-  const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
+  const edm::EDGetTokenT<edm::View<reco::Track>> tracks_token_;
   edm::InputTag theTracksLabel;
   std::string Prefix;
   std::string Suffix;
-  void produce(edm::Event &, const edm::EventSetup &) override;
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  const edm::EDPutTokenT<unsigned int> numberPut_;
+  const edm::EDPutTokenT<std::vector<double>> chi2Put_;
+  const edm::EDPutTokenT<std::vector<double>> ndofPut_;
+  const edm::EDPutTokenT<std::vector<double>> chi2ndofPut_;
+  const edm::EDPutTokenT<std::vector<float>> chargePut_;
+  const edm::EDPutTokenT<std::vector<float>> momentumPut_;
+  const edm::EDPutTokenT<std::vector<float>> ptPut_;
+  const edm::EDPutTokenT<std::vector<float>> pterrPut_;
+  const edm::EDPutTokenT<std::vector<unsigned int>> hitsvalidPut_;
+  const edm::EDPutTokenT<std::vector<unsigned int>> hitslostPut_;
+  const edm::EDPutTokenT<std::vector<double>> thetaPut_;
+  const edm::EDPutTokenT<std::vector<double>> thetaerrPut_;
+  const edm::EDPutTokenT<std::vector<double>> phiPut_;
+  const edm::EDPutTokenT<std::vector<double>> phierrPut_;
+  const edm::EDPutTokenT<std::vector<double>> etaPut_;
+  const edm::EDPutTokenT<std::vector<double>> etaerrPut_;
+  const edm::EDPutTokenT<std::vector<double>> dxyPut_;
+  const edm::EDPutTokenT<std::vector<double>> dxyerrPut_;
+  const edm::EDPutTokenT<std::vector<double>> dszPut_;
+  const edm::EDPutTokenT<std::vector<double>> dszerrPut_;
+  const edm::EDPutTokenT<std::vector<double>> qoverpPut_;
+  const edm::EDPutTokenT<std::vector<double>> qoverperrPut_;
+  const edm::EDPutTokenT<std::vector<double>> vxPut_;
+  const edm::EDPutTokenT<std::vector<double>> vyPut_;
+  const edm::EDPutTokenT<std::vector<double>> vzPut_;
+  const edm::EDPutTokenT<std::vector<int>> algoPut_;
 };
 #endif

--- a/CalibTracker/SiStripCommon/plugins/ShallowTracksProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTracksProducer.cc
@@ -9,119 +9,142 @@
 ShallowTracksProducer::ShallowTracksProducer(const edm::ParameterSet& iConfig)
     : tracks_token_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("Tracks"))),
       Prefix(iConfig.getParameter<std::string>("Prefix")),
-      Suffix(iConfig.getParameter<std::string>("Suffix")) {
-  produces<unsigned int>(Prefix + "number" + Suffix);
-  produces<std::vector<double>>(Prefix + "chi2" + Suffix);
-  produces<std::vector<double>>(Prefix + "ndof" + Suffix);
-  produces<std::vector<double>>(Prefix + "chi2ndof" + Suffix);
-  produces<std::vector<float>>(Prefix + "charge" + Suffix);
-  produces<std::vector<float>>(Prefix + "momentum" + Suffix);
-  produces<std::vector<float>>(Prefix + "pt" + Suffix);
-  produces<std::vector<float>>(Prefix + "pterr" + Suffix);
-  produces<std::vector<unsigned int>>(Prefix + "hitsvalid" + Suffix);
-  produces<std::vector<unsigned int>>(Prefix + "hitslost" + Suffix);
-  produces<std::vector<double>>(Prefix + "theta" + Suffix);
-  produces<std::vector<double>>(Prefix + "thetaerr" + Suffix);
-  produces<std::vector<double>>(Prefix + "phi" + Suffix);
-  produces<std::vector<double>>(Prefix + "phierr" + Suffix);
-  produces<std::vector<double>>(Prefix + "eta" + Suffix);
-  produces<std::vector<double>>(Prefix + "etaerr" + Suffix);
-  produces<std::vector<double>>(Prefix + "dxy" + Suffix);
-  produces<std::vector<double>>(Prefix + "dxyerr" + Suffix);
-  produces<std::vector<double>>(Prefix + "dsz" + Suffix);
-  produces<std::vector<double>>(Prefix + "dszerr" + Suffix);
-  produces<std::vector<double>>(Prefix + "qoverp" + Suffix);
-  produces<std::vector<double>>(Prefix + "qoverperr" + Suffix);
-  produces<std::vector<double>>(Prefix + "vx" + Suffix);
-  produces<std::vector<double>>(Prefix + "vy" + Suffix);
-  produces<std::vector<double>>(Prefix + "vz" + Suffix);
-  produces<std::vector<int>>(Prefix + "algo" + Suffix);
-}
+      Suffix(iConfig.getParameter<std::string>("Suffix")),
+      numberPut_(produces<unsigned int>(Prefix + "number" + Suffix)),
+      chi2Put_(produces<std::vector<double>>(Prefix + "chi2" + Suffix)),
+      ndofPut_(produces<std::vector<double>>(Prefix + "ndof" + Suffix)),
+      chi2ndofPut_(produces<std::vector<double>>(Prefix + "chi2ndof" + Suffix)),
+      chargePut_(produces<std::vector<float>>(Prefix + "charge" + Suffix)),
+      momentumPut_(produces<std::vector<float>>(Prefix + "momentum" + Suffix)),
+      ptPut_(produces<std::vector<float>>(Prefix + "pt" + Suffix)),
+      pterrPut_(produces<std::vector<float>>(Prefix + "pterr" + Suffix)),
+      hitsvalidPut_(produces<std::vector<unsigned int>>(Prefix + "hitsvalid" + Suffix)),
+      hitslostPut_(produces<std::vector<unsigned int>>(Prefix + "hitslost" + Suffix)),
+      thetaPut_(produces<std::vector<double>>(Prefix + "theta" + Suffix)),
+      thetaerrPut_(produces<std::vector<double>>(Prefix + "thetaerr" + Suffix)),
+      phiPut_(produces<std::vector<double>>(Prefix + "phi" + Suffix)),
+      phierrPut_(produces<std::vector<double>>(Prefix + "phierr" + Suffix)),
+      etaPut_(produces<std::vector<double>>(Prefix + "eta" + Suffix)),
+      etaerrPut_(produces<std::vector<double>>(Prefix + "etaerr" + Suffix)),
+      dxyPut_(produces<std::vector<double>>(Prefix + "dxy" + Suffix)),
+      dxyerrPut_(produces<std::vector<double>>(Prefix + "dxyerr" + Suffix)),
+      dszPut_(produces<std::vector<double>>(Prefix + "dsz" + Suffix)),
+      dszerrPut_(produces<std::vector<double>>(Prefix + "dszerr" + Suffix)),
+      qoverpPut_(produces<std::vector<double>>(Prefix + "qoverp" + Suffix)),
+      qoverperrPut_(produces<std::vector<double>>(Prefix + "qoverperr" + Suffix)),
+      vxPut_(produces<std::vector<double>>(Prefix + "vx" + Suffix)),
+      vyPut_(produces<std::vector<double>>(Prefix + "vy" + Suffix)),
+      vzPut_(produces<std::vector<double>>(Prefix + "vz" + Suffix)),
+      algoPut_(produces<std::vector<int>>(Prefix + "algo" + Suffix)) {}
 
-void ShallowTracksProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  auto number = std::make_unique<unsigned int>(0);
-  auto chi2 = std::make_unique<std::vector<double>>();
-  auto ndof = std::make_unique<std::vector<double>>();
-  auto chi2ndof = std::make_unique<std::vector<double>>();
-  auto charge = std::make_unique<std::vector<float>>();
-  auto momentum = std::make_unique<std::vector<float>>();
-  auto pt = std::make_unique<std::vector<float>>();
-  auto pterr = std::make_unique<std::vector<float>>();
-  auto hitsvalid = std::make_unique<std::vector<unsigned int>>();
-  auto hitslost = std::make_unique<std::vector<unsigned int>>();
-  auto theta = std::make_unique<std::vector<double>>();
-  auto thetaerr = std::make_unique<std::vector<double>>();
-  auto phi = std::make_unique<std::vector<double>>();
-  auto phierr = std::make_unique<std::vector<double>>();
-  auto eta = std::make_unique<std::vector<double>>();
-  auto etaerr = std::make_unique<std::vector<double>>();
-  auto dxy = std::make_unique<std::vector<double>>();
-  auto dxyerr = std::make_unique<std::vector<double>>();
-  auto dsz = std::make_unique<std::vector<double>>();
-  auto dszerr = std::make_unique<std::vector<double>>();
-  auto qoverp = std::make_unique<std::vector<double>>();
-  auto qoverperr = std::make_unique<std::vector<double>>();
-  auto vx = std::make_unique<std::vector<double>>();
-  auto vy = std::make_unique<std::vector<double>>();
-  auto vz = std::make_unique<std::vector<double>>();
-  auto algo = std::make_unique<std::vector<int>>();
-
+void ShallowTracksProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Handle<edm::View<reco::Track>> tracks;
   iEvent.getByToken(tracks_token_, tracks);
 
-  *number = tracks->size();
+  unsigned int number = tracks->size();
+  std::vector<double> chi2;
+  chi2.reserve(number);
+  std::vector<double> ndof;
+  ndof.reserve(number);
+  std::vector<double> chi2ndof;
+  chi2ndof.reserve(number);
+  std::vector<float> charge;
+  charge.reserve(number);
+  std::vector<float> momentum;
+  momentum.reserve(number);
+  std::vector<float> pt;
+  pt.reserve(number);
+  std::vector<float> pterr;
+  pterr.reserve(number);
+  std::vector<unsigned int> hitsvalid;
+  hitsvalid.reserve(number);
+  std::vector<unsigned int> hitslost;
+  hitslost.reserve(number);
+  std::vector<double> theta;
+  theta.reserve(number);
+  std::vector<double> thetaerr;
+  thetaerr.reserve(number);
+  std::vector<double> phi;
+  phi.reserve(number);
+  std::vector<double> phierr;
+  phierr.reserve(number);
+  std::vector<double> eta;
+  eta.reserve(number);
+  std::vector<double> etaerr;
+  etaerr.reserve(number);
+  std::vector<double> dxy;
+  dxy.reserve(number);
+  std::vector<double> dxyerr;
+  dxyerr.reserve(number);
+  std::vector<double> dsz;
+  dsz.reserve(number);
+  std::vector<double> dszerr;
+  dszerr.reserve(number);
+  std::vector<double> qoverp;
+  qoverp.reserve(number);
+  std::vector<double> qoverperr;
+  qoverperr.reserve(number);
+  std::vector<double> vx;
+  vx.reserve(number);
+  std::vector<double> vy;
+  vy.reserve(number);
+  std::vector<double> vz;
+  vz.reserve(number);
+  std::vector<int> algo;
+  algo.reserve(number);
+
   for (auto const& track : *tracks) {
-    chi2->push_back(track.chi2());
-    ndof->push_back(track.ndof());
-    chi2ndof->push_back(track.chi2() / track.ndof());
-    charge->push_back(track.charge());
-    momentum->push_back(track.p());
-    pt->push_back(track.pt());
-    pterr->push_back(track.ptError());
-    hitsvalid->push_back(track.numberOfValidHits());
-    hitslost->push_back(track.numberOfLostHits());
-    theta->push_back(track.theta());
-    thetaerr->push_back(track.thetaError());
-    phi->push_back(track.phi());
-    phierr->push_back(track.phiError());
-    eta->push_back(track.eta());
-    etaerr->push_back(track.etaError());
-    dxy->push_back(track.dxy());
-    dxyerr->push_back(track.dxyError());
-    dsz->push_back(track.dsz());
-    dszerr->push_back(track.dszError());
-    qoverp->push_back(track.qoverp());
-    qoverperr->push_back(track.qoverpError());
-    vx->push_back(track.vx());
-    vy->push_back(track.vy());
-    vz->push_back(track.vz());
-    algo->push_back((int)track.algo());
+    chi2.push_back(track.chi2());
+    ndof.push_back(track.ndof());
+    chi2ndof.push_back(track.chi2() / track.ndof());
+    charge.push_back(track.charge());
+    momentum.push_back(track.p());
+    pt.push_back(track.pt());
+    pterr.push_back(track.ptError());
+    hitsvalid.push_back(track.numberOfValidHits());
+    hitslost.push_back(track.numberOfLostHits());
+    theta.push_back(track.theta());
+    thetaerr.push_back(track.thetaError());
+    phi.push_back(track.phi());
+    phierr.push_back(track.phiError());
+    eta.push_back(track.eta());
+    etaerr.push_back(track.etaError());
+    dxy.push_back(track.dxy());
+    dxyerr.push_back(track.dxyError());
+    dsz.push_back(track.dsz());
+    dszerr.push_back(track.dszError());
+    qoverp.push_back(track.qoverp());
+    qoverperr.push_back(track.qoverpError());
+    vx.push_back(track.vx());
+    vy.push_back(track.vy());
+    vz.push_back(track.vz());
+    algo.push_back((int)track.algo());
   }
 
-  iEvent.put(std::move(number), Prefix + "number" + Suffix);
-  iEvent.put(std::move(chi2), Prefix + "chi2" + Suffix);
-  iEvent.put(std::move(ndof), Prefix + "ndof" + Suffix);
-  iEvent.put(std::move(chi2ndof), Prefix + "chi2ndof" + Suffix);
-  iEvent.put(std::move(charge), Prefix + "charge" + Suffix);
-  iEvent.put(std::move(momentum), Prefix + "momentum" + Suffix);
-  iEvent.put(std::move(pt), Prefix + "pt" + Suffix);
-  iEvent.put(std::move(pterr), Prefix + "pterr" + Suffix);
-  iEvent.put(std::move(hitsvalid), Prefix + "hitsvalid" + Suffix);
-  iEvent.put(std::move(hitslost), Prefix + "hitslost" + Suffix);
-  iEvent.put(std::move(theta), Prefix + "theta" + Suffix);
-  iEvent.put(std::move(thetaerr), Prefix + "thetaerr" + Suffix);
-  iEvent.put(std::move(phi), Prefix + "phi" + Suffix);
-  iEvent.put(std::move(phierr), Prefix + "phierr" + Suffix);
-  iEvent.put(std::move(eta), Prefix + "eta" + Suffix);
-  iEvent.put(std::move(etaerr), Prefix + "etaerr" + Suffix);
-  iEvent.put(std::move(dxy), Prefix + "dxy" + Suffix);
-  iEvent.put(std::move(dxyerr), Prefix + "dxyerr" + Suffix);
-  iEvent.put(std::move(dsz), Prefix + "dsz" + Suffix);
-  iEvent.put(std::move(dszerr), Prefix + "dszerr" + Suffix);
-  iEvent.put(std::move(qoverp), Prefix + "qoverp" + Suffix);
-  iEvent.put(std::move(qoverperr), Prefix + "qoverperr" + Suffix);
-  iEvent.put(std::move(vx), Prefix + "vx" + Suffix);
-  iEvent.put(std::move(vy), Prefix + "vy" + Suffix);
-  iEvent.put(std::move(vz), Prefix + "vz" + Suffix);
-  iEvent.put(std::move(algo), Prefix + "algo" + Suffix);
+  iEvent.emplace(numberPut_, std::move(number));
+  iEvent.emplace(chi2Put_, std::move(chi2));
+  iEvent.emplace(ndofPut_, std::move(ndof));
+  iEvent.emplace(chi2ndofPut_, std::move(chi2ndof));
+  iEvent.emplace(chargePut_, std::move(charge));
+  iEvent.emplace(momentumPut_, std::move(momentum));
+  iEvent.emplace(ptPut_, std::move(pt));
+  iEvent.emplace(pterrPut_, std::move(pterr));
+  iEvent.emplace(hitsvalidPut_, std::move(hitsvalid));
+  iEvent.emplace(hitslostPut_, std::move(hitslost));
+  iEvent.emplace(thetaPut_, std::move(theta));
+  iEvent.emplace(thetaerrPut_, std::move(thetaerr));
+  iEvent.emplace(phiPut_, std::move(phi));
+  iEvent.emplace(phierrPut_, std::move(phierr));
+  iEvent.emplace(etaPut_, std::move(eta));
+  iEvent.emplace(etaerrPut_, std::move(etaerr));
+  iEvent.emplace(dxyPut_, std::move(dxy));
+  iEvent.emplace(dxyerrPut_, std::move(dxyerr));
+  iEvent.emplace(dszPut_, std::move(dsz));
+  iEvent.emplace(dszerrPut_, std::move(dszerr));
+  iEvent.emplace(qoverpPut_, std::move(qoverp));
+  iEvent.emplace(qoverperrPut_, std::move(qoverperr));
+  iEvent.emplace(vxPut_, std::move(vx));
+  iEvent.emplace(vyPut_, std::move(vy));
+  iEvent.emplace(vzPut_, std::move(vz));
+  iEvent.emplace(algoPut_, std::move(algo));
 }


### PR DESCRIPTION
#### PR description:

-converted modules from legacy to thread-efficient versions
-added ESGetToken as needed
-avoid unnecessary memory usage

only modules used in the integration tests were changed, based on  #25090

#### PR validation:

Code compiles