### PR TITLE
runTheMatrix.py: Change confusing message about number of threads.

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -43,8 +43,7 @@ class MatrixRunner(object):
             self.maxThreads=4
             print('resetting to default number of process threads = %s' %  self.maxThreads)
 
-        print('Running in %s process thread(s)' % self.maxThreads)
-        print('Running in %s thread(s) per process thread' % self.nThreads)
+        print('Running %s %s, each with %s thread%s per process' % (self.maxThreads, 'concurrent jobs' if self.maxThreads > 1 else 'job', self.nThreads, 's' if self.nThreads > 1 else ''))
 
 
         for wf in self.workFlows:
@@ -105,4 +104,3 @@ class MatrixRunner(object):
         anyFail=sum(totfailed)
 
         return anyFail
-

--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -40,10 +40,11 @@ class MatrixRunner(object):
         noRun=(self.maxThreads==0)
         if noRun:
             print('Not running the wf, only creating cfgs and logs')
-            print('resetting to default number of threads')
             self.maxThreads=4
+            print('resetting to default number of process threads = %s' %  self.maxThreads)
 
-        print('Running in %s thread(s)' % self.maxThreads)
+        print('Running in %s process thread(s)' % self.maxThreads)
+        print('Running in %s thread(s) per process thread' % self.nThreads)
 
 
         for wf in self.workFlows:

--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -43,7 +43,7 @@ class MatrixRunner(object):
             self.maxThreads=4
             print('resetting to default number of process threads = %s' %  self.maxThreads)
 
-        print('Running %s %s, each with %s thread%s per process' % (self.maxThreads, 'concurrent jobs' if self.maxThreads > 1 else 'job', self.nThreads, 's' if self.nThreads > 1 else ''))
+        print('Running %s %s %s, each with %s thread%s per process' % ('up to' if self.maxThreads > 1 else '', self.maxThreads, 'concurrent jobs' if self.maxThreads > 1 else 'job', self.nThreads, 's' if self.nThreads > 1 else ''))
 
 
         for wf in self.workFlows:


### PR DESCRIPTION
"Running in 4 thread(s)"  becomes
"Running up to 4 concurrent jobs, each with 1 thread per process"

Concurrent jobs is the number of python threads used, one per workflow, not to be confused with the number of TBB threads cmsRun uses.

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
