### PR TITLE
Add trigger to btv offline

### DIFF
--- a/DQMOffline/Trigger/plugins/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/BTVHLTOfflineSource.cc
@@ -326,6 +326,12 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
   for (auto& v : hltPathsAll_) {
     unsigned index = triggerNames.triggerIndex(v.getPath());
     if (!(index < triggerNames.size())) {
+      edm::LogInfo("BTVHLTOfflineSource") << "Path " << v.getPath() << " not in menu, skipping event";
+      continue;
+    }
+
+    if(!triggerResults->accept(index)){
+      edm::LogInfo("BTVHLTOfflineSource") << "Path " << v.getPath() << " not accepted, skipping event";
       continue;
     }
 

--- a/DQMOffline/Trigger/plugins/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/BTVHLTOfflineSource.cc
@@ -330,7 +330,7 @@ void BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetu
       continue;
     }
 
-    if(!triggerResults->accept(index)){
+    if (!triggerResults->accept(index)) {
       edm::LogInfo("BTVHLTOfflineSource") << "Path " << v.getPath() << " not accepted, skipping event";
       continue;
     }


### PR DESCRIPTION
This PR adds a trigger requirement in BTVHLTOfflineSource.
Previously where were checking that the HLT path used for monitoring was defined in the menu, but we were not actually requiring that it be accepted by the event. This PR fixes that. 

Changes expected are fewer accepted event in the BTV DQM monitoring associated with BTVHLTOfflineSource.
(Before we were getting all events, now we only monitor those passing the trigger. 


#### PR validation:

Validated with standard runTheMatrix commands. 


