### PR TITLE
Phase2-gem49 Use constants defined in DataFormats

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -325,7 +325,10 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
     GEMDetId detId(gemNum.baseNumberToUnitNumber(num));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("Geometry") << fv.name() << " with " << history.tags.size() << " Levels and ID " << detId << " Mask " << std::hex << GEMDetId::chamberIdMask << std::dec << " and " << GEMDetId(((detId.rawId()) & GEMDetId::chamberIdMask)) << " Levels " << theRingLevel << ":" << theSectorLevel << ":" << history.tags.size() << ":" << fv.copyNos().size();
+    edm::LogVerbatim("Geometry") << fv.name() << " with " << history.tags.size() << " Levels and ID " << detId
+                                 << " Mask " << std::hex << GEMDetId::chamberIdMask << std::dec << " and "
+                                 << GEMDetId(((detId.rawId()) & GEMDetId::chamberIdMask)) << " Levels " << theRingLevel
+                                 << ":" << theSectorLevel << ":" << history.tags.size() << ":" << fv.copyNos().size();
     for (unsigned int k = 0; k < history.tags.size(); ++k)
       edm::LogVerbatim("Geometry") << "[" << k << "] Tag " << history.tags[k] << " Offset " << history.offsets[k]
                                    << " copy " << history.copyNos[k];

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -3,9 +3,9 @@
 
  Description: GEM Geometry builder from DD and DD4HEP
               DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
-//
-// Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) following what Ianna Osburne made for DTs (DD4HEP migration)
-//          Created:  27 Jan 2020 
+              Sergio Lo Meo (sergio.lo.meo@cern.ch) following what Ianna Osburne made for DTs (DD4HEP migration)
+              Updated by Sunanda Banerjee (Fermilab) to make it working for dd4hep
+              Updated:  7 August 2020 
 */
 #include "Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
@@ -62,6 +62,9 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 #endif
   bool doSuper = fv.firstChild();
 
+  MuonGeometryNumbering mdddnum(muonConstants);
+  GEMNumberingScheme gemNum(muonConstants);
+
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Geometry") << "doSuperChamber = " << doSuper << " with " << fv.geoHistory() << " Levels "
                                << mdddnum.geoHistoryToBaseNumber(fv.geoHistory()).getLevels();
@@ -69,9 +72,6 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 #endif
   // loop over superchambers
   std::vector<GEMSuperChamber*> superChambers;
