### PR TITLE
Introduce SiPhase2OuterTrackerLorentzAngle 

### DIFF
--- a/CalibTracker/SiPhase2TrackerESProducers/BuildFile.xml
+++ b/CalibTracker/SiPhase2TrackerESProducers/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/MessageLogger"/>
+<use name="CondFormats/DataRecord"/>
+<use name="CondFormats/SiPhase2TrackerObjects"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/CalibTracker/SiPhase2TrackerESProducers/interface/SiPhase2OuterTrackerFakeLorentzAngleESSource.h
+++ b/CalibTracker/SiPhase2TrackerESProducers/interface/SiPhase2OuterTrackerFakeLorentzAngleESSource.h
@@ -1,0 +1,56 @@
+#ifndef CalibTracker_SiPhase2TrackerESProducers_SiPhase2OuterTrackerFakeLorentzAngleESSource_h
+#define CalibTracker_SiPhase2TrackerESProducers_SiPhase2OuterTrackerFakeLorentzAngleESSource_h
+// -*- C++ -*-
+//
+// Package:    SiPhase2OuterTrackerFakeLorentzAngleESSource
+// Class:      SiPhase2OuterTrackerFakeLorentzAngleESSource
+//
+/**\class SiPhase2OuterTrackerFakeLorentzAngleESSource SiPhase2OuterTrackerFakeLorentzAngleESSource.h CalibTracker/SiPhase2TrackerESProducers/src/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+ Description: <one line class summary>
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  July 31st, 2020
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
+//
+// class decleration
+//
+
+class SiPhase2OuterTrackerFakeLorentzAngleESSource : public edm::ESProducer,
+                                                     public edm::EventSetupRecordIntervalFinder {
+public:
+  SiPhase2OuterTrackerFakeLorentzAngleESSource(const edm::ParameterSet &);
+  ~SiPhase2OuterTrackerFakeLorentzAngleESSource() override;
+
+  virtual std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> produce(const SiPhase2OuterTrackerLorentzAngleRcd &);
+  static void fillDescriptions(edm::ConfigurationDescriptions &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_tTopoToken;
+  edm::ESGetToken<GeometricDet, IdealGeometryRecord> m_geomDetToken;
+  const float LAvalue_;
+};
+#endif

--- a/CalibTracker/SiPhase2TrackerESProducers/interface/SiPhase2OuterTrackerFakeLorentzAngleESSource.h
+++ b/CalibTracker/SiPhase2TrackerESProducers/interface/SiPhase2OuterTrackerFakeLorentzAngleESSource.h
@@ -40,7 +40,7 @@ public:
   SiPhase2OuterTrackerFakeLorentzAngleESSource(const edm::ParameterSet &);
   ~SiPhase2OuterTrackerFakeLorentzAngleESSource() override;
 
-  virtual std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> produce(const SiPhase2OuterTrackerLorentzAngleRcd &);
+  void produce(){};
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
 protected:
@@ -48,9 +48,14 @@ protected:
                       const edm::IOVSyncValue &,
                       edm::ValidityInterval &) override;
 
+  virtual std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> produceOTLA(const SiPhase2OuterTrackerLorentzAngleRcd &);
+  virtual std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> produceOTSimLA(
+      const SiPhase2OuterTrackerLorentzAngleSimRcd &);
+
 private:
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_tTopoToken;
   edm::ESGetToken<GeometricDet, IdealGeometryRecord> m_geomDetToken;
   const float LAvalue_;
+  const std::string recordName_;
 };
 #endif

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/BuildFile.xml
@@ -1,0 +1,9 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="CondFormats/DataRecord"/>
+<use name="CondFormats/SiPhase2TrackerObjects"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<library file="*.cc" name="CalibTrackerSiPixelESProducersPlugins">
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/BuildFile.xml
@@ -4,6 +4,6 @@
 <use name="CondFormats/SiPhase2TrackerObjects"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<library file="*.cc" name="CalibTrackerSiPixelESProducersPlugins">
+<library file="*.cc" name="CalibTrackerSiPhase2TrackerESProducersPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
@@ -1,0 +1,75 @@
+// -*- C++ -*-
+//
+// Package:    SiPhase2OuterTrackerFakeLorentzAngleESSource
+// Class:      SiPhase2OuterTrackerFakeLorentzAngleESSource
+//
+/**\class SiPhase2OuterTrackerFakeLorentzAngleESSource SiPhase2OuterTrackerFakeLorentzAngleESSource.h CalibTracker/SiPhase2TrackerESProducers/src/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+ Description: <one line class summary>
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Jul 31st, 2020
+//
+//
+
+// user include files
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "CalibTracker/SiPhase2TrackerESProducers/interface/SiPhase2OuterTrackerFakeLorentzAngleESSource.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/TrackerNumberingBuilder/interface/utils.h"
+//
+// constructors and destructor
+//
+SiPhase2OuterTrackerFakeLorentzAngleESSource::SiPhase2OuterTrackerFakeLorentzAngleESSource(
+    const edm::ParameterSet& conf_)
+    : LAvalue_(conf_.getParameter<double>("LAValue")) {
+  edm::LogInfo("SiPhase2OuterTrackerFakeLorentzAngleESSource::SiPhase2OuterTrackerFakeLorentzAngleESSource");
+  // the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this).setConsumes(m_tTopoToken).setConsumes(m_geomDetToken);
+  findingRecord<SiPhase2OuterTrackerLorentzAngleRcd>();
+}
+
+SiPhase2OuterTrackerFakeLorentzAngleESSource::~SiPhase2OuterTrackerFakeLorentzAngleESSource() {}
+
+std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> SiPhase2OuterTrackerFakeLorentzAngleESSource::produce(
+    const SiPhase2OuterTrackerLorentzAngleRcd& iRecord) {
+  using namespace edm::es;
+  SiPhase2OuterTrackerLorentzAngle* obj = new SiPhase2OuterTrackerLorentzAngle();
+
+  const auto& geomDet = iRecord.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
+  for (const auto detId : TrackerGeometryUtils::getSiStripDetIds(geomDet)) {
+    const DetId detectorId = DetId(detId);
+    const int subDet = detectorId.subdetId();
+    if (detectorId.det() == DetId::Detector::Tracker) {
+      if (subDet == StripSubdetector::TOB || subDet == StripSubdetector::TID) {
+        if (!obj->putLorentzAngle(detId, LAvalue_))
+          edm::LogError("SiPhase2OuterTrackerFakeLorentzAngleESSource")
+              << "[SiPhase2OuterTrackerFakeLorentzAngleESSource::produce] detid already exists" << std::endl;
+
+      }  // if it's a OT DetId
+    }    // check if Tracker
+  }      // loop on DetIds
+
+  return std::unique_ptr<SiPhase2OuterTrackerLorentzAngle>(obj);
+}
+
+void SiPhase2OuterTrackerFakeLorentzAngleESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                                  const edm::IOVSyncValue& iosv,
+                                                                  edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
+}
+
+void SiPhase2OuterTrackerFakeLorentzAngleESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("LAValue", 0.07);
+  descriptions.add("siPhase2OTFakeLorentzAngleESSource", desc);
+}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/SourceFactory.h"
+DEFINE_FWK_EVENTSETUP_SOURCE(SiPhase2OuterTrackerFakeLorentzAngleESSource);

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
@@ -86,7 +86,7 @@ void SiPhase2OuterTrackerFakeLorentzAngleESSource::setIntervalFor(const edm::eve
 void SiPhase2OuterTrackerFakeLorentzAngleESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<double>("LAValue", 0.07);
-  desc.add<std::string>("recordName", "LorenzAngle");
+  desc.add<std::string>("recordName", "LorentzAngle");
   descriptions.add("siPhase2OTFakeLorentzAngleESSource", desc);
 }
 

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
@@ -49,7 +49,7 @@ namespace fakeOTLA {
   std::unique_ptr<T> produceRecord(const float value, const GeometricDet& geomDet) {
     using namespace edm::es;
     T* obj = new T();
-    for (const auto detId : TrackerGeometryUtils::getSiStripDetIds(geomDet)) {
+    for (const auto detId : TrackerGeometryUtils::getOuterTrackerDetIds(geomDet)) {
       const DetId detectorId = DetId(detId);
       const int subDet = detectorId.subdetId();
       if (detectorId.det() == DetId::Detector::Tracker) {

--- a/CalibTracker/SiPhase2TrackerESProducers/python/SiPhase2OuterTrackerFakeLorentzAngleESSource_cfi.py
+++ b/CalibTracker/SiPhase2TrackerESProducers/python/SiPhase2OuterTrackerFakeLorentzAngleESSource_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from CalibTracker.SiPhase2TrackerESProducers.siPhase2OTFakeLorentzAngleESSource_cfi import siPhase2OTFakeLorentzAngleESSource
+SiPhase2OTFakeLorentzAngleESSource = siPhase2OTFakeLorentzAngleESSource.clone(LAValue = 0.07,
+                                                                              recordName = 'LorentzAngle')

--- a/CondCore/SiPhase2TrackerPlugins/src/plugin.cc
+++ b/CondCore/SiPhase2TrackerPlugins/src/plugin.cc
@@ -3,7 +3,7 @@
 #include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 
 #include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
-#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
 
 REGISTER_PLUGIN(TrackerDetToDTCELinkCablingMapRcd, TrackerDetToDTCELinkCablingMap);
 REGISTER_PLUGIN(SiPhase2OuterTrackerLorentzAngleRcd, SiPhase2OuterTrackerLorentzAngle);

--- a/CondCore/SiPhase2TrackerPlugins/src/plugin.cc
+++ b/CondCore/SiPhase2TrackerPlugins/src/plugin.cc
@@ -1,5 +1,10 @@
 #include "CondCore/ESSources/interface/registration_macros.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
+
 #include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 
 REGISTER_PLUGIN(TrackerDetToDTCELinkCablingMapRcd, TrackerDetToDTCELinkCablingMap);
+REGISTER_PLUGIN(SiPhase2OuterTrackerLorentzAngleRcd, SiPhase2OuterTrackerLorentzAngle);
+REGISTER_PLUGIN(SiPhase2OuterTrackerLorentzAngleSimRcd, SiPhase2OuterTrackerLorentzAngle);

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -237,6 +237,7 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(RPFlatParams);
   PAYLOAD_2XML_CLASS(RecoIdealGeometry);
   PAYLOAD_2XML_CLASS(RunInfo);
+  PAYLOAD_2XML_CLASS(SiPhase2OuterTrackerLorentzAngle);
   PAYLOAD_2XML_CLASS(SiPixel2DTemplateDBObject);
   PAYLOAD_2XML_CLASS(SiPixelCPEGenericErrorParm);
   PAYLOAD_2XML_CLASS(SiPixelCalibConfiguration);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -272,6 +272,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE(RPFlatParams)
       FETCH_PAYLOAD_CASE(RecoIdealGeometry)
       FETCH_PAYLOAD_CASE(RunInfo)
+      FETCH_PAYLOAD_CASE(SiPhase2OuterTrackerLorentzAngle)
       FETCH_PAYLOAD_CASE(SiPixelCalibConfiguration)
       FETCH_PAYLOAD_CASE(SiPixelCPEGenericErrorParm)
       FETCH_PAYLOAD_CASE(SiPixelFedCablingMap)

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -298,6 +298,7 @@ namespace cond {
         IMPORT_PAYLOAD_CASE(RPFlatParams)
         IMPORT_PAYLOAD_CASE(RecoIdealGeometry)
         IMPORT_PAYLOAD_CASE(RunInfo)
+        IMPORT_PAYLOAD_CASE(SiPhase2OuterTrackerLorentzAngle)
         IMPORT_PAYLOAD_CASE(SiPixelCalibConfiguration)
         IMPORT_PAYLOAD_CASE(SiPixelCPEGenericErrorParm)
         IMPORT_PAYLOAD_CASE(SiPixelFedCablingMap)

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -266,6 +266,7 @@
 #include "CondFormats/MFObjects/interface/MagFieldConfig.h"
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"
 #include "CondFormats/Common/interface/BaseKeyed.h"
 

--- a/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
@@ -3,11 +3,12 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 /*Record associated to SiPhase2OuterTrackerLorentzAngle Object: the SimRcd is used in simulation only*/
 class SiPhase2OuterTrackerLorentzAngleRcd
     : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleRcd,
-                                                            boost::mpl::vector<TrackerTopologyRcd> > {};
+                                                            edm::mpl::Vector<TrackerTopologyRcd> > {};
 class SiPhase2OuterTrackerLorentzAngleSimRcd
     : public edm::eventsetup::EventSetupRecordImplementation<SiPhase2OuterTrackerLorentzAngleSimRcd> {};
 

