### PR TITLE
New ParticleNet training for UL

### DIFF
--- a/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
@@ -11,8 +11,8 @@ pfParticleNetTagInfos = pfDeepBoostedJetTagInfos.clone(
 
 pfParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
-    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V00/preprocess.json',
-    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/General/V00/ParticleNet.onnx',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess.json',
+    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/particle-net.onnx',
     flav_names = ["probTbcq",  "probTbqq",  "probTbc",   "probTbq",  "probTbel", "probTbmu", "probTbta",
                   "probWcq",   "probWqq",   "probZbb",   "probZcc",  "probZqq",  "probHbb", "probHcc",
                   "probHqqqq", "probQCDbb", "probQCDcc", "probQCDb", "probQCDc", "probQCDothers"],
@@ -20,8 +20,8 @@ pfParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
 
 pfMassDecorrelatedParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
-    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V00/preprocess.json',
-    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V00/ParticleNet.onnx',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/preprocess.json',
+    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/particle-net.onnx',
     flav_names = ["probXbb", "probXcc", "probXqq", "probQCDbb", "probQCDcc",
                   "probQCDb", "probQCDc", "probQCDothers"],
 )


### PR DESCRIPTION
#### PR description:

This PR updates the ParticleNet tagger to the new training [V01] developed for the UL re-MiniAOD. The training is derived on UL17+UL18 samples and using Puppi tune V14. The new training improves the performance for UL samples and the new Puppi tune. More information can be found in the JME talks [[1](https://indico.cern.ch/event/939494/contributions/3947427/attachments/2081304/3495876/20.07.28_JMAR_ParticleNet_for_UL.pdf), [2](https://indico.cern.ch/event/942994/contributions/3966501/attachments/2083817/3500446/ParticleNET_PUPPItunechecks.pdf)] the BTV [talk](https://indico.cern.ch/event/916807/contributions/3968324/attachments/2084999/3502626/20.08.05_ParticleNet_BTV.pdf).

Requires: https://github.com/cms-data/RecoBTag-Combined/pull/34

The new ParticleNet models use the "dynamic axis" feature of ONNX to avoid zero padding the particle/SV sequence, thus reduce the inference time by more than a factor of two compared to the V00 models.

[V00]

```
TimeReport   0.071098     0.071098     0.071098  pfMassDecorrelatedParticleNetJetTags
TimeReport   0.068718     0.068718     0.068718  pfParticleNetJetTags
```

[V01]

```
TimeReport   0.029899     0.029899     0.029899  pfMassDecorrelatedParticleNetJetTags
TimeReport   0.029965     0.029965     0.029965  pfParticleNetJetTags
```

(Measured on a `ZprimeToTT_M1000_W10_TuneCP2_13TeV-madgraphMLM-pythia8` sample.)

#### PR validation:

The CMSSW implementation is compared to the training framework and consistent results are obtained.
