### PR TITLE
Migrate GEM/CSC validation to esConsumes

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -16,7 +16,6 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
@@ -89,8 +88,7 @@ CSCTriggerPrimitivesProducer::~CSCTriggerPrimitivesProducer() {}
 
 void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
   // get the csc geometry
-  edm::ESHandle<CSCGeometry> h = setup.getHandle(cscToken_);
-  builder_->setCSCGeometry(&*h);
+  builder_->setCSCGeometry(&setup.getData(cscToken_));
 
   // get the gem geometry if it's there
   edm::ESHandle<GEMGeometry> h_gem = setup.getHandle(gemToken_);

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -40,10 +40,11 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
-#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "CondFormats/DataRecord/interface/CSCDBL1TPParametersRcd.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 
 // temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
 class CSCTriggerPrimitivesProducer : public edm::one::EDProducer<> {

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -1,7 +1,7 @@
 /*
- *  Routine to calculate CSC efficiencies 
+ *  Routine to calculate CSC efficiencies
  *  Comments about the program logic are denoted by //----
- * 
+ *
  *  Stoyan Stoynev, Northwestern University.
  */
 
@@ -74,8 +74,7 @@ bool CSCEfficiency::filter(edm::Event &event, const edm::EventSetup &eventSetup)
   //---- Get the CSC Geometry :
   if (printalot)
     printf("\tget the CSC geometry.\n");
-  edm::ESHandle<CSCGeometry> cscGeom;
-  eventSetup.get<MuonGeometryRecord>().get(cscGeom);
+  edm::ESHandle<CSCGeometry> cscGeom = eventSetup.getHandle(geomToken_);
 
   // use theTrackingGeometry instead of cscGeom?
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
@@ -1685,6 +1684,8 @@ CSCEfficiency::CSCEfficiency(const edm::ParameterSet &pset) {
   tk_token = consumes<edm::View<reco::Track> >(pset.getParameter<edm::InputTag>("tracksTag"));
   sh_token = consumes<edm::PSimHitContainer>(pset.getParameter<edm::InputTag>("simHitTag"));
 
+  geomToken_ = esConsumes<CSCGeometry, MuonGeometryRecord>();
+
   edm::ParameterSet serviceParameters = pset.getParameter<edm::ParameterSet>("ServiceParameters");
   // maybe use the service for getting magnetic field, propagators, etc. ...
   theService = new MuonServiceProxy(serviceParameters, consumesCollector());
@@ -1942,11 +1943,11 @@ CSCEfficiency::CSCEfficiency(const edm::ParameterSet &pset) {
           //
           /*
 	  sprintf(SpecName,"Sim_Rechits_each_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].SimRechits_each = 
+	  ChHist[ec][st][rg][iChamber-FirstCh].SimRechits_each =
 	    new TH1F(SpecName,"Existing RecHit (Sim), each;layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
 	  //
 	  sprintf(SpecName,"Sim_Simhits_each_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].SimSimhits_each = 
+	  ChHist[ec][st][rg][iChamber-FirstCh].SimSimhits_each =
 	    new TH1F(SpecName,"Existing SimHit (Sim), each;layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
 	  */
           theFile->cd();

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
@@ -3,58 +3,39 @@
 
 /** \class CSCEfficiency
  *
- * Efficiency calculations 
+ * Efficiency calculations
  * Stoyan Stoynev, Northwestern University
  */
 
 // how many of the headers below are not needed?...
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Utilities/interface/InputTag.h>
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
-#include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
 
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-#include "DataFormats/MuonDetId/interface/CSCDetId.h"
-#include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
-
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
-#include <Geometry/CSCGeometry/interface/CSCChamber.h>
-#include <Geometry/CSCGeometry/interface/CSCLayer.h>
-#include <Geometry/CSCGeometry/interface/CSCLayerGeometry.h>
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
-
-#include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
-#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCStripDigi.h"
-#include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
-
-#include "DataFormats/CSCDigi/interface/CSCComparatorDigi.h"
-#include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
-
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -68,7 +49,7 @@
 #include "TrackingTools/DetLayers/interface/NavigationDirection.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 
-#include <RecoMuon/TrackingTools/interface/MuonServiceProxy.h>
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -144,6 +125,8 @@ private:
   edm::EDGetTokenT<edm::PSimHitContainer> sh_token;
 
   edm::EDGetTokenT<edm::TriggerResults> ht_token;
+
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
 
   //
   unsigned int printout_NEvents;

--- a/RecoLocalMuon/CSCValidation/src/CSCValidation.cc
+++ b/RecoLocalMuon/CSCValidation/src/CSCValidation.cc
@@ -122,6 +122,8 @@ CSCValidation::CSCValidation(const ParameterSet& pset) {
   // setup trees to hold global position data for rechits and segments
   if (writeTreeToFile)
     histos->setupTrees();
+
+  geomToken_ = esConsumes<CSCGeometry, MuonGeometryRecord>();
 }
 
 //////////////////
@@ -195,8 +197,7 @@ void CSCValidation::analyze(const Event& event, const EventSetup& eventSetup) {
   }
 
   // Get the CSC Geometry :
-  edm::ESHandle<CSCGeometry> cscGeom;
-  eventSetup.get<MuonGeometryRecord>().get(cscGeom);
+  edm::ESHandle<CSCGeometry> cscGeom = eventSetup.getHandle(geomToken_);
 
   // Get the RecHits collection :
   edm::Handle<CSCRecHit2DCollection> recHits;

--- a/RecoLocalMuon/CSCValidation/src/CSCValidation.h
+++ b/RecoLocalMuon/CSCValidation/src/CSCValidation.h
@@ -19,25 +19,18 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
-#include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCStripDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCComparatorDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 
 #include "EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h"
@@ -64,9 +57,7 @@
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
-#include "DataFormats/MuonDetId/interface/CSCDetId.h"
-#include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
-#include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutRecord.h"
@@ -75,9 +66,6 @@
 #include "FWCore/Common/interface/TriggerNames.h"
 
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
-#include "Geometry/CSCGeometry/interface/CSCChamber.h"
-#include "Geometry/CSCGeometry/interface/CSCLayer.h"
-#include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -258,6 +246,7 @@ private:
   edm::EDGetTokenT<edm::TriggerResults> tr_token;
   edm::EDGetTokenT<reco::TrackCollection> sa_token;
   edm::EDGetTokenT<edm::PSimHitContainer> sh_token;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
 
   // module on/off switches
   bool makeOccupancyPlots;

--- a/Validation/CSCRecHits/src/CSCRecHitValidation.h
+++ b/Validation/CSCRecHits/src/CSCRecHitValidation.h
@@ -3,14 +3,15 @@
 
 // user include files
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
-#include <DQMServices/Core/interface/DQMStore.h>
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
 
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "SimMuon/MCTruth/interface/PSimHitMap.h"
 #include "Validation/CSCRecHits/src/CSCRecHit2DValidation.h"
 #include "Validation/CSCRecHits/src/CSCSegmentValidation.h"
@@ -24,7 +25,7 @@ public:
 
 private:
   PSimHitMap theSimHitMap;
-  const CSCGeometry *theCSCGeometry;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
 
   CSCRecHit2DValidation *the2DValidation;
   CSCSegmentValidation *theSegmentValidation;

--- a/Validation/MuonCSCDigis/interface/CSCBaseValidation.h
+++ b/Validation/MuonCSCDigis/interface/CSCBaseValidation.h
@@ -4,7 +4,6 @@
 // user include files
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 

--- a/Validation/MuonCSCDigis/interface/CSCStubMatcher.h
+++ b/Validation/MuonCSCDigis/interface/CSCStubMatcher.h
@@ -105,7 +105,7 @@ private:
   std::shared_ptr<CSCDigiMatcher> cscDigiMatcher_;
   std::shared_ptr<GEMDigiMatcher> gemDigiMatcher_;
 
-  edm::ESHandle<CSCGeometry> csc_geom_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
   const CSCGeometry* cscGeometry_;
 
   // all stubs (not necessarily matching) in crossed chambers with digis

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
@@ -55,8 +55,7 @@ void CSCDigiValidation::analyze(const edm::Event &e, const edm::EventSetup &even
   theSimHitMap.fill(e);
 
   // find the geometry & conditions for this event
-  edm::ESHandle<CSCGeometry> hGeom = eventSetup.getHandle(geomToken_);
-  const CSCGeometry *pGeom = &*hGeom;
+  const CSCGeometry *pGeom = &eventSetup.getData(geomToken_);
 
   theStripDigiValidation->setGeometry(pGeom);
   theWireDigiValidation->setGeometry(pGeom);

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.cc
@@ -1,7 +1,5 @@
 #include "Validation/MuonCSCDigis/plugins/CSCDigiValidation.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Validation/MuonCSCDigis/interface/CSCALCTDigiValidation.h"
 #include "Validation/MuonCSCDigis/interface/CSCCLCTDigiValidation.h"
 #include "Validation/MuonCSCDigis/interface/CSCComparatorDigiValidation.h"
@@ -37,6 +35,7 @@ CSCDigiValidation::CSCDigiValidation(const edm::ParameterSet &ps)
     theWireDigiValidation->setSimHitMap(&theSimHitMap);
     theComparatorDigiValidation->setSimHitMap(&theSimHitMap);
   }
+  geomToken_ = esConsumes<CSCGeometry, MuonGeometryRecord>();
 }
 
 CSCDigiValidation::~CSCDigiValidation() {}
@@ -56,8 +55,7 @@ void CSCDigiValidation::analyze(const edm::Event &e, const edm::EventSetup &even
   theSimHitMap.fill(e);
 
   // find the geometry & conditions for this event
-  edm::ESHandle<CSCGeometry> hGeom;
-  eventSetup.get<MuonGeometryRecord>().get(hGeom);
+  edm::ESHandle<CSCGeometry> hGeom = eventSetup.getHandle(geomToken_);
   const CSCGeometry *pGeom = &*hGeom;
 
   theStripDigiValidation->setGeometry(pGeom);

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.h
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.h
@@ -5,11 +5,13 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "SimMuon/MCTruth/interface/PSimHitMap.h"
 
 class CSCStripDigiValidation;
@@ -35,6 +37,8 @@ private:
   std::unique_ptr<CSCComparatorDigiValidation> theComparatorDigiValidation;
   std::unique_ptr<CSCALCTDigiValidation> theALCTDigiValidation;
   std::unique_ptr<CSCCLCTDigiValidation> theCLCTDigiValidation;
+
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
 };
 
 #endif

--- a/Validation/MuonCSCDigis/plugins/CSCDigiValidation.h
+++ b/Validation/MuonCSCDigis/plugins/CSCDigiValidation.h
@@ -3,7 +3,6 @@
 
 // user include files
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -50,12 +50,7 @@ void CSCStubMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetu
   iEvent.getByToken(lctToken_, lctsH_);
   iEvent.getByToken(mplctToken_, mplctsH_);
 
-  edm::ESHandle<CSCGeometry> hGeom = iSetup.getHandle(geomToken_);
-  if (hGeom.isValid()) {
-    cscGeometry_ = hGeom.product();
-  } else {
-    edm::LogError("CSCStubMatcher") << "+++ Info: CSC geometry is unavailable.";
-  }
+  cscGeometry_ = &iSetup.getData(geomToken_);
 }
 
 // do the matching

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -37,6 +37,8 @@ CSCStubMatcher::CSCStubMatcher(const edm::ParameterSet& pSet, edm::ConsumesColle
   alctToken_ = iC.consumes<CSCALCTDigiCollection>(cscALCT.getParameter<edm::InputTag>("inputTag"));
   lctToken_ = iC.consumes<CSCCorrelatedLCTDigiCollection>(cscLCT.getParameter<edm::InputTag>("inputTag"));
   mplctToken_ = iC.consumes<CSCCorrelatedLCTDigiCollection>(cscMPLCT.getParameter<edm::InputTag>("inputTag"));
+
+  geomToken_ = iC.esConsumes<CSCGeometry, MuonGeometryRecord>();
 }
 
 void CSCStubMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -48,9 +50,9 @@ void CSCStubMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetu
   iEvent.getByToken(lctToken_, lctsH_);
   iEvent.getByToken(mplctToken_, mplctsH_);
 
-  iSetup.get<MuonGeometryRecord>().get(csc_geom_);
-  if (csc_geom_.isValid()) {
-    cscGeometry_ = &*csc_geom_;
+  edm::ESHandle<CSCGeometry> hGeom = iSetup.getHandle(geomToken_);
+  if (hGeom.isValid()) {
+    cscGeometry_ = hGeom.product();
   } else {
     edm::LogError("CSCStubMatcher") << "+++ Info: CSC geometry is unavailable.";
   }

--- a/Validation/MuonGEMDigis/interface/GEMDigiMatcher.h
+++ b/Validation/MuonGEMDigis/interface/GEMDigiMatcher.h
@@ -132,7 +132,7 @@ private:
 
   std::shared_ptr<GEMSimHitMatcher> muonSimHitMatcher_;
 
-  edm::ESHandle<GEMGeometry> gem_geom_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
   const GEMGeometry* gemGeometry_;
 
   template <class T>

--- a/Validation/MuonGEMDigis/plugins/GEMCheckGeometry.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMCheckGeometry.cc
@@ -1,10 +1,7 @@
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/GEMGeometry/interface/GEMEtaPartitionSpecs.h"
-#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Validation/MuonGEMDigis/plugins/GEMCheckGeometry.h"
 
 #include <iomanip>
@@ -15,18 +12,15 @@ GEMCheckGeometry::GEMCheckGeometry(const edm::ParameterSet &gc) {
   minPhi_ = gc.getUntrackedParameter<double>("minPhi", -180.);
   maxPhi_ = gc.getUntrackedParameter<double>("maxPhi", +180.);
   detailPlot_ = gc.getParameter<bool>("detailPlot");
+  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
 }
 
 void GEMCheckGeometry::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &Run, edm::EventSetup const &iSetup) {
   if (!detailPlot_)
     return;
-  const GEMGeometry *GEMGeometry_;
 
-  try {
-    edm::ESHandle<GEMGeometry> hGeom;
-    iSetup.get<MuonGeometryRecord>().get(hGeom);
-    GEMGeometry_ = &*hGeom;
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry> &e) {
+  const GEMGeometry *GEMGeometry_ = &iSetup.getData(geomToken_);
+  if (!GEMGeometry_) {
     edm::LogError("MuonGEMGeometry") << "+++ Error : GEM geometry  is unavailable on event loop. +++\n";
     return;
   }

--- a/Validation/MuonGEMDigis/plugins/GEMCheckGeometry.h
+++ b/Validation/MuonGEMDigis/plugins/GEMCheckGeometry.h
@@ -9,6 +9,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 class GEMCheckGeometry : public DQMEDAnalyzer {
 public:
@@ -25,6 +27,7 @@ private:
   double minPhi_;
   double maxPhi_;
   bool detailPlot_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 };
 
 #endif

--- a/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.cc
@@ -6,6 +6,8 @@ GEMCoPadDigiValidation::GEMCoPadDigiValidation(const edm::ParameterSet& pset)
 
   const auto& copad_tag = copad_pset.getParameter<edm::InputTag>("inputTag");
   copad_token_ = consumes<GEMCoPadDigiCollection>(copad_tag);
+  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
+  geomTokenBeginRun_ = esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 
   gem_bx_min_ = copad_pset.getParameter<int>("minBX");
   gem_bx_max_ = copad_pset.getParameter<int>("maxBX");
@@ -14,7 +16,7 @@ GEMCoPadDigiValidation::GEMCoPadDigiValidation(const edm::ParameterSet& pset)
 void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
                                             edm::Run const& run,
                                             edm::EventSetup const& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomTokenBeginRun_);
 
   // NOTE Occupancy
   booker.setCurrentFolder("MuonGEMDigisV/GEMDigisTask/CoPad/Occupancy");
@@ -92,7 +94,7 @@ void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 GEMCoPadDigiValidation::~GEMCoPadDigiValidation() {}
 
 void GEMCoPadDigiValidation::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomToken_);
 
   edm::Handle<GEMCoPadDigiCollection> copad_collection;
   event.getByToken(copad_token_, copad_collection);

--- a/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.h
+++ b/Validation/MuonGEMDigis/plugins/GEMCoPadDigiValidation.h
@@ -23,6 +23,8 @@ private:
 
   // Parameters
   edm::EDGetTokenT<GEMCoPadDigiCollection> copad_token_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomTokenBeginRun_;
 
   //
   int gem_bx_min_, gem_bx_max_;

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
@@ -6,12 +6,14 @@ GEMPadDigiClusterValidation::GEMPadDigiClusterValidation(const edm::ParameterSet
   const auto& pad_cluster_pset = pset.getParameterSet("gemPadCluster");
   const auto& pad_cluster_tag = pad_cluster_pset.getParameter<edm::InputTag>("inputTag");
   pad_cluster_token_ = consumes<GEMPadDigiClusterCollection>(pad_cluster_tag);
+  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
+  geomTokenBeginRun_ = esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 }
 
 void GEMPadDigiClusterValidation::bookHistograms(DQMStore::IBooker& booker,
                                                  edm::Run const& Run,
                                                  edm::EventSetup const& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomTokenBeginRun_);
 
   // NOTE Occupancy
   booker.setCurrentFolder("MuonGEMDigisV/GEMDigisTask/PadCluster/Occupancy");
@@ -109,7 +111,7 @@ void GEMPadDigiClusterValidation::bookHistograms(DQMStore::IBooker& booker,
 GEMPadDigiClusterValidation::~GEMPadDigiClusterValidation() {}
 
 void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomToken_);
 
   edm::Handle<GEMPadDigiClusterCollection> collection;
   event.getByToken(pad_cluster_token_, collection);

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.h
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.h
@@ -21,6 +21,8 @@ private:
   MEMap3Ids me_detail_bx_;
 
   edm::EDGetTokenT<GEMPadDigiClusterCollection> pad_cluster_token_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomTokenBeginRun_;
 };
 
 #endif  // Validation_MuonGEMDigis_GEMPadDigiClusterValidation_h

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
@@ -5,12 +5,14 @@ GEMPadDigiValidation::GEMPadDigiValidation(const edm::ParameterSet& pset)
   const auto& pad_pset = pset.getParameterSet("gemPadDigi");
   const auto& pad_tag = pad_pset.getParameter<edm::InputTag>("inputTag");
   pad_token_ = consumes<GEMPadDigiCollection>(pad_tag);
