### PR TITLE
Don't use an uninitialized edm::Hande in GEDPhotonProducer

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -65,7 +65,7 @@ private:
                             const EcalRecHitCollection* ecalBarrelHits,
                             const EcalRecHitCollection* ecalEndcapHits,
                             const EcalRecHitCollection* preshowerHits,
-                            CaloTowerCollection const& hcalTowers,
+                            CaloTowerCollection const* hcalTowers,
                             const reco::VertexCollection& pvVertices,
                             reco::PhotonCollection& outputCollection,
                             int& iSC);


### PR DESCRIPTION
#### PR description:

Dereferencing an uninitialized edm::Handle leads to dereferencing a nullptr which is undefined behavior.

#### PR validation:

Used with #30928 and ran workflow 136.7611 which had failed in the other pull requests tests. Now it succeeds.