### PR TITLE
migrate from run2_miniAOD_devel to run2_miniAOD_UL for miniAOD setup UL workflows

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -116,8 +116,8 @@ phase2_common.toModify(
     )
 )
 
-from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-run2_miniAOD_devel.toModify(
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+run2_miniAOD_UL.toModify(
     puppi,
     EtaMinUseDeltaZ = 2.4,
     PtMaxCharged = 20.,

--- a/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
@@ -64,9 +64,9 @@ def applyDeepBtagging( process, postfix="" ) :
         'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
         ) + pfDeepBoostedJetTagsAll
     )
-    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-    run2_miniAOD_devel.toModify(_btagDiscriminators, 
-                                names = _btagDiscriminators.names + pfParticleNetJetTagsAll + pfHiggsInteractionNetTagsProbs)
+    from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+    run2_miniAOD_UL.toModify(_btagDiscriminators,
+                             names = _btagDiscriminators.names + pfParticleNetJetTagsAll + pfHiggsInteractionNetTagsProbs)
     updateJetCollection(
        process,
        jetSource = cms.InputTag('slimmedJetsAK8NoDeepTags'),

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -23,6 +23,6 @@ lostTracks = cms.EDProducer("PATLostTracks",
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )
 
-from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-run2_miniAOD_devel.toModify(lostTracks, passThroughCut="pt>2", allowMuonId=True)
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+run2_miniAOD_UL.toModify(lostTracks, passThroughCut="pt>2", allowMuonId=True)
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -55,7 +55,7 @@ def miniAOD_customizeCommon(process):
     process.patElectrons.usePfCandidateMultiMap = True
     process.patElectrons.pfCandidateMultiMap    = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap")
     process.patElectrons.electronIDSources = cms.PSet()
-    run2_miniAOD_devel.toModify( process.patElectrons, getdBFromTrack = True) 
+    run2_miniAOD_UL.toModify( process.patElectrons, getdBFromTrack = True)
     from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
     run2_miniAOD_80XLegacy.toModify(process.patElectrons,
                                     addPFClusterIso = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -30,7 +30,7 @@ def miniAOD_customizeCommon(process):
     process.patMuons.computeSoftMuonMVA = True
 
     process.patMuons.addTriggerMatching = True
-    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+    from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
     from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
     from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
     from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
@@ -38,7 +38,7 @@ def miniAOD_customizeCommon(process):
     run2_muon_2017.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
     run2_muon_2018.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
     run2_muon_2016.toModify( process.patMuons, mvaTrainingFile = "RecoMuon/MuonIdentification/data/mu_2016_BDTG.weights.xml")
-    run2_miniAOD_devel.toModify( process.patMuons, getdBFromTrack = True) 
+    run2_miniAOD_UL.toModify( process.patMuons, getdBFromTrack = True)
     process.patMuons.computePuppiCombinedIso = True
     #
     # disable embedding of electron and photon associated objects already stored by the ReducedEGProducer
@@ -388,7 +388,7 @@ def miniAOD_customizeCommon(process):
 
     from Configuration.Eras.Modifier_run2_tau_ul_2016_cff import run2_tau_ul_2016
     from Configuration.Eras.Modifier_run2_tau_ul_2018_cff import run2_tau_ul_2018
-    for era in [run2_miniAOD_devel,run2_tau_ul_2016,run2_tau_ul_2018]:
+    for era in [run2_miniAOD_UL,run2_tau_ul_2016,run2_tau_ul_2018]:
         era.toReplaceWith(process.slimmedTaus,
                           getattr(process, _updatedTauNameNew).clone(src = _noUpdatedTauName))
         era.toReplaceWith(process.deepTauIDTask,
@@ -403,24 +403,24 @@ def miniAOD_customizeCommon(process):
     _makePatTausTaskWithDeadECalVeto.add(
         process.hpsPFTauDiscriminationByDeadECALElectronRejectionForMiniAOD
     )
-    run2_miniAOD_devel.toReplaceWith(
+    run2_miniAOD_UL.toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithDeadECalVeto
     )
     _withDeadEcalTauIDPs = cms.PSet(
         process.patTaus.tauIDSources,
         againstElectronDeadECAL = cms.InputTag("hpsPFTauDiscriminationByDeadECALElectronRejectionForMiniAOD")
     )
-    run2_miniAOD_devel.toModify(process.patTaus,
-                                tauIDSources = _withDeadEcalTauIDPs)
+    run2_miniAOD_UL.toModify(process.patTaus,
+                             tauIDSources = _withDeadEcalTauIDPs)
     #... and to boosted taus
-    run2_miniAOD_devel.toModify(process.hpsPFTauDiscriminationByDeadECALElectronRejectionBoosted,
-                                extrapolateToECalEntrance = True)
+    run2_miniAOD_UL.toModify(process.hpsPFTauDiscriminationByDeadECALElectronRejectionBoosted,
+                             extrapolateToECalEntrance = True)
     _withDeadEcalTauIDBoostedPs = cms.PSet(
         process.patTausBoosted.tauIDSources,
         againstElectronDeadECAL = cms.InputTag("hpsPFTauDiscriminationByDeadECALElectronRejectionBoosted")
     )
-    run2_miniAOD_devel.toModify(process.patTausBoosted,
-                                tauIDSources = _withDeadEcalTauIDBoostedPs)
+    run2_miniAOD_UL.toModify(process.patTausBoosted,
+                             tauIDSources = _withDeadEcalTauIDBoostedPs)
 
     #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
@@ -526,8 +526,8 @@ def miniAOD_customizeCommon(process):
         graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"
     )
 
-    run2_miniAOD_devel.toModify(task, func=lambda t: t.add(process.deepMETsResolutionTune, process.deepMETsResponseTune))
-    run2_miniAOD_devel.toModify(process.slimmedMETs, addDeepMETs = True)
+    run2_miniAOD_UL.toModify(task, func=lambda t: t.add(process.deepMETsResolutionTune, process.deepMETsResponseTune))
+    run2_miniAOD_UL.toModify(process.slimmedMETs, addDeepMETs = True)
 
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)
     process.load("TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff")
@@ -606,9 +606,9 @@ def miniAOD_customizeData(process):
     process.load("RecoCTPPS.Configuration.recoCTPPS_cff")
     task = getPatAlgosToolsTask(process)
     from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-    from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-    (ctpps_2016 & ~run2_miniAOD_devel).toModify(task, func=lambda t: t.add(process.ctppsLocalTrackLiteProducer, process.ctppsProtons))
-    (ctpps_2016 & run2_miniAOD_devel).toModify(task, func=lambda t: t.add(process.recoCTPPSTask))
+    from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+    (ctpps_2016 & ~run2_miniAOD_UL).toModify(task, func=lambda t: t.add(process.ctppsLocalTrackLiteProducer, process.ctppsProtons))
+    (ctpps_2016 & run2_miniAOD_UL).toModify(task, func=lambda t: t.add(process.recoCTPPSTask))
 
 def miniAOD_customizeAllData(process):
     miniAOD_customizeCommon(process)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -506,8 +506,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, _myPatMet).metSource = cms.InputTag("pfMet"+postfix)
             getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
         if metType == "PF":
