### PR TITLE
PPS: adding missing IO rule for class TotemRPUVPattern

### DIFF
--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -40,6 +40,9 @@
   <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="bool fittable" target="fittable_">
   <![CDATA[fittable_ = onfile.fittable;]]>
   </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="TotemRPUVPattern::ProjectionType projection" target="projection_">
+  <![CDATA[projection_ = onfile.projection;]]>
+  </ioread>
   <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="edm::DetSetVector<TotemRPRecHit> hits" target="hits_">
   <![CDATA[hits_ = onfile.hits;]]>
   </ioread>


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/28252 renamed data members of class ``TotemRPUVPattern``. It provided IO rules for backward compatibility with previously created ROOT files. Unfortunately, an IO rule for ``projection`` data member was missing. The present PR adds this missing PR.

#### PR validation

This PR was tested with a UL AOD file (created with 10_6 which doesn't have the class members renamed). Before applying the proposed change, the method ``TotemRPUVPattern::projection()`` returns 0 (invalid). With the proposed changes, the method returns 1 or 2, as expected.