### PR TITLE
Extend thinning to support slimming

### DIFF
--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -758,6 +758,26 @@ namespace edm {
   };
 }  // namespace edm
 
+// Thinning support
+#include "DataFormats/Common/interface/fillCollectionForThinning.h"
+namespace edmNew {
+  template <typename T, typename Selector>
+  void fillCollectionForThinning(edmNew::DetSet<T> const& detset,
+                                 Selector& selector,
+                                 unsigned int& iIndex,
+                                 edmNew::DetSetVector<T>& output,
+                                 edm::ThinnedAssociation& association) {
+    typename edmNew::DetSetVector<T>::FastFiller ff(output, detset.detId());
+    for (auto iter = detset.begin(), end = detset.end(); iter != end; ++iter, ++iIndex) {
+      edm::detail::fillCollectionForThinning(*iter, selector, iIndex, ff, association);
+    }
+    if (detset.begin() != detset.end()) {
+      // need to decrease the global index by one because the outer loop will increase it
+      --iIndex;
+    }
+  }
+}  // namespace edmNew
+
 #ifdef DSVN_USE_ATOMIC
 #undef DSVN_USE_ATOMIC
 #endif

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -438,7 +438,7 @@ namespace edmNew {
 
     explicit DetSetVector(int isubdet = 0) : m_subdetId(isubdet) {}
 
-    DetSetVector(std::shared_ptr<dslv::LazyGetter<T> > iGetter, const std::vector<det_id_type>& iDets, int isubdet = 0);
+    DetSetVector(std::shared_ptr<dslv::LazyGetter<T>> iGetter, const std::vector<det_id_type>& iDets, int isubdet = 0);
 
     ~DetSetVector() {
       // delete content if T is pointer...
@@ -670,7 +670,7 @@ namespace edmNew {
       assert(item.initializing());
       {
         TSFastFiller ff(*this, item);
-        (*boost::any_cast<std::shared_ptr<Getter> >(&m_getter))->fill(ff);
+        (*boost::any_cast<std::shared_ptr<Getter>>(&m_getter))->fill(ff);
       }
       assert(item.isValid());
     }
@@ -721,7 +721,7 @@ namespace edm {
     };
 
     template <typename T>
-    struct FindTrait<edmNew::DetSetVector<T>, edmNew::DetSet<T> > {
+    struct FindTrait<edmNew::DetSetVector<T>, edmNew::DetSet<T>> {
       typedef FindSetForNewDetSetVector<T> value;
     };
   }  // namespace refhelper
@@ -735,7 +735,7 @@ namespace edmNew {
   edm::Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type> makeRefTo(
       const HandleT& iHandle, typename HandleT::element_type::value_type::const_iterator itIter) {
     static_assert(std::is_same<typename HandleT::element_type,
-                               DetSetVector<typename HandleT::element_type::value_type::value_type> >::value,
+                               DetSetVector<typename HandleT::element_type::value_type::value_type>>::value,
                   "Handle and DetSetVector do not have compatible types.");
     auto index = itIter - &iHandle->data().front();
     return edm::Ref<typename HandleT::element_type, typename HandleT::element_type::value_type::value_type>(
@@ -747,7 +747,7 @@ namespace edmNew {
 
 namespace edm {
   template <typename T>
-  class ContainerMaskTraits<edmNew::DetSetVector<T> > {
+  class ContainerMaskTraits<edmNew::DetSetVector<T>> {
   public:
     typedef T value_type;
 
@@ -760,6 +760,12 @@ namespace edm {
 
 // Thinning support
 #include "DataFormats/Common/interface/fillCollectionForThinning.h"
+namespace edm::detail {
+  template <typename T>
+  struct ElementType<edmNew::DetSetVector<T>> {
+    using type = typename edmNew::DetSetVector<T>::data_type;
+  };
+}  // namespace edm::detail
 namespace edmNew {
   template <typename T, typename Selector>
   void fillCollectionForThinning(edmNew::DetSet<T> const& detset,

--- a/DataFormats/Common/interface/EDProductGetter.h
+++ b/DataFormats/Common/interface/EDProductGetter.h
@@ -67,6 +67,17 @@ namespace edm {
                                     std::vector<WrapperBase const*>& foundContainers,
                                     std::vector<unsigned int>& keys) const = 0;
 
+    // This overload is allowed to be called also without getIt()
+    // being called first, but he thinned ProductID must come from an
+    // existing RefCore. The input key is the index of the desired
+    // element in the container identified by the parent ProductID.
+    // If the return value is not null, then the desired element was found
+    // in a thinned container. If the desired element is not found, then
+    // an optional without a value is returned.
+    virtual std::optional<unsigned int> getThinnedKeyFrom(ProductID const& parent,
+                                                          unsigned int key,
+                                                          ProductID const& thinned) const = 0;
+
     unsigned int transitionIndex() const { return transitionIndex_(); }
 
     // ---------- member functions ---------------------------

--- a/DataFormats/Common/interface/EDProductGetter.h
+++ b/DataFormats/Common/interface/EDProductGetter.h
@@ -78,9 +78,15 @@ namespace edm {
     // being called first, but the thinned ProductID must come from an
     // existing RefCore. The input key is the index of the desired
     // element in the container identified by the parent ProductID.
-    // If the return value is not null, then the desired element was found
-    // in a thinned container. If the desired element is not found, then
-    // an optional without a value is returned.
+    // Returns an std::variant whose contents can be
+    // - unsigned int for the index in the thinned collection if the
+    //   desired element was found in the thinned collection
+    // - function creating an edm::Exception if parent is not a parent
+    //   of any thinned collection, thinned is not really a thinned
+    //   collection, or parent and thinned have no thinning
+    //   relationship
+    // - std::monostate if thinned is thinned from parent, but the key
+    //   is not found in the thinned collection
     virtual OptionalThinnedKey getThinnedKeyFrom(ProductID const& parent,
                                                  unsigned int key,
                                                  ProductID const& thinned) const = 0;

--- a/DataFormats/Common/interface/EDProductGetter.h
+++ b/DataFormats/Common/interface/EDProductGetter.h
@@ -19,17 +19,24 @@
 // user include files
 
 // system include files
+#include <functional>
 #include <optional>
 #include <string>
 #include <tuple>
+#include <variant>
 #include <vector>
 
 // forward declarations
 
 namespace edm {
 
+  class Exception;
   class ProductID;
   class WrapperBase;
+  namespace detail {
+    using GetThinnedKeyFromExceptionFactory = std::function<edm::Exception()>;
+  }
+  using OptionalThinnedKey = std::variant<unsigned int, detail::GetThinnedKeyFromExceptionFactory, std::monostate>;
 
   class EDProductGetter {
   public:
@@ -74,9 +81,9 @@ namespace edm {
     // If the return value is not null, then the desired element was found
     // in a thinned container. If the desired element is not found, then
     // an optional without a value is returned.
-    virtual std::optional<unsigned int> getThinnedKeyFrom(ProductID const& parent,
-                                                          unsigned int key,
-                                                          ProductID const& thinned) const = 0;
+    virtual OptionalThinnedKey getThinnedKeyFrom(ProductID const& parent,
+                                                 unsigned int key,
+                                                 ProductID const& thinned) const = 0;
 
     unsigned int transitionIndex() const { return transitionIndex_(); }
 

--- a/DataFormats/Common/interface/EDProductGetter.h
+++ b/DataFormats/Common/interface/EDProductGetter.h
@@ -75,7 +75,7 @@ namespace edm {
                                     std::vector<unsigned int>& keys) const = 0;
 
     // This overload is allowed to be called also without getIt()
-    // being called first, but he thinned ProductID must come from an
+    // being called first, but the thinned ProductID must come from an
     // existing RefCore. The input key is the index of the desired
     // element in the container identified by the parent ProductID.
     // If the return value is not null, then the desired element was found

--- a/DataFormats/Common/interface/RefItemGet.h
+++ b/DataFormats/Common/interface/RefItemGet.h
@@ -115,6 +115,26 @@ namespace edm {
   inline bool isThinnedAvailable(RefCore const& product, KEY const& iKey) {
     return refitem::IsThinnedAvailableImpl<C, KEY>::isThinnedAvailable_(product, iKey);
   }
+
+  /// Return a Ref to thinned collection corresponding to an element of the Ref to parent collection
+  //
+  // The thinned may point to parent collection, in which case the Ref-to-parent is returned
+  //
+  // If there are no thinned collections containing the element of the Ref-to-parent, a Null Ref is returned.
+  template <typename C, typename T, typename F>
+  Ref<C, T, F> thinnedRefFrom(Ref<C, T, F> const& parent,
+                              RefProd<C> const& thinned,
+                              edm::EDProductGetter const& prodGetter) {
+    if (parent.id() == thinned.id()) {
+      return parent;
+    }
+
+    auto thinnedKey = prodGetter.getThinnedKeyFrom(parent.id(), parent.key(), thinned.id());
+    if (thinnedKey.has_value()) {
+      return Ref<C, T, F>(thinned, *thinnedKey);
+    }
+    return Ref<C, T, F>();
+  }
 }  // namespace edm
 
 #endif

--- a/DataFormats/Common/interface/RefItemGet.h
+++ b/DataFormats/Common/interface/RefItemGet.h
@@ -7,6 +7,7 @@ RefItemGet: Free function to get pointer to a referenced item.
 
 
 ----------------------------------------------------------------------*/
+#include "DataFormats/Common/interface/EDProductGetter.h"
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreGet.h"
 

--- a/DataFormats/Common/interface/RefItemGet.h
+++ b/DataFormats/Common/interface/RefItemGet.h
@@ -137,7 +137,9 @@ namespace edm {
     if (std::holds_alternative<unsigned int>(thinnedKey)) {
       return Ref<C, T, F>(thinned, std::get<unsigned int>(thinnedKey));
     } else if (std::holds_alternative<detail::GetThinnedKeyFromExceptionFactory>(thinnedKey)) {
-      throw std::get<detail::GetThinnedKeyFromExceptionFactory>(thinnedKey)();
+      auto ex = std::get<detail::GetThinnedKeyFromExceptionFactory>(thinnedKey)();
+      ex.addContext("Calling edm::thinnedRefFrom()");
+      throw ex;
     }
 
     return Ref<C, T, F>();

--- a/DataFormats/Common/interface/RefItemGet.h
+++ b/DataFormats/Common/interface/RefItemGet.h
@@ -121,7 +121,7 @@ namespace edm {
   //
   // The thinned may point to parent collection, in which case the Ref-to-parent is returned
   //
-  // If there are no thinned collections containing the element of the Ref-to-parent, a Null Ref is returned.
+  // If thinned does not contain the element of the Ref-to-parent, a Null Ref is returned.
   template <typename C, typename T, typename F>
   Ref<C, T, F> thinnedRefFrom(Ref<C, T, F> const& parent,
                               RefProd<C> const& thinned,

--- a/DataFormats/Common/interface/ThinnedRefSet.h
+++ b/DataFormats/Common/interface/ThinnedRefSet.h
@@ -1,0 +1,50 @@
+#ifndef DataFormats_Common_ThinnedRefSet_h
+#define DataFormats_Common_ThinnedRefSet_h
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefItemGet.h"
+
+#include <unordered_set>
+
+namespace edm {
+  class EDProductGetter;
+
+  template <typename C>
+  class ThinnedRefSet {
+  public:
+    class Filler {
+    public:
+      Filler(ThinnedRefSet<C>* set, RefProd<C> refProd, edm::EDProductGetter const& prodGetter)
+          : set_(set), refProd_(refProd), prodGetter_(prodGetter) {}
+
+      template <typename T, typename F>
+      void insert(Ref<C, T, F> const& ref) {
+        if (ref.isNull())
+          return;
+        auto thinnedRef = thinnedRefFrom(ref, refProd_, prodGetter_);
+        set_->keys_.insert(thinnedRef.key());
+      }
+
+    private:
+      ThinnedRefSet<C>* set_;
+      RefProd<C> refProd_;
+      edm::EDProductGetter const& prodGetter_;
+    };
+
+    ThinnedRefSet() = default;
+
+    Filler fill(RefProd<C> refProd, edm::EDProductGetter const& prodGetter) {
+      return Filler(this, refProd, prodGetter);
+    }
+
+    void clear() { keys_.clear(); }
+
+    bool contains(unsigned int key) const { return keys_.find(key) != keys_.end(); }
+
+  private:
+    std::unordered_set<unsigned int> keys_;
+  };
+}  // namespace edm
+
+#endif

--- a/DataFormats/Common/interface/ThinnedRefSet.h
+++ b/DataFormats/Common/interface/ThinnedRefSet.h
@@ -20,10 +20,12 @@ namespace edm {
 
       template <typename T, typename F>
       void insert(Ref<C, T, F> const& ref) {
-        if (ref.isNull())
-          return;
-        auto thinnedRef = thinnedRefFrom(ref, refProd_, prodGetter_);
-        set_->keys_.insert(thinnedRef.key());
+        if (ref.isNonnull()) {
+          auto thinnedRef = thinnedRefFrom(ref, refProd_, prodGetter_);
+          if (thinnedRef.isNonnull()) {
+            set_->keys_.insert(thinnedRef.key());
+          }
+        }
       }
 
     private:

--- a/DataFormats/Common/interface/ThinnedRefSet.h
+++ b/DataFormats/Common/interface/ThinnedRefSet.h
@@ -1,5 +1,46 @@
 #ifndef DataFormats_Common_ThinnedRefSet_h
 #define DataFormats_Common_ThinnedRefSet_h
+//
+// Package:     DataFormats/Common
+// Class  :     ThinnedRefSet
+//
+/**\class ThinnedRefSet ThinnedRefSet.h "ThinnedRefSet.h"
+
+ Description: A minimal set interface (insertion, contains(), clear()) for a set of Ref keys to a thinned collection
+
+ Usage:
+
+    A ThinnedRefSet contains Ref keys to a thinned collection. The
+keys are inserted as Refs to the thinned collection itself, or to any
+parent collections of the thinned collection.
+
+The main use case are Selector classes for edm::ThinningProducer.
+There, an object of the class would be stored as a member of the
+Selector class, filled in Selector::preChoose(), calling contains() in
+Selector::choose(), and cleared in Selector::reset().
+
+Example of filling
+\code
+class ExampleSelector {
+  ...
+  edm::ThinnedRefSet<ThingCollection> keysToSave_;
+};
+
+void ExampleSelector::preChoose(edm::Handle<ThingCollection> tc, edm::Event const& e, edm::EventSetup const&) {
+  auto filler = keysToSave_.fill(edm::RefProd(tc), event.productGetter());
+  for (auto const& object : event.get(objectCollectionToken_) {
+    filler.insert(object.refToThing());
+  }
+}
+\endcode
+
+Example of querying if a key is present
+\code
+bool ExampleSelector::choose(unsigned int iIndex, Thing const& iItem) const {
+  return keysToSave_.contains(iIndex);
+}
+\endcode
+ */
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Ref.h"
@@ -15,13 +56,13 @@ namespace edm {
   public:
     class Filler {
     public:
-      Filler(ThinnedRefSet<C>* set, RefProd<C> refProd, edm::EDProductGetter const& prodGetter)
-          : set_(set), refProd_(refProd), prodGetter_(prodGetter) {}
+      Filler(ThinnedRefSet<C>* set, RefProd<C> thinned, edm::EDProductGetter const& prodGetter)
+          : set_(set), thinnedRefProd_(thinned), prodGetter_(prodGetter) {}
 
       template <typename T, typename F>
       void insert(Ref<C, T, F> const& ref) {
         if (ref.isNonnull()) {
-          auto thinnedRef = thinnedRefFrom(ref, refProd_, prodGetter_);
+          auto thinnedRef = thinnedRefFrom(ref, thinnedRefProd_, prodGetter_);
           if (thinnedRef.isNonnull()) {
             set_->keys_.insert(thinnedRef.key());
           }
@@ -30,14 +71,14 @@ namespace edm {
 
     private:
       ThinnedRefSet<C>* set_;
-      RefProd<C> refProd_;
+      RefProd<C> thinnedRefProd_;
       edm::EDProductGetter const& prodGetter_;
     };
 
     ThinnedRefSet() = default;
 
-    Filler fill(RefProd<C> refProd, edm::EDProductGetter const& prodGetter) {
-      return Filler(this, refProd, prodGetter);
+    Filler fill(RefProd<C> thinned, edm::EDProductGetter const& prodGetter) {
+      return Filler(this, thinned, prodGetter);
     }
 
     void clear() { keys_.clear(); }

--- a/DataFormats/Common/interface/fillCollectionForThinning.h
+++ b/DataFormats/Common/interface/fillCollectionForThinning.h
@@ -1,0 +1,18 @@
+#ifndef DataFormats_Common_fillCollectionForThinning_h
+#define DataFormats_Common_fillCollectionForThinning_h
+
+// Implementation detail of thinning
+//
+// Need to be declared here in order to provide a customization hook
+// for edmNew::DetSetVector. Definition is in ThinningProducer.h
+namespace edm {
+  class ThinnedAssociation;
+
+  namespace detail {
+    template <typename Item, typename Selector, typename Collection>
+    void fillCollectionForThinning(
+        Item const& item, Selector& selector, unsigned int iIndex, Collection& output, ThinnedAssociation& association);
+  }
+}  // namespace edm
+
+#endif

--- a/DataFormats/Common/interface/fillCollectionForThinning.h
+++ b/DataFormats/Common/interface/fillCollectionForThinning.h
@@ -1,18 +1,27 @@
 #ifndef DataFormats_Common_fillCollectionForThinning_h
 #define DataFormats_Common_fillCollectionForThinning_h
 
+#include <type_traits>
+
 // Implementation detail of thinning
 //
-// Need to be declared here in order to provide a customization hook
-// for edmNew::DetSetVector. Definition is in ThinningProducer.h
+// Need to be declared here in order to provide a customization hooks
+// for edmNew::DetSetVector.
 namespace edm {
   class ThinnedAssociation;
 
   namespace detail {
+    // by default a linear container
+    template <typename Collection>
+    struct ElementType {
+      using type = typename std::remove_reference<decltype(*std::declval<Collection>().begin())>::type;
+    };
+
+    // Defined in ThinningProducer.h
     template <typename Item, typename Selector, typename Collection>
     void fillCollectionForThinning(
         Item const& item, Selector& selector, unsigned int iIndex, Collection& output, ThinnedAssociation& association);
-  }
+  }  // namespace detail
 }  // namespace edm
 
 #endif

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -13,27 +13,74 @@ namespace edm {
   class WrapperBase;
 
   namespace detail {
-    // This function provides a common implementation of
-    // EDProductGetter::getThinnedProduct() for EventPrincipal,
-    // DataGetterHelper, and BareRootProductGetter.
-    //
-    // getThinnedProduct assumes getIt was already called and failed to find
-    // the product. The input key is the index of the desired element in the
-    // container identified by ProductID (which cannot be found).
-    // If the return value is not null, then the desired element was
-    // found in a thinned container. If the desired element is not
-    // found, then an optional without a value is returned.
+    constexpr unsigned int kThinningDoNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
+
+    class ThinnedOrSlimmedProduct {
+    public:
+      ThinnedOrSlimmedProduct() = default;
+      explicit ThinnedOrSlimmedProduct(bool thinnedAvailable) : thinnedAvailable_{thinnedAvailable} {}
+      explicit ThinnedOrSlimmedProduct(WrapperBase const* thinned, unsigned int key)
+          : thinnedProduct_{thinned}, thinnedKey_{key}, thinnedAvailable_{true} {}
+      explicit ThinnedOrSlimmedProduct(ThinnedAssociation const* slimmed, unsigned int key)
+          : slimmedAssociation_{slimmed}, thinnedKey_{key} {}
+
+      bool thinnedAvailable() const { return thinnedAvailable_; }
+      bool hasThinned() const { return thinnedProduct_ != nullptr; }
+      bool hasSlimmed() const { return slimmedAssociation_ != nullptr; }
+
+      std::tuple<WrapperBase const*, unsigned int> thinnedProduct() const {
+        return std::tuple(thinnedProduct_, thinnedKey_);
+      }
+
+      std::tuple<ThinnedAssociation const*, unsigned int> slimmedAssociation() const {
+        return std::tuple(slimmedAssociation_, thinnedKey_);
+      }
+
+    private:
+      WrapperBase const* thinnedProduct_ = nullptr;
+      ThinnedAssociation const* slimmedAssociation_ = nullptr;
+      unsigned int thinnedKey_ = 0;
+      bool thinnedAvailable_ = false;
+    };
+
+    class SlimmedProducts {
+    public:
+      SlimmedProducts() = default;
+      explicit SlimmedProducts(bool thinnedAvailable) : thinnedAvailable_{thinnedAvailable} {}
+      explicit SlimmedProducts(ThinnedAssociation const* slimmed, std::vector<unsigned int> keys)
+          : slimmedAssociation_{slimmed}, slimmedKeys_{std::move(keys)} {}
+
+      SlimmedProducts(SlimmedProducts const&) = delete;
+      SlimmedProducts& operator=(SlimmedProducts const&) = delete;
+      SlimmedProducts(SlimmedProducts&&) = default;
+      SlimmedProducts& operator=(SlimmedProducts&&) = default;
+
+      bool thinnedAvailable() const { return thinnedAvailable_; }
+      bool hasSlimmed() const { return slimmedAssociation_ != nullptr; }
+
+      std::tuple<ThinnedAssociation const*, std::vector<unsigned int>> moveSlimmedAssociation() {
+        return std::tuple(slimmedAssociation_, std::move(slimmedKeys_));
+      }
+
+    private:
+      ThinnedAssociation const* slimmedAssociation_ = nullptr;
+      std::vector<unsigned int> slimmedKeys_;
+      bool thinnedAvailable_ = false;
+    };
+
     template <typename F1, typename F2, typename F3>
-    std::optional<std::tuple<WrapperBase const*, unsigned int> > getThinnedProduct(
-        ProductID const& pid,
-        unsigned int key,
-        ThinnedAssociationsHelper const& thinnedAssociationsHelper,
-        F1 pidToBid,
-        F2 getThinnedAssociation,
-        F3 getByProductID) {
+    ThinnedOrSlimmedProduct getThinnedOnlyProduct(ProductID const& pid,
+                                                  unsigned int key,
+                                                  ThinnedAssociationsHelper const& thinnedAssociationsHelper,
+                                                  F1 pidToBid,
+                                                  F2 getThinnedAssociation,
+                                                  F3 getByProductID) {
       BranchID parent = pidToBid(pid);
 
       // Loop over thinned containers which were made by selecting elements from the parent container
+      ThinnedAssociation const* slimmedAssociation = nullptr;
+      unsigned int slimmedIndex = 0;
+      bool thinnedAvailable = false;
       for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
                 iEnd = thinnedAssociationsHelper.parentEnd(parent);
            associatedBranches != iEnd;
@@ -46,31 +93,204 @@ namespace edm {
           continue;
         }
 
+        // Get the thinned container if it exists (need to check
+        // before the key because of constraints on slimmed
+        // containers
+        ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
+        WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID);
+        if (thinnedCollection != nullptr and not associatedBranches->isSlimmed()) {
+          thinnedAvailable = true;
+        }
+
         // Does this thinned container have the element referenced by key?
         auto thinnedIndex = thinnedAssociation->getThinnedIndex(key);
         if (not thinnedIndex.has_value()) {
           continue;
         }
 
-        // Get the thinned container and return a pointer if we can find it
-        ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
+        // if the thinned container is also slimmed, store the
+        // association for possible later use and ignore for now
+        if (associatedBranches->isSlimmed()) {
+          assert(slimmedAssociation == nullptr);
+          slimmedAssociation = thinnedAssociation;
+          slimmedIndex = *thinnedIndex;
+          continue;
+        }
+
+        // Return a pointer to thinned container if we can find it
+        if (thinnedCollection != nullptr) {
+          return ThinnedOrSlimmedProduct(thinnedCollection, *thinnedIndex);
+        }
+
+        // Thinned container is not found, try looking recursively in thinned containers
+        // which were made by selecting elements from this thinned container.
+        auto thinnedOrSlimmed = getThinnedOnlyProduct(thinnedCollectionPID,
+                                                      *thinnedIndex,
+                                                      thinnedAssociationsHelper,
+                                                      pidToBid,
+                                                      getThinnedAssociation,
+                                                      getByProductID);
+        if (thinnedOrSlimmed.hasThinned()) {
+          return thinnedOrSlimmed;
+        } else if (thinnedOrSlimmed.thinnedAvailable()) {
+          thinnedAvailable = true;
+        } else if (thinnedOrSlimmed.hasSlimmed()) {
+          assert(slimmedAssociation == nullptr);
+          std::tie(slimmedAssociation, slimmedIndex) = thinnedOrSlimmed.slimmedAssociation();
+        }
+      }
+
+      if (not thinnedAvailable and slimmedAssociation != nullptr) {
+        return ThinnedOrSlimmedProduct(slimmedAssociation, slimmedIndex);
+      }
+      return ThinnedOrSlimmedProduct(thinnedAvailable);
+    }
+
+    // the return value is to a slimmed collection in case one is found
+    template <typename F1, typename F2, typename F3>
+    SlimmedProducts getThinnedOnlyProducts(ProductID const& pid,
+                                           ThinnedAssociationsHelper const& thinnedAssociationsHelper,
+                                           F1 pidToBid,
+                                           F2 getThinnedAssociation,
+                                           F3 getByProductID,
+                                           std::vector<WrapperBase const*>& foundContainers,
+                                           std::vector<unsigned int>& keys) {
+      BranchID parent = pidToBid(pid);
+
+      // Loop over thinned containers which were made by selecting elements from the parent container
+      ThinnedAssociation const* slimmedAssociation = nullptr;
+      std::vector<unsigned int> slimmedIndexes;
+      bool thinnedAvailable = false;
+      for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
+                iEnd = thinnedAssociationsHelper.parentEnd(parent);
+           associatedBranches != iEnd;
+           ++associatedBranches) {
+        ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(associatedBranches->association());
+        if (thinnedAssociation == nullptr)
+          continue;
+
+        if (associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
+          continue;
+        }
+
+        // Get the thinned container if it exists (need to check
+        // before the key because of constraints on slimmed
+        // containers
+        ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
         WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID);
+        if (thinnedCollection != nullptr and not associatedBranches->isSlimmed()) {
+          thinnedAvailable = true;
+        }
+
+        unsigned nKeys = keys.size();
+        std::vector<unsigned int> thinnedIndexes(nKeys, kThinningDoNotLookForThisIndex);
+        bool hasAny = false;
+        for (unsigned k = 0; k < nKeys; ++k) {
+          // Already found this one
+          if (foundContainers[k] != nullptr) {
+            continue;
+          }
+          // Already know this one is not in this thinned container
+          if (keys[k] == kThinningDoNotLookForThisIndex) {
+            continue;
+          }
+          // Does the thinned container hold the entry of interest?
+          if (auto thinnedIndex = thinnedAssociation->getThinnedIndex(keys[k]); thinnedIndex.has_value()) {
+            thinnedIndexes[k] = *thinnedIndex;
+            hasAny = true;
+          }
+        }
+        if (!hasAny) {
+          continue;
+        }
+
+        // if the thinned container is also slimmed, store the
+        // association and the keys to thinned for possible later use
+        // and ignore for now
+        if (associatedBranches->isSlimmed()) {
+          assert(slimmedAssociation == nullptr);
+          slimmedAssociation = thinnedAssociation;
+          slimmedIndexes = std::move(thinnedIndexes);
+          continue;
+        }
+
+        // Set the pointers and indexes into the thinned container (if we can find it)
         if (thinnedCollection == nullptr) {
           // Thinned container is not found, try looking recursively in thinned containers
           // which were made by selecting elements from this thinned container.
-          auto thinnedCollectionKey = getThinnedProduct(thinnedCollectionPID,
-                                                        *thinnedIndex,
-                                                        thinnedAssociationsHelper,
-                                                        pidToBid,
-                                                        getThinnedAssociation,
-                                                        getByProductID);
-          if (thinnedCollectionKey.has_value()) {
-            return thinnedCollectionKey;
-          } else {
-            continue;
+          auto slimmed = getThinnedOnlyProducts(thinnedCollectionPID,
+                                                thinnedAssociationsHelper,
+                                                pidToBid,
+                                                getThinnedAssociation,
+                                                getByProductID,
+                                                foundContainers,
+                                                thinnedIndexes);
+          if (slimmed.thinnedAvailable()) {
+            thinnedAvailable = true;
+          } else if (slimmed.hasSlimmed()) {
+            assert(slimmedAssociation == nullptr);
+            std::tie(slimmedAssociation, slimmedIndexes) = slimmed.moveSlimmedAssociation();
+          }
+          for (unsigned k = 0; k < nKeys; ++k) {
+            if (foundContainers[k] == nullptr)
+              continue;
+            if (thinnedIndexes[k] == kThinningDoNotLookForThisIndex)
+              continue;
+            keys[k] = thinnedIndexes[k];
+          }
+        } else {
+          for (unsigned k = 0; k < nKeys; ++k) {
+            if (thinnedIndexes[k] == kThinningDoNotLookForThisIndex)
+              continue;
+            keys[k] = thinnedIndexes[k];
+            foundContainers[k] = thinnedCollection;
           }
         }
-        return std::tuple(thinnedCollection, *thinnedIndex);
+      }
+      if (not thinnedAvailable and slimmedAssociation != nullptr) {
+        return SlimmedProducts(slimmedAssociation, std::move(slimmedIndexes));
+      }
+      return SlimmedProducts(thinnedAvailable);
+    }
+
+    // This function provides a common implementation of
+    // EDProductGetter::getThinnedProduct() for EventPrincipal,
+    // DataGetterHelper, and BareRootProductGetter.
+    //
+    // getThinnedProduct assumes getIt was already called and failed to find
+    // the product. The input key is the index of the desired element in the
+    // container identified by ProductID (which cannot be found).
+    // If the return value is not null, then the desired element was
+    // found in a thinned container. If the desired element is not
+    // found, then an optional without a value is returned.
+    template <typename F1, typename F2, typename F3>
+    std::optional<std::tuple<WrapperBase const*, unsigned int>> getThinnedProduct(
+        ProductID const& pid,
+        unsigned int key,
+        ThinnedAssociationsHelper const& thinnedAssociationsHelper,
+        F1 pidToBid,
+        F2 getThinnedAssociation,
+        F3 getByProductID) {
+      auto thinnedOrSlimmed =
+          getThinnedOnlyProduct(pid, key, thinnedAssociationsHelper, pidToBid, getThinnedAssociation, getByProductID);
+
+      if (thinnedOrSlimmed.hasThinned()) {
+        return thinnedOrSlimmed.thinnedProduct();
+      } else if (thinnedOrSlimmed.hasSlimmed()) {
+        auto [slimmedAssociation, slimmedIndex] = thinnedOrSlimmed.slimmedAssociation();
+        ProductID const& slimmedCollectionPID = slimmedAssociation->thinnedCollectionID();
+        WrapperBase const* slimmedCollection = getByProductID(slimmedCollectionPID);
+        if (slimmedCollection == nullptr) {
+          // Slimmed container is not found, try looking recursively in thinned containers
+          // which were made by selecting elements from this thinned container.
+          return getThinnedProduct(slimmedCollectionPID,
+                                   slimmedIndex,
+                                   thinnedAssociationsHelper,
+                                   pidToBid,
+                                   getThinnedAssociation,
+                                   getByProductID);
+        }
+        return std::tuple(slimmedCollection, slimmedIndex);
       }
       return std::nullopt;
     }
@@ -98,68 +318,35 @@ namespace edm {
                             F3 getByProductID,
                             std::vector<WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) {
-      BranchID parent = pidToBid(pid);
-
-      // Loop over thinned containers which were made by selecting elements from the parent container
-      for (auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
-                iEnd = thinnedAssociationsHelper.parentEnd(parent);
-           associatedBranches != iEnd;
-           ++associatedBranches) {
-        ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(associatedBranches->association());
-        if (thinnedAssociation == nullptr)
-          continue;
-
-        if (associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
-          continue;
-        }
-
-        unsigned nKeys = keys.size();
-        constexpr unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
-        std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
-        bool hasAny = false;
-        for (unsigned k = 0; k < nKeys; ++k) {
-          // Already found this one
-          if (foundContainers[k] != nullptr)
-            continue;
-          // Already know this one is not in this thinned container
-          if (keys[k] == doNotLookForThisIndex)
-            continue;
-          // Does the thinned container hold the entry of interest?
-          if (auto thinnedIndex = thinnedAssociation->getThinnedIndex(keys[k]); thinnedIndex.has_value()) {
-            thinnedIndexes[k] = *thinnedIndex;
-            hasAny = true;
-          }
-        }
-        if (!hasAny) {
-          continue;
-        }
-        // Get the thinned container and set the pointers and indexes into
-        // it (if we can find it)
-        ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
-        WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID);
-        if (thinnedCollection == nullptr) {
-          // Thinned container is not found, try looking recursively in thinned containers
-          // which were made by selecting elements from this thinned container.
-          getThinnedProducts(thinnedCollectionPID,
+      auto slimmed = getThinnedOnlyProducts(
+          pid, thinnedAssociationsHelper, pidToBid, getThinnedAssociation, getByProductID, foundContainers, keys);
+      if (not slimmed.thinnedAvailable() and slimmed.hasSlimmed()) {
+        // no thinned procucts found, try out slimmed next if one is available
+        auto [slimmedAssociation, slimmedIndexes] = slimmed.moveSlimmedAssociation();
+        ProductID const& slimmedCollectionPID = slimmedAssociation->thinnedCollectionID();
+        WrapperBase const* slimmedCollection = getByProductID(slimmedCollectionPID);
+        unsigned const nKeys = keys.size();
+        if (slimmedCollection == nullptr) {
+          getThinnedProducts(slimmedCollectionPID,
                              thinnedAssociationsHelper,
                              pidToBid,
                              getThinnedAssociation,
                              getByProductID,
                              foundContainers,
-                             thinnedIndexes);
+                             slimmedIndexes);
           for (unsigned k = 0; k < nKeys; ++k) {
             if (foundContainers[k] == nullptr)
               continue;
-            if (thinnedIndexes[k] == doNotLookForThisIndex)
+            if (slimmedIndexes[k] == kThinningDoNotLookForThisIndex)
               continue;
-            keys[k] = thinnedIndexes[k];
+            keys[k] = slimmedIndexes[k];
           }
         } else {
           for (unsigned k = 0; k < nKeys; ++k) {
-            if (thinnedIndexes[k] == doNotLookForThisIndex)
+            if (slimmedIndexes[k] == kThinningDoNotLookForThisIndex)
               continue;
-            keys[k] = thinnedIndexes[k];
-            foundContainers[k] = thinnedCollection;
+            keys[k] = slimmedIndexes[k];
+            foundContainers[k] = slimmedCollection;
           }
         }
       }

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -165,6 +165,88 @@ namespace edm {
       }
     }
 
+    // This function provides a common implementation of
+    // EDProductGetter::getThinnedKeyFrom() for EventPrincipal,
+    // DataGetterHelper, and BareRootProductGetter.
+    //
+    // The thinned ProductID must come from an existing RefCore. The
+    // input key is the index of the desired element in the container
+    // identified by the parent ProductID. If the return value is not
+    // null, then the desired element was found in a thinned container.
+    // If the desired element is not found, then an optional without a
+    // value is returned.
+    template <typename F>
+    std::optional<unsigned int> getThinnedKeyFrom_implementation(
+        ProductID const& parentID,
+        BranchID const& parent,
+        unsigned int key,
+        ProductID const& thinnedID,
+        BranchID thinned,
+        ThinnedAssociationsHelper const& thinnedAssociationsHelper,
+        F&& getThinnedAssociation) {
+      if (thinnedAssociationsHelper.parentBegin(parent) == thinnedAssociationsHelper.parentEnd(parent)) {
+        throw Exception(errors::InvalidReference)
+            << "Parent collection with ProductID " << parentID << " has not been thinned";
+      }
+
+      bool foundParent = false;
+      std::vector<ThinnedAssociation const*> thinnedAssociationParentage;
+      while (not foundParent) {
+        // TODO: be smarter than linear search every time?
+        auto branchesToThinned = std::find_if(
+            thinnedAssociationsHelper.begin(), thinnedAssociationsHelper.end(), [&thinned](auto& associatedBranches) {
+              return associatedBranches.thinned() == thinned;
+            });
+        if (branchesToThinned == thinnedAssociationsHelper.end()) {
+          if (thinnedAssociationParentage.empty()) {
+            throw Exception(errors::ProductNotFound)
+                << "Thinned collection with ProductID " << thinnedID << " not found";
+          } else {
+            throw Exception(errors::InvalidReference) << "Requested thinned collection with ProductID " << thinnedID
+                                                      << " is not thinned from the parent collection with ProductID "
+                                                      << parentID << " or from any collection thinned from it.";
+          }
+        }
+
+        ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(branchesToThinned->association());
+        if (thinnedAssociation == nullptr) {
+          Exception ex{errors::LogicError};
+          if (thinnedAssociationParentage.empty()) {
+            ex << "ThinnedAssociation corresponding to thinned collection with ProductID " << thinnedID
+               << " not found.";
+          } else {
+            ex << "Intermediate ThinnedAssociation between the requested thinned ProductID " << thinnedID
+               << " and parent " << parentID << " not found.";
+          }
+          ex << " This should not happen.\nPlease contact the core framework developers.";
+          throw ex;
+        }
+
+        thinnedAssociationParentage.push_back(thinnedAssociation);
+        if (branchesToThinned->parent() == parent) {
+          foundParent = true;
+        } else {
+          // next iteration with current parent as the thinned collection
+          thinned = branchesToThinned->parent();
+        }
+      }
+
+      // found the parent, now need to rewind the parentage chain to
+      // find the index in the requested thinned collection
+      unsigned int thinnedIndex = key;
+      for (auto iAssociation = thinnedAssociationParentage.rbegin(), iEnd = thinnedAssociationParentage.rend();
+           iAssociation != iEnd;
+           ++iAssociation) {
+        auto optIndex = (*iAssociation)->getThinnedIndex(thinnedIndex);
+        if (optIndex) {
+          thinnedIndex = *optIndex;
+        } else {
+          return std::nullopt;
+        }
+      }
+      return thinnedIndex;
+    }
+
   }  // namespace detail
 }  // namespace edm
 

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -380,10 +380,16 @@ namespace edm {
     //
     // The thinned ProductID must come from an existing RefCore. The
     // input key is the index of the desired element in the container
-    // identified by the parent ProductID. If the return value is not
-    // null, then the desired element was found in a thinned container.
-    // If the desired element is not found, then an optional without a
-    // value is returned.
+    // identified by the parent ProductID. Returns an std::variant
+    // whose contents can be
+    // - unsigned int for the index in the thinned collection if the
+    //   desired element was found in the thinned collection
+    // - function creating an edm::Exception if parent is not a parent
+    //   of any thinned collection, thinned is not really a thinned
+    //   collection, or parent and thinned have no thinning
+    //   relationship
+    // - std::monostate if thinned is thinned from parent, but the key
+    //   is not found in the thinned collection
     template <typename F>
     std::variant<unsigned int, GetThinnedKeyFromExceptionFactory, std::monostate> getThinnedKeyFrom_implementation(
         ProductID const& parentID,

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -414,16 +414,17 @@ namespace edm {
               return associatedBranches.thinned() == thinned;
             });
         if (branchesToThinned == thinnedAssociationsHelper.end()) {
-          if (thinnedAssociationParentage.empty()) {
-            throw Exception(errors::ProductNotFound)
-                << "Thinned collection with ProductID " << thinnedID << " not found";
-          } else {
-            return [parentID, thinnedID]() {
-              return Exception(errors::InvalidReference) << "Requested thinned collection with ProductID " << thinnedID
-                                                         << " is not thinned from the parent collection with ProductID "
-                                                         << parentID << " or from any collection thinned from it.";
-            };
-          }
+          return [parentID, thinnedID, thinnedIsThinned = not thinnedAssociationParentage.empty()]() {
+            Exception ex(errors::InvalidReference);
+            ex << "Requested thinned collection with ProductID " << thinnedID
+               << " is not thinned from the parent collection with ProductID " << parentID
+               << " or from any collection thinned from it.";
+            if (not thinnedIsThinned) {
+              ex << " In fact, the collection " << thinnedID
+                 << " passed in as a 'thinned' collection has not been thinned at all.";
+            }
+            return ex;
+          };
         }
 
         ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(branchesToThinned->association());

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -48,7 +48,7 @@ namespace edm {
     // This is a helper function to recursively search for a thinned
     // product containing the parent key on the same "slimming depth". That
     // means that when the recursion encounters a slimmed collection,
-    // the tree travelsal does not proceed onto the children of the
+    // the tree traversal does not proceed onto the children of the
     // slimmed collection. Instead, the slimmed ThinnedAssociation is
     // recorded for the case that the entire tree on a given "slimming
     // depth" does not have any thinned-only collections.
@@ -78,7 +78,7 @@ namespace edm {
       if (associatedBranches == iEnd) {
         return ThinnedOrSlimmedProduct();
       }
-      bool const slimmedAllowed = associatedBranches + 1 == iEnd;
+      bool const slimmedAllowed = (associatedBranches + 1 == iEnd);
       if (slimmedAllowed and associatedBranches->isSlimmed()) {
         // Slimmed container can be considered only if it has no (thinned) siblings
         ThinnedAssociation const* slimmedAssociation = getThinnedAssociation(associatedBranches->association());

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -393,7 +393,12 @@ namespace edm {
         BranchID thinned,
         ThinnedAssociationsHelper const& thinnedAssociationsHelper,
         F&& getThinnedAssociation) {
-      if (thinnedAssociationsHelper.parentBegin(parent) == thinnedAssociationsHelper.parentEnd(parent)) {
+      // need to explicitly check for equality of parent BranchID,
+      // because ThinnedAssociationsHelper::parentBegin() uses
+      // std::lower_bound() that returns a valid iterator in case the
+      // parent is not found
+      if (auto iParent = thinnedAssociationsHelper.parentBegin(parent);
+          iParent == thinnedAssociationsHelper.parentEnd(parent) or iParent->parent() != parent) {
         return [parentID]() {
           return Exception(errors::InvalidReference)
                  << "Parent collection with ProductID " << parentID << " has not been thinned";

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -1,6 +1,8 @@
 #ifndef DataFormats_Common_getThinned_implementation_h
 #define DataFormats_Common_getThinned_implementation_h
 
+#include <algorithm>
+#include <cassert>
 #include <optional>
 #include <tuple>
 
@@ -8,6 +10,7 @@
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 
 namespace edm {
   class WrapperBase;

--- a/DataFormats/Common/test/BuildFile.xml
+++ b/DataFormats/Common/test/BuildFile.xml
@@ -27,6 +27,10 @@
 <bin file="Ref_t.cpp">
 </bin>
 
+<bin file="ThinnedRefSet_t.cpp">
+  <use name="catch2"/>
+</bin>
+
 <bin file="RefVector_t.cpp">
 </bin>
 

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -169,6 +169,10 @@ namespace {
                             std::vector<WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
+    std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
+      return std::nullopt;
+    }
+
     unsigned int transitionIndex_() const override { return 0U; }
 
     edm::Wrapper<T> const* prod_;

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -169,8 +169,8 @@ namespace {
                             std::vector<WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
-    std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
-      return std::nullopt;
+    edm::OptionalThinnedKey getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
+      return std::monostate{};
     }
 
     unsigned int transitionIndex_() const override { return 0U; }

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -40,6 +40,12 @@ public:
                           std::vector<edm::WrapperBase const*>& wrappers,
                           std::vector<unsigned int>& keys) const override {}
 
+  std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const&,
+                                                unsigned int,
+                                                edm::ProductID const&) const override {
+    return std::nullopt;
+  }
+
 private:
   unsigned int transitionIndex_() const override { return 0U; }
 

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -40,10 +40,8 @@ public:
                           std::vector<edm::WrapperBase const*>& wrappers,
                           std::vector<unsigned int>& keys) const override {}
 
-  std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const&,
-                                                unsigned int,
-                                                edm::ProductID const&) const override {
-    return std::nullopt;
+  edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const&, unsigned int, edm::ProductID const&) const override {
+    return std::monostate{};
   }
 
 private:

--- a/DataFormats/Common/test/ThinnedRefSet_t.cpp
+++ b/DataFormats/Common/test/ThinnedRefSet_t.cpp
@@ -1,0 +1,99 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/ThinnedRefSet.h"
+
+#include "SimpleEDProductGetter.h"
+
+#include <memory>
+#include <vector>
+
+TEST_CASE("ThinnedRefSet", "[ThinnedRefSet]") {
+  SECTION("Default constructor") { edm::ThinnedRefSet<int> set; }
+
+  SECTION("std::vector<int>") {
+    SimpleEDProductGetter getter;
+
+    edm::ProductID id(1, 42U);
+    REQUIRE(id.isValid());
+
+    auto prod = std::make_unique<std::vector<int>>();
+    for (int i = 0; i < 10; ++i) {
+      prod->push_back(i);
+    }
+    getter.addProduct(id, std::move(prod));
+
+    edm::ThinnedRefSet<std::vector<int>> refSet;
+    edm::RefProd<std::vector<int>> refProd(id, &getter);
+    auto filler = refSet.fill(refProd, getter);
+
+    filler.insert(edm::Ref<std::vector<int>>(id, 0, &getter));
+    filler.insert(edm::Ref<std::vector<int>>(id, 4, &getter));
+    filler.insert(edm::Ref<std::vector<int>>(id, 9, &getter));
+
+    REQUIRE(refSet.contains(0));
+    REQUIRE(not refSet.contains(1));
+    REQUIRE(not refSet.contains(2));
+    REQUIRE(not refSet.contains(3));
+    REQUIRE(refSet.contains(4));
+    REQUIRE(not refSet.contains(5));
+    REQUIRE(not refSet.contains(6));
+    REQUIRE(not refSet.contains(7));
+    REQUIRE(not refSet.contains(8));
+    REQUIRE(refSet.contains(9));
+    REQUIRE(not refSet.contains(10));
+  }
+
+  SECTION("edmNew::DetSetVector<int>") {
+    SimpleEDProductGetter getter;
+
+    edm::ProductID id(1, 75U);
+    REQUIRE(id.isValid());
+
+    {
+      auto detsets = std::make_unique<edmNew::DetSetVector<int>>(2);
+      {
+        edmNew::DetSetVector<int>::FastFiller filler(*detsets, 1);
+        filler.push_back(1);
+        filler.push_back(2);
+        filler.push_back(3);
+      }
+      {
+        edmNew::DetSetVector<int>::FastFiller filler(*detsets, 2);
+        filler.push_back(10);
+        filler.push_back(20);
+      }
+      REQUIRE(detsets->size() == 2);
+      REQUIRE(detsets->dataSize() == 5);
+      REQUIRE(detsets->detsetSize(0) == 3);
+      REQUIRE(detsets->detsetSize(1) == 2);
+
+      auto ds = detsets->find(1);
+      REQUIRE(ds != detsets->end());
+      REQUIRE(ds->id() == 1);
+      REQUIRE(detsets->find(3) == detsets->end());
+
+      getter.addProduct(id, std::move(detsets));
+    }
+
+    edm::ThinnedRefSet<edmNew::DetSetVector<int>> refSet;
+    edm::RefProd<edmNew::DetSetVector<int>> refProd(id, &getter);
+    auto filler = refSet.fill(refProd, getter);
+
+    REQUIRE(*(edm::Ref<edmNew::DetSetVector<int>, int>(id, 0, &getter)) == 1);
+    REQUIRE(*(edm::Ref<edmNew::DetSetVector<int>, int>(id, 2, &getter)) == 3);
+    REQUIRE(*(edm::Ref<edmNew::DetSetVector<int>, int>(id, 4, &getter)) == 20);
+
+    filler.insert(edm::Ref<edmNew::DetSetVector<int>, int>(id, 0, &getter));
+    filler.insert(edm::Ref<edmNew::DetSetVector<int>, int>(id, 2, &getter));
+    filler.insert(edm::Ref<edmNew::DetSetVector<int>, int>(id, 4, &getter));
+
+    REQUIRE(refSet.contains(0));
+    REQUIRE(not refSet.contains(1));
+    REQUIRE(refSet.contains(2));
+    REQUIRE(not refSet.contains(3));
+    REQUIRE(refSet.contains(4));
+    REQUIRE(not refSet.contains(5));
+  }
+}

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -298,6 +298,10 @@ namespace {
                             std::vector<WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
+    std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
+      return std::nullopt;
+    }
+
     unsigned int transitionIndex_() const override { return 0U; }
 
     TestGetter() : hold_() {}

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -298,8 +298,8 @@ namespace {
                             std::vector<WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
-    std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
-      return std::nullopt;
+    edm::OptionalThinnedKey getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
+      return std::monostate{};
     }
 
     unsigned int transitionIndex_() const override { return 0U; }

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -51,6 +51,12 @@ namespace testPtr {
                             std::vector<edm::WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
+    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const&,
+                                                  unsigned int,
+                                                  edm::ProductID const&) const override {
+      return std::nullopt;
+    }
+
     unsigned int transitionIndex_() const override { return 0U; }
 
     TestGetter() : hold_() {}

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -51,10 +51,10 @@ namespace testPtr {
                             std::vector<edm::WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
-    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const&,
-                                                  unsigned int,
-                                                  edm::ProductID const&) const override {
-      return std::nullopt;
+    edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const&,
+                                              unsigned int,
+                                              edm::ProductID const&) const override {
+      return std::monostate{};
     }
 
     unsigned int transitionIndex_() const override { return 0U; }

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -189,6 +189,10 @@ namespace {
                             std::vector<WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
+    std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
+      return std::nullopt;
+    }
+
     unsigned int transitionIndex_() const override { return 0U; }
     TestGetter() : hold_(nullptr) {}
   };

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -189,8 +189,8 @@ namespace {
                             std::vector<WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
-    std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
-      return std::nullopt;
+    edm::OptionalThinnedKey getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
+      return std::monostate{};
     }
 
     unsigned int transitionIndex_() const override { return 0U; }

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -184,6 +184,10 @@ namespace {
                             std::vector<WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
+    std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
+      return std::nullopt;
+    }
+
     unsigned int transitionIndex_() const override { return 0U; }
 
     TestGetter() : hold_() {}

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -184,8 +184,8 @@ namespace {
                             std::vector<WrapperBase const*>& wrappers,
                             std::vector<unsigned int>& keys) const override {}
 
-    std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
-      return std::nullopt;
+    edm::OptionalThinnedKey getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override {
+      return std::monostate{};
     }
 
     unsigned int transitionIndex_() const override { return 0U; }

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -116,6 +116,10 @@ namespace fwlite {
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const;
 
+    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
+                                                  unsigned int key,
+                                                  edm::ProductID const& thinned) const;
+
     fwlite::LuminosityBlock const& getLuminosityBlock();
     fwlite::Run const& getRun();
 

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -116,9 +116,9 @@ namespace fwlite {
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const;
 
-    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
-                                                  unsigned int key,
-                                                  edm::ProductID const& thinned) const;
+    edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const& parent,
+                                              unsigned int key,
+                                              edm::ProductID const& thinned) const;
 
     fwlite::LuminosityBlock const& getLuminosityBlock();
     fwlite::Run const& getRun();

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -76,6 +76,10 @@ namespace fwlite {
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys,
                             Long_t eventEntry) const;
+    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
+                                                  unsigned int key,
+                                                  edm::ProductID const& thinned,
+                                                  Long_t eventEntry) const;
 
     // ---------- static member functions --------------------
 

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -76,10 +76,10 @@ namespace fwlite {
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys,
                             Long_t eventEntry) const;
-    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
-                                                  unsigned int key,
-                                                  edm::ProductID const& thinned,
-                                                  Long_t eventEntry) const;
+    edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const& parent,
+                                              unsigned int key,
+                                              edm::ProductID const& thinned,
+                                              Long_t eventEntry) const;
 
     // ---------- static member functions --------------------
 

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -168,6 +168,9 @@ namespace fwlite {
     void getThinnedProducts(edm::ProductID const& pid,
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const;
+    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
+                                                  unsigned int key,
+                                                  edm::ProductID const& thinned) const;
 
     edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
 

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -168,9 +168,9 @@ namespace fwlite {
     void getThinnedProducts(edm::ProductID const& pid,
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const;
-    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
-                                                  unsigned int key,
-                                                  edm::ProductID const& thinned) const;
+    edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const& parent,
+                                              unsigned int key,
+                                              edm::ProductID const& thinned) const;
 
     edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
 

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -128,6 +128,10 @@ namespace fwlite {
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const;
 
+    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
+                                                  unsigned int key,
+                                                  edm::ProductID const& thinned) const;
+
   private:
     MultiChainEvent(Event const&);  // stop default
 

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -128,9 +128,9 @@ namespace fwlite {
                             std::vector<edm::WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const;
 
-    std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
-                                                  unsigned int key,
-                                                  edm::ProductID const& thinned) const;
+    edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const& parent,
+                                              unsigned int key,
+                                              edm::ProductID const& thinned) const;
 
   private:
     MultiChainEvent(Event const&);  // stop default

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -229,6 +229,12 @@ namespace fwlite {
     event_->getThinnedProducts(pid, foundContainers, keys);
   }
 
+  std::optional<unsigned int> ChainEvent::getThinnedKeyFrom(edm::ProductID const& parent,
+                                                            unsigned int key,
+                                                            edm::ProductID const& thinned) const {
+    return event_->getThinnedKeyFrom(parent, key, thinned);
+  }
+
   bool ChainEvent::isValid() const { return event_->isValid(); }
   ChainEvent::operator bool() const { return *event_; }
 

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -229,9 +229,9 @@ namespace fwlite {
     event_->getThinnedProducts(pid, foundContainers, keys);
   }
 
-  std::optional<unsigned int> ChainEvent::getThinnedKeyFrom(edm::ProductID const& parent,
-                                                            unsigned int key,
-                                                            edm::ProductID const& thinned) const {
+  edm::OptionalThinnedKey ChainEvent::getThinnedKeyFrom(edm::ProductID const& parent,
+                                                        unsigned int key,
+                                                        edm::ProductID const& thinned) const {
     return event_->getThinnedKeyFrom(parent, key, thinned);
   }
 

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -425,6 +425,32 @@ namespace fwlite {
         keys);
   }
 
+  std::optional<unsigned int> DataGetterHelper::getThinnedKeyFrom(edm::ProductID const& parentID,
+                                                                  unsigned int key,
+                                                                  edm::ProductID const& thinnedID,
+                                                                  Long_t eventEntry) const {
+    edm::BranchID parent = branchMap_->productToBranchID(parentID);
+    if (!parent.isValid())
+      return std::nullopt;
+    edm::BranchID thinned = branchMap_->productToBranchID(thinnedID);
+    if (!thinned.isValid())
+      return std::nullopt;
+
+    try {
+      return edm::detail::getThinnedKeyFrom_implementation(
+          parentID,
+          parent,
+          key,
+          thinnedID,
+          thinned,
+          branchMap_->thinnedAssociationsHelper(),
+          [this, eventEntry](edm::BranchID const& branchID) { return getThinnedAssociation(branchID, eventEntry); });
+    } catch (edm::Exception& ex) {
+      ex.addContext("Calling DataGetterHelper::getThinnedKeyFrom()");
+      throw ex;
+    }
+  }
+
   edm::ThinnedAssociation const* DataGetterHelper::getThinnedAssociation(edm::BranchID const& branchID,
                                                                          Long_t eventEntry) const {
     edm::WrapperBase const* wrapperBase = getByBranchID(branchID, eventEntry);

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -89,6 +89,19 @@ namespace fwlite {
         event_->getThinnedProducts(pid, foundContainers, keys);
       }
 
+      // This overload is allowed to be called also without getIt()
+      // being called first, but he thinned ProductID must come from an
+      // existing RefCore. The input key is the index of the desired
+      // element in the container identified by the parent ProductID.
+      // If the return value is not null, then the desired element was found
+      // in a thinned container. If the desired element is not found, then
+      // an optional without a value is returned.
+      std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
+                                                    unsigned int key,
+                                                    edm::ProductID const& thinned) const override {
+        return event_->getThinnedKeyFrom(parent, key, thinned);
+      }
+
     private:
       unsigned int transitionIndex_() const override { return 0U; }
 
@@ -377,6 +390,13 @@ namespace fwlite {
                                  std::vector<unsigned int>& keys) const {
     Long_t eventEntry = branchMap_.getEventEntry();
     return dataHelper_.getThinnedProducts(pid, foundContainers, keys, eventEntry);
+  }
+
+  std::optional<unsigned int> Event::getThinnedKeyFrom(edm::ProductID const& parent,
+                                                       unsigned int key,
+                                                       edm::ProductID const& thinned) const {
+    Long_t eventEntry = branchMap_.getEventEntry();
+    return dataHelper_.getThinnedKeyFrom(parent, key, thinned, eventEntry);
   }
 
   edm::TriggerNames const& Event::triggerNames(edm::TriggerResults const& triggerResults) const {

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -96,9 +96,9 @@ namespace fwlite {
       // If the return value is not null, then the desired element was found
       // in a thinned container. If the desired element is not found, then
       // an optional without a value is returned.
-      std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
-                                                    unsigned int key,
-                                                    edm::ProductID const& thinned) const override {
+      edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const& parent,
+                                                unsigned int key,
+                                                edm::ProductID const& thinned) const override {
         return event_->getThinnedKeyFrom(parent, key, thinned);
       }
 
@@ -392,9 +392,9 @@ namespace fwlite {
     return dataHelper_.getThinnedProducts(pid, foundContainers, keys, eventEntry);
   }
 
-  std::optional<unsigned int> Event::getThinnedKeyFrom(edm::ProductID const& parent,
-                                                       unsigned int key,
-                                                       edm::ProductID const& thinned) const {
+  edm::OptionalThinnedKey Event::getThinnedKeyFrom(edm::ProductID const& parent,
+                                                   unsigned int key,
+                                                   edm::ProductID const& thinned) const {
     Long_t eventEntry = branchMap_.getEventEntry();
     return dataHelper_.getThinnedKeyFrom(parent, key, thinned, eventEntry);
   }

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -90,7 +90,7 @@ namespace fwlite {
       }
 
       // This overload is allowed to be called also without getIt()
-      // being called first, but he thinned ProductID must come from an
+      // being called first, but the thinned ProductID must come from an
       // existing RefCore. The input key is the index of the desired
       // element in the container identified by the parent ProductID.
       // If the return value is not null, then the desired element was found

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -44,6 +44,12 @@ namespace fwlite {
         event_->getThinnedProducts(pid, foundContainers, keys);
       }
 
+      std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
+                                                    unsigned int key,
+                                                    edm::ProductID const& thinned) const override {
+        return event_->getThinnedKeyFrom(parent, key, thinned);
+      }
+
     private:
       unsigned int transitionIndex_() const override { return 0U; }
 
@@ -342,6 +348,19 @@ namespace fwlite {
       (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
       event2_->getThinnedProducts(pid, wrappers, keys);
     }
+  }
+
+  std::optional<unsigned int> MultiChainEvent::getThinnedKeyFrom(edm::ProductID const& parent,
+                                                                 unsigned int key,
+                                                                 edm::ProductID const& thinned) const {
+    // First try the first file
+    auto edp = event1_->getThinnedKeyFrom(parent, key, thinned);
+    // Did not find the product, try secondary file
+    if (not edp.has_value()) {
+      (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
+      edp = event2_->getThinnedKeyFrom(parent, key, thinned);
+    }
+    return edp;
   }
 
   bool MultiChainEvent::isValid() const { return event1_->isValid(); }

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -44,9 +44,9 @@ namespace fwlite {
         event_->getThinnedProducts(pid, foundContainers, keys);
       }
 
-      std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
-                                                    unsigned int key,
-                                                    edm::ProductID const& thinned) const override {
+      edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const& parent,
+                                                unsigned int key,
+                                                edm::ProductID const& thinned) const override {
         return event_->getThinnedKeyFrom(parent, key, thinned);
       }
 
@@ -350,13 +350,13 @@ namespace fwlite {
     }
   }
 
-  std::optional<unsigned int> MultiChainEvent::getThinnedKeyFrom(edm::ProductID const& parent,
-                                                                 unsigned int key,
-                                                                 edm::ProductID const& thinned) const {
+  edm::OptionalThinnedKey MultiChainEvent::getThinnedKeyFrom(edm::ProductID const& parent,
+                                                             unsigned int key,
+                                                             edm::ProductID const& thinned) const {
     // First try the first file
     auto edp = event1_->getThinnedKeyFrom(parent, key, thinned);
     // Did not find the product, try secondary file
-    if (not edp.has_value()) {
+    if (std::holds_alternative<std::monostate>(edp)) {
       (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
       edp = event2_->getThinnedKeyFrom(parent, key, thinned);
     }

--- a/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
+++ b/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
@@ -18,11 +18,12 @@ namespace edm {
   class ThinnedAssociationBranches {
   public:
     ThinnedAssociationBranches();
-    ThinnedAssociationBranches(BranchID const&, BranchID const&, BranchID const&);
+    ThinnedAssociationBranches(BranchID const&, BranchID const&, BranchID const&, bool slimmed);
 
     BranchID const& parent() const { return parent_; }
     BranchID const& association() const { return association_; }
     BranchID const& thinned() const { return thinned_; }
+    bool isSlimmed() const { return slimmed_; }
 
     bool operator<(ThinnedAssociationBranches const& rhs) const { return parent_ < rhs.parent_; }
 
@@ -30,6 +31,7 @@ namespace edm {
     BranchID parent_;
     BranchID association_;
     BranchID thinned_;
+    bool slimmed_ = false;
   };
 
   class ThinnedAssociationsHelper {
@@ -42,7 +44,7 @@ namespace edm {
     std::vector<ThinnedAssociationBranches>::const_iterator parentBegin(BranchID const&) const;
     std::vector<ThinnedAssociationBranches>::const_iterator parentEnd(BranchID const&) const;
 
-    void addAssociation(BranchID const&, BranchID const&, BranchID const&);
+    void addAssociation(BranchID const&, BranchID const&, BranchID const&, bool slimmed);
     void addAssociation(ThinnedAssociationBranches const&);
 
     std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > associationToBranches() const;
@@ -78,6 +80,8 @@ namespace edm {
         std::map<BranchID, bool>& keepAssociation) const;
     std::vector<ThinnedAssociationBranches>::const_iterator lower_bound(
         ThinnedAssociationBranches const& branches) const;
+
+    void ensureSlimmingConstraints() const;
 
     std::vector<ThinnedAssociationBranches> vThinnedAssociationBranches_;
   };

--- a/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
+++ b/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
@@ -3,14 +3,17 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include <algorithm>
 
+#include <fmt/format.h>
+
 namespace edm {
 
   ThinnedAssociationBranches::ThinnedAssociationBranches() {}
 
   ThinnedAssociationBranches::ThinnedAssociationBranches(BranchID const& parent,
                                                          BranchID const& association,
-                                                         BranchID const& thinned)
-      : parent_(parent), association_(association), thinned_(thinned) {}
+                                                         BranchID const& thinned,
+                                                         bool slimmed)
+      : parent_(parent), association_(association), thinned_(thinned), slimmed_(slimmed) {}
 
   ThinnedAssociationsHelper::ThinnedAssociationsHelper() {}
 
@@ -24,7 +27,7 @@ namespace edm {
 
   std::vector<ThinnedAssociationBranches>::const_iterator ThinnedAssociationsHelper::parentBegin(
       BranchID const& parent) const {
-    ThinnedAssociationBranches target(parent, BranchID(), BranchID());
+    ThinnedAssociationBranches target(parent, BranchID(), BranchID(), false);
     return std::lower_bound(vThinnedAssociationBranches_.begin(),
                             vThinnedAssociationBranches_.end(),
                             target,
@@ -35,7 +38,7 @@ namespace edm {
 
   std::vector<ThinnedAssociationBranches>::const_iterator ThinnedAssociationsHelper::parentEnd(
       BranchID const& parent) const {
-    ThinnedAssociationBranches target(parent, BranchID(), BranchID());
+    ThinnedAssociationBranches target(parent, BranchID(), BranchID(), false);
     return std::upper_bound(vThinnedAssociationBranches_.begin(),
                             vThinnedAssociationBranches_.end(),
                             target,
@@ -57,17 +60,119 @@ namespace edm {
 
   void ThinnedAssociationsHelper::addAssociation(BranchID const& parent,
                                                  BranchID const& association,
-                                                 BranchID const& thinned) {
-    addAssociation(ThinnedAssociationBranches(parent, association, thinned));
+                                                 BranchID const& thinned,
+                                                 bool slimmed) {
+    addAssociation(ThinnedAssociationBranches(parent, association, thinned, slimmed));
   }
 
   void ThinnedAssociationsHelper::addAssociation(ThinnedAssociationBranches const& branches) {
     vThinnedAssociationBranches_.insert(lower_bound(branches), branches);
+    if (branches.isSlimmed()) {
+      try {
+        ensureSlimmingConstraints();
+      } catch (edm::Exception& ex) {
+        ex.addContext("Calling ThinnedAssociationsHelper::addAssociation()");
+        ex.addAdditionalInfo(fmt::format("When adding a slimmed collection with BranchID {}", branches.thinned().id()));
+        throw ex;
+      }
+    }
+  }
+}  // namespace edm
+
+namespace {
+  struct SlimmedCount {
+    edm::BranchID parent;
+    int slimmedChildrenCount;
+  };
+
+  int countSlimmingChildren(edm::ThinnedAssociationsHelper const& helper,
+                            edm::BranchID const& parent,
+                            std::vector<SlimmedCount> const& counts);
+  void addSlimmingChildrenCount(edm::ThinnedAssociationsHelper const& helper,
+                                edm::ThinnedAssociationBranches const& branches,
+                                std::vector<SlimmedCount> const& counts,
+                                int& slimmedCount) {
+    int slimmingChildren = countSlimmingChildren(helper, branches.thinned(), counts);
+    if (slimmingChildren >= 2) {
+      throw edm::Exception(edm::errors::LogicError)
+          << "Encountered a parent collection with BranchID " << branches.thinned().id()
+          << " that has more than one thinned children that are either themselves slimmed, or have further thinned "
+             "children that are slimmed. This is not allowed, but this particular check should not fire (it should "
+             "have been caught earlier). Please contact framework developers.";
+    }
+
+    if (slimmingChildren == 0 and branches.isSlimmed()) {
+      ++slimmingChildren;
+    }
+
+    slimmedCount += slimmingChildren;
+    if (slimmedCount >= 2) {
+      throw edm::Exception(edm::errors::LogicError)
+          << "Encountered a parent collection with BranchID " << branches.parent().id()
+          << " that has more than one thinned children that are either themselves slimmed, or have further thinned "
+             "children that are slimmed. This is not allowed. In the thinning parentage tree, any parent may have "
+             "slimmed collections in at most one path to any leaf thinned collections of that parent.";
+    }
   }
 
-  std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> >
-  ThinnedAssociationsHelper::associationToBranches() const {
-    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > temp;
+  int countSlimmingChildren(edm::ThinnedAssociationsHelper const& helper,
+                            edm::BranchID const& parent,
+                            std::vector<SlimmedCount> const& counts) {
+    auto begin = helper.parentBegin(parent);
+    auto end = helper.parentEnd(parent);
+    if (begin == end)
+      return 0;
+
+    // if already visited, can just return the count
+    auto pos =
+        std::lower_bound(counts.begin(), counts.end(), parent, [](SlimmedCount const& c, edm::BranchID const& b) {
+          return c.parent < b;
+        });
+    if (pos != counts.end() && pos->parent == parent) {
+      return pos->slimmedChildrenCount;
+    }
+
+    int slimmedCount = 0;
+    for (auto iItem = begin; iItem != end; ++iItem) {
+      addSlimmingChildrenCount(helper, *iItem, counts, slimmedCount);
+    }
+    return slimmedCount;
+  }
+}  // namespace
+
+namespace edm {
+  void ThinnedAssociationsHelper::ensureSlimmingConstraints() const {
+    // ThinnedAssociationBranches defines an edge between a parent and
+    // a thinned collection in the parentage tree of the thinned
+    // collections. It is required that for a given parentage tree
+    // there is at most one path from the root node to any leaf nodes
+    // that has slimming edges.
+
+    std::vector<::SlimmedCount> counts;
+    BranchID prevParent;
+    std::vector<SlimmedCount>::iterator currentCount;
+    for (auto iItem = begin(), iEnd = end(); iItem != iEnd; ++iItem) {
+      if (iItem->parent() == prevParent) {
+        addSlimmingChildrenCount(*this, *iItem, counts, currentCount->slimmedChildrenCount);
+      } else {
+        currentCount = std::lower_bound(
+            counts.begin(), counts.end(), iItem->parent(), [](SlimmedCount const& c, BranchID const& b) {
+              return c.parent < b;
+            });
+        // has the tree with iItem->parent() as root node already been counted?
+        if (currentCount != counts.end() && currentCount->parent == iItem->parent()) {
+          continue;
+        }
+        currentCount = counts.insert(currentCount, ::SlimmedCount{iItem->parent(), 0});
+        addSlimmingChildrenCount(*this, *iItem, counts, currentCount->slimmedChildrenCount);
+        prevParent = iItem->parent();
+      }
+    }
+  }
+
+  std::vector<std::pair<BranchID, ThinnedAssociationBranches const*>> ThinnedAssociationsHelper::associationToBranches()
+      const {
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*>> temp;
     for (auto const& item : vThinnedAssociationBranches_) {
       temp.push_back(std::make_pair(item.association(), &item));
     }
@@ -85,7 +190,7 @@ namespace edm {
     keepAssociation.clear();
     // Copy the elements in vThinnedAssociationBranches_ into a vector sorted on
     // the association BranchID so we can do searches on that BranchID faster.
-    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > assocToBranches = associationToBranches();
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*>> assocToBranches = associationToBranches();
 
     for (auto association : associationDescriptions) {
       if (association
@@ -101,7 +206,7 @@ namespace edm {
 
   bool ThinnedAssociationsHelper::shouldKeepAssociation(
       BranchID const& association,
-      std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > const& associationToBranches,
+      std::vector<std::pair<BranchID, ThinnedAssociationBranches const*>> const& associationToBranches,
       std::set<BranchID>& branchesInRecursion,
       std::set<BranchID> const& keptProductsInEvent,
       std::map<BranchID, bool>& keepAssociation) const {
@@ -183,7 +288,7 @@ namespace edm {
     if (associationsFromSecondary.empty())
       return;
 
-    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > assocToBranches =
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*>> assocToBranches =
         helper.associationToBranches();
 
     for (BranchID const& association : associationsFromSecondary) {
@@ -221,7 +326,7 @@ namespace edm {
         if (iter != droppedBranchIDToKeptBranchID.end()) {
           thinned = BranchID(iter->second);
         }
-        addAssociation(parent, associationBranches.association(), thinned);
+        addAssociation(parent, associationBranches.association(), thinned, associationBranches.isSlimmed());
       }
     }
   }
@@ -231,7 +336,7 @@ namespace edm {
     if (associationsFromSecondary.empty())
       return;
 
-    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > assocToBranches =
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*>> assocToBranches =
         fileAssociationsHelper.associationToBranches();
 
     for (BranchID const& association : associationsFromSecondary) {

--- a/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
+++ b/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
@@ -152,6 +152,9 @@ namespace edm {
     BranchID prevParent;
     std::vector<SlimmedCount>::iterator currentCount;
     for (auto iItem = begin(), iEnd = end(); iItem != iEnd; ++iItem) {
+      if (iItem->parent() == BranchID()) {
+        continue;
+      }
       if (iItem->parent() == prevParent) {
         addSlimmingChildrenCount(*this, *iItem, counts, currentCount->slimmedChildrenCount);
       } else {

--- a/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
+++ b/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
@@ -93,7 +93,7 @@ namespace {
                                 std::vector<SlimmedCount> const& counts,
                                 int& slimmedCount) {
     int slimmingChildren = countSlimmingChildren(helper, branches.thinned(), counts);
-    if (slimmingChildren >= 2) {
+    if (slimmingChildren > 1) {
       throw edm::Exception(edm::errors::LogicError)
           << "Encountered a parent collection with BranchID " << branches.thinned().id()
           << " that has more than one thinned children that are either themselves slimmed, or have further thinned "
@@ -106,7 +106,7 @@ namespace {
     }
 
     slimmedCount += slimmingChildren;
-    if (slimmedCount >= 2) {
+    if (slimmedCount > 1) {
       throw edm::Exception(edm::errors::LogicError)
           << "Encountered a parent collection with BranchID " << branches.parent().id()
           << " that has more than one thinned children that are either themselves slimmed, or have further thinned "

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -209,7 +209,8 @@
 
  <class name="std::vector<TFormula*>"/>
 
- <class name="edm::ThinnedAssociationBranches" ClassVersion="4">
+ <class name="edm::ThinnedAssociationBranches" ClassVersion="5">
+  <version ClassVersion="5" checksum="3178849990"/>
   <version ClassVersion="4" checksum="377132180"/>
  </class>
  <class name="std::vector<edm::ThinnedAssociationBranches>"/>

--- a/DataFormats/TestObjects/interface/TrackOfDSVThings.h
+++ b/DataFormats/TestObjects/interface/TrackOfDSVThings.h
@@ -1,0 +1,26 @@
+#ifndef DataFormats_TestObjects_TrackOfDSVThings_h
+#define DataFormats_TestObjects_TrackOfDSVThings_h
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/RefToBaseVector.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+
+namespace edmtest {
+
+  struct TrackOfDSVThings {
+    TrackOfDSVThings() = default;
+
+    edm::Ref<edmNew::DetSetVector<Thing>, Thing> ref1;
+    edm::Ref<edmNew::DetSetVector<Thing>, Thing> ref2;
+    edm::RefVector<edmNew::DetSetVector<Thing>, Thing> refVector1;
+  };
+}  // namespace edmtest
+
+namespace edmtest {
+  typedef std::vector<edmtest::TrackOfDSVThings> TrackOfDSVThingsCollection;
+}
+
+#endif

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -18,6 +18,7 @@
 #include "DataFormats/TestObjects/interface/ThingWithMerge.h"
 #include "DataFormats/TestObjects/interface/ThingWithIsEqual.h"
 #include "DataFormats/TestObjects/interface/TrackOfThings.h"
+#include "DataFormats/TestObjects/interface/TrackOfDSVThings.h"
 
 #include "DataFormats/TestObjects/interface/StreamTestSimple.h"
 #include "DataFormats/TestObjects/interface/StreamTestThing.h"

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -137,6 +137,16 @@
  <class name="edm::Wrapper<std::vector<edmtest::Thing> >"/>
  <class name="edm::Wrapper<std::vector<edmtest::OtherThing> >"/>
 
+ <class name="edmNew::DetSetVector<edmtest::Thing>"/>
+ <class name="edm::Ref<edmNew::DetSetVector<edmtest::Thing>, edmtest::Thing, edmNew::DetSetVector<edmtest::Thing>::FindForDetSetVector>"/>
+ <class name="edm::RefVector<edmNew::DetSetVector<edmtest::Thing>, edmtest::Thing, edmNew::DetSetVector<edmtest::Thing>::FindForDetSetVector>"/>
+ <class name="edm::Wrapper<edmNew::DetSetVector<edmtest::Thing> >"/>
+ <class name="edmtest::TrackOfDSVThings" ClassVersion="3">
+  <version ClassVersion="3" checksum="635556054"/>
+ </class>
+ <class name="std::vector<edmtest::TrackOfDSVThings>"/>
+ <class name="edm::Wrapper<std::vector<edmtest::TrackOfDSVThings> >"/>
+
  <class name="edmtestprod::Simple" ClassVersion="10">
   <version ClassVersion="10" checksum="2751437416"/>
  </class>

--- a/FWCore/FWLite/src/BareRootProductGetter.cc
+++ b/FWCore/FWLite/src/BareRootProductGetter.cc
@@ -184,6 +184,31 @@ void BareRootProductGetter::getThinnedProducts(edm::ProductID const& pid,
       keys);
 }
 
+std::optional<unsigned int> BareRootProductGetter::getThinnedKeyFrom(edm::ProductID const& parentID,
+                                                                     unsigned int key,
+                                                                     edm::ProductID const& thinnedID) const {
+  Long_t eventEntry = branchMap_.getEventTree()->GetReadEntry();
+  edm::BranchID parent = branchMap_.productToBranchID(parentID);
+  if (!parent.isValid())
+    return std::nullopt;
+  edm::BranchID thinned = branchMap_.productToBranchID(thinnedID);
+  if (!thinned.isValid())
+    return std::nullopt;
+  try {
+    return edm::detail::getThinnedKeyFrom_implementation(
+        parentID,
+        parent,
+        key,
+        thinnedID,
+        thinned,
+        branchMap_.thinnedAssociationsHelper(),
+        [this, eventEntry](edm::BranchID const& branchID) { return getThinnedAssociation(branchID, eventEntry); });
+  } catch (edm::Exception& ex) {
+    ex.addContext("Calling DataGetterHelper::getThinnedKeyFrom()");
+    throw ex;
+  }
+}
+
 BareRootProductGetter::Buffer* BareRootProductGetter::createNewBuffer(edm::BranchID const& branchID) const {
   //find the branch
   edm::BranchDescription const& bdesc = branchMap_.branchIDToBranch(branchID);

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -72,6 +72,17 @@ public:
                           std::vector<edm::WrapperBase const*>& foundContainers,
                           std::vector<unsigned int>& keys) const override;
 
+  // This overload is allowed to be called also without getIt()
+  // being called first, but he thinned ProductID must come from an
+  // existing RefCore. The input key is the index of the desired
+  // element in the container identified by the parent ProductID.
+  // If the return value is not null, then the desired element was found
+  // in a thinned container. If the desired element is not found, then
+  // an optional without a value is returned.
+  std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
+                                                unsigned int key,
+                                                edm::ProductID const& thinned) const override;
+
 private:
   // ---------- static member functions --------------------
 

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -73,7 +73,7 @@ public:
                           std::vector<unsigned int>& keys) const override;
 
   // This overload is allowed to be called also without getIt()
-  // being called first, but he thinned ProductID must come from an
+  // being called first, but the thinned ProductID must come from an
   // existing RefCore. The input key is the index of the desired
   // element in the container identified by the parent ProductID.
   // If the return value is not null, then the desired element was found

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -79,9 +79,9 @@ public:
   // If the return value is not null, then the desired element was found
   // in a thinned container. If the desired element is not found, then
   // an optional without a value is returned.
-  std::optional<unsigned int> getThinnedKeyFrom(edm::ProductID const& parent,
-                                                unsigned int key,
-                                                edm::ProductID const& thinned) const override;
+  edm::OptionalThinnedKey getThinnedKeyFrom(edm::ProductID const& parent,
+                                            unsigned int key,
+                                            edm::ProductID const& thinned) const override;
 
 private:
   // ---------- static member functions --------------------

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -137,6 +137,9 @@ namespace edm {
     void getThinnedProducts(ProductID const& pid,
                             std::vector<WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const override;
+    std::optional<unsigned int> getThinnedKeyFrom(ProductID const& parent,
+                                                  unsigned int key,
+                                                  ProductID const& thinned) const override;
 
     ProductID branchIDToProductID(BranchID const& bid) const;
 

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -137,9 +137,9 @@ namespace edm {
     void getThinnedProducts(ProductID const& pid,
                             std::vector<WrapperBase const*>& foundContainers,
                             std::vector<unsigned int>& keys) const override;
-    std::optional<unsigned int> getThinnedKeyFrom(ProductID const& parent,
-                                                  unsigned int key,
-                                                  ProductID const& thinned) const override;
+    OptionalThinnedKey getThinnedKeyFrom(ProductID const& parent,
+                                         unsigned int key,
+                                         ProductID const& thinned) const override;
 
     ProductID branchIDToProductID(BranchID const& bid) const;
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -237,6 +237,9 @@ namespace edm {
     void getThinnedProducts(ProductID const&,
                             std::vector<WrapperBase const*>&,
                             std::vector<unsigned int>&) const override;
+    std::optional<unsigned int> getThinnedKeyFrom(ProductID const& parent,
+                                                  unsigned int key,
+                                                  ProductID const& thinned) const override;
 
     void findProducts(std::vector<ProductResolverBase const*> const& holders,
                       TypeID const& typeID,

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -237,9 +237,9 @@ namespace edm {
     void getThinnedProducts(ProductID const&,
                             std::vector<WrapperBase const*>&,
                             std::vector<unsigned int>&) const override;
-    std::optional<unsigned int> getThinnedKeyFrom(ProductID const& parent,
-                                                  unsigned int key,
-                                                  ProductID const& thinned) const override;
+    OptionalThinnedKey getThinnedKeyFrom(ProductID const& parent,
+                                         unsigned int key,
+                                         ProductID const& thinned) const override;
 
     void findProducts(std::vector<ProductResolverBase const*> const& holders,
                       TypeID const& typeID,

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -140,6 +140,7 @@ namespace edm {
       using namespace detail;
       fillCollectionForThinning(*iter, *selector_, iIndex, thinnedCollection, thinnedAssociation);
     }
+    selector_->reset();
 
     OrphanHandle<Collection> orphanHandle = event.emplace(outputToken_, std::move(thinnedCollection));
 

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -39,17 +39,6 @@ namespace edm {
       static constexpr bool value = true;
     };
 
-    // by default a linear container
-    template <typename Collection, typename = std::void_t<>>
-    struct ElementType {
-      using type = typename std::remove_reference<decltype(*std::declval<Collection>().begin())>::type;
-    };
-    // specialization for a nested container (mainly edmNew::DetSetVector)
-    template <typename Collection>
-    struct ElementType<Collection, std::void_t<decltype(std::declval<Collection>().begin()->begin())>> {
-      using type = typename std::remove_reference<decltype(*(std::declval<Collection>().begin()->begin()))>::type;
-    };
-
     template <typename Item, typename Selector, typename Collection>
     void fillCollectionForThinning(Item const& item,
                                    Selector& selector,

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -325,6 +325,23 @@ namespace edm {
         keys);
   }
 
+  std::optional<unsigned int> EventPrincipal::getThinnedKeyFrom(ProductID const& parentID,
+                                                                unsigned int key,
+                                                                ProductID const& thinnedID) const {
+    BranchID parent = pidToBid(parentID);
+    BranchID thinned = pidToBid(thinnedID);
+
+    try {
+      return detail::getThinnedKeyFrom_implementation(
+          parentID, parent, key, thinnedID, thinned, *thinnedAssociationsHelper_, [this](BranchID const& branchID) {
+            return getThinnedAssociation(branchID);
+          });
+    } catch (Exception& ex) {
+      ex.addContext("Calling EventPrincipal::getThinnedKeyFrom()");
+      throw ex;
+    }
+  }
+
   Provenance EventPrincipal::getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const {
     BranchID bid = pidToBid(pid);
     return getProvenance(bid, mcc);

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -325,17 +325,26 @@ namespace edm {
         keys);
   }
 
-  std::optional<unsigned int> EventPrincipal::getThinnedKeyFrom(ProductID const& parentID,
-                                                                unsigned int key,
-                                                                ProductID const& thinnedID) const {
+  OptionalThinnedKey EventPrincipal::getThinnedKeyFrom(ProductID const& parentID,
+                                                       unsigned int key,
+                                                       ProductID const& thinnedID) const {
     BranchID parent = pidToBid(parentID);
     BranchID thinned = pidToBid(thinnedID);
 
     try {
-      return detail::getThinnedKeyFrom_implementation(
+      auto ret = detail::getThinnedKeyFrom_implementation(
           parentID, parent, key, thinnedID, thinned, *thinnedAssociationsHelper_, [this](BranchID const& branchID) {
             return getThinnedAssociation(branchID);
           });
+      if (auto factory = std::get_if<detail::GetThinnedKeyFromExceptionFactory>(&ret)) {
+        return [func = *factory]() {
+          auto ex = func();
+          ex.addContext("Calling EventPrincipal::getThinnedKeyFrom()");
+          return ex;
+        };
+      } else {
+        return ret;
+      }
     } catch (Exception& ex) {
       ex.addContext("Calling EventPrincipal::getThinnedKeyFrom()");
       throw ex;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -894,6 +894,11 @@ namespace edm {
     assert(false);
   }
 
+  std::optional<unsigned int> Principal::getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const {
+    assert(false);
+    return std::nullopt;
+  }
+
   void Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductResolverBase const* phb) const {
     phb->putOrMergeProduct(std::move(prod));
   }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -894,9 +894,9 @@ namespace edm {
     assert(false);
   }
 
-  std::optional<unsigned int> Principal::getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const {
+  OptionalThinnedKey Principal::getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const {
     assert(false);
-    return std::nullopt;
+    return std::monostate{};
   }
 
   void Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductResolverBase const* phb) const {

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -439,6 +439,15 @@ namespace edm {
     }
   }
 
+  void Worker::registerThinnedAssociations(ProductRegistry const& registry, ThinnedAssociationsHelper& helper) {
+    try {
+      implRegisterThinnedAssociations(registry, helper);
+    } catch (cms::Exception& ex) {
+      ex.addContext("Calling registerThinnedAssociations() for module " + description().moduleLabel());
+      throw ex;
+    }
+  }
+
   void Worker::skipOnPath(EventPrincipal const& iEvent) {
     if (earlyDeleteHelper_) {
       earlyDeleteHelper_->pathFinished(iEvent);

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -177,9 +177,7 @@ namespace edm {
     void respondToOpenInputFile(FileBlock const& fb) { implRespondToOpenInputFile(fb); }
     void respondToCloseInputFile(FileBlock const& fb) { implRespondToCloseInputFile(fb); }
 
-    void registerThinnedAssociations(ProductRegistry const& registry, ThinnedAssociationsHelper& helper) {
-      implRegisterThinnedAssociations(registry, helper);
-    }
+    void registerThinnedAssociations(ProductRegistry const& registry, ThinnedAssociationsHelper& helper);
 
     void reset() {
       cached_exception_ = std::exception_ptr();

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -198,7 +198,7 @@
     <use name="FWCore/Framework"/>
   </library>
 
-  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc" name="SomeTestModules">
+  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,SlimmingThingProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc" name="SomeTestModules">
     <flags EDM_PLUGIN="1"/>
     <lib name="FWCoreIntegrationWaitingServer"/>
     <use name="FWCore/Framework"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -198,7 +198,7 @@
     <use name="FWCore/Framework"/>
   </library>
 
-  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,SlimmingThingProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc" name="SomeTestModules">
+  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,SlimmingThingProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,DetSetVectorThingProducer.cc,TrackOfDSVThingsProducer.cc,ThinningDSVThingProducer.cc,SlimmingDSVThingProducer.cc,ThinningDSVTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc" name="SomeTestModules">
     <flags EDM_PLUGIN="1"/>
     <lib name="FWCoreIntegrationWaitingServer"/>
     <use name="FWCore/Framework"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -198,7 +198,7 @@
     <use name="FWCore/Framework"/>
   </library>
 
-  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc" name="SomeTestModules">
+  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc" name="SomeTestModules">
     <flags EDM_PLUGIN="1"/>
     <lib name="FWCoreIntegrationWaitingServer"/>
     <use name="FWCore/Framework"/>

--- a/FWCore/Integration/test/DetSetVectorThingProducer.cc
+++ b/FWCore/Integration/test/DetSetVectorThingProducer.cc
@@ -1,0 +1,66 @@
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "FWCore/Integration/test/ThingAlgorithm.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+namespace edmtest {
+  class DetSetVectorThingProducer : public edm::global::EDProducer<> {
+  public:
+    explicit DetSetVectorThingProducer(edm::ParameterSet const& iConfig)
+        : detSets_(iConfig.getParameter<std::vector<int>>("detSets")),
+          nPerDetSet_(iConfig.getParameter<int>("nThings")),
+          alg_(iConfig.getParameter<int>("offsetDelta"),
+               nPerDetSet_ * detSets_.size(),
+               iConfig.getParameter<bool>("grow")),
+          evToken_(produces<edmNew::DetSetVector<Thing>>()) {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<int>("offsetDelta", 0)
+          ->setComment(
+              "How much extra to increment the value used when creating Things for a new container. E.g. the last "
+              "value "
+              "used to create Thing from the previous event is incremented by 'offsetDelta' to compute the value to "
+              "use "
+              "of the first Thing created in the next Event.");
+      desc.add<std::vector<int>>("detSets", std::vector<int>{1, 2, 3})->setComment("Vector of DetSet ids");
+      desc.add<int>("nThings", 20)->setComment("How many Things to put in each DetSet.");
+      desc.add<bool>("grow", false)
+          ->setComment("If true, multiply 'nThings' by the value of offset for each run of the algorithm.");
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override {
+      edmNew::DetSetVector<Thing> ret(2);
+
+      ThingCollection tmp;
+      alg_.run(tmp);
+      assert(tmp.end() == tmp.begin() + nPerDetSet_ * detSets_.size());
+      auto begin = tmp.begin();
+      auto end = begin + nPerDetSet_;
+
+      for (int detSetID : detSets_) {
+        edmNew::DetSetVector<Thing>::FastFiller filler(ret, detSetID);
+        std::copy(begin, end, std::back_inserter(filler));
+        begin = end;
+        std::advance(end, nPerDetSet_);
+      }
+
+      e.emplace(evToken_, std::move(ret));
+    }
+
+  private:
+    std::vector<int> detSets_;
+    unsigned int nPerDetSet_;
+    ThingAlgorithm alg_;
+    edm::EDPutTokenT<edmNew::DetSetVector<Thing>> evToken_;
+  };
+
+}  // namespace edmtest
+
+using edmtest::DetSetVectorThingProducer;
+DEFINE_FWK_MODULE(DetSetVectorThingProducer);

--- a/FWCore/Integration/test/DetSetVectorThinningTest1_cfg.py
+++ b/FWCore/Integration/test/DetSetVectorThinningTest1_cfg.py
@@ -1,0 +1,130 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.thingProducer = cms.EDProducer(
+    "DetSetVectorThingProducer",
+    offsetDelta = cms.int32(100),
+    nThings = cms.int32(50),
+    detSets = cms.vint32(1,2,3)
+)
+
+process.trackOfThingsProducerA = cms.EDProducer("TrackOfDSVThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(
+        list(range(0,9)) +
+        list(range(50,59)) +
+        list(range(100,109))
+    ),
+    nTracks = cms.uint32(8*3)
+)
+
+process.thinningThingProducerA = cms.EDProducer("ThinningDSVThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedDetSets = cms.uint32(3),
+    expectedDetSetSize = cms.uint32(50),
+)
+
+process.slimmingThingProducerA = cms.EDProducer("SlimmingDSVThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedDetSets = cms.uint32(3),
+    expectedDetSetSize = cms.uint32(50),
+)
+
+process.testA = cms.EDAnalyzer("ThinningDSVTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    expectedParentContent = cms.VPSet(
+        cms.PSet(id = cms.uint32(1), values = cms.vint32(range(0,50))),
+        cms.PSet(id = cms.uint32(2), values = cms.vint32(range(50,100))),
+        cms.PSet(id = cms.uint32(3), values = cms.vint32(range(100,150))),
+    ),
+    expectedThinnedContent = cms.VPSet(
+        cms.PSet(id = cms.uint32(1), values = cms.vint32(range(0,9))),
+        cms.PSet(id = cms.uint32(2), values = cms.vint32(range(50,59))),
+        cms.PSet(id = cms.uint32(3), values = cms.vint32(range(100,109))),
+    ),
+    expectedIndexesIntoParent = cms.vuint32(
+        list(range(0,9)) +
+        list(range(50,59)) +
+        list(range(100,109))
+    ),
+    expectedNumberOfTracks = cms.uint32(8*3),
+    expectedValues = cms.vint32(
+        list(range(0,9)) +
+        list(range(50,59)) +
+        list(range(100,109))
+    )
+)
+
+process.slimmingTestA = cms.EDAnalyzer("ThinningDSVTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('slimmingThingProducerA'),
+    associationTag = cms.InputTag('slimmingThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.VPSet(
+        cms.PSet(id = cms.uint32(1), values = cms.vint32(range(0,50))),
+        cms.PSet(id = cms.uint32(2), values = cms.vint32(range(50,100))),
+        cms.PSet(id = cms.uint32(3), values = cms.vint32(range(100,150))),
+    ),
+    expectedThinnedContent = cms.VPSet(
+        cms.PSet(id = cms.uint32(1), values = cms.vint32(range(0,9))),
+        cms.PSet(id = cms.uint32(2), values = cms.vint32(range(50,59))),
+        cms.PSet(id = cms.uint32(3), values = cms.vint32(range(100,109))),
+    ),
+    expectedIndexesIntoParent = cms.vuint32(
+        list(range(0,9)) +
+        list(range(50,59)) +
+        list(range(100,109))
+    ),
+    expectedNumberOfTracks = cms.uint32(8*3),
+    expectedValues = cms.vint32(
+        list(range(0,9)) +
+        list(range(50,59)) +
+        list(range(100,109))
+    )
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testDetSetVectorThinningTest1.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_trackOfThingsProducerA_*_*',
+        'keep *_slimmingThingProducerA_*_*',
+    )
+)
+
+
+process.p = cms.Path(
+    process.thingProducer
+    * process.trackOfThingsProducerA
+    * process.thinningThingProducerA
+    * process.slimmingThingProducerA
+    * process.testA
+    * process.slimmingTestA
+)
+
+process.ep = cms.EndPath(
+    process.out
+)

--- a/FWCore/Integration/test/DetSetVectorThinningTest1_cfg.py
+++ b/FWCore/Integration/test/DetSetVectorThinningTest1_cfg.py
@@ -36,7 +36,6 @@ process.trackOfThingsProducerA = cms.EDProducer("TrackOfDSVThingsProducer",
 process.thinningThingProducerA = cms.EDProducer("ThinningDSVThingProducer",
     inputTag = cms.InputTag('thingProducer'),
     trackTag = cms.InputTag('trackOfThingsProducerA'),
-    offsetToThinnedKey = cms.uint32(0),
     expectedDetSets = cms.uint32(3),
     expectedDetSetSize = cms.uint32(50),
 )

--- a/FWCore/Integration/test/DetSetVectorThinningTest1_cfg.py
+++ b/FWCore/Integration/test/DetSetVectorThinningTest1_cfg.py
@@ -23,6 +23,18 @@ process.thingProducer = cms.EDProducer(
     detSets = cms.vint32(1,2,3)
 )
 
+process.anotherThingProducer = cms.EDProducer("DetSetVectorThingProducer",
+    offsetDelta = cms.int32(100),
+    nThings = cms.int32(50),
+    detSets = cms.vint32(1,2,3)
+)
+
+process.thirdThingProducer = cms.EDProducer("DetSetVectorThingProducer",
+    offsetDelta = cms.int32(100),
+    nThings = cms.int32(50),
+    detSets = cms.vint32(1,2,3)
+)
+
 process.trackOfThingsProducerA = cms.EDProducer("TrackOfDSVThingsProducer",
     inputTag = cms.InputTag('thingProducer'),
     keysToReference = cms.vuint32(
@@ -31,6 +43,26 @@ process.trackOfThingsProducerA = cms.EDProducer("TrackOfDSVThingsProducer",
         list(range(100,109))
     ),
     nTracks = cms.uint32(8*3)
+)
+
+process.trackOfAnotherThingsProducerA = cms.EDProducer("TrackOfDSVThingsProducer",
+    inputTag = cms.InputTag('anotherThingProducer'),
+    keysToReference = cms.vuint32(
+        list(range(0,5)) +
+        list(range(50,55)) +
+        list(range(100,105))
+    ),
+    nTracks = cms.uint32(4*3)
+)
+
+process.trackOfThirdThingsProducerA = cms.EDProducer("TrackOfDSVThingsProducer",
+    inputTag = cms.InputTag('thirdThingProducer'),
+    keysToReference = cms.vuint32(
+        list(range(0,3)) +
+        list(range(50,53)) +
+        list(range(100,103))
+    ),
+    nTracks = cms.uint32(2*3)
 )
 
 process.thinningThingProducerA = cms.EDProducer("ThinningDSVThingProducer",
@@ -46,6 +78,30 @@ process.slimmingThingProducerA = cms.EDProducer("SlimmingDSVThingProducer",
     offsetToThinnedKey = cms.uint32(0),
     expectedDetSets = cms.uint32(3),
     expectedDetSetSize = cms.uint32(50),
+)
+
+process.thinningAnotherThingProducerA = cms.EDProducer("ThinningDSVThingProducer",
+    inputTag = cms.InputTag('anotherThingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    expectedDetSets = cms.uint32(3),
+    expectedDetSetSize = cms.uint32(50),
+    thinnedRefSetIgnoreInvalidParentRef = cms.bool(True),
+)
+
+process.thinningAnotherThingProducerA2 = cms.EDProducer("ThinningDSVThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfAnotherThingsProducerA'),
+    expectedDetSets = cms.uint32(3),
+    expectedDetSetSize = cms.uint32(50),
+    thinnedRefSetIgnoreInvalidParentRef = cms.bool(True),
+)
+
+process.thinningAnotherThingProducerA3 = cms.EDProducer("ThinningDSVThingProducer",
+    inputTag = cms.InputTag('anotherThingProducer'),
+    trackTag = cms.InputTag('trackOfThirdThingsProducerA'),
+    expectedDetSets = cms.uint32(3),
+    expectedDetSetSize = cms.uint32(50),
+    thinnedRefSetIgnoreInvalidParentRef = cms.bool(True),
 )
 
 process.testA = cms.EDAnalyzer("ThinningDSVTestAnalyzer",
@@ -105,6 +161,42 @@ process.slimmingTestA = cms.EDAnalyzer("ThinningDSVTestAnalyzer",
     )
 )
 
+process.anotherTestA = cms.EDAnalyzer("ThinningDSVTestAnalyzer",
+    parentTag = cms.InputTag('anotherThingProducer'),
+    thinnedTag = cms.InputTag('thinningAnotherThingProducerA'),
+    associationTag = cms.InputTag('thinningAnotherThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    expectedParentContent = cms.VPSet(),
+    expectedThinnedContent = cms.VPSet(),
+    expectedIndexesIntoParent = cms.vuint32(),
+    expectedNumberOfTracks = cms.uint32(8*3),
+    expectedValues = cms.vint32()
+)
+
+process.anotherTestA2 = cms.EDAnalyzer("ThinningDSVTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningAnotherThingProducerA2'),
+    associationTag = cms.InputTag('thinningAnotherThingProducerA2'),
+    trackTag = cms.InputTag('trackOfAnotherThingsProducerA'),
+    expectedParentContent = cms.VPSet(),
+    expectedThinnedContent = cms.VPSet(),
+    expectedIndexesIntoParent = cms.vuint32(),
+    expectedNumberOfTracks = cms.uint32(4*3),
+    expectedValues = cms.vint32()
+)
+
+process.anotherTestA3 = cms.EDAnalyzer("ThinningDSVTestAnalyzer",
+    parentTag = cms.InputTag('anotherThingProducer'),
+    thinnedTag = cms.InputTag('thinningAnotherThingProducerA3'),
+    associationTag = cms.InputTag('thinningAnotherThingProducerA3'),
+    trackTag = cms.InputTag('trackOfThirdThingsProducerA'),
+    expectedParentContent = cms.VPSet(),
+    expectedThinnedContent = cms.VPSet(),
+    expectedIndexesIntoParent = cms.vuint32(),
+    expectedNumberOfTracks = cms.uint32(2*3),
+    expectedValues = cms.vint32()
+)
+
 process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testDetSetVectorThinningTest1.root'),
     outputCommands = cms.untracked.vstring(
@@ -114,14 +206,23 @@ process.out = cms.OutputModule("PoolOutputModule",
     )
 )
 
-
 process.p = cms.Path(
     process.thingProducer
+    * process.anotherThingProducer
+    * process.thirdThingProducer
     * process.trackOfThingsProducerA
+    * process.trackOfAnotherThingsProducerA
+    * process.trackOfThirdThingsProducerA
     * process.thinningThingProducerA
     * process.slimmingThingProducerA
+    * process.thinningAnotherThingProducerA
+    * process.thinningAnotherThingProducerA2
+    * process.thinningAnotherThingProducerA3
     * process.testA
     * process.slimmingTestA
+    * process.anotherTestA
+    * process.anotherTestA2
+    * process.anotherTestA3
 )
 
 process.ep = cms.EndPath(

--- a/FWCore/Integration/test/DetSetVectorThinningTest2_cfg.py
+++ b/FWCore/Integration/test/DetSetVectorThinningTest2_cfg.py
@@ -1,0 +1,50 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testDetSetVectorThinningTest1.root')
+)
+
+process.slimmingTestA = cms.EDAnalyzer("ThinningDSVTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('slimmingThingProducerA'),
+    associationTag = cms.InputTag('slimmingThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.VPSet(
+        cms.PSet(id = cms.uint32(1), values = cms.vint32(range(0,50))),
+        cms.PSet(id = cms.uint32(2), values = cms.vint32(range(50,100))),
+        cms.PSet(id = cms.uint32(3), values = cms.vint32(range(100,150))),
+    ),
+    expectedThinnedContent = cms.VPSet(
+        cms.PSet(id = cms.uint32(1), values = cms.vint32(range(0,9))),
+        cms.PSet(id = cms.uint32(2), values = cms.vint32(range(50,59))),
+        cms.PSet(id = cms.uint32(3), values = cms.vint32(range(100,109))),
+    ),
+    expectedIndexesIntoParent = cms.vuint32(
+        list(range(0,9)) +
+        list(range(50,59)) +
+        list(range(100,109))
+    ),
+    expectedNumberOfTracks = cms.uint32(8*3),
+    expectedValues = cms.vint32(
+        list(range(0,9)) +
+        list(range(50,59)) +
+        list(range(100,109))
+    )
+)
+
+process.p = cms.Path(
+    process.slimmingTestA
+)

--- a/FWCore/Integration/test/SlimmingDSVThingProducer.cc
+++ b/FWCore/Integration/test/SlimmingDSVThingProducer.cc
@@ -28,6 +28,8 @@ namespace edmtest {
 
     std::optional<edmtest::Thing> choose(unsigned int iIndex, edmtest::Thing const& iItem) const;
 
+    void reset() { keysToSave_.clear(); }
+
   private:
     edm::EDGetTokenT<TrackOfDSVThingsCollection> const trackToken_;
     std::set<unsigned int> keysToSave_;

--- a/FWCore/Integration/test/SlimmingDSVThingProducer.cc
+++ b/FWCore/Integration/test/SlimmingDSVThingProducer.cc
@@ -1,0 +1,101 @@
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/TrackOfDSVThings.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/ThinningProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <set>
+#include <string>
+
+namespace edmtest {
+
+  class SlimmingDSVThingSelector {
+  public:
+    SlimmingDSVThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc);
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
+    void preChoose(edm::Handle<edmNew::DetSetVector<Thing>> tc, edm::Event const& event, edm::EventSetup const& es);
+
+    std::optional<edmtest::Thing> choose(unsigned int iIndex, edmtest::Thing const& iItem) const;
+
+  private:
+    edm::EDGetTokenT<TrackOfDSVThingsCollection> const trackToken_;
+    std::set<unsigned int> keysToSave_;
+    unsigned int const offsetToThinnedKey_;
+    unsigned int const offsetToValue_;
+    unsigned int const expectedDetSets_;
+    unsigned int const expectedDetSetSize_;
+    int const slimmedValueFactor_;
+  };
+
+  SlimmingDSVThingSelector::SlimmingDSVThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc)
+      : trackToken_(cc.consumes<TrackOfDSVThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"))),
+        offsetToThinnedKey_(pset.getParameter<unsigned int>("offsetToThinnedKey")),
+        offsetToValue_(pset.getParameter<unsigned int>("offsetToValue")),
+        expectedDetSets_(pset.getParameter<unsigned int>("expectedDetSets")),
+        expectedDetSetSize_(pset.getParameter<unsigned int>("expectedDetSetSize")),
+        slimmedValueFactor_(pset.getParameter<int>("slimmedValueFactor")) {}
+
+  void SlimmingDSVThingSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<edm::InputTag>("trackTag");
+    desc.add<unsigned int>("offsetToThinnedKey");
+    desc.add<unsigned int>("offsetToValue", 0);
+    desc.add<unsigned int>("expectedDetSets");
+    desc.add<unsigned int>("expectedDetSetSize");
+    desc.add<int>("slimmedValueFactor", 1);
+  }
+
+  void SlimmingDSVThingSelector::preChoose(edm::Handle<edmNew::DetSetVector<Thing>> tc,
+                                           edm::Event const& event,
+                                           edm::EventSetup const& es) {
+    for (auto const& track : event.get(trackToken_)) {
+      keysToSave_.insert(track.ref1.key() - offsetToThinnedKey_);
+      keysToSave_.insert(track.ref2.key() - offsetToThinnedKey_);
+    }
+
+    // Just checking to see if the collection got passed in. Not really using it for anything.
+    if (tc->size() != expectedDetSets_) {
+      throw cms::Exception("TestFailure") << "SlimmingDSVThingSelector::preChoose, number of DetSets = " << tc->size()
+                                          << " expected = " << expectedDetSets_;
+    }
+    for (auto const& ds : *tc) {
+      if (ds.size() != expectedDetSetSize_) {
+        throw cms::Exception("TestFailure")
+            << "SlimmingDSVThingSelector::preChoose, number of elements in DetSet with id " << ds.id() << " = "
+            << ds.size() << " expected = " << expectedDetSetSize_;
+      }
+    }
+  }
+
+  std::optional<edmtest::Thing> SlimmingDSVThingSelector::choose(unsigned int iIndex,
+                                                                 edmtest::Thing const& iItem) const {
+    // Just checking to see the element in the container got passed in OK. Not really using it.
+    // Just using %10 because it coincidentally works with the arbitrary numbers I picked, no meaning really.
+    auto const expected = slimmedValueFactor_ * (iIndex + offsetToValue_);
+    if (static_cast<unsigned>(iItem.a % 10) != static_cast<unsigned>(expected % 10)) {
+      throw cms::Exception("TestFailure") << "SlimmingDSVThingSelector::choose, item content = " << iItem.a
+                                          << " index = " << iIndex << " expected " << expected;
+    }
+
+    // Save the Things referenced by the Tracks
+    if (keysToSave_.find(iIndex) == keysToSave_.end())
+      return std::nullopt;
+    auto copy = iItem;
+    copy.a *= 10;
+    return copy;
+  }
+}  // namespace edmtest
+
+using SlimmingDSVThingProducer =
+    edm::ThinningProducer<edmNew::DetSetVector<edmtest::Thing>, edmtest::SlimmingDSVThingSelector>;
+DEFINE_FWK_MODULE(SlimmingDSVThingProducer);

--- a/FWCore/Integration/test/SlimmingTest1_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest1_cfg.py
@@ -1,0 +1,348 @@
+# This process is the first step of a test that involves multiple
+# processing steps. It tests the thinning and slimming collections and
+# redirecting Refs, Ptrs, and RefToBases.
+#
+# From thingProducer collection (50 elements)
+# - A: elements 0-19
+# - B: elements 0-10
+# - C: elements 11-19
+# - D: elements 0-5
+# - E: elements 6-10
+# - F: elements 6-8
+# - G: elements 9-10
+#
+# thingProducer (0-49)
+# |\- thinningThingProducerA (0-19)
+# |   \- thinningThingProducerAB (0-10)
+# |      |\- thinningThingProducerABE (6-10)
+# |      |   \- thinningThingProducerABEF (6-8) slimmed (in job reading file F)
+# |      |
+# |      |\- thinningThingProducerABF (6-8)
+# |      |
+# |      \-- thinningThingProducerABG (9-10)
+# |
+# |\- thinningThingProducerB (0-10) slimmed
+# |   |\- thinningThingProducerBD (0-5)
+# |   |
+# |   |\- thinningThingProducerBE (6-10) slimmed
+# |   |   |\- thinningThingProducerBEF (6-8)
+# |   |   |
+# |   |   \-- thinningThingProducerBEG (9-10)
+# |   |
+# |   \- thinningThingProducerBF (6-8)
+# |
+# \-- thinningThingProducerC (11-19)
+#
+# cases to be tested
+# A:  everything can be put in one file, when reading thinned are read
+# B: file including ABF, ABG, BF, BEG
+#   - ABF is preferred over BF for elements 6-8
+#   - ABG is preferred over BEG for elements 9-10
+#   - then drop ABF, ABG, and can get BF but not BEG
+#   - then drop BF, can get BEG
+# C: file including BF, BEF
+#   - BF is preferred of BEF
+#   - then drop BF, and get BEF
+# D: file including ABE, BD
+#   - ABE is preferred over BD for elements 0-5 (leading to product not found)
+#   - drop ABE, then BD works
+# E: file including BD, BEF
+#   - BD is preferred over BEF for elements 6-8 (leading to product not found)
+#   - drop BD, then BEF works
+# F: file including ABE
+#   - slim ABE further to ABEF
+#   - then try to merge with B file with BEG, should fail
+
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.thingProducer = cms.EDProducer("ThingProducer",
+                                       offsetDelta = cms.int32(100),
+                                       nThings = cms.int32(50)
+)
+
+process.trackOfThingsProducerA = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(range(0, 20))
+)
+
+process.trackOfThingsProducerB = process.trackOfThingsProducerA.clone(keysToReference = range(0,11))
+process.trackOfThingsProducerC = process.trackOfThingsProducerA.clone(keysToReference = range(11,20))
+process.trackOfThingsProducerD = process.trackOfThingsProducerA.clone(keysToReference = range(0,6))
+process.trackOfThingsProducerE = process.trackOfThingsProducerA.clone(keysToReference = range(6,11))
+process.trackOfThingsProducerF = process.trackOfThingsProducerA.clone(keysToReference = range(6,9))
+process.trackOfThingsProducerG = process.trackOfThingsProducerA.clone(keysToReference = range(9,11))
+
+process.thinningThingProducerA = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+process.thinningThingProducerAB = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(20)
+)
+process.thinningThingProducerABE = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerAB'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(11)
+)
+process.thinningThingProducerABF = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerAB'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(11)
+)
+process.thinningThingProducerABG = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerAB'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(11)
+)
+
+process.thinningThingProducerB = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+process.thinningThingProducerBD = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(11),
+    slimmedValueFactor = cms.int32(10)
+)
+process.thinningThingProducerBE = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(11),
+    slimmedValueFactor = cms.int32(10)
+)
+process.thinningThingProducerBEF = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerBE'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(6),
+    expectedCollectionSize = cms.uint32(5),
+    slimmedValueFactor = cms.int32(100)
+)
+process.thinningThingProducerBEG = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerBE'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    offsetToThinnedKey = cms.uint32(6),
+    expectedCollectionSize = cms.uint32(5),
+    slimmedValueFactor = cms.int32(100)
+)
+process.thinningThingProducerBF = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(11),
+    slimmedValueFactor = cms.int32(10)
+)
+
+process.thinningThingProducerC = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    expectedParentContent = cms.vint32(range(0,50)),
+    expectedThinnedContent = cms.vint32(range(0,20)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,20)),
+    expectedValues = cms.vint32(range(0,20)),
+)
+
+process.testABF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerAB'),
+    thinnedTag = cms.InputTag('thinningThingProducerABF'),
+    associationTag = cms.InputTag('thinningThingProducerABF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,9)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,50)),
+    expectedThinnedContent = cms.vint32(range(0,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,11)),
+    expectedValues = cms.vint32(range(0,11)),
+)
+
+process.testBD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBD'),
+    associationTag = cms.InputTag('thinningThingProducerBD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(0,6)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,6)),
+    expectedValues = cms.vint32(range(0,6)),
+)
+
+process.testBE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBE'),
+    associationTag = cms.InputTag('thinningThingProducerBE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(2),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,11)),
+    expectedValues = cms.vint32(range(6,11)),
+)
+
+process.testBEG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEG'),
+    associationTag = cms.InputTag('thinningThingProducerBEG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(9,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(3,5)),
+    expectedValues = cms.vint32(range(9,11)),
+)
+
+
+
+process.outA = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest1A.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer_*_*',
+    )
+)
+
+process.outB = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest1B.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_trackOfThingsProducerF_*_*',
+        'keep *_trackOfThingsProducerG_*_*',
+        'keep *_thinningThingProducerABF_*_*',
+        'keep *_thinningThingProducerABG_*_*',
+        'keep *_thinningThingProducerBF_*_*',
+        'keep *_thinningThingProducerBEG_*_*',
+    )
+)
+
+process.outC = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest1C.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_trackOfThingsProducerF_*_*',
+        'keep *_thinningThingProducerBF_*_*',
+        'keep *_thinningThingProducerBEF_*_*',
+    )
+)
+
+process.outD = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest1D.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_trackOfThingsProducerD_*_*',
+        'keep *_trackOfThingsProducerE_*_*',
+        'keep *_thinningThingProducerABE_*_*',
+        'keep *_thinningThingProducerBD_*_*',
+    )
+)
+
+process.outE = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest1E.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_trackOfThingsProducerD_*_*',
+        'keep *_trackOfThingsProducerF_*_*',
+        'keep *_thinningThingProducerBD_*_*',
+        'keep *_thinningThingProducerBEF_*_*',
+    )
+)
+
+process.outF = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest1F.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_trackOfThingsProducerF_*_*',
+        'keep *_thinningThingProducerABE_*_*',
+    )
+)
+
+
+process.p = cms.Path(
+    process.thingProducer
+    * process.trackOfThingsProducerA
+    * process.trackOfThingsProducerB
+    * process.trackOfThingsProducerC
+    * process.trackOfThingsProducerD
+    * process.trackOfThingsProducerE
+    * process.trackOfThingsProducerF
+    * process.trackOfThingsProducerG
+    * process.thinningThingProducerA
+    * process.thinningThingProducerAB
+    * process.thinningThingProducerABE
+    * process.thinningThingProducerABF
+    * process.thinningThingProducerABG
+    * process.thinningThingProducerB
+    * process.thinningThingProducerBD
+    * process.thinningThingProducerBE
+    * process.thinningThingProducerBEF
+    * process.thinningThingProducerBEG
+    * process.thinningThingProducerBF
+    * process.thinningThingProducerC
+    * process.testA
+    * process.testABF
+    * process.testB
+    * process.testBD
+    * process.testBE
+    * process.testBEG
+)
+
+
+process.ep = cms.EndPath(
+    process.outA
+    * process.outB
+    * process.outC
+    * process.outD
+    * process.outE
+    * process.outF
+)

--- a/FWCore/Integration/test/SlimmingTest1_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest1_cfg.py
@@ -52,6 +52,8 @@
 # F: file including ABE
 #   - slim ABE further to ABEF
 #   - then try to merge with B file with BEG, should fail
+# G: file including A
+#    - try to thin from thingProducer, should fail
 
 
 import FWCore.ParameterSet.Config as cms
@@ -307,6 +309,15 @@ process.outF = cms.OutputModule("PoolOutputModule",
     )
 )
 
+process.outG = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest1G.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_trackOfThingsProducerB_*_*',
+        'keep *_thinningThingProducerA_*_*',
+    )
+)
+
 
 process.p = cms.Path(
     process.thingProducer
@@ -345,4 +356,5 @@ process.ep = cms.EndPath(
     * process.outD
     * process.outE
     * process.outF
+    * process.outG
 )

--- a/FWCore/Integration/test/SlimmingTest1_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest1_cfg.py
@@ -10,6 +10,8 @@
 # - E: elements 6-10
 # - F: elements 6-8
 # - G: elements 9-10
+# - H: elements 0-19
+# - I: elements 11-15
 #
 # thingProducer (0-49)
 # |\- thinningThingProducerA (0-19)
@@ -32,6 +34,7 @@
 # |   \- thinningThingProducerBF (6-8)
 # |
 # |\- thinningThingProducerC (11-19)
+# |   \- thinnindThingProducerCI (11-15)
 # |
 # \-- thinningThingProducerH (0-19), no product because of event filtering
 #
@@ -58,6 +61,9 @@
 #   - try to thin from thingProducer, should fail
 # H: file including H, B
 #   - non-existing H is preferred, all Refs are Null
+# I: file including B, CI
+#   - CI is preferred over B for elements 0-10 (leading to product not fond)
+#   - drop CU, then B works
 
 import FWCore.ParameterSet.Config as cms
 
@@ -94,6 +100,7 @@ process.trackOfThingsProducerE = process.trackOfThingsProducerA.clone(keysToRefe
 process.trackOfThingsProducerF = process.trackOfThingsProducerA.clone(keysToReference = range(6,9))
 process.trackOfThingsProducerG = process.trackOfThingsProducerA.clone(keysToReference = range(9,11))
 process.trackOfThingsProducerH = process.trackOfThingsProducerA.clone()
+process.trackOfThingsProducerI = process.trackOfThingsProducerA.clone(keysToReference = range(11,16))
 
 process.thinningThingProducerA = cms.EDProducer("ThinningThingProducer",
     inputTag = cms.InputTag('thingProducer'),
@@ -173,6 +180,13 @@ process.thinningThingProducerC = cms.EDProducer("ThinningThingProducer",
     trackTag = cms.InputTag('trackOfThingsProducerC'),
     offsetToThinnedKey = cms.uint32(0),
     expectedCollectionSize = cms.uint32(50)
+)
+process.thinningThingProducerCI = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    offsetToThinnedKey = cms.uint32(11),
+    offsetToValue = cms.uint32(11),
+    expectedCollectionSize = cms.uint32(9)
 )
 
 process.thinningThingProducerH = cms.EDProducer("ThinningThingProducer",
@@ -341,6 +355,17 @@ process.outH = cms.OutputModule("PoolOutputModule",
     )
 )
 
+process.outI = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest1I.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_trackOfThingsProducerB_*_*',
+        'keep *_trackOfThingsProducerI_*_*',
+        'keep *_thinningThingProducerB_*_*',
+        'keep *_thinningThingProducerCI_*_*',
+    )
+)
+
 
 process.p = cms.Path(
     process.thingProducer
@@ -351,6 +376,7 @@ process.p = cms.Path(
     * process.trackOfThingsProducerE
     * process.trackOfThingsProducerF
     * process.trackOfThingsProducerG
+    * process.trackOfThingsProducerI
     * process.thinningThingProducerA
     * process.thinningThingProducerAB
     * process.thinningThingProducerABE
@@ -363,6 +389,7 @@ process.p = cms.Path(
     * process.thinningThingProducerBEG
     * process.thinningThingProducerBF
     * process.thinningThingProducerC
+    * process.thinningThingProducerCI
     * process.testA
     * process.testABF
     * process.testB
@@ -386,4 +413,5 @@ process.ep = cms.EndPath(
     * process.outF
     * process.outG
     * process.outH
+    * process.outI
 )

--- a/FWCore/Integration/test/SlimmingTest1_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest1_cfg.py
@@ -69,13 +69,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("EmptySource")
 

--- a/FWCore/Integration/test/SlimmingTest2A_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2A_cfg.py
@@ -1,0 +1,99 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2A")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1A.root')
+)
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32(range(0,50)),
+    expectedThinnedContent = cms.vint32(range(0,20)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,20)),
+    expectedValues = cms.vint32(range(0,20)),
+)
+
+process.testABF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerAB'),
+    thinnedTag = cms.InputTag('thinningThingProducerABF'),
+    associationTag = cms.InputTag('thinningThingProducerABF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,9)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    parentWasDropped = cms.bool(True),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,50)),
+    expectedThinnedContent = cms.vint32(range(0,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,11)),
+    expectedValues = cms.vint32(range(0,11)),
+)
+
+process.testBD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBD'),
+    associationTag = cms.InputTag('thinningThingProducerBD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(0,6)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,6)),
+    expectedValues = cms.vint32(range(0,6)),
+)
+
+process.testBE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBE'),
+    associationTag = cms.InputTag('thinningThingProducerBE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(2),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,11)),
+    expectedValues = cms.vint32(range(6,11)),
+)
+
+process.testBEG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEG'),
+    associationTag = cms.InputTag('thinningThingProducerBEG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(9,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(3,5)),
+    expectedValues = cms.vint32(range(9,11)),
+)
+
+process.p = cms.Path(
+    process.testA
+    * process.testABF
+    * process.testB
+    * process.testBD
+    * process.testBE
+    * process.testBEG
+)

--- a/FWCore/Integration/test/SlimmingTest2A_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2A_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2A")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest1A.root')

--- a/FWCore/Integration/test/SlimmingTest2B_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2B_cfg.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2B")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1B.root')
+)
+
+process.testABF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerAB'),
+    thinnedTag = cms.InputTag('thinningThingProducerABF'),
+    associationTag = cms.InputTag('thinningThingProducerABF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,9)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.testABG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerAB'),
+    thinnedTag = cms.InputTag('thinningThingProducerABG'),
+    associationTag = cms.InputTag('thinningThingProducerABG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(9,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(9,11)),
+    expectedValues = cms.vint32(range(9,11)),
+)
+
+process.testBF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBF'),
+    associationTag = cms.InputTag('thinningThingProducerBF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,9)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.testBEG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEG'),
+    associationTag = cms.InputTag('thinningThingProducerBEG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(9,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(3,5)),
+    expectedValues = cms.vint32(range(9,11)),
+)
+
+process.outB = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest2B.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerABF_*_*',
+        'drop *_thinningThingProducerABG_*_*',
+    )
+)
+
+process.p = cms.Path(
+    process.testABF
+    * process.testABG
+    * process.testBF
+    * process.testBEG
+)
+
+process.ep = cms.EndPath(
+    process.outB
+)

--- a/FWCore/Integration/test/SlimmingTest2B_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2B_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2B")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest1B.root')

--- a/FWCore/Integration/test/SlimmingTest2C_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2C_cfg.py
@@ -1,0 +1,62 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2C")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1C.root')
+)
+
+process.testBF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBF'),
+    associationTag = cms.InputTag('thinningThingProducerBF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,9)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.testBEF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEF'),
+    associationTag = cms.InputTag('thinningThingProducerBEF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,3)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.outC = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest2C.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerBF_*_*',
+    )
+)
+
+process.p = cms.Path(
+    process.testBF
+    * process.testBEF
+)
+
+process.ep = cms.EndPath(
+    process.outC
+)

--- a/FWCore/Integration/test/SlimmingTest2C_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2C_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2C")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest1C.root')

--- a/FWCore/Integration/test/SlimmingTest2D_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2D_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2D")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1D.root')
+)
+
+process.testABE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerAB'),
+    thinnedTag = cms.InputTag('thinningThingProducerABE'),
+    associationTag = cms.InputTag('thinningThingProducerABE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,11)),
+    expectedValues = cms.vint32(range(6,11)),
+)
+
+process.testBD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBD'),
+    associationTag = cms.InputTag('thinningThingProducerBD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(1),
+    refToParentIsAvailable = cms.bool(False),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(0,6)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,6)),
+    expectedValues = cms.vint32(range(0,6)),
+)
+
+process.outD = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest2D.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerABE_*_*',
+    )
+)
+
+process.p = cms.Path(
+    process.testABE
+    * process.testBD
+)
+
+process.ep = cms.EndPath(
+    process.outD
+)

--- a/FWCore/Integration/test/SlimmingTest2D_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2D_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2D")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest1D.root')

--- a/FWCore/Integration/test/SlimmingTest2E_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2E_cfg.py
@@ -1,0 +1,62 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2E")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1E.root')
+)
+
+process.testBD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBD'),
+    associationTag = cms.InputTag('thinningThingProducerBD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(0,6)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,6)),
+    expectedValues = cms.vint32(range(0,6)),
+)
+
+process.testBEF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEF'),
+    associationTag = cms.InputTag('thinningThingProducerBEF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    refToParentIsAvailable = cms.bool(False),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,3)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.outE = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest2E.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerBD_*_*',
+    )
+)
+
+process.p = cms.Path(
+    process.testBD
+    * process.testBEF
+)
+
+process.ep = cms.EndPath(
+    process.outE
+)

--- a/FWCore/Integration/test/SlimmingTest2E_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2E_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2E")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest1E.root')

--- a/FWCore/Integration/test/SlimmingTest2F_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2F_cfg.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2F")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1F.root')
+)
+
+process.thinningThingProducerABEF = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerABE'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(6),
+    offsetToValue = cms.uint32(6),
+    expectedCollectionSize = cms.uint32(5)
+)
+
+process.testABEF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerABE'),
+    thinnedTag = cms.InputTag('thinningThingProducerABEF'),
+    associationTag = cms.InputTag('thinningThingProducerABEF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,3)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.outF = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest2F.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_thinningThingProducerABEF_*_*',
+        'keep *_trackOfThingsProducerF_*_*',
+    )
+)
+
+process.p = cms.Path(
+    process.thinningThingProducerABEF
+    * process.testABEF
+)
+
+process.ep = cms.EndPath(
+    process.outF
+)

--- a/FWCore/Integration/test/SlimmingTest2F_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2F_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2F")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
 

--- a/FWCore/Integration/test/SlimmingTest2G_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2G_cfg.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2G")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1G.root')
+)
+
+# Here thinningThingProducerB leads to an association with
+# default-constructed BranchID for the parent to be inserted. That
+# should not lead to other failures as long as the thinning producer
+# is not run.
+process.rejectingFilter = cms.EDFilter("TestFilterModule",
+    acceptValue = cms.untracked.int32(-1)
+)
+process.thinningThingProducerB = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('doesNotExist', '', 'PROD'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerAB = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(20)
+)
+
+process.p = cms.Path(
+    process.rejectingFilter *
+    process.thinningThingProducerB
+)
+process.p2 = cms.Path(
+    process.thinningThingProducerAB
+)

--- a/FWCore/Integration/test/SlimmingTest2G_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2G_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2G")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
 

--- a/FWCore/Integration/test/SlimmingTest2H_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2H_cfg.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2H")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1H.root')
+)
+
+process.testH = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerH'),
+    associationTag = cms.InputTag('thinningThingProducerH'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    refToParentIsAvailable = cms.bool(False),
+    expectedValues = cms.vint32(range(0,19)),
+)
+
+process.p = cms.Path(
+    process.testH
+)

--- a/FWCore/Integration/test/SlimmingTest2H_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2H_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2H")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest1H.root')

--- a/FWCore/Integration/test/SlimmingTest2I_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2I_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2I")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest1I.root')
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    parentWasDropped = cms.bool(True),
+    refToParentIsAvailable = cms.bool(False),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedThinnedContent = cms.vint32(range(0,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,11)),
+    expectedValues = cms.vint32(range(0,11)),
+)
+
+process.testCI = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerC'),
+    thinnedTag = cms.InputTag('thinningThingProducerCI'),
+    associationTag = cms.InputTag('thinningThingProducerCI'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(range(11,16)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,5)),
+    expectedValues = cms.vint32(range(11,16)),
+)
+
+process.outI = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest2I.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerCI_*_*',
+    )
+)
+
+process.p = cms.Path(
+    process.testB
+    * process.testCI
+)
+
+process.ep = cms.EndPath(
+    process.outI
+)

--- a/FWCore/Integration/test/SlimmingTest2I_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest2I_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST2I")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest1I.root')

--- a/FWCore/Integration/test/SlimmingTest3B_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3B_cfg.py
@@ -1,0 +1,63 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3B")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest2B.root')
+)
+
+process.testBF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBF'),
+    associationTag = cms.InputTag('thinningThingProducerBF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,10)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(6,9)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.testBEG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEG'),
+    associationTag = cms.InputTag('thinningThingProducerBEG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    refToParentIsAvailable = cms.bool(False),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(9,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(3,5)),
+    expectedValues = cms.vint32(range(9,11)),
+)
+
+process.outB = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest3B.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerBF_*_*',
+    )
+)
+
+process.p = cms.Path(
+    process.testBF
+    * process.testBEG
+)
+
+process.ep = cms.EndPath(
+    process.outB
+)

--- a/FWCore/Integration/test/SlimmingTest3B_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3B_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST3B")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest2B.root')

--- a/FWCore/Integration/test/SlimmingTest3C_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3C_cfg.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3C")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest2C.root')
+)
+
+process.testBEF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEF'),
+    associationTag = cms.InputTag('thinningThingProducerBEF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    refSlimmedCount = cms.int32(2),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,3)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.p = cms.Path(
+    process.testBEF
+)

--- a/FWCore/Integration/test/SlimmingTest3C_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3C_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST3C")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest2C.root')

--- a/FWCore/Integration/test/SlimmingTest3D_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3D_cfg.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3D")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest2D.root')
+)
+
+process.testBD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerB'),
+    thinnedTag = cms.InputTag('thinningThingProducerBD'),
+    associationTag = cms.InputTag('thinningThingProducerBD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(1),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(0,6)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,6)),
+    expectedValues = cms.vint32(range(0,6)),
+)
+
+process.p = cms.Path(
+    process.testBD
+)

--- a/FWCore/Integration/test/SlimmingTest3D_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3D_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST3D")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest2D.root')

--- a/FWCore/Integration/test/SlimmingTest3E_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3E_cfg.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3E")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest2E.root')
+)
+
+process.testBEF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEF'),
+    associationTag = cms.InputTag('thinningThingProducerBEF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    refSlimmedCount = cms.int32(2),
+    expectedParentContent = cms.vint32(range(0,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,3)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.p = cms.Path(
+    process.testBEF
+)

--- a/FWCore/Integration/test/SlimmingTest3E_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3E_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST3E")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest2E.root')

--- a/FWCore/Integration/test/SlimmingTest3F_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3F_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3F")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest2F.root')
+)
+
+process.testABEF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerABE'),
+    thinnedTag = cms.InputTag('thinningThingProducerABEF'),
+    associationTag = cms.InputTag('thinningThingProducerABEF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,3)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.outF = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSlimmingTest3F.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+    )
+)
+
+process.p = cms.Path(
+    process.testABEF
+)
+
+process.ep = cms.EndPath(
+    process.outF
+)

--- a/FWCore/Integration/test/SlimmingTest3F_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3F_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST3F")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest2F.root')

--- a/FWCore/Integration/test/SlimmingTest3I_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3I_cfg.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3I")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest2I.root')
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    parentWasDropped = cms.bool(True),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedThinnedContent = cms.vint32(range(0,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,11)),
+    expectedValues = cms.vint32(range(0,11)),
+)
+
+process.p = cms.Path(
+    process.testB
+)

--- a/FWCore/Integration/test/SlimmingTest3I_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest3I_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST3I")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest2I.root')

--- a/FWCore/Integration/test/SlimmingTest4B_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest4B_cfg.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST4B")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest3B.root')
+)
+
+process.testBEG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerBE'),
+    thinnedTag = cms.InputTag('thinningThingProducerBEG'),
+    associationTag = cms.InputTag('thinningThingProducerBEG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    parentSlimmedCount = cms.int32(2),
+    thinnedSlimmedCount = cms.int32(2),
+    refSlimmedCount = cms.int32(2),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(9,11)),
+    expectedIndexesIntoParent = cms.vuint32(range(3,5)),
+    expectedValues = cms.vint32(range(9,11)),
+)
+
+process.p = cms.Path(
+    process.testBEG
+)

--- a/FWCore/Integration/test/SlimmingTest4B_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest4B_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST4B")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest3B.root')

--- a/FWCore/Integration/test/SlimmingTest4F_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest4F_cfg.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST4F")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testSlimmingTest3F.root'),
+  secondaryFileNames = cms.untracked.vstring('file:testSlimmingTest3B.root')
+)
+
+process.testABEF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerABE'),
+    thinnedTag = cms.InputTag('thinningThingProducerABEF'),
+    associationTag = cms.InputTag('thinningThingProducerABEF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32(range(6,11)),
+    expectedThinnedContent = cms.vint32(range(6,9)),
+    expectedIndexesIntoParent = cms.vuint32(range(0,3)),
+    expectedValues = cms.vint32(range(6,9)),
+)
+
+process.p = cms.Path(
+    process.testABEF
+)

--- a/FWCore/Integration/test/SlimmingTest4F_cfg.py
+++ b/FWCore/Integration/test/SlimmingTest4F_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST4F")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring('file:testSlimmingTest3F.root'),

--- a/FWCore/Integration/test/SlimmingTestFartherSiblings_cfg.py
+++ b/FWCore/Integration/test/SlimmingTestFartherSiblings_cfg.py
@@ -1,0 +1,62 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.thingProducer = cms.EDProducer("ThingProducer",
+                                       offsetDelta = cms.int32(100),
+                                       nThings = cms.int32(50)
+)
+
+process.trackOfThingsProducerB = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3)
+)
+
+process.trackOfThingsProducerC = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(4, 5, 6, 7)
+)
+
+process.slimmingThingProducerB = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerC = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.slimmingThingProducerC = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(4)
+)
+
+process.p = cms.Path(
+    process.thingProducer *
+    process.trackOfThingsProducerB *
+    process.trackOfThingsProducerC *
+    process.slimmingThingProducerB *
+    process.thinningThingProducerC *
+    process.slimmingThingProducerC
+)

--- a/FWCore/Integration/test/SlimmingTestFartherSiblings_cfg.py
+++ b/FWCore/Integration/test/SlimmingTestFartherSiblings_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("EmptySource")
 

--- a/FWCore/Integration/test/SlimmingTestSiblings_cfg.py
+++ b/FWCore/Integration/test/SlimmingTestSiblings_cfg.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.thingProducer = cms.EDProducer("ThingProducer",
+                                       offsetDelta = cms.int32(100),
+                                       nThings = cms.int32(50)
+)
+
+process.trackOfThingsProducerB = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3)
+)
+
+process.trackOfThingsProducerC = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(4, 5, 6, 7)
+)
+
+process.slimmingThingProducerB = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.slimmingThingProducerC = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.p = cms.Path(
+    process.thingProducer *
+    process.trackOfThingsProducerB *
+    process.trackOfThingsProducerC *
+    process.slimmingThingProducerB *
+    process.slimmingThingProducerC
+)

--- a/FWCore/Integration/test/SlimmingTestSiblings_cfg.py
+++ b/FWCore/Integration/test/SlimmingTestSiblings_cfg.py
@@ -2,13 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1)
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.source = cms.Source("EmptySource")
 

--- a/FWCore/Integration/test/SlimmingThingProducer.cc
+++ b/FWCore/Integration/test/SlimmingThingProducer.cc
@@ -31,6 +31,8 @@ namespace edmtest {
 
     std::optional<edmtest::Thing> choose(unsigned int iIndex, edmtest::Thing const& iItem) const;
 
+    void reset() { keysToSave_.clear(); }
+
   private:
     edm::EDGetTokenT<TrackOfThingsCollection> const trackToken_;
     edm::ESGetToken<edmtest::WhatsIt, GadgetRcd> const setupToken_;

--- a/FWCore/Integration/test/SlimmingThingProducer.cc
+++ b/FWCore/Integration/test/SlimmingThingProducer.cc
@@ -1,8 +1,3 @@
-
-/** \class edm::ThinningThingSelector
-\author W. David Dagenhart, created 11 June 2014
-*/
-
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TestObjects/interface/Thing.h"
 #include "DataFormats/TestObjects/interface/ThingCollection.h"
@@ -26,34 +21,35 @@
 
 namespace edmtest {
 
-  class ThinningThingSelector {
+  class SlimmingThingSelector {
   public:
-    ThinningThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc);
+    SlimmingThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc);
 
     static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
     void preChoose(edm::Handle<edmtest::ThingCollection> tc, edm::Event const& event, edm::EventSetup const& es);
 
-    bool choose(unsigned int iIndex, edmtest::Thing const& iItem);
+    std::optional<edmtest::Thing> choose(unsigned int iIndex, edmtest::Thing const& iItem) const;
 
   private:
-    edm::EDGetTokenT<TrackOfThingsCollection> trackToken_;
+    edm::EDGetTokenT<TrackOfThingsCollection> const trackToken_;
+    edm::ESGetToken<edmtest::WhatsIt, GadgetRcd> const setupToken_;
     std::set<unsigned int> keysToSave_;
-    unsigned int offsetToThinnedKey_;
-    unsigned int offsetToValue_;
-    unsigned int expectedCollectionSize_;
-    int slimmedValueFactor_;
+    unsigned int const offsetToThinnedKey_;
+    unsigned int const offsetToValue_;
+    unsigned int const expectedCollectionSize_;
+    int const slimmedValueFactor_;
   };
 
-  ThinningThingSelector::ThinningThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc) {
-    trackToken_ = cc.consumes<TrackOfThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"));
-    offsetToThinnedKey_ = pset.getParameter<unsigned int>("offsetToThinnedKey");
-    offsetToValue_ = pset.getParameter<unsigned int>("offsetToValue");
-    expectedCollectionSize_ = pset.getParameter<unsigned int>("expectedCollectionSize");
-    slimmedValueFactor_ = pset.getParameter<int>("slimmedValueFactor");
-  }
+  SlimmingThingSelector::SlimmingThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc)
+      : trackToken_(cc.consumes<TrackOfThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"))),
+        setupToken_(cc.esConsumes<edmtest::WhatsIt, GadgetRcd>()),
+        offsetToThinnedKey_(pset.getParameter<unsigned int>("offsetToThinnedKey")),
+        offsetToValue_(pset.getParameter<unsigned int>("offsetToValue")),
+        expectedCollectionSize_(pset.getParameter<unsigned int>("expectedCollectionSize")),
+        slimmedValueFactor_(pset.getParameter<int>("slimmedValueFactor")) {}
 
-  void ThinningThingSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  void SlimmingThingSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
     desc.add<edm::InputTag>("trackTag");
     desc.add<unsigned int>("offsetToThinnedKey");
     desc.add<unsigned int>("offsetToValue", 0);
@@ -61,7 +57,7 @@ namespace edmtest {
     desc.add<int>("slimmedValueFactor", 1);
   }
 
-  void ThinningThingSelector::preChoose(edm::Handle<edmtest::ThingCollection> tc,
+  void SlimmingThingSelector::preChoose(edm::Handle<edmtest::ThingCollection> tc,
                                         edm::Event const& event,
                                         edm::EventSetup const& es) {
     for (auto const& track : event.get(trackToken_)) {
@@ -73,31 +69,32 @@ namespace edmtest {
 
     // Just checking to see if the collection got passed in. Not really using it for anything.
     if (tc->size() != expectedCollectionSize_) {
-      throw cms::Exception("TestFailure") << "ThinningThingSelector::preChoose, collection size = " << tc->size()
+      throw cms::Exception("TestFailure") << "SlimmingThingSelector::preChoose, collection size = " << tc->size()
                                           << " expected size = " << expectedCollectionSize_;
     }
 
     // Just checking to see the EventSetup works from here. Not really using it for anything.
-    edm::ESHandle<edmtest::WhatsIt> pSetup;
-    es.get<GadgetRcd>().get(pSetup);
+    edm::ESHandle<edmtest::WhatsIt> pSetup = es.getHandle(setupToken_);
     pSetup.isValid();
   }
 
-  bool ThinningThingSelector::choose(unsigned int iIndex, edmtest::Thing const& iItem) {
+  std::optional<edmtest::Thing> SlimmingThingSelector::choose(unsigned int iIndex, edmtest::Thing const& iItem) const {
     // Just checking to see the element in the container got passed in OK. Not really using it.
     // Just using %10 because it coincidentally works with the arbitrary numbers I picked, no meaning really.
     auto const expected = slimmedValueFactor_ * (iIndex + offsetToValue_);
     if (static_cast<unsigned>(iItem.a % 10) != static_cast<unsigned>(expected % 10)) {
-      throw cms::Exception("TestFailure") << "ThinningThingSelector::choose, item content = " << iItem.a
+      throw cms::Exception("TestFailure") << "SlimmingThingSelector::choose, item content = " << iItem.a
                                           << " index = " << iIndex << " expected " << expected;
     }
 
     // Save the Things referenced by the Tracks
     if (keysToSave_.find(iIndex) == keysToSave_.end())
-      return false;
-    return true;
+      return {};
+    auto copy = iItem;
+    copy.a *= 10;
+    return copy;
   }
 }  // namespace edmtest
 
-typedef edm::ThinningProducer<edmtest::ThingCollection, edmtest::ThinningThingSelector> ThinningThingProducer;
-DEFINE_FWK_MODULE(ThinningThingProducer);
+typedef edm::ThinningProducer<edmtest::ThingCollection, edmtest::SlimmingThingSelector> SlimmingThingProducer;
+DEFINE_FWK_MODULE(SlimmingThingProducer);

--- a/FWCore/Integration/test/ThinnedRefFromTestAnalyzer.cc
+++ b/FWCore/Integration/test/ThinnedRefFromTestAnalyzer.cc
@@ -1,0 +1,109 @@
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "DataFormats/TestObjects/interface/TrackOfThings.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+
+namespace {
+  template <typename F>
+  void requireExceptionCategory(edm::errors::ErrorCodes code, F&& function) {
+    bool threwException = false;
+    try {
+      function();
+    } catch (edm::Exception& ex) {
+      if (ex.categoryCode() != code) {
+        throw cms::Exception("TestFailure")
+            << "Got edm::Exception with category code " << ex.categoryCode() << " expected " << code << " message:\n"
+            << ex.explainSelf();
+      }
+      threwException = true;
+    }
+    if (not threwException) {
+      throw cms::Exception("TestFailure") << "Expected edm::Exception, but was not thrown";
+    }
+  }
+}  // namespace
+
+namespace edmtest {
+  class ThinnedRefFromTestAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit ThinnedRefFromTestAnalyzer(edm::ParameterSet const& pset);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    void analyze(edm::StreamID streamID, edm::Event const& e, edm::EventSetup const& c) const override;
+
+  private:
+    const edm::EDGetTokenT<ThingCollection> parentToken_;
+    const edm::EDGetTokenT<ThingCollection> thinnedToken_;
+    const edm::EDGetTokenT<ThingCollection> unrelatedToken_;
+    const edm::EDGetTokenT<TrackOfThingsCollection> trackToken_;
+  };
+
+  ThinnedRefFromTestAnalyzer::ThinnedRefFromTestAnalyzer(edm::ParameterSet const& pset)
+      : parentToken_{consumes<ThingCollection>(pset.getParameter<edm::InputTag>("parentTag"))},
+        thinnedToken_{consumes<ThingCollection>(pset.getParameter<edm::InputTag>("thinnedTag"))},
+        unrelatedToken_{consumes<ThingCollection>(pset.getParameter<edm::InputTag>("unrelatedTag"))},
+        trackToken_{consumes<TrackOfThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"))} {}
+
+  void ThinnedRefFromTestAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("parentTag");
+    desc.add<edm::InputTag>("thinnedTag");
+    desc.add<edm::InputTag>("unrelatedTag");
+    desc.add<edm::InputTag>("trackTag");
+    descriptions.addDefault(desc);
+  }
+
+  void ThinnedRefFromTestAnalyzer::analyze(edm::StreamID streamID,
+                                           edm::Event const& event,
+                                           edm::EventSetup const& c) const {
+    auto parentHandle = event.getHandle(parentToken_);
+    auto thinnedHandle = event.getHandle(thinnedToken_);
+    auto unrelatedHandle = event.getHandle(unrelatedToken_);
+    auto const& trackCollection = event.get(trackToken_);
+
+    edm::RefProd parentRefProd{parentHandle};
+    edm::RefProd thinnedRefProd{thinnedHandle};
+    edm::RefProd unrelatedRefProd{unrelatedHandle};
+
+    requireExceptionCategory(edm::errors::InvalidReference, [&]() {
+      auto invalidParentRef = edm::thinnedRefFrom(edm::Ref(unrelatedHandle, 0), thinnedRefProd, event.productGetter());
+    });
+
+    for (auto const& track : trackCollection) {
+      auto parentRef1 = edm::thinnedRefFrom(track.ref1, parentRefProd, event.productGetter());
+      if (parentRef1.id() != track.ref1.id()) {
+        throw cms::Exception("TestFailure")
+            << "Ref1-to-parent ProductID " << parentRef1.id() << " expected " << track.ref1.id();
+      }
+      if (parentRef1.key() != track.ref1.key()) {
+        throw cms::Exception("TestFailure")
+            << "Ref1-to-parent key " << parentRef1.key() << " expected " << track.ref1.key();
+      }
+
+      auto thinnedRef1 = edm::thinnedRefFrom(track.ref1, thinnedRefProd, event.productGetter());
+      if (thinnedRef1.id() != thinnedRefProd.id()) {
+        throw cms::Exception("TestFailure")
+            << "Ref1-to-thinned ProductID " << thinnedRef1.id() << " expected " << thinnedRefProd.id();
+      }
+
+      requireExceptionCategory(edm::errors::ProductNotFound, [&]() {
+        auto invalidThinnedRef = edm::thinnedRefFrom(track.ref1, unrelatedRefProd, event.productGetter());
+      });
+    }
+  }
+}  // namespace edmtest
+
+using edmtest::ThinnedRefFromTestAnalyzer;
+DEFINE_FWK_MODULE(ThinnedRefFromTestAnalyzer);

--- a/FWCore/Integration/test/ThinnedRefFromTestAnalyzer.cc
+++ b/FWCore/Integration/test/ThinnedRefFromTestAnalyzer.cc
@@ -80,6 +80,12 @@ namespace edmtest {
     requireExceptionCategory(edm::errors::InvalidReference, [&]() {
       auto invalidParentRef = edm::thinnedRefFrom(edm::Ref(unrelatedHandle, 0), thinnedRefProd, event.productGetter());
     });
+    if (auto invalidParentRef =
+            edm::tryThinnedRefFrom(edm::Ref(unrelatedHandle, 0), thinnedRefProd, event.productGetter());
+        invalidParentRef.isNonnull()) {
+      throw cms::Exception("TestFailure") << "Expected to get Null Ref when passing in a Ref to unrelated parent "
+                                             "collection, got a non-null Ref instead";
+    }
 
     for (auto const& track : trackCollection) {
       auto parentRef1 = edm::thinnedRefFrom(track.ref1, parentRefProd, event.productGetter());
@@ -98,9 +104,14 @@ namespace edmtest {
             << "Ref1-to-thinned ProductID " << thinnedRef1.id() << " expected " << thinnedRefProd.id();
       }
 
-      requireExceptionCategory(edm::errors::ProductNotFound, [&]() {
+      requireExceptionCategory(edm::errors::InvalidReference, [&]() {
         auto invalidThinnedRef = edm::thinnedRefFrom(track.ref1, unrelatedRefProd, event.productGetter());
       });
+      if (auto invalidThinnedRef = edm::tryThinnedRefFrom(track.ref1, unrelatedRefProd, event.productGetter());
+          invalidThinnedRef.isNonnull()) {
+        throw cms::Exception("TestFailure") << "Expected to get Null Ref when passing in a RefProd to unrelated "
+                                               "thinned collection, got a non-null Ref instead";
+      }
     }
   }
 }  // namespace edmtest

--- a/FWCore/Integration/test/ThinningDSVTestAnalyzer.cc
+++ b/FWCore/Integration/test/ThinningDSVTestAnalyzer.cc
@@ -1,0 +1,437 @@
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/transform.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/TrackOfDSVThings.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+
+#include <vector>
+
+namespace edmtest {
+
+  class ThinningDSVTestAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit ThinningDSVTestAnalyzer(edm::ParameterSet const& pset);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    virtual void analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const& c) const override;
+
+  private:
+    void incrementExpectedValue(std::vector<int>::const_iterator& iter) const;
+
+    edm::EDGetTokenT<edmNew::DetSetVector<Thing>> parentToken_;
+    edm::EDGetTokenT<edmNew::DetSetVector<Thing>> thinnedToken_;
+    edm::EDGetTokenT<edm::ThinnedAssociation> associationToken_;
+    edm::EDGetTokenT<TrackOfDSVThingsCollection> trackToken_;
+
+    struct DSContent {
+      unsigned int id;
+      std::vector<int> values;
+    };
+
+    bool parentWasDropped_;
+    std::vector<DSContent> expectedParentContent_;
+    bool thinnedWasDropped_;
+    bool thinnedIsAlias_;
+    bool refToParentIsAvailable_;
+    std::vector<DSContent> expectedThinnedContent_;
+    std::vector<unsigned int> expectedIndexesIntoParent_;
+    bool associationShouldBeDropped_;
+    unsigned int expectedNumberOfTracks_;
+    std::vector<int> expectedValues_;
+    int parentSlimmedValueFactor_;
+    int thinnedSlimmedValueFactor_;
+    int refSlimmedValueFactor_;
+  };
+
+  ThinningDSVTestAnalyzer::ThinningDSVTestAnalyzer(edm::ParameterSet const& pset)
+      : parentToken_(consumes<edmNew::DetSetVector<Thing>>(pset.getParameter<edm::InputTag>("parentTag"))),
+        thinnedToken_(consumes<edmNew::DetSetVector<Thing>>(pset.getParameter<edm::InputTag>("thinnedTag"))),
+        associationToken_(consumes<edm::ThinnedAssociation>(pset.getParameter<edm::InputTag>("associationTag"))),
+        trackToken_(consumes<TrackOfDSVThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"))),
+        parentWasDropped_(pset.getParameter<bool>("parentWasDropped")),
+        thinnedWasDropped_(pset.getParameter<bool>("thinnedWasDropped")),
+        thinnedIsAlias_(pset.getParameter<bool>("thinnedIsAlias")),
+        refToParentIsAvailable_(pset.getParameter<bool>("refToParentIsAvailable")),
+        associationShouldBeDropped_(pset.getParameter<bool>("associationShouldBeDropped")),
+        expectedNumberOfTracks_(pset.getParameter<unsigned int>("expectedNumberOfTracks")),
+        expectedValues_(pset.getParameter<std::vector<int>>("expectedValues")) {
+    auto makeDSContent = [](edm::ParameterSet const& p) {
+      return DSContent{p.getParameter<unsigned int>("id"), p.getParameter<std::vector<int>>("values")};
+    };
+    if (!parentWasDropped_) {
+      expectedParentContent_ = edm::vector_transform(
+          pset.getParameter<std::vector<edm::ParameterSet>>("expectedParentContent"), makeDSContent);
+    }
+    if (!thinnedWasDropped_) {
+      expectedThinnedContent_ = edm::vector_transform(
+          pset.getParameter<std::vector<edm::ParameterSet>>("expectedThinnedContent"), makeDSContent);
+    }
+    if (!associationShouldBeDropped_) {
+      expectedIndexesIntoParent_ = pset.getParameter<std::vector<unsigned int>>("expectedIndexesIntoParent");
+    }
+
+    auto slimmedFactor = [](int count, int factor) {
+      int ret = 1;
+      for (int i = 0; i < count; ++i) {
+        ret *= factor;
+      }
+      return ret;
+    };
+    int const slimmedValueFactor = pset.getParameter<int>("slimmedValueFactor");
+    parentSlimmedValueFactor_ = slimmedFactor(pset.getParameter<int>("parentSlimmedCount"), slimmedValueFactor);
+    thinnedSlimmedValueFactor_ = slimmedFactor(pset.getParameter<int>("thinnedSlimmedCount"), slimmedValueFactor);
+    refSlimmedValueFactor_ = slimmedFactor(pset.getParameter<int>("refSlimmedCount"), slimmedValueFactor);
+  }
+
+  void ThinningDSVTestAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("parentTag");
+    desc.add<edm::InputTag>("thinnedTag");
+    desc.add<edm::InputTag>("associationTag");
+    desc.add<edm::InputTag>("trackTag");
+    desc.add<bool>("parentWasDropped", false);
+    desc.add<bool>("thinnedWasDropped", false);
+    desc.add<bool>("thinnedIsAlias", false);
+    desc.add<bool>("refToParentIsAvailable", true)
+        ->setComment(
+            "If Ref-to-parent is generally available. With thinnedRefFrom it may happen that the Ref-to-parent is not "
+            "available, but the Ref-to-thinned is. In such case this parameter should be set to 'False', and the "
+            "'expectedValues' should be set to correspond the values via Ref-to-thinned.");
+    std::vector<int> defaultV;
+    std::vector<unsigned int> defaultVU;
+    std::vector<edm::ParameterSet> defaultVPSet;
+    edm::ParameterSetDescription dsValidator;
+    dsValidator.add<unsigned int>("id");
+    dsValidator.add<std::vector<int>>("values", defaultV);
+    desc.addVPSet("expectedParentContent", dsValidator, defaultVPSet);
+    desc.addVPSet("expectedThinnedContent", dsValidator, defaultVPSet);
+    desc.add<std::vector<unsigned int>>("expectedIndexesIntoParent", defaultVU);
+    desc.add<bool>("associationShouldBeDropped", false);
+    desc.add<unsigned int>("expectedNumberOfTracks", 5);
+    desc.add<std::vector<int>>("expectedValues");
+    desc.add<int>("parentSlimmedCount", 0);
+    desc.add<int>("thinnedSlimmedCount", 0);
+    desc.add<int>("refSlimmedCount", 0);
+    desc.add<int>("slimmedValueFactor", 10);
+    descriptions.addDefault(desc);
+  }
+
+  void ThinningDSVTestAnalyzer::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const&) const {
+    auto parentCollection = event.getHandle(parentToken_);
+    auto thinnedCollection = event.getHandle(thinnedToken_);
+    auto associationCollection = event.getHandle(associationToken_);
+    auto trackCollection = event.getHandle(trackToken_);
+
+    if (parentWasDropped_) {
+      if (parentCollection.isValid()) {
+        throw cms::Exception("TestFailure") << "parent collection present, should have been dropped";
+      }
+    } else if (!expectedParentContent_.empty()) {
+      if (parentCollection->size() != expectedParentContent_.size()) {
+        throw cms::Exception("TestFailure") << "parent collection has unexpected size, got " << parentCollection->size()
+                                            << " expected " << expectedParentContent_.size();
+      }
+
+      auto iExpected = expectedParentContent_.begin();
+      for (auto const& detset : *parentCollection) {
+        auto const& expectedContent = *iExpected;
+        ++iExpected;
+
+        if (detset.id() != expectedContent.id) {
+          throw cms::Exception("TestFailure")
+              << "parent collection detset has unexpected id " << detset.id() << " expected " << expectedContent.id;
+        }
+        if (detset.size() != expectedContent.values.size()) {
+          throw cms::Exception("TestFailure")
+              << "parent collection detset with id " << detset.id() << " has unexpected size, got " << detset.size()
+              << " expected " << expectedContent.values.size();
+        }
+        auto iValue = expectedContent.values.begin();
+        for (auto const& thing : detset) {
+          // Just some numbers that match the somewhat arbitrary values put in
+          // by the ThingProducer.
+          int expected =
+              static_cast<int>(*iValue + (event.eventAuxiliary().event() - 1) * 100) * parentSlimmedValueFactor_;
+          if (thing.a != expected) {
+            throw cms::Exception("TestFailure")
+                << "parent collection has unexpected content for detset with id " << detset.id() << ", got " << thing.a
+                << " expected " << expected << " (element " << std::distance(expectedContent.values.begin(), iValue)
+                << ")";
+          }
+          ++iValue;
+        }
+      }
+    }
+
+    // Check to see the content is what we expect based on what was written
+    // by ThingProducer and TrackOfThingsProducer. The values are somewhat
+    // arbitrary and meaningless.
+    edm::RefProd<edmNew::DetSetVector<Thing>> thinnedRefProd;
+    if (thinnedWasDropped_) {
+      if (thinnedCollection.isValid()) {
+        throw cms::Exception("TestFailure") << "thinned collection present, should have been dropped";
+      }
+    } else {
+      thinnedRefProd = edm::RefProd<edmNew::DetSetVector<Thing>>{thinnedCollection};
+      if (thinnedCollection->size() != expectedThinnedContent_.size()) {
+        throw cms::Exception("TestFailure")
+            << "thinned collection has unexpected size, got " << thinnedCollection->size() << " expected "
+            << expectedThinnedContent_.size();
+      }
+
+      auto iExpected = expectedThinnedContent_.begin();
+      for (auto const& detset : *thinnedCollection) {
+        auto const& expectedContent = *iExpected;
+        ++iExpected;
+
+        if (detset.id() != expectedContent.id) {
+          throw cms::Exception("TestFailure")
+              << "thinned collection detset has unexpected id " << detset.id() << " expected " << expectedContent.id;
+        }
+        if (detset.size() != expectedContent.values.size()) {
+          throw cms::Exception("TestFailure")
+              << "thinned collection detset with id " << detset.id() << " has unexpected size, got " << detset.size()
+              << " expected " << expectedContent.values.size();
+        }
+        auto iValue = expectedContent.values.begin();
+        for (auto const& thing : detset) {
+          int expected =
+              static_cast<int>(*iValue + (event.eventAuxiliary().event() - 1) * 100) * thinnedSlimmedValueFactor_;
+          if (thing.a != expected) {
+            throw cms::Exception("TestFailure")
+                << "thinned collection has unexpected content for detset with id " << detset.id() << ", got " << thing.a
+                << " expected " << expected << " (element " << std::distance(expectedContent.values.begin(), iValue)
+                << ")";
+          }
+          ++iValue;
+        }
+      }
+    }
+
+    if (associationShouldBeDropped_ && associationCollection.isValid()) {
+      throw cms::Exception("TestFailure") << "association collection should have been dropped but was not";
+    }
+    if (!associationShouldBeDropped_) {
+      unsigned int expectedIndex = 0;
+      if (associationCollection->indexesIntoParent().size() != expectedIndexesIntoParent_.size()) {
+        throw cms::Exception("TestFailure")
+            << "association collection has unexpected size " << associationCollection->indexesIntoParent().size()
+            << " expected " << expectedIndexesIntoParent_.size();
+      }
+      for (auto const& association : associationCollection->indexesIntoParent()) {
+        if (association != expectedIndexesIntoParent_.at(expectedIndex)) {
+          throw cms::Exception("TestFailure")
+              << "association collection has unexpected content, for index " << expectedIndex << " got " << association
+              << " expected " << expectedIndexesIntoParent_.at(expectedIndex);
+        }
+        ++expectedIndex;
+      }
+    }
+
+    if (!parentWasDropped_ && !associationShouldBeDropped_) {
+      if (associationCollection->parentCollectionID() != parentCollection.id()) {
+        throw cms::Exception("TestFailure") << "analyze parent ProductID is not correct";
+      }
+    }
+
+    if (!thinnedWasDropped_ && !associationShouldBeDropped_) {
+      if (associationCollection->thinnedCollectionID() != thinnedCollection.id()) {
+        throw cms::Exception("TestFailure") << "analyze thinned ProductID is not correct";
+      }
+    }
+
+    if (trackCollection->size() != expectedNumberOfTracks_) {
+      throw cms::Exception("TestFailure")
+          << "unexpected Track size " << trackCollection->size() << " expected " << expectedNumberOfTracks_;
+    }
+
+    int eventOffset = (static_cast<int>(event.eventAuxiliary().event()) - 1) * 100;
+
+    std::vector<int>::const_iterator expectedValue = expectedValues_.begin();
+    for (auto const& track : *trackCollection) {
+      if (not refToParentIsAvailable_ or *expectedValue == -1) {
+        if (track.ref1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ref1 is available when it should not be, refers to "
+                                              << track.ref1.id() << " key " << track.ref1.key();
+        }
+      } else {
+        if (!track.ref1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ref1 is not available when it should be";
+        }
+        // Check twice to test some possible caching problems.
+        const int expected = (*expectedValue + eventOffset) * refSlimmedValueFactor_;
+        if (track.ref1->a != expected) {
+          throw cms::Exception("TestFailure")
+              << "Unexpected values from ref1, got " << track.ref1->a << " expected " << expected;
+        }
+        if (track.ref1->a != expected) {
+          throw cms::Exception("TestFailure")
+              << "Unexpected values from ref1 (2nd try), got " << track.ref1->a << " expected " << expected;
+          ;
+        }
+      }
+
+      if (not thinnedWasDropped_) {
+        auto refToThinned = edm::thinnedRefFrom(track.ref1, thinnedRefProd, event.productGetter());
+        if (*expectedValue == -1) {
+          if (refToThinned.isNonnull()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref1) is non-null when it should be null";
+          }
+          if (refToThinned.isAvailable()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref1) is available when it should not be";
+          }
+        } else {
+          if (refToThinned.isNull()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref1) is null when it should not be";
+          }
+          if (refToThinned.id() != thinnedCollection.id()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref).id() " << refToThinned.id()
+                                                << " differs from expectation " << thinnedCollection.id();
+          }
+          if (not refToThinned.isAvailable()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref1) is not available when it should be";
+          }
+          // Check twice to test some possible caching problems.
+          // need to account for slimming because going through an explicit ref-to-slimmed
+          const int expected = (*expectedValue + eventOffset) * thinnedSlimmedValueFactor_;
+          if (refToThinned->a != expected) {
+            throw cms::Exception("TestFailure")
+                << "Unexpected values from thinnedRefFrom(ref1), got " << refToThinned->a << " expected " << expected;
+          }
+          if (refToThinned->a != expected) {
+            throw cms::Exception("TestFailure") << "Unexpected values from thinnedRefFrom(ref1) (2nd try) "
+                                                << refToThinned->a << " expected " << expected;
+          }
+        }
+      }
+      incrementExpectedValue(expectedValue);
+
+      if (not refToParentIsAvailable_ or *expectedValue == -1) {
+        if (track.ref2.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ref2 is available when it should not be";
+        }
+      } else {
+        if (!track.ref2.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ref2 is not available when it should be";
+        }
+
+        const int expected = (*expectedValue + eventOffset) * refSlimmedValueFactor_;
+        if (track.ref2->a != expected) {
+          throw cms::Exception("TestFailure")
+              << "unexpected values from ref2, got " << track.ref2->a << " expected " << expected;
+        }
+        if (track.ref2->a != expected) {
+          throw cms::Exception("TestFailure")
+              << "unexpected values from ref2 (2nd try), got " << track.ref2->a << " expected " << expected;
+        }
+      }
+
+      if (not thinnedWasDropped_) {
+        auto refToThinned = edm::thinnedRefFrom(track.ref2, thinnedRefProd, event.productGetter());
+        if (*expectedValue == -1) {
+          if (refToThinned.isNonnull()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref2) is non-null when it should be null";
+          }
+          if (refToThinned.isAvailable()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref2) is available when it should not be";
+          }
+        } else {
+          if (refToThinned.isNull()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref2) is null when it should not be";
+          }
+          if (refToThinned.id() != thinnedCollection.id()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref2).id() " << refToThinned.id()
+                                                << " differs from expectation " << thinnedCollection.id();
+          }
+          if (not refToThinned.isAvailable()) {
+            throw cms::Exception("TestFailure") << "thinnedRefFrom(ref2) is not available when it should be";
+          }
+          // Check twice to test some possible caching problems.
+          // need to account for slimming because going through an explicit ref-to-slimmed
+          const int expected = (*expectedValue + eventOffset) * thinnedSlimmedValueFactor_;
+          if (refToThinned->a != expected) {
+            throw cms::Exception("TestFailure")
+                << "Unexpected values from thinnedRefFrom(ref2), got " << refToThinned->a << " expected " << expected;
+          }
+          if (refToThinned->a != expected) {
+            throw cms::Exception("TestFailure") << "Unexpected values from thinnedRefFrom(ref2) (2nd try), got "
+                                                << refToThinned->a << " expected " << expected;
+          }
+        }
+      }
+
+      incrementExpectedValue(expectedValue);
+
+      // Test RefVector
+      unsigned int k = 0;
+      bool allPresent = true;
+      for (auto iExpectedValue : expectedValues_) {
+        if (iExpectedValue != -1) {
+          if (not thinnedWasDropped_) {
+            auto refToThinned = edm::thinnedRefFrom(track.refVector1[k], thinnedRefProd, event.productGetter());
+            // need to account for slimming because going through an explicit ref-to-slimmed
+            const int expected = (iExpectedValue + eventOffset) * thinnedSlimmedValueFactor_;
+            if (refToThinned->a != expected) {
+              throw cms::Exception("TestFailure") << "unexpected values from thinnedRefFrom(refVector1), got "
+                                                  << refToThinned->a << " expected " << expected;
+            }
+          }
+          if (refToParentIsAvailable_) {
+            const int expected = (iExpectedValue + eventOffset) * refSlimmedValueFactor_;
+            if (track.refVector1[k]->a != expected) {
+              throw cms::Exception("TestFailure")
+                  << "unexpected values from refVector1, got " << track.refVector1[k]->a << " expected " << expected;
+            }
+          }
+        } else {
+          allPresent = false;
+        }
+        ++k;
+      }
+
+      if (refToParentIsAvailable_ and allPresent) {
+        if (!track.refVector1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "unexpected value (false) from refVector::isAvailable";
+        }
+      } else {
+        if (track.refVector1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "unexpected value (true) from refVector::isAvailable";
+        }
+      }
+      k = 0;
+      for (auto iExpectedValue : expectedValues_) {
+        if (refToParentIsAvailable_ and iExpectedValue != -1) {
+          const int expected = (iExpectedValue + eventOffset) * refSlimmedValueFactor_;
+          if (track.refVector1[k]->a != expected) {
+            throw cms::Exception("TestFailure")
+                << "unexpected values from refVector1, got " << track.refVector1[k]->a << " expected " << expected;
+          }
+        } else {
+          allPresent = false;
+        }
+        ++k;
+      }
+    }
+  }
+
+  void ThinningDSVTestAnalyzer::incrementExpectedValue(std::vector<int>::const_iterator& iter) const {
+    ++iter;
+    if (iter == expectedValues_.end())
+      iter = expectedValues_.begin();
+  }
+}  // namespace edmtest
+using edmtest::ThinningDSVTestAnalyzer;
+DEFINE_FWK_MODULE(ThinningDSVTestAnalyzer);