-
-  MuonGeometryNumbering mdddnum(muonConstants);
-  GEMNumberingScheme gemNum(muonConstants);
   while (doSuper) {
     // getting chamber id from eta partitions
     fv.firstChild();
@@ -312,7 +312,6 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 
   MuonGeometryNumbering mdddnum(muonConstants);
   GEMNumberingScheme gemNum(muonConstants);
-  static constexpr uint32_t chamberIdMask = ~(31 << 19);
   static constexpr uint32_t levelChamb = 7;
   int chamb(0), region(0);
   int theLevelPart = muonConstants.getValue("level");
@@ -326,10 +325,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
     GEMDetId detId(gemNum.baseNumberToUnitNumber(num));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("Geometry") << fv.name() << " with " << history.tags.size() << " Levels and ID " << detId
-                                 << " Mask " << std::hex << chamberIdMask << ":" << chamberIdMask1 << std::dec
-                                 << " and " << GEMDetId(((detId.rawId()) & chamberIdMask)) << " Levels " << theRingLevel
-                                 << ":" << theSectorLevel << ":" << history.tags.size() << ":" << fv.copyNos().size();
+    edm::LogVerbatim("Geometry") << fv.name() << " with " << history.tags.size() << " Levels and ID " << detId << " Mask " << std::hex << GEMDetId::chamberIdMask << std::dec << " and " << GEMDetId(((detId.rawId()) & GEMDetId::chamberIdMask)) << " Levels " << theRingLevel << ":" << theSectorLevel << ":" << history.tags.size() << ":" << fv.copyNos().size();
     for (unsigned int k = 0; k < history.tags.size(); ++k)
       edm::LogVerbatim("Geometry") << "[" << k << "] Tag " << history.tags[k] << " Offset " << history.offsets[k]
                                    << " copy " << history.copyNos[k];
@@ -369,9 +365,9 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 
   auto& partitions = theGeometry.etaPartitions();
   for (auto& gemChamber : chambers) {
-    uint32_t id0 = ((gemChamber->id().rawId()) & chamberIdMask);
+    uint32_t id0 = ((gemChamber->id().rawId()) & GEMDetId::chamberIdMask);
     for (auto& etaPart : partitions) {
-      if (((etaPart->id().rawId()) & chamberIdMask) == id0) {
+      if (((etaPart->id().rawId()) & GEMDetId::chamberIdMask) == id0) {
         gemChamber->add(etaPart);
       }
     }

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.cc
@@ -3,9 +3,9 @@
 
  Description: ME0 Geometry builder from DD & DD4hep
               DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
-//
-// Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) following what Ianna Osborne made for DTs (DD4HEP migration)
-//          Created:  29 Apr 2019 
+              Sergio Lo Meo (sergio.lo.meo@cern.ch) following what Ianna Osborne made for DTs (DD4HEP migration)
+              Updated by Sunanda Banerjee (Fermilab) to make it work for DDD/DD4Hep
+            Updated:  7 August 2020
 */
 #include "Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.h"
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
@@ -375,8 +375,6 @@ ME0Geometry* ME0GeometryBuilder::buildGeometry(cms::DDFilteredView& fv, const Mu
   MuonGeometryNumbering mdddnum(muonConstants);
   ME0NumberingScheme me0Num(muonConstants);
 
-  static constexpr uint32_t layerIdMask = ~(31 << 13);
-  static constexpr uint32_t chamberIdMask = ~((31 << 8) | (31 << 13));
   static constexpr uint32_t levelChamber = 7;
   static constexpr uint32_t levelLayer = 8;
   uint32_t theLevelPart = muonConstants.getValue("level");
@@ -389,12 +387,7 @@ ME0Geometry* ME0GeometryBuilder::buildGeometry(cms::DDFilteredView& fv, const Mu
     MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
     ME0DetId detId(me0Num.baseNumberToUnitNumber(num));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("ME0Geometry") << fv.name() << " with " << history.tags.size() << " Levels and ID " << detId
-                                    << " Mask " << std::hex << chamberIdMask << ":" << layerIdMask << std::dec
-                                    << " and " << ME0DetId(((detId.rawId()) & chamberIdMask)) << ":"
-                                    << ME0DetId(((detId.rawId()) & layerIdMask)) << " Sector Level "
-                                    << ":" << theSectorLevel << ":" << history.tags.size() << ":"
-                                    << fv.copyNos().size();
+    edm::LogVerbatim("ME0Geometry") << fv.name() << " with " << history.tags.size() << " Levels and ID " << detId << " Mask " << std::hex << ME0DetId::chamberIdMask_ << ":" << ME0DetId::layerIdMask_ << std::dec << " and " << ME0DetId(((detId.rawId()) & ME0DetId::chamberIdMask_)) << ":" << ME0DetId(((detId.rawId()) & ME0DetId::layerIdMask_)) << " Sector Level " << theSectorLevel << ":" << history.tags.size() << ":" << fv.copyNos().size();
     for (unsigned int k = 0; k < history.tags.size(); ++k)
       edm::LogVerbatim("ME0Geometry") << "[" << k << "] Tag " << history.tags[k] << " Offset " << history.offsets[k]
                                       << " copy " << history.copyNos[k];
@@ -417,18 +410,18 @@ ME0Geometry* ME0GeometryBuilder::buildGeometry(cms::DDFilteredView& fv, const Mu
 
   auto const& partitions = geometry->etaPartitions();
   for (auto& layer : layers) {
-    uint32_t id0 = ((layer->id().rawId()) & layerIdMask);
+    uint32_t id0 = ((layer->id().rawId()) & ME0DetId::layerIdMask_);
     for (auto& etaPart : partitions) {
-      if (((etaPart->id().rawId()) & layerIdMask) == id0) {
+      if (((etaPart->id().rawId()) & ME0DetId::layerIdMask_) == id0) {
         layer->add(etaPart);
       }
     }
     geometry->add(layer);
   }
   for (auto& chamber : chambers) {
-    uint32_t id0 = ((chamber->id().rawId()) & chamberIdMask);
+    uint32_t id0 = ((chamber->id().rawId()) & ME0DetId::chamberIdMask_);
     for (auto& layer : layers) {
-      if (((layer->id().rawId()) & chamberIdMask) == id0) {
+      if (((layer->id().rawId()) & ME0DetId::chamberIdMask_) == id0) {
         chamber->add(layer);
       }
     }

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilder.cc
@@ -387,7 +387,11 @@ ME0Geometry* ME0GeometryBuilder::buildGeometry(cms::DDFilteredView& fv, const Mu
     MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
     ME0DetId detId(me0Num.baseNumberToUnitNumber(num));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("ME0Geometry") << fv.name() << " with " << history.tags.size() << " Levels and ID " << detId << " Mask " << std::hex << ME0DetId::chamberIdMask_ << ":" << ME0DetId::layerIdMask_ << std::dec << " and " << ME0DetId(((detId.rawId()) & ME0DetId::chamberIdMask_)) << ":" << ME0DetId(((detId.rawId()) & ME0DetId::layerIdMask_)) << " Sector Level " << theSectorLevel << ":" << history.tags.size() << ":" << fv.copyNos().size();
+    edm::LogVerbatim("ME0Geometry") << fv.name() << " with " << history.tags.size() << " Levels and ID " << detId
+                                    << " Mask " << std::hex << ME0DetId::chamberIdMask_ << ":" << ME0DetId::layerIdMask_
+                                    << std::dec << " and " << ME0DetId(((detId.rawId()) & ME0DetId::chamberIdMask_))
+                                    << ":" << ME0DetId(((detId.rawId()) & ME0DetId::layerIdMask_)) << " Sector Level "
+                                    << theSectorLevel << ":" << history.tags.size() << ":" << fv.copyNos().size();
     for (unsigned int k = 0; k < history.tags.size(); ++k)
       edm::LogVerbatim("ME0Geometry") << "[" << k << "] Tag " << history.tags[k] << " Offset " << history.offsets[k]
                                       << " copy " << history.copyNos[k];


### PR DESCRIPTION
#### PR description:

Use constants defined in the DetId classes for GEM and ME0

#### PR validation:

Tested using scripts in Geometry/GEMGeometryBuilder/test/python

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special