--- a/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
@@ -1,0 +1,14 @@
+#ifndef CondFormats_SiPhase2OuterTrackerCondDataRecords_h
+#define CondFormats_SiPhase2OuterTrackerCondDataRecords_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+/*Record associated to SiPhase2OuterTrackerLorentzAngle Object: the SimRcd is used in simulation only*/
+class SiPhase2OuterTrackerLorentzAngleRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleRcd,
+                                                            boost::mpl::vector<TrackerTopologyRcd> > {};
+class SiPhase2OuterTrackerLorentzAngleSimRcd
+    : public edm::eventsetup::EventSetupRecordImplementation<SiPhase2OuterTrackerLorentzAngleSimRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
@@ -10,6 +10,6 @@ class SiPhase2OuterTrackerLorentzAngleRcd
     : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleRcd,
                                                             edm::mpl::Vector<TrackerTopologyRcd> > {};
 class SiPhase2OuterTrackerLorentzAngleSimRcd
-    : public edm::eventsetup::EventSetupRecordImplementation<SiPhase2OuterTrackerLorentzAngleSimRcd> {};
-
+    : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleSimRcd,
+                                                            edm::mpl::Vector<TrackerTopologyRcd> > {};
 #endif

--- a/CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h
+++ b/CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h
@@ -1,0 +1,1 @@
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h" 

--- a/CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h
+++ b/CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h
@@ -1,1 +1,1 @@
-#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h" 
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"

--- a/CondFormats/DataRecord/interface/SiStripCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiStripCondDataRecords.h
@@ -21,7 +21,7 @@ class SiStripDCSStatusRcd : public edm::eventsetup::EventSetupRecordImplementati
 
 class SiStripFedCablingRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripFedCablingRcd> {};
 
-/*Recod associated to SiStripLorenzaAngle Object: the SimRcd is used in simulation only*/
+/*Record associated to SiStripLorentzAngle Object: the SimRcd is used in simulation only*/
 class SiStripLorentzAngleRcd
     : public edm::eventsetup::DependentRecordImplementation<SiStripLorentzAngleRcd,
                                                             edm::mpl::Vector<TrackerTopologyRcd> > {};
@@ -60,5 +60,12 @@ class SiStripApvSimulationParametersRcd
 
 /*Records for upgrade */
 class Phase2TrackerCablingRcd : public edm::eventsetup::EventSetupRecordImplementation<Phase2TrackerCablingRcd> {};
+
+/*Record associated to SiPhase2OuterTrackerLorentzAngle Object: the SimRcd is used in simulation only*/
+class SiPhase2OuterTrackerLorentzAngleRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleRcd,
+                                                            boost::mpl::vector<TrackerTopologyRcd> > {};
+class SiPhase2OuterTrackerLorentzAngleSimRcd
+    : public edm::eventsetup::EventSetupRecordImplementation<SiPhase2OuterTrackerLorentzAngleSimRcd> {};
 
 #endif

--- a/CondFormats/DataRecord/interface/SiStripCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiStripCondDataRecords.h
@@ -61,11 +61,4 @@ class SiStripApvSimulationParametersRcd
 /*Records for upgrade */
 class Phase2TrackerCablingRcd : public edm::eventsetup::EventSetupRecordImplementation<Phase2TrackerCablingRcd> {};
 
-/*Record associated to SiPhase2OuterTrackerLorentzAngle Object: the SimRcd is used in simulation only*/
-class SiPhase2OuterTrackerLorentzAngleRcd
-    : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleRcd,
-                                                            boost::mpl::vector<TrackerTopologyRcd> > {};
-class SiPhase2OuterTrackerLorentzAngleSimRcd
-    : public edm::eventsetup::EventSetupRecordImplementation<SiPhase2OuterTrackerLorentzAngleSimRcd> {};
-
 #endif

--- a/CondFormats/DataRecord/src/SiPhase2OuterTrackerCondDataRecords.cc
+++ b/CondFormats/DataRecord/src/SiPhase2OuterTrackerCondDataRecords.cc
@@ -1,0 +1,5 @@
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
+
+EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerLorentzAngleRcd);
+EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerLorentzAngleSimRcd);

--- a/CondFormats/DataRecord/src/SiStripCondDataRecords.cc
+++ b/CondFormats/DataRecord/src/SiStripCondDataRecords.cc
@@ -42,5 +42,3 @@ EVENTSETUP_RECORD_REG(SiStripApvSimulationParametersRcd);
 
 EVENTSETUP_RECORD_REG(Phase2TrackerCablingRcd);
 
-EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerLorentzAngleRcd);
-EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerLorentzAngleSimRcd);

--- a/CondFormats/DataRecord/src/SiStripCondDataRecords.cc
+++ b/CondFormats/DataRecord/src/SiStripCondDataRecords.cc
@@ -41,3 +41,6 @@ EVENTSETUP_RECORD_REG(SiStripConfObjectRcd);
 EVENTSETUP_RECORD_REG(SiStripApvSimulationParametersRcd);
 
 EVENTSETUP_RECORD_REG(Phase2TrackerCablingRcd);
+
+EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerLorentzAngleRcd);
+EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerLorentzAngleSimRcd);

--- a/CondFormats/DataRecord/src/SiStripCondDataRecords.cc
+++ b/CondFormats/DataRecord/src/SiStripCondDataRecords.cc
@@ -41,4 +41,3 @@ EVENTSETUP_RECORD_REG(SiStripConfObjectRcd);
 EVENTSETUP_RECORD_REG(SiStripApvSimulationParametersRcd);
 
 EVENTSETUP_RECORD_REG(Phase2TrackerCablingRcd);
-

--- a/CondFormats/SiPhase2TrackerObjects/BuildFile.xml
+++ b/CondFormats/SiPhase2TrackerObjects/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
 <use name="DataFormats/DetId"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
 <use name="rootrflx"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
@@ -25,8 +25,12 @@ public:
   SiPhase2OuterTrackerLorentzAngle(){};
   ~SiPhase2OuterTrackerLorentzAngle(){};
 
-  inline void putLorentsAngles(std::unordered_map<unsigned int, float>& LA) { m_LA = LA; }
+  inline void putLorentzAngles(std::unordered_map<unsigned int, float>& LA) { m_LA = LA; }
   inline const std::unordered_map<unsigned int, float>& getLorentzAngles() const { return m_LA; }
+
+  void getLorentzAnglesByModuleType(const TrackerGeometry* trackerGeometry,
+                                    const TrackerGeometry::ModuleType& theType,
+                                    std::unordered_map<unsigned int, float>& out) const;
 
   void getLorentzAngles_PSP(const TrackerGeometry*, std::unordered_map<unsigned int, float>&) const;
   void getLorentzAngles_PSS(const TrackerGeometry*, std::unordered_map<unsigned int, float>&) const;

--- a/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
@@ -3,6 +3,7 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include <vector>
 #include <map>
@@ -26,6 +27,10 @@ public:
 
   inline void putLorentsAngles(std::unordered_map<unsigned int, float>& LA) { m_LA = LA; }
   inline const std::unordered_map<unsigned int, float>& getLorentzAngles() const { return m_LA; }
+
+  void getLorentzAngles_PSP(const TrackerGeometry*, std::unordered_map<unsigned int, float>&) const;
+  void getLorentzAngles_PSS(const TrackerGeometry*, std::unordered_map<unsigned int, float>&) const;
+  void getLorentzAngles_2S(const TrackerGeometry*, std::unordered_map<unsigned int, float>&) const;
 
   bool putLorentzAngle(const uint32_t&, float);
   float getLorentzAngle(const uint32_t&) const;

--- a/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
@@ -17,6 +17,9 @@
  * a single detIds and lorentzAngles (putLorentzAngle).
  * In the same way getLorentzAngles returns the complete map, while getLorentzAngle
  * the value corresponding to a given DetId.
+ * The three methods getLorentzAngles_PSP, getLorentzAngles_PSS and getLorentzAngles_2S
+ * are provided to retrieve by reference the Lorentz Angle values map for the P- and S- sensors,
+ * in the PS modules separately, as well as the values for the S-senors in the 2S modules.
  * The printDebug method prints LorentzAngles for all detIds.
  */
 
@@ -28,13 +31,17 @@ public:
   inline void putLorentzAngles(std::unordered_map<unsigned int, float>& LA) { m_LA = LA; }
   inline const std::unordered_map<unsigned int, float>& getLorentzAngles() const { return m_LA; }
 
-  void getLorentzAnglesByModuleType(const TrackerGeometry* trackerGeometry,
-                                    const TrackerGeometry::ModuleType& theType,
-                                    std::unordered_map<unsigned int, float>& out) const;
+  void getLorentzAngles_PSP(const TrackerGeometry* geo, std::unordered_map<unsigned int, float>& out) const {
+    getLorentzAnglesByModuleType(geo, TrackerGeometry::ModuleType::Ph2PSP, out);
+  }
 
-  void getLorentzAngles_PSP(const TrackerGeometry*, std::unordered_map<unsigned int, float>&) const;
-  void getLorentzAngles_PSS(const TrackerGeometry*, std::unordered_map<unsigned int, float>&) const;
-  void getLorentzAngles_2S(const TrackerGeometry*, std::unordered_map<unsigned int, float>&) const;
+  void getLorentzAngles_PSS(const TrackerGeometry* geo, std::unordered_map<unsigned int, float>& out) const {
+    getLorentzAnglesByModuleType(geo, TrackerGeometry::ModuleType::Ph2PSS, out);
+  }
+
+  void getLorentzAngles_2S(const TrackerGeometry* geo, std::unordered_map<unsigned int, float>& out) const {
+    getLorentzAnglesByModuleType(geo, TrackerGeometry::ModuleType::Ph2SS, out);
+  }
 
   bool putLorentzAngle(const uint32_t&, float);
   float getLorentzAngle(const uint32_t&) const;
@@ -43,6 +50,10 @@ public:
   void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
 private:
+  void getLorentzAnglesByModuleType(const TrackerGeometry* trackerGeometry,
+                                    const TrackerGeometry::ModuleType& theType,
+                                    std::unordered_map<unsigned int, float>& out) const;
+
   std::unordered_map<unsigned int, float> m_LA;
 
   COND_SERIALIZABLE;