--- a/FWCore/Integration/test/ThinningDSVTestAnalyzer.cc
+++ b/FWCore/Integration/test/ThinningDSVTestAnalyzer.cc
@@ -258,6 +258,10 @@ namespace edmtest {
           << "unexpected Track size " << trackCollection->size() << " expected " << expectedNumberOfTracks_;
     }
 
+    if (expectedValues_.empty()) {
+      return;
+    }
+
     int eventOffset = (static_cast<int>(event.eventAuxiliary().event()) - 1) * 100;
 
     std::vector<int>::const_iterator expectedValue = expectedValues_.begin();

--- a/FWCore/Integration/test/ThinningDSVThingProducer.cc
+++ b/FWCore/Integration/test/ThinningDSVThingProducer.cc
@@ -1,0 +1,98 @@
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/TrackOfDSVThings.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/ThinningProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <set>
+#include <string>
+
+namespace edmtest {
+
+  class ThinningDSVThingSelector {
+  public:
+    ThinningDSVThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc);
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
+    void preChoose(edm::Handle<edmNew::DetSetVector<Thing>> tc, edm::Event const& event, edm::EventSetup const& es);
+
+    bool choose(unsigned int iIndex, edmtest::Thing const& iItem) const;
+
+  private:
+    edm::EDGetTokenT<TrackOfDSVThingsCollection> const trackToken_;
+    std::set<unsigned int> keysToSave_;
+    unsigned int const offsetToThinnedKey_;
+    unsigned int const offsetToValue_;
+    unsigned int const expectedDetSets_;
+    unsigned int const expectedDetSetSize_;
+    int const slimmedValueFactor_;
+  };
+
+  ThinningDSVThingSelector::ThinningDSVThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc)
+      : trackToken_(cc.consumes<TrackOfDSVThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"))),
+        offsetToThinnedKey_(pset.getParameter<unsigned int>("offsetToThinnedKey")),
+        offsetToValue_(pset.getParameter<unsigned int>("offsetToValue")),
+        expectedDetSets_(pset.getParameter<unsigned int>("expectedDetSets")),
+        expectedDetSetSize_(pset.getParameter<unsigned int>("expectedDetSetSize")),
+        slimmedValueFactor_(pset.getParameter<int>("slimmedValueFactor")) {}
+
+  void ThinningDSVThingSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<edm::InputTag>("trackTag");
+    desc.add<unsigned int>("offsetToThinnedKey");
+    desc.add<unsigned int>("offsetToValue", 0);
+    desc.add<unsigned int>("expectedDetSets");
+    desc.add<unsigned int>("expectedDetSetSize");
+    desc.add<int>("slimmedValueFactor", 1);
+  }
+
+  void ThinningDSVThingSelector::preChoose(edm::Handle<edmNew::DetSetVector<Thing>> tc,
+                                           edm::Event const& event,
+                                           edm::EventSetup const& es) {
+    for (auto const& track : event.get(trackToken_)) {
+      keysToSave_.insert(track.ref1.key() - offsetToThinnedKey_);
+      keysToSave_.insert(track.ref2.key() - offsetToThinnedKey_);
+    }
+
+    // Just checking to see if the collection got passed in. Not really using it for anything.
+    if (tc->size() != expectedDetSets_) {
+      throw cms::Exception("TestFailure") << "ThinningDSVThingSelector::preChoose, number of DetSets = " << tc->size()
+                                          << " expected = " << expectedDetSets_;
+    }
+    for (auto const& ds : *tc) {
+      if (ds.size() != expectedDetSetSize_) {
+        throw cms::Exception("TestFailure")
+            << "ThinningDSVThingSelector::preChoose, number of elements in DetSet with id " << ds.id() << " = "
+            << ds.size() << " expected = " << expectedDetSetSize_;
+      }
+    }
+  }
+
+  bool ThinningDSVThingSelector::choose(unsigned int iIndex, edmtest::Thing const& iItem) const {
+    // Just checking to see the element in the container got passed in OK. Not really using it.
+    // Just using %10 because it coincidentally works with the arbitrary numbers I picked, no meaning really.
+    auto const expected = slimmedValueFactor_ * (iIndex + offsetToValue_);
+    if (static_cast<unsigned>(iItem.a % 10) != static_cast<unsigned>(expected % 10)) {
+      throw cms::Exception("TestFailure") << "ThinningDSVThingSelector::choose, item content = " << iItem.a
+                                          << " index = " << iIndex << " expected " << expected;
+    }
+
+    // Save the Things referenced by the Tracks
+    if (keysToSave_.find(iIndex) == keysToSave_.end())
+      return false;
+    return true;
+  }
+}  // namespace edmtest
+
+using ThinningDSVThingProducer =
+    edm::ThinningProducer<edmNew::DetSetVector<edmtest::Thing>, edmtest::ThinningDSVThingSelector>;
+DEFINE_FWK_MODULE(ThinningDSVThingProducer);

