### PR TITLE
added esConsumes to modules in RecoHGCal/TICL and related packages

### DIFF
--- a/RecoEgamma/EgammaTools/interface/HGCalEgammaIDHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalEgammaIDHelper.h
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -80,6 +81,7 @@ private:
   edm::EDGetTokenT<HGCRecHitCollection> recHitsFH_;
   edm::EDGetTokenT<HGCRecHitCollection> recHitsBH_;
   edm::EDGetTokenT<std::unordered_map<DetId, const HGCRecHit*>> hitMap_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
   hgcal::RecHitTools recHitTools_;
   bool debug_;
 };

--- a/RecoEgamma/EgammaTools/src/HGCalEgammaIDHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalEgammaIDHelper.cc
@@ -30,7 +30,9 @@ void HGCalEgammaIDHelper::eventInit(const edm::Event& iEvent, const edm::EventSe
   edm::Handle<std::unordered_map<DetId, const HGCRecHit*>> hitMapHandle;
   iEvent.getByToken(hitMap_, hitMapHandle);
 
-  recHitTools_.getEventSetup(iSetup);
+  edm::ESHandle<CaloGeometry> geom;
+  iSetup.get<CaloGeometryRecord>().get(geom);
+  recHitTools_.setGeometry(*geom);
   pcaHelper_.setRecHitTools(&recHitTools_);
   isoHelper_.setRecHitTools(&recHitTools_);
   pcaHelper_.setHitMap(hitMapHandle.product());

--- a/RecoEgamma/EgammaTools/src/HGCalEgammaIDHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalEgammaIDHelper.cc
@@ -16,6 +16,7 @@ HGCalEgammaIDHelper::HGCalEgammaIDHelper(const edm::ParameterSet& iConfig, edm::
   recHitsFH_ = iC.consumes<HGCRecHitCollection>(fhRecHitInputTag_);
   recHitsBH_ = iC.consumes<HGCRecHitCollection>(bhRecHitInputTag_);
   hitMap_ = iC.consumes<std::unordered_map<DetId, const HGCRecHit*>>(hitMapInputTag_);
+  caloGeometry_ = iC.esConsumes<CaloGeometry, CaloGeometryRecord>();
   pcaHelper_.setdEdXWeights(dEdXWeights_);
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
 }
@@ -30,8 +31,7 @@ void HGCalEgammaIDHelper::eventInit(const edm::Event& iEvent, const edm::EventSe
   edm::Handle<std::unordered_map<DetId, const HGCRecHit*>> hitMapHandle;
   iEvent.getByToken(hitMap_, hitMapHandle);
 
-  edm::ESHandle<CaloGeometry> geom;
-  iSetup.get<CaloGeometryRecord>().get(geom);
+  edm::ESHandle<CaloGeometry> geom = iSetup.getHandle(caloGeometry_);
   recHitTools_.setGeometry(*geom);
   pcaHelper_.setRecHitTools(&recHitTools_);
   isoHelper_.setRecHitTools(&recHitTools_);

--- a/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
@@ -47,7 +47,11 @@ FilteredLayerClustersProducer::FilteredLayerClustersProducer(const edm::Paramete
   produces<std::vector<float>>(iteration_label_);
 }
 
-void FilteredLayerClustersProducer::beginRun(edm::Run const&, edm::EventSetup const& es) { rhtools_.getEventSetup(es); }
+void FilteredLayerClustersProducer::beginRun(edm::Run const&, edm::EventSetup const& es) { 
+    edm::ESHandle<CaloGeometry> geom;
+    es.get<CaloGeometryRecord>().get(geom);
+    rhtools_.setGeometry(*geom);
+}
 
 void FilteredLayerClustersProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // hgcalMultiClusters

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -10,6 +10,9 @@
 #include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 
 #include "TrackstersPCA.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 
 using namespace ticl;
 
@@ -55,7 +58,10 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
   if (input.regions.empty())
     return;
 
-  rhtools_.getEventSetup(input.es);
+  edm::ESHandle<CaloGeometry> geom;
+  edm::EventSetup const &es = input.es;
+  es.get<CaloGeometryRecord>().get(geom);
+  rhtools_.setGeometry(*geom);
 
   theGraph_->setVerbosity(PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_);
   theGraph_->clear();

--- a/RecoHGCal/TICL/plugins/SeedingRegionByTracks.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByTracks.h
@@ -22,6 +22,10 @@
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
 namespace ticl {
   class SeedingRegionByTracks final : public SeedingRegionAlgoBase {
@@ -45,6 +49,9 @@ namespace ticl {
     const std::string propName_;
     edm::ESHandle<MagneticField> bfield_;
     std::unique_ptr<GeomDet> firstDisk_[2];
+    edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> hdc_token_;
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bfield_token_;
+    edm::ESGetToken<Propagator, TrackingComponentsRecord> propagator_token_;
   };
 }  // namespace ticl
 #endif

--- a/RecoHGCal/TICL/plugins/TICLLayerTileProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLLayerTileProducer.cc
@@ -7,6 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/HGCalReco/interface/TICLLayerTile.h"
@@ -24,6 +25,7 @@ public:
 private:
   edm::EDGetTokenT<std::vector<reco::CaloCluster>> clusters_token_;
   edm::EDGetTokenT<std::vector<reco::CaloCluster>> clusters_HFNose_token_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometry_token_;
   hgcal::RecHitTools rhtools_;
   std::string detector_;
   bool doNose_;
@@ -34,6 +36,7 @@ TICLLayerTileProducer::TICLLayerTileProducer(const edm::ParameterSet &ps)
   clusters_HFNose_token_ =
       consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_HFNose_clusters"));
   clusters_token_ = consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"));
+  geometry_token_ = esConsumes<CaloGeometry, CaloGeometryRecord, edm::Transition::BeginRun>();
 
   doNose_ = (detector_ == "HFNose");
 
@@ -43,10 +46,9 @@ TICLLayerTileProducer::TICLLayerTileProducer(const edm::ParameterSet &ps)
     produces<TICLLayerTiles>();
 }
 
-void TICLLayerTileProducer::beginRun(edm::Run const &, edm::EventSetup const &es) { 
-     edm::ESHandle<CaloGeometry> geom;
-     es.get<CaloGeometryRecord>().get(geom);
-    rhtools_.setGeometry(*geom); 
+void TICLLayerTileProducer::beginRun(edm::Run const &, edm::EventSetup const &es) {
+  edm::ESHandle<CaloGeometry> geom = es.getHandle(geometry_token_);
+  rhtools_.setGeometry(*geom);
 }
 
 void TICLLayerTileProducer::produce(edm::Event &evt, const edm::EventSetup &) {

--- a/RecoHGCal/TICL/plugins/TICLLayerTileProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLLayerTileProducer.cc
@@ -43,7 +43,11 @@ TICLLayerTileProducer::TICLLayerTileProducer(const edm::ParameterSet &ps)
     produces<TICLLayerTiles>();
 }
 
-void TICLLayerTileProducer::beginRun(edm::Run const &, edm::EventSetup const &es) { rhtools_.getEventSetup(es); }
+void TICLLayerTileProducer::beginRun(edm::Run const &, edm::EventSetup const &es) { 
+     edm::ESHandle<CaloGeometry> geom;
+     es.get<CaloGeometryRecord>().get(geom);
+    rhtools_.setGeometry(*geom); 
+}
 
 void TICLLayerTileProducer::produce(edm::Event &evt, const edm::EventSetup &) {
   auto result = std::make_unique<TICLLayerTiles>();

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -143,7 +143,9 @@ void TrackstersMergeProducer::dumpTrackster(const Trackster &t) const {
 }
 
 void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es) {
-  rhtools_.getEventSetup(es);
+  edm::ESHandle<CaloGeometry> geom;
+  es.get<CaloGeometryRecord>().get(geom);
+  rhtools_.setGeometry(*geom);
   auto result = std::make_unique<std::vector<Trackster>>();
   auto mergedTrackstersTRK = std::make_unique<std::vector<Trackster>>();
 

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/HGCalReco/interface/Common.h"
@@ -45,6 +46,7 @@ private:
   const edm::EDGetTokenT<std::vector<TICLSeedingRegion>> seedingTrk_token_;
   const edm::EDGetTokenT<std::vector<reco::CaloCluster>> clusters_token_;
   const edm::EDGetTokenT<std::vector<reco::Track>> tracks_token_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometry_token_;
   const bool optimiseAcrossTracksters_;
   const int eta_bin_window_;
   const int phi_bin_window_;
@@ -76,6 +78,7 @@ TrackstersMergeProducer::TrackstersMergeProducer(const edm::ParameterSet &ps, co
       seedingTrk_token_(consumes<std::vector<TICLSeedingRegion>>(ps.getParameter<edm::InputTag>("seedingTrk"))),
       clusters_token_(consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"))),
       tracks_token_(consumes<std::vector<reco::Track>>(ps.getParameter<edm::InputTag>("tracks"))),
+      geometry_token_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       optimiseAcrossTracksters_(ps.getParameter<bool>("optimiseAcrossTracksters")),
       eta_bin_window_(ps.getParameter<int>("eta_bin_window")),
       phi_bin_window_(ps.getParameter<int>("phi_bin_window")),
@@ -143,8 +146,7 @@ void TrackstersMergeProducer::dumpTrackster(const Trackster &t) const {
 }
 
 void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es) {
-  edm::ESHandle<CaloGeometry> geom;
-  es.get<CaloGeometryRecord>().get(geom);
+  edm::ESHandle<CaloGeometry> geom = es.getHandle(geometry_token_);
   rhtools_.setGeometry(*geom);
   auto result = std::make_unique<std::vector<Trackster>>();
   auto mergedTrackstersTRK = std::make_unique<std::vector<Trackster>>();

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -36,7 +36,9 @@ public:
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }
   void getEventSetup(const edm::EventSetup& es) {
     clusterTools->getEventSetup(es);
-    rhtools_.getEventSetup(es);
+    edm::ESHandle<CaloGeometry> geom;
+    es.get<CaloGeometryRecord>().get(geom);
+    rhtools_.setGeometry(*geom);
     maxlayer = rhtools_.lastLayerBH();
     points.clear();
     minpos.clear();

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
@@ -35,7 +35,9 @@ public:
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }
   void getEventSetup(const edm::EventSetup& es) {
     clusterTools->getEventSetup(es);
-    rhtools_.getEventSetup(es);
+    edm::ESHandle<CaloGeometry> geom;
+    es.get<CaloGeometryRecord>().get(geom);
+    rhtools_.setGeometry(*geom);
   }
 
   typedef std::vector<reco::BasicCluster> ClusterCollection;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
@@ -14,6 +14,7 @@
 #include "DataFormats/HGCRecHit/interface/HGCUncalibratedRecHit.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
+
 class HGCalRecHitAbsAlgo {
 public:
   /// Constructor
@@ -22,7 +23,8 @@ public:
   /// Destructor
   virtual ~HGCalRecHitAbsAlgo(){};
 
-  inline void set(const edm::EventSetup& es) { rhtools_.getEventSetup(es); }
+  inline void set(const edm::EventSetup& es) {  edm::ESHandle<CaloGeometry> geom;
+    es.get<CaloGeometryRecord>().get(geom); rhtools_.setGeometry(*geom); }
 
   /// make rechits from dataframes
   virtual void setLayerWeights(const std::vector<float>& weights){};

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
@@ -14,7 +14,6 @@
 #include "DataFormats/HGCRecHit/interface/HGCUncalibratedRecHit.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
-
 class HGCalRecHitAbsAlgo {
 public:
   /// Constructor
@@ -23,8 +22,7 @@ public:
   /// Destructor
   virtual ~HGCalRecHitAbsAlgo(){};
 
-  inline void set(const edm::EventSetup& es) {  edm::ESHandle<CaloGeometry> geom;
-    es.get<CaloGeometryRecord>().get(geom); rhtools_.setGeometry(*geom); }
+  inline void set(const CaloGeometry& geom) { rhtools_.setGeometry(geom); }
 
   /// make rechits from dataframes
   virtual void setLayerWeights(const std::vector<float>& weights){};

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -7,6 +7,8 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "DataFormats/ForwardDetId/interface/HFNoseDetId.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 class CaloGeometry;
 class CaloSubdetectorGeometry;
@@ -23,8 +25,9 @@ namespace hgcal {
     RecHitTools() : geom_(nullptr), fhOffset_(0), bhOffset_(0), fhLastLayer_(0), noseLastLayer_(0), geometryType_(0) {}
     ~RecHitTools() {}
 
-    void getEvent(const edm::Event&);
-    void getEventSetup(const edm::EventSetup&);
+    //void getEvent(const edm::Event&);
+    //void getEventSetup(const edm::EventSetup&);
+    void setGeometry(CaloGeometry const&);
     const CaloSubdetectorGeometry* getSubdetectorGeometry(const DetId& id) const;
 
     GlobalPoint getPosition(const DetId& id) const;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -25,8 +25,6 @@ namespace hgcal {
     RecHitTools() : geom_(nullptr), fhOffset_(0), bhOffset_(0), fhLastLayer_(0), noseLastLayer_(0), geometryType_(0) {}
     ~RecHitTools() {}
 
-    //void getEvent(const edm::Event&);
-    //void getEventSetup(const edm::EventSetup&);
     void setGeometry(CaloGeometry const&);
     const CaloSubdetectorGeometry* getSubdetectorGeometry(const DetId& id) const;
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
@@ -38,7 +38,8 @@ void ClusterTools::getEvent(const edm::Event& ev) {
 void ClusterTools::getEventSetup(const edm::EventSetup& es) {
   edm::ESHandle<CaloGeometry> geom;
   es.get<CaloGeometryRecord>().get(geom);
-  rhtools_.setGeometry(*geom); }
+  rhtools_.setGeometry(*geom);
+}
 
 float ClusterTools::getClusterHadronFraction(const reco::CaloCluster& clus) const {
   float energy = 0.f, energyHad = 0.f;

--- a/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
@@ -25,7 +26,6 @@ ClusterTools::ClusterTools(const edm::ParameterSet& conf, edm::ConsumesCollector
       bhtok(sumes.consumes<HGCRecHitCollection>(conf.getParameter<edm::InputTag>("HGCBHInput"))) {}
 
 void ClusterTools::getEvent(const edm::Event& ev) {
-  rhtools_.getEvent(ev);
   edm::Handle<HGCRecHitCollection> temp;
   ev.getByToken(eetok, temp);
   eerh_ = temp.product();
@@ -35,7 +35,10 @@ void ClusterTools::getEvent(const edm::Event& ev) {
   bhrh_ = temp.product();
 }
 
-void ClusterTools::getEventSetup(const edm::EventSetup& es) { rhtools_.getEventSetup(es); }
+void ClusterTools::getEventSetup(const edm::EventSetup& es) {
+  edm::ESHandle<CaloGeometry> geom;
+  es.get<CaloGeometryRecord>().get(geom);
+  rhtools_.setGeometry(*geom); }
 
 float ClusterTools::getClusterHadronFraction(const reco::CaloCluster& clus) const {
   float energy = 0.f, energyHad = 0.f;

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -65,13 +65,13 @@ namespace {
 
 }  // namespace
 
-void RecHitTools::getEvent(const edm::Event& ev) {}
+//void RecHitTools::getEvent(const edm::Event& ev) {}
 
-void RecHitTools::getEventSetup(const edm::EventSetup& es) {
-  edm::ESHandle<CaloGeometry> geom;
-  es.get<CaloGeometryRecord>().get(geom);
+void RecHitTools::setGeometry(const CaloGeometry& geom) {
+  //edm::ESHandle<CaloGeometry> geom;
+  //es.get<CaloGeometryRecord>().get(geom);
 
-  geom_ = geom.product();
+  geom_ = &geom;
   unsigned int wmaxEE(0), wmaxFH(0);
   auto geomEE = static_cast<const HGCalGeometry*>(
       geom_->getSubdetectorGeometry(DetId::HGCalEE, ForwardSubdetector::ForwardEmpty));

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -65,12 +65,7 @@ namespace {
 
 }  // namespace
 
-//void RecHitTools::getEvent(const edm::Event& ev) {}
-
 void RecHitTools::setGeometry(const CaloGeometry& geom) {
-  //edm::ESHandle<CaloGeometry> geom;
-  //es.get<CaloGeometryRecord>().get(geom);
-
   geom_ = &geom;
   unsigned int wmaxEE(0), wmaxFH(0);
   auto geomEE = static_cast<const HGCalGeometry*>(

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -59,7 +59,9 @@ public:
   virtual void getEventSetupPerAlgorithm(const edm::EventSetup &es) {}
 
   inline void getEventSetup(const edm::EventSetup &es) {
-    rhtools_.getEventSetup(es);
+    edm::ESHandle<CaloGeometry> geom;
+    es.get<CaloGeometryRecord>().get(geom);
+    rhtools_.setGeometry(*geom);
     maxlayer_ = rhtools_.lastLayer(isNose_);
     lastLayerEE_ = rhtools_.lastLayerEE(isNose_);
     lastLayerFH_ = rhtools_.lastLayerFH();

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -90,7 +90,9 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps) : 
 }
 
 void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es) {
-  tools_->getEventSetup(es);
+  edm::ESHandle<CaloGeometry> geom;
+  es.get<CaloGeometryRecord>().get(geom);
+  tools_->setGeometry(*geom);
   rechitMaker_->set(es);
   if (hgcEE_isSiFE_) {
     edm::ESHandle<HGCalGeometry> hgceeGeoHandle;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -93,7 +93,7 @@ void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es) {
   edm::ESHandle<CaloGeometry> geom;
   es.get<CaloGeometryRecord>().get(geom);
   tools_->setGeometry(*geom);
-  rechitMaker_->set(es);
+  rechitMaker_->set(*geom);
   if (hgcEE_isSiFE_) {
     edm::ESHandle<HGCalGeometry> hgceeGeoHandle;
     es.get<IdealGeometryRecord>().get("HGCalEESensitive", hgceeGeoHandle);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -36,11 +36,9 @@ public:
                      const edm::Event& iEvent,
                      const edm::EventSetup& iSetup) override {
     // Setup RecHitTools to properly compute the position of the HGCAL Cells vie their DetIds
-    {
-      edm::ESHandle<CaloGeometry> geom;
-      iSetup.get<CaloGeometryRecord>().get(geom);
-      recHitTools_.setGeometry(*geom);
-    }
+    edm::ESHandle<CaloGeometry> geoHandle;
+    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    recHitTools_.setGeometry(*geoHandle);
 
     for (unsigned int i = 0; i < qualityTests_.size(); ++i) {
       qualityTests_.at(i)->beginEvent(iEvent, iSetup);
@@ -50,8 +48,6 @@ public:
     iEvent.getByToken(recHitToken_, recHitHandle);
     const HGCRecHitCollection& rechits = *recHitHandle;
 
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
     const CaloGeometry* geom = geoHandle.product();
 
     unsigned skipped_rechits = 0;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -36,7 +36,11 @@ public:
                      const edm::Event& iEvent,
                      const edm::EventSetup& iSetup) override {
     // Setup RecHitTools to properly compute the position of the HGCAL Cells vie their DetIds
-    recHitTools_.getEventSetup(iSetup);
+    {
+      edm::ESHandle<CaloGeometry> geom;
+      iSetup.get<CaloGeometryRecord>().get(geom);
+      recHitTools_.setGeometry(*geom);
+    }
 
     for (unsigned int i = 0; i < qualityTests_.size(); ++i) {
       qualityTests_.at(i)->beginEvent(iEvent, iSetup);

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -43,7 +43,11 @@ namespace {
 
 void RealisticSimClusterMapper::updateEvent(const edm::Event& ev) { ev.getByToken(simClusterToken_, simClusterH_); }
 
-void RealisticSimClusterMapper::update(const edm::EventSetup& es) { rhtools_.getEventSetup(es); }
+void RealisticSimClusterMapper::update(const edm::EventSetup& es) { 
+  edm::ESHandle<CaloGeometry> geom;
+  es.get<CaloGeometryRecord>().get(geom); 
+  rhtools_.setGeometry(*geom);
+}
 
 void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
                                               const std::vector<bool>& rechitMask,

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -43,9 +43,9 @@ namespace {
 
 void RealisticSimClusterMapper::updateEvent(const edm::Event& ev) { ev.getByToken(simClusterToken_, simClusterH_); }
 
-void RealisticSimClusterMapper::update(const edm::EventSetup& es) { 
+void RealisticSimClusterMapper::update(const edm::EventSetup& es) {
   edm::ESHandle<CaloGeometry> geom;
-  es.get<CaloGeometryRecord>().get(geom); 
+  es.get<CaloGeometryRecord>().get(geom);
   rhtools_.setGeometry(*geom);
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LayerClusterAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LayerClusterAssociatorByEnergyScoreProducer.cc
@@ -41,7 +41,9 @@ LayerClusterAssociatorByEnergyScoreProducer::~LayerClusterAssociatorByEnergyScor
 void LayerClusterAssociatorByEnergyScoreProducer::produce(edm::StreamID,
                                                           edm::Event &iEvent,
                                                           const edm::EventSetup &es) const {
-  rhtools_->getEventSetup(es);
+    edm::ESHandle<CaloGeometry> geom;
+    es.get<CaloGeometryRecord>().get(geom);
+    rhtools_->setGeometry(*geom);
 
   const std::unordered_map<DetId, const HGCRecHit *> *hitMap = &iEvent.get(hitMap_);
 

--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -191,7 +191,9 @@ void HGCalHitCalibration::fillWithRecHits(std::map<DetId, const HGCRecHit*>& hit
 void HGCalHitCalibration::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  recHitTools_.getEventSetup(iSetup);
+  edm::ESHandle<CaloGeometry> geom;
+  iSetup.get<CaloGeometryRecord>().get(geom);
+  recHitTools_.setGeometry(*geom);
 
   Handle<HGCRecHitCollection> recHitHandleEE;
   Handle<HGCRecHitCollection> recHitHandleFH;

--- a/Validation/HGCalValidation/plugins/HGCalShowerSeparation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalShowerSeparation.cc
@@ -160,7 +160,9 @@ void HGCalShowerSeparation::bookHistograms(DQMStore::IBooker& ibooker,
 void HGCalShowerSeparation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  recHitTools_.getEventSetup(iSetup);
+  edm::ESHandle<CaloGeometry> geom;
+  iSetup.get<CaloGeometryRecord>().get(geom);
+  recHitTools_.setGeometry(*geom);
 
   Handle<std::vector<CaloParticle>> caloParticleHandle;
   iEvent.getByToken(caloParticles_, caloParticleHandle);

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -178,7 +178,9 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   event.getByToken(label_cp_effic, caloParticleHandle);
   std::vector<CaloParticle> const& caloParticles = *caloParticleHandle;
 
-  tools_->getEventSetup(setup);
+  edm::ESHandle<CaloGeometry> geom;
+  setup.get<CaloGeometryRecord>().get(geom);
+  tools_->setGeometry(*geom);
   histoProducerAlgo_->setRecHitTools(tools_);
 
   edm::Handle<hgcal::LayerClusterToCaloParticleAssociator> LCAssocByEnergyScoreHandle;


### PR DESCRIPTION
#### PR description:

while adding esConsumes to the modules the RecHitTools class was modified to decouple EventSetup from it.

#### PR validation:

the code compiles