### PR TITLE
Add SiPixelGenErrorDBObject payload inspector

### DIFF
--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -499,6 +499,8 @@ namespace SiPixelPI {
     }
   }
 
+  enum DetType { t_barrel = 0, t_forward = 1 };
+
   enum regions {
     BPixL1o,        //0  Barrel Pixel Layer 1 outer
     BPixL1i,        //1  Barrel Pixel Layer 1 inner

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -52,3 +52,13 @@
   <use name="CalibTracker/SiPixelESProducers"/>
   <use name="boost_python"/>
 </library>
+
+<library file="SiPixelGenErrorDBObject_PayloadInspector.cc" name="SiPixelGenErrorDBObject_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/Common"/>
+  <use name="CondFormats/SiPixelTransient"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
+  <use name="boost_python"/>
+</library>

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc
@@ -48,8 +48,6 @@
 
 namespace {
 
-  enum MapType { t_barrel = 0, t_forward = 1 };
-
   /************************************************
   // header plotting
   *************************************************/
@@ -140,11 +138,10 @@ namespace {
     }
   };
 
-
- /************************************************
+  /************************************************
   // testing TH2Poly classes for plotting
   *************************************************/
-  template <MapType myType>
+  template <SiPixelPI::DetType myType>
   class SiPixelGenErrorIDs
       : public cond::payloadInspector::PlotImage<SiPixelGenErrorDBObject, cond::payloadInspector::SINGLE_IOV> {
   public:
@@ -162,14 +159,14 @@ namespace {
       if (payload.get()) {
         // Book the TH2Poly
         Phase1PixelMaps theMaps("text");
-        if (myType == t_barrel) {
-          theMaps.bookBarrelHistograms("templateIDsBarrel", "IDs", "template IDs");
+        if (myType == SiPixelPI::t_barrel) {
+          theMaps.bookBarrelHistograms("generrorIDsBarrel", "genErrorIDs", "genError IDs");
           // book the barrel bins of the TH2Poly
-          theMaps.bookBarrelBins("templateIDsBarrel");
-        } else if (myType == t_forward) {
-          theMaps.bookForwardHistograms("templateIDsForward", "IDs", "template IDs");
+          theMaps.bookBarrelBins("generrorIDsBarrel");
+        } else if (myType == SiPixelPI::t_forward) {
+          theMaps.bookForwardHistograms("generrorIDsForward", "genErrorIDs", "genError IDs");
           // book the forward bins of the TH2Poly
-          theMaps.bookForwardBins("templateIDsForward");
+          theMaps.bookForwardBins("generrorIDsForward");
         }
 
         std::map<unsigned int, short> templMap = payload->getGenErrorIDs();
@@ -191,31 +188,23 @@ namespace {
           }
         }
 
-        /*
-        std::vector<unsigned int> detids;
-        std::transform(templMap.begin(),
-                       templMap.end(),
-                       std::back_inserter(detids),
-                       [](const std::map<unsigned int, short>::value_type& pair) { return pair.first; });
-	*/
-
         for (auto const& entry : templMap) {
-          COUT << "DetID: " << entry.first << " template ID: " << entry.second << std::endl;
+          COUT << "DetID: " << entry.first << " generror ID: " << entry.second << std::endl;
           auto detid = DetId(entry.first);
-          if ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (myType == t_barrel)) {
-            theMaps.fillBarrelBin("templateIDsBarrel", entry.first, entry.second);
-          } else if ((detid.subdetId() == PixelSubdetector::PixelEndcap) && (myType == t_forward)) {
-            theMaps.fillForwardBin("templateIDsForward", entry.first, entry.second);
+          if ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (myType == SiPixelPI::t_barrel)) {
+            theMaps.fillBarrelBin("generrorIDsBarrel", entry.first, entry.second);
+          } else if ((detid.subdetId() == PixelSubdetector::PixelEndcap) && (myType == SiPixelPI::t_forward)) {
+            theMaps.fillForwardBin("generrorIDsForward", entry.first, entry.second);
           }
         }
 
         theMaps.beautifyAllHistograms();
 
-        TCanvas canvas("Canv", "Canv", (myType == t_barrel) ? 1200 : 1500, 1000);
-        if (myType == t_barrel) {
-          theMaps.DrawBarrelMaps("templateIDsBarrel", canvas);
-        } else if (myType == t_forward) {
-          theMaps.DrawForwardMaps("templateIDsForward", canvas);
+        TCanvas canvas("Canv", "Canv", (myType == SiPixelPI::t_barrel) ? 1200 : 1500, 1000);
+        if (myType == SiPixelPI::t_barrel) {
+          theMaps.DrawBarrelMaps("generrorIDsBarrel", canvas);
+        } else if (myType == SiPixelPI::t_forward) {
+          theMaps.DrawForwardMaps("generrorIDsForward", canvas);
         }
 
         canvas.cd();
@@ -227,15 +216,14 @@ namespace {
     }
   };
 
-  using SiPixelGenErrorIDsBPixMap = SiPixelGenErrorIDs<t_barrel>;
-  using SiPixelGenErrorIDsFPixMap = SiPixelGenErrorIDs<t_forward>;
+  using SiPixelGenErrorIDsBPixMap = SiPixelGenErrorIDs<SiPixelPI::t_barrel>;
+  using SiPixelGenErrorIDsFPixMap = SiPixelGenErrorIDs<SiPixelPI::t_forward>;
 
-}
+}  // namespace
 
 // Register the classes as boost python plugin
 PAYLOAD_INSPECTOR_MODULE(SiPixelGenErrorDBObject) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorHeaderTable);
