### PR TITLE
Remove data folder of SimG4CMS/Forward

### DIFF
--- a/SimG4CMS/Forward/data/download.url
+++ b/SimG4CMS/Forward/data/download.url
@@ -1,1 +1,0 @@
-http://cmsdoc.cern.ch/cms/data/CMSSW/SimG4CMS/Forward/data/CastorShowerLibrary_CMSSW500_Standard.root


### PR DESCRIPTION
#### PR description:

Removes redundant folder 
After: https://github.com/cms-sw/cmsdist/pull/6124/files
this folder is not needed anymore.

#### PR validation:

ls /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc820/cms/cmssw/CMSSW_11_2_X_2020-08-03-1100/external/slc7_amd64_gcc820/data/SimG4CMS/Forward/data/

: the file is there (i.e. it's distributed by the external)
