### PR TITLE
Fix to enable hpsPFTauDiscriminationByDeadECALElectronRejection in run2 reminiAODs (10_6_X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -395,26 +395,23 @@ def miniAOD_customizeCommon(process):
                           deepTauIDTaskNew_)
 
     #-- Adding tauID against dead ECal towers to taus
-    process.hpsPFTauDiscriminationByDeadECALElectronRejectionForMiniAOD = \
-        process.hpsPFTauDiscriminationByDeadECALElectronRejection.clone(
-            extrapolateToECalEntrance = True
-        )
+    # note: default (AOD) behoviour of the tauID modified (leading track
+    #       extrapolation to ECAL enabled) in the HPS PFTau master
+    #       configuration for this era.
     _makePatTausTaskWithDeadECalVeto = process.makePatTausTask.copy()
     _makePatTausTaskWithDeadECalVeto.add(
-        process.hpsPFTauDiscriminationByDeadECALElectronRejectionForMiniAOD
+        process.hpsPFTauDiscriminationByDeadECALElectronRejection
     )
     run2_miniAOD_UL.toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithDeadECalVeto
     )
     _withDeadEcalTauIDPs = cms.PSet(
         process.patTaus.tauIDSources,
-        againstElectronDeadECAL = cms.InputTag("hpsPFTauDiscriminationByDeadECALElectronRejectionForMiniAOD")
+        againstElectronDeadECAL = cms.InputTag("hpsPFTauDiscriminationByDeadECALElectronRejection")
     )
     run2_miniAOD_UL.toModify(process.patTaus,
                              tauIDSources = _withDeadEcalTauIDPs)
     #... and to boosted taus
-    run2_miniAOD_UL.toModify(process.hpsPFTauDiscriminationByDeadECALElectronRejectionBoosted,
-                             extrapolateToECalEntrance = True)
     _withDeadEcalTauIDBoostedPs = cms.PSet(
         process.patTausBoosted.tauIDSources,
         againstElectronDeadECAL = cms.InputTag("hpsPFTauDiscriminationByDeadECALElectronRejectionBoosted")

--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import copy
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
 
 '''
 
@@ -303,6 +304,11 @@ hpsPFTauDiscriminationByDeadECALElectronRejection = pfRecoTauDiscriminationAgain
     Prediscriminants = requireDecayMode.clone(),
     extrapolateToECalEntrance = cms.bool(False)
 )
+run2_miniAOD_devel.toModify(
+    hpsPFTauDiscriminationByDeadECALElectronRejection,
+    extrapolateToECalEntrance = True
+)
+
 ## ByMVA6rawElectronRejection
 hpsPFTauDiscriminationByMVA6rawElectronRejection = pfRecoTauDiscriminationAgainstElectronMVA6.clone(
     PFTauProducer = cms.InputTag('hpsPFTauProducer'),

--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import copy
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
 '''
 
@@ -304,7 +304,7 @@ hpsPFTauDiscriminationByDeadECALElectronRejection = pfRecoTauDiscriminationAgain
     Prediscriminants = requireDecayMode.clone(),
     extrapolateToECalEntrance = cms.bool(False)
 )
-run2_miniAOD_devel.toModify(
+run2_miniAOD_UL.toModify(
     hpsPFTauDiscriminationByDeadECALElectronRejection,
     extrapolateToECalEntrance = True
 )


### PR DESCRIPTION
#### PR description:

Changes to fix the 10_6_X-related part of https://github.com/cms-sw/cmssw/issues/31015 issue:
* Move era-dependent modification of the anti-electron-in-deadECal tauID from miniAOD to the HPS PFTau master configuration;
* Run such a modified tauID as part of the `makePatTausTask` within miniAOD sequence rather than its copy.

Introduced changes modify a bit logic of python configurations, but are expected to **not change** outputs.

#### PR validation:

Validated with configuration produced with the following cmsDriver command (with and without `run2_miniAOD_devel` era):
```
cmsDriver miniAOD2016 --filein /store/relval/CMSSW_10_6_12/RelValZTT_13UP16/AODSIM/PU25ns_106X_mcRun2_asymptotic_v13_hltul16_postVFP-v1/20000/157664D1-7172-C346-A158-010C1A5FEEFC.root file:MiniAOD2016.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions auto:run2_mc --step PAT --nThreads 4 --geometry DB:Extended --scenario pp --era Run2_2016,run2_miniAOD_devel -n -1 --no_exec
```