+  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
+  geomTokenBeginRun_ = esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 }
 
 void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
                                           edm::Run const& Run,
                                           edm::EventSetup const& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomTokenBeginRun_);
 
   // NOTE Occupancy
   booker.setCurrentFolder("MuonGEMDigisV/GEMDigisTask/Pad/Occupancy");
@@ -109,7 +111,7 @@ void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 GEMPadDigiValidation::~GEMPadDigiValidation() {}
 
 void GEMPadDigiValidation::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomToken_);
 
   edm::Handle<GEMPadDigiCollection> collection;
   event.getByToken(pad_token_, collection);

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.h
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.h
@@ -14,6 +14,8 @@ public:
 private:
   // NOTE Parameters
   edm::EDGetTokenT<GEMPadDigiCollection> pad_token_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomTokenBeginRun_;
 
   // NOTE MonitorElemnts
   MEMap2Ids me_occ_det_;

--- a/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.cc
@@ -10,12 +10,14 @@ GEMStripDigiValidation::GEMStripDigiValidation(const edm::ParameterSet& pset)
   const auto& simhit_pset = pset.getParameterSet("gemSimHit");
   const auto& simhit_tag = simhit_pset.getParameter<edm::InputTag>("inputTag");
   simhit_token_ = consumes<edm::PSimHitContainer>(simhit_tag);
