### PR TITLE
Run3-gem46 Make 2 constants public (used in GeometryBuilder)

### DIFF
--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -63,6 +63,8 @@ private:
   static constexpr uint32_t FormatMask = 0x1;
   static constexpr uint32_t kGEMIdFormat = 0x1000000;
   static constexpr uint32_t kMuonIdMask = 0xF0000000;
+
+public:
   static constexpr uint32_t chamberIdMask = ~(RollMask << RollStartBit);
   static constexpr uint32_t superChamberIdMask = chamberIdMask + ~(LayerMask << LayerStartBit);
 

--- a/DataFormats/MuonDetId/interface/ME0DetId.h
+++ b/DataFormats/MuonDetId/interface/ME0DetId.h
@@ -89,6 +89,7 @@ private:
   static const int RollStartBit_ = LayerStartBit_ + LayerNumBits_;
   static const unsigned int RollMask_ = 0X1F;
 
+public:
   static const uint32_t chamberIdMask_ = ~((LayerMask_ << LayerStartBit_) | (RollMask_ << RollStartBit_));
   static const uint32_t layerIdMask_ = ~(RollMask_ << RollStartBit_);
 


### PR DESCRIPTION
#### PR description:

Make 2 constants public (used in GeometryBuilder)

#### PR validation:

Tested using runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special