### PR TITLE
Minor updates to Sonic (Core and Triton)

### DIFF
--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -63,7 +63,7 @@ void SonicClientBase::finish(bool success, std::exception_ptr eptr) {
 void SonicClientBase::fillBasePSetDescription(edm::ParameterSetDescription& desc, bool allowRetry) {
   //restrict allowed values
   desc.ifValue(edm::ParameterDescription<std::string>("mode", "PseudoAsync", true),
-               edm::allowedValues<std::string>("Sync","Async","PseudoAsync"));
+               edm::allowedValues<std::string>("Sync", "Async", "PseudoAsync"));
   if (allowRetry)
     desc.addUntracked<unsigned>("allowedTries", 0);
 }

--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -1,6 +1,6 @@
 #include "HeterogeneousCore/SonicCore/interface/SonicClientBase.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/ParameterSet/interface/EmptyGroupDescription.h"
+#include "FWCore/ParameterSet/interface/allowedValues.h"
 
 SonicClientBase::SonicClientBase(const edm::ParameterSet& params)
     : allowedTries_(params.getUntrackedParameter<unsigned>("allowedTries", 0)) {
@@ -63,8 +63,7 @@ void SonicClientBase::finish(bool success, std::exception_ptr eptr) {
 void SonicClientBase::fillBasePSetDescription(edm::ParameterSetDescription& desc, bool allowRetry) {
   //restrict allowed values
   desc.ifValue(edm::ParameterDescription<std::string>("mode", "PseudoAsync", true),
-               "Sync" >> edm::EmptyGroupDescription() or "Async" >> edm::EmptyGroupDescription() or
-                   "PseudoAsync" >> edm::EmptyGroupDescription());
+               edm::allowedValues<std::string>("Sync","Async","PseudoAsync"));
   if (allowRetry)
     desc.addUntracked<unsigned>("allowedTries", 0);
 }

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -19,7 +19,7 @@ They are stored by name in the input and output maps.
 The consistency of dimension and type information (received from server vs. provided by user) is checked at runtime.
 The model information from the server can be printed by enabling `verbose` output in the `TritonClient` configuration.
 
-`TritonClient` requires several parameters:
+`TritonClient` takes several parameters:
 * `modelName`: name of model with which to perform inference
 * `modelVersion`: version number of model (default: -1, use latest available version on server)
 * `batchSize`: number of objects sent per request
@@ -29,6 +29,7 @@ The model information from the server can be printed by enabling `verbose` outpu
 * `port`: server port
 * `timeout`: maximum time a request is allowed to take
   * currently not used, will be supported in next Triton version
+* `outputs`: optional, specify which output(s) the server should send
 
 Useful `TritonData` accessors include:
 * `dims()`: return dimensions (provided by server)

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -40,16 +40,22 @@ Useful `TritonData` accessors include:
 * `byteSize()`: return # bytes for data type
 * `dname()`: return name of data type
 
+There are specific local input and output containers that should be used in producers.
+Here, `T` is a primitive type, and the two aliases listed below are passed to `TritonInputData::toServer()`
+and returned by `TritonOutputData::fromServer()`, respectively:
+* `TritonInput<T> = std::vector<std::vector<T>>`
+* `TritonOutput<T> = std::vector<edm::Span<const T*>>`
+
 In a SONIC Triton producer, the basic flow should follow this pattern:
 1. `acquire()`:  
     a. access input object(s) from `TritonInputMap`  
-    b. allocate input data using `std::make_shared<std::vector<std::vector<T>>>()`  
+    b. allocate input data using `std::make_shared<TritonInput<T>>()`  
     c. fill input data  
     d. set input shape(s) (optional, only if any variable dimensions)  
     e. convert using `toServer()` function of input object(s)  
 2. `produce()`:  
     a. access output object(s) from `TritonOutputMap`  
-    b. obtain output data as `std::vector<edm::Span<T>>` using `fromServer()` function of output object(s) (sets output shape(s) if variable dimensions exist)  
+    b. obtain output data as `TritonOutput<T>` using `fromServer()` function of output object(s) (sets output shape(s) if variable dimensions exist)  
     c. fill output products  
 
 Several example producers (running ResNet50 or Graph Attention Network), along with instructions to run a local server,

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -49,9 +49,8 @@ In a SONIC Triton producer, the basic flow should follow this pattern:
     e. convert using `toServer()` function of input object(s)  
 2. `produce()`:  
     a. access output object(s) from `TritonOutputMap`  
-    b. allocate output data as `std::vector<T>()`  
-    c. convert using `fromServer()` function of output object(s) (sets output shape(s) if variable dimensions exist)  
-    d. fill output products  
+    b. obtain output data as `std::vector<edm::Span<T>>` using `fromServer()` function of output object(s) (sets output shape(s) if variable dimensions exist)  
+    c. fill output products  
 
 Several example producers (running ResNet50 or Graph Attention Network), along with instructions to run a local server,
 can be found in the [test](./test) directory.

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -43,7 +43,7 @@ Useful `TritonData` accessors include:
 In a SONIC Triton producer, the basic flow should follow this pattern:
 1. `acquire()`:  
     a. access input object(s) from `TritonInputMap`  
-    b. allocate input data using `std::make_shared<std::vector<T>>()`  
+    b. allocate input data using `std::make_shared<std::vector<std::vector<T>>>()`  
     c. fill input data  
     d. set input shape(s) (optional, only if any variable dimensions)  
     e. convert using `toServer()` function of input object(s)  

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -2,6 +2,7 @@
 #define HeterogeneousCore_SonicTriton_TritonData
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/Span.h"
 
 #include <vector>
 #include <string>
@@ -32,7 +33,7 @@ public:
   template <typename DT>
   void toServer(std::shared_ptr<std::vector<DT>> ptr);
   template <typename DT>
-  void fromServer(std::vector<DT>& data_out) const;
+  std::vector<edm::Span<const DT*>> fromServer() const;
 
   //const accessors
   const std::vector<int64_t>& dims() const { return dims_; }
@@ -82,7 +83,7 @@ template <typename DT>
 void TritonInputData::toServer(std::shared_ptr<std::vector<DT>> ptr);
 template <>
 template <typename DT>
-void TritonOutputData::fromServer(std::vector<DT>& dataOut) const;
+std::vector<edm::Span<const DT*>> TritonOutputData::fromServer() const;
 template <>
 void TritonInputData::reset();
 template <>

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -31,7 +31,7 @@ public:
 
   //io accessors
   template <typename DT>
-  void toServer(std::shared_ptr<std::vector<DT>> ptr);
+  void toServer(std::shared_ptr<std::vector<std::vector<DT>>> ptr);
   template <typename DT>
   std::vector<edm::Span<const DT*>> fromServer() const;
 
@@ -80,7 +80,7 @@ using TritonOutputMap = std::unordered_map<std::string, TritonOutputData>;
 //avoid "explicit specialization after instantiation" error
 template <>
 template <typename DT>
-void TritonInputData::toServer(std::shared_ptr<std::vector<DT>> ptr);
+void TritonInputData::toServer(std::shared_ptr<std::vector<std::vector<DT>>> ptr);
 template <>
 template <typename DT>
 std::vector<edm::Span<const DT*>> TritonOutputData::fromServer() const;

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -14,6 +14,12 @@
 
 #include "request_grpc.h"
 
+//aliases for local input and output types
+template <typename DT>
+using TritonInput = std::vector<std::vector<DT>>;
+template <typename DT>
+using TritonOutput = std::vector<edm::Span<const DT*>>;
+
 //store all the info needed for triton input and output
 template <typename IO>
 class TritonData {
@@ -31,9 +37,9 @@ public:
 
   //io accessors
   template <typename DT>
-  void toServer(std::shared_ptr<std::vector<std::vector<DT>>> ptr);
+  void toServer(std::shared_ptr<TritonInput<DT>> ptr);
   template <typename DT>
-  std::vector<edm::Span<const DT*>> fromServer() const;
+  TritonOutput<DT> fromServer() const;
 
   //const accessors
   const std::vector<int64_t>& dims() const { return dims_; }
@@ -80,10 +86,10 @@ using TritonOutputMap = std::unordered_map<std::string, TritonOutputData>;
 //avoid "explicit specialization after instantiation" error
 template <>
 template <typename DT>
-void TritonInputData::toServer(std::shared_ptr<std::vector<std::vector<DT>>> ptr);
+void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr);
 template <>
 template <typename DT>
-std::vector<edm::Span<const DT*>> TritonOutputData::fromServer() const;
+TritonOutput<DT> TritonOutputData::fromServer() const;
 template <>
 void TritonInputData::reset();
 template <>

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -26,6 +26,7 @@ namespace triton_utils {
 extern template std::string triton_utils::printColl(const std::vector<int64_t>& coll, const std::string& delim);
 extern template std::string triton_utils::printColl(const std::vector<uint8_t>& coll, const std::string& delim);
 extern template std::string triton_utils::printColl(const std::vector<float>& coll, const std::string& delim);
-extern template std::string triton_utils::printColl(const std::unordered_set<std::string>& coll, const std::string& delim);
+extern template std::string triton_utils::printColl(const std::unordered_set<std::string>& coll,
+                                                    const std::string& delim);
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <unordered_set>
 
 #include "request_grpc.h"
 
@@ -11,8 +12,8 @@ namespace triton_utils {
 
   using Error = nvidia::inferenceserver::client::Error;
 
-  template <typename T>
-  std::string printVec(const std::vector<T>& vec, const std::string& delim = ", ");
+  template <typename C>
+  std::string printColl(const C& coll, const std::string& delim = ", ");
 
   //helper to turn triton error into exception
   void throwIfError(const Error& err, std::string_view msg);
@@ -22,8 +23,9 @@ namespace triton_utils {
 
 }  // namespace triton_utils
 
-extern template std::string triton_utils::printVec(const std::vector<int64_t>& vec, const std::string& delim);
-extern template std::string triton_utils::printVec(const std::vector<uint8_t>& vec, const std::string& delim);
-extern template std::string triton_utils::printVec(const std::vector<float>& vec, const std::string& delim);
+extern template std::string triton_utils::printColl(const std::vector<int64_t>& coll, const std::string& delim);
+extern template std::string triton_utils::printColl(const std::vector<uint8_t>& coll, const std::string& delim);
+extern template std::string triton_utils::printColl(const std::vector<float>& coll, const std::string& delim);
+extern template std::string triton_utils::printColl(const std::unordered_set<std::string>& coll, const std::string& delim);
 
 #endif

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -76,7 +76,7 @@ TritonClient::TritonClient(const edm::ParameterSet& params)
 
   //allow selecting only some outputs from server
   const auto& v_outputs = params.getUntrackedParameter<std::vector<std::string>>("outputs");
-  std::unordered_set s_outputs(v_outputs.begin(),v_outputs.end());
+  std::unordered_set s_outputs(v_outputs.begin(), v_outputs.end());
 
   //setup output map
   if (verbose_)
@@ -84,7 +84,7 @@ TritonClient::TritonClient(const edm::ParameterSet& params)
            << "\n";
   for (const auto& nicOutput : nicOutputs) {
     const auto& oname = nicOutput->Name();
-    if (!s_outputs.empty() and s_outputs.find(oname)==s_outputs.end())
+    if (!s_outputs.empty() and s_outputs.find(oname) == s_outputs.end())
       continue;
     const auto& curr_itr = output_.emplace(
         std::piecewise_construct, std::forward_as_tuple(oname), std::forward_as_tuple(oname, nicOutput));
@@ -101,7 +101,8 @@ TritonClient::TritonClient(const edm::ParameterSet& params)
 
   //check if any requested outputs were not available
   if (!s_outputs.empty())
-    throw cms::Exception("MissingOutput") << "Some requested outputs were not available on the server: " << triton_utils::printColl(s_outputs);
+    throw cms::Exception("MissingOutput")
+        << "Some requested outputs were not available on the server: " << triton_utils::printColl(s_outputs);
 
   //check batch size limitations (after i/o setup)
   //triton uses max batch size = 0 to denote a model that does not support batching

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -69,7 +69,7 @@ void TritonInputData::toServer(std::shared_ptr<std::vector<DT>> ptr) {
 
 template <>
 template <typename DT>
-void TritonOutputData::fromServer(std::vector<DT>& dataOut) const {
+std::vector<edm::Span<const DT*>> TritonOutputData::fromServer() const {
   if (!result_) {
     throw cms::Exception("TritonDataError") << name_ << " output(): missing result";
   }
@@ -89,7 +89,8 @@ void TritonOutputData::fromServer(std::vector<DT>& dataOut) const {
   }
 
   uint64_t nOutput = sizeShape();
-  dataOut.resize(nOutput * batchSize_, 0);
+  std::vector<edm::Span<const DT*>> dataOut;
+  dataOut.reserve(batchSize_);
   for (unsigned i0 = 0; i0 < batchSize_; ++i0) {
     const uint8_t* r0;
     size_t contentByteSize;
@@ -99,8 +100,11 @@ void TritonOutputData::fromServer(std::vector<DT>& dataOut) const {
       throw cms::Exception("TritonDataError") << name_ << " output(): unexpected content byte size " << contentByteSize
                                               << " (expected " << nOutput * byteSize_ << ")";
     }
-    std::memcpy(&(dataOut[i0 * nOutput]), r0, contentByteSize);
+    const DT* r1 = reinterpret_cast<const DT*>(r0);
+    dataOut.emplace_back(r1, r1 + nOutput);
   }
+
+  return dataOut;
 }
 
 template <>
@@ -123,4 +127,5 @@ template class TritonData<nic::InferContext::Output>;
 template void TritonInputData::toServer(std::shared_ptr<std::vector<float>> data_in);
 template void TritonInputData::toServer(std::shared_ptr<std::vector<int64_t>> data_in);
 
-template void TritonOutputData::fromServer(std::vector<float>& data_out) const;
+template std::vector<edm::Span<const float*>> TritonOutputData::fromServer() const;
+

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -38,7 +38,7 @@ TritonData<IO>::TritonData(const std::string& name, std::shared_ptr<IO> data)
 //io accessors
 template <>
 template <typename DT>
-void TritonInputData::toServer(std::shared_ptr<std::vector<std::vector<DT>>> ptr) {
+void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr) {
   const auto& data_in = *ptr;
 
   //check batch size
@@ -74,7 +74,7 @@ void TritonInputData::toServer(std::shared_ptr<std::vector<std::vector<DT>>> ptr
 
 template <>
 template <typename DT>
-std::vector<edm::Span<const DT*>> TritonOutputData::fromServer() const {
+TritonOutput<DT> TritonOutputData::fromServer() const {
   if (!result_) {
     throw cms::Exception("TritonDataError") << name_ << " output(): missing result";
   }
@@ -94,7 +94,7 @@ std::vector<edm::Span<const DT*>> TritonOutputData::fromServer() const {
   }
 
   uint64_t nOutput = sizeShape();
-  std::vector<edm::Span<const DT*>> dataOut;
+  TritonOutput<DT> dataOut;
   dataOut.reserve(batchSize_);
   for (unsigned i0 = 0; i0 < batchSize_; ++i0) {
     const uint8_t* r0;
@@ -129,8 +129,8 @@ void TritonOutputData::reset() {
 template class TritonData<nic::InferContext::Input>;
 template class TritonData<nic::InferContext::Output>;
 
-template void TritonInputData::toServer(std::shared_ptr<std::vector<std::vector<float>>> data_in);
-template void TritonInputData::toServer(std::shared_ptr<std::vector<std::vector<int64_t>>> data_in);
+template void TritonInputData::toServer(std::shared_ptr<TritonInput<float>> data_in);
+template void TritonInputData::toServer(std::shared_ptr<TritonInput<int64_t>> data_in);
 
-template std::vector<edm::Span<const float*>> TritonOutputData::fromServer() const;
+template TritonOutput<float> TritonOutputData::fromServer() const;
 

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -50,8 +50,8 @@ void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr) {
   if (variableDims_) {
     if (shape_.size() != dims_.size()) {
       throw cms::Exception("TritonDataError")
-          << name_ << " input(): incorrect or missing shape (" << triton_utils::printVec(shape_)
-          << ") for model with variable dimensions (" << triton_utils::printVec(dims_) << ")";
+          << name_ << " input(): incorrect or missing shape (" << triton_utils::printColl(shape_)
+          << ") for model with variable dimensions (" << triton_utils::printColl(dims_) << ")";
     } else {
       triton_utils::throwIfError(data_->SetShape(shape_), name_ + " input(): unable to set input shape");
     }
@@ -83,8 +83,8 @@ TritonOutput<DT> TritonOutputData::fromServer() const {
   if (variableDims_) {
     if (shape_.size() != dims_.size()) {
       throw cms::Exception("TritonDataError")
-          << name_ << " output(): incorrect or missing shape (" << triton_utils::printVec(shape_)
-          << ") for model with variable dimensions (" << triton_utils::printVec(dims_) << ")";
+          << name_ << " output(): incorrect or missing shape (" << triton_utils::printColl(shape_)
+          << ") for model with variable dimensions (" << triton_utils::printColl(dims_) << ")";
     }
   }
 

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -43,7 +43,8 @@ void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr) {
 
   //check batch size
   if (data_in.size() != batchSize_) {
-    throw cms::Exception("TritonDataError") << name_ << " input(): input vector has size " << data_in.size() << " but specified batch size is " << batchSize_;
+    throw cms::Exception("TritonDataError") << name_ << " input(): input vector has size " << data_in.size()
+                                            << " but specified batch size is " << batchSize_;
   }
 
   //shape must be specified for variable dims
@@ -133,4 +134,3 @@ template void TritonInputData::toServer(std::shared_ptr<TritonInput<float>> data
 template void TritonInputData::toServer(std::shared_ptr<TritonInput<int64_t>> data_in);
 
 template TritonOutput<float> TritonOutputData::fromServer() const;
-

--- a/HeterogeneousCore/SonicTriton/src/triton_utils.cc
+++ b/HeterogeneousCore/SonicTriton/src/triton_utils.cc
@@ -3,19 +3,17 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <sstream>
-#include <iterator>
+#include <experimental/iterator>
 
 namespace triton_utils {
 
-  template <typename T>
-  std::string printVec(const std::vector<T>& vec, const std::string& delim) {
-    if (vec.empty())
+  template <typename C>
+  std::string printColl(const C& coll, const std::string& delim) {
+    if (coll.empty())
       return "";
     std::stringstream msg;
     //avoid trailing delim
-    std::copy(vec.begin(), vec.end() - 1, std::ostream_iterator<T>(msg, delim.c_str()));
-    //last element
-    msg << vec.back();
+    std::copy(std::begin(coll), std::end(coll), std::experimental::make_ostream_joiner(msg, delim));
     return msg.str();
   }
 
@@ -32,6 +30,7 @@ namespace triton_utils {
 
 }  // namespace triton_utils
 
-template std::string triton_utils::printVec(const std::vector<int64_t>& vec, const std::string& delim);
-template std::string triton_utils::printVec(const std::vector<uint8_t>& vec, const std::string& delim);
-template std::string triton_utils::printVec(const std::vector<float>& vec, const std::string& delim);
+template std::string triton_utils::printColl(const std::vector<int64_t>& coll, const std::string& delim);
+template std::string triton_utils::printColl(const std::vector<uint8_t>& coll, const std::string& delim);
+template std::string triton_utils::printColl(const std::vector<float>& coll, const std::string& delim);
+template std::string triton_utils::printColl(const std::unordered_set<std::string>& coll, const std::string& delim);

--- a/HeterogeneousCore/SonicTriton/test/TritonGraphProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonGraphProducer.cc
@@ -60,14 +60,13 @@ public:
   void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
     //check the results
     const auto& output1 = iOutput.begin()->second;
-    std::vector<float> tmp;
     // convert from server format
-    output1.fromServer(tmp);
+    const auto& tmp = output1.fromServer<float>();
     std::stringstream msg;
     for (int i = 0; i < output1.shape()[0]; ++i) {
       msg << "output " << i << ": ";
       for (int j = 0; j < output1.shape()[1]; ++j) {
-        msg << tmp[output1.shape()[1] * i + j] << " ";
+        msg << tmp[0][output1.shape()[1] * i + j] << " ";
       }
       msg << "\n";
     }

--- a/HeterogeneousCore/SonicTriton/test/TritonGraphProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonGraphProducer.cc
@@ -34,13 +34,13 @@ public:
     //set shapes
     auto& input1 = iInput.at("x__0");
     input1.shape() = {nnodes, input1.dims()[1]};
-    auto data1 = std::make_shared<std::vector<std::vector<float>>>(1);
+    auto data1 = std::make_shared<TritonInput<float>>(1);
     auto& vdata1 = (*data1)[0];
     vdata1.reserve(input1.sizeShape());
 
     auto& input2 = iInput.at("edgeindex__1");
     input2.shape() = {input2.dims()[0], nedges};
-    auto data2 = std::make_shared<std::vector<std::vector<int64_t>>>(1);
+    auto data2 = std::make_shared<TritonInput<int64_t>>(1);
     auto& vdata2 = (*data2)[0];
     vdata2.reserve(input2.sizeShape());
 

--- a/HeterogeneousCore/SonicTriton/test/TritonGraphProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonGraphProducer.cc
@@ -34,23 +34,25 @@ public:
     //set shapes
     auto& input1 = iInput.at("x__0");
     input1.shape() = {nnodes, input1.dims()[1]};
-    auto data1 = std::make_shared<std::vector<float>>();
-    data1->reserve(input1.sizeShape());
+    auto data1 = std::make_shared<std::vector<std::vector<float>>>(1);
+    auto& vdata1 = (*data1)[0];
+    vdata1.reserve(input1.sizeShape());
 
     auto& input2 = iInput.at("edgeindex__1");
     input2.shape() = {input2.dims()[0], nedges};
-    auto data2 = std::make_shared<std::vector<int64_t>>();
-    data2->reserve(input2.sizeShape());
+    auto data2 = std::make_shared<std::vector<std::vector<int64_t>>>(1);
+    auto& vdata2 = (*data2)[0];
+    vdata2.reserve(input2.sizeShape());
 
     //fill
     std::normal_distribution<float> randx(-10, 4);
     for (unsigned i = 0; i < input1.sizeShape(); ++i) {
-      data1->push_back(randx(rng));
+      vdata1.push_back(randx(rng));
     }
 
     std::uniform_int_distribution<int> randedge(0, nnodes - 1);
     for (unsigned i = 0; i < input2.sizeShape(); ++i) {
-      data2->push_back(randedge(rng));
+      vdata2.push_back(randedge(rng));
     }
 
     // convert to server format

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -54,14 +54,13 @@ public:
 
 private:
   void findTopN(const TritonOutputData& scores, unsigned n = 5) const {
-    std::vector<float> tmp;
-    scores.fromServer(tmp);
+    const auto& tmp = scores.fromServer<float>();
     auto dim = scores.sizeDims();
     for (unsigned i0 = 0; i0 < scores.batchSize(); i0++) {
       //match score to type by index, then put in largest-first map
       std::map<float, std::string, std::greater<float>> score_map;
       for (unsigned i = 0; i < std::min((unsigned)dim, (unsigned)imageList_.size()); ++i) {
-        score_map.emplace(tmp[i0 * dim + i], imageList_[i]);
+        score_map.emplace(tmp[i0][i], imageList_[i]);
       }
       //get top n
       std::stringstream msg;

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -35,7 +35,7 @@ public:
     auto& input1 = iInput.begin()->second;
     auto data1 = std::make_shared<TritonInput<float>>();
     data1->reserve(input1.batchSize());
-    for(unsigned i = 0; i < input1.batchSize(); ++i){
+    for (unsigned i = 0; i < input1.batchSize(); ++i) {
       data1->emplace_back(input1.sizeDims(), 0.5f);
     }
     // convert to server format

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -33,7 +33,8 @@ public:
     // create an npix x npix x ncol image w/ arbitrary color value
     // model only has one input, so just pick begin()
     auto& input1 = iInput.begin()->second;
-    auto data1 = std::make_shared<std::vector<float>>(input1.sizeDims() * input1.batchSize(), 0.5f);
+    auto data1 = std::make_shared<std::vector<std::vector<float>>>();
+    data1->resize(input1.batchSize(),std::vector<float>(input1.sizeDims(), 0.5f));
     // convert to server format
     input1.toServer(data1);
   }

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -33,8 +33,11 @@ public:
     // create an npix x npix x ncol image w/ arbitrary color value
     // model only has one input, so just pick begin()
     auto& input1 = iInput.begin()->second;
-    auto data1 = std::make_shared<std::vector<std::vector<float>>>();
-    data1->resize(input1.batchSize(),std::vector<float>(input1.sizeDims(), 0.5f));
+    auto data1 = std::make_shared<TritonInput<float>>();
+    data1->reserve(input1.batchSize());
+    for(unsigned i = 0; i < input1.batchSize(); ++i){
+      data1->emplace_back(input1.sizeDims(), 0.5f);
+    }
     // convert to server format
     input1.toServer(data1);
   }


### PR DESCRIPTION
#### PR description:

* use `edm::allowedValues` for base client mode parameter description
* use `edm::Span` to avoid copying output vectors in Triton
* reorganize Triton output format as `std::vector<edm::Span<...>>` (# entries = batch size), and reorganize input format similarly for consistency; assign aliases `TritonOutput` and `TritonInput` to make the interfaces nicer
* allow selecting only some outputs from server (if empty, keep all outputs)
* reorganize utility function for printing collections

#### PR validation:

Ran SonicCore unit tests and SonicTriton standalone tests.

attn: @violatingcp @drankincms @nhanvtran @jeffkrupa @jmduarte @lgray @jpata