### PR TITLE
fix premix nano step

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -732,6 +732,8 @@ class UpgradeWorkflowPremix(UpgradeWorkflow):
                 if m:
                     d["--filein"] = filein.replace(m.group(), "step%d_"%(int(m.group("ind"))+1))
             stepDict[stepName][k] = d
+            # run2/3 WFs use Nano (not NanoPU) in PU WF
+            stepDict[self.getStepName(step)][k] = merge([d])
     def condition(self, fragment, stepList, key, hasHarvest):
         if not 'PU' in key:
             return False


### PR DESCRIPTION
#### PR description:

Resolves bug from #30988: Run2/3 workflows use Nano step (rather than NanoPU step), but the premix special workflows were only modifying the input file name for the NanoPU step. The modification is now propagated to the Nano step as well.

#### PR validation:

Checked cmsDriver commands from `runTheMatrix.py -l 11834.99 --dryRun`.