+  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
+  geomTokenBeginRun_ = esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 }
 
 void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
                                             edm::Run const& run,
                                             edm::EventSetup const& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomTokenBeginRun_);
   if (gem == nullptr) {
     edm::LogError(kLogCategory_) << "Failed to initialize GEM geometry.";
     return;
@@ -162,7 +164,7 @@ void GEMStripDigiValidation::bookHistograms(DQMStore::IBooker& booker,
 GEMStripDigiValidation::~GEMStripDigiValidation() {}
 
 void GEMStripDigiValidation::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomToken_);
   if (gem == nullptr) {
     edm::LogError(kLogCategory_) << "Failed to initialize GEM geometry.";
     return;

--- a/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.h
+++ b/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.h
@@ -15,6 +15,8 @@ private:
   // ParameterSet
   edm::EDGetTokenT<GEMDigiCollection> strip_token_;
   edm::EDGetTokenT<edm::PSimHitContainer> simhit_token_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomTokenBeginRun_;
 
   // NOTE Monitor elements
 

--- a/Validation/MuonGEMHits/interface/GEMBaseValidation.h
+++ b/Validation/MuonGEMHits/interface/GEMBaseValidation.h
@@ -7,7 +7,6 @@
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -92,6 +91,7 @@ protected:
   // NOTE Constants
   const Int_t kMuonPDGId_ = 13;
   const std::string kLogCategory_;  // see member initializer list
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 };
 
 template <typename T>

--- a/Validation/MuonGEMHits/interface/GEMBaseValidation.h
+++ b/Validation/MuonGEMHits/interface/GEMBaseValidation.h
@@ -22,7 +22,6 @@ public:
   void analyze(const edm::Event& e, const edm::EventSetup&) override = 0;
 
 protected:
-  const GEMGeometry* initGeometry(const edm::EventSetup&);
   Int_t getDetOccBinX(Int_t chamber_id, Int_t layer_id);
   Bool_t isMuonSimHit(const PSimHit&);
 
@@ -92,6 +91,7 @@ protected:
   const Int_t kMuonPDGId_ = 13;
   const std::string kLogCategory_;  // see member initializer list
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomTokenBeginRun_;
 };
 
 template <typename T>

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -9,12 +9,14 @@ GEMSimHitValidation::GEMSimHitValidation(const edm::ParameterSet& pset)
   simhit_token_ = consumes<edm::PSimHitContainer>(simhit_tag);
 
   tof_range_ = pset.getUntrackedParameter<std::vector<Double_t> >("TOFRange");
+  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
+  geomTokenBeginRun_ = esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 }
 
 GEMSimHitValidation::~GEMSimHitValidation() {}
 
 void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run const& run, edm::EventSetup const& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomTokenBeginRun_);
 
   // NOTE Time of flight
   booker.setCurrentFolder("MuonGEMHitsV/GEMHitsTask/TimeOfFlight");
@@ -155,7 +157,7 @@ std::tuple<Double_t, Double_t> GEMSimHitValidation::getTOFRange(Int_t station_id
 }
 
 void GEMSimHitValidation::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomToken_);
 
   edm::Handle<edm::PSimHitContainer> simhit_container;
   event.getByToken(simhit_token_, simhit_container);

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.h
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.h
@@ -20,6 +20,8 @@ private:
 
   // Parameters
   edm::EDGetTokenT<edm::PSimHitContainer> simhit_token_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomTokenBeginRun_;
   std::vector<Double_t> tof_range_;
 
   // Monitor elemnts

--- a/Validation/MuonGEMHits/src/GEMBaseValidation.cc
+++ b/Validation/MuonGEMHits/src/GEMBaseValidation.cc
@@ -16,12 +16,9 @@ GEMBaseValidation::GEMBaseValidation(const edm::ParameterSet& ps, std::string lo
   eta_range_ = ps.getUntrackedParameter<std::vector<Double_t> >("EtaOccRange");
 
   detail_plot_ = ps.getParameter<Bool_t>("detailPlot");
-  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
 }
 
 GEMBaseValidation::~GEMBaseValidation() {}
-
-const GEMGeometry* GEMBaseValidation::initGeometry(edm::EventSetup const& setup) { return &setup.getData(geomToken_); }
 
 Int_t GEMBaseValidation::getDetOccBinX(Int_t chamber_id, Int_t layer_id) { return 2 * chamber_id + layer_id - 2; }
 

--- a/Validation/MuonGEMHits/src/GEMBaseValidation.cc
+++ b/Validation/MuonGEMHits/src/GEMBaseValidation.cc
@@ -16,16 +16,12 @@ GEMBaseValidation::GEMBaseValidation(const edm::ParameterSet& ps, std::string lo
   eta_range_ = ps.getUntrackedParameter<std::vector<Double_t> >("EtaOccRange");
 
   detail_plot_ = ps.getParameter<Bool_t>("detailPlot");
+  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
 }
 
 GEMBaseValidation::~GEMBaseValidation() {}
 
-const GEMGeometry* GEMBaseValidation::initGeometry(edm::EventSetup const& setup) {
-  edm::ESHandle<GEMGeometry> geom_handle;
-  setup.get<MuonGeometryRecord>().get(geom_handle);
-  const GEMGeometry* gem = &*geom_handle;
-  return gem;
-}
+const GEMGeometry* GEMBaseValidation::initGeometry(edm::EventSetup const& setup) { return &setup.getData(geomToken_); }
 
 Int_t GEMBaseValidation::getDetOccBinX(Int_t chamber_id, Int_t layer_id) { return 2 * chamber_id + layer_id - 2; }
 

--- a/Validation/MuonGEMRecHits/interface/GEMRecHitMatcher.h
+++ b/Validation/MuonGEMRecHits/interface/GEMRecHitMatcher.h
@@ -14,7 +14,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
@@ -91,7 +90,7 @@ private:
   edm::EDGetTokenT<GEMRecHitCollection> gemRecHitToken_;
   edm::Handle<GEMRecHitCollection> gemRecHitH_;
 
-  edm::ESHandle<GEMGeometry> gem_geom_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
   const GEMGeometry* gemGeometry_;
 
   int minBX_, maxBX_;

--- a/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
+++ b/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
@@ -12,12 +12,14 @@ GEMRecHitValidation::GEMRecHitValidation(const edm::ParameterSet& pset)
   const auto& simhit_pset = pset.getParameterSet("gemSimHit");
   const auto& simhit_tag = simhit_pset.getParameter<edm::InputTag>("inputTag");
   simhit_token_ = consumes<edm::PSimHitContainer>(simhit_tag);
