### PR TITLE
Add ghost LCTs in CSC stub matcher

### DIFF
--- a/Validation/MuonCSCDigis/interface/CSCStubMatcher.h
+++ b/Validation/MuonCSCDigis/interface/CSCStubMatcher.h
@@ -123,7 +123,7 @@ private:
   template <class D>
   std::set<unsigned int> selectDetIds(D&, int) const;
 
-  bool hsFromSimHitMean_;
+  bool addGhostLCTs_;
 
   int minNHitsChamber_;
   int minNHitsChamberALCT_;

--- a/Validation/MuonCSCDigis/python/muonCSCStubPSet.py
+++ b/Validation/MuonCSCDigis/python/muonCSCStubPSet.py
@@ -24,7 +24,7 @@ muonCSCStubPSet = cms.PSet(
         minBX = cms.int32(7),
         maxBX = cms.int32(9),
         minNHitsChamber = cms.int32(4),
-        hsFromSimHitMean = cms.bool(True),
+        addGhosts = cms.bool(True)
     ),
     #csc LCT, central BX 8
     cscMPLCT = cms.PSet(

--- a/Validation/MuonCSCDigis/src/CSCDigiMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCDigiMatcher.cc
@@ -71,7 +71,7 @@ void CSCDigiMatcher::matchComparatorsToSimTrack(const CSCComparatorDigiCollectio
     const auto& comp_digis_in_det = comparators.get(layer_id);
     for (auto c = comp_digis_in_det.first; c != comp_digis_in_det.second; ++c) {
       if (verboseComparator_)
-        cout << "sdigi " << layer_id << " (comparator, comparator, Tbin ) " << *c << endl;
+        edm::LogInfo("CSCDigiMatcher") << "sdigi " << layer_id << " (comparator, comparator, Tbin ) " << *c;
 
       // check that the first BX for this digi wasn't too early or too late
       if (c->getTimeBin() < minBXComparator_ || c->getTimeBin() > maxBXComparator_)
@@ -83,7 +83,7 @@ void CSCDigiMatcher::matchComparatorsToSimTrack(const CSCComparatorDigiCollectio
         continue;
 
       if (verboseComparator_)
-        cout << "Matched comparator " << *c << endl;
+        edm::LogInfo("CSCDigiMatcher") << "Matched comparator " << *c;
       detid_to_comparators_[id].push_back(*c);
       chamber_to_comparators_[layer_id.chamberId().rawId()].push_back(*c);
     }
@@ -97,7 +97,7 @@ void CSCDigiMatcher::matchStripsToSimTrack(const CSCStripDigiCollection& strips)
     for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
       if (id.station() == 1 and (id.ring() == 1 or id.ring() == 4))
         if (verboseStrip_)
-          cout << "CSCid " << id << " Strip digi (strip, strip, Tbin ) " << (*digiIt) << endl;
+          edm::LogInfo("CSCDigiMatcher") << "CSCid " << id << " Strip digi (strip, strip, Tbin ) " << (*digiIt);
     }
   }
 
@@ -115,7 +115,7 @@ void CSCDigiMatcher::matchStripsToSimTrack(const CSCStripDigiCollection& strips)
     const auto& strip_digis_in_det = strips.get(layer_id);
     for (auto c = strip_digis_in_det.first; c != strip_digis_in_det.second; ++c) {
       if (verboseStrip_)
-        cout << "sdigi " << layer_id << " (strip, Tbin ) " << *c << endl;
+        edm::LogInfo("CSCDigiMatcher") << "sdigi " << layer_id << " (strip, Tbin ) " << *c;
 
       int strip = c->getStrip();  // strips are counted from 1
       // check that it matches a strip that was hit by SimHits from our track
@@ -123,7 +123,7 @@ void CSCDigiMatcher::matchStripsToSimTrack(const CSCStripDigiCollection& strips)
         continue;
 
       if (verboseStrip_)
-        cout << "Matched strip " << *c << endl;
+        edm::LogInfo("CSCDigiMatcher") << "Matched strip " << *c;
       detid_to_strips_[id].push_back(*c);
       chamber_to_strips_[layer_id.chamberId().rawId()].push_back(*c);
     }
@@ -144,6 +144,9 @@ void CSCDigiMatcher::matchWiresToSimTrack(const CSCWireDigiCollection& wires) {
 
     const auto& wire_digis_in_det = wires.get(layer_id);
     for (auto w = wire_digis_in_det.first; w != wire_digis_in_det.second; ++w) {
+      if (verboseStrip_)
+        edm::LogInfo("CSCDigiMatcher") << "wdigi " << layer_id << " (wire, Tbin ) " << *w;
+
       // check that the first BX for this digi wasn't too early or too late
       if (w->getTimeBin() < minBXWire_ || w->getTimeBin() > maxBXWire_)
         continue;
@@ -154,7 +157,7 @@ void CSCDigiMatcher::matchWiresToSimTrack(const CSCWireDigiCollection& wires) {
         continue;
 
       if (verboseStrip_)
-        cout << "Matched wire digi " << *w << endl;
+        edm::LogInfo("CSCDigiMatcher") << "Matched wire digi " << *w << endl;
       detid_to_wires_[id].push_back(*w);
       chamber_to_wires_[layer_id.chamberId().rawId()].push_back(*w);
     }

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -52,7 +52,7 @@ void CSCStubMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetu
   if (csc_geom_.isValid()) {
     cscGeometry_ = &*csc_geom_;
   } else {
-    std::cout << "+++ Info: CSC geometry is unavailable. +++\n";
+    edm::LogError("CSCStubMatcher") << "+++ Info: CSC geometry is unavailable.";
   }
 }
 
@@ -82,7 +82,7 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
   for (const auto& id : cathode_ids) {
     CSCDetId ch_id(id);
     if (verboseCLCT_) {
-      cout << "To check CSC chamber " << ch_id << endl;
+      edm::LogInfo("CSCStubMatcher") << "To check CSC chamber " << ch_id;
     }
 
     int ring = ch_id.ring();
@@ -100,14 +100,13 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
 
     // print out the digis
     if (verboseCLCT_) {
-      cout << "clct: comparators " << ch_id << endl;
+      edm::LogInfo("CSCStubMatcher") << "clct: comparators " << ch_id;
       int layer = 0;
       for (const auto& p : comps) {
         layer++;
         for (const auto& q : p) {
-          cout << "L" << layer << " " << q << " " << q.getHalfStrip() << " ";
+          edm::LogInfo("CSCStubMatcher") << "L" << layer << " " << q << " " << q.getHalfStrip() << " ";
         }
-        cout << endl;
       }
     }
 
@@ -121,7 +120,7 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
 
     for (auto c = clcts_in_det.first; c != clcts_in_det.second; ++c) {
       if (verboseCLCT_)
-        cout << "clct " << ch_id2 << " " << *c << endl;
+        edm::LogInfo("CSCStubMatcher") << "clct " << ch_id2 << " " << *c;
 
       if (!c->isValid())
         continue;
@@ -140,23 +139,20 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
         layer++;
         for (const auto& q : p) {
           if (verboseCLCT_)
-            cout << "L" << layer << " " << q << " " << q.getHalfStrip() << " " << std::endl;
+            edm::LogInfo("CSCStubMatcher") << "L" << layer << " " << q << " " << q.getHalfStrip() << " " << std::endl;
           for (const auto& clctComp : (*c).getHits()[layer - 1]) {
             if (clctComp == 65535)
               continue;
             if (verboseCLCT_) {
-              std::cout << "\t" << clctComp << " " << endl;
+              edm::LogInfo("CSCStubMatcher") << "\t" << clctComp << " ";
             }
             if (q.getHalfStrip() == clctComp or (isME1a and q.getHalfStrip() + 128 == clctComp)) {
               nMatches++;
               if (verboseCLCT_) {
-                cout << "\t\tnMatches " << nMatches << std::endl;
+                edm::LogInfo("CSCStubMatcher") << "\t\tnMatches " << nMatches << std::endl;
               }
             }
           }
-        }
-        if (verboseCLCT_) {
-          cout << endl;
         }
       }
 
@@ -165,7 +161,7 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
         continue;
 
       if (verboseCLCT_)
-        cout << "clctGOOD" << endl;
+        edm::LogInfo("CSCStubMatcher") << "clctGOOD";
 
       // store matching CLCTs in this chamber
       if (std::find(chamber_to_clcts_[id].begin(), chamber_to_clcts_[id].end(), *c) == chamber_to_clcts_[id].end()) {
@@ -173,9 +169,9 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
       }
     }
     if (chamber_to_clcts_[id].size() > 2) {
-      cout << "WARNING!!! too many CLCTs " << chamber_to_clcts_[id].size() << " in " << ch_id << endl;
+      edm::LogInfo("CSCStubMatcher") << "WARNING!!! too many CLCTs " << chamber_to_clcts_[id].size() << " in " << ch_id;
       for (auto& c : chamber_to_clcts_[id])
-        cout << "  " << c << endl;
+        edm::LogInfo("CSCStubMatcher") << "  " << c;
     }
   }
 }