--- a/FWCore/Integration/test/ThinningDSVThingProducer.cc
+++ b/FWCore/Integration/test/ThinningDSVThingProducer.cc
@@ -28,6 +28,8 @@ namespace edmtest {
 
     bool choose(unsigned int iIndex, edmtest::Thing const& iItem) const;
 
+    void reset() { keysToSave_.clear(); }
+
   private:
     edm::EDGetTokenT<TrackOfDSVThingsCollection> const trackToken_;
     edm::ThinnedRefSet<edmNew::DetSetVector<Thing>> keysToSave_;

--- a/FWCore/Integration/test/ThinningDSVThingProducer.cc
+++ b/FWCore/Integration/test/ThinningDSVThingProducer.cc
@@ -41,6 +41,9 @@ namespace edmtest {
 
   ThinningDSVThingSelector::ThinningDSVThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc)
       : trackToken_(cc.consumes<TrackOfDSVThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"))),
+        keysToSave_(pset.getParameter<bool>("thinnedRefSetIgnoreInvalidParentRef")
+                        ? edm::ThinnedRefSetMode::ignoreInvalidParentRef
+                        : edm::ThinnedRefSetMode::throwOnInvalidParentRef),
         offsetToValue_(pset.getParameter<unsigned int>("offsetToValue")),
         expectedDetSets_(pset.getParameter<unsigned int>("expectedDetSets")),
         expectedDetSetSize_(pset.getParameter<unsigned int>("expectedDetSetSize")),
@@ -52,6 +55,7 @@ namespace edmtest {
     desc.add<unsigned int>("expectedDetSets");
     desc.add<unsigned int>("expectedDetSetSize");
     desc.add<int>("slimmedValueFactor", 1);
+    desc.add<bool>("thinnedRefSetIgnoreInvalidParentRef", false);
   }
 
   void ThinningDSVThingSelector::preChoose(edm::Handle<edmNew::DetSetVector<Thing>> tc,

--- a/FWCore/Integration/test/ThinningTest1_cfg.py
+++ b/FWCore/Integration/test/ThinningTest1_cfg.py
@@ -33,6 +33,9 @@
 #
 # The ThinningTestAnalyzer checks that things are working as
 # they are supposed to work.
+#
+# The ThinnedRefFromTestAnalyzer includes additional checks
+# for thinnedRefFrom()
 
 import FWCore.ParameterSet.Config as cms
 
@@ -59,6 +62,10 @@ process.thingProducer = cms.EDProducer("ThingProducer",
 process.thingProducer2 = cms.EDProducer("ThingProducer",
                                         offsetDelta = cms.int32(100),
                                         nThings = cms.int32(50)
+)
+process.thingProducerNotThinned = cms.EDProducer("ThingProducer",
+                                                 offsetDelta = cms.int32(100),
+                                                 nThings = cms.int32(50)
 )
 
 process.thingProducer2alias = cms.EDAlias(
@@ -145,6 +152,11 @@ process.trackOfThingsProducerN = cms.EDProducer("TrackOfThingsProducer",
 process.trackOfThingsProducerO = cms.EDProducer("TrackOfThingsProducer",
     inputTag = cms.InputTag('thingProducer'),
     keysToReference = cms.vuint32(44, 45, 46, 47)
+)
+
+process.trackOfThingsProducerA2 = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer2'),
+    keysToReference = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
 )
 
 process.trackOfThingsProducerD2 = cms.EDProducer("TrackOfThingsProducer",
@@ -291,6 +303,13 @@ process.aliasO = cms.EDAlias(
   )
 )
 
+process.thinningThingProducerA2 = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer2'),
+    trackTag = cms.InputTag('trackOfThingsProducerA2'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
 process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
     parentTag = cms.InputTag('thingProducer'),
     thinnedTag = cms.InputTag('thinningThingProducerA'),
@@ -329,6 +348,20 @@ process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
     expectedValues = cms.vint32(4, 5, 6, 7)
 )
 
+process.thinnedRefTestA = cms.EDAnalyzer("ThinnedRefFromTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    unrelatedTag = cms.InputTag('thingProducerNotThinned'),
+    trackTag = cms.InputTag('trackOfThingsProducerA')
+)
+
+process.thinnedRefTestA2 = cms.EDAnalyzer("ThinnedRefFromTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    unrelatedTag = cms.InputTag('thingProducer2'),
+    trackTag = cms.InputTag('trackOfThingsProducerA')
+)
+
 process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testThinningTest1.root'),
     outputCommands = cms.untracked.vstring(
@@ -349,6 +382,8 @@ process.out2 = cms.OutputModule("EventStreamFileWriter",
         'keep *',
         'drop *_thingProducer_*_*',
         'drop *_thingProducer2_*_*',
+        'drop *_thingProducerNotThinned_*_*',
+        'drop *_trackOfThingsProducerA2_*_*',
         'drop *_thinningThingProducerD_*_*',
         'drop *_thinningThingProducerH_*_*',
         'drop *_thinningThingProducerI_*_*',
@@ -363,7 +398,7 @@ process.out2 = cms.OutputModule("EventStreamFileWriter",
     )
 )
 
-process.p = cms.Path(process.thingProducer * process.thingProducer2
+process.p = cms.Path(process.thingProducer * process.thingProducer2 * process.thingProducerNotThinned
                                            * process.trackOfThingsProducerA
                                            * process.trackOfThingsProducerB
                                            * process.trackOfThingsProducerC
@@ -380,6 +415,7 @@ process.p = cms.Path(process.thingProducer * process.thingProducer2
                                            * process.trackOfThingsProducerM
                                            * process.trackOfThingsProducerN
                                            * process.trackOfThingsProducerO
+                                           * process.trackOfThingsProducerA2
                                            * process.trackOfThingsProducerD2
                                            * process.trackOfThingsProducerE2
                                            * process.trackOfThingsProducerF2
@@ -398,9 +434,12 @@ process.p = cms.Path(process.thingProducer * process.thingProducer2
                                            * process.thinningThingProducerM
                                            * process.thinningThingProducerN
                                            * process.thinningThingProducerO
+                                           * process.thinningThingProducerA2
                                            * process.testA
                                            * process.testB
                                            * process.testC
+                                           * process.thinnedRefTestA
+                                           * process.thinnedRefTestA2
                     )
 
 process.endPath = cms.EndPath(process.out * process.out2)

--- a/FWCore/Integration/test/ThinningTest1_cfg.py
+++ b/FWCore/Integration/test/ThinningTest1_cfg.py
@@ -310,6 +310,20 @@ process.thinningThingProducerA2 = cms.EDProducer("ThinningThingProducer",
     expectedCollectionSize = cms.uint32(50)
 )
 
+process.slimmingThingProducerA = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.slimmingThingProducerA2 = cms.EDProducer("SlimmingThingProducer",
+    inputTag = cms.InputTag('thingProducer2'),
+    trackTag = cms.InputTag('trackOfThingsProducerA2'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
 process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
     parentTag = cms.InputTag('thingProducer'),
     thinnedTag = cms.InputTag('thinningThingProducerA'),
@@ -360,6 +374,40 @@ process.thinnedRefTestA2 = cms.EDAnalyzer("ThinnedRefFromTestAnalyzer",
     thinnedTag = cms.InputTag('thinningThingProducerA'),
     unrelatedTag = cms.InputTag('thingProducer2'),
     trackTag = cms.InputTag('trackOfThingsProducerA')
+)
+
+process.slimmingTestA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('slimmingThingProducerA'),
+    associationTag = cms.InputTag('slimmingThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                       30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49
+    ),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.slimmingTestA2 = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer2'),
+    thinnedTag = cms.InputTag('slimmingThingProducerA2'),
+    associationTag = cms.InputTag('slimmingThingProducerA2'),
+    trackTag = cms.InputTag('trackOfThingsProducerA2'),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                       30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49
+    ),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
@@ -435,11 +483,15 @@ process.p = cms.Path(process.thingProducer * process.thingProducer2 * process.th
                                            * process.thinningThingProducerN
                                            * process.thinningThingProducerO
                                            * process.thinningThingProducerA2
+                                           * process.slimmingThingProducerA
+                                           * process.slimmingThingProducerA2
                                            * process.testA
                                            * process.testB
                                            * process.testC
                                            * process.thinnedRefTestA
                                            * process.thinnedRefTestA2
+                                           * process.slimmingTestA
+                                           * process.slimmingTestA2
                     )
 
 process.endPath = cms.EndPath(process.out * process.out2)

--- a/FWCore/Integration/test/ThinningTest2_cfg.py
+++ b/FWCore/Integration/test/ThinningTest2_cfg.py
@@ -98,6 +98,23 @@ process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
     expectedValues = cms.vint32(4, 5, 6, 7)
 )
 
+process.slimmingTestA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer', '', 'PROD'),
+    thinnedTag = cms.InputTag('slimmingThingProducerA'),
+    associationTag = cms.InputTag('slimmingThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    thinnedSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                       30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49
+    ),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
 process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testThinningTest2.root'),
     outputCommands = cms.untracked.vstring(
@@ -116,6 +133,7 @@ process.out = cms.OutputModule("PoolOutputModule",
 )
 
 process.p = cms.Path(process.thinningThingProducerD2 * process.testA * process.testB * process.testC
+                     * process.slimmingTestA
                      * process.thingProducer
                      * process.thinningThingProducerD
                      * process.thinningThingProducerETEST

--- a/FWCore/Integration/test/ThinningTest3_cfg.py
+++ b/FWCore/Integration/test/ThinningTest3_cfg.py
@@ -240,6 +240,16 @@ process.out = cms.OutputModule("PoolOutputModule",
     )
 )
 
+process.outSlim = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTest3Slimming.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer2alias_*_*',
+        'drop *_aliasO_*_*',
+        'drop *_thinningThingProducer*_*_*',
+    )
+)
+
 process.p = cms.Path(process.thinningThingProducerE2 *
                      process.thinningThingProducerF2 *
                      process.testA *
@@ -260,4 +270,4 @@ process.p = cms.Path(process.thinningThingProducerE2 *
                      process.testO
 )
 
-process.endPath = cms.EndPath(process.out)
+process.endPath = cms.EndPath(process.out*process.outSlim)

--- a/FWCore/Integration/test/ThinningTest4Slimming_cfg.py
+++ b/FWCore/Integration/test/ThinningTest4Slimming_cfg.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST4")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testThinningTest3Slimming.root')
+)
+
+process.slimmingTestA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer', '', 'PROD'),
+    thinnedTag = cms.InputTag('slimmingThingProducerA'),
+    associationTag = cms.InputTag('slimmingThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    thinnedSlimmedCount = cms.int32(1),
+    refSlimmedCount = cms.int32(1),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                       30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49
+    ),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.p = cms.Path(process.slimmingTestA)

--- a/FWCore/Integration/test/ThinningThingProducer.cc
+++ b/FWCore/Integration/test/ThinningThingProducer.cc
@@ -36,6 +36,8 @@ namespace edmtest {
 
     bool choose(unsigned int iIndex, edmtest::Thing const& iItem);
 
+    void reset() { keysToSave_.clear(); }
+
   private:
     edm::EDGetTokenT<TrackOfThingsCollection> trackToken_;
     std::set<unsigned int> keysToSave_;

--- a/FWCore/Integration/test/TrackOfDSVThingsProducer.cc
+++ b/FWCore/Integration/test/TrackOfDSVThingsProducer.cc
@@ -1,0 +1,75 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/TrackOfDSVThings.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+namespace edm {
+  class EventSetup;
+}
+
+namespace edmtest {
+
+  class TrackOfDSVThingsProducer : public edm::global::EDProducer<> {
+  public:
+    explicit TrackOfDSVThingsProducer(edm::ParameterSet const&);
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+  private:
+    void incrementKey(std::vector<unsigned int>::const_iterator& key) const;
+
+    const edm::EDGetTokenT<edmNew::DetSetVector<Thing>> inputToken_;
+    const edm::EDPutTokenT<TrackOfDSVThingsCollection> outputToken_;
+    const std::vector<unsigned int> keysToReference_;
+    const unsigned int nTracks_;
+  };
+
+  TrackOfDSVThingsProducer::TrackOfDSVThingsProducer(edm::ParameterSet const& pset)
+      : inputToken_(consumes<edmNew::DetSetVector<Thing>>(pset.getParameter<edm::InputTag>("inputTag"))),
+        outputToken_(produces<TrackOfDSVThingsCollection>()),
+        keysToReference_(pset.getParameter<std::vector<unsigned int>>("keysToReference")),
+        nTracks_(pset.getParameter<unsigned int>("nTracks")) {}
+
+  void TrackOfDSVThingsProducer::incrementKey(std::vector<unsigned int>::const_iterator& key) const {
+    ++key;
+    if (key == keysToReference_.end())
+      key = keysToReference_.begin();
+  }
+
+  void TrackOfDSVThingsProducer::produce(edm::StreamID, edm::Event& event, edm::EventSetup const&) const {
+    edm::Handle<edmNew::DetSetVector<Thing>> inputCollection = event.getHandle(inputToken_);
+
+    TrackOfDSVThingsCollection result;
+
+    // Arbitrarily fabricate some fake data with TrackOfThings pointing to
+    // Thing objects in products written to the event by a different module.
+    // The numbers in the keys here are made up, passed in via the configuration
+    // and have no meaning other than that we will later check that we can
+    // read out what we put in here.
+    std::vector<unsigned int>::const_iterator key = keysToReference_.begin();
+    for (unsigned int i = 0; i < nTracks_; ++i) {
+      edmtest::TrackOfDSVThings trackOfThings;
+
+      trackOfThings.ref1 = edm::Ref<edmNew::DetSetVector<Thing>, Thing>(inputCollection, *key);
+      incrementKey(key);
+
+      trackOfThings.ref2 = edm::Ref<edmNew::DetSetVector<Thing>, Thing>(inputCollection, *key);
+      incrementKey(key);
+
+      for (auto iKey : keysToReference_) {
+        trackOfThings.refVector1.push_back(edm::Ref<edmNew::DetSetVector<Thing>, Thing>(inputCollection, iKey));
+      }
+
+      result.push_back(trackOfThings);
+    }
+
+    event.emplace(outputToken_, std::move(result));
+  }
+}  // namespace edmtest
+using edmtest::TrackOfDSVThingsProducer;
+DEFINE_FWK_MODULE(TrackOfDSVThingsProducer);

--- a/FWCore/Integration/test/run_ThinningTests.sh
+++ b/FWCore/Integration/test/run_ThinningTests.sh
@@ -20,6 +20,30 @@ pushd ${LOCAL_TMP_DIR}
 
   cmsRun -p ${LOCAL_TEST_DIR}/ThinningTestStreamerIn_cfg.py || die "cmsRun ThinningTestStreamerIn_cfg.py" $?
 
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTest4Slimming_cfg.py || die "cmsRun ThinningTest4Slimming_cfg.py" $?
+
+
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTestSiblings_cfg.py && die "cmsRun SlimmingTestSiblings_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTestFartherSiblings_cfg.py && die "cmsRun SlimmingTestFartherSiblings_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest1_cfg.py || die "cmsRun SlimmingTest1_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2A_cfg.py || die "cmsRun SlimmingTest2A_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2B_cfg.py || die "cmsRun SlimmingTest2B_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2C_cfg.py || die "cmsRun SlimmingTest2C_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2D_cfg.py || die "cmsRun SlimmingTest2D_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2E_cfg.py || die "cmsRun SlimmingTest2E_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2F_cfg.py || die "cmsRun SlimmingTest2E_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3B_cfg.py || die "cmsRun SlimmingTest3B_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3C_cfg.py || die "cmsRun SlimmingTest3C_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3D_cfg.py || die "cmsRun SlimmingTest3D_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3E_cfg.py || die "cmsRun SlimmingTest3E_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest4B_cfg.py || die "cmsRun SlimmingTest4B_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest4F_cfg.py && die "cmsRun SlimmingTest4F_cfg.py" $?
+
 popd
 
 exit 0

--- a/FWCore/Integration/test/run_ThinningTests.sh
+++ b/FWCore/Integration/test/run_ThinningTests.sh
@@ -22,6 +22,8 @@ pushd ${LOCAL_TMP_DIR}
 
   cmsRun -p ${LOCAL_TEST_DIR}/ThinningTest4Slimming_cfg.py || die "cmsRun ThinningTest4Slimming_cfg.py" $?
 
+  cmsRun -p ${LOCAL_TEST_DIR}/DetSetVectorThinningTest1_cfg.py || die "cmsRun DetSetVectorThinningTest1_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/DetSetVectorThinningTest2_cfg.py || die "cmsRun DetSetVectorThinningTest2_cfg.py" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTestSiblings_cfg.py && die "cmsRun SlimmingTestSiblings_cfg.py" $?
 

--- a/FWCore/Integration/test/run_ThinningTests.sh
+++ b/FWCore/Integration/test/run_ThinningTests.sh
@@ -38,6 +38,7 @@ pushd ${LOCAL_TMP_DIR}
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2E_cfg.py || die "cmsRun SlimmingTest2E_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2F_cfg.py || die "cmsRun SlimmingTest2E_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2G_cfg.py || die "cmsRun SlimmingTest2G_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2H_cfg.py || die "cmsRun SlimmingTest2H_cfg.py" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3B_cfg.py || die "cmsRun SlimmingTest3B_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3C_cfg.py || die "cmsRun SlimmingTest3C_cfg.py" $?

--- a/FWCore/Integration/test/run_ThinningTests.sh
+++ b/FWCore/Integration/test/run_ThinningTests.sh
@@ -37,6 +37,7 @@ pushd ${LOCAL_TMP_DIR}
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2D_cfg.py || die "cmsRun SlimmingTest2D_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2E_cfg.py || die "cmsRun SlimmingTest2E_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2F_cfg.py || die "cmsRun SlimmingTest2E_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2G_cfg.py || die "cmsRun SlimmingTest2G_cfg.py" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3B_cfg.py || die "cmsRun SlimmingTest3B_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3C_cfg.py || die "cmsRun SlimmingTest3C_cfg.py" $?

--- a/FWCore/Integration/test/run_ThinningTests.sh
+++ b/FWCore/Integration/test/run_ThinningTests.sh
@@ -43,6 +43,7 @@ pushd ${LOCAL_TMP_DIR}
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3C_cfg.py || die "cmsRun SlimmingTest3C_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3D_cfg.py || die "cmsRun SlimmingTest3D_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3E_cfg.py || die "cmsRun SlimmingTest3E_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3F_cfg.py || die "cmsRun SlimmingTest3F_cfg.py" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest4B_cfg.py || die "cmsRun SlimmingTest4B_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest4F_cfg.py && die "cmsRun SlimmingTest4F_cfg.py" $?

--- a/FWCore/Integration/test/run_ThinningTests.sh
+++ b/FWCore/Integration/test/run_ThinningTests.sh
@@ -39,12 +39,14 @@ pushd ${LOCAL_TMP_DIR}
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2F_cfg.py || die "cmsRun SlimmingTest2E_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2G_cfg.py || die "cmsRun SlimmingTest2G_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2H_cfg.py || die "cmsRun SlimmingTest2H_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest2I_cfg.py || die "cmsRun SlimmingTest2I_cfg.py" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3B_cfg.py || die "cmsRun SlimmingTest3B_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3C_cfg.py || die "cmsRun SlimmingTest3C_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3D_cfg.py || die "cmsRun SlimmingTest3D_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3E_cfg.py || die "cmsRun SlimmingTest3E_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3F_cfg.py || die "cmsRun SlimmingTest3F_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest3I_cfg.py || die "cmsRun SlimmingTest3I_cfg.py" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest4B_cfg.py || die "cmsRun SlimmingTest4B_cfg.py" $?
   cmsRun -p ${LOCAL_TEST_DIR}/SlimmingTest4F_cfg.py && die "cmsRun SlimmingTest4F_cfg.py" $?

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -98,6 +98,7 @@ namespace edm {
       void getThinnedProducts(ProductID const& pid,
                               std::vector<WrapperBase const*>& wrappers,
                               std::vector<unsigned int>& keys) const override;
+      std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override;
 
       unsigned int transitionIndex_() const override;
 

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -98,7 +98,7 @@ namespace edm {
       void getThinnedProducts(ProductID const& pid,
                               std::vector<WrapperBase const*>& wrappers,
                               std::vector<unsigned int>& keys) const override;
-      std::optional<unsigned int> getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override;
+      OptionalThinnedKey getThinnedKeyFrom(ProductID const&, unsigned int, ProductID const&) const override;
 
       unsigned int transitionIndex_() const override;
 

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -494,6 +494,11 @@ namespace edm {
       eventPrincipal_->getThinnedProducts(pid, wrappers, keys);
   }
 
+  std::optional<unsigned int> StreamerInputSource::EventPrincipalHolder::getThinnedKeyFrom(
+      edm::ProductID const& parent, unsigned int index, edm::ProductID const& thinned) const {
+    return eventPrincipal_ ? eventPrincipal_->getThinnedKeyFrom(parent, index, thinned) : std::optional<unsigned int>{};
+  }
+
   unsigned int StreamerInputSource::EventPrincipalHolder::transitionIndex_() const {
     assert(eventPrincipal_ != nullptr);
     return eventPrincipal_->transitionIndex();

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -494,9 +494,13 @@ namespace edm {
       eventPrincipal_->getThinnedProducts(pid, wrappers, keys);
   }
 
-  std::optional<unsigned int> StreamerInputSource::EventPrincipalHolder::getThinnedKeyFrom(
+  edm::OptionalThinnedKey StreamerInputSource::EventPrincipalHolder::getThinnedKeyFrom(
       edm::ProductID const& parent, unsigned int index, edm::ProductID const& thinned) const {
-    return eventPrincipal_ ? eventPrincipal_->getThinnedKeyFrom(parent, index, thinned) : std::optional<unsigned int>{};
+    if (eventPrincipal_) {
+      return eventPrincipal_->getThinnedKeyFrom(parent, index, thinned);
+    } else {
+      return std::monostate{};
+    }
   }
 
   unsigned int StreamerInputSource::EventPrincipalHolder::transitionIndex_() const {


### PR DESCRIPTION
#### PR description:

This PR extends the framework's thinning feature to support slimming as outlined in https://github.com/cms-sw/cmssw/pull/30544#issuecomment-659771991:
* If there are both thinned and thinned+slimmed collections present, a de-reference of Ref-to-parent goes always only to the thinned collections
   * Even if none of the thinned collections contain the requested element (in which case `nullptr` is returned) and the thinned+slimmed collection would contain the requested element
   * I.e. Ref de-reference means
      * if parent collection is available, return element in it
      * else if any thinned collection (branch) exists
         * if a thinned collection containing the element is available, return the element
         * else return `nullptr`
      * else if a slimmed collection (branch) exists, take the first slimmed collection searching downward through the parentage tree of thinned/slimmed collections, and apply this algorithm recursively with the slimmed collection as the parent collection
      * else return `nullptr`
* The parentage tree of thinned and thinned+slimmed collections may have at most one path from the root (parent) collection to any leaf collection that has slimmed collections visible in that job
   * i.e. one can do e.g. `parent -> slimmed1 -> thinned2 -> slimmed3`, but not any of
      ```
      parent --> slimmed11
             \-> slimmed21

      parent --> thinned11 -> slimmed12
             \-> thinned21 -> slimmed22

      parent --> thinned11 -> slimmed12
             \-> slimmed21 -> thinned22
      ```
   * Notably having `slimmed1X` and `slimmed2Y` modules in separate jobs is allowed, assuming the other slimmed products are not visible there.
      * Trying to read both `slimmed1X` and `slimmed2Y` from different files (via primary and secondary inputs) results an error

In addition, this PR
* adds an implementation of `thinnedRefFrom()` (suggested in https://github.com/cms-sw/cmssw/pull/30544#issuecomment-655506600) in a way that does not lead to asking asking products from ProductResolvers (https://github.com/cms-sw/cmssw/pull/30544#issuecomment-657605835)
* adds support for thinning `edmNew::DetSetVector` (needed for #30445)
* adds `ThinnedRefSet` to help with `Selector` to keep track of keys to input collection that may come from any of the parent collections in the parentage tree of thinned collections
* adds `reset()` function to be required on the thinning `Selector` classes. It will be called after the object loop to allow clearing any intermediate data structures.

#### PR validation:

Framework unit tests pass.