### PR TITLE
Don't use uninitialized edm::Handle in AnalyticalTrackSelector

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -261,12 +261,13 @@ void AnalyticalTrackSelector::run(edm::Event& evt, const edm::EventSetup& es) co
   vertexBeamSpot = *hBsp;
 
   // Select good primary vertices for use in subsequent track selection
-  edm::Handle<reco::VertexCollection> hVtx;
+  const reco::VertexCollection dummyVtx;
+  const reco::VertexCollection* vtxPtr = &dummyVtx;
   std::vector<Point> points;
   std::vector<float> vterr, vzerr;
   if (useVertices_) {
-    evt.getByToken(vertices_, hVtx);
-    selectVertices(0, *hVtx, points, vterr, vzerr);
+    vtxPtr = &evt.get(vertices_);
+    selectVertices(0, *vtxPtr, points, vterr, vzerr);
     // Debug
     LogDebug("SelectVertex") << points.size() << " good pixel vertices";
   }
@@ -291,7 +292,7 @@ void AnalyticalTrackSelector::run(edm::Event& evt, const edm::EventSetup& es) co
     trackRefs_.resize(hSrcTrack->size());
 
   std::vector<float> mvaVals_(hSrcTrack->size(), -99.f);
-  processMVA(evt, es, vertexBeamSpot, *(hVtx.product()), 0, mvaVals_, true);
+  processMVA(evt, es, vertexBeamSpot, *vtxPtr, 0, mvaVals_, true);
 
   // Loop over tracks
   size_t current = 0;


### PR DESCRIPTION

#### PR description:

Dereferencing an uninitialized Handle will dereference a nullptr which is undefined behavior.

This was found by #30928.

#### PR validation:

Used #30928 and ran addOn test which was previously failing. Now it succeeds.