--- a/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
@@ -1,0 +1,47 @@
+#ifndef CondCore_SiPhase2TrackerObjects_SiPhase2OuterTrackerLorentzAngle_h
+#define CondCore_SiPhase2TrackerObjects_SiPhase2OuterTrackerLorentzAngle_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include <vector>
+#include <map>
+#include <iostream>
+#include <cstdint>
+
+/**
+ * Stores the lorentz angle value for all DetIds.
+ * The values are saved internally in a std::map<detid, lorentzAngle>.
+ * It can be filled either by the complete map (putLorentzAngles) or passing
+ * a single detIds and lorentzAngles (putLorentzAngle).
+ * In the same way getLorentzAngles returns the complete map, while getLorentzAngle
+ * the value corresponding to a given DetId.
+ * The printDebug method prints LorentzAngles for all detIds.
+ * The printSummary mehtod uses the SiStripDetSummary class to produce a summary
+ * of LorentzAngle values divided by subdetector and layer/disk.
+ */
+
+class SiPhase2OuterTrackerLorentzAngle {
+public:
+  SiPhase2OuterTrackerLorentzAngle(){};
+  ~SiPhase2OuterTrackerLorentzAngle(){};
+
+  inline void putLorentsAngles(std::map<unsigned int, float>& LA) { m_LA = LA; }
+  inline const std::map<unsigned int, float>& getLorentzAngles() const { return m_LA; }
+
+  bool putLorentzAngle(const uint32_t&, float);
+  float getLorentzAngle(const uint32_t&) const;
+
+  // Prints LorentzAngles for all detIds.
+  void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
+
+  // Prints the mean value of the LorentzAngle divided by subdetector, layer and mono/stereo.
+  //void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
+
+private:
+  std::map<unsigned int, float> m_LA;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
@@ -10,15 +10,13 @@
 #include <cstdint>
 
 /**
- * Stores the lorentz angle value for all DetIds.
- * The values are saved internally in a std::map<detid, lorentzAngle>.
+ * Stores the Lorentz Angle value for all DetIds.
+ * The values are saved internally in a std::unordered_map<detid, lorentzAngle>.
  * It can be filled either by the complete map (putLorentzAngles) or passing
  * a single detIds and lorentzAngles (putLorentzAngle).
  * In the same way getLorentzAngles returns the complete map, while getLorentzAngle
  * the value corresponding to a given DetId.
  * The printDebug method prints LorentzAngles for all detIds.
- * The printSummary mehtod uses the SiStripDetSummary class to produce a summary
- * of LorentzAngle values divided by subdetector and layer/disk.
  */
 
 class SiPhase2OuterTrackerLorentzAngle {
@@ -35,11 +33,8 @@ public:
   // Prints LorentzAngles for all detIds.
   void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
-  // Prints the mean value of the LorentzAngle divided by subdetector, layer and mono/stereo.
-  //void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
-
 private:
-  std::map<unsigned int, float> m_LA;
+  std::unordered_map<unsigned int, float> m_LA;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h
@@ -24,8 +24,8 @@ public:
   SiPhase2OuterTrackerLorentzAngle(){};
   ~SiPhase2OuterTrackerLorentzAngle(){};
 
-  inline void putLorentsAngles(std::map<unsigned int, float>& LA) { m_LA = LA; }
-  inline const std::map<unsigned int, float>& getLorentzAngles() const { return m_LA; }
+  inline void putLorentsAngles(std::unordered_map<unsigned int, float>& LA) { m_LA = LA; }
+  inline const std::unordered_map<unsigned int, float>& getLorentzAngles() const { return m_LA; }
 
   bool putLorentzAngle(const uint32_t&, float);
   float getLorentzAngle(const uint32_t&) const;

--- a/CondFormats/SiPhase2TrackerObjects/src/SiPhase2OuterTrackerLorentzAngle.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/SiPhase2OuterTrackerLorentzAngle.cc
@@ -1,0 +1,52 @@
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+bool SiPhase2OuterTrackerLorentzAngle::putLorentzAngle(const uint32_t& detid, float value) {
+  std::map<unsigned int, float>::const_iterator id = m_LA.find(detid);
+  if (id != m_LA.end()) {
+    edm::LogError("SiPhase2OuterTrackerLorentzAngle") << "SiPhase2OuterTrackerLorentzAngle for DetID " << detid
+                                                      << " is already stored. Skippig this put" << std::endl;
+    return false;
+  } else
+    m_LA[detid] = value;
+  return true;
+}
+float SiPhase2OuterTrackerLorentzAngle::getLorentzAngle(const uint32_t& detid) const {
+  std::map<unsigned int, float>::const_iterator id = m_LA.find(detid);
+  if (id != m_LA.end())
+    return id->second;
+  else {
+    edm::LogError("SiPhase2OuterTrackerLorentzAngle")
+        << "SiPhase2OuterTrackerLorentzAngle for DetID " << detid << " is not stored" << std::endl;
+  }
+  return 0;
+}
+
+void SiPhase2OuterTrackerLorentzAngle::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const {
+  std::map<unsigned int, float> detid_la = getLorentzAngles();
+  std::map<unsigned int, float>::const_iterator it;
+  size_t count = 0;
+  ss << "SiPhase2OuterTrackerLorentzAngleReader:" << std::endl;
+  ss << "detid \t Lorentz angle" << std::endl;
+  for (it = detid_la.begin(); it != detid_la.end(); ++it) {
+    ss << it->first << "\t" << it->second << std::endl;
+    ++count;
+  }
+}
+
+/*
+void SiPhase2OuterTrackerLorentzAngle::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const {
+  std::map<unsigned int, float> detid_la = getLorentzAngles();
+  std::map<unsigned int, float>::const_iterator it;
+
+  SiStripDetSummary summary{trackerTopo};
+
+  for (it = detid_la.begin(); it != detid_la.end(); ++it) {
+    DetId detid(it->first);
+    float value = it->second;
+    summary.add(detid, value);
+  }
+  ss << "Summary of lorentz angles:" << std::endl;
+  summary.print(ss);
+}
+*/

--- a/CondFormats/SiPhase2TrackerObjects/src/SiPhase2OuterTrackerLorentzAngle.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/SiPhase2OuterTrackerLorentzAngle.cc
@@ -2,7 +2,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 bool SiPhase2OuterTrackerLorentzAngle::putLorentzAngle(const uint32_t& detid, float value) {
-  std::map<unsigned int, float>::const_iterator id = m_LA.find(detid);
+  std::unordered_map<unsigned int, float>::const_iterator id = m_LA.find(detid);
   if (id != m_LA.end()) {
     edm::LogError("SiPhase2OuterTrackerLorentzAngle") << "SiPhase2OuterTrackerLorentzAngle for DetID " << detid
                                                       << " is already stored. Skippig this put" << std::endl;
@@ -12,7 +12,7 @@ bool SiPhase2OuterTrackerLorentzAngle::putLorentzAngle(const uint32_t& detid, fl
   return true;
 }
 float SiPhase2OuterTrackerLorentzAngle::getLorentzAngle(const uint32_t& detid) const {
-  std::map<unsigned int, float>::const_iterator id = m_LA.find(detid);
+  std::unordered_map<unsigned int, float>::const_iterator id = m_LA.find(detid);
   if (id != m_LA.end())
     return id->second;
   else {
@@ -23,8 +23,8 @@ float SiPhase2OuterTrackerLorentzAngle::getLorentzAngle(const uint32_t& detid) c
 }
 
 void SiPhase2OuterTrackerLorentzAngle::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const {
-  std::map<unsigned int, float> detid_la = getLorentzAngles();
-  std::map<unsigned int, float>::const_iterator it;
+  std::unordered_map<unsigned int, float> detid_la = getLorentzAngles();
+  std::unordered_map<unsigned int, float>::const_iterator it;
   size_t count = 0;
   ss << "SiPhase2OuterTrackerLorentzAngleReader:" << std::endl;
   ss << "detid \t Lorentz angle" << std::endl;
@@ -33,20 +33,3 @@ void SiPhase2OuterTrackerLorentzAngle::printDebug(std::stringstream& ss, const T
     ++count;
   }
 }
-
-/*
-void SiPhase2OuterTrackerLorentzAngle::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const {
-  std::map<unsigned int, float> detid_la = getLorentzAngles();
-  std::map<unsigned int, float>::const_iterator it;
-
-  SiStripDetSummary summary{trackerTopo};
-
-  for (it = detid_la.begin(); it != detid_la.end(); ++it) {
-    DetId detid(it->first);
-    float value = it->second;
-    summary.add(detid, value);
-  }
-  ss << "Summary of lorentz angles:" << std::endl;
-  summary.print(ss);
-}
-*/

--- a/CondFormats/SiPhase2TrackerObjects/src/SiPhase2OuterTrackerLorentzAngle.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/SiPhase2OuterTrackerLorentzAngle.cc
@@ -5,7 +5,7 @@ bool SiPhase2OuterTrackerLorentzAngle::putLorentzAngle(const uint32_t& detid, fl
   std::unordered_map<unsigned int, float>::const_iterator id = m_LA.find(detid);
   if (id != m_LA.end()) {
     edm::LogError("SiPhase2OuterTrackerLorentzAngle") << "SiPhase2OuterTrackerLorentzAngle for DetID " << detid
-                                                      << " is already stored. Skippig this put" << std::endl;
+                                                      << " is already stored. Skipping this put" << std::endl;
     return false;
   } else
     m_LA[detid] = value;
@@ -17,47 +17,26 @@ float SiPhase2OuterTrackerLorentzAngle::getLorentzAngle(const uint32_t& detid) c
   if (id != m_LA.end())
     return id->second;
   else {
-    edm::LogError("SiPhase2OuterTrackerLorentzAngle")
+    throw cms::Exception("SiPhase2OuterTrackerLorentzAngle")
         << "SiPhase2OuterTrackerLorentzAngle for DetID " << detid << " is not stored" << std::endl;
   }
-  return 0;
 }
 
-void SiPhase2OuterTrackerLorentzAngle::getLorentzAngles_PSP(const TrackerGeometry* trackerGeometry,
-                                                            std::unordered_map<unsigned int, float>& out) const {
+void SiPhase2OuterTrackerLorentzAngle::getLorentzAnglesByModuleType(const TrackerGeometry* trackerGeometry,
+                                                                    const TrackerGeometry::ModuleType& theType,
+                                                                    std::unordered_map<unsigned int, float>& out) const {
   for (const auto& [det, LA] : m_LA) {
-    if (trackerGeometry->getDetectorType(det) == TrackerGeometry::ModuleType::Ph2PSP) {
-      out[det] = LA;
-    }
-  }
-}
-
-void SiPhase2OuterTrackerLorentzAngle::getLorentzAngles_PSS(const TrackerGeometry* trackerGeometry,
-                                                            std::unordered_map<unsigned int, float>& out) const {
-  for (const auto& [det, LA] : m_LA) {
-    if (trackerGeometry->getDetectorType(det) == TrackerGeometry::ModuleType::Ph2PSS) {
-      out[det] = LA;
-    }
-  }
-}
-
-void SiPhase2OuterTrackerLorentzAngle::getLorentzAngles_2S(const TrackerGeometry* trackerGeometry,
-                                                           std::unordered_map<unsigned int, float>& out) const {
-  for (const auto& [det, LA] : m_LA) {
-    if (trackerGeometry->getDetectorType(det) == TrackerGeometry::ModuleType::Ph2SS) {
+    if (trackerGeometry->getDetectorType(det) == theType) {
       out[det] = LA;
     }
   }
 }
 
 void SiPhase2OuterTrackerLorentzAngle::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const {
-  std::unordered_map<unsigned int, float> detid_la = getLorentzAngles();
-  std::unordered_map<unsigned int, float>::const_iterator it;
-  size_t count = 0;
+  const std::unordered_map<unsigned int, float>& detid_la = getLorentzAngles();
   ss << "SiPhase2OuterTrackerLorentzAngleReader:" << std::endl;
   ss << "detid \t Lorentz angle" << std::endl;
-  for (it = detid_la.begin(); it != detid_la.end(); ++it) {
-    ss << it->first << "\t" << it->second << std::endl;
-    ++count;
+  for (const auto& it : detid_la) {
+    ss << it.first << "\t" << it.second << std::endl;
   }
 }

--- a/CondFormats/SiPhase2TrackerObjects/src/SiPhase2OuterTrackerLorentzAngle.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/SiPhase2OuterTrackerLorentzAngle.cc
@@ -11,6 +11,7 @@ bool SiPhase2OuterTrackerLorentzAngle::putLorentzAngle(const uint32_t& detid, fl
     m_LA[detid] = value;
   return true;
 }
+
 float SiPhase2OuterTrackerLorentzAngle::getLorentzAngle(const uint32_t& detid) const {
   std::unordered_map<unsigned int, float>::const_iterator id = m_LA.find(detid);
   if (id != m_LA.end())
@@ -20,6 +21,33 @@ float SiPhase2OuterTrackerLorentzAngle::getLorentzAngle(const uint32_t& detid) c
         << "SiPhase2OuterTrackerLorentzAngle for DetID " << detid << " is not stored" << std::endl;
   }
   return 0;
+}
+
+void SiPhase2OuterTrackerLorentzAngle::getLorentzAngles_PSP(const TrackerGeometry* trackerGeometry,
+                                                            std::unordered_map<unsigned int, float>& out) const {
+  for (const auto& [det, LA] : m_LA) {
+    if (trackerGeometry->getDetectorType(det) == TrackerGeometry::ModuleType::Ph2PSP) {
+      out[det] = LA;
+    }
+  }
+}
+
+void SiPhase2OuterTrackerLorentzAngle::getLorentzAngles_PSS(const TrackerGeometry* trackerGeometry,
+                                                            std::unordered_map<unsigned int, float>& out) const {
+  for (const auto& [det, LA] : m_LA) {
+    if (trackerGeometry->getDetectorType(det) == TrackerGeometry::ModuleType::Ph2PSS) {
+      out[det] = LA;
+    }
+  }
+}
+
+void SiPhase2OuterTrackerLorentzAngle::getLorentzAngles_2S(const TrackerGeometry* trackerGeometry,
+                                                           std::unordered_map<unsigned int, float>& out) const {
+  for (const auto& [det, LA] : m_LA) {
+    if (trackerGeometry->getDetectorType(det) == TrackerGeometry::ModuleType::Ph2SS) {
+      out[det] = LA;
+    }
+  }
 }
 
 void SiPhase2OuterTrackerLorentzAngle::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const {

--- a/CondFormats/SiPhase2TrackerObjects/src/T_EventSetup_SiPhase2OuterTrackerLorentzAngle.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/T_EventSetup_SiPhase2OuterTrackerLorentzAngle.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(SiPhase2OuterTrackerLorentzAngle);

--- a/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
@@ -5,6 +5,4 @@
 	</class>
 	<class name="DTCELinkId" class_version="0">
 	</class>
-	<!-- <class name="SiPhase2OuterTrackerLorentzAngle" class_version="0"> -->
-	<!-- </class> -->
 </lcgdict>

--- a/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
@@ -5,4 +5,6 @@
 	</class>
 	<class name="DTCELinkId" class_version="0">
 	</class>
+	<!-- <class name="SiPhase2OuterTrackerLorentzAngle" class_version="0"> -->
+	<!-- </class> -->
 </lcgdict>

--- a/CondFormats/SiPhase2TrackerObjects/src/headers.h
+++ b/CondFormats/SiPhase2TrackerObjects/src/headers.h
@@ -1,2 +1,3 @@
 #include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"

--- a/CondFormats/SiPhase2TrackerObjects/test/BuildFile.xml
+++ b/CondFormats/SiPhase2TrackerObjects/test/BuildFile.xml
@@ -1,0 +1,3 @@
+<bin file="testSerializationSiPhase2TrackerObjects.cpp">
+  <use   name="CondFormats/SiPhase2TrackerObjects"/>
+</bin>

--- a/CondFormats/SiPhase2TrackerObjects/test/testSerializationSiPhase2TrackerObjects.cpp
+++ b/CondFormats/SiPhase2TrackerObjects/test/testSerializationSiPhase2TrackerObjects.cpp
@@ -1,0 +1,7 @@
+#include "CondFormats/Serialization/interface/Test.h"
+#include "CondFormats/SiPhase2TrackerObjects/src/headers.h"
+
+int main() {
+  testSerialization<SiPhase2OuterTrackerLorentzAngle>();
+  return 0;
+}

--- a/CondTools/SiPhase2Tracker/plugins/BuildFile.xml
+++ b/CondTools/SiPhase2Tracker/plugins/BuildFile.xml
@@ -6,4 +6,6 @@
 <use name="CondFormats/Common"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiPhase2TrackerObjects"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
 <flags EDM_PLUGIN="1"/>

--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
@@ -1,0 +1,176 @@
+// -*- C++ -*-
+//
+// Package:  CondTools/SiPhase2Tracker   
+// Class:    SiPhase2OuterTrackerLorentzAngleWriter     
+//
+/**\class SiPhase2OuterTrackerLorentzAngleWriter SiPhase2OuterTrackerLorentzAngleWriter.cc Tracker/Tools/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
+
+ Description: Put the values of the Lorentz angle for each strip detId in as database file
+
+ Implementation:
+     [Notes on implementation]
+     
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Mon, 18 May 2020 18:00:00 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <iostream>
+#include <string>
+#include <map>
+
+// user include files
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+//
+// class declaration
+//
+
+// If the analyzer does not use TFileService, please remove
+// the template argument to the base class so the class inherits
+// from  edm::one::EDAnalyzer<>
+// This will improve performance in multithreaded jobs.
+
+
+class SiPhase2OuterTrackerLorentzAngleWriter : public edm::one::EDAnalyzer<>
+{
+   public:
+      explicit SiPhase2OuterTrackerLorentzAngleWriter(const edm::ParameterSet&);
+      ~SiPhase2OuterTrackerLorentzAngleWriter();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+
+      // ----------member data ---------------------------
+      std::string m_record;
+      std::string m_tag;
+      float m_value;
+      SiPhase2OuterTrackerLorentzAngle* lorentzAngle;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+SiPhase2OuterTrackerLorentzAngleWriter::SiPhase2OuterTrackerLorentzAngleWriter(const edm::ParameterSet& iConfig)
+   : m_record(iConfig.getParameter<std::string>("record")),
+     m_tag(iConfig.getParameter<std::string>("tag")),
+     m_value(iConfig.getParameter<double>("value")){}
+
+SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter()
+{
+  delete lorentzAngle;
+  std::cout << "SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter" << std::endl;
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+   std::cout << "SiPhase2OuterTrackerLorentzAngleWriter::analyze " << std::endl;
+    
+    
+   // Database services (write)
+   edm::Service<cond::service::PoolDBOutputService> mydbservice;
+   if ( ! mydbservice.isAvailable() )
+   {
+      std::cout << "Service is unavailable" << std::endl;
+      return;
+   }      
+   std::string tag = mydbservice->tag(m_record);
+   unsigned int irun = iEvent.id().run();
+   std::cout << "tag : " << tag << std::endl;
+   std::cout << "run : " << irun << std::endl;
+   
+   // map to be filled
+   std::map< unsigned int, float > detsLAtoDB;
+          
+   // Retrieve tracker topology from geometry
+   edm::ESHandle<TrackerTopology> tTopoHandle;
+   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+   const TrackerTopology* const tTopo = tTopoHandle.product();
+
+   // Retrieve old style tracker geometry from geometry
+   edm::ESHandle<TrackerGeometry> pDD;
+   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+   std::cout << " There are " << pDD->detUnits().size() << " modules" << std::endl;
+
+   for (const auto& it : pDD->detUnits()) {
+      const DetId detid = it->geographicalId();
+      const unsigned int rawDetId = detid.rawId();
+      int subid = detid.subdetId();
+
+      if(subid == StripSubdetector::TOB || subid == StripSubdetector::TID ){
+	detsLAtoDB[rawDetId] = m_value;
+      } 
+
+   }
+
+   // SiStripLorentzAngle object
+   lorentzAngle = new SiPhase2OuterTrackerLorentzAngle();
+   lorentzAngle->putLorentsAngles(detsLAtoDB);
+   std::cout<<"currentTime "<<mydbservice->currentTime()<<std::endl;
+   mydbservice->writeOne(lorentzAngle,mydbservice->currentTime(),m_record);
+   
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+SiPhase2OuterTrackerLorentzAngleWriter::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+SiPhase2OuterTrackerLorentzAngleWriter::endJob()
+{
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+SiPhase2OuterTrackerLorentzAngleWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("record","SiPhase2OuterTrackerLorentzAngleRcd");
+    desc.add<std::string>("tag","SiPhase2OuterTrackerLorentzAngle");
+    desc.add<double>("value",0.07);
+    descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPhase2OuterTrackerLorentzAngleWriter);

--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
@@ -63,14 +63,6 @@ private:
 };
 
 //
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
 // constructors and destructor
 //
 SiPhase2OuterTrackerLorentzAngleWriter::SiPhase2OuterTrackerLorentzAngleWriter(const edm::ParameterSet& iConfig)
@@ -80,7 +72,8 @@ SiPhase2OuterTrackerLorentzAngleWriter::SiPhase2OuterTrackerLorentzAngleWriter(c
 
 SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter() {
   delete lorentzAngle;
-  edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter") << "SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter" << std::endl;
+  edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter")
+      << "SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter" << std::endl;
 }
 
 //
@@ -91,7 +84,8 @@ SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter(
 void SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
   using namespace edm;
-  edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter") << "SiPhase2OuterTrackerLorentzAngleWriter::analyze " << std::endl;
+  edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter")
+      << "SiPhase2OuterTrackerLorentzAngleWriter::analyze " << std::endl;
 
   // Database services (write)
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
@@ -116,7 +110,8 @@ void SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, c
   // Retrieve old style tracker geometry from geometry
   edm::ESHandle<TrackerGeometry> pDD;
   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-  edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter") << " There are " << pDD->detUnits().size() << " modules" << std::endl;
+  edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter")
+      << " There are " << pDD->detUnits().size() << " modules in this geometry." << std::endl;
 
   for (auto const& det_u : pDD->detUnits()) {
     const DetId detid = det_u->geographicalId();
@@ -127,12 +122,15 @@ void SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, c
       assert(pixdet);
       LogDebug("SiPhase2OuterTrackerLorentzAngleWriter") << rawId << " is a " << subid << " det" << std::endl;
       if (subid == StripSubdetector::TOB || subid == StripSubdetector::TID) {
+        LogDebug("SiPhase2OuterTrackerLorentzAngleWriter")
+            << "subdetector ID:" << subid << " layer:" << tTopo->layer(detid) << std::endl;
         detsLAtoDB[rawId] = m_value;
       }
     }
   }
 
-  edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter") << " There are " << detsLAtoDB.size() << " values assigned" << std::endl;
+  edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter")
+      << " There are " << detsLAtoDB.size() << " OT Lorentz Angle values assigned" << std::endl;
 
   // SiStripLorentzAngle object
   lorentzAngle = new SiPhase2OuterTrackerLorentzAngle();

--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //
-// Package:  CondTools/SiPhase2Tracker   
-// Class:    SiPhase2OuterTrackerLorentzAngleWriter     
+// Package:  CondTools/SiPhase2Tracker
+// Class:    SiPhase2OuterTrackerLorentzAngleWriter
 //
 /**\class SiPhase2OuterTrackerLorentzAngleWriter SiPhase2OuterTrackerLorentzAngleWriter.cc Tracker/Tools/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
 
@@ -17,7 +17,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <iostream>
@@ -28,6 +27,7 @@
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -48,26 +48,23 @@
 // from  edm::one::EDAnalyzer<>
 // This will improve performance in multithreaded jobs.
 
+class SiPhase2OuterTrackerLorentzAngleWriter : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiPhase2OuterTrackerLorentzAngleWriter(const edm::ParameterSet&);
+  ~SiPhase2OuterTrackerLorentzAngleWriter() override;
 
-class SiPhase2OuterTrackerLorentzAngleWriter : public edm::one::EDAnalyzer<>
-{
-   public:
-      explicit SiPhase2OuterTrackerLorentzAngleWriter(const edm::ParameterSet&);
-      ~SiPhase2OuterTrackerLorentzAngleWriter();
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-
-   private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
-
-      // ----------member data ---------------------------
-      std::string m_record;
-      std::string m_tag;
-      float m_value;
-      SiPhase2OuterTrackerLorentzAngle* lorentzAngle;
+  // ----------member data ---------------------------
+  std::string m_record;
+  std::string m_tag;
+  float m_value;
+  SiPhase2OuterTrackerLorentzAngle* lorentzAngle;
 };
 
 //
@@ -82,94 +79,86 @@ class SiPhase2OuterTrackerLorentzAngleWriter : public edm::one::EDAnalyzer<>
 // constructors and destructor
 //
 SiPhase2OuterTrackerLorentzAngleWriter::SiPhase2OuterTrackerLorentzAngleWriter(const edm::ParameterSet& iConfig)
-   : m_record(iConfig.getParameter<std::string>("record")),
-     m_tag(iConfig.getParameter<std::string>("tag")),
-     m_value(iConfig.getParameter<double>("value")){}
+    : m_record(iConfig.getParameter<std::string>("record")),
+      m_tag(iConfig.getParameter<std::string>("tag")),
+      m_value(iConfig.getParameter<double>("value")) {}
 
-SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter()
-{
+SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter() {
   delete lorentzAngle;
   std::cout << "SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter" << std::endl;
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   std::cout << "SiPhase2OuterTrackerLorentzAngleWriter::analyze " << std::endl;
-    
-    
-   // Database services (write)
-   edm::Service<cond::service::PoolDBOutputService> mydbservice;
-   if ( ! mydbservice.isAvailable() )
-   {
-      std::cout << "Service is unavailable" << std::endl;
-      return;
-   }      
-   std::string tag = mydbservice->tag(m_record);
-   unsigned int irun = iEvent.id().run();
-   std::cout << "tag : " << tag << std::endl;
-   std::cout << "run : " << irun << std::endl;
-   
-   // map to be filled
-   std::map< unsigned int, float > detsLAtoDB;
-          
-   // Retrieve tracker topology from geometry
-   edm::ESHandle<TrackerTopology> tTopoHandle;
-   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-   const TrackerTopology* const tTopo = tTopoHandle.product();
+void SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
+  using namespace edm;
+  std::cout << "SiPhase2OuterTrackerLorentzAngleWriter::analyze " << std::endl;
 
-   // Retrieve old style tracker geometry from geometry
-   edm::ESHandle<TrackerGeometry> pDD;
-   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-   std::cout << " There are " << pDD->detUnits().size() << " modules" << std::endl;
+  // Database services (write)
+  edm::Service<cond::service::PoolDBOutputService> mydbservice;
+  if (!mydbservice.isAvailable()) {
+    std::cout << "Service is unavailable" << std::endl;
+    return;
+  }
 
-   for (const auto& it : pDD->detUnits()) {
-      const DetId detid = it->geographicalId();
-      const unsigned int rawDetId = detid.rawId();
-      int subid = detid.subdetId();
+  std::string tag = mydbservice->tag(m_record);
+  unsigned int irun = iEvent.id().run();
+  std::cout << "tag : " << tag << std::endl;
+  std::cout << "run : " << irun << std::endl;
 
-      if(subid == StripSubdetector::TOB || subid == StripSubdetector::TID ){
-	detsLAtoDB[rawDetId] = m_value;
-      } 
+  // map to be filled
+  std::map<unsigned int, float> detsLAtoDB;
 
-   }
+  // Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  const TrackerTopology* const tTopo = tTopoHandle.product();
 
-   // SiStripLorentzAngle object
-   lorentzAngle = new SiPhase2OuterTrackerLorentzAngle();
-   lorentzAngle->putLorentsAngles(detsLAtoDB);
-   std::cout<<"currentTime "<<mydbservice->currentTime()<<std::endl;
-   mydbservice->writeOne(lorentzAngle,mydbservice->currentTime(),m_record);
-   
+  // Retrieve old style tracker geometry from geometry
+  edm::ESHandle<TrackerGeometry> pDD;
+  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+  std::cout << " There are " << pDD->detUnits().size() << " modules" << std::endl;
+
+  for (auto const& det_u : pDD->detUnits()) {
+    const DetId detid = det_u->geographicalId();
+    uint32_t rawId = detid.rawId();
+    int subid = detid.subdetId();
+    if (detid.det() == DetId::Detector::Tracker) {
+      const Phase2TrackerGeomDetUnit* pixdet = dynamic_cast<const Phase2TrackerGeomDetUnit*>(det_u);
+      assert(pixdet);
+      std::cout << rawId << " is a " << subid << " det" << std::endl;
+      if (subid == StripSubdetector::TOB || subid == StripSubdetector::TID) {
+        detsLAtoDB[rawId] = m_value;
+      }
+    }
+  }
+
+  std::cout << " There are " << detsLAtoDB.size() << " values assigned" << std::endl;
+
+  // SiStripLorentzAngle object
+  lorentzAngle = new SiPhase2OuterTrackerLorentzAngle();
+  lorentzAngle->putLorentsAngles(detsLAtoDB);
+  std::cout << "currentTime " << mydbservice->currentTime() << std::endl;
+  mydbservice->writeOne(lorentzAngle, mydbservice->currentTime(), m_record);
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void
-SiPhase2OuterTrackerLorentzAngleWriter::beginJob()
-{
-}
+void SiPhase2OuterTrackerLorentzAngleWriter::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-SiPhase2OuterTrackerLorentzAngleWriter::endJob()
-{
-}
+void SiPhase2OuterTrackerLorentzAngleWriter::endJob() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-SiPhase2OuterTrackerLorentzAngleWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-    edm::ParameterSetDescription desc;
-    desc.add<std::string>("record","SiPhase2OuterTrackerLorentzAngleRcd");
-    desc.add<std::string>("tag","SiPhase2OuterTrackerLorentzAngle");
-    desc.add<double>("value",0.07);
-    descriptions.addDefault(desc);
+void SiPhase2OuterTrackerLorentzAngleWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("record", "SiPhase2OuterTrackerLorentzAngleRcd");
+  desc.add<std::string>("tag", "SiPhase2OuterTrackerLorentzAngle");
+  desc.add<double>("value", 0.07);
+  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in

--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
@@ -3,9 +3,9 @@
 // Package:  CondTools/SiPhase2Tracker
 // Class:    SiPhase2OuterTrackerLorentzAngleWriter
 //
-/**\class SiPhase2OuterTrackerLorentzAngleWriter SiPhase2OuterTrackerLorentzAngleWriter.cc Tracker/Tools/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
+/**\class SiPhase2OuterTrackerLorentzAngleWriter SiPhase2OuterTrackerLorentzAngleWriter.cc CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
 
- Description: Put the values of the Lorentz angle for each strip detId in as database file
+ Description: Put the values of the Lorentz angle for Phase-2 Outer Tracker detId in as database file
 
  Implementation:
      [Notes on implementation]
@@ -59,7 +59,6 @@ private:
   std::string m_record;
   std::string m_tag;
   float m_value;
-  SiPhase2OuterTrackerLorentzAngle* lorentzAngle;
 };
 
 //
@@ -71,7 +70,6 @@ SiPhase2OuterTrackerLorentzAngleWriter::SiPhase2OuterTrackerLorentzAngleWriter(c
       m_value(iConfig.getParameter<double>("value")) {}
 
 SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter() {
-  delete lorentzAngle;
   edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter")
       << "SiPhase2OuterTrackerLorentzAngleWriter::~SiPhase2OuterTrackerLorentzAngleWriter" << std::endl;
 }
@@ -133,10 +131,11 @@ void SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, c
       << " There are " << detsLAtoDB.size() << " OT Lorentz Angle values assigned" << std::endl;
 
   // SiStripLorentzAngle object
-  lorentzAngle = new SiPhase2OuterTrackerLorentzAngle();
-  lorentzAngle->putLorentsAngles(detsLAtoDB);
+
+  auto lorentzAngle = std::make_unique<SiPhase2OuterTrackerLorentzAngle>();
+  lorentzAngle->putLorentzAngles(detsLAtoDB);
   edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter") << "currentTime " << mydbservice->currentTime() << std::endl;
-  mydbservice->writeOne(lorentzAngle, mydbservice->currentTime(), m_record);
+  mydbservice->writeOne(lorentzAngle.get(), mydbservice->currentTime(), m_record);
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
@@ -6,10 +6,27 @@ import os, shlex, shutil, getpass
 #import subprocess
 
 import FWCore.ParameterSet.Config as cms
-
 process = cms.Process("TEST")
 
-tag = 'SiPhase2OuterTrackerLorentzAngle_T6'
+###################################################################
+# Messages
+###################################################################
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.categories.append("SiPhase2OuterTrackerLorentzAngleWriter")  
+process.MessageLogger.categories.append("SiPhase2OuterTrackerLorentzAngle")
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+  SiPhase2OuterTrackerLorentzAngleWriter = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+  SiPhase2OuterTrackerLorentzAngle = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+)
+process.MessageLogger.statistics.append('cout') 
+
+tag = 'SiPhase2OuterTrackerLorentzAngle_T15'
 suffix = 'v0'
 outfile = tag+'_'+suffix+'.db'
 outdb = 'sqlite_file:'+outfile
@@ -22,12 +39,12 @@ if os.path.exists(outfile):
 process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = cms.string(outdb)
 
-process.load('Configuration.Geometry.GeometryExtended2026D35Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D35_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T6')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic')
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+tag = 'SiPhase2OuterTrackerLorentzAngle'
+suffix = 'v0'
+
+outdb = 'sqlite_file:'+tag+'_'+suffix+'.db'
+
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = cms.string(outdb)
+
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15')
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+process.source = cms.Source("EmptyIOVSource",
+    lastValue = cms.uint64(1),
+    timetype = cms.string('Run'),
+    firstValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    process.CondDB,
+    timetype = cms.untracked.string('Run'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiPhase2OuterTrackerLorentzAngleRcd'),
+        tag = cms.string(tag)
+    ))
+)
+
+process.LAPayload = cms.EDAnalyzer("SiPhase2OuterTrackerLorentzAngleWriter")
+process.LAPayload.tag = cms.string(tag)
+
+process.p = cms.Path(process.LAPayload)
+

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
@@ -1,9 +1,7 @@
 #! /usr/bin/env cmsRun
 # Author: Marco Musich (May 2020)
 from __future__ import print_function
-#import os
 import os, shlex, shutil, getpass
-#import subprocess
 
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("TEST")

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
@@ -1,21 +1,33 @@
+#! /usr/bin/env cmsRun
+# Author: Marco Musich (May 2020)
+from __future__ import print_function
+#import os
+import os, shlex, shutil, getpass
+#import subprocess
+
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-tag = 'SiPhase2OuterTrackerLorentzAngle'
+tag = 'SiPhase2OuterTrackerLorentzAngle_T6'
 suffix = 'v0'
+outfile = tag+'_'+suffix+'.db'
+outdb = 'sqlite_file:'+outfile
 
-outdb = 'sqlite_file:'+tag+'_'+suffix+'.db'
+if os.path.exists(outfile):
+  oldfile = outfile.replace(".db","_old.db")
+  print(">>> Backing up locally existing '%s' -> '%s'"%(outfile,oldfile))
+  shutil.move(outfile,oldfile)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = cms.string(outdb)
 
-process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D35Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D35_cff')
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T6')
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -83,20 +83,20 @@ allTags["Template"] = {
 ## Outer Tracker records
 ##
 
-tempConnectionString="sqlite_file:/tmp/musich/CMSSW_11_1_X_2020-05-17-2300/src/CondTools/SiPhase2Tracker/test/OTLorentzAngles.db"
+tempConnectionString="frontier://FrontierPrep/CMS_CONDITIONS"
 
 allTags["OTLA"] = {
-    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
-    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
-    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
-    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
 }
 
 allTags["SimOTLA"] = {
-    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
-    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
-    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
-    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
 }
 
 ##

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -83,6 +83,7 @@ allTags["Template"] = {
 ## Outer Tracker records
 ##
 
+'''
 tempConnectionString="frontier://FrontierPrep/CMS_CONDITIONS"
 
 allTags["OTLA"] = {
@@ -98,7 +99,7 @@ allTags["SimOTLA"] = {
     'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
     'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
 }
-
+'''
 ##
 ## All of the following conditions are not yet in active use, but will be activated in GT along the way
 ##
@@ -112,7 +113,7 @@ allTags["Template2Dden"] = {
 }
 
 # list of active tags to be replaced
-activeKeys = ["LA","LAWidth","SimLA","LAfromAlignment","GenError","Template","SimOTLA","OTLA"]
+activeKeys = ["LA","LAWidth","SimLA","LAfromAlignment","GenError","Template"]#,"SimOTLA","OTLA"]
 
 # list of geometries supported
 activeDets = ["T15","T17","T19","T20","T21","T22","T23"]

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -7,6 +7,8 @@ SiPixelSimLARecord        =   "SiPixelLorentzAngleSimRcd"
 SiPixelGenErrorRecord     =   "SiPixelGenErrorDBObjectRcd"       
 SiPixelTemplatesRecord    =   "SiPixelTemplateDBObjectRcd"       
 SiPixel2DTemplatesRecord  =   "SiPixel2DTemplateDBObjectRcd"     
+TrackerLARecord           =   "SiPhase2OuterTrackerLorentzAngleRcd"
+TrackerSimLARecord        =   "SiPhase2OuterTrackerLorentzAngleSimRcd"
 
 ##
 ## Active geometries: https://github.com/cms-sw/cmssw/blob/master/Configuration/Geometry/README.md
@@ -78,6 +80,26 @@ allTags["Template"] = {
 }
 
 ##
+## Outer Tracker records
+##
+
+tempConnectionString="sqlite_file:/tmp/musich/CMSSW_11_1_X_2020-05-17-2300/src/CondTools/SiPhase2Tracker/test/OTLorentzAngles.db"
+
+allTags["OTLA"] = {
+    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+}
+
+allTags["SimOTLA"] = {
+    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-05-19 14:00:00.000"] ), ),  #uH = 0.07/T
+}
+
+##
 ## All of the following conditions are not yet in active use, but will be activated in GT along the way
 ##
 
@@ -90,7 +112,7 @@ allTags["Template2Dden"] = {
 }
 
 # list of active tags to be replaced
-activeKeys = ["LA","LAWidth","SimLA","LAfromAlignment","GenError","Template"]
+activeKeys = ["LA","LAWidth","SimLA","LAfromAlignment","GenError","Template","SimOTLA","OTLA"]
 
 # list of geometries supported
 activeDets = ["T15","T17","T19","T20","T21","T22","T23"]

--- a/Configuration/Geometry/python/GeometryExtended2026D49_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D49_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D49XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D50_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D50_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D50XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D51_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D51_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D51XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D53_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D53_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D53XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D54_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D54_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D54XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D56_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D56_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D56XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D57_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D57_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D57XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D58_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D58_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D58XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D59_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D59_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D59XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D60_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D60_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D61_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D61_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D61XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D62_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D62_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D62XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D63_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D63_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D63XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D64_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D64_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D64XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D65_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D65_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D65XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -281,6 +281,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -315,6 +316,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -349,6 +351,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -141,6 +141,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -175,6 +176,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -209,6 +211,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -243,6 +246,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1008,7 +1008,7 @@ upgradeProperties[2026] = {
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
         'Era' : 'Phase2C11',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D64' : {
         'Geom' : 'Extended2026D64',                   # N.B.: Geometry with square 50x50 um2 pixels in the Inner Tracker.
@@ -1016,7 +1016,7 @@ upgradeProperties[2026] = {
         'GT' : 'auto:phase2_realistic_T22',
         'ProcessModifier': 'phase2_PixelCPEGeneric',  # Pixel Template reconstruction is temporarily inactive (will update once conditions are availalble).
         'Era' : 'Phase2C11',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D65' : {
         'Geom' : 'Extended2026D65',                   # N.B.: Geometry with 3D pixels in the Inner Tracker.
@@ -1024,7 +1024,7 @@ upgradeProperties[2026] = {
         'GT' : 'auto:phase2_realistic_T23',           # This symbolic GT has no pixel template / GenError informations.
         'ProcessModifier': 'phase2_PixelCPEGeneric',  # This modifier removes all need for IT template information. DO NOT USE for standard planar sensors.
         'Era' : 'Phase2C11',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
 }
 

--- a/Geometry/TrackerNumberingBuilder/interface/utils.h
+++ b/Geometry/TrackerNumberingBuilder/interface/utils.h
@@ -14,6 +14,15 @@ namespace TrackerGeometryUtils {
 
   std::vector<uint32_t> getSiStripDetIds(const GeometricDet& geomDet);
 
+  /**
+ * A helper method to get the full list of OuterTracker DetIds from the GeometricDet
+ *
+ * The DetIds are sorted by subdetector, but otherwise keep the ordering from
+ * GeometricDet::deepComponents (for compatibility with SiStripDetInfoFileReader)
+ */
+
+  std::vector<uint32_t> getOuterTrackerDetIds(const GeometricDet& geomDet);
+
 }  // namespace TrackerGeometryUtils
 
 #endif  // GEOMETRY_TRACKERNUMBERINGBUILDER_UTILS_H

--- a/Geometry/TrackerNumberingBuilder/src/utils.cc
+++ b/Geometry/TrackerNumberingBuilder/src/utils.cc
@@ -1,5 +1,6 @@
 #include "Geometry/TrackerNumberingBuilder/interface/utils.h"
 #include "DataFormats/TrackerCommon/interface/SiStripEnums.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
 std::vector<uint32_t> TrackerGeometryUtils::getSiStripDetIds(const GeometricDet& geomDet) {
   std::vector<const GeometricDet*> deepComp;
@@ -14,4 +15,19 @@ std::vector<uint32_t> TrackerGeometryUtils::getSiStripDetIds(const GeometricDet&
   std::stable_sort(
       std::begin(stripDetIds), std::end(stripDetIds), [](DetId a, DetId b) { return a.subdetId() < b.subdetId(); });
   return stripDetIds;
+}
+
+std::vector<uint32_t> TrackerGeometryUtils::getOuterTrackerDetIds(const GeometricDet& geomDet) {
+  std::vector<const GeometricDet*> deepComp;
+  geomDet.deepComponents(deepComp);
+  std::vector<uint32_t> OTDetIds;
+  for (const auto* dep : deepComp) {
+    const auto detId = dep->geographicalId();
+    if ((detId.det() == DetId::Detector::Tracker) && (detId.subdetId() > PixelSubdetector::PixelEndcap)) {
+      OTDetIds.push_back(detId);
+    }
+  }
+  std::stable_sort(
+      std::begin(OTDetIds), std::end(OTDetIds), [](DetId a, DetId b) { return a.subdetId() < b.subdetId(); });
+  return OTDetIds;
 }

--- a/RecoLocalTracker/Phase2TrackerRecHits/BuildFile.xml
+++ b/RecoLocalTracker/Phase2TrackerRecHits/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="RecoLocalTracker/ClusterParameterEstimator"/>
 <use name="DataFormats/Phase2TrackerCluster"/>
+<use name="CondFormats/SiPhase2TrackerObjects"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
@@ -38,7 +38,7 @@ private:
 
   const MagneticField& magfield_;
   const TrackerGeometry& geom_;
-  const SiPhase2OuterTrackerLorentzAngle& LorentzAngleMap_;
+  const SiPhase2OuterTrackerLorentzAngle& lorentzAngleMap_;
 
   float tanLorentzAnglePerTesla_;
   unsigned int m_off;

--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
@@ -7,6 +7,7 @@
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -24,7 +25,10 @@ public:
   };
 
 public:
-  Phase2StripCPE(edm::ParameterSet& conf, const MagneticField&, const TrackerGeometry&);
+  Phase2StripCPE(edm::ParameterSet& conf,
+                 const MagneticField&,
+                 const TrackerGeometry&,
+                 const SiPhase2OuterTrackerLorentzAngle&);
   LocalValues localParameters(const Phase2TrackerCluster1D& cluster, const GeomDetUnit& det) const override;
   LocalVector driftDirection(const Phase2TrackerGeomDetUnit& det) const;
 
@@ -34,6 +38,8 @@ private:
 
   const MagneticField& magfield_;
   const TrackerGeometry& geom_;
+  const SiPhase2OuterTrackerLorentzAngle& LorentzAngleMap_;
+
   float tanLorentzAnglePerTesla_;
   unsigned int m_off;
 

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
@@ -7,6 +7,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 
 #include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
@@ -28,6 +29,7 @@ private:
 
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pDDToken_;
+  edm::ESGetToken<SiPhase2OuterTrackerLorentzAngle, SiPhase2OuterTrackerLorentzAngleRcd> lorentzAngleToken_;
   CPE_t cpeNum_;
   edm::ParameterSet pset_;
 };
@@ -47,6 +49,7 @@ Phase2StripCPEESProducer::Phase2StripCPEESProducer(const edm::ParameterSet& p) {
   if (cpeNum_ != GEOMETRIC) {
     c.setConsumes(magfieldToken_);
     c.setConsumes(pDDToken_);
+    c.setConsumes(lorentzAngleToken_);
   }
 }
 
@@ -55,7 +58,8 @@ std::unique_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > Phase2StripC
   std::unique_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > cpe_;
   switch (cpeNum_) {
     case DEFAULT:
-      cpe_ = std::make_unique<Phase2StripCPE>(pset_, iRecord.get(magfieldToken_), iRecord.get(pDDToken_));
+      cpe_ = std::make_unique<Phase2StripCPE>(
+          pset_, iRecord.get(magfieldToken_), iRecord.get(pDDToken_), iRecord.get(lorentzAngleToken_));
       break;
 
     case GEOMETRIC:

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
@@ -9,7 +9,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 
-#include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
+#include "RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
 #include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 #include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEGeometric.h"
@@ -22,7 +22,7 @@
 class Phase2StripCPEESProducer : public edm::ESProducer {
 public:
   Phase2StripCPEESProducer(const edm::ParameterSet&);
-  std::unique_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > produce(const TkStripCPERecord& iRecord);
+  std::unique_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > produce(const TkPhase2OTCPERecord& iRecord);
 
 private:
   enum CPE_t { DEFAULT, GEOMETRIC };
@@ -54,7 +54,7 @@ Phase2StripCPEESProducer::Phase2StripCPEESProducer(const edm::ParameterSet& p) {
 }
 
 std::unique_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > Phase2StripCPEESProducer::produce(
-    const TkStripCPERecord& iRecord) {
+    const TkPhase2OTCPERecord& iRecord) {
   std::unique_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > cpe_;
   switch (cpeNum_) {
     case DEFAULT:

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
@@ -21,7 +21,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-#include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
+#include "RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h"
 #include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 
 #include <vector>
@@ -51,7 +51,7 @@ void Phase2TrackerRecHits::produce(edm::StreamID sid, edm::Event& event, const e
 
   // load the cpe via the eventsetup
   edm::ESHandle<ClusterParameterEstimator<Phase2TrackerCluster1D> > cpe;
-  eventSetup.get<TkStripCPERecord>().get(cpeTag_, cpe);
+  eventSetup.get<TkPhase2OTCPERecord>().get(cpeTag_, cpe);
 
   // Get the geometry
   edm::ESHandle<TrackerGeometry> geomHandle;

--- a/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEESProducer_cfi.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEESProducer_cfi.py
@@ -1,9 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 phase2StripCPEESProducer = cms.ESProducer("Phase2StripCPEESProducer",
-  ComponentType = cms.string('Phase2StripCPE'),
-  parameters    = cms.PSet(
-    LorentzAngle_DB = cms.bool(False),			
-    TanLorentzAnglePerTesla = cms.double(0.07)
-  )
-)
+                                          ComponentType = cms.string('Phase2StripCPE'),
+                                          parameters    = cms.PSet(LorentzAngle_DB = cms.bool(True),			
+                                                                   TanLorentzAnglePerTesla = cms.double(0.07)
+                                                                   )
+                                         )

--- a/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPE.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPE.cc
@@ -29,12 +29,8 @@ Phase2StripCPE::LocalValues Phase2StripCPE::localParameters(const Phase2TrackerC
 LocalVector Phase2StripCPE::driftDirection(const Phase2TrackerGeomDetUnit& det) const {
   LocalVector lbfield = (det.surface()).toLocal(magfield_.inTesla(det.surface().position()));
 
-  float langle = 0.;
-  if (use_LorentzAngle_DB_) {
-    langle = LorentzAngleMap_.getLorentzAngle(det.geographicalId().rawId());
-  } else {
-    langle = tanLorentzAnglePerTesla_;
-  }
+  float langle =
+      use_LorentzAngle_DB_ ? LorentzAngleMap_.getLorentzAngle(det.geographicalId().rawId()) : tanLorentzAnglePerTesla_;
 
   float dir_x = -langle * lbfield.y();
   float dir_y = langle * lbfield.x();

--- a/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPE.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPE.cc
@@ -8,7 +8,7 @@ Phase2StripCPE::Phase2StripCPE(edm::ParameterSet& conf,
                                const SiPhase2OuterTrackerLorentzAngle& LorentzAngle)
     : magfield_(magf),
       geom_(geom),
-      LorentzAngleMap_(LorentzAngle),
+      lorentzAngleMap_(LorentzAngle),
       tanLorentzAnglePerTesla_(conf.getParameter<double>("TanLorentzAnglePerTesla")) {
   use_LorentzAngle_DB_ = conf.getParameter<bool>("LorentzAngle_DB");
   fillParam();
@@ -30,7 +30,7 @@ LocalVector Phase2StripCPE::driftDirection(const Phase2TrackerGeomDetUnit& det) 
   LocalVector lbfield = (det.surface()).toLocal(magfield_.inTesla(det.surface().position()));
 
   float langle =
-      use_LorentzAngle_DB_ ? LorentzAngleMap_.getLorentzAngle(det.geographicalId().rawId()) : tanLorentzAnglePerTesla_;
+      use_LorentzAngle_DB_ ? lorentzAngleMap_.getLorentzAngle(det.geographicalId().rawId()) : tanLorentzAnglePerTesla_;
 
   float dir_x = -langle * lbfield.y();
   float dir_y = langle * lbfield.x();

--- a/RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h
@@ -1,0 +1,19 @@
+#ifndef RecoLocalTracker_Records_TkPhase2OTCPERecord_h
+#define RecoLocalTracker_Records_TkPhase2OTCPERecord_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
+
+#include "boost/mpl/vector.hpp"
+
+class TkPhase2OTCPERecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          TkPhase2OTCPERecord,
+          boost::mpl::vector<TrackerDigiGeometryRecord, IdealMagneticFieldRecord, SiPhase2OuterTrackerLorentzAngleRcd> > {
+};
+
+#endif

--- a/RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h
@@ -7,13 +7,12 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
-
-#include "boost/mpl/vector.hpp"
+#include "FWCore/Utilities/interface/mplVector.h"
 
 class TkPhase2OTCPERecord
     : public edm::eventsetup::DependentRecordImplementation<
           TkPhase2OTCPERecord,
-          boost::mpl::vector<TrackerDigiGeometryRecord, IdealMagneticFieldRecord, SiPhase2OuterTrackerLorentzAngleRcd> > {
+          edm::mpl::Vector<TrackerDigiGeometryRecord, IdealMagneticFieldRecord, SiPhase2OuterTrackerLorentzAngleRcd> > {
 };
 
 #endif

--- a/RecoLocalTracker/Records/interface/TkStripCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkStripCPERecord.h
@@ -8,6 +8,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
 #include "FWCore/Utilities/interface/mplVector.h"
 
 class TkStripCPERecord
@@ -20,6 +21,5 @@ class TkStripCPERecord
                                                                              SiStripLatencyRcd,
                                                                              SiStripNoisesRcd,
                                                                              SiStripApvGainRcd,
-                                                                             SiStripBadChannelRcd> > {};
-
+                                                                             SiPhase2OuterTrackerLorentzAngleRcd> > {};
 #endif

--- a/RecoLocalTracker/Records/interface/TkStripCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkStripCPERecord.h
@@ -12,14 +12,14 @@
 
 class TkStripCPERecord
     : public edm::eventsetup::DependentRecordImplementation<TkStripCPERecord,
-                                                           edm::mpl::Vector<TrackerDigiGeometryRecord,
-                                                                               IdealMagneticFieldRecord,
-                                                                               SiStripLorentzAngleDepRcd,
-                                                                               SiStripBackPlaneCorrectionDepRcd,
-                                                                               SiStripConfObjectRcd,
-                                                                               SiStripLatencyRcd,
-                                                                               SiStripNoisesRcd,
-                                                                               SiStripApvGainRcd,
-                                                                               SiStripBadChannelRcd> > {};
+                                                            edm::mpl::Vector<TrackerDigiGeometryRecord,
+                                                                             IdealMagneticFieldRecord,
+                                                                             SiStripLorentzAngleDepRcd,
+                                                                             SiStripBackPlaneCorrectionDepRcd,
+                                                                             SiStripConfObjectRcd,
+                                                                             SiStripLatencyRcd,
+                                                                             SiStripNoisesRcd,
+                                                                             SiStripApvGainRcd,
+                                                                             SiStripBadChannelRcd> > {};
 
 #endif

--- a/RecoLocalTracker/Records/interface/TkStripCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkStripCPERecord.h
@@ -8,18 +8,18 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
-#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
 #include "FWCore/Utilities/interface/mplVector.h"
 
 class TkStripCPERecord
     : public edm::eventsetup::DependentRecordImplementation<TkStripCPERecord,
-                                                            edm::mpl::Vector<TrackerDigiGeometryRecord,
-                                                                             IdealMagneticFieldRecord,
-                                                                             SiStripLorentzAngleDepRcd,
-                                                                             SiStripBackPlaneCorrectionDepRcd,
-                                                                             SiStripConfObjectRcd,
-                                                                             SiStripLatencyRcd,
-                                                                             SiStripNoisesRcd,
-                                                                             SiStripApvGainRcd,
-                                                                             SiPhase2OuterTrackerLorentzAngleRcd> > {};
+                                                           edm::mpl::Vector<TrackerDigiGeometryRecord,
+                                                                               IdealMagneticFieldRecord,
+                                                                               SiStripLorentzAngleDepRcd,
+                                                                               SiStripBackPlaneCorrectionDepRcd,
+                                                                               SiStripConfObjectRcd,
+                                                                               SiStripLatencyRcd,
+                                                                               SiStripNoisesRcd,
+                                                                               SiStripApvGainRcd,
+                                                                               SiStripBadChannelRcd> > {};
+
 #endif

--- a/RecoLocalTracker/Records/src/TkPhase2OTCPERecord.cc
+++ b/RecoLocalTracker/Records/src/TkPhase2OTCPERecord.cc
@@ -1,0 +1,4 @@
+#include "RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(TkPhase2OTCPERecord);

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -53,7 +53,7 @@ private:
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> geometricSearchTrackerToken_;
-  edm::ESGetToken<ClusterParameterEstimator<Phase2TrackerCluster1D>, TkStripCPERecord> phase2TrackerCPEToken_;
+  edm::ESGetToken<ClusterParameterEstimator<Phase2TrackerCluster1D>, TkPhase2OTCPERecord> phase2TrackerCPEToken_;
 
   MeasurementTrackerImpl::BadStripCutsDet badStripCuts_;
 

--- a/RecoTracker/Record/interface/CkfComponentsRecord.h
+++ b/RecoTracker/Record/interface/CkfComponentsRecord.h
@@ -17,26 +17,25 @@
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"  // FIXME should be in the dependencies of the SiPixelQualityRcd
-
 #include "FWCore/Utilities/interface/mplVector.h"
 
 class CkfComponentsRecord
     : public edm::eventsetup::DependentRecordImplementation<CkfComponentsRecord,
-                                                            boost::mpl::vector<TrackerDigiGeometryRecord,
-                                                                               TkPixelCPERecord,
-                                                                               TkStripCPERecord,
-                                                                               TkPhase2OTCPERecord,
-                                                                               TransientRecHitRecord,
-                                                                               TrackingComponentsRecord,
-                                                                               TrackerRecoGeometryRecord,
-                                                                               TrackerTopologyRcd,
-                                                                               SiStripQualityRcd,
-                                                                               SiStripDetCablingRcd,
-                                                                               SiStripNoisesRcd,
-                                                                               SiStripRegionCablingRcd,
-                                                                               SiPixelQualityRcd,
-                                                                               SiPixelFedCablingMapRcd,
-                                                                               IdealMagneticFieldRecord,
-                                                                               SiPixelLorentzAngleRcd,
-                                                                               SiStripLorentzAngleDepRcd> > {};
+                                                            edm::mpl::Vector<TrackerDigiGeometryRecord,
+                                                                             TkPixelCPERecord,
+                                                                             TkStripCPERecord,
+                                                                             TkPhase2OTCPERecord,
+                                                                             TransientRecHitRecord,
+                                                                             TrackingComponentsRecord,
+                                                                             TrackerRecoGeometryRecord,
+                                                                             TrackerTopologyRcd,
+                                                                             SiStripQualityRcd,
+                                                                             SiStripDetCablingRcd,
+                                                                             SiStripNoisesRcd,
+                                                                             SiStripRegionCablingRcd,
+                                                                             SiPixelQualityRcd,
+                                                                             SiPixelFedCablingMapRcd,
+                                                                             IdealMagneticFieldRecord,
+                                                                             SiPixelLorentzAngleRcd,
+                                                                             SiStripLorentzAngleDepRcd> > {};
 #endif

--- a/RecoTracker/Record/interface/CkfComponentsRecord.h
+++ b/RecoTracker/Record/interface/CkfComponentsRecord.h
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
+#include "RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
@@ -21,21 +22,21 @@
 
 class CkfComponentsRecord
     : public edm::eventsetup::DependentRecordImplementation<CkfComponentsRecord,
-                                                            edm::mpl::Vector<TrackerDigiGeometryRecord,
-                                                                             TkPixelCPERecord,
-                                                                             TkStripCPERecord,
-                                                                             TransientRecHitRecord,
-                                                                             TrackingComponentsRecord,
-                                                                             TrackerRecoGeometryRecord,
-                                                                             TrackerTopologyRcd,
-                                                                             SiStripQualityRcd,
-                                                                             SiStripDetCablingRcd,
-                                                                             SiStripNoisesRcd,
-                                                                             SiStripRegionCablingRcd,
-                                                                             SiPixelQualityRcd,
-                                                                             SiPixelFedCablingMapRcd,
-                                                                             IdealMagneticFieldRecord,
-                                                                             SiPixelLorentzAngleRcd,
-                                                                             SiStripLorentzAngleDepRcd> > {};
-
+                                                            boost::mpl::vector<TrackerDigiGeometryRecord,
+                                                                               TkPixelCPERecord,
+                                                                               TkStripCPERecord,
+                                                                               TkPhase2OTCPERecord,
+                                                                               TransientRecHitRecord,
+                                                                               TrackingComponentsRecord,
+                                                                               TrackerRecoGeometryRecord,
+                                                                               TrackerTopologyRcd,
+                                                                               SiStripQualityRcd,
+                                                                               SiStripDetCablingRcd,
+                                                                               SiStripNoisesRcd,
+                                                                               SiStripRegionCablingRcd,
+                                                                               SiPixelQualityRcd,
+                                                                               SiPixelFedCablingMapRcd,
+                                                                               IdealMagneticFieldRecord,
+                                                                               SiPixelLorentzAngleRcd,
+                                                                               SiStripLorentzAngleDepRcd> > {};
 #endif

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -40,7 +40,7 @@ private:
   std::optional<edm::ESGetToken<PixelClusterParameterEstimator, TkPixelCPERecord>> ppToken_;
   std::optional<edm::ESGetToken<SiStripRecHitMatcher, TkStripCPERecord>> mpToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
-  std::optional<edm::ESGetToken<ClusterParameterEstimator<Phase2TrackerCluster1D>, TkStripCPERecord>> p2OTToken_;
+  std::optional<edm::ESGetToken<ClusterParameterEstimator<Phase2TrackerCluster1D>, TkPhase2OTCPERecord>> p2OTToken_;
   bool const computeCoarseLocalPositionFromDisk_;
 };
 

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2OTCondition_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2OTCondition_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+SiPhase2OTFakeLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
+                                                  LAValue = cms.double(0.07)
+                                                  )
+
+es_prefer_fake_LA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeLorentzAngleESSource")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2OTCondition_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2OTCondition_cff.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-SiPhase2OTFakeLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
-                                                  LAValue = cms.double(0.07)
-                                                  )
-
-es_prefer_fake_LA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeLorentzAngleESSource")

--- a/SLHCUpgradeSimulations/Geometry/python/fakePhase2OuterTrackerConditions_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakePhase2OuterTrackerConditions_cff.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+##
+## Fake Sim Outer Tracker Lorentz Angle
+##
+
+SiPhase2OTFakeLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
+                                                  LAValue = cms.double(0.07),
+                                                  recordName = cms.string("LorentzAngle")
+                                                  )
+
+es_prefer_fake_LA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeLorentzAngleESSource")
+
+##
+## Fake Sim Outer Tracker Lorentz Angle
+##
+
+SiPhase2OTFakeSimLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
+                                                     LAValue = cms.double(0.07),
+                                                     recordName = cms.string("SimLorentzAngle")
+                                                     )
+
+es_prefer_fake_simLA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeSimLorentzAngleESSource")
+

--- a/SimTracker/SiPhase2Digitizer/plugins/BuildFile.xml
+++ b/SimTracker/SiPhase2Digitizer/plugins/BuildFile.xml
@@ -2,6 +2,7 @@
   <use name="CalibTracker/SiPixelESProducers"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/SiPixelObjects"/>
+  <use name="CondFormats/SiPhase2TrackerObjects"/>
   <use name="SimGeneral/PreMixingModule"/>
   <use name="SimGeneral/MixingModule"/>
   <use name="SimGeneral/NoiseGenerators"/>

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -15,8 +15,9 @@
 using namespace edm;
 
 void PSPDigitizerAlgorithm::init(const edm::EventSetup& es) {
-  if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
-    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(SiPhase2OTLorentzAngle_);
+  if (use_LorentzAngle_DB_) {  // Get Lorentz angle from DB record
+    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(siPhase2OTLorentzAngle_);
+  }
 
   es.get<TrackerDigiGeometryRecord>().get(geom_);
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -6,6 +6,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 
 // Geometry
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -13,7 +14,13 @@
 
 using namespace edm;
 
-void PSPDigitizerAlgorithm::init(const edm::EventSetup& es) { es.get<TrackerDigiGeometryRecord>().get(geom_); }
+void PSPDigitizerAlgorithm::init(const edm::EventSetup& es) {
+  if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
+    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(SiPhase2OTLorentzAngle_);
+
+  es.get<TrackerDigiGeometryRecord>().get(geom_);
+}
+
 PSPDigitizerAlgorithm::PSPDigitizerAlgorithm(const edm::ParameterSet& conf)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<ParameterSet>("AlgorithmCommon"),
                                       conf.getParameter<ParameterSet>("PSPDigitizerAlgorithm")) {

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
@@ -6,6 +6,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 
 // Geometry
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -13,7 +14,12 @@
 
 using namespace edm;
 
-void PSSDigitizerAlgorithm::init(const edm::EventSetup& es) { es.get<TrackerDigiGeometryRecord>().get(geom_); }
+void PSSDigitizerAlgorithm::init(const edm::EventSetup& es) {
+  if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
+    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(SiPhase2OTLorentzAngle_);
+
+  es.get<TrackerDigiGeometryRecord>().get(geom_);
+}
 PSSDigitizerAlgorithm::PSSDigitizerAlgorithm(const edm::ParameterSet& conf)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<ParameterSet>("AlgorithmCommon"),
                                       conf.getParameter<ParameterSet>("PSSDigitizerAlgorithm")) {

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
@@ -16,7 +16,7 @@ using namespace edm;
 
 void PSSDigitizerAlgorithm::init(const edm::EventSetup& es) {
   if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
-    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(SiPhase2OTLorentzAngle_);
+    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(siPhase2OTLorentzAngle_);
 
   es.get<TrackerDigiGeometryRecord>().get(geom_);
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -27,6 +27,7 @@
 #include "CondFormats/SiPixelObjects/interface/PixelROC.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
 #include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 
 // Geometry
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -771,7 +772,10 @@ LocalVector Phase2TrackerDigitizerAlgorithm::DriftDirection(const Phase2TrackerG
 
   // Read Lorentz angle from DB:
   if (use_LorentzAngle_DB_) {
-    float lorentzAngle = SiPixelLorentzAngle_->getLorentzAngle(detId);
+    bool isPixel = (Sub_detid == PixelSubdetector::PixelBarrel || Sub_detid == PixelSubdetector::PixelEndcap);
+
+    float lorentzAngle =
+        isPixel ? SiPixelLorentzAngle_->getLorentzAngle(detId) : SiPhase2OTLorentzAngle_->getLorentzAngle(detId);
     float alpha2 = std::pow(lorentzAngle, 2);
 
     dir_x = -(lorentzAngle * Bfield.y() + alpha2 * Bfield.z() * Bfield.x());

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -775,7 +775,7 @@ LocalVector Phase2TrackerDigitizerAlgorithm::DriftDirection(const Phase2TrackerG
     bool isPixel = (Sub_detid == PixelSubdetector::PixelBarrel || Sub_detid == PixelSubdetector::PixelEndcap);
 
     float lorentzAngle =
-        isPixel ? SiPixelLorentzAngle_->getLorentzAngle(detId) : SiPhase2OTLorentzAngle_->getLorentzAngle(detId);
+        isPixel ? siPixelLorentzAngle_->getLorentzAngle(detId) : siPhase2OTLorentzAngle_->getLorentzAngle(detId);
     float alpha2 = std::pow(lorentzAngle, 2);
 
     dir_x = -(lorentzAngle * Bfield.y() + alpha2 * Bfield.z() * Bfield.x());
@@ -869,7 +869,7 @@ void Phase2TrackerDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomD
   int ncol = pixdet->specificTopology().ncolumns();
   if (ncol < 0)
     return;
-  std::vector<SiPixelQuality::disabledModuleType> disabledModules = SiPixelBadModule_->getBadComponentList();
+  std::vector<SiPixelQuality::disabledModuleType> disabledModules = siPixelBadModule_->getBadComponentList();
 
   SiPixelQuality::disabledModuleType badmodule;
   for (size_t id = 0; id < disabledModules.size(); id++) {
@@ -892,7 +892,7 @@ void Phase2TrackerDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomD
     // follow the example of getBadRocPositions in CondFormats/SiPixelObjects/src/SiPixelQuality.cc
     std::vector<GlobalPixel> badrocpositions;
     for (size_t j = 0; j < static_cast<size_t>(ncol); j++) {
-      if (SiPixelBadModule_->IsRocBad(detID, j)) {
+      if (siPixelBadModule_->IsRocBad(detID, j)) {
         std::vector<CablingPathToDetUnit> path = fedCablingMap_.product()->pathToDetUnit(detID);
         for (auto const& p : path) {
           const PixelROC* myroc = fedCablingMap_.product()->findItem(p);

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -41,6 +41,7 @@ class SiPixelFedCablingMap;
 class SiPixelGainCalibrationOfflineSimService;
 class SiPixelLorentzAngle;
 class SiPixelQuality;
+class SiPhase2OuterTrackerLorentzAngle;
 class TrackerGeometry;
 class TrackerTopology;
 
@@ -83,8 +84,11 @@ public:
   void loadAccumulator(uint32_t detId, const std::map<int, float>& accumulator);
 
 protected:
-  // Accessing Lorentz angle from DB:
+  // Accessing Inner Tracker Lorentz angle from DB:
   edm::ESHandle<SiPixelLorentzAngle> SiPixelLorentzAngle_;
+
+  // Accessing Outer Tracker Lorentz angle from DB:
+  edm::ESHandle<SiPhase2OuterTrackerLorentzAngle> SiPhase2OTLorentzAngle_;
 
   // Accessing Dead pixel modules from DB:
   edm::ESHandle<SiPixelQuality> SiPixelBadModule_;

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -85,13 +85,13 @@ public:
 
 protected:
   // Accessing Inner Tracker Lorentz angle from DB:
-  edm::ESHandle<SiPixelLorentzAngle> SiPixelLorentzAngle_;
+  edm::ESHandle<SiPixelLorentzAngle> siPixelLorentzAngle_;
 
   // Accessing Outer Tracker Lorentz angle from DB:
-  edm::ESHandle<SiPhase2OuterTrackerLorentzAngle> SiPhase2OTLorentzAngle_;
+  edm::ESHandle<SiPhase2OuterTrackerLorentzAngle> siPhase2OTLorentzAngle_;
 
   // Accessing Dead pixel modules from DB:
-  edm::ESHandle<SiPixelQuality> SiPixelBadModule_;
+  edm::ESHandle<SiPixelQuality> siPixelBadModule_;
 
   // Accessing Map and Geom:
   edm::ESHandle<SiPixelFedCablingMap> fedCablingMap_;

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -37,12 +37,12 @@ void Pixel3DDigitizerAlgorithm::init(const edm::EventSetup& es) {
   }
 
   if (use_deadmodule_DB_) {
-    es.get<SiPixelQualityRcd>().get(SiPixelBadModule_);
+    es.get<SiPixelQualityRcd>().get(siPixelBadModule_);
   }
 
   if (use_LorentzAngle_DB_) {
     // Get Lorentz angle from DB record
-    es.get<SiPixelLorentzAngleSimRcd>().get(SiPixelLorentzAngle_);
+    es.get<SiPixelLorentzAngleSimRcd>().get(siPixelLorentzAngle_);
   }
 
   // gets the map and geometry from the DB (to kill ROCs)

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -27,10 +27,10 @@ void PixelDigitizerAlgorithm::init(const edm::EventSetup& es) {
     theSiPixelGainCalibrationService_->setESObjects(es);
 
   if (use_deadmodule_DB_)
-    es.get<SiPixelQualityRcd>().get(SiPixelBadModule_);
+    es.get<SiPixelQualityRcd>().get(siPixelBadModule_);
 
   if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
-    es.get<SiPixelLorentzAngleSimRcd>().get(SiPixelLorentzAngle_);
+    es.get<SiPixelLorentzAngleSimRcd>().get(siPixelLorentzAngle_);
 
   // gets the map and geometry from the DB (to kill ROCs)
   es.get<SiPixelFedCablingMapRcd>().get(fedCablingMap_);

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
@@ -29,7 +29,7 @@ namespace {
 
 void SSDigitizerAlgorithm::init(const edm::EventSetup& es) {
   if (use_LorentzAngle_DB_) {  // Get Lorentz angle from DB record
-    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(SiPhase2OTLorentzAngle_);
+    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(siPhase2OTLorentzAngle_);
   }
 
   es.get<TrackerDigiGeometryRecord>().get(geom_);

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
@@ -6,6 +6,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 
 // Geometry
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -25,7 +26,15 @@ namespace {
            (nFactorial(N - i) * nFactorial(N + 2 - i) * nFactorial(i));
   }
 }  // namespace
-void SSDigitizerAlgorithm::init(const edm::EventSetup& es) { es.get<TrackerDigiGeometryRecord>().get(geom_); }
+
+void SSDigitizerAlgorithm::init(const edm::EventSetup& es) { 
+  if (use_LorentzAngle_DB_){  // Get Lorentz angle from DB record
+    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(SiPhase2OTLorentzAngle_);
+  }  
+
+  es.get<TrackerDigiGeometryRecord>().get(geom_); 
+}
+
 SSDigitizerAlgorithm::SSDigitizerAlgorithm(const edm::ParameterSet& conf)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<ParameterSet>("AlgorithmCommon"),
                                       conf.getParameter<ParameterSet>("SSDigitizerAlgorithm")),

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
@@ -27,12 +27,12 @@ namespace {
   }
 }  // namespace
 
-void SSDigitizerAlgorithm::init(const edm::EventSetup& es) { 
-  if (use_LorentzAngle_DB_){  // Get Lorentz angle from DB record
+void SSDigitizerAlgorithm::init(const edm::EventSetup& es) {
+  if (use_LorentzAngle_DB_) {  // Get Lorentz angle from DB record
     es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(SiPhase2OTLorentzAngle_);
-  }  
+  }
 
-  es.get<TrackerDigiGeometryRecord>().get(geom_); 
+  es.get<TrackerDigiGeometryRecord>().get(geom_);
 }
 
 SSDigitizerAlgorithm::SSDigitizerAlgorithm(const edm::ParameterSet& conf)

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -109,7 +109,7 @@ phase2TrackerDigitizer = cms.PSet(
       SigmaZero = cms.double(0.00037),  		#D.B.: 3.7um spread for 300um-thick sensor, renormalized in digitizerAlgo
       SigmaCoeff = cms.double(1.80),  		#D.B.: to be confirmed with simulations in CMSSW_6.X
       ClusterWidth = cms.double(3),		#D.B.: this is used as number of sigmas for charge collection (3=+-3sigmas)
-      LorentzAngle_DB = cms.bool(False),			
+      LorentzAngle_DB = cms.bool(True),			
       TanLorentzAnglePerTesla_Endcap = cms.double(0.07),
       TanLorentzAnglePerTesla_Barrel = cms.double(0.07),
       KillModules = cms.bool(False),
@@ -147,7 +147,7 @@ phase2TrackerDigitizer = cms.PSet(
       SigmaZero = cms.double(0.00037),  		#D.B.: 3.7um spread for 300um-thick sensor, renormalized in digitizerAlgo
       SigmaCoeff = cms.double(1.80),  		#D.B.: to be confirmed with simulations in CMSSW_6.X
       ClusterWidth = cms.double(3),		#D.B.: this is used as number of sigmas for charge collection (3=+-3sigmas)
-      LorentzAngle_DB = cms.bool(False),			
+      LorentzAngle_DB = cms.bool(True),			
       TanLorentzAnglePerTesla_Endcap = cms.double(0.07),
       TanLorentzAnglePerTesla_Barrel = cms.double(0.07),
       KillModules = cms.bool(False),
@@ -185,7 +185,7 @@ phase2TrackerDigitizer = cms.PSet(
       SigmaZero = cms.double(0.00037),  		#D.B.: 3.7um spread for 300um-thick sensor, renormalized in digitizerAlgo
       SigmaCoeff = cms.double(1.80),  		#D.B.: to be confirmed with simulations in CMSSW_6.X
       ClusterWidth = cms.double(3),		#D.B.: this is used as number of sigmas for charge collection (3=+-3sigmas)
-      LorentzAngle_DB = cms.bool(False),			
+      LorentzAngle_DB = cms.bool(True),			
       TanLorentzAnglePerTesla_Endcap = cms.double(0.07),
       TanLorentzAnglePerTesla_Barrel = cms.double(0.07),
       KillModules = cms.bool(False),

--- a/TrackingTools/Records/interface/TransientRecHitRecord.h
+++ b/TrackingTools/Records/interface/TransientRecHitRecord.h
@@ -9,15 +9,14 @@
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
 #include "RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-
 #include "FWCore/Utilities/interface/mplVector.h"
 
 class TransientRecHitRecord
     : public edm::eventsetup::DependentRecordImplementation<TransientRecHitRecord,
-                                                            boost::mpl::vector<CaloGeometryRecord,
-                                                                               TrackerDigiGeometryRecord,
-                                                                               TkStripCPERecord,
-                                                                               TkPixelCPERecord,
-                                                                               TkPhase2OTCPERecord,
-                                                                               GlobalTrackingGeometryRecord> > {};
+                                                            edm::mpl::Vector<CaloGeometryRecord,
+                                                                             TrackerDigiGeometryRecord,
+                                                                             TkStripCPERecord,
+                                                                             TkPixelCPERecord,
+                                                                             TkPhase2OTCPERecord,
+                                                                             GlobalTrackingGeometryRecord> > {};
 #endif

--- a/TrackingTools/Records/interface/TransientRecHitRecord.h
+++ b/TrackingTools/Records/interface/TransientRecHitRecord.h
@@ -7,15 +7,17 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
+#include "RecoLocalTracker/Records/interface/TkPhase2OTCPERecord.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 #include "FWCore/Utilities/interface/mplVector.h"
 
 class TransientRecHitRecord
     : public edm::eventsetup::DependentRecordImplementation<TransientRecHitRecord,
-                                                            edm::mpl::Vector<CaloGeometryRecord,
-                                                                             TrackerDigiGeometryRecord,
-                                                                             TkStripCPERecord,
-                                                                             TkPixelCPERecord,
-                                                                             GlobalTrackingGeometryRecord> > {};
+                                                            boost::mpl::vector<CaloGeometryRecord,
+                                                                               TrackerDigiGeometryRecord,
+                                                                               TkStripCPERecord,
+                                                                               TkPixelCPERecord,
+                                                                               TkPhase2OTCPERecord,
+                                                                               GlobalTrackingGeometryRecord> > {};
 #endif


### PR DESCRIPTION
#### PR description:

The primary goal of this PR is to introduce a new DB object to store per-`DetId` Lorentz Angle calibration values for the Phase-2 Outer Tracker. A new `CondFormat` called `SiPhase2OuterTrackerLorentzAngle` is introduced and used to populate the newly created `EventSetup` records `SiPhase2OuterTrackerLorentzAngleRcd` and `SiPhase2OuterTrackerLorentzAngleSimRcd`.
The former is then used to provide the calibration to the Outer Tracker local reconstruction via `Phase2StripCPEE`, while the latter is used to provide the simulation Lorentz Angle to the Phase2 Tracker digitizer concrete implementations for the OT (`PSPDigitizerAlgorithm`, `PSSDigitizerAlgorithm` and `SSDigitizerAlgorithm`).
   * The `EventSetup` records are for the moment populated via an ad-hoc `ESSource` called `SiPhase2OuterTrackerFakeLorentzAngleESSource` which can be used for both records, but eventually the input data will come from `CondDB` via `GlobalTag` once this PR is accepted. The `ESSource` is percolated via `fakePhase2OuterTrackerConditions_cff` to all the active phase-2 geometries.
   * The `ESSource` is configured in such a way to produce same values of the hardcoded Lorentz Angles used so far in the Simulation and Local Reconstruction (wich is &mu;<sub>H</sub>=0.07/T).     
   * Few utilities are added to fetch, import, dump, etc. the new data-base objects, as well as a DB object writer.
   * I profit of this PR to decouple the Phase-2 OT local reconstruction from the Phase-0 SiStrip dependent record `TkStripCPERecord` by introducing a new dependent record `TkPhase2OTCPERecord` which goes in the spirit of what was proposed originally at https://github.com/cms-sw/cmssw/pull/28101. The new dependent record at the moment depends only on the Phase Outer Tracker LA, but will depend on more records as more pieces are added to the local reconstruction. `TkPhase2OTCPERecord` is then subsequently percolated to the appropriate classes in Tracking.

The changes proposed here have been discussed at the Tracker Phase-2 simulation meeting of [May 22nd 2020](https://indico.cern.ch/event/879043/contributions/3874511/attachments/2043128/3422322/mm_phase2SimMeeting_22May2020.pdf), but have then been postponed to allow other urgent developments to enter the release.

#### PR validation:

The local branch passes the following workflows tests (one for each active geometry):

```
runTheMatrix.py --what upgrade -l 23206.0,23606.0,24406.0,24806.0,26606.0,27006.0,27406.0,27806.0,28206.0,28606.0,29006.0
```
as well as the unit tests of the respective packages involved.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.
cc:
@emiglior @skinnari @tsusa @mtosi @JanFSchulte 
