### PR TITLE
Add missing GEN fragment for relvals

### DIFF
--- a/Configuration/Generator/python/H125GGgluonfusion_13TeV_TuneCP5_cfi.py
+++ b/Configuration/Generator/python/H125GGgluonfusion_13TeV_TuneCP5_cfi.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         # put here the efficiency of your filter (1. if no filter)
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         # put here the cross section of your process (in pb)
+                         crossSection = cms.untracked.double(0.05),
+                         comEnergy = cms.double(13000.0),
+                         maxEventsToPrint = cms.untracked.int32(3),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,                     
+        processParameters = cms.vstring(
+            'HiggsSM:gg2H = on',
+            '25:onMode = off',
+            '25:onIfMatch = 22 22',
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+        )
+                         )
+


### PR DESCRIPTION
#### PR description:
Add missing GEN fragment H125GGgluonfusion_13TeV_TuneCP5_cfi for relvals. It is part of the upgradeWorkflowComponent
`('H125GGgluonfusion_13TeV_TuneCP5_cfi', UpgradeFragment(Kby(9,50),'H125GGgluonfusion_13')),`

https://github.com/cms-sw/cmssw/blob/master/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py#L1069

#### PR validation:
`runTheMatrix.py --what upgrade -l 10848.0 --wm init`
looks OK.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No backport is needed