+  geomToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
+  geomTokenBeginRun_ = esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 }
 
 GEMRecHitValidation::~GEMRecHitValidation() {}
 
 void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run const& run, edm::EventSetup const& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomTokenBeginRun_);
 
   // NOTE Cluster Size
   booker.setCurrentFolder("MuonGEMRecHitsV/GEMRecHitsTask/ClusterSize");
@@ -189,7 +191,7 @@ Bool_t GEMRecHitValidation::matchRecHitAgainstSimHit(GEMRecHitCollection::const_
 }
 
 void GEMRecHitValidation::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-  const GEMGeometry* gem = initGeometry(setup);
+  const GEMGeometry* gem = &setup.getData(geomToken_);
 
   edm::Handle<edm::PSimHitContainer> simhit_container;
   event.getByToken(simhit_token_, simhit_container);

--- a/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.h
+++ b/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.h
@@ -15,9 +15,10 @@ private:
   Bool_t matchRecHitAgainstSimHit(GEMRecHitCollection::const_iterator, Int_t);
 
   // Parameter
-
   edm::EDGetTokenT<GEMRecHitCollection> rechit_token_;
   edm::EDGetTokenT<edm::PSimHitContainer> simhit_token_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomTokenBeginRun_;
 
   // MonitorElement
   MonitorElement* me_cls_;

--- a/Validation/MuonGEMRecHits/src/GEMRecHitMatcher.cc
+++ b/Validation/MuonGEMRecHits/src/GEMRecHitMatcher.cc
@@ -14,6 +14,7 @@ GEMRecHitMatcher::GEMRecHitMatcher(const edm::ParameterSet& pset, edm::ConsumesC
   gemDigiMatcher_.reset(new GEMDigiMatcher(pset, std::move(iC)));
 
   gemRecHitToken_ = iC.consumes<GEMRecHitCollection>(gemRecHit.getParameter<edm::InputTag>("inputTag"));
+  geomToken_ = iC.esConsumes<GEMGeometry, MuonGeometryRecord>();
 }
 
 void GEMRecHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -21,12 +22,7 @@ void GEMRecHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSe
 
   iEvent.getByToken(gemRecHitToken_, gemRecHitH_);
 
-  iSetup.get<MuonGeometryRecord>().get(gem_geom_);
-  if (gem_geom_.isValid()) {
-    gemGeometry_ = &*gem_geom_;
-  } else {
-    std::cout << "+++ Info: GEM geometry is unavailable. +++\n";
-  }
+  gemGeometry_ = &iSetup.getData(geomToken_);
 }
 
 /// do the matching
@@ -60,7 +56,7 @@ void GEMRecHitMatcher::matchRecHitsToSimTrack(const GEMRecHitCollection& rechits
 
     for (auto d = rechits_in_det.first; d != rechits_in_det.second; ++d) {
       if (verbose())
-        cout << "recHit " << p_id << " " << *d << endl;
+        edm::LogInfo("GEMDigiMatcher") << "recHit " << p_id << " " << *d << endl;
 
       // check that the rechit is within BX range
       if (d->BunchX() < minBX_ || d->BunchX() > maxBX_)
@@ -80,7 +76,7 @@ void GEMRecHitMatcher::matchRecHitsToSimTrack(const GEMRecHitCollection& rechits
       if (!stripFound)
         continue;
       if (verbose())
-        cout << "oki" << endl;
+        edm::LogInfo("GEMDigiMatcher") << "oki" << endl;
 
       recHits_.push_back(*d);
       detid_to_recHits_[id].push_back(*d);

--- a/Validation/MuonHits/interface/CSCSimHitMatcher.h
+++ b/Validation/MuonHits/interface/CSCSimHitMatcher.h
@@ -8,6 +8,8 @@
    Author: Sven Dildick (TAMU), Tao Huang (TAMU)
 */
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Validation/MuonHits/interface/MuonSimHitMatcher.h"
 
@@ -75,7 +77,7 @@ private:
 
   void clear();
 
-  edm::ESHandle<CSCGeometry> csc_geom_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
 };
 
 #endif

--- a/Validation/MuonHits/interface/DTSimHitMatcher.h
+++ b/Validation/MuonHits/interface/DTSimHitMatcher.h
@@ -8,6 +8,8 @@
    Author: Sven Dildick (TAMU), Tao Huang (TAMU)
 */
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Validation/MuonHits/interface/MuonSimHitMatcher.h"
 
@@ -73,7 +75,7 @@ private:
   std::map<unsigned int, edm::PSimHitContainer> layer_to_hits_;
   std::map<unsigned int, edm::PSimHitContainer> superlayer_to_hits_;
 
-  edm::ESHandle<DTGeometry> dt_geom_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> geomToken_;
 };
 
 #endif

--- a/Validation/MuonHits/interface/GEMSimHitMatcher.h
+++ b/Validation/MuonHits/interface/GEMSimHitMatcher.h
@@ -8,6 +8,8 @@
    Author: Sven Dildick (TAMU), Tao Huang (TAMU)
 */
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "Validation/MuonHits/interface/MuonSimHitMatcher.h"
 
@@ -77,7 +79,7 @@ private:
 
   void clear();
 
-  edm::ESHandle<GEMGeometry> gem_geom_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 
   std::map<unsigned int, edm::PSimHitContainer> superchamber_to_hits_;
 

--- a/Validation/MuonHits/interface/ME0SimHitMatcher.h
+++ b/Validation/MuonHits/interface/ME0SimHitMatcher.h
@@ -8,6 +8,8 @@
    Author: Sven Dildick (TAMU), Tao Huang (TAMU)
 */
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 #include "Validation/MuonHits/interface/MuonSimHitMatcher.h"
 
@@ -62,7 +64,7 @@ public:
 private:
   void matchSimHitsToSimTrack();
 
-  edm::ESHandle<ME0Geometry> me0_geom_;
+  edm::ESGetToken<ME0Geometry, MuonGeometryRecord> geomToken_;
 
   // detids with hits in pads
   std::map<unsigned int, std::set<int> > detids_to_pads_;

--- a/Validation/MuonHits/interface/MuonSimHitMatcher.h
+++ b/Validation/MuonHits/interface/MuonSimHitMatcher.h
@@ -11,7 +11,6 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/Validation/MuonHits/interface/RPCSimHitMatcher.h
+++ b/Validation/MuonHits/interface/RPCSimHitMatcher.h
@@ -8,6 +8,8 @@
    Author: Sven Dildick (TAMU), Tao Huang (TAMU)
 */
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 #include "Validation/MuonHits/interface/MuonSimHitMatcher.h"
 
@@ -44,7 +46,7 @@ public:
 private:
   void matchSimHitsToSimTrack();
 
-  edm::ESHandle<RPCGeometry> rpc_geom_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> geomToken_;
 };
 
 #endif

--- a/Validation/MuonHits/plugins/MuonSimHitsValidAnalyzer.cc
+++ b/Validation/MuonHits/plugins/MuonSimHitsValidAnalyzer.cc
@@ -68,6 +68,7 @@ MuonSimHitsValidAnalyzer::MuonSimHitsValidAnalyzer(const edm::ParameterSet& iPSe
   nummu_DT = 0;
   nummu_CSC = 0;
   nummu_RPC = 0;
+  geomToken_ = esConsumes<DTGeometry, MuonGeometryRecord>();
 }
 
 MuonSimHitsValidAnalyzer::~MuonSimHitsValidAnalyzer() {}
@@ -309,15 +310,13 @@ void MuonSimHitsValidAnalyzer::fillDT(const edm::Event& iEvent, const edm::Event
   edm::PSimHitContainer::const_iterator itHit;
 
   /// access the DT
-  /// access the DT geometry
-  edm::ESHandle<DTGeometry> theDTGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theDTGeometry);
-  if (!theDTGeometry.isValid()) {
+  edm::ESHandle<DTGeometry> hGeom = iSetup.getHandle(geomToken_);
+  if (!hGeom.isValid()) {
     edm::LogWarning("MuonSimHitsValidAnalyzer::fillDT")
         << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
   }
-  const DTGeometry& theDTMuon(*theDTGeometry);
+  const DTGeometry& theDTMuon(*hGeom);
 
   /// get DT information
   edm::Handle<edm::PSimHitContainer> MuonDTContainer;

--- a/Validation/MuonHits/plugins/MuonSimHitsValidAnalyzer.h
+++ b/Validation/MuonHits/plugins/MuonSimHitsValidAnalyzer.h
@@ -6,7 +6,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -87,6 +86,7 @@ private:
 
   /// Input tags
   edm::EDGetTokenT<edm::PSimHitContainer> DTHitsToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> geomToken_;
 
   // Monitor elements
   // DT

--- a/Validation/MuonHits/src/CSCSimHitMatcher.cc
+++ b/Validation/MuonHits/src/CSCSimHitMatcher.cc
@@ -15,13 +15,7 @@ CSCSimHitMatcher::CSCSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
 
 /// initialize the event
 void CSCSimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<CSCGeometry> hGeom = iSetup.getHandle(geomToken_);
-  if (hGeom.isValid()) {
-    geometry_ = hGeom.product();
-  } else {
-    hasGeometry_ = false;
-    edm::LogWarning("CSCSimHitMatcher") << "+++ Info: CSC geometry is unavailable. +++\n";
-  }
+  geometry_ = &iSetup.getData(geomToken_);
   MuonSimHitMatcher::init(iEvent, iSetup);
 }
 