-            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-            run2_miniAOD_devel.toModify(getattr(process, _myPatMet), srcLeptons = \
+            from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+            run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
               cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
@@ -627,8 +627,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             _myPatMet = "pat"+metType+"Met"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
             getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
-            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-            run2_miniAOD_devel.toModify(getattr(process, _myPatMet), srcLeptons = \
+            from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+            run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
               cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
@@ -651,8 +651,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             _myPatMet = "patMETs"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
             getattr(process, _myPatMet).srcPFCands=copy.copy(self.getvalue("pfCandCollection"))
-            from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-            run2_miniAOD_devel.toModify(getattr(process, _myPatMet), srcLeptons = \
+            from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+            run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
               cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
@@ -829,8 +829,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                            useDeltaRforFootprint = cms.bool(False)
                                            )
             if self.getvalue("Puppi"):
-              from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-              run2_miniAOD_devel.toModify(pfCandsNoJets, useDeltaRforFootprint = True)
+              from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+              run2_miniAOD_UL.toModify(pfCandsNoJets, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 
@@ -841,9 +841,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                 useDeltaRforFootprint = cms.bool(False)
                                                 )
             if not self.getvalue("onMiniAOD"):
-              from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-              run2_miniAOD_devel.toModify(pfCandsNoJetsNoEle, useDeltaRforFootprint = True)
-              run2_miniAOD_devel.toModify(pfCandsNoJetsNoEle, veto = cms.InputTag("pfeGammaToCandidate","electrons"))
+              from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+              run2_miniAOD_UL.toModify(pfCandsNoJetsNoEle, useDeltaRforFootprint = True)
+              run2_miniAOD_UL.toModify(pfCandsNoJetsNoEle, veto = cms.InputTag("pfeGammaToCandidate","electrons"))
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
@@ -854,8 +854,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
             if not self.getvalue("onMiniAOD"):
-              from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-              run2_miniAOD_devel.toModify(pfCandsNoJetsNoEleNoMu, useDeltaRforFootprint = True)
+              from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+              run2_miniAOD_UL.toModify(pfCandsNoJetsNoEleNoMu, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJetsNoEleNoMu"+postfix, pfCandsNoJetsNoEleNoMu, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMu"+postfix)
 
@@ -866,8 +866,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
             if self.getvalue("Puppi"):
-              from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-              run2_miniAOD_devel.toModify(pfCandsNoJetsNoEleNoMuNoTau, useDeltaRforFootprint = True)
+              from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+              run2_miniAOD_UL.toModify(pfCandsNoJetsNoEleNoMuNoTau, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)
 
@@ -878,9 +878,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               useDeltaRforFootprint = cms.bool(False)
                                               )
             if not self.getvalue("onMiniAOD"):
-              from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-              run2_miniAOD_devel.toModify(pfCandsForUnclusteredUnc, useDeltaRforFootprint = True)
-              run2_miniAOD_devel.toModify(pfCandsForUnclusteredUnc, veto = cms.InputTag("pfeGammaToCandidate","photons"))
+              from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+              run2_miniAOD_UL.toModify(pfCandsForUnclusteredUnc, useDeltaRforFootprint = True)
+              run2_miniAOD_UL.toModify(pfCandsForUnclusteredUnc, veto = cms.InputTag("pfeGammaToCandidate","photons"))
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)
 
