### PR TITLE
Fix to enable hpsPFTauDiscriminationByDeadECALElectronRejection in run2 reminiAODs

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -375,27 +375,16 @@ def miniAOD_customizeCommon(process):
         process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2.PATTauProducer=_noUpdatedTauName
         task.add(process.rerunIsolationMVADBnewDMwLTPhase2Task)
 
-    #-- Rerun tauID against dead ECal towers to taus for the run2_miniAOD_UL era
+    #-- Rerun tauID against dead ECal towers to taus for the various re-MiniAOD eras
     # to enable default behoviour with leading track extrapolation to ECAL
     _makePatTausTaskWithDeadECalVeto = process.makePatTausTask.copy()
     _makePatTausTaskWithDeadECalVeto.add(
         process.hpsPFTauDiscriminationByDeadECALElectronRejection
     )
-    run2_miniAOD_UL.toReplaceWith(
+    _run2_miniAOD_ANY = (run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL)
+    _run2_miniAOD_ANY.toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithDeadECalVeto
     )
-    #... and remove this tauID for other eras from list of sources to preserve
-    #    an original setup
-    _withoutDeadEcalTauIDPs = process.patTaus.tauIDSources.clone()
-    del _withoutDeadEcalTauIDPs.againstElectronDeadECAL
-    (run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17).toModify(
-        process.patTaus, tauIDSources = _withoutDeadEcalTauIDPs
-        )
-    _withoutDeadEcalTauIDBoostedPs = process.patTausBoosted.tauIDSources.clone()
-    del _withoutDeadEcalTauIDBoostedPs.againstElectronDeadECAL
-    (run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17).toModify(
-        process.patTausBoosted, tauIDSources = _withoutDeadEcalTauIDBoostedPs
-        )
 
     #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()
@@ -410,7 +399,6 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
     _rerun_puppijets_task = task.copy()
     _rerun_puppijets_task.add(process.puppi, process.ak4PFJetsPuppi)
-    _run2_miniAOD_ANY = (run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL)
     (_run2_miniAOD_ANY | pA_2016 | pp_on_AA_2018).toReplaceWith(task, _rerun_puppijets_task)
 
     from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -375,6 +375,28 @@ def miniAOD_customizeCommon(process):
         process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2.PATTauProducer=_noUpdatedTauName
         task.add(process.rerunIsolationMVADBnewDMwLTPhase2Task)
 
+    #-- Rerun tauID against dead ECal towers to taus for the run2_miniAOD_UL era
+    # to enable default behoviour with leading track extrapolation to ECAL
+    _makePatTausTaskWithDeadECalVeto = process.makePatTausTask.copy()
+    _makePatTausTaskWithDeadECalVeto.add(
+        process.hpsPFTauDiscriminationByDeadECALElectronRejection
+    )
+    run2_miniAOD_UL.toReplaceWith(
+        process.makePatTausTask, _makePatTausTaskWithDeadECalVeto
+    )
+    #... and remove this tauID for other eras from list of sources to preserve
+    #    an original setup
+    _withoutDeadEcalTauIDPs = process.patTaus.tauIDSources.clone()
+    del _withoutDeadEcalTauIDPs.againstElectronDeadECAL
+    (run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17).toModify(
+        process.patTaus, tauIDSources = _withoutDeadEcalTauIDPs
+        )
+    _withoutDeadEcalTauIDBoostedPs = process.patTausBoosted.tauIDSources.clone()
+    del _withoutDeadEcalTauIDBoostedPs.againstElectronDeadECAL
+    (run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17).toModify(
+        process.patTausBoosted, tauIDSources = _withoutDeadEcalTauIDBoostedPs
+        )
+
     #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()
     _makePatTausTaskWithTauReReco.add(process.PFTauTask)


### PR DESCRIPTION
#### PR description:
Changes to fix the master/11_2_X-related part of https://github.com/cms-sw/cmssw/issues/31015 issue:
* Rerun the anti-electron-in-deadECal tauID with any of  `run2_miniAOD_80XLegacy`, `run2_miniAOD_94XFall17`, `run2_miniAOD_UL` re-miniAOD modifiers to enable desired behaviour with leading track extrapolation to the ECal surface.

Introduced changes are expected to:
* not change output when run for non-reminiAOD eras/modifiers,
* modify considered tauID with any of  `run2_miniAOD_80XLegacy`, `run2_miniAOD_94XFall17`, `run2_miniAOD_UL` re-miniAOD modifers.

#### PR validation:

`runTheMatrix.py -l limited -i all` successful

Checks with custom configurations for miniAOD production (with cmsDriver) that setups with considered modifiers are as expected.