@@ -38,27 +32,24 @@ void CSCSimHitMatcher::match(const SimTrack& track, const SimVertex& vertex) {
   if (std::abs(track.momentum().eta()) > 2.45)
     return;
 
-  if (hasGeometry_) {
-    matchSimHitsToSimTrack();
+  matchSimHitsToSimTrack();
 
-    if (verbose_) {
-      edm::LogInfo("CSCSimHitMatcher") << "nTrackIds " << track_ids_.size() << " nSelectedCSCSimHits " << hits_.size()
-                                       << endl;
-      edm::LogInfo("CSCSimHitMatcher") << "detids CSC " << detIds(0).size() << endl;
+  if (verbose_) {
+    edm::LogInfo("CSCSimHitMatcher") << "nTrackIds " << track_ids_.size() << " nSelectedCSCSimHits " << hits_.size();
+    edm::LogInfo("CSCSimHitMatcher") << "detids CSC " << detIds(0).size();
 
-      for (const auto& id : detIds(0)) {
-        const auto& simhits = hitsInDetId(id);
-        const auto& simhits_gp = simHitsMeanPosition(simhits);
-        const auto& strips = hitStripsInDetId(id);
-        CSCDetId cscid(id);
-        if (cscid.station() == 1 and (cscid.ring() == 1 or cscid.ring() == 4)) {
-          edm::LogInfo("CSCSimHitMatcher") << "cscdetid " << CSCDetId(id) << ": " << simhits.size() << " "
-                                           << simhits_gp.phi() << " " << detid_to_hits_[id].size() << endl;
-          edm::LogInfo("CSCSimHitMatcher") << "nStrip " << strips.size() << endl;
-          edm::LogInfo("CSCSimHitMatcher") << "strips : ";
-          for (const auto& p : strips) {
-            edm::LogInfo("CSCSimHitMatcher") << p;
-          }
+    for (const auto& id : detIds(0)) {
+      const auto& simhits = hitsInDetId(id);
+      const auto& simhits_gp = simHitsMeanPosition(simhits);
+      const auto& strips = hitStripsInDetId(id);
+      CSCDetId cscid(id);
+      if (cscid.station() == 1 and (cscid.ring() == 1 or cscid.ring() == 4)) {
+        edm::LogInfo("CSCSimHitMatcher") << "cscdetid " << CSCDetId(id) << ": " << simhits.size() << " "
+                                         << simhits_gp.phi() << " " << detid_to_hits_[id].size();
+        edm::LogInfo("CSCSimHitMatcher") << "nStrip " << strips.size();
+        edm::LogInfo("CSCSimHitMatcher") << "strips : ";
+        for (const auto& p : strips) {
+          edm::LogInfo("CSCSimHitMatcher") << p;
         }
       }
     }

--- a/Validation/MuonHits/src/CSCSimHitMatcher.cc
+++ b/Validation/MuonHits/src/CSCSimHitMatcher.cc
@@ -10,13 +10,14 @@ CSCSimHitMatcher::CSCSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
   discardEleHits_ = simHitPSet_.getParameter<bool>("discardEleHits");
 
   simHitInput_ = iC.consumes<edm::PSimHitContainer>(simHitPSet_.getParameter<edm::InputTag>("inputTag"));
+  geomToken_ = iC.esConsumes<CSCGeometry, MuonGeometryRecord>();
 }
 
 /// initialize the event
 void CSCSimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(csc_geom_);
-  if (csc_geom_.isValid()) {
-    geometry_ = &*csc_geom_;
+  edm::ESHandle<CSCGeometry> hGeom = iSetup.getHandle(geomToken_);
+  if (hGeom.isValid()) {
+    geometry_ = hGeom.product();
   } else {
     hasGeometry_ = false;
     edm::LogWarning("CSCSimHitMatcher") << "+++ Info: CSC geometry is unavailable. +++\n";

--- a/Validation/MuonHits/src/DTSimHitMatcher.cc
+++ b/Validation/MuonHits/src/DTSimHitMatcher.cc
@@ -15,13 +15,7 @@ DTSimHitMatcher::DTSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesColle
 
 /// initialize the event
 void DTSimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<DTGeometry> hGeom = iSetup.getHandle(geomToken_);
-  if (hGeom.isValid()) {
-    geometry_ = hGeom.product();
-  } else {
-    hasGeometry_ = false;
-    edm::LogWarning("DTSimHitMatcher") << "+++ Info: DT geometry is unavailable. +++\n";
-  }
+  geometry_ = &iSetup.getData(geomToken_);
   MuonSimHitMatcher::init(iEvent, iSetup);
 }
 
@@ -30,22 +24,19 @@ void DTSimHitMatcher::match(const SimTrack& track, const SimVertex& vertex) {
   // instantiates the track ids and simhits
   MuonSimHitMatcher::match(track, vertex);
 
-  if (hasGeometry_) {
-    matchSimHitsToSimTrack();
+  matchSimHitsToSimTrack();
 
-    if (verbose_) {
-      edm::LogInfo("DTSimHitMatcher") << "nTrackIds " << track_ids_.size() << " nSelectedDTSimHits " << hits_.size()
-                                      << endl;
-      edm::LogInfo("DTSimHitMatcher") << "detids DT " << detIds(0).size() << endl;
+  if (verbose_) {
+    edm::LogInfo("DTSimHitMatcher") << "nTrackIds " << track_ids_.size() << " nSelectedDTSimHits " << hits_.size();
+    edm::LogInfo("DTSimHitMatcher") << "detids DT " << detIds(0).size();
 
-      const auto& dt_det_ids = detIds(0);
-      for (const auto& id : dt_det_ids) {
-        const auto& dt_simhits = MuonSimHitMatcher::hitsInDetId(id);
-        const auto& dt_simhits_gp = simHitsMeanPosition(dt_simhits);
-        edm::LogInfo("DTSimHitMatcher") << "DTWireId " << DTWireId(id) << ": nHits " << dt_simhits.size() << " eta "
-                                        << dt_simhits_gp.eta() << " phi " << dt_simhits_gp.phi() << " nCh "
-                                        << chamber_to_hits_[id].size() << endl;
-      }
+    const auto& dt_det_ids = detIds(0);
+    for (const auto& id : dt_det_ids) {
+      const auto& dt_simhits = MuonSimHitMatcher::hitsInDetId(id);
+      const auto& dt_simhits_gp = simHitsMeanPosition(dt_simhits);
+      edm::LogInfo("DTSimHitMatcher") << "DTWireId " << DTWireId(id) << ": nHits " << dt_simhits.size() << " eta "
+                                      << dt_simhits_gp.eta() << " phi " << dt_simhits_gp.phi() << " nCh "
+                                      << chamber_to_hits_[id].size();
     }
   }
 }
@@ -246,7 +237,7 @@ std::set<unsigned int> DTSimHitMatcher::hitWiresInDTLayerId(unsigned int detid, 
       DTWireId wid(id, wn);
       for (const auto& h : MuonSimHitMatcher::hitsInDetId(wid.rawId())) {
         if (verbose_)
-          edm::LogInfo("DTSimHitMatcher") << "central DTWireId " << wid << " simhit " << h << endl;
+          edm::LogInfo("DTSimHitMatcher") << "central DTWireId " << wid << " simhit " << h;
         int smin = wn - margin_n_wires;
         smin = (smin > 0) ? smin : 1;
         int smax = wn + margin_n_wires;
@@ -254,7 +245,7 @@ std::set<unsigned int> DTSimHitMatcher::hitWiresInDTLayerId(unsigned int detid, 
         for (int ss = smin; ss <= smax; ++ss) {
           DTWireId widd(id, ss);
           if (verbose_)
-            edm::LogInfo("DTSimHitMatcher") << "\tadding DTWireId to collection " << widd << endl;
+            edm::LogInfo("DTSimHitMatcher") << "\tadding DTWireId to collection " << widd;
           result.insert(widd.rawId());
         }
       }
@@ -268,7 +259,7 @@ std::set<unsigned int> DTSimHitMatcher::hitWiresInDTSuperLayerId(unsigned int de
   const auto& layers(dynamic_cast<const DTGeometry*>(geometry_)->superLayer(DTSuperLayerId(detid))->layers());
   for (const auto& l : layers) {
     if (verbose_)
-      edm::LogInfo("DTSimHitMatcher") << "hitWiresInDTSuperLayerId::l id " << l->id() << endl;
+      edm::LogInfo("DTSimHitMatcher") << "hitWiresInDTSuperLayerId::l id " << l->id();
     const auto& p(hitWiresInDTLayerId(l->id().rawId(), margin_n_wires));
     result.insert(p.begin(), p.end());
   }
@@ -280,7 +271,7 @@ std::set<unsigned int> DTSimHitMatcher::hitWiresInDTChamberId(unsigned int detid
   const auto& superLayers(dynamic_cast<const DTGeometry*>(geometry_)->chamber(DTChamberId(detid))->superLayers());
   for (const auto& sl : superLayers) {
     if (verbose_)
-      edm::LogInfo("DTSimHitMatcher") << "hitWiresInDTChamberId::sl id " << sl->id() << endl;
+      edm::LogInfo("DTSimHitMatcher") << "hitWiresInDTChamberId::sl id " << sl->id();
     const auto& p(hitWiresInDTSuperLayerId(sl->id().rawId(), margin_n_wires));
     result.insert(p.begin(), p.end());
   }

--- a/Validation/MuonHits/src/DTSimHitMatcher.cc
+++ b/Validation/MuonHits/src/DTSimHitMatcher.cc
@@ -10,13 +10,14 @@ DTSimHitMatcher::DTSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesColle
   discardEleHits_ = simHitPSet_.getParameter<bool>("discardEleHits");
 
   simHitInput_ = iC.consumes<edm::PSimHitContainer>(simHitPSet_.getParameter<edm::InputTag>("inputTag"));
+  geomToken_ = iC.esConsumes<DTGeometry, MuonGeometryRecord>();
 }
 
 /// initialize the event
 void DTSimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(dt_geom_);
-  if (dt_geom_.isValid()) {
-    geometry_ = &*dt_geom_;
+  edm::ESHandle<DTGeometry> hGeom = iSetup.getHandle(geomToken_);
+  if (hGeom.isValid()) {
+    geometry_ = hGeom.product();
   } else {
     hasGeometry_ = false;
     edm::LogWarning("DTSimHitMatcher") << "+++ Info: DT geometry is unavailable. +++\n";

--- a/Validation/MuonHits/src/GEMSimHitMatcher.cc
+++ b/Validation/MuonHits/src/GEMSimHitMatcher.cc
@@ -15,13 +15,7 @@ GEMSimHitMatcher::GEMSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
 
 /// initialize the event
 void GEMSimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<GEMGeometry> hGeom = iSetup.getHandle(geomToken_);
-  if (hGeom.isValid()) {
-    geometry_ = hGeom.product();
-  } else {
-    hasGeometry_ = false;
-    edm::LogWarning("GEMSimHitMatcher") << "+++ Info: GEM geometry is unavailable. +++\n";
-  }
+  geometry_ = &iSetup.getData(geomToken_);
   MuonSimHitMatcher::init(iEvent, iSetup);
 }
 
@@ -36,35 +30,32 @@ void GEMSimHitMatcher::match(const SimTrack& track, const SimVertex& vertex) {
   if (std::abs(track.momentum().eta()) < 1.55)
     return;
 
-  if (hasGeometry_) {
-    matchSimHitsToSimTrack();
+  matchSimHitsToSimTrack();
 
-    if (verbose_) {
-      edm::LogInfo("GEMSimHitMatcher") << "nTrackIds " << track_ids_.size() << " nSelectedGEMSimHits " << hits_.size()
-                                       << endl;
-      edm::LogInfo("GEMSimHitMatcher") << "detids GEM " << detIds(0).size() << endl;
+  if (verbose_) {
+    edm::LogInfo("GEMSimHitMatcher") << "nTrackIds " << track_ids_.size() << " nSelectedGEMSimHits " << hits_.size();
+    edm::LogInfo("GEMSimHitMatcher") << "detids GEM " << detIds(0).size();
 
-      const auto& gem_ch_ids = detIds();
-      for (const auto& id : gem_ch_ids) {
-        const auto& gem_simhits = MuonSimHitMatcher::hitsInDetId(id);
-        const auto& gem_simhits_gp = simHitsMeanPosition(gem_simhits);
-        edm::LogInfo("GEMSimHitMatcher") << "gemchid " << GEMDetId(id) << ": nHits " << gem_simhits.size() << " phi "
-                                         << gem_simhits_gp.phi() << " nCh " << chamber_to_hits_[id].size() << endl;
-        const auto& strips = hitStripsInDetId(id);
-        edm::LogInfo("GEMSimHitMatcher") << "nStrip " << strips.size() << endl;
-        edm::LogInfo("GEMSimHitMatcher") << "strips : ";
-        for (const auto& p : strips) {
-          edm::LogInfo("GEMSimHitMatcher") << p;
-        }
+    const auto& gem_ch_ids = detIds();
+    for (const auto& id : gem_ch_ids) {
+      const auto& gem_simhits = MuonSimHitMatcher::hitsInDetId(id);
+      const auto& gem_simhits_gp = simHitsMeanPosition(gem_simhits);
+      edm::LogInfo("GEMSimHitMatcher") << "gemchid " << GEMDetId(id) << ": nHits " << gem_simhits.size() << " phi "
+                                       << gem_simhits_gp.phi() << " nCh " << chamber_to_hits_[id].size();
+      const auto& strips = hitStripsInDetId(id);
+      edm::LogInfo("GEMSimHitMatcher") << "nStrip " << strips.size();
+      edm::LogInfo("GEMSimHitMatcher") << "strips : ";
+      for (const auto& p : strips) {
+        edm::LogInfo("GEMSimHitMatcher") << p;
       }
-      const auto& gem_sch_ids = superChamberIds();
-      for (const auto& id : gem_sch_ids) {
-        const auto& gem_simhits = hitsInSuperChamber(id);
-        const auto& gem_simhits_gp = simHitsMeanPosition(gem_simhits);
-        edm::LogInfo("GEMSimHitMatcher") << "gemschid " << GEMDetId(id) << ": " << nCoincidencePadsWithHits() << " | "
-                                         << gem_simhits.size() << " " << gem_simhits_gp.phi() << " "
-                                         << superchamber_to_hits_[id].size() << endl;
-      }
+    }
+    const auto& gem_sch_ids = superChamberIds();
+    for (const auto& id : gem_sch_ids) {
+      const auto& gem_simhits = hitsInSuperChamber(id);
+      const auto& gem_simhits_gp = simHitsMeanPosition(gem_simhits);
+      edm::LogInfo("GEMSimHitMatcher") << "gemschid " << GEMDetId(id) << ": " << nCoincidencePadsWithHits() << " | "
+                                       << gem_simhits.size() << " " << gem_simhits_gp.phi() << " "
+                                       << superchamber_to_hits_[id].size();
     }
   }
 }
@@ -77,10 +68,6 @@ void GEMSimHitMatcher::matchSimHitsToSimTrack() {
 
       const GEMDetId& p_id(h.detUnitId());
 
-      if (verbose_)
-        std::cout << "Candidate GEM simhit " << p_id << " " << h << " " << h.particleType() << " " << h.processType()
-                  << std::endl;
-
       int pdgid = h.particleType();
 
       // consider only the muon hits
@@ -90,9 +77,6 @@ void GEMSimHitMatcher::matchSimHitsToSimTrack() {
       // discard electron hits in the GEM chambers
       if (discardEleHits_ && std::abs(pdgid) == 11)
         continue;
-
-      if (verbose_)
-        std::cout << "...was matched" << std::endl;
 
       detid_to_hits_[p_id.rawId()].push_back(h);
       hits_.push_back(h);

--- a/Validation/MuonHits/src/GEMSimHitMatcher.cc
+++ b/Validation/MuonHits/src/GEMSimHitMatcher.cc
@@ -10,13 +10,14 @@ GEMSimHitMatcher::GEMSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
   discardEleHits_ = simHitPSet_.getParameter<bool>("discardEleHits");
 
   simHitInput_ = iC.consumes<edm::PSimHitContainer>(simHitPSet_.getParameter<edm::InputTag>("inputTag"));
+  geomToken_ = iC.esConsumes<GEMGeometry, MuonGeometryRecord>();
 }
 
 /// initialize the event
 void GEMSimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(gem_geom_);
-  if (gem_geom_.isValid()) {
-    geometry_ = dynamic_cast<const GEMGeometry*>(&*gem_geom_);
+  edm::ESHandle<GEMGeometry> hGeom = iSetup.getHandle(geomToken_);
+  if (hGeom.isValid()) {
+    geometry_ = hGeom.product();
   } else {
     hasGeometry_ = false;
     edm::LogWarning("GEMSimHitMatcher") << "+++ Info: GEM geometry is unavailable. +++\n";

--- a/Validation/MuonHits/src/ME0SimHitMatcher.cc
+++ b/Validation/MuonHits/src/ME0SimHitMatcher.cc
@@ -10,13 +10,14 @@ ME0SimHitMatcher::ME0SimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
   discardEleHits_ = simHitPSet_.getParameter<bool>("discardEleHits");
 
   simHitInput_ = iC.consumes<edm::PSimHitContainer>(simHitPSet_.getParameter<edm::InputTag>("inputTag"));
+  geomToken_ = iC.esConsumes<ME0Geometry, MuonGeometryRecord>();
 }
 
 /// initialize the event
 void ME0SimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(me0_geom_);
-  if (me0_geom_.isValid()) {
-    geometry_ = &*me0_geom_;
+  edm::ESHandle<ME0Geometry> hGeom = iSetup.getHandle(geomToken_);
+  if (hGeom.isValid()) {
+    geometry_ = hGeom.product();
   } else {
     hasGeometry_ = false;
     edm::LogWarning("ME0SimHitMatcher") << "+++ Info: ME0 geometry is unavailable. +++\n";

--- a/Validation/MuonHits/src/ME0SimHitMatcher.cc
+++ b/Validation/MuonHits/src/ME0SimHitMatcher.cc
@@ -15,13 +15,7 @@ ME0SimHitMatcher::ME0SimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
 
 /// initialize the event
 void ME0SimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<ME0Geometry> hGeom = iSetup.getHandle(geomToken_);
-  if (hGeom.isValid()) {
-    geometry_ = hGeom.product();
-  } else {
-    hasGeometry_ = false;
-    edm::LogWarning("ME0SimHitMatcher") << "+++ Info: ME0 geometry is unavailable. +++\n";
-  }
+  geometry_ = &iSetup.getData(geomToken_);
   MuonSimHitMatcher::init(iEvent, iSetup);
 }
 
@@ -30,26 +24,23 @@ void ME0SimHitMatcher::match(const SimTrack& track, const SimVertex& vertex) {
   // instantiates the track ids and simhits
   MuonSimHitMatcher::match(track, vertex);
 
-  if (hasGeometry_) {
-    matchSimHitsToSimTrack();
+  matchSimHitsToSimTrack();
 
-    if (verbose_) {
-      edm::LogInfo("ME0SimHitMatcher") << "nTrackIds " << track_ids_.size() << " nSelectedME0SimHits " << hits_.size()
-                                       << endl;
-      edm::LogInfo("ME0SimHitMatcher") << "detids ME0 " << detIds().size() << endl;
+  if (verbose_) {
+    edm::LogInfo("ME0SimHitMatcher") << "nTrackIds " << track_ids_.size() << " nSelectedME0SimHits " << hits_.size();
+    edm::LogInfo("ME0SimHitMatcher") << "detids ME0 " << detIds().size();
 
-      const auto& me0_ch_ids = detIds();
-      for (const auto& id : me0_ch_ids) {
-        const auto& me0_simhits = MuonSimHitMatcher::hitsInChamber(id);
-        const auto& me0_simhits_gp = simHitsMeanPosition(me0_simhits);
-        edm::LogInfo("ME0SimHitMatcher") << "me0chid " << ME0DetId(id) << ": nHits " << me0_simhits.size() << " phi "
-                                         << me0_simhits_gp.phi() << " nCh " << chamber_to_hits_[id].size() << endl;
-        const auto& strips = hitStripsInDetId(id);
-        edm::LogInfo("ME0SimHitMatcher") << "nStrip " << strips.size() << endl;
-        edm::LogInfo("ME0SimHitMatcher") << "strips : ";
-        for (const auto& p : strips) {
-          edm::LogInfo("ME0SimHitMatcher") << p;
-        }
+    const auto& me0_ch_ids = detIds();
+    for (const auto& id : me0_ch_ids) {
+      const auto& me0_simhits = MuonSimHitMatcher::hitsInChamber(id);
+      const auto& me0_simhits_gp = simHitsMeanPosition(me0_simhits);
+      edm::LogInfo("ME0SimHitMatcher") << "me0chid " << ME0DetId(id) << ": nHits " << me0_simhits.size() << " phi "
+                                       << me0_simhits_gp.phi() << " nCh " << chamber_to_hits_[id].size();
+      const auto& strips = hitStripsInDetId(id);
+      edm::LogInfo("ME0SimHitMatcher") << "nStrip " << strips.size();
+      edm::LogInfo("ME0SimHitMatcher") << "strips : ";
+      for (const auto& p : strips) {
+        edm::LogInfo("ME0SimHitMatcher") << p;
       }
     }
   }

--- a/Validation/MuonHits/src/RPCSimHitMatcher.cc
+++ b/Validation/MuonHits/src/RPCSimHitMatcher.cc
@@ -16,13 +16,7 @@ RPCSimHitMatcher::RPCSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
 
 /// initialize the event
 void RPCSimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<RPCGeometry> hGeom = iSetup.getHandle(geomToken_);
-  if (hGeom.isValid()) {
-    geometry_ = hGeom.product();
-  } else {
-    hasGeometry_ = false;
-    edm::LogWarning("RPCSimHitMatcher") << "+++ Info: RPC geometry is unavailable. +++\n";
-  }
+  geometry_ = &iSetup.getData(geomToken_);
   MuonSimHitMatcher::init(iEvent, iSetup);
 }
 
@@ -31,26 +25,24 @@ void RPCSimHitMatcher::match(const SimTrack& track, const SimVertex& vertex) {
   // instantiates the track ids and simhits
   MuonSimHitMatcher::match(track, vertex);
 
-  if (hasGeometry_) {
-    matchSimHitsToSimTrack();
+  matchSimHitsToSimTrack();
 
-    if (verbose_) {
-      edm::LogInfo("RPCSimHitMatcher") << "nSimHits " << simHits_.size() << " nTrackIds " << track_ids_.size() << endl;
-      edm::LogInfo("RPCSimHitMatcher") << "detids RPC " << detIds().size() << endl;
+  if (verbose_) {
+    edm::LogInfo("RPCSimHitMatcher") << "nSimHits " << simHits_.size() << " nTrackIds " << track_ids_.size();
+    edm::LogInfo("RPCSimHitMatcher") << "detids RPC " << detIds().size();
 
-      const auto& ch_ids = chamberIds();
-      for (const auto& id : ch_ids) {
-        const auto& simhits = MuonSimHitMatcher::hitsInChamber(id);
-        const auto& simhits_gp = simHitsMeanPosition(simhits);
-        edm::LogInfo("RPCSimHitMatcher") << "RPCDetId " << RPCDetId(id) << ": nHits " << simhits.size() << " eta "
-                                         << simhits_gp.eta() << " phi " << simhits_gp.phi() << " nCh "
-                                         << chamber_to_hits_[id].size() << endl;
-        const auto& strips = hitStripsInDetId(id);
-        edm::LogInfo("RPCSimHitMatcher") << "nStrips " << strips.size() << endl;
-        edm::LogInfo("RPCSimHitMatcher") << "strips : ";
-        for (const auto& p : strips) {
-          edm::LogInfo("RPCSimHitMatcher") << p;
-        }
+    const auto& ch_ids = chamberIds();
+    for (const auto& id : ch_ids) {
+      const auto& simhits = MuonSimHitMatcher::hitsInChamber(id);
+      const auto& simhits_gp = simHitsMeanPosition(simhits);
+      edm::LogInfo("RPCSimHitMatcher") << "RPCDetId " << RPCDetId(id) << ": nHits " << simhits.size() << " eta "
+                                       << simhits_gp.eta() << " phi " << simhits_gp.phi() << " nCh "
+                                       << chamber_to_hits_[id].size();
+      const auto& strips = hitStripsInDetId(id);
+      edm::LogInfo("RPCSimHitMatcher") << "nStrips " << strips.size();
+      edm::LogInfo("RPCSimHitMatcher") << "strips : ";
+      for (const auto& p : strips) {
+        edm::LogInfo("RPCSimHitMatcher") << p;
       }
     }
   }

--- a/Validation/MuonHits/src/RPCSimHitMatcher.cc
+++ b/Validation/MuonHits/src/RPCSimHitMatcher.cc
@@ -11,13 +11,14 @@ RPCSimHitMatcher::RPCSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
   discardEleHits_ = simHitPSet_.getParameter<bool>("discardEleHits");
 
   simHitInput_ = iC.consumes<edm::PSimHitContainer>(simHitPSet_.getParameter<edm::InputTag>("inputTag"));
+  geomToken_ = iC.esConsumes<RPCGeometry, MuonGeometryRecord>();
 }
 
 /// initialize the event
 void RPCSimHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(rpc_geom_);
-  if (rpc_geom_.isValid()) {
-    geometry_ = &*rpc_geom_;
+  edm::ESHandle<RPCGeometry> hGeom = iSetup.getHandle(geomToken_);
+  if (hGeom.isValid()) {
+    geometry_ = hGeom.product();
   } else {
     hasGeometry_ = false;
     edm::LogWarning("RPCSimHitMatcher") << "+++ Info: RPC geometry is unavailable. +++\n";

--- a/Validation/MuonME0Validation/interface/ME0BaseValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0BaseValidation.h
@@ -10,7 +10,6 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -35,6 +34,7 @@ protected:
   std::vector<double> RangeZR_;
   edm::EDGetToken InputTagToken_;
   int nBinXY_;
+  edm::ESGetToken<ME0Geometry, MuonGeometryRecord> geomToken_;
 
 private:
 };

--- a/Validation/MuonME0Validation/interface/ME0RecHitsValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0RecHitsValidation.h
@@ -2,11 +2,7 @@
 #define ME0RecHitsValidation_H
 
 #include "Validation/MuonME0Validation/interface/ME0BaseValidation.h"
-
-// Data Format
 #include "DataFormats/GEMRecHit/interface/ME0RecHitCollection.h"
-#include "DataFormats/MuonDetId/interface/GEMDetId.h"
-#include <DataFormats/GEMRecHit/interface/ME0RecHit.h>
 
 class ME0RecHitsValidation : public ME0BaseValidation {
 public:

--- a/Validation/MuonME0Validation/interface/ME0SegmentsValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0SegmentsValidation.h
@@ -2,16 +2,9 @@
 #define ME0SegmentsValidation_H
 
 #include "Validation/MuonME0Validation/interface/ME0BaseValidation.h"
-
-#include <DataFormats/GEMRecHit/interface/ME0Segment.h>
-#include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
-
-#include "DataFormats/GEMDigi/interface/ME0DigiPreReco.h"
 #include "DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h"
+#include "DataFormats/GEMRecHit/interface/ME0SegmentCollection.h"
 #include "DataFormats/GEMRecHit/interface/ME0RecHitCollection.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include <DataFormats/GEMRecHit/interface/ME0RecHit.h>
 
 class ME0SegmentsValidation : public ME0BaseValidation {
 public:

--- a/Validation/MuonME0Validation/plugins/MuonME0DigisHarvestor.cc
+++ b/Validation/MuonME0Validation/plugins/MuonME0DigisHarvestor.cc
@@ -3,7 +3,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/MuonME0Validation/plugins/MuonME0DigisHarvestor.h
+++ b/Validation/MuonME0Validation/plugins/MuonME0DigisHarvestor.h
@@ -2,7 +2,6 @@
 #define MuonME0DigisHarvestor_H
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DQMServices/Core/interface/DQMEDHarvester.h"

--- a/Validation/MuonME0Validation/plugins/MuonME0SegHarvestor.cc
+++ b/Validation/MuonME0Validation/plugins/MuonME0SegHarvestor.cc
@@ -3,7 +3,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/MuonME0Validation/plugins/MuonME0SegHarvestor.h
+++ b/Validation/MuonME0Validation/plugins/MuonME0SegHarvestor.h
@@ -2,7 +2,6 @@
 #define MuonME0SegHarvestor_H
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DQMServices/Core/interface/DQMEDHarvester.h"

--- a/Validation/MuonME0Validation/src/ME0BaseValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0BaseValidation.cc
@@ -16,6 +16,7 @@ ME0BaseValidation::ME0BaseValidation(const edm::ParameterSet &ps) {
   layerLabel.push_back("4");
   layerLabel.push_back("5");
   layerLabel.push_back("6");
+  geomToken_ = esConsumes<ME0Geometry, MuonGeometryRecord>();
 }
 
 ME0BaseValidation::~ME0BaseValidation() {}

--- a/Validation/MuonME0Validation/src/ME0DigisValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0DigisValidation.cc
@@ -158,9 +158,7 @@ void ME0DigisValidation::bookHistograms(DQMStore::IBooker &ibooker,
 ME0DigisValidation::~ME0DigisValidation() {}
 
 void ME0DigisValidation::analyze(const edm::Event &e, const edm::EventSetup &iSetup) {
-  edm::ESHandle<ME0Geometry> hGeom;
-  iSetup.get<MuonGeometryRecord>().get(hGeom);
-  const ME0Geometry *ME0Geometry_ = (&*hGeom);
+  const ME0Geometry *ME0Geometry_ = &iSetup.getData(geomToken_);
 
   edm::Handle<edm::PSimHitContainer> ME0Hits;
   e.getByToken(InputTagToken_, ME0Hits);

--- a/Validation/MuonME0Validation/src/ME0HitsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0HitsValidation.cc
@@ -58,9 +58,7 @@ void ME0HitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run cons
 ME0HitsValidation::~ME0HitsValidation() {}
 
 void ME0HitsValidation::analyze(const edm::Event &e, const edm::EventSetup &iSetup) {
-  edm::ESHandle<ME0Geometry> hGeom;
-  iSetup.get<MuonGeometryRecord>().get(hGeom);
-  const ME0Geometry *ME0Geometry_ = (&*hGeom);
+  const ME0Geometry *ME0Geometry_ = &iSetup.getData(geomToken_);
 
   edm::Handle<edm::PSimHitContainer> ME0Hits;
   e.getByToken(InputTagToken_, ME0Hits);
@@ -79,7 +77,7 @@ void ME0HitsValidation::analyze(const edm::Event &e, const edm::EventSetup &iSet
 
     // Int_t even_odd = id.chamber()%2;
     if (ME0Geometry_->idToDet(hits->detUnitId()) == nullptr) {
-      std::cout << "simHit did not matched with GEMGeometry." << std::endl;
+      edm::LogInfo("ME0HitsValidation") << "simHit did not matched with GEMGeometry." << std::endl;
       continue;
     }
 

--- a/Validation/MuonME0Validation/src/ME0RecHitsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0RecHitsValidation.cc
@@ -59,9 +59,8 @@ void ME0RecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
 ME0RecHitsValidation::~ME0RecHitsValidation() {}
 
 void ME0RecHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &iSetup) {
-  edm::ESHandle<ME0Geometry> hGeom;
-  iSetup.get<MuonGeometryRecord>().get(hGeom);
-  const ME0Geometry *ME0Geometry_ = (&*hGeom);
+  const ME0Geometry *ME0Geometry_ = &iSetup.getData(geomToken_);
+
   edm::Handle<edm::PSimHitContainer> ME0Hits;
   e.getByToken(InputTagToken_, ME0Hits);
 
@@ -83,7 +82,7 @@ void ME0RecHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &i
 
     // Int_t even_odd = id.chamber()%2;
     if (ME0Geometry_->idToDet(hits->detUnitId()) == nullptr) {
-      std::cout << "simHit did not matched with GEMGeometry." << std::endl;
+      edm::LogInfo("ME0RecHitsValidation") << "simHit did not matched with GEMGeometry." << std::endl;
       continue;
     }
 

--- a/Validation/MuonME0Validation/src/ME0SegmentsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0SegmentsValidation.cc
@@ -18,10 +18,6 @@ ME0SegmentsValidation::ME0SegmentsValidation(const edm::ParameterSet &cfg) : ME0
 void ME0SegmentsValidation::bookHistograms(DQMStore::IBooker &ibooker,
                                            edm::Run const &Run,
                                            edm::EventSetup const &iSetup) {
-  // edm::ESHandle<ME0Geometry> hGeom;
-  // iSetup.get<MuonGeometryRecord>().get(hGeom);
-  // const ME0Geometry* ME0Geometry_ =( &*hGeom);
-
   LogDebug("MuonME0SegmentsValidation") << "Info : Loading Geometry information\n";
   ibooker.setCurrentFolder("MuonME0RecHitsV/ME0SegmentsTask");
 
@@ -109,9 +105,7 @@ void ME0SegmentsValidation::bookHistograms(DQMStore::IBooker &ibooker,
 ME0SegmentsValidation::~ME0SegmentsValidation() {}
 
 void ME0SegmentsValidation::analyze(const edm::Event &e, const edm::EventSetup &iSetup) {
-  edm::ESHandle<ME0Geometry> hGeom;
-  iSetup.get<MuonGeometryRecord>().get(hGeom);
-  const ME0Geometry *ME0Geometry_ = (&*hGeom);
+  const ME0Geometry *ME0Geometry_ = &iSetup.getData(geomToken_);
 
   edm::Handle<edm::PSimHitContainer> ME0Hits;
   e.getByToken(InputTagToken_, ME0Hits);


### PR DESCRIPTION
#### PR description:

Migrate GEM and CSC validation to esConsumes and edm::ESGetToken to provide better threading efficiency, in response to #31061.

Included: 
RecoLocalMuon/CSCEfficiency
RecoLocalMuon/CSCValidation
Validation/CSCRecHits
Validation/MuonCSCDigis
Validation/MuonGEMDigis
Validation/MuonGEMHits
Validation/MuonGEMRecHits
Validation/MuonHits
Validation/MuonME0Validation

#### PR validation:

Tested with WF 23234.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A