@@ -207,7 +203,7 @@ void CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts) {
         continue;
 
       if (verboseALCT_)
-        cout << "alct " << ch_id << " " << *a << endl;
+        edm::LogInfo("CSCStubMatcher") << "alct " << ch_id << " " << *a;
 
       // check that the BX for stub wasn't too early or too late
       if (a->getBX() < minBXALCT_ || a->getBX() > maxBXALCT_)
@@ -223,7 +219,7 @@ void CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts) {
         continue;
       }
       if (verboseALCT_)
-        cout << "alctGOOD" << endl;
+        edm::LogInfo("CSCStubMatcher") << "alctGOOD";
 
       // store matching ALCTs in this chamber
       if (std::find(chamber_to_alcts_[id].begin(), chamber_to_alcts_[id].end(), *a) == chamber_to_alcts_[id].end()) {
@@ -231,9 +227,9 @@ void CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts) {
       }
     }
     if (chamber_to_alcts_[id].size() > 2) {
-      cout << "WARNING!!! too many ALCTs " << chamber_to_alcts_[id].size() << " in " << ch_id << endl;
+      edm::LogInfo("CSCStubMatcher") << "WARNING!!! too many ALCTs " << chamber_to_alcts_[id].size() << " in " << ch_id;
       for (auto& a : chamber_to_alcts_[id])
-        cout << "  " << a << endl;
+        edm::LogInfo("CSCStubMatcher") << "  " << a;
     }
   }
 }