@@ -1484,8 +1484,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 addToProcessAndTask(_myPatMet, getattr(process,'patMETs' ).clone(), process, task)
                 getattr(process, _myPatMet).metSource = cms.InputTag("pfMetT1"+postfix)
                 getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
-                from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-                run2_miniAOD_devel.toModify(getattr(process, _myPatMet), srcLeptons = \
+                from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+                run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
                   cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                                   cms.InputTag("pfeGammaToCandidate","electrons"),
                                 copy.copy(self.getvalue("muonCollection")),

--- a/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
+++ b/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
@@ -14,7 +14,7 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 
-from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
 def applyDefaultSettings(ctppsProtons):
   ctppsProtons.association_cuts_45.x_cut_apply = False
@@ -30,7 +30,7 @@ def applyDefaultSettings(ctppsProtons):
   ctppsProtons.association_cuts_56.th_y_cut_apply = False
 
   # update for re-miniAOD
-  run2_miniAOD_devel.toModify(ctppsProtons,
+  run2_miniAOD_UL.toModify(ctppsProtons,
     pixelDiscardBXShiftedTracks = True,
     association_cuts_45 = dict(ti_tr_min = -1.5, ti_tr_max = 2.0),
     association_cuts_56 = dict(ti_tr_min = -1.5, ti_tr_max = 2.0),
@@ -44,7 +44,7 @@ def apply2017Settings(ctppsProtons):
   ctppsProtons.association_cuts_56.xi_cut_value = 0.015
 
   # update for re-miniAOD
-  run2_miniAOD_devel.toModify(ctppsProtons,
+  run2_miniAOD_UL.toModify(ctppsProtons,
     association_cuts_45 = dict(
       x_cut_apply = False,
       y_cut_apply = False,
@@ -83,7 +83,7 @@ def apply2018Settings(ctppsProtons):
   ctppsProtons.association_cuts_56.th_y_cut_value = 20E-6
 
   # update for re-miniAOD
-  run2_miniAOD_devel.toModify(ctppsProtons,
+  run2_miniAOD_UL.toModify(ctppsProtons,
     association_cuts_45 = dict(
       x_cut_apply = True,
       x_cut_value = 4. * 0.16008188,

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -110,8 +110,9 @@ run2_miniAOD_94XFall17.toModify(
 
 from RecoEgamma.EgammaPhotonProducers.reducedEgamma_tools import calibrateReducedEgamma
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
-modifyReducedEGammaRun2MiniAOD9XFall17_ = run2_miniAOD_94XFall17.makeProcessModifier(calibrateReducedEgamma)
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-modifyReducedEGammaRun2MiniAOD8XLegacy_ = run2_miniAOD_80XLegacy.makeProcessModifier(calibrateReducedEgamma)
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+modifyReducedEGammaRun2MiniAOD = (
+    run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy | run2_miniAOD_UL).makeProcessModifier(calibrateReducedEgamma)
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify( reducedEgamma, ootPhotons = cms.InputTag("") )

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -14,8 +14,8 @@ calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016Legacy)
 
-from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-run2_miniAOD_devel.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+run2_miniAOD_UL.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)
 
 calibratedEgammaPatSettings = calibratedEgammaSettings.clone(
     recHitCollectionEB = cms.InputTag('reducedEgamma','reducedEBRecHits'),

--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -147,8 +147,9 @@ def appendEgamma8XLegacyAppendableModifiers (modifiers):
     modifiers.append(egamma8XLegacyEtScaleSysModifier)
 
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
-run2_miniAOD_94XFall17.toModify(egamma_modifications,appendReducedEgammaEnergyScaleAndSmearingModifier)
-   
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+(run2_miniAOD_94XFall17 | run2_miniAOD_UL).toModify(egamma_modifications,appendReducedEgammaEnergyScaleAndSmearingModifier)
+
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 #80X doesnt have the bug which prevents GsfTracks used to match conversions so set true
 run2_miniAOD_80XLegacy.toModify(egamma9X105XUpdateModifier,allowGsfTrackForConvs = True)

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 from RecoJets.JetProducers.PileupJetIDParams_cfi import *
 
 #_stdalgos_4x = cms.VPSet(full,   cutbased,PhilV1)
@@ -33,7 +33,7 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
      usePuppi = cms.bool(False),
 #     residualsTxt     = cms.FileInPath("RecoJets/JetProducers/data/download.url") # must be an existing file
 )
-run2_miniAOD_devel.toModify(pileupJetId, algos = _chsalgos_106X_UL17)
+run2_miniAOD_UL.toModify(pileupJetId, algos = _chsalgos_106X_UL17)
 
 # Calculate variables, but don't run MVAs
 pileupJetIdCalculator = pileupJetId.clone(

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -42,6 +42,6 @@ METSignificanceParams_Data=cms.PSet(
       useDeltaRforFootprint = cms.bool(False)
       )
 
-from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-run2_miniAOD_devel.toModify(METSignificanceParams, useDeltaRforFootprint = True)
-run2_miniAOD_devel.toModify(METSignificanceParams_Data, useDeltaRforFootprint = True)
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+run2_miniAOD_UL.toModify(METSignificanceParams, useDeltaRforFootprint = True)
+run2_miniAOD_UL.toModify(METSignificanceParams_Data, useDeltaRforFootprint = True)

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
@@ -44,8 +44,8 @@ boostedTauSeeds = cms.EDProducer("BoostedTauSeedsProducer",
     verbosity = cms.int32(0)
 )
 #enable correct behaviour of overlap removal in boosted tau seeding
-from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-run2_miniAOD_devel.toModify(boostedTauSeeds, correctlyExcludeOverlap = True)
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+run2_miniAOD_UL.toModify(boostedTauSeeds, correctlyExcludeOverlap = True)
 
 boostedHPSPFTausTask = cms.Task(
     pfPileUpForBoostedTaus,


### PR DESCRIPTION
This PR switches from a generic run2_miniAOD_devel modifier to the run2 UL re-miniAOD target run2_miniAOD_UL.

Additionally, RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py now enables the electron/photon scales and smearing (something missed in #30199) 

Tests 
- regular setup of re-miniAOD workflows runs and produces differences in expected places compared to the baseline (which is equivalent to the original UL miniAOD)
    - This is mostly an integration test with a bit conceptual validation; the comparison here was done at a bit earlier step in CMSSW_10_6_X_2020-07-29-2300
- (non-ideal) identity test is done to compare UL reminiAOD made in CMSSW_11_2_X_2020-07-29-1100 (which has all bugfixes and UL-specific settings enabled with run2_miniAOD_UL) with CMSSW_10_6_X_2020-08-05-1100 + this PR using 112X GT. This test is done only for data wf 136.88811 (reprocessing of 2018). 
    - Reco comparisons are available in https://slava77sk.web.cern.ch/slava77sk/reco/relvaldiffs/CMSSW_10_6_X_2020-08-05-1100-sign1107/ {red is 106X with GT from 112X and black is 112X} (I looked mostly at 136.88811 in reco comparisons all_\* directory; the dqm plots in dqm_\* are available as well, but apparently some plot formats or selections have changed)
    - detailed comparison shows mostly expected unchanged results (e.g. no differences in packedCandidates, except for puppi-related noLepton weights)  with some differences
        - many small differences are apparently related to the minor/acceptable changes and bugfixes introduced during puppi migration to RECO ( #29254  )
    - differences in taus have several sources:
        - againstElectronDeadECAL in taus was not properly updated in master ==> bugfix in #31047
        - againstElectron\*MVA6 were not backported from after #27465
        - I'm guessing that the small differences in deepTau discriminants are due to the changes in the PUPPI variables (esp the puppiWeightNoLep )
        - minor changes in basic discriminants are expected from #28417 (not backported), e.g. in byCombinedIsolationDeltaBetaCorrRaw3Hits have small differences beyond numerical precision
    - differences in slimmedMETsNoHF UnclusteredEn: see #31071 , apparently the master version is incorrect
    - very small differences in slimmedMETs UnclusteredEn (one event out of 4K tested), apparently due to different way of matching candidates by dR in 106X vs directly by Ptr (part of #29254 not backported to 106X)



