### PR TITLE
Add weights config for 2018 Run Dependent MC

### DIFF
--- a/Configuration/StandardSequences/python/RunsAndWeights.py
+++ b/Configuration/StandardSequences/python/RunsAndWeights.py
@@ -1,3 +1,4 @@
 RunsAndWeights = {
-    'Run2012_AB_C_D_oneRunPerEra' : 'SimGeneral.Configuration.RunsAndWeights_Run2012_AB_C_D_oneRunPerEra'
+    'Run2012_AB_C_D_oneRunPerEra' : 'SimGeneral.Configuration.RunsAndWeights_Run2012_AB_C_D_oneRunPerEra',
+    'RunsAndWeights_Run2018_ABCD' : 'SimGeneral.Configuration.RunsAndWeights_Run2018_ABCD'
     }

--- a/Configuration/StandardSequences/python/RunsAndWeights.py
+++ b/Configuration/StandardSequences/python/RunsAndWeights.py
@@ -1,4 +1,4 @@
 RunsAndWeights = {
     'Run2012_AB_C_D_oneRunPerEra' : 'SimGeneral.Configuration.RunsAndWeights_Run2012_AB_C_D_oneRunPerEra',
-    'RunsAndWeights_Run2018_ABCD' : 'SimGeneral.Configuration.RunsAndWeights_Run2018_ABCD'
+    'Run2018_ABCD' : 'SimGeneral.Configuration.RunsAndWeights_Run2018_ABCD'
     }

--- a/SimGeneral/Configuration/python/RunsAndWeights_Run2018_ABCD.py
+++ b/SimGeneral/Configuration/python/RunsAndWeights_Run2018_ABCD.py
@@ -1,0 +1,6 @@
+# Scenario of Run Dependent MC 2018 with 9 iovs
+# For reference, see steps['DIGIPRMXUP18_PU25_RD'] defined in Configuration/PyReleaseValidation/python/relval_steps.py, https://github.com/cms-sw/cmssw/pull/29457
+# format: [(IOV, integrated lumi),..]
+# for 2018: Total int lumi = ~59.74 /fb (Golden JSON)
+
+runProbabilityDistribution=[(315257,6.64),(316082,6.64),(316720,6.64),(317527,6.64),(320917,6.64),(321414,6.64),(321973,6.64),(322492,6.64),(324245,6.64)]


### PR DESCRIPTION
#### PR description:
This PR introduces weights used for 2018 Run Dependent MC.

#### PR validation:
No. The test should be done when agreeing on how to pass information to WMAgents

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport should be done to 11_1, for a pilot of the production.
