### PR TITLE
Fix circular dependencies between Geometry packages

### DIFF
--- a/DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h
+++ b/DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
-#include "DataFormats/GeometrySurface/interface/LocalErrorExtended.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/LocalErrorExtended.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
 

--- a/DataFormats/GeometryCommonDetAlgo/interface/LocalErrorBaseExtended.h
+++ b/DataFormats/GeometryCommonDetAlgo/interface/LocalErrorBaseExtended.h
@@ -1,7 +1,6 @@
-#ifndef LocalErrorType_H
-#define LocalErrorType_H
+#ifndef DataFormats_GeometryCommonDetAlgo_LocalErrorBaseExtended_h
+#define DataFormats_GeometryCommonDetAlgo_LocalErrorBaseExtended_h
 
-#include "DataFormats/GeometryCommonDetAlgo/interface/DeepCopyPointer.h"
 #include "DataFormats/GeometrySurface/interface/TrivialError.h"
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
 //

--- a/DataFormats/GeometryCommonDetAlgo/interface/LocalErrorExtended.h
+++ b/DataFormats/GeometryCommonDetAlgo/interface/LocalErrorExtended.h
@@ -1,7 +1,7 @@
-#ifndef _TRACKER_LOCAL_ERROR_H_
-#define _TRACKER_LOCAL_ERROR_H_
+#ifndef DataFormats_GeometryCommonDetAlgo_LocalErrorExtended_h
+#define DataFormats_GeometryCommonDetAlgo_LocalErrorExtended_h
 
-#include "DataFormats/GeometrySurface/interface/LocalErrorBaseExtended.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/LocalErrorBaseExtended.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/ErrorMatrixTag.h"
 
 /**

--- a/Geometry/CommonTopologies/interface/MuonGeomDet.h
+++ b/Geometry/CommonTopologies/interface/MuonGeomDet.h
@@ -2,8 +2,7 @@
 #define CommonDet_MuonGeomDet_H
 
 #include "Geometry/CommonTopologies/interface/GeomDet.h"
-#include "DataFormats/GeometrySurface/interface/LocalError.h"
-#include "DataFormats/GeometrySurface/interface/LocalErrorExtended.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/LocalErrorExtended.h"
 
 class MuonGeomDet : public GeomDet {
 protected:


### PR DESCRIPTION
#### PR description:

Broke the circular dependency between GeometryCommonDetAlgo and GeometrySurface.

#### PR validation:

The code compiles and using `git grep` finds no other includes of the old places for the header files.