@@ -310,17 +306,17 @@ void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& l
       bool lct_gem2_match(false);
 
       if (verboseLCT_) {
-        cout << ch_id << " " << ch_id2 << endl;
-        cout << lct << endl;
-        cout << "getCLCT " << lct.getCLCT() << "\ngetALCT " << lct.getALCT() << "\ngetGEM1 " << lct.getGEM1()
-             << "\ngetGEM2 " << lct.getGEM2() << endl;
+        edm::LogInfo("CSCStubMatcher") << ch_id << " " << ch_id2;
+        edm::LogInfo("CSCStubMatcher") << lct;
+        edm::LogInfo("CSCStubMatcher") << "getCLCT " << lct.getCLCT() << "\ngetALCT " << lct.getALCT() << "\ngetGEM1 "
+                                       << lct.getGEM1() << "\ngetGEM2 " << lct.getGEM2();
       }
       // Check if matched to an CLCT
       for (const auto& p : clctsInChamber(id)) {
         if (p == lct.getCLCT()) {
           lct_clct_match = true;
           if (verboseLCT_)
-            cout << "\t...lct_clct_match" << endl;
+            edm::LogInfo("CSCStubMatcher") << "\t...lct_clct_match";
           break;
         }
       }
@@ -330,7 +326,7 @@ void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& l
         if (p == lct.getALCT()) {
           lct_alct_match = true;
           if (verboseLCT_)
-            cout << "\t...lct_alct_match" << endl;
+            edm::LogInfo("CSCStubMatcher") << "\t...lct_alct_match";
           break;
         }
       }
@@ -343,7 +339,7 @@ void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& l
           if (p == lct.getGEM1()) {
             lct_gem1_match = true;
             if (verboseLCT_)
-              cout << "\t...lct_gem1_match" << endl;
+              edm::LogInfo("CSCStubMatcher") << "\t...lct_gem1_match";
             break;
           }
         }
@@ -354,7 +350,7 @@ void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& l
           if (p == lct.getGEM2()) {
             lct_gem2_match = true;
             if (verboseLCT_)
-              cout << "\t...lct_gem2_match" << endl;
+              edm::LogInfo("CSCStubMatcher") << "\t...lct_gem2_match";
             break;
           }
         }
@@ -370,7 +366,7 @@ void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& l
 
       if (lct_matched) {
         if (verboseLCT_)
-          cout << "...was matched" << endl;
+          edm::LogInfo("CSCStubMatcher") << "...was matched";
         if (std::find(chamber_to_lcts_[id].begin(), chamber_to_lcts_[id].end(), lct) == chamber_to_lcts_[id].end()) {
           chamber_to_lcts_[id].emplace_back(lct);
         }

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -282,7 +282,8 @@ void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& l
           int hs1 = lct11.getStrip();
           int hs2 = lct22.getStrip();
 
-          if (!(wg1 == wg2 || hs1 == hs2) and lct11.getType() == CSCCorrelatedLCTDigi::ALCTCLCT and lct22.getType() == CSCCorrelatedLCTDigi::ALCTCLCT) {
+          if (!(wg1 == wg2 || hs1 == hs2) and lct11.getType() == CSCCorrelatedLCTDigi::ALCTCLCT and
+              lct22.getType() == CSCCorrelatedLCTDigi::ALCTCLCT) {
             CSCCorrelatedLCTDigi lct12 = lct11;
             lct12.setWireGroup(wg2);
             lct12.setALCT(lct22.getALCT());


### PR DESCRIPTION
#### PR description:

When two muons cross a CSC, two LCTs (L1, L2) may be produced from two ALCTs (a1, a2) and two CLCTs (c1, c2). This assignment is arbitrary in the local trigger, L1 = a1 x c1, L2 = a2 x c2. Where "1" is first in-time, "2" is second in-time. The EMTF examines all possible options for track building, including the ghost LCTs L1' = a1 x c2 and L2 = a2 x c1. I add an option - by default turned on - to match true muons to all LCTs.

#### PR validation:

Tested in CMSSW_11_2_0_pre3 on `/RelValSingleMuFlatPt2To100/CMSSW_11_0_0-PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/GEN-SIM-DIGI-RAW`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