-  //PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorDBObjectTest);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorIDsBPixMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorIDsFPixMap);
 }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc
@@ -1,0 +1,241 @@
+/*!
+  \file SiPixelTemplateDBObject_PayloadInspector
+  \Payload Inspector Plugin for SiPixelTemplateDBObject
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2020/04/16 18:00:00 $
+*/
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+#include "CondCore/SiPixelPlugins/interface/Phase1PixelMaps.h"
+
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h"
+#include "CondFormats/SiPixelTransient/interface/SiPixelGenError.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <memory>
+#include <map>
+#include <sstream>
+#include <iostream>
+#include <algorithm>
+#include <boost/range/adaptor/indexed.hpp>
+
+// include ROOT
+#include "TH2.h"
+#include "TProfile2D.h"
+#include "TH2Poly.h"
+#include "TGraph.h"
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TGraph.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+#include "TGaxis.h"
+
+namespace {
+
+  enum MapType { t_barrel = 0, t_forward = 1 };
+
+  /************************************************
+  // header plotting
+  *************************************************/
+  class SiPixelGenErrorHeaderTable
+      : public cond::payloadInspector::PlotImage<SiPixelGenErrorDBObject, cond::payloadInspector::SINGLE_IOV> {
+  public:
+    SiPixelGenErrorHeaderTable()
+        : cond::payloadInspector::PlotImage<SiPixelGenErrorDBObject, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelGenErrorDBObject Header summary") {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      auto tagname = tag.name;
+      std::vector<SiPixelGenErrorStore> thePixelTemp_;
+      std::shared_ptr<SiPixelGenErrorDBObject> payload = fetchPayload(std::get<1>(iov));
+
+      if (payload.get()) {
+        if (!SiPixelGenError::pushfile(*payload, thePixelTemp_)) {
+          throw cms::Exception("SiPixelGenErrorDBObject_PayloadInspector")
+              << "\nERROR: GenErrors not filled correctly. Check the conditions. Using "
+                 "SiPixelGenErrorDBObject version "
+              << payload->version() << "\n\n";
+        }
+
+        // store the map of ID / interesting quantities
+        SiPixelGenError templ(thePixelTemp_);
+        TCanvas canvas("GenError Header Summary", "GenError Header summary", 1400, 1000);
+        canvas.cd();
+
+        unsigned int tempSize = thePixelTemp_.size();
+
+        canvas.SetTopMargin(0.07);
+        canvas.SetBottomMargin(0.06);
+        canvas.SetLeftMargin(0.17);
+        canvas.SetRightMargin(0.03);
+        canvas.Modified();
+        canvas.SetGrid();
+
+        auto h2_GenErrorHeaders = std::make_unique<TH2F>("Header", ";;", tempSize, 0, tempSize, 6, 0., 6.);
+        h2_GenErrorHeaders->SetStats(false);
+
+        for (const auto& theTemp : thePixelTemp_ | boost::adaptors::indexed(1)) {
+          auto tempValue = theTemp.value();
+          auto tempIndex = theTemp.index();
+          float uH = roundoff(tempValue.head.lorxwidth / tempValue.head.zsize / tempValue.head.Bfield, 4);
+          h2_GenErrorHeaders->SetBinContent(tempIndex, 6, tempValue.head.ID);
+          h2_GenErrorHeaders->SetBinContent(tempIndex, 5, tempValue.head.Bfield);
+          h2_GenErrorHeaders->SetBinContent(tempIndex, 4, uH);
+          h2_GenErrorHeaders->SetBinContent(tempIndex, 3, tempValue.head.xsize);
+          h2_GenErrorHeaders->SetBinContent(tempIndex, 2, tempValue.head.ysize);
+          h2_GenErrorHeaders->SetBinContent(tempIndex, 1, tempValue.head.zsize);
+          h2_GenErrorHeaders->GetYaxis()->SetBinLabel(6, "GenErrorID");
+          h2_GenErrorHeaders->GetYaxis()->SetBinLabel(5, "B-field [T]");
+          h2_GenErrorHeaders->GetYaxis()->SetBinLabel(4, "#mu_{H} [1/T]");
+          h2_GenErrorHeaders->GetYaxis()->SetBinLabel(3, "x-size [#mum]");
+          h2_GenErrorHeaders->GetYaxis()->SetBinLabel(2, "y-size [#mum]");
+          h2_GenErrorHeaders->GetYaxis()->SetBinLabel(1, "z-size [#mum]");
+          h2_GenErrorHeaders->GetXaxis()->SetBinLabel(tempIndex, "");
+        }
+
+        h2_GenErrorHeaders->GetXaxis()->LabelsOption("h");
+        h2_GenErrorHeaders->GetXaxis()->SetNdivisions(500 + tempSize, false);
+        h2_GenErrorHeaders->GetYaxis()->SetLabelSize(0.05);
+        h2_GenErrorHeaders->SetMarkerSize(1.5);
+
+        canvas.cd();
+        h2_GenErrorHeaders->Draw("TEXT");
+
+        auto ltx = TLatex();
+        ltx.SetTextFont(62);
+        ltx.SetTextColor(kBlue);
+        ltx.SetTextSize(0.045);
+        ltx.SetTextAlign(11);
+        ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                         1 - gPad->GetTopMargin() + 0.01,
+                         (tagname + ", IOV:" + std::to_string(std::get<0>(iov))).c_str());
+
+        std::string fileName(m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+      }
+      return true;
+    }
+
+    float roundoff(float value, unsigned char prec) {
+      float pow_10 = pow(10.0f, (float)prec);
+      return round(value * pow_10) / pow_10;
+    }
+  };
+
+
+ /************************************************
+  // testing TH2Poly classes for plotting
+  *************************************************/
+  template <MapType myType>
+  class SiPixelGenErrorIDs
+      : public cond::payloadInspector::PlotImage<SiPixelGenErrorDBObject, cond::payloadInspector::SINGLE_IOV> {
+  public:
+    SiPixelGenErrorIDs()
+        : cond::payloadInspector::PlotImage<SiPixelGenErrorDBObject, cond::payloadInspector::SINGLE_IOV>(
+              "SiPixelGenError ID Values") {}
+
+    bool fill() override {
+      gStyle->SetPalette(kRainBow);
+
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      std::shared_ptr<SiPixelGenErrorDBObject> payload = fetchPayload(std::get<1>(iov));
+
+      if (payload.get()) {
+        // Book the TH2Poly
+        Phase1PixelMaps theMaps("text");
+        if (myType == t_barrel) {
+          theMaps.bookBarrelHistograms("templateIDsBarrel", "IDs", "template IDs");
+          // book the barrel bins of the TH2Poly
+          theMaps.bookBarrelBins("templateIDsBarrel");
+        } else if (myType == t_forward) {
+          theMaps.bookForwardHistograms("templateIDsForward", "IDs", "template IDs");
+          // book the forward bins of the TH2Poly
+          theMaps.bookForwardBins("templateIDsForward");
+        }
+
+        std::map<unsigned int, short> templMap = payload->getGenErrorIDs();
+
+        if (templMap.size() == SiPixelPI::phase0size || templMap.size() > SiPixelPI::phase1size) {
+          edm::LogError("SiPixelGenErrorDBObject_PayloadInspector")
+              << "There are " << templMap.size()
+              << " DetIds in this payload. SiPixelTempateIDs maps are not supported for non-Phase1 Pixel geometries !";
+          TCanvas canvas("Canv", "Canv", 1200, 1000);
+          SiPixelPI::displayNotSupported(canvas, templMap.size());
+          std::string fileName(m_imageFileName);
+          canvas.SaveAs(fileName.c_str());
+          return false;
+        } else {
+          if (templMap.size() < SiPixelPI::phase1size) {
+            edm::LogWarning("SiPixelGenErrorDBObject_PayloadInspector")
+                << "\n ********* WARNING! ********* \n There are " << templMap.size() << " DetIds in this payload !"
+                << "\n **************************** \n";
+          }
+        }
+
+        /*
+        std::vector<unsigned int> detids;
+        std::transform(templMap.begin(),
+                       templMap.end(),
+                       std::back_inserter(detids),
+                       [](const std::map<unsigned int, short>::value_type& pair) { return pair.first; });
+	*/
+
+        for (auto const& entry : templMap) {
+          COUT << "DetID: " << entry.first << " template ID: " << entry.second << std::endl;
+          auto detid = DetId(entry.first);
+          if ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (myType == t_barrel)) {
+            theMaps.fillBarrelBin("templateIDsBarrel", entry.first, entry.second);
+          } else if ((detid.subdetId() == PixelSubdetector::PixelEndcap) && (myType == t_forward)) {
+            theMaps.fillForwardBin("templateIDsForward", entry.first, entry.second);
+          }
+        }
+
+        theMaps.beautifyAllHistograms();
+
+        TCanvas canvas("Canv", "Canv", (myType == t_barrel) ? 1200 : 1500, 1000);
+        if (myType == t_barrel) {
+          theMaps.DrawBarrelMaps("templateIDsBarrel", canvas);
+        } else if (myType == t_forward) {
+          theMaps.DrawForwardMaps("templateIDsForward", canvas);
+        }
+
+        canvas.cd();
+
+        std::string fileName(m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+      }
+      return true;
+    }
+  };
+
+  using SiPixelGenErrorIDsBPixMap = SiPixelGenErrorIDs<t_barrel>;
+  using SiPixelGenErrorIDsFPixMap = SiPixelGenErrorIDs<t_forward>;
+
+}
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(SiPixelGenErrorDBObject) {
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorHeaderTable);
+  //PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorDBObjectTest);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorIDsBPixMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorIDsFPixMap);
+}

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc
@@ -59,6 +59,8 @@ namespace {
               "SiPixelGenErrorDBObject Header summary") {}
 
     bool fill() override {
+      gStyle->SetHistMinimumZero();  // will display zero as zero in the text map
+
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
       auto tagname = tag.name;
@@ -93,7 +95,10 @@ namespace {
         for (const auto& theTemp : thePixelTemp_ | boost::adaptors::indexed(1)) {
           auto tempValue = theTemp.value();
           auto tempIndex = theTemp.index();
-          float uH = roundoff(tempValue.head.lorxwidth / tempValue.head.zsize / tempValue.head.Bfield, 4);
+          float uH = -99.;
+          if (tempValue.head.Bfield != 0.) {
+            uH = roundoff(tempValue.head.lorxwidth / tempValue.head.zsize / tempValue.head.Bfield, 4);
+          }
           h2_GenErrorHeaders->SetBinContent(tempIndex, 6, tempValue.head.ID);
           h2_GenErrorHeaders->SetBinContent(tempIndex, 5, tempValue.head.Bfield);
           h2_GenErrorHeaders->SetBinContent(tempIndex, 4, uH);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -119,6 +119,8 @@ namespace {
               "SiPixelTemplateDBObject Header summary") {}
 
     bool fill() override {
+      gStyle->SetHistMinimumZero();  // will display zero as zero in the text map
+
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
       auto tagname = tag.name;
@@ -153,7 +155,10 @@ namespace {
         for (const auto& theTemp : thePixelTemp_ | boost::adaptors::indexed(1)) {
           auto tempValue = theTemp.value();
           auto tempIndex = theTemp.index();
-          float uH = roundoff(tempValue.head.lorxwidth / tempValue.head.zsize / tempValue.head.Bfield, 4);
+          float uH = -99.;
+          if (tempValue.head.Bfield != 0.) {
+            uH = roundoff(tempValue.head.lorxwidth / tempValue.head.zsize / tempValue.head.Bfield, 4);
+          }
           h2_TemplateHeaders->SetBinContent(tempIndex, 6, tempValue.head.ID);
           h2_TemplateHeaders->SetBinContent(tempIndex, 5, tempValue.head.Bfield);
           h2_TemplateHeaders->SetBinContent(tempIndex, 4, uH);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -48,8 +48,6 @@
 
 namespace {
 
-  enum MapType { t_barrel = 0, t_forward = 1 };
-
   /************************************************
     test class
   *************************************************/
@@ -203,7 +201,7 @@ namespace {
   /************************************************
   // testing TH2Poly classes for plotting
   *************************************************/
-  template <MapType myType>
+  template <SiPixelPI::DetType myType>
   class SiPixelTemplateLA
       : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV> {
     struct header_info {
@@ -267,10 +265,10 @@ namespace {
         // Book the TH2Poly
         Phase1PixelMaps theMaps("COLZ L");
 
-        if (myType == t_barrel) {
+        if (myType == SiPixelPI::t_barrel) {
           theMaps.bookBarrelHistograms("templateLABarrel", "#muH", "#mu_{H} [1/T]");
           theMaps.bookBarrelBins("templateLABarrel");
-        } else if (myType == t_forward) {
+        } else if (myType == SiPixelPI::t_forward) {
           theMaps.bookForwardHistograms("templateLAForward", "#muH", "#mu_{H} [1/T]");
           theMaps.bookForwardBins("templateLAForward");
         }
@@ -303,19 +301,19 @@ namespace {
                << " B-field: " << theInfos[entry.second].Bfield << std::endl;
 
           auto detid = DetId(entry.first);
-          if ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (myType == t_barrel)) {
+          if ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (myType == SiPixelPI::t_barrel)) {
             theMaps.fillBarrelBin("templateLABarrel", entry.first, uH);
-          } else if ((detid.subdetId() == PixelSubdetector::PixelEndcap) && (myType == t_forward)) {
+          } else if ((detid.subdetId() == PixelSubdetector::PixelEndcap) && (myType == SiPixelPI::t_forward)) {
             theMaps.fillForwardBin("templateLAForward", entry.first, uH);
           }
         }
 
         theMaps.beautifyAllHistograms();
 
-        TCanvas canvas("Canv", "Canv", (myType == t_barrel) ? 1200 : 1600, 1000);
-        if (myType == t_barrel) {
+        TCanvas canvas("Canv", "Canv", (myType == SiPixelPI::t_barrel) ? 1200 : 1600, 1000);
+        if (myType == SiPixelPI::t_barrel) {
           theMaps.DrawBarrelMaps("templateLABarrel", canvas);
-        } else if (myType == t_forward) {
+        } else if (myType == SiPixelPI::t_forward) {
           theMaps.DrawForwardMaps("templateLAForward", canvas);
         }
 
@@ -327,13 +325,13 @@ namespace {
     }  // fill
   };
 
-  using SiPixelTemplateLABPixMap = SiPixelTemplateLA<t_barrel>;
-  using SiPixelTemplateLAFPixMap = SiPixelTemplateLA<t_forward>;
+  using SiPixelTemplateLABPixMap = SiPixelTemplateLA<SiPixelPI::t_barrel>;
+  using SiPixelTemplateLAFPixMap = SiPixelTemplateLA<SiPixelPI::t_forward>;
 
   /************************************************
   // testing TH2Poly classes for plotting
   *************************************************/
-  template <MapType myType>
+  template <SiPixelPI::DetType myType>
   class SiPixelTemplateIDs
       : public cond::payloadInspector::PlotImage<SiPixelTemplateDBObject, cond::payloadInspector::SINGLE_IOV> {
   public:
@@ -351,12 +349,12 @@ namespace {
       if (payload.get()) {
         // Book the TH2Poly
         Phase1PixelMaps theMaps("text");
-        if (myType == t_barrel) {
-          theMaps.bookBarrelHistograms("templateIDsBarrel", "IDs", "template IDs");
+        if (myType == SiPixelPI::t_barrel) {
+          theMaps.bookBarrelHistograms("templateIDsBarrel", "templateIDs", "template IDs");
           // book the barrel bins of the TH2Poly
           theMaps.bookBarrelBins("templateIDsBarrel");
-        } else if (myType == t_forward) {
-          theMaps.bookForwardHistograms("templateIDsForward", "IDs", "template IDs");
+        } else if (myType == SiPixelPI::t_forward) {
+          theMaps.bookForwardHistograms("templateIDsForward", "templateIDs", "template IDs");
           // book the forward bins of the TH2Poly
           theMaps.bookForwardBins("templateIDsForward");
         }
@@ -391,19 +389,19 @@ namespace {
         for (auto const& entry : templMap) {
           COUT << "DetID: " << entry.first << " template ID: " << entry.second << std::endl;
           auto detid = DetId(entry.first);
-          if ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (myType == t_barrel)) {
+          if ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (myType == SiPixelPI::t_barrel)) {
             theMaps.fillBarrelBin("templateIDsBarrel", entry.first, entry.second);
-          } else if ((detid.subdetId() == PixelSubdetector::PixelEndcap) && (myType == t_forward)) {
+          } else if ((detid.subdetId() == PixelSubdetector::PixelEndcap) && (myType == SiPixelPI::t_forward)) {
             theMaps.fillForwardBin("templateIDsForward", entry.first, entry.second);
           }
         }
 
         theMaps.beautifyAllHistograms();
 
-        TCanvas canvas("Canv", "Canv", (myType == t_barrel) ? 1200 : 1500, 1000);
-        if (myType == t_barrel) {
+        TCanvas canvas("Canv", "Canv", (myType == SiPixelPI::t_barrel) ? 1200 : 1500, 1000);
+        if (myType == SiPixelPI::t_barrel) {
           theMaps.DrawBarrelMaps("templateIDsBarrel", canvas);
-        } else if (myType == t_forward) {
+        } else if (myType == SiPixelPI::t_forward) {
           theMaps.DrawForwardMaps("templateIDsForward", canvas);
         }
 
@@ -416,8 +414,8 @@ namespace {
     }
   };
 
-  using SiPixelTemplateIDsBPixMap = SiPixelTemplateIDs<t_barrel>;
-  using SiPixelTemplateIDsFPixMap = SiPixelTemplateIDs<t_forward>;
+  using SiPixelTemplateIDsBPixMap = SiPixelTemplateIDs<SiPixelPI::t_barrel>;
+  using SiPixelTemplateIDsFPixMap = SiPixelTemplateIDs<SiPixelPI::t_forward>;
 
 }  // namespace
 

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -5,6 +5,7 @@
 #include "CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc"
+#include "CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
@@ -163,6 +164,22 @@ int main(int argc, char** argv) {
   SiPixelVCalOffsetValuesEndcap histo22;
   histo22.process("frontier://FrontierPrep/CMS_CONDITIONS", PI::mk_input(tag, 1, 1));
   edm::LogPrint("testSiPixelPayloadInspector") << histo22.data() << std::endl;
+
+  // SiPixelGenErrors
+
+  tag = "SiPixelGenErrorDBObject_phase1_BoR3_HV350_Tr2000";
+  start = boost::lexical_cast<unsigned long long>(1);
+  end = boost::lexical_cast<unsigned long long>(1);
+
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising SiPixelGenErrors plots " << std::endl;
+
+  SiPixelGenErrorHeaderTable histo23;
+  histo23.process(connectionString, PI::mk_input(tag, end, end));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo23.data() << std::endl;
+
+  SiPixelGenErrorIDsBPixMap histo24;
+  histo24.process(connectionString, PI::mk_input(tag, end, end));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo24.data() << std::endl;
 
   inputs.clear();
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
#### PR description:

This PR adds few payload inspector classes for the `SiPixelGenErrorDBObject` `CondFormat`.
In addition few improvements are implemented for the `SiPixelTemplateDBObject` one.  
Unit tests are updated accordingly.

#### PR validation:

Relies on the existing and extended unit tests.
Example of output plot obtainable with these changes:

![image](https://user-images.githubusercontent.com/5082376/89180837-dee96280-d592-11ea-91ea-8b6d0ebb719c.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, and no backport is needed.
cc:
@tvami 

