### PR TITLE
Fix improper static_cast in HcalAmplifier (part 2)

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
@@ -44,8 +44,8 @@ void HcalAmplifier::amplify(CaloSamples& frame, CLHEP::HepRandomEngine* engine) 
   }
   pe2fC(frame);
 
-  if (frame.id() == DetId::Hcal && ((frame.id().subdetId() == HcalGenericDetId::HcalGenBarrel) ||
-                                    (frame.id().subdetId() == HcalGenericDetId::HcalGenEndcap))) {
+  if (frame.id().det() == DetId::Hcal && ((frame.id().subdetId() == HcalGenericDetId::HcalGenBarrel) ||
+                                          (frame.id().subdetId() == HcalGenericDetId::HcalGenEndcap))) {
     const HcalSimParameters& params = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(frame.id()));
     if (params.delayQIE() > 0)
       applyQIEdelay(frame, params.delayQIE());

--- a/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
@@ -44,8 +44,8 @@ void HcalAmplifier::amplify(CaloSamples& frame, CLHEP::HepRandomEngine* engine) 
   }
   pe2fC(frame);
 
-  if ((frame.id().subdetId() == HcalGenericDetId::HcalGenBarrel) ||
-      (frame.id().subdetId() == HcalGenericDetId::HcalGenEndcap)) {
+  if (frame.id() == DetId::Hcal && ((frame.id().subdetId() == HcalGenericDetId::HcalGenBarrel) ||
+                                    (frame.id().subdetId() == HcalGenericDetId::HcalGenEndcap))) {
     const HcalSimParameters& params = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(frame.id()));
     if (params.delayQIE() > 0)
       applyQIEdelay(frame, params.delayQIE());


### PR DESCRIPTION
#### PR description:

Followup to #30829. The issue persisted because ZDC DetIds have subdet = 2, but det = Calo (not Hcal). Checking only the subdet was not sufficient.

I determined this as follows:
```
cmsrel CMSSW_11_2_UBSAN_X_2020-07-31-2300
cd CMSSW_11_2_UBSAN_X_2020-07-31-2300/src
cmsenv
git cms-addpkg SimCalorimetry/HcalSimAlgos SimCalorimetry/HcalSimProducers
USER_CXXFLAGS="-g -fno-omit-frame-pointer" scram b
runTheMatrix.py -l 11834.24
cd 11834.24_TTbar_14TeV+TTbar_14TeV_TuneCP5_2021PU_GenSimFull_0T+DigiFullPU_0T_2021PU+RecoFullPU_0T_2021PU+HARVESTFullPU_0T_2021PU+NanoFull_2021PU
UBSAN_OPTIONS=print_stacktrace=1 cmsRun step2_DIGI_L1_DIGI2RAW_HLT_PU.py
```
and then used `addr2line` on the UBSAN stack trace (which printed addresses like `CMSSW_11_2_UBSAN_X_2020-07-31-2300/lib/slc7_amd64_gcc820/libSimCalorimetryHcalSimAlgos.so+0xbdd68` rather than line numbers).

That produced the following:
```
#0 /uscms_data/d3/pedrok/phase2/CMSSW_11_2_UBSAN_X_2020-07-31-2300/src/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc:51
#1 /uscms_data/d3/pedrok/phase2/CMSSW_11_2_UBSAN_X_2020-07-31-2300/src/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc:34
#2 /uscms_data/d3/pedrok/phase2/CMSSW_11_2_UBSAN_X_2020-07-31-2300/src/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc:110
#3 /uscms_data/d3/pedrok/phase2/CMSSW_11_2_UBSAN_X_2020-07-31-2300/src/SimCalorimetry/HcalSimAlgos/interface/HcalDigitizerTraits.h:55
#4 /uscms_data/d3/pedrok/phase2/CMSSW_11_2_UBSAN_X_2020-07-31-2300/src/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc:490
#5 /uscms_data/d3/pedrok/phase2/CMSSW_11_2_UBSAN_X_2020-07-31-2300/src/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc:35
```

https://github.com/cms-sw/cmssw/blob/e8703674b3fe9dc89fc03174d924c8d571440985/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc#L490 points to ZDC, which allowed me to understand the problem.

#### PR validation:

Ran 11834.24 in UBSAN IB and saw that the error message went away.