### PR TITLE
Selector by region

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
@@ -17,10 +17,10 @@
 class TrackSelectorByRegion final : public edm::global::EDProducer<> {
 public:
   explicit TrackSelectorByRegion(const edm::ParameterSet& conf)
-      : tracksToken_(consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracks"))) {
-    inputTrkRegionToken_ = consumes<edm::OwnVector<TrackingRegion>>(conf.getParameter<edm::InputTag>("regions"));
-    produce_collection = conf.getParameter<bool>("produceTrackCollection");
-    produce_mask = conf.getParameter<bool>("produceMask");
+      : produce_collection(conf.getParameter<bool>("produceTrackCollection")),
+        produce_mask(conf.getParameter<bool>("produceMask")),
+        tracksToken_(consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracks"))),
+        inputTrkRegionToken_(consumes<edm::OwnVector<TrackingRegion>>(conf.getParameter<edm::InputTag>("regions"))) {
     if (produce_collection)
       produces<reco::TrackCollection>();
     if (produce_mask)
@@ -47,34 +47,32 @@ private:
     auto tracksHandle = iEvent.getHandle(tracksToken_);
 
     const auto& tracks = *tracksHandle;
-    auto mask = std::make_unique<MaskCollection>(tracks.size(), false);
+    auto mask = std::make_unique<MaskCollection>(tracks.size(), false);  // output mask
     const auto& regions = *regionsHandle;
 
-    for (auto const& region: regions) {
+    for (auto const& region : regions) {
       auto const& region_mask = region.checkTracks(tracks);
       for (size_t i = 0; i < region_mask.size(); ++i) {
         mask->at(i) = mask->at(i) or region_mask[i];
       }
     }
 
-    if (produce_mask) {
-      iEvent.put(std::move(mask));
-    }
-
     if (produce_collection) {
       auto output_tracks = std::make_unique<reco::TrackCollection>();  // selected output collection
       size_t size = 0;
       for (size_t i = 0; i < mask->size(); i++) {
-        if (mask[i])
+        if (mask->at(i))
           ++size;
       }
       output_tracks->reserve(size);
-
       for (size_t i = 0; i < mask->size(); i++) {
-        if (mask[i])
+        if (mask->at(i))
           output_tracks->push_back(tracks[i]);
       }
       iEvent.put(std::move(output_tracks));
+    }
+    if (produce_mask) {
+      iEvent.put(std::move(mask));
     }
   }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
@@ -1,0 +1,83 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+
+#include <vector>
+#include <memory>
+
+class TrackSelectorByRegion final : public edm::global::EDProducer<> {
+public:
+  explicit TrackSelectorByRegion(const edm::ParameterSet& conf)
+      : tracksToken_(consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracks"))) {
+    inputTrkRegionToken_ = consumes<edm::OwnVector<TrackingRegion>>(conf.getParameter<edm::InputTag>("regions"));
+    produce_collection = conf.getParameter<bool>("produceTrackCollection");
+    produce_mask = conf.getParameter<bool>("produceMask");
+    if (produce_collection)
+      produces<reco::TrackCollection>();
+    if (produce_mask)
+      produces<std::vector<bool>>();
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("tracks", edm::InputTag("hltPixelTracks"));
+    desc.add<edm::InputTag>("regions", edm::InputTag(""));
+    desc.add<bool>("produceTrackCollection", true);
+    desc.add<bool>("produceMask", true);
+    descriptions.add("trackSelectorByRegion", desc);
+  }
+
+private:
+  using MaskCollection = std::vector<bool>;
+
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const override {
+    if (not produce_collection)
+      if (not produce_mask)
+        return;
+    // products
+    auto mask = std::make_unique<MaskCollection>();                  // mask w/ the same size of the input collection
+    auto output_tracks = std::make_unique<reco::TrackCollection>();  // selected output collection
+
+    auto regionsHandle = iEvent.getHandle(inputTrkRegionToken_);
+    auto tracksHandle = iEvent.getHandle(tracksToken_);
+
+    const auto& tracks = *tracksHandle;
+    mask->assign(tracks.size(), false);
+    const auto& regions = *regionsHandle;
+
+    for (const auto& region : regions)
+      if (const auto* roi = dynamic_cast<const TrackingRegion*>(&region)) {
+        auto amask = roi->checkTracks(tracks);
+        for (size_t it = 0; it < amask.size(); it++) {
+          mask->at(it) = mask->at(it) or amask.at(it);
+        }
+      }
+
+    if (produce_collection)
+      for (size_t it = 0; it < mask->size(); it++)
+        if (mask->at(it))
+          output_tracks->push_back(tracks[it]);
+
+    if (produce_mask)
+      iEvent.put(std::move(mask));
+    if (produce_collection)
+      iEvent.put(std::move(output_tracks));
+  }
+  bool produce_collection;
+  bool produce_mask;
+  edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+  edm::EDGetTokenT<edm::OwnVector<TrackingRegion>> inputTrkRegionToken_;
+};
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TrackSelectorByRegion);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
@@ -51,11 +51,7 @@ private:
     const auto& regions = *regionsHandle;
 
     for (auto const& region : regions) {
-      auto const& region_mask = region.checkTracks(tracks);
-      assert(mask->size() == region_mask.size());
-      for (size_t i = 0; i < region_mask.size(); ++i) {
-        (*mask)[i] = (*mask)[i] or region_mask[i];
-      }
+      region.checkTracks(tracks, *mask);
     }
 
     if (produce_collection) {

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
@@ -94,6 +94,10 @@ public:
     return nullptr;
   }
 
+  /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
+  /// Does not reset the elements corresponding to the tracks that are not compatible.
+  void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const override;
+
   std::unique_ptr<TrackingRegion> clone() const override { return std::make_unique<CosmicTrackingRegion>(*this); }
 
   std::string name() const override { return "CosmicTrackingRegion"; }

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
@@ -25,7 +25,7 @@ namespace {
 using namespace std;
 
 void CosmicTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
-  math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+  const math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
 
   assert(mask.size() == tracks.size());
   int i = -1;

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
@@ -24,6 +24,30 @@ namespace {
 
 using namespace std;
 
+void CosmicTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
+  math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+
+  assert(mask.size() == tracks.size());
+  int i = -1;
+  for (auto const& track : tracks) {
+    i++;
+    if (mask[i])
+      continue;
+
+    if (track.pt() < ptMin()) {
+      continue;
+    }
+    if (std::abs(track.dxy(regOrigin)) > originRBound()) {
+      continue;
+    }
+    if (std::abs(track.dz(regOrigin)) > originZBound()) {
+      continue;
+    }
+
+    mask[i] = true;
+  }
+}
+
 TrackingRegion::Hits CosmicTrackingRegion::hits(const edm::EventSetup& es,
                                                 const SeedingLayerSetsHits::SeedingLayer& layer) const {
   TrackingRegion::Hits result;

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -52,8 +52,8 @@ public:
                                               float dr = 0,
                                               float dz = 0) const override;
 
-  /// return a mask over a track collection reflecting the compatability to the GlobalTrackingRegion
-  std::vector<bool> checkTracks(reco::TrackCollection const& InputCollection) const override;
+  /// updates an existing mask over a track collection reflecting the compatability to the GlobalTrackingRegion
+  void checkTracks(reco::TrackCollection const& InputCollection, std::vector<bool>& mask) const override;
 
   std::unique_ptr<TrackingRegion> clone() const override { return std::make_unique<GlobalTrackingRegion>(*this); }
 

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -52,6 +52,9 @@ public:
                                               float dr = 0,
                                               float dz = 0) const override;
 
+  /// return a mask over a track collection reflecting the compatability to the GlobalTrackingRegion
+  std::vector<bool> checkTracks(reco::TrackCollection const& InputCollection) const override;
+
   std::unique_ptr<TrackingRegion> clone() const override { return std::make_unique<GlobalTrackingRegion>(*this); }
 
   std::string name() const override { return "GlobalTrackingRegion"; }

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -52,8 +52,9 @@ public:
                                               float dr = 0,
                                               float dz = 0) const override;
 
-  /// updates an existing mask over a track collection reflecting the compatability to the GlobalTrackingRegion
-  void checkTracks(reco::TrackCollection const& InputCollection, std::vector<bool>& mask) const override;
+  /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
+  /// Does not reset the elements corresponding to the tracks that are not compatible.
+  void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const override;
 
   std::unique_ptr<TrackingRegion> clone() const override { return std::make_unique<GlobalTrackingRegion>(*this); }
 

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -175,8 +175,8 @@ public:
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
-  /// return a mask over a track collection reflecting the compatability to the RectangularEtaPhiTrackingRegion
-  std::vector<bool> checkTracks(reco::TrackCollection const& InputCollection) const override;
+  /// updates an existing mask over a track collection reflecting the compatability to the RectangularEtaPhiTrackingRegion
+  void checkTracks(reco::TrackCollection const& InputCollection, std::vector<bool>& mask) const override;
 
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -175,8 +175,9 @@ public:
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
-  /// updates an existing mask over a track collection reflecting the compatability to the RectangularEtaPhiTrackingRegion
-  void checkTracks(reco::TrackCollection const& InputCollection, std::vector<bool>& mask) const override;
+  /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
+  /// Does not reset the elements corresponding to the tracks that are not compatible.
+  void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const override;
 
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -175,6 +175,9 @@ public:
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
+  /// return a mask over a track collection reflecting the compatability to the RectangularEtaPhiTrackingRegion
+  std::vector<bool> checkTracks(reco::TrackCollection const& InputCollection) const override;
+
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,
                                               const edm::EventSetup& iSetup,

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -19,6 +19,9 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
 #include <utility>
 
 #include <sstream>
@@ -95,6 +98,9 @@ public:
 
   /// get hits from layer compatible with region constraints
   virtual Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
+
+  /// return a mask over a track collection reflecting the compatability to the region
+  virtual std::vector<bool> checkTracks(reco::TrackCollection const& InputCollection) const = 0;
 
   /// clone region with new vertex position
   std::unique_ptr<TrackingRegion> restrictedRegion(const GlobalPoint& originPos,

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -99,12 +99,14 @@ public:
   /// get hits from layer compatible with region constraints
   virtual Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
 
-  /// updates an existing  mask over a track collection reflecting the compatability to the region
-  virtual void checkTracks(reco::TrackCollection const& InputCollection, std::vector<bool>& mask) const = 0;
+  /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
+  /// Does not reset the elements corresponding to the tracks that are not compatible.
+  virtual void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const = 0;
 
-  std::vector<bool> checkTracks(reco::TrackCollection const& InputCollection) const {
-    std::vector<bool> region_mask(InputCollection.size(), false);
-    checkTracks(InputCollection, region_mask);
+  /// retutns a boolean mask over the TrackCollection reflecting the comapatbility of each track with the region constraints
+  std::vector<bool> checkTracks(reco::TrackCollection const& tracks) const {
+    std::vector<bool> region_mask(tracks.size(), false);
+    checkTracks(tracks, region_mask);
     return region_mask;
   }
   /// clone region with new vertex position

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -103,7 +103,7 @@ public:
   /// Does not reset the elements corresponding to the tracks that are not compatible.
   virtual void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const = 0;
 
-  /// retutns a boolean mask over the TrackCollection reflecting the comapatbility of each track with the region constraints
+  /// return a boolean mask over the TrackCollection reflecting the compatibility of each track with the region constraints
   std::vector<bool> checkTracks(reco::TrackCollection const& tracks) const {
     std::vector<bool> region_mask(tracks.size(), false);
     checkTracks(tracks, region_mask);

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -99,9 +99,14 @@ public:
   /// get hits from layer compatible with region constraints
   virtual Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
 
-  /// return a mask over a track collection reflecting the compatability to the region
-  virtual std::vector<bool> checkTracks(reco::TrackCollection const& InputCollection) const = 0;
+  /// updates an existing  mask over a track collection reflecting the compatability to the region
+  virtual void checkTracks(reco::TrackCollection const& InputCollection, std::vector<bool>& mask) const = 0;
 
+  std::vector<bool> checkTracks(reco::TrackCollection const& InputCollection) const {
+    std::vector<bool> region_mask(InputCollection.size(), false);
+    checkTracks(InputCollection, region_mask);
+    return region_mask;
+  }
   /// clone region with new vertex position
   std::unique_ptr<TrackingRegion> restrictedRegion(const GlobalPoint& originPos,
                                                    const float& originRBound,

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -113,13 +113,12 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
   }
 }
 
-void GlobalTrackingRegion::checkTracks(reco::TrackCollection const& InputCollection, std::vector<bool>& mask) const {
+void GlobalTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
   math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
-  if (mask.size() < InputCollection.size())
-    mask.resize(InputCollection.size(), false);
 
+  assert(mask.size() == tracks.size());
   int i = -1;
-  for (auto const& track : InputCollection) {
+  for (auto const& track : tracks) {
     i++;
     if (mask[i])
       continue;

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -42,14 +42,13 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
   bool isBarrel = layer->isBarrel();
   bool isPixel = (layer->subDetector() == PixelBarrel || layer->subDetector() == PixelEndcap);
 
-  if
-    UNLIKELY(!outerlayer) {
-      GlobalPoint ohit = outerHit->globalPosition();
-      lr = std::sqrt(sqr(ohit.x() - origin().x()) + sqr(ohit.y() - origin().y()));
-      gz = ohit.z();
-      dr = outerHit->errorGlobalR();
-      dz = outerHit->errorGlobalZ();
-    }
+  if UNLIKELY (!outerlayer) {
+    GlobalPoint ohit = outerHit->globalPosition();
+    lr = std::sqrt(sqr(ohit.x() - origin().x()) + sqr(ohit.y() - origin().y()));
+    gz = ohit.z();
+    dr = outerHit->errorGlobalR();
+    dz = outerHit->errorGlobalZ();
+  }
 
   PixelRecoPointRZ outerred(lr, gz);
 
@@ -60,12 +59,11 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
                               ? PixelRecoPointRZ(-originRBound(), origin().z() - originZBound())
                               : PixelRecoPointRZ(originRBound(), origin().z() - originZBound());
 
-  if
-    UNLIKELY((!thePrecise) && (isPixel)) {
-      auto VcotMin = PixelRecoLineRZ(vtxR, outerred).cotLine();
-      auto VcotMax = PixelRecoLineRZ(vtxL, outerred).cotLine();
-      return std::make_unique<HitEtaCheck>(isBarrel, outerred, VcotMax, VcotMin);
-    }
+  if UNLIKELY ((!thePrecise) && (isPixel)) {
+    auto VcotMin = PixelRecoLineRZ(vtxR, outerred).cotLine();
+    auto VcotMax = PixelRecoLineRZ(vtxL, outerred).cotLine();
+    return std::make_unique<HitEtaCheck>(isBarrel, outerred, VcotMax, VcotMin);
+  }
 
   constexpr float nSigmaPhi = 3.;
 
@@ -90,28 +88,49 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
   SimpleLineRZ rightLine(vtxR, outerR);
   HitRZConstraint rzConstraint(leftLine, rightLine);
 
-  if
-    UNLIKELY(theUseMS) {
-      MultipleScatteringParametrisation iSigma(layer, iSetup);
-      PixelRecoPointRZ vtxMean(0., origin().z());
+  if UNLIKELY (theUseMS) {
+    MultipleScatteringParametrisation iSigma(layer, iSetup);
+    PixelRecoPointRZ vtxMean(0., origin().z());
 
-      float innerScatt = 3.f * (outerlayer ? iSigma(ptMin(), vtxMean, outerred, outerlayer->seqNum())
-                                           : iSigma(ptMin(), vtxMean, outerred));
+    float innerScatt = 3.f * (outerlayer ? iSigma(ptMin(), vtxMean, outerred, outerlayer->seqNum())
+                                         : iSigma(ptMin(), vtxMean, outerred));
 
-      float cotTheta = SimpleLineRZ(vtxMean, outerred).cotLine();
+    float cotTheta = SimpleLineRZ(vtxMean, outerred).cotLine();
 
-      if (isBarrel) {
-        float sinTheta = 1 / std::sqrt(1 + sqr(cotTheta));
-        corr = innerScatt / sinTheta + dz;
-      } else {
-        float cosTheta = 1 / std::sqrt(1 + sqr(1 / cotTheta));
-        corr = innerScatt / cosTheta + dr;
-      }
+    if (isBarrel) {
+      float sinTheta = 1 / std::sqrt(1 + sqr(cotTheta));
+      corr = innerScatt / sinTheta + dz;
+    } else {
+      float cosTheta = 1 / std::sqrt(1 + sqr(1 / cotTheta));
+      corr = innerScatt / cosTheta + dr;
     }
+  }
 
   if (isBarrel) {
     return std::make_unique<HitZCheck>(rzConstraint, HitZCheck::Margin(corr, corr));
   } else {
     return std::make_unique<HitRCheck>(rzConstraint, HitRCheck::Margin(corr, corr));
   }
+}
+
+std::vector<bool> GlobalTrackingRegion::checkTracks(reco::TrackCollection const& InputCollection) const {
+  std::vector<bool> mask(InputCollection.size(), false);
+  int it = -1;
+  math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+  for (auto const& track : InputCollection) {
+    it++;
+    if (track.pt() < ptMin()) {
+      continue;
+    }
+    if (std::abs(track.dxy(regOrigin)) > originRBound()) {
+      continue;
+    }
+    if (std::abs(track.dz(regOrigin)) > originZBound()) {
+      continue;
+    }
+
+    mask[it] = true;
+  }
+
+  return mask;
 }

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -114,7 +114,7 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
 }
 
 void GlobalTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
-  math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+  const math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
 
   assert(mask.size() == tracks.size());
   int i = -1;

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -113,12 +113,17 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
   }
 }
 
-std::vector<bool> GlobalTrackingRegion::checkTracks(reco::TrackCollection const& InputCollection) const {
-  std::vector<bool> mask(InputCollection.size(), false);
-  int it = -1;
+void GlobalTrackingRegion::checkTracks(reco::TrackCollection const& InputCollection, std::vector<bool>& mask) const {
   math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+  if (mask.size() < InputCollection.size())
+    mask.resize(InputCollection.size(), false);
+
+  int i = -1;
   for (auto const& track : InputCollection) {
-    it++;
+    i++;
+    if (mask[i])
+      continue;
+
     if (track.pt() < ptMin()) {
       continue;
     }
@@ -129,8 +134,6 @@ std::vector<bool> GlobalTrackingRegion::checkTracks(reco::TrackCollection const&
       continue;
     }
 
-    mask[it] = true;
+    mask[i] = true;
   }
-
-  return mask;
 }

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -32,6 +32,7 @@
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "TrackingTools/KalmanUpdators/interface/EtaPhiMeasurementEstimator.h"
+#include "DataFormats/Math/interface/normalizedPhi.h"
 
 #include <iostream>
 #include <algorithm>
@@ -51,6 +52,9 @@ std::vector<bool> RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollec
   std::vector<bool> mask(InputCollection.size(), false);
   int it = -1;
   math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+  auto phi0 = phiDirection() + 0.5 * (phiMargin().right() - phiMargin().left());
+  auto dphi = 0.5 * (phiMargin().right() + phiMargin().left());
+
   for (auto const& track : InputCollection) {
     it++;
     if (track.pt() < ptMin()) {
@@ -60,7 +64,7 @@ std::vector<bool> RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollec
     if (!etaRange().inside(track.eta())) {
       continue;
     }
-    if (std::abs(reco::deltaPhi(track.phi(), phiDirection())) > phiMargin().right()) {
+    if (std::abs(proxim(track.phi(), phi0) - phi0) > dphi) {
       continue;
     }
     if (std::abs(track.dxy(regOrigin)) > originRBound()) {

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -48,17 +48,14 @@ namespace {
 using namespace PixelRecoUtilities;
 using namespace std;
 
-void RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollection const& InputCollection,
-                                                  std::vector<bool>& mask) const {
+void RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
   math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
   auto phi0 = phiDirection() + 0.5 * (phiMargin().right() - phiMargin().left());
   auto dphi = 0.5 * (phiMargin().right() + phiMargin().left());
 
-  if (mask.size() < InputCollection.size())
-    mask.resize(InputCollection.size(), false);
-
+  assert(mask.size() == tracks.size());
   int i = -1;
-  for (auto const& track : InputCollection) {
+  for (auto const& track : tracks) {
     i++;
     if (mask[i])
       continue;

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -48,19 +48,24 @@ namespace {
 using namespace PixelRecoUtilities;
 using namespace std;
 
-std::vector<bool> RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollection const& InputCollection) const {
-  std::vector<bool> mask(InputCollection.size(), false);
-  int it = -1;
+void RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollection const& InputCollection,
+                                                  std::vector<bool>& mask) const {
   math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
   auto phi0 = phiDirection() + 0.5 * (phiMargin().right() - phiMargin().left());
   auto dphi = 0.5 * (phiMargin().right() + phiMargin().left());
 
+  if (mask.size() < InputCollection.size())
+    mask.resize(InputCollection.size(), false);
+
+  int i = -1;
   for (auto const& track : InputCollection) {
-    it++;
+    i++;
+    if (mask[i])
+      continue;
+
     if (track.pt() < ptMin()) {
       continue;
     }
-
     if (!etaRange().inside(track.eta())) {
       continue;
     }
@@ -73,10 +78,8 @@ std::vector<bool> RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollec
     if (std::abs(track.dz(regOrigin)) > originZBound()) {
       continue;
     }
-    mask[it] = true;
+    mask[i] = true;
   }
-
-  return mask;
 }
 
 RectangularEtaPhiTrackingRegion::UseMeasurementTracker RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -49,7 +49,7 @@ using namespace PixelRecoUtilities;
 using namespace std;
 
 void RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
-  math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+  const math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
   auto phi0 = phiDirection() + 0.5 * (phiMargin().right() - phiMargin().left());
   auto dphi = 0.5 * (phiMargin().right() + phiMargin().left());
 

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -47,6 +47,34 @@ namespace {
 using namespace PixelRecoUtilities;
 using namespace std;
 
+std::vector<bool> RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollection const& InputCollection) const {
+  std::vector<bool> mask(InputCollection.size(), false);
+  int it = -1;
+  math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+  for (auto const& track : InputCollection) {
+    it++;
+    if (track.pt() < ptMin()) {
+      continue;
+    }
+
+    if (!etaRange().inside(track.eta())) {
+      continue;
+    }
+    if (std::abs(reco::deltaPhi(track.phi(), phiDirection())) > phiMargin().right()) {
+      continue;
+    }
+    if (std::abs(track.dxy(regOrigin)) > originRBound()) {
+      continue;
+    }
+    if (std::abs(track.dz(regOrigin)) > originZBound()) {
+      continue;
+    }
+    mask[it] = true;
+  }
+
+  return mask;
+}
+
 RectangularEtaPhiTrackingRegion::UseMeasurementTracker RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(
     const std::string& name) {
   std::string tmp = name;


### PR DESCRIPTION
#### PR description:

Module that can take in a track collection and a tracking region , then produce the subset track collection with tracks that are compliant to the constraints in tracking region

### PR validation:

Results for CMSSW_11_2_0_pre2 , RelValZMM_14

A brief overview :

RvR := Regionally reconstructed tracks passing the selector
GvR := Global pixel tracks passing the selector

####  SUMMARY for TrackingRegion  :  hltIterL3MuonPixelTracksTrackingRegions, TrackCollection  :  hltIterL3MuonPixelTracks
* Total number of events triggered evts    :    15301
* Regionally reconstructed tracks          :    16852
* Total RvR Tracks                         :    16256
* Missed RegReco Tracks in  RvR Tracks     :    596
* Total GvR Tracks                         :    16331
* Matched RegReco Tracks in  GvR Tracks    :    16244
* Missed RegReco Tracks in  GvR Tracks     :    608
* Addtional Tracks in GvR                  :    87

####  SUMMARY for TrackingRegion  :  hltPixelTracksTrackingRegionsL3MuonNoVtx, TrackCollection  :  hltPixelTracksL3MuonNoVtx
* Total number of events triggered evts    :    8242
* Regionally reconstructed tracks          :    216052
* Total RvR Tracks                         :    126371
* Missed RegReco Tracks in  RvR Tracks     :    89681
* Total GvR Tracks                         :    126269
* Matched RegReco Tracks in  GvR Tracks    :    125859
* Missed RegReco Tracks in  GvR Tracks     :    90193
* Addtional Tracks in GvR                  :    410

Plots for the same are attached alongside 
![TrackSelectorByRegion(3)](https://user-images.githubusercontent.com/32837065/90008355-d04d2a80-dcb9-11ea-85c7-d4bb846f2559.png)
![TrackSelectorByRegion(2)](https://user-images.githubusercontent.com/32837065/90008360-d216ee00-dcb9-11ea-93b7-dcf2f3b6a094.png)
![TrackSelectorByRegion(1)](https://user-images.githubusercontent.com/32837065/90008361-d2af8480-dcb9-11ea-88e9-077f5c151873.png)
![TrackSelectorByRegion](https://user-images.githubusercontent.com/32837065/90008364-d3e0b180-dcb9-11ea-8b1e-af754800bb09.png)



